### PR TITLE
[ignore this one?] fix for the photo time outs... [SDK] for MINI apps

### DIFF
--- a/cloud/packages/sdk/src/app/server/index.ts
+++ b/cloud/packages/sdk/src/app/server/index.ts
@@ -4,12 +4,12 @@
  * Creates and manages a server for Apps in the MentraOS ecosystem.
  * Handles webhook endpoints, session management, and cleanup.
  */
-import express, {type Express} from "express"
-import path from "path"
-import fs from "fs"
-import {AppSession} from "../session/index"
-import {createAuthMiddleware} from "../webview"
-import {newSDKUpdate} from "../../constants/log-messages/updates"
+import express, { type Express } from "express";
+import path from "path";
+import fs from "fs";
+import { AppSession } from "../session/index";
+import { createAuthMiddleware } from "../webview";
+import { newSDKUpdate } from "../../constants/log-messages/updates";
 
 import {
   WebhookRequest,
@@ -18,13 +18,14 @@ import {
   StopWebhookRequest,
   ToolCall,
   WebhookRequestType,
-} from "../../types"
+  PhotoData,
+} from "../../types";
 
-import {Logger} from "pino"
-import {logger as rootLogger} from "../../logging/logger"
-import axios from "axios"
+import { Logger } from "pino";
+import { logger as rootLogger } from "../../logging/logger";
+import axios from "axios";
 
-export const GIVE_APP_CONTROL_OF_TOOL_RESPONSE: string = "GIVE_APP_CONTROL_OF_TOOL_RESPONSE"
+export const GIVE_APP_CONTROL_OF_TOOL_RESPONSE: string = "GIVE_APP_CONTROL_OF_TOOL_RESPONSE";
 
 /**
  * 🔧 Configuration options for App Server
@@ -41,32 +42,32 @@ export const GIVE_APP_CONTROL_OF_TOOL_RESPONSE: string = "GIVE_APP_CONTROL_OF_TO
  */
 export interface AppServerConfig {
   /** 📦 Unique identifier for your App (e.g., 'org.company.appname') must match what you specified at https://console.mentra.glass */
-  packageName: string
+  packageName: string;
   /** 🔑 API key for authentication with MentraOS Cloud */
-  apiKey: string
+  apiKey: string;
   /** 🌐 Port number for the server (default: 7010) */
-  port?: number
+  port?: number;
 
   /** Cloud API URL (default: 'api.mentra.glass') */
-  cloudApiUrl?: string
+  cloudApiUrl?: string;
 
   /** 🛣️ [DEPRECATED] do not set: The SDK will automatically expose an endpoint at '/webhook' */
-  webhookPath?: string
+  webhookPath?: string;
   /**
    * 📂 Directory for serving static files (e.g., images, logos)
    * Set to false to disable static file serving
    */
-  publicDir?: string | false
+  publicDir?: string | false;
 
   /** ❤️ Enable health check endpoint at /health (default: true) */
-  healthCheck?: boolean
+  healthCheck?: boolean;
   /**
    * 🔐 Secret key used to sign session cookies
    * This must be a strong, unique secret
    */
-  cookieSecret?: string
+  cookieSecret?: string;
   /** App instructions string shown to the user */
-  appInstructions?: string
+  appInstructions?: string;
 }
 
 /**
@@ -99,19 +100,32 @@ export interface AppServerConfig {
  * await server.start();
  * ```
  */
+/** Registry entry for photo requests that persists across session reconnections */
+interface PhotoRequestRegistryEntry {
+  userId: string;
+  createdAt: number;
+  resolve: (photoData: PhotoData) => void;
+  reject: (reason: string) => void;
+}
+
 export class AppServer {
   /** Express app instance */
-  private app: Express
+  private app: Express;
   /** Map of active user sessions by sessionId */
-  private activeSessions = new Map<string, AppSession>()
+  private activeSessions = new Map<string, AppSession>();
   /** Map of active user sessions by userId */
-  private activeSessionsByUserId = new Map<string, AppSession>()
+  private activeSessionsByUserId = new Map<string, AppSession>();
   /** Array of cleanup handlers to run on shutdown */
-  private cleanupHandlers: Array<() => void> = []
+  private cleanupHandlers: Array<() => void> = [];
   /** App instructions string shown to the user */
-  private appInstructions: string | null = null
+  private appInstructions: string | null = null;
+  /**
+   * Registry for photo requests that persists across session lifecycle.
+   * This fixes race conditions where sessions reconnect during photo capture.
+   */
+  private photoRequestRegistry = new Map<string, PhotoRequestRegistryEntry>();
 
-  public readonly logger: Logger
+  public readonly logger: Logger;
 
   constructor(private config: AppServerConfig) {
     // Set defaults and merge with provided config
@@ -121,22 +135,22 @@ export class AppServer {
       publicDir: false,
       healthCheck: true,
       ...config,
-    }
+    };
 
     this.logger = rootLogger.child({
       app: this.config.packageName,
       packageName: this.config.packageName,
       service: "app-server",
-    })
+    });
 
     // Initialize Express app
-    this.app = express()
-    this.app.use(express.json())
+    this.app = express();
+    this.app.use(express.json());
 
-    const cookieParser = require("cookie-parser")
+    const cookieParser = require("cookie-parser");
     this.app.use(
       cookieParser(this.config.cookieSecret || `AOS_${this.config.packageName}_${this.config.apiKey.substring(0, 8)}`),
-    )
+    );
 
     // Apply authentication middleware
     this.app.use(
@@ -144,30 +158,30 @@ export class AppServer {
         apiKey: this.config.apiKey,
         packageName: this.config.packageName,
         getAppSessionForUser: (userId: string) => {
-          return this.activeSessionsByUserId.get(userId) || null
+          return this.activeSessionsByUserId.get(userId) || null;
         },
         cookieSecret:
           this.config.cookieSecret || `AOS_${this.config.packageName}_${this.config.apiKey.substring(0, 8)}`,
       }) as any,
-    )
+    );
 
-    this.appInstructions = (config as any).appInstructions || null
+    this.appInstructions = (config as any).appInstructions || null;
 
     // Setup server features
-    this.setupWebhook()
-    this.setupSettingsEndpoint()
-    this.setupHealthCheck()
-    this.setupToolCallEndpoint()
-    this.setupPhotoUploadEndpoint()
-    this.setupMentraAuthRedirect()
-    this.setupPublicDir()
-    this.setupShutdown()
+    this.setupWebhook();
+    this.setupSettingsEndpoint();
+    this.setupHealthCheck();
+    this.setupToolCallEndpoint();
+    this.setupPhotoUploadEndpoint();
+    this.setupMentraAuthRedirect();
+    this.setupPublicDir();
+    this.setupShutdown();
   }
 
   // Expose Express app for custom routes.
   // This is useful for adding custom API routes or middleware.
   public getExpressApp(): Express {
-    return this.app
+    return this.app;
   }
 
   /**
@@ -180,9 +194,9 @@ export class AppServer {
    * @param userId - User's identifier
    */
   protected async onSession(session: AppSession, sessionId: string, userId: string): Promise<void> {
-    this.logger.info(`🚀 Starting new session handling for session ${sessionId} and user ${userId}`)
+    this.logger.info(`🚀 Starting new session handling for session ${sessionId} and user ${userId}`);
     // Core session handling logic (onboarding removed)
-    this.logger.info(`✅ Session handling completed for session ${sessionId} and user ${userId}`)
+    this.logger.info(`✅ Session handling completed for session ${sessionId} and user ${userId}`);
   }
 
   /**
@@ -195,14 +209,14 @@ export class AppServer {
    * @param reason - Reason for stopping
    */
   protected async onStop(sessionId: string, userId: string, reason: string): Promise<void> {
-    this.logger.debug(`Session ${sessionId} stopped for user ${userId}. Reason: ${reason}`)
+    this.logger.debug(`Session ${sessionId} stopped for user ${userId}. Reason: ${reason}`);
 
     // Default implementation: close the session if it exists
-    const session = this.activeSessions.get(sessionId)
+    const session = this.activeSessions.get(sessionId);
     if (session) {
-      session.disconnect()
-      this.activeSessions.delete(sessionId)
-      this.activeSessionsByUserId.delete(userId)
+      session.disconnect();
+      this.activeSessions.delete(sessionId);
+      this.activeSessionsByUserId.delete(userId);
     }
   }
 
