### PR TITLE
Add Android Bluetooth ownership diagnostics

### DIFF
--- a/docs/mentra-bluetooth-sdk-android-native-api-plan.md
+++ b/docs/mentra-bluetooth-sdk-android-native-api-plan.md
@@ -48,11 +48,13 @@ class MentraBluetoothSdk private constructor(
 
     fun getGlassesStatus(): MentraGlassesStatus
     fun getBluetoothStatus(): MentraBluetoothStatus
+    fun getKnownDevices(model: MentraDeviceModel? = null): List<MentraKnownDevice>
 
     fun startScan(model: MentraDeviceModel)
     fun stopScan()
     fun connect(device: MentraDiscoveredDevice)
     fun connectByName(model: MentraDeviceModel, deviceName: String)
+    fun connectByAddress(model: MentraDeviceModel, address: String, name: String? = null)
     fun connectDefault()
     fun connectSimulated()
     fun disconnect()
@@ -164,12 +166,25 @@ Add typed public models before exposing the facade:
 
 - `MentraDeviceModel`: `G1`, `G2`, `MENTRA_LIVE`, `MENTRA_NEX`, `MACH1`, `Z100`, `FRAME`, `SIMULATED`, `R1`.
 - `MentraDiscoveredDevice`: `model`, `name`, optional `address`, optional `rssi`.
+- `MentraKnownDevice`: `model`, `name`, `address`, `bonded`, and Android system `connected` state. This powers partner diagnostics when Android already knows about a glasses device but BLE scan does not produce a usable advertisement.
 - `MentraGlassesStatus`: current snapshot of connected, fully booted, battery, charging, model, firmware, serial, Wi-Fi, hotspot, head-up, controller, and signal state.
 - `MentraBluetoothStatus`: current snapshot of searching, mic, current mic, search results, Wi-Fi scan results, permission availability, and audio availability.
 - `MentraDisplayTextRequest`, `MentraDisplayEventRequest`, `MentraDashboardPositionRequest`, `MentraDashboardMenuItem`, `MentraPhotoRequest`, `MentraStreamRequest`, `MentraVideoRecordingRequest`, `MentraMicConfig`, `MentraBluetoothError`.
 - Settings models/enums for values currently routed through `DeviceStore.apply()`: `MentraGalleryMode`, `MentraButtonMode`, `MentraButtonPhotoSettings`, `MentraButtonVideoRecordingSettings`, `MentraCameraFov`, and `MentraMicPreference`.
 
 For Java ergonomics, models with many optional fields should have builders instead of huge constructors.
+
+## Android Bluetooth Ownership Diagnostics
+
+Android does not expose which app owns a BLE GATT connection through public app APIs. The SDK can, however, detect that Android already has a matching glasses device bonded or connected at the system Bluetooth layer.
+
+Add these diagnostics to the Android facade:
+
+- `getKnownDevices(model)` returns matching bonded/connected Android Bluetooth devices, including address and connection state.
+- `connectByAddress(model, address, name)` attempts direct GATT connection to a known device address. This helps when a device is already paired or not advertising a useful name.
+- If a scan produces no SDK results after the configured diagnostic delay but Android reports a matching connected device, emit `MentraBluetoothError(code = "device_connected_elsewhere", ...)`.
+
+The error must not claim to know the owning package. In normal app APIs, Android does not reveal whether MentraOS, a React Native sample, a native sample, or another partner app owns that connection. Customer-facing copy should say another app or previous SDK process may already own the glasses connection and that only one app can own the glasses BLE connection at a time.
 
 ## Store Sync Boundary
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -80,6 +80,12 @@ class BluetoothSdkModule : Module() {
                 }
 
                 override fun onError(error: MentraBluetoothError) {
+                    val body = mutableMapOf<String, Any>(
+                            "code" to error.code,
+                            "message" to error.message
+                    )
+                    body.putAll(error.values)
+                    sendEvent("bluetooth_error", body)
                     sendEvent("pair_failure", mapOf("error" to error.message))
                 }
 
@@ -127,6 +133,7 @@ class BluetoothSdkModule : Module() {
             "mic_pcm",
             "mic_lc3",
             "stream_status",
+            "bluetooth_error",
             "keep_alive_ack",
             "mtk_update_complete",
             "ota_update_available",
@@ -158,6 +165,20 @@ class BluetoothSdkModule : Module() {
 
         Function("getBluetoothStatus") {
             sdk?.getBluetoothStatus()?.values ?: DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY)
+        }
+
+        Function("getKnownDevices") { deviceModel: String? ->
+            sdk?.getKnownDevices(deviceModel?.let { MentraDeviceModel.fromDeviceType(it) })
+                    ?.map {
+                        mapOf(
+                                "deviceModel" to it.model.deviceType,
+                                "deviceName" to it.name,
+                                "deviceAddress" to it.address,
+                                "bonded" to it.bonded,
+                                "connected" to it.connected,
+                        )
+                    }
+                    ?: emptyList<Map<String, Any>>()
         }
 
         Function("set") { category: String, key: String, value: Any ->
@@ -216,6 +237,10 @@ class BluetoothSdkModule : Module() {
 
         AsyncFunction("connectDevice") { deviceModel: String, deviceName: String ->
             sdk?.connectByName(MentraDeviceModel.fromDeviceType(deviceModel), deviceName)
+        }
+
+        AsyncFunction("connectDeviceByAddress") { deviceModel: String, deviceAddress: String, deviceName: String? ->
+            sdk?.connectByAddress(MentraDeviceModel.fromDeviceType(deviceModel), deviceAddress, deviceName)
         }
 
         AsyncFunction("connectSimulated") { sdk?.connectSimulated() }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -184,11 +184,22 @@ public class Bridge private constructor() {
         /** Send discovered device */
         @JvmStatic
         fun sendDiscoveredDevice(deviceModel: String, deviceName: String) {
+            sendDiscoveredDevice(deviceModel, deviceName, null)
+        }
+
+        /** Send discovered device */
+        @JvmStatic
+        fun sendDiscoveredDevice(deviceModel: String, deviceName: String, deviceAddress: String?) {
             val searchResults =
                     DeviceStore.store.getCategory("bluetooth")["searchResults"] as?
                             List<Map<String, String>>
                             ?: emptyList()
-            val newResult = mapOf("deviceModel" to deviceModel, "deviceName" to deviceName)
+            val newResult =
+                    mutableMapOf("deviceModel" to deviceModel, "deviceName" to deviceName).apply {
+                        if (!deviceAddress.isNullOrBlank()) {
+                            put("deviceAddress", deviceAddress)
+                        }
+                    }
             val allResults = searchResults + newResult
             val uniqueResults = allResults.associateBy { it["deviceName"] }.values.toList()
             DeviceStore.set("bluetooth", "searchResults", uniqueResults)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1419,6 +1419,28 @@ class DeviceManager {
         sgc?.connectById(deviceName)
     }
 
+    fun connectByAddress(deviceModel: String, address: String, name: String?) {
+        Bridge.log("MAN: Connecting to wearable by address: $address")
+
+        if (!DeviceTypes.ALL.contains(deviceModel)) {
+            Bridge.log("MAN: Unsupported wearable for address connection: $deviceModel")
+            return
+        }
+
+        val displayName = name?.takeIf { it.isNotBlank() } ?: address
+        pendingWearable = deviceModel
+        defaultWearable = deviceModel
+        deviceName = displayName
+        deviceAddress = address
+
+        disconnect()
+        Thread.sleep(100)
+        searching = true
+
+        initSGC(deviceModel)
+        sgc?.connectById(displayName)
+    }
+
     fun connectSimulated() {
         defaultWearable = DeviceTypes.SIMULATED
         deviceName = DeviceTypes.SIMULATED

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
@@ -5,6 +5,7 @@ import com.mentra.bluetoothsdk.utils.DeviceTypes
 
 data class MentraBluetoothSdkConfig(
     val deliverCallbacksOnMainThread: Boolean = true,
+    val scanNoResultsDiagnosticDelayMs: Long = 5_000L,
 )
 
 enum class MentraDeviceModel(val deviceType: String) {
@@ -36,6 +37,14 @@ data class MentraPairedDevice(
     val model: MentraDeviceModel,
     val name: String,
     val address: String? = null,
+)
+
+data class MentraKnownDevice(
+    val model: MentraDeviceModel,
+    val name: String,
+    val address: String,
+    val bonded: Boolean,
+    val connected: Boolean,
 )
 
 data class MentraGlassesStatus(
@@ -207,6 +216,7 @@ data class MentraBluetoothError(
     val code: String,
     val message: String,
     val cause: Throwable? = null,
+    val values: Map<String, Any> = emptyMap(),
 )
 
 enum class MentraScanStopReason {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1,8 +1,16 @@
 package com.mentra.bluetoothsdk
 
+import android.Manifest
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothManager
+import android.bluetooth.BluetoothProfile
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
+import androidx.core.content.ContextCompat
 import com.mentra.bluetoothsdk.utils.PhoneAudioMonitor
 import java.util.Collections
 
@@ -19,6 +27,7 @@ class MentraBluetoothSdk private constructor(
     private val discoveredDeviceNames = mutableSetOf<String>()
     private val bridgeEventSinkId: String
     private val storeListenerId: String
+    private var scanDiagnosticGeneration = 0
 
     init {
         listeners.add(listener)
@@ -57,20 +66,36 @@ class MentraBluetoothSdk private constructor(
     fun getBluetoothStatus(): MentraBluetoothStatus =
         MentraBluetoothStatus(DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY))
 
+    @JvmOverloads
+    fun getKnownDevices(model: MentraDeviceModel? = null): List<MentraKnownDevice> =
+        collectKnownBluetoothDevices(model)
+
     fun startScan(model: MentraDeviceModel) {
         discoveredDeviceNames.clear()
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "searching", true)
         deviceManager.findCompatibleDevices(model.deviceType)
+        scheduleScanNoResultsDiagnostic(model)
     }
 
     fun stopScan() {
+        scanDiagnosticGeneration += 1
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "searching", false)
         dispatchToListeners { it.onScanStopped(MentraScanStopReason.CANCELLED) }
     }
 
     fun connect(device: MentraDiscoveredDevice) {
+        if (!device.address.isNullOrBlank()) {
+            connectByAddress(device.model, device.address, device.name)
+            return
+        }
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_wearable", device.model.deviceType)
         deviceManager.connectByName(device.name)
+    }
+
+    @JvmOverloads
+    fun connectByAddress(model: MentraDeviceModel, address: String, name: String? = null) {
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_wearable", model.deviceType)
+        deviceManager.connectByAddress(model.deviceType, address, name)
     }
 
     fun connectByName(model: MentraDeviceModel, deviceName: String) {
@@ -296,10 +321,147 @@ class MentraBluetoothSdk private constructor(
             val name = result["deviceName"] as? String ?: result["name"] as? String ?: return@forEach
             if (!discoveredDeviceNames.add(name)) return@forEach
             val model = MentraDeviceModel.fromDeviceType(result["deviceModel"] as? String)
-            val device = MentraDiscoveredDevice(model = model, name = name)
+            val device = MentraDiscoveredDevice(
+                model = model,
+                name = name,
+                address = result["deviceAddress"] as? String ?: result["address"] as? String,
+                rssi = (result["rssi"] as? Number)?.toInt(),
+            )
             dispatchToListeners { it.onDeviceDiscovered(device) }
         }
     }
+
+    private fun scheduleScanNoResultsDiagnostic(model: MentraDeviceModel) {
+        if (config.scanNoResultsDiagnosticDelayMs <= 0) return
+
+        val generation = ++scanDiagnosticGeneration
+        mainHandler.postDelayed(
+            {
+                if (generation != scanDiagnosticGeneration) return@postDelayed
+                val bluetoothStatus = DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY)
+                val glassesStatus = DeviceStore.store.getCategory("glasses")
+                val isSearching = bluetoothStatus["searching"] as? Boolean ?: false
+                val isConnected = glassesStatus["connected"] as? Boolean ?: false
+                if (!isSearching || isConnected || discoveredDeviceNames.isNotEmpty()) return@postDelayed
+
+                val connectedKnownDevices = getKnownDevices(model).filter { it.connected }
+                if (connectedKnownDevices.isEmpty()) return@postDelayed
+
+                val deviceNames = connectedKnownDevices.joinToString { it.name }
+                val devices = connectedKnownDevices.map { it.toMap() }
+                dispatchToListeners {
+                    it.onError(
+                        MentraBluetoothError(
+                            code = "device_connected_elsewhere",
+                            message =
+                                "$deviceNames already appears connected at the Android Bluetooth layer. " +
+                                    "Only one app can own the glasses BLE connection at a time; close or force-stop " +
+                                    "any other app using the glasses, then retry scanning.",
+                            values = mapOf(
+                                "deviceModel" to model.deviceType,
+                                "devices" to devices,
+                            ),
+                        )
+                    )
+                }
+            },
+            config.scanNoResultsDiagnosticDelayMs,
+        )
+    }
+
+    private fun collectKnownBluetoothDevices(model: MentraDeviceModel?): List<MentraKnownDevice> {
+        if (!hasBluetoothConnectPermission()) return emptyList()
+
+        val bluetoothManager =
+            appContext.getSystemService(Context.BLUETOOTH_SERVICE) as? BluetoothManager
+                ?: return emptyList()
+        val adapter = bluetoothManager.adapter ?: BluetoothAdapter.getDefaultAdapter() ?: return emptyList()
+        val devicesByAddress = linkedMapOf<String, BluetoothDevice>()
+
+        try {
+            adapter.bondedDevices?.forEach { device ->
+                device.address?.let { devicesByAddress[it] = device }
+            }
+        } catch (_: SecurityException) {
+            return emptyList()
+        }
+
+        val connectedGattDevices =
+            try {
+                bluetoothManager.getConnectedDevices(BluetoothProfile.GATT)
+            } catch (_: SecurityException) {
+                emptyList()
+            } catch (_: IllegalArgumentException) {
+                emptyList()
+            }
+
+        connectedGattDevices.forEach { device ->
+            device.address?.let { devicesByAddress[it] = device }
+        }
+        val connectedAddresses = connectedGattDevices.mapNotNull { it.address }.toSet()
+
+        return devicesByAddress.values.mapNotNull { device ->
+            val name = device.safeName() ?: return@mapNotNull null
+            val inferredModel = inferModelFromName(name) ?: return@mapNotNull null
+            if (model != null && inferredModel != model) return@mapNotNull null
+
+            val address = device.address ?: return@mapNotNull null
+            MentraKnownDevice(
+                model = inferredModel,
+                name = name,
+                address = address,
+                bonded = device.bondState == BluetoothDevice.BOND_BONDED,
+                connected =
+                    connectedAddresses.contains(address) ||
+                        isDeviceConnected(bluetoothManager, device),
+            )
+        }
+    }
+
+    private fun isDeviceConnected(bluetoothManager: BluetoothManager, device: BluetoothDevice): Boolean =
+        try {
+            bluetoothManager.getConnectionState(device, BluetoothProfile.GATT) == BluetoothProfile.STATE_CONNECTED
+        } catch (_: SecurityException) {
+            false
+        } catch (_: IllegalArgumentException) {
+            false
+        }
+
+    private fun BluetoothDevice.safeName(): String? =
+        try {
+            name
+        } catch (_: SecurityException) {
+            null
+        }
+
+    private fun hasBluetoothConnectPermission(): Boolean =
+        Build.VERSION.SDK_INT < Build.VERSION_CODES.S ||
+            ContextCompat.checkSelfPermission(appContext, Manifest.permission.BLUETOOTH_CONNECT) ==
+                PackageManager.PERMISSION_GRANTED
+
+    private fun inferModelFromName(name: String): MentraDeviceModel? =
+        when {
+            isMentraLiveName(name) -> MentraDeviceModel.MENTRA_LIVE
+            else -> null
+        }
+
+    private fun isMentraLiveName(name: String): Boolean {
+        val normalized = name.lowercase()
+        return name == "Xy_A" ||
+            name.startsWith("XyBLE_") ||
+            name.startsWith("MENTRA_LIVE_BLE") ||
+            name.startsWith("MENTRA_LIVE_BT") ||
+            normalized.startsWith("mentra_live")
+    }
+
+    private fun MentraKnownDevice.toMap(): Map<String, Any> =
+        mapOf(
+            "deviceModel" to model.deviceType,
+            "deviceName" to name,
+            "deviceAddress" to address,
+            "bonded" to bonded,
+            "connected" to connected,
+        )
 
     private fun dispatchBridgeEvent(eventName: String, data: Map<String, Any>) {
         when (eventName) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -808,7 +808,7 @@ public class MentraLive extends SGCManager {
                 Bridge.log("LIVE: Found compatible " + glassType + " glasses device: " + deviceName);
                 // EventBus.getDefault().post(new GlassesBluetoothSearchDiscoverEvent(
                         // smartGlassesDevice.deviceModelName, deviceName));
-                Bridge.sendDiscoveredDevice(DeviceTypes.LIVE, deviceName);
+                Bridge.sendDiscoveredDevice(DeviceTypes.LIVE, deviceName, deviceAddress);
 
                 // If this is the specific device we want to connect to by name, connect to it
                 if (savedDeviceName != null && savedDeviceName.equals(deviceName)) {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -140,6 +140,14 @@ export type PairFailureEvent = {
   error: string
 }
 
+export type BluetoothErrorEvent = {
+  type?: "bluetooth_error"
+  code: string
+  message: string
+  devices?: KnownDevice[]
+  deviceModel?: string
+}
+
 export type AudioPairingNeededEvent = {
   type: "audio_pairing_needed"
   device_name: string
@@ -261,6 +269,7 @@ export type BluetoothSdkModuleEvents = {
   switch_status: (event: SwitchStatusEvent) => void
   rgb_led_control_response: (event: RgbLedControlResponseEvent) => void
   pair_failure: (event: PairFailureEvent) => void
+  bluetooth_error: (event: BluetoothErrorEvent) => void
   audio_pairing_needed: (event: AudioPairingNeededEvent) => void
   audio_connected: (event: AudioConnectedEvent) => void
   audio_disconnected: (event: AudioDisconnectedEvent) => void
@@ -360,6 +369,14 @@ export interface DeviceSearchResult {
   deviceModel: string
   deviceName: string
   deviceAddress?: string
+}
+
+export interface KnownDevice {
+  deviceModel: string
+  deviceName: string
+  deviceAddress: string
+  bonded: boolean
+  connected: boolean
 }
 
 export interface WifiSearchResult {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
@@ -7,6 +7,7 @@ import {
   GlassesMediaVolumeGetResult,
   GlassesMediaVolumeSetResult,
   GlassesStatus,
+  KnownDevice,
 } from "./BluetoothSdk.types"
 
 type GlassesListener = (changed: Partial<GlassesStatus>) => void
@@ -16,6 +17,7 @@ declare class BluetoothSdkModule extends NativeModule<BluetoothSdkModuleEvents> 
   // Observable Store Functions (native)
   getGlassesStatus(): GlassesStatus
   getBluetoothStatus(): BluetoothStatus
+  getKnownDevices(deviceModel?: string | null): KnownDevice[]
   update(category: string, values: Record<string, any>): Promise<void>
 
   // Display Commands
@@ -28,6 +30,7 @@ declare class BluetoothSdkModule extends NativeModule<BluetoothSdkModuleEvents> 
   connectDefault(): Promise<void>
   connectByName(deviceName: string): Promise<void>
   connectDevice(deviceModel: string, deviceName: string): Promise<void>
+  connectDeviceByAddress(deviceModel: string, deviceAddress: string, deviceName?: string | null): Promise<void>
   connectDiscoveredDevice(device: DeviceSearchResult): Promise<void>
   connectDefaultController(): Promise<void>
   disconnectController(): Promise<void>
@@ -131,6 +134,9 @@ NativeBluetoothSdkModule.updateBluetoothSettings = function (values: Record<stri
 }
 
 NativeBluetoothSdkModule.connectDiscoveredDevice = function (device: DeviceSearchResult) {
+  if (device.deviceAddress) {
+    return this.connectDeviceByAddress(device.deviceModel, device.deviceAddress, device.deviceName)
+  }
   return this.connectDevice(device.deviceModel, device.deviceName)
 }
 


### PR DESCRIPTION
## Summary

- Add Android native SDK APIs to list Android-known Mentra Bluetooth devices and connect directly by device address.
- Emit a `device_connected_elsewhere` diagnostic when scanning finds no SDK-visible devices but Android reports a matching connected device.
- Forward the diagnostic through the Expo bridge as `bluetooth_error`, keep `pair_failure` compatibility, and expose matching TypeScript APIs for React Native callers.
- Pass Mentra Live scan result addresses through discovery so examples and partner apps can connect to a selected discovered device without relying only on saved defaults.
- Update the Android native API plan with the new diagnostic/direct-connect surface and the Android limitation that the owning package name is not available.

## Companion PR

- Partner Kit examples/docs PR: https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Partner-Kit/pull/2

## Android Screenshot

![Android example showing known device diagnostics](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Partner-Kit/blob/codex/sdk-connected-device-diagnostics/docs/pr-assets/android-known-device-diagnostics.png?raw=true)

## Validation

- `./gradlew :mentra-bluetooth-sdk:compileDebugKotlin` in `mobile/android`
- `./gradlew :mentra-bluetooth-sdk:publishToMavenLocal :lc3Lib:publishToMavenLocal --no-daemon` in `mobile/android`
- `npm run build` in `mobile/modules/bluetooth-sdk`
- `bun run test -- --runInBand` in `mobile`
- Live device check: Android example connected to `Mentra_Live_E613` on `SM_N986U`, showing known-device state, SDK connection status, battery, Wi-Fi, and firmware/version data.
