### PR TITLE
[HOTFIX] - Add ADDITIONAL_PRE_INSTALLED_APPS

### DIFF
--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -8,6 +8,11 @@ PORT=80
 
 ADMIN_EMAILS=alex1115alex@gmail.com,alex1115alex+tester@gmail.com,isaiah@mentra.glass,israelov@mentra.glass,cayden@mentra.glass,nicolo@mentra.glass,nirhbay@mentra.glass,roger@mentra.glass
 
+# Additional Pre-installed Apps (optional, comma-separated package names)
+# These apps will be added on top of the default pre-installed apps
+# Example: ADDITIONAL_PRE_INSTALLED_APPS=com.mentra.mentraai.beta,com.custom.app
+ADDITIONAL_PRE_INSTALLED_APPS=
+
 # Services URLs
 CLOUD_URL=cloud
 APPSTORE_URL=appstore

--- a/cloud/packages/cloud/src/routes/apps.routes.ts
+++ b/cloud/packages/cloud/src/routes/apps.routes.ts
@@ -34,6 +34,10 @@ const ALLOWED_API_KEY_PACKAGES = [
   "test.augmentos.mira",
   "cloud.augmentos.mira",
   "com.augmentos.mira",
+  "com.mentra.mentraai.beta",
+  // "com.mentra.mentraai.dev",  //later
+  // "com.mentra.mentraai" //later
+
 ];
 
 const AUGMENTOS_AUTH_JWT_SECRET = process.env.AUGMENTOS_AUTH_JWT_SECRET || "";

--- a/cloud/packages/cloud/src/services/core/app.service.ts
+++ b/cloud/packages/cloud/src/services/core/app.service.ts
@@ -51,15 +51,28 @@ export const PRE_INSTALLED_DEBUG = [
 
 // export const PRE_INSTALLED = ["cloud.augmentos.live-captions-global", "cloud.augmentos.notify", "cloud.augmentos.mira"];
 
+// Add debug apps in non-production environments
 if (
   process.env.NODE_ENV !== "production" ||
   process.env.DEBUG_APPS === "true"
 ) {
-  // If we're in debug mode, add the debug apps to the preinstalled list.
   PRE_INSTALLED.push(...PRE_INSTALLED_DEBUG);
   logger.info(
     { PRE_INSTALLED_DEBUG },
     "Debug mode enabled - adding debug apps to preinstalled list:",
+  );
+}
+
+// Add additional pre-installed apps from environment variable
+if (process.env.ADDITIONAL_PRE_INSTALLED_APPS) {
+  const additionalApps = process.env.ADDITIONAL_PRE_INSTALLED_APPS.split(",")
+    .map((app) => app.trim())
+    .filter((app) => app.length > 0);
+
+  PRE_INSTALLED.push(...additionalApps);
+  logger.info(
+    { additionalApps },
+    "Adding additional pre-installed apps from ADDITIONAL_PRE_INSTALLED_APPS:",
   );
 }
 


### PR DESCRIPTION

Introduces a new environment variable that allows adding custom pre-installed apps on top of the default ones (livecaptions, notify, mira). This enables different Mentra AI versions to be deployed across environments:

- Development: com.mentra.mentraai.dev
- Staging/Beta: com.mentra.mentraai.beta
- Production: com.mentra.mentraai

Key changes:
- Added ADDITIONAL_PRE_INSTALLED_APPS env variable support in app.service.ts
- Updated .env.example with documentation and usage examples
- Added Mentra AI package names to ALLOWED_API_KEY_PACKAGES whitelist
- Apps added via this variable are auto-installed and cannot be uninstalled

This provides flexibility to install different versions of Mira or other official apps per environment without code changes. Future work will include automatic migration to remove old Mira versions when Mentra AI is deployed.


**_**I deployed this to the dev backend, and it works now. @isaiahb , please approve for the staging backend.**_**