### PR TITLE
fix(asg_client): WHIP streaming safeguards, rotation fix, 16:9 default

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -17,6 +17,8 @@ import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
 import com.mentra.asg_client.hardware.K900RgbLedController;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
+import com.mentra.asg_client.io.streaming.services.SrtStreamingService;
+import com.mentra.asg_client.io.streaming.services.WhipStreamingService;
 import com.mentra.asg_client.audio.AudioAssets;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.service.core.CameraRestartCooldown;
@@ -710,11 +712,11 @@ public class MediaCaptureService {
      * Start video recording with specific parameters, settings, and max time
      */
     private void startVideoRecording(String videoFilePath, String requestId, VideoSettings settings, boolean enableFlash, boolean enableSound, int maxRecordingTimeMinutes) {
-        // Check if RTMP streaming is active - videos cannot interrupt streams
-        if (RtmpStreamingService.isStreaming()) {
-            Log.e(TAG, "Cannot start video - RTMP streaming active");
+        // Check if any streaming is active - videos cannot interrupt streams
+        if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot start video - streaming active");
             if (mMediaCaptureListener != null) {
-                mMediaCaptureListener.onMediaError(requestId, "Camera busy with streaming", 
+                mMediaCaptureListener.onMediaError(requestId, "Camera busy with streaming",
                     MediaUploadQueueManager.MEDIA_TYPE_VIDEO);
             }
             return;
@@ -1156,10 +1158,10 @@ public class MediaCaptureService {
             Log.i(TAG, "⏱️ [TIMING] LOCAL Photo request START");
         }
         
-        // Check if RTMP streaming is active - photos cannot interrupt streams
-        if (RtmpStreamingService.isStreaming()) {
-            Log.e(TAG, "Cannot take photo - RTMP streaming active");
-            sendPhotoErrorResponse("local", "CAMERA_BUSY", "Camera busy with RTMP streaming");
+        // Check if any streaming is active - photos cannot interrupt streams
+        if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot take photo - streaming active");
+            sendPhotoErrorResponse("local", "CAMERA_BUSY", "Camera busy with streaming");
             return;
         }
         
@@ -1333,10 +1335,10 @@ public class MediaCaptureService {
 
         Log.d(TAG, "Taking photo and uploading to " + webhookUrl + " with compression: " + compress);
 
-        // Check if RTMP streaming is active - photos cannot interrupt streams
-        if (RtmpStreamingService.isStreaming()) {
-            Log.e(TAG, "Cannot take photo - RTMP streaming active");
-            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with RTMP streaming");
+        // Check if any streaming is active - photos cannot interrupt streams
+        if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot take photo - streaming active");
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with streaming");
             return;
         }
 
@@ -2320,10 +2322,10 @@ public class MediaCaptureService {
             Log.i(TAG, "⏱️ [TIMING] BLE Photo request START - ID: " + requestId);
         }
 
-        // Check if RTMP streaming is active - photos cannot interrupt streams
-        if (RtmpStreamingService.isStreaming()) {
-            Log.e(TAG, "Cannot take photo - RTMP streaming active");
-            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with RTMP streaming");
+        // Check if any streaming is active - photos cannot interrupt streams
+        if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot take photo - streaming active");
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with streaming");
             return;
         }
 
@@ -2470,10 +2472,10 @@ public class MediaCaptureService {
      * This avoids taking a duplicate photo
      */
     private void reusePhotoForBleTransfer(String existingPhotoPath, String requestId, String bleImgId, boolean save, String size) {
-        // Check if RTMP streaming is active - avoid BLE transfers during streams
-        if (RtmpStreamingService.isStreaming()) {
-            Log.e(TAG, "Cannot transfer photo via BLE - RTMP streaming active");
-            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with RTMP streaming");
+        // Check if any streaming is active - avoid BLE transfers during streams
+        if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot transfer photo via BLE - streaming active");
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with streaming");
             return;
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/RtmpStreamConfig.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/RtmpStreamConfig.java
@@ -10,7 +10,7 @@ public class RtmpStreamConfig {
 
     // Default values (matching current hardcoded values)
     public static final int DEFAULT_VIDEO_WIDTH = 960;
-    public static final int DEFAULT_VIDEO_HEIGHT = 720;
+    public static final int DEFAULT_VIDEO_HEIGHT = 540;
     public static final int DEFAULT_VIDEO_BITRATE = 1000000; // 1 Mbps
     public static final int DEFAULT_VIDEO_FPS = 15;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfig.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/config/WhipStreamConfig.java
@@ -8,7 +8,7 @@ import org.json.JSONObject;
 public class WhipStreamConfig {
 
   public static final int DEFAULT_VIDEO_WIDTH = 960;
-  public static final int DEFAULT_VIDEO_HEIGHT = 720;
+  public static final int DEFAULT_VIDEO_HEIGHT = 540;
   public static final int DEFAULT_VIDEO_FPS = 15;
   public static final int DEFAULT_VIDEO_BITRATE = 1000000; // 1 Mbps
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -65,6 +65,7 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mSensorOrientation;
   private int mFrameRotation;
   private boolean mIsFrontCamera;
+  private boolean mLoggedFrameSize = false;
 
   @Override
   public void initialize(SurfaceTextureHelper surfaceTextureHelper, Context context,
@@ -220,6 +221,13 @@ public class WhipCameraCapturer implements VideoCapturer {
       // it works correctly at any aspect ratio (including 16:9).
       mSurfaceTextureHelper.startListening(frame -> {
         TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
+
+        if (!mLoggedFrameSize) {
+          mLoggedFrameSize = true;
+          Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
+              + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
+              + ", sensor orientation: " + mSensorOrientation + ")");
+        }
 
         Matrix transformMatrix = new Matrix();
         transformMatrix.preTranslate(0.5f, 0.5f);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -215,6 +215,10 @@ public class WhipCameraCapturer implements VideoCapturer {
       // manipulation.  The WebRTC encoder / receiver handles the rotation from
       // mFrameRotation, matching how RTMP/SRT use orientationHint metadata.
       mSurfaceTextureHelper.startListening(frame -> {
+        // Retain the buffer before wrapping in a new VideoFrame — the new frame's
+        // release() will decrement the refcount, and SurfaceTextureHelper will also
+        // release the original frame.  Without retain() this double-release crashes.
+        frame.getBuffer().retain();
         VideoFrame rotatedFrame = new VideoFrame(
             frame.getBuffer(), mFrameRotation, frame.getTimestampNs());
         mObserver.onFrameCaptured(rotatedFrame);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.streaming.services;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.graphics.Matrix;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
@@ -18,6 +19,7 @@ import androidx.annotation.NonNull;
 
 import org.webrtc.CapturerObserver;
 import org.webrtc.SurfaceTextureHelper;
+import org.webrtc.TextureBufferImpl;
 import org.webrtc.VideoCapturer;
 import org.webrtc.VideoFrame;
 
@@ -108,10 +110,12 @@ public class WhipCameraCapturer implements VideoCapturer {
       mIsFrontCamera = false;
     }
 
-    // Let the WebRTC stack handle rotation via metadata (like RTMP/SRT use
-    // MediaRecorder.setOrientationHint). This avoids GPU-level pixel rotation
-    // which causes aspect-ratio stretching at non-square resolutions (e.g. 16:9).
-    mFrameRotation = mSensorOrientation;
+    // Frame rotation = 0 for fixed-landscape devices like glasses.
+    // WebRTC's rotation field causes the stack to transpose dimensions (unlike
+    // RTMP's orientationHint which is just metadata). We handle rotation via
+    // GPU texture transform instead, which rotates content in-place without
+    // changing buffer dimensions.
+    mFrameRotation = 0;
 
     Log.d(TAG, "Sensor orientation: " + mSensorOrientation
         + ", isFront: " + mIsFrontCamera + ", frame rotation: " + mFrameRotation);
@@ -211,18 +215,27 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mCaptureSession.setRepeatingRequest(builder.build(), null, mCameraHandler);
 
-      // Pass frames through with rotation metadata only — no GPU-level pixel
-      // manipulation.  The WebRTC encoder / receiver handles the rotation from
-      // mFrameRotation, matching how RTMP/SRT use orientationHint metadata.
+      // Apply GPU-level texture rotation to correct for sensor orientation.
+      // This rotates content in-place without changing buffer dimensions, so
+      // it works correctly at any aspect ratio (including 16:9).
       mSurfaceTextureHelper.startListening(frame -> {
-        // Retain the buffer before wrapping in a new VideoFrame — the new frame's
-        // release() will decrement the refcount, and SurfaceTextureHelper will also
-        // release the original frame.  Without retain() this double-release crashes.
-        frame.getBuffer().retain();
-        VideoFrame rotatedFrame = new VideoFrame(
-            frame.getBuffer(), mFrameRotation, frame.getTimestampNs());
-        mObserver.onFrameCaptured(rotatedFrame);
-        rotatedFrame.release();
+        TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
+
+        Matrix transformMatrix = new Matrix();
+        transformMatrix.preTranslate(0.5f, 0.5f);
+        if (mIsFrontCamera) {
+          transformMatrix.preScale(-1f, 1f);
+        }
+        transformMatrix.preRotate(-mSensorOrientation);
+        transformMatrix.preTranslate(-0.5f, -0.5f);
+
+        TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
+            transformMatrix, texBuffer.getWidth(), texBuffer.getHeight());
+
+        VideoFrame modifiedFrame = new VideoFrame(
+            modifiedBuffer, mFrameRotation, frame.getTimestampNs());
+        mObserver.onFrameCaptured(modifiedFrame);
+        modifiedFrame.release();
       });
 
       mObserver.onCapturerStarted(true);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -2,7 +2,6 @@ package com.mentra.asg_client.io.streaming.services;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-import android.graphics.Matrix;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
@@ -19,7 +18,6 @@ import androidx.annotation.NonNull;
 
 import org.webrtc.CapturerObserver;
 import org.webrtc.SurfaceTextureHelper;
-import org.webrtc.TextureBufferImpl;
 import org.webrtc.VideoCapturer;
 import org.webrtc.VideoFrame;
 
@@ -110,10 +108,10 @@ public class WhipCameraCapturer implements VideoCapturer {
       mIsFrontCamera = false;
     }
 
-    // Frame rotation = 0 for fixed-landscape devices like glasses.
-    // The texture transform already handles the sensor's physical rotation.
-    // Setting rotation here would cause the encoder to rotate again (double-rotation).
-    mFrameRotation = 0;
+    // Let the WebRTC stack handle rotation via metadata (like RTMP/SRT use
+    // MediaRecorder.setOrientationHint). This avoids GPU-level pixel rotation
+    // which causes aspect-ratio stretching at non-square resolutions (e.g. 16:9).
+    mFrameRotation = mSensorOrientation;
 
     Log.d(TAG, "Sensor orientation: " + mSensorOrientation
         + ", isFront: " + mIsFrontCamera + ", frame rotation: " + mFrameRotation);
@@ -213,30 +211,14 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mCaptureSession.setRepeatingRequest(builder.build(), null, mCameraHandler);
 
-      // Connect SurfaceTextureHelper's frame listener to WebRTC's video pipeline.
-      // Match Camera2Session's approach exactly:
-      // 1. Apply -sensorOrientation rotation to texture transform (GPU-level, no pixel copy)
-      // 2. Set frameRotation metadata for the encoder
+      // Pass frames through with rotation metadata only — no GPU-level pixel
+      // manipulation.  The WebRTC encoder / receiver handles the rotation from
+      // mFrameRotation, matching how RTMP/SRT use orientationHint metadata.
       mSurfaceTextureHelper.startListening(frame -> {
-        TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
-
-        // Build transform matrix matching CameraSession.createTextureBufferWithModifiedTransformMatrix
-        Matrix transformMatrix = new Matrix();
-        transformMatrix.preTranslate(0.5f, 0.5f);
-        if (mIsFrontCamera) {
-          transformMatrix.preScale(-1f, 1f);
-        }
-        transformMatrix.preRotate(-mSensorOrientation);
-        transformMatrix.preTranslate(-0.5f, -0.5f);
-
-        // Apply transform to texture buffer (GPU-level rotation, no pixel copy)
-        TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
-            transformMatrix, texBuffer.getWidth(), texBuffer.getHeight());
-
-        VideoFrame modifiedFrame = new VideoFrame(
-            modifiedBuffer, mFrameRotation, frame.getTimestampNs());
-        mObserver.onFrameCaptured(modifiedFrame);
-        modifiedFrame.release();
+        VideoFrame rotatedFrame = new VideoFrame(
+            frame.getBuffer(), mFrameRotation, frame.getTimestampNs());
+        mObserver.onFrameCaptured(rotatedFrame);
+        rotatedFrame.release();
       });
 
       mObserver.onCapturerStarted(true);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -18,10 +18,14 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
 import com.mentra.asg_client.audio.AudioAssets;
+import com.mentra.asg_client.camera.CameraNeo;
 import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.streaming.config.WhipStreamConfig;
 import com.mentra.asg_client.io.streaming.interfaces.StreamingStatusCallback;
+import com.mentra.asg_client.service.core.constants.BatteryConstants;
+import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.utils.WakeLockManager;
 
 import org.webrtc.RTCStats;
 import org.webrtc.RTCStatsCollectorCallback;
@@ -51,6 +55,8 @@ import org.webrtc.VideoTrack;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -124,6 +130,15 @@ public class WhipStreamingService extends Service {
   private enum StreamState { IDLE, STARTING, STREAMING, STOPPING, RECONNECTING }
   private volatile StreamState mStreamState = StreamState.IDLE;
   private final Object mStateLock = new Object();
+
+  // ---- Stream timeout (keep-alive) ----
+  private static final long STREAM_TIMEOUT_MS = 60000; // 60 seconds
+  private Timer mStreamTimeoutTimer;
+
+  // ---- Battery monitoring ----
+  private static IStateManager sStateManager;
+  private Handler mBatteryMonitorHandler;
+  private Runnable mBatteryCheckRunnable;
 
   // ---- Reconnection ----
   private static final int MAX_RECONNECT_ATTEMPTS = 3;
@@ -234,6 +249,13 @@ public class WhipStreamingService extends Service {
 
   /** Start streaming to the currently configured WHIP URL. */
   private void startStreaming() {
+    // Check if camera is busy with photo/video capture
+    if (CameraNeo.isCameraInUse()) {
+      Log.e(TAG, "Cannot start WHIP stream - camera is busy with photo/video capture");
+      notifyError("camera_busy");
+      return;
+    }
+
     synchronized (mStateLock) {
       if (mStreamState != StreamState.IDLE && mStreamState != StreamState.RECONNECTING) {
         Log.w(TAG, "startStreaming() called in state " + mStreamState + ", ignoring");
@@ -241,6 +263,10 @@ public class WhipStreamingService extends Service {
       }
       mStreamState = StreamState.STARTING;
     }
+
+    // Acquire wake lock to prevent device sleep during streaming
+    WakeLockManager.acquireFullWakeLockAndBringToForeground(
+        getApplicationContext(), 2180000, 5000);
 
     if (!mIsReconnecting) {
       mReconnectAttempts = 0;
@@ -276,6 +302,8 @@ public class WhipStreamingService extends Service {
     }
 
     mMainHandler.removeCallbacks(mStatsRunnable);
+    cancelStreamTimeout();
+    stopBatteryMonitoring();
     Log.d(TAG, "Stopping WHIP streaming (forReconnect=" + forReconnect + ")");
 
     if (mWhipResourceUrl != null) {
@@ -298,6 +326,7 @@ public class WhipStreamingService extends Service {
       }
       mIsReconnecting = false;
       mReconnectAttempts = 0;
+      WakeLockManager.releaseAllWakeLocks();
       resetState();
       notifyStopped();
       updateNotification("Stream stopped");
@@ -536,6 +565,8 @@ public class WhipStreamingService extends Service {
             mLastVideoBytesSent = 0;
             mLastAudioBytesSent = 0;
             mMainHandler.postDelayed(mStatsRunnable, STATS_INTERVAL_MS);
+            scheduleStreamTimeout(mCurrentStreamId);
+            startBatteryMonitoring();
             Log.d(TAG, "Streaming started via WHIP");
             if (mLedEnabled && mHardwareManager != null && mHardwareManager.supportsRecordingLed()) {
               mHardwareManager.setRecordingLedOn();
@@ -769,6 +800,107 @@ public class WhipStreamingService extends Service {
   }
 
   // -----------------------------------------------------------------------
+  // Stream timeout (keep-alive)
+  // -----------------------------------------------------------------------
+
+  private void scheduleStreamTimeout(String streamId) {
+    cancelStreamTimeout();
+
+    mStreamTimeoutTimer = new Timer("WhipStreamTimeout-" + streamId);
+    mStreamTimeoutTimer.schedule(new TimerTask() {
+      @Override
+      public void run() {
+        mMainHandler.post(() -> {
+          synchronized (mStateLock) {
+            if (mStreamState != StreamState.STREAMING) return;
+          }
+          Log.w(TAG, "Stream timed out - no keep-alive received within " + STREAM_TIMEOUT_MS + "ms");
+          notifyError("Stream timed out - no keep-alive from cloud");
+          stopStreaming();
+        });
+      }
+    }, STREAM_TIMEOUT_MS);
+  }
+
+  private void cancelStreamTimeout() {
+    if (mStreamTimeoutTimer != null) {
+      mStreamTimeoutTimer.cancel();
+      mStreamTimeoutTimer = null;
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Battery monitoring
+  // -----------------------------------------------------------------------
+
+  private void startBatteryMonitoring() {
+    stopBatteryMonitoring();
+
+    if (mBatteryMonitorHandler == null) {
+      mBatteryMonitorHandler = new Handler(Looper.getMainLooper());
+    }
+
+    mBatteryCheckRunnable = new Runnable() {
+      @Override
+      public void run() {
+        boolean shouldStop = false;
+        boolean shouldReschedule = false;
+
+        synchronized (mStateLock) {
+          if (mStreamState == StreamState.IDLE || mStreamState == StreamState.STOPPING) {
+            return; // Stream ended, stop monitoring
+          }
+
+          if (mHardwareManager == null) {
+            Log.w(TAG, "HardwareManager not available during battery monitoring - will retry");
+            shouldReschedule = true;
+          } else if (mStreamState == StreamState.STREAMING) {
+            int batteryLevel = mHardwareManager.getBatteryLevel();
+
+            if (batteryLevel >= 0 && batteryLevel < BatteryConstants.MIN_BATTERY_LEVEL) {
+              Log.w(TAG, "Battery dropped to " + batteryLevel
+                  + "% during WHIP streaming - stopping");
+              shouldStop = true;
+
+              if (mHardwareManager.supportsAudioPlayback()) {
+                mHardwareManager.playAudioAsset(AudioAssets.BATTERY_LOW);
+              }
+            } else {
+              shouldReschedule = true;
+            }
+          } else {
+            // Reconnecting — keep monitoring
+            shouldReschedule = true;
+          }
+        }
+
+        if (shouldReschedule && mBatteryMonitorHandler != null) {
+          mBatteryMonitorHandler.postDelayed(this,
+              BatteryConstants.BATTERY_CHECK_INTERVAL_MS);
+        }
+
+        if (shouldStop) {
+          stopStreaming();
+        }
+      }
+    };
+
+    mBatteryMonitorHandler.postDelayed(mBatteryCheckRunnable,
+        BatteryConstants.BATTERY_CHECK_INTERVAL_MS);
+    Log.d(TAG, "Started battery monitoring for WHIP streaming");
+  }
+
+  private void stopBatteryMonitoring() {
+    if (mBatteryMonitorHandler != null) {
+      if (mBatteryCheckRunnable != null) {
+        mBatteryMonitorHandler.removeCallbacks(mBatteryCheckRunnable);
+        mBatteryCheckRunnable = null;
+      }
+      mBatteryMonitorHandler.removeCallbacksAndMessages(null);
+    }
+  }
+
+  // -----------------------------------------------------------------------
   // Static public API
   // -----------------------------------------------------------------------
 
@@ -833,6 +965,27 @@ public class WhipStreamingService extends Service {
   /** Get the current stream ID, or null if not streaming. */
   public static String getCurrentStreamId() {
     return sInstance != null ? sInstance.mCurrentStreamId : null;
+  }
+
+  /** Set the state manager for battery monitoring. */
+  public static void setStateManager(IStateManager stateManager) {
+    sStateManager = stateManager;
+  }
+
+  /**
+   * Reset the stream timeout timer (called by keep-alive commands).
+   * @return true if the streamId matches the current stream
+   */
+  public static boolean resetStreamTimeout(String streamId) {
+    if (sInstance == null) return false;
+    boolean matches = streamId != null && streamId.equals(sInstance.mCurrentStreamId);
+    if (matches || sInstance.mStreamState == StreamState.STREAMING) {
+      sInstance.scheduleStreamTimeout(streamId);
+      // Re-acquire wake lock on keep-alive
+      WakeLockManager.acquireFullWakeLockAndBringToForeground(
+          sInstance.getApplicationContext(), 2180000, 5000);
+    }
+    return matches;
   }
 
   public static void setStreamConfig(WhipStreamConfig config) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -253,6 +253,13 @@ public class WhipStreamingService extends Service {
     if (CameraNeo.isCameraInUse()) {
       Log.e(TAG, "Cannot start WHIP stream - camera is busy with photo/video capture");
       notifyError("camera_busy");
+      // If we were reconnecting, reset state so we don't get stuck in RECONNECTING
+      if (mIsReconnecting) {
+        mIsReconnecting = false;
+        mReconnectAttempts = 0;
+        resetState();
+        notifyStopped();
+      }
       return;
     }
 
@@ -979,7 +986,7 @@ public class WhipStreamingService extends Service {
   public static boolean resetStreamTimeout(String streamId) {
     if (sInstance == null) return false;
     boolean matches = streamId != null && streamId.equals(sInstance.mCurrentStreamId);
-    if (matches || sInstance.mStreamState == StreamState.STREAMING) {
+    if (matches) {
       sInstance.scheduleStreamTimeout(streamId);
       // Re-acquire wake lock on keep-alive
       WakeLockManager.acquireFullWakeLockAndBringToForeground(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/GalleryCommandHandler.java
@@ -7,6 +7,8 @@ import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
+import com.mentra.asg_client.io.streaming.services.SrtStreamingService;
+import com.mentra.asg_client.io.streaming.services.WhipStreamingService;
 import com.mentra.asg_client.utils.GalleryStatusHelper;
 
 import org.json.JSONObject;
@@ -120,8 +122,8 @@ public class GalleryCommandHandler implements ICommandHandler {
     private String getCameraBusyState() {
         try {
             // Check if RTMP streaming is active
-            if (RtmpStreamingService.isStreaming()) {
-                Log.d(TAG, "Camera is busy: RTMP streaming active");
+            if (RtmpStreamingService.isStreaming() || SrtStreamingService.isStreaming() || WhipStreamingService.isStreaming()) {
+                Log.d(TAG, "Camera is busy: streaming active");
                 return "stream";
             }
             

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -166,6 +166,7 @@ public class StreamCommandHandler implements ICommandHandler {
                     WhipStreamConfig config = WhipStreamConfig.fromJson(videoJson, audioJson);
                     Log.d(TAG, "Starting WHIP stream to: " + streamUrl);
                     WhipStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
+                    WhipStreamingService.setStateManager(stateManager);
                     break;
                 }
             }
@@ -271,9 +272,12 @@ public class StreamCommandHandler implements ICommandHandler {
                 }
             }
 
-            if (WhipStreamingService.isStreaming()) {
-                streamingManager.sendKeepAliveAck(streamId, ackId);
-                return true;
+            if (WhipStreamingService.isStreaming() || WhipStreamingService.isReconnecting()) {
+                boolean valid = WhipStreamingService.resetStreamTimeout(streamId);
+                if (valid || WhipStreamingService.isStreaming()) {
+                    streamingManager.sendKeepAliveAck(streamId, ackId);
+                    return true;
+                }
             }
 
             Log.w(TAG, "Keep-alive for unknown stream, not currently streaming: " + streamId);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProtocolDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProtocolDetector.java
@@ -166,14 +166,28 @@ public class CommandProtocolDetector {
             if (json.has("C")) {
                 String dataPayload = json.optString("C", "");
                 try {
-                    new JSONObject(dataPayload); // Test if valid JSON
+                    JSONObject innerJson = new JSONObject(dataPayload);
+                    // Reject chunked messages — ChunkedMessageProtocolStrategy handles these.
+                    // Without this check, chunks get routed as commands with empty type.
+                    String t = innerJson.optString("type", innerJson.optString("t", ""));
+                    if ("chunked_msg".equals(t) || "ck".equals(t)) {
+                        return false;
+                    }
                     return true;
                 } catch (JSONException e) {
                     return false; // Invalid JSON in C field, let K900 strategy handle it
                 }
             }
             // Standard JSON format (no C field)
-            return json.has("type") || json.has("mId");
+            if (json.has("type") || json.has("mId")) {
+                // Also reject direct-format chunks
+                String t = json.optString("type", json.optString("t", ""));
+                if ("chunked_msg".equals(t) || "ck".equals(t)) {
+                    return false;
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override


### PR DESCRIPTION
## Summary
- **WHIP safeguards**: Port all RTMP safeguards to WhipStreamingService — camera busy check (`CameraNeo.isCameraInUse()`), battery monitoring with auto-stop, 60s keep-alive timeout, and wake lock management
- **Photo/video capture guards**: Update all 5 guards in MediaCaptureService + GalleryCommandHandler to block during SRT and WHIP streaming (previously only checked RTMP)
- **Rotation fix**: Replace GPU-level Matrix texture rotation in WhipCameraCapturer with metadata-based rotation (`mFrameRotation = mSensorOrientation`), matching how RTMP/SRT use `orientationHint`. Fixes 16:9 aspect ratio stretching
- **Default resolution**: Change default from 960x720 (4:3) to 960x540 (16:9) in both RtmpStreamConfig and WhipStreamConfig (SRT inherits via RtmpStreamConfig)
- **Chunked message fix**: Fix `JsonCommandProtocolStrategy.canHandle()` intercepting chunked messages (`t:"ck"`) before `ChunkedMessageProtocolStrategy` could handle them, causing photo requests to fail with "No handler found for command"

## Test plan
- [ ] Start WHIP stream → verify camera busy check rejects photo capture attempts
- [ ] Start WHIP stream → verify stream auto-stops after 60s without keep-alive
- [ ] Start WHIP stream → verify stream auto-stops on low battery
- [ ] Start WHIP stream at 960x540 → verify no aspect ratio stretching on receiver
- [ ] Start RTMP/SRT stream at 960x540 → verify no regression
- [ ] Verify wake lock keeps device awake during WHIP streaming
- [ ] Send a chunked take_photo command → verify chunks reassemble and photo is taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)