### PR TITLE
Add unified display brightness control with ambient AUTO mode

### DIFF
--- a/mcu_client/nrf5340_ble_simulator/CMakeLists.txt
+++ b/mcu_client/nrf5340_ble_simulator/CMakeLists.txt
@@ -28,6 +28,7 @@ add_subdirectory(src/mos_components/mos_font_storage)
 add_subdirectory(src/mos_components/mos_lvgl_display)
 add_subdirectory(src/mos_components/mos_jlink_usb_switch)
 add_subdirectory(src/mos_components/mos_dfu_progress)
+add_subdirectory(src/mos_components/mos_brightness)
 add_subdirectory(src/protobuf)
 add_subdirectory(src/proto)
 

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/CMakeLists.txt
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/CMakeLists.txt
@@ -1,0 +1,2 @@
+target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include/.)
+target_sources(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src/mos_brightness.c)

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/include/mos_brightness.h
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/include/mos_brightness.h
@@ -1,0 +1,82 @@
+/***
+ * @Author       : Cole
+ * @Date         : 2026-04-15 10:46:58
+ * @LastEditTime : 2026-04-15 11:21:18
+ * @FilePath     : mos_brightness.h
+ * @Description  :
+ * @ Copyright (c) MentraOS Contributors 2026
+ * @ SPDX-License-Identifier: Apache-2.0
+ */
+
+
+#ifndef MOS_BRIGHTNESS_H_
+#define MOS_BRIGHTNESS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct
+{
+	uint32_t current_level_percent;
+	bool auto_enabled;
+	float multiplier;
+	float last_lux;
+	float filtered_lux;
+	int last_sensor_error;
+	bool sample_log_enabled;
+} mos_brightness_status_t;
+
+/**
+ * @brief Submit a manual brightness request
+ *
+ * The brightness component owns all internal state. Callers do not mutate
+ * internal fields directly; they submit a manual request and the component
+ * applies it, disabling AUTO mode if necessary.
+ *
+ * @param level_percent  Manual brightness level (0-100%; values above 100 are clamped)
+ */
+void mos_brightness_request_manual(uint32_t level_percent);
+
+/**
+ * @brief Submit an AUTO enable/disable request
+ *
+ * When enabled: OPT3006 is polled every 1500 ms; brightness follows a
+ * piecewise linear lux-to-percent curve scaled by the current multiplier.
+ * When disabled: the last manually-requested brightness level is restored.
+ *
+ * @param enabled  true to start AUTO polling, false to restore manual level
+ */
+void mos_brightness_request_auto_enabled(bool enabled);
+
+/**
+ * @brief Submit an AUTO multiplier update request
+ *
+ * Scales the lux-to-percent mapping curve output. AUTO brightness still respects
+ * the calibrated minimum/maximum brightness limits after multiplier scaling.
+ * Values outside [0.10, 3.00] are clamped.
+ *
+ * @param multiplier  sensitivity scale factor
+ */
+void mos_brightness_request_multiplier(float multiplier);
+
+/**
+ * @brief Enable or disable per-sample AUTO brightness logging
+ *
+ * The sample log is intentionally off by default because AUTO polls every
+ * 1500 ms. Enable it from shell only when collecting tuning logs.
+ *
+ * @param enabled  true to print each AUTO sample at info level
+ */
+void mos_brightness_set_sample_log_enabled(bool enabled);
+
+/**
+ * @brief Read a snapshot of brightness state for UI/debugging
+ *
+ * This is the only public read API. External code should not depend on
+ * individual internal fields or derive state transitions itself.
+ *
+ * @param status  Output snapshot pointer
+ */
+void mos_brightness_get_status(mos_brightness_status_t *status);
+
+#endif /* MOS_BRIGHTNESS_H_ */

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/src/mos_brightness.c
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_brightness/src/mos_brightness.c
@@ -1,0 +1,314 @@
+/*
+ * @Author       : Cole
+ * @Date         : 2026-04-15 10:46:46
+ * @LastEditTime : 2026-04-15 16:47:46
+ * @FilePath     : mos_brightness.c
+ * @Description  :
+ *
+ *  Copyright (c) MentraOS Contributors 2026
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mos_brightness.h"
+
+#include <stdlib.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+
+#include "display/lcd/a6n.h"
+#include "mos_opt3006.h"
+
+LOG_MODULE_REGISTER(mos_brightness, LOG_LEVEL_INF);
+
+/* ---------- Tuned for the installed sensor position ----------
+ *
+ * The OPT3006 inlet faces downward near the frame, so installed readings are
+ * much lower than standard desk lux meter readings. Treat this curve as
+ * "effective device lux" rather than room illuminance.
+ */
+#define BRIGHTNESS_POLL_INTERVAL_MS 1500U /* 亮度轮询间隔时间（毫秒）/ Brightness polling interval (ms) */
+#define BRIGHTNESS_MIN_MULTIPLIER 0.10f /* 最小亮度乘数（10%）/ Minimum brightness multiplier (10%) */
+#define BRIGHTNESS_MAX_MULTIPLIER 3.00f /* 最大亮度乘数（300%）/ Maximum brightness multiplier (300%) */
+#define BRIGHTNESS_MIN_PERCENT 30U /* 最小亮度百分比（30%）/ Minimum brightness percent (30%) */
+#define BRIGHTNESS_MAX_PERCENT 100U /* 最大亮度百分比（100%）/ Maximum brightness percent (100%) */
+#define BRIGHTNESS_UP_HYSTERESIS_PCT 3U /* 亮度上调滞后阈值（+3%）/ Upward hysteresis threshold (+3%) */
+#define BRIGHTNESS_DOWN_HYSTERESIS_PCT 4U /* 亮度下调滞后阈值（-4%）/ Downward hysteresis threshold (-4%) */
+#define BRIGHTNESS_MIN_APPLY_INTERVAL_MS 5000LL /* 亮度最小应用间隔（毫秒）/ Minimum interval between brightness applies (ms) */
+
+/* 亮度 EMA 平滑系数 / EMA smoothing factor for brightness */
+#define BRIGHTNESS_EMA_ALPHA 0.30f /* EMA 系数（0-1，越大响应越快）/ EMA alpha (0-1, larger means faster response) */
+
+typedef struct
+{
+    float lux;  // 光照强度（单位：勒克斯）/ Light intensity in lux
+    uint32_t brightness_percent;  // 亮度百分比（0-100%）/ Brightness percent (0-100%)
+} brightness_point_t;
+
+static const brightness_point_t s_curve[] = {
+    {0.0f, 30U}, {10.0f, 30U}, {30.0f, 50U}, {80.0f, 58U}, {150.0f, 68U}, {300.0f, 85U}, {500.0f, 100U},
+};
+
+/* ---------- state ---------- */
+
+static uint32_t s_current_level = 50U; /* actual display brightness (0-100%) */
+static uint32_t s_manual_level = 50U; /* saved manual level for AUTO→OFF restore */
+static bool s_auto_enabled = false;
+static float s_multiplier = 1.0f; /* brightness multiplier (0.10-3.00) */
+static float s_last_lux = -1.0f; /* -1 = not yet read */
+static float s_filtered_lux = -1.0f; /* -1 = not yet initialized */
+static int s_last_sensor_error = 0;
+static int64_t s_last_auto_apply_ms = 0;
+static bool s_auto_apply_initialized = false;
+static bool s_sample_log_enabled = false;// 前期调试用，用于记录传感器数据，正式项目中可删除或改为 runtime 可控/ For debugging, used to record sensor data, can be deleted or made runtime controllable in the formal project
+
+static struct k_work_delayable s_work;
+static bool s_work_initialized = false;
+
+/* ---------- forward declarations ---------- */
+
+static void brightness_work_handler(struct k_work *work);
+static void brightness_ensure_initialized(void);
+static void brightness_schedule(uint32_t delay_ms);
+static uint32_t brightness_compute_auto_level(float lux, float multiplier);
+static void brightness_apply(uint32_t level, bool update_manual, bool disable_auto, const char *src);
+
+/* ---------- helpers ---------- */
+
+static uint32_t clamp_percent(uint32_t v)
+{
+    return (v > BRIGHTNESS_MAX_PERCENT) ? BRIGHTNESS_MAX_PERCENT : v;
+}
+
+static float clamp_multiplier(float m)
+{
+    if (m < BRIGHTNESS_MIN_MULTIPLIER)
+        return BRIGHTNESS_MIN_MULTIPLIER;
+    if (m > BRIGHTNESS_MAX_MULTIPLIER)
+        return BRIGHTNESS_MAX_MULTIPLIER;
+    return m;
+}
+
+static void brightness_ensure_initialized(void)
+{
+    if (!s_work_initialized)
+    {
+        k_work_init_delayable(&s_work, brightness_work_handler);
+        s_work_initialized = true;
+    }
+}
+
+static void brightness_schedule(uint32_t delay_ms)
+{
+    brightness_ensure_initialized();
+    (void)k_work_reschedule(&s_work, K_MSEC(delay_ms));
+}
+
+static uint32_t brightness_compute_auto_level(float lux, float multiplier)
+{
+    float cm = clamp_multiplier(multiplier);
+    size_t n = ARRAY_SIZE(s_curve);
+    float base;
+
+    if (lux <= s_curve[0].lux)
+    {
+        base = (float)s_curve[0].brightness_percent;
+    }
+    else if (lux >= s_curve[n - 1].lux)
+    {
+        base = (float)s_curve[n - 1].brightness_percent;
+    }
+    else
+    {
+        base = (float)s_curve[n - 1].brightness_percent;
+        for (size_t i = 1; i < n; ++i)
+        {
+            if (lux <= s_curve[i].lux)
+            {
+                float range = s_curve[i].lux - s_curve[i - 1].lux;
+                float t = (range > 0.0f) ? ((lux - s_curve[i - 1].lux) / range) : 0.0f;
+                base = (float)s_curve[i - 1].brightness_percent
+                       + t * ((float)s_curve[i].brightness_percent - (float)s_curve[i - 1].brightness_percent);
+                break;
+            }
+        }
+    }
+
+    float scaled = base * cm;
+    if (scaled < (float)BRIGHTNESS_MIN_PERCENT)
+        scaled = (float)BRIGHTNESS_MIN_PERCENT;
+    if (scaled > (float)BRIGHTNESS_MAX_PERCENT)
+        scaled = (float)BRIGHTNESS_MAX_PERCENT;
+    return (uint32_t)(scaled + 0.5f);
+}
+
+static void brightness_apply(uint32_t level, bool update_manual, bool disable_auto, const char *src)
+{
+    level = clamp_percent(level);
+
+    if (disable_auto && s_auto_enabled)
+    {
+        LOG_INF("[BRIGHTNESS] %s: disabling AUTO", src);
+        s_auto_enabled = false;
+        s_auto_apply_initialized = false;
+        if (s_work_initialized)
+        {
+            (void)k_work_cancel_delayable(&s_work);
+        }
+    }
+
+    if (update_manual)
+    {
+        s_manual_level = level;
+    }
+
+    if (s_current_level == level)
+    {
+        return;
+    }
+    uint8_t reg = (uint8_t)((level * 255U) / 100U);
+    int ret = a6n_set_brightness(reg);
+    if (ret == 0)
+    {
+        s_current_level = level;
+        LOG_INF("[BRIGHTNESS] %s: %u%% -> reg 0x%02X", src, level, reg);
+    }
+    else
+    {
+        LOG_ERR("[BRIGHTNESS] %s: a6n_set_brightness(0x%02X) failed: %d", src, reg, ret);
+    }
+}
+
+/* ---------- AUTO polling work handler ---------- */
+static void brightness_work_handler(struct k_work *work)
+{
+    ARG_UNUSED(work);
+
+    if (!s_auto_enabled)
+    {
+        return;
+    }
+
+    float lux = 0.0f;
+    int ret = opt3006_read_lux(&lux);
+    if (ret != 0)
+    {
+        s_last_sensor_error = ret;
+        LOG_WRN("[BRIGHTNESS] opt3006_read_lux failed: %d", ret);
+        brightness_schedule(BRIGHTNESS_POLL_INTERVAL_MS);
+        return;
+    }
+    s_last_sensor_error = 0;
+    s_last_lux = lux;
+    if (s_filtered_lux < 0.0f)
+    {
+        s_filtered_lux = lux;
+    }
+    else
+    {
+        s_filtered_lux = (s_filtered_lux * (1.0f - BRIGHTNESS_EMA_ALPHA)) + (lux * BRIGHTNESS_EMA_ALPHA);
+    }
+
+    uint32_t target = brightness_compute_auto_level(s_filtered_lux, s_multiplier);
+    uint32_t current = s_current_level;
+    uint32_t delta = (target > current) ? (target - current) : (current - target);
+    uint32_t hysteresis = (target > current) ? BRIGHTNESS_UP_HYSTERESIS_PCT : BRIGHTNESS_DOWN_HYSTERESIS_PCT;
+    int64_t now = k_uptime_get();
+    bool interval_elapsed =
+        !s_auto_apply_initialized || ((now - s_last_auto_apply_ms) >= BRIGHTNESS_MIN_APPLY_INTERVAL_MS);
+
+    if (s_sample_log_enabled)
+    {
+        LOG_INF("[BRIGHTNESS] AUTO lux=%.2f filt=%.2f mult=%.2f target=%u%% current=%u%% delta=%u%% hyst=%u%%",
+                (double)lux, (double)s_filtered_lux, (double)s_multiplier, target, current, delta, hysteresis);
+    }
+
+    if ((delta >= hysteresis) && interval_elapsed)
+    {
+        brightness_apply(target, false, false, "auto");
+        s_last_auto_apply_ms = now;
+        s_auto_apply_initialized = true;
+    }
+
+    if (s_auto_enabled)
+    {
+        brightness_schedule(BRIGHTNESS_POLL_INTERVAL_MS);
+    }
+}
+
+/* ============================================================
+ * Public API
+ * ============================================================ */
+
+void mos_brightness_request_manual(uint32_t level_percent)
+{
+    brightness_apply(level_percent, true, true, "manual");
+}
+
+void mos_brightness_request_auto_enabled(bool enabled)
+{
+    bool prev = s_auto_enabled;
+
+    if (enabled)
+    {
+        brightness_ensure_initialized();
+        s_auto_enabled = true;
+        s_filtered_lux = -1.0f;
+        s_last_sensor_error = 0;
+        s_auto_apply_initialized = false;
+        LOG_INF("[BRIGHTNESS] AUTO %s -> ON  manual_level=%u%% mult=%.2f", prev ? "ON" : "OFF", s_manual_level,
+                (double)s_multiplier);
+        brightness_schedule(0U);
+    }
+    else
+    {
+        s_auto_enabled = false;
+        s_auto_apply_initialized = false;
+        if (s_work_initialized)
+        {
+            (void)k_work_cancel_delayable(&s_work);
+        }
+        LOG_INF("[BRIGHTNESS] AUTO %s -> OFF  restoring manual=%u%%", prev ? "ON" : "OFF", s_manual_level);
+        brightness_apply(s_manual_level, false, false, "auto-off restore");
+    }
+}
+
+void mos_brightness_request_multiplier(float multiplier)
+{
+    float prev = s_multiplier;
+    float clamped = clamp_multiplier(multiplier);
+    s_multiplier = clamped;
+
+    if (multiplier != clamped)
+    {
+        LOG_WRN("[BRIGHTNESS] multiplier %.2f clamped to %.2f", (double)multiplier, (double)clamped);
+    }
+    LOG_INF("[BRIGHTNESS] multiplier %.2f -> %.2f auto=%s", (double)prev, (double)clamped,
+            s_auto_enabled ? "ON" : "OFF");
+
+    if (s_auto_enabled)
+    {
+        brightness_schedule(0U);
+    }
+}
+
+void mos_brightness_set_sample_log_enabled(bool enabled)
+{
+    s_sample_log_enabled = enabled;
+    LOG_INF("[BRIGHTNESS] AUTO sample log %s", enabled ? "ON" : "OFF");
+}
+
+void mos_brightness_get_status(mos_brightness_status_t *status)
+{
+    if (!status)
+    {
+        return;
+    }
+
+    status->current_level_percent = s_current_level;
+    status->auto_enabled = s_auto_enabled;
+    status->multiplier = s_multiplier;
+    status->last_lux = s_last_lux;
+    status->filtered_lux = s_filtered_lux;
+    status->last_sensor_error = s_last_sensor_error;
+    status->sample_log_enabled = s_sample_log_enabled;
+}

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_lvgl_display/src/mos_lvgl_display.c
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_lvgl_display/src/mos_lvgl_display.c
@@ -1,7 +1,7 @@
 /*
  * @Author       : Cole
  * @Date         : 2026-01-30 09:30:43
- * @LastEditTime : 2026-03-26 16:57:07
+ * @LastEditTime : 2026-04-15 17:05:34
  * @FilePath     : mos_lvgl_display.c
  * @Description  :
  *
@@ -26,6 +26,7 @@
 #include "bal_os.h"
 #include "display_config.h"
 #include "main.h"
+#include "mos_brightness.h"
 #include "mos_lvgl_display.h"
 #include "protobuf_handler.h"
 #if defined(CONFIG_LVGL)
@@ -3021,7 +3022,7 @@ void lvgl_dispaly_init(void *p1, void *p2, void *p3)
                     /* 配置 Bank0 寄存器 50%=127/255 / Configure Bank0 registers (50% = 127/255) */
                     /* a6n_set_brightness(0x7f); */
                     /* 初始亮度 30% / Set initial brightness to 30% */