@@ -215,9 +229,9 @@ export class AppServer {
    * @returns Optional string response that will be sent back to MentraOS Cloud
    */
   protected async onToolCall(toolCall: ToolCall): Promise<string | undefined> {
-    this.logger.debug(`Tool call received: ${toolCall.toolId}`)
-    this.logger.debug(`Parameters: ${JSON.stringify(toolCall.toolParameters)}`)
-    return undefined
+    this.logger.debug(`Tool call received: ${toolCall.toolId}`);
+    this.logger.debug(`Parameters: ${JSON.stringify(toolCall.toolParameters)}`);
+    return undefined;
   }
 
   /**
@@ -229,60 +243,60 @@ export class AppServer {
   public start(): Promise<void> {
     return new Promise((resolve) => {
       this.app.listen(this.config.port, async () => {
-        this.logger.info(`🎯 App server running at http://localhost:${this.config.port}`)
+        this.logger.info(`🎯 App server running at http://localhost:${this.config.port}`);
         if (this.config.publicDir) {
-          this.logger.info(`📂 Serving static files from ${this.config.publicDir}`)
+          this.logger.info(`📂 Serving static files from ${this.config.publicDir}`);
         }
 
         // 🔑 Grab SDK version
         try {
           // Look for the actual installed @mentra/sdk package.json in node_modules
-          const sdkPkgPath = path.resolve(process.cwd(), "node_modules/@mentra/sdk/package.json")
+          const sdkPkgPath = path.resolve(process.cwd(), "node_modules/@mentra/sdk/package.json");
 
-          let currentVersion = "unknown"
+          let currentVersion = "unknown";
 
           if (fs.existsSync(sdkPkgPath)) {
-            const sdkPkg = JSON.parse(fs.readFileSync(sdkPkgPath, "utf-8"))
+            const sdkPkg = JSON.parse(fs.readFileSync(sdkPkgPath, "utf-8"));
 
             // Get the actual installed version
-            currentVersion = sdkPkg.version || "not-found" // located in the node module
+            currentVersion = sdkPkg.version || "not-found"; // located in the node module
           } else {
-            this.logger.debug({sdkPkgPath}, "No @mentra/sdk package.json found at path")
+            this.logger.debug({ sdkPkgPath }, "No @mentra/sdk package.json found at path");
           }
 
           // this.logger.debug(`Developer is using SDK version: ${currentVersion}`);
 
           // Fetch latest SDK version from the API endpoint
-          let latest: string | null = null
+          let latest: string | null = null;
           try {
-            const cloudHost = "api.mentra.glass"
+            const cloudHost = "api.mentra.glass";
             const response = await axios.get(
               `https://${cloudHost}/api/sdk/version`,
-              {timeout: 3000}, // 3 second timeout
-            )
+              { timeout: 3000 }, // 3 second timeout
+            );
             if (response.data && response.data.success && response.data.data) {
-              latest = response.data.data.latest
+              latest = response.data.data.latest;
             }
           } catch {
             this.logger.debug(
               "Failed to fetch latest SDK version - skipping version check (offline or API unavailable)",
-            )
+            );
           }
 
           if (currentVersion === "not-found") {
             this.logger.warn(
               `⚠️ @mentra/sdk not found in your project dependencies. Please install it with: npm install @mentra/sdk`,
-            )
+            );
           } else if (latest && latest !== currentVersion) {
-            this.logger.warn(newSDKUpdate(latest))
+            this.logger.warn(newSDKUpdate(latest));
           }
         } catch (err) {
-          this.logger.error(err, "Version check failed")
+          this.logger.error(err, "Version check failed");
         }
 
-        resolve()
-      })
-    })
+        resolve();
+      });
+    });
   }
 
   /**
@@ -290,9 +304,9 @@ export class AppServer {
    * Gracefully shuts down the server and cleans up all sessions.
    */
   public async stop(): Promise<void> {
-    this.logger.info("\n🛑 Shutting down...")
-    await this.cleanup()
-    process.exit(0)
+    this.logger.info("\n🛑 Shutting down...");
+    await this.cleanup();
+    process.exit(0);
   }
 
   /**
@@ -305,15 +319,15 @@ export class AppServer {
    * @returns JWT token string
    */
   protected generateToken(userId: string, sessionId: string, secretKey: string): string {
-    const {createToken} = require("../token/utils")
+    const { createToken } = require("../token/utils");
     return createToken(
       {
         userId,
         packageName: this.config.packageName,
         sessionId,
       },
-      {secretKey},
-    )
+      { secretKey },
+    );
   }
 
   /**
@@ -323,7 +337,7 @@ export class AppServer {
    * @param handler - Function to call during cleanup
    */
   protected addCleanupHandler(handler: () => void): void {
-    this.cleanupHandlers.push(handler)
+    this.cleanupHandlers.push(handler);
   }
 
   /**
@@ -332,38 +346,38 @@ export class AppServer {
    */
   private setupWebhook(): void {
     if (!this.config.webhookPath) {
-      this.logger.error("❌ Webhook path not set")
-      throw new Error("Webhook path not set")
+      this.logger.error("❌ Webhook path not set");
+      throw new Error("Webhook path not set");
     }
 
     this.app.post(this.config.webhookPath, async (req, res) => {
       try {
-        const webhookRequest = req.body as WebhookRequest
+        const webhookRequest = req.body as WebhookRequest;
 
         // Handle session request
         if (webhookRequest.type === WebhookRequestType.SESSION_REQUEST) {
-          await this.handleSessionRequest(webhookRequest, res)
+          await this.handleSessionRequest(webhookRequest, res);
         }
         // Handle stop request
         else if (webhookRequest.type === WebhookRequestType.STOP_REQUEST) {
-          await this.handleStopRequest(webhookRequest, res)
+          await this.handleStopRequest(webhookRequest, res);
         }
         // Unknown webhook type
         else {
-          this.logger.error("❌ Unknown webhook request type")
+          this.logger.error("❌ Unknown webhook request type");
           res.status(400).json({
             status: "error",
             message: "Unknown webhook request type",
-          } as WebhookResponse)
+          } as WebhookResponse);
         }
       } catch (error) {
-        this.logger.error(error, "❌ Error handling webhook: " + (error as Error).message)
+        this.logger.error(error, "❌ Error handling webhook: " + (error as Error).message);
         res.status(500).json({
           status: "error",
           message: "Error handling webhook: " + (error as Error).message,
-        } as WebhookResponse)
+        } as WebhookResponse);
       }
