### PR TITLE
feat(cli): add mentra tunnel command for local development

### DIFF
--- a/cloud/bun.lock
+++ b/cloud/bun.lock
@@ -59,6 +59,7 @@
         "commander": "^11.1.0",
         "inquirer": "^9.2.12",
         "jsonwebtoken": "^9.0.2",
+        "localtunnel": "^2.0.2",
         "yaml": "^2.3.4",
       },
       "devDependencies": {
@@ -1469,7 +1470,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.2", "", { "dependencies": { "bun-types": "1.3.2" } }, "sha512-t15P7k5UIgHKkxwnMNkJbWlh/617rkDGEdSsDbu+qNHTaz9SKf7aC8fiIlUdD5RPpH6GEkP0cK7WlvmrEBRtWg=="],
+    "@types/bun": ["@types/bun@1.3.6", "", { "dependencies": { "bun-types": "1.3.6" } }, "sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -2631,6 +2632,8 @@
 
     "livekit-server-sdk": ["livekit-server-sdk@2.14.0", "", { "dependencies": { "@bufbuild/protobuf": "^1.10.1", "@livekit/protocol": "^1.42.0", "camelcase-keys": "^9.0.0", "jose": "^5.1.2" } }, "sha512-7lZBkiVOOnPIYz6XyQ9teVxlkLQVve7JFuiYgLkYQCLZQLSZPjIboqP1ZocbLbPx4ijceYwVfOZHktF0YbfvVw=="],
 
+    "localtunnel": ["localtunnel@2.0.2", "", { "dependencies": { "axios": "0.21.4", "debug": "4.3.2", "openurl": "1.1.1", "yargs": "17.1.1" }, "bin": { "lt": "bin/lt.js" } }, "sha512-n418Cn5ynvJd7m/N1d9WVJISLJF/ellZnfsLnx8WBWGzxv/ntNcFkJ1o6se5quUhCplfLGBNL5tYHiq5WF3Nug=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
@@ -2826,6 +2829,8 @@
     "openai": ["openai@4.104.0", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" }, "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA=="],
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
+
+    "openurl": ["openurl@1.1.1", "", {}, "sha512-d/gTkTb1i1GKz5k3XE3XFV/PxQ1k45zDqGP2OA7YhgsaLoqm6qRvARAZOFer1fcXritWlGBRCu/UgeS4HAnXAA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
@@ -3611,7 +3616,7 @@
 
     "@mentra/appstore-webview/typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
-    "@mentra/cli/bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
+    "@mentra/cli/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "@mentra/cloud/@types/node": ["@types/node@16.18.126", "", {}, "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw=="],
 
@@ -3767,7 +3772,7 @@
 
     "@types/body-parser/@types/node": ["@types/node@22.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.2", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-i/Gln4tbzKNuxP70OWhJRZz1MRfvqExowP7U6JKoI8cntFrtxg7RJK3jvz7wQW54UuvNC8tbKHHri5fy74FVqg=="],
+    "@types/bun/bun-types": ["bun-types@1.3.6", "", { "dependencies": { "@types/node": "*" } }, "sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ=="],
 
     "@types/connect/@types/node": ["@types/node@22.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA=="],
 
@@ -3958,6 +3963,12 @@
     "langsmith/uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
     "livekit-server-sdk/jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "localtunnel/axios": ["axios@0.21.4", "", { "dependencies": { "follow-redirects": "^1.14.0" } }, "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg=="],
+
+    "localtunnel/debug": ["debug@4.3.2", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw=="],
+
+    "localtunnel/yargs": ["yargs@17.1.1", "", { "dependencies": { "cliui": "^7.0.2", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.0", "y18n": "^5.0.5", "yargs-parser": "^20.2.2" } }, "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ=="],
 
     "log-symbols/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -4431,6 +4442,12 @@
 
     "langsmith/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "localtunnel/debug/ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
+
+    "localtunnel/yargs/cliui": ["cliui@7.0.4", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^7.0.0" } }, "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ=="],
+
+    "localtunnel/yargs/yargs-parser": ["yargs-parser@20.2.9", "", {}, "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="],
+
     "log-symbols/chalk/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "log-symbols/chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -4663,6 +4680,10 @@
 
     "account-portal/eslint/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "localtunnel/yargs/cliui/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "localtunnel/yargs/cliui/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "mongodb-connection-string-url/whatwg-url/tr46/punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "mongoose/mongodb/mongodb-connection-string-url/@types/whatwg-url": ["@types/whatwg-url@8.2.2", "", { "dependencies": { "@types/node": "*", "@types/webidl-conversions": "*" } }, "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA=="],
@@ -4708,6 +4729,10 @@
     "@typescript-eslint/eslint-plugin/@typescript-eslint/utils/@typescript-eslint/typescript-estree/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "account-portal/eslint/file-entry-cache/flat-cache/rimraf": ["rimraf@3.0.2", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "bin.js" } }, "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA=="],
+
+    "localtunnel/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "localtunnel/yargs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "mongoose/mongodb/mongodb-connection-string-url/@types/whatwg-url/@types/node": ["@types/node@22.19.0", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xpr/lmLPQEj+TUnHmR+Ab91/glhJvsqcjB+yY0Ix9GO70H6Lb4FHH5GeqdOE5btAx7eIMwuHkp4H2MSkLcqWbA=="],
 

--- a/cloud/packages/cli/README.md
+++ b/cloud/packages/cli/README.md
@@ -106,6 +106,17 @@ mentra cloud add my-cloud --name "My Cloud" --url https://my-cloud.mentra.glass
 mentra cloud use my-cloud
 ```
 
+### Local Tunneling
+
+```bash
+mentra tunnel                    # Start tunnel to localhost:3000
+mentra tunnel --port 8080        # Forward to different port
+mentra tunnel --subdomain myapp  # Request specific subdomain
+mentra tunnel --host <url>       # Use custom tunnel server
+```
+
+Start a reverse tunnel for local TPA development. Routes webhooks from Mentra Cloud to your localhost.
+
 ### Global Options
 
 ```bash

--- a/cloud/packages/cli/package.json
+++ b/cloud/packages/cli/package.json
@@ -31,7 +31,8 @@
     "cli-table3": "^0.6.3",
     "chalk": "^5.3.0",
     "inquirer": "^9.2.12",
-    "yaml": "^2.3.4"
+    "yaml": "^2.3.4",
+    "localtunnel": "^2.0.2"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/cloud/packages/cli/src/commands/tunnel.ts
+++ b/cloud/packages/cli/src/commands/tunnel.ts
@@ -1,0 +1,119 @@
+/**
+ * Tunnel Command
+ *
+ * Commands: tunnel
+ */
+
+import {Command} from "commander"
+import localtunnel from "localtunnel"
+import chalk from "chalk"
+
+// Type for request info from localtunnel
+interface TunnelRequestInfo {
+  method?: string
+  path?: string
+}
+
+export const tunnelCommand = new Command("tunnel")
+  .description("Start reverse tunnel to localhost")
+  .option("-p, --port <port>", "Local server port", "3000")
+  .option("-s, --subdomain <subdomain>", "Request specific subdomain")
+  .option("--host <host>", "Tunnel server URL", "https://tunnel.mentra.run")
+  .action(async (options) => {
+    const port = parseInt(options.port, 10)
+    const subdomain = options.subdomain
+    const host = options.host
+
+    // Validate port
+    if (isNaN(port) || port < 1 || port > 65535) {
+      console.error(chalk.red("✗") + ` Invalid port: ${options.port}`)
+      console.error(chalk.gray("  Port must be a number between 1 and 65535"))
+      process.exit(2)
+    }
+
+    try {
+      console.log(chalk.cyan("🔗 Starting tunnel..."))
+      console.log(chalk.gray(`   Port: ${port}`))
+      if (subdomain) {
+        console.log(chalk.gray(`   Requested subdomain: ${subdomain}`))
+      }
+      console.log(chalk.gray(`   Server: ${host}`))
+      console.log()
+
+      // Create tunnel
+      const tunnel = await localtunnel({
+        port,
+        subdomain,
+        host,
+      })
+
+      // Display tunnel URL
+      console.log(chalk.green("✓") + " Tunnel active!")
+      console.log()
+      console.log(chalk.bold(`  🔗 Tunnel URL: ${chalk.cyan(tunnel.url)}`))
+      console.log(chalk.bold(`  🏠 Forwarding to: ${chalk.cyan(`http://localhost:${port}`)}`))
+      console.log()
+      console.log(chalk.yellow("⚠️  Update publicUrl in console: ") + chalk.cyan("https://console.mentra.glass"))
+      console.log()
+      console.log(chalk.gray("Waiting for connections... (Ctrl+C to stop)"))
+      console.log()
+
+      // Track request count
+      let requestCount = 0
+
+      // Listen for incoming requests
+      tunnel.on("request", (info: TunnelRequestInfo) => {
+        requestCount++
+        const timestamp = new Date().toLocaleTimeString()
+        const method = info.method || "GET"
+        const path = info.path || "/"
+
+        // Colored output based on method
+        let methodColor = chalk.blue
+        if (method === "POST") methodColor = chalk.green
+        if (method === "PUT" || method === "PATCH") methodColor = chalk.yellow
+        if (method === "DELETE") methodColor = chalk.red
+
+        console.log(`[${chalk.gray(timestamp)}] ${methodColor(method.padEnd(6))} ${chalk.cyan(path)}`)
+      })
+
+      // Handle errors
+      tunnel.on("error", (err: any) => {
+        console.error(chalk.red("✗") + " Tunnel error:", err.message)
+      })
+
+      // Handle close
+      tunnel.on("close", () => {
+        console.log()
+        console.log(chalk.yellow("⚠️  Tunnel closed"))
+        console.log(chalk.gray(`   Total requests: ${requestCount}`))
+        process.exit(0)
+      })
+
+      // Graceful shutdown on Ctrl+C
+      process.on("SIGINT", () => {
+        console.log()
+        console.log(chalk.yellow("⏸  Shutting down tunnel..."))
+        tunnel.close()
+      })
+
+      process.on("SIGTERM", () => {
+        tunnel.close()
+      })
+    } catch (err: any) {
+      console.error(chalk.red("✗") + " Failed to start tunnel:", err.message)
+      console.error()
+
+      // Provide helpful error messages
+      if (err.message.includes("ECONNREFUSED")) {
+        console.error(chalk.yellow("💡 Tip:") + " Make sure your local server is running on port " + port)
+        console.error(chalk.gray("   Try: bun run dev"))
+      } else if (err.message.includes("tunnel server")) {
+        console.error(chalk.yellow("💡 Tip:") + " Cannot connect to tunnel server")
+        console.error(chalk.gray(`   Server: ${host}`))
+        console.error(chalk.gray("   Try using --host https://loca.lt to test with public server"))
+      }
+
+      process.exit(1)
+    }
+  })

--- a/cloud/packages/cli/src/index.ts
+++ b/cloud/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import {authCommand} from "./commands/auth"
 import {cloudCommand} from "./commands/cloud"
 import {appCommand} from "./commands/app"
 import {orgCommand} from "./commands/org"
+import {tunnelCommand} from "./commands/tunnel"
 
 const program = new Command()
 
@@ -20,6 +21,7 @@ program.addCommand(authCommand)
 program.addCommand(cloudCommand)
 program.addCommand(appCommand)
 program.addCommand(orgCommand)
+program.addCommand(tunnelCommand)
 
 // Global options
 program.option("--json", "Output JSON")

--- a/cloud/packages/cli/src/types/localtunnel.d.ts
+++ b/cloud/packages/cli/src/types/localtunnel.d.ts
@@ -1,0 +1,25 @@
+declare module "localtunnel" {
+  interface TunnelOptions {
+    port: number
+    subdomain?: string
+    host?: string
+    local_host?: string
+    local_https?: boolean
+    local_cert?: string
+    local_key?: string
+    local_ca?: string
+    allow_invalid_cert?: boolean
+  }
+
+  interface Tunnel {
+    url: string
+    on(event: "request", listener: (info: {method?: string; path?: string}) => void): void
+    on(event: "error", listener: (err: Error) => void): void
+    on(event: "close", listener: () => void): void
+    close(): void
+  }
+
+  function localtunnel(options: TunnelOptions): Promise<Tunnel>
+
+  export default localtunnel
+}


### PR DESCRIPTION
## Description
Implements the `mentra tunnel` command for local TPA development (Issue #1391).

## Changes
- Add `mentra tunnel` command that creates a reverse tunnel to localhost
- Uses [localtunnel](cci:1://file:///Users/shivanisharma/MentraOS/cloud/packages/cli/src/types/localtunnel.d.ts:21:2-21:63) package for tunnel server communication
- Options: `--port`, `--subdomain`, `--host`
- Features: colored request logging, graceful shutdown, port validation
- Add TypeScript type declarations for localtunnel
- Update README documentation

## Testing
Tested with `--host https://loca.lt` since `tunnel.mentra.run` isn't deployed yet.

## Design Note
The codebase uses simple tick/cross symbols for output, but the tunnel command uses emojis (🔗, 🏠, ⚠️) because it's a long-running interactive command like ngrok. The emojis add visual clarity when staring at the terminal waiting for requests. This also matches the expected output from the original issue.

Closes #1391