### PR TITLE
Wait for settings' update before going back home when setting up without glasses

### DIFF
--- a/mobile/src/app/pairing/prep-controller.tsx
+++ b/mobile/src/app/pairing/prep-controller.tsx
@@ -1,7 +1,6 @@
 import {ControllerTypes, DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useRoute} from "@react-navigation/native"
-import CoreModule from "core"
-import {Linking, PermissionsAndroid, Image, Platform, ScrollView, View} from "react-native"
+import {Linking, PermissionsAndroid, Image, Platform, View} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
 import {Button, Header, Icon, Screen, Text} from "@/components/ignite"
@@ -9,12 +8,10 @@ import {useNavigationHistory} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
 import {showAlert} from "@/utils/AlertUtils"
+import {completeSimulatedSetup} from "@/utils/completeSimulatedSetup"
 import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
-import GlassesDisplayMirror from "@/components/mirror/GlassesDisplayMirror"
 import {useState} from "react"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
-import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
-import {useAppletStatusStore} from "@/stores/applets"
 
 export default function PairingPrepScreen() {
   const route = useRoute()
@@ -212,7 +209,7 @@ export default function PairingPrepScreen() {
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {
-      await CoreModule.connectSimulated()
+      await completeSimulatedSetup()
       clearHistoryAndGoHome()
       return
     }

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -1,7 +1,6 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useRoute} from "@react-navigation/native"
-import CoreModule from "core"
-import {Linking, PermissionsAndroid, Image, Platform, ScrollView, View} from "react-native"
+import {Linking, PermissionsAndroid, Image, Platform, View} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
 import {Button, Header, Icon, Screen, Text} from "@/components/ignite"
@@ -9,6 +8,7 @@ import {useNavigationHistory} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
 import {showAlert} from "@/utils/AlertUtils"
+import {completeSimulatedSetup} from "@/utils/completeSimulatedSetup"
 import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import GlassesDisplayMirror from "@/components/mirror/GlassesDisplayMirror"
 import {useState} from "react"
@@ -212,7 +212,7 @@ export default function PairingPrepScreen() {
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {
-      await CoreModule.connectSimulated()
+      await completeSimulatedSetup()
       clearHistoryAndGoHome()
       return
     }

--- a/mobile/src/utils/completeSimulatedSetup.ts
+++ b/mobile/src/utils/completeSimulatedSetup.ts
@@ -1,0 +1,46 @@
+import {DeviceTypes} from "@/../../cloud/packages/types/src"
+import CoreModule from "core"
+
+import {waitForGlassesState} from "@/stores/glasses"
+import {SETTINGS, useSettingsStore} from "@/stores/settings"
+
+const SIMULATED_SETUP_TIMEOUT_MS = 400
+const SIMULATED_SETUP_POLL_INTERVAL_MS = 50
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitForSimulatedSettingsPersistence(): Promise<boolean> {
+  const deadline = Date.now() + SIMULATED_SETUP_TIMEOUT_MS
+
+  while (Date.now() < deadline) {
+    const settingsStore = useSettingsStore.getState()
+    const defaultWearable = settingsStore.getSetting(SETTINGS.default_wearable.key)
+    const deviceName = settingsStore.getSetting(SETTINGS.device_name.key)
+
+    if (defaultWearable === DeviceTypes.SIMULATED && deviceName === DeviceTypes.SIMULATED) {
+      return true
+    }
+
+    await sleep(SIMULATED_SETUP_POLL_INTERVAL_MS)
+  }
+
+  return false
+}
+
+export async function completeSimulatedSetup() {
+  await CoreModule.connectSimulated()
+
+  const [glassesConnected, settingsPersisted] = await Promise.all([
+    waitForGlassesState("connected", (connected) => connected === true, SIMULATED_SETUP_TIMEOUT_MS),
+    waitForSimulatedSettingsPersistence(),
+  ])
+
+  if (glassesConnected && settingsPersisted) {
+    return
+  }
+
+  // Fall back to an explicit JS-side write so home state can't race ahead of
+  // the native save_setting bridge event.
+  await useSettingsStore.getState().setSetting(SETTINGS.default_wearable.key, DeviceTypes.SIMULATED)
+  await useSettingsStore.getState().setSetting(SETTINGS.device_name.key, DeviceTypes.SIMULATED)
+}


### PR DESCRIPTION
Bug video: https://mentra-labs.slack.com/archives/C0A8015JBPT/p1776735408075239?thread_ts=1776735368.806169&cid=C0A8015JBPT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated simulated device pairing workflow with improved state synchronization and enhanced error handling to ensure more reliable setup completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->