-                    protobuf_set_brightness_level(100); /* 0-100 */
+                    mos_brightness_request_manual(30); /* 0-100 */
                     mos_delay_us(6);
 
                     /* 设置显示格式为 GRAY16 (4-bit) / Set display format to GRAY16 (4-bit) */

--- a/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.c
+++ b/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.c
@@ -16,6 +16,7 @@
  * Tag 35: DisplayScrollingText     - Display animated scrolling text (No response)
  * Tag 37: BrightnessConfig         - Set display brightness level (Projector, No response)
  * Tag 38: AutoBrightnessConfig     - Configure automatic brightness adjustment (No response)
+ * Tag 39: AutoBrightnessMultiplier - Adjust AUTO brightness sensitivity (No response)
  * Tag 46: ClearDisplay             - Clear display content (No response)
  *
  * === GlassesToPhone (Outgoing) Messages ===
@@ -53,7 +54,8 @@
 #include "../../custom_driver_module/drivers/display/lcd/a6n.h"
 #include "main.h"
 #include "mos_ble_service.h"
-#include "mos_components/mos_lvgl_display/include/mos_lvgl_display.h"  // **NEW: For protobuf text display**
+#include "mos_brightness.h"
+#include "mos_components/mos_lvgl_display/include/mos_lvgl_display.h"
 // #include "mos_gx8002.h"         // VAD path kept for quick rollback
 // #include "mos_i2s_slave.h"      // VAD path kept for quick rollback
 #include "pdm_audio_stream.h"
