### PR TITLE
Fix WHIP video stretch

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -11,11 +11,13 @@ import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
 import android.hardware.camera2.params.StreamConfigurationMap;
+import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
 import android.util.Range;
 import android.util.Size;
+import android.view.Display;
 import android.view.Surface;
 import android.view.WindowManager;
 
@@ -69,6 +71,8 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mWidth;
   private int mHeight;
   private int mFps;
+  private int mCameraSurfaceWidth;
+  private int mCameraSurfaceHeight;
   private int mCaptureWidth;
   private int mCaptureHeight;
   private int mCropX;
@@ -76,7 +80,6 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mCropWidth;
   private int mCropHeight;
   private int mSensorOrientation;
-  private int mFrameRotation;
   private boolean mIsFrontCamera;
   private boolean mLoggedFrameSize = false;
 
@@ -101,8 +104,6 @@ public class WhipCameraCapturer implements VideoCapturer {
     mCameraThread.getLooper().getThread().setPriority(Thread.MIN_PRIORITY);
     mCameraHandler = new Handler(mCameraThread.getLooper());
 
-    mSurfaceTextureHelper.setTextureSize(width, height);
-
     CameraManager cameraManager =
         (CameraManager) mContext.getSystemService(Context.CAMERA_SERVICE);
 
@@ -113,6 +114,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       return;
     }
 
+    int initialFrameRotation;
     try {
       CameraCharacteristics chars = cameraManager.getCameraCharacteristics(cameraId);
       Integer sensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
@@ -120,29 +122,35 @@ public class WhipCameraCapturer implements VideoCapturer {
       Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
       mIsFrontCamera = facing != null && facing == CameraCharacteristics.LENS_FACING_FRONT;
       Size captureSize = chooseCaptureSize(chars, width, height);
-      mCaptureWidth = captureSize.getWidth();
-      mCaptureHeight = captureSize.getHeight();
+      mCameraSurfaceWidth = captureSize.getWidth();
+      mCameraSurfaceHeight = captureSize.getHeight();
+      Size normalizedCaptureSize = normalizeLandscapeSize(captureSize);
+      mCaptureWidth = normalizedCaptureSize.getWidth();
+      mCaptureHeight = normalizedCaptureSize.getHeight();
       updateOutputCrop();
-      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
-      mFrameRotation = getFrameOrientation();
+      mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
+      initialFrameRotation = getFrameOrientation();
     } catch (CameraAccessException e) {
       Log.w(TAG, "Failed to get camera characteristics", e);
       mSensorOrientation = 90;
       mIsFrontCamera = false;
+      mCameraSurfaceWidth = width;
+      mCameraSurfaceHeight = height;
       mCaptureWidth = width;
       mCaptureHeight = height;
       updateOutputCrop();
-      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
-      mFrameRotation = 0;
+      mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
+      initialFrameRotation = 0;
     }
 
     Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
-        + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", selected camera size: " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
+        + ", normalized capture size: " + mCaptureWidth + "x" + mCaptureHeight
         + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", " + mCropY
         + ")"
         + ", sensor orientation: " + mSensorOrientation
         + ", isFront: " + mIsFrontCamera
-        + ", frame rotation: " + mFrameRotation);
+        + ", frame rotation: " + initialFrameRotation);
 
     try {
       cameraManager.openCamera(cameraId, new CameraDevice.StateCallback() {
@@ -244,16 +252,18 @@ public class WhipCameraCapturer implements VideoCapturer {
       // 2. Preserve frame rotation metadata so downstream width/height handling stays correct.
       mSurfaceTextureHelper.startListening(frame -> {
         TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
+        int frameRotation = getFrameOrientation();
 
         if (!mLoggedFrameSize) {
           mLoggedFrameSize = true;
           Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
               + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
-              + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+              + ", selected camera size: " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
+              + ", normalized capture size: " + mCaptureWidth + "x" + mCaptureHeight
               + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", "
               + mCropY + ")"
               + ", sensor orientation: " + mSensorOrientation
-              + ", frame rotation: " + mFrameRotation + ")");
+              + ", frame rotation: " + frameRotation + ")");
         }
 
         TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
@@ -264,7 +274,7 @@ public class WhipCameraCapturer implements VideoCapturer {
         }
 
         VideoFrame modifiedFrame = new VideoFrame(
-            outputBuffer, mFrameRotation, frame.getTimestampNs());
+            outputBuffer, frameRotation, frame.getTimestampNs());
         mObserver.onFrameCaptured(modifiedFrame);
         modifiedFrame.release();
       });
@@ -382,7 +392,20 @@ public class WhipCameraCapturer implements VideoCapturer {
       return ServiceUtils.determineDefaultRotationForDevice(mContext);
     }
 
-    switch (windowManager.getDefaultDisplay().getRotation()) {
+    Display display = null;
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+      display = mContext.getDisplay();
+    }
+    if (display == null) {
+      @SuppressWarnings("deprecation")
+      Display fallbackDisplay = windowManager.getDefaultDisplay();
+      display = fallbackDisplay;
+    }
+    if (display == null) {
+      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    }
+
+    switch (display.getRotation()) {
       case Surface.ROTATION_90:
         return 90;
       case Surface.ROTATION_180:
@@ -413,7 +436,8 @@ public class WhipCameraCapturer implements VideoCapturer {
     }
 
     Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
-    Size bestSize = normalizeLandscapeSize(outputSizes[0]);
+    Size bestRawSize = outputSizes[0];
+    Size bestSize = normalizeLandscapeSize(bestRawSize);
     int bestTransformPenalty = Integer.MAX_VALUE;
     long bestSourceArea = Long.MAX_VALUE;
     long bestCropAreaDelta = Long.MAX_VALUE;
@@ -438,6 +462,7 @@ public class WhipCameraCapturer implements VideoCapturer {
               && cropAreaDelta < bestCropAreaDelta);
 
       if (isBetter) {
+        bestRawSize = rawSize;
         bestSize = candidate;
         bestTransformPenalty = transformPenalty;
         bestSourceArea = candidateArea;
@@ -447,14 +472,14 @@ public class WhipCameraCapturer implements VideoCapturer {
 
     Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
     if (bestTransformPenalty == 1) {
-      Log.d(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+      Log.d(TAG, "Selected camera size " + bestRawSize.getWidth() + "x" + bestRawSize.getHeight()
           + " will be cropped and downscaled to " + requestedWidth + "x" + requestedHeight);
     } else if (bestTransformPenalty == 2) {
-      Log.w(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+      Log.w(TAG, "Selected camera size " + bestRawSize.getWidth() + "x" + bestRawSize.getHeight()
           + " cannot reach requested " + requestedWidth + "x" + requestedHeight
           + " without upscaling");
     }
-    return bestSize;
+    return bestRawSize;
   }
 
   private void updateOutputCrop() {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -71,6 +71,10 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mFps;
   private int mCaptureWidth;
   private int mCaptureHeight;
+  private int mCropX;
+  private int mCropY;
+  private int mCropWidth;
+  private int mCropHeight;
   private int mSensorOrientation;
   private int mFrameRotation;
   private boolean mIsFrontCamera;
@@ -118,6 +122,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       Size captureSize = chooseCaptureSize(chars, width, height);
       mCaptureWidth = captureSize.getWidth();
       mCaptureHeight = captureSize.getHeight();
+      updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
       mFrameRotation = getFrameOrientation();
     } catch (CameraAccessException e) {
@@ -126,12 +131,15 @@ public class WhipCameraCapturer implements VideoCapturer {
       mIsFrontCamera = false;
       mCaptureWidth = width;
       mCaptureHeight = height;
+      updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
       mFrameRotation = 0;
     }
 
     Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
         + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", " + mCropY
+        + ")"
         + ", sensor orientation: " + mSensorOrientation
         + ", isFront: " + mIsFrontCamera
         + ", frame rotation: " + mFrameRotation);
@@ -242,15 +250,21 @@ public class WhipCameraCapturer implements VideoCapturer {
           Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
               + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
               + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+              + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", "
+              + mCropY + ")"
               + ", sensor orientation: " + mSensorOrientation
               + ", frame rotation: " + mFrameRotation + ")");
         }
 
         TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
             createTextureTransformMatrix(), texBuffer.getWidth(), texBuffer.getHeight());
+        VideoFrame.Buffer outputBuffer = adaptOutputBuffer(modifiedBuffer);
+        if (outputBuffer != modifiedBuffer) {
+          modifiedBuffer.release();
+        }
 
         VideoFrame modifiedFrame = new VideoFrame(
-            modifiedBuffer, mFrameRotation, frame.getTimestampNs());
+            outputBuffer, mFrameRotation, frame.getTimestampNs());
         mObserver.onFrameCaptured(modifiedFrame);
         modifiedFrame.release();
       });