-    })
+    });
   }
 
   /**
@@ -373,74 +387,77 @@ export class AppServer {
   private setupToolCallEndpoint(): void {
     this.app.post("/tool", async (req, res) => {
       try {
-        const toolCall = req.body as ToolCall
+        const toolCall = req.body as ToolCall;
         if (this.activeSessionsByUserId.has(toolCall.userId)) {
-          toolCall.activeSession = this.activeSessionsByUserId.get(toolCall.userId) || null
+          toolCall.activeSession = this.activeSessionsByUserId.get(toolCall.userId) || null;
         } else {
-          toolCall.activeSession = null
+          toolCall.activeSession = null;
         }
-        this.logger.info({body: req.body}, `🔧 Received tool call: ${toolCall.toolId}`)
+        this.logger.info({ body: req.body }, `🔧 Received tool call: ${toolCall.toolId}`);
         // Call the onToolCall handler and get the response
-        const response = await this.onToolCall(toolCall)
+        const response = await this.onToolCall(toolCall);
 
         // Send back the response if one was provided
         if (response !== undefined) {
-          res.json({status: "success", reply: response})
+          res.json({ status: "success", reply: response });
         } else {
-          res.json({status: "success", reply: null})
+          res.json({ status: "success", reply: null });
         }
       } catch (error) {
-        this.logger.error(error, "❌ Error handling tool call:")
+        this.logger.error(error, "❌ Error handling tool call:");
         res.status(500).json({
           status: "error",
           message: error instanceof Error ? error.message : "Unknown error occurred calling tool",
-        })
+        });
       }
-    })
+    });
     this.app.get("/tool", async (req, res) => {
-      res.json({status: "success", reply: "Hello, world!"})
-    })
+      res.json({ status: "success", reply: "Hello, world!" });
+    });
   }
 
   /**
    * Handle a session request webhook
    */
   private async handleSessionRequest(request: SessionWebhookRequest, res: express.Response): Promise<void> {
-    const {sessionId, userId, mentraOSWebsocketUrl, augmentOSWebsocketUrl} = request
-    this.logger.info({userId}, `🗣️ Received session request for user ${userId}, session ${sessionId}\n\n`)
+    const { sessionId, userId, mentraOSWebsocketUrl, augmentOSWebsocketUrl } = request;
+    this.logger.info({ userId }, `🗣️ Received session request for user ${userId}, session ${sessionId}\n\n`);
 
     // Check for existing session (user might be switching clouds)
     // If an existing session exists, we need to clean it up properly to avoid:
     // 1. Orphaned sessions with open WebSockets
     // 2. Cleanup handlers that corrupt the new session's map entries
     // See: cloud/issues/018-app-disconnect-resurrection
-    const existingSession = this.activeSessions.get(sessionId)
+    const existingSession = this.activeSessions.get(sessionId);
     if (existingSession) {
       this.logger.info(
-        {sessionId, userId},
+        { sessionId, userId },
         `🔄 Existing session found for ${sessionId} - sending OWNERSHIP_RELEASE and disconnecting before new connection`,
-      )
+      );
 
       try {
         // Send OWNERSHIP_RELEASE to tell the old cloud not to resurrect this app
         // The old cloud will mark the app as DORMANT instead of trying to restart it
-        await existingSession.releaseOwnership("switching_clouds")
+        await existingSession.releaseOwnership("switching_clouds");
       } catch (error) {
-        this.logger.warn({error, sessionId}, `⚠️ Failed to send OWNERSHIP_RELEASE to old session - continuing anyway`)
+        this.logger.warn(
+          { error, sessionId },
+          `⚠️ Failed to send OWNERSHIP_RELEASE to old session - continuing anyway`,
+        );
       }
 
       try {
         // Disconnect the old session explicitly
-        existingSession.disconnect()
+        existingSession.disconnect();
       } catch (error) {
-        this.logger.warn({error, sessionId}, `⚠️ Failed to disconnect old session - continuing anyway`)
+        this.logger.warn({ error, sessionId }, `⚠️ Failed to disconnect old session - continuing anyway`);
       }
 
       // Remove from maps immediately (don't wait for cleanup handler)
-      this.activeSessions.delete(sessionId)
-      this.activeSessionsByUserId.delete(userId)
+      this.activeSessions.delete(sessionId);
+      this.activeSessionsByUserId.delete(userId);
 
-      this.logger.info({sessionId, userId}, `✅ Old session cleaned up, proceeding with new connection`)
+      this.logger.info({ sessionId, userId }, `✅ Old session cleaned up, proceeding with new connection`);
     }
 
     // Create new App session
@@ -450,42 +467,42 @@ export class AppServer {
       mentraOSWebsocketUrl: mentraOSWebsocketUrl || augmentOSWebsocketUrl, // The websocket URL for the specific MentraOS server that this userSession is connecting to.
       appServer: this,
       userId,
-    })
+    });
 
     // Setup session event handlers
     const cleanupDisconnect = session.events.onDisconnected((info) => {
       // Handle different disconnect info formats (string or object)
       if (typeof info === "string") {
-        this.logger.info(`👋 Session ${sessionId} disconnected: ${info}`)
+        this.logger.info(`👋 Session ${sessionId} disconnected: ${info}`);
       } else {
         // It's an object with detailed disconnect information
         this.logger.info(
           `👋 Session ${sessionId} disconnected: ${info.message} (code: ${info.code}, reason: ${info.reason})`,
-        )
+        );
 
         // Check if this is a user session end event
         // This happens when the UserSession is disposed after 1 minute grace period
         if (info.sessionEnded === true) {
-          this.logger.info(`🛑 User session ended for session ${sessionId}, calling onStop`)
+          this.logger.info(`🛑 User session ended for session ${sessionId}, calling onStop`);
 
           // Call onStop with session end reason
           // This allows apps to clean up resources when the user's session ends
           this.onStop(sessionId, userId, "User session ended").catch((error) => {
-            this.logger.error(error, `❌ Error in onStop handler for session end:`)
-          })
+            this.logger.error(error, `❌ Error in onStop handler for session end:`);
+          });
         }
         // Check if this is a permanent disconnection after exhausted reconnection attempts
         else if (info.permanent === true) {
-          this.logger.info(`🛑 Permanent disconnection detected for session ${sessionId}, calling onStop`)
+          this.logger.info(`🛑 Permanent disconnection detected for session ${sessionId}, calling onStop`);
 
           // Keep track of the original session before removal
           // const session = this.activeSessions.get(sessionId);
-          const _session = this.activeSessions.get(sessionId)
+          const _session = this.activeSessions.get(sessionId);
 
           // Call onStop with a reconnection failure reason
           this.onStop(sessionId, userId, `Connection permanently lost: ${info.reason}`).catch((error) => {
-            this.logger.error(error, `❌ Error in onStop handler for permanent disconnection:`)
-          })
+            this.logger.error(error, `❌ Error in onStop handler for permanent disconnection:`);
+          });
         }
       }
 
@@ -498,34 +515,34 @@ export class AppServer {
       // By checking identity (===), we only delete if we're still the current session.
       // See: cloud/issues/018-app-disconnect-resurrection
       if (this.activeSessions.get(sessionId) === session) {
-        this.activeSessions.delete(sessionId)
+        this.activeSessions.delete(sessionId);
       } else {
-        this.logger.debug({sessionId}, `🔄 Session ${sessionId} cleanup skipped - a newer session has taken over`)
+        this.logger.debug({ sessionId }, `🔄 Session ${sessionId} cleanup skipped - a newer session has taken over`);
       }
       if (this.activeSessionsByUserId.get(userId) === session) {
-        this.activeSessionsByUserId.delete(userId)
+        this.activeSessionsByUserId.delete(userId);
       }
-    })
+    });
 
     const cleanupError = session.events.onError((error) => {
-      this.logger.error(error, `❌ [Session ${sessionId}] Error:`)
-    })
+      this.logger.error(error, `❌ [Session ${sessionId}] Error:`);
+    });
 
     // Start the session
     try {
-      await session.connect(sessionId)
-      this.activeSessions.set(sessionId, session)
-      this.activeSessionsByUserId.set(userId, session)
-      await this.onSession(session, sessionId, userId)
-      res.status(200).json({status: "success"} as WebhookResponse)
+      await session.connect(sessionId);
+      this.activeSessions.set(sessionId, session);
+      this.activeSessionsByUserId.set(userId, session);
+      await this.onSession(session, sessionId, userId);
+      res.status(200).json({ status: "success" } as WebhookResponse);
     } catch (error) {
-      this.logger.error(error, "❌ Failed to connect:")
-      cleanupDisconnect()
-      cleanupError()
+      this.logger.error(error, "❌ Failed to connect:");
+      cleanupDisconnect();
+      cleanupError();
       res.status(500).json({
         status: "error",
         message: "Failed to connect",
-      } as WebhookResponse)
+      } as WebhookResponse);
     }
   }
 
@@ -533,18 +550,18 @@ export class AppServer {
    * Handle a stop request webhook
    */
   private async handleStopRequest(request: StopWebhookRequest, res: express.Response): Promise<void> {
-    const {sessionId, userId, reason} = request
-    this.logger.info(`\n\n🛑 Received stop request for user ${userId}, session ${sessionId}, reason: ${reason}\n\n`)
+    const { sessionId, userId, reason } = request;
+    this.logger.info(`\n\n🛑 Received stop request for user ${userId}, session ${sessionId}, reason: ${reason}\n\n`);
 
     try {
-      await this.onStop(sessionId, userId, reason)
-      res.status(200).json({status: "success"} as WebhookResponse)
+      await this.onStop(sessionId, userId, reason);
+      res.status(200).json({ status: "success" } as WebhookResponse);
     } catch (error) {
-      this.logger.error(error, "❌ Error handling stop request:")
+      this.logger.error(error, "❌ Error handling stop request:");
       res.status(500).json({
         status: "error",
         message: "Failed to process stop request",
-      } as WebhookResponse)
+      } as WebhookResponse);
     }
   }
 
