### PR TITLE
Fix GitHub Actions failures: update reanimated, WebRTC-SDK, and add m…

### DIFF
--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -66,11 +66,11 @@ jobs:
       - name: Build iOS app for Simulator
         working-directory: ./mobile/ios
         run: |
-          xcodebuild -workspace AOS.xcworkspace \
+          xcodebuild build-for-testing \
+                     -workspace AOS.xcworkspace \
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4' \
                      -derivedDataPath build
 
       - name: Build iOS app for Device

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "16.0"
+          xcode-version: "16.4"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
@@ -71,9 +71,8 @@ jobs:
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -arch arm64 \
-                     -derivedDataPath build \
-                     ONLY_ACTIVE_ARCH=YES
+                     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+                     -derivedDataPath build
 
       - name: Build iOS app for Device
         working-directory: ./mobile/ios

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -60,6 +60,9 @@ jobs:
         working-directory: ./mobile/ios
         run: pod install
 
+      - name: List available simulators
+        run: xcrun simctl list devices available
+
       - name: Build iOS app for Simulator
         working-directory: ./mobile/ios
         run: |
@@ -67,8 +70,7 @@ jobs:
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -derivedDataPath build \
-                     -destination 'platform=iOS Simulator,name=iPhone 15'
+                     -derivedDataPath build
 
       - name: Build iOS app for Device
         working-directory: ./mobile/ios

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "15.4"
+          xcode-version: "16.0"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -70,6 +70,7 @@ jobs:
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
+                     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
                      -derivedDataPath build
 
       - name: Build iOS app for Device

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -70,7 +70,7 @@ jobs:
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+                     -destination 'platform=iOS Simulator,name=iPhone 16 Pro,OS=18.4' \
                      -derivedDataPath build
 
       - name: Build iOS app for Device

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: "15.4"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -66,12 +66,14 @@ jobs:
       - name: Build iOS app for Simulator
         working-directory: ./mobile/ios
         run: |
-          xcodebuild build-for-testing \
+          xcodebuild \
                      -workspace AOS.xcworkspace \
                      -scheme AOS \
                      -configuration Debug \
                      -sdk iphonesimulator \
-                     -derivedDataPath build
+                     -arch arm64 \
+                     -derivedDataPath build \
+                     ONLY_ACTIVE_ARCH=YES
 
       - name: Build iOS app for Device
         working-directory: ./mobile/ios

--- a/.github/workflows/mentraos-manager-ios-build.yml
+++ b/.github/workflows/mentraos-manager-ios-build.yml
@@ -68,7 +68,7 @@ jobs:
                      -configuration Debug \
                      -sdk iphonesimulator \
                      -derivedDataPath build \
-                     -destination 'generic/platform=iOS Simulator'
+                     -destination 'platform=iOS Simulator,name=iPhone 15'
 
       - name: Build iOS app for Device
         working-directory: ./mobile/ios

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -106,6 +106,16 @@ export default [
     },
   },
 
+  // Jest setup files configuration
+  {
+    files: ["**/jest.setup.js", "**/jest.config.js", "**/*.test.{js,ts,jsx,tsx}", "**/*.spec.{js,ts,jsx,tsx}"],
+    languageOptions: {
+      globals: {
+        ...globals.jest,
+      },
+    },
+  },
+
   // React Native-only rules (scoped override)
   // NOTE: eslint-plugin-react-native rules were being applied to web code (e.g., the console),
   // triggering RN-only checks like react-native/no-raw-text in regular React. The plugin does not

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -74,7 +74,7 @@
         "react-native-pager-view": "6.5.1",
         "react-native-permissions": "^5.4.1",
         "react-native-popover-view": "^6.1.0",
-        "react-native-reanimated": "~3.16.7",
+        "react-native-reanimated": "~3.18.0",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.5.0",
         "react-native-share": "^12.2.0",
