### PR TITLE
Mentra bluetooth sdk phase 5

### DIFF
--- a/docs/mentra-bluetooth-sdk-plan.md
+++ b/docs/mentra-bluetooth-sdk-plan.md
@@ -733,61 +733,58 @@ Bluetooth SDK and Crust versions will be kept in sync for simplicity. When eithe
 
 ## Phase 5: Documentation
 
-### 5.1 README for Bluetooth SDK
+Phase 5 documentation should be split by audience:
 
-```markdown
-# Mentra Bluetooth SDK
+- The public package README stays intentionally thin: install, minimal usage, and partner support pointer.
+- Detailed getting started material, API reference, production checklist, troubleshooting, and example apps live in a new private partner repo so they can be bundled with partner/commercial SDK access.
 
-SDK for communicating with smart glasses.
+Private repo name: `Mentra-Bluetooth-SDK-Partner-Kit`.
 
-## Installation
+### 5.1 Public README for Bluetooth SDK
 
-### React Native / Expo
+The npm/package README should not become the full customer playbook. Keep it short:
 
-npm install @mentra/bluetooth-sdk
+- Package purpose
+- Development-build requirement
+- Install commands
+- Minimal connect/display snippet
+- Pointer to private partner docs for full onboarding and support
 
-### Android (Maven)
+### 5.2 Private Partner Documentation Repo
 
-implementation 'com.mentra:bluetooth-sdk:1.0.0'
+Initial contents:
 
-### iOS (CocoaPods)
+- `README.md`
+- `docs/getting-started.md`
+- `docs/api-reference.md`
+- `docs/display-guide.md`
+- `docs/audio-guide.md`
+- `docs/hardware-integration.md`
+- `docs/troubleshooting.md`
+- `docs/production-checklist.md`
+- `examples/react-native`
 
-pod 'MentraBluetoothSDK'
+The private repo should be the customer-facing source of truth for:
 
-## Quick Start
+- React Native / Expo setup
+- Device scanning/discovery
+- Connection management
+- Display text/images
+- Audio streaming and local transcription
+- Button/gesture/head-up events
+- Camera/gallery/streaming APIs
+- OTA and production release validation
 
-import BluetoothSdk from '@mentra/bluetooth-sdk';
+### 5.3 Example App
 
-const buttonSub = BluetoothSdk.addListener('button_press', (event) => {
-console.log('Button pressed:', event.buttonId);
-});
+The private repo should include a runnable React Native development-build example demonstrating:
 
-// Find compatible devices for a model
-await BluetoothSdk.findCompatibleDevices('Mentra Live');
-
-// Connect using the saved/default device, or use connectByName(...)
-await BluetoothSdk.connectDefault();
-
-// Display text
-await BluetoothSdk.displayText({
-text: 'Hello World',
-x: 0,
-y: 0,
-size: 24,
-});
-
-// Later
-buttonSub.remove();
-```
-
-### 5.2 Documentation Site
-
-- Getting Started (Android, iOS, React Native)
-- API Reference
-- Hardware Integration Notes
-- Audio Streaming Guide
-- Display Control Guide
-- Camera Control Guide
+- Device scanning/discovery
+- Connection management
+- Display text
+- Display clearing
+- Status subscriptions
+- Button/battery event handling
 
 ---
 
@@ -840,15 +837,24 @@ buttonSub.remove();
 
 ### Phase 5: Documentation & Example (Week 4)
 
-- [ ] Write main README
-- [ ] Create getting started guide (React Native focus)
-- [ ] Document API reference
-- [ ] Create React Native example app demonstrating:
+- [ ] Create private GitHub partner docs repo and push scaffold
+- [x] Draft private partner docs repo scaffold locally
+- [x] Write thin public package README
+- [x] Write private repo main README
+- [x] Create private getting started guide (React Native focus)
+- [x] Document initial private API reference
+- [x] Create initial private React Native example app demonstrating:
   - Device scanning/discovery
   - Connection management
-  - Display text/images
+  - Display text
+  - Display clearing
+  - Status subscriptions
+  - Button/battery events
+- [ ] Expand private example app with:
+  - Display images
   - Audio streaming
-  - Button/gesture events
+  - Camera/gallery flows
+- [ ] Validate a fresh third-party Expo/RN consumer app can install the published package, prebuild iOS/Android, and run `pod install`
 
 ### Phase 6: MentraOS Migration
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -2,30 +2,36 @@
 
 SDK for communicating with Mentra smart glasses from React Native and Expo apps.
 
-# API documentation
+## Documentation
 
-- Documentation for this package will live in the MentraOS repository alongside the SDK source.
+This package README is intentionally brief. Full partner documentation, getting started guides, production checklists, and example apps live in the private `Mentra-Bluetooth-SDK-Partner-Kit` repository for licensed partners.
 
-# Installation in managed Expo projects
+## Installation
 
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
+The SDK contains native code and requires a React Native or Expo development build. It does not run inside Expo Go.
 
-# Installation in bare React Native projects
-
-For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-### Add the package to your npm dependencies
-
-```
+```sh
 npm install @mentra/bluetooth-sdk
+npx expo prebuild
+npx pod-install
 ```
 
-### Configure for Android
+## Minimal Usage
 
-### Configure for iOS
+```ts
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
-Run `npx pod-install` after installing the npm package.
+const removeStatusListener = BluetoothSdk.onGlassesStatus((status) => {
+  console.log("Glasses status changed", status)
+})
 
-# Contributing
+await BluetoothSdk.findCompatibleDevices("Mentra Live")
+await BluetoothSdk.connectDefault()
+await BluetoothSdk.displayText({text: "Hello from Mentra", x: 0, y: 0, size: 24})
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide](https://github.com/expo/expo#contributing).
+removeStatusListener()
+```
+
+## Support
+
+For integration support, request access to the private partner documentation repo from Mentra.


### PR DESCRIPTION
See https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Partner-Kit

# Summary

This phase sets up the documentation split for the Bluetooth SDK’s partner/commercial distribution model. The public SDK package README now stays intentionally thin, while the full onboarding material is owned by a new private partner repo.

# Changes

- Updated mobile/modules/bluetooth-sdk/README.md with concise install instructions, dev-build requirement, minimal usage, and a pointer to the private Partner Kit.
- Updated docs/mentra-bluetooth-sdk-plan.md to define Phase 5 as a public/private docs split.
- Documented the private repo name: Mentra-Bluetooth-SDK-Partner-Kit.
- Marked completed Phase 5 docs scaffold items and left follow-ups for richer examples and third-party release validation.
- Created and pushed the private GitHub repo: Mentra-Community/Mentra-Bluetooth-SDK-Partner-Kit.

# Validation

- Verified the Partner Kit GitHub repo exists and is PRIVATE.
- Ran Prettier checks for the changed public docs.
- Confirmed the MentraOS working tree is clean after commit.

# Follow-Up

- Expand the Partner Kit example with display images, audio streaming, and camera/gallery flows.
- Before external release, validate a fresh third-party Expo/RN consumer app can install the published SDK package, prebuild iOS/Android, and run pod install.