### PR TITLE
Surface specific temp token exchange failure codes

### DIFF
--- a/cloud/packages/cloud/src/api/hono/routes/auth.routes.test.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/auth.routes.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const validateApiKey = mock(async () => true);
-const exchangeTemporaryToken = mock(async () => ({ userId: "user@example.com" }));
+const exchangeTemporaryToken = mock(async () => ({
+  success: true as const,
+  userId: "user@example.com",
+}));
 
 mock.module("../../../services/sdk/sdk.auth.service", () => ({
   validateApiKey,
@@ -26,6 +29,8 @@ mock.module("../../../services/logging/pino-logger", () => ({
     child: () => ({
       error: mock(() => undefined),
       debug: mock(() => undefined),
+      warn: mock(() => undefined),
+      info: mock(() => undefined),
     }),
   },
 }));
@@ -38,7 +43,10 @@ describe("POST /exchange-user-token", () => {
     validateApiKey.mockResolvedValue(true);
 
     exchangeTemporaryToken.mockReset();
-    exchangeTemporaryToken.mockResolvedValue({ userId: "user@example.com" });
+    exchangeTemporaryToken.mockResolvedValue({
+      success: true as const,
+      userId: "user@example.com",
+    });
   });
 
   test("accepts legacy bearer tokens when packageName is provided in the JSON body", async () => {
@@ -81,5 +89,54 @@ describe("POST /exchange-user-token", () => {
       error: "Invalid credentials",
     });
     expect(exchangeTemporaryToken).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    {
+      reason: "token_not_found" as const,
+      message: "Temporary token not found",
+      status: 401,
+    },
+    {
+      reason: "token_used" as const,
+      message: "Temporary token already used",
+      status: 401,
+    },
+    {
+      reason: "token_expired" as const,
+      message: "Temporary token expired",
+      status: 401,
+    },
+    {
+      reason: "token_package_mismatch" as const,
+      message: "Temporary token was issued for a different app",
+      status: 401,
+    },
+    {
+      reason: "exchange_error" as const,
+      message: "Failed to exchange token",
+      status: 500,
+    },
+  ])("surfaces $reason with status $status and a stable code", async ({ reason, message, status }) => {
+    exchangeTemporaryToken.mockResolvedValue({ success: false, reason });
+
+    const response = await app.request("http://localhost/exchange-user-token", {
+      method: "POST",
+      headers: {
+        "authorization": "Bearer com.example.app:secret-key",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        aos_temp_token: "temp-token",
+        packageName: "com.example.app",
+      }),
+    });
+
+    expect(response.status).toBe(status);
+    expect(await response.json()).toEqual({
+      success: false,
+      code: reason,
+      error: message,
+    });
   });
 });

--- a/cloud/packages/cloud/src/api/hono/routes/auth.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/auth.routes.ts
@@ -6,7 +6,7 @@
 
 import { Hono } from "hono";
 import jwt from "jsonwebtoken";
-import { tokenService } from "../../../services/core/temp-token.service";
+import { tokenService, type ExchangeTokenFailureReason } from "../../../services/core/temp-token.service";
 import appService from "../../../services/core/app.service";
 import { logger as rootLogger } from "../../../services/logging/pino-logger";
 import type { AppEnv, AppContext } from "../../../types/hono";