@@ -559,8 +576,8 @@ export class AppServer {
           status: "healthy",
           app: this.config.packageName,
           activeSessions: this.activeSessions.size,
-        })
-      })
+        });
+      });
     }
   }
 
@@ -571,58 +588,58 @@ export class AppServer {
   private setupSettingsEndpoint(): void {
     this.app.post("/settings", async (req, res) => {
       try {
-        const {userIdForSettings, settings} = req.body
+        const { userIdForSettings, settings } = req.body;
 
         if (!userIdForSettings || !Array.isArray(settings)) {
           return res.status(400).json({
             status: "error",
             message: "Missing userId or settings array in request body",
-          })
+          });
         }
 
-        this.logger.info(`⚙️ Received settings update for user ${userIdForSettings}`)
+        this.logger.info(`⚙️ Received settings update for user ${userIdForSettings}`);
 
         // Find all active sessions for this user
-        const userSessions: AppSession[] = []
+        const userSessions: AppSession[] = [];
 
         // Look through all active sessions
         this.activeSessions.forEach((session, _sessionId) => {
           // Check if the session has this userId (not directly accessible)
           // We're relying on the webhook handler to have already verified this
           if (session.userId === userIdForSettings) {
-            userSessions.push(session)
+            userSessions.push(session);
           }
-        })
+        });
 
         if (userSessions.length === 0) {
-          this.logger.warn(`⚠️ No active sessions found for user ${userIdForSettings}`)
+          this.logger.warn(`⚠️ No active sessions found for user ${userIdForSettings}`);
         } else {
-          this.logger.info(`🔄 Updating settings for ${userSessions.length} active sessions`)
+          this.logger.info(`🔄 Updating settings for ${userSessions.length} active sessions`);
         }
 
         // Update settings for all of the user's sessions
         for (const session of userSessions) {
-          session.updateSettingsForTesting(settings)
+          session.updateSettingsForTesting(settings);
         }
 
         // Allow subclasses to handle settings updates if they implement the method
         if (typeof (this as any).onSettingsUpdate === "function") {
-          await (this as any).onSettingsUpdate(userIdForSettings, settings)
+          await (this as any).onSettingsUpdate(userIdForSettings, settings);
         }
 
         res.json({
           status: "success",
           message: "Settings updated successfully",
           sessionsUpdated: userSessions.length,
-        })
+        });
       } catch (error) {
-        this.logger.error(error, "❌ Error handling settings update:")
+        this.logger.error(error, "❌ Error handling settings update:");
         res.status(500).json({
           status: "error",
           message: "Internal server error processing settings update",
-        })
+        });
       }
-    })
+    });
   }
 
   /**
@@ -631,9 +648,9 @@ export class AppServer {
    */
   private setupPublicDir(): void {
     if (this.config.publicDir) {
-      const publicPath = path.resolve(this.config.publicDir)
-      this.app.use(express.static(publicPath))
-      this.logger.info(`📂 Serving static files from ${publicPath}`)
+      const publicPath = path.resolve(this.config.publicDir);
+      this.app.use(express.static(publicPath));
+      this.logger.info(`📂 Serving static files from ${publicPath}`);
     }
   }
 
@@ -642,8 +659,8 @@ export class AppServer {
    * Registers process signal handlers for graceful shutdown.
    */
   private setupShutdown(): void {
-    process.on("SIGTERM", () => this.stop())
-    process.on("SIGINT", () => this.stop())
+    process.on("SIGTERM", () => this.stop());
+    process.on("SIGINT", () => this.stop());
   }
 
   /**
@@ -654,29 +671,29 @@ export class AppServer {
   private async cleanup(): Promise<void> {
     // Close all active sessions with ownership release for clean handoff
     for (const [sessionId, session] of this.activeSessions) {
-      this.logger.info(`👋 Closing session ${sessionId} with ownership release`)
+      this.logger.info(`👋 Closing session ${sessionId} with ownership release`);
       try {
         // Release ownership first, then disconnect
         // This tells the cloud not to resurrect this app
         await session.disconnect({
           releaseOwnership: true,
           reason: "clean_shutdown",
-        })
+        });
       } catch (error) {
-        this.logger.error(error, `Error during cleanup of session ${sessionId}`)
+        this.logger.error(error, `Error during cleanup of session ${sessionId}`);
         // Still try to disconnect even if release fails
         try {
-          await session.disconnect()
+          await session.disconnect();
         } catch {
           // Ignore secondary errors
         }
       }
     }
-    this.activeSessions.clear()
-    this.activeSessionsByUserId.clear()
+    this.activeSessions.clear();
+    this.activeSessionsByUserId.clear();
 
     // Run cleanup handlers
-    this.cleanupHandlers.forEach((handler) => handler())
+    this.cleanupHandlers.forEach((handler) => handler());
   }
 
   /**
@@ -684,7 +701,7 @@ export class AppServer {
    * Creates a /photo-upload endpoint for receiving photos directly from ASG glasses
    */
   private setupPhotoUploadEndpoint(): void {
-    const multer = require("multer")
+    const multer = require("multer");
 
     // Configure multer for handling multipart form data
     const upload = multer({
@@ -695,41 +712,83 @@ export class AppServer {
       fileFilter: (req: any, file: any, cb: any) => {
         // Accept image files only
         if (file.mimetype && file.mimetype.startsWith("image/")) {
-          cb(null, true)
+          cb(null, true);
         } else {
-          cb(new Error("Only image files are allowed"), false)
+          cb(new Error("Only image files are allowed"), false);
         }
       },
-    })
+    });
 
     this.app.post("/photo-upload", upload.single("photo"), async (req: any, res: any) => {
       try {
-        const {requestId, type, success, errorCode, errorMessage} = req.body
-        const photoFile = req.file
+        const { requestId, type, success, errorCode, errorMessage } = req.body;
+        const photoFile = req.file;
 
-        console.log("Received photo response: ", req.body)
+        console.log("Received photo response: ", req.body);
 
         this.logger.info(
-          {requestId, type, success, errorCode},
+          { requestId, type, success, errorCode },
           `📸 Received photo response: ${requestId} (type: ${type})`,
-        )
+        );
 
         if (!requestId) {
-          this.logger.error("No requestId in photo response")
+          this.logger.error("No requestId in photo response");
           return res.status(400).json({
             success: false,
             error: "No requestId provided",
-          })
+          });
         }
 
-        // Find the corresponding session that made this photo request
-        const session = this.findSessionByPhotoRequestId(requestId)
+        // First, check the AppServer-level registry (persists across session reconnections)
+        const registryEntry = this.photoRequestRegistry.get(requestId);
+
+        // Debug: Log registry state
+        this.logger.info(
+          {
+            requestId,
+            registrySize: this.photoRequestRegistry.size,
+            registryKeys: Array.from(this.photoRequestRegistry.keys()),
+            activeSessionsCount: this.activeSessions.size,
+            activeSessionsByUserIdCount: this.activeSessionsByUserId.size,
+          },
+          "📸 Photo upload received - checking registry and sessions",
+        );
+
+        // Find session - try registry first, then fall back to session-level lookup
+        let session: AppSession | undefined;
+
+        if (registryEntry) {
+          // Found in registry - get user's current session (may be different from original)
+          session = this.activeSessionsByUserId.get(registryEntry.userId);
+          this.logger.info(
+            { requestId, userId: registryEntry.userId, hasCurrentSession: !!session },
+            "📸 Found photo request in registry",
+          );
+        }
+
+        // Fall back to session-level lookup for backwards compatibility
         if (!session) {
-          this.logger.warn({requestId}, "No active session found for photo request")
+          session = this.findSessionByPhotoRequestId(requestId);
+          this.logger.info(
+            { requestId, foundViaSessionLookup: !!session },
+            "📸 Session lookup via pendingPhotoRequests",
+          );
+        }
+
+        if (!session) {
+          this.logger.warn(
+            {
+              requestId,
+              inRegistry: !!registryEntry,
+              registryKeys: Array.from(this.photoRequestRegistry.keys()),
+              activeSessionIds: Array.from(this.activeSessions.keys()),
+            },
+            "No active session found for photo request",
+          );
           return res.status(404).json({
             success: false,
             error: "No active session found for this photo request",
-          })
+          });
         }
 
         // Handle error response (no photo file, but has error info)
