### PR TITLE
fix: use expo-image for app switcher screenshots on Android

### DIFF
--- a/mobile/src/components/home/AppSwitcher.tsx
+++ b/mobile/src/components/home/AppSwitcher.tsx
@@ -1,5 +1,6 @@
 import React, {RefObject, useCallback, useEffect, useRef, useState} from "react"
-import {View, Dimensions, Pressable, Image, Platform} from "react-native"
+import {View, Dimensions, Pressable, Platform} from "react-native"
+import {Image} from "expo-image"
 import {Text} from "@/components/ignite/"
 import Animated, {
   useSharedValue,
@@ -205,11 +206,11 @@ function AppCardItem({app, index, count, translateX, onDismiss, onSelect}: AppCa
           )}
 
           {app.screenshot && (
-            <View className="flex-1 items-center justify-end" style={{overflow: "hidden"}}>
+            <View className="flex-1" style={{overflow: "hidden"}}>
               <Image
                 source={{uri: app.screenshot}}
-                className="w-full h-full"
-                style={{resizeMode: "cover", height: "100%"}}
+                style={{width: "100%", height: "100%"}}
+                contentFit="cover"
               />
             </View>
           )}


### PR DESCRIPTION
## Summary
- Switched `AppSwitcher` from `react-native` `Image` to `expo-image` `Image` to fix zoomed-in screenshots on Android
- RN's `Image` with `resizeMode` as a style property is unreliable on Android — images render at native pixel dimensions instead of fitting the container, causing a zoomed-in appearance
- Also removed unnecessary `justify-end`/`items-center` on the screenshot container

Closes OS-1135

## Test plan
- [ ] Open several apps on Android, then open the app switcher — screenshots should no longer appear zoomed in
- [ ] Verify iOS app switcher screenshots still display correctly
- [ ] Check that apps without screenshots still show the fallback icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)