### PR TITLE
fix(audio): set PDM channel count to mono for LC3 encode

### DIFF
--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_pdm/include/pdm_audio_stream.h
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_pdm/include/pdm_audio_stream.h
@@ -26,7 +26,7 @@ typedef enum
 /* Audio configuration constants */
 #define PDM_SAMPLE_RATE            16000   // 16 kHz voice optimized
 #define PDM_BIT_DEPTH              16      // PCM bit depth, measured in bits
-#define PDM_CHANNELS               2       // Mono microphone input
+#define PDM_CHANNELS               1       // Mono microphone input
 #define PDM_AUDIO_CHANNELS         PDM_CHANNELS
 #define PDM_FRAME_SIZE_SAMPLES     160     // 10ms frame @ 16kHz
 #define PDM_FRAME_SIZE_BYTES       (PDM_FRAME_SIZE_SAMPLES * 2)  // 16-bit samples


### PR DESCRIPTION
Align LC3 encoder channel config with mono PCM path to reduce audio artifacts in PDM capture on evt1.
The pdm_audio_stream.c file has already included the equivalent simple filtering logic in dev-nexfirmware-evt1. This hotfix only completes the alignment of the PDM_CHANNELS paramet