@@ -742,55 +801,68 @@ export class AppServer {
               code: errorCode || "UNKNOWN_ERROR",
               message: errorMessage || "Unknown error occurred",
             },
+          };
+
+          // If found via registry, reject the promise and clean up
+          if (registryEntry) {
+            registryEntry.reject(`${errorResponse.error.code}: ${errorResponse.error.message}`);
+            this.photoRequestRegistry.delete(requestId);
           }
 
-          // Deliver error to the session (logging happens in camera module)
-          session.camera.handlePhotoError(errorResponse)
+          // Also notify the session's camera module
+          session.camera.handlePhotoError(errorResponse);
 
           // Respond to ASG client
           return res.json({
             success: true,
             requestId,
             message: "Photo error received successfully",
-          })
+          });
         }
 
         // Handle successful photo upload
         if (!photoFile) {
-          this.logger.error({requestId}, "No photo file in successful upload")
+          this.logger.error({ requestId }, "No photo file in successful upload");
           return res.status(400).json({
             success: false,
             error: "No photo file provided for successful upload",
-          })
+          });
         }
 
         // Create photo data object
-        const photoData = {
+        const photoData: PhotoData = {
           buffer: photoFile.buffer,
           mimeType: photoFile.mimetype,
           filename: photoFile.originalname || "photo.jpg",
           requestId,
           size: photoFile.size,
           timestamp: new Date(),
+        };
+
+        // If found via registry, resolve the promise and clean up
+        if (registryEntry) {
+          registryEntry.resolve(photoData);
+          this.photoRequestRegistry.delete(requestId);
+          this.logger.info({ requestId }, "📸 Photo delivered via AppServer registry");
         }
 
-        // Deliver photo to the session
-        session.camera.handlePhotoReceived(photoData)
+        // Also notify the session's camera module for consistency
+        session.camera.handlePhotoReceived(photoData);
 
         // Respond to ASG client
         res.json({
           success: true,
           requestId,
           message: "Photo received successfully",
-        })
+        });
       } catch (error) {
-        this.logger.error(error, "❌ Error handling photo response")
+        this.logger.error(error, "❌ Error handling photo response");
         res.status(500).json({
           success: false,
           error: "Internal server error processing photo response",
-        })
+        });
       }
-    })
+    });
   }
 
   /**
@@ -800,12 +872,12 @@ export class AppServer {
   private setupMentraAuthRedirect(): void {
     this.app.get("/mentra-auth", (req, res) => {
       // Redirect to the account.mentra.glass OAuth flow with the app's package name
-      const authUrl = `https://account.mentra.glass/auth?packagename=${encodeURIComponent(this.config.packageName)}`
+      const authUrl = `https://account.mentra.glass/auth?packagename=${encodeURIComponent(this.config.packageName)}`;
 
-      this.logger.info(`🔐 Redirecting to MentraOS OAuth flow: ${authUrl}`)
+      this.logger.info(`🔐 Redirecting to MentraOS OAuth flow: ${authUrl}`);
 
-      res.redirect(302, authUrl)
-    })
+      res.redirect(302, authUrl);
+    });
   }
 
   /**
@@ -814,10 +886,56 @@ export class AppServer {
   private findSessionByPhotoRequestId(requestId: string): AppSession | undefined {
     for (const [_sessionId, session] of this.activeSessions) {
       if (session.camera.hasPhotoPendingRequest(requestId)) {
-        return session
+        return session;
       }
     }
-    return undefined
+    return undefined;
+  }
+
+  /**
+   * Register a photo request at the AppServer level.
+   * This persists the request across session reconnections so photos can be
+   * delivered even if the user's session disconnects and reconnects.
+   *
+   * @param requestId - Unique photo request ID
+   * @param userId - User ID making the request
+   * @param resolve - Promise resolve function to call with photo data
+   * @param reject - Promise reject function to call on error/timeout
+   */
+  public registerPhotoRequest(
+    requestId: string,
+    userId: string,
+    resolve: (photoData: PhotoData) => void,
+    reject: (reason: string) => void,
+  ): void {
+    this.photoRequestRegistry.set(requestId, {
+      userId,
+      createdAt: Date.now(),
+      resolve,
+      reject,
+    });
+
+    this.logger.info(
+      { requestId, userId, registrySize: this.photoRequestRegistry.size },
+      "📸 Photo request registered at AppServer level",
+    );
+
+    // Set 60-second timeout to prevent memory leaks
+    setTimeout(() => {
+      const entry = this.photoRequestRegistry.get(requestId);
+      if (entry) {
+        this.logger.warn({ requestId }, "📸 Photo request timed out at AppServer level");
+        entry.reject("Photo request timed out");
+        this.photoRequestRegistry.delete(requestId);
+      }
+    }, 60000);
+  }
+
+  /**
+   * Unregister a photo request (called when request is fulfilled or cancelled)
+   */
+  public unregisterPhotoRequest(requestId: string): void {
+    this.photoRequestRegistry.delete(requestId);
   }
 }
 
