### PR TITLE
disable endianness auto swapping for audio chunks from livekit-bridge…

### DIFF
--- a/cloud/docker-compose.dev.yml
+++ b/cloud/docker-compose.dev.yml
@@ -22,6 +22,7 @@ services:
       - CONTAINER_ENVIRONMENT=true
       - CLOUD_HOST_NAME=cloud
       - LIVEKIT_GRPC_SOCKET=/var/run/livekit/bridge.sock
+      - LIVEKIT_PCM_ENDIAN=off
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
disable endianness auto swapping for audio chunks from livekit-bridge, default to off / little-endian