### PR TITLE
fix(mobile): sort running miniapps tray to match app switcher order

### DIFF
--- a/mobile/src/components/home/AppSwitcherButtton.tsx
+++ b/mobile/src/components/home/AppSwitcherButtton.tsx
@@ -42,6 +42,7 @@ export default function AppSwitcherButton({swipeProgress, onGridButtonPress, blu
   const [androidBlur] = useSetting(SETTINGS.android_blur.key)
 
   useEffect(() => {
+    let isCancelled = false
     const sortApps = async () => {
       let list = [...backgroundApps]
       if (foregroundApp) {
@@ -59,9 +60,14 @@ export default function AppSwitcherButton({swipeProgress, onGridButtonPress, blu
           return a.time.value - b.time.value
         })
         .map((entry) => entry.app)
-      setAppsList(sortedList)
+      if (!isCancelled) {
+        setAppsList(sortedList)
+      }
     }
     sortApps()
+    return () => {
+      isCancelled = true
+    }
   }, [backgroundApps, foregroundApp])
 
   const panGesture = Gesture.Pan()

--- a/mobile/src/components/home/AppSwitcherButtton.tsx
+++ b/mobile/src/components/home/AppSwitcherButtton.tsx
@@ -6,7 +6,7 @@ import {Icon, Text} from "@/components/ignite"
 import AppIcon from "@/components/home/AppIcon"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
-import {ClientAppletInterface, useActiveApps, useActiveBackgroundApps, useActiveForegroundApp} from "@/stores/applets"
+import {ClientAppletInterface, getLastOpenTime, useActiveApps, useActiveBackgroundApps, useActiveForegroundApp} from "@/stores/applets"
 import {RefObject, useEffect, useRef, useState} from "react"
 import {scheduleOnRN} from "react-native-worklets"
 import {BlurView} from "expo-blur"
@@ -42,11 +42,26 @@ export default function AppSwitcherButton({swipeProgress, onGridButtonPress, blu
   const [androidBlur] = useSetting(SETTINGS.android_blur.key)
 
   useEffect(() => {
-    let list = [...backgroundApps]
-    if (foregroundApp) {
-      list.push(foregroundApp)
+    const sortApps = async () => {
+      let list = [...backgroundApps]
+      if (foregroundApp) {
+        list.push(foregroundApp)
+      }
+      const timestamps = await Promise.all(
+        list.map(async (app) => ({
+          app,
+          time: await getLastOpenTime(app.packageName),
+        })),
+      )
+      const sortedList = timestamps
+        .sort((a, b) => {
+          if (a.time.is_error() || b.time.is_error()) return 0
+          return a.time.value - b.time.value
+        })
+        .map((entry) => entry.app)
+      setAppsList(sortedList)
     }
-    setAppsList(list)
+    sortApps()
   }, [backgroundApps, foregroundApp])
 
   const panGesture = Gesture.Pan()


### PR DESCRIPTION
## Summary
- Sorts the bottom "Running Miniapps" tray by `getLastOpenTime`, matching the app switcher carousel's ordering logic
- Previously the tray just combined background + foreground apps without sorting, causing inconsistent ordering between the two views

Fixes OS-1217

## Test plan
- [ ] Open 3+ miniapps
- [ ] Verify the order of apps in the bottom tray matches the order in the app switcher carousel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App switcher now displays apps sorted by last-open time, prioritizing recently used applications for easier access.
  * Sorting is performed asynchronously to keep the UI responsive while the list updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->