@@ -2171,7 +2171,7 @@
 
     "react-native-ratings": ["react-native-ratings@8.0.4", "", { "dependencies": { "lodash": "^4.17.15" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-Xczu5lskIIRD6BEdz9A0jDRpEck/SFxRqiglkXi0u67yAtI1/pcJC76P4MukCbT8K4BPVl+42w83YqXBoBRl7A=="],
 
-    "react-native-reanimated": ["react-native-reanimated@3.16.7", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.0.0-0", "@babel/plugin-transform-class-properties": "^7.0.0-0", "@babel/plugin-transform-classes": "^7.0.0-0", "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0", "@babel/plugin-transform-optional-chaining": "^7.0.0-0", "@babel/plugin-transform-shorthand-properties": "^7.0.0-0", "@babel/plugin-transform-template-literals": "^7.0.0-0", "@babel/plugin-transform-unicode-regex": "^7.0.0-0", "@babel/preset-typescript": "^7.16.7", "convert-source-map": "^2.0.0", "invariant": "^2.2.4" }, "peerDependencies": { "@babel/core": "^7.0.0-0", "react": "*", "react-native": "*" } }, "sha512-qoUUQOwE1pHlmQ9cXTJ2MX9FQ9eHllopCLiWOkDkp6CER95ZWeXhJCP4cSm6AD4jigL5jHcZf/SkWrg8ttZUsw=="],
+    "react-native-reanimated": ["react-native-reanimated@3.18.0", "", { "dependencies": { "@babel/plugin-transform-arrow-functions": "^7.0.0-0", "@babel/plugin-transform-class-properties": "^7.0.0-0", "@babel/plugin-transform-classes": "^7.0.0-0", "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0", "@babel/plugin-transform-optional-chaining": "^7.0.0-0", "@babel/plugin-transform-shorthand-properties": "^7.0.0-0", "@babel/plugin-transform-template-literals": "^7.0.0-0", "@babel/plugin-transform-unicode-regex": "^7.0.0-0", "@babel/preset-typescript": "^7.16.7", "convert-source-map": "^2.0.0", "invariant": "^2.2.4", "react-native-is-edge-to-edge": "1.1.7" }, "peerDependencies": { "@babel/core": "^7.0.0-0", "react": "*", "react-native": "*" } }, "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q=="],
 
     "react-native-safe-area-context": ["react-native-safe-area-context@4.12.0", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-ukk5PxcF4p3yu6qMZcmeiZgowhb5AsKRnil54YFUUAXVIS7PJcMHGGC+q44fCiBg44/1AJk5njGMez1m9H0BVQ=="],
 

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -1458,7 +1458,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-keyboard-controller (1.17.5):
+  - react-native-keyboard-controller (1.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1471,7 +1471,7 @@ PODS:
     - React-featureflags
     - React-graphics
     - React-ImageManager
-    - react-native-keyboard-controller/common (= 1.17.5)
+    - react-native-keyboard-controller/common (= 1.18.2)
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -1480,7 +1480,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-keyboard-controller/common (1.17.5):
+  - react-native-keyboard-controller/common (1.18.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2164,7 +2164,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNPermissions (5.4.1):
+  - RNPermissions (5.4.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2185,7 +2185,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated (3.16.7):
+  - RNReanimated (3.18.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2197,7 +2197,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2205,10 +2207,10 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated (= 3.16.7)
-    - RNReanimated/worklets (= 3.16.7)
+    - RNReanimated/reanimated (= 3.18.0)
+    - RNReanimated/worklets (= 3.18.0)
     - Yoga
-  - RNReanimated/reanimated (3.16.7):
+  - RNReanimated/reanimated (3.18.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2220,7 +2222,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2228,9 +2232,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - RNReanimated/reanimated/apple (= 3.16.7)
+    - RNReanimated/reanimated/apple (= 3.18.0)
     - Yoga
-  - RNReanimated/reanimated/apple (3.16.7):
+  - RNReanimated/reanimated/apple (3.18.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2242,7 +2246,9 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2251,7 +2257,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNReanimated/worklets (3.16.7):
+  - RNReanimated/worklets (3.18.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2263,7 +2269,33 @@ PODS:
     - React-Fabric
     - React-featureflags
     - React-graphics
+    - React-hermes
     - React-ImageManager
+    - React-jsi
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - RNReanimated/worklets/apple (= 3.18.0)
+    - Yoga
+  - RNReanimated/worklets/apple (3.18.0):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.10.14.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-hermes
+    - React-ImageManager
+    - React-jsi
     - React-NativeModulesApple
     - React-RCTFabric
     - React-rendererdebug
@@ -2931,7 +2963,7 @@ SPEC CHECKSUMS:
   react-native-bottom-tabs: 4e29ba5631b9890b9d15d3f1ef35c03a89a1bc2e
   react-native-config: 644074ab88db883fcfaa584f03520ec29589d7df
   react-native-image-picker: c5da8aa14fdffbd4d77338c352f52a8d85fcacec
-  react-native-keyboard-controller: b3d68f377e97666bf539ee7d8d6d77ac7a50f9ca
+  react-native-keyboard-controller: c7b394ca5fa3bca2264d4bd37bd4ab1aeb62a991
   react-native-mmkv: 5c69dce0d439e1791a884f6b166e76fc7fadaca6
   react-native-netinfo: cec9c4e86083cb5b6aba0e0711f563e2fbbff187
   react-native-pager-view: 9517b214fb7321493339fbcf53a30abd54fea07b
@@ -2974,8 +3006,8 @@ SPEC CHECKSUMS:
   RNGestureHandler: fffddeb8af59709c6d8de11b6461a6af63cad532
   RNInAppBrowser: 6d3eb68d471b9834335c664704719b8be1bfdb20
   RNLocalize: 9b5bc41c885b6138233c9ce6de8affb22cbc1e4f
-  RNPermissions: 66e7065dd1826bf37f8d180248b2cb2c4ae26aca
-  RNReanimated: 2e5069649cbab2c946652d3b97589b2ae0526220
+  RNPermissions: 166b6880aa94483ac566c35f3d7ec9b999239e7e
+  RNReanimated: 6b9d5b5919acb1900ce0d36ef95906026c517674
   RNScreens: c7c659490e59cb0887cb098a9c9e9431392c05b2
   RNSentry: 39b6ae6ce58dafc766ae3704c50a420d79e6a999
   RNShare: 65a462152ef2bc44baf4ce388b5d9ef796507cd2

--- a/mobile/ios/Podfile.lock
+++ b/mobile/ios/Podfile.lock
@@ -117,9 +117,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - livekit-react-native-webrtc (137.0.1):
+  - livekit-react-native-webrtc (137.0.2):
     - React-Core
-    - WebRTC-SDK (= 137.7151.02)
+    - WebRTC-SDK (= 137.7151.04)
   - LiveKitExpoPlugin (1.0.1):
     - ExpoModulesCore
     - livekit-react-native
@@ -2349,7 +2349,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSentry (6.20.0):
+  - RNSentry (6.22.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2370,7 +2370,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sentry/HybridSDK (= 8.53.2)
+    - Sentry/HybridSDK (= 8.56.2)
     - Yoga
   - RNShare (12.2.0):
     - DoubleConversion
@@ -2441,12 +2441,12 @@ PODS:
   - SDWebImage (5.19.7):
     - SDWebImage/Core (= 5.19.7)
   - SDWebImage/Core (5.19.7)
-  - SDWebImageAVIFCoder (0.11.0):
+  - SDWebImageAVIFCoder (0.11.1):
     - libavif/core (>= 0.11.0)
     - SDWebImage (~> 5.10)
   - SDWebImageSVGCoder (1.7.0):
     - SDWebImage/Core (~> 5.6)
-  - Sentry/HybridSDK (8.53.2)
+  - Sentry/HybridSDK (8.56.2)
   - SocketRocket (0.7.1)
   - SWCompression (4.8.6):
     - BitByteData (~> 2.0)
@@ -2491,7 +2491,7 @@ PODS:
     - SWCompression/Deflate
   - SwiftUIIntrospect (1.3.0)
   - UMAppLoader (5.0.1)
-  - WebRTC-SDK (137.7151.02)
+  - WebRTC-SDK (137.7151.04)
   - Yoga (0.0.0)
   - ZXingObjC/Core (3.6.9)
   - ZXingObjC/OneD (3.6.9):
@@ -2925,7 +2925,7 @@ SPEC CHECKSUMS:
   libavif: 84bbb62fb232c3018d6f1bab79beea87e35de7b7
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   livekit-react-native: 9f0c7e58d3b794cb3e21bfb85a07504e3d9805dd
-  livekit-react-native-webrtc: b433ea8c3845cbef1ca9b59c6155e322fcda3bdd
+  livekit-react-native-webrtc: c03e72c608fbb8284a99e095dd7835a85bdb0279
   LiveKitExpoPlugin: 8e0f4bdffa921c27c13e1504ea0e668b6f859278
   onnxruntime-c: a909204639a1f035f575127ac406f781ac797c9c
   onnxruntime-objc: b6fab0f1787aa6f7190c2013f03037df4718bd8b
@@ -3009,19 +3009,19 @@ SPEC CHECKSUMS:
   RNPermissions: 166b6880aa94483ac566c35f3d7ec9b999239e7e
   RNReanimated: 6b9d5b5919acb1900ce0d36ef95906026c517674
   RNScreens: c7c659490e59cb0887cb098a9c9e9431392c05b2
-  RNSentry: 39b6ae6ce58dafc766ae3704c50a420d79e6a999
+  RNSentry: bc0d4437ab65513097b88e1b4ee3b63ec6194009
   RNShare: 65a462152ef2bc44baf4ce388b5d9ef796507cd2
   RNSVG: b889dc9c1948eeea0576a16cc405c91c37a12c19
   RNWifi: 6669d0fe0f82592d64383d0d4ac1ff888d15f8bc
   SDWebImage: 8a6b7b160b4d710e2a22b6900e25301075c34cb3
-  SDWebImageAVIFCoder: 00310d246aab3232ce77f1d8f0076f8c4b021d90
+  SDWebImageAVIFCoder: afe194a084e851f70228e4be35ef651df0fc5c57
   SDWebImageSVGCoder: 15a300a97ec1c8ac958f009c02220ac0402e936c
-  Sentry: 59993bffde4a1ac297ba6d268dc4bbce068d7c1b
+  Sentry: b53951377b78e21a734f5dc8318e333dbfc682d7
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   SWCompression: 9379873ad5e9f25b31db88c441649b59a4c2bab7
   SwiftUIIntrospect: fee9aa07293ee280373a591e1824e8ddc869ba5d
   UMAppLoader: 7e7e0eaa7854ffd652c00a68c443afb28c3bedba
-  WebRTC-SDK: d20de357dcbf7c9696b124b39f3ff62125107e4b
+  WebRTC-SDK: 40d4f5ba05cadff14e4db5614aec402a633f007e
   Yoga: feb4910aba9742cfedc059e2b2902e22ffe9954a
   ZXingObjC: 8898711ab495761b2dbbdec76d90164a6d7e14c5
 

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -1,3 +1,5 @@
+/* eslint-env jest */
+
 // Mock AsyncStorage
 jest.mock("@react-native-async-storage/async-storage", () =>
   require("@react-native-async-storage/async-storage/jest/async-storage-mock"),
@@ -31,9 +33,7 @@ jest.mock("react-native-bluetooth-classic", () => ({
   accept: jest.fn(),
   cancelAccept: jest.fn(),
   isBluetoothAvailable: jest.fn(),
-  isBluetoothEnabled: jest.fn(),
   startDiscovery: jest.fn(),
-  cancelDiscovery: jest.fn(),
 }))
 
 // Mock react-native-mmkv
@@ -51,6 +51,97 @@ jest.mock("react-native-mmkv", () => {
       clearAll: jest.fn(() => mockStorage.clear()),
       getAllKeys: jest.fn(() => Array.from(mockStorage.keys())),
     })),
+  }
+})
+
+// Mock react-native-localize
+jest.mock("react-native-localize", () => ({
+  getLocales: jest.fn(() => [
+    {
+      countryCode: "US",
+      languageTag: "en-US",
+      languageCode: "en",
+      isRTL: false,
+    },
+  ]),
+  getNumberFormatSettings: jest.fn(() => ({
+    decimalSeparator: ".",
+    groupingSeparator: ",",
+  })),
+  getCalendar: jest.fn(() => "gregorian"),
+  getCountry: jest.fn(() => "US"),
+  getCurrencies: jest.fn(() => ["USD", "EUR"]),
+  getTemperatureUnit: jest.fn(() => "celsius"),
+  getTimeZone: jest.fn(() => "America/New_York"),
+  uses24HourClock: jest.fn(() => false),
+  usesMetricSystem: jest.fn(() => false),
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+}))
+
+// Mock expo-audio
+jest.mock("expo-audio", () => ({
+  createAudioPlayer: jest.fn(() => ({
+    src: null,
+    play: jest.fn(),
+    pause: jest.fn(),
+    stop: jest.fn(),
+    remove: jest.fn(),
+  })),
+}))
+
+// Mock MantleBridge
+jest.mock("@/bridge/MantleBridge", () => {
+  const {EventEmitter} = require("events")
+
+  class MockMantleBridge extends EventEmitter {
+    static getInstance = jest.fn(() => new MockMantleBridge())
+    connect = jest.fn()
+    disconnect = jest.fn()
+    sendMessage = jest.fn()
+    cleanup = jest.fn()
+  }
+
+  return {
+    default: new MockMantleBridge(),
+  }
+})
+
+// Mock SocketComms to avoid complex dependency chains
+jest.mock("@/managers/SocketComms", () => ({
+  default: {
+    getInstance: jest.fn(() => ({
+      connect: jest.fn(),
+      disconnect: jest.fn(),
+      send_socket_message: jest.fn(),
+      cleanup: jest.fn(),
+    })),
+  },
+}))
+
+// Mock WebSocketManager to avoid circular dependency issues
+jest.mock("@/managers/WebSocketManager", () => {
+  const {EventEmitter} = require("events")
+
+  const WebSocketStatus = {
+    DISCONNECTED: "disconnected",
+    CONNECTING: "connecting",
+    CONNECTED: "connected",
+    ERROR: "error",
+  }
+
+  class MockWebSocketManager extends EventEmitter {
+    connect = jest.fn()
+    disconnect = jest.fn()
+    isConnected = jest.fn(() => false)
+    sendText = jest.fn()
+    sendBinary = jest.fn()
+    cleanup = jest.fn()
+  }
+
+  return {
+    WebSocketStatus,
+    default: new MockWebSocketManager(),
   }
 })
 

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -10,12 +10,19 @@
       "hasInstallScript": true,
       "dependencies": {
         "@bottom-tabs/react-navigation": "^0.9.2",
+        "@config-plugins/react-native-webrtc": "^12.0.0",
         "@expo-google-fonts/space-grotesk": "^0.2.3",
         "@expo/metro-runtime": "~4.0.1",
+        "@livekit/react-native": "^2.9.1",
+        "@livekit/react-native-expo-plugin": "^1.0.1",
+        "@livekit/react-native-webrtc": "^137.0.1",
         "@react-native-async-storage/async-storage": "1.23.1",
+        "@react-native-community/netinfo": "^11.4.1",
+        "@react-native-community/slider": "^4.5.7",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
         "@react-navigation/native-stack": "^7.2.0",
+        "@sentry/react-native": "^6.20.0",
         "@shopify/flash-list": "1.7.3",
         "@supabase/supabase-js": "^2.50.0",
         "apisauce": "3.0.1",
@@ -23,21 +30,29 @@
         "date-fns": "^4.1.0",
         "expo": "~52.0.47",
         "expo-application": "~6.0.2",
+        "expo-audio": "~0.3.5",
+        "expo-av": "~15.0.2",
         "expo-build-properties": "~0.13.3",
+        "expo-calendar": "~14.0.6",
         "expo-camera": "~16.0.18",
         "expo-font": "~13.0.4",
         "expo-image": "~2.0.7",
         "expo-linear-gradient": "~14.0.2",
         "expo-linking": "~7.0.5",
         "expo-localization": "16.0.1",
+        "expo-location": "~18.0.10",
+        "expo-media-library": "~17.0.6",
         "expo-navigation-bar": "~4.0.9",
         "expo-router": "~4.0.21",
         "expo-splash-screen": "~0.29.24",
+        "expo-squircle-view": "^1.1.0",
         "expo-status-bar": "~2.0.1",
         "expo-system-ui": "~4.0.9",
+        "expo-task-manager": "~12.0.6",
         "expo-web-browser": "~14.0.2",
         "i18next": "^23.16.8",
         "intl-pluralrules": "^2.0.1",
+        "livekit-client": "^2.15.6",
         "mobx-state-tree": "^7.0.2",
         "posthog-react-native": "^4.1.4",
         "react": "18.3.1",
@@ -49,8 +64,7 @@
         "react-native-bottom-tabs": "^0.9.2",
         "react-native-canvas": "^0.1.40",
         "react-native-circular-progress": "^1.4.1",
-        "react-native-config": "^1.5.5",
-        "react-native-create-thumbnail": "^2.1.1",
+        "react-native-config": "1.5.5",
         "react-native-drawer-layout": "^4.1.11",
         "react-native-elements": "^3.4.3",
         "react-native-fs": "^2.20.0",
@@ -60,21 +74,27 @@
         "react-native-inappbrowser-reborn": "^3.7.0",
         "react-native-keyboard-controller": "^1.17.5",
         "react-native-linear-gradient": "^2.8.3",
+        "react-native-localize": "^3.5.2",
         "react-native-mmkv": "3.1.0",
+        "react-native-pager-view": "6.5.1",
         "react-native-permissions": "^5.4.1",
-        "react-native-reanimated": "~3.16.7",
+        "react-native-popover-view": "^6.1.0",
+        "react-native-reanimated": "~3.18.0",
         "react-native-safe-area-context": "4.12.0",
         "react-native-screens": "~4.5.0",
         "react-native-share": "^12.2.0",
         "react-native-shimmer-placeholder": "^2.0.9",
         "react-native-svg": "15.8.0",
+        "react-native-tab-view": "^4.1.2",
         "react-native-toast-message": "^2.3.0",
         "react-native-url-polyfill": "^2.0.0",
         "react-native-video": "^6.16.1",
         "react-native-view-shot": "^4.0.3",
         "react-native-webview": "13.12.5",
+        "react-native-wifi-reborn": "^4.13.6",
         "semver": "^7.7.2",
-        "tar-js": "^0.3.0"
+        "tar-js": "^0.3.0",
+        "zustand": "^5.0.8"
       },
       "devDependencies": {
         "@babel/core": "^7.27.4",
@@ -536,6 +556,7 @@
     },
     "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -550,6 +571,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -563,6 +585,7 @@
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -576,6 +599,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -591,6 +615,7 @@
     },
     "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -676,6 +701,7 @@
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -778,6 +804,7 @@
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -936,6 +963,7 @@
     },
     "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
       "version": "7.18.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.18.6",
@@ -993,6 +1021,7 @@
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1033,6 +1062,7 @@
     },
     "node_modules/@babel/plugin-transform-class-static-block": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-class-features-plugin": "^7.27.1",
@@ -1093,6 +1123,7 @@
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1107,6 +1138,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1120,6 +1152,7 @@
     },
     "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1134,6 +1167,7 @@
     },
     "node_modules/@babel/plugin-transform-dynamic-import": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1147,6 +1181,7 @@
     },
     "node_modules/@babel/plugin-transform-explicit-resource-management": {
       "version": "7.28.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1161,6 +1196,7 @@
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1230,6 +1266,7 @@
     },
     "node_modules/@babel/plugin-transform-json-strings": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1269,6 +1306,7 @@
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1282,6 +1320,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1310,6 +1349,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1326,6 +1366,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.27.1",
@@ -1354,6 +1395,7 @@
     },
     "node_modules/@babel/plugin-transform-new-target": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1410,6 +1452,7 @@
     },
     "node_modules/@babel/plugin-transform-object-super": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -1493,6 +1536,7 @@
     },
     "node_modules/@babel/plugin-transform-property-literals": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1602,6 +1646,7 @@
     },
     "node_modules/@babel/plugin-transform-regexp-modifiers": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1616,6 +1661,7 @@
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1707,6 +1753,7 @@
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1737,6 +1784,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
@@ -1750,6 +1798,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-property-regex": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1778,6 +1827,7 @@
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-create-regexp-features-plugin": "^7.27.1",
@@ -1792,6 +1842,7 @@
     },
     "node_modules/@babel/preset-env": {
       "version": "7.28.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.0",
@@ -1874,6 +1925,7 @@
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -1896,6 +1948,7 @@
     },
     "node_modules/@babel/preset-modules": {
       "version": "0.1.6-no-external-plugins",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
@@ -2037,6 +2090,21 @@
         "react": "*",
         "react-native": "*",
         "react-native-bottom-tabs": "*"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@config-plugins/react-native-webrtc": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@config-plugins/react-native-webrtc/-/react-native-webrtc-12.0.0.tgz",
+      "integrity": "sha512-EIYR+ArIOFBz8cEHSdPjxqFPhaN+nNeoPnI6iVStctYKZdl6AEgmXq6Qfpds6qyin1W4JP7wq2jJh32OsRfwxg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "^53"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -2928,6 +2996,31 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -3512,6 +3605,205 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@livekit/components-core": {
+      "version": "0.12.10",
+      "resolved": "https://registry.npmjs.org/@livekit/components-core/-/components-core-0.12.10.tgz",
+      "integrity": "sha512-lSGci8c8IB/qCi42g1tzNtDGpnBWH1XSSk/OA9Lzk7vqOG0LlkwD3zXfBeKfO2eWFmYRfrZ2GD59GaH2NtTgag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@floating-ui/dom": "1.6.13",
+        "loglevel": "1.9.1",
+        "rxjs": "7.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "livekit-client": "^2.13.3",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@livekit/components-core/node_modules/loglevel": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.1.tgz",
+      "integrity": "sha512-hP3I3kCrDIMuRwAwHltphhDM1r8i55H33GgqjXbrisuJhF4kRhW1dNuxsRklp4bXl8DSdLaNLuiL4A/LWRfxvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/@livekit/components-react": {
+      "version": "2.9.15",
+      "resolved": "https://registry.npmjs.org/@livekit/components-react/-/components-react-2.9.15.tgz",
+      "integrity": "sha512-b+gA0sRJHMsyr/BoMBoY1vSXQmP3h5NmxZTUt+VG8xjzCYDjmUuiDUrKVwMIUoy1vK9I6uNfo+hp6qbLo84jfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-core": "0.12.10",
+        "clsx": "2.1.1",
+        "usehooks-ts": "3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@livekit/krisp-noise-filter": "^0.2.12 || ^0.3.0",
+        "livekit-client": "^2.13.3",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "tslib": "^2.6.2"
+      },
+      "peerDependenciesMeta": {
+        "@livekit/krisp-noise-filter": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.42.0.tgz",
+      "integrity": "sha512-42sYSCay2PZrn5yHHt+O3RQpTElcTrA7bqg7iYbflUApeerA5tUCJDr8Z4abHsYHVKjqVUbkBq/TPmT3X6aYOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@livekit/react-native": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native/-/react-native-2.9.1.tgz",
+      "integrity": "sha512-oN1aWQeAuo3NhhrQRCI/V9upi8PhRQRFyZHBqnU/AlxYFyTKWKGmtVJtJWkGW+zNUF3lEF+nZMnpIHft9aJdqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/components-react": "^2.8.1",
+        "array.prototype.at": "^1.1.1",
+        "event-target-shim": "6.0.2",
+        "events": "^3.3.0",
+        "loglevel": "^1.8.0",
+        "promise.allsettled": "^1.0.5",
+        "react-native-quick-base64": "2.1.1",
+        "react-native-url-polyfill": "^1.3.0",
+        "typed-emitter": "^2.1.0",
+        "web-streams-polyfill": "^4.1.0",
+        "well-known-symbols": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@livekit/react-native-webrtc": "^137.0.1",
+        "livekit-client": "^2.15.4",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native-expo-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native-expo-plugin/-/react-native-expo-plugin-1.0.1.tgz",
+      "integrity": "sha512-CSPjjzgDDlBH1ZyFyaw7/FW2Ql1S51eUkIxv/vjGwVshn+lUD6eQ9VgfUh7ha84itvjXi9X87FvP0XWKn9CiFQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@livekit/react-native": "^2.1.0",
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc": {
+      "version": "137.0.2",
+      "resolved": "https://registry.npmjs.org/@livekit/react-native-webrtc/-/react-native-webrtc-137.0.2.tgz",
+      "integrity": "sha512-0aXYATcBraOMDTteKzmfH5ICNHw8xFyMPHmhKg14+94fAGZ2hGjdHZUSkzL14+e508W486aIAmbXipuSQCCJgA==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4",
+        "event-target-shim": "6.0.2"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@livekit/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/@livekit/react-native/node_modules/event-target-shim": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-6.0.2.tgz",
+      "integrity": "sha512-8q3LsZjRezbFZ2PN+uP+Q7pnHUMmAOziU2vA2OwoFaKIXxlxl38IylhSSgUorWu/rf4er67w0ikBqjBFk/pomA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      }
+    },
+    "node_modules/@livekit/react-native/node_modules/react-native-url-polyfill": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-1.3.0.tgz",
+      "integrity": "sha512-w9JfSkvpqqlix9UjDvJjm1EjSt652zVQ6iwCIj1cVVkwXf4jQhQgTNXY6EVTwuAmUjg6BC6k9RHCBynoLFo3IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url-without-unicode": "8.0.0-3"
+      },
+      "peerDependencies": {
+        "react-native": "*"
+      }
+    },
+    "node_modules/@livekit/react-native/node_modules/web-streams-polyfill": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.2.0.tgz",
+      "integrity": "sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "license": "MIT",
@@ -3612,6 +3904,21 @@
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
+    },
+    "node_modules/@react-native-community/netinfo": {
+      "version": "11.4.1",
+      "resolved": "https://registry.npmjs.org/@react-native-community/netinfo/-/netinfo-11.4.1.tgz",
+      "integrity": "sha512-B0BYAkghz3Q2V09BF88RA601XursIEA111tnc2JOaN7axJWmNefmfjZqw/KdSxKZp7CZUuPpjBmz/WCR9uaHYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native": ">=0.59"
+      }
+    },
+    "node_modules/@react-native-community/slider": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@react-native-community/slider/-/slider-4.5.7.tgz",
+      "integrity": "sha512-WMDDZjNF2Bd8M8TrSqKf5xhM9ikdfCHtSPur64Ow3bB/OVrKufUQZ59NmYdNZNeGPvcHHTsafuYTY8zfZfbchQ==",
+      "license": "MIT"
     },
     "node_modules/@react-native/assets-registry": {
       "version": "0.76.9",
@@ -3811,6 +4118,12 @@
         "@babel/core": "*"
       }
     },