@@ -400,43 +414,91 @@ public class WhipCameraCapturer implements VideoCapturer {
 
     Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
     Size bestSize = normalizeLandscapeSize(outputSizes[0]);
-    float requestedAspectRatio = requestedSize.getWidth() / (float) requestedSize.getHeight();
-    long requestedArea = (long) requestedSize.getWidth() * requestedSize.getHeight();
-    double bestAspectDelta = Double.MAX_VALUE;
-    boolean bestMeetsRequestedSize = false;
-    long bestAreaDelta = Long.MAX_VALUE;
+    int bestTransformPenalty = Integer.MAX_VALUE;
+    long bestSourceArea = Long.MAX_VALUE;
+    long bestCropAreaDelta = Long.MAX_VALUE;
 
     for (Size rawSize : outputSizes) {
       Size candidate = normalizeLandscapeSize(rawSize);
-      float candidateAspectRatio = candidate.getWidth() / (float) candidate.getHeight();
-      double aspectDelta = Math.abs(candidateAspectRatio - requestedAspectRatio);
-      boolean meetsRequestedSize = candidate.getWidth() >= requestedSize.getWidth()
-          && candidate.getHeight() >= requestedSize.getHeight();
+      Size croppedSize = getCenterCropSize(candidate.getWidth(), candidate.getHeight(),
+          requestedSize.getWidth(), requestedSize.getHeight());
+      boolean meetsRequestedSize = croppedSize.getWidth() >= requestedSize.getWidth()
+          && croppedSize.getHeight() >= requestedSize.getHeight();
+      boolean exactOutput = croppedSize.getWidth() == requestedSize.getWidth()
+          && croppedSize.getHeight() == requestedSize.getHeight();
+      int transformPenalty = exactOutput ? 0 : meetsRequestedSize ? 1 : 2;
       long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
-      long areaDelta = Math.abs(candidateArea - requestedArea);
+      long cropArea = (long) croppedSize.getWidth() * croppedSize.getHeight();
+      long cropAreaDelta = Math.abs(cropArea
+          - ((long) requestedSize.getWidth() * requestedSize.getHeight()));
 
-      boolean isBetter = aspectDelta < bestAspectDelta
-          || (Double.compare(aspectDelta, bestAspectDelta) == 0
-              && meetsRequestedSize && !bestMeetsRequestedSize)
-          || (Double.compare(aspectDelta, bestAspectDelta) == 0
-              && meetsRequestedSize == bestMeetsRequestedSize
-              && areaDelta < bestAreaDelta);
+      boolean isBetter = transformPenalty < bestTransformPenalty
+          || (transformPenalty == bestTransformPenalty && candidateArea < bestSourceArea)
+          || (transformPenalty == bestTransformPenalty && candidateArea == bestSourceArea
+              && cropAreaDelta < bestCropAreaDelta);
 
       if (isBetter) {
         bestSize = candidate;
-        bestAspectDelta = aspectDelta;
-        bestMeetsRequestedSize = meetsRequestedSize;
-        bestAreaDelta = areaDelta;
+        bestTransformPenalty = transformPenalty;
+        bestSourceArea = candidateArea;
+        bestCropAreaDelta = cropAreaDelta;
       }
     }
 
     Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
-    if (bestAspectDelta > 0.01d) {
+    if (bestTransformPenalty == 1) {
+      Log.d(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+          + " will be cropped and downscaled to " + requestedWidth + "x" + requestedHeight);
+    } else if (bestTransformPenalty == 2) {
       Log.w(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
-          + " is not a close aspect-ratio match for requested " + requestedWidth + "x"
-          + requestedHeight);
+          + " cannot reach requested " + requestedWidth + "x" + requestedHeight
+          + " without upscaling");
     }
     return bestSize;
+  }
+
+  private void updateOutputCrop() {
+    Size cropSize = getCenterCropSize(mCaptureWidth, mCaptureHeight, mWidth, mHeight);
+    mCropWidth = cropSize.getWidth();
+    mCropHeight = cropSize.getHeight();
+    mCropX = Math.max(0, (mCaptureWidth - mCropWidth) / 2);
+    mCropY = Math.max(0, (mCaptureHeight - mCropHeight) / 2);
+  }
+
+  private VideoFrame.Buffer adaptOutputBuffer(TextureBufferImpl buffer) {
+    boolean needsCrop = mCropX != 0 || mCropY != 0
+        || mCropWidth != buffer.getWidth() || mCropHeight != buffer.getHeight();
+    boolean needsScale = buffer.getWidth() != mWidth || buffer.getHeight() != mHeight;
+
+    if (!needsCrop && !needsScale) {
+      return buffer;
+    }
+
+    return buffer.cropAndScale(mCropX, mCropY, mCropWidth, mCropHeight, mWidth, mHeight);
+  }
+
+  private Size getCenterCropSize(int sourceWidth, int sourceHeight, int targetWidth,
+      int targetHeight) {
+    if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+      return new Size(sourceWidth, sourceHeight);
+    }
+
+    float sourceAspectRatio = sourceWidth / (float) sourceHeight;
+    float targetAspectRatio = targetWidth / (float) targetHeight;
+    int cropWidth = sourceWidth;
+    int cropHeight = sourceHeight;
+
+    if (Math.abs(sourceAspectRatio - targetAspectRatio) > 0.0001f) {
+      if (sourceAspectRatio > targetAspectRatio) {
+        cropWidth = Math.round(sourceHeight * targetAspectRatio);
+      } else {
+        cropHeight = Math.round(sourceWidth / targetAspectRatio);
+      }
+    }
+
+    cropWidth = Math.max(1, Math.min(sourceWidth, cropWidth));
+    cropHeight = Math.max(1, Math.min(sourceHeight, cropHeight));
+    return new Size(cropWidth, cropHeight);
   }
 
   private Size normalizeLandscapeSize(Size size) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -10,7 +10,6 @@ import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
