### PR TITLE
Fix WHIP video stretch

### DIFF
--- a/.github/workflows/porter-us-west.yml
+++ b/.github/workflows/porter-us-west.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Manual trigger only — no auto-deploy
   push:
     branches:
-      - cloud/064-bstack-cli
+      - hotfix/075-hot-path-allocation
     paths:
       - "cloud/**"
       - ".github/workflows/porter-us-west.yml"

--- a/.github/workflows/porter-us-west.yml
+++ b/.github/workflows/porter-us-west.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch: # Manual trigger only — no auto-deploy
   push:
     branches:
-      - hotfix/075-hot-path-allocation
+      - cloud/issues-077-heap-diagnostics
     paths:
       - "cloud/**"
       - ".github/workflows/porter-us-west.yml"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -71,6 +71,10 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mFps;
   private int mCaptureWidth;
   private int mCaptureHeight;
+  private int mCropX;
+  private int mCropY;
+  private int mCropWidth;
+  private int mCropHeight;
   private int mSensorOrientation;
   private int mFrameRotation;
   private boolean mIsFrontCamera;
@@ -118,6 +122,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       Size captureSize = chooseCaptureSize(chars, width, height);
       mCaptureWidth = captureSize.getWidth();
       mCaptureHeight = captureSize.getHeight();
+      updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
       mFrameRotation = getFrameOrientation();
     } catch (CameraAccessException e) {
@@ -126,12 +131,15 @@ public class WhipCameraCapturer implements VideoCapturer {
       mIsFrontCamera = false;
       mCaptureWidth = width;
       mCaptureHeight = height;
+      updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
       mFrameRotation = 0;
     }
 
     Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
         + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", " + mCropY
+        + ")"
         + ", sensor orientation: " + mSensorOrientation
         + ", isFront: " + mIsFrontCamera
         + ", frame rotation: " + mFrameRotation);
@@ -242,15 +250,21 @@ public class WhipCameraCapturer implements VideoCapturer {
           Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
               + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
               + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+              + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", "
+              + mCropY + ")"
               + ", sensor orientation: " + mSensorOrientation
               + ", frame rotation: " + mFrameRotation + ")");
         }
 
         TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
             createTextureTransformMatrix(), texBuffer.getWidth(), texBuffer.getHeight());
+        VideoFrame.Buffer outputBuffer = adaptOutputBuffer(modifiedBuffer);
+        if (outputBuffer != modifiedBuffer) {
+          modifiedBuffer.release();
+        }
 
         VideoFrame modifiedFrame = new VideoFrame(
-            modifiedBuffer, mFrameRotation, frame.getTimestampNs());
+            outputBuffer, mFrameRotation, frame.getTimestampNs());
         mObserver.onFrameCaptured(modifiedFrame);
         modifiedFrame.release();
       });
@@ -400,43 +414,91 @@ public class WhipCameraCapturer implements VideoCapturer {
 
     Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
     Size bestSize = normalizeLandscapeSize(outputSizes[0]);
-    float requestedAspectRatio = requestedSize.getWidth() / (float) requestedSize.getHeight();
-    long requestedArea = (long) requestedSize.getWidth() * requestedSize.getHeight();
-    double bestAspectDelta = Double.MAX_VALUE;
-    boolean bestMeetsRequestedSize = false;
-    long bestAreaDelta = Long.MAX_VALUE;
+    int bestTransformPenalty = Integer.MAX_VALUE;
+    long bestSourceArea = Long.MAX_VALUE;
+    long bestCropAreaDelta = Long.MAX_VALUE;
 
     for (Size rawSize : outputSizes) {
       Size candidate = normalizeLandscapeSize(rawSize);
-      float candidateAspectRatio = candidate.getWidth() / (float) candidate.getHeight();
-      double aspectDelta = Math.abs(candidateAspectRatio - requestedAspectRatio);
-      boolean meetsRequestedSize = candidate.getWidth() >= requestedSize.getWidth()
-          && candidate.getHeight() >= requestedSize.getHeight();
+      Size croppedSize = getCenterCropSize(candidate.getWidth(), candidate.getHeight(),
+          requestedSize.getWidth(), requestedSize.getHeight());
+      boolean meetsRequestedSize = croppedSize.getWidth() >= requestedSize.getWidth()
+          && croppedSize.getHeight() >= requestedSize.getHeight();
+      boolean exactOutput = croppedSize.getWidth() == requestedSize.getWidth()
+          && croppedSize.getHeight() == requestedSize.getHeight();
+      int transformPenalty = exactOutput ? 0 : meetsRequestedSize ? 1 : 2;
       long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
-      long areaDelta = Math.abs(candidateArea - requestedArea);
+      long cropArea = (long) croppedSize.getWidth() * croppedSize.getHeight();
+      long cropAreaDelta = Math.abs(cropArea
+          - ((long) requestedSize.getWidth() * requestedSize.getHeight()));
 
-      boolean isBetter = aspectDelta < bestAspectDelta
-          || (Double.compare(aspectDelta, bestAspectDelta) == 0
-              && meetsRequestedSize && !bestMeetsRequestedSize)
-          || (Double.compare(aspectDelta, bestAspectDelta) == 0
-              && meetsRequestedSize == bestMeetsRequestedSize
-              && areaDelta < bestAreaDelta);
+      boolean isBetter = transformPenalty < bestTransformPenalty
+          || (transformPenalty == bestTransformPenalty && candidateArea < bestSourceArea)
+          || (transformPenalty == bestTransformPenalty && candidateArea == bestSourceArea
+              && cropAreaDelta < bestCropAreaDelta);
 
       if (isBetter) {
         bestSize = candidate;
-        bestAspectDelta = aspectDelta;
-        bestMeetsRequestedSize = meetsRequestedSize;
-        bestAreaDelta = areaDelta;
+        bestTransformPenalty = transformPenalty;
+        bestSourceArea = candidateArea;
+        bestCropAreaDelta = cropAreaDelta;
       }
     }
 
     Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
-    if (bestAspectDelta > 0.01d) {
+    if (bestTransformPenalty == 1) {
+      Log.d(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+          + " will be cropped and downscaled to " + requestedWidth + "x" + requestedHeight);
+    } else if (bestTransformPenalty == 2) {
       Log.w(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
-          + " is not a close aspect-ratio match for requested " + requestedWidth + "x"
-          + requestedHeight);
+          + " cannot reach requested " + requestedWidth + "x" + requestedHeight
+          + " without upscaling");
     }
     return bestSize;
+  }
+
+  private void updateOutputCrop() {
+    Size cropSize = getCenterCropSize(mCaptureWidth, mCaptureHeight, mWidth, mHeight);
+    mCropWidth = cropSize.getWidth();
+    mCropHeight = cropSize.getHeight();
+    mCropX = Math.max(0, (mCaptureWidth - mCropWidth) / 2);
+    mCropY = Math.max(0, (mCaptureHeight - mCropHeight) / 2);
+  }
+
+  private VideoFrame.Buffer adaptOutputBuffer(TextureBufferImpl buffer) {
+    boolean needsCrop = mCropX != 0 || mCropY != 0
+        || mCropWidth != buffer.getWidth() || mCropHeight != buffer.getHeight();
+    boolean needsScale = buffer.getWidth() != mWidth || buffer.getHeight() != mHeight;
+
+    if (!needsCrop && !needsScale) {
+      return buffer;
+    }
+
+    return buffer.cropAndScale(mCropX, mCropY, mCropWidth, mCropHeight, mWidth, mHeight);
+  }
+
+  private Size getCenterCropSize(int sourceWidth, int sourceHeight, int targetWidth,
+      int targetHeight) {
+    if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+      return new Size(sourceWidth, sourceHeight);
+    }
+
+    float sourceAspectRatio = sourceWidth / (float) sourceHeight;
+    float targetAspectRatio = targetWidth / (float) targetHeight;
+    int cropWidth = sourceWidth;
+    int cropHeight = sourceHeight;
+
+    if (Math.abs(sourceAspectRatio - targetAspectRatio) > 0.0001f) {
+      if (sourceAspectRatio > targetAspectRatio) {
+        cropWidth = Math.round(sourceHeight * targetAspectRatio);
+      } else {
+        cropHeight = Math.round(sourceWidth / targetAspectRatio);
+      }
+    }
+
+    cropWidth = Math.max(1, Math.min(sourceWidth, cropWidth));
+    cropHeight = Math.max(1, Math.min(sourceHeight, cropHeight));
+    return new Size(cropWidth, cropHeight);
   }
 
   private Size normalizeLandscapeSize(Size size) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -3,19 +3,25 @@ package com.mentra.asg_client.io.streaming.services;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
 import android.util.Range;
+import android.util.Size;
 import android.view.Surface;
+import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+
+import com.mentra.asg_client.service.utils.ServiceUtils;
 
 import org.webrtc.CapturerObserver;
 import org.webrtc.SurfaceTextureHelper;
@@ -23,6 +29,7 @@ import org.webrtc.TextureBufferImpl;
 import org.webrtc.VideoCapturer;
 import org.webrtc.VideoFrame;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -62,6 +69,8 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mWidth;
   private int mHeight;
   private int mFps;
+  private int mCaptureWidth;
+  private int mCaptureHeight;
   private int mSensorOrientation;
   private int mFrameRotation;
   private boolean mIsFrontCamera;
