### PR TITLE
fix : mini-app icons overlapping pair glasses button

### DIFF
--- a/mobile/src/app/(tabs)/home.tsx
+++ b/mobile/src/app/(tabs)/home.tsx
@@ -74,7 +74,7 @@ export default function Homepage() {
           <Group>
             <PairGlassesCard />
           </Group>
-          <View className="flex-1" />
+          <View style={{flex: 1, minHeight: 32}} />
           <AppsGrid />
         </>
       )
@@ -88,7 +88,7 @@ export default function Homepage() {
           {appSwitcherUi && <DeviceStatus />}
           {!offlineMode && !appSwitcherUi && <BackgroundAppsLink />}
         </Group>
-        <View className="h-2" />
+        <View className="h-6" />
         {!appSwitcherUi && <ActiveForegroundApp />}
         <AppsGrid />
       </>


### PR DESCRIPTION
### Summary

- Fix icon/button overlap.
- Add minimum gap (unpaired).
- Increase gap (paired).

### Test plan

- Check unpaired home screen.
- Check disconnected paired screen.
- Verify button is tappable.
- Verify grid still scrolls.

### Reference

Incident : #2254.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing adjustments in the home page layout for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->