@@ -67,12 +69,6 @@ static uint32_t current_battery_level = 85;
 
 // Global battery charging state
 static bool current_charging_state = false;
-
-// Global brightness level state (0-100%)
-static uint32_t current_brightness_level = 50;
-
-// Global auto brightness state
-static bool auto_brightness_enabled = false;
 
 // Audio streaming error counter
 static uint32_t streaming_errors = 0;
@@ -123,6 +119,8 @@ static const char *protobuf_message_name(uint32_t which_payload)
             return "BrightnessConfig";
         case 38:
             return "AutoBrightnessConfig";
+        case 39:
+            return "AutoBrightnessMultiplier";
         case 45:
             return "DisplayHeightConfig";
         case 44:
@@ -434,6 +432,14 @@ void protobuf_parse_control_message(const uint8_t *protobuf_data, uint16_t len)
                 if (phone_msg.which_payload == mentraos_ble_PhoneToGlasses_auto_brightness_tag)
                 {
                     protobuf_process_auto_brightness_config(&phone_msg.payload.auto_brightness);
+                }
+                break;
+
+            case 39:  // auto_brightness_mult_tag
+                LOG_INF("Processing Auto Brightness Multiplier...");
+                if (phone_msg.which_payload == mentraos_ble_PhoneToGlasses_auto_brightness_mult_tag)
+                {
+                    protobuf_process_auto_brightness_multiplier(&phone_msg.payload.auto_brightness_mult);
                 }
                 break;
 