@@ -834,7 +952,7 @@ export class AppServer {
  * const config: AppServerConfig = { ... };
  * ```
  */
-export type TpaServerConfig = AppServerConfig
+export type TpaServerConfig = AppServerConfig;
 
 /**
  * @deprecated Use `AppServer` instead. `TpaServer` is deprecated and will be removed in a future version.
@@ -851,12 +969,12 @@ export type TpaServerConfig = AppServerConfig
  */
 export class TpaServer extends AppServer {
   constructor(config: TpaServerConfig) {
-    super(config)
+    super(config);
     // Emit a deprecation warning to help developers migrate
     console.warn(
       "⚠️  DEPRECATION WARNING: TpaServer is deprecated and will be removed in a future version. " +
         "Please use AppServer instead. " +
         'Simply replace "TpaServer" with "AppServer" in your code.',
-    )
+    );
   }
 }

--- a/cloud/packages/sdk/src/app/session/modules/camera.ts
+++ b/cloud/packages/sdk/src/app/session/modules/camera.ts
@@ -15,23 +15,23 @@ import {
   isRtmpStreamStatus,
   ManagedStreamStatus,
   StreamStatusCheckResponse,
-} from "../../../types"
-import {VideoConfig, AudioConfig, StreamConfig, StreamStatusHandler} from "../../../types/rtmp-stream"
-import {StreamType} from "../../../types/streams"
-import {Logger} from "pino"
-import {CameraManagedExtension, ManagedStreamOptions, ManagedStreamResult} from "./camera-managed-extension"
-import {cameraWarnLog} from "../../../utils/permissions-utils"
+} from "../../../types";
+import { VideoConfig, AudioConfig, StreamConfig, StreamStatusHandler } from "../../../types/rtmp-stream";
+import { StreamType } from "../../../types/streams";
+import { Logger } from "pino";
+import { CameraManagedExtension, ManagedStreamOptions, ManagedStreamResult } from "./camera-managed-extension";
+import { cameraWarnLog } from "../../../utils/permissions-utils";
 
 /**
  * Options for photo requests
  */
 export interface PhotoRequestOptions {
   /** Whether to save the photo to the device gallery */
-  saveToGallery?: boolean
+  saveToGallery?: boolean;
   /** Custom webhook URL to override the TPA's default webhookUrl */
-  customWebhookUrl?: string
+  customWebhookUrl?: string;
   /** Authentication token for custom webhook authentication */
-  authToken?: string
+  authToken?: string;
   /**
    * Desired photo size. All sizes are optimized for fast transfer.
    * - small: 640x480 (VGA) - ultra-fast transfers
@@ -39,9 +39,9 @@ export interface PhotoRequestOptions {
    * - large: 1920x1080 (1080p) - high quality
    * - full: native sensor resolution - maximum detail (slower transfer)
    */
-  size?: "small" | "medium" | "large" | "full"
+  size?: "small" | "medium" | "large" | "full";
   /** Image compression level for upload optimization. Defaults to "none". */
-  compress?: "none" | "medium" | "heavy"
+  compress?: "none" | "medium" | "heavy";
 }
 
 /**
@@ -49,13 +49,13 @@ export interface PhotoRequestOptions {
  */
 export interface RtmpStreamOptions {
   /** The RTMP URL to stream to (e.g., rtmp://server.example.com/live/stream-key) */
-  rtmpUrl: string
+  rtmpUrl: string;
   /** Optional video configuration settings */
-  video?: VideoConfig
+  video?: VideoConfig;
   /** Optional audio configuration settings */
-  audio?: AudioConfig
+  audio?: AudioConfig;
   /** Optional stream configuration settings */
-  stream?: StreamConfig
+  stream?: StreamConfig;
 }
 
 /**
@@ -86,28 +86,28 @@ export interface RtmpStreamOptions {
  * ```
  */
 export class CameraModule {
-  private session: any // Reference to AppSession
-  private packageName: string
-  private sessionId: string
-  private logger: Logger
+  private session: any; // Reference to AppSession
+  private packageName: string;
+  private sessionId: string;
+  private logger: Logger;
 
   // Photo functionality
   /** Map to store pending photo request promises */
   private pendingPhotoRequests = new Map<
     string,
     {
-      resolve: (value: PhotoData) => void
-      reject: (reason?: string) => void
+      resolve: (value: PhotoData) => void;
+      reject: (reason?: string) => void;
     }
-  >()
+  >();
 
   // Streaming functionality
-  private isStreaming: boolean = false
-  private currentStreamUrl?: string
-  private currentStreamState?: RtmpStreamStatus
+  private isStreaming: boolean = false;
+  private currentStreamUrl?: string;
+  private currentStreamState?: RtmpStreamStatus;
 
   // Managed streaming extension
-  private managedExtension: CameraManagedExtension
+  private managedExtension: CameraManagedExtension;
 
   /**
    * Create a new CameraModule
@@ -118,13 +118,13 @@ export class CameraModule {
    * @param logger - Logger instance for debugging
    */
   constructor(session: any, packageName: string, sessionId: string, logger?: Logger) {
-    this.session = session
-    this.packageName = packageName
-    this.sessionId = sessionId
-    this.logger = logger || (console as any)
+    this.session = session;
+    this.packageName = packageName;
+    this.sessionId = sessionId;
+    this.logger = logger || (console as any);
 
     // Initialize managed extension
-    this.managedExtension = new CameraManagedExtension(session, packageName, sessionId, this.logger)
+    this.managedExtension = new CameraManagedExtension(session, packageName, sessionId, this.logger);
   }
 
   // =====================================
@@ -151,16 +151,32 @@ export class CameraModule {
    */
   async requestPhoto(options?: PhotoRequestOptions): Promise<PhotoData> {
     return new Promise((resolve, reject) => {
-      const baseUrl = this.session?.getHttpsServerUrl?.() || ""
-      cameraWarnLog(baseUrl, this.packageName, "requestPhoto")
+      const baseUrl = this.session?.getHttpsServerUrl?.() || "";
+      cameraWarnLog(baseUrl, this.packageName, "requestPhoto");
       try {
-        console.log("DEBUG: requestPhoto options:", options)
+        console.log("DEBUG: requestPhoto options:", options);
 
         // Generate unique request ID
-        const requestId = `photo_req_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`
+        const requestId = `photo_req_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 
         // Store promise resolvers for when we get the response
-        this.pendingPhotoRequests.set(requestId, {resolve, reject})
+        this.pendingPhotoRequests.set(requestId, { resolve, reject });
+
+        // Also register with AppServer for persistence across session reconnections
+        // This fixes race conditions where session disconnects during photo capture
+        if (this.session?.appServer && this.session?.userId) {
+          this.logger.info({ requestId, userId: this.session.userId }, "📸 Registering photo request with AppServer");
+          this.session.appServer.registerPhotoRequest(requestId, this.session.userId, resolve, reject);
+        } else {
+          this.logger.warn(
+            {
+              requestId,
+              hasAppServer: !!this.session?.appServer,
+              hasUserId: !!this.session?.userId,
+            },
+            "📸 Cannot register with AppServer - missing appServer or userId",
+          );
+        }
 
         // Create photo request message
         const message: PhotoRequest = {
@@ -174,10 +190,10 @@ export class CameraModule {
           authToken: options?.authToken,
           size: options?.size || "medium",
           compress: options?.compress || "none",
-        }
+        };
 
         // Send request to cloud
-        this.session.sendMessage(message)
+        this.session.sendMessage(message);
 
         this.logger.info(
           {
@@ -187,14 +203,14 @@ export class CameraModule {
             hasAuthToken: !!options?.authToken,
           },
           `📸 Photo request sent`,
-        )
+        );
 
         // If using custom webhook URL, resolve immediately since photo will be uploaded directly to custom endpoint
         if (options?.customWebhookUrl) {
           this.logger.info(
-            {requestId, customWebhookUrl: options.customWebhookUrl},
+            { requestId, customWebhookUrl: options.customWebhookUrl },
             `📸 Using custom webhook URL - resolving promise immediately since photo will be uploaded directly to custom endpoint`,
-          )
+          );
 
           // Create a mock PhotoData object for custom webhook URLs
           const mockPhotoData: PhotoData = {
@@ -204,40 +220,40 @@ export class CameraModule {
             requestId,
             size: 0,
             timestamp: new Date(),
-          }
+          };
 
           // Resolve immediately and clean up
-          this.pendingPhotoRequests.delete(requestId)
-          resolve(mockPhotoData)
-          return
+          this.pendingPhotoRequests.delete(requestId);
+          resolve(mockPhotoData);
+          return;
         }
 
         // Set timeout to avoid hanging promises (only for non-custom webhook requests)
-        const timeoutMs = 30000 // 30 seconds
+        const timeoutMs = 30000; // 30 seconds
         if (this.session && this.session.resources) {
           // Use session's resource tracker for automatic cleanup
           this.session.resources.setTimeout(() => {
             if (this.pendingPhotoRequests.has(requestId)) {
-              this.pendingPhotoRequests.get(requestId)!.reject("Photo request timed out")
-              this.pendingPhotoRequests.delete(requestId)
-              this.logger.warn({requestId}, `📸 Photo request timed out`)
+              this.pendingPhotoRequests.get(requestId)!.reject("Photo request timed out");
+              this.pendingPhotoRequests.delete(requestId);
+              this.logger.warn({ requestId }, `📸 Photo request timed out`);
             }
-          }, timeoutMs)
+          }, timeoutMs);
         } else {
           // Fallback to regular setTimeout if session not available
           setTimeout(() => {
             if (this.pendingPhotoRequests.has(requestId)) {
-              this.pendingPhotoRequests.get(requestId)!.reject("Photo request timed out")
-              this.pendingPhotoRequests.delete(requestId)
-              this.logger.warn({requestId}, `📸 Photo request timed out`)
+              this.pendingPhotoRequests.get(requestId)!.reject("Photo request timed out");
+              this.pendingPhotoRequests.delete(requestId);
+              this.logger.warn({ requestId }, `📸 Photo request timed out`);
             }
-          }, timeoutMs)
+          }, timeoutMs);
         }
       } catch (error: unknown) {
-        const errorMessage = error instanceof Error ? error.message : String(error)
-        reject(`Failed to request photo: ${errorMessage}`)
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        reject(`Failed to request photo: ${errorMessage}`);
       }
-    })
+    });
   }
 
   /**
@@ -250,19 +266,22 @@ export class CameraModule {
    * @internal This method is used internally by AppSession
    */
   handlePhotoReceived(photoData: PhotoData): void {
-    const {requestId} = photoData
-    const pendingRequest = this.pendingPhotoRequests.get(requestId)
+    const { requestId } = photoData;
+    const pendingRequest = this.pendingPhotoRequests.get(requestId);
 
     if (pendingRequest) {
-      this.logger.info({requestId}, `📸 Photo received for request ${requestId}`)
+      this.logger.info({ requestId }, `📸 Photo received for request ${requestId}`);
 
       // Resolve the promise with the photo data
-      pendingRequest.resolve(photoData)
+      pendingRequest.resolve(photoData);
 
-      // Clean up
-      this.pendingPhotoRequests.delete(requestId)
+      // Clean up from both session and AppServer registry
+      this.pendingPhotoRequests.delete(requestId);
+      if (this.session?.appServer) {
+        this.session.appServer.unregisterPhotoRequest(requestId);
+      }
     } else {
-      this.logger.warn({requestId}, `📸 Received photo for unknown request ID: ${requestId}`)
+      this.logger.warn({ requestId }, `📸 Received photo for unknown request ID: ${requestId}`);
     }
   }
 
@@ -276,32 +295,35 @@ export class CameraModule {
    * @internal This method is used internally by AppSession
    */
   handlePhotoError(errorResponse: {
-    requestId: string
-    success: false
+    requestId: string;
+    success: false;
     error: {
-      code: string
-      message: string
-    }
+      code: string;
+      message: string;
+    };
   }): void {
-    const {requestId, error} = errorResponse
-    const pendingRequest = this.pendingPhotoRequests.get(requestId)
+    const { requestId, error } = errorResponse;
+    const pendingRequest = this.pendingPhotoRequests.get(requestId);
 
     if (pendingRequest) {
       this.logger.error(
-        {requestId, errorCode: error.code, errorMessage: error.message},
+        { requestId, errorCode: error.code, errorMessage: error.message },
         `📸 Photo capture failed: ${error.code} - ${error.message}`,
-      )
+      );
 
       // Reject the promise with the error information
-      pendingRequest.reject(`${error.code}: ${error.message}`)
+      pendingRequest.reject(`${error.code}: ${error.message}`);
 
-      // Clean up
-      this.pendingPhotoRequests.delete(requestId)
+      // Clean up from both session and AppServer registry
+      this.pendingPhotoRequests.delete(requestId);
+      if (this.session?.appServer) {
+        this.session.appServer.unregisterPhotoRequest(requestId);
+      }
     } else {
       this.logger.warn(
-        {requestId, errorCode: error.code, errorMessage: error.message},
+        { requestId, errorCode: error.code, errorMessage: error.message },
         `📸 Received photo error for unknown request ID: ${requestId}`,
-      )
+      );
     }
   }
 
@@ -312,7 +334,7 @@ export class CameraModule {
    * @returns true if there's a pending request
    */
   hasPhotoPendingRequest(requestId: string): boolean {
-    return this.pendingPhotoRequests.has(requestId)
+    return this.pendingPhotoRequests.has(requestId);
   }
 
   /**
@@ -321,7 +343,7 @@ export class CameraModule {
    * @returns Number of pending photo requests
    */
   getPhotoPendingRequestCount(): number {
-    return this.pendingPhotoRequests.size
+    return this.pendingPhotoRequests.size;
   }
 
   /**
@@ -330,7 +352,7 @@ export class CameraModule {
    * @returns Array of pending request IDs
    */
   getPhotoPendingRequestIds(): string[] {
-    return Array.from(this.pendingPhotoRequests.keys())
+    return Array.from(this.pendingPhotoRequests.keys());
   }
 
   /**
@@ -340,14 +362,18 @@ export class CameraModule {
    * @returns true if the request was cancelled, false if it wasn't found
    */
   cancelPhotoRequest(requestId: string): boolean {
-    const pendingRequest = this.pendingPhotoRequests.get(requestId)
+    const pendingRequest = this.pendingPhotoRequests.get(requestId);
     if (pendingRequest) {
-      pendingRequest.reject("Photo request cancelled")
-      this.pendingPhotoRequests.delete(requestId)
-      this.logger.info({requestId}, `📸 Photo request cancelled`)
-      return true
+      pendingRequest.reject("Photo request cancelled");
+      this.pendingPhotoRequests.delete(requestId);
+      // Also unregister from AppServer
+      if (this.session?.appServer) {
+        this.session.appServer.unregisterPhotoRequest(requestId);
+      }
+      this.logger.info({ requestId }, `📸 Photo request cancelled`);
+      return true;
     }
-    return false
+    return false;
   }
 
   /**
@@ -356,15 +382,19 @@ export class CameraModule {
    * @returns Number of requests that were cancelled
    */
   cancelAllPhotoRequests(): number {
-    const count = this.pendingPhotoRequests.size
+    const count = this.pendingPhotoRequests.size;
 
-    for (const [requestId, {reject}] of this.pendingPhotoRequests) {
-      reject("Photo request cancelled - session cleanup")
-      this.logger.info({requestId}, `📸 Photo request cancelled during cleanup`)
+    for (const [requestId, { reject }] of this.pendingPhotoRequests) {
+      reject("Photo request cancelled - session cleanup");
+      // Also unregister from AppServer
+      if (this.session?.appServer) {
+        this.session.appServer.unregisterPhotoRequest(requestId);
+      }
+      this.logger.info({ requestId }, `📸 Photo request cancelled during cleanup`);
     }
 
-    this.pendingPhotoRequests.clear()
-    return count
+    this.pendingPhotoRequests.clear();
+    return count;
   }
 
   // =====================================
@@ -387,12 +417,12 @@ export class CameraModule {
    * ```
    */
   async startStream(options: RtmpStreamOptions): Promise<void> {
-    this.logger.info({rtmpUrl: options.rtmpUrl}, `📹 RTMP stream request starting`)
+    this.logger.info({ rtmpUrl: options.rtmpUrl }, `📹 RTMP stream request starting`);
 
-    cameraWarnLog(this.session.getHttpsServerUrl?.(), this.packageName, "startStream")
+    cameraWarnLog(this.session.getHttpsServerUrl?.(), this.packageName, "startStream");
 
     if (!options.rtmpUrl) {
-      throw new Error("rtmpUrl is required")
+      throw new Error("rtmpUrl is required");
     }
 
     if (this.isStreaming) {
@@ -402,8 +432,8 @@ export class CameraModule {
           requestedUrl: options.rtmpUrl,
         },
         `📹 Already streaming error`,
-      )
-      throw new Error("Already streaming. Stop the current stream before starting a new one.")
+      );
+      throw new Error("Already streaming. Stop the current stream before starting a new one.");
     }
 
     // Create stream request message
@@ -416,22 +446,22 @@ export class CameraModule {
       audio: options.audio,
       stream: options.stream,
       timestamp: new Date(),
-    }
+    };
 
     // Save stream URL for reference
-    this.currentStreamUrl = options.rtmpUrl
+    this.currentStreamUrl = options.rtmpUrl;
 
     // Send the request
     try {
-      this.session.sendMessage(message)
-      this.isStreaming = true
+      this.session.sendMessage(message);
+      this.isStreaming = true;
 
-      this.logger.info({rtmpUrl: options.rtmpUrl}, `📹 RTMP stream request sent successfully`)
-      return Promise.resolve()
+      this.logger.info({ rtmpUrl: options.rtmpUrl }, `📹 RTMP stream request sent successfully`);
+      return Promise.resolve();
     } catch (error) {
-      this.logger.error({error, rtmpUrl: options.rtmpUrl}, `📹 Failed to send RTMP stream request`)
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      return Promise.reject(`Failed to request RTMP stream: ${errorMessage}`)
+      this.logger.error({ error, rtmpUrl: options.rtmpUrl }, `📹 Failed to send RTMP stream request`);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return Promise.reject(`Failed to request RTMP stream: ${errorMessage}`);
     }
   }
 
@@ -452,12 +482,12 @@ export class CameraModule {
         currentStreamUrl: this.currentStreamUrl,
       },
       `📹 RTMP stream stop request`,
-    )
+    );
 
     if (!this.isStreaming) {
-      this.logger.info(`📹 Not streaming - no-op`)
+      this.logger.info(`📹 Not streaming - no-op`);
       // Not an error - just a no-op if not streaming
-      return Promise.resolve()
+      return Promise.resolve();
     }
 
     // Create stop request message
@@ -467,15 +497,15 @@ export class CameraModule {
       sessionId: this.sessionId,
       streamId: this.currentStreamState?.streamId, // Include streamId if available
       timestamp: new Date(),
-    }
+    };
 
     // Send the request
     try {
-      this.session.sendMessage(message)
-      return Promise.resolve()
+      this.session.sendMessage(message);
+      return Promise.resolve();
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error)
-      return Promise.reject(`Failed to stop RTMP stream: ${errorMessage}`)
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      return Promise.reject(`Failed to stop RTMP stream: ${errorMessage}`);
     }
   }
 