+    "node_modules/@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA==",
+      "license": "MIT"
+    },
     "node_modules/@react-native/normalize-colors": {
       "version": "0.76.9",
       "license": "MIT"
@@ -3939,6 +4252,324 @@
       "dependencies": {
         "component-type": "^1.2.1",
         "join-component": "^1.1.0"
+      }
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-8.55.0.tgz",
+      "integrity": "sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-8.55.0.tgz",
+      "integrity": "sha512-cP3BD/Q6pquVQ+YL+rwCnorKuTXiS9KXW8HNKu4nmmBAyf7urjs+F6Hr1k9MXP5yQ8W3yK7jRWd09Yu6DHWOiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-8.55.0.tgz",
+      "integrity": "sha512-roCDEGkORwolxBn8xAKedybY+Jlefq3xYmgN2fr3BTnsXjSYOPC7D1/mYqINBat99nDtvgFvNfRcZPiwwZ1hSw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.0",
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-8.55.0.tgz",
+      "integrity": "sha512-nIkfgRWk1091zHdu4NbocQsxZF1rv1f7bbp3tTIlZYbrH62XVZosx5iHAuZG0Zc48AETLE7K4AX9VGjvQj8i9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "8.55.0",
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/babel-plugin-component-annotate": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.2.0.tgz",
+      "integrity": "sha512-GFpS3REqaHuyX4LCNqlneAQZIKyHb5ePiI1802n0fhtYjk68I1DTQ3PnbzYi50od/vAsTQVCknaS5F6tidNqTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-8.55.0.tgz",
+      "integrity": "sha512-1A31mCEWCjaMxJt6qGUK+aDnLDcK6AwLAZnqpSchNysGni1pSn1RWSmk9TBF8qyTds5FH8B31H480uxMPUJ7Cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "8.55.0",
+        "@sentry-internal/feedback": "8.55.0",
+        "@sentry-internal/replay": "8.55.0",
+        "@sentry-internal/replay-canvas": "8.55.0",
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/cli": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.53.0.tgz",
+      "integrity": "sha512-n2ZNb+5Z6AZKQSI0SusQ7ZzFL637mfw3Xh4C3PEyVSn9LiF683fX0TTq8OeGmNZQS4maYfS95IFD+XpydU0dEA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.7",
+        "progress": "^2.0.3",
+        "proxy-from-env": "^1.1.0",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "sentry-cli": "bin/sentry-cli"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@sentry/cli-darwin": "2.53.0",
+        "@sentry/cli-linux-arm": "2.53.0",
+        "@sentry/cli-linux-arm64": "2.53.0",
+        "@sentry/cli-linux-i686": "2.53.0",
+        "@sentry/cli-linux-x64": "2.53.0",
+        "@sentry/cli-win32-arm64": "2.53.0",
+        "@sentry/cli-win32-i686": "2.53.0",
+        "@sentry/cli-win32-x64": "2.53.0"
+      }
+    },
+    "node_modules/@sentry/cli-darwin": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.53.0.tgz",
+      "integrity": "sha512-NNPfpILMwKgpHiyJubHHuauMKltkrgLQ5tvMdxNpxY60jBNdo5VJtpESp4XmXlnidzV4j1z61V4ozU6ttDgt5Q==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.53.0.tgz",
+      "integrity": "sha512-NdRzQ15Ht83qG0/Lyu11ciy/Hu/oXbbtJUgwzACc7bWvHQA8xEwTsehWexqn1529Kfc5EjuZ0Wmj3MHmp+jOWw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-arm64": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.53.0.tgz",
+      "integrity": "sha512-xY/CZ1dVazsSCvTXzKpAgXaRqfljVfdrFaYZRUaRPf1ZJRGa3dcrivoOhSIeG/p5NdYtMvslMPY9Gm2MT0M83A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-i686": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.53.0.tgz",
+      "integrity": "sha512-0REmBibGAB4jtqt9S6JEsFF4QybzcXHPcHtJjgMi5T0ueh952uG9wLzjSxQErCsxTKF+fL8oG0Oz5yKBuCwCCQ==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-linux-x64": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.53.0.tgz",
+      "integrity": "sha512-9UGJL+Vy5N/YL1EWPZ/dyXLkShlNaDNrzxx4G7mTS9ywjg+BIuemo6rnN7w43K1NOjObTVO6zY0FwumJ1pCyLg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "linux",
+        "freebsd",
+        "android"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-arm64": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.53.0.tgz",
+      "integrity": "sha512-G1kjOjrjMBY20rQcJV2GA8KQE74ufmROCDb2GXYRfjvb1fKAsm4Oh8N5+Tqi7xEHdjQoLPkE4CNW0aH68JSUDQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-i686": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.53.0.tgz",
+      "integrity": "sha512-qbGTZUzesuUaPtY9rPXdNfwLqOZKXrJRC1zUFn52hdo6B+Dmv0m/AHwRVFHZP53Tg1NCa8bDei2K/uzRN0dUZw==",
+      "cpu": [
+        "x86",
+        "ia32"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/cli-win32-x64": {
+      "version": "2.53.0",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.53.0.tgz",
+      "integrity": "sha512-1TXYxYHtwgUq5KAJt3erRzzUtPqg7BlH9T7MdSPHjJatkrr/kwZqnVe2H6Arr/5NH891vOlIeSPHBdgJUAD69g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-8.55.0.tgz",
+      "integrity": "sha512-6g7jpbefjHYs821Z+EBJ8r4Z7LT5h80YSWRJaylGS4nW5W5Z2KXzpdnyFarv37O7QjauzVC2E+PABmpkw5/JGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-8.55.0.tgz",
+      "integrity": "sha512-/qNBvFLpvSa/Rmia0jpKfJdy16d4YZaAnH/TuKLAtm0BWlsPQzbXCU4h8C5Hsst0Do0zG613MEtEmWpWrVOqWA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "8.55.0",
+        "@sentry/core": "8.55.0",
+        "hoist-non-react-statics": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
+    },
+    "node_modules/@sentry/react-native": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-6.22.0.tgz",
+      "integrity": "sha512-Xt8ZuYa7YsMTG7hFU8awfNpVWijH6kWdyqykML6qVohBmP2OS57oSAd4fAdCmbtaIbHs8Drux+uPtb/SdOy2Vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/babel-plugin-component-annotate": "4.2.0",
+        "@sentry/browser": "8.55.0",
+        "@sentry/cli": "2.53.0",
+        "@sentry/core": "8.55.0",
+        "@sentry/react": "8.55.0",
+        "@sentry/types": "8.55.0",
+        "@sentry/utils": "8.55.0"
+      },
+      "bin": {
+        "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
+      },
+      "peerDependencies": {
+        "expo": ">=49.0.0",
+        "react": ">=17.0.0",
+        "react-native": ">=0.65.0"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-8.55.0.tgz",
+      "integrity": "sha512-6LRT0+r6NWQ+RtllrUW2yQfodST0cJnkOmdpHA75vONgBUhpKwiJ4H7AmgfoTET8w29pU6AnntaGOe0LJbOmog==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "8.55.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-8.55.0.tgz",
+      "integrity": "sha512-cYcl39+xcOivBpN9d8ZKbALl+DxZKo/8H0nueJZ0PO4JA+MJGhSm6oHakXxLPaiMoNLTX7yor8ndnQIuFg+vmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "8.55.0"
+      },
+      "engines": {
+        "node": ">=14.18"
       }
     },
     "node_modules/@shopify/flash-list": {
@@ -4113,30 +4744,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
-      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
-    "node_modules/@types/eslint-scope": {
-      "version": "3.7.7",
-      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
-      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/eslint": "*",
-        "@types/estree": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -4553,204 +5160,12 @@
         "@urql/core": "^5.0.0"
       }
     },
