### PR TITLE
Add nightly builds, ASG PR builds, and shared keystore support

### DIFF
--- a/.github/workflows/mentraos-asg-client-build.yml
+++ b/.github/workflows/mentraos-asg-client-build.yml
@@ -11,11 +11,64 @@ on:
       - dev
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   build:
     runs-on: self-hosted
 
     steps:
+      - name: Update PR comment - Build started
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- pr-review-helper -->';
+            const comment = comments.data.find(c => c.body.includes(marker));
+            if (!comment) return;
+
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+
+            // Check for existing working build link to preserve
+            const existingDownloadMatch = comment.body.match(/\[📥 \*\*Download ASG APK\*\*\]\((https:\/\/github\.com[^)]+\.apk)\)/);
+            const existingShaMatch = comment.body.match(/🕶️ ASG Client[\s\S]*?✅ \*\*Ready to test!\*\* \(commit `([a-f0-9]+)`\)/);
+
+            let buildStatus = `### 🕶️ ASG Client Build\n⏳ **Building...** (commit \`${sha}\`)`;
+
+            // If there's a previous working build, show it
+            if (existingDownloadMatch && existingShaMatch && existingShaMatch[1] !== sha) {
+              buildStatus += `\n\n📦 **Previous build:** (commit \`${existingShaMatch[1]}\`) - [📥 **Download ASG APK**](${existingDownloadMatch[1]})`;
+            }
+
+            const newBody = comment.body.replace(
+              /<!-- asg-build-status -->[\s\S]*?<!-- \/asg-build-status -->/,
+              `<!-- asg-build-status -->\n${buildStatus}\n<!-- /asg-build-status -->`
+            );
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: newBody
+            });
+
+      - name: Get cache week number
+        id: cache-week
+        run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
+
+      - name: Clean build artifacts (preserve caches)
+        run: |
+          # Only clean build outputs, NOT dependency caches
+          rm -rf asg_client/app/build asg_client/.gradle asg_client/StreamPackLite
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -45,21 +98,197 @@ jobs:
           git checkout working
 
       - name: Cache Gradle dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: asg-gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('asg_client/**/*.gradle*', 'asg_client/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
+            asg-gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+            asg-gradle-${{ runner.os }}-
 
-      - name: Build Debug APK
+      - name: Build Release APK
+        id: gradle-build
         working-directory: ./asg_client
-        run: ./gradlew assembleDebug
+        run: ./gradlew assembleRelease --build-cache --parallel
+        continue-on-error: true
 
-      - name: Upload Debug APK
+      - name: Retry build with clean cache (if first attempt failed)
+        if: steps.gradle-build.outcome == 'failure'
+        working-directory: ./asg_client
+        run: |
+          echo "First build failed, cleaning Gradle cache and retrying..."
+          # Stop Gradle daemons first to release file locks
+          ./gradlew --stop || true
+          rm -rf ~/.gradle/caches ~/.gradle/wrapper || true
+          ./gradlew assembleRelease --build-cache --parallel
+
+      - name: Fail if both builds failed
+        if: steps.gradle-build.outcome == 'failure'
+        run: |
+          # Check if retry succeeded by looking for the APK
+          if [ ! -f "asg_client/app/build/outputs/apk/release/app-release.apk" ]; then
+            echo "Both build attempts failed"
+            exit 1
+          fi
+
+      - name: Upload Release APK (artifact)
         uses: actions/upload-artifact@v4
         with:
-          name: asg-client-debug
-          path: asg_client/app/build/outputs/apk/debug/app-debug.apk
+          name: asg-client-release
+          path: asg_client/app/build/outputs/apk/release/app-release.apk
+
+      - name: Upload APK to pr-builds release
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = require('path');
+
+            const prNumber = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const apkName = `asg-pr-${prNumber}-${sha}.apk`;
+            const apkPath = 'asg_client/app/build/outputs/apk/release/app-release.apk';
+
+            // Get the pr-builds release
+            const release = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: 'pr-builds'
+            });
+
+            // Delete existing asset with same name if it exists
+            for (const asset of release.data.assets) {
+              if (asset.name === apkName) {
+                console.log(`Deleting existing asset: ${asset.name}`);
+                await github.rest.repos.deleteReleaseAsset({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  asset_id: asset.id
+                });
+                break;
+              }
+            }
+
+            // Read the APK file
+            const apkData = fs.readFileSync(apkPath);
+
+            // Upload the APK
+            console.log(`Uploading ${apkName} (${apkData.length} bytes)...`);
+            await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.data.id,
+              name: apkName,
+              data: apkData
+            });
+
+            console.log(`Successfully uploaded ${apkName}`);
+
+      - name: Cleanup old release assets
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: 'pr-builds'
+              });
+
+              for (const asset of release.data.assets) {
+                const createdAt = new Date(asset.created_at);
+                if (createdAt < sevenDaysAgo) {
+                  console.log(`Deleting old asset: ${asset.name} (created ${asset.created_at})`);
+                  await github.rest.repos.deleteReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    asset_id: asset.id
+                  });
+                }
+              }
+            } catch (error) {
+              console.log('Cleanup skipped:', error.message);
+            }
+
+      - name: Update PR comment - Build succeeded
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- pr-review-helper -->';
+            const comment = comments.data.find(c => c.body.includes(marker));
+            if (!comment) return;
+
+            const prNumber = context.payload.pull_request.number;
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const apkName = `asg-pr-${prNumber}-${sha}.apk`;
+            const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds/${apkName}`;
+
+            const buildStatus = `### 🕶️ ASG Client Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download ASG APK**](${downloadUrl})`;
+
+            const newBody = comment.body.replace(
+              /<!-- asg-build-status -->[\s\S]*?<!-- \/asg-build-status -->/,
+              `<!-- asg-build-status -->\n${buildStatus}\n<!-- /asg-build-status -->`
+            );
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: newBody
+            });
+
+      - name: Update PR comment - Build failed
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const marker = '<!-- pr-review-helper -->';
+            const comment = comments.data.find(c => c.body.includes(marker));
+            if (!comment) return;
+
+            const sha = context.payload.pull_request.head.sha.substring(0, 7);
+            const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+            // Check if there was a previous working build
+            const previousDownloadMatch = comment.body.match(/\[📥 \*\*Download ASG APK\*\*\]\((https:\/\/github\.com[^)]+\.apk)\)/);
+            const previousShaMatch = comment.body.match(/🕶️ ASG Client[\s\S]*?✅ \*\*Ready to test!\*\* \(commit `([a-f0-9]+)`\)/)
+                                  || comment.body.match(/📦 \*\*Previous build:\*\* \(commit `([a-f0-9]+)`\)/);
+
+            let buildStatus = `### 🕶️ ASG Client Build\n❌ **Build failed** (commit \`${sha}\`) - [View logs](${runUrl})`;
+
+            if (previousDownloadMatch && previousShaMatch && previousShaMatch[1] !== sha) {
+              buildStatus += `\n\n📦 **Previous build:** (commit \`${previousShaMatch[1]}\`) - [📥 **Download ASG APK**](${previousDownloadMatch[1]})`;
+            }
+
+            const newBody = comment.body.replace(
+              /<!-- asg-build-status -->[\s\S]*?<!-- \/asg-build-status -->/,
+              `<!-- asg-build-status -->\n${buildStatus}\n<!-- /asg-build-status -->`
+            );
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: newBody
+            });

