### PR TITLE
fix(docs): correct developer console URL

### DIFF
--- a/cloud/docs/docs.json
+++ b/cloud/docs/docs.json
@@ -156,7 +156,7 @@
     "primary": {
       "type": "button",
       "label": "Developer Portal",
-      "href": "https://dev.mentraos.com"
+      "href": "https://console.mentraglass.com"
     }
   },
   "contextual": {

--- a/cloud/docs/quickstart.mdx
+++ b/cloud/docs/quickstart.mdx
@@ -12,7 +12,7 @@ Before you begin, make sure you have:
     Install [Bun](https://bun.sh) - our JavaScript runtime and package manager
   </Step>
   <Step title="Developer Account">
-    Sign up at [dev.mentraos.com](https://dev.mentraos.com) to get your API key
+    Sign up at [console.mentraglass.com](https://console.mentraglass.com) to get your API key
   </Step>
   <Step title="MentraOS App">
     Install the MentraOS mobile app and connect your smart glasses
@@ -96,7 +96,7 @@ bun run app.ts
 
 <Steps>
   <Step title="Open Developer Portal">
-    Go to [dev.mentraos.com](https://dev.mentraos.com) and navigate to your app
+    Go to [console.mentraglass.com](https://console.mentraglass.com) and navigate to your app
   </Step>
   <Step title="Set Webhook URL">
     Set your webhook URL to `http://your-server.com/webhook`


### PR DESCRIPTION
Replace incorrect dev.mentraos.com with console.mentraglass.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer portal links in Quick Start guide.

* **Chores**
  * Updated Developer Portal navigation button URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->