### PR TITLE
fix(mobile): prevent back gesture from exiting miniapp WebViews

### DIFF
--- a/mobile/src/app/applet/webview.tsx
+++ b/mobile/src/app/applet/webview.tsx
@@ -1,5 +1,5 @@
 import {useLocalSearchParams} from "expo-router"
-import {useRef, useState, useEffect} from "react"
+import {useRef, useState, useEffect, useCallback} from "react"
 import {Dimensions, Platform, View} from "react-native"
 import {WebView} from "react-native-webview"
 import Animated, {useSharedValue, useAnimatedStyle, withTiming} from "react-native-reanimated"
@@ -7,7 +7,7 @@ import Animated, {useSharedValue, useAnimatedStyle, withTiming} from "react-nati
 import {Header, Screen, Text} from "@/components/ignite"
 import MiniappErrorScreen from "@/components/miniapps/MiniappErrorScreen"
 import LoadingOverlay from "@/components/ui/LoadingOverlay"
-import {useNavigationHistory} from "@/contexts/NavigationHistoryContext"
+import {focusEffectPreventBack, useNavigationHistory} from "@/contexts/NavigationHistoryContext"
 import restComms from "@/services/RestComms"
 import miniComms from "@/services/MiniComms"
 import {SETTINGS, useSetting, useSettingsStore} from "@/stores/settings"
