### PR TITLE
nrf5340_ble_simulator: use IMU_EN default-low and fix empty DisplayText clearing

### DIFF
--- a/mcu_client/nrf5340_ble_simulator/app.overlay
+++ b/mcu_client/nrf5340_ble_simulator/app.overlay
@@ -24,8 +24,8 @@
         vad_power-gpios         = <&gpio1 0 GPIO_ACTIVE_HIGH>;
         gx8002_vad_int-gpios    = <&gpio0 22 GPIO_ACTIVE_HIGH>;
         vad_voice_detect-gpios  = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-        ear_en-gpios            = <&gpio0 19 GPIO_ACTIVE_HIGH>;  // P0.19 for Ear Power Enable
-
+        imu_en-gpios            = <&gpio0 19 GPIO_ACTIVE_HIGH>;   // P0.19 for IMU Enable
+        watchdog_int-gpios      = <&gpio0 4 GPIO_ACTIVE_HIGH>;  // P0.04 for watchdog interrupt
         /* RDY: low asserted (per IQS / ProxFusion datasheet); idle high, falling edge = window start */
         iqs7211a_rdy-gpios      = <&gpio1 14 GPIO_ACTIVE_LOW>;
     };

--- a/mcu_client/nrf5340_ble_simulator/src/main.c
+++ b/mcu_client/nrf5340_ble_simulator/src/main.c
@@ -440,7 +440,7 @@ static void num_comp_reply(bool accept)
  * @return 0 on success, negative value on error
  */
 #define USER_NODE DT_PATH(zephyr_user)
-static const struct gpio_dt_spec ear_en = GPIO_DT_SPEC_GET(USER_NODE, ear_en_gpios);
+static const struct gpio_dt_spec imu_en = GPIO_DT_SPEC_GET(USER_NODE, imu_en_gpios);
 #if DT_NODE_HAS_PROP(USER_NODE, vad_power_gpios)
 static const struct gpio_dt_spec mic_power = GPIO_DT_SPEC_GET(USER_NODE, vad_power_gpios);
 #define MIC_POWER_GPIO_AVAILABLE 1
@@ -449,13 +449,13 @@ static const struct gpio_dt_spec mic_power = GPIO_DT_SPEC_GET(USER_NODE, vad_pow
 #endif
 
 /**
- * @brief Control ear_en on/off | 控制 ear_en 开关
- * @param enable true to set HIGH, false to set LOW | true拉高，false拉低
+ * @brief Control IMU enable line | 控制 IMU 使能引脚
+ * @param enable true to drive IMU_EN high, false to drive it low | true 拉高使能，false 拉低关闭
  */
-void ear_en_control(bool enable)
+void imu_en_control(bool enable)
 {
-    gpio_pin_set_dt(&ear_en, enable ? 1 : 0);
-    LOG_INF("ear_en %s", enable ? "HIGH" : "LOW");
+    gpio_pin_set_dt(&imu_en, enable ? 1 : 0);
+    LOG_INF("imu_en %s (physical %s)", enable ? "ENABLED" : "DISABLED", enable ? "HIGH" : "LOW");
 }
 
 /**
@@ -481,21 +481,21 @@ void configure_default_low_pins(void)
 int init_user_gpio(void)
 {
     int err;
-    /* ear_en: configure as output and pull HIGH | ear_en：配置为输出并拉高 */
-    if (gpio_is_ready_dt(&ear_en))
+    /* imu_en: configure as output and default drive LOW | imu_en：配置为输出并默认拉低 */
+    if (gpio_is_ready_dt(&imu_en))
     {
-        err = gpio_pin_configure_dt(&ear_en, GPIO_OUTPUT_ACTIVE);
+        err = gpio_pin_configure_dt(&imu_en, GPIO_OUTPUT_INACTIVE);
         if (err != 0)
         {
-            LOG_ERR("ear_en GPIO config error: %d", err);
+            LOG_ERR("imu_en GPIO config error: %d", err);
             return err;
         }
-        ear_en_control(true);  // Ensure ear_en is HIGH
-        LOG_INF("ear_en GPIO configured and set to HIGH");
+        imu_en_control(false);  // Ensure IMU_EN defaults LOW
+        LOG_INF("imu_en GPIO configured and driven LOW by default");
     }
     else
     {
-        LOG_WRN("ear_en GPIO not ready, skipping");
+        LOG_WRN("imu_en GPIO not ready, skipping");
     }
 
     /* Mic power rail enable for both VAD and PDM paths */

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_button/src/mos_button_app.c
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_button/src/mos_button_app.c
@@ -19,7 +19,7 @@
 
 /* External function from main.c | 来自main.c的外部函数 */
 extern void configure_default_low_pins(void);
-extern void ear_en_control(bool enable);
+extern void imu_en_control(bool enable);
 
 LOG_MODULE_REGISTER(mos_button_app, LOG_LEVEL_INF);
 
@@ -362,7 +362,7 @@ static int prepare_for_sleep(bool turn_off_peripherals)
         LOG_INF("Turning off peripherals before sleep...");
 
         (void)mos_gx8002_power_control(false);  // Disable GX8002(VAD) power control
-        ear_en_control(false);
+        imu_en_control(false);
         /* Disable LDSW1 | 禁用LDSW1 */
 
         /* Put OPT3006 into shutdown mode | 关闭 OPT3006 */

--- a/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_lvgl_display/src/caption_state.c
+++ b/mcu_client/nrf5340_ble_simulator/src/mos_components/mos_lvgl_display/src/caption_state.c
@@ -37,10 +37,6 @@ void caption_state_ingest(const char *text)
     }
 
     text_len = strlen(text);
