### PR TITLE
fix: add workspace cleanup step for Android builds

### DIFF
--- a/.github/workflows/mentraos-manager-android-build.yml
+++ b/.github/workflows/mentraos-manager-android-build.yml
@@ -16,6 +16,13 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      - name: Clean workspace
+        run: |
+          # Clean previous build artifacts
+          rm -rf mobile/node_modules mobile/.pnpm-store mobile/.pnpm
+          rm -rf mobile/android/build mobile/android/.gradle
+          rm -rf ~/.pnpm-store 2>/dev/null || true
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -36,6 +43,8 @@ jobs:
       - name: Install pnpm
         run: |
           npm install -g pnpm@8
+          # Verify pnpm is in PATH
+          which pnpm
           pnpm --version
 
       - name: Configure pnpm store


### PR DESCRIPTION
Self-hosted runners can have stale state from previous runs. Added workspace cleanup to ensure:
- No leftover node_modules or pnpm stores
- Clean gradle build directories
- Fresh state for each build

Also added verification that pnpm is properly in PATH after installation.

🤖 Generated with [Claude Code](https://claude.ai/code)