@@ -97,6 +97,30 @@ async function validateAppApiKeyMiddleware(c: AppContext, next: () => Promise<vo
 
   c.set("sdk", { packageName, apiKey });
   await next();
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Map a temp-token exchange failure reason to a stable client-facing
+ * error message. The `code` returned alongside this message is the
+ * machine-readable identifier callers should branch on.
+ */
+function tempTokenErrorMessage(reason: ExchangeTokenFailureReason): string {
+  switch (reason) {
+    case "token_not_found":
+      return "Temporary token not found";
+    case "token_used":
+      return "Temporary token already used";
+    case "token_expired":
+      return "Temporary token expired";
+    case "token_package_mismatch":
+      return "Temporary token was issued for a different app";
+    case "exchange_error":
+      return "Failed to exchange token";
+  }
 }
 
 // ============================================================================
@@ -214,11 +238,19 @@ async function exchangeUserToken(c: AppContext) {
     // both resolve the token against the same validated App identity.
     const result = await tokenService.exchangeTemporaryToken(aos_temp_token, sdk.packageName);
 
-    if (result) {
+    if (result.success) {
       return c.json({ success: true, userId: result.userId });
-    } else {
-      return c.json({ success: false, error: "Invalid or expired token" }, 401);
     }
+
+    const status = result.reason === "exchange_error" ? 500 : 401;
+    return c.json(
+      {
+        success: false,
+        code: result.reason,
+        error: tempTokenErrorMessage(result.reason),
+      },
+      status,
+    );
   } catch (error) {
     logger.error(error, "Failed to exchange webview token");
     return c.json({ success: false, error: "Failed to exchange token" }, 500);
@@ -247,7 +279,7 @@ async function exchangeStoreToken(c: AppContext) {
 
     const result = await tokenService.exchangeTemporaryToken(aos_temp_token, packageName);
 
-    if (result) {
+    if (result.success) {
       const supabaseToken = JOE_MAMA_USER_JWT;
 
       const { User } = await import("../../../models/user.model");
@@ -269,9 +301,17 @@ async function exchangeStoreToken(c: AppContext) {
           coreToken,
         },
       });
-    } else {
-      return c.json({ success: false, error: "Invalid or expired token" }, 401);
     }
+
+    const status = result.reason === "exchange_error" ? 500 : 401;
+    return c.json(
+      {
+        success: false,
+        code: result.reason,
+        error: tempTokenErrorMessage(result.reason),
+      },
+      status,
+    );
   } catch (error) {
     logger.error(error, "Failed to exchange store token");
     return c.json({ success: false, error: "Failed to exchange token" }, 500);

--- a/cloud/packages/cloud/src/api/hono/store/store.auth.api.ts
+++ b/cloud/packages/cloud/src/api/hono/store/store.auth.api.ts
@@ -99,13 +99,15 @@ async function exchangeStoreToken(c: AppContext) {
 
     const result = await tokenService.exchangeTemporaryToken(aos_temp_token, packageName);
 
-    if (!result) {
+    if (!result.success) {
+      const status = result.reason === "exchange_error" ? 500 : 401;
       return c.json(
         {
           success: false,
+          code: result.reason,
           error: "Invalid or expired token",
         },
-        401,
+        status,
       );
     }
 

--- a/cloud/packages/cloud/src/api/hono/store/store.auth.api.ts
+++ b/cloud/packages/cloud/src/api/hono/store/store.auth.api.ts
@@ -100,14 +100,14 @@ async function exchangeStoreToken(c: AppContext) {
     const result = await tokenService.exchangeTemporaryToken(aos_temp_token, packageName);
 
     if (!result.success) {
-      const status = result.reason === "exchange_error" ? 500 : 401;
+      const isServerError = result.reason === "exchange_error";
       return c.json(
         {
           success: false,
           code: result.reason,
-          error: "Invalid or expired token",
+          error: isServerError ? "Failed to exchange token" : "Invalid or expired token",
         },
-        status,
+        isServerError ? 500 : 401,
       );
     }
 

--- a/cloud/packages/cloud/src/services/core/temp-token.service.ts
+++ b/cloud/packages/cloud/src/services/core/temp-token.service.ts
@@ -9,19 +9,26 @@ const logger = rootLogger.child({ service: "temp-token.service" });
 
 // Environment variable for JWT signing
 export const APP_AUTH_JWT_PRIVATE_KEY: string | null =
-  process.env.APP_AUTH_JWT_PRIVATE_KEY ||
-  process.env.TPA_AUTH_JWT_PRIVATE_KEY ||
-  null;
+  process.env.APP_AUTH_JWT_PRIVATE_KEY || process.env.TPA_AUTH_JWT_PRIVATE_KEY || null;
 if (!APP_AUTH_JWT_PRIVATE_KEY) {
   console.warn("[token.service] APP_AUTH_JWT_PRIVATE_KEY is not set");
 }
 
 /**
- * Interface for the result of exchanging a temporary token
+ * Reason a temp token exchange failed. Surfaced to callers via a stable
+ * machine-readable code; richer detail (mismatched package names, token
+ * prefix, etc.) is logged server-side rather than returned in the response.
  */
-interface ExchangeTokenResult {
-  userId: string;
-}
+export type ExchangeTokenFailureReason =
+  | "token_not_found"
+  | "token_used"
+  | "token_expired"
+  | "token_package_mismatch"
+  | "exchange_error";
+
+export type ExchangeTokenOutcome =
+  | { success: true; userId: string }
+  | { success: false; reason: ExchangeTokenFailureReason };
 
 /**
  * Service for managing temporary tokens and user authentication tokens.
@@ -37,10 +44,7 @@ export class TokenService {
    * @returns Promise resolving to the generated temporary token string
    * @throws Error if token generation or storage fails
    */
-  async generateTemporaryToken(
-    userId: string,
-    packageName: string,
-  ): Promise<string> {
+  async generateTemporaryToken(userId: string, packageName: string): Promise<string> {
     const logger = rootLogger.child({
       service: "temp-token.service",
       userId,
@@ -60,17 +64,12 @@ export class TokenService {
 
     try {
       await tempTokenDoc.save();
-      logger.info(
-        `Generated temporary token for user ${userId} and package ${packageName}`,
-      );
+      logger.info(`Generated temporary token for user ${userId} and package ${packageName}`);
       return token;
     } catch (error) {
       {
         const err = error instanceof Error ? error : new Error(String(error));
-        logger.error(
-          err,
-          `Error saving temporary token for user ${userId}, package ${packageName}:`,
-        );
+        logger.error(err, `Error saving temporary token for user ${userId}, package ${packageName}:`);
       }
       throw new Error("Failed to generate temporary token");
     }
@@ -86,12 +85,11 @@ export class TokenService {
    *
    * @param tempToken - The temporary token string to exchange
    * @param requestingPackageName - The package name of the App making the exchange request
-   * @returns Promise resolving to an object containing the userId if valid, null otherwise
+   * @returns Promise resolving to a discriminated outcome. On failure,
+   *   `reason` identifies which check failed so callers can surface a
+   *   precise error to clients without leaking server-side detail.
    */
-  async exchangeTemporaryToken(
-    tempToken: string,
-    requestingPackageName: string,
-  ): Promise<ExchangeTokenResult | null> {
+  async exchangeTemporaryToken(tempToken: string, requestingPackageName: string): Promise<ExchangeTokenOutcome> {
     const logger = rootLogger.child({
       service: "temp-token.service",
       requestingPackageName,
@@ -104,12 +102,12 @@ export class TokenService {
 
       if (!tokenDoc) {
         logger.warn(`Temporary token not found: ${tempToken}`);
-        return null; // Token doesn't exist
+        return { success: false, reason: "token_not_found" };
       }
 
       if (tokenDoc.used) {
         logger.warn(`Temporary token already used: ${tempToken}`);
-        return null; // Token already used
+        return { success: false, reason: "token_used" };
       }
 
       // Check if the token has expired (TTL index should handle this, but double-check)
@@ -122,15 +120,13 @@ export class TokenService {
         logger.warn(`Temporary token expired: ${tempToken}`);
         // Optionally delete the expired token here if TTL isn't reliable enough
         // await TempToken.deleteOne({ token: tempToken });
-        return null;
+        return { success: false, reason: "token_expired" };
       }
 
       // **Crucial Security Check:** Verify the requesting App matches the one the token was issued for.
       if (tokenDoc.packageName !== requestingPackageName) {
-        logger.error(
-          `Token mismatch: Token for ${tokenDoc.packageName} used by ${requestingPackageName}`,
-        );
-        return null; // Token not intended for this application
+        logger.error(`Token mismatch: Token for ${tokenDoc.packageName} used by ${requestingPackageName}`);
+        return { success: false, reason: "token_package_mismatch" };
       }
 
       // Mark the token as used to prevent replay attacks
@@ -140,13 +136,13 @@ export class TokenService {
       logger.info(
         `Successfully exchanged temporary token for user ${tokenDoc.userId}, requested by ${requestingPackageName}`,
       );
-      return { userId: tokenDoc.userId };
+      return { success: true, userId: tokenDoc.userId };
     } catch (error) {
       {
         const err = error instanceof Error ? error : new Error(String(error));
         logger.error(err, `Error exchanging temporary token ${tempToken}:`);
       }
-      return null; // Return null on any error during exchange
+      return { success: false, reason: "exchange_error" };
     }
   }
 
@@ -163,10 +159,7 @@ export class TokenService {
    * @returns Promise resolving to a signed JWT token string
    * @throws Error if private key is not configured or token generation fails
    */
-  async issueUserToken(
-    aosUserId: string,
-    packageName: string,
-  ): Promise<string> {
+  async issueUserToken(aosUserId: string, packageName: string): Promise<string> {
     // Algorithm used for signing - RS256 (RSA with SHA-256)
     const alg: string = "RS256";
 
@@ -181,10 +174,7 @@ export class TokenService {
 
       // Generate a frontend token using the app's API key hash instead of a shared secret
       // This allows the App to verify the token using their own API key
-      const frontendTokenHash: string = await appService.hashWithApiKey(
-        aosUserId,
-        packageName,
-      );
+      const frontendTokenHash: string = await appService.hashWithApiKey(aosUserId, packageName);
 
       // Create and sign the JWT token with both user ID and frontend token
       const token: string = await new SignJWT({
@@ -198,10 +188,7 @@ export class TokenService {
         .sign(privateKey);
       return token;
     } catch (error) {
-      logger.error(
-        { error, aosUserId, packageName },
-        "[token.service] Failed to issue user token",
-      );
+      logger.error({ error, aosUserId, packageName }, "[token.service] Failed to issue user token");
       throw new Error("[token.service] Failed to generate signed user token");
     }
   }


### PR DESCRIPTION
## Summary

`POST /api/auth/exchange-user-token` and `POST /api/auth/exchange-store-token` collapse four distinct failure modes into a single generic `401 "Invalid or expired token"`. That makes it impossible for SDK callers (e.g. mini app backends calling `exchangeToken(...)`) to know whether the token was not found, already used, expired, or minted for a different package, without us pulling server logs.

This PR threads a stable `code` field through to the response so callers can self-diagnose, while keeping the rich detail (mismatched package names, token prefix) server-side only.

### Behavior change

`exchangeTemporaryToken()` now returns a discriminated outcome (`{ success: true, userId } | { success: false, reason }`) instead of `Result | null`. The two route handlers map the failure reason to:

- `code: "token_not_found"` → 401 `"Temporary token not found"`
- `code: "token_used"` → 401 `"Temporary token already used"`
- `code: "token_expired"` → 401 `"Temporary token expired"`
- `code: "token_package_mismatch"` → 401 `"Temporary token was issued for a different app"`
- `code: "exchange_error"` → 500 `"Failed to exchange token"`

Status codes for the four token-failure branches stay at 401 to preserve existing client branching. Only `exchange_error` (truly unexpected DB/IO failure) becomes a 500 instead of being silently bucketed as a 401, which matches its actual semantics.

No request shape changes. No public auth contract changes. SDK clients that ignore the new `code` field continue to work exactly as they did before — they just see slightly more specific error strings.

### Why this is safe

- Scope: 4 cloud files. No SDK changes. No mobile changes. No middleware changes.
- The change builds on top of the auth-header parsing hotfix (`8a0b1f7eb9`) already in `main`.
- Server-side logs were already emitting the precise branch (`Token mismatch: Token for X used by Y`, `not found`, `already used`, `expired`); this PR just lets the response say which one.
- Detail in the response is intentionally limited to a fixed enum of codes — we do not echo back the package names that were minted vs. requesting. That stays in logs only.

### Motivating incident

A partner reported their `exchangeToken(...)` call returning `Invalid or expired token` after the prior hotfix. We have no way to tell from the response which of the four failure branches is firing. With this change deployed, his next failed call self-identifies the actual cause.

## Test plan

- [x] `bun test packages/cloud/src/api/hono/routes/auth.utils.test.ts packages/cloud/src/api/hono/routes/auth.routes.test.ts` — 12 tests pass (added 5 parameterized cases, one per failure code)
- [x] `bun x tsc -p packages/cloud/tsconfig.json --noEmit` — clean
- [x] `bun x eslint` on the 4 changed files — clean
- [ ] Smoke test in staging: hit `/api/auth/exchange-user-token` with (a) a legitimate token to confirm 200, (b) a never-existed token to confirm `code: "token_not_found"`, (c) a token minted for a different package than the API key authenticates as to confirm `code: "token_package_mismatch"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)