### PR TITLE
Homescreen: increase drop shadow blur behind miniapp names

### DIFF
--- a/mobile/src/components/home/AppsGrid.tsx
+++ b/mobile/src/components/home/AppsGrid.tsx
@@ -528,9 +528,9 @@ export function AppsGrid({showAllApps = false, onOpenApp, onAddToHome, searchQue
             <Text
               className="text-foreground text-center mt-1 text-[12px] shrink"
               style={{
-                textShadowColor: "rgba(0,0,0,0.3)",
-                textShadowOffset: {width: 0, height: 1},
-                textShadowRadius: 2,
+                textShadowColor: "rgba(0,0,0,0.5)",
+                textShadowOffset: {width: 0, height: 0},
+                textShadowRadius: 6,
               }}
               numberOfLines={2}
               ellipsizeMode="tail"


### PR DESCRIPTION
## Summary
- Increased `textShadowRadius` from 2 to 6 for a more diffused shadow
- Centered shadow offset (removed 1px downward bias)
- Raised shadow opacity from 0.3 to 0.5 so the softer shadow remains visible

Makes the text shadow behind app names on the homescreen more diffused, similar to iOS home screen app labels.

Closes OS-1212

## Test plan
- [ ] Open homescreen on device/simulator and verify app name shadows look diffused and readable
- [ ] Compare with iOS home screen for visual parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced text shadow effects on app labels in the apps grid for improved visual clarity and a more polished appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->