### PR TITLE
fix(mobile): make miniapp name shadow ultra-subtle

### DIFF
--- a/mobile/src/components/home/AppsGrid.tsx
+++ b/mobile/src/components/home/AppsGrid.tsx
@@ -528,9 +528,9 @@ export function AppsGrid({showAllApps = false, onOpenApp, onAddToHome, searchQue
             <Text
               className="text-foreground text-center mt-1 text-[12px] shrink"
               style={{
-                textShadowColor: "rgba(0,0,0,0.5)",
+                textShadowColor: "rgba(0,0,0,0.08)",
                 textShadowOffset: {width: 0, height: 0},
-                textShadowRadius: 6,
+                textShadowRadius: 30,
               }}
               numberOfLines={2}
               ellipsizeMode="tail"


### PR DESCRIPTION
## Summary
- Reduce text shadow opacity from 0.5 to 0.08 and increase blur radius from 6 to 30
- Shadow now looks like a faint dark backsplash rather than a visible box behind the text
- Mimics the ultra-subtle iOS homescreen style

Fixes OS-1212

## Test plan
- [ ] Open homescreen and verify miniapp name shadows are barely visible / diffused
- [ ] Check readability on both light and dark wallpapers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the text shadow effect on app names for improved visual clarity and presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->