-    "node_modules/@webassemblyjs/ast": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
-      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
-      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
-      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
-      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
-      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
-      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
-      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/wasm-gen": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
-      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/ieee754": "^1.2.0"
-      }
-    },
-    "node_modules/@webassemblyjs/leb128": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
-      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@webassemblyjs/utf8": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
-      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
-      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/helper-wasm-section": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-opt": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1",
-        "@webassemblyjs/wast-printer": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
-      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
-      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-buffer": "1.14.1",
-        "@webassemblyjs/wasm-gen": "1.14.1",
-        "@webassemblyjs/wasm-parser": "1.14.1"
-      }
-    },
-    "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
-      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@webassemblyjs/helper-api-error": "1.13.2",
-        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
-        "@webassemblyjs/ieee754": "1.13.2",
-        "@webassemblyjs/leb128": "1.13.2",
-        "@webassemblyjs/utf8": "1.13.2"
-      }
-    },
-    "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
-      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@webassemblyjs/ast": "1.14.1",
-        "@xtuc/long": "4.2.2"
-      }
-    },
     "node_modules/@xmldom/xmldom": {
       "version": "0.7.13",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@xtuc/ieee754": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@xtuc/long": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -4802,20 +5217,6 @@
         "acorn-walk": "^8.0.2"
       }
     },