@@ -759,81 +765,23 @@ int protobuf_generate_echo_response(const uint8_t *input_data, uint16_t input_le
     }
 }
 
-// ============== BRIGHTNESS CONTROL FUNCTIONS ==============
-
-uint32_t protobuf_get_brightness_level(void)
-{
-    return current_brightness_level;
-}
-
-bool protobuf_get_auto_brightness_enabled(void)
-{
-    return auto_brightness_enabled;
-}
-
-void protobuf_set_brightness_level(uint32_t level)
-{
-    // Clamp level to 0-100
-    if (level > 100)
-    {
-        level = 100;
-    }
-
-    // Manual brightness setting automatically disables auto brightness
-    if (auto_brightness_enabled)
-    {
-        LOG_INF("Manual brightness setting - disabling auto brightness");
-        auto_brightness_enabled = false;
-    }
-
-    current_brightness_level = level;
-
-    // Update display projector brightness (0-100% -> 0x00-0xFF register values)
-    // Map 0-100% to 0x00-0xFF register values for A6N projector
-    uint8_t projector_reg_value = (level * 255) / 100;  // Linear mapping: 0%->0x00, 100%->0xFF
-
-    LOG_INF("Setting projector brightness: %u%% -> reg_value 0x%02X (0x00-0xFF)", level, projector_reg_value);
-
-    int ret = a6n_set_brightness(projector_reg_value);
-    if (ret == 0)
-    {
-        LOG_INF("✅ Display projector brightness set to reg_value 0x%02X/0xFF", projector_reg_value);
-    }
-    else
-    {
-        LOG_ERR("❌ Failed to set display projector brightness: %d", ret);
-    }
-}
-
 void protobuf_process_brightness_config(const mentraos_ble_BrightnessConfig *brightness_config)
 {
     if (!brightness_config)
     {
-        LOG_ERR("Invalid brightness config pointer");
+        LOG_ERR("[PROTOBUF] Invalid BrightnessConfig pointer");
         return;
     }
 
-    uint32_t new_level = brightness_config->value;
-
-    // Value validation
-    bool valid_range = (new_level <= 100);
-
-    if (!valid_range)
+    uint32_t level = brightness_config->value;
+    if (level > 100U)
     {
-        LOG_WRN("[PROTOBUF] Brightness value %u exceeds maximum (100), will clamp", new_level);
+        LOG_WRN("[PROTOBUF] BrightnessConfig %u out of range, clamped to 100", level);
+        level = 100U;
     }
 
-    uint32_t clamped_level = (new_level > 100) ? 100 : new_level;
-    uint32_t previous_level = current_brightness_level;
-    bool previous_auto = auto_brightness_enabled;
-    LOG_INF("[PROTOBUF] BrightnessConfig request=%u%% clamp=%u%% prev=%u%% auto=%s", new_level, clamped_level,
-            previous_level, previous_auto ? "ON" : "OFF");
-
-    // Clamp and set the new brightness level (this will disable auto brightness)
-    protobuf_set_brightness_level(new_level);
-
-    LOG_INF("[PROTOBUF] BrightnessConfig applied new=%u%% delta=%+d%% auto=%s", current_brightness_level,
-            (int32_t)current_brightness_level - (int32_t)previous_level, auto_brightness_enabled ? "ON" : "OFF");
+    LOG_INF("[PROTOBUF] BrightnessConfig -> %u%%", level);
+    mos_brightness_request_manual(level);
 }
 
 void protobuf_process_display_text(const mentraos_ble_DisplayText *display_text)