-import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Build;
 import android.os.Handler;
 import android.os.HandlerThread;
@@ -109,54 +108,45 @@ public class WhipCameraCapturer implements VideoCapturer {
     CameraManager cameraManager =
         (CameraManager) mContext.getSystemService(Context.CAMERA_SERVICE);
 
-    String cameraId = selectBackCamera(cameraManager);
-    if (cameraId == null) {
-      Log.e(TAG, "No back-facing camera found");
-      mObserver.onCapturerStarted(false);
-      return;
-    }
-
     int initialFrameRotation;
     try {
+      String cameraId = WhipCameraFormatSelector.selectBackCamera(cameraManager);
+      if (cameraId == null) {
+        Log.e(TAG, "No back-facing camera found");
+        mObserver.onCapturerStarted(false);
+        return;
+      }
+
       CameraCharacteristics chars = cameraManager.getCameraCharacteristics(cameraId);
       Integer sensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
       mSensorOrientation = sensorOrientation != null ? sensorOrientation : 90;
       Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
       mIsFrontCamera = facing != null && facing == CameraCharacteristics.LENS_FACING_FRONT;
-      Size captureSize = chooseCaptureSize(chars, width, height);
+      WhipCameraFormatSelector.SelectionResult selection =
+          WhipCameraFormatSelector.selectCaptureSize(chars, width, height);
+      Size captureSize = selection.getRawCaptureSize();
       mCameraSurfaceWidth = captureSize.getWidth();
       mCameraSurfaceHeight = captureSize.getHeight();
-      Size normalizedCaptureSize = normalizeLandscapeSize(captureSize);
+      Size normalizedCaptureSize = selection.getNormalizedCaptureSize();
       mCaptureWidth = normalizedCaptureSize.getWidth();
       mCaptureHeight = normalizedCaptureSize.getHeight();
       initializeDeviceRotationState();
       updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
       initialFrameRotation = getFrameOrientation();
-    } catch (CameraAccessException e) {
-      Log.w(TAG, "Failed to get camera characteristics", e);
-      mSensorOrientation = 90;
-      mIsFrontCamera = false;
-      mCameraSurfaceWidth = width;
-      mCameraSurfaceHeight = height;
-      mCaptureWidth = width;
-      mCaptureHeight = height;
-      initializeDeviceRotationState();
-      updateOutputCrop();
-      mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
-      initialFrameRotation = 0;
-    }
 
-    Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
-        + ", selected camera size: " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
-        + ", normalized capture size: " + mCaptureWidth + "x" + mCaptureHeight
-        + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", " + mCropY
-        + ")"
-        + ", sensor orientation: " + mSensorOrientation
-        + ", isFront: " + mIsFrontCamera
-        + ", frame rotation: " + initialFrameRotation);
+      if (selection.hasSupportedSizes()) {
+        Log.d(TAG, "Available SurfaceTexture sizes: "
+            + Arrays.toString(selection.getAvailableOutputSizes()));
+        if (selection.getTransformPenalty() == 1) {
+          Log.d(TAG, "Selected camera size " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
+              + " will be cropped and downscaled to " + width + "x" + height);
+        } else if (selection.getTransformPenalty() == 2) {
+          Log.w(TAG, "Selected camera size " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
+              + " cannot reach requested " + width + "x" + height + " without upscaling");
+        }
+      }
 