@@ -485,7 +515,7 @@ export class CameraModule {
    * @returns True if a stream is active or initializing
    */
   isCurrentlyStreaming(): boolean {
-    return this.isStreaming
+    return this.isStreaming;
   }
 
   /**
@@ -494,7 +524,7 @@ export class CameraModule {
    * @returns The RTMP URL of the current stream, or undefined if not streaming
    */
   getCurrentStreamUrl(): string | undefined {
-    return this.currentStreamUrl
+    return this.currentStreamUrl;
   }
 
   /**
@@ -503,7 +533,7 @@ export class CameraModule {
    * @returns The current stream status, or undefined if not available
    */
   getStreamStatus(): RtmpStreamStatus | undefined {
-    return this.currentStreamState
+    return this.currentStreamState;
   }
 
   /**
@@ -512,9 +542,9 @@ export class CameraModule {
    */
   subscribeToStreamStatusUpdates(): void {
     if (this.session) {
-      this.session.subscribe(StreamType.RTMP_STREAM_STATUS)
+      this.session.subscribe(StreamType.RTMP_STREAM_STATUS);
     } else {
-      this.logger.error("Cannot subscribe to status updates: session reference not available")
+      this.logger.error("Cannot subscribe to status updates: session reference not available");
     }
   }
 
@@ -523,7 +553,7 @@ export class CameraModule {
    */
   unsubscribeFromStreamStatusUpdates(): void {
     if (this.session) {
-      this.session.unsubscribe(StreamType.RTMP_STREAM_STATUS)
+      this.session.unsubscribe(StreamType.RTMP_STREAM_STATUS);
     }
   }
 
@@ -547,12 +577,12 @@ export class CameraModule {
    */
   onStreamStatus(handler: StreamStatusHandler): () => void {
     if (!this.session) {
-      this.logger.error("Cannot listen for status updates: session reference not available")
-      return () => {}
+      this.logger.error("Cannot listen for status updates: session reference not available");
+      return () => {};
     }
 
-    this.subscribeToStreamStatusUpdates()
-    return this.session.on(StreamType.RTMP_STREAM_STATUS, handler)
+    this.subscribeToStreamStatusUpdates();
+    return this.session.on(StreamType.RTMP_STREAM_STATUS, handler);
   }
 
   /**
@@ -569,12 +599,12 @@ export class CameraModule {
         currentIsStreaming: this.isStreaming,
       },
       `📹 Stream state update`,
-    )
+    );
 
     // Verify this is a valid stream response
     if (!isRtmpStreamStatus(message)) {
-      this.logger.warn({message}, `📹 Received invalid stream status message`)
-      return
+      this.logger.warn({ message }, `📹 Received invalid stream status message`);
+      return;
     }
 
     // Convert to StreamStatus format
@@ -586,7 +616,7 @@ export class CameraModule {
       appId: message.appId,
       stats: message.stats,
       timestamp: message.timestamp || new Date(),
-    }
+    };
 
     this.logger.info(
       {
@@ -596,7 +626,7 @@ export class CameraModule {
         wasStreaming: this.isStreaming,
       },
       `📹 Stream status processed`,
-    )
+    );
 
     // Update local state based on status
     if (status.status === "stopped" || status.status === "error" || status.status === "timeout") {
@@ -606,13 +636,13 @@ export class CameraModule {
           wasStreaming: this.isStreaming,
         },
         `📹 Stream stopped - updating local state`,
-      )
-      this.isStreaming = false
-      this.currentStreamUrl = undefined
+      );
+      this.isStreaming = false;
+      this.currentStreamUrl = undefined;
     }
 
     // Save the latest status
-    this.currentStreamState = status
+    this.currentStreamState = status;
   }
 
   // =====================================
@@ -638,7 +668,7 @@ export class CameraModule {
    * ```
    */
   async startManagedStream(options?: ManagedStreamOptions): Promise<ManagedStreamResult> {
-    return this.managedExtension.startManagedStream(options)
+    return this.managedExtension.startManagedStream(options);
   }
 
   /**
@@ -650,7 +680,7 @@ export class CameraModule {
    * @returns Promise that resolves when the stop request is sent
    */
   async stopManagedStream(): Promise<void> {
-    return this.managedExtension.stopManagedStream()
+    return this.managedExtension.stopManagedStream();
   }
 
   /**
@@ -660,7 +690,7 @@ export class CameraModule {
    * @returns Cleanup function to unregister the handler
    */
   onManagedStreamStatus(handler: (status: ManagedStreamStatus) => void): () => void {
-    return this.managedExtension.onManagedStreamStatus(handler)
+    return this.managedExtension.onManagedStreamStatus(handler);
   }
 
   /**
@@ -669,7 +699,7 @@ export class CameraModule {
    * @returns true if a managed stream is active
    */
   isManagedStreamActive(): boolean {
-    return this.managedExtension.isManagedStreamActive()
+    return this.managedExtension.isManagedStreamActive();
   }
 
   /**
@@ -678,7 +708,7 @@ export class CameraModule {
    * @returns Current stream URLs or undefined if not streaming
    */
   getManagedStreamUrls(): ManagedStreamResult | undefined {
-    return this.managedExtension.getManagedStreamUrls()
+    return this.managedExtension.getManagedStreamUrls();
   }
 
   /**
@@ -703,25 +733,25 @@ export class CameraModule {
    * ```
    */
   async checkExistingStream(): Promise<{
-    hasActiveStream: boolean
+    hasActiveStream: boolean;
     streamInfo?: {
-      type: "managed" | "unmanaged"
-      streamId: string
-      status: string
-      createdAt: Date
+      type: "managed" | "unmanaged";
+      streamId: string;
+      status: string;
+      createdAt: Date;
       // For managed streams
-      hlsUrl?: string
-      dashUrl?: string
-      webrtcUrl?: string
-      previewUrl?: string
-      thumbnailUrl?: string
-      activeViewers?: number
+      hlsUrl?: string;
+      dashUrl?: string;
+      webrtcUrl?: string;
+      previewUrl?: string;
+      thumbnailUrl?: string;
+      activeViewers?: number;
       // For unmanaged streams
-      rtmpUrl?: string
-      requestingAppId?: string
-    }
+      rtmpUrl?: string;
+      requestingAppId?: string;
+    };
   }> {
-    return this.managedExtension.checkExistingStream()
+    return this.managedExtension.checkExistingStream();
   }
 
   /**
@@ -729,7 +759,7 @@ export class CameraModule {
    * @internal
    */
   handleStreamCheckResponse(response: StreamStatusCheckResponse): void {
-    this.managedExtension.handleStreamCheckResponse(response)
+    this.managedExtension.handleStreamCheckResponse(response);
   }
 
   /**
@@ -737,7 +767,7 @@ export class CameraModule {
    * @internal
    */
   handleManagedStreamStatus(message: ManagedStreamStatus): void {
-    this.managedExtension.handleManagedStreamStatus(message)
+    this.managedExtension.handleManagedStreamStatus(message);
   }
 
   // =====================================
@@ -751,7 +781,7 @@ export class CameraModule {
    * @internal This method is used internally by AppSession
    */
   updateSessionId(newSessionId: string): void {
-    this.sessionId = newSessionId
+    this.sessionId = newSessionId;
   }
 
   /**
@@ -759,22 +789,22 @@ export class CameraModule {
    *
    * @returns Object with counts of cancelled requests
    */
-  cancelAllRequests(): {photoRequests: number} {
-    const photoRequests = this.cancelAllPhotoRequests()
+  cancelAllRequests(): { photoRequests: number } {
+    const photoRequests = this.cancelAllPhotoRequests();
 
     // Stop streaming if active
     if (this.isStreaming) {
       this.stopStream().catch((error) => {
-        this.logger.error({error}, "Error stopping stream during cleanup")
-      })
+        this.logger.error({ error }, "Error stopping stream during cleanup");
+      });
     }
 
     // Clean up managed extension
-    this.managedExtension.cleanup()
+    this.managedExtension.cleanup();
 
-    return {photoRequests}
+    return { photoRequests };
   }
 }
 
 // Re-export types for convenience
-export {VideoConfig, AudioConfig, StreamConfig, StreamStatusHandler}
+export { VideoConfig, AudioConfig, StreamConfig, StreamStatusHandler };


### PR DESCRIPTION
Fix photo request timeouts in SDK by adding server-level registry

Photo requests were timing out when sessions reconnected during photo
capture. The race condition occurred because the session-level pending
request map was cleared on reconnect, losing track of in-flight photos.

Changes:
- Add photoRequestRegistry at AppServer level that persists across
  session lifecycle
- Photo upload endpoint now resolves requests from the server registry
  instead of relying on potentially stale session state
- Properly handle cases where photos arrive after session reconnection
