### PR TITLE
Dev merged client two locations

### DIFF
--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/AugmentosService.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/AugmentosService.java
@@ -132,7 +132,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
     private final Handler screenCaptureHandler = new Handler();
     private Runnable screenCaptureRunnable;
     private LocationSystem locationSystem;
-    private boolean locationSystemBound = false; // [NEW]
+    private boolean locationSystemBound = false;
     private long currTime = 0;
     private long lastPressed = 0;
     private final long lastTapped = 0;
@@ -196,7 +196,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
         }
     };
 
-    // [NEW] Connection to LocationSystem service
+    // connection to LocationSystem service
     private ServiceConnection locationServiceConnection = new ServiceConnection() {
         @Override
         public void onServiceConnected(ComponentName className, IBinder service) {
@@ -538,7 +538,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
             handleBatteryOptimization(this);
         }
 
-        // [NEW] Start and bind to the LocationSystem service
+        // start and bind to the LocationSystem service
         Intent locationIntent = new Intent(this, LocationSystem.class);
         startService(locationIntent);
         bindService(locationIntent, locationServiceConnection, Context.BIND_AUTO_CREATE);
@@ -580,8 +580,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
         //    ServerComms.getInstance().connectWebSocket(authHandler.getCoreToken());
         initializeServerCommsCallbacks();
 
-        // [REMOVED] The direct instantiation is replaced by the bound service logic
-        // locationSystem = new LocationSystem(this);
+        // the direct instantiation is replaced by the bound service logic
 
         // Start periodic datetime sending
         datetimeRunnable = new Runnable() {
@@ -2396,7 +2395,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
             edgeAppSystem.destroy();
         }
 
-        // [NEW] Unbind from LocationSystem service
+        // unbind from LocationSystem service
         if (locationSystemBound) {
             unbindService(locationServiceConnection);
             locationSystemBound = false;

--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/AugmentosService.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/AugmentosService.java
@@ -132,6 +132,7 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
     private final Handler screenCaptureHandler = new Handler();
     private Runnable screenCaptureRunnable;
     private LocationSystem locationSystem;
+    private boolean locationSystemBound = false; // [NEW]
     private long currTime = 0;
     private long lastPressed = 0;
     private final long lastTapped = 0;
@@ -194,6 +195,27 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
             }
         }
     };
+
+    // [NEW] Connection to LocationSystem service
+    private ServiceConnection locationServiceConnection = new ServiceConnection() {
+        @Override
+        public void onServiceConnected(ComponentName className, IBinder service) {
+            LocationSystem.LocationBinder binder = (LocationSystem.LocationBinder) service;
+            locationSystem = binder.getService();
+            locationSystemBound = true;
+            // Provide the valid instance to ServerComms
+            ServerComms.getInstance(AugmentosService.this).setLocationSystem(locationSystem);
+            Log.d(TAG, "LocationSystem service bound");
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName arg0) {
+            locationSystem = null;
+            locationSystemBound = false;
+            Log.d(TAG, "LocationSystem service unbound");
+        }
+    };
+
     private NotificationSystem notificationSystem;
     private CalendarSystem calendarSystem;
 
@@ -516,6 +538,11 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
             handleBatteryOptimization(this);
         }
 
