### PR TITLE
Fix store deeplinks and add /start smart deeplink

### DIFF
--- a/cloud/websites/store/src/App.tsx
+++ b/cloud/websites/store/src/App.tsx
@@ -44,6 +44,7 @@ const AppRoutes: FC = () => {
       <Routes>
         <Route path="/" element={<AppStore />} />
         <Route path="/package/:packageName" element={<AppDetailsV2 />} />
+        <Route path="/package/:packageName/start" element={<AppDetailsV2 />} />
         <Route path="/login" element={<LoginPage />} />
         <Route path="/forgot-password" element={<ForgotPasswordPage />} />
         <Route path="/reset-password" element={<ResetPasswordPage redirectUrl="/" />} />

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -50,6 +50,11 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
               host: "apps.mentra.glass",
               pathPrefix: "/package/",
             },
+            {
+              scheme: "https",
+              host: "apps.mentraglass.com",
+              pathPrefix: "/package/",
+            },
           ],
           category: ["DEFAULT", "BROWSABLE"],
         },
@@ -62,7 +67,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       buildNumber: "154",
       bundleIdentifier: "com.mentra.mentra",
       googleServicesFile: "./GoogleService-Info.plist",
-      associatedDomains: ["applinks:apps.mentra.glass"],
+      associatedDomains: ["applinks:apps.mentra.glass", "applinks:apps.mentraglass.com"],
       infoPlist: {
         NSCameraUsageDescription: "This app needs access to your camera to capture images.",
         NSMicrophoneUsageDescription:

--- a/mobile/src/app/index.tsx
+++ b/mobile/src/app/index.tsx
@@ -98,6 +98,8 @@ export default function InitScreen() {
     const pendingRoute = getPendingRoute()
     if (pendingRoute) {
       setPendingRoute(null)
+      // Navigate to home first so the deep link screen has a proper back destination
+      clearHistoryAndGoHome({transition: "fade"})
       setTimeout(() => processUrl(pendingRoute), DEEPLINK_DELAY)
       return
     }

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -1,7 +1,7 @@
 import * as Linking from "expo-linking"
 import * as WebBrowser from "expo-web-browser"
 import {FC, ReactNode, createContext, useContext, useEffect} from "react"
-import {Platform} from "react-native"
+import {AppState, Platform} from "react-native"
 
 // import {Linking} from "react-native"
 // import {useAuth} from "@/contexts/AuthContext"
@@ -9,6 +9,19 @@ import {NavObject, useNavigationHistory, getCurrentRoute} from "@/contexts/Navig
 import {useAppletStatusStore} from "@/stores/applets"
 import mentraAuth from "@/utils/auth/authClient"
 import {BackgroundTimer} from "@/utils/timers"
+
+/** Returns immediately if the app is already active, otherwise waits for it. */
+const waitForActive = (): Promise<void> => {
+  if (AppState.currentState === "active") return Promise.resolve()
+  return new Promise((resolve) => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        sub.remove()
+        resolve()
+      }
+    })
+  })
+}
 
 export interface DeepLinkRoute {
   pattern: string
@@ -130,6 +143,8 @@ const deepLinkRoutes: DeepLinkRoute[] = [
         navObject.replace(`/`)
         return
       }
+      // Deep links can fire while the app is still in the background state.
+      await waitForActive()
       // Ensure applet list is up-to-date (may be empty after cold start)
       await useAppletStatusStore.getState().refreshApplets()
       const applet = useAppletStatusStore.getState().apps.find((app) => app.packageName === packageName)
@@ -145,7 +160,9 @@ const deepLinkRoutes: DeepLinkRoute[] = [
         }
         setTimeout(() => tryStart(10), 100)
       } else {
-        navObject.replace(`/store?packageName=${packageName}`)
+        // Not installed — reset to home, then push store so back goes home
+        navObject.replaceAll("/home")
+        setTimeout(() => navObject.push("/miniapps/store/store", {packageName}), 150)
       }
     },
     requiresAuth: true,