@@ -80,6 +89,7 @@ public class WhipCameraCapturer implements VideoCapturer {
     mWidth = width;
     mHeight = height;
     mFps = fps;
+    mLoggedFrameSize = false;
 
     // Low-priority camera thread (matches StreamPackLite CameraExecutorManager)
     mCameraThread = new HandlerThread("WhipCameraThread");
@@ -99,27 +109,32 @@ public class WhipCameraCapturer implements VideoCapturer {
       return;
     }
 
-    // Get sensor orientation and camera facing for texture transform + frame rotation
     try {
       CameraCharacteristics chars = cameraManager.getCameraCharacteristics(cameraId);
-      mSensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
+      Integer sensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
+      mSensorOrientation = sensorOrientation != null ? sensorOrientation : 90;
       Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
       mIsFrontCamera = facing != null && facing == CameraCharacteristics.LENS_FACING_FRONT;
+      Size captureSize = chooseCaptureSize(chars, width, height);
+      mCaptureWidth = captureSize.getWidth();
+      mCaptureHeight = captureSize.getHeight();
+      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
+      mFrameRotation = getFrameOrientation();
     } catch (CameraAccessException e) {
       Log.w(TAG, "Failed to get camera characteristics", e);
       mSensorOrientation = 90;
       mIsFrontCamera = false;
+      mCaptureWidth = width;
+      mCaptureHeight = height;
+      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
+      mFrameRotation = 0;
     }
 
-    // Frame rotation = 0 for fixed-landscape devices like glasses.
-    // WebRTC's rotation field causes the stack to transpose dimensions (unlike
-    // RTMP's orientationHint which is just metadata). We handle rotation via
-    // GPU texture transform instead, which rotates content in-place without
-    // changing buffer dimensions.
-    mFrameRotation = 0;
-
-    Log.d(TAG, "Sensor orientation: " + mSensorOrientation
-        + ", isFront: " + mIsFrontCamera + ", frame rotation: " + mFrameRotation);
+    Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
+        + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", sensor orientation: " + mSensorOrientation
+        + ", isFront: " + mIsFrontCamera
+        + ", frame rotation: " + mFrameRotation);
 
     try {
       cameraManager.openCamera(cameraId, new CameraDevice.StateCallback() {
@@ -216,9 +231,9 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mCaptureSession.setRepeatingRequest(builder.build(), null, mCameraHandler);
 
-      // Apply GPU-level texture rotation to correct for sensor orientation.
-      // This rotates content in-place without changing buffer dimensions, so
-      // it works correctly at any aspect ratio (including 16:9).
+      // Match the stock WebRTC Camera2 session semantics:
+      // 1. Apply a texture transform for sensor/front-camera correction.
+      // 2. Preserve frame rotation metadata so downstream width/height handling stays correct.
       mSurfaceTextureHelper.startListening(frame -> {
         TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
 
@@ -226,19 +241,13 @@ public class WhipCameraCapturer implements VideoCapturer {
           mLoggedFrameSize = true;
           Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
               + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
-              + ", sensor orientation: " + mSensorOrientation + ")");
+              + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+              + ", sensor orientation: " + mSensorOrientation
+              + ", frame rotation: " + mFrameRotation + ")");
         }
-
-        Matrix transformMatrix = new Matrix();
-        transformMatrix.preTranslate(0.5f, 0.5f);
-        if (mIsFrontCamera) {
-          transformMatrix.preScale(-1f, 1f);
-        }
-        transformMatrix.preRotate(-mSensorOrientation);
-        transformMatrix.preTranslate(-0.5f, -0.5f);
 
         TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
-            transformMatrix, texBuffer.getWidth(), texBuffer.getHeight());
+            createTextureTransformMatrix(), texBuffer.getWidth(), texBuffer.getHeight());
 
         VideoFrame modifiedFrame = new VideoFrame(
             modifiedBuffer, mFrameRotation, frame.getTimestampNs());
@@ -248,7 +257,7 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mObserver.onCapturerStarted(true);
       Log.d(TAG, "Camera capture started with power-saving optimizations: "
-          + mWidth + "x" + mHeight + " @" + mFps + "fps");
+          + mCaptureWidth + "x" + mCaptureHeight + " @" + mFps + "fps");
 
     } catch (CameraAccessException e) {
       Log.e(TAG, "Failed to start repeating request", e);
@@ -327,5 +336,111 @@ public class WhipCameraCapturer implements VideoCapturer {
       Log.e(TAG, "Failed to enumerate cameras", e);
       return null;
     }
+  }
+
+  private Matrix createTextureTransformMatrix() {
+    Matrix transformMatrix = new Matrix();
+    transformMatrix.preTranslate(0.5f, 0.5f);
+    if (mIsFrontCamera) {
+      transformMatrix.preScale(-1f, 1f);
+    }
+    transformMatrix.preRotate(-mSensorOrientation);
+    transformMatrix.preTranslate(-0.5f, -0.5f);
+    return transformMatrix;
+  }
+
+  private int getFrameOrientation() {
+    int deviceOrientation = getDeviceOrientationDegrees();
+    if (!mIsFrontCamera) {
+      deviceOrientation = (360 - deviceOrientation) % 360;
+    }
+    return (mSensorOrientation + deviceOrientation) % 360;
+  }
+
+  private int getDeviceOrientationDegrees() {
+    if (ServiceUtils.isK900Device(mContext)) {
+      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    }
+
+    WindowManager windowManager =
+        (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
+    if (windowManager == null) {
+      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    }
+
+    switch (windowManager.getDefaultDisplay().getRotation()) {
+      case Surface.ROTATION_90:
+        return 90;
+      case Surface.ROTATION_180:
+        return 180;
+      case Surface.ROTATION_270:
+        return 270;
+      case Surface.ROTATION_0:
+      default:
+        return 0;
+    }
+  }
+
+  private Size chooseCaptureSize(CameraCharacteristics characteristics, int requestedWidth,
+      int requestedHeight) {
+    StreamConfigurationMap configurationMap =
+        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+    if (configurationMap == null) {
+      Log.w(TAG, "No stream configuration map; using requested size "
+          + requestedWidth + "x" + requestedHeight);
+      return new Size(requestedWidth, requestedHeight);
+    }
+
+    Size[] outputSizes = configurationMap.getOutputSizes(SurfaceTexture.class);
+    if (outputSizes == null || outputSizes.length == 0) {
+      Log.w(TAG, "No SurfaceTexture output sizes; using requested size "
+          + requestedWidth + "x" + requestedHeight);
+      return new Size(requestedWidth, requestedHeight);
+    }
+
+    Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
+    Size bestSize = normalizeLandscapeSize(outputSizes[0]);
+    float requestedAspectRatio = requestedSize.getWidth() / (float) requestedSize.getHeight();
+    long requestedArea = (long) requestedSize.getWidth() * requestedSize.getHeight();
+    double bestAspectDelta = Double.MAX_VALUE;
+    boolean bestMeetsRequestedSize = false;
+    long bestAreaDelta = Long.MAX_VALUE;
+
+    for (Size rawSize : outputSizes) {
+      Size candidate = normalizeLandscapeSize(rawSize);
+      float candidateAspectRatio = candidate.getWidth() / (float) candidate.getHeight();
+      double aspectDelta = Math.abs(candidateAspectRatio - requestedAspectRatio);
+      boolean meetsRequestedSize = candidate.getWidth() >= requestedSize.getWidth()
+          && candidate.getHeight() >= requestedSize.getHeight();
+      long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
+      long areaDelta = Math.abs(candidateArea - requestedArea);
+
+      boolean isBetter = aspectDelta < bestAspectDelta
+          || (Double.compare(aspectDelta, bestAspectDelta) == 0
+              && meetsRequestedSize && !bestMeetsRequestedSize)
+          || (Double.compare(aspectDelta, bestAspectDelta) == 0
+              && meetsRequestedSize == bestMeetsRequestedSize
+              && areaDelta < bestAreaDelta);
+
+      if (isBetter) {
+        bestSize = candidate;
+        bestAspectDelta = aspectDelta;
+        bestMeetsRequestedSize = meetsRequestedSize;
+        bestAreaDelta = areaDelta;
+      }
+    }
+
+    Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
+    if (bestAspectDelta > 0.01d) {
+      Log.w(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+          + " is not a close aspect-ratio match for requested " + requestedWidth + "x"
+          + requestedHeight);
+    }
+    return bestSize;
+  }
+
+  private Size normalizeLandscapeSize(Size size) {
+    return new Size(Math.max(size.getWidth(), size.getHeight()),
+        Math.min(size.getWidth(), size.getHeight()));
   }
 }