-    try {
       cameraManager.openCamera(cameraId, new CameraDevice.StateCallback() {
         @Override
         public void onOpened(@NonNull CameraDevice camera) {
@@ -181,9 +171,29 @@ public class WhipCameraCapturer implements VideoCapturer {
         }
       }, mCameraHandler);
     } catch (CameraAccessException e) {
-      Log.e(TAG, "Failed to open camera", e);
+      mSensorOrientation = 90;
+      mIsFrontCamera = false;
+      mCameraSurfaceWidth = width;
+      mCameraSurfaceHeight = height;
+      mCaptureWidth = width;
+      mCaptureHeight = height;
+      initializeDeviceRotationState();
+      updateOutputCrop();
+      mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
+      initialFrameRotation = 0;
+      Log.e(TAG, "Failed to configure or open camera", e);
       mObserver.onCapturerStarted(false);
+      return;
     }
+
+    Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
+        + ", selected camera size: " + mCameraSurfaceWidth + "x" + mCameraSurfaceHeight
+        + ", normalized capture size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", crop window: " + mCropWidth + "x" + mCropHeight + " @ (" + mCropX + ", " + mCropY
+        + ")"
+        + ", sensor orientation: " + mSensorOrientation
+        + ", isFront: " + mIsFrontCamera
+        + ", frame rotation: " + initialFrameRotation);
   }
 
   private void createCaptureSession() {
@@ -348,24 +358,6 @@ public class WhipCameraCapturer implements VideoCapturer {
     return false;
   }
 
-  private String selectBackCamera(CameraManager cameraManager) {
-    try {
-      for (String id : cameraManager.getCameraIdList()) {
-        CameraCharacteristics chars = cameraManager.getCameraCharacteristics(id);
-        Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
-        if (facing != null && facing == CameraCharacteristics.LENS_FACING_BACK) {
-          return id;
-        }
-      }
-      // Fallback: return first available camera
-      String[] ids = cameraManager.getCameraIdList();
-      return ids.length > 0 ? ids[0] : null;
-    } catch (CameraAccessException e) {
-      Log.e(TAG, "Failed to enumerate cameras", e);
-      return null;
-    }
-  }
-
   private Matrix createTextureTransformMatrix() {
     Matrix transformMatrix = new Matrix();
     transformMatrix.preTranslate(0.5f, 0.5f);
@@ -425,70 +417,6 @@ public class WhipCameraCapturer implements VideoCapturer {
       default:
         return 0;
     }
-  }
-
-  private Size chooseCaptureSize(CameraCharacteristics characteristics, int requestedWidth,
-      int requestedHeight) {
-    StreamConfigurationMap configurationMap =
-        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
-    if (configurationMap == null) {
-      Log.w(TAG, "No stream configuration map; using requested size "
-          + requestedWidth + "x" + requestedHeight);
-      return new Size(requestedWidth, requestedHeight);
-    }
-
-    Size[] outputSizes = configurationMap.getOutputSizes(SurfaceTexture.class);
-    if (outputSizes == null || outputSizes.length == 0) {
-      Log.w(TAG, "No SurfaceTexture output sizes; using requested size "
-          + requestedWidth + "x" + requestedHeight);
-      return new Size(requestedWidth, requestedHeight);
-    }
-
-    Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
-    Size bestRawSize = outputSizes[0];
-    Size bestSize = normalizeLandscapeSize(bestRawSize);
-    int bestTransformPenalty = Integer.MAX_VALUE;
-    long bestSourceArea = Long.MAX_VALUE;
-    long bestCropAreaDelta = Long.MAX_VALUE;
-
-    for (Size rawSize : outputSizes) {
-      Size candidate = normalizeLandscapeSize(rawSize);
-      Size croppedSize = getCenterCropSize(candidate.getWidth(), candidate.getHeight(),
-          requestedSize.getWidth(), requestedSize.getHeight());
-      boolean meetsRequestedSize = croppedSize.getWidth() >= requestedSize.getWidth()
-          && croppedSize.getHeight() >= requestedSize.getHeight();
-      boolean exactOutput = croppedSize.getWidth() == requestedSize.getWidth()
-          && croppedSize.getHeight() == requestedSize.getHeight();
-      int transformPenalty = exactOutput ? 0 : meetsRequestedSize ? 1 : 2;
-      long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
-      long cropArea = (long) croppedSize.getWidth() * croppedSize.getHeight();
-      long cropAreaDelta = Math.abs(cropArea
-          - ((long) requestedSize.getWidth() * requestedSize.getHeight()));
-
-      boolean isBetter = transformPenalty < bestTransformPenalty
-          || (transformPenalty == bestTransformPenalty && candidateArea < bestSourceArea)
-          || (transformPenalty == bestTransformPenalty && candidateArea == bestSourceArea
-              && cropAreaDelta < bestCropAreaDelta);
-
-      if (isBetter) {
-        bestRawSize = rawSize;
-        bestSize = candidate;
-        bestTransformPenalty = transformPenalty;
-        bestSourceArea = candidateArea;
-        bestCropAreaDelta = cropAreaDelta;
-      }
-    }
-
-    Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
-    if (bestTransformPenalty == 1) {
-      Log.d(TAG, "Selected camera size " + bestRawSize.getWidth() + "x" + bestRawSize.getHeight()
-          + " will be cropped and downscaled to " + requestedWidth + "x" + requestedHeight);
-    } else if (bestTransformPenalty == 2) {
-      Log.w(TAG, "Selected camera size " + bestRawSize.getWidth() + "x" + bestRawSize.getHeight()
-          + " cannot reach requested " + requestedWidth + "x" + requestedHeight
-          + " without upscaling");
-    }
-    return bestRawSize;
   }
 
   private void updateOutputCrop() {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -3,19 +3,25 @@ package com.mentra.asg_client.io.streaming.services;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Matrix;
+import android.graphics.SurfaceTexture;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCaptureSession;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraDevice;
 import android.hardware.camera2.CameraManager;
 import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.params.StreamConfigurationMap;
 import android.os.Handler;
 import android.os.HandlerThread;
 import android.util.Log;
 import android.util.Range;
+import android.util.Size;
 import android.view.Surface;
+import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+
+import com.mentra.asg_client.service.utils.ServiceUtils;
 
 import org.webrtc.CapturerObserver;
 import org.webrtc.SurfaceTextureHelper;
@@ -23,6 +29,7 @@ import org.webrtc.TextureBufferImpl;
 import org.webrtc.VideoCapturer;
 import org.webrtc.VideoFrame;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -62,6 +69,8 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mWidth;
   private int mHeight;
   private int mFps;
+  private int mCaptureWidth;
+  private int mCaptureHeight;
   private int mSensorOrientation;
   private int mFrameRotation;
   private boolean mIsFrontCamera;
@@ -80,6 +89,7 @@ public class WhipCameraCapturer implements VideoCapturer {
     mWidth = width;
     mHeight = height;
     mFps = fps;
+    mLoggedFrameSize = false;
 
     // Low-priority camera thread (matches StreamPackLite CameraExecutorManager)
     mCameraThread = new HandlerThread("WhipCameraThread");
@@ -99,27 +109,32 @@ public class WhipCameraCapturer implements VideoCapturer {
       return;
     }
 
-    // Get sensor orientation and camera facing for texture transform + frame rotation
     try {
       CameraCharacteristics chars = cameraManager.getCameraCharacteristics(cameraId);
-      mSensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
+      Integer sensorOrientation = chars.get(CameraCharacteristics.SENSOR_ORIENTATION);
+      mSensorOrientation = sensorOrientation != null ? sensorOrientation : 90;
       Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
       mIsFrontCamera = facing != null && facing == CameraCharacteristics.LENS_FACING_FRONT;
+      Size captureSize = chooseCaptureSize(chars, width, height);
+      mCaptureWidth = captureSize.getWidth();
+      mCaptureHeight = captureSize.getHeight();
+      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
+      mFrameRotation = getFrameOrientation();
     } catch (CameraAccessException e) {
       Log.w(TAG, "Failed to get camera characteristics", e);
       mSensorOrientation = 90;
       mIsFrontCamera = false;
+      mCaptureWidth = width;
+      mCaptureHeight = height;
+      mSurfaceTextureHelper.setTextureSize(mCaptureWidth, mCaptureHeight);
+      mFrameRotation = 0;
     }
 
-    // Frame rotation = 0 for fixed-landscape devices like glasses.
-    // WebRTC's rotation field causes the stack to transpose dimensions (unlike
-    // RTMP's orientationHint which is just metadata). We handle rotation via
-    // GPU texture transform instead, which rotates content in-place without
-    // changing buffer dimensions.
-    mFrameRotation = 0;
-
-    Log.d(TAG, "Sensor orientation: " + mSensorOrientation
-        + ", isFront: " + mIsFrontCamera + ", frame rotation: " + mFrameRotation);
+    Log.d(TAG, "Requested capture: " + mWidth + "x" + mHeight
+        + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+        + ", sensor orientation: " + mSensorOrientation
+        + ", isFront: " + mIsFrontCamera
+        + ", frame rotation: " + mFrameRotation);
 
     try {
       cameraManager.openCamera(cameraId, new CameraDevice.StateCallback() {
@@ -216,9 +231,9 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mCaptureSession.setRepeatingRequest(builder.build(), null, mCameraHandler);
 
-      // Apply GPU-level texture rotation to correct for sensor orientation.
-      // This rotates content in-place without changing buffer dimensions, so
-      // it works correctly at any aspect ratio (including 16:9).
+      // Match the stock WebRTC Camera2 session semantics:
+      // 1. Apply a texture transform for sensor/front-camera correction.
+      // 2. Preserve frame rotation metadata so downstream width/height handling stays correct.
       mSurfaceTextureHelper.startListening(frame -> {
         TextureBufferImpl texBuffer = (TextureBufferImpl) frame.getBuffer();
 
@@ -226,19 +241,13 @@ public class WhipCameraCapturer implements VideoCapturer {
           mLoggedFrameSize = true;
           Log.i(TAG, "DIAG: First frame buffer size: " + texBuffer.getWidth() + "x"
               + texBuffer.getHeight() + " (requested: " + mWidth + "x" + mHeight
-              + ", sensor orientation: " + mSensorOrientation + ")");
+              + ", selected camera size: " + mCaptureWidth + "x" + mCaptureHeight
+              + ", sensor orientation: " + mSensorOrientation
+              + ", frame rotation: " + mFrameRotation + ")");
         }
-
-        Matrix transformMatrix = new Matrix();
-        transformMatrix.preTranslate(0.5f, 0.5f);
-        if (mIsFrontCamera) {
-          transformMatrix.preScale(-1f, 1f);
-        }
-        transformMatrix.preRotate(-mSensorOrientation);
-        transformMatrix.preTranslate(-0.5f, -0.5f);
 
         TextureBufferImpl modifiedBuffer = texBuffer.applyTransformMatrix(
-            transformMatrix, texBuffer.getWidth(), texBuffer.getHeight());
+            createTextureTransformMatrix(), texBuffer.getWidth(), texBuffer.getHeight());
 
         VideoFrame modifiedFrame = new VideoFrame(
             modifiedBuffer, mFrameRotation, frame.getTimestampNs());
@@ -248,7 +257,7 @@ public class WhipCameraCapturer implements VideoCapturer {
 
       mObserver.onCapturerStarted(true);
       Log.d(TAG, "Camera capture started with power-saving optimizations: "
-          + mWidth + "x" + mHeight + " @" + mFps + "fps");
+          + mCaptureWidth + "x" + mCaptureHeight + " @" + mFps + "fps");
 
     } catch (CameraAccessException e) {
       Log.e(TAG, "Failed to start repeating request", e);
@@ -327,5 +336,111 @@ public class WhipCameraCapturer implements VideoCapturer {
       Log.e(TAG, "Failed to enumerate cameras", e);
       return null;
     }
+  }
+
+  private Matrix createTextureTransformMatrix() {
+    Matrix transformMatrix = new Matrix();
+    transformMatrix.preTranslate(0.5f, 0.5f);
+    if (mIsFrontCamera) {
+      transformMatrix.preScale(-1f, 1f);
+    }
+    transformMatrix.preRotate(-mSensorOrientation);
+    transformMatrix.preTranslate(-0.5f, -0.5f);
+    return transformMatrix;
+  }
+
+  private int getFrameOrientation() {
+    int deviceOrientation = getDeviceOrientationDegrees();
+    if (!mIsFrontCamera) {
+      deviceOrientation = (360 - deviceOrientation) % 360;
+    }
+    return (mSensorOrientation + deviceOrientation) % 360;
+  }
+
+  private int getDeviceOrientationDegrees() {
+    if (ServiceUtils.isK900Device(mContext)) {
+      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    }
+
+    WindowManager windowManager =
+        (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
+    if (windowManager == null) {
+      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    }
+
+    switch (windowManager.getDefaultDisplay().getRotation()) {
+      case Surface.ROTATION_90:
+        return 90;
+      case Surface.ROTATION_180:
+        return 180;
+      case Surface.ROTATION_270:
+        return 270;
+      case Surface.ROTATION_0:
+      default:
+        return 0;
+    }
+  }
+
+  private Size chooseCaptureSize(CameraCharacteristics characteristics, int requestedWidth,
+      int requestedHeight) {
+    StreamConfigurationMap configurationMap =
+        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+    if (configurationMap == null) {
+      Log.w(TAG, "No stream configuration map; using requested size "
+          + requestedWidth + "x" + requestedHeight);
+      return new Size(requestedWidth, requestedHeight);
+    }
+
+    Size[] outputSizes = configurationMap.getOutputSizes(SurfaceTexture.class);
+    if (outputSizes == null || outputSizes.length == 0) {
+      Log.w(TAG, "No SurfaceTexture output sizes; using requested size "
+          + requestedWidth + "x" + requestedHeight);
+      return new Size(requestedWidth, requestedHeight);
+    }
+
+    Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
+    Size bestSize = normalizeLandscapeSize(outputSizes[0]);
+    float requestedAspectRatio = requestedSize.getWidth() / (float) requestedSize.getHeight();
+    long requestedArea = (long) requestedSize.getWidth() * requestedSize.getHeight();
+    double bestAspectDelta = Double.MAX_VALUE;
+    boolean bestMeetsRequestedSize = false;
+    long bestAreaDelta = Long.MAX_VALUE;
+
+    for (Size rawSize : outputSizes) {
+      Size candidate = normalizeLandscapeSize(rawSize);
+      float candidateAspectRatio = candidate.getWidth() / (float) candidate.getHeight();
+      double aspectDelta = Math.abs(candidateAspectRatio - requestedAspectRatio);
+      boolean meetsRequestedSize = candidate.getWidth() >= requestedSize.getWidth()
+          && candidate.getHeight() >= requestedSize.getHeight();
+      long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
+      long areaDelta = Math.abs(candidateArea - requestedArea);
+
+      boolean isBetter = aspectDelta < bestAspectDelta
+          || (Double.compare(aspectDelta, bestAspectDelta) == 0
+              && meetsRequestedSize && !bestMeetsRequestedSize)
+          || (Double.compare(aspectDelta, bestAspectDelta) == 0
+              && meetsRequestedSize == bestMeetsRequestedSize
+              && areaDelta < bestAreaDelta);
+
+      if (isBetter) {
+        bestSize = candidate;
+        bestAspectDelta = aspectDelta;
+        bestMeetsRequestedSize = meetsRequestedSize;
+        bestAreaDelta = areaDelta;
+      }
+    }
+
+    Log.d(TAG, "Available SurfaceTexture sizes: " + Arrays.toString(outputSizes));
+    if (bestAspectDelta > 0.01d) {
+      Log.w(TAG, "Selected camera size " + bestSize.getWidth() + "x" + bestSize.getHeight()
+          + " is not a close aspect-ratio match for requested " + requestedWidth + "x"
+          + requestedHeight);
+    }
+    return bestSize;
+  }
+
+  private Size normalizeLandscapeSize(Size size) {
+    return new Size(Math.max(size.getWidth(), size.getHeight()),
+        Math.min(size.getWidth(), size.getHeight()));
   }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -80,6 +80,8 @@ public class WhipCameraCapturer implements VideoCapturer {
   private int mCropWidth;
   private int mCropHeight;
   private int mSensorOrientation;
+  private boolean mUseFixedDeviceRotation;
+  private int mFallbackDeviceRotation;
   private boolean mIsFrontCamera;
   private boolean mLoggedFrameSize = false;
 
@@ -127,6 +129,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       Size normalizedCaptureSize = normalizeLandscapeSize(captureSize);
       mCaptureWidth = normalizedCaptureSize.getWidth();
       mCaptureHeight = normalizedCaptureSize.getHeight();
+      initializeDeviceRotationState();
       updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
       initialFrameRotation = getFrameOrientation();
@@ -138,6 +141,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       mCameraSurfaceHeight = height;
       mCaptureWidth = width;
       mCaptureHeight = height;
+      initializeDeviceRotationState();
       updateOutputCrop();
       mSurfaceTextureHelper.setTextureSize(mCameraSurfaceWidth, mCameraSurfaceHeight);
       initialFrameRotation = 0;
@@ -381,15 +385,20 @@ public class WhipCameraCapturer implements VideoCapturer {
     return (mSensorOrientation + deviceOrientation) % 360;
   }
 
+  private void initializeDeviceRotationState() {
+    mUseFixedDeviceRotation = ServiceUtils.isK900Device(mContext);
+    mFallbackDeviceRotation = ServiceUtils.determineDefaultRotationForDevice(mContext);
+  }
+
   private int getDeviceOrientationDegrees() {
-    if (ServiceUtils.isK900Device(mContext)) {
-      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+    if (mUseFixedDeviceRotation) {
+      return mFallbackDeviceRotation;
     }
 
     WindowManager windowManager =
         (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
     if (windowManager == null) {
-      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+      return mFallbackDeviceRotation;
     }
 
     Display display = null;
@@ -402,7 +411,7 @@ public class WhipCameraCapturer implements VideoCapturer {
       display = fallbackDisplay;
     }
     if (display == null) {
-      return ServiceUtils.determineDefaultRotationForDevice(mContext);
+      return mFallbackDeviceRotation;
     }
 
     switch (display.getRotation()) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraFormatSelector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraFormatSelector.java
@@ -1,0 +1,185 @@
+package com.mentra.asg_client.io.streaming.services;
+
+import android.content.Context;
+import android.graphics.SurfaceTexture;
+import android.hardware.camera2.CameraAccessException;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.util.Size;
+
+/**
+ * Shared capture-size selection logic for WHIP camera streaming.
+ */
+public final class WhipCameraFormatSelector {
+
+  private WhipCameraFormatSelector() {
+  }
+
+  public static final class SelectionResult {
+    private final Size mRawCaptureSize;
+    private final Size mNormalizedCaptureSize;
+    private final int mTransformPenalty;
+    private final Size[] mAvailableOutputSizes;
+
+    SelectionResult(Size rawCaptureSize, Size normalizedCaptureSize, int transformPenalty,
+        Size[] availableOutputSizes) {
+      mRawCaptureSize = rawCaptureSize;
+      mNormalizedCaptureSize = normalizedCaptureSize;
+      mTransformPenalty = transformPenalty;
+      mAvailableOutputSizes = availableOutputSizes;
+    }
+
+    public Size getRawCaptureSize() {
+      return mRawCaptureSize;
+    }
+
+    public Size getNormalizedCaptureSize() {
+      return mNormalizedCaptureSize;
+    }
+
+    public int getTransformPenalty() {
+      return mTransformPenalty;
+    }
+
+    public boolean requiresUpscale() {
+      return mTransformPenalty == 2;
+    }
+
+    public boolean hasSupportedSizes() {
+      return mAvailableOutputSizes != null && mAvailableOutputSizes.length > 0;
+    }
+
+    public Size[] getAvailableOutputSizes() {
+      return mAvailableOutputSizes;
+    }
+  }
+
+  public static SelectionResult selectCaptureSize(Context context, int requestedWidth,
+      int requestedHeight) throws CameraAccessException {
+    CameraManager cameraManager =
+        (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
+    if (cameraManager == null) {
+      return null;
+    }
+
+    String cameraId = selectBackCamera(cameraManager);
+    if (cameraId == null) {
+      return null;
+    }
+
+    CameraCharacteristics characteristics = cameraManager.getCameraCharacteristics(cameraId);
+    return selectCaptureSize(characteristics, requestedWidth, requestedHeight);
+  }
+
+  public static String selectBackCamera(CameraManager cameraManager) throws CameraAccessException {
+    for (String id : cameraManager.getCameraIdList()) {
+      CameraCharacteristics chars = cameraManager.getCameraCharacteristics(id);
+      Integer facing = chars.get(CameraCharacteristics.LENS_FACING);
+      if (facing != null && facing == CameraCharacteristics.LENS_FACING_BACK) {
+        return id;
+      }
+    }
+
+    String[] ids = cameraManager.getCameraIdList();
+    return ids.length > 0 ? ids[0] : null;
+  }
+
+  public static SelectionResult selectCaptureSize(CameraCharacteristics characteristics,
+      int requestedWidth, int requestedHeight) {
+    StreamConfigurationMap configurationMap =
+        characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+    if (configurationMap == null) {
+      Size requestedSize = new Size(requestedWidth, requestedHeight);
+      return new SelectionResult(requestedSize, normalizeLandscapeSize(requestedSize), 0,
+          new Size[0]);
+    }
+
+    Size[] outputSizes = configurationMap.getOutputSizes(SurfaceTexture.class);
+    if (outputSizes == null || outputSizes.length == 0) {
+      Size requestedSize = new Size(requestedWidth, requestedHeight);
+      return new SelectionResult(requestedSize, normalizeLandscapeSize(requestedSize), 0,
+          new Size[0]);
+    }
+
+    Size requestedSize = normalizeLandscapeSize(new Size(requestedWidth, requestedHeight));
+    Size bestRawSize = outputSizes[0];
+    Size bestNormalizedSize = normalizeLandscapeSize(bestRawSize);
+    int bestTransformPenalty = Integer.MAX_VALUE;
+    long bestSourceArea = 0;
+    long bestCropAreaDelta = Long.MAX_VALUE;
+
+    for (Size rawSize : outputSizes) {
+      Size candidate = normalizeLandscapeSize(rawSize);
+      Size croppedSize = getCenterCropSize(candidate.getWidth(), candidate.getHeight(),
+          requestedSize.getWidth(), requestedSize.getHeight());
+      boolean meetsRequestedSize = croppedSize.getWidth() >= requestedSize.getWidth()
+          && croppedSize.getHeight() >= requestedSize.getHeight();
+      boolean exactOutput = croppedSize.getWidth() == requestedSize.getWidth()
+          && croppedSize.getHeight() == requestedSize.getHeight();
+      int transformPenalty = exactOutput ? 0 : meetsRequestedSize ? 1 : 2;
+      long candidateArea = (long) candidate.getWidth() * candidate.getHeight();
+      long cropArea = (long) croppedSize.getWidth() * croppedSize.getHeight();
+      long cropAreaDelta = Math.abs(cropArea
+          - ((long) requestedSize.getWidth() * requestedSize.getHeight()));
+
+      boolean isBetter = transformPenalty < bestTransformPenalty
+          || (transformPenalty == bestTransformPenalty
+              && isPreferredSourceArea(transformPenalty, candidateArea, bestSourceArea))
+          || (transformPenalty == bestTransformPenalty && candidateArea == bestSourceArea
+              && cropAreaDelta < bestCropAreaDelta);
+
+      if (isBetter) {
+        bestRawSize = rawSize;
+        bestNormalizedSize = candidate;
+        bestTransformPenalty = transformPenalty;
+        bestSourceArea = candidateArea;
+        bestCropAreaDelta = cropAreaDelta;
+      }
+    }
+
+    return new SelectionResult(bestRawSize, bestNormalizedSize, bestTransformPenalty, outputSizes);
+  }
+
+  private static boolean isPreferredSourceArea(int transformPenalty, long candidateArea,
+      long bestSourceArea) {
+    if (bestSourceArea == 0) {
+      return true;
+    }
+
+    if (transformPenalty == 2) {
+      return candidateArea > bestSourceArea;
+    }
+
+    return candidateArea < bestSourceArea;
+  }
+
+  static Size getCenterCropSize(int sourceWidth, int sourceHeight, int targetWidth,
+      int targetHeight) {
+    if (sourceWidth <= 0 || sourceHeight <= 0 || targetWidth <= 0 || targetHeight <= 0) {
+      return new Size(sourceWidth, sourceHeight);
+    }
+
+    float sourceAspectRatio = sourceWidth / (float) sourceHeight;
+    float targetAspectRatio = targetWidth / (float) targetHeight;
+    int cropWidth = sourceWidth;
+    int cropHeight = sourceHeight;
+
+    if (Math.abs(sourceAspectRatio - targetAspectRatio) > 0.0001f) {
+      if (sourceAspectRatio > targetAspectRatio) {
+        cropWidth = Math.round(sourceHeight * targetAspectRatio);
+      } else {
+        cropHeight = Math.round(sourceWidth / targetAspectRatio);
+      }
+    }
+
+    cropWidth = Math.max(1, Math.min(sourceWidth, cropWidth));
+    cropHeight = Math.max(1, Math.min(sourceHeight, cropHeight));
+    return new Size(cropWidth, cropHeight);
+  }
+
+  static Size normalizeLandscapeSize(Size size) {
+    return new Size(Math.max(size.getWidth(), size.getHeight()),
+        Math.min(size.getWidth(), size.getHeight()));
+  }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -151,6 +151,13 @@ public class StreamCommandHandler implements ICommandHandler {
             switch (protocol) {
                 case RTMP: {
                     RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
+                    if (isResolutionTooHigh(config.getVideoWidth(), config.getVideoHeight())) {
+                        Log.w(TAG, "Rejecting RTMP stream request that exceeds supported camera output: "
+                                + config.getVideoWidth() + "x" + config.getVideoHeight());
+                        streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
+                                "Resolution too high");
+                        return false;
+                    }
                     Log.d(TAG, "Starting RTMP stream to: " + streamUrl);
                     RtmpStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
                     RtmpStreamingService.setStateManager(stateManager);
@@ -158,6 +165,13 @@ public class StreamCommandHandler implements ICommandHandler {
                 }
                 case SRT: {
                     RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
+                    if (isResolutionTooHigh(config.getVideoWidth(), config.getVideoHeight())) {
+                        Log.w(TAG, "Rejecting SRT stream request that exceeds supported camera output: "
+                                + config.getVideoWidth() + "x" + config.getVideoHeight());
+                        streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
+                                "Resolution too high");
+                        return false;
+                    }
                     Log.d(TAG, "Starting SRT stream to: " + streamUrl);
                     SrtStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
                     SrtStreamingService.setStateManager(stateManager);
@@ -165,7 +179,7 @@ public class StreamCommandHandler implements ICommandHandler {
                 }
                 case WHIP: {
                     WhipStreamConfig config = WhipStreamConfig.fromJson(videoJson, audioJson);
-                    if (isWhipResolutionTooHigh(config)) {
+                    if (isResolutionTooHigh(config.getVideoWidth(), config.getVideoHeight())) {
                         Log.w(TAG, "Rejecting WHIP stream request that exceeds supported camera output: "
                                 + config.getVideoWidth() + "x" + config.getVideoHeight());
                         streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
@@ -187,14 +201,13 @@ public class StreamCommandHandler implements ICommandHandler {
         }
     }
 
-    private boolean isWhipResolutionTooHigh(WhipStreamConfig config) {
+    private boolean isResolutionTooHigh(int width, int height) {
         try {
             WhipCameraFormatSelector.SelectionResult selection =
-                    WhipCameraFormatSelector.selectCaptureSize(context, config.getVideoWidth(),
-                            config.getVideoHeight());
+                    WhipCameraFormatSelector.selectCaptureSize(context, width, height);
             return selection != null && selection.hasSupportedSizes() && selection.requiresUpscale();
         } catch (Exception e) {
-            Log.w(TAG, "Unable to validate WHIP resolution; allowing request", e);
+            Log.w(TAG, "Unable to validate requested stream resolution; allowing request", e);
             return false;
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -151,13 +151,6 @@ public class StreamCommandHandler implements ICommandHandler {
             switch (protocol) {
                 case RTMP: {
                     RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
-                    if (isResolutionTooHigh(config.getVideoWidth(), config.getVideoHeight())) {
-                        Log.w(TAG, "Rejecting RTMP stream request that exceeds supported camera output: "
-                                + config.getVideoWidth() + "x" + config.getVideoHeight());
-                        streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
-                                "Resolution too high");
-                        return false;
-                    }
                     Log.d(TAG, "Starting RTMP stream to: " + streamUrl);
                     RtmpStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
                     RtmpStreamingService.setStateManager(stateManager);
@@ -165,13 +158,6 @@ public class StreamCommandHandler implements ICommandHandler {
                 }
                 case SRT: {
                     RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
-                    if (isResolutionTooHigh(config.getVideoWidth(), config.getVideoHeight())) {
-                        Log.w(TAG, "Rejecting SRT stream request that exceeds supported camera output: "
-                                + config.getVideoWidth() + "x" + config.getVideoHeight());
-                        streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
-                                "Resolution too high");
-                        return false;
-                    }
                     Log.d(TAG, "Starting SRT stream to: " + streamUrl);
                     SrtStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
                     SrtStreamingService.setStateManager(stateManager);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.mentra.asg_client.io.streaming.config.RtmpStreamConfig;
 import com.mentra.asg_client.io.streaming.config.WhipStreamConfig;
+import com.mentra.asg_client.io.streaming.services.WhipCameraFormatSelector;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
 import com.mentra.asg_client.io.streaming.services.SrtStreamingService;
 import com.mentra.asg_client.io.streaming.services.WhipStreamingService;
@@ -164,6 +165,13 @@ public class StreamCommandHandler implements ICommandHandler {
                 }
                 case WHIP: {
                     WhipStreamConfig config = WhipStreamConfig.fromJson(videoJson, audioJson);
+                    if (isWhipResolutionTooHigh(config)) {
+                        Log.w(TAG, "Rejecting WHIP stream request that exceeds supported camera output: "
+                                + config.getVideoWidth() + "x" + config.getVideoHeight());
+                        streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR,
+                                "Resolution too high");
+                        return false;
+                    }
                     Log.d(TAG, "Starting WHIP stream to: " + streamUrl);
                     WhipStreamingService.startStreaming(context, streamUrl, streamId, flash, sound, config);
                     WhipStreamingService.setStateManager(stateManager);
@@ -175,6 +183,18 @@ public class StreamCommandHandler implements ICommandHandler {
         } catch (Exception e) {
             Log.e(TAG, "Error handling start stream command", e);
             streamingManager.sendStreamStatusResponse(false, ServiceConstants.STATUS_ERROR, e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean isWhipResolutionTooHigh(WhipStreamConfig config) {
+        try {
+            WhipCameraFormatSelector.SelectionResult selection =
+                    WhipCameraFormatSelector.selectCaptureSize(context, config.getVideoWidth(),
+                            config.getVideoHeight());
+            return selection != null && selection.hasSupportedSizes() && selection.requiresUpscale();
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to validate WHIP resolution; allowing request", e);
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- fix WHIP/WebRTC stretch by using supported camera surface sizes and preserving WebRTC rotation semantics
- crop frames to the requested output size so 960x540 requests can use crop-friendly camera modes like 960x720
- address review feedback by using raw camera-reported sizes for SurfaceTexture, recomputing frame rotation per frame, and removing redundant texture-size setup

## Testing
- On-device validation via user logs confirmed the capturer selected supported sizes and produced the expected output shape
- `./gradlew app:compileDebugJavaWithJavac` cannot complete in this workspace because `asg_client/.env` is missing and the local `:core`, `:extension-rtmp`, and `:extension-srt` Gradle projects do not expose Android variants here

## Notes
- This is a clean replacement for the earlier polluted branch/PR so review is limited to `WhipCameraCapturer`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic capture-size selection and preflight validation to block unsupported high-resolution starts.
  * Resolution selection now prefers best-fit source sizes with center-crop logic to minimize transform.

* **Bug Fixes**
  * Per-frame rotation computed dynamically for correct orientation on front/back cameras.
  * Frames now conditionally cropped/scaled to reliably match requested output; falls back to requested dimensions on camera errors.

* **Chores**
  * Expanded startup and first-frame diagnostics for requested/selected sizes, crop window, and rotation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->