### PR TITLE
samsung audio fix

### DIFF
--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/smarterglassesmanager/hci/MicrophoneLocalAndBluetooth.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/smarterglassesmanager/hci/MicrophoneLocalAndBluetooth.java
@@ -295,7 +295,13 @@ public class MicrophoneLocalAndBluetooth {
             audioManager.setMode(AudioManager.MODE_IN_CALL);
             EventBus.getDefault().post(new ScoStartEvent(true));
         } else {
-            audioManager.setMode(AudioManager.MODE_NORMAL);
+            // Samsung devices work better with MODE_IN_COMMUNICATION for non-SCO recording
+            if ("samsung".equalsIgnoreCase(android.os.Build.MANUFACTURER)) {
+                audioManager.setMode(AudioManager.MODE_IN_COMMUNICATION);
+                Log.d(TAG, "Samsung device - using MODE_IN_COMMUNICATION for better audio routing");
+            } else {
+                audioManager.setMode(AudioManager.MODE_NORMAL);
+            }
             EventBus.getDefault().post(new ScoStartEvent(false));
         }
 
@@ -306,14 +312,38 @@ public class MicrophoneLocalAndBluetooth {
         }
 
         try {
-            recorder = new AudioRecord(MediaRecorder.AudioSource.CAMCORDER,
+            // Choose audio source based on device manufacturer
+            // Samsung devices work better with VOICE_RECOGNITION source
+            int audioSource = MediaRecorder.AudioSource.CAMCORDER;
+            if ("samsung".equalsIgnoreCase(android.os.Build.MANUFACTURER)) {
+                // VOICE_RECOGNITION is more cooperative on Samsung devices
+                audioSource = MediaRecorder.AudioSource.VOICE_RECOGNITION;
+                Log.d(TAG, "Samsung device detected - using VOICE_RECOGNITION audio source for better app cooperation");
+            }
+            
+            recorder = new AudioRecord(audioSource,
                     SAMPLING_RATE_IN_HZ, CHANNEL_CONFIG, AUDIO_FORMAT, bufferSize * 2);
+            
+            Log.d(TAG, "AudioRecord created with source: " + audioSource + 
+                  " (CAMCORDER=" + MediaRecorder.AudioSource.CAMCORDER + 
+                  ", VOICE_RECOGNITION=" + MediaRecorder.AudioSource.VOICE_RECOGNITION + ")");
 
             if (recorder.getState() != AudioRecord.STATE_INITIALIZED) {
                 Log.e(TAG, "Failed to initialize AudioRecord");
                 Toast.makeText(this.mContext, "Error starting onboard microphone", Toast.LENGTH_LONG).show();
                 stopRecording();
                 return;
+            }
+            
+            // On Samsung devices, set the audio session ID to help with detection
+            if ("samsung".equalsIgnoreCase(android.os.Build.MANUFACTURER)) {
+                try {
+                    // This might help with Samsung's audio routing
+                    recorder.setPreferredDevice(null); // Clear any preferred device
+                    Log.d(TAG, "Samsung: Cleared preferred audio device for better sharing");
+                } catch (Exception e) {
+                    Log.e(TAG, "Error setting Samsung audio preferences", e);
+                }
             }
             
             // Register our AudioRecord with the PhoneMicrophoneManager for conflict detection


### PR DESCRIPTION
Fixes microphone switching on Samsung devices when using "phone mic". It worked fine on Motorola and Pixel devices, but not on Samsung devices. It now works on Samsung devices.
 
Correct behavior (which Samsung phones can now do): 

When using "phone mic", MentraOS will release the mic when other apps access the microphone, and switch to the glasses microphone (if applicable). When other apps stop using the phone's microphone, MentraOS will switch back to using the phone's microphone.

NOTE: NEED TO TEST THIS ON NICHE DEVICES (XIAOMI, REDMI, OPPO, ONEPLUS, VIVO, HUAWEI).