-    "node_modules/acorn-import-phases": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
-      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      },
-      "peerDependencies": {
-        "acorn": "^8.14.0"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
@@ -4848,7 +5249,6 @@
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "4"
@@ -5001,7 +5401,6 @@
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -5040,6 +5439,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/array.prototype.at": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.at/-/array.prototype.at-1.1.3.tgz",
+      "integrity": "sha512-TX4J1Uig4skvpOakrvP8q/uyhUj+ZDNmQoZpHf3MsKTrXcMHDPrgJlpv2nRJMfANrsmhg1JoOGrg3yOp209SWg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/array.prototype.findlast": {
@@ -5115,6 +5533,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array.prototype.map": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.8.tgz",
+      "integrity": "sha512-YocPM7bYYu2hXGxWpb5vwZ8cMeudNHYtYBcUDY4Z1GWa53qcnQMWSl25jeBHNzitjl9HW2AWW4ro/S/nftUaOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-object-atoms": "^1.0.0",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/array.prototype.tosorted": {
       "version": "1.1.4",
       "dev": true,
@@ -5132,7 +5571,6 @@
     },
     "node_modules/arraybuffer.prototype.slice": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.1",
@@ -5171,7 +5609,6 @@
     },
     "node_modules/async-function": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5194,7 +5631,6 @@
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "possible-typed-array-names": "^1.0.0"
@@ -5660,7 +6096,6 @@
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.0",
@@ -5688,7 +6123,6 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5816,17 +6250,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/chrome-trace-event": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
-      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/chromium-edge-launcher": {
       "version": "0.2.0",
       "license": "Apache-2.0",