--- a/.github/workflows/mentraos-manager-android-build.yml
+++ b/.github/workflows/mentraos-manager-android-build.yml
@@ -41,7 +41,7 @@ jobs:
             const existingDownloadMatch = comment.body.match(/\[📥 \*\*Download APK\*\*\]\((https:\/\/github\.com[^)]+\.apk)\)/);
             const existingShaMatch = comment.body.match(/✅ \*\*Ready to test!\*\* \(commit `([a-f0-9]+)`\)/);
 
-            let buildStatus = `### 📱 Android Build\n⏳ **Building...** (commit \`${sha}\`)`;
+            let buildStatus = `### 📱 Mobile App Build\n⏳ **Building...** (commit \`${sha}\`)`;
 
             // If there's a previous working build, show it
             if (existingDownloadMatch && existingShaMatch && existingShaMatch[1] !== sha) {
@@ -180,7 +180,7 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
             const sha = context.payload.pull_request.head.sha.substring(0, 7);
-            const apkName = `pr-${prNumber}-${sha}.apk`;
+            const apkName = `mobile-pr-${prNumber}-${sha}.apk`;
             const apkPath = 'mobile/android/app/build/outputs/apk/release/app-release.apk';
 
             // Get the pr-builds release
@@ -265,10 +265,10 @@ jobs:
 
             const prNumber = context.payload.pull_request.number;
             const sha = context.payload.pull_request.head.sha.substring(0, 7);
-            const apkName = `pr-${prNumber}-${sha}.apk`;
+            const apkName = `mobile-pr-${prNumber}-${sha}.apk`;
             const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/pr-builds/${apkName}`;
 
-            const buildStatus = `### 📱 Android Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download APK**](${downloadUrl})`;
+            const buildStatus = `### 📱 Mobile App Build\n✅ **Ready to test!** (commit \`${sha}\`)\n\n[📥 **Download APK**](${downloadUrl})`;
 
             const newBody = comment.body.replace(
               /<!-- android-build-status -->[\s\S]*?<!-- \/android-build-status -->/,
@@ -305,7 +305,7 @@ jobs:
             const previousShaMatch = comment.body.match(/✅ \*\*Ready to test!\*\* \(commit `([a-f0-9]+)`\)/)
                                   || comment.body.match(/📦 \*\*Previous build:\*\* \(commit `([a-f0-9]+)`\)/);
 
-            let buildStatus = `### 📱 Android Build\n❌ **Build failed** (commit \`${sha}\`) - [View logs](${runUrl})`;
+            let buildStatus = `### 📱 Mobile App Build\n❌ **Build failed** (commit \`${sha}\`) - [View logs](${runUrl})`;
 
             if (previousDownloadMatch && previousShaMatch && previousShaMatch[1] !== sha) {
               buildStatus += `\n\n📦 **Previous build:** (commit \`${previousShaMatch[1]}\`) - [📥 **Download APK**](${previousDownloadMatch[1]})`;

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,311 @@
+name: Nightly Builds
+
+on:
+  schedule:
+    # Run at 2am PT (10am UTC) every day
+    - cron: "0 10 * * *"
+  workflow_dispatch:
+    inputs:
+      skip_cleanup:
+        description: "Skip cleanup of old builds"
+        required: false
+        default: "false"
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  build-mobile:
+    name: Build Mobile App
+    runs-on: self-hosted
+
+    steps:
+      - name: Get cache week number
+        id: cache-week
+        run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
+
+      - name: Clean build artifacts (preserve caches)
+        run: |
+          rm -rf mobile/android/build mobile/android/app/build mobile/android/.gradle
+          rm -rf mobile/node_modules
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('mobile/android/**/*.gradle*', 'mobile/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+            gradle-${{ runner.os }}-
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('mobile/bun.lockb') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        working-directory: ./mobile
+        run: bun install
+
+      - name: Setup environment
+        working-directory: ./mobile
+        run: |
+          cp .env.example .env
+
+      - name: Run Expo prebuild
+        working-directory: ./mobile
+        run: bun expo prebuild --platform android
+
+      - name: Fix React Native symlinks
+        working-directory: ./mobile
+        run: |
+          if [ -f "./fix-react-native-symlinks.sh" ]; then
+            chmod +x ./fix-react-native-symlinks.sh
+            ./fix-react-native-symlinks.sh
+          fi
+
+      - name: Build Android Release APK
+        working-directory: ./mobile/android
+        run: ./gradlew assembleRelease --build-cache --parallel
+        env:
+          SENTRY_DISABLE_AUTO_UPLOAD: "true"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mobile-nightly
+          path: mobile/android/app/build/outputs/apk/release/app-release.apk
+
+  build-asg:
+    name: Build ASG Client
+    runs-on: self-hosted
+
+    steps:
+      - name: Get cache week number
+        id: cache-week
+        run: echo "week=$(date +%Y-%U)" >> $GITHUB_OUTPUT
+
+      - name: Clean build artifacts (preserve caches)
+        run: |
+          rm -rf asg_client/app/build asg_client/.gradle asg_client/StreamPackLite
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+
+      - name: Setup environment
+        working-directory: ./asg_client
+        run: |
+          cp .env.example .env
+
+      - name: Clone StreamPackLite dependency
+        working-directory: ./asg_client
+        run: |
+          git clone https://github.com/Mentra-Community/StreamPackLite.git
+          cd StreamPackLite
+          git checkout working
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: asg-gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-${{ hashFiles('asg_client/**/*.gradle*', 'asg_client/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            asg-gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
+            asg-gradle-${{ runner.os }}-
+
+      - name: Build Release APK
+        working-directory: ./asg_client
+        run: ./gradlew assembleRelease --build-cache --parallel
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: asg-nightly
+          path: asg_client/app/build/outputs/apk/release/app-release.apk
+
+  upload-releases:
+    name: Upload to Releases
+    needs: [build-mobile, build-asg]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download mobile artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: mobile-nightly
+          path: ./mobile-apk
+
+      - name: Download ASG artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: asg-nightly
+          path: ./asg-apk
+
+      - name: Get build info
+        id: build-info
+        run: |
+          echo "date=$(date +%Y-%m-%d)" >> $GITHUB_OUTPUT
+          echo "sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+      - name: Upload APKs to nightly-builds release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const date = '${{ steps.build-info.outputs.date }}';
+            const sha = '${{ steps.build-info.outputs.sha }}';
+
+            // Get or create the nightly-builds release
+            let release;
+            try {
+              release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: 'nightly-builds'
+              });
+            } catch (error) {
+              if (error.status === 404) {
+                // Create the release if it doesn't exist
+                release = await github.rest.repos.createRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag_name: 'nightly-builds',
+                  name: 'Nightly Builds',
+                  body: `Automated nightly builds from the \`dev\` branch.\n\n**Latest builds:** ${date} (${sha})\n\n## Download Links\n\n- [Mobile App (latest)](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/nightly-builds/mobile-latest.apk)\n- [ASG Client (latest)](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/nightly-builds/asg-latest.apk)\n\n---\n\n*Builds older than 7 days are automatically cleaned up.*`,
+                  prerelease: true,
+                  draft: false
+                });
+              } else {
+                throw error;
+              }
+            }
+
+            const releaseId = release.data.id;
+
+            // Files to upload
+            const uploads = [
+              { path: './mobile-apk/app-release.apk', latestName: 'mobile-latest.apk', datedName: `mobile-nightly-${date}-${sha}.apk` },
+              { path: './asg-apk/app-release.apk', latestName: 'asg-latest.apk', datedName: `asg-nightly-${date}-${sha}.apk` }
+            ];
+
+            for (const upload of uploads) {
+              const apkData = fs.readFileSync(upload.path);
+
+              // Delete existing -latest.apk if it exists
+              for (const asset of release.data.assets) {
+                if (asset.name === upload.latestName) {
+                  console.log(`Deleting existing ${upload.latestName}`);
+                  await github.rest.repos.deleteReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    asset_id: asset.id
+                  });
+                  break;
+                }
+              }
+
+              // Upload the -latest.apk
+              console.log(`Uploading ${upload.latestName} (${apkData.length} bytes)...`);
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+                name: upload.latestName,
+                data: apkData
+              });
+
+              // Also upload dated version (for history)
+              console.log(`Uploading ${upload.datedName} (${apkData.length} bytes)...`);
+              await github.rest.repos.uploadReleaseAsset({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                release_id: releaseId,
+                name: upload.datedName,
+                data: apkData
+              });
+            }
+
+            // Update release body with latest build info
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: releaseId,
+              body: `Automated nightly builds from the \`dev\` branch.\n\n**Latest builds:** ${date} (${sha})\n\n## Download Links\n\n- [Mobile App (latest)](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/nightly-builds/mobile-latest.apk)\n- [ASG Client (latest)](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/download/nightly-builds/asg-latest.apk)\n\n---\n\n*Builds older than 7 days are automatically cleaned up.*`
+            });
+
+            console.log('Successfully uploaded all APKs');
+
+      - name: Cleanup old nightly builds
+        if: ${{ github.event.inputs.skip_cleanup != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag: 'nightly-builds'
+              });
+
+              for (const asset of release.data.assets) {
+                // Skip -latest.apk files
+                if (asset.name.endsWith('-latest.apk')) continue;
+
+                const createdAt = new Date(asset.created_at);
+                if (createdAt < sevenDaysAgo) {
+                  console.log(`Deleting old asset: ${asset.name} (created ${asset.created_at})`);
+                  await github.rest.repos.deleteReleaseAsset({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    asset_id: asset.id
+                  });
+                }
+              }
+            } catch (error) {
+              console.log('Cleanup skipped:', error.message);
+            }

