### PR TITLE
Fix pre-existing mobile review issues

### DIFF
--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -1,8 +1,8 @@
-import {ControllerTypes, DeviceTypes} from "@/../../cloud/packages/types/src"
+import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import CoreModule from "core"
 import {ActivityIndicator, View} from "react-native"
 
-import {Button, Icon} from "@/components/ignite"
+import {Button} from "@/components/ignite"
 import {useNavigationHistory} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useGlassesStore} from "@/stores/glasses"
@@ -46,7 +46,7 @@ export const ConnectDeviceButton = () => {
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
     if (isSearching) {
-      await CoreModule.disconnectController()
+      await CoreModule.disconnect()
     } else {
       await connectGlasses()
     }
@@ -133,7 +133,7 @@ export const ConnectControllerButton = () => {
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
     if (isSearching) {
-      await CoreModule.disconnect()
+      await CoreModule.disconnectController()
     } else {
       await connectController()
     }

--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -4,7 +4,7 @@ import {useLocalMiniApps} from "@/stores/applets"
 import LocalMiniApp from "@/components/home/LocalMiniApp"
 import composer from "@/services/Composer"
 import {usePathname} from "expo-router"
-import {Screen, Text} from "@/components/ignite"
+import {Screen} from "@/components/ignite"
 import {useNavigationHistory} from "@/contexts/NavigationHistoryContext"
 import {MiniAppCapsuleMenu} from "@/components/miniapps/CapsuleMenu"
 import CoreModule, {MicPcmEvent} from "core"
@@ -59,8 +59,10 @@ function Compositor() {
   const viewShotRef = useRef<View>(null)
   const [packageName, setPackageName] = useState<string | null>(null)
   const {getCurrentParams} = useNavigationHistory()
-  const [offlineCaptionsRunning, setOfflineCaptionsRunning] = useSetting(SETTINGS.offline_captions_running.key)
-  const [offlineTranslationRunning, setOfflineTranslationRunning] = useSetting(SETTINGS.offline_translation_running.key)
+  const [offlineCaptionsRunning, _setOfflineCaptionsRunning] = useSetting(SETTINGS.offline_captions_running.key)
+  const [offlineTranslationRunning, _setOfflineTranslationRunning] = useSetting(
+    SETTINGS.offline_translation_running.key,
+  )
 
   useEffect(() => {
     if (pathname.includes("/applet/local")) {
@@ -114,12 +116,12 @@ function Compositor() {
   //   },
   // })
 
-  const transcription = useRef<string>("")
-  let useExecutorch = false
-  let useCactus = false
-  let useExpoSpeech = true
+  const _transcription = useRef<string>("")
+  const _useExecutorch = false
+  const _useCactus = false
+  const _useExpoSpeech = true
 
-  const handlePcm = async (pcm: ArrayBuffer) => {
+  const handlePcm = async (_pcm: ArrayBuffer) => {
     // if (useExpoSpeech) {
     //   const audioChunk = decodePcm16ToFloat32(pcm)
     //   SpeechTranscriber.realtimeBufferTranscribe(
@@ -152,34 +154,31 @@ function Compositor() {
   }
 
   useEffect(() => {
-    const initSTT = async () => {
-      // await CoreModule.update("core", {
-      //   should_send_pcm: true,
-      // })
+    // await CoreModule.update("core", {
+    //   should_send_pcm: true,
+    // })
 
-      // await cactusSTT.download({
-      //   onProgress: (progress: number) => {
-      //     console.log("COMPOSITOR: Downloading cactus model...", progress)
-      //   },
-      // })
+    // await cactusSTT.download({
+    //   onProgress: (progress: number) => {
+    //     console.log("COMPOSITOR: Downloading cactus model...", progress)
+    //   },
+    // })
 
-      // await cactusSTT.streamTranscribeStart({
-      //   confirmationThreshold: 0.99,
-      //   minChunkSize: 32000,
-      // })
+    // await cactusSTT.streamTranscribeStart({
+    //   confirmationThreshold: 0.99,
+    //   minChunkSize: 32000,
+    // })
 
-      const pcmSub = CoreModule.addListener("mic_pcm", (event: MicPcmEvent) => {
-        // console.log("COMPOSITOR: Received mic pcm:", event.base64)
-        // const samples = decodePcm16Base64ToFloat32(event.base64)
-        // sttModule.streamInsert(samples)
-        handlePcm(event.pcm)
-      })
+    const pcmSub = CoreModule.addListener("mic_pcm", (event: MicPcmEvent) => {
+      // console.log("COMPOSITOR: Received mic pcm:", event.base64)
+      // const samples = decodePcm16Base64ToFloat32(event.base64)
+      // sttModule.streamInsert(samples)
+      handlePcm(event.pcm)
+    })
 
-      return () => {
-        pcmSub?.remove()
-      }
+    return () => {
+      pcmSub?.remove()
     }
-    initSTT()
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

This PR fixes two pre-existing mobile issues that were surfaced while reviewing #2607, but are independent from the Bluetooth SDK refactor. Keeping them separate lets #2607 stay focused on the SDK split while still addressing valid review feedback.

## Changes

- Return the `mic_pcm` listener cleanup directly from `Compositor` so React can unsubscribe it on unmount.
- Make the glasses connecting button cancel glasses connection attempts with `disconnect()`, and the controller connecting button cancel controller connection attempts with `disconnectController()`.
- Remove/rename adjacent unused locals/imports only where required by the existing pre-commit hook for touched files.

## Validation

- Pre-commit hook passed for each commit.
- `git diff --check origin/dev...HEAD` passed.
- `cd mobile && bunx eslint src/effects/Compositor.tsx src/components/glasses/ConnectDeviceButton.tsx --quiet` passed.