@@ -5925,6 +6348,15 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -6286,7 +6718,6 @@
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6302,7 +6733,6 @@
     },
     "node_modules/data-view-byte-length": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -6318,7 +6748,6 @@
     },
     "node_modules/data-view-byte-offset": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -6520,7 +6949,6 @@
     },
     "node_modules/define-data-property": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0",
@@ -6543,7 +6971,6 @@
     },
     "node_modules/define-properties": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.0.1",
@@ -6589,6 +7016,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
       }
     },
     "node_modules/destroy": {
@@ -6802,21 +7240,6 @@
         "once": "^1.4.0"
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.18.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
-      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
@@ -6850,7 +7273,6 @@
     },
     "node_modules/es-abstract": {
       "version": "1.24.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "array-buffer-byte-length": "^1.0.2",
@@ -6915,6 +7337,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+      "license": "MIT"
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
@@ -6927,6 +7355,26 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
+        "is-map": "^2.0.2",
+        "is-set": "^2.0.2",
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es-iterator-helpers": {
@@ -6955,14 +7403,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -6988,7 +7428,6 @@
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -6999,7 +7438,6 @@
     },
     "node_modules/es-to-primitive": {
       "version": "1.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7",
@@ -7771,6 +8209,7 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -7794,9 +8233,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -7917,6 +8354,34 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-audio": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-0.3.5.tgz",
+      "integrity": "sha512-gzpDH3vZI1FDL1Q8pXryACtNIW+idZ/zIZ8WqdTRzJuzxucazrG2gLXUS2ngcXQBn09Jyz4RUnU10Tu2N7/Hgg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-av": {
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.0.2.tgz",
+      "integrity": "sha512-AHIHXdqLgK1dfHZF0JzX3YSVySGMrWn9QtPzaVjw54FAzvXfMt4sIoq4qRL/9XWCP9+ICcCs/u3EcvmxQjrfcA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-build-properties": {
       "version": "0.13.3",
       "license": "MIT",
@@ -7926,6 +8391,16 @@
       },
       "peerDependencies": {
         "expo": "*"
+      }
+    },
+    "node_modules/expo-calendar": {
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-14.0.6.tgz",
+      "integrity": "sha512-aOby7ueR8lB9sWTHXkECZiPDZNVRsGQYhJTe05puNZicMWCV4c53Z/LRiCTTq3LBXV4zpBOB5rXiCyA1f082yA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-camera": {
@@ -8035,6 +8510,25 @@
         "react": "*"
       }
     },
+    "node_modules/expo-location": {
+      "version": "18.0.10",
+      "resolved": "https://registry.npmjs.org/expo-location/-/expo-location-18.0.10.tgz",
+      "integrity": "sha512-R0Iioz0UZ9Ts8TACPngh8uDFbajJhVa5/igLqWB8Pq/gp8UHuwj7PC8XbZV7avsFoShYjaxrOhf4U7IONeKLgg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-media-library": {
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/expo-media-library/-/expo-media-library-17.0.6.tgz",
+      "integrity": "sha512-LUnfrddmee1xLOkyG2NN1l9xQbtvMX3fbM1brEGHg0SKSndvjod3FQdhTzZEYAariqW2RSxQR8v1IsheIoLQXg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-modules-autolinking": {
       "version": "2.0.8",
       "license": "MIT",
@@ -8142,6 +8636,17 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-squircle-view": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expo-squircle-view/-/expo-squircle-view-1.1.0.tgz",
+      "integrity": "sha512-paLpUKfAlFHbgrkfcTxmzTEbF0wbiLF0arTE4kLq2VWRWWmZxqLTzNDZM9JRmdEIrDeF3natRaxWJyYvwzx3Lg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/expo-status-bar": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8171,6 +8676,19 @@
     "node_modules/expo-system-ui/node_modules/@react-native/normalize-colors": {
       "version": "0.76.8",
       "license": "MIT"
+    },
+    "node_modules/expo-task-manager": {
+      "version": "12.0.6",
+      "resolved": "https://registry.npmjs.org/expo-task-manager/-/expo-task-manager-12.0.6.tgz",
+      "integrity": "sha512-yGbS64OL95z7tAQAvryy0sGHuQgrcpvnJsdyuGL8MA9bcPtr+kytLZ4dOCDac7foQS7+FLDGgtiAR6v/64B5Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "unimodules-app-loader": "~5.0.1"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
     },
     "node_modules/expo-web-browser": {
       "version": "14.0.2",
@@ -8496,7 +9014,6 @@
     },
     "node_modules/for-each": {
       "version": "0.3.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-callable": "^1.2.7"
@@ -8607,7 +9124,6 @@
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -8626,7 +9142,6 @@
     },
     "node_modules/functions-have-names": {
       "version": "1.2.3",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8698,7 +9213,6 @@
     },
     "node_modules/get-symbol-description": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -8758,14 +9272,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
-    },
     "node_modules/globals": {
       "version": "13.24.0",
       "dev": true,
@@ -8793,7 +9299,6 @@
     },
     "node_modules/globalthis": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-properties": "^1.2.1",
@@ -8845,7 +9350,6 @@
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8863,7 +9367,6 @@
     },
     "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-define-property": "^1.0.0"
@@ -8874,7 +9377,6 @@
     },
     "node_modules/has-proto": {
       "version": "1.2.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.0"
@@ -9014,7 +9516,6 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "6",
@@ -9239,7 +9740,6 @@
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -9275,9 +9775,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -9297,7 +9812,6 @@
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "async-function": "^1.0.0",
@@ -9315,7 +9829,6 @@
     },
     "node_modules/is-bigint": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-bigints": "^1.0.2"
@@ -9329,7 +9842,6 @@
     },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9356,7 +9868,6 @@
     },
     "node_modules/is-callable": {
       "version": "1.2.7",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9380,7 +9891,6 @@
     },
     "node_modules/is-data-view": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9396,7 +9906,6 @@
     },
     "node_modules/is-date-object": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9438,7 +9947,6 @@
     },
     "node_modules/is-finalizationregistry": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9467,7 +9975,6 @@
     },
     "node_modules/is-generator-function": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9494,7 +10001,6 @@
     },
     "node_modules/is-map": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9505,7 +10011,6 @@
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9523,7 +10028,6 @@
     },
     "node_modules/is-number-object": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9574,7 +10078,6 @@
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9591,7 +10094,6 @@
     },
     "node_modules/is-set": {
       "version": "2.0.3",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9602,7 +10104,6 @@
     },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9626,7 +10127,6 @@
     },
     "node_modules/is-string": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9641,7 +10141,6 @@
     },
     "node_modules/is-symbol": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -9657,7 +10156,6 @@
     },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "which-typed-array": "^1.1.16"
