### PR TITLE
Rename of core update type to bluetooth

### DIFF
--- a/docs/mentra-bluetooth-sdk-plan.md
+++ b/docs/mentra-bluetooth-sdk-plan.md
@@ -279,30 +279,30 @@ Remove MentraOS-specific side effects from Bluetooth SDK. The `apply()` function
 "glasses" to "headUp" -> sendCurrentState(); sendHeadUp(...)
 
 // Hardware settings
-"core" to "brightness" -> sgc?.setBrightness(...)
-"core" to "auto_brightness" -> sgc?.setBrightness(...)
-"core" to "dashboard_height" -> sgc?.setDashboardHeightOnly(...)
-"core" to "dashboard_depth" -> sgc?.setDashboardDepthOnly(...)
-"core" to "head_up_angle" -> sgc?.setHeadUpAngle(...)
-"core" to "dashboard_menu_apps" -> sgc?.setDashboardMenu(...)
-"core" to "gallery_mode" -> sgc?.sendGalleryMode()
-"core" to "screen_disabled" -> sgc?.exit()/clearDisplay()
-"core" to "button_mode" -> sgc?.sendButtonModeSetting()
-"core" to "button_photo_size" -> sgc?.sendButtonPhotoSettings()
-"core" to "button_camera_led" -> sgc?.sendButtonCameraLedSetting()
-"core" to "button_max_recording_time" -> sgc?.sendButtonMaxRecordingTime()
-"core" to "camera_fov" -> sgc?.sendCameraFovSetting()
-"core" to "button_video_width" -> sgc?.sendButtonVideoRecordingSettings()
-"core" to "button_video_height" -> sgc?.sendButtonVideoRecordingSettings()
-"core" to "button_video_fps" -> sgc?.sendButtonVideoRecordingSettings()
-"core" to "preferred_mic" -> setMicState(...)
-"core" to "default_wearable" -> initSGC(...)
+"bluetooth" to "brightness" -> sgc?.setBrightness(...)
+"bluetooth" to "auto_brightness" -> sgc?.setBrightness(...)
+"bluetooth" to "dashboard_height" -> sgc?.setDashboardHeightOnly(...)
+"bluetooth" to "dashboard_depth" -> sgc?.setDashboardDepthOnly(...)
+"bluetooth" to "head_up_angle" -> sgc?.setHeadUpAngle(...)
+"bluetooth" to "dashboard_menu_apps" -> sgc?.setDashboardMenu(...)
+"bluetooth" to "gallery_mode" -> sgc?.sendGalleryMode()
+"bluetooth" to "screen_disabled" -> sgc?.exit()/clearDisplay()
+"bluetooth" to "button_mode" -> sgc?.sendButtonModeSetting()
+"bluetooth" to "button_photo_size" -> sgc?.sendButtonPhotoSettings()
+"bluetooth" to "button_camera_led" -> sgc?.sendButtonCameraLedSetting()
+"bluetooth" to "button_max_recording_time" -> sgc?.sendButtonMaxRecordingTime()
+"bluetooth" to "camera_fov" -> sgc?.sendCameraFovSetting()
+"bluetooth" to "button_video_width" -> sgc?.sendButtonVideoRecordingSettings()
+"bluetooth" to "button_video_height" -> sgc?.sendButtonVideoRecordingSettings()
+"bluetooth" to "button_video_fps" -> sgc?.sendButtonVideoRecordingSettings()
+"bluetooth" to "preferred_mic" -> setMicState(...)
+"bluetooth" to "default_wearable" -> initSGC(...)
 
 // Explicit Phase 2 exceptions
-"core" to "offline_captions_running" -> setMicState(...)
-"core" to "should_send_pcm" -> setMicState(...)
-"core" to "should_send_lc3" -> setMicState(...)
-"core" to "should_send_transcript" -> setMicState(...)
+"bluetooth" to "offline_captions_running" -> setMicState(...)
+"bluetooth" to "should_send_pcm" -> setMicState(...)
+"bluetooth" to "should_send_lc3" -> setMicState(...)
+"bluetooth" to "should_send_transcript" -> setMicState(...)
 ```
 
 `auth_email` and `core_token` remain Bluetooth SDK state for MentraLive plumbing, but they do not need `apply()` side-effect branches because hardware paths read the latest values directly from `DeviceStore`.
@@ -481,7 +481,7 @@ BluetoothSdk.onBluetoothStatus(callback)
 BluetoothSdk.onGlassesStatus(callback)
 ```
 
-`BluetoothSdk.update(category, values)` remains the low-level native store bridge used by these typed helpers. External callers should prefer `updateBluetoothSettings()` and `updateGlasses()` so the internal native store category names (`"core"` / `"glasses"`) do not become part of the partner-facing API.
+`BluetoothSdk.update(category, values)` remains the low-level native store bridge used by these typed helpers. External callers should prefer `updateBluetoothSettings()` and `updateGlasses()` so the internal native store category names (`"bluetooth"` / `"glasses"`) do not become part of the partner-facing API. Native stores still accept `"core"` as a legacy alias for `"bluetooth"` to avoid silently splitting persisted state during the rename.
 
 **Typed hardware/app events emitted to JavaScript:**
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -72,9 +72,9 @@ class BluetoothSdkModule : Module() {
 
             // Configure observable store event emission
             DeviceStore.store.configure { category, changes ->
-                when (category) {
+                when (ObservableStore.normalizeCategory(category)) {
                     "glasses" -> sendEvent("glasses_status", changes)
-                    "core" -> sendEvent("bluetooth_status", changes)
+                    ObservableStore.BLUETOOTH_CATEGORY -> sendEvent("bluetooth_status", changes)
                 }
             }
         }
@@ -83,20 +83,23 @@ class BluetoothSdkModule : Module() {
 
         Function("getGlassesStatus") { DeviceStore.store.getCategory("glasses") }
 
-        Function("getBluetoothStatus") { DeviceStore.store.getCategory("core") }
+        Function("getBluetoothStatus") {
+            DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY)
+        }
 
         Function("set") { category: String, key: String, value: Any ->
             DeviceStore.apply(category, key, value)
         }
 
         Function("update") { category: String, values: Map<String, Any> ->
-            values.forEach { (key, value) -> DeviceStore.apply(category, key, value) }
+            val normalizedCategory = ObservableStore.normalizeCategory(category)
+            values.forEach { (key, value) -> DeviceStore.apply(normalizedCategory, key, value) }
             // Persist core_token to SharedPreferences so MentraLive.getCoreToken() finds it
             // (bridge may run this after glasses_ready; prefs survive retries and next connection)
-            if (category == "core") {
+            if (normalizedCategory == ObservableStore.BLUETOOTH_CATEGORY) {
                 values["core_token"]?.let { token ->
                     val len = (token as? String)?.length ?: 0
-                    android.util.Log.d("BluetoothSdkModule", "update(core) core_token received, len=$len")
+                    android.util.Log.d("BluetoothSdkModule", "update(bluetooth) core_token received, len=$len")
                     if (token is String && token.isNotEmpty()) {
                         val ctx = appContext.reactContext ?: appContext.currentActivity
                         ctx?.let {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -153,13 +153,13 @@ public class Bridge private constructor() {
         @JvmStatic
         fun sendDiscoveredDevice(deviceModel: String, deviceName: String) {
             val searchResults =
-                    DeviceStore.store.getCategory("core")["searchResults"] as?
+                    DeviceStore.store.getCategory("bluetooth")["searchResults"] as?
                             List<Map<String, String>>
                             ?: emptyList()
             val newResult = mapOf("deviceModel" to deviceModel, "deviceName" to deviceName)
             val allResults = searchResults + newResult
             val uniqueResults = allResults.associateBy { it["deviceName"] }.values.toList()
-            DeviceStore.set("core", "searchResults", uniqueResults)
+            DeviceStore.set("bluetooth", "searchResults", uniqueResults)
         }
 
         // MARK: - Hardware Events
@@ -320,7 +320,7 @@ public class Bridge private constructor() {
         @JvmStatic
         fun updateWifiScanResults(networks: List<Map<String, Any>>) {
             var storedNetworks: List<Map<String, Any>> =
-                    DeviceStore.get("core", "wifiScanResults") as? List<Map<String, Any>>
+                    DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
                             ?: emptyList()
             // add the networks to the storedNetworks array, removing duplicates by ssid
             val updatedNetworks = storedNetworks.toMutableList()
@@ -329,7 +329,7 @@ public class Bridge private constructor() {
                     updatedNetworks.add(network)
                 }
             }
-            DeviceStore.apply("core", "wifiScanResults", updatedNetworks)
+            DeviceStore.apply("bluetooth", "wifiScanResults", updatedNetworks)
         }
 
         /** Send gallery status - matches iOS MentraLive.swift handleGalleryStatus pattern */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -73,101 +73,101 @@ class DeviceManager {
 
     // settings:
     private var defaultWearable: String
-        get() = DeviceStore.store.get("core", "default_wearable") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "default_wearable", value)
+        get() = DeviceStore.store.get("bluetooth", "default_wearable") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "default_wearable", value)
 
     private var pendingWearable: String
-        get() = DeviceStore.store.get("core", "pending_wearable") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "pending_wearable", value)
+        get() = DeviceStore.store.get("bluetooth", "pending_wearable") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "pending_wearable", value)
 
     public var deviceName: String
-        get() = DeviceStore.store.get("core", "device_name") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "device_name", value)
+        get() = DeviceStore.store.get("bluetooth", "device_name") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "device_name", value)
 
     public var deviceAddress: String
-        get() = DeviceStore.store.get("core", "device_address") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "device_address", value)
+        get() = DeviceStore.store.get("bluetooth", "device_address") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "device_address", value)
 
     private var defaultController: String
-        get() = DeviceStore.store.get("core", "default_controller") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "default_controller", value)
+        get() = DeviceStore.store.get("bluetooth", "default_controller") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "default_controller", value)
 
     private var pendingController: String