+        // [NEW] Start and bind to the LocationSystem service
+        Intent locationIntent = new Intent(this, LocationSystem.class);
+        startService(locationIntent);
+        bindService(locationIntent, locationServiceConnection, Context.BIND_AUTO_CREATE);
+
         // Automatically connect to glasses on service start
         String preferredWearable = SmartGlassesManager.getPreferredWearable(this);
         if(!preferredWearable.isEmpty()) {
@@ -553,7 +580,8 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
         //    ServerComms.getInstance().connectWebSocket(authHandler.getCoreToken());
         initializeServerCommsCallbacks();
 
-        locationSystem = new LocationSystem(this);
+        // [REMOVED] The direct instantiation is replaced by the bound service logic
+        // locationSystem = new LocationSystem(this);
 
         // Start periodic datetime sending
         datetimeRunnable = new Runnable() {
@@ -2366,6 +2394,12 @@ public class AugmentosService extends LifecycleService implements AugmentOsActio
 
         if(edgeAppSystem != null) {
             edgeAppSystem.destroy();
+        }
+
+        // [NEW] Unbind from LocationSystem service
+        if (locationSystemBound) {
+            unbindService(locationServiceConnection);
+            locationSystemBound = false;
         }
     }
 

--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/LocationSystem.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/LocationSystem.java
@@ -47,14 +47,9 @@ public class LocationSystem extends Service {
     public double latestAccessedLong = 0;
     private FusedLocationProviderClient fusedLocationProviderClient;
     private LocationCallback locationCallback;
-    private LocationCallback fastLocationCallback;
 
     // Store last known location
     private Location lastKnownLocation = null;
-
-    private final Handler locationSendingLoopHandler = new Handler(Looper.getMainLooper());
-    private Runnable locationSendingRunnableCode;
-    private final long locationSendTime = 1000 * 60 * 30; // 30 minutes
 
     /**
      * Class for clients to access this service
@@ -75,8 +70,9 @@ public class LocationSystem extends Service {
         fusedLocationProviderClient = LocationServices.getFusedLocationProviderClient(this);
         setupLocationCallbacks();
         getLastKnownLocation();
-        requestFastLocationUpdate(); // Get a quick fix immediately on startup
-        scheduleLocationUpdates();
+        
+        // Start with standard mode by default.
+        setHighAccuracyMode(false); 
     }
     
     @Override
@@ -214,64 +210,37 @@ public class LocationSystem extends Service {
                 });
     }
 
-    public void requestFastLocationUpdate() {
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            return;
-        }
+    public void setHighAccuracyMode(boolean enabled) {
+        stopLocationUpdates(); // Always stop previous requests
 
-        LocationRequest fastLocationRequest = LocationRequest.create();
-        fastLocationRequest.setPriority(LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY);
-        fastLocationRequest.setInterval(1000);              // Update every 1 second
-        fastLocationRequest.setFastestInterval(500);        // Fastest update interval 0.5 seconds
-        fastLocationRequest.setMaxWaitTime(3000);           // Wait at most 3 seconds for a fix
+        if (enabled) {
+            Log.d(TAG, "LocationSystem: Enabling high accuracy mode (realtime).");
+            LocationRequest realtimeRequest = LocationRequest.create();
+            realtimeRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
+            realtimeRequest.setInterval(1000); // 1 second
+            realtimeRequest.setFastestInterval(500);
 
-        fusedLocationProviderClient.requestLocationUpdates(
-                fastLocationRequest,
-                fastLocationCallback,
-                Looper.getMainLooper()
-        );
-
-        // Set a timeout to cancel this request if it takes too long
-        locationSendingLoopHandler.postDelayed(() -> {
-            fusedLocationProviderClient.removeLocationUpdates(fastLocationCallback);
-            // If we didn't get a fast fix, request a more accurate one
-            if (!firstLockAcquired) {
-                requestLocationUpdate();
+            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                return;
             }
-        }, 5000); // Give up on fast fix after 5 seconds
-    }
+            fusedLocationProviderClient.requestLocationUpdates(realtimeRequest, locationCallback, Looper.getMainLooper());
+        } else {
+            Log.d(TAG, "LocationSystem: Disabling high accuracy mode, reverting to standard 15-minute updates.");
+            LocationRequest standardRequest = LocationRequest.create();
+            standardRequest.setPriority(LocationRequest.PRIORITY_LOW_POWER);
+            standardRequest.setInterval(900000); // 15 minutes
+            standardRequest.setFastestInterval(300000); // 5 minutes
 
-    public void requestLocationUpdate() {
-        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            return;
+            if (ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
+                return;
+            }
+            fusedLocationProviderClient.requestLocationUpdates(standardRequest, locationCallback, Looper.getMainLooper());
         }
-
-        LocationRequest locationRequest = LocationRequest.create();
-        locationRequest.setPriority(LocationRequest.PRIORITY_HIGH_ACCURACY);
-        locationRequest.setInterval(10000);              // Keep GPS on for 10 seconds
-        locationRequest.setFastestInterval(5000);        // Fastest update interval 5 seconds
-        locationRequest.setMaxWaitTime(15000);           // Wait up to 15 seconds for a fix (down from 60)
-
-        fusedLocationProviderClient.requestLocationUpdates(
-                locationRequest,
-                locationCallback,
-                Looper.getMainLooper()
-        );
-
-        // Set a timeout to cancel this request if it takes too long
-        locationSendingLoopHandler.postDelayed(() -> {
-            stopLocationUpdates();
-        }, 20000); // Give up after 20 seconds total
     }
 
     public void stopLocationUpdates() {
         if (fusedLocationProviderClient != null && locationCallback != null) {
             fusedLocationProviderClient.removeLocationUpdates(locationCallback);
-        }
-        
-        // Also remove updates from fast callback to be safe
-        if (fusedLocationProviderClient != null && fastLocationCallback != null) {
-            fusedLocationProviderClient.removeLocationUpdates(fastLocationCallback);
         }
     }
 
@@ -299,54 +268,8 @@ public class LocationSystem extends Service {
         return latestAccessedLong;
     }
 
-    // Add a flag and a polling interval for first lock
-    private boolean firstLockAcquired = false;
-    private final long firstLockPollingInterval = 5000; // 5 seconds
-
-    public void scheduleLocationUpdates() {
-        locationSendingRunnableCode = new Runnable() {
-            @Override
-            public void run() {
-                if (!firstLockAcquired) {
-                    // For first lock, try to get a fast fix first
-                    requestFastLocationUpdate();
-                    locationSendingLoopHandler.postDelayed(this, firstLockPollingInterval);
-                } else {
-                    // Once first fix is obtained, request high-accuracy location
-                    requestLocationUpdate();
-                    locationSendingLoopHandler.postDelayed(this, locationSendTime);
-                }
-            }
-        };
-        locationSendingLoopHandler.post(locationSendingRunnableCode);
-    }
-
     private void setupLocationCallbacks() {
-        // Fast, low-accuracy callback for initial fix
-        fastLocationCallback = new LocationCallback() {
-            @Override
-            public void onLocationResult(LocationResult locationResult) {
-                if (locationResult == null || locationResult.getLocations().isEmpty()) return;
-
-                Location location = locationResult.getLastLocation();
-                lat = location.getLatitude();
-                lng = location.getLongitude();
-                lastKnownLocation = location;
-
-                Log.d(TAG, "Fast location fix obtained: " + lat + ", " + lng);
-
-                sendLocationToServer();
-                fusedLocationProviderClient.removeLocationUpdates(fastLocationCallback);
-
-                if (!firstLockAcquired) {
-                    firstLockAcquired = true;
-                    // After getting fast fix, immediately request high accuracy fix
-                    requestLocationUpdate();
-                }
-            }
-        };
-
-        // High-accuracy callback for better location
+        // A single, unified callback for all location updates.
         locationCallback = new LocationCallback() {
             @Override
             public void onLocationResult(LocationResult locationResult) {
@@ -357,14 +280,8 @@ public class LocationSystem extends Service {
                 lng = location.getLongitude();
                 lastKnownLocation = location;
 
-                Log.d(TAG, "Accurate location fix obtained: " + lat + ", " + lng);
-
+                Log.d(TAG, "LocationSystem: Received location update: " + lat + ", " + lng);
                 sendLocationToServer();
-                stopLocationUpdates();
-
-                if (!firstLockAcquired) {
-                    firstLockAcquired = true;
-                }
             }
         };
     }
@@ -378,11 +295,6 @@ public class LocationSystem extends Service {
      * Call this method to cleanup all resources when the app is being destroyed
      */
     public void cleanup() {
-        // Remove all pending callbacks
-        if (locationSendingLoopHandler != null) {
-            locationSendingLoopHandler.removeCallbacksAndMessages(null);
-        }
-        
         // Make sure location updates are stopped
         stopLocationUpdates();
     }

--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/augmentos_backend/ServerComms.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/augmentos_backend/ServerComms.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.augmentos.augmentos_core.BuildConfig;
 import com.augmentos.augmentos_core.CalendarItem;
+import com.augmentos.augmentos_core.LocationSystem;
 import com.augmentos.augmentos_core.smarterglassesmanager.speechrecognition.AsrStreamKey;
 import com.augmentos.augmentos_core.smarterglassesmanager.speechrecognition.augmentos.SpeechRecAugmentos;
 import com.augmentos.augmentoslib.enums.AsrStreamType;
@@ -52,6 +53,7 @@ public class ServerComms {
     private static ServerComms instance;
     private String coreToken;
     private Context context;
+    private LocationSystem locationSystem; // [NEW] Property to hold the managed instance
 
     // ------------------------------------------------------------------------
     // AUDIO QUEUE SYSTEM (IMPROVED)
@@ -90,6 +92,11 @@ public class ServerComms {
 
     public void setServerCommsCallback(ServerCommsCallback callback) {
         this.serverCommsCallback = callback;
+    }
+
+    // [NEW] Setter for AugmentosService to provide the valid LocationSystem instance
+    public void setLocationSystem(LocationSystem locationSystem) {
+        this.locationSystem = locationSystem;
     }
 
     private ServerComms(Context context) {
@@ -637,6 +644,22 @@ public class ServerComms {
 //        Log.d(TAG, "Received message of type: " + msg);
 
         switch (type) {
+            case "SET_LOCATION_ACCURACY":
+                try {
+                    String rate = msg.getJSONObject("payload").getString("rate");
+                    // For the MVP, we only care if the rate is 'realtime' or not
+                    boolean enableHigh = "realtime".equals(rate);
+                    // [MODIFIED] Use the managed instance variable with a null check
+                    if (locationSystem != null) {
+                        locationSystem.setHighAccuracyMode(enableHigh);
+                    } else {
+                        Log.w(TAG, "LocationSystem not available to ServerComms, cannot set accuracy mode");
+                    }
+                } catch (JSONException e) {
+                    Log.e(TAG, "Error parsing SET_LOCATION_ACCURACY payload", e);
+                }
+                break;
+
             case "connection_ack":
                 Log.d(TAG, "Received connection_ack. Possibly store sessionId if needed.");
                 startAudioSenderThread();

--- a/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/augmentos_backend/ServerComms.java
+++ b/augmentos_core/app/src/main/java/com/augmentos/augmentos_core/augmentos_backend/ServerComms.java
@@ -53,7 +53,7 @@ public class ServerComms {
     private static ServerComms instance;
     private String coreToken;
     private Context context;
-    private LocationSystem locationSystem; // [NEW] Property to hold the managed instance
+    private LocationSystem locationSystem; // property to hold the managed instance
 
     // ------------------------------------------------------------------------
     // AUDIO QUEUE SYSTEM (IMPROVED)
@@ -94,7 +94,7 @@ public class ServerComms {
         this.serverCommsCallback = callback;
     }
 
-    // [NEW] Setter for AugmentosService to provide the valid LocationSystem instance
+    // setter for AugmentosService to provide the valid LocationSystem instance
     public void setLocationSystem(LocationSystem locationSystem) {
         this.locationSystem = locationSystem;
     }
@@ -647,9 +647,7 @@ public class ServerComms {
             case "SET_LOCATION_ACCURACY":
                 try {
                     String rate = msg.getJSONObject("payload").getString("rate");
-                    // For the MVP, we only care if the rate is 'realtime' or not
                     boolean enableHigh = "realtime".equals(rate);
-                    // [MODIFIED] Use the managed instance variable with a null check
                     if (locationSystem != null) {
                         locationSystem.setHighAccuracyMode(enableHigh);
                     } else {

--- a/augmentos_manager/app.json
+++ b/augmentos_manager/app.json
@@ -55,7 +55,11 @@
         "NSCalendarUsageDescription": "MentraOS accesses your calendar to display upcoming events and reminders directly on your smart glasses. For example, the app can show 'Meeting with John at 3 PM in Conference Room A' or remind you '15 minutes until dentist appointment' on your glasses display.",
         "NSPhotoLibraryUsageDescription": "This app needs access to your photo library to provide you with photo based information on your glasses.",
         "NSUserNotificationUsageDescription": "This app needs access to your notifications to provide you with notifications.",
-        "UIBackgroundModes": ["bluetooth-central", "audio"],
+        "UIBackgroundModes": [
+          "bluetooth-central", 
+          "audio",
+          "location"
+        ],
         "UIRequiresFullScreen": true,
         "UISupportedInterfaceOrientations": [
           "UIInterfaceOrientationPortrait",

--- a/augmentos_manager/ios/AOS/Info.plist
+++ b/augmentos_manager/ios/AOS/Info.plist
@@ -19,7 +19,7 @@
     <key>CFBundlePackageType</key>
     <string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.2.0</string>
+    <string>2.1.6</string>
     <key>CFBundleSignature</key>
     <string>????</string>
     <key>CFBundleURLTypes</key>

--- a/augmentos_manager/ios/BleManager/LocationManager.swift
+++ b/augmentos_manager/ios/BleManager/LocationManager.swift
@@ -36,6 +36,23 @@ class LocationManager: NSObject, CLLocationManagerDelegate {
     self.locationChangedCallback = callback
   }
   
+  // on/off switch for high accuracy mode that gets triggered via the cloud for specific apps
+  public func setHighAccuracyMode(enabled: Bool) {
+    if enabled {
+      print("LocationManager: Enabling high accuracy mode (Best for Navigation)")
+      locationManager.allowsBackgroundLocationUpdates = true
+      locationManager.pausesLocationUpdatesAutomatically = false
+      locationManager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+      locationManager.distanceFilter = kCLDistanceFilterNone
+    } else {
+      print("LocationManager: Disabling high accuracy mode, reverting to standard.")
+      locationManager.allowsBackgroundLocationUpdates = false
+      locationManager.pausesLocationUpdatesAutomatically = true
+      locationManager.desiredAccuracy = kCLLocationAccuracyBest
+      locationManager.distanceFilter = 2 // Default 2 meters
+    }
+  }
+  
   // MARK: - CLLocationManagerDelegate Methods
   
   func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {

--- a/augmentos_manager/ios/BleManager/ServerComms.swift
+++ b/augmentos_manager/ios/BleManager/ServerComms.swift
@@ -386,7 +386,7 @@ class ServerComms {
     
     print("Received message of type: \(type)")
     
-    // [NEW] Handle new location command for the MVP
+    // // checks for our new location commands from the cloud before handling any other message type
     if type == "SET_LOCATION_ACCURACY" {
         if let payload = msg["payload"] as? [String: Any],
            let rate = payload["rate"] as? String {

--- a/augmentos_manager/ios/BleManager/ServerComms.swift
+++ b/augmentos_manager/ios/BleManager/ServerComms.swift
@@ -386,6 +386,15 @@ class ServerComms {
     
     print("Received message of type: \(type)")
     
+    // [NEW] Handle new location command for the MVP
+    if type == "SET_LOCATION_ACCURACY" {
+        if let payload = msg["payload"] as? [String: Any],
+           let rate = payload["rate"] as? String {
+            self.locationManager.setHighAccuracyMode(enabled: rate == "realtime")
+        }
+        return // End processing for this message type
+    }
+
     switch type {
     case "connection_ack":
       startAudioSenderThread()


### PR DESCRIPTION
Enabled a switch that enables a high accuracy, realtime location mode on the native clients that are triggered via the cloud. This pr only contains the client changes. The “switch” can be triggered by using the “debug” backend and running the nav or running MVP.

Changes:

ios
- pinfo list enables background location by default via expo (App.json)
- LocationManager.swift: Implements setHighAccuracyMode(enabled: Bool) to toggle CLLocationManager between kCLLocationAccuracyBestForNavigation and the standard kCLLocationAccuracyBest.
- ServerComms.swift: Updates the message handler to parse the SET_LOCATION_ACCURACY command.
- app.json: Adds "location" to UIBackgroundModes to enable background location updates and prevent crashes.

android
- LocationSystem.java: Refactored to remove the old timer logic and implement a clean setHighAccuracyMode(boolean enabled) switch. This toggles between a 1sec PRIORITY_HIGH_ACCURACY request and a 15-minute PRIORITY_LOW_POWER request.
- AugmentosService.java & ServerComms.java: Includes an architectural fix to ensure ServerComms gets a valid, context-aware instance of the LocationSystem service, resolving a NullPointerException.
