### PR TITLE
push for the double value in the setting in dev portal

### DIFF
--- a/cloud/websites/console/.env.example
+++ b/cloud/websites/console/.env.example
@@ -1,3 +1,3 @@
 VITE_API_URL=http://localhost:8002
-VITE_SUPABASE_URL=https://***.supabase.co
-VITE_SUPABASE_ANON_KEY=key_here
+VITE_SUPABASE_URL=https://ykbiunzfbbtwlzdprmeh.supabase.co
+VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InlrYml1bnpmYmJ0d2x6ZHBybWVoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3MzQyODA2OTMsImV4cCI6MjA0OTg1NjY5M30.rbEsE8IRz-gb3-D0H8VAJtGw-xvipl1Nc-gCnnQ748U

--- a/cloud/websites/console/src/components/forms/SettingsEditor.tsx
+++ b/cloud/websites/console/src/components/forms/SettingsEditor.tsx
@@ -1,5 +1,5 @@
 // components/forms/SettingsEditor.tsx
-import React from "react";
+import React, { use, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -60,6 +60,8 @@ interface SettingsEditorProps {
   settings: Setting[];
   onChange: (settings: Setting[]) => void;
   className?: string;
+  setSameValueWarning: (value: boolean) => void;
+  toast: typeof import("sonner").toast;
 }
 
 /**
@@ -82,7 +84,10 @@ interface SortableSettingItemProps {
   ) => void;
   addSelectOption: (settingIndex: number) => void;
   removeSelectOption: (settingIndex: number, optionIndex: number) => void;
+  toast: typeof import("sonner").toast;
+  setSameValueWarning: (value: boolean) => void;
 }
+const specialSettings = ["multiselect", "select"]
 
 const SortableSettingItem: React.FC<SortableSettingItemProps> = ({
   setting,
@@ -96,6 +101,8 @@ const SortableSettingItem: React.FC<SortableSettingItemProps> = ({
   updateSelectOptions,
   addSelectOption,
   removeSelectOption,
+  toast,
+  setSameValueWarning,
 }) => {
   const {
     attributes,
@@ -639,20 +646,46 @@ const SortableSettingItem: React.FC<SortableSettingItemProps> = ({
                               }
                               className="flex-1"
                             />
+                            {/* right here boss */}
                             <Input
                               placeholder="Value"
                               value={option.value}
                               onChange={(
                                 e: React.ChangeEvent<HTMLInputElement>,
-                              ) =>
+                              ) => {
+                                const newValue = e.currentTarget.value;
+                                
+                                // Check for conflicts and show toast if needed
+                                if (specialSettings.includes(newValue)) {
+                                  toast?.error("Warning: This is a reserved setting type!");
+                                  setSameValueWarning(false);
+                                } else if (setting.options && 
+                                          setting.options.filter((_: any, idx: number) => idx !== optionIndex)
+                                            .some((otherOpt: any) => otherOpt.value === newValue)) {
+                                  toast?.error("Warning: Duplicate option value!");
+                                  setSameValueWarning(true);
+                                  
+                                }
+                                else {
+                                  setSameValueWarning(false);
+                                } 
+                                
+                                
                                 updateSelectOptions(
                                   index,
                                   optionIndex,
                                   "value",
-                                  e.currentTarget.value,
-                                )
-                              }
-                              className="flex-1 font-mono"
+                                  newValue,
+                                );
+                              }}
+                              className={`flex-1 font-mono ${
+                                specialSettings.includes(option.value) ||
+                                (setting.options && 
+                                 setting.options.filter((_: any, idx: number) => idx !== optionIndex)
+                                   .some((otherOpt: any) => otherOpt.value === option.value))
+                                  ? "text-red-500"
+                                  : ""
+                              }`}
                             />
                             <Button
                               onClick={() =>
@@ -794,6 +827,8 @@ const SettingsEditor: React.FC<SettingsEditorProps> = ({
   settings,
   onChange,
   className,
+  setSameValueWarning,
+  toast
 }) => {
   const [activeId, setActiveId] = React.useState<string | null>(null);
   const [editingIndex, setEditingIndex] = React.useState<number | null>(null);
@@ -940,6 +975,7 @@ const SettingsEditor: React.FC<SettingsEditorProps> = ({
           "options" in currentSetting &&
           Array.isArray((currentSetting as any).options)
         ) {
+          
           updates.options = (currentSetting as any).options;
           // Convert single defaultValue to array, or preserve if already array
           if (Array.isArray(currentSetting.defaultValue)) {
@@ -1211,6 +1247,8 @@ const SettingsEditor: React.FC<SettingsEditorProps> = ({
                   updateSelectOptions={updateSelectOptions}
                   addSelectOption={addSelectOption}
                   removeSelectOption={removeSelectOption}
+                  toast={toast}
+                  setSameValueWarning={setSameValueWarning}
                 />
               ))}
             </div>

--- a/cloud/websites/console/src/hooks/useAuth.tsx
+++ b/cloud/websites/console/src/hooks/useAuth.tsx
@@ -181,7 +181,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setTokenReady(false); // Mark token as not ready during exchange
 
       const response = await axios.post(
-        `${import.meta.env.VITE_API_URL || 'http://localhost:8002'}/api/auth/exchange-token`,
+        `${import.meta.env.VITE_API_URL || 'http://localhost:8002/api'}/auth/exchange-token`,
         { supabaseToken },
         { headers: { 'Content-Type': 'application/json' } }
       );

--- a/cloud/websites/console/src/pages/EditApp.tsx
+++ b/cloud/websites/console/src/pages/EditApp.tsx
@@ -123,6 +123,7 @@ const EditApp: React.FC = () => {
   const [importConfigData, setImportConfigData] = useState<any>(null);
   const [isImporting, setIsImporting] = useState(false);
   const [importError, setImportError] = useState<string | null>(null);
+  const [sameValueWarning , setSameValueWarning] = useState(false);
 
   // File input ref for import
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -443,6 +444,7 @@ const EditApp: React.FC = () => {
     try {
       if (!packageName) throw new Error("Package name is missing");
       if (!currentOrg) throw new Error("No organization selected");
+      if (sameValueWarning) throw new Error("Please resolve duplicate option values in settings before saving.");
 
       // Normalize URLs before submission
       const normalizedData = {
@@ -1446,6 +1448,8 @@ const EditApp: React.FC = () => {
                   <SettingsEditor
                     settings={formData.settings || []}
                     onChange={handleSettingsChange}
+                    setSameValueWarning={setSameValueWarning}
+                    toast = {toast}
                   />
                 </div>
 


### PR DESCRIPTION
Fixed an issue where having multiple options with the same value caused the UI to mark all duplicates as selected.

Resolved a bug where selecting one option with a duplicate value would highlight all options sharing that value..

Images :

When typing two duplicate values:
<img width="1526" height="912" alt="image" src="https://github.com/user-attachments/assets/9e41c646-333a-4a87-b545-b512d3057553" />

when pressing the the save changes: 
<img width="1559" height="1147" alt="image" src="https://github.com/user-attachments/assets/651c03ab-4413-427d-b148-332d293d28a0" />
