### PR TITLE
fix: change Porter deployment workflows back to ubuntu-latest

### DIFF
--- a/.github/workflows/cloud-isaiah.yml
+++ b/.github/workflows/cloud-isaiah.yml
@@ -5,7 +5,7 @@
 name: Deploy cloud-isaiah
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/cloud-test.yml
+++ b/.github/workflows/cloud-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter-debug.yml
+++ b/.github/workflows/porter-debug.yml
@@ -5,7 +5,7 @@
 name: 🚀 [debug] Porter.run Deploy
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter-dev.yml
+++ b/.github/workflows/porter-dev.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter-prod-global.yml
+++ b/.github/workflows/porter-prod-global.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   east-asia:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
 
   # France
   france:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter-prod.yml
+++ b/.github/workflows/porter-prod.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter-staging.yml
+++ b/.github/workflows/porter-staging.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/porter_app_cloud-dev_4965.yml
+++ b/.github/workflows/porter_app_cloud-dev_4965.yml
@@ -5,7 +5,7 @@
 name: Deploy to cloud-dev
 jobs:
   porter-deploy:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Porter deployments don't need the self-hosted runner since they're just deploying to cloud infrastructure. Using ubuntu-latest is more reliable and doesn't consume self-hosted runner resources.

Changed workflows:
- porter_app_cloud-dev_4965.yml
- porter-dev.yml
- porter-prod-global.yml
- porter-debug.yml
- porter-staging.yml
- porter-prod.yml
- cloud-test.yml
- cloud-isaiah.yml

🤖 Generated with [Claude Code](https://claude.ai/code)