@@ -9671,7 +10169,6 @@
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9682,7 +10179,6 @@
     },
     "node_modules/is-weakref": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3"
@@ -9696,7 +10192,6 @@
     },
     "node_modules/is-weakset": {
       "version": "2.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -9721,7 +10216,6 @@
     },
     "node_modules/isarray": {
       "version": "2.0.5",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/isexe": {
@@ -9826,6 +10320,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/iterate-iterator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.2.tgz",
+      "integrity": "sha512-t91HubM4ZDQ70M9wqp+pcNpu8OyJ9UAtXntT/Bcsvp5tZMnz9vRa+IunKXeI8AnfZMTv0jNuVEmGeLSMjVvfPw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/iterate-value": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+      "integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-get-iterator": "^1.0.2",
+        "iterate-iterator": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/iterator.prototype": {
@@ -10608,6 +11124,15 @@
       "version": "1.1.0",
       "license": "MIT"
     },
+    "node_modules/jose": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.0.tgz",
+      "integrity": "sha512-TTQJyoEoKcC1lscpVDCSsVgYzUDg/0Bt3WE//WiTPK6uOCQC2KZS4MpugbMWt/zyjkopgZoXhZuCi00gLudfUA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
@@ -10941,15 +11466,25 @@
       "version": "1.2.4",
       "license": "MIT"
     },
-    "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6.11.5"
+    "node_modules/livekit-client": {
+      "version": "2.15.8",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.15.8.tgz",
+      "integrity": "sha512-M+GnlmoY+JOfGGhDov5f4V273YZ9DuWFBaPwz42fliC3TsFTzEcJoRqqE7uLtEGAnloqbLPk+sIvW/XSU4Z4/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.42.0",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "ts-debounce": "^4.0.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
       }
     },
     "node_modules/locate-path": {
@@ -11061,6 +11596,19 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/loose-envify": {
@@ -11680,17 +12228,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mobx": {
-      "version": "6.13.7",
-      "resolved": "https://registry.npmjs.org/mobx/-/mobx-6.13.7.tgz",
-      "integrity": "sha512-aChaVU/DO5aRPmk1GX8L+whocagUUpBQqoPtJk+cm7UOXUk87J4PeWCh6nNmTTIfEhiR9DI/+FnA8dln/hTK7g==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mobx"
-      }
-    },
     "node_modules/mobx-state-tree": {
       "version": "7.0.2",
       "license": "MIT",
@@ -11879,7 +12416,6 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11890,7 +12426,6 @@
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -11898,7 +12433,6 @@
     },
     "node_modules/object.assign": {
       "version": "4.1.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -12149,7 +12683,6 @@
     },
     "node_modules/own-keys": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "get-intrinsic": "^1.2.6",
@@ -12471,7 +13004,6 @@
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -12651,6 +13183,26 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/promise.allsettled": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.7.tgz",
+      "integrity": "sha512-hezvKvQQmsFkOdrZfYxUxkyxl8mgFQeT259Ajj9PXdbg9VzBCWrItOev72JyWxkCD5VSSqAeHmlN3tWx4DlmsA==",
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.map": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
+        "iterate-value": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "license": "MIT",
@@ -12771,17 +13323,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -13063,13 +13604,6 @@
         }
       }
     },
-    "node_modules/react-native-create-thumbnail": {
-      "version": "2.1.1",
-      "license": "MIT",
-      "peerDependencies": {
-        "react-native": ">=0.59.0"
-      }
-    },
     "node_modules/react-native-drawer-layout": {
       "version": "4.1.12",
       "license": "MIT",
@@ -13222,9 +13756,39 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-localize": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/react-native-localize/-/react-native-localize-3.5.2.tgz",
+      "integrity": "sha512-HfQdwv5sRjh4AQ8a97OTjXYcxPNRlBxiQb861c7Ob6mRuNYCPtaJ45QTcZxZr31vAM3THvtOBp1soqWlQFxjnA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@expo/config-plugins": "^9.0.0 || ^10.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-macos": "*"
+      },
+      "peerDependenciesMeta": {
+        "@expo/config-plugins": {
+          "optional": true
+        },
+        "react-native-macos": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-native-mmkv": {
       "version": "3.1.0",
       "license": "(MIT AND BSD-3-Clause)",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-pager-view": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-pager-view/-/react-native-pager-view-6.5.1.tgz",
+      "integrity": "sha512-YdX7bP+rPYvATMU7HzlMq9JaG3ui/+cVRbFZFGW+QshDULANFg9ECR1BA7H7JTIcO/ZgWCwF+1aVmYG5yBA9Og==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13244,6 +13808,29 @@
         }
       }
     },
+    "node_modules/react-native-popover-view": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-popover-view/-/react-native-popover-view-6.1.0.tgz",
+      "integrity": "sha512-j1CB+yPwTKlBvIJBNb1AwiHyF/r+W5+AJIbHk79GRa+0z6PVtW4C7NWJWPqUVkCMOcJtewl6Pr6f2dc/87cVyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "deprecated-react-native-prop-types": "^2.3.0",
+        "prop-types": "^15.8.1"
+      }
+    },
+    "node_modules/react-native-quick-base64": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/react-native-quick-base64/-/react-native-quick-base64-2.1.1.tgz",
+      "integrity": "sha512-/L+SaapDLcLcHA3Kj0/cvEhFS/oLXyD6DUXwdckTR/75bzUjqf1FrusUTvJho/lzXnCR1VtBGn+EEvrLmkDTmw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-ratings": {
       "version": "8.0.4",
       "license": "MIT",
@@ -13256,7 +13843,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.16.7",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.0.tgz",
+      "integrity": "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
@@ -13269,10 +13858,21 @@
         "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
         "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "invariant": "^2.2.4"
+        "invariant": "^2.2.4",
+        "react-native-is-edge-to-edge": "1.1.7"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-reanimated/node_modules/react-native-is-edge-to-edge": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.1.7.tgz",
+      "integrity": "sha512-EH6i7E8epJGIcu7KpfXYXiV2JFIYITtq+rVS8uEb+92naMRBdxhTuS8Wn2Q7j9sqyO0B+Xbaaf9VdipIAmGW4w==",
+      "license": "MIT",
+      "peerDependencies": {
         "react": "*",
         "react-native": "*"
       }
@@ -13338,6 +13938,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-tab-view": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/react-native-tab-view/-/react-native-tab-view-4.1.3.tgz",
+      "integrity": "sha512-COj2HBeM4IqKCAadUdZAUWrFyO8++wlgObsgOt6xrwqdEnu9HX/74uesC0MGlgwIalFffXqTh5F3CC3pUjFPug==",
+      "license": "MIT",
+      "dependencies": {
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*",
+        "react-native-pager-view": ">= 6.0.0"
+      }
+    },
     "node_modules/react-native-toast-message": {
       "version": "2.3.3",
       "license": "MIT",
@@ -13354,65 +13968,6 @@
       },
       "peerDependencies": {
         "react-native": "*"
-      }
-    },
-    "node_modules/react-native-vector-icons": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-10.3.0.tgz",
-      "integrity": "sha512-IFQ0RE57819hOUdFvgK4FowM5aMXg7C7XKsuGLevqXkkIJatc3QopN0wYrb2IrzUgmdpfP+QVIbI3S6h7M0btw==",
-      "deprecated": "react-native-vector-icons package has moved to a new model of per-icon-family packages. See the https://github.com/oblador/react-native-vector-icons/blob/master/MIGRATION.md on how to migrate",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "prop-types": "^15.7.2",
-        "yargs": "^16.1.1"
-      },
-      "bin": {
-        "fa-upgrade.sh": "bin/fa-upgrade.sh",
-        "fa5-upgrade": "bin/fa5-upgrade.sh",
-        "fa6-upgrade": "bin/fa6-upgrade.sh",
-        "generate-icon": "bin/generate-icon.js"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "license": "ISC",
-      "peer": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/react-native-vector-icons/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "license": "ISC",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/react-native-video": {
@@ -13446,6 +14001,15 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-wifi-reborn": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/react-native-wifi-reborn/-/react-native-wifi-reborn-4.13.6.tgz",
+      "integrity": "sha512-vlZYgRnFapVVeJ8z0G0k7k6wUi9mUPhW6ji008mp5BBKMbZNL0AxdyHUOW3uP1emKYK7eRIvfx6AuECpG2mAsg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react-native": ">=0.13"
       }
     },
     "node_modules/react-native/node_modules/babel-plugin-syntax-hermes-parser": {
@@ -13630,7 +14194,6 @@
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13669,7 +14232,6 @@
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13895,9 +14457,17 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -13933,7 +14503,6 @@
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -13948,7 +14517,6 @@
     },
     "node_modules/safe-regex-test": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14004,6 +14572,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/sdp": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+      "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
       }
     },
     "node_modules/selfsigned": {
@@ -14067,17 +14650,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/serve-static": {
       "version": "1.16.2",
       "license": "MIT",
@@ -14104,7 +14676,6 @@
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14120,7 +14691,6 @@
     },
     "node_modules/set-function-name": {
       "version": "2.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "define-data-property": "^1.1.4",
@@ -14134,7 +14704,6 @@
     },
     "node_modules/set-proto": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -14203,7 +14772,6 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14221,7 +14789,6 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14236,7 +14803,6 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14253,7 +14819,6 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -14434,7 +14999,6 @@
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -14532,7 +15096,6 @@
     },
     "node_modules/string.prototype.trim": {
       "version": "1.2.10",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14552,7 +15115,6 @@
     },
     "node_modules/string.prototype.trimend": {
       "version": "1.0.9",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -14569,7 +15131,6 @@
     },
     "node_modules/string.prototype.trimstart": {
       "version": "1.0.8",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -14760,17 +15321,6 @@
         "url": "https://opencollective.com/synckit"
       }
     },
