### PR TITLE
feat(102): phase 1 observability for event-loop stall cascade

### DIFF
--- a/.github/workflows/porter-debug.yml
+++ b/.github/workflows/porter-debug.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - cloud/issues-048
+      - cloud/pod-loop-stall-cascade
     paths:
       - "cloud/**"
       - ".github/workflows/porter-debug.yml"

--- a/cloud/issues/102-pod-loop-stall-cascade/design.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/design.md
@@ -1,0 +1,566 @@
+# Design: Cloud Pod Event-Loop Stall Cascade — Phase 1 Implementation (Revised)
+
+## Overview
+
+**What this doc covers:** File-by-file implementation plan for the observability changes in [spec.md](./spec.md). All code-level changes (S1-S6) land in one PR; the K8s liveness widening (S8) is applied separately via Porter dashboard.
+
+**What you need to know first:** [spike.md](./spike.md), [spike-independent-2026-04-23.md](./spike-independent-2026-04-23.md), [implementation-review-2026-04-23.md](./implementation-review-2026-04-23.md), [spec.md](./spec.md).
+
+**What changed from the v1 design:** Per Codex's review:
+
+- S2 expanded from "fan-out only" to per-substage timing inside `processAudioData`
+- `userIdHash` correlation key added to `slow-audio-fanout`
+- `gapStartedAtMs` added to heartbeat-gap payload
+- Vitals self-timing reuses captured session count instead of re-scanning
+- Natural-GC observer gated behind a runtime support check (Bun does not support `gc` PerformanceObserver entries today)
+- New: pod-level UDP counter deltas in vitals
+- S6 (was: probe widening) renamed to S8 with documented tradeoffs; readiness widening dropped
+
+**Who should read this:** PR reviewers; the engineer on call after the next us-central crash who will read these logs.
+
+---
+
+## Branch Plan
+
+One PR for code (S1-S6). Liveness widening (S8) is platform config, applied through Porter UI separately to keep blast radius bounded.
+
+Branch: `cloud/pod-loop-stall-cascade` off `origin/dev`. Already created.
+
+---
+
+## Changes Summary
+
+| Component                                      | File                                                                                    | Change                                                                                                                       |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| S1: Slow audio handler/batch log               | `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts`                               | Per-invocation timer + `slow-audio-call` warning (already implemented in v1)                                                 |
+| S2: Audio substage timings                     | `cloud/packages/cloud/src/services/session/AudioManager.ts`                             | Per-substage timers in `processAudioData` + `op_audio_*_ms` cumulative + `slow-audio-stage` outlier warnings                 |
+| S3: Fan-out instrumentation w/ correlation key | `cloud/packages/cloud/src/services/session/AudioManager.ts`                             | Wrap `relayAudioToApps` + `slow-audio-fanout` warning, payload includes `userIdHash`                                         |
+| S4: Heartbeat tick + gap-start timestamp       | `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`                       | 500ms `setInterval`, log gaps > 1s, payload includes `gapStartedAtMs`                                                        |
+| S5: logVitals self-timing (clean)              | `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`                       | Wrap body in `performance.now()` brackets, reuse already-captured session count                                              |
+| S6: Pod-level UDP counter deltas               | `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts` + `UdpAudioServer.ts` | UdpAudioServer exposes `getStatsSnapshot()`, vitals computes deltas                                                          |
+| S7: Natural-GC observer (gated)                | `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`                       | Check `PerformanceObserver.supportedEntryTypes`; install only if `gc` supported, otherwise log `natural-gc-unsupported` once |
+
+Estimated diff: ~200 lines added, ~10 lines modified, 3 files. No deletions.
+
+---
+
+## S1: Slow UDP Audio Handler / Batch Log
+
+### File: `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts`
+
+Already implemented in v1. No code changes needed in the revised design — the implementation correctly times one handler invocation (which processes a reorder-buffer batch). Codex flagged a docs-vs-code mismatch (docs said "per iteration"); fixed in spec.md by clarifying this is "per handler invocation / batch."
+
+The `packetsToProcess` field already in the log payload distinguishes "one expensive packet" from "large flushed batch."
+
+No changes required to the v1 implementation of S1. Spec wording corrected.
+
+---
+
+## S2 + S3: AudioManager Substage Timings + Fan-out Correlation Key
+
+### File: `cloud/packages/cloud/src/services/session/AudioManager.ts`
+
+This is the largest change. Two parts:
+
+#### Part A: Add substage timing constants and helper
+
+```typescript
+// Issue 102: per-substage outlier threshold for processAudioData stages.
+// Each substage is sub-millisecond in steady state; 10ms = ~10× normal.
+const SLOW_AUDIO_STAGE_MS = 10
+
+type AudioStage = "lc3Decode" | "appFanout" | "transcriptionFeed" | "translationFeed" | "microphoneUpdate"
+```
+
+Also add a helper method on the class to record substage timings (cuts repetition):
+
+```typescript
+/**
+ * Issue 102: record one substage's wall-time inside processAudioData.
+ * Adds to cumulative operationTimers (op_audio_<stage>_ms appears in vitals)
+ * and warns on outliers.
+ */
+private recordAudioStage(stage: AudioStage, durationMs: number, bytes: number): void {
+  operationTimers.addTiming(`audio_${stage}`, durationMs);
+  if (durationMs > SLOW_AUDIO_STAGE_MS) {
+    this.logger.warn(
+      {
+        feature: "slow-audio-stage",
+        stage,
+        durationMs: Math.round(durationMs * 10) / 10,
+        userIdHash: this.userIdHash(),
+        bytes,
+      },
+      `Slow audio substage ${stage}: ${Math.round(durationMs)}ms`,
+    );
+  }
+}
+
+/**
+ * Issue 102: privacy-preserving session correlation key matching the
+ * userIdHash already used by UdpAudioServer (FNV-1a 32-bit hash of userId).
+ * Cached so we don't recompute per audio packet.
+ */
+private cachedUserIdHash: number | null = null;
+private userIdHash(): number {
+  if (this.cachedUserIdHash !== null) return this.cachedUserIdHash;
+  this.cachedUserIdHash = fnv1a32(this.userSession.userId);
+  return this.cachedUserIdHash;
+}
+```
+
+`fnv1a32` should reuse whatever helper UdpAudioServer uses. If none is exported, add a local copy or extract it. Implementation notes below.
+
+#### Part B: Instrument substages in `processAudioData`
+
+Wrap each substage call (LC3 decode, fan-out, transcription feed, translation feed, microphone update) in a `performance.now()` bracket and call `recordAudioStage`.
+
+```typescript
+async processAudioData(audioData: ArrayBuffer | any, source: "udp" | "legacy" = "udp") {
+  if (this.disposed) return undefined;
+
+  // ... existing packet counter logic ...
+
+  try {
+    this.userSession.lastAudioTimestamp = Date.now();
+    if (audioData) {
+      // ... existing buffer normalization ...
+      if (!incomingBuf) return undefined;
+
+      let buf: Buffer;
+      if (this.audioFormat === "lc3" && this.lc3Service) {
+        // S2: time LC3 decode
+        const tLc3 = performance.now();
+        try {
+          const lc3ArrayBuffer = incomingBuf.buffer.slice(
+            incomingBuf.byteOffset,
+            incomingBuf.byteOffset + incomingBuf.byteLength,
+          );
+          const pcmArrayBuffer = await this.lc3Service.decodeAudioChunk(lc3ArrayBuffer);
+          if (!pcmArrayBuffer || pcmArrayBuffer.byteLength === 0) {
+            return undefined;
+          }
+          buf = Buffer.from(pcmArrayBuffer);
+        } catch (decodeError) {
+          this.logger.error(decodeError, "LC3 decode error");
+          return undefined;
+        } finally {
+          this.recordAudioStage("lc3Decode", performance.now() - tLc3, incomingBuf.byteLength);
+        }
+      } else {
+        buf = incomingBuf;
+      }
+
+      // ... existing PCM remainder logic ...
+      if (buf.length === 0) return undefined;
+
+      // S2: time app fan-out (relayAudioToApps internally has its own
+      // slow-fanout warning via S3; the wrapper here is for cumulative bucket)
+      const tFanout = performance.now();
+      this.relayAudioToApps(buf);
+      this.recordAudioStage("appFanout", performance.now() - tFanout, buf.length);
+
+      // S2: time transcription feed
+      const tTranscription = performance.now();
+      this.userSession.transcriptionManager.feedAudio(buf);
+      this.recordAudioStage("transcriptionFeed", performance.now() - tTranscription, buf.length);
+
+      // S2: time translation feed
+      const tTranslation = performance.now();
+      this.userSession.translationManager.feedAudio(buf);
+      this.recordAudioStage("translationFeed", performance.now() - tTranslation, buf.length);
+
+      // S2: time microphone update
+      const tMic = performance.now();
+      this.userSession.microphoneManager.onAudioReceived();
+      this.recordAudioStage("microphoneUpdate", performance.now() - tMic, buf.length);
+    }
+    return audioData;
+  } catch (error) {
+    this.logger.error(error, `Error processing audio data`);
+    return undefined;
+  }
+}
+```
+
+**Note about LC3 timing semantics:** `lc3Service.decodeAudioChunk` is `await`ed, so the timer captures wall-clock not pure CPU. If the underlying implementation is sync (native binding, common case), the time IS event-loop blocking. If genuinely async, the duration includes time the loop spent on other handlers. Either reading is informative — large LC3 numbers correlated with `heartbeat-gap` events is the signal we want.
+
+#### Part C: Add `userIdHash` to fan-out warning
+
+Update `relayAudioToApps`'s finally block (already added in v1) to include the correlation key:
+
+```typescript
+} finally {
+  const durationMs = performance.now() - t0;
+  if (durationMs > SLOW_RELAY_MS || subCount > FANOUT_WARN) {
+    this.logger.warn(
+      {
+        feature: "slow-audio-fanout",
+        durationMs: Math.round(durationMs * 10) / 10,
+        subscribers: subCount,
+        bytes,
+        userIdHash: this.userIdHash(),    // NEW: correlation key
+      },
+      `Slow audio fan-out: ${Math.round(durationMs)}ms across ${subCount} subscribers`,
+    );
+  }
+}
+```
+
+#### Imports / new additions to AudioManager.ts
+
+```typescript
+import {operationTimers} from "../metrics/SystemVitalsLogger"
+```
+
+`operationTimers` is already exported from SystemVitalsLogger. New import.
+
+For `fnv1a32`: check if `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts` already exports a hashing helper. If not, add a small inline implementation:
+
+```typescript
+/** FNV-1a 32-bit hash, matches the userIdHash used in UdpAudioServer. */
+function fnv1a32(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash = (hash * 0x01000193) >>> 0
+  }
+  return hash
+}
+```
+
+**Verify** during implementation that this matches whatever produces `userIdHash` in UdpAudioServer (look at how the mobile client computes it for the UDP handshake — must match exactly). If the existing helper is in a shared module, prefer importing that.
+
+---
+
+## S4: Heartbeat Tick with `gapStartedAtMs`
+
+### File: `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+The v1 implementation is correct except for the missing `gapStartedAtMs`. One-line addition to the payload:
+
+```typescript
+private startHeartbeat(): void {
+  this.lastHeartbeatTick = Date.now();
+  this.heartbeatInterval = setInterval(() => {
+    const now = Date.now();
+    const elapsed = now - this.lastHeartbeatTick;
+    this.lastHeartbeatTick = now;
+
+    if (elapsed > HEARTBEAT_GAP_THRESHOLD_MS) {
+      const gapMs = elapsed - HEARTBEAT_INTERVAL_MS;
+      logger.warn(
+        {
+          feature: "heartbeat-gap",
+          gapMs,
+          expectedMs: HEARTBEAT_INTERVAL_MS,
+          actualMs: elapsed,
+          gapStartedAtMs: now - elapsed,    // NEW: approximate trigger time
+          rssMB: Math.round(process.memoryUsage().rss / 1048576),
+          activeSessions: UserSession.getAllSessions().length,
+        },
+        `Heartbeat gap: ${gapMs}ms (expected ${HEARTBEAT_INTERVAL_MS}ms, actual ${elapsed}ms, started ~${new Date(now - elapsed).toISOString()})`,
+      );
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+}
+```
+
+The log message also includes the human-readable trigger time so investigators reading raw logs (not just structured queries) see it without having to compute.
+
+---
+
+## S5: logVitals Self-Timing (Without Polluting the Measurement)
+
+### File: `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+The v1 implementation calls `UserSession.getAllSessions()` a second time in the finally block. Per Codex: this adds noise to the measurement we're trying to take.
+
+Fix: capture session count once at the top of `logVitals` (it's already captured for the body) and reference it in the finally block. Need to hoist `sessions.length` to a variable that's accessible from the finally block.
+
+```typescript
+private logVitals(): void {
+  const vitalsT0 = performance.now();
+  let sessionCountForLog = 0;    // NEW: captured for self-timing payload
+  try {
+    const memUsage = process.memoryUsage();
+    const sessions = UserSession.getAllSessions();
+    sessionCountForLog = sessions.length;    // NEW: capture once
+    const mongoStats = mongoQueryStats.getAndReset();
+
+    // ... rest of body unchanged ...
+
+  } catch (error) {
+    logger.error(error, "Failed to log system vitals");
+  } finally {
+    const vitalsDurationMs = performance.now() - vitalsT0;
+    const baseLog = {
+      feature: "vitals-self-timing",
+      durationMs: Math.round(vitalsDurationMs * 10) / 10,
+      activeSessions: sessionCountForLog,    // NEW: reuse captured value, no second scan
+    };
+    if (vitalsDurationMs > VITALS_SELF_SLOW_MS) {
+      logger.warn(baseLog, `⚠️ logVitals slow: ${Math.round(vitalsDurationMs)}ms`);
+    } else {
+      logger.info(baseLog, `logVitals: ${Math.round(vitalsDurationMs)}ms`);
+    }
+  }
+}
+```
+
+If the body throws before the session scan happens, `sessionCountForLog` remains 0, which is fine — vitals threw, we know nothing.
+
+---
+
+## S6: Pod-Level UDP Counter Deltas
+
+### File: `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts`
+
+Expose a snapshot reader:
+
+```typescript
+/**
+ * Issue 102: snapshot of all cumulative counters, for SystemVitalsLogger
+ * to compute deltas per vitals window.
+ */
+public getStatsSnapshot(): {
+  packetsReceived: number;
+  packetsDropped: number;
+  pingsReceived: number;
+  packetsDecrypted: number;
+  decryptionFailures: number;
+  registeredSessions: number;
+} {
+  return {
+    packetsReceived: this.packetsReceived,
+    packetsDropped: this.packetsDropped,
+    pingsReceived: this.pingsReceived,
+    packetsDecrypted: this.packetsDecrypted,
+    decryptionFailures: this.decryptionFailures,
+    registeredSessions: this.sessionMap.size,
+  };
+}
+```
+
+Add this as a public method on the `UdpAudioServer` class, near `start()` / `stop()`.
+
+### File: `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+Import the singleton:
+
+```typescript
+import {udpAudioServer} from "../udp/UdpAudioServer"
+```
+
+Add a private field to hold the previous snapshot:
+
+```typescript
+// Issue 102: previous UDP stats snapshot for delta calculation per vitals window.
+private prevUdpStats: {
+  packetsReceived: number;
+  packetsDropped: number;
+  pingsReceived: number;
+  packetsDecrypted: number;
+  decryptionFailures: number;
+} | null = null;
+```
+
+Inside `logVitals` (near where mongoStats is read), compute the UDP delta:
+
+```typescript
+// Issue 102: pod-level UDP counter deltas per 30s window
+const udpStats = udpAudioServer.getStatsSnapshot()
+const udpDelta = this.prevUdpStats
+  ? {
+      udpPacketsReceivedDelta: udpStats.packetsReceived - this.prevUdpStats.packetsReceived,
+      udpPacketsDroppedDelta: udpStats.packetsDropped - this.prevUdpStats.packetsDropped,
+      udpPacketsDecryptedDelta: udpStats.packetsDecrypted - this.prevUdpStats.packetsDecrypted,
+      udpDecryptionFailuresDelta: udpStats.decryptionFailures - this.prevUdpStats.decryptionFailures,
+    }
+  : {
+      udpPacketsReceivedDelta: 0,
+      udpPacketsDroppedDelta: 0,
+      udpPacketsDecryptedDelta: 0,
+      udpDecryptionFailuresDelta: 0,
+    }
+this.prevUdpStats = {
+  packetsReceived: udpStats.packetsReceived,
+  packetsDropped: udpStats.packetsDropped,
+  pingsReceived: udpStats.pingsReceived,
+  packetsDecrypted: udpStats.packetsDecrypted,
+  decryptionFailures: udpStats.decryptionFailures,
+}
+```
+
+Then merge `udpDelta` and `udpRegisteredSessions: udpStats.registeredSessions` into the final `logger.info(...)` payload that emits the system-vitals row. (Find the existing `logger.info({...}, "system-vitals")` call near the bottom of `logVitals` and spread the new fields into the object.)
+
+First-window edge case: `prevUdpStats === null` returns deltas of 0. That's correct — we have no baseline yet.
+
+---
+
+## S7: Natural-GC Observer — Gated Behind Runtime Support Check
+
+### File: `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+Replace v1's `startGcObserver()` with a runtime-checked variant:
+
+```typescript
+/**
+ * Issue 102: install a natural V8 GC observer ONLY if Bun's PerformanceObserver
+ * supports the 'gc' entryType. As of investigation 2026-04-23, Bun's
+ * supportedEntryTypes is ["mark","measure","resource"] — no 'gc'. Installing
+ * blindly would silently emit nothing, which would look like "no GC pauses"
+ * post-deploy. Explicitly logging the unsupported state once at startup
+ * preserves the signal that this instrumentation source is broken in this
+ * runtime, so investigators don't misread the silence.
+ */
+private startGcObserver(): void {
+  const supported = PerformanceObserver.supportedEntryTypes ?? [];
+  if (!supported.includes("gc")) {
+    logger.warn(
+      {
+        feature: "natural-gc-unsupported",
+        supportedEntryTypes: supported,
+      },
+      `Natural GC observer NOT installed: 'gc' entryType not supported by this runtime`,
+    );
+    return;
+  }
+  try {
+    this.gcObserver = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        if (entry.duration > NATURAL_GC_THRESHOLD_MS) {
+          const memUsage = process.memoryUsage();
+          logger.warn(
+            {
+              feature: "natural-gc",
+              durationMs: Math.round(entry.duration * 10) / 10,
+              kind: (entry as any).detail?.kind ?? "unknown",
+              rssMB: Math.round(memUsage.rss / 1048576),
+              heapUsedMB: Math.round(memUsage.heapUsed / 1048576),
+            },
+            `Natural GC: ${Math.round(entry.duration)}ms`,
+          );
+        }
+      }
+    });
+    this.gcObserver.observe({ entryTypes: ["gc"] });
+    logger.info(
+      { thresholdMs: NATURAL_GC_THRESHOLD_MS },
+      `Natural GC observer started (logging GCs > ${NATURAL_GC_THRESHOLD_MS}ms)`,
+    );
+  } catch (err) {
+    logger.warn({ err }, "Could not install natural GC observer");
+  }
+}
+```
+
+The `supportedEntryTypes` check is the new line: if `gc` isn't in the array, log the unsupported event and return without installing.
+
+---
+
+## S8: K8s Liveness Widening (Out of Code PR, Liveness Only)
+
+Applied through Porter dashboard, NOT in this PR's code. Per spec.md, **only widen liveness, not readiness**:
+
+- **Liveness:** `failureThreshold: 15 → 30`, `timeoutSeconds: 3 → 10`
+- **Readiness:** unchanged (`failureThreshold: 5`, `timeoutSeconds: 5`)
+
+Rationale repeated here for the operator: widening readiness keeps a stalled pod in the LB rotation, which on single-pod us-central means user-visible hangs instead of brief 503 bursts. We accept the 503 burst as the more recoverable failure mode until multi-pod lands.
+
+Apply this AFTER S1-S6 have been deployed to one quiet region and validated.
+
+---
+
+## Constants and Imports Summary
+
+### Added to `UdpAudioServer.ts`
+
+```typescript
+const SLOW_AUDIO_CALL_MS = 50 // (already present from v1)
+```
+
+Plus the new public method `getStatsSnapshot()`.
+
+### Added to `AudioManager.ts`
+
+```typescript
+import {operationTimers} from "../metrics/SystemVitalsLogger"
+
+const SLOW_RELAY_MS = 20 // (already present from v1)
+const FANOUT_WARN = 10 // (already present from v1)
+const SLOW_AUDIO_STAGE_MS = 10 // NEW
+
+type AudioStage = "lc3Decode" | "appFanout" | "transcriptionFeed" | "translationFeed" | "microphoneUpdate"
+
+// fnv1a32 helper if not already imported from elsewhere
+```
+
+### Added / changed in `SystemVitalsLogger.ts`
+
+```typescript
+import {PerformanceObserver} from "node:perf_hooks" // (already from v1)
+import {udpAudioServer} from "../udp/UdpAudioServer" // NEW
+
+const HEARTBEAT_INTERVAL_MS = 500 // (already from v1)
+const HEARTBEAT_GAP_THRESHOLD_MS = 1_000 // (already from v1)
+const VITALS_SELF_SLOW_MS = 500 // (already from v1)
+const NATURAL_GC_THRESHOLD_MS = 100 // (already from v1)
+```
+
+No new external dependencies.
+
+---
+
+## Testing
+
+### Local
+
+1. `bun run lint` passes
+2. `bun run typecheck` passes
+3. `bun run test` passes
+4. `bun run dev` boots cleanly. After ~30 seconds:
+   - `feature="vitals-self-timing"` info log appears
+   - Either `feature="natural-gc-unsupported"` (one entry at startup, expected on current Bun) OR `feature="natural-gc"` entries occasionally
+   - No `heartbeat-gap` under idle dev
+   - No `slow-audio-call` / `slow-audio-stage` / `slow-audio-fanout` under idle dev
+5. Locally simulate a slow substage: temporarily inject a 100ms `setTimeout` await in one of the substages → confirm `slow-audio-stage` log fires with the right `stage` value
+
+### Smoke (one quiet region first)
+
+Deploy to us-east. After 30 minutes, run the smoke query from spec.md. Expect zero outlier warnings; confirm `vitals-self-timing` and `natural-gc-unsupported` (or `natural-gc`) appear at expected cadence.
+
+### Acceptance (after one us-central crash)
+
+Per spec.md acceptance section. Pull the trigger time from `gapStartedAtMs` in the heartbeat-gap log, then query the 90s window before that time across all Phase 1 features. Each hypothesis should be confirmable or ruleable.
+
+---
+
+## Risks and Open Questions
+
+**Risk: `fnv1a32` reimplementation drift.** If we add a local `fnv1a32` in AudioManager.ts and UdpAudioServer.ts has its own, they could diverge. **Mitigation**: during implementation, check if UdpAudioServer exports a hashing helper. If yes, import. If no, extract to a shared util and import from both. Verify identical outputs against a known input before merge.
+
+**Risk: substage timers add per-packet overhead.** ~5 `performance.now()` calls per audio packet. Each is ~50ns in Bun. At 100 pkt/s that's 25μs/sec total — negligible.
+
+**Risk: outlier warnings flood logs during a cascade.** During an 80s blockage we might log thousands of `slow-audio-stage` entries. Acceptable: the post-incident query is filterable, the volume itself is information ("cascade of N entries" vs "1 pathological entry"). If volume is genuinely problematic, add a per-substage rate limiter in a follow-up.
+
+**Risk: Bun adds `gc` PerformanceObserver support in a future version.** Then the gated install activates automatically. That's fine — that's the intended behavior. The gate just protects us from silent failure today.
+
+**Risk: `getStatsSnapshot()` reads counters that aren't atomic.** Bun is single-threaded JS so number reads are atomic in JS semantics. No concern.
+
+**Risk: probe widening encourages investigators to ignore the underlying cascade.** Mitigation: spec.md explicitly documents that S8 is a band-aid, not a fix; the K8s probe widening is paired with the explicit "resolve permanently via Phase 2 + multi-pod" in the operator-facing language.
+
+---
+
+## Summary
+
+Six instrumentation additions across three files (~200 lines added, no behavior change). Probe widening (S8) handled separately via Porter UI, liveness-only for now. After one us-central crash cycle, the resulting logs answer:
+
+1. **What time did the cascade start?** → `gapStartedAtMs` in heartbeat-gap (S4)
+2. **What audio substage burned the time?** → op*audio*\*\_ms in vitals + `slow-audio-stage` warnings (S2)
+3. **Cascade vs pathological vs fan-out?** → `slow-audio-call` shape + `slow-audio-fanout` count (S1, S3)
+4. **What pod-level UDP load corresponded?** → udpPacketsReceivedDelta etc. in vitals (S6)
+5. **Was vitals itself the trigger?** → `vitals-self-timing` (S5)
+6. **Did natural GC contribute?** → `natural-gc` if Bun supports it; otherwise we know it's unmeasurable today (S7)
+
+With those answers, Phase 2 designs the actual fix instead of guessing.

--- a/cloud/issues/102-pod-loop-stall-cascade/implementation-review-2026-04-23.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/implementation-review-2026-04-23.md
@@ -1,0 +1,344 @@
+# Implementation Review: Phase 1 Observability PR
+
+## Context
+
+This review is for the uncommitted implementation currently on
+`cloud/pod-loop-stall-cascade`. The implementation appears to follow the original
+`spec.md` and `design.md` closely:
+
+- `UdpAudioServer.ts`: adds `slow-audio-call`
+- `AudioManager.ts`: adds `slow-audio-fanout`
+- `SystemVitalsLogger.ts`: adds heartbeat gap, vitals self-timing, natural GC observer
+
+Since those docs were written, an independent follow-up investigation captured in
+`spike-independent-2026-04-23.md` changed the design context. The important new
+evidence is that during the most recent us-central failure, HTTP/timers were
+starved while UDP/audio logs continued. That makes the failure look less like a
+complete event-loop freeze and more like UDP/audio monopolizing the loop.
+
+Bottom line: this is a good first draft, but I would not ship it as-is. It will
+confirm some useful facts, but it still leaves the highest-value question
+ambiguous: which part of audio processing monopolizes the loop?
+
+## Review Summary
+
+Blocking concerns:
+
+1. `PerformanceObserver` GC instrumentation probably does not work in Bun/JSC.
+2. Audio instrumentation is too narrow; it times app fan-out but misses LC3,
+   transcription, translation, and mic-update substages.
+3. `slow-audio-fanout` omits the user/session identifier promised by the spec,
+   making correlation with `slow-audio-call` much harder.
+
+Non-blocking but important:
+
+1. Heartbeat gap timestamps need explicit interpretation or a `gapStartedAt`
+   field.
+2. The S1 docs say "per iteration," but the implementation measures one UDP
+   handler invocation/batch.
+3. Some docs are stale (`spek.md`, transcript-history note, natural-GC
+   expectations).
+
+## Blocking Comments
+
+### 1. Natural GC observer will likely be silent in Bun
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts:255-297`
+- `cloud/issues/102-pod-loop-stall-cascade/design.md:383`
+- `cloud/issues/102-pod-loop-stall-cascade/spec.md:S5`
+
+The implementation installs a Node-style `PerformanceObserver` for
+`entryTypes: ["gc"]`. The design says this may not emit on all Bun versions, but
+the acceptance criteria still expect `natural-gc` to answer whether natural GC
+caused the stall.
+
+I tested the local Bun runtime:
+
+```bash
+bun -e 'import { PerformanceObserver } from "node:perf_hooks"; console.log(JSON.stringify(PerformanceObserver.supportedEntryTypes))'
+```
+
+It returned:
+
+```json
+["mark", "measure", "resource"]
+```
+
+A second local smoke test registering `entryTypes: ["gc"]`, forcing
+`Bun.gc(true)`, and waiting briefly produced zero entries. `observe()` does not
+throw, so this code will log "Natural GC observer started" and then probably
+emit no `natural-gc` events. That is dangerous because post-deploy silence would
+look like "no natural GC pauses," when the real meaning is "this instrumentation
+source does not work."
+
+Recommended change:
+
+- Remove S5 from this PR, or gate it behind an explicit support check that logs
+  `feature="natural-gc-unsupported"` when `gc` is absent from
+  `PerformanceObserver.supportedEntryTypes`.
+- If natural GC remains important, design a Bun/JSC-specific mechanism in a
+  follow-up. Do not make `natural-gc` part of acceptance until it is proven to
+  emit in the deployed runtime.
+
+Suggested reviewer response:
+
+> Please do not ship the GC observer as an acceptance signal until we prove it
+> emits in Bun. Right now it can fail silently by logging "started" and then
+> producing no events forever.
+
+### 2. Audio instrumentation misses the likely expensive substages
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/session/AudioManager.ts:265-338`
+- `cloud/packages/cloud/src/services/session/AudioManager.ts:362-435`
+- `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts:265-303`
+
+The independent investigation suggests UDP/audio can monopolize the loop while
+HTTP disappears. The current PR adds:
+
+- outer UDP handler timing in `UdpAudioServer`
+- app fan-out timing in `relayAudioToApps`
+
+But `AudioManager.processAudioData` includes several other hot substages:
+
+```ts
+// AudioManager.ts
+await this.lc3Service.decodeAudioChunk(...)
+this.relayAudioToApps(buf);
+this.userSession.transcriptionManager.feedAudio(buf);
+this.userSession.translationManager.feedAudio(buf);
+this.userSession.microphoneManager.onAudioReceived();
+```
+
+`relayAudioToApps` is only one of these. In the newest incident, the dangerous
+load looked like aggregate active microphone/audio sessions, not an obvious
+single app fan-out explosion. If Soniox `writeAudio`, transcription buffering,
+LC3 decode, or mic updates are the expensive part, this PR can deploy, we can
+wait for another crash, and still not know the culprit.
+
+Recommended change:
+
+Add substage timing inside `AudioManager.processAudioData`:
+
+- `audio_lc3Decode_ms`
+- `audio_normalize_ms`
+- `audio_appFanout_ms`
+- `audio_transcriptionFeed_ms`
+- `audio_translationFeed_ms`
+- `audio_microphoneUpdate_ms`
+
+Log a structured `feature="slow-audio-stage"` warning when any stage crosses a
+small threshold, and add cumulative operation timers for the same stages so the
+next `system-vitals` row shows the breakdown.
+
+Suggested reviewer response:
+
+> The current implementation tells us whether app fan-out is bad, but it does
+> not tell us whether transcription/translation writes or LC3 decode are bad.
+> The next crash can still come back as "audioProcessing=80s" with
+> `slow-audio-fanout=0`, which is not enough to choose Phase 2.
+
+### 3. `slow-audio-fanout` cannot be correlated to `slow-audio-call`
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/session/AudioManager.ts:423-432`
+- `cloud/issues/102-pod-loop-stall-cascade/spec.md:S2`
+
+The spec says the `slow-audio-fanout` payload includes:
+
+```ts
+{
+  feature: "slow-audio-fanout",
+  durationMs: <number>,
+  subscribers: <length>,
+  bytes: <buffer length>,
+  userId: <session userId>,
+}
+```
+
+The implementation logs only:
+
+```ts
+{
+  feature: "slow-audio-fanout",
+  durationMs,
+  subscribers,
+  bytes,
+}
+```
+
+That omission matters. `slow-audio-call` logs `userIdHash`, while
+`slow-audio-fanout` logs no user/session key. If fan-out warnings appear during
+a crash, we cannot reliably tie them back to the UDP handler or the session.
+
+Recommended change:
+
+- Add a privacy-preserving session key to both logs. Prefer `userIdHash` if it
+  is already available through the UDP path, or a stable hash of
+  `this.userSession.userId`.
+- If raw user IDs are acceptable in existing prod logs, at least match the spec
+  and include `userId`; but for this incident I would prefer a hash.
+
+Suggested reviewer response:
+
+> Please include a correlation key on `slow-audio-fanout`. Without it, the log
+> answers "some session had fan-out" but not "was it the same session whose UDP
+> handler went slow?"
+
+## Important Non-Blocking Comments
+
+### 4. Heartbeat gap logs happen at recovery time, not trigger time
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts:231-252`
+
+The heartbeat gap is useful, but the design language says it "pinpoints the
+trigger moment with 500ms resolution." The log timestamp is actually when the
+timer callback finally runs after starvation, not when starvation began.
+
+For a gap log:
+
+```ts
+actualMs = elapsed;
+gapStartedAtApprox = logTimestamp - actualMs;
+```
+
+Recommended change:
+
+- Add `gapStartedAtMs` or `approxGapStartedAt` to the payload.
+- Update the docs and query instructions to sort by approximate start time, not
+  just log time.
+
+Suggested reviewer response:
+
+> Keep the heartbeat, but make the payload harder to misread. Otherwise the next
+> investigator may look at logs immediately before the heartbeat log, which are
+> recovery logs, not trigger logs.
+
+### 5. S1 measures a handler invocation/batch, not a loop iteration
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts:265-303`
+- `cloud/issues/102-pod-loop-stall-cascade/spec.md:S1`
+- `cloud/issues/102-pod-loop-stall-cascade/design.md:25`
+
+The spec says "when a single for-loop iteration takes more than
+`SLOW_AUDIO_CALL_MS`." The code starts the timer before the loop and stops it
+after the loop, so it measures one UDP handler invocation across the entire
+`packetsToProcess` batch.
+
+That might be the right measurement, but the docs should be precise:
+
+- `packetsToProcess=1`, `duration=500ms` means one chunk was expensive.
+- `packetsToProcess=10`, `duration=500ms` may mean ten ordinary chunks or one
+  expensive chunk inside the batch.
+
+Recommended change:
+
+- Either move the timer inside the loop if true per-packet timing is needed, or
+  rename the concept in docs/log text to "handler/batch duration."
+
+Suggested reviewer response:
+
+> The implementation and docs disagree here. Please either time each
+> `audioChunk` or update the spec/design to say this is per handler invocation
+> over a possible reorder-buffer batch.
+
+### 6. Vitals self-timing does a second session scan
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts:648-652`
+
+`logVitals()` already calls `UserSession.getAllSessions()` near the top. The
+finally block calls it again to log `activeSessions`.
+
+This is probably not a big cost, but the whole reason for S4 is to determine
+whether vitals itself can be expensive. A second session lookup in the measured
+finally block adds avoidable noise.
+
+Recommended change:
+
+- Capture `sessionCount` once if possible.
+- If `logVitals()` throws before sessions are available, fall back to a safe
+  `undefined` or a cheap map size accessor if one exists.
+
+Suggested reviewer response:
+
+> Minor, but avoid adding extra census work to the self-timing path we are
+> trying to measure.
+
+### 7. Probe widening should not be described as harmless
+
+**Files:**
+
+- `cloud/issues/102-pod-loop-stall-cascade/spec.md:S6`
+- `cloud/issues/102-pod-loop-stall-cascade/design.md:S6`
+
+Widening liveness/readiness thresholds may reduce restarts, but it changes the
+failure mode. For an 80s audio starvation window, widening probes can keep the
+same stuck single pod in rotation longer. Users may see hung requests/timeouts
+instead of a shorter nginx 503/restart cycle.
+
+Recommended change:
+
+- Keep probe widening separate, as the design already says.
+- Add a clearer operator warning: this is a mitigation with user-visible
+  tradeoffs, not just a harmless survivability band-aid.
+- Consider widening liveness only after code instrumentation lands; be more
+  cautious with readiness.
+
+Suggested reviewer response:
+
+> Probe widening buys investigation time, but it can also route traffic to a pod
+> that is not scheduling HTTP. Please document that tradeoff before applying it
+> in Porter.
+
+## Documentation Corrections
+
+Please update these before handing the PR to reviewers:
+
+- `design.md:7` links to `spek.md`; should be `spec.md`.
+- `design.md:383` says Bun supports `gc` PerformanceObserver entries. Local
+  evidence says this should be softened or removed.
+- `design.md:505` mentions `transcription.history.en-US` retaining 1,843 items.
+  Current code says transcript history was removed in issue 098.
+- `spec.md:S2` includes `userId` in `slow-audio-fanout`; implementation does not.
+- `spec.md:S5` acceptance expects `natural-gc`; that should not be an acceptance
+  criterion until the runtime support is proven.
+
+## Suggested Revised Phase 1 Scope
+
+I would reshape Phase 1 as:
+
+1. Keep `slow-audio-call`, but clarify it as handler/batch timing.
+2. Add `slow-audio-stage` and cumulative operation timers inside
+   `AudioManager.processAudioData`.
+3. Keep `slow-audio-fanout`, but add a correlation key.
+4. Keep `heartbeat-gap`, but include an approximate gap start timestamp.
+5. Keep `vitals-self-timing`, with a small cleanup to avoid extra session scans.
+6. Remove `natural-gc` or mark it explicitly unsupported until proven otherwise.
+7. Add pod-level UDP counters to vitals if feasible:
+   - packets received per interval
+   - packets dropped per interval
+   - active UDP sessions
+
+That revised scope is still observability-only, but it is more likely to answer
+the next question we actually need answered:
+
+> Which exact audio substage monopolizes the event loop when us-central crosses
+> the liveness-failure threshold?
+
+## Review Verdict
+
+Do not merge as-is.
+
+The implementation is close to the original design, but the original design is
+now stale against the latest evidence. If merged unchanged, it may confirm that
+"audio is involved" yet still fail to identify whether the expensive work is LC3
+decode, app fan-out, transcription feed, translation feed, or UDP scheduling.
+
+Recommended next action: revise the implementation and docs together, then run a
+small local smoke check for log shape before deploying to a quiet region.

--- a/cloud/issues/102-pod-loop-stall-cascade/spec.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spec.md
@@ -208,6 +208,24 @@ Explicitly out of scope for this PR:
 
 Adding any of these without the data could mask the real cause and make Phase 2 diagnosis harder.
 
+### S10. Heap snapshot admin API (bundled infrastructure change)
+
+**File:** `cloud/packages/cloud/src/api/hono/routes/admin.routes.ts`
+
+Not strictly observability for the cascade — but bundled into this PR because it enables on-demand heap captures for the [103 non-session heap growth](../103-non-session-heap-growth/) investigation the existing instrumentation can't answer on its own.
+
+**Before:** `POST /api/admin/memory/heap-snapshot` used a `node:inspector` Session + HeapProfiler addHeapSnapshotChunk streaming dance to produce Chrome-compatible `.heapsnapshot` files. ~35 lines of boilerplate per request.
+
+**After:**
+
+- `POST /api/admin/memory/heap-snapshot` — same contract, implementation is now one line via `v8.writeHeapSnapshot(filePath)`.
+- `GET /api/admin/memory/heap-snapshot-v8` — **new**. Streams the snapshot directly to the caller as an `attachment; filename="heap-<ts>.heapsnapshot"` download, so operators can pull a snapshot without shelling into the pod to retrieve the temp file.
+- `GET /api/admin/memory/heap-snapshot-bun` — unchanged. Kept for local scripts / Safari-style tooling that want the Bun JSC-format output.
+
+**Self-DoS guard** (added after CodeRabbit 🟠 Major review): both V8-path handlers share a module-level `heapSnapshotInFlight` flag. Concurrent requests return 429 instead of stacking two 2×-heap allocations on top of an already stressed pod. Both handlers carry an explicit WARNING JSDoc instructing operators not to invoke during an active degradation window — `v8.getHeapSnapshot()` and `v8.writeHeapSnapshot()` are synchronous and block the event loop for the full snapshot generation (which is exactly what this PR is investigating). The flag covers the expensive blocking generation phase; post-generation streaming is cheap and concurrent downloads of already-generated snapshot data are fine.
+
+**Why bundle into this PR:** the heap-snapshot endpoint was being used during the same investigation that produced this PR; keeping them separate created review churn without a corresponding benefit.
+
 ---
 
 ## Non-Goals

--- a/cloud/issues/102-pod-loop-stall-cascade/spec.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spec.md
@@ -48,7 +48,7 @@ Phase 1 instruments to answer all three.
 
 **After:** Same outer cumulative timer (preserved for vitals), plus an inline check: when one **handler invocation** (which processes a batch of 1+ packets from the reorder buffer) takes longer than `SLOW_AUDIO_CALL_MS` (default 50ms), log a structured warning.
 
-```
+```json
 {
   feature: "slow-audio-call",
   durationMs: <number>,
@@ -81,7 +81,7 @@ Note: the timer brackets one handler invocation (the for-loop over the reorder b
    - `op_audio_microphoneUpdate_ms`
 
 2. **Outlier warning**: when any single substage call exceeds `SLOW_AUDIO_STAGE_MS` (default 10ms), log:
-   ```
+   ```json
    {
      feature: "slow-audio-stage",
      stage: "lc3Decode" | "appFanout" | "transcriptionFeed" | "translationFeed" | "microphoneUpdate",
@@ -103,7 +103,7 @@ The 10ms per-substage threshold is conservative: each substage is sub-millisecon
 
 **After:** Wrap `relayAudioToApps` with a timer; warn when slow OR fan-out is high:
 
-```
+```json
 {
   feature: "slow-audio-fanout",
   durationMs: <number>,
@@ -125,7 +125,7 @@ Thresholds: `SLOW_RELAY_MS = 20`, `FANOUT_WARN = 10` subscribers.
 
 **After:** Add a 500ms `setInterval` that records the tick time. When the next tick fires more than `HEARTBEAT_GAP_THRESHOLD_MS` (default 1000ms) late, log:
 
-```
+```json
 {
   feature: "heartbeat-gap",
   gapMs: <elapsed - HEARTBEAT_INTERVAL_MS>,

--- a/cloud/issues/102-pod-loop-stall-cascade/spec.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spec.md
@@ -1,0 +1,339 @@
+# Spec: Cloud Pod Event-Loop Stall Cascade — Phase 1 Observability (Revised)
+
+## Overview
+
+**What this doc covers:** The exact behavior changes that ship in the first PR for issue 102. Phase 1 is **observability only** — no behavior changes, no fixes. The goal is to land enough instrumentation that one more crash cycle gives us definitive answers about the trigger and the specific audio substage that monopolizes the loop. Phase 2 (the actual fix) will be specified in a separate PR after Phase 1 data lands.
+
+**Why this doc exists:** Three prior diagnoses of these crashes were confidently wrong (see [spike.md](./spike.md)). The fourth would likely also be wrong without disambiguating data. Spending one cycle on instrumentation before designing the fix is strictly faster than shipping a guess that turns out to address nothing.
+
+**What you need to know first:**
+
+- [spike.md](./spike.md) — original investigation and evidence
+- [spike-independent-2026-04-23.md](./spike-independent-2026-04-23.md) — second independent investigation that found UDP/audio continued running while HTTP/timers were starved (the failure is event-loop _monopolization_, not freeze)
+- [implementation-review-2026-04-23.md](./implementation-review-2026-04-23.md) — Codex's review of the original Phase 1 draft. This spec incorporates all of its blocking and non-blocking points.
+
+**Who should read this:** PR reviewers. Cloud engineers who will analyze the next crash with the new logs.
+
+---
+
+## The Problem in 30 Seconds
+
+us-central crashes 4-6 times per day. The most recent crash (2026-04-23 23:34 UTC, restart #5) had:
+
+- An 80.7s `event-loop-gap` log (timer expected at 1s, fired 80.7s late)
+- Almost all op_total during that window in `op_audioProcessing_ms`
+- HTTP request logs went silent for ~80s while UDP/audio logs continued
+- ~96 UDP packets/sec processed pod-wide during the starved window
+- ~10 mic-active sessions; no single-user storm
+
+This is event-loop _monopolization_ by UDP/audio, not a complete freeze. K8s liveness on `/livez` times out (because HTTP can't be scheduled), pod is killed.
+
+The existing telemetry cannot answer:
+
+- Which audio substage burns the time (LC3 decode, app fan-out, transcription feed, translation feed, microphone update)?
+- What pod-level UDP load corresponds to the dangerous regime?
+- When did the cascade _start_ (the gap log timestamp is the recovery moment)?
+
+Phase 1 instruments to answer all three.
+
+---
+
+## Spec
+
+### S1. Slow UDP audio handler / batch duration log
+
+**File:** `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts`
+
+**Before:** `handleAudioPacket` wraps its for-loop with `operationTimers.addTiming("audioProcessing", ...)` which only records cumulative wall-time across all calls in a 30s vitals window. Individual call durations are not visible.
+
+**After:** Same outer cumulative timer (preserved for vitals), plus an inline check: when one **handler invocation** (which processes a batch of 1+ packets from the reorder buffer) takes longer than `SLOW_AUDIO_CALL_MS` (default 50ms), log a structured warning.
+
+```
+{
+  feature: "slow-audio-call",
+  durationMs: <number>,
+  packetsToProcess: <length>,    // batch size; 1 in normal operation, larger after reorder-buffer flush
+  userIdHash: <number>,
+  activeSessions: <count>,
+  rssMB: <number>,
+}
+```
+
+Note: the timer brackets one handler invocation (the for-loop over the reorder buffer's flushed packets), **not one packet**. `packetsToProcess` is the batch size so investigators can distinguish "one expensive packet" from "many ordinary packets in a flushed batch."
+
+50ms threshold rationale: steady-state op_audioProcessing is ~400ms / 30s ÷ ~3500 calls ≈ 115μs per call. 50ms is ~400× normal — clear outlier without being so tight that it floods logs in steady state.
+
+**Net effect:** answers questions like "is one packet pathologically slow?" (high duration, low packetsToProcess) vs "is the reorder buffer flushing big batches?" (high duration, high packetsToProcess).
+
+### S2. Audio substage timings inside `processAudioData`
+
+**File:** `cloud/packages/cloud/src/services/session/AudioManager.ts`
+
+**Before:** `processAudioData` is one black box. We know the cumulative time but not which of LC3 decode, fan-out, transcription feed, translation feed, or microphone update consumes it.
+
+**After:** Insert per-substage timers inside `processAudioData`. Two outputs per substage:
+
+1. **Cumulative timer** added to `operationTimers` so vitals emits `op_audio_<stage>_ms` per 30s window:
+   - `op_audio_lc3Decode_ms` (only emits when audioFormat=lc3)
+   - `op_audio_appFanout_ms`
+   - `op_audio_transcriptionFeed_ms`
+   - `op_audio_translationFeed_ms`
+   - `op_audio_microphoneUpdate_ms`
+
+2. **Outlier warning**: when any single substage call exceeds `SLOW_AUDIO_STAGE_MS` (default 10ms), log:
+   ```
+   {
+     feature: "slow-audio-stage",
+     stage: "lc3Decode" | "appFanout" | "transcriptionFeed" | "translationFeed" | "microphoneUpdate",
+     durationMs: <number>,
+     userIdHash: <number>,    // privacy-preserving correlation key
+     bytes: <buffer length>,
+   }
+   ```
+
+The 10ms per-substage threshold is conservative: each substage is sub-millisecond in steady state. A 10ms substage call is ~10× normal — caught early, not so tight as to flood.
+
+**Net effect:** the next crash answers "which substage burns the time" by reading op*audio*\*\_ms in vitals, and "which calls were the worst" by reading slow-audio-stage warnings. This is the highest-value addition — it directly determines what Phase 2 fixes.
+
+### S3. Slow audio fan-out warning (with correlation key)
+
+**File:** `cloud/packages/cloud/src/services/session/AudioManager.ts`
+
+**Before:** No fan-out instrumentation.
+
+**After:** Wrap `relayAudioToApps` with a timer; warn when slow OR fan-out is high:
+
+```
+{
+  feature: "slow-audio-fanout",
+  durationMs: <number>,
+  subscribers: <length>,
+  bytes: <buffer length>,
+  userIdHash: <number>,    // matches S1 and S2 keys for cross-log correlation
+}
+```
+
+Thresholds: `SLOW_RELAY_MS = 20`, `FANOUT_WARN = 10` subscribers.
+
+**Net effect:** distinguishes "fan-out blowup" hypothesis (many subs per session OR slow per-sub `connection.send()`). Includes the correlation key explicitly demanded by Codex's review (the original implementation omitted it).
+
+### S4. Heartbeat tick at 500ms with `gapStartedAtMs`
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+**Before:** Loop-liveness is monitored via the existing 1s/2s gap detector. That misses sub-2s hiccups (which may be the leading edge of a cascade) and its log timestamp is when the timer callback eventually fires — i.e., the _recovery_ moment, not the _trigger_ moment.
+
+**After:** Add a 500ms `setInterval` that records the tick time. When the next tick fires more than `HEARTBEAT_GAP_THRESHOLD_MS` (default 1000ms) late, log:
+
+```
+{
+  feature: "heartbeat-gap",
+  gapMs: <elapsed - HEARTBEAT_INTERVAL_MS>,
+  expectedMs: 500,
+  actualMs: <elapsed>,
+  gapStartedAtMs: <Date.now() - elapsed>,    // approximate trigger time, not log time
+  rssMB: <number>,
+  activeSessions: <count>,
+}
+```
+
+`gapStartedAtMs` is critical: without it, investigators reading the heartbeat-gap entry will look at logs immediately preceding the **log timestamp** (which are recovery flush logs), not logs preceding the **trigger** (which are what caused the cascade). With `gapStartedAtMs`, the query for "what was happening at trigger time" is correct.
+
+**Net effect:** finer trigger-moment resolution + investigators can find the actual leading cause without reading the wrong log window.
+
+### S5. logVitals self-timing
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+
+**Before:** `logVitals()` itself isn't timed. If the per-session memory census takes seconds, that IS the trigger and we wouldn't know.
+
+**After:** Wrap `logVitals` body in `performance.now()` brackets. Always log `{feature: "vitals-self-timing", durationMs}` at info level. Warn if duration > `VITALS_SELF_SLOW_MS` (default 500ms).
+
+**Important** (per Codex review): use the session count already captured at the top of `logVitals` for the log payload — do **not** call `UserSession.getAllSessions()` a second time in the finally block. The whole point is to measure logVitals' real cost; adding a second session scan in the measurement path itself adds noise.
+
+**Net effect:** rules vitals-as-trigger in or out without polluting its own measurement.
+
+### S6. Pod-level UDP counters in vitals
+
+**File:** `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts` (read), `cloud/packages/cloud/src/services/udp/UdpAudioServer.ts` (expose)
+
+**Before:** UdpAudioServer's packet counters (`packetsReceived`, `packetsDropped`, etc.) only appear in the periodic "UDP audio stats" log every 100 packets. Hard to correlate with vitals windows.
+
+**After:** Each 30s vitals row includes:
+
+- `udpPacketsReceivedDelta` — packets received this 30s window
+- `udpPacketsDroppedDelta` — packets dropped this window
+- `udpPacketsDecryptedDelta` — packets decrypted this window
+- `udpDecryptionFailuresDelta` — decryption failures this window
+- `udpRegisteredSessions` — current count of UDP-registered sessions
+
+Implementation: `UdpAudioServer` exposes `getStatsSnapshot()` returning current counter values + active session count. `SystemVitalsLogger` keeps the previous snapshot and computes the delta each window.
+
+**Net effect:** quantifies the regime where the cascade fires. Per the independent spike, dangerous load was ~96 pkt/s pod-wide with ~70 sessions; Phase 1 confirms or refines that threshold.
+
+### S7. Natural GC observer — REMOVED from Phase 1
+
+**Status:** Cut. Codex tested locally and confirmed Bun's `PerformanceObserver.supportedEntryTypes` returns `["mark","measure","resource"]` — `"gc"` is **not** supported. A Node-style observer would silently emit nothing, which is worse than not having it: post-deploy silence would look like "no natural GC pauses" when it really means "instrumentation is broken in this runtime."
+
+**If we keep an observer at all** (optional): gate it behind a runtime check. If `gc` is not in `supportedEntryTypes`, log `{feature: "natural-gc-unsupported"}` once at startup and don't install. Otherwise install normally. This way the absence of natural-gc data is itself an explicit signal.
+
+**For real natural-GC visibility**, a follow-up needs a Bun/JSC-specific mechanism (e.g., periodic `bun:jsc.heapStats()` snapshots and inferring GC from heap deltas). Out of scope for Phase 1.
+
+### S8. K8s probe widening — separate change, with documented tradeoffs
+
+**File:** Helm/Porter probe configuration (handled outside this PR).
+
+Per Codex's review: probe widening is **not a harmless band-aid**; it changes the user-visible failure mode. Specifically:
+
+- **Liveness** widening (`failureThreshold 15 → 30`, `timeoutSeconds 3 → 10`): pod takes longer to be killed/restarted. Reasonable tradeoff for Phase 1 — gives us survivable window for the cascades we observe today.
+- **Readiness** widening: keeps a stalled pod in the LB rotation longer. On single-pod us-central, when readiness fails the user sees a brief nginx 503 (which currently fires the BetterStack incident). When readiness succeeds despite the pod being stalled, the user sees **hung HTTP requests** instead. Both are bad on single-pod; **only multi-pod actually fixes this**.
+
+Recommended approach for Phase 1: **widen liveness only, leave readiness tight.** Then a stalled pod still gets removed from the LB quickly (visible as a 503 burst, monitorable), but doesn't get restarted on every 80s gap (fewer churn cycles to investigate per day).
+
+This change is applied via Porter UI separately from the code PR. Operator should:
+
+1. Land code PR (S1-S6)
+2. Verify logs in one quiet region
+3. Apply liveness widening to us-central
+4. Document explicitly: "we are accepting longer 503 bursts in exchange for fewer restarts; resolve permanently via Phase 2 + multi-pod."
+
+### S9. No actual fix in Phase 1
+
+Explicitly out of scope for this PR:
+
+- UDP backpressure (might be the right fix; we don't know yet)
+- `setImmediate` yield in audio drain (same)
+- Capping subscribers per session (same)
+- Any other behavioral change
+
+Adding any of these without the data could mask the real cause and make Phase 2 diagnosis harder.
+
+---
+
+## Non-Goals
+
+- **Identifying the trigger in this PR.** That happens after Phase 1 lands and one more crash cycle gives us logs.
+- **Multi-pod deployment.** Eventual fix via the cloud scaling plan; blocked today by single-pod assumptions in the architecture (see spike.md). This issue stabilizes single-pod _until_ the scaling plan lands.
+- **Vertical scaling.** Tactical option that buys headroom without addressing the cascade mechanism. Worth doing in parallel; not a substitute.
+- **Replacing pino with sync logger.** Async buffering loses logs near death; nice to fix but not required for this investigation since S4 (heartbeat) gives us the trigger timestamp via `gapStartedAtMs`.
+- **Fixing PR #2592's mobile reconnect storm.** Separate workstream (issue 101). Reduces _background_ load but is not a per-crash trigger per spike.md.
+- **Working natural-GC observer.** Cut from Phase 1; needs Bun-specific mechanism in a follow-up.
+
+---
+
+## Decision Log
+
+| Decision                                                         | Alternatives considered                               | Why we chose this                                                                                                                                                                                        |
+| ---------------------------------------------------------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Ship instrumentation only in Phase 1                             | Ship UDP backpressure / yielding / subscriber cap now | Three prior diagnoses were wrong. Without disambiguating data, the fourth is also a guess. Cost of one extra deploy cycle is < cost of shipping wrong fix and re-investigating.                          |
+| Add per-substage audio timing (S2)                               | Keep just the cumulative `op_audioProcessing_ms`      | Without substage breakdown, the next crash returns "audio = 80s" again and we still can't choose Phase 2. This is the highest-value addition per Codex's review.                                         |
+| 10ms per-substage threshold                                      | 5ms, 50ms                                             | Substages are sub-millisecond in steady state. 10ms = 10× normal — caught early without being so tight it floods steady-state logs.                                                                      |
+| Per-call audio at 50ms                                           | 10ms, 200ms                                           | 50ms is ~400× the steady-state per-call duration. Catches all real anomalies, doesn't flood.                                                                                                             |
+| Heartbeat at 500ms with `gapStartedAtMs`                         | Match existing 1s/2s gap detector                     | The existing detector misses 1-2s hiccups AND its timestamp is recovery time, not trigger time. 500ms catches the leading edge; `gapStartedAtMs` makes the log self-explain when the cascade started.    |
+| `logVitals` self-timing always logged at info                    | Only log on slow                                      | Want a baseline distribution; if it stays under 50ms in days of logs we can rule out vitals as trigger.                                                                                                  |
+| Reuse session count in vitals self-timing finally block          | Re-call `getAllSessions()`                            | Per Codex: the whole point of S5 is to measure logVitals' real cost. Adding a second `getAllSessions()` in the measurement path itself adds noise.                                                       |
+| Cut natural-GC observer (S7)                                     | Ship it as written; ship behind support check         | Codex confirmed Bun doesn't support the `gc` entryType. Shipping silently-broken instrumentation is worse than not shipping it; investigators would misread silence as "no GC pauses."                   |
+| Widen liveness only, not readiness                               | Widen both                                            | Per Codex: readiness widening keeps a stalled pod in LB rotation, surfacing as user-visible hangs instead of 503 bursts. On single-pod that's strictly worse. Only widen liveness until multi-pod lands. |
+| K8s probe widening as a separate change                          | Bundle with code                                      | Probe config is platform-level (Helm/Porter), different review path, different rollback. Bundling risks making the observability hard to roll out cleanly.                                               |
+| Add UDP delta counters to vitals (S6)                            | Read from existing periodic UDP audio stats logs      | Vitals already aggregates per 30s and is the natural correlation point. Periodic UDP stats fire every 100 packets, not on a wall-clock interval — hard to align with vitals windows.                     |
+| Privacy-preserving `userIdHash` (not raw `userId`) on audio logs | Raw userId                                            | Existing UDP path already uses userIdHash; matching that key avoids logging raw user IDs in slow-call/stage/fanout entries.                                                                              |
+
+---
+
+## Testing
+
+### Local
+
+1. `bun run lint` passes
+2. `bun run typecheck` passes
+3. `bun run test` passes (no behavior changes; existing tests should be unaffected)
+4. `bun run dev` boots the cloud locally; verify on startup logs:
+   - `vitals-self-timing` (info) appears every ~30s
+   - Either "Natural GC observer started" OR "natural-gc-unsupported" (depending on runtime)
+   - No `heartbeat-gap` warnings under idle dev (would indicate spurious detection)
+   - No `slow-audio-call` / `slow-audio-stage` / `slow-audio-fanout` under idle dev
+
+### Smoke (one quiet region first)
+
+Deploy to us-east (currently 0 sessions). After 30 minutes:
+
+```sql
+SELECT JSONExtract(raw,'feature','Nullable(String)') as f, count() as n
+FROM remote(t373499_mentracloud_prod_logs)
+WHERE dt >= now() - INTERVAL 30 MINUTE
+  AND JSONExtract(raw,'region','Nullable(String)')='us-east'
+  AND JSONExtract(raw,'feature','Nullable(String)') IN
+    ('vitals-self-timing','heartbeat-gap','slow-audio-call','slow-audio-stage',
+     'slow-audio-fanout','natural-gc','natural-gc-unsupported')
+GROUP BY f ORDER BY n DESC
+```
+
+Expected:
+
+- `vitals-self-timing` ≈ 60 entries (one per 30s, 30 min)
+- `heartbeat-gap` ≈ 0
+- `slow-audio-call` / `slow-audio-stage` / `slow-audio-fanout` ≈ 0
+- Either `natural-gc` (if Bun version supports) OR `natural-gc-unsupported` (one entry at startup)
+
+If anything spurious fires under steady state, tune thresholds in a follow-up before rolling to us-central.
+
+### Acceptance after one us-central crash
+
+Query the 90 seconds before the trigger time (`gapStartedAtMs` from the heartbeat log):
+
+```sql
+-- Replace <TRIGGER_TIME> with the gapStartedAtMs from the heartbeat-gap log
+SELECT dt, JSONExtract(raw,'feature','Nullable(String)') AS feat,
+            JSONExtract(raw,'stage','Nullable(String)') AS stage,
+            JSONExtract(raw,'durationMs','Nullable(Float64)') AS ms,
+            JSONExtract(raw,'gapMs','Nullable(Float64)') AS gap,
+            JSONExtract(raw,'gapStartedAtMs','Nullable(Int64)') AS gap_start,
+            JSONExtract(raw,'packetsToProcess','Nullable(Int32)') AS pkts,
+            JSONExtract(raw,'subscribers','Nullable(Int32)') AS subs,
+            JSONExtract(raw,'userIdHash','Nullable(Int64)') AS uid_hash
+FROM remote(t373499_mentracloud_prod_logs)
+WHERE dt >= '<TRIGGER_TIME-90s>' AND dt <= '<TRIGGER_TIME+5s>'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)') IN
+    ('heartbeat-gap','slow-audio-call','slow-audio-stage','slow-audio-fanout',
+     'vitals-self-timing','event-loop-gap')
+ORDER BY dt
+```
+
+Use the results to answer:
+
+1. **Trigger moment** (S4): the first `heartbeat-gap` entry's `gapStartedAtMs` tells us when. What was logged in the 5-10s before that timestamp?
+2. **Which substage** (S2): what does `slow-audio-stage` show? Are entries dominated by one stage (`lc3Decode`, `appFanout`, `transcriptionFeed`, etc.)? What does op*audio*\*\_ms show in the post-recovery vitals row?
+3. **Cascade vs pathological** (S1): many `slow-audio-call` entries with low `packetsToProcess` and moderate durations? Or one with multi-second duration? Or any with very high `packetsToProcess` (reorder-buffer flush)?
+4. **Fan-out** (S3): any `slow-audio-fanout` entries with `subscribers > 10` near the trigger? Same `userIdHash` as a `slow-audio-call`?
+5. **UDP load** (S6): what was `udpPacketsReceivedDelta` and `udpRegisteredSessions` in the vitals window before the cascade?
+6. **Vitals as trigger** (S5): any `vitals-self-timing` entries > 500ms in the 60s before the trigger?
+
+Each answered question narrows Phase 2's scope. After one crash cycle, we should be able to point to a specific substage + load condition and design the actual fix.
+
+---
+
+## Rollout
+
+1. Branch `cloud/pod-loop-stall-cascade` off `dev`. Done.
+2. PR S1-S6 to `dev`.
+3. Deploy to us-east. Validate baselines per Smoke section above.
+4. Deploy to us-central with S8 (liveness widening only) applied separately via Porter dashboard.
+5. Wait for next us-central crash (typically <12 hours).
+6. Analyze logs per Acceptance section.
+7. Open Phase 2 PR with the actual fix, scoped by the data.
+
+---
+
+## Key Numbers
+
+| Metric                                  | Today                                             | After Phase 1 (expected)                                                        |
+| --------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Visibility into trigger moment          | Gap detector log timestamps recovery, not trigger | 500ms-resolution `gapStartedAtMs` in heartbeat log                              |
+| Visibility into per-call audio duration | 0 (only cumulative)                               | All handler invocations > 50ms logged with batch size + userIdHash              |
+| Visibility into audio substages         | 0 (one black box)                                 | Per-substage cumulative timers in vitals + outliers > 10ms warned               |
+| Visibility into fan-out impact          | 0                                                 | All fan-outs > 20ms or > 10 subs logged with userIdHash for correlation         |
+| Visibility into pod-level UDP load      | Only periodic 100-packet stats                    | Per-vitals-window deltas (received, dropped, decrypted, fail) + active sessions |
+| Visibility into natural GC              | 0 (only forced)                                   | Either real `natural-gc` logs OR explicit `natural-gc-unsupported` startup log  |
+| K8s liveness threshold                  | 75s blockage                                      | ~300s blockage (only after S8 applied)                                          |
+| Crashes per day on us-central           | 4-6                                               | Should decrease (S8 band-aid only); root cause still pending Phase 2            |

--- a/cloud/issues/102-pod-loop-stall-cascade/spec.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spec.md
@@ -18,7 +18,7 @@
 
 ## The Problem in 30 Seconds
 
-us-central crashes 4-6 times per day. The most recent crash (2026-04-23 23:34 UTC, restart #5) had:
+us-central is crashing daily. The most recent crash (2026-04-23 23:34 UTC, restart #5) had:
 
 - An 80.7s `event-loop-gap` log (timer expected at 1s, fired 80.7s late)
 - Almost all op_total during that window in `op_audioProcessing_ms`
@@ -336,4 +336,4 @@ Each answered question narrows Phase 2's scope. After one crash cycle, we should
 | Visibility into pod-level UDP load      | Only periodic 100-packet stats                    | Per-vitals-window deltas (received, dropped, decrypted, fail) + active sessions |
 | Visibility into natural GC              | 0 (only forced)                                   | Either real `natural-gc` logs OR explicit `natural-gc-unsupported` startup log  |
 | K8s liveness threshold                  | 75s blockage                                      | ~300s blockage (only after S8 applied)                                          |
-| Crashes per day on us-central           | 4-6                                               | Should decrease (S8 band-aid only); root cause still pending Phase 2            |
+| Crash frequency on us-central           | Daily                                             | Should decrease (S8 band-aid only); root cause still pending Phase 2            |

--- a/cloud/issues/102-pod-loop-stall-cascade/spike-independent-2026-04-23.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spike-independent-2026-04-23.md
@@ -1,0 +1,443 @@
+# Spike Addendum: Independent Investigation of us-central Loop Starvation
+
+## Overview
+
+This is a second, independent spike for issue 102. It was written after re-running
+the investigation directly against Porter and BetterStack instead of relying on the
+previous AI SRE narrative or the first `spike.md`.
+
+The short version:
+
+- The newest us-central restart was a liveness-probe kill, not OOM.
+- `/livez` timed out, so the HTTP/timer side of the process was starved.
+- BetterStack recorded an 80.7s event-loop gap.
+- The corresponding `system-vitals` row attributed almost all blocked operation
+  time to `op_audioProcessing_ms`.
+- MongoDB slow-query spikes are mostly recovery artifacts, not the initiating cause.
+- The process was not frozen solid: UDP/audio logs continued while HTTP logs
+  disappeared. The better model is "UDP/audio callbacks monopolized the event
+  loop enough to starve HTTP probes and timers."
+
+This addendum corrects one important overstatement in the first spike: the event
+loop was not completely unable to execute JavaScript for 80 seconds. It was unable
+to schedule the liveness/readiness HTTP handlers and timer callbacks in time,
+while the UDP/audio path continued to run.
+
+## Tools Used
+
+All queries were read-only.
+
+- Porter CLI for Kubernetes pod state and events:
+
+```bash
+porter kubectl --cluster 4689 -- describe pod -n default cloud-prod-cloud-7b9847b4d9-npg5d
+```
+
+- Repo BetterStack CLI with credentials supplied by Doppler:
+
+```bash
+doppler run --project mentra-sre --config dev -- bun cloud/tools/bstack/bstack.ts ...
+```
+
+- `bstack sql` raw ClickHouse queries against:
+
+```sql
+s3Cluster(primary, t373499_mentracloud_prod_s3)
+```
+
+Region filter:
+
+```sql
+JSONExtract(raw,'region','Nullable(String)')='us-central'
+```
+
+## Incident Re-Checked
+
+The investigation focused on the freshest restart visible at the time:
+
+| Field              | Value                               |
+| ------------------ | ----------------------------------- |
+| Pod                | `cloud-prod-cloud-7b9847b4d9-npg5d` |
+| Region             | `us-central`                        |
+| Container finished | `2026-04-23 23:34:29 UTC`           |
+| Restart count      | `5`                                 |
+| Exit code          | `137`                               |
+| Container reason   | `Error`                             |
+| Memory limit       | `4096M`                             |
+| RSS before kill    | about `704MB`                       |
+
+Porter events for the same pod showed both probes failing:
+
+- `Readiness probe failed: Get "http://10.78.0.170:80/health": context deadline exceeded`
+- `Liveness probe failed: Get "http://10.78.0.170:80/livez": context deadline exceeded`
+- `Container cloud-prod-cloud failed liveness probe, will be restarted`
+
+This proves the immediate Kubernetes mechanism: the pod was killed because
+`/livez` did not respond within the liveness threshold. Since `/livez` is a
+literal `c.text("ok")`, a timeout there means the HTTP handler could not get
+scheduled promptly. It does not implicate MongoDB or `/health` work.
+
+## Proof 1: Event-Loop Gap at the Kill
+
+Query:
+
+```bash
+doppler run --project mentra-sre --config dev -- bun cloud/tools/bstack/bstack.ts sql "
+SELECT
+  dt,
+  JSONExtract(raw,'gapMs','Nullable(Float64)') AS gap_ms,
+  JSONExtract(raw,'actualMs','Nullable(Float64)') AS actual_ms,
+  JSONExtract(raw,'rssMB','Nullable(Float64)') AS rss_mb,
+  JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:20:00'
+  AND dt <= '2026-04-23 23:36:00'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)')='event-loop-gap'
+ORDER BY dt"
+```
+
+Result:
+
+| dt                           |  gap_ms | actual_ms | rss_mb | sessions |
+| ---------------------------- | ------: | --------: | -----: | -------: |
+| `2026-04-23 23:34:26.882000` | `79739` |   `80739` |  `704` |     `71` |
+
+This proves a timer callback expected every 1s ran about 80.7s after its previous
+tick. The pod was not killed because memory hit the container limit: RSS was only
+about 704MB against a 4096MB limit.
+
+## Proof 2: Vitals Attribute the Starved Window to Audio Processing
+
+Query:
+
+```bash
+doppler run --project mentra-sre --config dev -- bun cloud/tools/bstack/bstack.ts sql "
+SELECT
+  dt,
+  JSONExtract(raw,'rssMB','Nullable(Float64)') AS rss,
+  JSONExtract(raw,'heapUsedMB','Nullable(Float64)') AS heap,
+  JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions,
+  JSONExtract(raw,'op_audioProcessing_ms','Nullable(Float64)') AS audio_ms,
+  JSONExtract(raw,'op_appMessage_ms','Nullable(Float64)') AS app_ms,
+  JSONExtract(raw,'opTotalMs','Nullable(Float64)') AS total_ms,
+  JSONExtract(raw,'opBudgetUsedPct','Nullable(Float64)') AS budget_pct
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:20:00'
+  AND dt <= '2026-04-23 23:36:00'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)')='system-vitals'
+ORDER BY dt"
+```
+
+Key rows:
+
+| dt                        | sessions | audio_ms | app_ms | total_ms | budget_pct |
+| ------------------------- | -------: | -------: | -----: | -------: | ---------: |
+| `2026-04-23 23:32:24.908` |     `71` |    `345` |   `35` |    `414` |        `1` |
+| `2026-04-23 23:32:54.920` |     `71` |    `319` |  `429` |    `781` |        `3` |
+| `2026-04-23 23:34:27.109` |     `71` |  `80118` |   `20` |  `80153` |      `267` |
+| `2026-04-23 23:35:01.462` |      `1` |     null |   `12` |     `13` |        `0` |
+
+The `23:34:27.109` row is the first vitals row after the delayed timer fires.
+Nearly all accumulated measured operation time in that interval is
+`op_audioProcessing_ms`.
+
+This does not yet prove which substage inside audio is slow. The current code
+wraps the `UdpAudioServer` call into `session.audioManager.processAudioData(...)`.
+That includes, depending on session state:
+
+- LC3 decode
+- app audio fan-out
+- transcription `feedAudio`
+- translation `feedAudio`
+- microphone activity update
+
+The existing cumulative timer cannot distinguish those substages.
+
+## Proof 3: MongoDB Was Not the Initiating Cause
+
+Slow-query counts before the starved window were ordinary for this pod. The huge
+MongoDB durations appear only at recovery time, when delayed callbacks all flush
+after the loop becomes schedulable again.
+
+Query shape:
+
+```bash
+doppler run --project mentra-sre --config dev -- bun cloud/tools/bstack/bstack.ts sql "
+SELECT
+  toStartOfInterval(dt, INTERVAL 30 SECOND) AS bucket,
+  count() AS logs,
+  countIf(JSONExtract(raw,'feature','Nullable(String)')='slow-query') AS slow_queries,
+  max(JSONExtract(raw,'durationMs','Nullable(Float64)')) AS max_slow_ms
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:20:00'
+  AND dt <= '2026-04-23 23:36:00'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+GROUP BY bucket
+ORDER BY bucket"
+```
+
+Key rows:
+
+| bucket                |   logs | slow_queries | max_slow_ms |
+| --------------------- | -----: | -----------: | ----------: |
+| `2026-04-23 23:32:30` | `1768` |          `5` |     `162.8` |
+| `2026-04-23 23:33:00` |  `636` |          `2` |     `110.5` |
+| `2026-04-23 23:33:30` |   `57` |          `0` |        null |
+| `2026-04-23 23:34:00` | `3575` |         `31` |   `81560.8` |
+| `2026-04-23 23:34:30` |  `259` |         `10` |     `355.7` |
+
+The 81.5s slow-query max in the `23:34:00` bucket aligns with the event-loop gap.
+That is consistent with query callbacks being delayed behind the event-loop
+starvation, not with Atlas suddenly taking 81.5s and causing `/livez` to time out.
+
+## Proof 4: UDP/Audio Continued While HTTP Disappeared
+
+This is the key refinement over the first spike.
+
+Per-second log counts around the incident:
+
+| second                        |              logs |       udp_server |        audio_mgr | http | vitals |
+| ----------------------------- | ----------------: | ---------------: | ---------------: | ---: | -----: |
+| `23:33:00`                    |              `59` |              `1` |              `2` |  `9` |    `0` |
+| `23:33:01`                    |             `110` |              `1` |              `2` |  `3` |    `0` |
+| `23:33:02`                    |             `110` |              `4` |              `4` | `10` |    `0` |
+| `23:33:06`                    |              `25` |              `4` |              `5` |  `3` |    `0` |
+| `23:33:07`                    |               `8` |              `5` |              `1` |  `0` |    `0` |
+| `23:33:08` through `23:34:25` | usually `1-4`/sec | mostly UDP/audio | mostly UDP/audio |  `0` |    `0` |
+| `23:34:26`                    |              `34` |              `3` |              `4` |  `0` |    `1` |
+| `23:34:27`                    |            `3087` |             `10` |              `7` | `64` |    `3` |
+
+Interpretation:
+
+- HTTP request logs vanish after about `23:33:06`.
+- UDP/audio logs continue throughout the starvation window.
+- Timer-based vitals and event-loop-gap logs only appear at recovery.
+- HTTP logs burst again after recovery.
+
+So the event loop was not literally executing no JavaScript. It was spending its
+schedulable time in UDP/audio work, starving timers and HTTP long enough for K8s
+liveness to kill the container.
+
+## Proof 5: UDP Packet Counters Advanced During Starvation
+
+UDP server stats log every 100 received packets. During the HTTP-starved window,
+the pod-level UDP packet counter continued increasing.
+
+Selected rows:
+
+| dt                        | packetsReceived | activeSessions |
+| ------------------------- | --------------: | -------------: |
+| `2026-04-23 23:33:06.007` |       `1237300` |           `69` |
+| `2026-04-23 23:33:20.111` |       `1238500` |           `69` |
+| `2026-04-23 23:33:40.707` |       `1240600` |           `69` |
+| `2026-04-23 23:34:00.077` |       `1242400` |           `69` |
+| `2026-04-23 23:34:20.007` |       `1244200` |           `69` |
+| `2026-04-23 23:34:26.875` |       `1245000` |           `69` |
+
+This is about 7,700 UDP packets processed between `23:33:06` and `23:34:26`.
+That is roughly 96 packets/sec pod-wide.
+
+Per-user audio manager stats show no single user owns the entire incident. Around
+ten users each logged 100-packet increments every roughly 8-11 seconds. The
+pattern looks like aggregate audio load across many mic-active sessions, not one
+obvious single-user storm.
+
+## Proof 6: GC Probe Does Not Explain the 80s Stall
+
+GC probe rows before the kill were around 110-140ms, not seconds:
+
+| dt                        |   gc_ms | rss_mb | sessions |
+| ------------------------- | ------: | -----: | -------: |
+| `2026-04-23 23:31:54.640` | `139.9` |  `700` |     `72` |
+| `2026-04-23 23:32:54.623` | `120.6` |  `697` |     `71` |
+| `2026-04-23 23:34:27.230` | `117.4` |  `704` |     `71` |
+
+This does not rule out every possible natural JSC GC behavior, but it makes the
+forced full-GC probe an unlikely direct explanation for an 80s liveness failure.
+
+Also, local Bun did not appear to emit `PerformanceObserver` `gc` entries:
+
+```bash
+bun -e 'import { PerformanceObserver } from "node:perf_hooks"; console.log(JSON.stringify(PerformanceObserver.supportedEntryTypes))'
+```
+
+Returned:
+
+```json
+["mark", "measure", "resource"]
+```
+
+And a forced `Bun.gc(true)` with a `PerformanceObserver` for `entryTypes: ["gc"]`
+emitted zero entries. That means the proposed `natural-gc` instrumentation in
+the first design probably will not provide useful data in this runtime.
+
+## What This Proves
+
+High confidence:
+
+1. The immediate K8s failure mode is liveness timeout on `/livez`, followed by
+   exit 137.
+2. The pod was not OOMKilled and was far below the 4GB memory limit.
+3. The stall aligns with an 80.7s event-loop/timer gap.
+4. The measured operation bucket for the starved interval is almost entirely
+   audio processing.
+5. MongoDB slow-query spikes during the incident are recovery symptoms, not the
+   cause of `/livez` timing out.
+6. UDP/audio processing continued while HTTP request handling stopped, so the
+   failure is better described as event-loop starvation/monopolization than a
+   complete runtime freeze.
+
+Medium confidence:
+
+1. The trigger is aggregate audio load across many active mic sessions, not one
+   single user's reconnect storm.
+2. The dangerous threshold is around 70-90 active sessions with 30+ mic-active
+   sessions and about 100 UDP packets/sec pod-wide.
+3. The audio path likely needs explicit yielding/backpressure/drop behavior so
+   HTTP and timers cannot be starved by UDP receive callbacks.
+
+Not yet proven:
+
+1. Which exact audio substage burns the time:
+   - LC3 decode
+   - app audio fan-out
+   - transcription stream writes
+   - translation stream writes
+   - some combination of the above
+2. Whether a rare pathological packet/buffer state contributes.
+3. Whether Bun's UDP callback scheduling can starve HTTP independently of per
+   packet CPU cost.
+
+## Corrections to the Existing Phase 1 Plan
+
+The current Phase 1 direction is mostly right, but it should be adjusted.
+
+Keep:
+
+- per-invocation UDP audio timing
+- packet batch size in the slow-call log
+- heartbeat/gap timing, with analysis adjusted for delayed emission
+- vitals self-timing
+
+Change:
+
+- Replace or remove `PerformanceObserver` natural-GC instrumentation unless a
+  Bun/JSC-specific working mechanism is found.
+- Do not only instrument `relayAudioToApps`; that misses transcription and
+  translation sends.
+- Split `AudioManager.processAudioData(...)` into substage timings:
+  - `audio_lc3Decode_ms`
+  - `audio_appFanout_ms`
+  - `audio_transcriptionFeed_ms`
+  - `audio_translationFeed_ms`
+  - `audio_microphoneUpdate_ms`
+- Add `userIdHash` or a privacy-preserving session key to fan-out/substage logs
+  so they can be correlated with `slow-audio-call` without logging raw user IDs.
+- Consider a pod-level UDP receive rate metric per vitals interval:
+  `udpPacketsReceivedDelta`, `udpPacketsDroppedDelta`, and active UDP sessions.
+
+## Working Hypothesis
+
+The most likely root cause is not MongoDB, readiness, GC, or reconnect storm.
+
+The most likely root cause is:
+
+> Under us-central load, Bun's UDP receive path plus synchronous audio processing
+> can monopolize the single JS event loop for long enough that HTTP handlers and
+> timers are starved. K8s liveness probes to `/livez` then time out for enough
+> consecutive probes that kubelet kills the container. MongoDB "slow" queries and
+> reconnect storms are downstream recovery artifacts.
+
+The next fix should be designed around protecting the event loop from UDP/audio
+starvation:
+
+- introduce bounded audio work per tick
+- yield between chunks/batches
+- drop or coalesce audio packets when behind
+- separate UDP/audio processing from probe-serving where possible
+- measure per-audio-substage cost before choosing the exact intervention
+
+## Evidence Index
+
+Current pod state:
+
+```bash
+porter kubectl --cluster 4689 -- describe pod -n default cloud-prod-cloud-7b9847b4d9-npg5d
+```
+
+Event-loop gap:
+
+```sql
+SELECT dt,
+       JSONExtract(raw,'gapMs','Nullable(Float64)') AS gap_ms,
+       JSONExtract(raw,'actualMs','Nullable(Float64)') AS actual_ms,
+       JSONExtract(raw,'rssMB','Nullable(Float64)') AS rss_mb,
+       JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:20:00'
+  AND dt <= '2026-04-23 23:36:00'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)')='event-loop-gap'
+ORDER BY dt;
+```
+
+System vitals operation budget:
+
+```sql
+SELECT dt,
+       JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions,
+       JSONExtract(raw,'op_audioProcessing_ms','Nullable(Float64)') AS audio_ms,
+       JSONExtract(raw,'op_appMessage_ms','Nullable(Float64)') AS app_ms,
+       JSONExtract(raw,'opTotalMs','Nullable(Float64)') AS total_ms,
+       JSONExtract(raw,'opBudgetUsedPct','Nullable(Float64)') AS budget_pct
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:20:00'
+  AND dt <= '2026-04-23 23:36:00'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)')='system-vitals'
+ORDER BY dt;
+```
+
+Per-second service mix:
+
+```sql
+SELECT toStartOfInterval(dt, INTERVAL 1 SECOND) AS sec,
+       count() AS logs,
+       countIf(JSONExtractString(raw,'service')='UdpAudioServer') AS udp_server,
+       countIf(JSONExtractString(raw,'service')='AudioManager') AS audio_mgr,
+       countIf(JSONExtractString(raw,'service')='hono-http') AS http,
+       countIf(JSONExtractString(raw,'service')='SystemVitalsLogger') AS vitals
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:33:00'
+  AND dt <= '2026-04-23 23:34:30'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+GROUP BY sec
+ORDER BY sec;
+```
+
+UDP stats during starvation:
+
+```sql
+SELECT dt,
+       JSONExtractString(raw,'service') AS service,
+       JSONExtractString(raw,'message') AS message,
+       JSONExtract(raw,'packetsReceived','Nullable(Int32)') AS pod_udp_count,
+       JSONExtract(raw,'lastSequence','Nullable(Int32)') AS seq,
+       JSONExtract(raw,'lastAudioBytes','Nullable(Int32)') AS last_bytes,
+       JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type=1
+  AND dt >= '2026-04-23 23:33:00'
+  AND dt <= '2026-04-23 23:34:27'
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central'
+  AND JSONExtract(raw,'feature','Nullable(String)')='udp-audio'
+ORDER BY dt;
+```

--- a/cloud/issues/102-pod-loop-stall-cascade/spike.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spike.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**What this doc covers:** Investigation of recurring SIGKILL crashes on the us-central cloud pod. The pod crashes 4-6 times per day with exit code 137. Direct gap-detector evidence shows 40-80 second event-loop blockages preceding each kill. Cumulative `op_audioProcessing_ms` accounts for ~99% of the blocked sync time, but **we have not yet proven what initiates the stall**, and three different mechanisms are equally compatible with the data.
+**What this doc covers:** Investigation of recurring SIGKILL crashes on the us-central cloud pod. The pod is crashing daily with exit code 137. Direct gap-detector evidence shows 40-80 second event-loop blockages preceding each kill. Cumulative `op_audioProcessing_ms` accounts for ~99% of the blocked sync time, but **we have not yet proven what initiates the stall**, and three different mechanisms are equally compatible with the data.
 
 **Why this doc exists:** Multiple prior investigations (BetterStack AI SRE, internal triage) reached confident-but-wrong conclusions: "MongoDB query slowness," "readiness probe timeout from Mongo saturation," "reconnect storm trigger." All three were falsified by direct examination of source + telemetry. This spike captures what we actually know, what we falsified, and why the next step must be instrumentation rather than speculative fix.
 
@@ -27,7 +27,7 @@ Multi-pod requires Redis (or equivalent) for cross-pod session lookup, a UDP rou
 
 ## The Pattern in 30 Seconds
 
-us-central pod crashes 4-6 times per day:
+us-central pod crashes daily:
 
 - Exit code 137 (SIGKILL)
 - Container Reason: "Error" (not OOMKilled)
@@ -173,7 +173,7 @@ Multi-pod is the eventual fix and is covered by the separate cloud scaling plan.
 
 Multi-pod is blocked today by the single-pod assumptions catalogued earlier in this spike (in-memory `UserSession` map, UDP server binding, photo-response routing, no shared session store). The scaling plan addresses these via Redis-backed session registry, a UDP routing layer, and sticky LB. That work is multi-week.
 
-**This issue exists because we cannot wait for multi-pod to stop the crashes.** us-central is crashing 4-6 times per day right now. Single-pod stabilization needs to land first; multi-pod lands after.
+**This issue exists because we cannot wait for multi-pod to stop the crashes.** us-central is crashing daily right now. Single-pod stabilization needs to land first; multi-pod lands after.
 
 Vertical scaling (more CPU/memory for us-central) is a separate option that doesn't conflict with this work. It buys headroom but doesn't address the cascade mechanism. Worth doing in parallel as a defensive measure, but not a substitute for fixing the cascade itself.
 

--- a/cloud/issues/102-pod-loop-stall-cascade/spike.md
+++ b/cloud/issues/102-pod-loop-stall-cascade/spike.md
@@ -1,0 +1,208 @@
+# Spike: Cloud Pod Event-Loop Stall Cascade (us-central)
+
+## Overview
+
+**What this doc covers:** Investigation of recurring SIGKILL crashes on the us-central cloud pod. The pod crashes 4-6 times per day with exit code 137. Direct gap-detector evidence shows 40-80 second event-loop blockages preceding each kill. Cumulative `op_audioProcessing_ms` accounts for ~99% of the blocked sync time, but **we have not yet proven what initiates the stall**, and three different mechanisms are equally compatible with the data.
+
+**Why this doc exists:** Multiple prior investigations (BetterStack AI SRE, internal triage) reached confident-but-wrong conclusions: "MongoDB query slowness," "readiness probe timeout from Mongo saturation," "reconnect storm trigger." All three were falsified by direct examination of source + telemetry. This spike captures what we actually know, what we falsified, and why the next step must be instrumentation rather than speculative fix.
+
+**Why we are fixing this on a single pod, not horizontally scaling first:** us-central runs a single pod handling 60+ sessions. Other regions handle 7-18 sessions per pod and are stable. The eventual fix is multi-pod (covered by the cloud scaling plan), but it is blocked today by these single-pod assumptions in the architecture:
+
+- A user's glasses WebSocket lands on a specific pod (Cloudflare LB hash)
+- The mini-app webhook lands an SDK WebSocket which must reach the same pod (in-memory `UserSession` map)
+- UDP audio register binds session to a specific pod's UDP server
+- No Redis, no shared session store, no pod-to-pod routing
+- Photo response REST calls must reach the pod with the originating session in `pendingPhotoRequests`
+
+Multi-pod requires Redis (or equivalent) for cross-pod session lookup, a UDP routing layer, and sticky LB. That work belongs to the cloud scaling plan and is a multi-week project. **We need single-pod us-central to stop crashing before the scaling plan lands.** This spike is for what we can do in the meantime — single-pod stabilization.
+
+**Who should read this:** Cloud + SRE engineers triaging us-central crashes. Anyone considering "the obvious fix" to know what's been ruled out.
+
+**Depends on:**
+
+- Direct evidence from BetterStack `system-vitals`, `event-loop-gap`, `slow-query`, `gc-probe` features
+- Porter kubectl describe output for the affected pod
+
+---
+
+## The Pattern in 30 Seconds
+
+us-central pod crashes 4-6 times per day:
+
+- Exit code 137 (SIGKILL)
+- Container Reason: "Error" (not OOMKilled)
+- Container memory limit 4096MB; pod RSS at death usually 800-1010MB (well under limit)
+- Last logs before death: 0-1 ms 200 OK responses (pod is responsive _just before_ the kill)
+- No SIGTERM-handler log line emitted before SIGKILL
+- Other regions (east-asia, france, us-west, us-east) are stable for days/weeks
+
+Direct gap-detector log from the most recent crash (2026-04-23 19:48 UTC):
+
+```
+event-loop-gap: 80,497ms (expected 1000ms, actual 81,497ms)
+```
+
+This is ground truth: the JS event loop was blocked for 80.5 seconds before the kill.
+
+---
+
+## What We Proved
+
+### 1. The event loop was demonstrably blocked
+
+`SystemVitalsLogger`'s gap detector ([SystemVitalsLogger.ts:163-185](../../packages/cloud/src/services/metrics/SystemVitalsLogger.ts#L163-L185)) is a 1-second `setInterval` that logs when its tick takes >2 seconds. For the 19:48 crash it logged a single gap of 80,497ms. Multiple independent signals confirm the same blockage:
+
+- **Vitals callback fired 63 seconds late** (last normal sample 19:47:12, next at 19:48:45 — should have been 19:47:42)
+- **Log volume cratered then burst**: 1,716 logs/30s (normal) → 59 logs/30s (during blockage, pino async-buffered) → 2,605 logs/30s (drain after recovery)
+- **8 Mongo queries each timed at 81,371-81,566 ms within the same second** — impossible unless their callbacks were queued behind the blockage and all fired together when it cleared
+
+### 2. The 75-second K8s threshold determines kill vs survive
+
+K8s liveness config: `timeout=3s period=5s failureThreshold=15`. To trigger kill: 15 consecutive failed probes = ~75 seconds of sustained blockage.
+
+Looking at peak `op_audioProcessing_ms` bursts on the prior pod (lived 4h56m):
+
+- 17:12: 39,334 ms cascade — survived (only ~40s of blockage, 8 probes failed, under threshold)
+- 17:31: 8,377 ms — survived
+- 17:36: 1,844 ms — survived
+- 18:26: ~80s+ blockage — killed
+
+These cascades happen 3-4 times per pod life. Whether they cause death is largely determined by whether the blockage exceeds 75 seconds — which appears to be a coin-flip on the cascade's amplification factor.
+
+### 3. Cumulative measured sync time was in the audio path
+
+For the 19:48 blockage window, op_total breakdown:
+
+```
+op_audioProcessing:  80,114 ms    (99.96% of total)
+op_glassesMessage:        7 ms
+op_appMessage:           18 ms
+op_displayRendering:     11 ms
+opTotalMs:           80,150 ms
+```
+
+The `addTiming("audioProcessing")` call wraps the synchronous portion of `UdpAudioServer.handleAudioPacket`'s for-loop over `packetsToProcess` ([UdpAudioServer.ts:259-278](../../packages/cloud/src/services/udp/UdpAudioServer.ts#L259-L278)). Because `processAudioData` is `async` but called without await, the sync portion of each call (which for PCM is the entire body) executes inline on the caller's stack.
+
+So 80 seconds of sync wall-time during the blockage can be attributed to code reachable through this for loop. **What we cannot determine from the timer alone is whether the 80s came from many small calls (cascade), one giant call (pathological bug), or a fan-out blowup in `relayAudioToApps`.**
+
+---
+
+## What We Falsified
+
+### Falsified hypothesis 1: "MongoDB slow queries caused the 503"
+
+Origin: BetterStack AI SRE tool's first analysis.
+
+**What was wrong:**
+
+- `/health` endpoint does NOT touch MongoDB. [hono-app.ts:222-276](../../packages/cloud/src/hono-app.ts#L222-L276) only reads in-memory session map + `process.memoryUsage()`. So Mongo slowness cannot cause `/health` to return 503.
+- The 8 slow queries each timed at ~81,500ms were **callbacks waiting for the blocked event loop to fire them**, not Mongo being slow. Atlas had answered; the JS runtime couldn't process the response.
+
+### Falsified hypothesis 2: "Readiness probe times out because /health is heavy"
+
+Origin: BetterStack AI SRE tool's revised analysis.
+
+**What was wrong:**
+
+- `/health` is in-process and emits a `health-timing` log only when duration exceeds 50ms. **Zero `health-timing` entries** appeared in the 30-min window around the incident. `/health` was always fast when invocable.
+- The pod was serving 0-1 ms responses (including the BetterStack uptime probe itself hitting `/favicon.ico`) within 4 seconds of SIGKILL. This is not a "probe timeout" pattern — it's "pod was alive and responsive, then suddenly killed."
+
+### Falsified hypothesis 3: "GC pauses from heap growth blocked the loop"
+
+Origin: my first internal hypothesis.
+
+**What was wrong:**
+
+- gc-probe (forced full-GC, sync, measured wall-clock pause) returned 165-184 ms across the entire pre-crash window. That is not enough to fail a 3-second liveness timeout, let alone 15 consecutive ones.
+- Heap did grow (117 → 739 MB over 4.9 hours on the prior pod) but the actual GC pause durations did not.
+
+Caveat: we only measure **forced** GC duration. Natural major GCs (V8's "MarkCompact" on heap pressure) might be longer. We have no instrumentation for natural GC duration. Hypothesis is unsupported but not strictly disproved.
+
+### Falsified hypothesis 4: "Reconnect storm from one user triggers the cascade"
+
+Origin: my second internal hypothesis after seeing `Glasses reconnect #4850` in the pre-crash logs.
+
+**What was wrong:**
+
+- Reconnect counter is **cumulative across the session's life**, not a current rate.
+- Per-30s reconnect rate for the 7 minutes before the 19:48 crash was flat at 35-40 (≈80/min). It was actually slightly _declining_ (32 at 19:47:00) when the blockage began at 19:47:24.
+- The system was handling that reconnect rate cleanly for a long time. There was no spike correlating with crash onset.
+
+The reconnect rate **is** chronically elevated (single users at #4850 reconnects exposes a real client bug, see issue 101) but it is background load, not a per-event trigger.
+
+---
+
+## What We Don't Know
+
+**The trigger.** What blocks the event loop initially? The audio bucket accounts for 99% of the _measured_ time during the blockage, but that measurement starts _after_ something already paused the loop long enough for backlog to build. Candidates we cannot distinguish without further instrumentation:
+
+1. **Natural V8 major GC.** Heap was 533 MB at 19:47:12. A MarkCompact at that size could take several seconds. We don't measure natural GCs.
+2. **`logVitals()` itself.** Vitals callback fires every 30 seconds and iterates all sessions, calling `session.getMemoryCensus()` which walks several owner maps per session. If that iteration takes seconds at peak session count, it IS the trigger and the audio cascade is just downstream amplification. (The largest historical owner — `transcription.history` — was removed by issue 098 on dev; this hypothesis is about whatever else the census walks today, not about that specific map.)
+3. **`relayAudioToApps` fan-out** ([AudioManager.ts:353-389](../../packages/cloud/src/services/session/AudioManager.ts#L353-L389)). Per audio packet, iterates subscribed apps and calls `connection.send(audioData)` synchronously. If sub count grew unbounded for some session, a single packet could trigger N synchronous WS sends.
+4. **A specific pathological audio packet.** LC3 decode edge case, buffer alignment edge case, etc.
+5. **Mongo connection pool exhaustion.** During the blockage we saw 8 queries waiting for the same ~81,500ms — could indicate pool was already saturated when the blockage started.
+6. **Kernel/Azure-VM-level event.** I/O throttling, CPU steal, page reclaim. Hard to verify without node-level metrics.
+
+The amplifier mechanism is also unconfirmed:
+
+- **A. High-volume cascade.** Many UDP packets queue in kernel buffer during initial pause; loop drains them sequentially; drain takes longer than incoming rate; cascade. UDP backpressure (drop packets when behind) would fix this.
+- **B. Pathological single call.** One `processAudioData` call entered some bug and took 80 seconds. Backpressure wouldn't help; need to find the bug.
+- **C. Fan-out blowup.** `relayAudioToApps` iterating an unbounded subscriber list. Cap subscribers per session.
+
+The op_audioProcessing timer alone cannot distinguish A, B, or C. They all produce the same aggregate measurement.
+
+---
+
+## Why Confident-Wrong Diagnoses Keep Happening
+
+Three independent investigations confidently identified different "root causes" and proposed three different fixes, all of which were wrong on inspection. The shared failure mode:
+
+1. The op_total / op_audioProcessing / mongoBlockingMs telemetry **measures cumulative wall-time, not work**. When the loop is blocked, the next available log/measurement attributes the blockage to whichever bucket the next-completed operation lives in. It's easy to misread "audio bucket has 80s" as "audio is the cause" when it might be "audio is what was running when the loop unblocked."
+
+2. The pod **was responsive** in the moments immediately before SIGKILL (1ms response times). It is counterintuitive that an apparently-healthy pod was killed; this leads investigators to look for something happening _at the moment of death_ rather than ~80 seconds prior.
+
+3. The Mongo callback storm during loop recovery looks identical in BetterStack's UI to a real Mongo slowdown. Both show "many slow queries clustered in a small time window." Distinguishing requires reading the application source to know that `/health` doesn't query Mongo.
+
+The lesson: **stop reasoning from telemetry alone.** We need to instrument the actual code path with a measurement that disambiguates trigger vs amplifier, before designing any fix.
+
+---
+
+## Relationship to Multi-Pod (Cloud Scaling Plan)
+
+Multi-pod is the eventual fix and is covered by the separate cloud scaling plan. It is the right long-term answer: each pod carries a fraction of session load, no single pod approaches the cascade threshold, regional capacity scales horizontally with demand.
+
+Multi-pod is blocked today by the single-pod assumptions catalogued earlier in this spike (in-memory `UserSession` map, UDP server binding, photo-response routing, no shared session store). The scaling plan addresses these via Redis-backed session registry, a UDP routing layer, and sticky LB. That work is multi-week.
+
+**This issue exists because we cannot wait for multi-pod to stop the crashes.** us-central is crashing 4-6 times per day right now. Single-pod stabilization needs to land first; multi-pod lands after.
+
+Vertical scaling (more CPU/memory for us-central) is a separate option that doesn't conflict with this work. It buys headroom but doesn't address the cascade mechanism. Worth doing in parallel as a defensive measure, but not a substitute for fixing the cascade itself.
+
+---
+
+## Recommendation
+
+Do **not** ship a speculative fix for the cascade. Three prior diagnoses were wrong; the fourth would also likely be wrong without disambiguating data.
+
+Ship a small, targeted observability PR (~50 lines, no behavior change) and let one more crash cycle answer the trigger-vs-amplifier question definitively. See [spec.md](./spec.md) and [design.md](./design.md).
+
+Then, with data in hand, design the actual fix.
+
+---
+
+## Evidence Index
+
+For anyone re-running this investigation:
+
+```bash
+# Direct event-loop-gap log for the 19:48 crash
+bstack sql "SELECT dt, JSONExtract(raw,'gapMs','Nullable(Float64)') as gap_ms, JSONExtract(raw,'rssMB','Nullable(Float64)') as rss FROM s3Cluster(primary, t373499_mentracloud_prod_s3) WHERE _row_type=1 AND dt >= '2026-04-23 19:00:00' AND dt <= '2026-04-23 20:00:00' AND JSONExtract(raw,'feature','Nullable(String)')='event-loop-gap' AND JSONExtract(raw,'region','Nullable(String)')='us-central'"
+
+# Pod restart timeline (us-central, 44 hours)
+bstack sql "SELECT toStartOfInterval(dt, INTERVAL 1 HOUR) as hour, count() as restarts FROM (SELECT dt, JSONExtract(raw,'uptimeSeconds','Nullable(Int32)') as up FROM s3Cluster(primary, t373499_mentracloud_prod_s3) WHERE _row_type=1 AND dt >= '2026-04-22 00:00:00' AND dt <= '2026-04-23 20:00:00' AND JSONExtract(raw,'feature','Nullable(String)')='system-vitals' AND JSONExtract(raw,'region','Nullable(String)')='us-central' AND up < 60) GROUP BY hour ORDER BY hour"
+
+# Reconnect rate per 30s before crash (proves no spike)
+bstack sql "SELECT toStartOfInterval(dt, INTERVAL 30 SECOND) as bucket, countIf(JSONExtract(raw,'message','Nullable(String)') LIKE '%Glasses reconnect #%') as reconnects FROM s3Cluster(primary, t373499_mentracloud_prod_s3) WHERE _row_type=1 AND dt >= '2026-04-23 19:40:00' AND dt <= '2026-04-23 19:50:00' AND JSONExtract(raw,'region','Nullable(String)')='us-central' GROUP BY bucket ORDER BY bucket"
+
+# Pod kill state (verify exit 137, Reason)
+porter kubectl --cluster 4689 -- describe pod -n default -l "app.kubernetes.io/name=cloud-prod-cloud" | grep -A8 "Last State"
+```

--- a/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
@@ -524,10 +524,31 @@ async function getMemorySnapshot(c: AppContext) {
 }
 
 /**
+ * Self-DoS guard for V8 heap snapshot endpoints. Both v8.getHeapSnapshot and
+ * v8.writeHeapSnapshot are SYNCHRONOUS — they block the event loop for the
+ * full snapshot generation (which scales with heap size) and require ~2× the
+ * current heap in memory. Two concurrent requests would stack that 2×
+ * allocation on top of an already stressed pod and can trigger OOM.
+ *
+ * Do NOT invoke these endpoints during an active degradation window. Taking
+ * a snapshot while a pod is stalled/OOM-ing will extend the stall and can
+ * push the pod past its memory limit before the snapshot finishes streaming.
+ */
+let heapSnapshotInFlight = false;
+
+/**
  * POST /api/admin/memory/heap-snapshot
  * Trigger a Chrome-compatible V8 heap snapshot and write it to a temp file.
+ *
+ * WARNING: synchronous, blocks the event loop, requires ~2× heap in memory.
+ * See `heapSnapshotInFlight` above — do not call during a degradation window.
  */
 async function takeHeapSnapshotHandler(c: AppContext) {
+  if (heapSnapshotInFlight) {
+    return c.json({ error: "Heap snapshot already in progress" }, 429);
+  }
+  heapSnapshotInFlight = true;
+
   const filename = `heap-${Date.now()}.heapsnapshot`;
   const filePath = path.join(os.tmpdir(), filename);
 
@@ -540,14 +561,24 @@ async function takeHeapSnapshotHandler(c: AppContext) {
   } catch (error) {
     logger.error(error, "Error taking heap snapshot");
     return c.json({ error: "Failed to take heap snapshot" }, 500);
+  } finally {
+    heapSnapshotInFlight = false;
   }
 }
 
 /**
  * GET /api/admin/memory/heap-snapshot-v8
  * Stream a Chrome-compatible V8 heap snapshot directly to the caller.
+ *
+ * WARNING: synchronous, blocks the event loop, requires ~2× heap in memory.
+ * See `heapSnapshotInFlight` above — do not call during a degradation window.
  */
 async function downloadHeapSnapshotHandler(c: AppContext) {
+  if (heapSnapshotInFlight) {
+    return c.json({ error: "Heap snapshot already in progress" }, 429);
+  }
+  heapSnapshotInFlight = true;
+
   const filename = `heap-${Date.now()}.heapsnapshot`;
 
   try {
@@ -561,6 +592,13 @@ async function downloadHeapSnapshotHandler(c: AppContext) {
   } catch (error) {
     logger.error(error, "Error streaming V8 heap snapshot");
     return c.json({ error: "Failed to stream heap snapshot" }, 500);
+  } finally {
+    // Note: for the streaming endpoint the flag clears when the handler returns,
+    // not when the stream finishes. That is intentional — the snapshot generation
+    // (the expensive blocking part) happens during v8.getHeapSnapshot() BEFORE
+    // the stream is returned. Streaming the already-generated JSON to the caller
+    // is cheap and concurrent downloads are fine.
+    heapSnapshotInFlight = false;
   }
 }
 

--- a/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
@@ -6,10 +6,10 @@
 
 import { Hono } from "hono";
 import jwt from "jsonwebtoken";
+import { Readable } from "node:stream";
+import v8 from "node:v8";
 import os from "os";
 import path from "path";
-import fs from "fs";
-import * as inspector from "node:inspector";
 import App, { AppI } from "../../../models/app.model";
 import { Organization } from "../../../models/organization.model";
 import { memoryTelemetryService } from "../../../services/debug/MemoryTelemetryService";
@@ -57,10 +57,10 @@ app.post("/apps/:packageName/reject", validateAdminEmail, rejectApp);
 // Memory telemetry routes
 app.get("/memory/now", validateAdminEmail, getMemorySnapshot);
 app.post("/memory/heap-snapshot", validateAdminEmail, takeHeapSnapshotHandler);
+app.get("/memory/heap-snapshot-v8", validateAdminEmail, downloadHeapSnapshotHandler);
 
-// Bun-native heap snapshot — returns JSON directly (loadable in Chrome DevTools → Memory → Load).
-// Lighter than the Node inspector-based POST version above.
-// Save response as .heapsnapshot file, then load in Chrome DevTools Memory tab.
+// Bun/JSC-native heap snapshot — returns JSON directly for local scripts/Safari-style
+// tooling. For Chrome DevTools, use /memory/heap-snapshot-v8 instead.
 app.get("/memory/heap-snapshot-bun", validateAdminEmail, (c: AppContext) => {
   try {
     const snapshot = Bun.generateHeapSnapshot();
@@ -525,7 +525,7 @@ async function getMemorySnapshot(c: AppContext) {
 
 /**
  * POST /api/admin/memory/heap-snapshot
- * Trigger a heap snapshot and write it to a temp file.
+ * Trigger a Chrome-compatible V8 heap snapshot and write it to a temp file.
  */
 async function takeHeapSnapshotHandler(c: AppContext) {
   const filename = `heap-${Date.now()}.heapsnapshot`;
@@ -544,37 +544,31 @@ async function takeHeapSnapshotHandler(c: AppContext) {
 }
 
 /**
- * Helper function to take a heap snapshot.
+ * GET /api/admin/memory/heap-snapshot-v8
+ * Stream a Chrome-compatible V8 heap snapshot directly to the caller.
+ */
+async function downloadHeapSnapshotHandler(c: AppContext) {
+  const filename = `heap-${Date.now()}.heapsnapshot`;
+
+  try {
+    const snapshotStream = Readable.toWeb(v8.getHeapSnapshot()) as unknown as ReadableStream<Uint8Array>;
+
+    return c.body(snapshotStream, 200, {
+      "Cache-Control": "no-store",
+      "Content-Disposition": `attachment; filename="${filename}"`,
+      "Content-Type": "application/json",
+    });
+  } catch (error) {
+    logger.error(error, "Error streaming V8 heap snapshot");
+    return c.json({ error: "Failed to stream heap snapshot" }, 500);
+  }
+}
+
+/**
+ * Helper function to take a Chrome-compatible V8 heap snapshot.
  */
 async function takeHeapSnapshot(filePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const session = new inspector.Session();
-    try {
-      session.connect();
-      const writeStream = fs.createWriteStream(filePath);
-      session.post("HeapProfiler.enable");
-      session.on("HeapProfiler.addHeapSnapshotChunk", (m: any) => {
-        writeStream.write(m.params.chunk);
-      });
-      session.post("HeapProfiler.takeHeapSnapshot", { reportProgress: false }, (err) => {
-        writeStream.end();
-        session.post("HeapProfiler.disable");
-        session.disconnect();
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
-        }
-      });
-    } catch (error) {
-      try {
-        session.disconnect();
-      } catch {
-        /* ignore disconnect errors */
-      }
-      reject(error);
-    }
-  });
+  v8.writeHeapSnapshot(filePath);
 }
 
 export default app;

--- a/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/admin.routes.ts
@@ -579,27 +579,38 @@ async function downloadHeapSnapshotHandler(c: AppContext) {
   }
   heapSnapshotInFlight = true;
 
-  const filename = `heap-${Date.now()}.heapsnapshot`;
-
+  let nodeStream: Readable;
   try {
-    const snapshotStream = Readable.toWeb(v8.getHeapSnapshot()) as unknown as ReadableStream<Uint8Array>;
-
-    return c.body(snapshotStream, 200, {
-      "Cache-Control": "no-store",
-      "Content-Disposition": `attachment; filename="${filename}"`,
-      "Content-Type": "application/json",
-    });
+    nodeStream = v8.getHeapSnapshot();
   } catch (error) {
-    logger.error(error, "Error streaming V8 heap snapshot");
-    return c.json({ error: "Failed to stream heap snapshot" }, 500);
-  } finally {
-    // Note: for the streaming endpoint the flag clears when the handler returns,
-    // not when the stream finishes. That is intentional — the snapshot generation
-    // (the expensive blocking part) happens during v8.getHeapSnapshot() BEFORE
-    // the stream is returned. Streaming the already-generated JSON to the caller
-    // is cheap and concurrent downloads are fine.
     heapSnapshotInFlight = false;
+    logger.error(error, "Error starting V8 heap snapshot");
+    return c.json({ error: "Failed to stream heap snapshot" }, 500);
   }
+
+  // Hold the flag until the stream fully drains (or errors). A slow client
+  // transferring the ~25MB snapshot over seconds would otherwise let another
+  // admin request trigger a second v8.getHeapSnapshot() while the first is
+  // still buffered in memory — stacking the 2× heap allocation the guard is
+  // meant to prevent. 'close' fires after both clean end and error, so it
+  // covers every exit path. Use `once` so we never double-clear.
+  const release = () => {
+    heapSnapshotInFlight = false;
+  };
+  nodeStream.once("close", release);
+  nodeStream.once("error", (err) => {
+    logger.error(err, "Error during V8 heap snapshot stream");
+    release();
+  });
+
+  const filename = `heap-${Date.now()}.heapsnapshot`;
+  const snapshotStream = Readable.toWeb(nodeStream) as unknown as ReadableStream<Uint8Array>;
+
+  return c.body(snapshotStream, 200, {
+    "Cache-Control": "no-store",
+    "Content-Disposition": `attachment; filename="${filename}"`,
+    "Content-Type": "application/json",
+  });
 }
 
 /**

--- a/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
+++ b/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
@@ -136,13 +136,25 @@ class SystemVitalsLogger {
   private lastHeartbeatTick: number = Date.now();
   private gcObserver?: PerformanceObserver;
   // Issue 102: previous UDP stats snapshot for delta calculation per vitals window.
+  // Initialized to all-zeros (not null) so the first vitals window after pod
+  // start captures the from-boot traffic as its delta instead of hardcoding 0.
+  // Otherwise startup-burst traffic in the first 30s is invisible — defeats
+  // the point of the instrumentation. Since UdpAudioServer's counters also
+  // start at 0, subtracting zeros from the current snapshot yields "packets
+  // received since boot," which IS the right value for the first window.
   private prevUdpStats: {
     packetsReceived: number;
     packetsDropped: number;
     pingsReceived: number;
     packetsDecrypted: number;
     decryptionFailures: number;
-  } | null = null;
+  } = {
+    packetsReceived: 0,
+    packetsDropped: 0,
+    pingsReceived: 0,
+    packetsDecrypted: 0,
+    decryptionFailures: 0,
+  };
 
   start(): void {
     if (this.vitalsInterval) return;
@@ -437,22 +449,17 @@ class SystemVitalsLogger {
       // Issue 102: pod-level UDP counter deltas per 30s vitals window.
       // UdpAudioServer exposes cumulative counters; we compute deltas against
       // the previous snapshot so the vitals row shows per-window traffic.
+      // The prev snapshot is initialized to all-zeros (see field init above),
+      // so the first window correctly captures from-boot traffic instead of
+      // being hardcoded to 0s.
       const udpStats = udpAudioServer.getStatsSnapshot();
-      const udpDelta = this.prevUdpStats
-        ? {
-            udpPacketsReceivedDelta: udpStats.packetsReceived - this.prevUdpStats.packetsReceived,
-            udpPacketsDroppedDelta: udpStats.packetsDropped - this.prevUdpStats.packetsDropped,
-            udpPingsReceivedDelta: udpStats.pingsReceived - this.prevUdpStats.pingsReceived,
-            udpPacketsDecryptedDelta: udpStats.packetsDecrypted - this.prevUdpStats.packetsDecrypted,
-            udpDecryptionFailuresDelta: udpStats.decryptionFailures - this.prevUdpStats.decryptionFailures,
-          }
-        : {
-            udpPacketsReceivedDelta: 0,
-            udpPacketsDroppedDelta: 0,
-            udpPingsReceivedDelta: 0,
-            udpPacketsDecryptedDelta: 0,
-            udpDecryptionFailuresDelta: 0,
-          };
+      const udpDelta = {
+        udpPacketsReceivedDelta: udpStats.packetsReceived - this.prevUdpStats.packetsReceived,
+        udpPacketsDroppedDelta: udpStats.packetsDropped - this.prevUdpStats.packetsDropped,
+        udpPingsReceivedDelta: udpStats.pingsReceived - this.prevUdpStats.pingsReceived,
+        udpPacketsDecryptedDelta: udpStats.packetsDecrypted - this.prevUdpStats.packetsDecrypted,
+        udpDecryptionFailuresDelta: udpStats.decryptionFailures - this.prevUdpStats.decryptionFailures,
+      };
       this.prevUdpStats = {
         packetsReceived: udpStats.packetsReceived,
         packetsDropped: udpStats.packetsDropped,

--- a/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
+++ b/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
@@ -16,11 +16,13 @@
  * See: cloud/issues/069-ws-disconnect-observability/spike.md
  */
 
+import { PerformanceObserver } from "node:perf_hooks";
 import { heapStats } from "bun:jsc";
 import { logger as rootLogger } from "../logging/pino-logger";
 import { UserSession } from "../session/UserSession";
 import { memoryLeakDetector } from "../debug/MemoryLeakDetector";
 import { mongoQueryStats } from "../../connections/mongodb.connection";
+import { udpAudioServer } from "../udp/UdpAudioServer";
 import { getDeviceStateCounters, resetDeviceStateCounters } from "./device-state-counters";
 
 const logger = rootLogger.child({ service: "SystemVitalsLogger" });
@@ -29,6 +31,22 @@ const VITALS_INTERVAL_MS = 30_000; // 30 seconds
 const GC_PROBE_INTERVAL_MS = 60_000; // 60 seconds
 const GAP_DETECTOR_INTERVAL_MS = 1_000; // 1 second
 const GAP_THRESHOLD_MS = 2_000; // log when interval takes >2x expected (event loop blocked >1s)
+
+// Issue 102: finer-grained loop-liveness signal at 500ms interval.
+// The existing 1s/2s gap detector misses sub-2s hiccups; in cascade conditions
+// the *first* hiccup that kicks off the cascade is often sub-2s. Catching the
+// leading edge at 500ms resolution is what tells us the trigger moment.
+const HEARTBEAT_INTERVAL_MS = 500;
+const HEARTBEAT_GAP_THRESHOLD_MS = 1_000;
+
+// Issue 102: warn when logVitals() itself runs longer than this.
+// Rules the "vitals census blocks the loop" hypothesis in or out.
+const VITALS_SELF_SLOW_MS = 500;
+
+// Issue 102: warn when a natural V8 GC pause exceeds this.
+// Natural minor GCs are typically <10ms; 100ms catches plausibly-relevant
+// pauses without flooding.
+const NATURAL_GC_THRESHOLD_MS = 100;
 
 /**
  * Operation timing accumulator.
@@ -113,6 +131,18 @@ class SystemVitalsLogger {
   private previousOwnerBytes = new Map<string, number>();
   private previousSessionOwnerBytes = new Map<string, number>();
   private memoryOwnerWarnCooldown = new Map<string, number>();
+  // Issue 102: finer-grained heartbeat tick (500ms) and natural-GC observer.
+  private heartbeatInterval?: NodeJS.Timeout;
+  private lastHeartbeatTick: number = Date.now();
+  private gcObserver?: PerformanceObserver;
+  // Issue 102: previous UDP stats snapshot for delta calculation per vitals window.
+  private prevUdpStats: {
+    packetsReceived: number;
+    packetsDropped: number;
+    pingsReceived: number;
+    packetsDecrypted: number;
+    decryptionFailures: number;
+  } | null = null;
 
   start(): void {
     if (this.vitalsInterval) return;
@@ -131,9 +161,15 @@ class SystemVitalsLogger {
     // If the 1s interval takes >2s, the event loop was blocked for the excess.
     this.startGapDetector();
 
+    // Issue 102: heartbeat tick at 500ms for finer trigger-moment resolution.
+    this.startHeartbeat();
+
+    // Issue 102: observe natural V8 GC pauses (not just our forced gc-probe).
+    this.startGcObserver();
+
     logger.info(
       { vitalsIntervalMs: VITALS_INTERVAL_MS, gcProbeIntervalMs: GC_PROBE_INTERVAL_MS },
-      "SystemVitalsLogger started (vitals + GC probe + gap detector)",
+      "SystemVitalsLogger started (vitals + GC probe + gap detector + heartbeat + natural-GC observer)",
     );
   }
 
@@ -149,6 +185,14 @@ class SystemVitalsLogger {
     if (this.gapDetectorInterval) {
       clearInterval(this.gapDetectorInterval);
       this.gapDetectorInterval = undefined;
+    }
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = undefined;
+    }
+    if (this.gcObserver) {
+      this.gcObserver.disconnect();
+      this.gcObserver = undefined;
     }
     logger.info("SystemVitalsLogger stopped");
   }
@@ -182,6 +226,103 @@ class SystemVitalsLogger {
         );
       }
     }, GAP_DETECTOR_INTERVAL_MS);
+  }
+
+  /**
+   * Issue 102: 500ms heartbeat tick for finer-grained loop-liveness signal.
+   * The existing 1s/2s gap detector misses sub-2s hiccups and (more importantly)
+   * the *first* hiccup before a cascade may be sub-2s. Catch the leading edge
+   * with 500ms resolution so the trigger moment is identifiable post-incident.
+   *
+   * Same payload shape as event-loop-gap but with feature="heartbeat-gap" so
+   * queries can be filtered separately from the existing gap stream.
+   */
+  private startHeartbeat(): void {
+    this.lastHeartbeatTick = Date.now();
+    this.heartbeatInterval = setInterval(() => {
+      const now = Date.now();
+      const elapsed = now - this.lastHeartbeatTick;
+      this.lastHeartbeatTick = now;
+
+      if (elapsed > HEARTBEAT_GAP_THRESHOLD_MS) {
+        const gapMs = elapsed - HEARTBEAT_INTERVAL_MS;
+        // Issue 102: gapStartedAtMs is the approximate trigger time, not log time.
+        // The log fires when the timer callback finally runs after starvation,
+        // so without this field investigators would query the wrong window
+        // (recovery flush logs instead of trigger logs).
+        const gapStartedAtMs = now - elapsed;
+        logger.warn(
+          {
+            feature: "heartbeat-gap",
+            gapMs,
+            expectedMs: HEARTBEAT_INTERVAL_MS,
+            actualMs: elapsed,
+            gapStartedAtMs,
+            rssMB: Math.round(process.memoryUsage().rss / 1048576),
+            activeSessions: UserSession.getAllSessions().length,
+          },
+          `Heartbeat gap: ${gapMs}ms (started ~${new Date(gapStartedAtMs).toISOString()}, recovered after ${elapsed}ms)`,
+        );
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  /**
+   * Issue 102: observe natural V8 GC events (not just our forced gc-probe).
+   *
+   * Gated behind an explicit runtime support check. As of investigation
+   * 2026-04-23, Bun's PerformanceObserver.supportedEntryTypes returns
+   * ["mark","measure","resource"] — it does NOT support "gc". Installing
+   * an observer for "gc" without checking would silently emit nothing,
+   * which post-deploy would look like "no natural GC pauses" when it
+   * really means "this instrumentation source is broken in this runtime."
+   *
+   * We log the unsupported state once at startup so that absence of
+   * natural-gc data is itself an explicit signal rather than ambiguous
+   * silence. If a future Bun release adds gc support, this auto-activates.
+   *
+   * For real natural-GC visibility on Bun today, a follow-up needs a
+   * Bun/JSC-specific mechanism (e.g. periodic bun:jsc.heapStats() snapshots
+   * and inferring GC behavior from heap deltas).
+   */
+  private startGcObserver(): void {
+    const supported = (PerformanceObserver as { supportedEntryTypes?: string[] }).supportedEntryTypes ?? [];
+    if (!supported.includes("gc")) {
+      logger.warn(
+        {
+          feature: "natural-gc-unsupported",
+          supportedEntryTypes: supported,
+        },
+        `Natural GC observer NOT installed: 'gc' entryType not supported by this runtime`,
+      );
+      return;
+    }
+    try {
+      this.gcObserver = new PerformanceObserver((list) => {
+        for (const entry of list.getEntries()) {
+          if (entry.duration > NATURAL_GC_THRESHOLD_MS) {
+            const memUsage = process.memoryUsage();
+            logger.warn(
+              {
+                feature: "natural-gc",
+                durationMs: Math.round(entry.duration * 10) / 10,
+                kind: (entry as any).detail?.kind ?? "unknown",
+                rssMB: Math.round(memUsage.rss / 1048576),
+                heapUsedMB: Math.round(memUsage.heapUsed / 1048576),
+              },
+              `Natural GC: ${Math.round(entry.duration)}ms`,
+            );
+          }
+        }
+      });
+      this.gcObserver.observe({ entryTypes: ["gc"] });
+      logger.info(
+        { thresholdMs: NATURAL_GC_THRESHOLD_MS },
+        `Natural GC observer started (logging GCs > ${NATURAL_GC_THRESHOLD_MS}ms)`,
+      );
+    } catch (err) {
+      logger.warn({ err }, "Could not install natural GC observer");
+    }
   }
 
   /**
@@ -276,10 +417,49 @@ class SystemVitalsLogger {
   }
 
   private logVitals(): void {
+    // Issue 102: self-timing. logVitals iterates all sessions and walks
+    // per-session memory census; this is a candidate trigger for the
+    // event-loop cascade. Always log the duration so we have a baseline
+    // distribution; warn if it ever exceeds VITALS_SELF_SLOW_MS.
+    //
+    // sessionCountForLog is captured once here and reused in the finally
+    // block so the self-timing payload does NOT do a second getAllSessions()
+    // call in the measurement path — that would add noise to the very
+    // measurement we're trying to take.
+    const vitalsT0 = performance.now();
+    let sessionCountForLog = 0;
     try {
       const memUsage = process.memoryUsage();
       const sessions = UserSession.getAllSessions();
+      sessionCountForLog = sessions.length;
       const mongoStats = mongoQueryStats.getAndReset();
+
+      // Issue 102: pod-level UDP counter deltas per 30s vitals window.
+      // UdpAudioServer exposes cumulative counters; we compute deltas against
+      // the previous snapshot so the vitals row shows per-window traffic.
+      const udpStats = udpAudioServer.getStatsSnapshot();
+      const udpDelta = this.prevUdpStats
+        ? {
+            udpPacketsReceivedDelta: udpStats.packetsReceived - this.prevUdpStats.packetsReceived,
+            udpPacketsDroppedDelta: udpStats.packetsDropped - this.prevUdpStats.packetsDropped,
+            udpPingsReceivedDelta: udpStats.pingsReceived - this.prevUdpStats.pingsReceived,
+            udpPacketsDecryptedDelta: udpStats.packetsDecrypted - this.prevUdpStats.packetsDecrypted,
+            udpDecryptionFailuresDelta: udpStats.decryptionFailures - this.prevUdpStats.decryptionFailures,
+          }
+        : {
+            udpPacketsReceivedDelta: 0,
+            udpPacketsDroppedDelta: 0,
+            udpPingsReceivedDelta: 0,
+            udpPacketsDecryptedDelta: 0,
+            udpDecryptionFailuresDelta: 0,
+          };
+      this.prevUdpStats = {
+        packetsReceived: udpStats.packetsReceived,
+        packetsDropped: udpStats.packetsDropped,
+        pingsReceived: udpStats.pingsReceived,
+        packetsDecrypted: udpStats.packetsDecrypted,
+        decryptionFailures: udpStats.decryptionFailures,
+      };
 
       let totalAppWebsockets = 0;
       let totalTranscriptionStreams = 0;
@@ -520,11 +700,33 @@ class SystemVitalsLogger {
           ...Object.fromEntries(Object.entries(operationSnapshot).map(([k, v]) => [`op_${k}_ms`, Math.round(v)])),
           opTotalMs: Math.round(totalOperationMs),
           opBudgetUsedPct: Math.round((totalOperationMs / VITALS_INTERVAL_MS) * 100),
+
+          // Issue 102: pod-level UDP load per 30s window. Quantifies the regime
+          // where the cascade fires (per the independent spike, dangerous
+          // load was ~96 pkt/s pod-wide with ~70 sessions).
+          ...udpDelta,
+          udpRegisteredSessions: udpStats.registeredSessions,
         },
         "system-vitals",
       );
     } catch (error) {
       logger.error(error, "Failed to log system vitals");
+    } finally {
+      // Issue 102: self-timing for the vitals callback itself. Reuse the
+      // session count captured at the top of try{} — do NOT call
+      // getAllSessions() again here, since that would add noise to the
+      // very measurement we're trying to take.
+      const vitalsDurationMs = performance.now() - vitalsT0;
+      const baseLog = {
+        feature: "vitals-self-timing",
+        durationMs: Math.round(vitalsDurationMs * 10) / 10,
+        activeSessions: sessionCountForLog,
+      };
+      if (vitalsDurationMs > VITALS_SELF_SLOW_MS) {
+        logger.warn(baseLog, `⚠️ logVitals slow: ${Math.round(vitalsDurationMs)}ms`);
+      } else {
+        logger.info(baseLog, `logVitals: ${Math.round(vitalsDurationMs)}ms`);
+      }
     }
   }
 }

--- a/cloud/packages/cloud/src/services/session/AudioManager.ts
+++ b/cloud/packages/cloud/src/services/session/AudioManager.ts
@@ -13,6 +13,7 @@ import { CloudToGlassesMessageType, ConnectionAck, StreamType } from "@mentra/sd
 import { AudioWriter } from "../debug/audio-writer";
 import { createLC3Service, LC3Service } from "../lc3/lc3.service";
 import { metricsService } from "../metrics/MetricsService";
+import { operationTimers } from "../metrics/SystemVitalsLogger";
 import { WebSocketReadyState } from "../websocket/types";
 
 import UserSession from "./UserSession";
@@ -55,6 +56,22 @@ export interface LC3Config {
   frameDurationMs: number; // 10ms
   frameSizeBytes: number; // 20 bytes per frame
 }
+
+// Issue 102: warn when a single relayAudioToApps invocation takes longer than
+// this. At the steady-state rate of ~115μs per audio call, 20ms indicates either
+// connection.send() backpressure (stuck app WS) or an unusually wide fan-out.
+const SLOW_RELAY_MS = 20;
+// Issue 102: warn when a session has more than this many audio_chunk subscribers.
+// Typical session has 1-5 apps subscribed. >10 suggests either subscriber-list
+// growth (hypothesis C) or an unusual app-install pattern worth investigating.
+const FANOUT_WARN = 10;
+// Issue 102: warn when one substage of processAudioData takes longer than this.
+// Each substage (LC3 decode, fan-out, transcription/translation feed, mic update)
+// is sub-millisecond in steady state; 10ms is ~10x normal — caught early without
+// flooding logs. The cumulative `op_audio_<stage>_ms` totals always emit per
+// vitals window regardless of this threshold.
+const SLOW_AUDIO_STAGE_MS = 10;
+type AudioStage = "lc3Decode" | "appFanout" | "transcriptionFeed" | "translationFeed" | "microphoneUpdate";
 
 /**
  * Manages audio data processing, buffering, and relaying
@@ -256,6 +273,11 @@ export class AudioManager {
         // Decode LC3 to PCM if audio format is LC3
         let buf: Buffer;
         if (this.audioFormat === "lc3" && this.lc3Service) {
+          // Issue 102: time the LC3 decode substage. The await means this
+          // captures wall-clock time including any loop yields; if the
+          // underlying decoder is sync (native binding), this is also the
+          // event-loop blocking time.
+          const tLc3 = performance.now();
           try {
             // IMPORTANT: Buffer.buffer returns the ENTIRE underlying ArrayBuffer, not just the slice.
             // For UDP audio, the buffer is sliced (buf.slice(6) to skip header), so byteOffset > 0.
@@ -270,13 +292,16 @@ export class AudioManager {
               if (this.processedFrameCount % 100 === 0) {
                 this.logger.warn({ feature: "lc3-decode" }, "LC3 decode returned empty data");
               }
+              this.recordAudioStage("lc3Decode", performance.now() - tLc3, incomingBuf.byteLength);
               return undefined;
             }
             buf = Buffer.from(pcmArrayBuffer);
           } catch (decodeError) {
             this.logger.error(decodeError, "LC3 decode error");
+            this.recordAudioStage("lc3Decode", performance.now() - tLc3, incomingBuf.byteLength);
             return undefined;
           }
+          this.recordAudioStage("lc3Decode", performance.now() - tLc3, incomingBuf.byteLength);
         } else {
           // PCM format - use incoming buffer directly
           buf = incomingBuf;
@@ -316,17 +341,31 @@ export class AudioManager {
 
         // Capture audio if enabled
 
+        // Issue 102: per-substage timings. Each substage gets its own
+        // op_audio_<stage>_ms cumulative bucket in vitals plus a
+        // slow-audio-stage outlier warning. Together they answer the
+        // "which substage burns the loop time" question that v1 of this
+        // PR could not — and that drives Phase 2's actual fix scope.
+
         // Relay to Apps if there are subscribers
+        const tFanout = performance.now();
         this.relayAudioToApps(buf);
+        this.recordAudioStage("appFanout", performance.now() - tFanout, buf.length);
 
         // Feed to TranscriptionManager
+        const tTranscription = performance.now();
         this.userSession.transcriptionManager.feedAudio(buf);
+        this.recordAudioStage("transcriptionFeed", performance.now() - tTranscription, buf.length);
 
         // Feed to TranslationManager (separate from transcription)
+        const tTranslation = performance.now();
         this.userSession.translationManager.feedAudio(buf);
+        this.recordAudioStage("translationFeed", performance.now() - tTranslation, buf.length);
 
         // Notify MicrophoneManager that we received audio
+        const tMic = performance.now();
         this.userSession.microphoneManager.onAudioReceived();
+        this.recordAudioStage("microphoneUpdate", performance.now() - tMic, buf.length);
       }
       return audioData;
     } catch (error) {
@@ -350,19 +389,60 @@ export class AudioManager {
    *
    * @param audioData Audio data to relay
    */
+  /**
+   * Issue 102: privacy-preserving correlation key shared across slow-audio-call,
+   * slow-audio-stage, and slow-audio-fanout warnings. Reads from
+   * UdpAudioManager which already maintains the FNV-1a 32-bit hash. Returns
+   * undefined for sessions whose UDP path hasn't registered yet (legacy WS
+   * audio path), in which case the userId is still in the logger context.
+   */
+  private getCorrelationUserIdHash(): number | undefined {
+    return this.userSession.udpAudioManager?.userIdHash;
+  }
+
+  /**
+   * Issue 102: record one substage's wall-time inside processAudioData. Adds
+   * to operationTimers (op_audio_<stage>_ms appears in vitals) and emits a
+   * slow-audio-stage warning on outliers. The async/sync semantics depend on
+   * the substage — LC3 decode is awaited (wall-clock time including loop
+   * yields), the rest are sync. Either reading is informative because the
+   * cumulative bucket per vitals window gives us the aggregate breakdown.
+   */
+  private recordAudioStage(stage: AudioStage, durationMs: number, bytes: number): void {
+    operationTimers.addTiming(`audio_${stage}`, durationMs);
+    if (durationMs > SLOW_AUDIO_STAGE_MS) {
+      this.logger.warn(
+        {
+          feature: "slow-audio-stage",
+          stage,
+          durationMs: Math.round(durationMs * 10) / 10,
+          userIdHash: this.getCorrelationUserIdHash(),
+          bytes,
+        },
+        `Slow audio substage ${stage}: ${Math.round(durationMs)}ms`,
+      );
+    }
+  }
+
   private relayAudioToApps(audioData: ArrayBuffer | Buffer): void {
+    // Issue 102: timer + fan-out instrumentation. Disambiguates cascade
+    // hypotheses A (cascade), B (pathological call), C (fan-out blowup).
+    const t0 = performance.now();
+    let subCount = 0;
+    let bytes = 0;
     try {
       // Get subscribers using subscriptionService instead of subscriptionManager
       const subscribedPackageNames = this.userSession.subscriptionManager.getSubscribedApps(StreamType.AUDIO_CHUNK);
+      subCount = subscribedPackageNames.length;
       // Skip if no subscribers
-      if (subscribedPackageNames.length === 0) {
+      if (subCount === 0) {
         if (this.logAudioChunkCount % 500 === 0) {
           this.logger.debug({ feature: "audio" }, "AUDIO_CHUNK: no subscribed apps");
         }
         this.logAudioChunkCount++;
         return;
       }
-      const bytes =
+      bytes =
         typeof Buffer !== "undefined" && Buffer.isBuffer(audioData)
           ? (audioData as Buffer).length
           : (audioData as ArrayBuffer).byteLength;
@@ -404,6 +484,23 @@ export class AudioManager {
       this.logAudioChunkCount++;
     } catch (error) {
       this.logger.error(error, `Error relaying audio:`);
+    } finally {
+      const durationMs = performance.now() - t0;
+      if (durationMs > SLOW_RELAY_MS || subCount > FANOUT_WARN) {
+        this.logger.warn(
+          {
+            feature: "slow-audio-fanout",
+            durationMs: Math.round(durationMs * 10) / 10,
+            subscribers: subCount,
+            bytes,
+            // Issue 102: correlation key matching slow-audio-call and
+            // slow-audio-stage so investigators can tie a fan-out warning
+            // back to the same UDP handler invocation / session.
+            userIdHash: this.getCorrelationUserIdHash(),
+          },
+          `Slow audio fan-out: ${Math.round(durationMs)}ms across ${subCount} subscribers`,
+        );
+      }
     }
   }
 

--- a/cloud/packages/cloud/src/services/udp/UdpAudioServer.ts
+++ b/cloud/packages/cloud/src/services/udp/UdpAudioServer.ts
@@ -286,31 +286,44 @@ export class UdpAudioServer {
 
     // Forward reordered packets to AudioManager
     // AudioManager handles LC3→PCM decoding if needed based on client's audio config
+    //
+    // Issue 102: processAudioData is async with an `await` on LC3 decode for LC3
+    // sessions. A plain sync for-loop measured with t0..finally would STOP timing
+    // at the first await, missing the post-await substages (appFanout,
+    // transcriptionFeed, translationFeed, microphoneUpdate). That would
+    // systematically underreport slow-audio-call durations for LC3 sessions — the
+    // exact observability gap this PR is supposed to close.
+    //
+    // Fix: capture the promises and record timing + emit the slow-call warning
+    // AFTER all of them settle. The function remains synchronous to its caller
+    // (Bun's UDP socket handler); the timing log is deferred to a microtask that
+    // fires once the real wall-clock is known. Per-promise .catch() prevents
+    // rejections from becoming unhandled, preserving existing error-log shape.
     const t0 = performance.now();
-    try {
-      for (const audioChunk of packetsToProcess) {
-        session.audioManager.processAudioData(audioChunk, "udp");
-      }
-    } catch (error) {
-      this.logger.error(
-        {
-          error,
-          userId: session.userId,
-          userIdHash,
-          sequence,
-          audioBytes: audioData.length,
-          feature: "udp-audio",
-        },
-        "Error processing UDP audio in AudioManager",
-      );
-    } finally {
+    const activeSessionsAtStart = this.sessionMap.size;
+    const pending = packetsToProcess.map((audioChunk) =>
+      Promise.resolve(session.audioManager.processAudioData(audioChunk, "udp")).catch((error: unknown) => {
+        this.logger.error(
+          {
+            error,
+            userId: session.userId,
+            userIdHash,
+            sequence,
+            audioBytes: audioData.length,
+            feature: "udp-audio",
+          },
+          "Error processing UDP audio in AudioManager",
+        );
+      }),
+    );
+    Promise.all(pending).finally(() => {
       const durationMs = performance.now() - t0;
       operationTimers.addTiming("audioProcessing", durationMs);
-      // Issue 102: catch outlier per-call durations to disambiguate the
-      // three competing cascade hypotheses. Many slow entries with normal-ish
-      // durations indicate a high-volume cascade; a single multi-second entry
-      // indicates a pathological call; entries with high packetsToProcess
-      // indicate a reorder-buffer flush; see cloud/issues/102-pod-loop-stall-cascade/.
+      // Catch outlier per-handler durations to disambiguate the cascade hypotheses.
+      // Many slow entries with normal-ish durations = high-volume cascade;
+      // a single multi-second entry = pathological call;
+      // high packetsToProcess = reorder-buffer flush.
+      // See cloud/issues/102-pod-loop-stall-cascade/.
       if (durationMs > SLOW_AUDIO_CALL_MS) {
         this.logger.warn(
           {
@@ -318,13 +331,13 @@ export class UdpAudioServer {
             durationMs: Math.round(durationMs * 10) / 10,
             packetsToProcess: packetsToProcess.length,
             userIdHash,
-            activeSessions: this.sessionMap.size,
+            activeSessions: activeSessionsAtStart,
             rssMB: Math.round(process.memoryUsage().rss / 1048576),
           },
           `Slow UDP audio handler: ${Math.round(durationMs)}ms over ${packetsToProcess.length} packet(s)`,
         );
       }
-    }
+    });
   }
 
   /**

--- a/cloud/packages/cloud/src/services/udp/UdpAudioServer.ts
+++ b/cloud/packages/cloud/src/services/udp/UdpAudioServer.ts
@@ -32,6 +32,12 @@ const MIN_PACKET_SIZE = 6; // 4 bytes hash + 2 bytes sequence
 const MIN_ENCRYPTED_PACKET_SIZE = 6 + NONCE_SIZE + TAG_SIZE; // header + nonce + minimum ciphertext (just tag)
 const LOG_INTERVAL = 100; // Log every N packets for debugging
 
+// Issue 102: warn when one UDP audio handler invocation takes longer than this.
+// Steady-state per-call duration is ~115μs (~400ms cumulative / 30s / ~3500 calls).
+// 50ms = ~400× normal, indicates either a pathological call, a packetsToProcess
+// flush from the reorder buffer, or a fan-out blowup downstream.
+const SLOW_AUDIO_CALL_MS = 50;
+
 export class UdpAudioServer {
   private socket: any = null;
   private sessionMap: Map<number, UserSession> = new Map(); // userIdHash → session
@@ -64,6 +70,30 @@ export class UdpAudioServer {
       this.logger.error({ error, port: UDP_PORT, feature: "udp-audio" }, "Failed to start UDP Audio Server");
       throw error;
     }
+  }
+
+  /**
+   * Issue 102: snapshot of all cumulative counters + active session count,
+   * for SystemVitalsLogger to compute per-vitals-window deltas. JS read of
+   * scalar fields is atomic on Bun's single-threaded loop, no concern about
+   * partial reads.
+   */
+  public getStatsSnapshot(): {
+    packetsReceived: number;
+    packetsDropped: number;
+    pingsReceived: number;
+    packetsDecrypted: number;
+    decryptionFailures: number;
+    registeredSessions: number;
+  } {
+    return {
+      packetsReceived: this.packetsReceived,
+      packetsDropped: this.packetsDropped,
+      pingsReceived: this.pingsReceived,
+      packetsDecrypted: this.packetsDecrypted,
+      decryptionFailures: this.decryptionFailures,
+      registeredSessions: this.sessionMap.size,
+    };
   }
 
   /**
@@ -274,7 +304,26 @@ export class UdpAudioServer {
         "Error processing UDP audio in AudioManager",
       );
     } finally {
-      operationTimers.addTiming("audioProcessing", performance.now() - t0);
+      const durationMs = performance.now() - t0;
+      operationTimers.addTiming("audioProcessing", durationMs);
+      // Issue 102: catch outlier per-call durations to disambiguate the
+      // three competing cascade hypotheses. Many slow entries with normal-ish
+      // durations indicate a high-volume cascade; a single multi-second entry
+      // indicates a pathological call; entries with high packetsToProcess
+      // indicate a reorder-buffer flush; see cloud/issues/102-pod-loop-stall-cascade/.
+      if (durationMs > SLOW_AUDIO_CALL_MS) {
+        this.logger.warn(
+          {
+            feature: "slow-audio-call",
+            durationMs: Math.round(durationMs * 10) / 10,
+            packetsToProcess: packetsToProcess.length,
+            userIdHash,
+            activeSessions: this.sessionMap.size,
+            rssMB: Math.round(process.memoryUsage().rss / 1048576),
+          },
+          `Slow UDP audio handler: ${Math.round(durationMs)}ms over ${packetsToProcess.length} packet(s)`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Phase 1 observability for [issue 102](cloud/issues/102-pod-loop-stall-cascade/) — the recurring us-central pod SIGKILL pattern (daily, 40-80s event-loop blockages). **No behavior changes; instrumentation only.** After one more crash cycle with these logs, we can design Phase 2 (the actual fix) against data instead of guessing.

Also bundles Codex's heap-snapshot API swap (`node:inspector` → `v8.writeHeapSnapshot`) + a new streaming download endpoint, useful for both this issue and the followup [103 non-session heap growth](cloud/issues/103-non-session-heap-growth/).

## Why this is observability-only

Three prior investigations of these crashes were confidently wrong ("MongoDB slow queries", "readiness probe timeout from Mongo saturation", "reconnect storm trigger"). See [spike.md](cloud/issues/102-pod-loop-stall-cascade/spike.md) for how each was falsified. A fourth speculative fix would likely also be wrong. The cost of one extra deploy cycle for observability is less than the cost of shipping a wrong fix and re-investigating.

## What ships

**Event-loop / timing signals** — `SystemVitalsLogger.ts`:
- `heartbeat-gap` — 500ms tick detector with `gapStartedAtMs` so investigators query the trigger window, not the recovery window
- `vitals-self-timing` — always-emitted logVitals duration (rules out vitals census as the trigger)
- `natural-gc` — gated behind `PerformanceObserver.supportedEntryTypes.includes("gc")`; Bun currently does not support it, so logs `natural-gc-unsupported` at startup (explicit signal, not silent failure)
- per-vitals-window UDP counter deltas (`udpPacketsReceivedDelta`, `udpPacketsDroppedDelta`, etc.) + `udpRegisteredSessions`

**Audio path signals** — `AudioManager.ts` + `UdpAudioServer.ts`:
- `slow-audio-call` — per-handler-invocation timer; `packetsToProcess` distinguishes pathological calls from reorder-buffer flushes
- Per-substage timers in `processAudioData`: `op_audio_lc3Decode_ms`, `op_audio_appFanout_ms`, `op_audio_transcriptionFeed_ms`, `op_audio_translationFeed_ms`, `op_audio_microphoneUpdate_ms` in vitals; `slow-audio-stage` warnings on outliers >10ms
- `slow-audio-fanout` — `relayAudioToApps` wrapper warning on slow sends or >10 subscribers
- `userIdHash` correlation key across `slow-audio-call`, `slow-audio-stage`, `slow-audio-fanout` so entries from the same session can be joined

**Heap snapshot admin API** — `admin.routes.ts` (Codex):
- `POST /api/admin/memory/heap-snapshot` — switched from `node:inspector` session to `v8.writeHeapSnapshot`. One line instead of the inspector dance, Chrome DevTools compatible.
- `GET /api/admin/memory/heap-snapshot-v8` (new) — streams the snapshot as a direct download.
- `GET /api/admin/memory/heap-snapshot-bun` — unchanged, kept for Safari/local scripts.

## Iteration path

This PR was revised after [Codex's independent spike](cloud/issues/102-pod-loop-stall-cascade/spike-independent-2026-04-23.md) and [implementation review](cloud/issues/102-pod-loop-stall-cascade/implementation-review-2026-04-23.md). The independent spike proved (via captured logs) that the failure mode is UDP/audio monopolization, not a complete event-loop freeze — HTTP/timers starve while UDP/audio continues. Codex's review then flagged seven concrete issues with the v1 instrumentation draft; all were addressed:

1. Natural-GC observer was silently broken in Bun → gated behind `supportedEntryTypes`
2. Audio instrumentation was too narrow (only `relayAudioToApps`) → per-substage timings for all 5 paths
3. `slow-audio-fanout` missing correlation key → `userIdHash` added
4. Heartbeat log timestamp ambiguity (recovery vs trigger) → `gapStartedAtMs` field
5. Vitals self-timing polluted its own measurement → hoisted `sessionCountForLog` capture
6. Readiness widening dropped from S8 (keeps stalled pod in LB rotation on single-pod)
7. Doc typos and stale references

## K8s probe widening (S8) — separate

Liveness threshold widening (`failureThreshold 15→30`, `timeoutSeconds 3→10`) is platform config applied through Porter UI, not in this PR. Readiness is explicitly NOT widened (per Codex: on single-pod, widening readiness surfaces user-visible hangs instead of brief 503 bursts).

## Why not multi-pod instead?

Multi-pod is the eventual fix via the cloud scaling plan but is blocked today by in-memory `UserSession` map + UDP server binding + photo-response routing (no Redis-backed registry). Multi-week project. us-central is crashing daily right now and can't wait. See spike.md.

## Test plan

- [x] `bunx tsc --noEmit` passes (0 errors in the cloud package)
- [x] `bun run lint` — no new errors on the 3 modified files (only pre-existing warnings)
- [ ] Deploy to a quiet region (us-east) first. After 30 min, confirm:
  - `vitals-self-timing` emits ~60 entries / 30min, all sub-50ms
  - `heartbeat-gap` does NOT fire under idle
  - `slow-audio-call` / `slow-audio-stage` / `slow-audio-fanout` do NOT fire under idle
  - Either `natural-gc` entries occasionally OR one `natural-gc-unsupported` at startup
- [ ] Apply liveness widening to us-central via Porter UI (S8)
- [ ] Wait for next us-central crash (~12h typical)
- [ ] Run the acceptance queries from [spec.md](cloud/issues/102-pod-loop-stall-cascade/spec.md#acceptance-after-one-us-central-crash) — each hypothesis should be confirmable or ruleable

## Risks

- **Outlier warnings could flood logs during a cascade.** Acceptable — the volume itself is information, and post-incident queries are filterable.
- **Per-packet `performance.now()` overhead.** ~5 extra calls per audio packet × ~50ns each = ~25μs/sec total at 100 pkt/s. Negligible.
- **Bun future versions may add `gc` PerformanceObserver support.** The gated install auto-activates. Intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Heartbeat-gap detection with approximate gapStartedAtMs.
  * Per-audio-stage timing and outlier warnings (stage, fan-out, call) with privacy-preserving userIdHash correlation.
  * Pod-level UDP counters exposed as per-30s deltas and a public UDP stats snapshot.
  * Heap-snapshot streaming endpoint with concurrency guard.
  * Vitals self-timing always logged; natural-GC instrumentation enabled only when supported (one-time unsupported warning).

* **Chores**
  * Added design, spec, spike, and implementation-review docs; CI branch inclusion for the new work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