-    if (text_len == 0U)
-    {
-        return;
-    }
 
     if (text_len >= CAPTION_TEXT_MAX_CHARS)
     {
@@ -51,7 +47,13 @@ void caption_state_ingest(const char *text)
 
     k_mutex_lock(&s_caption_state_lock, K_FOREVER);
     s_caption_pending_seq++;
-    memcpy(s_caption_pending_text, text, text_len);
+    /* Only copy when payload has content; for empty payload we still keep this as a valid
+     * update and rely on the '\0' write below to clear the displayed caption text.
+     * 仅在有内容时执行拷贝；空载荷也要作为有效更新保留，并依赖下面写入 '\0' 来清空显示字幕。 */
+    if (text_len > 0U)
+    {
+        memcpy(s_caption_pending_text, text, text_len);
+    }
     s_caption_pending_text[text_len] = '\0';
     s_caption_pending_valid = true;
     s_caption_pending_arrival_ms = k_uptime_get_32();

--- a/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.c
+++ b/mcu_client/nrf5340_ble_simulator/src/protobuf/protobuf_handler.c
@@ -753,12 +753,10 @@ void protobuf_process_display_text(const mentraos_ble_DisplayText *display_text)
 
     size_t text_length = strlen(display_text->text);
 
-    /* Ignore an empty first DisplayText while still on the welcome screen.
-     * Once we've already switched into the text scene, keep honoring BLE payloads as-is. */
-    if (text_length == 0U && display_is_welcome_screen_active())
+    /* Always honor app payload, including empty text, to avoid stale captions. */
+    if (text_length == 0U)
     {
-        LOG_INF("[PROTOBUF] Ignore empty DisplayText while welcome screen is active");
-        return;
+        LOG_INF("[PROTOBUF] DisplayText is empty, apply clear/hidden state from app payload");
     }
 
     uint32_t color_rgb888 = display_text->color;


### PR DESCRIPTION
…DisplayText updates

- rename devicetree and runtime control from ear_en to imu_en on P0.19
- default IMU_EN to low during gpio init and sleep path
- add watchdog_int gpio mapping on P0.04
- process empty caption payloads as valid clear events in caption_state/protobuf path
- prevent stale subtitle text when app sends empty DisplayText