--- a/.github/workflows/pr-checkout-helper.yml
+++ b/.github/workflows/pr-checkout-helper.yml
@@ -39,7 +39,7 @@ jobs:
             }
 
             // Full comment with markers for build status updates
-            checkoutInstructions = `<!-- pr-review-helper -->\n## 📋 PR Review Helper\n\n<!-- android-build-status -->\n### 📱 Android Build\n⏳ _Waiting for build..._\n<!-- /android-build-status -->\n\n---\n### 🔀 Test Locally\n${checkoutSection}`;
+            checkoutInstructions = `<!-- pr-review-helper -->\n## 📋 PR Review Helper\n\n<!-- android-build-status -->\n### 📱 Mobile App Build\n⏳ _Waiting for build..._\n<!-- /android-build-status -->\n\n<!-- asg-build-status -->\n### 🕶️ ASG Client Build\n⏳ _Waiting for build..._\n<!-- /asg-build-status -->\n\n---\n### 🔀 Test Locally\n${checkoutSection}`;
 
             await github.rest.issues.createComment({
               issue_number: prNumber,

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@
   </a>
 </div>
 
+<div align="center">
+  <h4>Nightly Builds</h4>
+  <p>
+    <a href="https://github.com/Mentra-Community/MentraOS/releases/download/nightly-builds/mobile-latest.apk">
+      <img src="https://img.shields.io/badge/Mobile_App-Download_APK-blue?style=for-the-badge&logo=android" alt="Download Mobile APK" />
+    </a>
+    <a href="https://github.com/Mentra-Community/MentraOS/releases/download/nightly-builds/asg-latest.apk">
+      <img src="https://img.shields.io/badge/ASG_Client-Download_APK-green?style=for-the-badge&logo=android" alt="Download ASG APK" />
+    </a>
+  </p>
+</div>
+
 ## Supported Smart Glasses
 
 Works with Even Realities G1, Mentra Mach 1, Mentra Live. See [smart glasses compatibility list here](./glasses-compatibility.md).

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -25,8 +25,10 @@ def asgStorePassword = project.hasProperty("ASG_STORE_PASSWORD") ? project.prope
 def asgKeyPassword = project.hasProperty("ASG_KEY_PASSWORD") ? project.property("ASG_KEY_PASSWORD") : ""
 def asgKeyAlias = project.hasProperty("ASG_KEY_ALIAS") ? project.property("ASG_KEY_ALIAS") : "asg"
 
-// Determine which signing config will be used
-def productionKeystoreFile = file("credentials/asg-keystore.jks")
+// Find keystore: check shared location first, then local
+def sharedKeystoreFile = new File(System.getProperty("user.home"), ".mentra/credentials/asg-keystore.jks")
+def localKeystoreFile = file("../credentials/asg-keystore.jks")
+def productionKeystoreFile = sharedKeystoreFile.exists() ? sharedKeystoreFile : localKeystoreFile
 def useReleaseKey = productionKeystoreFile.exists() && asgStorePassword ? true : false
 
 // Print signing configuration status during build
@@ -43,7 +45,7 @@ gradle.taskGraph.whenReady { taskGraph ->
         if (isReleaseBuild) {
             if (useReleaseKey) {
                 println "║  ✅ RELEASE BUILD: Using PRODUCTION signing key               ║"
-                println "║     Keystore: credentials/asg-keystore.jks                    ║"
+                println "║     Keystore: ${productionKeystoreFile.absolutePath.take(50).padRight(50)}║"
                 println "║     Key Alias: ${asgKeyAlias.padRight(48)}║"
             } else {
                 println "║  ⚠️  RELEASE BUILD: Using DEBUG signing key (FALLBACK!)       ║"
@@ -68,7 +70,7 @@ gradle.taskGraph.whenReady { taskGraph ->
         if (isDebugBuild && !isReleaseBuild) {
             if (useReleaseKey) {
                 println "║  🔧 DEBUG BUILD: Using PRODUCTION signing key                 ║"
-                println "║     Keystore: credentials/asg-keystore.jks                    ║"
+                println "║     Keystore: ${productionKeystoreFile.absolutePath.take(50).padRight(50)}║"
                 println "║     Key Alias: ${asgKeyAlias.padRight(48)}║"
                 println "║     ⚠️  Same signature as release builds                      ║"
             } else {
@@ -103,9 +105,8 @@ android {
         debug {
             // Use production keystore for debug builds if available (maintains app identity)
             // Otherwise fall back to default debug keystore
-            def productionKeystore = file("../credentials/asg-keystore.jks")
-            if (productionKeystore.exists() && asgStorePassword) {
-                storeFile productionKeystore
+            if (productionKeystoreFile.exists() && asgStorePassword) {
+                storeFile productionKeystoreFile
                 storePassword = asgStorePassword
                 keyAlias = asgKeyAlias
                 keyPassword = asgKeyPassword
@@ -121,9 +122,8 @@ android {
         release {
             // Use production keystore for release builds if available
             // Otherwise fall back to debug keystore (with warning)
-            def productionKeystore = file("../credentials/asg-keystore.jks")
-            if (productionKeystore.exists() && asgStorePassword) {
-                storeFile productionKeystore
+            if (productionKeystoreFile.exists() && asgStorePassword) {
+                storeFile productionKeystoreFile
                 storePassword = asgStorePassword
                 keyAlias = asgKeyAlias
                 keyPassword = asgKeyPassword


### PR DESCRIPTION
- Add nightly-builds.yml workflow (2am PT daily from dev branch)
  - Builds both mobile and ASG client
  - Uploads mobile-latest.apk and asg-latest.apk with stable URLs
  - Keeps dated archives for 7 days

- Update ASG client workflow for PR builds
  - Switch from debug to release builds
  - Upload APKs to pr-builds release as asg-pr-{n}-{sha}.apk
  - Add PR comment updates with download links

- Rename mobile PR builds to mobile-pr-{n}-{sha}.apk

- Add shared keystore location support (~/.mentra/credentials/)
  - Mobile: via Expo plugin (android.ts)
  - ASG: via build.gradle
  - Falls back to repo-local credentials/ folder

- Update README with nightly build download badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)