-        get() = DeviceStore.store.get("core", "pending_controller") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "pending_controller", value)
+        get() = DeviceStore.store.get("bluetooth", "pending_controller") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "pending_controller", value)
 
     private var controllerDeviceName: String
-        get() = DeviceStore.store.get("core", "controller_device_name") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "controller_device_name", value)
+        get() = DeviceStore.store.get("bluetooth", "controller_device_name") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "controller_device_name", value)
 
     private var searchingController: Boolean
-        get() = DeviceStore.store.get("core", "searchingController") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "searchingController", value)
+        get() = DeviceStore.store.get("bluetooth", "searchingController") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "searchingController", value)
 
     private var screenDisabled: Boolean
-        get() = DeviceStore.store.get("core", "screen_disabled") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "screen_disabled", value)
+        get() = DeviceStore.store.get("bluetooth", "screen_disabled") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "screen_disabled", value)
 
     private var preferredMic: String
-        get() = DeviceStore.store.get("core", "preferred_mic") as? String ?: "auto"
-        set(value) = DeviceStore.apply("core", "preferred_mic", value)
+        get() = DeviceStore.store.get("bluetooth", "preferred_mic") as? String ?: "auto"
+        set(value) = DeviceStore.apply("bluetooth", "preferred_mic", value)
 
     private var autoBrightness: Boolean
-        get() = DeviceStore.store.get("core", "auto_brightness") as? Boolean ?: true
-        set(value) = DeviceStore.apply("core", "auto_brightness", value)
+        get() = DeviceStore.store.get("bluetooth", "auto_brightness") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "auto_brightness", value)
 
     private var brightness: Int
-        get() = DeviceStore.store.get("core", "brightness") as? Int ?: 50
-        set(value) = DeviceStore.apply("core", "brightness", value)
+        get() = DeviceStore.store.get("bluetooth", "brightness") as? Int ?: 50
+        set(value) = DeviceStore.apply("bluetooth", "brightness", value)
 
     private var headUpAngle: Int
-        get() = DeviceStore.store.get("core", "head_up_angle") as? Int ?: 30
-        set(value) = DeviceStore.apply("core", "head_up_angle", value)
+        get() = DeviceStore.store.get("bluetooth", "head_up_angle") as? Int ?: 30
+        set(value) = DeviceStore.apply("bluetooth", "head_up_angle", value)
 
     private var sensingEnabled: Boolean
-        get() = DeviceStore.store.get("core", "sensing_enabled") as? Boolean ?: true
-        set(value) = DeviceStore.apply("core", "sensing_enabled", value)
+        get() = DeviceStore.store.get("bluetooth", "sensing_enabled") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "sensing_enabled", value)
 
     private var bypassVad: Boolean
-        get() = DeviceStore.store.get("core", "bypass_vad") as? Boolean ?: true
-        set(value) = DeviceStore.apply("core", "bypass_vad", value)
+        get() = DeviceStore.store.get("bluetooth", "bypass_vad") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "bypass_vad", value)
 
     private var offlineCaptionsRunning: Boolean
-        get() = DeviceStore.store.get("core", "offline_captions_running") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "offline_captions_running", value)
+        get() = DeviceStore.store.get("bluetooth", "offline_captions_running") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "offline_captions_running", value)
 
     private var shouldSendPcm: Boolean
-        get() = DeviceStore.store.get("core", "should_send_pcm") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "should_send_pcm", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_pcm") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_pcm", value)
 
     private var shouldSendLc3: Boolean
-        get() = DeviceStore.store.get("core", "should_send_lc3") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "should_send_lc3", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_lc3") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_lc3", value)
 
     private var shouldSendTranscript: Boolean
-        get() = DeviceStore.store.get("core", "should_send_transcript") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "should_send_transcript", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_transcript") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_transcript", value)
 
     private var contextualDashboard: Boolean
-        get() = DeviceStore.store.get("core", "contextual_dashboard") as? Boolean ?: true
-        set(value) = DeviceStore.apply("core", "contextual_dashboard", value)
+        get() = DeviceStore.store.get("bluetooth", "contextual_dashboard") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "contextual_dashboard", value)
 
     private var dashboardHeight: Int
-        get() = (DeviceStore.store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
-        set(value) = DeviceStore.apply("core", "dashboard_height", value)
+        get() = (DeviceStore.store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
+        set(value) = DeviceStore.apply("bluetooth", "dashboard_height", value)
 
     private var dashboardDepth: Int
-        get() = (DeviceStore.store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
-        set(value) = DeviceStore.apply("core", "dashboard_depth", value)
+        get() = (DeviceStore.store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
+        set(value) = DeviceStore.apply("bluetooth", "dashboard_depth", value)
 
     private var galleryMode: Boolean
-        get() = DeviceStore.store.get("core", "gallery_mode") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "gallery_mode", value)
+        get() = DeviceStore.store.get("bluetooth", "gallery_mode") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "gallery_mode", value)
 
     // state:
     private var searching: Boolean
-        get() = DeviceStore.store.get("core", "searching") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "searching", value)
+        get() = DeviceStore.store.get("bluetooth", "searching") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "searching", value)
 
     private var glassesBtcConnected: Boolean
         get() = DeviceStore.store.get("glasses", "btcConnected") as? Boolean ?: false
@@ -175,47 +175,47 @@ class DeviceManager {
 
     public var micRanking: MutableList<String>
         get() =
-                (DeviceStore.store.get("core", "micRanking") as? List<*>)
+                (DeviceStore.store.get("bluetooth", "micRanking") as? List<*>)
                         ?.mapNotNull { it as? String }
                         ?.toMutableList()
                         ?: MicMap.map["auto"]?.toMutableList() ?: mutableListOf()
-        set(value) = DeviceStore.apply("core", "micRanking", value)
+        set(value) = DeviceStore.apply("bluetooth", "micRanking", value)
 
     private var shouldSendBootingMessage: Boolean
-        get() = DeviceStore.store.get("core", "shouldSendBootingMessage") as? Boolean ?: true
-        set(value) = DeviceStore.apply("core", "shouldSendBootingMessage", value)
+        get() = DeviceStore.store.get("bluetooth", "shouldSendBootingMessage") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "shouldSendBootingMessage", value)
 
     // Guard against duplicate ready callbacks firing back-to-back.
     private var lastReadyHandledAtMs: Long = 0L
     private var lastReadyHandledKey: String = ""
 
     private var systemMicUnavailable: Boolean
-        get() = DeviceStore.store.get("core", "systemMicUnavailable") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "systemMicUnavailable", value)
+        get() = DeviceStore.store.get("bluetooth", "systemMicUnavailable") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "systemMicUnavailable", value)
 
     public var headUp: Boolean
         get() = DeviceStore.store.get("glasses", "headUp") as? Boolean ?: false
         set(value) = DeviceStore.apply("glasses", "headUp", value)
 
     private var micEnabled: Boolean
-        get() = DeviceStore.store.get("core", "micEnabled") as? Boolean ?: false
-        set(value) = DeviceStore.apply("core", "micEnabled", value)
+        get() = DeviceStore.store.get("bluetooth", "micEnabled") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "micEnabled", value)
 
     private var currentMic: String
-        get() = DeviceStore.store.get("core", "currentMic") as? String ?: ""
-        set(value) = DeviceStore.apply("core", "currentMic", value)
+        get() = DeviceStore.store.get("bluetooth", "currentMic") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "currentMic", value)
 
     private var searchResults: List<Any>
-        get() = DeviceStore.store.get("core", "searchResults") as? List<Any> ?: emptyList()
-        set(value) = DeviceStore.apply("core", "searchResults", value)
+        get() = DeviceStore.store.get("bluetooth", "searchResults") as? List<Any> ?: emptyList()
+        set(value) = DeviceStore.apply("bluetooth", "searchResults", value)
 
     private var wifiScanResults: List<Any>
-        get() = DeviceStore.store.get("core", "wifiScanResults") as? List<Any> ?: emptyList()
-        set(value) = DeviceStore.apply("core", "wifiScanResults", value)
+        get() = DeviceStore.store.get("bluetooth", "wifiScanResults") as? List<Any> ?: emptyList()
+        set(value) = DeviceStore.apply("bluetooth", "wifiScanResults", value)
 
     private var lastLog: MutableList<String>
