### PR TITLE
pkg app store look up

### DIFF
--- a/cloud/websites/store/src/pages/AppStore.tsx
+++ b/cloud/websites/store/src/pages/AppStore.tsx
@@ -53,6 +53,7 @@ const AppStore: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [apps, setApps] = useState<AppI[]>([]);
+  const [originalApps, setOriginalApps] = useState<AppI[]>([]);
   const [installingApp, setInstallingApp] = useState<string | null>(null);
   const [activeOrgFilter, setActiveOrgFilter] = useState<string | null>(orgId);
   const [orgName, setOrgName] = useState<string>("");
@@ -96,6 +97,7 @@ const AppStore: React.FC = () => {
         appList = await api.app.getAvailableApps(
           orgId ? filterOptions : undefined,
         );
+        // console.log("Fetched available apps:", pkgapps);
 
         // If we're filtering by organization, get the organization name from the first app
         if (orgId && appList.length > 0) {
@@ -108,7 +110,7 @@ const AppStore: React.FC = () => {
           }
         }
       } catch (err) {
-        console.error("Error fetching public apps:", err);
+        // console.error("Error fetching public apps:", err);
         setError("Failed to load apps. Please try again.");
         return;
       }
@@ -139,6 +141,7 @@ const AppStore: React.FC = () => {
       }
 
       setApps(appList);
+      setOriginalApps(appList);
     } catch (err) {
       console.error("Error fetching apps:", err);
       setError("Failed to load apps. Please try again.");
@@ -152,12 +155,20 @@ const AppStore: React.FC = () => {
     if (searchQuery.trim() === "") return apps;
 
     const query = searchQuery.toLowerCase();
-    return apps.filter(
+    const filtered = apps.filter(
       (app) =>
         app.name.toLowerCase().includes(query) ||
-        (app.description && app.description.toLowerCase().includes(query)),
+        (app.description && app.description.toLowerCase().includes(query)) ||
+        app.packageName.toLowerCase().includes(query), // Also match package name
     );
-  }, [apps, searchQuery]);
+    
+    // If we have a single app that was found by package search, show it regardless
+    if (apps.length === 1 && apps !== originalApps) {
+      return apps;
+    }
+    
+    return filtered;
+  }, [apps, originalApps, searchQuery]);
 
   /**
    * Handles search form submission
@@ -355,6 +366,69 @@ const AppStore: React.FC = () => {
     navigate("/login");
   }, [navigate]);
 
+  const handleSearchChange = useCallback(async (value: string) => {
+    setSearchQuery(value);
+    // console.log("🔍 Search input:", value);
+    
+    // Restore original apps if we had searched by package before
+    if (apps !== originalApps) {
+      setApps(originalApps);
+    }
+    
+    if (value.trim() === "") {
+      // console.log("📊 Total apps available:", originalApps.length);
+      return;
+    }
+
+    const query = value.toLowerCase();
+    const filtered = originalApps.filter(
+      (app) =>
+        app.name.toLowerCase().includes(query) ||
+        (app.description && app.description.toLowerCase().includes(query)),
+    );
+    
+    // console.log(`📊 Apps matching "${value}":`, filtered.length);
+    
+    // If no local matches, try searching by package name
+    if (filtered.length === 0) {
+      // console.log("🔎 No local matches found. Searching by package name...");
+      setIsLoading(true);
+      try {
+        const pkgApp = await api.app.getAppByPackageName(value);
+
+        if (pkgApp) {
+          // console.log("✅ Found app by package name:", pkgApp.name, `(${pkgApp.packageName})`);
+          // Check if user is authenticated to get install status
+          if (isAuthenticated && isAuthTokenReady()) {
+            try {
+              const installedApps = await api.app.getInstalledApps();
+              pkgApp.isInstalled = installedApps.some(app => app.packageName === pkgApp.packageName);
+              console.log(`📱 App install status: ${pkgApp.isInstalled ? 'INSTALLED' : 'NOT INSTALLED'}`);
+            } catch (error) {
+              console.error("⚠️ Error checking install status:", error);
+              pkgApp.isInstalled = false;
+            }
+          } else {
+            pkgApp.isInstalled = false;
+            // console.log("🔒 User not authenticated - showing as not installed");
+          }
+          
+          setApps([pkgApp]);
+          // Don't clear search query - let filteredApps handle it
+        } else {
+          // console.log("❌ No app found with package name:", value);
+        }
+      } catch (error) {
+        // console.error("⚠️ Error searching by package name:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    
+    
+  }, [apps, originalApps, isAuthenticated, isAuthTokenReady]);
+
+
   return (
     <div
       className="min-h-screen text-white"
@@ -382,7 +456,7 @@ const AppStore: React.FC = () => {
           >
             <SearchBar
               searchQuery={searchQuery}
-              onSearchChange={setSearchQuery}
+              onSearchChange={handleSearchChange}
               onSearchSubmit={handleSearch}
               onClear={() => {
                 setSearchQuery("");


### PR DESCRIPTION
Now in the app store, you can look up apps by package name, but it has to be the full package name. If you just type com..., nothing will show up. The package name must exist exactly as written for security reasons. We don’t want everyone to have access to all 1000k+ apps just by typing com lol. Here’s more detail:

<img width="415" height="472" alt="image" src="https://github.com/user-attachments/assets/dfba5d71-34d6-49db-8a73-eaa7e9eba2ed" />

doc: 
https://docs.google.com/document/d/1ob2AQDitX7lMBut9q7-8x0IZFvDmzGm9FnygJoNmNug/edit?usp=sharing