### PR TITLE
fix(store): hide Get button for incompatible miniapps

### DIFF
--- a/cloud/websites/store/src/components/AppCard.tsx
+++ b/cloud/websites/store/src/components/AppCard.tsx
@@ -210,19 +210,7 @@ const AppCard: React.FC<AppCardProps> = memo(
                 }>
                 <div className="text-[14px]">Installed</div>
               </Button>
-            ) : app.compatibility?.isCompatible === false ? (
-              // Incompatible app - show disabled "Get" button
-              <Button
-                disabled={true}
-                className="text-[11px] font-normal tracking-[0.1em] px-4 py-[6px] rounded-full w-[56px] h-[36px] flex items-center justify-center opacity-40 cursor-not-allowed"
-                style={{
-                  backgroundColor: "var(--button-bg)",
-                  color: "var(--button-text)",
-                }}
-                title="This app is incompatible with your glasses">
-                <div className="text-[14px] font-medium">Get</div>
-              </Button>
-            ) : (
+            ) : app.compatibility?.isCompatible === false ? null : (
               // )
               <Button
                 onClick={handleInstallClick}

--- a/cloud/websites/store/src/pages/AppDetailsDesktop.tsx
+++ b/cloud/websites/store/src/pages/AppDetailsDesktop.tsx
@@ -112,18 +112,7 @@ const AppDetailsDesktop: React.FC<AppDetailsDesktopProps> = ({
                       }}>
                       Installed
                     </Button>
-                  ) : app.compatibility?.isCompatible === false ? (
-                    <Button
-                      disabled={true}
-                      className="px-8 h-[44px] text-[18px] font-medium rounded-full opacity-40 cursor-not-allowed min-w-[242px]"
-                      style={{
-                        fontFamily: '"Red Hat Display", sans-serif',
-                        backgroundColor: "var(--button-bg)",
-                        color: "var(--button-text)",
-                      }}>
-                      Get
-                    </Button>
-                  ) : (
+                  ) : app.compatibility?.isCompatible === false ? null : (
                     <Button
                       onClick={handleInstall}
                       disabled={installingApp}

--- a/cloud/websites/store/src/pages/AppDetailsMobile.tsx
+++ b/cloud/websites/store/src/pages/AppDetailsMobile.tsx
@@ -148,18 +148,7 @@ const AppDetailsMobile: React.FC<AppDetailsMobileProps> = ({
                     }}>
                     Installed
                   </Button>
-                ) : app.compatibility?.isCompatible === false ? (
-                  <Button
-                    disabled={true}
-                    className="flex-1 h-[36px] text-[14px] font-medium rounded-full opacity-40 cursor-not-allowed"
-                    style={{
-                      fontFamily: '"Red Hat Display", sans-serif',
-                      backgroundColor: "var(--button-bg)",
-                      color: "var(--button-text)",
-                    }}>
-                    Get
-                  </Button>
-                ) : (
+                ) : app.compatibility?.isCompatible === false ? null : (
                   <Button
                     onClick={handleInstall}
                     disabled={installingApp}


### PR DESCRIPTION
## Summary
- Hide the "Get" button entirely when a miniapp is incompatible with the user's glasses, instead of showing a greyed-out disabled button
- Applied across AppCard (list view), AppDetailsDesktop, and AppDetailsMobile
- Incompatibility warning text with AlertTriangle icon is still shown on detail pages

Closes OS-1220

## Test plan
- [ ] Open the store with glasses that have incompatible apps
- [ ] Verify the "Get" button is hidden for incompatible apps in the app list
- [ ] Verify the "Get" button is hidden on desktop and mobile detail pages
- [ ] Verify the incompatibility warning text still appears on detail pages
- [ ] Verify compatible apps still show the "Get" button normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Incompatible apps no longer display a disabled "Get" button; the action button is now hidden entirely for incompatible applications across all app detail views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->