### PR TITLE
Disable EIS right after stopping streaming

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -205,14 +205,17 @@ public class StreamCommandHandler implements ICommandHandler {
         try {
             if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
                 RtmpStreamingService.stopStreaming(context);
+                SysControl.setEisEnable(context, true);
                 streamingManager.sendStreamStatusResponse(true, ServiceConstants.STATUS_STOPPING, null);
                 return true;
             } else if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
                 SrtStreamingService.stopStreaming(context);
+                SysControl.setEisEnable(context, true);
                 streamingManager.sendStreamStatusResponse(true, ServiceConstants.STATUS_STOPPING, null);
                 return true;
             } else if (WhipStreamingService.isStreaming() || WhipStreamingService.isReconnecting()) {
                 WhipStreamingService.stopStreaming(context);
+                SysControl.setEisEnable(context, true);
                 streamingManager.sendStreamStatusResponse(true, ServiceConstants.STATUS_STOPPING, null);
                 return true;
             } else {


### PR DESCRIPTION
Ticket: https://linear.app/mentralabs/issue/OS-1245/mentra-live-has-issues-toggling-eis-when-taking-videos-and-streaming

The issue could not be reproduced. It may be that hot glasses after long sessions contribute to added latency between EIS enabling and when it takes effect at the lower level. We are now re-enabling EIS when a steam stops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stream stop commands now properly manage system controls for all supported streaming protocols (RTMP, SRT, and WHIP).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->