--- a/cloud/issues/077-heap-diagnostics/spike.md
+++ b/cloud/issues/077-heap-diagnostics/spike.md
@@ -1,0 +1,305 @@
+# Spike & Spec: Heap Diagnostics — Find What's Growing
+
+**Issue:** 077
+**Related:** [075-heap-fragmentation-hot-path](../075-heap-fragmentation-hot-path/), [074-sdk-v3-merge-and-ship](../074-sdk-v3-merge-and-ship/), [057-cloud-observability](../057-cloud-observability/)
+**Status:** Spike + Spec
+**Date:** 2026-04-01
+
+---
+
+## Problem
+
+The cloud's heap grows ~300MB/hour with stable session count. We've fixed timer leaks (issue 074, PR #2377) and tried reducing hot-path allocation churn (issue 075, PR #2389). Neither stopped the growth. GC frees 0MB on every probe — the growing objects are reachable, not garbage.
+
+**We know memory is growing. We don't know WHAT is growing.**
+
+The missing observability: we can see `heapUsedMB` climbing in system-vitals, but we can't see which object types are accumulating. We're guessing instead of measuring.
+
+---
+
+## What We Have vs What We Need
+
+### Current tools (what we have)
+
+| Tool | What it tells us | Limitation |
+|------|-----------------|------------|
+| `process.memoryUsage()` | RSS, heap, external as numbers (logged every 30s) | Tells us memory IS growing, not WHAT is growing |
+| `Bun.generateHeapSnapshot()` | JSC-format JSON (~170MB) | OOM risk (doubles memory), slow Python analysis, no comparison view |
+| `MemoryLeakDetector` + `FinalizationRegistry` | Whether disposed objects get GC'd | Only useful for objects we explicitly track (UserSession). Doesn't help with live objects growing. |
+| `gc-probe` (forced GC every 60s) | GC duration, freed MB | Confirms GC frees 0MB. Doesn't say why. |
+
+### New tools (what Bun provides that we're not using)
+
+| Tool | What it tells us | Cost |
+|------|-----------------|------|
+| `heapStats()` from `bun:jsc` | `objectTypeCounts`: exact count of every object type in the heap (Array, Object, Function, Promise, Map, Set, etc.) | ~1ms, zero memory overhead, safe to call every 30-60s |
+| `heapStats().protectedObjectTypeCounts` | Objects that GC cannot collect (active timers, signals, pending I/O) | Same call as above |
+| `writeHeapSnapshot()` from `v8` | V8-compatible `.heapsnapshot` file loadable in Chrome DevTools Memory tab | ~2x memory spike (same risk as current), but the output supports Chrome's **Comparison** view |
+
+### The key gap
+
+`heapStats().objectTypeCounts` is the missing piece. If we logged it every 30-60 seconds, we'd see:
+
+```
+Hour 0: { Array: 50000, Object: 80000, Function: 20000, Map: 3000 }
+Hour 1: { Array: 150000, Object: 80000, Function: 20000, Map: 3000 }
+```
+
+Immediately: "Arrays tripled in an hour — something is pushing to arrays and not cleaning up." Instead of guessing for 8 hours about fragmentation vs allocation churn vs runtime bugs.
+
+### Chrome DevTools Comparison view
+
+The `writeHeapSnapshot()` from `v8` module (which Bun implements) produces `.heapsnapshot` files that Chrome DevTools can compare:
+
+1. Take snapshot A at time T
+2. Take snapshot B at time T+30min
+3. Load both in Chrome DevTools → Memory tab → select B → click "Comparison"
+4. DevTools shows a **Delta** column: which objects increased, by how many, and their retainer chains
+
+This is orders of magnitude more useful than our current Python script that just counts class names. The Delta + retainer chain tells us exactly what's growing and what's holding it alive.
+
+---
+
+## Spec
+
+### Change 1: Add `heapStats()` to SystemVitalsLogger (the main fix)
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+Every 30 seconds, the SystemVitalsLogger already logs `system-vitals` with RSS, heap, sessions, etc. Add `objectTypeCounts` from `heapStats()` to this log entry.
+
+```typescript
+import { heapStats } from "bun:jsc";
+
+// Inside logVitals():
+const jscStats = heapStats();
+
+// Log the top object types by count (don't log all ~400 types — just top 20)
+const topTypes = Object.entries(jscStats.objectTypeCounts)
+  .sort((a, b) => (b[1] as number) - (a[1] as number))
+  .slice(0, 20)
+  .reduce((acc, [k, v]) => { acc[k] = v; return acc; }, {} as Record<string, number>);
+
+// Add to the existing system-vitals log entry:
+{
+  feature: "system-vitals",
+  // ... existing fields ...
+  heapObjectCount: jscStats.objectCount,
+  heapProtectedObjectCount: jscStats.protectedObjectCount,
+  topObjectTypes: JSON.stringify(topTypes),
+  protectedTypes: JSON.stringify(jscStats.protectedObjectTypeCounts),
+}
+```
+
+**Why top 20:** The full `objectTypeCounts` has ~400 types. Logging all of them every 30s would bloat our BetterStack volume. The top 20 captures the dominant types — if something is leaking, it'll be in the top 20 because it's growing fast.
+
+**Why JSON.stringify:** BetterStack stores logs as a JSON `raw` field. Nested objects inside the log entry work, but flat stringified objects are easier to query with `JSONExtract`.
+
+**Queryability:** After deploying, we can find what's growing:
+
+```sql
+SELECT
+  toStartOfHour(dt) AS hour,
+  JSONExtractString(raw, 'topObjectTypes') AS types
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND JSONExtractString(raw, 'feature') = 'system-vitals'
+  AND JSONExtractString(raw, 'region') = 'us-central'
+  AND dt > now() - INTERVAL 6 HOUR
+ORDER BY dt ASC
+LIMIT 1 BY hour
+```
+
+Or via bstack:
+
+```bash
+bstack sql "SELECT dt, JSONExtractInt(raw, 'heapObjectCount') as objects FROM ..."
+```
+
+### Change 2: Add V8 heap snapshot endpoint
+
+**File:** `cloud/packages/cloud/src/api/hono/routes/admin.routes.ts`
+
+Add a new endpoint alongside the existing JSC one:
+
+```typescript
+import { writeHeapSnapshot } from "v8";
+
+app.get("/memory/heap-snapshot-v8", validateAdminEmail, async (c: AppContext) => {
+  try {
+    const filename = `heap-${Date.now()}.heapsnapshot`;
+    const filePath = path.join(os.tmpdir(), filename);
+
+    writeHeapSnapshot(filePath);
+
+    // Stream the file back and delete it after
+    const file = Bun.file(filePath);
+    const response = new Response(file, {
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Disposition": `attachment; filename="${filename}"`,
+      },
+    });
+
+    // Clean up after response is sent
+    setTimeout(() => fs.unlinkSync(filePath), 5000);
+
+    return response;
+  } catch (error) {
+    logger.error(error, "Failed to generate V8 heap snapshot");
+    return c.json({ error: "Failed to generate heap snapshot" }, 500);
+  }
+});
+```
+
+**Usage for comparison:**
+
+```bash
+# Take snapshot A
+curl -H "Authorization: Bearer $JWT" \
+  "https://uscentralapi.mentra.glass/api/admin/memory/heap-snapshot-v8" \
+  -o snapshot-a.heapsnapshot
+
+# Wait 30 minutes
+
+# Take snapshot B
+curl -H "Authorization: Bearer $JWT" \
+  "https://uscentralapi.mentra.glass/api/admin/memory/heap-snapshot-v8" \
+  -o snapshot-b.heapsnapshot
+
+# Load both in Chrome DevTools → Memory tab → Comparison
+```
+
+**WARNING:** Same OOM risk as the current JSC snapshot — doubles memory temporarily. Only use on low-traffic regions or right after a restart when memory is low. Consider adding a memory guard:
+
+```typescript
+const rss = process.memoryUsage.rss();
+if (rss > 2 * 1024 * 1024 * 1024) { // > 2GB
+  return c.json({ error: "RSS too high for safe snapshot. Try after a restart." }, 503);
+}
+```
+
+### Change 3: Add `heapStats` to the admin memory/now endpoint
+
+**File:** `cloud/packages/cloud/src/api/hono/routes/admin.routes.ts`
+
+Add `objectTypeCounts` to the existing `/api/admin/memory/now` response so `bstack session` and `analyze-heap.ts live` can show it:
+
+```typescript
+import { heapStats } from "bun:jsc";
+
+// In getMemorySnapshot handler, add to the response:
+const jscStats = heapStats();
+
+return c.json({
+  // ... existing fields ...
+  jsc: {
+    objectCount: jscStats.objectCount,
+    protectedObjectCount: jscStats.protectedObjectCount,
+    topObjectTypes: Object.entries(jscStats.objectTypeCounts)
+      .sort((a, b) => (b[1] as number) - (a[1] as number))
+      .slice(0, 30),
+    protectedTypes: jscStats.protectedObjectTypeCounts,
+  },
+});
+```
+
+### Change 4: Add `bstack heap-types` command
+
+**File:** `cloud/tools/bstack/bstack.ts`
+
+New command that queries the `topObjectTypes` field from system-vitals over time:
+
+```bash
+bstack heap-types --region us-central --duration 2h
+```
+
+Output:
+
+```
+🧠 Heap Object Types — us-central (last 2 HOUR)
+
+hour        │ objects   │ Array    │ Object  │ Function │ string  │ Map    │ Set
+────────────┼───────────┼──────────┼─────────┼──────────┼─────────┼────────┼──────
+18:00       │ 450,000   │ 85,000   │ 120,000 │ 45,000   │ 95,000  │ 8,000  │ 2,000
+19:00       │ 850,000   │ 285,000  │ 120,500 │ 45,200   │ 195,000 │ 8,100  │ 2,000
+
+  ⚠️ Array: +200,000 (+235%) — investigate what's pushing to arrays
+  ⚠️ string: +100,000 (+105%) — string accumulation (logging? transcript history?)
+```
+
+The command parses the `topObjectTypes` JSON string from the logs and shows growth over time, highlighting any type that grew >50%.
+
+---
+
+## What This Tells Us That We Can't See Today
+
+### Scenario A: Array/Object accumulation
+
+If we see `Array` count climbing 10x, we know something is appending to arrays without cleanup. Cross-reference with the code: which arrays in the session code grow without bounds? The transcript history is capped at 30 min, but maybe the pruning isn't working, or maybe there's a different array.
+
+### Scenario B: Function/closure accumulation
+
+If `Function` count climbs, closures are being created and not released. This points to event listeners, `.bind()` calls, or `logger.child()` creating closure chains. The Bun blog specifically calls out closures and `JSLexicalScope` objects as a common leak source.
+
+### Scenario C: Map/Set accumulation
+
+If `Map` or `Set` counts climb, some Map or Set in the code is getting entries added but never removed. We have Maps everywhere — `AppManager.apps`, `UserSession.sessions`, subscription maps, etc.
+
+### Scenario D: String accumulation
+
+If `string` count climbs, we're creating and retaining strings. Template literals in hot paths, log message construction, JSON.stringify results being held somewhere.
+
+### Scenario E: Promise accumulation
+
+If `Promise` count climbs, we have promises that never resolve or reject. The Bun blog specifically calls this out. Our webhook retry logic, Soniox connection timeouts, and async operations could leave dangling promises.
+
+### Scenario F: Everything proportional to sessions
+
+If all types scale with session count and stay flat when sessions are flat — then the growth IS genuinely coming from session initialization and Bun's inability to compact. In that case, we need the Chrome DevTools comparison to find the retainer chain.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add heapStats to system-vitals (highest priority)
+
+1. Add `heapStats()` call in SystemVitalsLogger
+2. Log top 20 object types + protected types every 30s
+3. Deploy to one region first (US West — 0 sessions, safe)
+4. Verify the data appears in BetterStack
+5. Deploy to all regions
+6. **Wait 2-4 hours** and query the data to see what's growing
+
+**Effort:** 30 minutes. **Risk:** Zero — `heapStats()` is ~1ms and doesn't affect the heap.
+
+### Phase 2: Add V8 snapshot endpoint
+
+1. Add `/api/admin/memory/heap-snapshot-v8` endpoint with memory guard
+2. Update `analyze-heap.ts` to use the V8 endpoint
+3. Test on a low-traffic region
+
+**Effort:** 30 minutes. **Risk:** Low (OOM-guarded).
+
+### Phase 3: Add bstack heap-types command
+
+1. Parse `topObjectTypes` from system-vitals logs
+2. Show growth over time with warnings for fast-growing types
+
+**Effort:** 1 hour.
+
+### Phase 4: Identify and fix the leak
+
+Once we see which types are growing, fix the specific code that's accumulating them. The fix depends entirely on what the data shows — could be a one-liner, could be an architectural change.
+
+---
+
+## Open Questions
+
+| # | Question | Notes |
+|---|----------|-------|
+| 1 | Does `heapStats()` include objects from Soniox SDK? | It should — all JS objects on the heap regardless of which module created them. |
+| 2 | Does `protectedObjectTypeCounts` overlap with `disposedSessionsPendingGC`? | No — protected objects are GC roots (timers, active I/O). `disposedSessionsPendingGC` tracks objects we've disposed but GC hasn't collected yet. Different concepts. |
+| 3 | Can `writeHeapSnapshot()` from `v8` module be streamed instead of written to disk? | Not sure. If so, we could pipe directly to the HTTP response without temp file. |
+| 4 | Is there a way to get retainer info without a full snapshot? | `heapStats()` doesn't provide retainers. For that we need the Chrome DevTools comparison. But knowing WHICH type is growing narrows the search to a few code files. |
+| 5 | Should we log `heapStats` less frequently than system-vitals? | 30s might be too frequent if the JSON is large. Could log every 5 minutes instead, or only log the delta from the previous reading. |

--- a/cloud/issues/078-memory-ownership-census/design.md
+++ b/cloud/issues/078-memory-ownership-census/design.md
@@ -1,0 +1,374 @@
+# Design: Memory Ownership Census
+
+## Overview
+
+**What this doc covers:** Implementation plan for the production-safe memory ownership census described in the 078 spec: shared types, estimator helpers, first-wave manager instrumentation, session aggregation, vitals logging, admin endpoint exposure, and CLI support.
+**Why this doc exists:** The spec defines the behavior. This doc maps it to concrete files and rollout order so the implementation stays focused and reviewable.
+**What you need to know first:** [078 spike](./spike.md) and [078 spec](./spec.md).
+**Who should read this:** Whoever implements the PR.
+
+## Changes Summary
+
+| Component | File | What changes |
+| --------- | ---- | ------------ |
+| Shared types | `cloud/packages/cloud/src/services/metrics/memory-census.ts` | New `MemoryOwnerStat` and `MemoryStatsProvider` interfaces |
+| Shared helpers | `cloud/packages/cloud/src/services/metrics/memory-estimate.ts` | String/JSON/array size estimators |
+| Session aggregation | `cloud/packages/cloud/src/services/session/UserSession.ts` | `getMemoryCensus()` and direct session-owned stats |
+| Transcription | `cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts` | Expose transcript history, VAD buffer, stream counts |
+| Translation | `cloud/packages/cloud/src/services/session/translation/TranslationManager.ts` | Expose translation audio buffer, stream counts |
+| Soniox provider | `cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts` | Expose utterance/pending-audio/token state |
+| App audio | `cloud/packages/cloud/src/services/session/AppAudioStreamManager.ts` | Expose pending chunks and stream counts |
+| Calendar | `cloud/packages/cloud/src/services/session/CalendarManager.ts` | Expose cached event counts/bytes |
+| Dashboard | `cloud/packages/cloud/src/services/session/dashboard/DashboardManager.ts` | Expose content-map counts/bytes |
+| App session | `cloud/packages/cloud/src/services/session/AppSession.ts` | Expose subscription history / set size |
+| Metrics | `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts` | Aggregate owners, compute deltas, log top owners and sessions |
+| Admin API | `cloud/packages/cloud/src/api/hono/routes/admin.routes.ts` | Add `memoryCensus` block to `/api/admin/memory/now` |
+| CLI | `cloud/tools/bstack/bstack.ts` | Add `memory-owners` command |
+
+## Shared Types
+
+### `memory-census.ts`
+
+This file should be deliberately tiny. It is a common contract, not a framework.
+
+```typescript
+export interface MemoryOwnerStat {
+  owner: string;
+  scope: "session" | "app-session" | "stream" | "global";
+  itemCount: number;
+  estimatedBytes: number;
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface SessionMemoryCensus {
+  estimatedBytes: number;
+  owners: MemoryOwnerStat[];
+}
+
+export interface MemoryStatsProvider {
+  getMemoryStats(): MemoryOwnerStat[];
+}
+```
+
+## Estimation Helpers
+
+### `memory-estimate.ts`
+
+Keep the helpers dumb and predictable:
+
+```typescript
+estimateStringBytes(str?: string | null): number
+estimateJsonBytes(value: unknown): number
+sumEstimatedBytes<T>(items: T[], fn: (item: T) => number): number
+```
+
+Rules:
+
+- always prefer cheap estimators
+- never recurse deeply by hand
+- never traverse object graphs trying to be “exact”
+- use payload size as the proxy
+
+If a structure stores 5,000 transcript segments, the estimate should be dominated by the text and obvious scalar fields. That is good enough.
+
+## Manager-Level Instrumentation
+
+### `TranscriptionManager.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners to emit
+
+- `transcription.history.legacy`
+- `transcription.history.{language}`
+- `transcription.vad-audio-buffer`
+- `transcription.streams`
+
+#### Estimation
+
+For transcript segments:
+
+```typescript
+estimatedBytes =
+  sum(segments, (s) =>
+    estimateStringBytes(s.text) +
+    estimateStringBytes(s.resultId) +
+    estimateStringBytes(s.speakerId) +
+    64 // fixed scalar/object overhead proxy
+  )
+```
+
+For `languageSegments`, emit one owner row per language. This matters because a single language may dominate.
+
+For `vadAudioBuffer`, estimate with total `byteLength`.
+
+### `TranslationManager.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners
+
+- `translation.audio-buffer`
+- `translation.streams`
+
+Estimate `audioBuffer` by summing `byteLength`.
+
+### `SonioxTranslationProvider.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners
+
+- `translation.soniox.pending-audio`
+- `translation.soniox.utterances.{language}`
+- `translation.soniox.latency-measurements`
+
+Utterance estimation should include:
+
+- original token text bytes
+- translation token text bytes
+- token counts
+- small fixed overhead per token
+
+Do not serialize the entire token objects into JSON on every tick. Walk the in-memory arrays directly and count text lengths.
+
+### `AppAudioStreamManager.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners
+
+- `app-audio.pending-chunks`
+- `app-audio.streams`
+
+Estimate pending chunks from their `byteLength`.
+
+### `CalendarManager.ts`
+
+Add `getMemoryStats()`.
+
+#### Owner
+
+- `calendar.events`
+
+This should almost always be bounded and small. That is useful: the census will make it trivially exonerable.
+
+### `DashboardManager.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners
+
+- `dashboard.main-content`
+- `dashboard.expanded-content`
+- `dashboard.always-on-content`
+- `dashboard.system-content`
+
+Estimate string content via `estimateStringBytes()`. For `Layout`, use guarded `estimateJsonBytes()`.
+
+### `AppSession.ts`
+
+Add `getMemoryStats()`.
+
+#### Owners
+
+- `app-session.subscription-history`
+- `app-session.subscriptions`
+
+Again, likely not dominant, but useful for eliminating suspicion.
+
+## Session Aggregation
+
+### `UserSession.ts`
+
+Add:
+
+```typescript
+public getMemoryCensus(): SessionMemoryCensus
+```
+
+The method should:
+
+1. build rows for direct session-owned fields
+2. call `getMemoryStats()` on managers/providers that implement it
+3. flatten everything into one list
+4. sum `estimatedBytes`
+
+#### Direct session-owned owners
+
+- `user-session.buffered-audio`
+- `user-session.audio-play-request-mapping`
+- `user-session.app-health-cache`
+- `user-session.loading-apps`
+
+#### Important implementation note
+
+Use feature detection, not hard interfaces everywhere:
+
+```typescript
+if ("getMemoryStats" in this.calendarManager) { ... }
+```
+
+This keeps the change incremental and avoids needing to thread a formal interface through every class declaration in one PR.
+
+## SystemVitals Aggregation
+
+### `SystemVitalsLogger.ts`
+
+This is the heart of the feature.
+
+#### New internal state
+
+Add a previous-owner snapshot map:
+
+```typescript
+private previousOwnerBytes = new Map<string, number>();
+```
+
+Per tick:
+
+1. iterate sessions
+2. collect `getMemoryCensus()` from each
+3. aggregate owner totals:
+   - `owner -> estimatedBytes`
+   - `owner -> itemCount`
+4. compute deltas from `previousOwnerBytes`
+5. sort and keep top N
+6. update `previousOwnerBytes`
+
+#### Top session derivation
+
+For each session:
+
+- total estimated bytes
+- top 3 owners in that session
+
+Then sort sessions descending and keep top 10.
+
+#### New log fields
+
+```typescript
+memoryEstimatedSessionBytes
+memoryOwnerCount
+memoryTopOwners
+memoryTopOwnerDeltas
+memoryTopSessions
+```
+
+All complex structures should be JSON strings, same pattern as other vitals fields.
+
+#### Growth warning
+
+Add a small rate-limited helper:
+
+```typescript
+private memoryOwnerWarnCooldown = new Map<string, number>();
+```
+
+If an owner is both large and still growing, emit `feature: "memory-owner-growth"` no more than once every 10 minutes per owner.
+
+## Admin Endpoint
+
+### `admin.routes.ts`
+
+Extend `/api/admin/memory/now`.
+
+The response already returns process and session information. Add:
+
+- aggregate census
+- top sessions
+- per-session owner rows
+
+This should be the canonical debugging endpoint for humans and scripts.
+
+## CLI
+
+### `bstack.ts`
+
+Add:
+
+```bash
+bstack memory-owners --region us-central --duration 2h
+```
+
+Suggested output shape:
+
+```text
+🧠 Memory Owners — us-central (last 2 HOUR)
+
+Top owners by size:
+owner                               bytes     items
+transcription.history.en-US         126 MB    18422
+translation.soniox.utterances.es     38 MB     4412
+
+Top owners by growth:
+owner                               delta
+transcription.history.en-US         +11 MB
+translation.audio-buffer            +0 MB
+```
+
+This command is intentionally log-based. It does not hit admin endpoints.
+
+## Rollout Order
+
+### Phase 1: Shared plumbing
+
+1. `memory-census.ts`
+2. `memory-estimate.ts`
+3. `UserSession.getMemoryCensus()`
+
+### Phase 2: Highest-value owners
+
+1. `TranscriptionManager`
+2. `TranslationManager`
+3. `SonioxTranslationProvider`
+4. `AppAudioStreamManager`
+
+### Phase 3: Control owners
+
+1. `CalendarManager`
+2. `DashboardManager`
+3. `AppSession`
+
+### Phase 4: Surfaces
+
+1. `SystemVitalsLogger`
+2. `/api/admin/memory/now`
+3. `bstack memory-owners`
+
+## Testing
+
+### Unit-level checks
+
+- each `getMemoryStats()` returns stable owner keys
+- zero-data cases return empty or zero rows
+- bounded structures report bounded counts
+- deltas are correct across consecutive vitals ticks
+
+### Integration checks
+
+- start one session, produce transcripts, verify `transcription.history.*` grows
+- stop transcript traffic, wait for prune window, verify growth flattens or shrinks
+- create translation activity, verify `translation.soniox.utterances.*`
+- confirm `/api/admin/memory/now` includes the same owners seen in logs
+
+### Success criteria
+
+The feature is successful if, after one prod deployment, the next heap-growth investigation can identify one or two concrete owner families without taking manual snapshots first.
+
+## Risks
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Too much CPU from estimation | Keep estimators shallow and payload-based; only inspect first-wave owners |
+| Log bloat | Log only top owners and top sessions, not the full census |
+| Misleading “exact bytes” interpretation | Call the field `estimatedBytes` everywhere |
+| Implementation spread across too many classes | First wave only; expand later if needed |
+
+## Decision Log
+
+| Decision | Alternatives considered | Why we chose this |
+| -------- | ----------------------- | ----------------- |
+| Use per-manager `getMemoryStats()` methods | One giant introspector in `SystemVitalsLogger` | Ownership belongs with the class that owns the structure. |
+| Estimate payload bytes instead of exact heap bytes | Deep heap walking / exact accounting | Exactness is not feasible in prod. Ranking and deltas are enough. |
+| Expose full detail only on admin endpoint | Put everything in logs | Full census would bloat logs; endpoint is better for drill-down. |

--- a/cloud/issues/078-memory-ownership-census/spec.md
+++ b/cloud/issues/078-memory-ownership-census/spec.md
@@ -1,0 +1,317 @@
+# Spec: Memory Ownership Census
+
+## Overview
+
+**What this doc covers:** Exact specification for adding a production-safe memory ownership census to the cloud so we can attribute retained memory to specific managers, buffers, maps, arrays, and sessions.
+**Why this doc exists:** Issue 077 tells us what heap types are growing. It does not tell us which code path owns them. This spec adds the missing ownership layer so the team can stop patching suspects one by one and start fixing proven owners.
+**What you need to know first:** [078 spike](./spike.md), [077-heap-diagnostics](../077-heap-diagnostics/), and [067-heap-growth-investigation](../067-heap-growth-investigation/).
+**Who should read this:** Anyone reviewing the implementation PR.
+
+## The Problem in 30 Seconds
+
+The cloud currently says:
+
+```text
+heapUsedMB = 612
+heapTopTypes = { Object: 1005280, string: 1040017, Array: 152682 }
+```
+
+That is not enough to debug the issue. We need it to say:
+
+```text
+topOwners = {
+  "transcription.history": 126_000_000,
+  "translation.soniox.utterances": 38_000_000,
+  "app-audio.pending-chunks": 9_000_000
+}
+
+topSessions = [
+  { userId: "...", estimatedBytes: 42_000_000, topOwner: "transcription.history" },
+  ...
+]
+```
+
+This spec is diagnostics-only. It changes no runtime behavior.
+
+## Spec
+
+### A1. Add a shared ownership-census type
+
+**New file:** `cloud/packages/cloud/src/services/metrics/memory-census.ts`
+
+Add shared types used by all memory-stat providers:
+
+```typescript
+export interface MemoryOwnerStat {
+  owner: string;              // e.g. "transcription.history.en-US"
+  scope: "session" | "app-session" | "stream" | "global";
+  itemCount: number;          // number of elements / entries / chunks
+  estimatedBytes: number;     // best-effort estimate, not exact heap size
+  metadata?: Record<string, string | number | boolean | null>;
+}
+
+export interface MemoryStatsProvider {
+  getMemoryStats(): MemoryOwnerStat[];
+}
+```
+
+**Important:** `estimatedBytes` is intentionally approximate. This is a ranking tool, not a billing meter. The job is to identify the owners that are growing, not to perfectly model JSC internals.
+
+### A2. Add lightweight estimator helpers
+
+**New file:** `cloud/packages/cloud/src/services/metrics/memory-estimate.ts`
+
+Add a tiny helper module with stable estimation functions:
+
+- `estimateStringBytes(str)` → `Buffer.byteLength(str, "utf8")`
+- `estimateJsonBytes(value)` → `Buffer.byteLength(JSON.stringify(value), "utf8")`, guarded with try/catch
+- `sumEstimatedBytes(array, fn)`
+
+**Rule:** estimate the payload size, not JSC overhead. Relative ranking matters more than exactness.
+
+### A3. Add `getMemoryStats()` to high-value managers first
+
+**Files:**
+
+- `services/session/transcription/TranscriptionManager.ts`
+- `services/session/translation/TranslationManager.ts`
+- `services/session/translation/providers/SonioxTranslationProvider.ts`
+- `services/session/AppAudioStreamManager.ts`
+- `services/session/CalendarManager.ts`
+- `services/session/dashboard/DashboardManager.ts`
+- `services/session/AppSession.ts`
+
+Each manager exposes its own owned structures as `MemoryOwnerStat[]`.
+
+#### Required first-wave owners
+
+**TranscriptionManager**
+
+- `transcription.history.legacy`
+- `transcription.history.{language}`
+- `transcription.vad-audio-buffer`
+- `transcription.streams`
+
+Estimate transcript history using text length plus fixed per-segment overhead.
+
+**TranslationManager**
+
+- `translation.audio-buffer`
+- `translation.streams`
+
+**SonioxTranslationProvider**
+
+- `translation.soniox.pending-audio`
+- `translation.soniox.utterances.{language}`
+- `translation.soniox.latency-measurements`
+
+Estimate utterance size from token text and token count.
+
+**AppAudioStreamManager**
+
+- `app-audio.pending-chunks`
+- `app-audio.streams`
+
+**CalendarManager**
+
+- `calendar.events`
+
+**DashboardManager**
+
+- `dashboard.main-content`
+- `dashboard.expanded-content`
+- `dashboard.always-on-content`
+- `dashboard.system-content`
+
+**AppSession**
+
+- `app-session.subscription-history`
+- `app-session.subscriptions`
+
+### A4. Add session-level aggregation in `UserSession`
+
+**File:** `cloud/packages/cloud/src/services/session/UserSession.ts`
+
+Add:
+
+```typescript
+getMemoryCensus(): {
+  estimatedBytes: number;
+  owners: MemoryOwnerStat[];
+}
+```
+
+This method:
+
+1. asks each owned manager/provider for `getMemoryStats()`
+2. flattens the results
+3. prefixes metadata with session context as needed
+4. returns total estimated bytes + per-owner breakdown
+
+Also include direct session-owned structures:
+
+- `user-session.buffered-audio`
+- `user-session.audio-play-request-mapping`
+- `user-session.loading-apps`
+- `user-session.app-health-cache`
+
+### A5. Add owner-growth tracking in `SystemVitalsLogger`
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+Every vitals tick:
+
+1. call `getMemoryCensus()` on every live `UserSession`
+2. aggregate by owner name across sessions
+3. compute per-owner delta from previous vitals tick
+4. compute top sessions by estimated bytes
+
+Add these new fields to `system-vitals`:
+
+```typescript
+memoryEstimatedSessionBytes
+memoryTopOwners          // JSON string: top 10 owners by estimatedBytes
+memoryTopOwnerDeltas     // JSON string: top 10 owners by +deltaBytes since last tick
+memoryTopSessions        // JSON string: top 10 sessions by estimatedBytes
+memoryOwnerCount         // number of owner rows aggregated
+```
+
+**Shape examples**
+
+```json
+memoryTopOwners: {
+  "transcription.history.en-US": 126349102,
+  "translation.soniox.utterances.es": 38118220
+}
+
+memoryTopOwnerDeltas: {
+  "transcription.history.en-US": 1142208,
+  "translation.audio-buffer": 0
+}
+```
+
+### A6. Add full census to `/api/admin/memory/now`
+
+**File:** `cloud/packages/cloud/src/api/hono/routes/admin.routes.ts`
+
+Extend the response with:
+
+```typescript
+memoryCensus: {
+  aggregate: {
+    estimatedBytes: number,
+    topOwners: Array<{ owner: string; estimatedBytes: number; itemCount: number }>,
+    topOwnerDeltas: Array<{ owner: string; deltaBytes: number }>,
+  },
+  topSessions: Array<{
+    userId: string,
+    estimatedBytes: number,
+    topOwners: Array<{ owner: string; estimatedBytes: number }>
+  }>
+}
+```
+
+And for each session object already returned by the endpoint, add:
+
+```typescript
+memory: {
+  estimatedBytes: number,
+  owners: MemoryOwnerStat[]
+}
+```
+
+This is the main human-debugging surface. The log entry is for trends; the admin endpoint is for inspection.
+
+### A7. Add growth thresholds and high-water marks
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+Track high-water marks in-process:
+
+- largest owner ever seen
+- largest per-session estimate ever seen
+- largest owner delta in one tick
+
+If an owner crosses a threshold, emit a one-off warn log:
+
+```json
+{
+  "feature": "memory-owner-growth",
+  "owner": "transcription.history.en-US",
+  "estimatedBytes": 73400320,
+  "deltaBytes": 5242880,
+  "userId": "..."
+}
+```
+
+**Threshold rules**
+
+- owner `estimatedBytes > 25MB`
+- or owner `deltaBytes > 2MB` in one 30s tick
+
+Rate-limit to once per owner per 10 minutes. This is a forensic breadcrumb, not spam.
+
+### A8. Add `bstack memory-owners`
+
+**File:** `cloud/tools/bstack/bstack.ts`
+
+New command:
+
+```bash
+bstack memory-owners --region us-central --duration 2h
+```
+
+It queries `memoryTopOwners` and `memoryTopOwnerDeltas` from `system-vitals` and shows:
+
+- top owners by size
+- top owners by growth
+- timestamps when growth accelerated
+
+### A9. Non-goals
+
+This issue does NOT include:
+
+- automatic heap snapshots
+- automatic process restarts
+- behavior changes to managers or retention windows
+- exact heap accounting
+
+This issue is observability only.
+
+## Decision Log
+
+| Decision | Alternatives considered | Why we chose this |
+| -------- | ----------------------- | ----------------- |
+| Add owner census as a new issue instead of expanding 077 | Fold ownership into 077 | Heap shape and code ownership are different layers. Keeping them separate preserves clarity. |
+| Use best-effort byte estimates | Try to model exact JSC heap bytes | Exact accounting is unrealistic and unnecessary. We need ranking and growth attribution. |
+| Instrument a high-value first wave of managers | Try to census the whole codebase at once | Faster path to signal. The likely owners are already concentrated in session-scoped managers. |
+| Put full detail on `/api/admin/memory/now`, not only in logs | Logs only | Logs are good for trends. Investigations need drill-down by session and owner. |
+| Add deltas, not just absolute sizes | Absolute sizes only | Root cause is about what is still growing, not only what is already large. |
+
+## Testing
+
+### Local verification
+
+1. Start cloud locally with one or two sessions.
+2. Hit `/api/admin/memory/now`.
+3. Verify each session returns `memory.estimatedBytes` and owner rows.
+4. Trigger transcript traffic, translation traffic, calendar events, and dashboard updates.
+5. Verify the expected owners increase.
+6. Dispose the session and verify the owner census drops to zero on the next tick.
+
+### Production verification
+
+After deploy:
+
+1. Query `system-vitals` for `memoryTopOwners` and `memoryTopOwnerDeltas`.
+2. Confirm the top owners are stable, interpretable names.
+3. Compare owner growth against heap growth over 2–6 hours.
+4. Use `/api/admin/memory/now` on a hot region to inspect the top sessions.
+
+## Rollout
+
+1. Ship 077 first if not already deployed.
+2. Deploy 078 to one lower-traffic region or debug environment.
+3. Verify log volume is acceptable.
+4. Promote to prod.
+5. Use `memory-owners` for the next live incident before making more behavioral fixes.

--- a/cloud/issues/078-memory-ownership-census/spike.md
+++ b/cloud/issues/078-memory-ownership-census/spike.md
@@ -1,0 +1,245 @@
+# Spike: Memory Ownership Census — Which Code Paths Own Heap Growth?
+
+## Overview
+
+**What this doc covers:** The missing observability layer between heap-shape data and root-cause fixes: a production-safe memory ownership census that attributes retained memory to specific managers, buffers, maps, arrays, and sessions.
+**Why this doc exists:** Issue 077 tells us what heap object types are growing (`Object`, `string`, `Array`). It still does not tell us which code path owns those objects. That is the question the team actually needs answered to stop chasing one suspect at a time.
+**What you need to know first:** [077-heap-diagnostics](../077-heap-diagnostics/) for heap-shape observability, [067-heap-growth-investigation](../067-heap-growth-investigation/) for the saved snapshots proving growth inside live sessions, and [075-heap-fragmentation-hot-path](../075-heap-fragmentation-hot-path/) for the allocation-churn hypothesis.
+**Who should read this:** Cloud engineers, anyone touching observability, and anyone trying to make memory incidents diagnosable instead of anecdotal.
+
+---
+
+## The Problem in 30 Seconds
+
+Today we can answer:
+
+- Is RSS growing?
+- Is heap growing?
+- Is GC freeing anything?
+- Are sessions stable?
+- What heap object families dominate?
+
+We still cannot answer the only question that matters for a fix:
+
+**Which code path owns the retained memory?**
+
+If the heap grows by 300MB/hour and the snapshots say `Object` + `string`, that is still too generic to act on. We need the cloud to say:
+
+```text
+Top owner growth, last 30m:
+1. TranscriptionManager.transcriptHistory  +118MB
+2. SonioxTranslationProvider.utterances    +41MB
+3. AppAudioStreamManager.pendingChunks     +9MB
+```
+
+Without that ownership layer, every investigation becomes:
+
+1. form a hypothesis
+2. patch one suspect
+3. deploy
+4. wait
+5. learn that heap still grows
+
+That is the loop the team is frustrated with.
+
+---
+
+## What We Already Have
+
+### Layer 1: Health / symptom observability
+
+From issues 055–072, the cloud can already tell us:
+
+- event-loop gaps
+- GC probe duration and freed MB
+- session counts
+- WS churn and close codes
+- MongoDB blocking totals
+- RSS / heap / external / ArrayBuffer trends
+
+This was necessary work. It ruled out a lot of bad theories and found real bugs.
+
+### Layer 2: Heap-shape observability
+
+Issue 077 adds:
+
+- `heapStats().objectTypeCounts`
+- protected object counts
+- V8 snapshot support for Chrome comparison
+
+This is also valuable. It answers: **what kinds of objects are growing?**
+
+### What is still missing
+
+Neither layer tells us:
+
+- which manager owns the objects
+- which sessions own the growth
+- which in-memory structure grew between two ticks
+- whether the growth is bounded cache behavior or an unbounded bug
+
+That is Layer 3: **ownership attribution**.
+
+---
+
+## What The Existing Evidence Already Suggests
+
+From the saved heap snapshots in `cloud/.heap/`:
+
+- `us-central-10min.json` → `us-central-20min.json` shows growth dominated by `string` and `Object`
+- session/manager instance counts scale normally with session count
+- later snapshots show the same pattern at much larger scale: generic payload/state objects dominate, not runaway class instance counts
+
+This strongly suggests the remaining issue is retained data inside healthy sessions, not “one extra manager leaked forever.”
+
+That narrows the likely owners to:
+
+- transcript history
+- token/utterance buffers
+- per-session caches
+- pending chunk queues
+- message/history arrays
+- App/session relay payloads
+
+But “likely” is not enough. We need hard numbers in prod.
+
+---
+
+## The Missing Dimensions
+
+To make the issue diagnosable, the cloud needs to surface four dimensions it does not currently track:
+
+### 1. Owner
+
+Not “Object” or “string.”
+
+Actual code owners like:
+
+- `transcription.history.en-US`
+- `transcription.history.fr-FR`
+- `transcription.vad-audio-buffer`
+- `translation.audio-buffer`
+- `translation.soniox.utterances`
+- `calendar.events`
+- `dashboard.main-content`
+- `app-audio.pending-chunks`
+
+### 2. Scope
+
+We need to know whether the memory is:
+
+- global (singleton/service-wide)
+- per-session
+- per-app-session
+- per-stream/provider
+
+### 3. Growth delta
+
+Absolute size alone is not enough. The key signal is:
+
+- current estimated bytes
+- delta since last vitals tick
+- high-water mark
+
+The question is not just “what is big?” It is “what is still growing?”
+
+### 4. Session attribution
+
+If 12 out of 80 sessions own 80% of the growth, that changes the investigation completely. We need:
+
+- top sessions by estimated memory
+- top sessions by growth over last N ticks
+- owner breakdown per top session
+
+---
+
+## Candidate Owners To Instrument First
+
+These are the high-value, long-lived structures that are likely to explain `Object`/`string` growth and are cheap to measure.
+
+### Transcription
+
+- `TranscriptionManager.transcriptHistory.segments`
+- `TranscriptionManager.transcriptHistory.languageSegments`
+- `TranscriptionManager.vadAudioBuffer`
+- `TranscriptionManager.activeSubscriptions`
+
+Why: transcript history literally stores strings and segment objects per session with 30-minute retention. It is a prime ownership candidate.
+
+### Translation / Soniox
+
+- `TranslationManager.audioBuffer`
+- `SonioxTranslationProvider.pendingAudioChunks`
+- `SonioxTranslationProvider.utterancesByLanguage`
+- `SonioxTranslationProvider.latencyMeasurements`
+
+Why: these hold token arrays, translated text fragments, and buffered audio during stream lifecycle gaps.
+
+### App / relay path
+
+- `AppAudioStreamManager.pendingChunks`
+- `AppSession.subscriptionHistory`
+- `UserSession.bufferedAudio`
+- `UserSession.audioPlayRequestMapping`
+
+Why: these are per-session retained queues/maps and are easy to make visible.
+
+### Dashboard / calendar / misc caches
+
+- `CalendarManager.events`
+- `DashboardManager.mainContent`
+- `DashboardManager.expandedContent`
+- `DashboardManager.alwaysOnContent`
+
+Why: likely not the main culprit, but good controls. They are bounded, so exposing them lets us quickly eliminate them from future incidents.
+
+---
+
+## What “Enough Observability” Actually Looks Like
+
+A memory incident is diagnosable when one prod query can answer:
+
+1. Which owner grew?
+2. By how much?
+3. In which sessions?
+4. Since when?
+5. What event correlated with the start?
+
+Today we have:
+
+- 4 and parts of 5
+
+Issue 077 gives us:
+
+- a weak version of 1 (“heap types”)
+
+What we still need is:
+
+- a strong version of 1 (“code owners”)
+- 2
+- 3
+
+That is what this issue proposes.
+
+---
+
+## Conclusions
+
+| Finding | Confidence |
+| ------- | ---------- |
+| The team is not back at square one | **Confirmed** — existing observability already ruled out multiple classes of failures |
+| Issue 077 is useful but insufficient | **Confirmed** — heap shape is not the same as code ownership |
+| The missing layer is ownership attribution, not more generic metrics | **High** |
+| A production-safe census of long-lived structures is the shortest path to root cause | **High** |
+| The census should focus on per-session retained structures first | **High** |
+
+---
+
+## Next Steps
+
+1. Implement a `MemoryStatProvider` / ownership-census interface for high-suspicion managers first.
+2. Add session-level aggregation to `UserSession`.
+3. Log the top owners and top sessions in `system-vitals`.
+4. Expose the full census in `/api/admin/memory/now`.
+5. Add a `bstack` command for owner growth over time.
+6. Use V8 snapshots only after the census points to a specific owner — snapshots become proof, not fishing.

--- a/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
+++ b/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
@@ -330,7 +330,8 @@ class SystemVitalsLogger {
                 heapProtectedCount: stats.protectedObjectCount,
                 heapTopTypes: JSON.stringify(Object.fromEntries(sorted)),
               };
-            } catch {
+            } catch (err) {
+              logger.error(err, "Failed to collect heapStats from bun:jsc");
               return {};
             }
           })(),