-        get() = DeviceStore.store.get("core", "lastLog") as? MutableList<String> ?: mutableListOf()
-        set(value) = DeviceStore.apply("core", "lastLog", value)
+        get() = DeviceStore.store.get("bluetooth", "lastLog") as? MutableList<String> ?: mutableListOf()
+        set(value) = DeviceStore.apply("bluetooth", "lastLog", value)
 
     // LC3 Audio Encoding
     // Audio output format enum
@@ -570,7 +570,7 @@ class DeviceManager {
                 Bridge.log("MAN: ERROR - LC3 encoder not initialized but format is LC3")
                 return
             }
-            val lc3FrameSize = (DeviceStore.store.get("core", "lc3_frame_size") as Number).toInt()
+            val lc3FrameSize = (DeviceStore.store.get("bluetooth", "lc3_frame_size") as Number).toInt()
             val lc3Data = Lc3Cpp.encodeLC3(lc3EncoderPtr, pcmData, lc3FrameSize)
             if (lc3Data == null || lc3Data.isEmpty()) {
                 Bridge.log("MAN: ERROR - LC3 encoding returned empty data")
@@ -1188,7 +1188,7 @@ class DeviceManager {
 
     fun requestWifiScan() {
         Bridge.log("MAN: Requesting wifi scan")
-        DeviceStore.apply("core", "wifiScanResults", emptyList<Any>())
+        DeviceStore.apply("bluetooth", "wifiScanResults", emptyList<Any>())
         sgc?.requestWifiScan()
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -16,7 +16,7 @@ object DeviceStore {
     val store = ObservableStore()
 
     /**
-     * [BluetoothSdkModule] applies batched `update("core", map)` key-by-key. Post to Main so the store has
+     * [BluetoothSdkModule] applies batched `update("bluetooth", map)` key-by-key. Post to Main so the store has
      * the latest value before BLE. Height and depth schedule independently so Nex sends one protobuf per change.
      */
     private val dashboardBleHandler = Handler(Looper.getMainLooper())
@@ -34,7 +34,7 @@ object DeviceStore {
         pendingDashboardHeightRunnable?.let { dashboardBleHandler.removeCallbacks(it) }
         val r = Runnable {
             pendingDashboardHeightRunnable = null
-            val h = (store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
+            val h = (store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
             DeviceManager.getInstance().sgc?.setDashboardHeightOnly(h)
         }
         pendingDashboardHeightRunnable = r
@@ -45,7 +45,7 @@ object DeviceStore {
         pendingDashboardDepthRunnable?.let { dashboardBleHandler.removeCallbacks(it) }
         val r = Runnable {
             pendingDashboardDepthRunnable = null
-            val d = (store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
+            val d = (store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
             DeviceManager.getInstance().sgc?.setDashboardDepthOnly(d)
         }
         pendingDashboardDepthRunnable = r
@@ -90,51 +90,51 @@ object DeviceStore {
         store.set("glasses", "ringSignalStrength", -1)
 
         // BLUETOOTH SDK STATE:
-        store.set("core", "systemMicUnavailable", false)
-        store.set("core", "searching", false)
-        store.set("core", "searchingController", false)
-        store.set("core", "micEnabled", false)
-        store.set("core", "currentMic", "")
-        store.set("core", "searchResults", emptyList<Any>())
-        store.set("core", "wifiScanResults", emptyList<Any>())
-        store.set("core", "micRanking", MicMap.map["auto"]!!)
-        store.set("core", "lastLog", mutableListOf<String>())
+        store.set("bluetooth", "systemMicUnavailable", false)
+        store.set("bluetooth", "searching", false)
+        store.set("bluetooth", "searchingController", false)
+        store.set("bluetooth", "micEnabled", false)
+        store.set("bluetooth", "currentMic", "")
+        store.set("bluetooth", "searchResults", emptyList<Any>())
+        store.set("bluetooth", "wifiScanResults", emptyList<Any>())
+        store.set("bluetooth", "micRanking", MicMap.map["auto"]!!)
+        store.set("bluetooth", "lastLog", mutableListOf<String>())
 
-        // CORE SETTINGS:
-        store.set("core", "default_wearable", "")
-        store.set("core", "pending_wearable", "")
-        store.set("core", "device_name", "")
-        store.set("core", "device_address", "")
-        store.set("core", "default_controller", "")
-        store.set("core", "pending_controller", "")
-        store.set("core", "controller_device_name", "")
-        store.set("core", "screen_disabled", false)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "sensing_enabled", true)
-        store.set("core", "brightness", 50)
-        store.set("core", "auto_brightness", true)
-        store.set("core", "dashboard_height", 4)
-        store.set("core", "dashboard_depth", 2)
-        store.set("core", "head_up_angle", 30)
-        store.set("core", "contextual_dashboard", true)
-        store.set("core", "gallery_mode", false)
-        store.set("core", "screen_disabled", false)
-        store.set("core", "button_mode", "photo")
-        store.set("core", "button_photo_size", "medium")
-        store.set("core", "button_camera_led", true)
-        store.set("core", "button_max_recording_time", 10)
-        store.set("core", "camera_fov", mapOf("fov" to 118, "roi_position" to 0))
-        store.set("core", "button_video_width", 1280)
-        store.set("core", "button_video_height", 720)
-        store.set("core", "button_video_fps", 30)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "lc3_frame_size", 60)
-        store.set("core", "auth_email", "")
-        store.set("core", "core_token", "")
-        store.set("core", "should_send_pcm", false)
-        store.set("core", "should_send_lc3", false)
-        store.set("core", "should_send_transcript", false)
-        store.set("core", "bypass_vad", false)
+        // BLUETOOTH SETTINGS:
+        store.set("bluetooth", "default_wearable", "")
+        store.set("bluetooth", "pending_wearable", "")
+        store.set("bluetooth", "device_name", "")
+        store.set("bluetooth", "device_address", "")
+        store.set("bluetooth", "default_controller", "")
+        store.set("bluetooth", "pending_controller", "")
+        store.set("bluetooth", "controller_device_name", "")
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "sensing_enabled", true)
+        store.set("bluetooth", "brightness", 50)
+        store.set("bluetooth", "auto_brightness", true)
+        store.set("bluetooth", "dashboard_height", 4)
+        store.set("bluetooth", "dashboard_depth", 2)
+        store.set("bluetooth", "head_up_angle", 30)
+        store.set("bluetooth", "contextual_dashboard", true)
+        store.set("bluetooth", "gallery_mode", false)
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "button_mode", "photo")
+        store.set("bluetooth", "button_photo_size", "medium")
+        store.set("bluetooth", "button_camera_led", true)
+        store.set("bluetooth", "button_max_recording_time", 10)
+        store.set("bluetooth", "camera_fov", mapOf("fov" to 118, "roi_position" to 0))
+        store.set("bluetooth", "button_video_width", 1280)
+        store.set("bluetooth", "button_video_height", 720)
+        store.set("bluetooth", "button_video_fps", 30)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "lc3_frame_size", 60)
+        store.set("bluetooth", "auth_email", "")
+        store.set("bluetooth", "core_token", "")
+        store.set("bluetooth", "should_send_pcm", false)
+        store.set("bluetooth", "should_send_lc3", false)
+        store.set("bluetooth", "should_send_transcript", false)
+        store.set("bluetooth", "bypass_vad", false)
     }
 
     fun get(category: String, key: String): Any? {
@@ -147,14 +147,15 @@ object DeviceStore {
 
     /** Apply changes with side effects */
     fun apply(category: String, key: String, value: Any) {
-        val oldValue = store.get(category, key)
-        store.set(category, key, value)
+        val normalizedCategory = ObservableStore.normalizeCategory(category)
+        val oldValue = store.get(normalizedCategory, key)
+        store.set(normalizedCategory, key, value)
         if (observableStoreWouldHaveSkipped(oldValue, value)) {
             return
         }
 
         // Trigger hardware updates based on setting changes
-        when (category to key) {
+        when (normalizedCategory to key) {
             "glasses" to "fullyBooted" -> {
                 if (value is Boolean) {
                     if (value) {
@@ -190,10 +191,10 @@ object DeviceStore {
                 }
             }
 
-            // CORE:
-            "core" to "brightness" -> {
+            // BLUETOOTH:
+            "bluetooth" to "brightness" -> {
                 val b = (value as? Number)?.toInt()  ?: 50
-                val auto = (store.get("core", "auto_brightness") as? Boolean) ?: true
+                val auto = (store.get("bluetooth", "auto_brightness") as? Boolean) ?: true
                 CoroutineScope(Dispatchers.Main).launch {
                     DeviceManager.getInstance().sgc?.setBrightness(b, auto)
                     DeviceManager.getInstance().sgc?.sendTextWall("Set brightness to $b%")
@@ -201,8 +202,8 @@ object DeviceStore {
                     DeviceManager.getInstance().sgc?.clearDisplay()
                 }
             }
-            "core" to "auto_brightness" -> {
-                val b = (store.get("core", "brightness") as? Int) ?: 50
+            "bluetooth" to "auto_brightness" -> {
+                val b = (store.get("bluetooth", "brightness") as? Int) ?: 50
                 val auto = (value as? Boolean) ?: true
                 val autoBrightnessChanged = (oldValue as? Boolean) != auto
                 CoroutineScope(Dispatchers.Main).launch {
@@ -219,27 +220,27 @@ object DeviceStore {
                     }
                 }
             }
-            "core" to "dashboard_height" -> {
+            "bluetooth" to "dashboard_height" -> {
                 scheduleDashboardHeightToGlasses()
             }
-            "core" to "dashboard_depth" -> {
+            "bluetooth" to "dashboard_depth" -> {
                 scheduleDashboardDepthToGlasses()
             }
-            "core" to "head_up_angle" -> {
+            "bluetooth" to "head_up_angle" -> {
                 (value as? Int)?.let { angle ->
                     DeviceManager.getInstance().sgc?.setHeadUpAngle(angle)
                 }
             }
-            "core" to "dashboard_menu_apps" -> {
+            "bluetooth" to "dashboard_menu_apps" -> {
                 @Suppress("UNCHECKED_CAST")
                 (value as? List<Map<String, Any>>)?.let { items ->
                     DeviceManager.getInstance().sgc?.setDashboardMenu(items)
                 }
             }
-            "core" to "gallery_mode" -> {
+            "bluetooth" to "gallery_mode" -> {
                 DeviceManager.getInstance().sgc?.sendGalleryMode()
             }
-            "core" to "screen_disabled" -> {
+            "bluetooth" to "screen_disabled" -> {
                 (value as? Boolean)?.let { disabled ->
                     if (disabled) {
                         DeviceManager.getInstance().sgc?.exit()
@@ -248,54 +249,54 @@ object DeviceStore {
                     }
                 }
             }
-            "core" to "button_mode" -> {
+            "bluetooth" to "button_mode" -> {
                 DeviceManager.getInstance().sgc?.sendButtonModeSetting()
             }
-            "core" to "button_photo_size" -> {
+            "bluetooth" to "button_photo_size" -> {
                 DeviceManager.getInstance().sgc?.sendButtonPhotoSettings()
             }
-            "core" to "button_camera_led" -> {
+            "bluetooth" to "button_camera_led" -> {
                 DeviceManager.getInstance().sgc?.sendButtonCameraLedSetting()
             }
-            "core" to "button_max_recording_time" -> {
+            "bluetooth" to "button_max_recording_time" -> {
                 DeviceManager.getInstance().sgc?.sendButtonMaxRecordingTime()
             }
-            "core" to "camera_fov" -> {
+            "bluetooth" to "camera_fov" -> {
                 DeviceManager.getInstance().sgc?.sendCameraFovSetting()
             }
-            "core" to "button_video_width",
-            "core" to "button_video_height",
-            "core" to "button_video_fps" -> {
+            "bluetooth" to "button_video_width",
+            "bluetooth" to "button_video_height",
+            "bluetooth" to "button_video_fps" -> {
                 DeviceManager.getInstance().sgc?.sendButtonVideoRecordingSettings()
             }
-            "core" to "preferred_mic" -> {
+            "bluetooth" to "preferred_mic" -> {
                 (value as? String)?.let { mic ->
-                    apply("core", "micRanking", MicMap.map[mic] ?: MicMap.map["auto"]!!)
+                    apply("bluetooth", "micRanking", MicMap.map[mic] ?: MicMap.map["auto"]!!)
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "offline_captions_running" -> {
+            "bluetooth" to "offline_captions_running" -> {
                 (value as? Boolean)?.let { running ->
                     Bridge.log("DeviceStore: offline_captions_running changed to $running")
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_pcm" -> {
+            "bluetooth" to "should_send_pcm" -> {
                 (value as? Boolean)?.let { pcm ->
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_lc3" -> {
+            "bluetooth" to "should_send_lc3" -> {
                 (value as? Boolean)?.let { lc3 ->
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_transcript" -> {
+            "bluetooth" to "should_send_transcript" -> {
                 (value as? Boolean)?.let { transcript ->
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "default_wearable" -> {
+            "bluetooth" to "default_wearable" -> {
                 (value as? String)?.let { wearable ->
                     Bridge.saveSetting("default_wearable", wearable)
                     if (wearable.contains(DeviceTypes.SIMULATED)) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ObservableStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ObservableStore.kt
@@ -4,6 +4,14 @@ import org.json.JSONObject
 
 /** Observable state management with immediate event emission */
 class ObservableStore {
+    companion object {
+        const val BLUETOOTH_CATEGORY = "bluetooth"
+        private const val LEGACY_CORE_CATEGORY = "core"
+
+        fun normalizeCategory(category: String): String =
+                if (category == LEGACY_CORE_CATEGORY) BLUETOOTH_CATEGORY else category
+    }
+
     private val values = mutableMapOf<String, Any>()
     private var onEmit: ((String, Map<String, Any>) -> Unit)? = null
 
@@ -12,7 +20,8 @@ class ObservableStore {
     }
 
     fun set(category: String, key: String, value: Any) {
-        val fullKey = "$category.$key"
+        val normalizedCategory = normalizeCategory(category)
+        val fullKey = "$normalizedCategory.$key"
         val oldValue = values[fullKey]
 
         // Skip if unchanged
@@ -21,13 +30,13 @@ class ObservableStore {
         values[fullKey] = value
 
         // Emit immediately
-        onEmit?.invoke(category, mapOf(key to value))
+        onEmit?.invoke(normalizedCategory, mapOf(key to value))
     }
 
-    fun get(category: String, key: String): Any? = values["$category.$key"]
+    fun get(category: String, key: String): Any? = values["${normalizeCategory(category)}.$key"]
 
     fun getCategory(category: String): Map<String, Any> {
-        val prefix = "$category."
+        val prefix = "${normalizeCategory(category)}."
         return values.filterKeys { it.startsWith(prefix) }.mapKeys { it.key.removePrefix(prefix) }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
@@ -353,7 +353,7 @@ class R1 : ControllerManager() {
         val connectedName = try { gatt?.device?.name } catch (e: SecurityException) { null }
         if (connectedName != null) {
             extractRingId(connectedName)?.let {
-                DeviceStore.apply("core", "controller_device_name", it)
+                DeviceStore.apply("bluetooth", "controller_device_name", it)
             }
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.java
@@ -220,7 +220,7 @@ public class G1 extends SGCManager {
         loadPairedDeviceNames();
         // goHomeHandler = new Handler();
         // this.smartGlassesDevice = smartGlassesDevice;
-        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("core", "device_name");
+        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("bluetooth", "device_name");
         this.bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         this.shouldUseGlassesMic = false;
 
@@ -700,8 +700,8 @@ public class G1 extends SGCManager {
                 queryBatteryStatusHandler.postDelayed(() -> queryBatteryStatus(), 10);
 
                 // setup brightness
-                int brightnessValue = ((Number) DeviceStore.INSTANCE.get("core", "brightness")).intValue();
-                Boolean shouldUseAutoBrightness = (Boolean) DeviceStore.INSTANCE.get("core", "auto_brightness");
+                int brightnessValue = ((Number) DeviceStore.INSTANCE.get("bluetooth", "brightness")).intValue();
+                Boolean shouldUseAutoBrightness = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "auto_brightness");
                 sendBrightnessCommandHandler
                         .postDelayed(() -> sendBrightnessCommand(brightnessValue, shouldUseAutoBrightness), 10);
 
@@ -1325,7 +1325,7 @@ public class G1 extends SGCManager {
         context.registerReceiver(bondingReceiver, filter);
         isBondingReceiverRegistered = true;
 
-        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("core", "device_name");
+        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("bluetooth", "device_name");
 
         if (!bluetoothAdapter.isEnabled()) {
             return;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1561,7 +1561,7 @@ class G2 : SGCManager() {
                                                             if (idNumber != null) {
                                                                 val deviceId = "$idNumber"
                                                                 DeviceStore.apply(
-                                                                        "core",
+                                                                        "bluetooth",
                                                                         "device_name",
                                                                         deviceId
                                                                 )

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -957,7 +957,7 @@ public class MentraLive extends SGCManager {
                 if (!isConnected && !isConnecting && !isKilled) {
                     // Prefer saved MAC for direct GATT connect (faster and more reliable than scanning).
                     // Falls back to name-based scan if no address is saved.
-                    String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("core", "device_address");
+                    String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("bluetooth", "device_address");
                     if (lastDeviceAddress != null && !lastDeviceAddress.isEmpty() && bluetoothAdapter != null) {
                         try {
                             BluetoothDevice device = bluetoothAdapter.getRemoteDevice(lastDeviceAddress);
@@ -1023,7 +1023,7 @@ public class MentraLive extends SGCManager {
                     DeviceStore.INSTANCE.apply("glasses", "bluetoothName", connectedDevice.getName());
                     // Persist MAC so reconnection can use direct GATT instead of scanning
                     if (connectedDevice.getAddress() != null) {
-                        DeviceStore.INSTANCE.apply("core", "device_address", connectedDevice.getAddress());
+                        DeviceStore.INSTANCE.apply("bluetooth", "device_address", connectedDevice.getAddress());
                     }
 
                     // Save the connected device name for future reconnections
@@ -3147,7 +3147,7 @@ public class MentraLive extends SGCManager {
      * Send stored user email to the ASG client for Sentry crash reporting
      */
     private void sendStoredUserEmailToAsgClient() {
-        Object emailObj = DeviceStore.INSTANCE.get("core", "auth_email");
+        Object emailObj = DeviceStore.INSTANCE.get("bluetooth", "auth_email");
         String storedEmail = emailObj instanceof String ? (String) emailObj : "";
 
         if (storedEmail == null || storedEmail.isEmpty()) {
@@ -3364,7 +3364,7 @@ public class MentraLive extends SGCManager {
 
     @Override
     public void sendGalleryMode() {
-        boolean active = (Boolean) DeviceStore.INSTANCE.get("core", "gallery_mode");
+        boolean active = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "gallery_mode");
         Bridge.log("LIVE: 📸 Sending gallery mode active to glasses: " + active);
         try {
             JSONObject json = new JSONObject();
@@ -3696,7 +3696,7 @@ public class MentraLive extends SGCManager {
         // var context = Bridge.getContext();
         // SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         // String lastDeviceAddress = prefs.getString(PREF_DEVICE_NAME, null);
-        String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("core", "device_address");
+        String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("bluetooth", "device_address");
 
         if (lastDeviceAddress != null && lastDeviceAddress.length() > 0) {
             // Connect to last known device if available
@@ -4436,7 +4436,7 @@ public class MentraLive extends SGCManager {
     @Override
     public void sendButtonVideoRecordingSettings() {
         try {
-            Object videoSettingsObj = DeviceStore.INSTANCE.get("core", "button_video_settings");
+            Object videoSettingsObj = DeviceStore.INSTANCE.get("bluetooth", "button_video_settings");
             int videoWidth = 1920;  // defaults
             int videoHeight = 1080;
             int videoFps = 30;
@@ -6039,7 +6039,7 @@ public class MentraLive extends SGCManager {
      * SharedPreferences for backward compatibility.
      */
     private String getCoreToken() {
-        Object fromStore = DeviceStore.INSTANCE.get("core", "core_token");
+        Object fromStore = DeviceStore.INSTANCE.get("bluetooth", "core_token");
         if (fromStore instanceof String) {
             String token = (String) fromStore;
             if (token != null && !token.isEmpty()) {
@@ -6102,7 +6102,7 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        String mode = (String) DeviceStore.INSTANCE.get("core", "button_mode");
+        String mode = (String) DeviceStore.INSTANCE.get("bluetooth", "button_mode");
 
         try {
             JSONObject json = new JSONObject();
@@ -6217,7 +6217,7 @@ public class MentraLive extends SGCManager {
      * Send button photo settings to glasses
      */
     public void sendButtonPhotoSettings() {
-        String size = (String) DeviceStore.INSTANCE.get("core", "button_photo_size");
+        String size = (String) DeviceStore.INSTANCE.get("bluetooth", "button_photo_size");
 
         Bridge.log("LIVE: Sending button photo setting: " + size);
 
@@ -6241,7 +6241,7 @@ public class MentraLive extends SGCManager {
      */
     @Override
     public void sendButtonCameraLedSetting() {
-        boolean enabled = (Boolean) DeviceStore.INSTANCE.get("core", "button_camera_led");
+        boolean enabled = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "button_camera_led");
 
         Bridge.log("LIVE: Sending button camera LED setting: " + enabled);
 
@@ -6268,7 +6268,7 @@ public class MentraLive extends SGCManager {
         int fov = 118;
         int roiPosition = 0;
         try {
-            Object raw = DeviceStore.INSTANCE.get("core", "camera_fov");
+            Object raw = DeviceStore.INSTANCE.get("bluetooth", "camera_fov");
             if (raw instanceof java.util.Map) {
                 @SuppressWarnings("unchecked")
                 java.util.Map<String, Object> map = (java.util.Map<String, Object>) raw;
@@ -6314,7 +6314,7 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        int minutes = (Integer) DeviceStore.INSTANCE.get("core", "button_max_recording_time");
+        int minutes = (Integer) DeviceStore.INSTANCE.get("bluetooth", "button_max_recording_time");
 
         try {
             JSONObject json = new JSONObject();

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -51,13 +51,13 @@ abstract class SGCManager {
 
     /** Default: full [setDashboardPosition] (e.g. G1 single command). Nex overrides to height protobuf only. */
     open fun setDashboardHeightOnly(height: Int) {
-        val depth = (DeviceStore.store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
+        val depth = (DeviceStore.store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
         setDashboardPosition(height, depth)
     }
 
     /** Default: full [setDashboardPosition]. Nex overrides to display_distance only. */
     open fun setDashboardDepthOnly(depth: Int) {
-        val height = (DeviceStore.store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
+        val height = (DeviceStore.store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
         setDashboardPosition(height, depth)
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -57,10 +57,10 @@ public class BluetoothSdkModule: Module {
             // Configure observable store event emission
             Task { @MainActor [weak self] in
                 DeviceStore.shared.store.configure { [weak self] category, changes in
-                    switch category {
+                    switch ObservableStore.normalizeCategory(category) {
                     case "glasses":
                         self?.sendEvent("glasses_status", changes)
-                    case "core":
+                    case ObservableStore.bluetoothCategory:
                         self?.sendEvent("bluetooth_status", changes)
                     default:
                         break
@@ -79,14 +79,15 @@ public class BluetoothSdkModule: Module {
 
         AsyncFunction("getBluetoothStatus") {
             await MainActor.run {
-                DeviceStore.shared.store.getCategory("core")
+                DeviceStore.shared.store.getCategory(ObservableStore.bluetoothCategory)
             }
         }
 
         AsyncFunction("update") { (category: String, values: [String: Any]) in
             await MainActor.run {
+                let normalizedCategory = ObservableStore.normalizeCategory(category)
                 for (key, value) in values {
-                    DeviceStore.shared.apply(category, key, value)
+                    DeviceStore.shared.apply(normalizedCategory, key, value)
                 }
             }
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -81,7 +81,7 @@ class Bridge {
     static func sendDiscoveredDevice(_ deviceModel: String, _ deviceName: String) {
         Task {
             await MainActor.run {
-                let searchResults = DeviceStore.shared.get("core", "searchResults") as? [[String: Any]] ?? []
+                let searchResults = DeviceStore.shared.get("bluetooth", "searchResults") as? [[String: Any]] ?? []
                 let newResult: [String: Any] = [
                     "deviceModel": deviceModel,
                     "deviceName": deviceName,
@@ -92,7 +92,7 @@ class Bridge {
                     guard let name = $0["deviceName"] as? String else { return false }
                     return seen.insert(name).inserted
                 }.reversed()
-                DeviceStore.shared.set("core", "searchResults", Array(uniqueResults))
+                DeviceStore.shared.set("bluetooth", "searchResults", Array(uniqueResults))
             }
         }
     }
@@ -215,7 +215,7 @@ class Bridge {
         Task {
             await MainActor.run {
                 var storedNetworks: [[String: Any]] =
-                    DeviceStore.shared.get("core", "wifiScanResults") as? [[String: Any]] ?? []
+                    DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
                 // add the networks to the storedNetworks array, removing duplicates by ssid
                 for network in networks {
                     if !storedNetworks.contains(where: {
@@ -224,7 +224,7 @@ class Bridge {
                         storedNetworks.append(network)
                     }
                 }
-                DeviceStore.shared.apply("core", "wifiScanResults", storedNetworks)
+                DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
             }
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -104,110 +104,110 @@ struct ViewState {
 
     /// settings:
     private var defaultWearable: String {
-        get { DeviceStore.shared.get("core", "default_wearable") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "default_wearable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "default_wearable") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "default_wearable", newValue) }
     }
 
     private var pendingWearable: String {
-        get { DeviceStore.shared.get("core", "pending_wearable") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "pending_wearable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "pending_wearable") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "pending_wearable", newValue) }
     }
 
     private var deviceName: String {
-        get { DeviceStore.shared.get("core", "device_name") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "device_name", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "device_name") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "device_name", newValue) }
     }
 
     private var deviceAddress: String {
-        get { DeviceStore.shared.get("core", "device_address") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "device_address", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "device_address") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "device_address", newValue) }
     }
 
     private var defaultController: String {
-        get { DeviceStore.shared.get("core", "default_controller") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "default_controller", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "default_controller") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "default_controller", newValue) }
     }
 
     private var pendingController: String {
-        get { DeviceStore.shared.get("core", "pending_controller") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "pending_controller", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "pending_controller") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "pending_controller", newValue) }
     }
 
     private var controllerDeviceName: String {
-        get { DeviceStore.shared.get("core", "controller_device_name") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "controller_device_name", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "controller_device_name") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "controller_device_name", newValue) }
     }
 
     private var screenDisabled: Bool {
-        get { DeviceStore.shared.get("core", "screen_disabled") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "screen_disabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "screen_disabled") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "screen_disabled", newValue) }
     }
 
     private var preferredMic: String {
-        get { DeviceStore.shared.get("core", "preferred_mic") as? String ?? "auto" }
-        set { DeviceStore.shared.apply("core", "preferred_mic", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "preferred_mic") as? String ?? "auto" }
+        set { DeviceStore.shared.apply("bluetooth", "preferred_mic", newValue) }
     }
 
     private var autoBrightness: Bool {
-        get { DeviceStore.shared.get("core", "auto_brightness") as? Bool ?? true }
-        set { DeviceStore.shared.apply("core", "auto_brightness", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "auto_brightness") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "auto_brightness", newValue) }
     }
 
     private var brightness: Int {
-        get { DeviceStore.shared.get("core", "brightness") as? Int ?? 50 }
-        set { DeviceStore.shared.apply("core", "brightness", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "brightness") as? Int ?? 50 }
+        set { DeviceStore.shared.apply("bluetooth", "brightness", newValue) }
     }
 
     private var headUpAngle: Int {
-        get { DeviceStore.shared.get("core", "head_up_angle") as? Int ?? 30 }
-        set { DeviceStore.shared.apply("core", "head_up_angle", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "head_up_angle") as? Int ?? 30 }
+        set { DeviceStore.shared.apply("bluetooth", "head_up_angle", newValue) }
     }
 
     private var sensingEnabled: Bool {
-        get { DeviceStore.shared.get("core", "sensing_enabled") as? Bool ?? true }
-        set { DeviceStore.shared.apply("core", "sensing_enabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "sensing_enabled") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "sensing_enabled", newValue) }
     }
 
     private var bypassVad: Bool {
-        get { DeviceStore.shared.get("core", "bypass_vad") as? Bool ?? true }
-        set { DeviceStore.shared.apply("core", "bypass_vad", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "bypass_vad") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "bypass_vad", newValue) }
     }
 
     private var offlineCaptionsRunning: Bool {
-        get { DeviceStore.shared.get("core", "offline_captions_running") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "offline_captions_running", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "offline_captions_running") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "offline_captions_running", newValue) }
     }
 
     private var shouldSendPcm: Bool {
-        get { DeviceStore.shared.get("core", "should_send_pcm") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "should_send_pcm", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_pcm") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_pcm", newValue) }
     }
 
     private var shouldSendLc3: Bool {
-        get { DeviceStore.shared.get("core", "should_send_lc3") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "should_send_lc3", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_lc3") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_lc3", newValue) }
     }
 
     private var shouldSendTranscript: Bool {
-        get { DeviceStore.shared.get("core", "should_send_transcript") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "should_send_transcript", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_transcript") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_transcript", newValue) }
     }
 
     private var contextualDashboard: Bool {
-        get { DeviceStore.shared.get("core", "contextual_dashboard") as? Bool ?? true }
-        set { DeviceStore.shared.apply("core", "contextual_dashboard", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "contextual_dashboard") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "contextual_dashboard", newValue) }
     }
 
     // state:
 
     private var searching: Bool {
-        get { DeviceStore.shared.get("core", "searching") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "searching", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searching") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "searching", newValue) }
     }
 
     private var searchingController: Bool {
-        get { DeviceStore.shared.get("core", "searchingController") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "searchingController", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searchingController") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "searchingController", newValue) }
     }
 
     private var glassesBtcConnected: Bool {
@@ -217,19 +217,19 @@ struct ViewState {
 
     private var micRanking: [String] {
         get {
-            DeviceStore.shared.get("core", "micRanking") as? [String] ?? MicMap.map["auto"]!
+            DeviceStore.shared.get("bluetooth", "micRanking") as? [String] ?? MicMap.map["auto"]!
         }
-        set { DeviceStore.shared.apply("core", "micRanking", newValue) }
+        set { DeviceStore.shared.apply("bluetooth", "micRanking", newValue) }
     }
 
     private var shouldSendBootingMessage: Bool {
-        get { DeviceStore.shared.get("core", "shouldSendBootingMessage") as? Bool ?? true }
-        set { DeviceStore.shared.apply("core", "shouldSendBootingMessage", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "shouldSendBootingMessage") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "shouldSendBootingMessage", newValue) }
     }
 
     private var systemMicUnavailable: Bool {
-        get { DeviceStore.shared.get("core", "systemMicUnavailable") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "systemMicUnavailable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "systemMicUnavailable") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "systemMicUnavailable", newValue) }
     }
 
     private var headUp: Bool {
@@ -238,33 +238,33 @@ struct ViewState {
     }
 
     private var micEnabled: Bool {
-        get { DeviceStore.shared.get("core", "micEnabled") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "micEnabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "micEnabled") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "micEnabled", newValue) }
     }
 
     private var currentMic: String {
-        get { DeviceStore.shared.get("core", "currentMic") as? String ?? "" }
-        set { DeviceStore.shared.apply("core", "currentMic", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "currentMic") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "currentMic", newValue) }
     }
 
     private var searchResults: [[String: Any]] {
-        get { DeviceStore.shared.get("core", "searchResults") as? [[String: Any]] ?? [] }
-        set { DeviceStore.shared.apply("core", "searchResults", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searchResults") as? [[String: Any]] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "searchResults", newValue) }
     }
 
     private var wifiScanResults: [[String: Any]] {
-        get { DeviceStore.shared.get("core", "wifiScanResults") as? [[String: Any]] ?? [] }
-        set { DeviceStore.shared.apply("core", "wifiScanResults", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "wifiScanResults", newValue) }
     }
 
     private var lastLog: [String] {
-        get { DeviceStore.shared.get("core", "lastLog") as? [String] ?? [] }
-        set { DeviceStore.shared.apply("core", "lastLog", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "lastLog") as? [String] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "lastLog", newValue) }
     }
 
     private var otherBtConnected: Bool {
-        get { DeviceStore.shared.get("core", "otherBtConnected") as? Bool ?? false }
-        set { DeviceStore.shared.apply("core", "otherBtConnected", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "otherBtConnected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "otherBtConnected", newValue) }
     }
 
     /// LC3 Audio Encoding
@@ -357,7 +357,7 @@ struct ViewState {
             Bridge.log("MAN: ERROR - LC3 converter not initialized but format is LC3")
             return
         }
-        let frameSize = DeviceStore.shared.get("core", "lc3_frame_size") as! Int
+        let frameSize = DeviceStore.shared.get("bluetooth", "lc3_frame_size") as! Int
         let lc3Data = lc3Converter.encode(pcmData, frameSize: frameSize) as Data
         guard lc3Data.count > 0 else {
             Bridge.log("MAN: ERROR - LC3 encoding returned empty data")
@@ -929,9 +929,9 @@ struct ViewState {
         Bridge.saveSetting("device_address", deviceAddress)
 
         // Re-apply display height after reconnection
-        let h = DeviceStore.shared.get("core", "dashboard_height") as? Int ?? 4
+        let h = DeviceStore.shared.get("bluetooth", "dashboard_height") as? Int ?? 4
         let d = NexDashboardDisplayWire.clampDepthFromStore(
-            DeviceStore.shared.get("core", "dashboard_depth")
+            DeviceStore.shared.get("bluetooth", "dashboard_depth")
         )
         sgc.setDashboardPosition(h, d)
     }
@@ -1103,7 +1103,7 @@ struct ViewState {
 
     func requestWifiScan() {
         Bridge.log("MAN: Requesting wifi scan")
-        DeviceStore.shared.apply("core", "wifiScanResults", [])
+        DeviceStore.shared.apply("bluetooth", "wifiScanResults", [])
         sgc?.requestWifiScan()
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -53,49 +53,49 @@ class DeviceStore {
         store.set("glasses", "ringSignalStrength", -1)
 
         // BLUETOOTH SDK STATE:
-        store.set("core", "systemMicUnavailable", false)
-        store.set("core", "searching", false)
-        store.set("core", "searchingController", false)
-        store.set("core", "micEnabled", false)
-        store.set("core", "currentMic", "")
-        store.set("core", "searchResults", [])
-        store.set("core", "wifiScanResults", [])
-        store.set("core", "micRanking", MicMap.map["auto"]!)
-        store.set("core", "lastLog", [])
-        store.set("core", "otherBtConnected", false)
+        store.set("bluetooth", "systemMicUnavailable", false)
+        store.set("bluetooth", "searching", false)
+        store.set("bluetooth", "searchingController", false)
+        store.set("bluetooth", "micEnabled", false)
+        store.set("bluetooth", "currentMic", "")
+        store.set("bluetooth", "searchResults", [])
+        store.set("bluetooth", "wifiScanResults", [])
+        store.set("bluetooth", "micRanking", MicMap.map["auto"]!)
+        store.set("bluetooth", "lastLog", [])
+        store.set("bluetooth", "otherBtConnected", false)
 
-        // CORE SETTINGS:
-        store.set("core", "default_wearable", "")
-        store.set("core", "pending_wearable", "")
-        store.set("core", "device_name", "")
-        store.set("core", "device_address", "")
-        store.set("core", "screen_disabled", false)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "sensing_enabled", true)
-        store.set("core", "brightness", 50)
-        store.set("core", "auto_brightness", true)
-        store.set("core", "dashboard_height", 4)
-        store.set("core", "dashboard_depth", 2)
-        store.set("core", "head_up_angle", 30)
-        store.set("core", "contextual_dashboard", true)
-        store.set("core", "gallery_mode", false)
-        store.set("core", "screen_disabled", false)
-        store.set("core", "button_mode", "photo")
-        store.set("core", "button_photo_size", "medium")
-        store.set("core", "button_camera_led", true)
-        store.set("core", "button_max_recording_time", 10)
-        store.set("core", "camera_fov", ["fov": 118, "roi_position": 0])
-        store.set("core", "button_video_width", 1280)
-        store.set("core", "button_video_height", 720)
-        store.set("core", "button_video_fps", 30)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "lc3_frame_size", 60)
-        store.set("core", "auth_email", "")
-        store.set("core", "core_token", "")
-        store.set("core", "should_send_pcm", false)
-        store.set("core", "should_send_lc3", false)
-        store.set("core", "should_send_transcript", false)
-        store.set("core", "bypass_vad", false)
+        // BLUETOOTH SETTINGS:
+        store.set("bluetooth", "default_wearable", "")
+        store.set("bluetooth", "pending_wearable", "")
+        store.set("bluetooth", "device_name", "")
+        store.set("bluetooth", "device_address", "")
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "sensing_enabled", true)
+        store.set("bluetooth", "brightness", 50)
+        store.set("bluetooth", "auto_brightness", true)
+        store.set("bluetooth", "dashboard_height", 4)
+        store.set("bluetooth", "dashboard_depth", 2)
+        store.set("bluetooth", "head_up_angle", 30)
+        store.set("bluetooth", "contextual_dashboard", true)
+        store.set("bluetooth", "gallery_mode", false)
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "button_mode", "photo")
+        store.set("bluetooth", "button_photo_size", "medium")
+        store.set("bluetooth", "button_camera_led", true)
+        store.set("bluetooth", "button_max_recording_time", 10)
+        store.set("bluetooth", "camera_fov", ["fov": 118, "roi_position": 0])
+        store.set("bluetooth", "button_video_width", 1280)
+        store.set("bluetooth", "button_video_height", 720)
+        store.set("bluetooth", "button_video_fps", 30)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "lc3_frame_size", 60)
+        store.set("bluetooth", "auth_email", "")
+        store.set("bluetooth", "core_token", "")
+        store.set("bluetooth", "should_send_pcm", false)
+        store.set("bluetooth", "should_send_lc3", false)
+        store.set("bluetooth", "should_send_transcript", false)
+        store.set("bluetooth", "bypass_vad", false)
     }
 
     func get(_ category: String, _ key: String) -> Any? {
@@ -110,7 +110,7 @@ class DeviceStore {
         dashboardHeightDebounceTask?.cancel()
         dashboardHeightDebounceTask = Task { @MainActor in
             try? await Task.yield()
-            let h = store.get("core", "dashboard_height") as? Int ?? 4
+            let h = store.get("bluetooth", "dashboard_height") as? Int ?? 4
             DeviceManager.shared.sgc?.setDashboardHeightOnly(h)
         }
     }
@@ -119,18 +119,19 @@ class DeviceStore {
         dashboardDepthDebounceTask?.cancel()
         dashboardDepthDebounceTask = Task { @MainActor in
             try? await Task.yield()
-            let d = store.get("core", "dashboard_depth") as? Int ?? 2
+            let d = store.get("bluetooth", "dashboard_depth") as? Int ?? 2
             DeviceManager.shared.sgc?.setDashboardDepthOnly(d)
         }
     }
 
     /// Apply changes with side effects
     func apply(_ category: String, _ key: String, _ value: Any) {
-        let oldValue = store.get(category, key)
-        store.set(category, key, value)
+        let normalizedCategory = ObservableStore.normalizeCategory(category)
+        let oldValue = store.get(normalizedCategory, key)
+        store.set(normalizedCategory, key, value)
 
         // Trigger hardware updates based on setting changes
-        switch (category, key) {
+        switch (normalizedCategory, key) {
         case ("glasses", "fullyBooted"):
             Bridge.log("STORE: Glasses fullyBooted changed to \(value)")
             // skip if the value is the same as the old value:
@@ -170,11 +171,11 @@ class DeviceStore {
                 Bridge.sendHeadUp(headUp)
             }
 
-        // CORE:
+        // BLUETOOTH:
 
-        case ("core", "brightness"):
+        case ("bluetooth", "brightness"):
             let b = value as? Int ?? 50
-            let auto = store.get("core", "auto_brightness") as? Bool ?? true
+            let auto = store.get("bluetooth", "auto_brightness") as? Bool ?? true
             Task {
                 DeviceManager.shared.sgc?.setBrightness(b, autoMode: auto)
                 DeviceManager.shared.sgc?.sendTextWall("Set brightness to \(b)%")
@@ -182,8 +183,8 @@ class DeviceStore {
                 DeviceManager.shared.sgc?.clearDisplay()
             }
 
-        case ("core", "auto_brightness"):
-            let b = store.get("core", "brightness") as? Int ?? 50
+        case ("bluetooth", "auto_brightness"):
+            let b = store.get("bluetooth", "brightness") as? Int ?? 50
             let auto = value as? Bool ?? true
             let autoBrightnessChanged = (oldValue as? Bool) != auto
             Task {
@@ -197,26 +198,26 @@ class DeviceStore {
                 }
             }
 
-        case ("core", "dashboard_height"):
+        case ("bluetooth", "dashboard_height"):
             scheduleDashboardHeightToGlasses()
 
-        case ("core", "dashboard_depth"):
+        case ("bluetooth", "dashboard_depth"):
             scheduleDashboardDepthToGlasses()
 
-        case ("core", "head_up_angle"):
+        case ("bluetooth", "head_up_angle"):
             if let angle = value as? Int {
                 DeviceManager.shared.sgc?.setHeadUpAngle(angle)
             }
 
-        case ("core", "dashboard_menu_apps"):
+        case ("bluetooth", "dashboard_menu_apps"):
             if let items = value as? [[String: Any]] {
                 DeviceManager.shared.sgc?.setDashboardMenu(items)
             }
 
-        case ("core", "gallery_mode"):
+        case ("bluetooth", "gallery_mode"):
             DeviceManager.shared.sgc?.sendGalleryMode()
 
-        case ("core", "screen_disabled"):
+        case ("bluetooth", "screen_disabled"):
             if let disabled = value as? Bool {
                 if disabled {
                     DeviceManager.shared.sgc?.exit()
@@ -225,52 +226,52 @@ class DeviceStore {
                 }
             }
 
-        case ("core", "button_mode"):
+        case ("bluetooth", "button_mode"):
             DeviceManager.shared.sgc?.sendButtonModeSetting()
 
-        case ("core", "button_photo_size"):
+        case ("bluetooth", "button_photo_size"):
             DeviceManager.shared.sgc?.sendButtonPhotoSettings()
 
-        case ("core", "button_camera_led"):
+        case ("bluetooth", "button_camera_led"):
             DeviceManager.shared.sgc?.sendButtonCameraLedSetting()
 
-        case ("core", "button_max_recording_time"):
+        case ("bluetooth", "button_max_recording_time"):
             DeviceManager.shared.sgc?.sendButtonMaxRecordingTime()
 
-        case ("core", "camera_fov"):
+        case ("bluetooth", "camera_fov"):
             DeviceManager.shared.sgc?.sendCameraFovSetting()
 
-        case ("core", "button_video_width"), ("core", "button_video_height"),
-             ("core", "button_video_fps"):
+        case ("bluetooth", "button_video_width"), ("bluetooth", "button_video_height"),
+             ("bluetooth", "button_video_fps"):
             DeviceManager.shared.sgc?.sendButtonVideoRecordingSettings()
 
-        case ("core", "preferred_mic"):
+        case ("bluetooth", "preferred_mic"):
             if let mic = value as? String {
-                apply("core", "micRanking", MicMap.map[mic] ?? MicMap.map["auto"]!)
+                apply("bluetooth", "micRanking", MicMap.map[mic] ?? MicMap.map["auto"]!)
                 DeviceManager.shared.setMicState()
             }
 
-        case ("core", "offline_captions_running"):
+        case ("bluetooth", "offline_captions_running"):
             if let running = value as? Bool {
                 DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_pcm"):
+        case ("bluetooth", "should_send_pcm"):
             if let pcm = value as? Bool {
                 DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_lc3"):
+        case ("bluetooth", "should_send_lc3"):
             if let lc3 = value as? Bool {
                 DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_transcript"):
+        case ("bluetooth", "should_send_transcript"):
             if let transcript = value as? Bool {
                 DeviceManager.shared.setMicState()
             }
 
-        case ("core", "default_wearable"):
+        case ("bluetooth", "default_wearable"):
             if let wearable = value as? String {
                 Bridge.saveSetting("default_wearable", wearable)
                 if wearable == DeviceTypes.SIMULATED {
@@ -278,7 +279,7 @@ class DeviceStore {
                 }
             }
 
-        case ("core", "device_name"):
+        case ("bluetooth", "device_name"):
             if let name = value as? String {
                 DeviceManager.shared.checkCurrentAudioDevice()
                 // listen for when the audio device is paired and connected

--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -9,6 +9,13 @@ import Foundation
 
 @MainActor
 class ObservableStore {
+    nonisolated static let bluetoothCategory = "bluetooth"
+    private nonisolated static let legacyCoreCategory = "core"
+
+    nonisolated static func normalizeCategory(_ category: String) -> String {
+        category == legacyCoreCategory ? bluetoothCategory : category
+    }
+
     private nonisolated(unsafe) var values: [String: Any] = [:]
     private var onEmit: ((String, [String: Any]) -> Void)?
 
@@ -17,7 +24,8 @@ class ObservableStore {
     }
 
     func set(_ category: String, _ key: String, _ value: Any) {
-        let fullKey = "\(category).\(key)"
+        let normalizedCategory = Self.normalizeCategory(category)
+        let fullKey = "\(normalizedCategory).\(key)"
         let oldValue = values[fullKey]
 
         // Skip if unchanged
@@ -28,16 +36,16 @@ class ObservableStore {
         values[fullKey] = value
 
         // Emit immediately
-        onEmit?(category, [key: value])
+        onEmit?(normalizedCategory, [key: value])
     }
 
     nonisolated func get(_ category: String, _ key: String) -> Any? {
-        values["\(category).\(key)"]
+        values["\(Self.normalizeCategory(category)).\(key)"]
     }
 
     func getCategory(_ category: String) -> [String: Any] {
         var result: [String: Any] = [:]
-        let prefix = "\(category)."
+        let prefix = "\(Self.normalizeCategory(category))."
         for (key, value) in values where key.hasPrefix(prefix) {
             let shortKey = String(key.dropFirst(prefix.count))
             result[shortKey] = value

--- a/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
@@ -263,7 +263,7 @@ class R1: NSObject, ControllerManager {
         Bridge.log("R1: Ring ready")
 
         if let name = ringPeripheral?.name, let id = extractRingId(name) {
-            DeviceStore.shared.apply("core", "controller_device_name", id)
+            DeviceStore.shared.apply("bluetooth", "controller_device_name", id)
         }
 
         // TODO: uncomment

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1433,7 +1433,7 @@ class G2: NSObject, SGCManager {
                             let idNumber = self.extractIdNumber(peripheralName)
                         {
                             let deviceId = "\(idNumber)"
-                            DeviceStore.shared.apply("core", "device_name", deviceId)
+                            DeviceStore.shared.apply("bluetooth", "device_name", deviceId)
                             Bridge.log("G2: Set device_name to \(deviceId)")
                         }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -624,7 +624,7 @@ extension MentraLive: CBCentralManagerDelegate {
             DeviceStore.shared.apply("glasses", "bluetoothName", name)
         }
         // Persist peripheral UUID so DeviceManager can sync it to RN settings
-        DeviceStore.shared.apply("core", "device_address", peripheral.identifier.uuidString)
+        DeviceStore.shared.apply("bluetooth", "device_address", peripheral.identifier.uuidString)
 
         // Audio Pairing: Setup Bluetooth audio after BLE connection
         if let deviceName = peripheral.name {
@@ -2338,7 +2338,7 @@ class MentraLive: NSObject, SGCManager {
     }
 
     func sendGalleryMode() {
-        let active = DeviceStore.shared.get("core", "gallery_mode") as! Bool
+        let active = DeviceStore.shared.get("bluetooth", "gallery_mode") as! Bool
         Bridge.log("LIVE: 📸 Sending gallery mode active to glasses: \(active)")
 
         let json: [String: Any] = [
@@ -2935,7 +2935,7 @@ class MentraLive: NSObject, SGCManager {
     private func uploadBleIncidentLogRelay(
         relay: BleIncidentLogRelayEntry, fileName: String, data: Data
     ) {
-        let token = DeviceStore.shared.get("core", "core_token") as? String ?? ""
+        let token = DeviceStore.shared.get("bluetooth", "core_token") as? String ?? ""
         guard !token.isEmpty else {
             sendTransferCompleteConfirmation(fileName: fileName, success: false)
             if let existing = bleIncidentLogRelays[relay.fileBaseKey] {
@@ -3140,7 +3140,7 @@ class MentraLive: NSObject, SGCManager {
     private func sendCoreTokenToAsgClient() {
         Bridge.log("Preparing to send coreToken to ASG client")
 
-        let coreToken = DeviceStore.shared.get("core", "core_token") as? String ?? ""
+        let coreToken = DeviceStore.shared.get("bluetooth", "core_token") as? String ?? ""
         if coreToken.isEmpty {
             Bridge.log("LIVE: No coreToken available to send to ASG client")
             return
@@ -3157,7 +3157,7 @@ class MentraLive: NSObject, SGCManager {
 
     /// Send stored user email to the ASG client for Sentry crash reporting
     private func sendStoredUserEmailToAsgClient() {
-        let storedEmail = DeviceStore.shared.store.get("core", "auth_email") as? String ?? ""
+        let storedEmail = DeviceStore.shared.store.get("bluetooth", "auth_email") as? String ?? ""
 
         guard !storedEmail.isEmpty else {
             Bridge.log("LIVE: No stored user email to send to ASG client")
@@ -4300,7 +4300,7 @@ extension MentraLive {
     // MARK: - Button Mode Settings
 
     func sendButtonModeSetting() {
-        let mode = DeviceStore.shared.get("core", "button_mode") as! String
+        let mode = DeviceStore.shared.get("bluetooth", "button_mode") as! String
         Bridge.log("Sending button mode setting to glasses: \(mode)")
 
         guard connectionState == ConnTypes.CONNECTED else {
@@ -4371,7 +4371,7 @@ extension MentraLive {
         sendButtonVideoRecordingSettings()
 
         // Send button max recording time
-        let maxTime = DeviceStore.shared.get("core", "button_max_recording_time") as! Int
+        let maxTime = DeviceStore.shared.get("bluetooth", "button_max_recording_time") as! Int
         sendButtonMaxRecordingTime(maxTime)
 
         // Send button photo settings
@@ -4389,7 +4389,7 @@ extension MentraLive {
 
     func sendButtonVideoRecordingSettings() {
         let settings =
-            DeviceStore.shared.get("core", "button_video_settings") as? [String: Any] ?? [
+            DeviceStore.shared.get("bluetooth", "button_video_settings") as? [String: Any] ?? [
                 "width": 1280,
                 "height": 720,
                 "fps": 30,
@@ -4424,7 +4424,7 @@ extension MentraLive {
     }
 
     func sendButtonMaxRecordingTime() {
-        let maxTime = DeviceStore.shared.get("core", "button_max_recording_time") as? Int ?? 10
+        let maxTime = DeviceStore.shared.get("bluetooth", "button_max_recording_time") as? Int ?? 10
         Bridge.log("Sending button max recording time: \(maxTime) minutes")
 
         guard connectionState == ConnTypes.CONNECTED else {
@@ -4440,7 +4440,7 @@ extension MentraLive {
     }
 
     func sendButtonPhotoSettings() {
-        let size = DeviceStore.shared.get("core", "button_photo_size") as! String
+        let size = DeviceStore.shared.get("bluetooth", "button_photo_size") as! String
 
         Bridge.log("Sending button photo setting: \(size)")
 
@@ -4457,7 +4457,7 @@ extension MentraLive {
     }
 
     func sendButtonCameraLedSetting() {
-        let enabled = DeviceStore.shared.get("core", "button_camera_led") as! Bool
+        let enabled = DeviceStore.shared.get("bluetooth", "button_camera_led") as! Bool
 
         Bridge.log("Sending button camera LED setting: \(enabled)")
 
@@ -4474,7 +4474,7 @@ extension MentraLive {
     }
 
     func sendCameraFovSetting() {
-        let settings = DeviceStore.shared.get("core", "camera_fov") as? [String: Any] ?? ["fov": 118, "roi_position": 0]
+        let settings = DeviceStore.shared.get("bluetooth", "camera_fov") as? [String: Any] ?? ["fov": 118, "roi_position": 0]
         let fov = settings["fov"] as? Int ?? 118
         let roiPosition = settings["roi_position"] as? Int ?? 0
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -116,12 +116,12 @@ extension SGCManager {
     // MARK: - Dashboard (default: combined wire format; Nex implements single-field)
 
     func setDashboardHeightOnly(_ height: Int) {
-        let d = DeviceStore.shared.get("core", "dashboard_depth") as? Int ?? 2
+        let d = DeviceStore.shared.get("bluetooth", "dashboard_depth") as? Int ?? 2
         setDashboardPosition(height, d)
     }
 
     func setDashboardDepthOnly(_ depth: Int) {
-        let h = DeviceStore.shared.get("core", "dashboard_height") as? Int ?? 4
+        let h = DeviceStore.shared.get("bluetooth", "dashboard_height") as? Int ?? 4
         setDashboardPosition(h, depth)
     }
 

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
@@ -127,7 +127,7 @@ NativeBluetoothSdkModule.updateGlasses = function (values: Partial<GlassesStatus
 }
 
 NativeBluetoothSdkModule.updateBluetoothSettings = function (values: Record<string, any>) {
-  return this.update("core", values)
+  return this.update("bluetooth", values)
 }
 
 NativeBluetoothSdkModule.onGlassesStatus = function (callback: GlassesListener) {


### PR DESCRIPTION
- Renames the internal native store category from "core" to "bluetooth".
- Keeps "core" as a native legacy alias to avoid silently splitting state for any lingering low-level callers.