### PR TITLE
Fix Android notifications not working

### DIFF
--- a/mobile/modules/core/android/src/main/java/com/mentra/core/CoreManager.kt
+++ b/mobile/modules/core/android/src/main/java/com/mentra/core/CoreManager.kt
@@ -55,7 +55,7 @@ class CoreManager {
     private var permissionCheckRunnable: Runnable? = null
 
     // notifications settings
-    public var notificationsEnabled = false
+    public var notificationsEnabled = true
     public var notificationsBlocklist = listOf<String>()
     // MARK: - End Unique
 

--- a/mobile/modules/core/android/src/main/java/com/mentra/core/CoreModule.kt
+++ b/mobile/modules/core/android/src/main/java/com/mentra/core/CoreModule.kt
@@ -298,6 +298,24 @@ class CoreModule : Module() {
             NotificationListener.getInstance(context).getInstalledApps()
         }
 
+        // MARK: - Notification Settings
+
+        Function("setNotificationsEnabled") { enabled: Boolean ->
+            CoreManager.getInstance().notificationsEnabled = enabled
+        }
+
+        Function("getNotificationsEnabled") {
+            CoreManager.getInstance().notificationsEnabled
+        }
+
+        Function("setNotificationsBlocklist") { blocklist: List<String> ->
+            CoreManager.getInstance().notificationsBlocklist = blocklist
+        }
+
+        Function("getNotificationsBlocklist") {
+            CoreManager.getInstance().notificationsBlocklist.toList()
+        }
+
         // MARK: - Settings Navigation
 
         AsyncFunction("openBluetoothSettings") {

--- a/mobile/modules/core/android/src/main/java/com/mentra/core/GlassesStore.kt
+++ b/mobile/modules/core/android/src/main/java/com/mentra/core/GlassesStore.kt
@@ -269,6 +269,17 @@ object GlassesStore {
             "core" to "device_name" -> {
                 // Device name changed - no additional action needed
             }
+            "core" to "notifications_enabled" -> {
+                (value as? Boolean)?.let { enabled ->
+                    CoreManager.getInstance().notificationsEnabled = enabled
+                }
+            }
+            "core" to "notifications_blocklist" -> {
+                @Suppress("UNCHECKED_CAST")
+                (value as? List<String>)?.let { blocklist ->
+                    CoreManager.getInstance().notificationsBlocklist = blocklist
+                }
+            }
             "core" to "lastLog" -> {
                 (value as? MutableList<String>)?.let { logs ->
                     // ensure the list is trimmed to 100 items (remove oldest items)

--- a/mobile/modules/core/src/CoreModule.ts
+++ b/mobile/modules/core/src/CoreModule.ts
@@ -102,6 +102,10 @@ declare class CoreModule extends NativeModule<CoreModuleEvents> {
       icon: string | null
     }>
   >
+  setNotificationsEnabled(enabled: boolean): void
+  getNotificationsEnabled(): boolean
+  setNotificationsBlocklist(blocklist: string[]): void
+  getNotificationsBlocklist(): string[]
 
   // Media Library Commands
   saveToGalleryWithDate(


### PR DESCRIPTION
- Default notificationsEnabled to true in CoreManager (was false, blocking all notifications)
- Add setNotificationsEnabled/getNotificationsEnabled functions to CoreModule
- Add setNotificationsBlocklist/getNotificationsBlocklist functions to CoreModule
- Add GlassesStore handlers to sync notifications_enabled and notifications_blocklist from settings
- Add TypeScript types for notification functions

The notification settings functions were accidentally removed in a cleanup commit on Nov 5, 2025.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added notification management controls enabling users to enable and disable notifications across the app.
  * Introduced notification blocklist functionality for granular control over notification delivery and preferences.
  
* **Changes**
  * Notifications are now enabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->