-    "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/tar": {
       "version": "6.2.1",
       "license": "ISC",
@@ -14915,75 +15465,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/terser-webpack-plugin": {
-      "version": "5.3.14",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.14.tgz",
-      "integrity": "sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25",
-        "jest-worker": "^27.4.5",
-        "schema-utils": "^4.3.0",
-        "serialize-javascript": "^6.0.2",
-        "terser": "^5.31.1"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "webpack": "^5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "uglify-js": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
-    "node_modules/terser-webpack-plugin/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "license": "ISC",
@@ -15112,6 +15593,12 @@
       "peerDependencies": {
         "typescript": ">=4.8.4"
       }
+    },
+    "node_modules/ts-debounce": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ts-debounce/-/ts-debounce-4.0.0.tgz",
+      "integrity": "sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==",
+      "license": "MIT"
     },
     "node_modules/ts-essentials": {
       "version": "9.4.2",
@@ -15303,7 +15790,6 @@
     },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15316,7 +15802,6 @@
     },
     "node_modules/typed-array-byte-length": {
       "version": "1.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.8",
@@ -15334,7 +15819,6 @@
     },
     "node_modules/typed-array-byte-offset": {
       "version": "1.0.4",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -15354,7 +15838,6 @@
     },
     "node_modules/typed-array-length": {
       "version": "1.0.7",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind": "^1.0.7",
@@ -15371,9 +15854,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.3.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15409,7 +15901,6 @@
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.3",
@@ -15466,6 +15957,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/unimodules-app-loader": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/unimodules-app-loader/-/unimodules-app-loader-5.0.1.tgz",
+      "integrity": "sha512-JI4dUMOovvLrZ1U/mrQrR73cxGH26H7NpfBxwE0hk59CBOyHO4YYpliI3hPSGgZzt+YEy2VZR6nrspSUXY8jyw==",
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",
@@ -15603,6 +16100,21 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/usehooks-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-3.1.1.tgz",
+      "integrity": "sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=16.15.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/utf8": {
       "version": "3.0.0",
       "license": "MIT"
@@ -15693,21 +16205,6 @@
       "version": "0.1.1",
       "license": "MIT"
     },
-    "node_modules/watchpack": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-      "integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "license": "MIT",
@@ -15730,91 +16227,30 @@
         "node": ">=12"
       }
     },
-    "node_modules/webpack": {
-      "version": "5.101.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
-      "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
+      "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.8",
-        "@types/json-schema": "^7.0.15",
-        "@webassemblyjs/ast": "^1.14.1",
-        "@webassemblyjs/wasm-edit": "^1.14.1",
-        "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.15.0",
-        "acorn-import-phases": "^1.0.3",
-        "browserslist": "^4.24.0",
-        "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.2",
-        "es-module-lexer": "^1.2.1",
-        "eslint-scope": "5.1.1",
-        "events": "^3.2.0",
-        "glob-to-regexp": "^0.4.1",
-        "graceful-fs": "^4.2.11",
-        "json-parse-even-better-errors": "^2.3.1",
-        "loader-runner": "^4.2.0",
-        "mime-types": "^2.1.27",
-        "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.3.3"
-      },
-      "bin": {
-        "webpack": "bin/webpack.js"
+        "sdp": "^3.2.0"
       },
       "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependenciesMeta": {
-        "webpack-cli": {
-          "optional": true
-        }
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
       }
     },
-    "node_modules/webpack-sources": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
-      "dev": true,
+    "node_modules/well-known-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/well-known-symbols/-/well-known-symbols-4.1.0.tgz",
+      "integrity": "sha512-lKhCpGfPkaJnPKyep1Uj44pNmyrdupYHtxci2ThUCC/Y0px44d9BWt2dbewDif4PwOqSI6KkCdwuL22CDUj4rw==",
       "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/webpack/node_modules/eslint-scope": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
-      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^4.1.1"
+        "get-intrinsic": "^1.2.7",
+        "has-symbols": "^1.1.0"
       },
       "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true,
-      "engines": {
-        "node": ">=4.0"
+        "node": ">= 0.4"
       }
     },
     "node_modules/whatwg-encoding": {
@@ -15886,7 +16322,6 @@
     },
     "node_modules/which-boxed-primitive": {
       "version": "1.1.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-bigint": "^1.1.0",
@@ -15904,7 +16339,6 @@
     },
     "node_modules/which-builtin-type": {
       "version": "1.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -15930,7 +16364,6 @@
     },
     "node_modules/which-collection": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-map": "^2.0.3",
@@ -15947,7 +16380,6 @@
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
@@ -16157,6 +16589,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.8.tgz",
+      "integrity": "sha512-gyPKpIaxY9XcO2vSMrLbiER7QMAMGOQZVRdJ6Zi782jkbzZygq5GI9nG8g+sMgitRtndwaBSl7uiqC49o1SSiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -104,7 +104,7 @@
     "react-native-pager-view": "6.5.1",
     "react-native-permissions": "^5.4.1",
     "react-native-popover-view": "^6.1.0",
-    "react-native-reanimated": "~3.16.7",
+    "react-native-reanimated": "~3.18.0",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.5.0",
     "react-native-share": "^12.2.0",


### PR DESCRIPTION
…issing mocks

- Update react-native-reanimated from 3.16.7 to 3.18.0 for RN 0.76.9 compatibility
- Update iOS WebRTC-SDK to 137.7151.04 to fix version mismatch
- Add mocks for react-native-localize, expo-audio, MantleBridge, and SocketComms
- Add Jest globals to eslint config for test files
- Fix duplicate keys in react-native-bluetooth-classic mock