### PR TITLE
Fix glasses connected state to require SOC ready

### DIFF
--- a/mobile/modules/core/android/src/main/java/com/mentra/core/GlassesStore.kt
+++ b/mobile/modules/core/android/src/main/java/com/mentra/core/GlassesStore.kt
@@ -109,14 +109,9 @@ object GlassesStore {
                     } else {
                         CoreManager.getInstance().handleDeviceDisconnected()
                     }
-                    // // if ready is true, set connected to true
-                    // if (value) {
-                    //     store.set("glasses", "connected", true)
-                    // }
-                    // // if ready is false, set connected to false
-                    // if (!value) {
-                    //     store.set("glasses", "connected", false)
-                    // }
+                    // connected state is driven by fullyBooted:
+                    // SOC must be ready for glasses to be considered connected
+                    store.set("glasses", "connected", value)
                 }
             }
             "glasses" to "headUp" -> {

--- a/mobile/modules/core/android/src/main/java/com/mentra/core/sgcs/MentraLive.java
+++ b/mobile/modules/core/android/src/main/java/com/mentra/core/sgcs/MentraLive.java
@@ -572,10 +572,8 @@ public class MentraLive extends SGCManager {
         // Actually update the connection state!
         GlassesStore.INSTANCE.apply("glasses", "connectionState", state);
 
-        if (state.equals(ConnTypes.CONNECTED)) {
-            GlassesStore.INSTANCE.apply("glasses", "connected", true);
-        } else if (state.equals(ConnTypes.DISCONNECTED)) {
-            GlassesStore.INSTANCE.apply("glasses", "connected", false);
+        // connected state is now driven by fullyBooted in GlassesStore
+        if (state.equals(ConnTypes.DISCONNECTED)) {
             GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
         }
     }
@@ -1057,7 +1055,8 @@ public class MentraLive extends SGCManager {
                         Bridge.log("LIVE: ✅ Core TX/RX and LC3 TX/RX characteristics found - BLE connection ready");
                         Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...");
 
-                        GlassesStore.INSTANCE.apply("glasses", "connected", true);
+                        // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
+                        // GlassesStore handles connected state based on fullyBooted
 
                         // Keep the state as CONNECTING until the glasses SOC responds
                         // connectionEvent(SmartGlassesConnectionState.CONNECTING);

--- a/mobile/modules/core/ios/Source/GlassesStore.swift
+++ b/mobile/modules/core/ios/Source/GlassesStore.swift
@@ -110,6 +110,9 @@ class GlassesStore {
                 } else {
                     CoreManager.shared.handleDeviceDisconnected()
                 }
+                // connected state is driven by fullyBooted:
+                // SOC must be ready for glasses to be considered connected
+                store.set("glasses", "connected", ready)
             }
 
         case ("glasses", "headUp"):

--- a/mobile/modules/core/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/core/ios/Source/sgcs/MentraLive.swift
@@ -731,7 +731,8 @@ extension MentraLive: CBPeripheralDelegate {
             Bridge.log("LIVE: ✅ Both TX and RX characteristics found - BLE connection ready")
             Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...")
 
-            GlassesStore.shared.apply("glasses", "connected", true)
+            // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
+            // GlassesStore handles connected state based on fullyBooted
 
             // Keep state as connecting until glasses are ready
             connectionState = ConnTypes.CONNECTING


### PR DESCRIPTION
## Summary
- `connected` was being set to `true` as soon as BLE GATT characteristics were discovered, **before the K900 SOC finished booting**
- This caused the `ConnectionOverlay` to disappear prematurely while the glasses were still in the readiness check loop (`ready=0`)
- Now `connected` is driven by `fullyBooted` in `GlassesStore` on both Android and iOS — the SOC must report `ready=1` before the glasses are considered connected

## Changes
- **GlassesStore.kt** (Android): Uncommented and cleaned up `fullyBooted` → `connected` state tie
- **GlassesStore.swift** (iOS): Added same `fullyBooted` → `connected` state tie
- **MentraLive.java** (Android): Removed premature `connected=true` at BLE characteristic discovery and from `updateConnectionState(CONNECTED)`
- **MentraLive.swift** (iOS): Removed premature `connected=true` at BLE characteristic discovery

## Impact
- `ConnectionOverlay` now stays visible during the entire SOC boot sequence
- OTA check-for-updates won't skip prematurely when BLE is up but SOC isn't ready
- Other device types (G1, MentraNex, Simulated) are unaffected — they already set `fullyBooted` and `connected` together