--- a/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
+++ b/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
@@ -16,6 +16,7 @@
  * See: cloud/issues/069-ws-disconnect-observability/spike.md
  */
 
+import { heapStats } from "bun:jsc";
 import { logger as rootLogger } from "../logging/pino-logger";
 import { UserSession } from "../session/UserSession";
 import { memoryLeakDetector } from "../debug/MemoryLeakDetector";
@@ -310,6 +311,29 @@ class SystemVitalsLogger {
 
           // Leak indicator
           disposedSessionsPendingGC: memoryLeakDetector.getDisposedPendingGCCount(),
+
+          // Heap object breakdown — shows WHAT is in the heap, not just how much.
+          // Before this, we only had heapUsedMB (a single number). Now we see
+          // the count of every object type: Array, Object, Function, string, Map, etc.
+          // If Arrays triple in an hour but everything else is flat, we know to
+          // grep for unbounded arrays. This replaces guessing with measuring.
+          // ~1ms cost, zero memory overhead. See: bun.com/blog/debugging-memory-leaks
+          ...(() => {
+            try {
+              const stats = heapStats();
+              // Top 15 types by count — captures dominant types without bloating logs
+              const sorted = Object.entries(stats.objectTypeCounts as Record<string, number>)
+                .sort((a, b) => b[1] - a[1])
+                .slice(0, 15);
+              return {
+                heapObjectCount: stats.objectCount,
+                heapProtectedCount: stats.protectedObjectCount,
+                heapTopTypes: JSON.stringify(Object.fromEntries(sorted)),
+              };
+            } catch {
+              return {};
+            }
+          })(),
 
           // Connection churn — the key evidence for client-side vs server-side disconnects.
           // If disconnects >> reconnects, sessions are being disposed (not surviving grace period).

--- a/cloud/packages/cloud/src/services/session/AppManager.ts
+++ b/cloud/packages/cloud/src/services/session/AppManager.ts
@@ -87,6 +87,16 @@ interface AppMessageResult {
   error?: string;
 }
 
+// ── Hot-path allocation reduction ──────────────────────────────────────────────
+// Pre-allocated, frozen result objects for sendMessageToApp to avoid per-call
+// heap allocations on the hot path.  Reduces GC pressure / heap fragmentation
+// on Bun/JSC where short-lived objects are especially costly.
+const SEND_SUCCESS: Readonly<AppMessageResult> = Object.freeze({ sent: true, resurrectionTriggered: false });
+const SEND_FAIL_STOPPING: Readonly<AppMessageResult> = Object.freeze({ sent: false, resurrectionTriggered: false, error: "App is being stopped" });
+const SEND_FAIL_GRACE: Readonly<AppMessageResult> = Object.freeze({ sent: false, resurrectionTriggered: false, error: "Connection lost, waiting for reconnection" });
+const SEND_FAIL_RESURRECTING: Readonly<AppMessageResult> = Object.freeze({ sent: false, resurrectionTriggered: false, error: "App is restarting" });
+const SEND_FAIL_CONNECTING: Readonly<AppMessageResult> = Object.freeze({ sent: false, resurrectionTriggered: false, error: "App is still connecting" });
+
 export class AppManager {
   private userSession: UserSession;
   private logger: Logger;
@@ -1666,27 +1676,15 @@ export class AppManager {
       const appState = this.getAppConnectionState(packageName);
 
       if (appState === AppSessionState.STOPPING) {
-        return {
-          sent: false,
-          resurrectionTriggered: false,
-          error: "App is being stopped",
-        };
+        return SEND_FAIL_STOPPING;
       }
 
       if (appState === AppSessionState.GRACE_PERIOD) {
-        return {
-          sent: false,
-          resurrectionTriggered: false,
-          error: "Connection lost, waiting for reconnection",
-        };
+        return SEND_FAIL_GRACE;
       }
 
       if (appState === AppSessionState.RESURRECTING) {
-        return {
-          sent: false,
-          resurrectionTriggered: false,
-          error: "App is restarting",
-        };
+        return SEND_FAIL_RESURRECTING;
       }
 
       // Get WebSocket from AppSession (Phase 4d)
@@ -1695,19 +1693,17 @@ export class AppManager {
 
       // If connection is connecting, then we can't send messages yet.
       if (websocket && websocket.readyState === WebSocketReadyState.CONNECTING) {
-        this.logger.warn(
-          {
-            userId: this.userSession.userId,
-            packageName,
-            service: "AppManager",
-          },
-          `App ${packageName} is still connecting, cannot send message yet`,
-        );
-        return {
-          sent: false,
-          resurrectionTriggered: false,
-          error: "App is still connecting",
-        };
+        if (this.logger.isLevelEnabled('debug')) {
+          this.logger.warn(
+            {
+              userId: this.userSession.userId,
+              packageName,
+              service: "AppManager",
+            },
+            `App ${packageName} is still connecting, cannot send message yet`,
+          );
+        }
+        return SEND_FAIL_CONNECTING;
       }
 
       // Check if websocket exists and is ready
@@ -1716,15 +1712,17 @@ export class AppManager {
           // Send message successfully
           websocket.send(JSON.stringify(message));
           metricsService.incrementMiniappMessagesOut();
-          this.logger.debug(
-            {
-              packageName,
-              messageType: message.type || "unknown",
-            },
-            `[AppManager:sendMessageToApp]: Message sent to App ${packageName} for user ${this.userSession.userId}`,
-          );
+          if (this.logger.isLevelEnabled('debug')) {
+            this.logger.debug(
+              {
+                packageName,
+                messageType: message.type || "unknown",
+              },
+              `[AppManager:sendMessageToApp]: Message sent to App ${packageName} for user ${this.userSession.userId}`,
+            );
+          }
 
-          return { sent: true, resurrectionTriggered: false };
+          return SEND_SUCCESS;
         } catch (sendError) {
           const logger = this.logger.child({ packageName });
           const errorMessage = sendError instanceof Error ? sendError.message : String(sendError);
@@ -1746,11 +1744,9 @@ export class AppManager {
 
       // manually trigger handleAppConnectionClosed, which will handle the grace period and resurrection logic.
       await this.handleAppConnectionClosed(packageName, 1069, "Connection not available for messaging");
-      return {
-        sent: false,
-        resurrectionTriggered: true,
-        error: "Connection not available for messaging",
-      };
+      // NOTE: This path returns a fresh object because resurrectionTriggered is true
+      // and the error string is unique to this code-path – not worth a frozen constant.
+      return { sent: false, resurrectionTriggered: true, error: "Connection not available for messaging" };
     } catch (error) {
       const logger = this.logger.child({ packageName });
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/cloud/packages/cloud/src/services/session/AppManager.ts
+++ b/cloud/packages/cloud/src/services/session/AppManager.ts
@@ -1712,15 +1712,13 @@ export class AppManager {
           // Send message successfully
           websocket.send(JSON.stringify(message));
           metricsService.incrementMiniappMessagesOut();
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              {
-                packageName,
-                messageType: message.type || "unknown",
-              },
-              `[AppManager:sendMessageToApp]: Message sent to App ${packageName} for user ${this.userSession.userId}`,
-            );
-          }
+          this.logger.debug(
+            {
+              packageName,
+              messageType: message.type || "unknown",
+            },
+            `[AppManager:sendMessageToApp]: Message sent to App ${packageName} for user ${this.userSession.userId}`,
+          );
 
           return SEND_SUCCESS;
         } catch (sendError) {

--- a/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
@@ -72,6 +72,17 @@ export class TranscriptionManager {
   private disposed = false;
   private pendingTimers = new Set<NodeJS.Timeout>();
 
+  // Hot-path allocation reduction: pre-allocated DataStream template to avoid
+  // per-message heap allocations in relayDataToApps, reducing GC pressure
+  // and heap fragmentation on Bun/JSC.
+  private _relayDataStream: DataStream = {
+    type: CloudToAppMessageType.DATA_STREAM,
+    sessionId: "",
+    streamType: "" as ExtendedStreamType,
+    data: null as any,
+    timestamp: 0 as any,
+  };
+
   // Health Monitoring
   private healthCheckInterval?: NodeJS.Timeout;
 
@@ -1898,17 +1909,20 @@ export class TranscriptionManager {
       // Get all apps subscribed to this base language
       const subscribedApps = this.userSession.subscriptionManager.getSubscribedApps(effectiveSubscription);
 
-      this.logger.debug(
-        {
-          subscription,
-          effectiveSubscription,
-          subscribedApps,
-          streamType,
-          dataType: data.type,
-          transcribeLanguage: data.transcribeLanguage,
-        },
-        "Broadcasting transcription data",
-      );
+      // Hot-path: guard debug log to avoid allocating the metadata object when debug is disabled
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          {
+            subscription,
+            effectiveSubscription,
+            subscribedApps,
+            streamType,
+            dataType: data.type,
+            transcribeLanguage: data.transcribeLanguage,
+          },
+          "Broadcasting transcription data",
+        );
+      }
 
       // Send to each app using APP MANAGER (with resurrection) instead of direct WebSocket
       for (const packageName of subscribedApps) {
@@ -1922,17 +1936,16 @@ export class TranscriptionManager {
           ? this.findAppTranscriptionSubscription(packageName, data.transcribeLanguage)
           : null;
 
-        const dataStream: DataStream = {
-          type: CloudToAppMessageType.DATA_STREAM,
-          sessionId: appSessionId,
-          streamType: (appSubscription || effectiveSubscription) as ExtendedStreamType,
-          data,
-          timestamp: new Date(),
-        };
+        // Hot-path allocation reduction: mutate pre-allocated template instead of
+        // creating a new object per message to reduce heap fragmentation on Bun/JSC.
+        this._relayDataStream.sessionId = appSessionId;
+        this._relayDataStream.streamType = (appSubscription || effectiveSubscription) as ExtendedStreamType;
+        this._relayDataStream.data = data;
+        this._relayDataStream.timestamp = Date.now() as any;
 
         try {
           // USE APP MANAGER instead of direct WebSocket (restores resurrection)
-          const result = await this.userSession.appManager.sendMessageToApp(packageName, dataStream);
+          const result = await this.userSession.appManager.sendMessageToApp(packageName, this._relayDataStream);
 
           if (!result.sent) {
             this.logger.warn(
@@ -1965,23 +1978,25 @@ export class TranscriptionManager {
         }
       }
 
-      // Enhanced debug logging to show transcription content and provider
-      this.logger.debug(
-        {
-          subscription,
-          effectiveSubscription,
-          provider: data.provider || "unknown",
-          dataType: data.type,
-          text: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
-          isFinal: data.isFinal,
-          confidence: data.confidence,
-          appsNotified: subscribedApps.length,
-          subscribedApps: Array.from(subscribedApps),
-        },
-        `📝 TRANSCRIPTION: [${data.provider || "unknown"}] ${data.isFinal ? "FINAL" : "interim"} "${
-          data.text || "no text"
-        }" → ${subscribedApps.length} apps`,
-      );
+      // Hot-path: guard debug log to avoid allocating metadata + string interpolation when debug is disabled
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          {
+            subscription,
+            effectiveSubscription,
+            provider: data.provider || "unknown",
+            dataType: data.type,
+            text: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
+            isFinal: data.isFinal,
+            confidence: data.confidence,
+            appsNotified: subscribedApps.length,
+            subscribedApps: Array.from(subscribedApps),
+          },
+          `📝 TRANSCRIPTION: [${data.provider || "unknown"}] ${data.isFinal ? "FINAL" : "interim"} "${
+            data.text || "no text"
+          }" → ${subscribedApps.length} apps`,
+        );
+      }
     } catch (error) {
       this.logger.error(
         {

--- a/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
@@ -75,12 +75,13 @@ export class TranscriptionManager {
   // Hot-path allocation reduction: pre-allocated DataStream template to avoid
   // per-message heap allocations in relayDataToApps, reducing GC pressure
   // and heap fragmentation on Bun/JSC.
+  private _relayTimestamp: Date = new Date();
   private _relayDataStream: DataStream = {
     type: CloudToAppMessageType.DATA_STREAM,
     sessionId: "",
     streamType: "" as ExtendedStreamType,
     data: null as any,
-    timestamp: 0 as any,
+    timestamp: this._relayTimestamp,
   };
 
   // Health Monitoring
@@ -1938,7 +1939,7 @@ export class TranscriptionManager {
         this._relayDataStream.sessionId = appSessionId;
         this._relayDataStream.streamType = (appSubscription || effectiveSubscription) as ExtendedStreamType;
         this._relayDataStream.data = data;
-        this._relayDataStream.timestamp = Date.now() as any;
+        this._relayTimestamp.setTime(Date.now());
 
         try {
           // USE APP MANAGER instead of direct WebSocket (restores resurrection)

--- a/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
@@ -1909,20 +1909,17 @@ export class TranscriptionManager {
       // Get all apps subscribed to this base language
       const subscribedApps = this.userSession.subscriptionManager.getSubscribedApps(effectiveSubscription);
 
-      // Hot-path: guard debug log to avoid allocating the metadata object when debug is disabled
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          {
-            subscription,
-            effectiveSubscription,
-            subscribedApps,
-            streamType,
-            dataType: data.type,
-            transcribeLanguage: data.transcribeLanguage,
-          },
-          "Broadcasting transcription data",
-        );
-      }
+      this.logger.debug(
+        {
+          subscription,
+          effectiveSubscription,
+          subscribedApps,
+          streamType,
+          dataType: data.type,
+          transcribeLanguage: data.transcribeLanguage,
+        },
+        "Broadcasting transcription data",
+      );
 
       // Send to each app using APP MANAGER (with resurrection) instead of direct WebSocket
       for (const packageName of subscribedApps) {
@@ -1978,25 +1975,22 @@ export class TranscriptionManager {
         }
       }
 
-      // Hot-path: guard debug log to avoid allocating metadata + string interpolation when debug is disabled
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          {
-            subscription,
-            effectiveSubscription,
-            provider: data.provider || "unknown",
-            dataType: data.type,
-            text: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
-            isFinal: data.isFinal,
-            confidence: data.confidence,
-            appsNotified: subscribedApps.length,
-            subscribedApps: Array.from(subscribedApps),
-          },
-          `📝 TRANSCRIPTION: [${data.provider || "unknown"}] ${data.isFinal ? "FINAL" : "interim"} "${
-            data.text || "no text"
-          }" → ${subscribedApps.length} apps`,
-        );
-      }
+      this.logger.debug(
+        {
+          subscription,
+          effectiveSubscription,
+          provider: data.provider || "unknown",
+          dataType: data.type,
+          text: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
+          isFinal: data.isFinal,
+          confidence: data.confidence,
+          appsNotified: subscribedApps.length,
+          subscribedApps: Array.from(subscribedApps),
+        },
+        `📝 TRANSCRIPTION: [${data.provider || "unknown"}] ${data.isFinal ? "FINAL" : "interim"} "${
+          data.text || "no text"
+        }" → ${subscribedApps.length} apps`,
+      );
     } catch (error) {
       this.logger.error(
         {

--- a/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
+++ b/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
@@ -67,12 +67,13 @@ export class TranslationManager {
    * Mutated in-place to avoid per-message heap allocation, reducing GC pressure
    * and heap fragmentation on Bun/JSC.
    */
+  private _relayTimestamp: Date = new Date();
   private _relayDataStream: DataStream = {
     type: CloudToAppMessageType.DATA_STREAM,
     sessionId: "",
     streamType: "" as ExtendedStreamType,
     data: null as any,
-    timestamp: 0 as any,
+    timestamp: this._relayTimestamp,
   };
 
   constructor(
@@ -728,7 +729,7 @@ export class TranslationManager {
         this._relayDataStream.sessionId = appSessionId;
         this._relayDataStream.streamType = subscription;
         this._relayDataStream.data = data;
-        this._relayDataStream.timestamp = Date.now() as any;
+        this._relayTimestamp.setTime(Date.now());
 
         try {
           const result = await this.userSession.appManager.sendMessageToApp(packageName, this._relayDataStream);

--- a/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
+++ b/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
@@ -62,6 +62,19 @@ export class TranslationManager {
   private disposed = false;
   private pendingTimers = new Set<NodeJS.Timeout>();
 
+  /**
+   * Pre-allocated DataStream template for relayDataToApps hot path.
+   * Mutated in-place to avoid per-message heap allocation, reducing GC pressure
+   * and heap fragmentation on Bun/JSC.
+   */
+  private _relayDataStream: DataStream = {
+    type: CloudToAppMessageType.DATA_STREAM,
+    sessionId: "",
+    streamType: "" as ExtendedStreamType,
+    data: null as any,
+    timestamp: 0 as any,
+  };
+
   constructor(
     private userSession: UserSession,
     private config: TranslationConfig = DEFAULT_TRANSLATION_CONFIG,
@@ -694,32 +707,34 @@ export class TranslationManager {
       // Get subscribed apps
       const subscribedApps = this.userSession.subscriptionManager.getSubscribedApps(subscription);
 
-      this.logger.debug(
-        {
-          subscription,
-          subscribedApps,
-          sourceLanguage: data.transcribeLanguage,
-          targetLanguage: data.translateLanguage,
-          didTranslate: data.didTranslate,
-          textPreview: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
-        },
-        "Broadcasting translation data to apps",
-      );
+      // Hot-path: guard debug log behind level check to avoid allocating the context object
+      if (this.logger.isLevelEnabled('debug')) {
+        this.logger.debug(
+          {
+            subscription,
+            subscribedApps,
+            sourceLanguage: data.transcribeLanguage,
+            targetLanguage: data.translateLanguage,
+            didTranslate: data.didTranslate,
+            textPreview: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
+          },
+          "Broadcasting translation data to apps",
+        );
+      }
 
       // Send to each app using AppManager
+      // Hot-path: mutate pre-allocated _relayDataStream instead of allocating a new
+      // object per message to reduce heap fragmentation on Bun/JSC.
       for (const packageName of subscribedApps) {
         const appSessionId = `${this.userSession.sessionId}-${packageName}`;
 
-        const dataStream: DataStream = {
-          type: CloudToAppMessageType.DATA_STREAM,
-          sessionId: appSessionId,
-          streamType: subscription,
-          data,
-          timestamp: new Date(),
-        };
+        this._relayDataStream.sessionId = appSessionId;
+        this._relayDataStream.streamType = subscription;
+        this._relayDataStream.data = data;
+        this._relayDataStream.timestamp = Date.now() as any;
 
         try {
-          const result = await this.userSession.appManager.sendMessageToApp(packageName, dataStream);
+          const result = await this.userSession.appManager.sendMessageToApp(packageName, this._relayDataStream);
 
           if (!result.sent) {
             this.logger.warn(

--- a/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
+++ b/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
@@ -707,20 +707,17 @@ export class TranslationManager {
       // Get subscribed apps
       const subscribedApps = this.userSession.subscriptionManager.getSubscribedApps(subscription);
 
-      // Hot-path: guard debug log behind level check to avoid allocating the context object
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          {
-            subscription,
-            subscribedApps,
-            sourceLanguage: data.transcribeLanguage,
-            targetLanguage: data.translateLanguage,
-            didTranslate: data.didTranslate,
-            textPreview: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
-          },
-          "Broadcasting translation data to apps",
-        );
-      }
+      this.logger.debug(
+        {
+          subscription,
+          subscribedApps,
+          sourceLanguage: data.transcribeLanguage,
+          targetLanguage: data.translateLanguage,
+          didTranslate: data.didTranslate,
+          textPreview: data.text ? `"${data.text.substring(0, 100)}${data.text.length > 100 ? "..." : ""}"` : "no text",
+        },
+        "Broadcasting translation data to apps",
+      );
 
       // Send to each app using AppManager
       // Hot-path: mutate pre-allocated _relayDataStream instead of allocating a new

--- a/cloud/websites/console/src/components/forms/AppTypeTooltip.tsx
+++ b/cloud/websites/console/src/components/forms/AppTypeTooltip.tsx
@@ -1,11 +1,6 @@
-import React from 'react';
-import { Info } from 'lucide-react';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import React from "react";
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const AppTypeTooltip: React.FC = () => {
   return (
@@ -18,18 +13,20 @@ const AppTypeTooltip: React.FC = () => {
           <div className="space-y-3">
             <div>
               <p className="font-semibold text-link">Standard Apps (Foreground)</p>
-              <p className="text-sm text-popover-foreground/80">
-                • Only one standard app can run at a time<br />
-                • Has primary control of the display<br />
-                • Starting a standard app closes any other running standard app
+              <p className="text-sm text-whitetext-popover-foreground/80">
+                • Only one standard app can run at a time
+                <br />
+                • Has primary control of the display
+                <br />• Starting a standard app closes any other running standard app
               </p>
             </div>
             <div>
               <p className="font-semibold text-success">Background Apps</p>
-              <p className="text-sm text-popover-foreground/80">
-                • Multiple background apps can be active simultaneously<br />
-                • Can temporarily take control of the display<br />
-                • Take priority when no standard app is displaying content
+              <p className="text-sm text-white text-popover-foreground/80">
+                • Multiple background apps can be active simultaneously
+                <br />
+                • Can temporarily take control of the display
+                <br />• Take priority when no standard app is displaying content
               </p>
             </div>
           </div>

--- a/cloud/websites/console/src/components/forms/AppTypeTooltip.tsx
+++ b/cloud/websites/console/src/components/forms/AppTypeTooltip.tsx
@@ -13,7 +13,7 @@ const AppTypeTooltip: React.FC = () => {
           <div className="space-y-3">
             <div>
               <p className="font-semibold text-link">Standard Apps (Foreground)</p>
-              <p className="text-sm text-whitetext-popover-foreground/80">
+              <p className="text-sm text-white">
                 • Only one standard app can run at a time
                 <br />
                 • Has primary control of the display
@@ -22,7 +22,7 @@ const AppTypeTooltip: React.FC = () => {
             </div>
             <div>
               <p className="font-semibold text-success">Background Apps</p>
-              <p className="text-sm text-white text-popover-foreground/80">
+              <p className="text-sm text-amber-white ">
                 • Multiple background apps can be active simultaneously
                 <br />
                 • Can temporarily take control of the display


### PR DESCRIPTION
## Summary
- fix the custom WHIP/WebRTC capturer to deliver frames with stock WebRTC-style transform plus rotation metadata
- select a real supported SurfaceTexture camera size close to the requested 16:9 stream size instead of assuming 960x540 is supported
- add diagnostics for requested size, chosen camera size, sensor orientation, frame rotation, and first delivered frame size

## Testing
- not run successfully in this workspace: `./gradlew app:compileDebugJavaWithJavac`
- blocked by missing local `asg_client/.env` and unresolved local StreamPackLite Gradle project variants in this checkout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added heap and memory-ownership diagnostics and admin tooling for investigating memory growth.
  * Improved camera capture: dynamic size selection, center-crop scaling, and accurate frame rotation.

* **Bug Fixes**
  * Better diagnostics/logging for camera capture startup and frame handling.

* **Refactor / Performance**
  * Reduced per-message allocations by reusing preallocated relay objects.

* **Documentation**
  * Added design and spike docs describing memory diagnostics and ownership census.

* **Style**
  * Updated tooltip visual styling and formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->