@@ -949,8 +897,8 @@ void protobuf_parse_text_brightness(const char *text)
 
                 if (brightness_value >= 0 && brightness_value <= 100)
                 {
-                    protobuf_set_brightness_level((uint32_t)brightness_value);
-                    LOG_INF("\n[UART BRIGHTNESS] Text brightness set to %d%%\n", brightness_value);
+                    mos_brightness_request_manual((uint32_t)brightness_value);
+                    LOG_INF("[UART BRIGHTNESS] Text brightness set to %d%%", brightness_value);
                 }
                 else
                 {
@@ -1010,8 +958,8 @@ void protobuf_process_display_distance_config(const mentraos_ble_DisplayDistance
     }
 
     LOG_INF("[PROTOBUF] DisplayDistanceConfig %srequest=%u -> distance=%u cm clamp=%u cm offset=%d px",
-            legacy_tier ? "legacy-tier " : "", (unsigned int)v, (unsigned int)distance_cm,
-            (unsigned int)clamped_cm, (int)offset);
+            legacy_tier ? "legacy-tier " : "", (unsigned int)v, (unsigned int)distance_cm, (unsigned int)clamped_cm,
+            (int)offset);
 
     ret = a6n_set_software_depth_offset(offset);
     if (ret != 0)
@@ -1036,18 +984,23 @@ void protobuf_process_auto_brightness_config(const mentraos_ble_AutoBrightnessCo
 {
     if (!auto_brightness_config)
     {
-        LOG_ERR("Invalid auto brightness config pointer");
+        LOG_ERR("[PROTOBUF] Invalid AutoBrightnessConfig pointer");
         return;
     }
+    LOG_INF("[PROTOBUF] AutoBrightnessConfig -> %s", auto_brightness_config->enabled ? "ON" : "OFF");
+    mos_brightness_request_auto_enabled(auto_brightness_config->enabled);
+}
 
-    bool enabled = auto_brightness_config->enabled;
-    bool previous_state = auto_brightness_enabled;
-
-    // Update the global auto brightness state
-    auto_brightness_enabled = enabled;
-
-    LOG_INF("[PROTOBUF] AutoBrightnessConfig %s->%s manual_level=%u%%", previous_state ? "ON" : "OFF",
-            enabled ? "ON" : "OFF", protobuf_get_brightness_level());
+void protobuf_process_auto_brightness_multiplier(
+    const mentraos_ble_AutoBrightnessMultiplier *auto_brightness_multiplier_msg)
+{
+    if (!auto_brightness_multiplier_msg)
+    {
+        LOG_ERR("[PROTOBUF] Invalid AutoBrightnessMultiplier pointer");
+        return;
+    }
+    LOG_INF("[PROTOBUF] AutoBrightnessMultiplier -> %.2f", (double)auto_brightness_multiplier_msg->multiplier);
+    mos_brightness_request_multiplier(auto_brightness_multiplier_msg->multiplier);
 }
 
 void protobuf_process_mic_state_config(const mentraos_ble_MicStateConfig *mic_state)

--- a/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.h
+++ b/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.h
@@ -127,34 +127,19 @@ void protobuf_set_charging_state(bool charging);
  */
 void protobuf_toggle_charging_state(void);
 
-/**
- * @brief Get current brightness level
- *
- * @return Current brightness level (0-100%)
- */
-uint32_t protobuf_get_brightness_level(void);
-
 void protobuf_process_display_height_config(const mentraos_ble_DisplayHeightConfig *config);
 void protobuf_process_display_distance_config(const mentraos_ble_DisplayDistanceConfig *config);
 
 /**
- * @brief Set brightness level and update LED 3
- * Note: Manual brightness setting automatically disables auto brightness
+ * @brief Process auto brightness multiplier configuration message
  *
- * @param level Brightness level (0-100%, will be clamped)
+ * @param auto_brightness_multiplier Pointer to auto brightness multiplier message
  */
-void protobuf_set_brightness_level(uint32_t level);
-
-/**
- * @brief Get current auto brightness state
- *
- * @return true if auto brightness is enabled, false otherwise
- */
-bool protobuf_get_auto_brightness_enabled(void);
+void protobuf_process_auto_brightness_multiplier(
+    const mentraos_ble_AutoBrightnessMultiplier *auto_brightness_multiplier);
 
 /**
  * @brief Process brightness configuration message
- * Note: This will automatically disable auto brightness mode
  *
  * @param brightness_config Pointer to brightness configuration message
  */

--- a/mcu_client/nrf5340_ble_simulator/src/shell_display_control.c
+++ b/mcu_client/nrf5340_ble_simulator/src/shell_display_control.c
@@ -15,10 +15,10 @@
  * Author: MentraOS Team
  */
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include <zephyr/device.h>
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
@@ -40,6 +40,8 @@
 
 // Include protobuf handler for battery functions
 #include "protobuf_handler.h"
+// Brightness component (AUTO + manual state)
+#include "mos_brightness.h"
 // A6N driver API for register read/write
 #include "../custom_driver_module/drivers/display/lcd/a6n.h"
 
@@ -75,7 +77,13 @@ static int cmd_display_help(const struct shell *shell, size_t argc, char **argv)
     shell_print(shell, "  display fill                     - Fill entire display (white)");
     shell_print(shell, "");
     shell_print(shell, "🔆 Brightness Control:");
-    shell_print(shell, "  display brightness <0-100> - Set display brightness (linear 0-100%)");
+    shell_print(shell, "  display brightness <0-100>      - Set display brightness (linear 0-100%%)");
+    shell_print(shell, "  display brightness auto status  - Show AUTO brightness status");
+    shell_print(shell, "  display brightness auto on      - Enable AUTO brightness");
+    shell_print(shell, "  display brightness auto off     - Disable AUTO brightness");
+    shell_print(shell, "  display brightness auto log on  - Enable AUTO sample log");
+    shell_print(shell, "  display brightness auto log off - Disable AUTO sample log");
+    shell_print(shell, "  display brightness auto multiplier <value> - Set AUTO multiplier (0.10-3.00)");
     shell_print(shell, "");
     shell_print(shell, "🎨 Pattern Control:");
     shell_print(shell, "  display pattern <0-5>            - Select specific pattern:");
@@ -111,6 +119,11 @@ static int cmd_display_help(const struct shell *shell, size_t argc, char **argv)
     shell_print(shell, "");
     shell_print(shell, "Examples:");
     shell_print(shell, "  display brightness 50            - Set brightness to 50%%");
+    shell_print(shell, "  display brightness auto status   - Show AUTO brightness status");
+    shell_print(shell, "  display brightness auto on       - Enable ambient-light AUTO mode");
+    shell_print(shell, "  display brightness auto log on   - Print AUTO sample log");
+    shell_print(shell, "  display brightness auto multiplier 1.20 - Increase AUTO sensitivity");
+    shell_print(shell, "  display brightness auto off      - Restore manual brightness");
     shell_print(shell, "  display pattern 2                - Show vertical zebra pattern");
     shell_print(shell, "  display battery 65               - Set 65%% battery, not charging");
     shell_print(shell, "  display battery 85 true          - Set 85%% battery, charging");
@@ -238,7 +251,16 @@ static int cmd_display_brightness(const struct shell *shell, size_t argc, char *
         return -EINVAL;
     }
 
-    int brightness_pct = atoi(argv[1]);
+    char *endptr = NULL;
+    long brightness_pct = strtol(argv[1], &endptr, 10);
+
+    if ((endptr == argv[1]) || (*endptr != '\0'))
+    {
+        shell_error(shell, "❌ Invalid brightness value: %s", argv[1]);
+        shell_print(shell, "Usage: display brightness <0-100>");
+        shell_print(shell, "AUTO:  display brightness auto <status|on|off|multiplier>");
+        return -EINVAL;
+    }
 
     // Validate brightness range
     if (brightness_pct < 0 || brightness_pct > 100)
@@ -247,25 +269,10 @@ static int cmd_display_brightness(const struct shell *shell, size_t argc, char *
         return -EINVAL;
     }
 
-    // Linear mapping from 0-100% to 0x00-0xFF register values
-    uint8_t reg_value = (brightness_pct * 255) / 100;
-
-    // 设置亮度 | Set brightness
-    LOG_INF("🔍 DEBUG: About to call a6n_set_brightness(0x%02X) from SHELL path", reg_value);
-    int ret = a6n_set_brightness(reg_value);
-    if (ret == 0)
-    {
-        shell_print(shell, "✅ A6N brightness set to %d%% (reg=0x%02X)", brightness_pct, reg_value);
-        LOG_INF("🔍 DEBUG: a6n_set_brightness() succeeded from SHELL path");
-    }
-    else
-    {
-        shell_error(shell, "❌ Failed to set brightness: %d", ret);
-        LOG_ERR("🔍 DEBUG: a6n_set_brightness() FAILED from SHELL path with error %d", ret);
-        return ret;
-    }
-
-    LOG_INF("Display brightness set to %d%% (0x%02X) via shell", brightness_pct, reg_value);
+    // Set brightness through the state machine (also disables AUTO brightness)
+    mos_brightness_request_manual((uint32_t)brightness_pct);
+    shell_print(shell, "✅ Brightness set to %ld%% (AUTO disabled)", brightness_pct);
+    LOG_INF("Display brightness set to %ld%% via shell", brightness_pct);
     return 0;
 }
 