@@ -162,11 +179,15 @@ const deepLinkRoutes: DeepLinkRoute[] = [
   },
   {
     pattern: "/package/:packageName",
-    handler: (url: string, params: Record<string, string>, navObject: NavObject) => {
+    handler: async (url: string, params: Record<string, string>, navObject: NavObject) => {
       const {packageName, preloaded, authed} = params
       if (preloaded && authed) {
-        // App is already running and initialized — navigate directly
-        navObject.replace(`/store?packageName=${packageName}`)
+        // Deep links can fire while the app is still in the background state.
+        // Navigation calls made before the app is active get lost, so wait first.
+        await waitForActive()
+        // Reset stack to home, then push store on top so back always goes home.
+        navObject.replaceAll("/home")
+        setTimeout(() => navObject.push("/miniapps/store/store", {packageName}), 150)
         return
       }
       // Cold start or not authenticated — store raw URL so processUrl re-matches it after init

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -6,6 +6,7 @@ import {Platform} from "react-native"
 // import {Linking} from "react-native"
 // import {useAuth} from "@/contexts/AuthContext"
 import {NavObject, useNavigationHistory} from "@/contexts/NavigationHistoryContext"
+import {useAppletStatusStore} from "@/stores/applets"
 import mentraAuth from "@/utils/auth/authClient"
 import {BackgroundTimer} from "@/utils/timers"
 
@@ -118,6 +119,31 @@ const deepLinkRoutes: DeepLinkRoute[] = [
     requiresAuth: true,
   },
 
+  // Smart start: activates the app if installed, otherwise shows the store page
+  {
+    pattern: "/package/:packageName/start",
+    handler: (url: string, params: Record<string, string>, navObject: NavObject) => {
+      const {packageName, preloaded, authed} = params
+      if (!preloaded || !authed) {
+        // Cold start or not authenticated — use pending route mechanism
+        navObject.setPendingRoute(`/package/${packageName}/start`)
+        navObject.replace(`/`)
+        return
+      }
+      const applet = useAppletStatusStore.getState().apps.find((app) => app.packageName === packageName)
+      if (applet) {
+        // Navigate to home first so startApplet's navigation logic works
+        navObject.replaceAll("/home")
+        setTimeout(() => {
+          useAppletStatusStore.getState().startApplet(applet)
+        }, 300)
+      } else {
+        navObject.replace(`/store?packageName=${packageName}`)
+      }
+    },
+    requiresAuth: true,
+  },
+
   // Store routes
   {
     pattern: "/store",
@@ -132,11 +158,11 @@ const deepLinkRoutes: DeepLinkRoute[] = [
     handler: (url: string, params: Record<string, string>, navObject: NavObject) => {
       const {packageName, preloaded, authed} = params
       if (preloaded && authed) {
-        // we've already loaded the app, so we can just navigate there directly
+        // App is already running and initialized — navigate directly
         navObject.replace(`/store?packageName=${packageName}`)
         return
       }
-      // we probably need to login first:
+      // Cold start or not authenticated — let index.tsx init handle it via pending route
       navObject.setPendingRoute(`/store?packageName=${packageName}`)
       navObject.replace(`/`)
     },
@@ -343,14 +369,6 @@ const deepLinkRoutes: DeepLinkRoute[] = [
 
   // Universal app link routes (for apps.mentra.glass)
   {
-    pattern: "/package/:packageName",
-    handler: async (url: string, params: Record<string, string>, navObject: NavObject) => {
-      const {packageName} = params
-      navObject.push(`/store?packageName=${packageName}`)
-    },
-    requiresAuth: true,
-  },
-  {
     pattern: "/apps/:packageName",
     handler: async (url: string, params: Record<string, string>, navObject: NavObject) => {
       const {packageName} = params
@@ -476,9 +494,19 @@ export const DeeplinkProvider: FC<{children: ReactNode}> = ({children}) => {
 
   const processUrl = async (url: string, initial: boolean = false) => {
     try {
-      // Add delay to ensure Root Layout is mounted
+      // For initial URLs (cold start), set the pending route BEFORE the delay.
+      // This prevents a race condition where index.tsx init completes during the
+      // delay and calls navigateToDestination() before the pending route is set,
+      // causing it to navigate to /home instead of the deep link target.
       if (initial) {
+        setPendingRoute(url)
         await new Promise((resolve) => setTimeout(resolve, 1000))
+        // If index.tsx already consumed and re-processed the pending route
+        // during the delay, don't double-process it
+        if (getPendingRoute() !== url) {
+          console.log("[DEEPLINK] Pending route was consumed during delay, skipping")
+          return
+        }
       }
 
       console.log("[LOGIN DEBUG] Deep link received:", url)

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -136,34 +136,28 @@ const deepLinkRoutes: DeepLinkRoute[] = [
   {
     pattern: "/package/:packageName/start",
     handler: async (url: string, params: Record<string, string>, navObject: NavObject) => {
+      
       const {packageName, preloaded, authed} = params
-      if (!preloaded || !authed) {
-        // Cold start or not authenticated — use pending route mechanism
-        navObject.setPendingRoute(url)
-        navObject.replace(`/`)
-        return
-      }
-      // Deep links can fire while the app is still in the background state.
-      await waitForActive()
-      // Ensure applet list is up-to-date (may be empty after cold start)
-      await useAppletStatusStore.getState().refreshApplets()
-      const applet = useAppletStatusStore.getState().apps.find((app) => app.packageName === packageName)
-      if (applet) {
-        // Navigate to home, then poll until the route has settled before starting
+      if (preloaded && authed) {
+        // Deep links can fire while the app is still in the background state.
+        // Navigation calls made before the app is active get lost, so wait first.
+        await waitForActive()
+        // Reset stack to home, then push store on top so back always goes home.
         navObject.replaceAll("/home")
-        const tryStart = (attempts: number) => {
-          if (getCurrentRoute() === "/home") {
-            useAppletStatusStore.getState().startApplet(applet)
-          } else if (attempts > 0) {
-            setTimeout(() => tryStart(attempts - 1), 100)
-          }
+        await useAppletStatusStore.getState().refreshApplets()
+        const applet = useAppletStatusStore.getState().apps.find((app) => app.packageName === packageName)
+        console.log("[DEEPLINK] Smart start for package:", packageName, "applet found:", !!applet)
+        if (applet) {
+          setTimeout(() => useAppletStatusStore.getState().startApplet(applet), 150)
+          return;
+        } else {
+          setTimeout(() => navObject.push("/miniapps/store/store", {packageName}), 150)
+          return
         }
-        setTimeout(() => tryStart(10), 100)
-      } else {
-        // Not installed — reset to home, then push store so back goes home
-        navObject.replaceAll("/home")
-        setTimeout(() => navObject.push("/miniapps/store/store", {packageName}), 150)
       }
+      // Cold start or not authenticated — store raw URL so processUrl re-matches it after init
+      navObject.setPendingRoute(url)
+      navObject.replace(`/`)
     },
     requiresAuth: true,
   },
@@ -520,8 +514,25 @@ export const DeeplinkProvider: FC<{children: ReactNode}> = ({children}) => {
     return params
   }
 
+  let lastProcessedUrl: string | null = null
+  let lastProcessedTime = 0
+
   const processUrl = async (url: string, initial: boolean = false) => {
     try {
+      // Deduplicate — iOS can fire the same universal link event multiple times,
+      // and on cold start both getInitialURL and addEventListener fire for the
+      // same URL. Initial calls skip the check but claim the URL so that the
+      // duplicate addEventListener call is blocked. The index.tsx re-processing
+      // call happens >2s later (1s initial delay + init time + 1s DEEPLINK_DELAY)
+      // so it naturally falls outside the dedup window.
+      const now = Date.now()
+      if (!initial && url === lastProcessedUrl && now - lastProcessedTime < 3000) {
+        console.log("[DEEPLINK] Ignoring duplicate URL:", url)
+        return
+      }
+      lastProcessedUrl = url
+      lastProcessedTime = now
+
       // For initial URLs (cold start), set the pending route BEFORE the delay.
       // This prevents a race condition where index.tsx init completes during the
       // delay and calls navigateToDestination() before the pending route is set,

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -5,7 +5,7 @@ import {Platform} from "react-native"
 
 // import {Linking} from "react-native"
 // import {useAuth} from "@/contexts/AuthContext"
-import {NavObject, useNavigationHistory} from "@/contexts/NavigationHistoryContext"
+import {NavObject, useNavigationHistory, getCurrentRoute} from "@/contexts/NavigationHistoryContext"
 import {useAppletStatusStore} from "@/stores/applets"
 import mentraAuth from "@/utils/auth/authClient"
 import {BackgroundTimer} from "@/utils/timers"
@@ -122,21 +122,28 @@ const deepLinkRoutes: DeepLinkRoute[] = [
   // Smart start: activates the app if installed, otherwise shows the store page
   {
     pattern: "/package/:packageName/start",
-    handler: (url: string, params: Record<string, string>, navObject: NavObject) => {
+    handler: async (url: string, params: Record<string, string>, navObject: NavObject) => {
       const {packageName, preloaded, authed} = params
       if (!preloaded || !authed) {
         // Cold start or not authenticated — use pending route mechanism
-        navObject.setPendingRoute(`/package/${packageName}/start`)
+        navObject.setPendingRoute(url)
         navObject.replace(`/`)
         return
       }
+      // Ensure applet list is up-to-date (may be empty after cold start)
+      await useAppletStatusStore.getState().refreshApplets()
       const applet = useAppletStatusStore.getState().apps.find((app) => app.packageName === packageName)
       if (applet) {
-        // Navigate to home first so startApplet's navigation logic works
+        // Navigate to home, then poll until the route has settled before starting
         navObject.replaceAll("/home")
-        setTimeout(() => {
-          useAppletStatusStore.getState().startApplet(applet)
-        }, 300)
+        const tryStart = (attempts: number) => {
+          if (getCurrentRoute() === "/home") {
+            useAppletStatusStore.getState().startApplet(applet)
+          } else if (attempts > 0) {
+            setTimeout(() => tryStart(attempts - 1), 100)
+          }
+        }
+        setTimeout(() => tryStart(10), 100)
       } else {
         navObject.replace(`/store?packageName=${packageName}`)
       }
@@ -162,8 +169,8 @@ const deepLinkRoutes: DeepLinkRoute[] = [
         navObject.replace(`/store?packageName=${packageName}`)
         return
       }
-      // Cold start or not authenticated — let index.tsx init handle it via pending route
-      navObject.setPendingRoute(`/store?packageName=${packageName}`)
+      // Cold start or not authenticated — store raw URL so processUrl re-matches it after init
+      navObject.setPendingRoute(url)
       navObject.replace(`/`)
     },
     requiresAuth: true,


### PR DESCRIPTION
## Summary
- **Fix deeplinks for `apps.mentraglass.com`**: Added the domain to Android intent filters and iOS associated domains (`.well-known` files already served on both domains)
- **Fix cold-start deeplink race condition**: Pending route is now set immediately before the 1s layout delay, so `index.tsx` init always finds it instead of navigating to `/home`
- **New `/package/:packageName/start` deeplink**: Activates the app via `startApplet` if installed (handles webview/settings/offline routing, compatibility checks, stopping other foreground apps), or shows the store page if not. Web store serves the same app details page as a browser fallback.
- **Cleanup**: Removed duplicate unreachable `/package/:packageName` route definition

## Deep link URLs (both domains)
| URL | Behavior |
|-----|----------|
| `apps.mentra.glass/package/com.mentra.notes` | Store page |
| `apps.mentraglass.com/package/com.mentra.notes` | Store page |
| `apps.mentra.glass/package/com.mentra.notes/start` | Activate if installed, store page if not |
| `apps.mentraglass.com/package/com.mentra.notes/start` | Activate if installed, store page if not |

## Test plan
- [ ] Tap `https://apps.mentra.glass/package/com.mentra.notes` — should open store page for Mentra Notes (not home screen)
- [ ] Tap `https://apps.mentraglass.com/package/com.mentra.notes` — same behavior
- [ ] Cold-start the app via a `/package/` deep link — should navigate to store page after init, not home
- [ ] Tap `/package/com.mentra.notes/start` with Notes installed — should activate the app
- [ ] Tap `/package/com.mentra.notes/start` with Notes not installed — should show store page
- [ ] Visit `/package/com.mentra.notes/start` in browser — should show app details page

Closes OS-1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a package "start" deep-link route that adapts behavior based on app readiness and authentication.
  * Extended domain support to include apps.mentraglass.com for both iOS and Android.

* **Bug Fixes**
  * Improved deep-link handling to avoid double-processing and race conditions during cold starts and initialization.
  * Updated deep-link flow to clear navigation history and return home before processing pending links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->