### PR TITLE
hotfix(104): patch @soniox/node eventQueue leak (~15 MB/hr/session)

### DIFF
--- a/cloud/bun.lock
+++ b/cloud/bun.lock
@@ -238,7 +238,7 @@
         "@mentra/utils": "workspace:*",
         "@sentry/bun": "^9.1.0",
         "@sentry/cli": "^2.42.1",
-        "@soniox/node": "^1.1.1",
+        "@soniox/node": "^2.0.0",
         "@supabase/supabase-js": "^2.49.1",
         "@types/ali-oss": "^6.16.11",
         "ali-oss": "^6.23.0",
@@ -666,6 +666,9 @@
         "vite": "^6.2.0",
       },
     },
+  },
+  "patchedDependencies": {
+    "@soniox/node@2.0.0": "patches/@soniox%2Fnode@2.0.0.patch",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1614,7 +1617,7 @@
 
     "@smithy/uuid": ["@smithy/uuid@1.1.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g=="],
 
-    "@soniox/node": ["@soniox/node@1.1.2", "", {}, "sha512-VVxwOW5KntJPHve2PxjdMYh+NpyaaqHr2eLqbp+zy/ajhtgOITy+zUSg6jnoIu4YylSK4+yl8yDgC3qy5XKkRw=="],
+    "@soniox/node": ["@soniox/node@2.0.0", "", {}, "sha512-yKuJN/8TdYmpLacAWqqNCS99nsA1EPRkm0DMYV6FbaSKGOFIEpU3eTWiYqApZh4lT1n6DoBPdDxVAFI7qzqIMA=="],
 
     "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
@@ -1726,7 +1729,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.10", "", { "dependencies": { "bun-types": "1.3.10" } }, "sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -3576,6 +3579,8 @@
 
     "zustand": ["zustand@5.0.12", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g=="],
 
+    "@augmentos/cloud-client/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -3646,9 +3651,9 @@
 
     "@mentra/captions/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
-    "@mentra/cli/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "@mentra/cli/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
-    "@mentra/cloud/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "@mentra/cloud/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@mentra/cloud/dotenv": ["dotenv@10.0.0", "", {}, "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="],
 
@@ -3780,7 +3785,7 @@
 
     "@types/body-parser/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
-    "@types/bun/bun-types": ["bun-types@1.3.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg=="],
+    "@types/bun/bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "@types/connect/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
@@ -4101,6 +4106,8 @@
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@augmentos/cloud-client/bun-types/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 

--- a/cloud/docker/Dockerfile.dev
+++ b/cloud/docker/Dockerfile.dev
@@ -20,6 +20,11 @@ COPY packages/sdk/package.json packages/sdk/tsconfig.json ./packages/sdk/
 COPY packages/utils/package.json packages/utils/tsconfig.json ./packages/utils/
 COPY packages/cloud/package.json packages/cloud/tsconfig.json ./packages/cloud/
 
+# Bun's patchedDependencies (cloud/package.json) requires the patch file to
+# exist at install time — without it, `bun install` errors with
+# "could not find patch file".
+COPY patches ./patches
+
 # Install dependencies only (skip prepare scripts that build SDK)
 # SDK will be built at runtime after volume mount
 RUN bun install --no-link --ignore-scripts

--- a/cloud/issues/103-non-session-heap-growth/spike.md
+++ b/cloud/issues/103-non-session-heap-growth/spike.md
@@ -1,0 +1,268 @@
+# Spike: Non-Session Heap Growth on Cloud Pod
+
+> **Resolved 2026-04-27 — root cause identified.** The non-session heap growth this spike opened the question on traces to a single upstream bug in `@soniox/node`'s `RealtimeSttSession.eventQueue`. See [104-soniox-eventqueue-leak/spike.md](../104-soniox-eventqueue-leak/spike.md) for the full retainer-chain trace and [104/spec.md](../104-soniox-eventqueue-leak/spec.md) for the fix being shipped (SDK patch via `patch-package` + upstream PR).
+
+## Overview
+
+**What this doc covers:** Evidence of a sustained heap leak on cloud pods that lives **outside** the UserSession ownership graph. On dev with two idle sessions and negligible traffic, heap grows ~18MB/hour. The per-session memory census accounts for roughly **0.001%** of what's actually retained — the other 99.999% is owned by something else. This spike catalogs the evidence and the candidate owners, without committing to a cause.
+
+**Why this doc exists:** Separate from the [102 event-loop cascade](../102-pod-loop-stall-cascade/). That issue is about UDP/audio monopolizing the event loop under load on us-central prod. This issue is about a slow memory accumulation visible even at near-zero load on dev. The two can interact — larger heap → longer natural GC → more fragile under cascade — but they are distinct problems with distinct fixes.
+
+**Why this is filed now:** Dev telemetry sample captured 2026-04-24 17:09 UTC shows:
+
+- `heapUsedMB: 429` on 2 sessions, uptime 17h45m (`uptimeSeconds: 63902`)
+- `memoryEstimatedSessionBytes: 6,214` (6KB across all sessions)
+- `heapObjectCount: 7,660,597`
+- `gc-probe` forced GC freed **0 MB** at 453MB heap
+- `disposedSessionsPendingGC: 3`
+
+Gap between session-tracked memory (6KB) and actual heap (429MB) is **~69,000×**. The existing census is blind to essentially everything.
+
+**Who should read this:** Cloud engineers. Anyone extending the memory census. Anyone triaging a long-running pod that grows past ~1GB RSS.
+
+**Relationship to issue 102:**
+
+- 102 instruments the audio path + event-loop timer starvation. Phase 1 won't catch this leak directly.
+- But heap growth here feeds into the cascade indirectly: larger heap → longer natural major GCs → shorter kill threshold margin. If this leak is fixed, 102's cascade gets more headroom per pod.
+- Fixing 103 does not replace 102. Fixing 102 does not replace 103.
+
+---
+
+## Evidence
+
+Raw log sample, dev, us-central-dev, v1011, 2026-04-24 17:09:41 UTC:
+
+```json
+{
+  "feature": "system-vitals",
+  "heapUsedMB": 429,
+  "heapTotalMB": 444,
+  "rssMB": 683,
+  "externalMB": 38,
+  "arrayBuffersMB": 9,
+  "activeSessions": 2,
+  "activeAppWebsockets": 2,
+  "activeTranscriptionStreams": 1,
+  "glassesWebSockets": 2,
+  "micActiveCount": 1,
+  "mongoQueryCount": 0,
+  "mongoTotalBlockingMs": 0,
+  "disposedSessionsPendingGC": 3,
+  "memoryEstimatedSessionBytes": 6214,
+  "memoryOwnerCount": 16,
+  "memoryTopOwners": [
+    { "owner": "calendar.events", "estimatedBytes": 3986, "itemCount": 23 },
+    { "owner": "app-session.subscription-history", "estimatedBytes": 1583, "itemCount": 11 },
+    { "owner": "app-session.subscriptions", "estimatedBytes": 277, "itemCount": 11 },
+    { "owner": "transcription.streams", "estimatedBytes": 256, "itemCount": 1 },
+    { "owner": "dashboard.widgets", "estimatedBytes": 65, "itemCount": 1 }
+  ],
+  "heapObjectCount": 7660597,
+  "heapTopTypes": {
+    "Object": 3006627,
+    "string": 2673323,
+    "Array": 188271,
+    "Function": 49478,
+    "Structure": 40934,
+    "UnlinkedFunctionExecutable": 29688,
+    "FunctionExecutable": 28115,
+    "Uint8Array": 12654,
+    "JSLexicalEnvironment": 11956,
+    "SymbolTable": 8668
+  },
+  "wsDisconnects": 0,
+  "wsReconnects": 0,
+  "uptimeSeconds": 63902
+}
+```
+
+Same window gc-probe:
+
+```json
+{
+  "feature": "gc-probe",
+  "gcDurationMs": 102.8,
+  "heapBeforeMB": 453,
+  "heapAfterMB": 453,
+  "freedMB": 0,
+  "rssMB": 698,
+  "activeSessions": 2
+}
+```
+
+And an unrelated but telling log, same minute:
+
+```json
+{
+  "feature": "app-cache",
+  "count": 1453,
+  "refreshMs": 209,
+  "refreshCount": 2131,
+  "msg": "App cache refreshed: 1453 apps in 209ms"
+}
+```
+
+---
+
+## What We Know
+
+1. **Leak is traffic-independent.** Two idle sessions, zero Mongo queries, zero WS disconnects in the current vitals window. Still ~18MB/hour growth over 17h45m.
+2. **Leak is outside UserSession.** Census walks UserSession-owned maps and reports 6KB total. The 429MB heap is ~99.999% unaccounted.
+3. **Everything in heap is reachable.** Forced `Bun.gc(true)` at 453MB freed 0MB. There is no garbage to collect; everything is live from some root.
+4. **Heap is dominated by generic types.** 3M `Object` + 2.67M `string` + 188K `Array` + 49K `Function` + 29K `UnlinkedFunctionExecutable`. These are the shapes V8/JSC uses for everything — not diagnostic on their own, but consistent with large retained object graphs (JSON results, parsed documents, callback closures) rather than raw buffers (`Uint8Array` only 12,654).
+5. **`disposedSessionsPendingGC: 3`.** Three sessions had `dispose()` called but are still reachable. Some strong reference somewhere is preventing collection. Small absolute number but a clear signal of a reference leak class.
+6. **App cache is a heavy background process.** 1,453 apps loaded per refresh, refresh #2,131 (~every 30s for 17h). If the cache retains references between refreshes, the leak math is enormous: `1,453 × avg_app_doc_size × historical_versions_retained`.
+7. **External memory is only 38MB.** So the leak is in the managed JS heap, not in native buffers (would appear in `external` or `arrayBuffers`).
+
+---
+
+## What We Don't Know
+
+- **Which root holds the 400+ MB.** Could be one big owner or the sum of many.
+- **Whether app-cache is the leak or is constant.** 1,453 docs × ~100KB each ≈ 145MB in heap at steady state. If this is flat, it's not a _leak_; it's just cost. If it grows with each refresh, it is.
+- **Whether Mongoose internals retain.** Mongoose tracks document subscribers, connection pool buffers, possibly query plan caches.
+- **Whether SDK clients (Soniox/Deepgram) retain buffers.** Each TranscriptionManager creates provider streams; closed streams might leave buffers reachable if a reference remains.
+- **Whether the leak is in Pino/logtail transport buffers.** Async log buffers queue messages; if flush never succeeds (or backpressure holds references), messages pile up.
+- **Whether bun-specific internals hold references longer than expected.** Bun's JSC differs from V8 in GC timing and closure retention edge cases.
+- **Whether `disposedSessionsPendingGC` is the whole story or a small tip.** 3 sessions could be 3MB or 300MB depending on what they hold.
+
+---
+
+## Candidate Causes (not yet tested)
+
+Ranked by plausibility given the evidence:
+
+### 1. App cache retention between refreshes
+
+`AppCache.ts` loads 1,453 app documents every ~30s. If old document objects are still reachable (e.g., old handler closures, event listeners, module references), each refresh accumulates. Over 2,131 refreshes at even 1% retention per cycle, you'd accumulate 30× the baseline over 17 hours.
+
+**To test**: grep AppCache for `Map<>` / `Array<>` fields that grow; check whether the old snapshot is fully released on refresh; add an owner entry in memory census for the cache.
+
+### 2. Mongoose document/plugin retention
+
+Mongoose's internal change-tracking and plugins can retain document references. The `slowQueryPlugin` in `mongodb.connection.ts` attaches pre/post hooks to every query; if the hook closures capture something, they retain it.
+
+**To test**: disable the slow-query plugin temporarily on dev; observe whether heap growth slows. Check Mongoose docs + source for internal caches.
+
+### 3. Soniox SDK client retained state
+
+Each session uses `SonioxClient` / transcription streams. Failed reconnects, closed-but-not-cleaned streams, or the SDK's internal retry state could leak. At 2,131 app-cache refreshes but only 1 active transcription stream, this isn't the dominant leak but could contribute.
+
+**To test**: audit `TranscriptionManager.dispose()` / translation cleanup paths for retained callbacks; instrument Soniox/Deepgram SDK client lifecycle.
+
+### 4. Disposed-but-referenced UserSession chain
+
+`disposedSessionsPendingGC: 3` says three old sessions are still reachable. If each retains its managers, audio buffers, and per-session caches, three leaked sessions could be 10-30 MB by themselves. Not the whole 400MB but a measurable fraction.
+
+**To test**: extend `MemoryLeakDetector` to record which root path is keeping each disposed session alive (heap-snapshot path or instrumented reference-holding).
+
+### 5. Pino / logtail transport buffer
+
+If the remote log endpoint is slow/flaky, pino's async buffer holds messages. Each message is small but millions × hundreds of bytes adds up.
+
+**To test**: check pino transport queue depth; temporarily log to stdout only on dev and re-observe growth rate.
+
+### 6. Dashboard / calendar / notification poll state
+
+Dashboard mini-app (per architecture doc) is separate process but cloud has `DashboardManager` per session. Calendar events are an observed owner (3,986 bytes / 23 items in census). These are small per-session and capped, so unlikely primary cause.
+
+---
+
+## Recommendation
+
+Two-step investigation (Phase 1 data-gathering):
+
+1. **Extend memory census to cover the likely blind spots.** Add owner entries for:
+   - App cache map size (`app-cache.documents`, `app-cache.subscribers`)
+   - Mongoose document cache if accessible
+   - Pino transport buffer depth if accessible
+   - Any module-level Maps/Sets holding per-user or per-app data
+
+   This is a small PR (~50 lines across 2-3 files). Doesn't fix anything, but the next 17-hour dev sample will show _which owner_ is growing.
+
+2. **Enable heap snapshot on signal.** Add a SIGUSR1 handler that writes a heap snapshot (`bun:jsc.heapStats()` + `writeHeapSnapshot` if available) to a known path. Operators can SIGUSR1 the dev pod when heap hits 600MB, load the snapshot in Chrome DevTools, and see the retention graph directly.
+
+   Larger PR (~100 lines, needs testing against actual Bun snapshot format) but gives us ground truth.
+
+Step 1 alone probably narrows the cause. Step 2 confirms.
+
+**Explicitly NOT in scope for this spike:**
+
+- Any fix. Need to know the cause first.
+- Changes to UserSession ownership. The leak is outside it.
+- Changes to GC behavior / heap limits. Treats symptom; leaves root cause.
+- Consolidation with issue 102. They are separate problems.
+
+---
+
+## Key Numbers
+
+| Metric                      | Current (dev, 17h45m, 2 sessions) | What we need                                   |
+| --------------------------- | --------------------------------- | ---------------------------------------------- |
+| Heap used                   | 429 MB                            | Expected ~80-150 MB at steady idle             |
+| Session-tracked memory      | 6 KB                              | —                                              |
+| Census blind-spot ratio     | ~69,000×                          | Want <2× (census within a factor of 2 of heap) |
+| Growth rate at idle         | ~18 MB/hour                       | Want <1 MB/hour                                |
+| `disposedSessionsPendingGC` | 3                                 | Want 0                                         |
+| Objects in heap             | 7.66M                             | —                                              |
+| Forced GC freed             | 0 MB                              | Want freed > 0 when heap is large              |
+
+---
+
+## Evidence Index
+
+Re-capture the sample:
+
+```bash
+doppler run --project mentra-sre --config dev -- \
+  bun cloud/tools/bstack/bstack.ts sql "
+SELECT dt,
+       JSONExtract(raw,'heapUsedMB','Nullable(Float64)') AS heap_mb,
+       JSONExtract(raw,'rssMB','Nullable(Float64)') AS rss_mb,
+       JSONExtract(raw,'activeSessions','Nullable(Int32)') AS sessions,
+       JSONExtract(raw,'memoryEstimatedSessionBytes','Nullable(Int64)') AS census_bytes,
+       JSONExtract(raw,'heapObjectCount','Nullable(Int64)') AS heap_obj_count,
+       JSONExtract(raw,'disposedSessionsPendingGC','Nullable(Int32)') AS pending_gc,
+       JSONExtract(raw,'uptimeSeconds','Nullable(Int32)') AS uptime_s
+FROM remote(t373499_augmentos_logs)
+WHERE dt >= now() - INTERVAL 1 HOUR
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central-dev'
+  AND JSONExtract(raw,'feature','Nullable(String)')='system-vitals'
+ORDER BY dt DESC
+LIMIT 20"
+```
+
+Heap growth rate over time:
+
+```bash
+doppler run --project mentra-sre --config dev -- \
+  bun cloud/tools/bstack/bstack.ts sql "
+SELECT toStartOfInterval(dt, INTERVAL 15 MINUTE) AS bucket,
+       round(avg(JSONExtract(raw,'heapUsedMB','Nullable(Float64)')), 0) AS heap_mb,
+       round(avg(JSONExtract(raw,'rssMB','Nullable(Float64)')), 0) AS rss_mb,
+       round(avg(JSONExtract(raw,'activeSessions','Nullable(Int32)')), 0) AS sessions
+FROM s3Cluster(primary, t373499_augmentos_s3)
+WHERE _row_type=1
+  AND dt >= now() - INTERVAL 24 HOUR
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central-dev'
+  AND JSONExtract(raw,'feature','Nullable(String)')='system-vitals'
+GROUP BY bucket
+ORDER BY bucket"
+```
+
+App cache refresh pattern:
+
+```bash
+doppler run --project mentra-sre --config dev -- \
+  bun cloud/tools/bstack/bstack.ts sql "
+SELECT dt,
+       JSONExtract(raw,'count','Nullable(Int32)') AS app_count,
+       JSONExtract(raw,'refreshMs','Nullable(Float64)') AS refresh_ms,
+       JSONExtract(raw,'refreshCount','Nullable(Int32)') AS refresh_count
+FROM remote(t373499_augmentos_logs)
+WHERE dt >= now() - INTERVAL 1 HOUR
+  AND JSONExtract(raw,'region','Nullable(String)')='us-central-dev'
+  AND JSONExtract(raw,'feature','Nullable(String)')='app-cache'
+ORDER BY dt DESC
+LIMIT 20"
+```

--- a/cloud/issues/104-soniox-eventqueue-leak/design.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/design.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-**What this doc covers:** File-by-file implementation plan for the changes spec'd in [spec.md](./spec.md). Three deliverables: SDK version bump, local `patch-package` patch, and the upstream PR submission.
+**What this doc covers:** File-by-file implementation plan for the changes spec'd in [spec.md](./spec.md). Three deliverables: SDK version bump, local `bun patch`, and the upstream PR submission.
 
 **What you need to know first:** [spike.md](./spike.md) for the heap-snapshot evidence; [spec.md](./spec.md) for the exact behavior changes and rationale.
 
@@ -53,7 +53,7 @@ cd cloud
 bun install
 ```
 
-This updates `bun.lock` to pin `@soniox/node@2.0.0`. The bun cache layout (`node_modules/.bun/@soniox+node@2.0.0/...`) replaces the `1.1.2` directory. patch-package needs the new version in path before recording the patch.
+This updates `bun.lock` to pin `@soniox/node@2.0.0`. The bun cache layout (`node_modules/.bun/@soniox+node@2.0.0/...`) replaces the `1.1.2` directory. `bun patch` materializes from this version when we record the patch in S2.
 
 Verification: `bunx tsc --noEmit` passes from `cloud/packages/cloud/`. If any new type errors appear due to v1→v2 changes, address them in the same commit (most likely scenario: a type widened or an import name changed for a peripheral symbol).
 
@@ -137,8 +137,8 @@ Bumps @soniox/node 1.1.1 -> 2.0.0 first so the patch targets the
 version Soniox is actively maintaining, and so the upstream PR and
 our local patch are both against the same source.
 
-Drop this patch + postinstall hook when upstream merges + ships the
-fix — see cloud/issues/104-soniox-eventqueue-leak/."
+Drop this patch + patchedDependencies entry when upstream merges + ships
+the fix — see cloud/issues/104-soniox-eventqueue-leak/."
 ```
 
 ---
@@ -297,7 +297,7 @@ The PR's URL goes back into our MentraOS commit message and into the patch's lea
 
 ## Constants and Imports
 
-None added in MentraOS source. The patch-package change is in `node_modules/`. The MentraOS source code is unchanged.
+None added in MentraOS source. The bun patch is recorded as a unified diff under `cloud/patches/` and applied by bun against `node_modules/` at install time. MentraOS source code is unchanged.
 
 The upstream PR adds one private field to `RealtimeSttSession`. No imports change.
 
@@ -307,7 +307,7 @@ The upstream PR adds one private field to `RealtimeSttSession`. No imports chang
 
 ### Local
 
-1. `bun install` from `cloud/packages/cloud/` — must succeed; postinstall must apply the patch.
+1. `bun install` from `cloud/` — must succeed; bun re-applies the patch automatically via `patchedDependencies`.
 2. `bunx tsc --noEmit` — must pass.
 3. Inspect `node_modules/.bun/@soniox+node@2.0.0/.../dist/index.mjs` — confirm patch applied (search for `iteratorAttached`).
 4. Programmatic check on `cloud-debug` after deploy:
@@ -338,7 +338,7 @@ Add `cloud/104-soniox-eventqueue-leak-fix` to the `branches:` list in `.github/w
 
 1. Branch `cloud/104-soniox-eventqueue-leak-fix` off `dev`. Done.
 2. S1: bump version, run `bun install`, `bunx tsc --noEmit`.
-3. S2: install patch-package, modify SDK files, generate patch, wire postinstall, verify clean reinstall.
+3. S2: `bun patch @soniox/node@2.0.0`, modify the materialized SDK files, `bun patch --commit`, verify clean reinstall.
 4. Open MentraOS PR against `dev`.
 5. Open upstream PR against `soniox/soniox-js` in parallel (S3).
 6. Add `cloud/104-soniox-eventqueue-leak-fix` to porter-debug.yml triggers, auto-deploy, soak ≥1h.
@@ -346,7 +346,7 @@ Add `cloud/104-soniox-eventqueue-leak-fix` to the `branches:` list in `.github/w
 8. Merge MentraOS PR → auto-deploys to cloud-dev.
 9. Watch us-central-dev memory floor for 24h.
 10. Cherry-pick to main → prod regions.
-11. When upstream ships the fix in a new release: bump version, delete patch, remove postinstall hook, close issue 104.
+11. When upstream ships the fix in a new release: bump version, delete `cloud/patches/@soniox%2Fnode@2.0.0.patch`, remove the `patchedDependencies` entry from `cloud/package.json`, close issue 104.
 
 ---
 
@@ -354,11 +354,11 @@ Add `cloud/104-soniox-eventqueue-leak-fix` to the `branches:` list in `.github/w
 
 **Risk: v1→v2 SDK changes break our wrapper.** Mitigated by spec'd typecheck pass; the diff shows only additive changes to consumed surface. If we hit a breaking change at runtime, fix in the same PR.
 
-**Risk: patch-package patch fails to apply after `bun install`.** patch-package exits non-zero, install fails loudly. That's the intended behavior — when upstream releases v2.0.1 with line numbers shifted, we want a hard fail so we know to update or drop the patch.
+**Risk: bun fails to apply the patch after a future SDK bump.** `bun install` exits non-zero and refuses to install — that's the intended behavior. When upstream releases v2.0.1 with line numbers shifted, we want a hard fail so we know to update or drop the patch.
 
 **Risk: upstream PR rejected by Soniox** (e.g., they prefer a different fix shape). We keep the local patch indefinitely. Cost: tracking patch validity across SDK versions. We'd reconsider the wrapper-drain workaround as Plan B.
 
-**Risk: postinstall script breaks Bun's install caching.** patch-package interacts with `node_modules` directly; bun's content-addressed cache may need to materialize files differently. Mitigated by step 5 of S2 (clean reinstall verification).
+**Risk: bun's patch reapplication interacts oddly with the content-addressed cache.** Mitigated by clean-reinstall verification (step 4 of S2). Verified empirically — `iteratorAttached` gates show up in `node_modules/.bun/@soniox+node@2.0.0/...` after every fresh install.
 
 **Risk: deploy to debug still leaks** because debug pod hasn't been restarted with the patched build. Mitigated by waiting for the porter-debug.yml workflow run to complete, then explicitly checking pod uptime in `system-vitals` to confirm we're looking at the post-deploy pod.
 
@@ -366,6 +366,6 @@ Add `cloud/104-soniox-eventqueue-leak-fix` to the `branches:` list in `.github/w
 
 ## Summary
 
-Three small changes (one version bump, one dev dep, one patch file). Zero MentraOS source-code changes. The upstream PR is parallel and independent. When upstream ships the fix, removing the patch is a 1-line PR.
+Three small changes (one version bump, one `patchedDependencies` entry, one patch file). Zero MentraOS source-code changes. The upstream PR is parallel and independent. When upstream ships the fix, removing the patch is a 1-line PR.
 
 The fix at the SDK layer (rather than as a wrapper-side workaround) means every Soniox SDK consumer eventually benefits and our codebase stays free of compensatory hacks.

--- a/cloud/issues/104-soniox-eventqueue-leak/design.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/design.md
@@ -1,0 +1,371 @@
+# Design: Patch Soniox SDK eventQueue Leak — Implementation
+
+## Overview
+
+**What this doc covers:** File-by-file implementation plan for the changes spec'd in [spec.md](./spec.md). Three deliverables: SDK version bump, local `patch-package` patch, and the upstream PR submission.
+
+**What you need to know first:** [spike.md](./spike.md) for the heap-snapshot evidence; [spec.md](./spec.md) for the exact behavior changes and rationale.
+
+**Who should read this:** PR reviewers; whoever lands the upstream PR; whoever drops the patch later when upstream ships the fix.
+
+---
+
+## Branch Plan
+
+One PR for the MentraOS-side change (S1 + S2 from spec). The upstream PR (S3) is an independent submission to `soniox/soniox-js` and doesn't block this PR's merge.
+
+Branch: `cloud/104-soniox-eventqueue-leak-fix` off `origin/dev`. Already created.
+
+---
+
+## Changes Summary
+
+| Component                       | File                                                                                                 | Change                                                                                                                               |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| S1: SDK version bump            | `cloud/packages/cloud/package.json`                                                                  | `"@soniox/node": "^1.1.1"` → `"^2.0.0"`                                                                                              |
+| S2: patchedDependencies entry   | `cloud/package.json`                                                                                 | Add `"patchedDependencies": { "@soniox/node@2.0.0": "patches/@soniox%2Fnode@2.0.0.patch" }` (bun native — no devDep, no postinstall) |
+| S2: the patch itself            | `cloud/patches/@soniox%2Fnode@2.0.0.patch` (new)                                                     | Generated patch — adds `iteratorAttached` flag + gates each `eventQueue.push(...)` in both `dist/index.mjs` and `dist/index.cjs`     |
+| S3: upstream PR (separate repo) | `soniox/soniox-js` `packages/node/src/realtime-stt-session.ts` (or wherever `RealtimeSttSession` is) | Same fix in TypeScript source                                                                                                        |
+
+Estimated diff in this repo: 3 files modified (`cloud/package.json`, `cloud/packages/cloud/package.json`, `cloud/bun.lock`), 1 file added (`cloud/patches/@soniox%2Fnode@2.0.0.patch`). The patch file is ~80 lines (covers both `.mjs` and `.cjs`).
+
+No changes to MentraOS source code.
+
+---
+
+## S1: Bump `@soniox/node` to `^2.0.0`
+
+### File: `cloud/packages/cloud/package.json`
+
+```diff
+   "dependencies": {
+     ...
+-    "@soniox/node": "^1.1.1",
++    "@soniox/node": "^2.0.0",
+     ...
+   }
+```
+
+After the edit:
+
+```bash
+cd cloud
+bun install
+```
+
+This updates `bun.lock` to pin `@soniox/node@2.0.0`. The bun cache layout (`node_modules/.bun/@soniox+node@2.0.0/...`) replaces the `1.1.2` directory. patch-package needs the new version in path before recording the patch.
+
+Verification: `bunx tsc --noEmit` passes from `cloud/packages/cloud/`. If any new type errors appear due to v1→v2 changes, address them in the same commit (most likely scenario: a type widened or an import name changed for a peripheral symbol).
+
+---
+
+## S2: bun patch + the patch file
+
+### Step 1 — prepare a writable copy
+
+```bash
+cd cloud
+bun patch @soniox/node@2.0.0
+```
+
+Bun materializes `node_modules/@soniox/node` (escapes the bun cache layout into a regular folder) and prints the path to edit.
+
+### Step 2 — modify the materialized SDK
+
+Edit both compiled bundles:
+
+```
+cloud/node_modules/@soniox/node/dist/index.mjs
+cloud/node_modules/@soniox/node/dist/index.cjs
+```
+
+The same change goes into both files. Locate the `RealtimeSttSession` class declaration and apply the diff from spec S2.
+
+The relevant lines in `index.mjs` (v2.0.0):
+
+- Field declarations near line 697 (`eventQueue = new AsyncEventQueue();`)
+- `[Symbol.asyncIterator]()` getter near line 888
+- `eventQueue.push(...)` calls in the message handler near lines 946, 952, 956, 960
+
+Same offsets exist in `index.cjs` (similar layout, slightly different module wrapper).
+
+The patch in spec.md S2 captures the change verbatim.
+
+### Step 3 — commit the patch
+
+```bash
+cd cloud
+bun patch --commit 'node_modules/@soniox/node'
+```
+
+This produces `cloud/patches/@soniox%2Fnode@2.0.0.patch` (bun encodes `/` as `%2F`) containing the unified diff for both `index.mjs` and `index.cjs`. It also writes the `patchedDependencies` field into `cloud/package.json` automatically.
+
+Verify the file is non-empty and contains both `+++ b/dist/index.mjs` and `+++ b/dist/index.cjs` headers.
+
+### Step 4 — verify the patch applies on a clean install
+
+```bash
+cd cloud
+rm -rf node_modules
+bun install
+```
+
+Bun re-extracts the package, then re-applies the patch automatically (no postinstall hook needed). Inspect `node_modules/.bun/@soniox+node@2.0.0/.../dist/index.mjs` to confirm the `iteratorAttached` field and the gates are present.
+
+### Why not `patch-package`?
+
+Initial attempt was `bun add -d patch-package` + `bunx patch-package @soniox/node`. It failed because patch-package looks for `node_modules/@soniox/node/package.json` at the workspace root, but bun's content-addressed cache layout puts the real files at `node_modules/.bun/@soniox+node@2.0.0/...` and only symlinks `packages/cloud/node_modules/@soniox/node`. Bun's native `bun patch` handles this correctly and avoids the extra dev dep + postinstall hook.
+
+### Step 5 — commit
+
+```bash
+git add cloud/packages/cloud/package.json cloud/package.json cloud/bun.lock cloud/patches/
+git commit -m "fix(104): patch @soniox/node eventQueue leak (upstream PR <link>)
+
+@soniox/node's RealtimeSttSession unconditionally pushes every event
+to an internal AsyncEventQueue, even when the consumer uses the .on()
+event-listener API (the documented usage). The queue is never drained
+and grows ~15 MB/hour per active session for the lifetime of the
+session — proven via heap snapshot retainer trace (see issue 104).
+
+This patch adds an iteratorAttached flag set in [Symbol.asyncIterator]()
+and gates every eventQueue.push(...) call on it. for await consumers
+unaffected (they call the iterator getter before any events arrive);
+.on() consumers no longer leak.
+
+Bumps @soniox/node 1.1.1 -> 2.0.0 first so the patch targets the
+version Soniox is actively maintaining, and so the upstream PR and
+our local patch are both against the same source.
+
+Drop this patch + postinstall hook when upstream merges + ships the
+fix — see cloud/issues/104-soniox-eventqueue-leak/."
+```
+
+---
+
+## S3: Upstream PR Submission
+
+### Prerequisites
+
+- GitHub auth: `gh auth status` must show admin/repo scope.
+- The fork: `gh repo fork soniox/soniox-js --clone --remote=upstream`. This creates a fork under your GitHub account, clones it locally, and adds `soniox/soniox-js` as the `upstream` remote.
+
+### Steps
+
+````bash
+# 1. Fork + clone
+cd /tmp
+gh repo fork soniox/soniox-js --clone --remote=upstream
+cd soniox-js
+
+# 2. Create branch
+git checkout -b fix/eventqueue-iterator-attach-gate
+
+# 3. Find the source file
+ls packages/node/src/
+# Likely: realtime-stt-session.ts  (or session/realtime-stt-session.ts)
+# Locate the class:
+grep -rn "class RealtimeSttSession" packages/node/src/
+
+# 4. Apply the same fix in TypeScript
+# Same shape as the S2 patch but in .ts source:
+#   - Add `iteratorAttached = false;` field
+#   - Set it in [Symbol.asyncIterator]() getter
+#   - Gate each eventQueue.push(...) on the flag
+#   (Their build will compile this to the same .mjs/.cjs we patched locally)
+
+# 5. Run their test suite
+cd packages/node
+npm test  # or whatever they use — check their CI config
+
+# 6. Commit
+cd /tmp/soniox-js
+git add packages/node/src/realtime-stt-session.ts  # or actual path
+git commit -m "fix(node): only push to eventQueue when iterator has been attached
+
+When a consumer uses session.on() event listeners (the documented
+pattern from soniox.com/docs/stt/SDKs/node-SDK) instead of the async
+iterator, the eventQueue grows unbounded — every event is pushed
+but nothing drains. Long-running sessions leak ~15 MB/hour of
+buffered RealtimeEvent objects.
+
+Fix: track whether [Symbol.asyncIterator]() has been called.
+Only push to eventQueue when it has. Both consumer paths continue
+to work; the dual-API just no longer double-allocates when only
+one is used."
+
+# 7. Push to fork
+git push -u origin fix/eventqueue-iterator-attach-gate
+
+# 8. Open PR
+gh pr create --repo soniox/soniox-js --base main \
+  --title "fix(node): only push to eventQueue when iterator attached" \
+  --body "$(cat <<'EOF'
+## Summary
+
+`RealtimeSttSession.eventQueue` is unconditionally pushed to on every
+WebSocket message, even when no consumer has called the async iterator
+(`for await...of session`). Consumers using the documented `.on()`
+listener pattern leak ~15 MB/hour of buffered `RealtimeEvent` objects
+on long-running sessions.
+
+## Reproduce
+
+```js
+import { SonioxNodeClient } from "@soniox/node";
+const client = new SonioxNodeClient({ api_key: "..." });
+const session = await client.realtime.transcribe({ ... });
+
+// Documented usage (per soniox.com/docs/stt/SDKs/node-SDK):
+session.on("result", (result) => {
+  // handle result
+});
+
+await session.connect();
+// Stream audio for any extended period.
+// Inspect the heap: session.eventQueue.queue.length grows by 1 per event.
+// Memory leaks indefinitely.
+````
+
+## Evidence
+
+Programmatic heap-snapshot retainer trace from a production Node pod
+(uptime 66h, 4 active sessions):
+
+- Single `AsyncEventQueue.queue` array contained **4,148+ elements**
+  after 1h of activity.
+- Same-pod 1h diff showed **+243,784 retained `"en"` strings** (the
+  `language` field on each token in each queued result), **+534,230**
+  generic `Object` instances. Loaded-code overhead (V8 `Structure`,
+  `FunctionExecutable`) was flat — pure data accumulation.
+- Heap snapshot file size: **41 MB → 104 MB in 1 hour**.
+- Verified the same bug exists in `@soniox/node@2.0.0`.
+
+Full investigation writeup with retainer chain:
+
+<link to issue 104 spike when public, or paste inline>
+
+## Fix
+
+Track whether `[Symbol.asyncIterator]()` has been called via a new
+`iteratorAttached` flag. Only push to `eventQueue` when the flag is set.
+
+```diff
+ class RealtimeSttSession implements AsyncIterable<RealtimeEvent> {
+   private readonly eventQueue = new AsyncEventQueue();
++  private iteratorAttached = false;
+
+   [Symbol.asyncIterator]() {
++    this.iteratorAttached = true;
+     return this.eventQueue[Symbol.asyncIterator]();
+   }
+
+   // (in handleMessage)
+   this.emitter.emit("result", filteredResult);
+-  this.eventQueue.push({ kind: "result", data: filteredResult });
++  if (this.iteratorAttached) {
++    this.eventQueue.push({ kind: "result", data: filteredResult });
++  }
+   // (same gating for endpoint/finalized/finished)
+ }
+```
+
+## Backward compatibility
+
+- `for await...of session` consumers: unaffected. The async iterator
+  protocol calls `[Symbol.asyncIterator]()` before requesting any
+  values; the flag is set before any events arrive.
+- `.on(event, handler)` consumers: unaffected. The emitter path is
+  unchanged.
+- API surface: no changes. The new field is private.
+
+## Test plan
+
+- Existing tests should pass unchanged.
+- Recommend adding a regression test:
+  - Subscribe to events via `.on("result", ...)` only.
+  - Drive the session for 1000+ events.
+  - Assert `(session as any).eventQueue.queue.length === 0`.
+    EOF
+    )"
+
+````
+
+The PR's URL goes back into our MentraOS commit message and into the patch's leading comment line.
+
+---
+
+## Constants and Imports
+
+None added in MentraOS source. The patch-package change is in `node_modules/`. The MentraOS source code is unchanged.
+
+The upstream PR adds one private field to `RealtimeSttSession`. No imports change.
+
+---
+
+## Testing
+
+### Local
+
+1. `bun install` from `cloud/packages/cloud/` — must succeed; postinstall must apply the patch.
+2. `bunx tsc --noEmit` — must pass.
+3. Inspect `node_modules/.bun/@soniox+node@2.0.0/.../dist/index.mjs` — confirm patch applied (search for `iteratorAttached`).
+4. Programmatic check on `cloud-debug` after deploy:
+   ```bash
+   doppler run --project mentra-sre --config dev -- \
+     curl -sS -o /tmp/heap-after.heapsnapshot \
+       -H "Authorization: Bearer $MENTRA_ADMIN_JWT" \
+       https://debug.augmentos.cloud/api/admin/memory/heap-snapshot-v8
+   python3 /tmp/heap-compare/heap-diff.py /tmp/heap-debug.heapsnapshot /tmp/heap-after.heapsnapshot
+````
+
+Expected: `"en"` count near baseline, no `Array (4148)`-class growth, retainer trace shows AsyncEventQueue.queue with ≤1 element.
+
+### Smoke (deploy to debug or dev)
+
+Add `cloud/104-soniox-eventqueue-leak-fix` to the `branches:` list in `.github/workflows/porter-debug.yml` to auto-deploy to `debug.augmentos.cloud`. After 15-30 min of activity, pull a heap snapshot and verify per the local test above.
+
+### Acceptance (after merge to dev)
+
+1. After deploy to `cloud-dev`, watch `system-vitals` `rssMB` and `heapUsedMB` over 24 hours.
+2. Expected: post-GC RSS floor stays near startup baseline (~250-300 MB) instead of climbing to 500+ MB.
+3. Expected: GC frequency drops because no steady stream of long-lived `RealtimeEvent` objects to clean up.
+4. Issue 104 stays open until upstream merges + releases v2.0.1+.
+
+---
+
+## Rollout
+
+1. Branch `cloud/104-soniox-eventqueue-leak-fix` off `dev`. Done.
+2. S1: bump version, run `bun install`, `bunx tsc --noEmit`.
+3. S2: install patch-package, modify SDK files, generate patch, wire postinstall, verify clean reinstall.
+4. Open MentraOS PR against `dev`.
+5. Open upstream PR against `soniox/soniox-js` in parallel (S3).
+6. Add `cloud/104-soniox-eventqueue-leak-fix` to porter-debug.yml triggers, auto-deploy, soak ≥1h.
+7. Pull post-fix heap snapshot from debug. Compare against `dev-2.heapsnapshot`. Confirm `AsyncEventQueue.queue` size collapsed.
+8. Merge MentraOS PR → auto-deploys to cloud-dev.
+9. Watch us-central-dev memory floor for 24h.
+10. Cherry-pick to main → prod regions.
+11. When upstream ships the fix in a new release: bump version, delete patch, remove postinstall hook, close issue 104.
+
+---
+
+## Risks and Open Questions
+
+**Risk: v1→v2 SDK changes break our wrapper.** Mitigated by spec'd typecheck pass; the diff shows only additive changes to consumed surface. If we hit a breaking change at runtime, fix in the same PR.
+
+**Risk: patch-package patch fails to apply after `bun install`.** patch-package exits non-zero, install fails loudly. That's the intended behavior — when upstream releases v2.0.1 with line numbers shifted, we want a hard fail so we know to update or drop the patch.
+
+**Risk: upstream PR rejected by Soniox** (e.g., they prefer a different fix shape). We keep the local patch indefinitely. Cost: tracking patch validity across SDK versions. We'd reconsider the wrapper-drain workaround as Plan B.
+
+**Risk: postinstall script breaks Bun's install caching.** patch-package interacts with `node_modules` directly; bun's content-addressed cache may need to materialize files differently. Mitigated by step 5 of S2 (clean reinstall verification).
+
+**Risk: deploy to debug still leaks** because debug pod hasn't been restarted with the patched build. Mitigated by waiting for the porter-debug.yml workflow run to complete, then explicitly checking pod uptime in `system-vitals` to confirm we're looking at the post-deploy pod.
+
+---
+
+## Summary
+
+Three small changes (one version bump, one dev dep, one patch file). Zero MentraOS source-code changes. The upstream PR is parallel and independent. When upstream ships the fix, removing the patch is a 1-line PR.
+
+The fix at the SDK layer (rather than as a wrapper-side workaround) means every Soniox SDK consumer eventually benefits and our codebase stays free of compensatory hacks.

--- a/cloud/issues/104-soniox-eventqueue-leak/spec.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/spec.md
@@ -1,0 +1,186 @@
+# Spec: Patch Soniox SDK eventQueue Leak
+
+## Overview
+
+**What this doc covers:** The exact behavior changes that ship in PR #<TBD> for issue 104. Three coordinated changes: (1) bump `@soniox/node` from `^1.1.1` to `^2.0.0`, (2) apply a local `bun patch` that gates `RealtimeSttSession.eventQueue.push(...)` on iterator attachment, (3) submit the same fix as a PR upstream against `soniox/soniox-js` ([PR #13](https://github.com/soniox/soniox-js/pull/13) — also patches `RealtimeTtsStream.audioQueue` which has the same shape).
+
+**Why this doc exists:** [spike.md](./spike.md) traces the non-session heap growth that has been climbing on every long-running cloud pod (~15 MB/hour per active session) to a specific upstream SDK bug. We could work around it in our wrapper code (~5-line drain loop), but chose the SDK-patch + upstream-PR path so every other Soniox SDK consumer also benefits.
+
+**What you need to know first:** [spike.md](./spike.md) for the heap-snapshot evidence, retainer chain, and v2.0.0 verification.
+
+**Who should read this:** PR reviewers. Anyone touching the transcription stack.
+
+---
+
+## Spec
+
+### S1. Bump `@soniox/node` to `^2.0.0`
+
+**File:** `cloud/packages/cloud/package.json`
+
+**Before:** `"@soniox/node": "^1.1.1"` (resolves to `1.1.2`).
+
+**After:** `"@soniox/node": "^2.0.0"` (resolves to `2.0.0`).
+
+**Net effect:** picks up upstream's latest. v1→v2 changes are mostly additive (new `tts` API on `SonioxNodeClient`; new `SonioxHttpError` class hierarchy for REST errors). Our consumed surface (`SonioxNodeClient`, `RealtimeSttSession`, `RealtimeUtteranceBuffer`, types `RealtimeResult`/`RealtimeToken`/`SttSessionConfig`) is unchanged. Only public-API addition on `RealtimeSttSession` is a private `connectTimeoutMs` field.
+
+Verification: `bunx tsc --noEmit` from `cloud/packages/cloud/` must pass with no new errors attributable to the bump.
+
+### S2. Apply the eventQueue-attach gate locally via `bun patch`
+
+**Files:**
+
+- `cloud/package.json` — add `patchedDependencies` field (bun native; no devDep, no postinstall hook)
+- `cloud/patches/@soniox%2Fnode@2.0.0.patch` (new) — generated patch (bun encodes `/` as `%2F`)
+- Modified working copy at `cloud/node_modules/@soniox/node/dist/index.{mjs,cjs}` before `bun patch --commit` records it
+
+**The change:** add an `iteratorAttached` flag on `RealtimeSttSession`; set it from the async-iterator getter; gate every `eventQueue.push(...)` call on the flag.
+
+```diff
+ class RealtimeSttSession {
+   emitter = new TypedEmitter();
+   eventQueue = new AsyncEventQueue();
++  iteratorAttached = false;
+
+   [Symbol.asyncIterator]() {
++    this.iteratorAttached = true;
+     return this.eventQueue[Symbol.asyncIterator]();
+   }
+
+   // ... in handleMessage:
+   this.emitter.emit("result", filteredResult);
+-  this.eventQueue.push({ kind: "result", data: filteredResult });
++  if (this.iteratorAttached) {
++    this.eventQueue.push({ kind: "result", data: filteredResult });
++  }
+   if (hasEndpoint) {
+     this.emitter.emit("endpoint");
+-    this.eventQueue.push({ kind: "endpoint" });
++    if (this.iteratorAttached) this.eventQueue.push({ kind: "endpoint" });
+   }
+   if (hasFinalized) {
+     this.emitter.emit("finalized");
+-    this.eventQueue.push({ kind: "finalized" });
++    if (this.iteratorAttached) this.eventQueue.push({ kind: "finalized" });
+   }
+   if (result.finished) {
+     this.emitter.emit("finished");
+-    this.eventQueue.push({ kind: "finished" });
++    if (this.iteratorAttached) this.eventQueue.push({ kind: "finished" });
+     this.settleFinish();
+     this.cleanup("finished");
+   }
+ }
+```
+
+The same modification applies to both `dist/index.mjs` and `dist/index.cjs`. `bun patch --commit` records both into a single `.patch` file at `cloud/patches/`.
+
+Bun reads `patchedDependencies` natively — no `postinstall` hook, no extra dev dependency. Our `cloud/package.json` gains:
+
+```json
+{
+  "patchedDependencies": {
+    "@soniox/node@2.0.0": "patches/@soniox%2Fnode@2.0.0.patch"
+  }
+}
+```
+
+**Net effect:** every `bun install` re-applies the patch from cache. `eventQueue.queue` grows by 0 entries when no consumer has called `[Symbol.asyncIterator]()` (our case — we only use `.on()`). `for await...of session` consumers are unaffected because the iterator-getter sets `iteratorAttached = true` before any events arrive.
+
+### S3. Submit the same fix upstream
+
+**Repo:** [github.com/soniox/soniox-js](https://github.com/soniox/soniox-js) — the SDK source. The published `@soniox/node` is its `packages/node` workspace.
+
+**Branch:** Fork → `fix/eventqueue-iterator-attach-gate`.
+
+**Change:** same as S2 but in TypeScript source (`packages/node/src/realtime-stt-session.ts` or wherever `RealtimeSttSession` lives upstream).
+
+**PR body:** the spike's evidence — heap snapshot retainer chain, before/after diff numbers, v2.0.0 reproducer note. Cross-link to this issue.
+
+When upstream merges + ships v2.0.1+: bump our pinned version, delete `cloud/patches/@soniox%2Fnode@2.0.0.patch`, remove the `patchedDependencies` entry from `cloud/package.json`, close issue 104.
+
+### S4. No changes to MentraOS code
+
+Explicitly out of scope for this PR:
+
+- `SonioxSdkStream.ts` — the wrapper is correct. Consumes events via the documented `.on()` pattern. No changes.
+- `SonioxTranscriptionProvider.ts` — uses a different code path (`SonioxNodeClient`, not `RealtimeSttSession`). Unaffected.
+- The `for await` drain-loop workaround alternative — not used. The SDK patch supersedes it.
+
+---
+
+## Non-Goals
+
+- **Migrating to Soniox's `for await...of session` API** — `.on()` is the documented usage and our wrapper is correct. No reason to refactor.
+- **Adding our own bounded queue around the SDK** — the SDK should be fixed at the source, not papered over.
+- **Switching transcription providers** — Soniox is fine. The bug is one isolated SDK design issue, not a vendor reliability concern.
+- **Capping `AsyncEventQueue.queue` size in the patch** — capping would change observable behavior for legit `for await` consumers (they'd silently lose events). The iterator-attach gate is the right fix because it preserves both APIs' semantics.
+
+---
+
+## Decision Log
+
+| Decision                                                  | Alternatives considered                                                | Why we chose this                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Patch the SDK + upstream PR                               | Drain-loop workaround in `SonioxSdkStream.ts` (5 lines)                | The SDK patch (a) fixes the bug for every other Soniox SDK consumer, (b) lives at the right architectural layer, (c) is removable in one commit when upstream ships the fix. The drain-loop hack would survive forever if we forget. User explicitly wanted to contribute upstream.                                                                                                                    |
+| Bump to `^2.0.0` before patching                          | Patch against `1.1.2`                                                  | Soniox is no longer maintaining v1; patches against v1 would be wasted work. v2 has the same bug, low-risk diff for our consumed surface, and upstream will only accept the PR against current source. Bumping first means the patch and the upstream PR both target the same version.                                                                                                                 |
+| `iteratorAttached` flag set in `[Symbol.asyncIterator]()` | Set on first `next()` call; explicit opt-in API                        | Setting in the iterator-getter is semantically correct — if a consumer obtained the iterator at all, they intend to consume from it (otherwise they wouldn't have called the getter). First-`next()` would lose events between getter call and first `next()`, breaking valid usage patterns.                                                                                                          |
+| `bun patch` (native) over `patch-package`                 | `patch-package` + `postinstall` hook; vendor a fork in `cloud/vendor/` | Bun has built-in `patchedDependencies` support — reads the same unified-diff format and re-applies on every install. No extra dev dep, no postinstall hook to maintain. `patch-package` works but errored on bun's content-addressed cache layout (couldn't find `node_modules/@soniox/node/package.json` — the symlink lives in the workspace `node_modules/`). Forking is heavyweight by comparison. |
+| Patch lives at `cloud/patches/`                           | Patch under `cloud/packages/cloud/patches/`                            | `bun patch` puts patches at the workspace root next to the `package.json` that declares `patchedDependencies`. That's the conventional bun layout and works out of the box.                                                                                                                                                                                                                            |
+| Keep `SonioxSdkStream.ts` exactly as-is                   | Add a comment + drain-loop "just in case"                              | The wrapper code is correct. Adding workaround code that fights the SDK is the kind of change that future engineers don't know is safe to remove. Keep our code clean; let the SDK be the layer that owns this responsibility.                                                                                                                                                                         |
+
+---
+
+## Testing
+
+### Local
+
+1. `bun install` from `cloud/packages/cloud/` — must succeed; postinstall must apply the patch and report "patching @soniox/node@2.0.0".
+2. `bunx tsc --noEmit` — must pass with zero errors.
+3. `bun run test` — must pass (transcription tests should be unaffected since `.on()` semantics didn't change).
+4. Inspect `node_modules/.bun/@soniox+node@2.0.0/.../dist/index.mjs` — confirm `iteratorAttached = false` field exists and `if (this.iteratorAttached)` guards each push.
+
+### Smoke (deploy to debug or dev)
+
+1. Deploy branch to `cloud-debug` (debug.augmentos.cloud) via the existing porter-debug.yml workflow trigger.
+2. Confirm a transcription session works end-to-end — open a webview, speak, verify text appears. The fix doesn't change `.on()` semantics; behavior should be identical.
+3. After ~15 minutes of activity, pull a heap snapshot and run `python3 /tmp/heap-compare/heap-diff.py against-baseline.heapsnapshot debug-now.heapsnapshot`. Expected:
+   - `AsyncEventQueue` `.queue` array size: **≤1 element** (instead of growing unboundedly).
+   - `"en"` count: stable instead of growing 200k+/hour.
+   - Total heap snapshot size: stable instead of growing 60+ MB/hour.
+
+### Acceptance after one prod cycle
+
+After merging to `dev` and deploying to us-central-prod:
+
+1. Track `system-vitals` `rssMB` and `heapUsedMB` over 24-72 hours.
+2. Expected: post-GC RSS floor stays near startup baseline (~250-300 MB) instead of climbing to 500+ MB over hours.
+3. Expected: GC frequency drops because there's no longer a steady stream of long-lived `RealtimeEvent` objects to clean up.
+4. Pull a heap snapshot mid-run. `AsyncEventQueue.queue` size should be ≤1.
+
+---
+
+## Rollout
+
+1. Branch `cloud/104-soniox-eventqueue-leak-fix` off `dev`. Done.
+2. Apply changes per S1, S2 in this PR.
+3. Open this PR against `dev`.
+4. Open the upstream PR per S3 in parallel (independent of MentraOS PR review).
+5. Deploy to `cloud-debug` for soak validation (≥1 hour).
+6. Merge MentraOS PR → auto-deploys to `cloud-dev` via porter-dev.yml.
+7. Watch dev for 24 hours; confirm memory floor stable.
+8. Cherry-pick to `main` → deploys to prod regions.
+9. When upstream merges + releases v2.0.1+: file follow-up PR to bump version + remove patch + remove postinstall hook + close issue 104.
+
+---
+
+## Key Numbers
+
+| Metric                                       | Today (with leak)      | After fix (expected)                     |
+| -------------------------------------------- | ---------------------- | ---------------------------------------- |
+| `AsyncEventQueue.queue` size after 1h on dev | 4,148+ elements        | ≤1                                       |
+| `"en"` strings in heap                       | 305,443 (and climbing) | <100                                     |
+| Heap snapshot file size on dev               | 104 MB (and growing)   | ~25 MB stable (transcription baseline)   |
+| Per-session memory growth                    | ~15 MB/hour            | ~0                                       |
+| Post-GC RSS floor on 66h pod                 | 525 MB (climbing)      | Stable near startup baseline (~250 MB)   |
+| us-central crashes per day (issue 102)       | Daily                  | Should reduce; this leak was a co-factor |

--- a/cloud/issues/104-soniox-eventqueue-leak/spec.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/spec.md
@@ -135,7 +135,7 @@ Explicitly out of scope for this PR:
 
 ### Local
 
-1. `bun install` from `cloud/packages/cloud/` — must succeed; postinstall must apply the patch and report "patching @soniox/node@2.0.0".
+1. `bun install` from `cloud/` — must succeed; bun re-applies the patch automatically via `patchedDependencies` (no postinstall hook).
 2. `bunx tsc --noEmit` — must pass with zero errors.
 3. `bun run test` — must pass (transcription tests should be unaffected since `.on()` semantics didn't change).
 4. Inspect `node_modules/.bun/@soniox+node@2.0.0/.../dist/index.mjs` — confirm `iteratorAttached = false` field exists and `if (this.iteratorAttached)` guards each push.
@@ -170,7 +170,7 @@ After merging to `dev` and deploying to us-central-prod:
 6. Merge MentraOS PR → auto-deploys to `cloud-dev` via porter-dev.yml.
 7. Watch dev for 24 hours; confirm memory floor stable.
 8. Cherry-pick to `main` → deploys to prod regions.
-9. When upstream merges + releases v2.0.1+: file follow-up PR to bump version + remove patch + remove postinstall hook + close issue 104.
+9. When upstream merges + releases v2.0.1+: file follow-up PR to bump version + delete `cloud/patches/@soniox%2Fnode@2.0.0.patch` + remove `patchedDependencies` entry from `cloud/package.json` + close issue 104.
 
 ---
 

--- a/cloud/issues/104-soniox-eventqueue-leak/spike.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/spike.md
@@ -130,7 +130,7 @@ Before tracing the chain to the SDK, we tested several other hypotheses surfaced
 
 Two parts that ship together:
 
-### Part 1 (in this PR): patch the SDK locally via `patch-package`
+### Part 1 (in this PR): patch the SDK locally via Bun `patchedDependencies`
 
 Modify `node_modules/@soniox/node/dist/index.mjs` and `index.cjs` to gate every `eventQueue.push(...)` call on a new `iteratorAttached` flag:
 
@@ -157,11 +157,11 @@ Modify `node_modules/@soniox/node/dist/index.mjs` and `index.cjs` to gate every 
 
 Backward compatible. Async-iterator consumers continue to work because the iterator getter sets the flag _before_ any events arrive (the iterator must be obtained before `for await` can iterate).
 
-`patch-package` records this as `cloud/patches/@soniox+node+2.0.0.patch` and re-applies on every `bun install` via a `postinstall` script.
+`bun patch --commit` records this as `cloud/patches/@soniox%2Fnode@2.0.0.patch` and Bun re-applies it automatically on every `bun install` via the `patchedDependencies` field in `cloud/package.json` — no extra dev dependency, no `postinstall` hook.
 
 ### Part 2 (separately, this same PR): submit the same fix upstream
 
-PR against [soniox/soniox-js](https://github.com/soniox/soniox-js) main branch with the heap-snapshot evidence + the same code change in TypeScript source. When upstream merges and ships v2.0.1+, we bump the version, delete `cloud/patches/`, and remove the postinstall hook.
+PR against [soniox/soniox-js](https://github.com/soniox/soniox-js) main branch with the heap-snapshot evidence + the same code change in TypeScript source ([PR #13](https://github.com/soniox/soniox-js/pull/13)). When upstream merges and ships v2.0.1+, we bump the version, delete `cloud/patches/@soniox%2Fnode@2.0.0.patch`, and remove the `patchedDependencies` entry from `cloud/package.json`.
 
 ### Why not just upgrade SDK and skip the patch?
 

--- a/cloud/issues/104-soniox-eventqueue-leak/spike.md
+++ b/cloud/issues/104-soniox-eventqueue-leak/spike.md
@@ -1,0 +1,233 @@
+# Spike: Soniox SDK `RealtimeSttSession.eventQueue` Unbounded Growth
+
+## Overview
+
+**What this doc covers:** Investigation that traced the non-session heap growth on cloud pods (issue 103) to a specific bug in the upstream `@soniox/node` SDK: `RealtimeSttSession` unconditionally pushes every event to an internal `AsyncEventQueue.queue` Array, even when the consumer uses the `.on()` event-listener API (the documented usage pattern) instead of the async iterator. The queue is never drained and grows by ~1 event per Soniox message for the full lifetime of the session.
+
+**Why this doc exists:** [103-non-session-heap-growth/spike.md](../103-non-session-heap-growth/spike.md) opened the question "where is the ~470-525 MB of post-GC RSS coming from on long-running pods?" The memory census saw 6 KB tracked vs ~280 MB in heap (a ~47,000× blind spot). This spike answers it conclusively, with retainer chains traced from the heap snapshot back to the SDK source.
+
+**Who should read this:** Cloud engineers reviewing the fix PR. Anyone using `@soniox/node` (or `@soniox/web`) via `.on()` listeners (the documented pattern) is affected; if you operate a long-running process, your pod is leaking too.
+
+**Depends on:**
+
+- Heap snapshots from `dev.augmentos.cloud` taken at `T+0` and `T+1h`. Diff at `/tmp/heap-compare/heap-diff.py`.
+- Programmatic retainer-chain trace via custom Python script that walks the V8 snapshot's `nodes`/`edges`/`strings` tables (no Chrome DevTools required).
+- Source inspection of `node_modules/.bun/@soniox+node@1.1.2/.../dist/index.mjs` and `node_modules/.bun/@soniox+node@1.1.2/.../dist/index.d.mts`.
+- Verified the same bug exists in `@soniox/node@2.0.0` (latest, published 2026-04-23).
+
+---
+
+## The Bug In 30 Seconds
+
+`RealtimeSttSession` exposes two consumer APIs for the same event stream:
+
+```typescript
+// API 1 — documented in https://soniox.com/docs/stt/SDKs/node-SDK
+session.on("result", (result) => { ... });
+
+// API 2 — undocumented (only visible via `class RealtimeSttSession implements AsyncIterable<RealtimeEvent>`)
+for await (const event of session) { ... }
+```
+
+The SDK's WebSocket message handler pushes every event to BOTH paths unconditionally:
+
+```javascript
+// @soniox/node@1.1.2 dist/index.mjs:945-960 (identical in v2.0.0:945-960)
+this.emitter.emit("result", filteredResult); // ← path 1
+this.eventQueue.push({ kind: "result", data: filteredResult }); // ← path 2
+
+if (hasEndpoint) {
+  this.emitter.emit("endpoint");
+  this.eventQueue.push({ kind: "endpoint" });
+}
+if (hasFinalized) {
+  this.emitter.emit("finalized");
+  this.eventQueue.push({ kind: "finalized" });
+}
+if (result.finished) {
+  this.emitter.emit("finished");
+  this.eventQueue.push({ kind: "finished" });
+}
+```
+
+Consumers who only use `.on()` (the documented happy path) never call `next()` on the iterator, so `eventQueue.queue` (a plain `Array`) accumulates one entry per event for the session's entire lifetime. A long-running session at typical Soniox token rates accumulates tens of thousands of events per hour.
+
+---
+
+## Evidence
+
+### Heap snapshot retainer chain (from production dev pod)
+
+After programmatically walking parent edges in the V8 heap snapshot, the chain from a leaked `"en"` string back to its root is:
+
+```
+"en" string × 305,443
+  ←language←  SonioxApiToken Object
+    ←element N←  Array (tokens[])
+      ←tokens←  metadata.soniox Object
+        ←data, raw←  RealtimeEvent record Object
+          ←element N←  Array (4148+ elements)        ← THE LEAKED BUFFER
+            ←queue←  AsyncEventQueue
+              ←eventQueue←  RealtimeSttSession
+                ←session←  SonioxSdkStream
+```
+
+Each retained `"en"` string is a `language: "en"` field on a `SonioxApiToken` inside a tokens array, inside the `data` field of a queued `RealtimeEvent`, inside `AsyncEventQueue.queue`. Same chain for every leaked token-text fragment (` the`, ` and`, ` of`, `ing`, `ly`, `e,`, ` y`, ` it`, ` was`, etc.).
+
+### Same-pod heap diff (1 hour of activity, 4 active sessions)
+
+| Constructor                    | Before (T+0) | After (T+1h) |        Δ | Growth |
+| ------------------------------ | -----------: | -----------: | -------: | -----: |
+| `Object`                       |      172,112 |      706,342 | +534,230 |  +310% |
+| `"en"` (token language tag)    |       61,659 |      305,443 | +243,784 |  +395% |
+| `" the"`                       |        1,740 |       10,580 |   +8,840 |  +509% |
+| `" and"`                       |          793 |        5,816 |   +5,023 |  +634% |
+| `" of"`                        |        1,086 |        5,903 |   +4,817 |  +443% |
+| `"ing"`                        |          549 |        3,330 |   +2,781 |  +507% |
+| `"ly"`                         |          286 |        1,650 |   +1,364 |  +477% |
+| `" I"`                         |          833 |        3,526 |   +2,693 |  +323% |
+| `Structure` (V8 hidden class)  |       41,341 |       41,540 |     +199 |  +0.5% |
+| `FunctionExecutable` (V8 code) |       27,126 |       27,365 |     +239 |  +0.9% |
+
+Loaded-code overhead (`Structure`, `FunctionExecutable`, `ModuleRecord`) was effectively flat across the same window. **This is pure data accumulation, not V8 metadata growth.**
+
+The heap snapshot file size itself grew **41 MB → 104 MB in one hour** — the largest single retainer was a single `Array (4148)` already at T+0, which would be substantially larger at T+1h.
+
+### Confirmed in v2.0.0
+
+Re-checked the published `@soniox/node@2.0.0` (2026-04-23). Same `eventQueue.push(...)` calls at the same positions in the message handler. The bug was not addressed in the v1→v2 release.
+
+### Affects every documented user
+
+The Soniox docs ([soniox.com/docs/stt/SDKs/node-SDK](https://soniox.com/docs/stt/SDKs/node-SDK)) demonstrate `.on()` as the canonical usage:
+
+```javascript
+session.on("result", (result) => {
+  const text = result.tokens.map((t) => t.text).join("");
+  if (text) console.log(text);
+});
+```
+
+This is exactly what MentraOS does in [SonioxSdkStream.ts:241-247](../../packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts#L241-L247). Any consumer following the docs is leaking.
+
+---
+
+## What We Falsified Along the Way
+
+Before tracing the chain to the SDK, we tested several other hypotheses surfaced from the heap shape:
+
+| Hypothesis                                              | Result                                                                                                                                                                                                           |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pino async transport buffer (revisit of issue 067)      | **Falsified.** `LOG_STDOUT_JSON=true` is set on dev (verified via `kubectl exec ... printenv`). Pino writes raw JSON to stdout via `pino.destination({ sync: false })`; Vector DaemonSet tails container stdout. |
+| `SonioxTranscriptionProvider.translationTokenBuffers`   | **Falsified.** The field doesn't appear in the heap snapshot (0 references).                                                                                                                                     |
+| `app-session.subscription-history` unbounded            | **Falsified.** 4 instances totaling 22 elements across all sessions. Bounded.                                                                                                                                    |
+| Mongoose document/plugin retention                      | **Falsified.** `ObjectId` count grew by only 561 (proportional to traffic, not unbounded).                                                                                                                       |
+| `TranscriptionManager._relayDataStream` template object | **Falsified.** Single instance, replaced on every relay call. Not a leak source.                                                                                                                                 |
+
+---
+
+## The Fix
+
+Two parts that ship together:
+
+### Part 1 (in this PR): patch the SDK locally via `patch-package`
+
+Modify `node_modules/@soniox/node/dist/index.mjs` and `index.cjs` to gate every `eventQueue.push(...)` call on a new `iteratorAttached` flag:
+
+```diff
+ class RealtimeSttSession {
+   emitter = new TypedEmitter();
+   eventQueue = new AsyncEventQueue();
++  iteratorAttached = false;
+
+   [Symbol.asyncIterator]() {
++    this.iteratorAttached = true;
+     return this.eventQueue[Symbol.asyncIterator]();
+   }
+
+   // ... in handleMessage:
+   this.emitter.emit("result", filteredResult);
+-  this.eventQueue.push({ kind: "result", data: filteredResult });
++  if (this.iteratorAttached) {
++    this.eventQueue.push({ kind: "result", data: filteredResult });
++  }
+   // (same gating for endpoint/finalized/finished pushes)
+ }
+```
+
+Backward compatible. Async-iterator consumers continue to work because the iterator getter sets the flag _before_ any events arrive (the iterator must be obtained before `for await` can iterate).
+
+`patch-package` records this as `cloud/patches/@soniox+node+2.0.0.patch` and re-applies on every `bun install` via a `postinstall` script.
+
+### Part 2 (separately, this same PR): submit the same fix upstream
+
+PR against [soniox/soniox-js](https://github.com/soniox/soniox-js) main branch with the heap-snapshot evidence + the same code change in TypeScript source. When upstream merges and ships v2.0.1+, we bump the version, delete `cloud/patches/`, and remove the postinstall hook.
+
+### Why not just upgrade SDK and skip the patch?
+
+We did upgrade — same bug exists in v2.0.0 (verified). The fix has to come from us either way.
+
+### Why not work around it in our wrapper code (drain loop)?
+
+A 5-line workaround (`for await (const _ of this.session) {}` next to the `.on()` calls in `SonioxSdkStream.ts`) would fix our heap without touching the SDK. We chose the SDK patch instead because:
+
+1. It contributes back to upstream — every other Soniox SDK user benefits.
+2. The bug fix lives at the right layer (the SDK shouldn't double-allocate).
+3. patch-package + upstream PR is the correct workflow for a known upstream bug.
+
+The wrapper-drain approach remains a valid alternative if upstream rejects the PR for any reason.
+
+---
+
+## Key Numbers
+
+| Metric                                         | Observed                                                                          |
+| ---------------------------------------------- | --------------------------------------------------------------------------------- |
+| `AsyncEventQueue.queue` size on dev at T+0     | 4,148 elements (1 active session using the SDK path)                              |
+| Retained `"en"` strings at T+0                 | 61,659                                                                            |
+| Retained `"en"` strings at T+1h                | 305,443                                                                           |
+| New `"en"` per hour (4 sessions, ~16 events/s) | +243,784                                                                          |
+| Heap snapshot size growth                      | 41 MB → 104 MB in 1 hour (+154%)                                                  |
+| Per-session estimated leak rate                | ~15 MB/hour at typical token rates                                                |
+| Memory floor on prior pod (66h uptime)         | RSS climbed 286 → 525 MB (+239 MB), heap 117 → 528 MB (+411 MB before GC reclaim) |
+
+---
+
+## Evidence Index
+
+The artifacts produced during this investigation live at:
+
+- `/tmp/heap-compare/dev-1.heapsnapshot` — V8 snapshot from dev pod at 2026-04-27 17:00 UTC (41 MB)
+- `/tmp/heap-compare/dev-2.heapsnapshot` — V8 snapshot from dev pod at 2026-04-27 18:00 UTC (104 MB)
+- `/tmp/heap-debug.heapsnapshot` — V8 snapshot from debug pod at 2026-04-24 21:30 UTC (22.8 MB), included for cross-pod comparison
+- `/tmp/heap-compare/heap-diff.py` — Python script (stdlib-only) that does constructor diff + retainer-class histogram across two `.heapsnapshot` files. Run as `python3 heap-diff.py BEFORE.heapsnapshot AFTER.heapsnapshot`.
+
+To re-confirm the leak on a future pod, pull a snapshot via:
+
+```bash
+doppler run --project mentra-sre --config dev -- \
+  curl -sS -o /tmp/heap.heapsnapshot \
+    -H "Authorization: Bearer $MENTRA_ADMIN_JWT" \
+    https://dev.augmentos.cloud/api/admin/memory/heap-snapshot-v8
+```
+
+Then count `AsyncEventQueue.queue` array sizes:
+
+```bash
+python3 -c "
+import json
+with open('/tmp/heap.heapsnapshot') as f: d = json.load(f)
+nodes = d['nodes']; strings = d['strings']
+nf = d['snapshot']['meta']['node_fields']
+type_idx = nf.index('type'); name_idx = nf.index('name'); edge_count_idx = nf.index('edge_count')
+node_types = d['snapshot']['meta']['node_types'][0]
+nfc = len(nf)
+for i in range(0, len(nodes), nfc):
+    t = node_types[nodes[i+type_idx]]
+    n = strings[nodes[i+name_idx]]
+    if n == 'AsyncEventQueue':
+        print(f'AsyncEventQueue at node {i//nfc}, edges: {nodes[i+edge_count_idx]}')
+"
+```
+
+If `AsyncEventQueue.queue` size > a few hundred, the bug is back.

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -67,5 +67,8 @@
     "tsx": "^4.19.3",
     "typescript": "^5.2.0",
     "typescript-eslint": "^8.24.0"
+  },
+  "patchedDependencies": {
+    "@soniox/node@2.0.0": "patches/@soniox%2Fnode@2.0.0.patch"
   }
 }

--- a/cloud/packages/cloud/package.json
+++ b/cloud/packages/cloud/package.json
@@ -43,7 +43,7 @@
     "@mentra/utils": "workspace:*",
     "@sentry/bun": "^9.1.0",
     "@sentry/cli": "^2.42.1",
-    "@soniox/node": "^1.1.1",
+    "@soniox/node": "^2.0.0",
     "@supabase/supabase-js": "^2.49.1",
     "@types/ali-oss": "^6.16.11",
     "ali-oss": "^6.23.0",

--- a/cloud/patches/@soniox%2Fnode@2.0.0.patch
+++ b/cloud/patches/@soniox%2Fnode@2.0.0.patch
@@ -1,0 +1,92 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 9e0ed3b3b5c4aabaff12f5a3dabd3be4d0e27193..367f927a15f5e64d2b62a2d1aab4a72536ab2eb8 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -695,6 +695,7 @@ function filterSpecialTokens(tokens) {
+ var RealtimeSttSession = class {
+ 	emitter = new TypedEmitter();
+ 	eventQueue = new AsyncEventQueue();
++	iteratorAttached = false;
+ 	apiKey;
+ 	wsBaseUrl;
+ 	config;
+@@ -885,6 +886,7 @@ var RealtimeSttSession = class {
+ 	* Async iterator for consuming events.
+ 	*/
+ 	[Symbol.asyncIterator]() {
++		this.iteratorAttached = true;
+ 		return this.eventQueue[Symbol.asyncIterator]();
+ 	}
+ 	/**
+@@ -943,21 +945,21 @@ var RealtimeSttSession = class {
+ 				tokens: userTokens
+ 			};
+ 			this.emitter.emit("result", filteredResult);
+-			this.eventQueue.push({
++			if (this.iteratorAttached) this.eventQueue.push({
+ 				kind: "result",
+ 				data: filteredResult
+ 			});
+ 			if (hasEndpoint) {
+ 				this.emitter.emit("endpoint");
+-				this.eventQueue.push({ kind: "endpoint" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "endpoint" });
+ 			}
+ 			if (hasFinalized) {
+ 				this.emitter.emit("finalized");
+-				this.eventQueue.push({ kind: "finalized" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "finalized" });
+ 			}
+ 			if (result.finished) {
+ 				this.emitter.emit("finished");
+-				this.eventQueue.push({ kind: "finished" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "finished" });
+ 				this.settleFinish();
+ 				this.cleanup("finished", void 0, "finished");
+ 			}
+diff --git a/dist/index.mjs b/dist/index.mjs
+index bf568ccb4ae2157cc5a4425be63263933190611b..8579117fce64354d9504fbb0be22502644b60d7d 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -695,6 +695,7 @@ function filterSpecialTokens(tokens) {
+ var RealtimeSttSession = class {
+ 	emitter = new TypedEmitter();
+ 	eventQueue = new AsyncEventQueue();
++	iteratorAttached = false;
+ 	apiKey;
+ 	wsBaseUrl;
+ 	config;
+@@ -885,6 +886,7 @@ var RealtimeSttSession = class {
+ 	* Async iterator for consuming events.
+ 	*/
+ 	[Symbol.asyncIterator]() {
++		this.iteratorAttached = true;
+ 		return this.eventQueue[Symbol.asyncIterator]();
+ 	}
+ 	/**
+@@ -943,21 +945,21 @@ var RealtimeSttSession = class {
+ 				tokens: userTokens
+ 			};
+ 			this.emitter.emit("result", filteredResult);
+-			this.eventQueue.push({
++			if (this.iteratorAttached) this.eventQueue.push({
+ 				kind: "result",
+ 				data: filteredResult
+ 			});
+ 			if (hasEndpoint) {
+ 				this.emitter.emit("endpoint");
+-				this.eventQueue.push({ kind: "endpoint" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "endpoint" });
+ 			}
+ 			if (hasFinalized) {
+ 				this.emitter.emit("finalized");
+-				this.eventQueue.push({ kind: "finalized" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "finalized" });
+ 			}
+ 			if (result.finished) {
+ 				this.emitter.emit("finished");
+-				this.eventQueue.push({ kind: "finished" });
++				if (this.iteratorAttached) this.eventQueue.push({ kind: "finished" });
+ 				this.settleFinish();
+ 				this.cleanup("finished", void 0, "finished");
+ 			}


### PR DESCRIPTION
## Summary

Hotfix cherry-pick of #2619 onto `main` for prod deployment.

Patches `@soniox/node`'s `RealtimeSttSession` to gate `eventQueue.push(...)` on whether the async iterator has been attached. With the documented `.on()` listener pattern (which we use), the queue grows unbounded — measured ~15 MB/hr per active session on dev pods, contributing to the 525 MB+ RSS climb on long-running pods that may be a co-factor in the 102 stall cascade.

## Validated on dev

Same fix shipped to `dev` via #2619, soaked for 70+ minutes with 5 active sessions:

| | Pre-fix `dev-2` (1h, 4 sessions) | Post-fix dev (70+ min, 5 sessions) |
|---|---|---|
| Buffered events across all `AsyncEventQueue.queue` | 18,678 | 0 |
| Heap snapshot file size | 104 MB | 26 MB |
| RSS trajectory | climbing to 525 MB+ | 273 → 272 → 283 MB |

## Cherry-picked commits

- `5e0087704` — fix(104): patch @soniox/node eventQueue leak (the bun patch + version bump + issue docs)
- `7c927d45b` — docs(104): correct spike's fix section to bun patchedDependencies

Skipped `eafc9efb1` (porter-debug.yml branch trigger — dev-only).

## Diff

8 files: `cloud/package.json` (`patchedDependencies`), `cloud/packages/cloud/package.json` (soniox 1.1.1 → 2.0.0), `cloud/bun.lock`, `cloud/patches/@soniox%2Fnode@2.0.0.patch` (new), and the issue 103 + 104 docs.

Zero MentraOS source changes.

## Upstream

Same fix submitted as [soniox/soniox-js#13](https://github.com/soniox/soniox-js/pull/13) (currently draft, awaiting maintainer review).