@@ -1485,6 +1492,111 @@ static int cmd_display_layout_padding(const struct shell *shell, size_t argc, ch
     return 0;
 }
 
+/* AUTO brightness shell commands */
+static int cmd_display_auto_status(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_status_t status = {0};
+    mos_brightness_get_status(&status);
+    shell_print(shell, "AUTO brightness: %s", status.auto_enabled ? "ON" : "OFF");
+    shell_print(shell, "  Multiplier : %.2f", (double)status.multiplier);
+    if (status.last_lux < 0.0f)
+    {
+        shell_print(shell, "  Last lux   : not sampled yet");
+    }
+    else
+    {
+        shell_print(shell, "  Last lux   : %.2f lx", (double)status.last_lux);
+    }
+    if (status.filtered_lux < 0.0f)
+    {
+        shell_print(shell, "  Filter lux : not initialized");
+    }
+    else
+    {
+        shell_print(shell, "  Filter lux : %.2f lx", (double)status.filtered_lux);
+    }
+    shell_print(shell, "  Sensor err : %d", status.last_sensor_error);
+    shell_print(shell, "  Sample log : %s", status.sample_log_enabled ? "ON" : "OFF");
+    shell_print(shell, "  Current    : %u%%", status.current_level_percent);
+    shell_print(shell, "  Note       : AUTO samples every 1500 ms when enabled");
+    return 0;
+}
+
+static int cmd_display_auto_on(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_request_auto_enabled(true);
+    shell_print(shell, "✅ AUTO brightness enabled");
+    shell_print(shell, "   Check with: display brightness auto status");
+    shell_print(shell, "   Log tag: mos_brightness, sample interval: 1500 ms");
+    return 0;
+}
+
+static int cmd_display_auto_off(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_request_auto_enabled(false);
+    shell_print(shell, "✅ AUTO brightness disabled, manual level restored");
+    return 0;
+}
+
+static int cmd_display_auto_multiplier(const struct shell *shell, size_t argc, char **argv)
+{
+    mos_brightness_status_t status = {0};
+
+    if (argc != 2)
+    {
+        shell_error(shell, "Usage: display brightness auto multiplier <0.10-3.00>");
+        mos_brightness_get_status(&status);
+        shell_print(shell, "  Current: %.2f", (double)status.multiplier);
+        return -EINVAL;
+    }
+    char *endptr = NULL;
+    float val = strtof(argv[1], &endptr);
+    if ((endptr == argv[1]) || (*endptr != '\0'))
+    {
+        shell_error(shell, "Invalid multiplier: %s", argv[1]);
+        shell_print(shell, "Usage: display brightness auto multiplier <0.10-3.00>");
+        return -EINVAL;
+    }
+    mos_brightness_request_multiplier(val);
+    mos_brightness_get_status(&status);
+    shell_print(shell, "✅ Multiplier set to %.2f (clamped if out of range)", (double)status.multiplier);
+    return 0;
+}
+
+static int cmd_display_auto_log_on(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_set_sample_log_enabled(true);
+    shell_print(shell, "✅ AUTO brightness sample log enabled");
+    return 0;
+}
+
+static int cmd_display_auto_log_off(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_set_sample_log_enabled(false);
+    shell_print(shell, "✅ AUTO brightness sample log disabled");
+    return 0;
+}
+
+static int cmd_display_auto_log_status(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    mos_brightness_status_t status = {0};
+    mos_brightness_get_status(&status);
+    shell_print(shell, "AUTO brightness sample log: %s", status.sample_log_enabled ? "ON" : "OFF");
+    return 0;
+}
+
 /* Shell subcommand definitions for fonts */
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_fonts,
                                SHELL_CMD(list, NULL, "List all available font sizes", cmd_display_fonts_list),