@@ -34,6 +34,21 @@ export default function AppWebView() {
 
   // Track if the server-side app start failed
   const [appStartFailed, setAppStartFailed] = useState(false)
+
+  // Track whether the WebView has back navigation history
+  const [webViewCanGoBack, setWebViewCanGoBack] = useState(false)
+
+  // Back press handler: navigate within WebView if possible, otherwise do nothing.
+  // Users must press X to exit the miniapp.
+  const handleWebViewBack = useCallback(() => {
+    if (webViewCanGoBack && webViewRef.current) {
+      webViewRef.current.goBack()
+    }
+  }, [webViewCanGoBack])
+
+  // Prevent iOS swipe-back gesture and intercept Android back button.
+  // Back navigates within the WebView; only X exits the miniapp.
+  focusEffectPreventBack(handleWebViewBack)
 
   // Two conditions for showing the webview content:
   // 1. WebView HTML has loaded (onLoadEnd fired)
@@ -281,11 +296,21 @@ export default function AppWebView() {
   if (showError) {
     return (
       <>
-        {appSwitcherUi && <MiniAppCapsuleMenu packageName={packageName} viewShotRef={viewShotRef} />}
+        {appSwitcherUi && <MiniAppCapsuleMenu packageName={packageName} viewShotRef={viewShotRef} onBackPress={handleWebViewBack} />}
         <Screen preset="fixed" safeAreaEdges={[appSwitcherUi && "top"]} className="px-0">
           {!appSwitcherUi && (
             <View className="px-6">
-              <Header leftIcon="chevron-left" onLeftPress={() => goBack()} title={appName} />
+              <Header
+              leftIcon="chevron-left"
+              onLeftPress={() => {
+                if (webViewCanGoBack && webViewRef.current) {
+                  webViewRef.current.goBack()
+                } else {
+                  goBack()
+                }
+              }}
+              title={appName}
+            />
             </View>
           )}
           <MiniappErrorScreen
@@ -332,7 +357,7 @@ export default function AppWebView() {
 
   return (
     <>
-      {appSwitcherUi && <MiniAppCapsuleMenu packageName={packageName} viewShotRef={viewShotRef} />}
+      {appSwitcherUi && <MiniAppCapsuleMenu packageName={packageName} viewShotRef={viewShotRef} onBackPress={handleWebViewBack} />}
       <Screen
         preset="fixed"
         // safeAreaEdges={[appSwitcherUi && "top"]}
@@ -345,7 +370,13 @@ export default function AppWebView() {
           <View className="px-6">
             <Header
               leftIcon="chevron-left"
-              onLeftPress={() => goBack()}
+              onLeftPress={() => {
+                if (webViewCanGoBack && webViewRef.current) {
+                  webViewRef.current.goBack()
+                } else {
+                  goBack()
+                }
+              }}
               title={appName}
               rightIcon="settings"
               onRightPress={() => {
@@ -378,6 +409,7 @@ export default function AppWebView() {
                 scalesPageToFit={false}
                 scrollEnabled={true}
                 bounces={false}
+                onNavigationStateChange={(navState) => setWebViewCanGoBack(navState.canGoBack)}
                 automaticallyAdjustContentInsets={false}
                 contentInsetAdjustmentBehavior="never"
                 injectedJavaScriptBeforeContentLoaded={`

--- a/mobile/src/app/applet/webview.tsx
+++ b/mobile/src/app/applet/webview.tsx
@@ -38,13 +38,21 @@ export default function AppWebView() {
   // Track whether the WebView has back navigation history
   const [webViewCanGoBack, setWebViewCanGoBack] = useState(false)
 
+  // Allow back to exit if route params are invalid (no X button on that screen)
+  const hasValidParams =
+    typeof webviewURL === "string" && typeof appName === "string" && typeof packageName === "string"
+
   // Back press handler: navigate within WebView if possible, otherwise do nothing.
   // Users must press X to exit the miniapp.
   const handleWebViewBack = useCallback(() => {
+    if (!hasValidParams) {
+      goBack()
+      return
+    }
     if (webViewCanGoBack && webViewRef.current) {
       webViewRef.current.goBack()
     }
-  }, [webViewCanGoBack])
+  }, [webViewCanGoBack, hasValidParams, goBack])
 
   // Prevent iOS swipe-back gesture and intercept Android back button.
   // Back navigates within the WebView; only X exits the miniapp.
@@ -69,7 +77,7 @@ export default function AppWebView() {
     opacity: loadingOpacity.value,
   }))
 
-  if (typeof webviewURL !== "string" || typeof appName !== "string" || typeof packageName !== "string") {
+  if (!hasValidParams) {
     return <Text>Missing required parameters</Text>
   }
 

--- a/mobile/src/components/miniapps/CapsuleMenu.tsx
+++ b/mobile/src/components/miniapps/CapsuleMenu.tsx
@@ -44,11 +44,13 @@ export function MiniAppCapsuleMenu({
   viewShotRef,
   onEllipsisPress,
   onMinusPress,
+  onBackPress,
 }: {
   packageName: string
   viewShotRef: React.RefObject<View | null>
   onEllipsisPress?: () => void
   onMinusPress?: () => void
+  onBackPress?: () => void
 }) {
   const {goBack} = useNavigationHistory()
   const insets = useSaferAreaInsets()
@@ -101,13 +103,20 @@ export function MiniAppCapsuleMenu({
     }
   }
 
-  focusEffectPreventBack(() => {
-    // Defer screenshot capture so it doesn't block the navigation animation
-    InteractionManager.runAfterInteractions(() => {
-      let shouldGoBack = Platform.OS === "android"
-      handleExit(shouldGoBack)
-    })
-  }, true)
+  focusEffectPreventBack(
+    onBackPress
+      ? () => {
+          onBackPress()
+        }
+      : () => {
+          // Defer screenshot capture so it doesn't block the navigation animation
+          InteractionManager.runAfterInteractions(() => {
+            let shouldGoBack = Platform.OS === "android"
+            handleExit(shouldGoBack)
+          })
+        },
+    onBackPress ? false : true,
+  )
 
   return (
     <View className="z-2 absolute right-2 items-center justify-end flex-row" style={{top: top}}>


### PR DESCRIPTION
## Summary
- **Disables iOS swipe-back gesture** on miniapp WebView screens so it no longer interferes with swipable elements (sliders, carousels, etc.)
- **Android back button** now navigates within the WebView history instead of immediately exiting the miniapp
- **Header back button** (non-capsule UI) tries WebView back first, only exits when there's no WebView history
- **X button** remains the only way to exit a miniapp

## Changes
- `webview.tsx`: Track WebView navigation state via `onNavigationStateChange`, call `focusEffectPreventBack` to block native back, pass `onBackPress` to CapsuleMenu
- `CapsuleMenu.tsx`: Accept `onBackPress` prop; when provided, use it as the back handler and disable iOS swipe-back gesture

## Test plan
- [ ] Open a miniapp with swipable elements (slider/carousel) on iOS — swiping should work without triggering exit
- [ ] On iOS, swipe right from the edge — should NOT exit the miniapp
- [ ] On Android, press back button — should navigate within miniapp WebView if there's history, otherwise do nothing
- [ ] Press X button — should still exit the miniapp and capture screenshot for app switcher
- [ ] Open a miniapp that navigates to a second page, press Android back — should go back to first page
- [ ] Verify non-capsule UI header back button navigates within WebView before exiting

Closes OS-1198

🤖 Generated with [Claude Code](https://claude.com/claude-code)