@@ -1518,11 +1630,35 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_max_temp_limit,
                                          cmd_display_max_temp_limit_get),
                                SHELL_SUBCMD_SET_END);
 
+/* Shell subcommand definitions for auto brightness sample logs */
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_brightness_auto_log,
+                               SHELL_CMD(on, NULL, "Enable AUTO sample log", cmd_display_auto_log_on),
+                               SHELL_CMD(off, NULL, "Disable AUTO sample log", cmd_display_auto_log_off),
+                               SHELL_CMD(status, NULL, "Show AUTO sample log state", cmd_display_auto_log_status),
+                               SHELL_SUBCMD_SET_END);
+
+/* Shell subcommand definitions for auto brightness */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+    sub_brightness_auto,
+    SHELL_CMD(status, NULL, "Show AUTO brightness state (enabled, lux, %%, multiplier)", cmd_display_auto_status),
+    SHELL_CMD(on, NULL, "Enable AUTO brightness (ambient light sensor)", cmd_display_auto_on),
+    SHELL_CMD(off, NULL, "Disable AUTO brightness, restore manual level", cmd_display_auto_off),
+    SHELL_CMD(log, &sub_brightness_auto_log, "AUTO sample log control (on/off/status)", cmd_display_auto_log_status),
+    SHELL_CMD_ARG(multiplier, NULL, "Set AUTO brightness multiplier <0.10-3.00>", cmd_display_auto_multiplier, 2, 0),
+    SHELL_SUBCMD_SET_END);
+
+/* Shell subcommand definitions for brightness */
+SHELL_STATIC_SUBCMD_SET_CREATE(
+    sub_brightness,
+    SHELL_CMD(auto, &sub_brightness_auto, "AUTO brightness control (on/off/status/multiplier)",
+              cmd_display_auto_status),
+    SHELL_SUBCMD_SET_END);
+
 /* Shell command definitions */
 SHELL_STATIC_SUBCMD_SET_CREATE(
     sub_display, SHELL_CMD(help, NULL, "Show display commands help", cmd_display_help),
     SHELL_CMD(info, NULL, "Show display information", cmd_display_info),
-    SHELL_CMD_ARG(brightness, NULL, "Set brightness (20/40/60/80/100%)", cmd_display_brightness, 2, 0),
+    SHELL_CMD_ARG(brightness, &sub_brightness, "Set brightness <0-100> (disables AUTO)", cmd_display_brightness, 2, 0),
     SHELL_CMD(clear, NULL, "Clear display", cmd_display_clear),
     SHELL_CMD(fill, NULL, "Fill display with white", cmd_display_fill),
     SHELL_CMD_ARG(text, NULL, "Write text: \"string\" [x y size] (overlay or positioned)", cmd_display_text, 2, 3),


### PR DESCRIPTION
## Summary

- Add `mos_brightness` component for unified manual and AUTO brightness control
- Move shell commands to `display brightness auto ...` to make AUTO brightness ownership explicit
- Tune AUTO brightness mapping for the installed OPT3006 position, where effective lux is much lower than room lux
- Add optional AUTO sample logging controlled by shell

## Changes

- Added shared brightness APIs for manual brightness, AUTO enable/disable, multiplier, sample logging, and status query
- Added shell commands:
  - `display brightness <0-100>`
  - `display brightness auto on/off/status`
  - `display brightness auto log on/off/status`
  - `display brightness auto multiplier <0.10-3.00>`
- AUTO brightness samples OPT3006 every 1500 ms when enabled
- AUTO brightness applies EMA filtering, hysteresis, and minimum apply interval to reduce flicker
- Brightness writes go through A6N Bank0 `0xE2`
- Protobuf brightness control now uses the shared `mos_brightness` module
- Initial display brightness now uses the shared brightness path

## AUTO Brightness Tuning

The OPT3006 is installed near the frame with the light inlet facing downward, so measured values are effective device lux rather than normal room lux.

Current curve:

| Effective lux | Brightness |
| --- | --- |
| 0 | 30% |
| 10 | 30% |
| 30 | 50% |
| 80 | 58% |
| 150 | 68% |
| 300 | 85% |
| 500+ | 100% |

## Logging

AUTO sample logs are disabled by default to avoid flooding the console.