### PR TITLE
Reapply Bluetooth SDK naming cleanup

### DIFF
--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -18,7 +18,7 @@ npx pod-install
 
 ## Minimal Usage
 
-`startScan()` starts the scan. Discovered devices arrive asynchronously through `onCoreStatus()` updates.
+`startScan()` starts the scan. Discovered devices arrive asynchronously through `onBluetoothStatus()` updates.
 
 ```ts
 import BluetoothSdk, {type Device} from "@mentra/bluetooth-sdk"
@@ -28,11 +28,11 @@ const removeStatusListener = BluetoothSdk.onGlassesStatus((status) => {
 })
 
 const firstDevice = new Promise<Device>((resolve) => {
-  let removeCoreListener = () => {}
-  removeCoreListener = BluetoothSdk.onCoreStatus((status) => {
+  let removeBluetoothListener = () => {}
+  removeBluetoothListener = BluetoothSdk.onBluetoothStatus((status) => {
     const device = status.searchResults?.[0]
     if (device) {
-      removeCoreListener()
+      removeBluetoothListener()
       resolve(device)
     }
   })

--- a/mobile/modules/bluetooth-sdk/android/build.gradle
+++ b/mobile/modules/bluetooth-sdk/android/build.gradle
@@ -37,7 +37,7 @@ if (useManagedAndroidSdkVersions) {
 }
 
 android {
-  namespace "com.mentra.core"
+  namespace "com.mentra.bluetoothsdk"
   defaultConfig {
     versionCode 1
     versionName packageJson.version

--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -35,6 +35,6 @@
   <uses-permission android:name="android.permission.VIBRATE"/>
 
   <application>
-    <service android:name="com.mentra.core.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|microphone"/>
+    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|microphone"/>
   </application>
 </manifest>

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -1,12 +1,12 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
-import com.mentra.core.utils.DeviceTypes
+import com.mentra.bluetoothsdk.utils.DeviceTypes
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
-class CoreModule : Module() {
+class BluetoothSdkModule : Module() {
     private var sdk: MentraBluetoothSdk? = null
-    private var deviceManager: CoreManager? = null
+    private var deviceManager: DeviceManager? = null
     private val sdkListener =
             object : MentraBluetoothSdkListener {
                 override fun onGlassesStatusChanged(status: GlassesStatusUpdate) {
@@ -14,7 +14,7 @@ class CoreModule : Module() {
                 }
 
                 override fun onBluetoothStatusChanged(status: BluetoothStatusUpdate) {
-                    sendEvent("core_status", status.toMap())
+                    sendEvent("bluetooth_status", status.toMap())
                 }
 
                 override fun onDeviceDiscovered(device: Device) {
@@ -123,12 +123,12 @@ class CoreModule : Module() {
             }
 
     override fun definition() = ModuleDefinition {
-        Name("Core")
+        Name("BluetoothSdk")
 
         // Define events that can be sent to JavaScript
         Events(
             "glasses_status",
-            "core_status",
+            "bluetooth_status",
             "log",
             "device_discovered",
             "default_device_changed",
@@ -184,7 +184,7 @@ class CoreModule : Module() {
                             ?: appContext.currentActivity
                                     ?: throw IllegalStateException("No context available")
             sdk = MentraBluetoothSdk.create(context, sdkListener)
-            deviceManager = CoreManager.getInstance()
+            deviceManager = DeviceManager.getInstance()
         }
 
         OnDestroy {
@@ -197,18 +197,18 @@ class CoreModule : Module() {
 
         Function("getGlassesStatus") {
             sdk?.getGlassesStatus()?.toMap()
-                    ?: GlassesStatus.fromMap(GlassesStore.store.getCategory("glasses")).toMap()
+                    ?: GlassesStatus.fromMap(DeviceStore.store.getCategory("glasses")).toMap()
         }
 
-        Function("getCoreStatus") {
-            sdk?.getBluetoothStatus()?.toMap() ?: GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY)
+        Function("getBluetoothStatus") {
+            sdk?.getBluetoothStatus()?.toMap() ?: DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY)
         }
 
         Function("getDefaultDevice") { sdk?.getDefaultDevice()?.toMap() }
 
         Function("set") { category: String, key: String, value: Any? ->
             if (value != null) {
-                GlassesStore.apply(category, key, value)
+                DeviceStore.apply(category, key, value)
             }
         }
 
@@ -216,16 +216,16 @@ class CoreModule : Module() {
             val normalizedCategory = ObservableStore.normalizeCategory(category)
             values.forEach { (key, value) ->
                 if (value != null) {
-                    GlassesStore.apply(normalizedCategory, key, value)
+                    DeviceStore.apply(normalizedCategory, key, value)
                 }
             }
             // Persist core_token to SharedPreferences so MentraLive.getCoreToken() finds it
             // (bridge may run this after glasses_ready; prefs survive retries and next connection)
             // TODO: move this to the mantle:
-            // if (category == "core") {
+            // if (category == "bluetooth") {
             //     values["core_token"]?.let { token ->
             //         val len = (token as? String)?.length ?: 0
-            //         android.util.Log.d("CoreModule", "update(core) core_token received, len=$len")
+            //         android.util.Log.d("BluetoothSdkModule", "update(core) core_token received, len=$len")
             //         if (token is String && token.isNotEmpty()) {
             //             val ctx = appContext.reactContext ?: appContext.currentActivity
             //             ctx?.let {
@@ -233,7 +233,7 @@ class CoreModule : Module() {
             //                     .edit()
             //                     .putString("core_token", token)
             //                     .apply()
-            //                 android.util.Log.d("CoreModule", "Persisted core_token to SharedPreferences, len=${token.length}")
+            //                 android.util.Log.d("BluetoothSdkModule", "Persisted core_token to SharedPreferences, len=${token.length}")
             //             }
             //         }
             //     }
@@ -473,7 +473,7 @@ class CoreModule : Module() {
                     appContext.reactContext
                             ?: appContext.currentActivity
                                     ?: throw IllegalStateException("No context available")
-            com.mentra.core.stt.STTTools.setSttModelDetails(context, path, languageCode)
+            com.mentra.bluetoothsdk.stt.STTTools.setSttModelDetails(context, path, languageCode)
         }
 
         AsyncFunction("getSttModelPath") { ->
@@ -481,7 +481,7 @@ class CoreModule : Module() {
                     appContext.reactContext
                             ?: appContext.currentActivity
                                     ?: throw IllegalStateException("No context available")
-            com.mentra.core.stt.STTTools.getSttModelPath(context)
+            com.mentra.bluetoothsdk.stt.STTTools.getSttModelPath(context)
         }
 
         AsyncFunction("checkSttModelAvailable") { ->
@@ -489,15 +489,15 @@ class CoreModule : Module() {
                     appContext.reactContext
                             ?: appContext.currentActivity
                                     ?: throw IllegalStateException("No context available")
-            com.mentra.core.stt.STTTools.checkSTTModelAvailable(context)
+            com.mentra.bluetoothsdk.stt.STTTools.checkSTTModelAvailable(context)
         }
 
         AsyncFunction("validateSttModel") { path: String ->
-            com.mentra.core.stt.STTTools.validateSTTModel(path)
+            com.mentra.bluetoothsdk.stt.STTTools.validateSTTModel(path)
         }
 
         AsyncFunction("extractTarBz2") { sourcePath: String, destinationPath: String ->
-            com.mentra.core.stt.STTTools.extractTarBz2(sourcePath, destinationPath)
+            com.mentra.bluetoothsdk.stt.STTTools.extractTarBz2(sourcePath, destinationPath)
         }
 
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -5,7 +5,7 @@
 //  Created by Matthew Fosse on 3/4/25.
 //
 
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
 import android.util.Base64
 import android.util.Log
@@ -20,7 +20,7 @@ import kotlin.jvm.Volatile
  * Android equivalent of the iOS Bridge.swift
  */
 public class Bridge private constructor() {
-    private var deviceManager: CoreManager? = null
+    private var deviceManager: DeviceManager? = null
 
     companion object {
         private const val TAG = "Bridge"
@@ -46,7 +46,7 @@ public class Bridge private constructor() {
 
         /**
          * Initialize the Bridge with event callback and context This should be called from
-         * CoreModule
+         * BluetoothSdkModule
          */
         @JvmStatic
         fun initialize(
@@ -191,7 +191,7 @@ public class Bridge private constructor() {
                 rssi: Int? = null
         ) {
             val searchResults =
-                    (GlassesStore.store.getCategory("core")["searchResults"] as? List<*>)
+                    (DeviceStore.store.getCategory("bluetooth")["searchResults"] as? List<*>)
                             ?.mapNotNull { result ->
                                 (result as? Map<*, *>)?.entries
                                         ?.mapNotNull { (key, value) ->
@@ -221,7 +221,7 @@ public class Bridge private constructor() {
                                 "$model:$name"
                             }
                             .asReversed()
-            GlassesStore.set("core", "searchResults", uniqueResults)
+            DeviceStore.set("bluetooth", "searchResults", uniqueResults)
         }
 
         // MARK: - Hardware Events
@@ -352,8 +352,8 @@ public class Bridge private constructor() {
         @JvmStatic
         fun sendStatus(statusObj: Map<String, Any>) {
             val body = HashMap<String, Any>()
-            body["core_status"] = statusObj
-            sendTypedMessage("core_status_update", body as Map<String, Any>)
+            body["bluetooth_status"] = statusObj
+            sendTypedMessage("bluetooth_status_update", body as Map<String, Any>)
         }
 
         /** Send glasses serial number */
@@ -380,7 +380,7 @@ public class Bridge private constructor() {
         @JvmStatic
         fun updateWifiScanResults(networks: List<Map<String, Any>>) {
             var storedNetworks: List<Map<String, Any>> =
-                    GlassesStore.get("core", "wifiScanResults") as? List<Map<String, Any>>
+                    DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
                             ?: emptyList()
             // add the networks to the storedNetworks array, removing duplicates by ssid
             val updatedNetworks = storedNetworks.toMutableList()
@@ -389,7 +389,7 @@ public class Bridge private constructor() {
                     updatedNetworks.add(network)
                 }
             }
-            GlassesStore.apply("core", "wifiScanResults", updatedNetworks)
+            DeviceStore.apply("bluetooth", "wifiScanResults", updatedNetworks)
         }
 
         /** Send gallery status - matches iOS MentraLive.swift handleGalleryStatus pattern */
@@ -602,9 +602,9 @@ public class Bridge private constructor() {
     }
 
     init {
-        deviceManager = CoreManager.Companion.getInstance()
+        deviceManager = DeviceManager.Companion.getInstance()
         if (deviceManager == null) {
-            Log.e(TAG, "Failed to initialize CoreManager in Bridge constructor")
+            Log.e(TAG, "Failed to initialize DeviceManager in Bridge constructor")
         }
     }
 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1,4 +1,4 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
 import android.bluetooth.BluetoothAdapter
 import android.content.BroadcastReceiver
@@ -10,23 +10,23 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.core.content.ContextCompat
-import com.mentra.core.controllers.ControllerManager
-import com.mentra.core.controllers.R1
-import com.mentra.core.services.ForegroundService
-import com.mentra.core.services.PhoneMic
-import com.mentra.core.sgcs.G1
-import com.mentra.core.sgcs.G2
-import com.mentra.core.sgcs.Mach1
-import com.mentra.core.sgcs.MentraLive
-import com.mentra.core.sgcs.MentraNex
-import com.mentra.core.sgcs.SGCManager
-import com.mentra.core.sgcs.Simulated
-import com.mentra.core.utils.ControllerTypes
-import com.mentra.core.utils.DeviceTypes
-import com.mentra.core.utils.MicMap
-import com.mentra.core.utils.MicTypes
+import com.mentra.bluetoothsdk.controllers.ControllerManager
+import com.mentra.bluetoothsdk.controllers.R1
+import com.mentra.bluetoothsdk.services.ForegroundService
+import com.mentra.bluetoothsdk.services.PhoneMic
+import com.mentra.bluetoothsdk.sgcs.G1
+import com.mentra.bluetoothsdk.sgcs.G2
+import com.mentra.bluetoothsdk.sgcs.Mach1
+import com.mentra.bluetoothsdk.sgcs.MentraLive
+import com.mentra.bluetoothsdk.sgcs.MentraNex
+import com.mentra.bluetoothsdk.sgcs.SGCManager
+import com.mentra.bluetoothsdk.sgcs.Simulated
+import com.mentra.bluetoothsdk.utils.ControllerTypes
+import com.mentra.bluetoothsdk.utils.DeviceTypes
+import com.mentra.bluetoothsdk.utils.MicMap
+import com.mentra.bluetoothsdk.utils.MicTypes
 import com.mentra.lc3Lib.Lc3Cpp
-import com.mentra.core.stt.SherpaOnnxTranscriber
+import com.mentra.bluetoothsdk.stt.SherpaOnnxTranscriber
 import java.text.SimpleDateFormat
 import java.util.*
 import java.util.concurrent.CountDownLatch
@@ -35,15 +35,15 @@ import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.jvm.JvmStatic
 
-class CoreManager {
+class DeviceManager {
     companion object {
 
-        @Volatile private var _instance: CoreManager? = null
+        @Volatile private var _instance: DeviceManager? = null
 
         @JvmStatic
-        fun getInstance(): CoreManager {
+        fun getInstance(): DeviceManager {
             return _instance
-                    ?: synchronized(this) { _instance ?: CoreManager().also { _instance = it } }
+                    ?: synchronized(this) { _instance ?: DeviceManager().also { _instance = it } }
         }
     }
 
@@ -73,157 +73,157 @@ class CoreManager {
 
     // settings:
     private var defaultWearable: String
-        get() = GlassesStore.store.get("core", "default_wearable") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "default_wearable", value)
+        get() = DeviceStore.store.get("bluetooth", "default_wearable") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "default_wearable", value)
 
     private var pendingWearable: String
-        get() = GlassesStore.store.get("core", "pending_wearable") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "pending_wearable", value)
+        get() = DeviceStore.store.get("bluetooth", "pending_wearable") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "pending_wearable", value)
 
     public var deviceName: String
-        get() = GlassesStore.store.get("core", "device_name") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "device_name", value)
+        get() = DeviceStore.store.get("bluetooth", "device_name") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "device_name", value)
 
     public var deviceAddress: String
-        get() = GlassesStore.store.get("core", "device_address") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "device_address", value)
+        get() = DeviceStore.store.get("bluetooth", "device_address") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "device_address", value)
 
     private var defaultController: String
-        get() = GlassesStore.store.get("core", "default_controller") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "default_controller", value)
+        get() = DeviceStore.store.get("bluetooth", "default_controller") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "default_controller", value)
 
     private var pendingController: String
-        get() = GlassesStore.store.get("core", "pending_controller") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "pending_controller", value)
+        get() = DeviceStore.store.get("bluetooth", "pending_controller") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "pending_controller", value)
 
     private var controllerDeviceName: String
-        get() = GlassesStore.store.get("core", "controller_device_name") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "controller_device_name", value)
+        get() = DeviceStore.store.get("bluetooth", "controller_device_name") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "controller_device_name", value)
 
     private var searchingController: Boolean
-        get() = GlassesStore.store.get("core", "searchingController") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "searchingController", value)
+        get() = DeviceStore.store.get("bluetooth", "searchingController") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "searchingController", value)
 
     private var screenDisabled: Boolean
-        get() = GlassesStore.store.get("core", "screen_disabled") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "screen_disabled", value)
+        get() = DeviceStore.store.get("bluetooth", "screen_disabled") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "screen_disabled", value)
 
     private var preferredMic: String
-        get() = GlassesStore.store.get("core", "preferred_mic") as? String ?: "auto"
-        set(value) = GlassesStore.apply("core", "preferred_mic", value)
+        get() = DeviceStore.store.get("bluetooth", "preferred_mic") as? String ?: "auto"
+        set(value) = DeviceStore.apply("bluetooth", "preferred_mic", value)
 
     private var autoBrightness: Boolean
-        get() = GlassesStore.store.get("core", "auto_brightness") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "auto_brightness", value)
+        get() = DeviceStore.store.get("bluetooth", "auto_brightness") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "auto_brightness", value)
 
     private var brightness: Int
-        get() = GlassesStore.store.get("core", "brightness") as? Int ?: 50
-        set(value) = GlassesStore.apply("core", "brightness", value)
+        get() = DeviceStore.store.get("bluetooth", "brightness") as? Int ?: 50
+        set(value) = DeviceStore.apply("bluetooth", "brightness", value)
 
     private var headUpAngle: Int
-        get() = GlassesStore.store.get("core", "head_up_angle") as? Int ?: 30
-        set(value) = GlassesStore.apply("core", "head_up_angle", value)
+        get() = DeviceStore.store.get("bluetooth", "head_up_angle") as? Int ?: 30
+        set(value) = DeviceStore.apply("bluetooth", "head_up_angle", value)
 
     private var sensingEnabled: Boolean
-        get() = GlassesStore.store.get("core", "sensing_enabled") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "sensing_enabled", value)
+        get() = DeviceStore.store.get("bluetooth", "sensing_enabled") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "sensing_enabled", value)
 
     public var powerSavingMode: Boolean
-        get() = GlassesStore.store.get("core", "power_saving_mode") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "power_saving_mode", value)
+        get() = DeviceStore.store.get("bluetooth", "power_saving_mode") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "power_saving_mode", value)
 
     private var bypassVad: Boolean
-        get() = GlassesStore.store.get("core", "bypass_vad") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "bypass_vad", value)
+        get() = DeviceStore.store.get("bluetooth", "bypass_vad") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "bypass_vad", value)
 
     private var offlineCaptionsRunning: Boolean
-        get() = GlassesStore.store.get("core", "offline_captions_running") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "offline_captions_running", value)
+        get() = DeviceStore.store.get("bluetooth", "offline_captions_running") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "offline_captions_running", value)
 
     private var localSttFallbackActive: Boolean
-        get() = GlassesStore.store.get("core", "local_stt_fallback_active") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "local_stt_fallback_active", value)
+        get() = DeviceStore.store.get("bluetooth", "local_stt_fallback_active") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "local_stt_fallback_active", value)
 
     private var shouldSendPcm: Boolean
-        get() = GlassesStore.store.get("core", "should_send_pcm") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "should_send_pcm", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_pcm") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_pcm", value)
 
     private var shouldSendLc3: Boolean
-        get() = GlassesStore.store.get("core", "should_send_lc3") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "should_send_lc3", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_lc3") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_lc3", value)
 
     private var shouldSendTranscript: Boolean
-        get() = GlassesStore.store.get("core", "should_send_transcript") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "should_send_transcript", value)
+        get() = DeviceStore.store.get("bluetooth", "should_send_transcript") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "should_send_transcript", value)
 
     private var contextualDashboard: Boolean
-        get() = GlassesStore.store.get("core", "contextual_dashboard") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "contextual_dashboard", value)
+        get() = DeviceStore.store.get("bluetooth", "contextual_dashboard") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "contextual_dashboard", value)
 
     private var dashboardHeight: Int
-        get() = (GlassesStore.store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
-        set(value) = GlassesStore.apply("core", "dashboard_height", value)
+        get() = (DeviceStore.store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
+        set(value) = DeviceStore.apply("bluetooth", "dashboard_height", value)
 
     private var dashboardDepth: Int
-        get() = (GlassesStore.store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
-        set(value) = GlassesStore.apply("core", "dashboard_depth", value)
+        get() = (DeviceStore.store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
+        set(value) = DeviceStore.apply("bluetooth", "dashboard_depth", value)
 
     private var galleryMode: Boolean
-        get() = GlassesStore.store.get("core", "gallery_mode") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "gallery_mode", value)
+        get() = DeviceStore.store.get("bluetooth", "gallery_mode") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "gallery_mode", value)
 
     // state:
     private var searching: Boolean
-        get() = GlassesStore.store.get("core", "searching") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "searching", value)
+        get() = DeviceStore.store.get("bluetooth", "searching") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "searching", value)
 
     private var glassesBtcConnected: Boolean
-        get() = GlassesStore.store.get("glasses", "btcConnected") as? Boolean ?: false
-        set(value) = GlassesStore.apply("glasses", "btcConnected", value)
+        get() = DeviceStore.store.get("glasses", "btcConnected") as? Boolean ?: false
+        set(value) = DeviceStore.apply("glasses", "btcConnected", value)
 
     public var micRanking: MutableList<String>
         get() =
-                (GlassesStore.store.get("core", "micRanking") as? List<*>)
+                (DeviceStore.store.get("bluetooth", "micRanking") as? List<*>)
                         ?.mapNotNull { it as? String }
                         ?.toMutableList()
                         ?: MicMap.map["auto"]?.toMutableList() ?: mutableListOf()
-        set(value) = GlassesStore.apply("core", "micRanking", value)
+        set(value) = DeviceStore.apply("bluetooth", "micRanking", value)
 
     private var shouldSendBootingMessage: Boolean
-        get() = GlassesStore.store.get("core", "shouldSendBootingMessage") as? Boolean ?: true
-        set(value) = GlassesStore.apply("core", "shouldSendBootingMessage", value)
+        get() = DeviceStore.store.get("bluetooth", "shouldSendBootingMessage") as? Boolean ?: true
+        set(value) = DeviceStore.apply("bluetooth", "shouldSendBootingMessage", value)
 
     // Guard against duplicate ready callbacks firing back-to-back.
     private var lastReadyHandledAtMs: Long = 0L
     private var lastReadyHandledKey: String = ""
 
     private var systemMicUnavailable: Boolean
-        get() = GlassesStore.store.get("core", "systemMicUnavailable") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "systemMicUnavailable", value)
+        get() = DeviceStore.store.get("bluetooth", "systemMicUnavailable") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "systemMicUnavailable", value)
 
     public var headUp: Boolean
-        get() = GlassesStore.store.get("glasses", "headUp") as? Boolean ?: false
-        set(value) = GlassesStore.apply("glasses", "headUp", value)
+        get() = DeviceStore.store.get("glasses", "headUp") as? Boolean ?: false
+        set(value) = DeviceStore.apply("glasses", "headUp", value)
 
     private var micEnabled: Boolean
-        get() = GlassesStore.store.get("core", "micEnabled") as? Boolean ?: false
-        set(value) = GlassesStore.apply("core", "micEnabled", value)
+        get() = DeviceStore.store.get("bluetooth", "micEnabled") as? Boolean ?: false
+        set(value) = DeviceStore.apply("bluetooth", "micEnabled", value)
 
     private var currentMic: String
-        get() = GlassesStore.store.get("core", "currentMic") as? String ?: ""
-        set(value) = GlassesStore.apply("core", "currentMic", value)
+        get() = DeviceStore.store.get("bluetooth", "currentMic") as? String ?: ""
+        set(value) = DeviceStore.apply("bluetooth", "currentMic", value)
 
     private var searchResults: List<Any>
-        get() = GlassesStore.store.get("core", "searchResults") as? List<Any> ?: emptyList()
-        set(value) = GlassesStore.apply("core", "searchResults", value)
+        get() = DeviceStore.store.get("bluetooth", "searchResults") as? List<Any> ?: emptyList()
+        set(value) = DeviceStore.apply("bluetooth", "searchResults", value)
 
     private var wifiScanResults: List<Any>
-        get() = GlassesStore.store.get("core", "wifiScanResults") as? List<Any> ?: emptyList()
-        set(value) = GlassesStore.apply("core", "wifiScanResults", value)
+        get() = DeviceStore.store.get("bluetooth", "wifiScanResults") as? List<Any> ?: emptyList()
+        set(value) = DeviceStore.apply("bluetooth", "wifiScanResults", value)
 
     private var lastLog: MutableList<String>
-        get() = GlassesStore.store.get("core", "lastLog") as? MutableList<String> ?: mutableListOf()
-        set(value) = GlassesStore.apply("core", "lastLog", value)
+        get() = DeviceStore.store.get("bluetooth", "lastLog") as? MutableList<String> ?: mutableListOf()
+        set(value) = DeviceStore.apply("bluetooth", "lastLog", value)
 
     // LC3 Audio Encoding
     // Audio output format enum
@@ -252,7 +252,7 @@ class CoreManager {
     private val viewStates = mutableListOf<ViewState>()
 
     init {
-        Bridge.log("CoreManager: init()")
+        Bridge.log("DeviceManager: init()")
         initializeViewStates()
         startForegroundService()
         // setupPermissionMonitoring()
@@ -308,8 +308,8 @@ class CoreManager {
 
     private fun checkAndReinitGlassesMic() {
         // if the glasses mic is marked as enabled (and the glasses are connected), but our last known lc3 event is from > 5 seconds ago, reinitialize the mic:
-        val glassesMicEnabled = GlassesStore.get("glasses", "micEnabled") as? Boolean ?: false
-        val glassesConnected = GlassesStore.get("glasses", "connected") as? Boolean ?: false
+        val glassesMicEnabled = DeviceStore.get("glasses", "micEnabled") as? Boolean ?: false
+        val glassesConnected = DeviceStore.get("glasses", "connected") as? Boolean ?: false
         if (!glassesMicEnabled || !glassesConnected) {
             return
         }
@@ -617,7 +617,7 @@ class CoreManager {
                 Bridge.log("MAN: ERROR - LC3 encoder not initialized but format is LC3")
                 return
             }
-            val lc3FrameSize = (GlassesStore.store.get("core", "lc3_frame_size") as Number).toInt()
+            val lc3FrameSize = (DeviceStore.store.get("bluetooth", "lc3_frame_size") as Number).toInt()
             val lc3Data = Lc3Cpp.encodeLC3(lc3EncoderPtr, pcmData, lc3FrameSize)
             if (lc3Data == null || lc3Data.isEmpty()) {
                 Bridge.log("MAN: ERROR - LC3 encoding returned empty data")
@@ -813,7 +813,7 @@ class CoreManager {
     }
 
     fun sendCurrentState() {
-        val hUp = GlassesStore.get("glasses", "headUp") as? Boolean ?: false
+        val hUp = DeviceStore.get("glasses", "headUp") as? Boolean ?: false
         // Bridge.log("MAN: sendCurrentState(): $isHeadUp")
         if (screenDisabled) {
             return
@@ -838,7 +838,7 @@ class CoreManager {
 
         var fullyBooted = sgc?.fullyBooted ?: false
         if (!fullyBooted) {
-            Bridge.log("MAN: CoreManager.sendCurrentState(): sgc not ready")
+            Bridge.log("MAN: DeviceManager.sendCurrentState(): sgc not ready")
             return
         }
 
@@ -1030,7 +1030,7 @@ class CoreManager {
             // sgc = FrameManager()
         }
         // update device model:
-        GlassesStore.apply("glasses", "deviceModel", sgc?.type ?: "")
+        DeviceStore.apply("glasses", "deviceModel", sgc?.type ?: "")
     }
 
     fun initController(controllerType: String) {
@@ -1126,7 +1126,7 @@ class CoreManager {
 
     fun handleDeviceDisconnected() {
         Bridge.log("MAN: Device disconnected")
-        GlassesStore.apply("glasses", "headUp", false)
+        DeviceStore.apply("glasses", "headUp", false)
     }
 
     fun handleControllerReady() {
@@ -1236,7 +1236,7 @@ class CoreManager {
 
     fun requestWifiScan() {
         Bridge.log("MAN: Requesting wifi scan")
-        GlassesStore.apply("core", "wifiScanResults", emptyList<Any>())
+        DeviceStore.apply("bluetooth", "wifiScanResults", emptyList<Any>())
         sgc?.requestWifiScan()
     }
 
@@ -1512,12 +1512,12 @@ class CoreManager {
         updateMicState()
         shouldSendBootingMessage = true // Reset for next first connect
         // clear glasses properties:
-        GlassesStore.apply("glasses", "deviceModel", "")
-        GlassesStore.apply("glasses", "fullyBooted", false)
-        GlassesStore.apply("glasses", "connected", false)
+        DeviceStore.apply("glasses", "deviceModel", "")
+        DeviceStore.apply("glasses", "fullyBooted", false)
+        DeviceStore.apply("glasses", "connected", false)
         // disconnect the controller as well:
         searchingController = false
-        GlassesStore.apply("glasses", "controllerConnected", false)
+        DeviceStore.apply("glasses", "controllerConnected", false)
         controller?.disconnect()
         controller = null
     }
@@ -1557,7 +1557,7 @@ class CoreManager {
         controllerDeviceName = ""
         Bridge.saveSetting("controller_device_name", "")
         Bridge.saveSetting("default_controller", "")
-        GlassesStore.apply("glasses", "controllerConnected", false)
+        DeviceStore.apply("glasses", "controllerConnected", false)
     }
 
     fun findCompatibleDevices(deviceModel: String) {
@@ -1585,8 +1585,8 @@ class CoreManager {
     fun stopScan() {
         controller?.stopScan()
         sgc?.stopScan()
-        GlassesStore.apply("core", "searching", false)
-        GlassesStore.apply("core", "searchingController", false)
+        DeviceStore.apply("bluetooth", "searching", false)
+        DeviceStore.apply("bluetooth", "searchingController", false)
     }
 
     // MARK: Cleanup

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -1,9 +1,9 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
 import android.os.Handler
 import android.os.Looper
-import com.mentra.core.utils.DeviceTypes
-import com.mentra.core.utils.MicMap
+import com.mentra.bluetoothsdk.utils.DeviceTypes
+import com.mentra.bluetoothsdk.utils.MicMap
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -11,12 +11,12 @@ import kotlinx.coroutines.launch
 import org.json.JSONObject
 
 /** Centralized observable state store for glasses and Bluetooth SDK settings */
-object GlassesStore {
+object DeviceStore {
 
     val store = ObservableStore()
 
     /**
-     * [CoreModule] applies batched `update("core", map)` key-by-key. Post to Main so the store has
+     * [BluetoothSdkModule] applies batched `update("bluetooth", map)` key-by-key. Post to Main so the store has
      * the latest value before BLE. Height and depth schedule independently so Nex sends one protobuf per change.
      */
     private val dashboardBleHandler = Handler(Looper.getMainLooper())
@@ -34,8 +34,8 @@ object GlassesStore {
         pendingDashboardHeightRunnable?.let { dashboardBleHandler.removeCallbacks(it) }
         val r = Runnable {
             pendingDashboardHeightRunnable = null
-            val h = (store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
-            CoreManager.getInstance().sgc?.setDashboardHeightOnly(h)
+            val h = (store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
+            DeviceManager.getInstance().sgc?.setDashboardHeightOnly(h)
         }
         pendingDashboardHeightRunnable = r
         dashboardBleHandler.post(r)
@@ -45,8 +45,8 @@ object GlassesStore {
         pendingDashboardDepthRunnable?.let { dashboardBleHandler.removeCallbacks(it) }
         val r = Runnable {
             pendingDashboardDepthRunnable = null
-            val d = (store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
-            CoreManager.getInstance().sgc?.setDashboardDepthOnly(d)
+            val d = (store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
+            DeviceManager.getInstance().sgc?.setDashboardDepthOnly(d)
         }
         pendingDashboardDepthRunnable = r
         dashboardBleHandler.post(r)
@@ -92,51 +92,51 @@ object GlassesStore {
         store.set("glasses", "ringSignalStrength", -1)
 
         // CORE STATE:
-        store.set("core", "systemMicUnavailable", false)
-        store.set("core", "searching", false)
-        store.set("core", "searchingController", false)
-        store.set("core", "micEnabled", false)
-        store.set("core", "currentMic", "")
-        store.set("core", "searchResults", emptyList<Any>())
-        store.set("core", "wifiScanResults", emptyList<Any>())
-        store.set("core", "micRanking", MicMap.map["auto"]!!)
-        store.set("core", "lastLog", mutableListOf<String>())
+        store.set("bluetooth", "systemMicUnavailable", false)
+        store.set("bluetooth", "searching", false)
+        store.set("bluetooth", "searchingController", false)
+        store.set("bluetooth", "micEnabled", false)
+        store.set("bluetooth", "currentMic", "")
+        store.set("bluetooth", "searchResults", emptyList<Any>())
+        store.set("bluetooth", "wifiScanResults", emptyList<Any>())
+        store.set("bluetooth", "micRanking", MicMap.map["auto"]!!)
+        store.set("bluetooth", "lastLog", mutableListOf<String>())
 
         // CORE SETTINGS:
-        store.set("core", "default_wearable", "")
-        store.set("core", "pending_wearable", "")
-        store.set("core", "device_name", "")
-        store.set("core", "device_address", "")
-        store.set("core", "default_controller", "")
-        store.set("core", "pending_controller", "")
-        store.set("core", "controller_device_name", "")
-        store.set("core", "screen_disabled", false)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "sensing_enabled", true)
-        store.set("core", "power_saving_mode", false)
-        store.set("core", "brightness", 50)
-        store.set("core", "auto_brightness", true)
-        store.set("core", "dashboard_height", 4)
-        store.set("core", "dashboard_depth", 2)
-        store.set("core", "head_up_angle", 30)
-        store.set("core", "contextual_dashboard", true)
-        store.set("core", "gallery_mode", true)
-        store.set("core", "screen_disabled", false)
-        store.set("core", "button_photo_size", "medium")
-        store.set("core", "button_camera_led", true)
-        store.set("core", "button_max_recording_time", 10)
-        store.set("core", "camera_fov", mapOf("fov" to 118, "roi_position" to 0))
-        store.set("core", "button_video_width", 1280)
-        store.set("core", "button_video_height", 720)
-        store.set("core", "button_video_fps", 30)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "lc3_frame_size", 60)
-        store.set("core", "auth_email", "")
-        store.set("core", "core_token", "")
-        store.set("core", "should_send_pcm", false)
-        store.set("core", "should_send_lc3", false)
-        store.set("core", "should_send_transcript", false)
-        store.set("core", "bypass_vad", false)
+        store.set("bluetooth", "default_wearable", "")
+        store.set("bluetooth", "pending_wearable", "")
+        store.set("bluetooth", "device_name", "")
+        store.set("bluetooth", "device_address", "")
+        store.set("bluetooth", "default_controller", "")
+        store.set("bluetooth", "pending_controller", "")
+        store.set("bluetooth", "controller_device_name", "")
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "sensing_enabled", true)
+        store.set("bluetooth", "power_saving_mode", false)
+        store.set("bluetooth", "brightness", 50)
+        store.set("bluetooth", "auto_brightness", true)
+        store.set("bluetooth", "dashboard_height", 4)
+        store.set("bluetooth", "dashboard_depth", 2)
+        store.set("bluetooth", "head_up_angle", 30)
+        store.set("bluetooth", "contextual_dashboard", true)
+        store.set("bluetooth", "gallery_mode", true)
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "button_photo_size", "medium")
+        store.set("bluetooth", "button_camera_led", true)
+        store.set("bluetooth", "button_max_recording_time", 10)
+        store.set("bluetooth", "camera_fov", mapOf("fov" to 118, "roi_position" to 0))
+        store.set("bluetooth", "button_video_width", 1280)
+        store.set("bluetooth", "button_video_height", 720)
+        store.set("bluetooth", "button_video_fps", 30)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "lc3_frame_size", 60)
+        store.set("bluetooth", "auth_email", "")
+        store.set("bluetooth", "core_token", "")
+        store.set("bluetooth", "should_send_pcm", false)
+        store.set("bluetooth", "should_send_lc3", false)
+        store.set("bluetooth", "should_send_transcript", false)
+        store.set("bluetooth", "bypass_vad", false)
     }
 
     fun get(category: String, key: String): Any? {
@@ -160,9 +160,9 @@ object GlassesStore {
             "glasses" to "fullyBooted" -> {
                 if (value is Boolean) {
                     if (value) {
-                        CoreManager.getInstance().handleDeviceReady()
+                        DeviceManager.getInstance().handleDeviceReady()
                     } else {
-                        CoreManager.getInstance().handleDeviceDisconnected()
+                        DeviceManager.getInstance().handleDeviceDisconnected()
                     }
                     // we shouldn't call store.set in this function as this is only intended for side-effects, not driving state updates
                 }
@@ -170,9 +170,9 @@ object GlassesStore {
             "glasses" to "controllerFullyBooted" -> {
                 if (value is Boolean) {
                     if (value) {
-                        CoreManager.getInstance().handleControllerReady()
+                        DeviceManager.getInstance().handleControllerReady()
                     } else {
-                        CoreManager.getInstance().handleControllerDisconnected()
+                        DeviceManager.getInstance().handleControllerDisconnected()
                     }
                 }
             }
@@ -181,130 +181,130 @@ object GlassesStore {
                     CoroutineScope(Dispatchers.Main).launch {
                         // give the glasses some extra time to finish booting:
                         delay(1000)
-                        CoreManager.getInstance().sgc?.connectController()
+                        DeviceManager.getInstance().sgc?.connectController()
                     }
                 }
             }
             "glasses" to "headUp" -> {
                 if (value is Boolean) {
-                    CoreManager.getInstance().sendCurrentState()
+                    DeviceManager.getInstance().sendCurrentState()
                     Bridge.sendHeadUp(value)
                 }
             }
 
             // BLUETOOTH:
-            "core" to "brightness" -> {
+            "bluetooth" to "brightness" -> {
                 val b = (value as? Number)?.toInt()  ?: 50
-                val auto = (store.get("core", "auto_brightness") as? Boolean) ?: true
+                val auto = (store.get("bluetooth", "auto_brightness") as? Boolean) ?: true
                 CoroutineScope(Dispatchers.Main).launch {
-                    CoreManager.getInstance().sgc?.setBrightness(b, auto)
-                    CoreManager.getInstance().sgc?.sendTextWall("Set brightness to $b%")
+                    DeviceManager.getInstance().sgc?.setBrightness(b, auto)
+                    DeviceManager.getInstance().sgc?.sendTextWall("Set brightness to $b%")
                     delay(800) // 0.8 seconds
-                    CoreManager.getInstance().sgc?.clearDisplay()
+                    DeviceManager.getInstance().sgc?.clearDisplay()
                 }
             }
-            "core" to "auto_brightness" -> {
-                val b = (store.get("core", "brightness") as? Int) ?: 50
+            "bluetooth" to "auto_brightness" -> {
+                val b = (store.get("bluetooth", "brightness") as? Int) ?: 50
                 val auto = (value as? Boolean) ?: true
                 val autoBrightnessChanged = (oldValue as? Boolean) != auto
                 CoroutineScope(Dispatchers.Main).launch {
-                    CoreManager.getInstance().sgc?.setBrightness(b, auto)
+                    DeviceManager.getInstance().sgc?.setBrightness(b, auto)
                     if (autoBrightnessChanged) {
-                        CoreManager.getInstance()
+                        DeviceManager.getInstance()
                                 .sgc
                                 ?.sendTextWall(
                                         if (auto) "Enabled auto brightness"
                                         else "Disabled auto brightness"
                                 )
                         delay(800) // 0.8 seconds
-                        CoreManager.getInstance().sgc?.clearDisplay()
+                        DeviceManager.getInstance().sgc?.clearDisplay()
                     }
                 }
             }
-            "core" to "dashboard_height" -> {
+            "bluetooth" to "dashboard_height" -> {
                 scheduleDashboardHeightToGlasses()
             }
-            "core" to "dashboard_depth" -> {
+            "bluetooth" to "dashboard_depth" -> {
                 scheduleDashboardDepthToGlasses()
             }
-            "core" to "head_up_angle" -> {
+            "bluetooth" to "head_up_angle" -> {
                 (value as? Int)?.let { angle ->
-                    CoreManager.getInstance().sgc?.setHeadUpAngle(angle)
+                    DeviceManager.getInstance().sgc?.setHeadUpAngle(angle)
                 }
             }
-            "core" to "menu_apps" -> {
+            "bluetooth" to "menu_apps" -> {
                 @Suppress("UNCHECKED_CAST")
                 (value as? List<Map<String, Any>>)?.let { items ->
-                    CoreManager.getInstance().sgc?.setDashboardMenu(items)
+                    DeviceManager.getInstance().sgc?.setDashboardMenu(items)
                 }
             }
-            "core" to "gallery_mode" -> {
-                CoreManager.getInstance().sgc?.sendGalleryMode()
+            "bluetooth" to "gallery_mode" -> {
+                DeviceManager.getInstance().sgc?.sendGalleryMode()
             }
-            "core" to "screen_disabled" -> {
+            "bluetooth" to "screen_disabled" -> {
                 (value as? Boolean)?.let { disabled ->
                     if (disabled) {
-                        CoreManager.getInstance().sgc?.exit()
+                        DeviceManager.getInstance().sgc?.exit()
                     } else {
-                        CoreManager.getInstance().sgc?.clearDisplay()
+                        DeviceManager.getInstance().sgc?.clearDisplay()
                     }
                 }
             }
-            "core" to "button_photo_size" -> {
-                CoreManager.getInstance().sgc?.sendButtonPhotoSettings()
+            "bluetooth" to "button_photo_size" -> {
+                DeviceManager.getInstance().sgc?.sendButtonPhotoSettings()
             }
-            "core" to "button_camera_led" -> {
-                CoreManager.getInstance().sgc?.sendButtonCameraLedSetting()
+            "bluetooth" to "button_camera_led" -> {
+                DeviceManager.getInstance().sgc?.sendButtonCameraLedSetting()
             }
-            "core" to "button_max_recording_time" -> {
-                CoreManager.getInstance().sgc?.sendButtonMaxRecordingTime()
+            "bluetooth" to "button_max_recording_time" -> {
+                DeviceManager.getInstance().sgc?.sendButtonMaxRecordingTime()
             }
-            "core" to "camera_fov" -> {
-                CoreManager.getInstance().sgc?.sendCameraFovSetting()
+            "bluetooth" to "camera_fov" -> {
+                DeviceManager.getInstance().sgc?.sendCameraFovSetting()
             }
-            "core" to "button_video_width",
-            "core" to "button_video_height",
-            "core" to "button_video_fps" -> {
-                CoreManager.getInstance().sgc?.sendButtonVideoRecordingSettings()
+            "bluetooth" to "button_video_width",
+            "bluetooth" to "button_video_height",
+            "bluetooth" to "button_video_fps" -> {
+                DeviceManager.getInstance().sgc?.sendButtonVideoRecordingSettings()
             }
-            "core" to "preferred_mic" -> {
+            "bluetooth" to "preferred_mic" -> {
                 (value as? String)?.let { mic ->
-                    apply("core", "micRanking", MicMap.map[mic] ?: MicMap.map["auto"]!!)
-                    CoreManager.getInstance().setMicState()
+                    apply("bluetooth", "micRanking", MicMap.map[mic] ?: MicMap.map["auto"]!!)
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "offline_captions_running" -> {
+            "bluetooth" to "offline_captions_running" -> {
                 (value as? Boolean)?.let { running ->
-                    Bridge.log("GlassesStore: offline_captions_running changed to $running")
-                    CoreManager.getInstance().setMicState()
+                    Bridge.log("DeviceStore: offline_captions_running changed to $running")
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "local_stt_fallback_active" -> {
+            "bluetooth" to "local_stt_fallback_active" -> {
                 (value as? Boolean)?.let { active ->
-                    Bridge.log("GlassesStore: local_stt_fallback_active changed to $active")
-                    CoreManager.getInstance().setMicState()
+                    Bridge.log("DeviceStore: local_stt_fallback_active changed to $active")
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_pcm" -> {
+            "bluetooth" to "should_send_pcm" -> {
                 (value as? Boolean)?.let { pcm ->
-                    CoreManager.getInstance().setMicState()
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_lc3" -> {
+            "bluetooth" to "should_send_lc3" -> {
                 (value as? Boolean)?.let { lc3 ->
-                    CoreManager.getInstance().setMicState()
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "should_send_transcript" -> {
+            "bluetooth" to "should_send_transcript" -> {
                 (value as? Boolean)?.let { transcript ->
-                    CoreManager.getInstance().setMicState()
+                    DeviceManager.getInstance().setMicState()
                 }
             }
-            "core" to "default_wearable" -> {
+            "bluetooth" to "default_wearable" -> {
                 (value as? String)?.let { wearable ->
                     Bridge.saveSetting("default_wearable", wearable)
                     if (wearable.contains(DeviceTypes.SIMULATED)) {
-                        CoreManager.getInstance().initSGC(wearable)
+                        DeviceManager.getInstance().initSGC(wearable)
                     }
                 }
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
@@ -1,7 +1,7 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
-import com.mentra.core.utils.ControllerTypes
-import com.mentra.core.utils.DeviceTypes
+import com.mentra.bluetoothsdk.utils.ControllerTypes
+import com.mentra.bluetoothsdk.utils.DeviceTypes
 
 data class MentraBluetoothSdkConfig(
     val deliverCallbacksOnMainThread: Boolean = true,

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1,11 +1,11 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
-import com.mentra.core.utils.ControllerTypes
-import com.mentra.core.utils.PhoneAudioMonitor
+import com.mentra.bluetoothsdk.utils.ControllerTypes
+import com.mentra.bluetoothsdk.utils.PhoneAudioMonitor
 import java.util.Collections
 
 class MentraBluetoothSdk private constructor(
@@ -15,7 +15,7 @@ class MentraBluetoothSdk private constructor(
 ) : AutoCloseable {
     private val appContext = context.applicationContext
     private val mainHandler = Handler(Looper.getMainLooper())
-    private val deviceManager: CoreManager
+    private val deviceManager: DeviceManager
     private val listeners =
         Collections.synchronizedSet(mutableSetOf<MentraBluetoothSdkListener>())
     private val discoveredDeviceNames = mutableSetOf<String>()
@@ -26,9 +26,9 @@ class MentraBluetoothSdk private constructor(
     init {
         listeners.add(listener)
         Bridge.initialize(appContext)
-        deviceManager = CoreManager.getInstance()
+        deviceManager = DeviceManager.getInstance()
         bridgeEventSinkId = Bridge.addEventSink { eventName, data -> dispatchBridgeEvent(eventName, data) }
-        storeListenerId = GlassesStore.store.addListener { category, changes -> dispatchStoreUpdate(category, changes) }
+        storeListenerId = DeviceStore.store.addListener { category, changes -> dispatchStoreUpdate(category, changes) }
     }
 
     companion object {
@@ -57,10 +57,10 @@ class MentraBluetoothSdk private constructor(
     }
 
     fun getGlassesStatus(): GlassesStatus =
-        GlassesStatus.fromMap(GlassesStore.store.getCategory("glasses"))
+        GlassesStatus.fromMap(DeviceStore.store.getCategory("glasses"))
 
     fun getBluetoothStatus(): BluetoothStatus =
-        BluetoothStatus.fromMap(GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY))
+        BluetoothStatus.fromMap(DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY))
 
     fun getDefaultDevice(): Device? = currentDefaultDevice()
 
@@ -71,9 +71,9 @@ class MentraBluetoothSdk private constructor(
         }
         suppressDefaultDeviceEvents = true
         try {
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "default_wearable", device.model.deviceType)
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "device_name", device.name)
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "device_address", device.address ?: "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "default_wearable", device.model.deviceType)
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "device_name", device.name)
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "device_address", device.address ?: "")
         } finally {
             suppressDefaultDeviceEvents = false
         }
@@ -83,9 +83,9 @@ class MentraBluetoothSdk private constructor(
     fun clearDefaultDevice() {
         suppressDefaultDeviceEvents = true
         try {
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "default_wearable", "")
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "device_name", "")
-            GlassesStore.apply(ObservableStore.CORE_CATEGORY, "device_address", "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "default_wearable", "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "device_name", "")
+            DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "device_address", "")
         } finally {
             suppressDefaultDeviceEvents = false
         }
@@ -97,13 +97,13 @@ class MentraBluetoothSdk private constructor(
             requireBluetoothReady("scan for glasses")
         }
         discoveredDeviceNames.clear()
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "searching", true)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "searching", true)
         deviceManager.findCompatibleDevices(model.deviceType)
     }
 
     fun stopScan() {
         deviceManager.stopScan()
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "searching", false)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "searching", false)
         dispatchToListeners { it.onScanStopped(ScanStopReason.CANCELLED) }
     }
 
@@ -123,7 +123,7 @@ class MentraBluetoothSdk private constructor(
         if (options.saveAsDefault && !isController) {
             setDefaultDevice(device)
         }
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "pending_wearable", device.model.deviceType)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "pending_wearable", device.model.deviceType)
         deviceManager.connectByName(device.name)
     }
 
@@ -178,75 +178,75 @@ class MentraBluetoothSdk private constructor(
 
     @JvmOverloads
     fun setBrightness(level: Int, autoMode: Boolean? = null) {
-        autoMode?.let { GlassesStore.apply(ObservableStore.CORE_CATEGORY, "auto_brightness", it) }
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "brightness", level)
+        autoMode?.let { DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "auto_brightness", it) }
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "brightness", level)
     }
 
     fun setAutoBrightness(enabled: Boolean) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "auto_brightness", enabled)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "auto_brightness", enabled)
     }
 
     fun setDashboardPosition(request: DashboardPositionRequest) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "dashboard_height", request.height)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "dashboard_depth", request.depth)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "dashboard_height", request.height)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "dashboard_depth", request.depth)
     }
 
     fun setDashboardMenu(items: List<DashboardMenuItem>) {
-        GlassesStore.apply(
-            ObservableStore.CORE_CATEGORY,
+        DeviceStore.apply(
+            ObservableStore.BLUETOOTH_CATEGORY,
             "menu_apps",
             items.map { it.toMap() },
         )
     }
 
     fun setHeadUpAngle(angleDegrees: Int) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "head_up_angle", angleDegrees)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "head_up_angle", angleDegrees)
     }
 
     fun setScreenDisabled(disabled: Boolean) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "screen_disabled", disabled)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "screen_disabled", disabled)
     }
 
     fun setGalleryMode(mode: GalleryMode) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "gallery_mode", mode == GalleryMode.AUTO)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "gallery_mode", mode == GalleryMode.AUTO)
     }
 
     fun setButtonPhotoSettings(settings: ButtonPhotoSettings) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_photo_size", settings.size.value)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_photo_size", settings.size.value)
     }
 
     fun setButtonVideoRecordingSettings(settings: ButtonVideoRecordingSettings) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_video_width", settings.width)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_video_height", settings.height)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_video_fps", settings.fps)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_video_width", settings.width)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_video_height", settings.height)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_video_fps", settings.fps)
     }
 
     fun setButtonCameraLed(enabled: Boolean) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_camera_led", enabled)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_camera_led", enabled)
     }
 
     fun setButtonMaxRecordingTime(minutes: Int) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "button_max_recording_time", minutes)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_max_recording_time", minutes)
     }
 
     fun setCameraFov(fov: CameraFov) {
-        GlassesStore.apply(
-            ObservableStore.CORE_CATEGORY,
+        DeviceStore.apply(
+            ObservableStore.BLUETOOTH_CATEGORY,
             "camera_fov",
             mapOf("fov" to fov.fov, "roi_position" to fov.roiPosition),
         )
     }
 
     fun setMicState(config: MicConfig) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "should_send_pcm", config.sendPcmData)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "should_send_lc3", config.sendLc3Data)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "should_send_transcript", config.sendTranscript)
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "bypass_vad", config.bypassVad)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "should_send_pcm", config.sendPcmData)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "should_send_lc3", config.sendLc3Data)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "should_send_transcript", config.sendTranscript)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "bypass_vad", config.bypassVad)
         deviceManager.setMicState()
     }
 
     fun setPreferredMic(preferredMic: MicPreference) {
-        GlassesStore.apply(ObservableStore.CORE_CATEGORY, "preferred_mic", preferredMic.value)
+        DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "preferred_mic", preferredMic.value)
     }
 
     fun setOwnAppAudioPlaying(playing: Boolean) {
@@ -352,7 +352,7 @@ class MentraBluetoothSdk private constructor(
 
     override fun close() {
         Bridge.removeEventSink(bridgeEventSinkId)
-        GlassesStore.store.removeListener(storeListenerId)
+        DeviceStore.store.removeListener(storeListenerId)
         listeners.clear()
     }
 
@@ -362,7 +362,7 @@ class MentraBluetoothSdk private constructor(
                 dispatchToListeners {
                     it.onGlassesStatusChanged(GlassesStatusUpdate.fromMap(glassesStatusChanges(changes)))
                 }
-            ObservableStore.CORE_CATEGORY -> {
+            ObservableStore.BLUETOOTH_CATEGORY -> {
                 dispatchToListeners {
                     it.onBluetoothStatusChanged(BluetoothStatusUpdate.fromMap(changes))
                 }
@@ -381,14 +381,14 @@ class MentraBluetoothSdk private constructor(
             merged =
                 merged +
                     mapOf(
-                        "wifiConnected" to ((GlassesStore.get("glasses", "wifiConnected") as? Boolean) ?: false),
-                        "wifiSsid" to ((GlassesStore.get("glasses", "wifiSsid") as? String) ?: ""),
-                        "wifiLocalIp" to ((GlassesStore.get("glasses", "wifiLocalIp") as? String) ?: ""),
+                        "wifiConnected" to ((DeviceStore.get("glasses", "wifiConnected") as? Boolean) ?: false),
+                        "wifiSsid" to ((DeviceStore.get("glasses", "wifiSsid") as? String) ?: ""),
+                        "wifiLocalIp" to ((DeviceStore.get("glasses", "wifiLocalIp") as? String) ?: ""),
                     )
         }
 
         if (changes.containsKey("signalStrengthUpdatedAt") && !changes.containsKey("signalStrength")) {
-            val signalStrength = (GlassesStore.get("glasses", "signalStrength") as? Number)?.toInt() ?: -1
+            val signalStrength = (DeviceStore.get("glasses", "signalStrength") as? Number)?.toInt() ?: -1
             merged = merged + ("signalStrength" to signalStrength)
         }
 
@@ -401,7 +401,7 @@ class MentraBluetoothSdk private constructor(
     }
 
     private fun currentDefaultDevice(): Device? {
-        val core = GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY)
+        val core = DeviceStore.store.getCategory(ObservableStore.BLUETOOTH_CATEGORY)
         val model = core["default_wearable"] as? String ?: return null
         val name = core["device_name"] as? String ?: return null
         if (model.isBlank() || name.isBlank()) return null

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ObservableStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/ObservableStore.kt
@@ -1,4 +1,4 @@
-package com.mentra.core
+package com.mentra.bluetoothsdk
 
 import java.util.UUID
 import org.json.JSONObject
@@ -6,11 +6,11 @@ import org.json.JSONObject
 /** Observable state management with immediate event emission */
 class ObservableStore {
     companion object {
-        const val CORE_CATEGORY = "core"
-        private const val LEGACY_BLUETOOTH_CATEGORY = "bluetooth"
+        const val BLUETOOTH_CATEGORY = "bluetooth"
+        private const val LEGACY_CORE_CATEGORY = "core"
 
         fun normalizeCategory(category: String): String =
-                if (category == LEGACY_BLUETOOTH_CATEGORY) CORE_CATEGORY else category
+                if (category == LEGACY_CORE_CATEGORY) BLUETOOTH_CATEGORY else category
     }
 
     private val values = mutableMapOf<String, Any>()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/ControllerManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/ControllerManager.kt
@@ -1,6 +1,6 @@
-package com.mentra.core.controllers
+package com.mentra.bluetoothsdk.controllers
 
-import com.mentra.core.GlassesStore
+import com.mentra.bluetoothsdk.DeviceStore
 
 abstract class ControllerManager {
     @JvmField var type: String = ""
@@ -92,67 +92,67 @@ abstract class ControllerManager {
     // Version Info
     abstract fun requestVersionInfo()
 
-    // GlassesStore-backed read-only getters for convenience
+    // DeviceStore-backed read-only getters for convenience
     val fullyBooted: Boolean
-        get() = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
 
     val connected: Boolean
-        get() = GlassesStore.get("glasses", "connected") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "connected") as? Boolean ?: false
 
     val appVersion: String
-        get() = GlassesStore.get("glasses", "appVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "appVersion") as? String ?: ""
 
     val buildNumber: String
-        get() = GlassesStore.get("glasses", "buildNumber") as? String ?: ""
+        get() = DeviceStore.get("glasses", "buildNumber") as? String ?: ""
 
     val deviceModel: String
-        get() = GlassesStore.get("glasses", "deviceModel") as? String ?: ""
+        get() = DeviceStore.get("glasses", "deviceModel") as? String ?: ""
 
     val androidVersion: String
-        get() = GlassesStore.get("glasses", "androidVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "androidVersion") as? String ?: ""
 
     val otaVersionUrl: String
-        get() = GlassesStore.get("glasses", "otaVersionUrl") as? String ?: ""
+        get() = DeviceStore.get("glasses", "otaVersionUrl") as? String ?: ""
 
     val firmwareVersion: String
-        get() = GlassesStore.get("glasses", "firmwareVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "firmwareVersion") as? String ?: ""
 
     val btMacAddress: String
-        get() = GlassesStore.get("glasses", "btMacAddress") as? String ?: ""
+        get() = DeviceStore.get("glasses", "btMacAddress") as? String ?: ""
 
     val serialNumber: String
-        get() = GlassesStore.get("glasses", "serialNumber") as? String ?: ""
+        get() = DeviceStore.get("glasses", "serialNumber") as? String ?: ""
 
     val style: String
-        get() = GlassesStore.get("glasses", "style") as? String ?: ""
+        get() = DeviceStore.get("glasses", "style") as? String ?: ""
 
     val color: String
-        get() = GlassesStore.get("glasses", "color") as? String ?: ""
+        get() = DeviceStore.get("glasses", "color") as? String ?: ""
 
     val micEnabled: Boolean
-        get() = GlassesStore.get("glasses", "micEnabled") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "micEnabled") as? Boolean ?: false
 
     val vadEnabled: Boolean
-        get() = GlassesStore.get("glasses", "vadEnabled") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "vadEnabled") as? Boolean ?: false
 
     val batteryLevel: Int
-        get() = GlassesStore.get("glasses", "batteryLevel") as? Int ?: -1
+        get() = DeviceStore.get("glasses", "batteryLevel") as? Int ?: -1
 
     val headUp: Boolean
-        get() = GlassesStore.get("glasses", "headUp") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "headUp") as? Boolean ?: false
 
     val charging: Boolean
-        get() = GlassesStore.get("glasses", "charging") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "charging") as? Boolean ?: false
 
     val caseOpen: Boolean
-        get() = GlassesStore.get("glasses", "caseOpen") as? Boolean ?: true
+        get() = DeviceStore.get("glasses", "caseOpen") as? Boolean ?: true
 
     val caseRemoved: Boolean
-        get() = GlassesStore.get("glasses", "caseRemoved") as? Boolean ?: true
+        get() = DeviceStore.get("glasses", "caseRemoved") as? Boolean ?: true
 
     val caseCharging: Boolean
-        get() = GlassesStore.get("glasses", "caseCharging") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "caseCharging") as? Boolean ?: false
 
     val caseBatteryLevel: Int
-        get() = GlassesStore.get("glasses", "caseBatteryLevel") as? Int ?: -1
+        get() = DeviceStore.get("glasses", "caseBatteryLevel") as? Int ?: -1
 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.controllers
+package com.mentra.bluetoothsdk.controllers
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
@@ -17,10 +17,10 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import androidx.core.content.ContextCompat
-import com.mentra.core.Bridge
-import com.mentra.core.CoreManager
-import com.mentra.core.GlassesStore
-import com.mentra.core.utils.ControllerTypes
+import com.mentra.bluetoothsdk.Bridge
+import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.DeviceStore
+import com.mentra.bluetoothsdk.utils.ControllerTypes
 import java.util.UUID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -127,7 +127,7 @@ class R1 : ControllerManager() {
         }
 
     // Public ring MAC parsed from advertisement manufacturer data (last 6 bytes), formatted
-    // as "AA:BB:CC:DD:EE:FF". This is what gets published to GlassesStore/controllerMacAddress.
+    // as "AA:BB:CC:DD:EE:FF". This is what gets published to DeviceStore/controllerMacAddress.
     private var ringMacAddress: String?
         get() = prefs.getString("r1_ringMacAddress", null)
         set(value) {
@@ -174,7 +174,7 @@ class R1 : ControllerManager() {
             val old = field
             field = value
             if (value != old && value >= 0) {
-                GlassesStore.apply("glasses", "controllerBatteryLevel", value)
+                DeviceStore.apply("glasses", "controllerBatteryLevel", value)
             }
         }
 
@@ -418,7 +418,7 @@ class R1 : ControllerManager() {
         val connectedName = try { gatt?.device?.name } catch (e: SecurityException) { null }
         if (connectedName != null) {
             extractRingId(connectedName)?.let {
-                GlassesStore.apply("core", "controller_device_name", it)
+                DeviceStore.apply("bluetooth", "controller_device_name", it)
             }
         }
 
@@ -427,9 +427,9 @@ class R1 : ControllerManager() {
             Bridge.log("R1: No ring MAC address found")
             return
         }
-        GlassesStore.apply("glasses", "controllerMacAddress", mac)
-        GlassesStore.apply("glasses", "controllerConnected", true)
-        // GlassesStore.apply("glasses", "controllerFullyBooted", true)
+        DeviceStore.apply("glasses", "controllerMacAddress", mac)
+        DeviceStore.apply("glasses", "controllerConnected", true)
+        // DeviceStore.apply("glasses", "controllerFullyBooted", true)
 
         // tell the ring to connect to the glasses if we have its mac address:
         connectToGlasses()
@@ -437,7 +437,7 @@ class R1 : ControllerManager() {
         // after a second, connect the glasses to the controller if needed:
         CoroutineScope(Dispatchers.Main).launch {
             delay(1000)
-            CoreManager.getInstance().sgc?.connectController()
+            DeviceManager.getInstance().sgc?.connectController()
         }
 
         startHeartbeat()
@@ -453,8 +453,8 @@ class R1 : ControllerManager() {
      * the 3-byte header + MAC. If the ring rejects this raw payload, decode the wrapper.
      */
     private fun connectToGlasses() {
-        // Try GlassesStore first; fall back to cached value in SharedPreferences.
-        val glassesMac = (GlassesStore.get("glasses", "btMacAddress") as? String)
+        // Try DeviceStore first; fall back to cached value in SharedPreferences.
+        val glassesMac = (DeviceStore.get("glasses", "btMacAddress") as? String)
             ?: prefs.getString("glasses_btMacAddress", null)
         if (glassesMac == null) {
             Bridge.log("R1: connectToGlasses: no glasses MAC")
@@ -505,7 +505,7 @@ class R1 : ControllerManager() {
         val r = object : Runnable {
             override fun run() {
                 mainHandler.postDelayed(this, 30_000L)
-                val isConnected = GlassesStore.get("glasses", "controllerConnected") as? Boolean ?: false
+                val isConnected = DeviceStore.get("glasses", "controllerConnected") as? Boolean ?: false
                 if (!isConnected) return
                 val char = batteryLevelChar
                 if (char != null) {
@@ -599,8 +599,8 @@ class R1 : ControllerManager() {
         readInFlight = false
         ringMacAddress = null
         ringBleAddress = null
-        GlassesStore.apply("glasses", "controllerConnected", false)
-        GlassesStore.apply("glasses", "controllerFullyBooted", false)
+        DeviceStore.apply("glasses", "controllerConnected", false)
+        DeviceStore.apply("glasses", "controllerFullyBooted", false)
     }
 
     // MARK: - GATT Callback
@@ -622,9 +622,9 @@ class R1 : ControllerManager() {
                         mainHandler.post {
                             disconnect()
                             ringBleAddress = null
-                            GlassesStore.apply("glasses", "controllerConnected", false)
-                            GlassesStore.apply("glasses", "controllerFullyBooted", false)
-                            GlassesStore.apply("glasses", "controllerSearching", true)
+                            DeviceStore.apply("glasses", "controllerConnected", false)
+                            DeviceStore.apply("glasses", "controllerFullyBooted", false)
+                            DeviceStore.apply("glasses", "controllerSearching", true)
                             mainHandler.postDelayed({ startScan() }, 1000)
                         }
                         return

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.services
+package com.mentra.bluetoothsdk.services
 
 import android.app.NotificationChannel
 import android.app.NotificationManager
@@ -10,7 +10,7 @@ import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 
 class ForegroundService : Service() {
     companion object {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/PhoneMic.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/PhoneMic.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.services
+package com.mentra.bluetoothsdk.services
 
 import android.Manifest
 import android.bluetooth.BluetoothAdapter
@@ -17,9 +17,9 @@ import android.telephony.PhoneStateListener
 import android.telephony.TelephonyManager
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
-import com.mentra.core.Bridge
-import com.mentra.core.CoreManager
-import com.mentra.core.utils.MicTypes
+import com.mentra.bluetoothsdk.Bridge
+import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.utils.MicTypes
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicBoolean
@@ -48,7 +48,7 @@ class PhoneMic private constructor(private val context: Context) {
         private const val MAX_SCO_RETRIES = 3
         private const val FOCUS_REGAIN_DELAY_MS = 500L
         private const val SAMSUNG_MIC_TEST_DELAY_MS = 500L
-        private const val MIC_SWITCH_DELAY_MS = 300L // Time for CoreManager to switch mics
+        private const val MIC_SWITCH_DELAY_MS = 300L // Time for DeviceManager to switch mics
     }
 
     // Audio recording components
@@ -125,7 +125,7 @@ class PhoneMic private constructor(private val context: Context) {
         // Check permissions
         if (!checkPermissions()) {
             Bridge.log("MIC: Microphone permissions not granted")
-            notifyCoreManager("permission_denied", emptyList())
+            notifyDeviceManager("permission_denied", emptyList())
             return false
         }
 
@@ -178,8 +178,8 @@ class PhoneMic private constructor(private val context: Context) {
         // Reset audio mode
         audioManager.mode = AudioManager.MODE_NORMAL
 
-        // Notify CoreManager
-        notifyCoreManager("recording_stopped", getAvailableInputDevices().values.toList())
+        // Notify DeviceManager
+        notifyDeviceManager("recording_stopped", getAvailableInputDevices().values.toList())
 
         Bridge.log("MIC: Recording stopped")
     }
@@ -216,7 +216,7 @@ class PhoneMic private constructor(private val context: Context) {
         // Check permissions
         if (!checkPermissions()) {
             Bridge.log("MIC: Microphone permissions not granted")
-            notifyCoreManager("permission_denied", emptyList())
+            notifyDeviceManager("permission_denied", emptyList())
             return false
         }
 
@@ -232,7 +232,7 @@ class PhoneMic private constructor(private val context: Context) {
         // Check for conflicts
         if (isPhoneCallActive) {
             Bridge.log("MIC: Cannot start recording - phone call active")
-            notifyCoreManager("phone_call_active", emptyList())
+            notifyDeviceManager("phone_call_active", emptyList())
             return false
         }
 
@@ -242,7 +242,7 @@ class PhoneMic private constructor(private val context: Context) {
             if (isSamsungDevice()) {
                 testMicrophoneAvailabilityOnSamsung()
             } else {
-                notifyCoreManager("audio_focus_denied", emptyList())
+                notifyDeviceManager("audio_focus_denied", emptyList())
             }
             return false
         }
@@ -257,7 +257,7 @@ class PhoneMic private constructor(private val context: Context) {
                 Bridge.log("MIC: Starting Bluetooth Classic (SCO)")
                 if (!audioManager.isBluetoothScoAvailableOffCall) {
                     Bridge.log("MIC: Bluetooth SCO not available")
-                    notifyCoreManager("bt_classic_unavailable", emptyList())
+                    notifyDeviceManager("bt_classic_unavailable", emptyList())
                     return false
                 }
                 return startRecordingBtClassic()
@@ -266,7 +266,7 @@ class PhoneMic private constructor(private val context: Context) {
                 Bridge.log("MIC: Starting high-quality Bluetooth mic")
                 if (!isHighQualityBluetoothAvailable()) {
                     Bridge.log("MIC: High-quality Bluetooth not available")
-                    notifyCoreManager("bt_hq_unavailable", emptyList())
+                    notifyDeviceManager("bt_hq_unavailable", emptyList())
                     return false
                 }
                 return startRecordingBtHighQuality()
@@ -428,7 +428,7 @@ class PhoneMic private constructor(private val context: Context) {
         // Check for conflicts
         if (isPhoneCallActive) {
             Bridge.log("MIC: Cannot start recording - phone call active")
-            notifyCoreManager("phone_call_active", emptyList())
+            notifyDeviceManager("phone_call_active", emptyList())
             return false
         }
 
@@ -439,7 +439,7 @@ class PhoneMic private constructor(private val context: Context) {
             if (isSamsungDevice()) {
                 testMicrophoneAvailabilityOnSamsung()
             } else {
-                notifyCoreManager("audio_focus_denied", emptyList())
+                notifyDeviceManager("audio_focus_denied", emptyList())
             }
             return false
         }
@@ -550,7 +550,7 @@ class PhoneMic private constructor(private val context: Context) {
         // Start recording thread
         startRecordingThread(bufferSize)
 
-        // Notify CoreManager
+        // Notify DeviceManager
         val activeDevice = getActiveInputDevice() ?: "Unknown"
         Bridge.log("MIC: Started recording from: $activeDevice")
         Bridge.log("MIC: Current audio mode: ${audioManager.mode} (NORMAL=${AudioManager.MODE_NORMAL}, IN_COMM=${AudioManager.MODE_IN_COMMUNICATION}, IN_CALL=${AudioManager.MODE_IN_CALL})")
@@ -562,7 +562,7 @@ class PhoneMic private constructor(private val context: Context) {
             }
         }
 
-        notifyCoreManager("recording_started", listOf(activeDevice))
+        notifyDeviceManager("recording_started", listOf(activeDevice))
 
         // Reset retry counter on success
         scoRetries = 0
@@ -598,8 +598,8 @@ class PhoneMic private constructor(private val context: Context) {
                                 byteBuffer.putShort(audioBuffer[i])
                             }
 
-                            // Send PCM data to CoreManager
-                            CoreManager.getInstance().handlePcm(pcmData)
+                            // Send PCM data to DeviceManager
+                            DeviceManager.getInstance().handlePcm(pcmData)
                         } else if (readResult < 0) {
                             // AudioRecord error (ERROR, ERROR_INVALID_OPERATION, ERROR_BAD_VALUE, ERROR_DEAD_OBJECT)
                             Bridge.log("MIC: AudioRecord.read() returned error: $readResult")
@@ -667,10 +667,10 @@ class PhoneMic private constructor(private val context: Context) {
                             if (isPhoneCallActive) {
                                 Bridge.log("MIC: Phone call started - stopping recording")
                                 if (isRecording.get()) {
-                                    // Notify CoreManager BEFORE stopping - allows switch to glasses
+                                    // Notify DeviceManager BEFORE stopping - allows switch to glasses
                                     // mic
-                                    notifyCoreManager("phone_call_interruption", emptyList())
-                                    // Give CoreManager time to switch to glasses mic
+                                    notifyDeviceManager("phone_call_interruption", emptyList())
+                                    // Give DeviceManager time to switch to glasses mic
                                     mainHandler.postDelayed(
                                             { stopRecording() },
                                             MIC_SWITCH_DELAY_MS
@@ -678,11 +678,11 @@ class PhoneMic private constructor(private val context: Context) {
                                 } else {
                                     // Not currently recording, but still notify about
                                     // unavailability
-                                    notifyCoreManager("phone_call_interruption", emptyList())
+                                    notifyDeviceManager("phone_call_interruption", emptyList())
                                 }
                             } else {
                                 Bridge.log("MIC: Phone call ended")
-                                notifyCoreManager(
+                                notifyDeviceManager(
                                         "phone_call_ended",
                                         getAvailableInputDevices().values.toList()
                                 )
@@ -709,7 +709,7 @@ class PhoneMic private constructor(private val context: Context) {
                             } else {
                                 // For other modes (BT, etc), respect audio focus loss
                                 if (isRecording.get()) {
-                                    notifyCoreManager("audio_focus_lost", emptyList())
+                                    notifyDeviceManager("audio_focus_lost", emptyList())
                                     stopRecording()
                                 }
                             }
@@ -725,7 +725,7 @@ class PhoneMic private constructor(private val context: Context) {
                                 if (isExternalAudioActive) {
                                     // External app is already recording (detected by AudioRecordingCallback)
                                     Bridge.log("MIC: AUDIOFOCUS_LOSS_TRANSIENT with external app recording - stopping")
-                                    notifyCoreManager("external_app_recording", emptyList())
+                                    notifyDeviceManager("external_app_recording", emptyList())
                                     stopRecording()
                                 } else {
                                     // AudioRecordingCallback might fire shortly after AUDIOFOCUS_LOSS_TRANSIENT
@@ -734,7 +734,7 @@ class PhoneMic private constructor(private val context: Context) {
                                     mainHandler.postDelayed({
                                         if (isRecording.get() && isExternalAudioActive) {
                                             Bridge.log("MIC: External app detected after delay - stopping")
-                                            notifyCoreManager("external_app_recording", emptyList())
+                                            notifyDeviceManager("external_app_recording", emptyList())
                                             stopRecording()
                                         } else if (isRecording.get()) {
                                             Bridge.log("MIC: No external app after delay - continuing recording")
@@ -756,7 +756,7 @@ class PhoneMic private constructor(private val context: Context) {
 
                             // Notify that focus is available again
                             if (!isRecording.get()) {
-                                notifyCoreManager(
+                                notifyDeviceManager(
                                         "audio_focus_available",
                                         getAvailableInputDevices().values.toList()
                                 )
@@ -788,19 +788,19 @@ class PhoneMic private constructor(private val context: Context) {
                                 if (isExternalAudioActive) {
                                     Bridge.log("MIC: External app started recording - isRecording: ${isRecording.get()}")
                                     if (isRecording.get()) {
-                                        // Notify CoreManager BEFORE stopping - allows switch to glasses mic
-                                        notifyCoreManager("external_app_recording", emptyList())
+                                        // Notify DeviceManager BEFORE stopping - allows switch to glasses mic
+                                        notifyDeviceManager("external_app_recording", emptyList())
                                         // Stop IMMEDIATELY to prevent audio corruption with Gboard
                                         stopRecording()
                                     } else {
                                         // Not currently recording, but still notify about
                                         // unavailability
-                                        notifyCoreManager("external_app_recording", emptyList())
+                                        notifyDeviceManager("external_app_recording", emptyList())
                                     }
                                 } else {
                                     Bridge.log("MIC: External app stopped recording")
-                                    // Notify CoreManager that phone mic is available again
-                                    notifyCoreManager(
+                                    // Notify DeviceManager that phone mic is available again
+                                    notifyDeviceManager(
                                             "external_app_stopped",
                                             getAvailableInputDevices().values.toList()
                                     )
@@ -901,7 +901,7 @@ class PhoneMic private constructor(private val context: Context) {
 
     private fun handleAudioRouteChange() {
         val availableInputs = getAvailableInputDevices().values.toList()
-        notifyCoreManager("audio_route_changed", availableInputs)
+        notifyDeviceManager("audio_route_changed", availableInputs)
     }
 
     private fun requestAudioFocus(): Boolean {
@@ -969,7 +969,7 @@ class PhoneMic private constructor(private val context: Context) {
                     } else {
                         Bridge.log("MIC: Samsung - mic taken by another app")
                         isExternalAudioActive = true
-                        notifyCoreManager("samsung_mic_conflict", emptyList())
+                        notifyDeviceManager("samsung_mic_conflict", emptyList())
                     }
                 },
                 SAMSUNG_MIC_TEST_DELAY_MS
@@ -1057,9 +1057,9 @@ class PhoneMic private constructor(private val context: Context) {
         }
     }
 
-    private fun notifyCoreManager(reason: String, availableInputs: List<String>) {
+    private fun notifyDeviceManager(reason: String, availableInputs: List<String>) {
         mainHandler.post {
-            CoreManager.getInstance()
+            DeviceManager.getInstance()
                     .onRouteChange(reason = reason, availableInputs = availableInputs)
         }
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.java
@@ -1,4 +1,4 @@
-package com.mentra.core.sgcs;
+package com.mentra.bluetoothsdk.sgcs;
 
 
 import android.bluetooth.BluetoothAdapter;
@@ -59,16 +59,16 @@ import java.util.Set;
 import java.util.HashSet;
 
 // Mentra
-import com.mentra.core.sgcs.SGCManager;
-import com.mentra.core.CoreManager;
-import com.mentra.core.Bridge;
-import com.mentra.core.utils.DeviceTypes;
-import com.mentra.core.utils.BitmapJavaUtils;
-import static com.mentra.core.utils.BitmapJavaUtils.convertBitmapTo1BitBmpBytes;
-import com.mentra.core.utils.G1Text;
-import com.mentra.core.utils.SmartGlassesConnectionState;
+import com.mentra.bluetoothsdk.sgcs.SGCManager;
+import com.mentra.bluetoothsdk.DeviceManager;
+import com.mentra.bluetoothsdk.Bridge;
+import com.mentra.bluetoothsdk.utils.DeviceTypes;
+import com.mentra.bluetoothsdk.utils.BitmapJavaUtils;
+import static com.mentra.bluetoothsdk.utils.BitmapJavaUtils.convertBitmapTo1BitBmpBytes;
+import com.mentra.bluetoothsdk.utils.G1Text;
+import com.mentra.bluetoothsdk.utils.SmartGlassesConnectionState;
 import com.mentra.lc3Lib.Lc3Cpp;
-import com.mentra.core.GlassesStore;
+import com.mentra.bluetoothsdk.DeviceStore;
 
 public class G1 extends SGCManager {
     private static final String TAG = "WearableAi_EvenRealitiesG1SGC";
@@ -215,13 +215,13 @@ public class G1 extends SGCManager {
         super();
         this.type = DeviceTypes.G1;
         this.hasMic = true;  // G1 has a built-in microphone
-        GlassesStore.INSTANCE.apply("glasses", "micEnabled", false);
+        DeviceStore.INSTANCE.apply("glasses", "micEnabled", false);
         Bridge.log("G1: G1 constructor");
         this.context = Bridge.getContext();
         loadPairedDeviceNames();
         // goHomeHandler = new Handler();
         // this.smartGlassesDevice = smartGlassesDevice;
-        preferredG1DeviceId = (String) GlassesStore.INSTANCE.get("core", "device_name");
+        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("bluetooth", "device_name");
         this.bluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
         this.shouldUseGlassesMic = false;
 
@@ -237,7 +237,7 @@ public class G1 extends SGCManager {
 
         // setup fonts
         g1Text = new G1Text();
-        GlassesStore.INSTANCE.apply("glasses", "caseRemoved", true);
+        DeviceStore.INSTANCE.apply("glasses", "caseRemoved", true);
     }
 
     private final BluetoothGattCallback leftGattCallback = createGattCallback("Left");
@@ -517,10 +517,10 @@ public class G1 extends SGCManager {
                             // }
 
                             if (deviceName.contains("R_")) {
-                                // Forward raw LC3 to CoreManager (matches iOS behavior)
+                                // Forward raw LC3 to DeviceManager (matches iOS behavior)
                                 // G1 uses 20-byte LC3 frames (default canonical config)
                                 if (shouldUseGlassesMic) {
-                                    CoreManager.getInstance().handleGlassesMicData(lc3, 20);
+                                    DeviceManager.getInstance().handleGlassesMicData(lc3, 20);
                                 }
                             } else {
                                 // Bridge.log("G1: Lc3 Audio data received. Seq: " + seq + ", Data: " +
@@ -533,7 +533,7 @@ public class G1 extends SGCManager {
                             if (deviceName.contains("R_")) {
                                 // Check for head down movement - initial F5 02 signal
                                 Bridge.log("G1: HEAD UP MOVEMENT DETECTED");
-                                GlassesStore.INSTANCE.apply("glasses", "headUp", true);
+                                DeviceStore.INSTANCE.apply("glasses", "headUp", true);
                             }
                         }
                         // HEAD DOWN MOVEMENTS
@@ -541,7 +541,7 @@ public class G1 extends SGCManager {
                             if (deviceName.contains("R_")) {
                             Bridge.log("G1: HEAD DOWN MOVEMENT DETECTED");
                                 // clearBmpDisplay();
-                                GlassesStore.INSTANCE.apply("glasses", "headUp", false);
+                                DeviceStore.INSTANCE.apply("glasses", "headUp", false);
                             }
                         }
                         // DOUBLE TAP
@@ -568,39 +568,39 @@ public class G1 extends SGCManager {
                                 int minBatt = Math.min(batteryLeft, batteryRight);
                                 // Bridge.log("G1: Minimum Battery Level: " + minBatt);
                                 // EventBus.getDefault().post(new BatteryLevelEvent(minBatt, false));
-                                GlassesStore.INSTANCE.apply("glasses", "batteryLevel", minBatt);
+                                DeviceStore.INSTANCE.apply("glasses", "batteryLevel", minBatt);
                             }
                         }
                         // CASE REMOVED
                         else if (data.length > 1 && (data[0] & 0xFF) == 0xF5
                                 && ((data[1] & 0xFF) == 0x07 || (data[1] & 0xFF) == 0x06)) {
-                            GlassesStore.INSTANCE.apply("glasses", "caseRemoved", true);
+                            DeviceStore.INSTANCE.apply("glasses", "caseRemoved", true);
                             Bridge.log("G1: CASE REMOVED");
                         }
                         // CASE OPEN
                         else if (data.length > 1 && (data[0] & 0xFF) == 0xF5 && (data[1] & 0xFF) == 0x08) {
-                            GlassesStore.INSTANCE.apply("glasses", "caseOpen", true);
-                            GlassesStore.INSTANCE.apply("glasses", "caseRemoved", false);
+                            DeviceStore.INSTANCE.apply("glasses", "caseOpen", true);
+                            DeviceStore.INSTANCE.apply("glasses", "caseRemoved", false);
                             // EventBus.getDefault()
                                     // .post(new CaseEvent(caseBatteryLevel, caseCharging, caseOpen, caseRemoved));
                         }
                         // CASE CLOSED
                         else if (data.length > 1 && (data[0] & 0xFF) == 0xF5 && (data[1] & 0xFF) == 0x0B) {
-                            GlassesStore.INSTANCE.apply("glasses", "caseOpen", false);
-                            GlassesStore.INSTANCE.apply("glasses", "caseRemoved", false);
+                            DeviceStore.INSTANCE.apply("glasses", "caseOpen", false);
+                            DeviceStore.INSTANCE.apply("glasses", "caseRemoved", false);
                             // EventBus.getDefault()
                                     // .post(new CaseEvent(caseBatteryLevel, caseCharging, caseOpen, caseRemoved));
                         }
                         // CASE CHARGING STATUS
                         else if (data.length > 3 && (data[0] & 0xFF) == 0xF5 && (data[1] & 0xFF) == 0x0E) {
-                            GlassesStore.INSTANCE.apply("glasses", "caseCharging", (data[2] & 0xFF) == 0x01);// TODO: verify this is correct
+                            DeviceStore.INSTANCE.apply("glasses", "caseCharging", (data[2] & 0xFF) == 0x01);// TODO: verify this is correct
                             // EventBus.getDefault()
                                     // .post(new CaseEvent(caseBatteryLevel, caseCharging, caseOpen, caseRemoved));
                         }
                         // CASE CHARGING INFO
                         else if (data.length > 3 && (data[0] & 0xFF) == 0xF5 && (data[1] & 0xFF) == 0x0F) {
                             int newCaseBatteryLevel = (data[2] & 0xFF);// TODO: verify this is correct
-                            GlassesStore.INSTANCE.apply("glasses", "caseBatteryLevel", newCaseBatteryLevel);
+                            DeviceStore.INSTANCE.apply("glasses", "caseBatteryLevel", newCaseBatteryLevel);
                             // EventBus.getDefault()
                                     // .post(new CaseEvent(caseBatteryLevel, caseCharging, caseOpen, caseRemoved));
                         }
@@ -701,13 +701,13 @@ public class G1 extends SGCManager {
                 queryBatteryStatusHandler.postDelayed(() -> queryBatteryStatus(), 10);
 
                 // setup brightness
-                int brightnessValue = ((Number) GlassesStore.INSTANCE.get("core", "brightness")).intValue();
-                Boolean shouldUseAutoBrightness = (Boolean) GlassesStore.INSTANCE.get("core", "auto_brightness");
+                int brightnessValue = ((Number) DeviceStore.INSTANCE.get("bluetooth", "brightness")).intValue();
+                Boolean shouldUseAutoBrightness = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "auto_brightness");
                 sendBrightnessCommandHandler
                         .postDelayed(() -> sendBrightnessCommand(brightnessValue, shouldUseAutoBrightness), 10);
 
-                // MIC state is handled by CoreManager.updateMicState() after reconnection
-                // Don't hardcode mic state here - let CoreManager restore the user's preference
+                // MIC state is handled by DeviceManager.updateMicState() after reconnection
+                // Don't hardcode mic state here - let DeviceManager restore the user's preference
 
                 // enable our AugmentOS notification key
                 sendWhiteListCommand(10);
@@ -770,18 +770,18 @@ public class G1 extends SGCManager {
             connectionState = SmartGlassesConnectionState.CONNECTED;
             Bridge.log("G1: Both glasses connected");
             lastConnectionTimestamp = System.currentTimeMillis();
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
-            GlassesStore.INSTANCE.apply("glasses", "connected", true);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
+            DeviceStore.INSTANCE.apply("glasses", "connected", true);
         } else if (isLeftConnected || isRightConnected) {
             connectionState = SmartGlassesConnectionState.CONNECTING;
             Bridge.log("G1: One glass connected");
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
-            GlassesStore.INSTANCE.apply("glasses", "connected", false);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
+            DeviceStore.INSTANCE.apply("glasses", "connected", false);
         } else {
             connectionState = SmartGlassesConnectionState.DISCONNECTED;
             Bridge.log("G1: No glasses connected");
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
-            GlassesStore.INSTANCE.apply("glasses", "connected", false);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
+            DeviceStore.INSTANCE.apply("glasses", "connected", false);
         }
     }
 
@@ -1127,9 +1127,9 @@ public class G1 extends SGCManager {
 
                         if (preferredG1DeviceId != null && preferredG1DeviceId.equals(parsedDeviceName)) {
                             // Store the information (matching iOS implementation)
-                            GlassesStore.INSTANCE.apply("glasses", "serialNumber", decodedSerial);
-                            GlassesStore.INSTANCE.apply("glasses", "style", decoded[0]);
-                            GlassesStore.INSTANCE.apply("glasses", "color", decoded[1]);
+                            DeviceStore.INSTANCE.apply("glasses", "serialNumber", decodedSerial);
+                            DeviceStore.INSTANCE.apply("glasses", "style", decoded[0]);
+                            DeviceStore.INSTANCE.apply("glasses", "color", decoded[1]);
 
                             // Emit the serial number information to React Native
                             emitSerialNumberInfo(decodedSerial, decoded[0], decoded[1]);
@@ -1326,7 +1326,7 @@ public class G1 extends SGCManager {
         context.registerReceiver(bondingReceiver, filter);
         isBondingReceiverRegistered = true;
 
-        preferredG1DeviceId = (String) GlassesStore.INSTANCE.get("core", "device_name");
+        preferredG1DeviceId = (String) DeviceStore.INSTANCE.get("bluetooth", "device_name");
 
         if (!bluetoothAdapter.isEnabled()) {
             return;
@@ -1689,13 +1689,13 @@ public class G1 extends SGCManager {
 
     @Override
     public void disconnect() {
-        GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
+        DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
         destroy();
     }
 
     @Override
     public void forget() {
-        GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
+        DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
         destroy();
     }
 
@@ -2117,7 +2117,7 @@ public class G1 extends SGCManager {
         }
 
         if (title.trim().isEmpty() && body.trim().isEmpty()) {
-            if (CoreManager.getInstance().getPowerSavingMode()) {
+            if (DeviceManager.getInstance().getPowerSavingMode()) {
                 sendExitCommand();
                 return;
             }
@@ -2141,12 +2141,12 @@ public class G1 extends SGCManager {
         Bridge.log("G1: EvenRealitiesG1SGC ONDESTROY");
         showHomeScreen();
         isKilled = true;
-        GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
+        DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
 
         // Reset battery levels
         batteryLeft = -1;
         batteryRight = -1;
-        GlassesStore.INSTANCE.apply("glasses", "batteryLevel", -1);
+        DeviceStore.INSTANCE.apply("glasses", "batteryLevel", -1);
 
         // stop BLE scanning
         stopScan();
@@ -2709,7 +2709,7 @@ public class G1 extends SGCManager {
         Bridge.log("G1: sendSetMicEnabled(): " + enable);
 
         isMicrophoneEnabled = enable; // Update the state tracker
-        GlassesStore.INSTANCE.apply("glasses", "micEnabled", enable);
+        DeviceStore.INSTANCE.apply("glasses", "micEnabled", enable);
         micEnableHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
@@ -3917,9 +3917,9 @@ public class G1 extends SGCManager {
 
             // Bridge.sendTypedMessage("glasses_serial_number", eventBody);
             Bridge.log("G1: 📱 Emitted serial number info: " + serialNumber + ", Style: " + style + ", Color: " + color);
-            GlassesStore.INSTANCE.apply("glasses", "serialNumber", serialNumber);
-            GlassesStore.INSTANCE.apply("glasses", "style", style);
-            GlassesStore.INSTANCE.apply("glasses", "color", color);
+            DeviceStore.INSTANCE.apply("glasses", "serialNumber", serialNumber);
+            DeviceStore.INSTANCE.apply("glasses", "style", style);
+            DeviceStore.INSTANCE.apply("glasses", "color", color);
 
         } catch (Exception e) {
             Bridge.log("G1: Error emitting serial number info: " + e.getMessage());

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.sgcs
+package com.mentra.bluetoothsdk.sgcs
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothGatt
@@ -19,10 +19,10 @@ import android.graphics.Rect
 import android.os.Handler
 import android.os.Looper
 import android.util.Base64
-import com.mentra.core.Bridge
-import com.mentra.core.CoreManager
-import com.mentra.core.GlassesStore
-import com.mentra.core.utils.DeviceTypes
+import com.mentra.bluetoothsdk.Bridge
+import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.DeviceStore
+import com.mentra.bluetoothsdk.utils.DeviceTypes
 import java.io.ByteArrayOutputStream
 import java.util.TimeZone
 import java.util.UUID
@@ -1066,7 +1066,7 @@ class G2 : SGCManager() {
             val old = _batteryLevel
             _batteryLevel = value
             if (value != old && value >= 0) {
-                GlassesStore.apply("glasses", "batteryLevel", value)
+                DeviceStore.apply("glasses", "batteryLevel", value)
                 Bridge.sendBatteryStatus(value, isCharging)
             }
         }
@@ -1569,7 +1569,7 @@ class G2 : SGCManager() {
                                                                 "G2: Auth sequence complete, glasses ready"
                                                         )
 
-                                                        // Set device_name so CoreManager can save
+                                                        // Set device_name so DeviceManager can save
                                                         // it for reconnection
                                                         val peripheralName =
                                                                 rightGatt?.device?.name
@@ -1579,8 +1579,8 @@ class G2 : SGCManager() {
                                                                     deviceNameToSerialNumber[it]
                                                                 }
                                                         if (serialNumber != null) {
-                                                            GlassesStore.apply(
-                                                                    "core",
+                                                            DeviceStore.apply(
+                                                                    "bluetooth",
                                                                     "device_name",
                                                                     serialNumber
                                                             )
@@ -1595,23 +1595,23 @@ class G2 : SGCManager() {
                                                                 rightGatt?.device?.name
                                                                         ?: leftGatt?.device?.name
                                                                                 ?: ""
-                                                        GlassesStore.apply(
+                                                        DeviceStore.apply(
                                                                 "glasses",
                                                                 "bluetoothName",
                                                                 btName
                                                         )
-                                                        GlassesStore.apply(
+                                                        DeviceStore.apply(
                                                                 "glasses",
                                                                 "deviceModel",
                                                                 DeviceTypes.G2
                                                         )
 
-                                                        GlassesStore.apply(
+                                                        DeviceStore.apply(
                                                                 "glasses",
                                                                 "connected",
                                                                 true
                                                         )
-                                                        GlassesStore.apply(
+                                                        DeviceStore.apply(
                                                                 "glasses",
                                                                 "fullyBooted",
                                                                 true
@@ -1732,7 +1732,7 @@ class G2 : SGCManager() {
     }
 
     private fun sendEvenHubHeartbeat() {
-        val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
         if (!isFullyBooted) {
             return
         }
@@ -1747,7 +1747,7 @@ class G2 : SGCManager() {
     }
 
     private fun sendDevSettingsHeartbeat() {
-        val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
         if (!isFullyBooted) {
             return
         }
@@ -1763,7 +1763,7 @@ class G2 : SGCManager() {
 
     private fun sendMenuApps() {
         val menuItems =
-                GlassesStore.get("core", "menu_apps") as? List<Map<String, Any>> ?: emptyList()
+                DeviceStore.get("bluetooth", "menu_apps") as? List<Map<String, Any>> ?: emptyList()
         if (menuItems.isNotEmpty()) {
             setDashboardMenu(menuItems)
         }
@@ -2338,11 +2338,11 @@ class G2 : SGCManager() {
 
     override fun setMicEnabled(enabled: Boolean) {
         Bridge.log("G2: setMicEnabled($enabled)")
-        val currentEnabled = GlassesStore.get("glasses", "micEnabled") as? Boolean ?: false
+        val currentEnabled = DeviceStore.get("glasses", "micEnabled") as? Boolean ?: false
 
         // if already enabled, set to disabled, then send enabled after 500ms:
         if (currentEnabled && enabled) {
-            GlassesStore.apply("glasses", "micEnabled", true)
+            DeviceStore.apply("glasses", "micEnabled", true)
             val msg = EvenHubProto.audioControlMessage(false)
             sendEvenHubCommand(msg)
             mainHandler.postDelayed({
@@ -2351,7 +2351,7 @@ class G2 : SGCManager() {
             }, 500)
             return
         }
-        GlassesStore.apply("glasses", "micEnabled", enabled)
+        DeviceStore.apply("glasses", "micEnabled", enabled)
         val msg = EvenHubProto.audioControlMessage(enabled)
         sendEvenHubCommand(msg)
     }
@@ -2477,8 +2477,8 @@ class G2 : SGCManager() {
         activeMenuAppId = null
         lastClickTimestamp = null
         lastMenuSelectTimestamp = null
-        GlassesStore.apply("glasses", "connected", false)
-        GlassesStore.apply("glasses", "fullyBooted", false)
+        DeviceStore.apply("glasses", "connected", false)
+        DeviceStore.apply("glasses", "fullyBooted", false)
     }
 
     override fun forget() {
@@ -2520,7 +2520,7 @@ class G2 : SGCManager() {
     }
 
     fun reconnectController() {
-        val mac = GlassesStore.get("glasses", "controllerMacAddress") as? String
+        val mac = DeviceStore.get("glasses", "controllerMacAddress") as? String
         if (mac.isNullOrEmpty()) {
             Bridge.log("G2: reconnectController - no MAC address found")
             return
@@ -2529,12 +2529,12 @@ class G2 : SGCManager() {
     }
 
     override fun connectController() {
-        val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
         if (!isFullyBooted) {
             Bridge.log("G2: connectController - g2 not fully booted, ignoring")
             return
         }
-        val mac = GlassesStore.get("glasses", "controllerMacAddress") as? String
+        val mac = DeviceStore.get("glasses", "controllerMacAddress") as? String
         if (mac.isNullOrEmpty()) {
             Bridge.log("G2: connectController - no MAC address found")
             return
@@ -2552,12 +2552,12 @@ class G2 : SGCManager() {
     }
 
     override fun disconnectController() {
-        val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
         if (!isFullyBooted) {
             Bridge.log("G2: disconnectController - g2 not fully booted, ignoring")
             return
         }
-        val mac = GlassesStore.get("glasses", "controllerMacAddress") as? String
+        val mac = DeviceStore.get("glasses", "controllerMacAddress") as? String
         if (mac.isNullOrEmpty()) {
             Bridge.log("G2: disconnectController - no MAC address found")
             return
@@ -2570,9 +2570,9 @@ class G2 : SGCManager() {
         val macData = hexParts.toByteArray()
         val msg = DevSettingsProto.ringConnectInfo(sendManager.nextMagicRandom(), false, macData)
         sendDevSettingsCommand(msg)
-        // GlassesStore.apply("glasses", "controllerMacAddress", "")
-        GlassesStore.apply("glasses", "controllerConnected", false)
-        GlassesStore.apply("glasses", "controllerFullyBooted", false)
+        // DeviceStore.apply("glasses", "controllerMacAddress", "")
+        DeviceStore.apply("glasses", "controllerConnected", false)
+        DeviceStore.apply("glasses", "controllerFullyBooted", false)
         Bridge.log("G2: Sent RING_DISCONNECT_INFO for MAC $mac")
     }
 
@@ -2719,10 +2719,10 @@ class G2 : SGCManager() {
                             val mac = extractMacFromScanRecord(result)
                             if (mac != null) {
                                 if (name.contains("_L_")) {
-                                    GlassesStore.apply("glasses", "leftMacAddress", mac)
-                                    GlassesStore.apply("glasses", "btMacAddress", mac)
+                                    DeviceStore.apply("glasses", "leftMacAddress", mac)
+                                    DeviceStore.apply("glasses", "btMacAddress", mac)
                                 } else if (name.contains("_R_")) {
-                                    GlassesStore.apply("glasses", "rightMacAddress", mac)
+                                    DeviceStore.apply("glasses", "rightMacAddress", mac)
                                 }
                             }
                             // Stop scanning once we have both
@@ -2947,8 +2947,8 @@ class G2 : SGCManager() {
                         startupPageCreated = false
                         pageCreated = false
                         pageHasTextContainer = false
-                        GlassesStore.apply("glasses", "connected", false)
-                        GlassesStore.apply("glasses", "fullyBooted", false)
+                        DeviceStore.apply("glasses", "connected", false)
+                        DeviceStore.apply("glasses", "fullyBooted", false)
 
                         startReconnectionTimer()
                     }
@@ -3211,26 +3211,26 @@ class G2 : SGCManager() {
     }
 
     private fun setFullyConnected() {
-        val isFullyConnected = GlassesStore.get("glasses", "connected") as? Boolean ?: false
-        val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        val isFullyConnected = DeviceStore.get("glasses", "connected") as? Boolean ?: false
+        val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
         if (!isFullyConnected) {
-            GlassesStore.apply("glasses", "connected", true)
+            DeviceStore.apply("glasses", "connected", true)
         }
         if (!isFullyBooted) {
-            GlassesStore.apply("glasses", "fullyBooted", true)
+            DeviceStore.apply("glasses", "fullyBooted", true)
         }
     }
 
     private fun setControllerFullyConnected() {
         val isControllerConnected =
-                GlassesStore.get("glasses", "controllerConnected") as? Boolean ?: false
+                DeviceStore.get("glasses", "controllerConnected") as? Boolean ?: false
         val isControllerFullyBooted =
-                GlassesStore.get("glasses", "controllerFullyBooted") as? Boolean ?: false
+                DeviceStore.get("glasses", "controllerFullyBooted") as? Boolean ?: false
         if (!isControllerConnected) {
-            GlassesStore.apply("glasses", "controllerConnected", true)
+            DeviceStore.apply("glasses", "controllerConnected", true)
         }
         if (!isControllerFullyBooted) {
-            GlassesStore.apply("glasses", "controllerFullyBooted", true)
+            DeviceStore.apply("glasses", "controllerFullyBooted", true)
         }
     }
 
@@ -3275,9 +3275,9 @@ class G2 : SGCManager() {
 
             if (eventType == OsEventType.DOUBLE_CLICK) {
                 // trigger dashboard:
-                val isHeadUp = GlassesStore.get("glasses", "headUp") as? Boolean ?: false
+                val isHeadUp = DeviceStore.get("glasses", "headUp") as? Boolean ?: false
                 // toggle head up:
-                GlassesStore.apply("glasses", "headUp", !isHeadUp)
+                DeviceStore.apply("glasses", "headUp", !isHeadUp)
                 // if (isHeadUp) {
                 //     // clear the display after a delay:
                 //     mainHandler.postDelayed({ clearDisplay() }, 500)
@@ -3293,8 +3293,8 @@ class G2 : SGCManager() {
                 currentTextContent = ""
                 currentBitmapBase64 = ""
                 // Firmware kills the mic on system exit; re-arm it if it should be on
-                GlassesStore.apply("glasses", "micEnabled", false)
-                CoreManager.getInstance().updateMicState()
+                DeviceStore.apply("glasses", "micEnabled", false)
+                DeviceManager.getInstance().updateMicState()
             }
             return
         }
@@ -3379,12 +3379,12 @@ class G2 : SGCManager() {
 
                 if ((ringFields[1] as? Int ?: 0) == 1) {
                     Bridge.log("G2: Ring maybe connected?")
-                    GlassesStore.apply("glasses", "controllerFullyBooted", true)
+                    DeviceStore.apply("glasses", "controllerFullyBooted", true)
                 }
 
                 if ((ringFields[4] as? Int ?: 0) == 62) {
                     Bridge.log("G2: Ring maybe reconnected?")
-                    GlassesStore.apply("glasses", "controllerFullyBooted", true)
+                    DeviceStore.apply("glasses", "controllerFullyBooted", true)
                 }
 
                 val connStatus = ringFields[4] as? Int ?: -1
@@ -3392,15 +3392,15 @@ class G2 : SGCManager() {
 
                 if (connStatus == 22) {
                     Bridge.log("G2: Ring disconnected")
-                    GlassesStore.apply("glasses", "controllerFullyBooted", false)
-                    GlassesStore.apply("glasses", "controllerSearching", true)
+                    DeviceStore.apply("glasses", "controllerFullyBooted", false)
+                    DeviceStore.apply("glasses", "controllerSearching", true)
                     reconnectController()
                 }
 
                 if (connStatus == 8) {
                     Bridge.log("G2: Ring maybe disconnected?")
-                    // GlassesStore.apply("glasses", "controllerFullyBooted", false)
-                    // GlassesStore.apply("glasses", "controllerSearching", true)
+                    // DeviceStore.apply("glasses", "controllerFullyBooted", false)
+                    // DeviceStore.apply("glasses", "controllerSearching", true)
                     // reconnectController()
                 }
             }
@@ -3456,8 +3456,8 @@ class G2 : SGCManager() {
         if (payload.contentEquals(byteArrayOf(0x08, 0x01, 0x1A, 0x00))) {
             Bridge.log("G2: gesture_ctrl response: dashboard closed")
             // Re-send mic on / update mic state
-            GlassesStore.apply("glasses", "micEnabled", false)
-            CoreManager.getInstance().updateMicState()
+            DeviceStore.apply("glasses", "micEnabled", false)
+            DeviceManager.getInstance().updateMicState()
             // Reset the text container
             sendTextWall(" ")
         }
@@ -3504,14 +3504,14 @@ class G2 : SGCManager() {
         (fields[5] as? ByteArray)?.let { leftVer ->
             val leftVersion = String(leftVer, Charsets.UTF_8)
             Bridge.log("G2: Left firmware: $leftVersion")
-            GlassesStore.apply("glasses", "leftFirmwareVersion", leftVersion)
+            DeviceStore.apply("glasses", "leftFirmwareVersion", leftVersion)
         }
 
         (fields[6] as? ByteArray)?.let { rightVer ->
             val rightVersion = String(rightVer, Charsets.UTF_8)
             Bridge.log("G2: Right firmware: $rightVersion")
-            GlassesStore.apply("glasses", "rightFirmwareVersion", rightVersion)
-            GlassesStore.apply("glasses", "firmwareVersion", rightVersion)
+            DeviceStore.apply("glasses", "rightFirmwareVersion", rightVersion)
+            DeviceStore.apply("glasses", "firmwareVersion", rightVersion)
         }
     }
 
@@ -3539,14 +3539,14 @@ class G2 : SGCManager() {
         }
         lastAudioFrame = audioData
         Bridge.log("G2: audio data from $sourceKey: ${data.take(10).joinToString("") { String.format("%02X", it) }}")
-        CoreManager.getInstance().handleGlassesMicData(audioData, 40)
+        DeviceManager.getInstance().handleGlassesMicData(audioData, 40)
     }
 
     // ---------- Reconnection ----------
 
     private fun startReconnectionTimer() {
         reconnectionManager.start {
-            val isFullyBooted = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+            val isFullyBooted = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
             if (isFullyBooted) {
                 Bridge.log("G2: Already connected, stopping reconnection")
                 return@start true

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.java
@@ -1,4 +1,4 @@
-package com.mentra.core.sgcs;
+package com.mentra.bluetoothsdk.sgcs;
 
 import android.content.Context;
 import android.content.res.Resources;
@@ -15,18 +15,18 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 
 // Mentra
-import com.mentra.core.sgcs.SGCManager;
-import com.mentra.core.CoreManager;
-import com.mentra.core.Bridge;
-import com.mentra.core.utils.DeviceTypes;
-import com.mentra.core.utils.ConnTypes;
-import com.mentra.core.utils.BitmapJavaUtils;
-import com.mentra.core.utils.SmartGlassesConnectionState;
-import com.mentra.core.utils.K900ProtocolUtils;
-import com.mentra.core.utils.MessageChunker;
-import com.mentra.core.utils.audio.Lc3Player;
-import com.mentra.core.utils.BlePhotoUploadService;
-import com.mentra.core.GlassesStore;
+import com.mentra.bluetoothsdk.sgcs.SGCManager;
+import com.mentra.bluetoothsdk.DeviceManager;
+import com.mentra.bluetoothsdk.Bridge;
+import com.mentra.bluetoothsdk.utils.DeviceTypes;
+import com.mentra.bluetoothsdk.utils.ConnTypes;
+import com.mentra.bluetoothsdk.utils.BitmapJavaUtils;
+import com.mentra.bluetoothsdk.utils.SmartGlassesConnectionState;
+import com.mentra.bluetoothsdk.utils.K900ProtocolUtils;
+import com.mentra.bluetoothsdk.utils.MessageChunker;
+import com.mentra.bluetoothsdk.utils.audio.Lc3Player;
+import com.mentra.bluetoothsdk.utils.BlePhotoUploadService;
+import com.mentra.bluetoothsdk.DeviceStore;
 
 // import com.augmentos.augmentos_core.R;
 // import com.augmentos.augmentos_core.smarterglassesmanager.smartglassescommunicators.SmartGlassesCommunicator;
@@ -97,7 +97,7 @@ public class Mach1 extends SGCManager {
     private int totalDashboardsIdk = 0;
 
     private boolean hasBattery() {
-        Object level = GlassesStore.INSTANCE.get("glasses", "batteryLevel");
+        Object level = DeviceStore.INSTANCE.get("glasses", "batteryLevel");
         return level instanceof Number && ((Number) level).intValue() != -1;
     }
 
@@ -108,17 +108,17 @@ public class Mach1 extends SGCManager {
         }
 
         // Update the connection state
-        GlassesStore.INSTANCE.apply("glasses", "connectionState", state);
+        DeviceStore.INSTANCE.apply("glasses", "connectionState", state);
 
         if (state.equals(ConnTypes.CONNECTED)) {
             // Match iOS: only declare fully booted once we have battery info too
             if (hasBattery()) {
-                GlassesStore.INSTANCE.apply("glasses", "connected", true);
-                GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+                DeviceStore.INSTANCE.apply("glasses", "connected", true);
+                DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
             }
         } else if (state.equals(ConnTypes.DISCONNECTED)) {
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
-            GlassesStore.INSTANCE.apply("glasses", "connected", false);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
+            DeviceStore.INSTANCE.apply("glasses", "connected", false);
         }
     }
 
@@ -413,8 +413,8 @@ public class Mach1 extends SGCManager {
             // Toggle dashboard on 2+ taps (same as iOS implementation)
             if (tapCount >= 2) {
                 isHeadUp = !isHeadUp;
-                // Notify CoreManager of head up state change (same as G1 does with IMU)
-                GlassesStore.INSTANCE.apply("glasses", "headUp", isHeadUp);
+                // Notify DeviceManager of head up state change (same as G1 does with IMU)
+                DeviceStore.INSTANCE.apply("glasses", "headUp", isHeadUp);
                 Log.d(TAG, "Mach1: Dashboard toggled via tap, isHeadUp: " + isHeadUp);
 
                 // Auto turn off the dashboard after 15 seconds
@@ -422,7 +422,7 @@ public class Mach1 extends SGCManager {
                     goHomeHandler.postDelayed(() -> {
                         if (isHeadUp) {
                             isHeadUp = false;
-                            GlassesStore.INSTANCE.apply("glasses", "headUp", false);
+                            DeviceStore.INSTANCE.apply("glasses", "headUp", false);
                             Log.d(TAG, "Mach1: Auto-disabling dashboard after 15 seconds");
                         }
                     }, 15000);
@@ -581,13 +581,13 @@ public class Mach1 extends SGCManager {
             return;
         }
         Log.d(TAG, "Ultralite new battery status: " + batteryStatus.getLevel());
-        GlassesStore.INSTANCE.apply("glasses", "batteryLevel", batteryStatus.getLevel());
+        DeviceStore.INSTANCE.apply("glasses", "batteryLevel", batteryStatus.getLevel());
 
         // Match iOS: if we're already connected but weren't fully booted yet (waiting
         // for battery), now that we have battery info we can declare fully booted.
         if (getConnectionState().equals(ConnTypes.CONNECTED) && !getFullyBooted()) {
-            GlassesStore.INSTANCE.apply("glasses", "connected", true);
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+            DeviceStore.INSTANCE.apply("glasses", "connected", true);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -1,4 +1,4 @@
-package com.mentra.core.sgcs;
+package com.mentra.bluetoothsdk.sgcs;
 
 import android.Manifest;
 import android.bluetooth.BluetoothAdapter;
@@ -32,25 +32,25 @@ import androidx.core.app.ActivityCompat;
 // import androidx.preference.PreferenceManager;
 
 // Mentra
-import com.mentra.core.sgcs.SGCManager;
-import com.mentra.core.CoreManager;
-import com.mentra.core.Bridge;
-import com.mentra.core.utils.DeviceTypes;
-import com.mentra.core.utils.ConnTypes;
-import com.mentra.core.utils.BitmapJavaUtils;
-import com.mentra.core.utils.SmartGlassesConnectionState;
-import com.mentra.core.utils.K900ProtocolUtils;
-import com.mentra.core.utils.MessageChunker;
-import com.mentra.core.utils.audio.Lc3Player;
-import com.mentra.core.utils.BlePhotoUploadService;
-import com.mentra.core.utils.IncidentLogBleRelayNaming;
-import com.mentra.core.utils.IncidentLogBleUploadService;
-import com.mentra.core.GlassesStore;
-import com.mentra.core.utils.PhoneAudioMonitor;
+import com.mentra.bluetoothsdk.sgcs.SGCManager;
+import com.mentra.bluetoothsdk.DeviceManager;
+import com.mentra.bluetoothsdk.Bridge;
+import com.mentra.bluetoothsdk.utils.DeviceTypes;
+import com.mentra.bluetoothsdk.utils.ConnTypes;
+import com.mentra.bluetoothsdk.utils.BitmapJavaUtils;
+import com.mentra.bluetoothsdk.utils.SmartGlassesConnectionState;
+import com.mentra.bluetoothsdk.utils.K900ProtocolUtils;
+import com.mentra.bluetoothsdk.utils.MessageChunker;
+import com.mentra.bluetoothsdk.utils.audio.Lc3Player;
+import com.mentra.bluetoothsdk.utils.BlePhotoUploadService;
+import com.mentra.bluetoothsdk.utils.IncidentLogBleRelayNaming;
+import com.mentra.bluetoothsdk.utils.IncidentLogBleUploadService;
+import com.mentra.bluetoothsdk.DeviceStore;
+import com.mentra.bluetoothsdk.utils.PhoneAudioMonitor;
 
 // old augmentos imports:
 import com.mentra.lc3Lib.Lc3Cpp;
-import com.mentra.core.utils.audio.Lc3Player;
+import com.mentra.bluetoothsdk.utils.audio.Lc3Player;
 
 
 
@@ -550,7 +550,7 @@ public class MentraLive extends SGCManager {
         }
 
         // Initialize connection state
-        GlassesStore.INSTANCE.apply("glasses", "connectionState", ConnTypes.DISCONNECTED);
+        DeviceStore.INSTANCE.apply("glasses", "connectionState", ConnTypes.DISCONNECTED);
 
         // Initialize CTKD bonding receiver
         initializeBondingReceiver();
@@ -684,28 +684,28 @@ public class MentraLive extends SGCManager {
         }
 
         // Actually update the connection state!
-        GlassesStore.INSTANCE.apply("glasses", "connectionState", state);
+        DeviceStore.INSTANCE.apply("glasses", "connectionState", state);
 
         if (state.equals(ConnTypes.CONNECTED)) {
-            GlassesStore.INSTANCE.apply("glasses", "connected", true);
+            DeviceStore.INSTANCE.apply("glasses", "connected", true);
             if (glassesReadyReceived) {
-                GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+                DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
             }
             // Drop cached version fields from the previous BLE session so the next version_info
             // repopulates RN. Otherwise a stale build (e.g. 38) can remain while ASG is still 36,
             // and the phone-side OTA check will disagree with glasses' PackageManager + ota_update_available.
-            GlassesStore.INSTANCE.apply("glasses", "buildNumber", "");
-            GlassesStore.INSTANCE.apply("glasses", "appVersion", "");
-            GlassesStore.INSTANCE.apply("glasses", "besFwVersion", "");
-            GlassesStore.INSTANCE.apply("glasses", "mtkFwVersion", "");
+            DeviceStore.INSTANCE.apply("glasses", "buildNumber", "");
+            DeviceStore.INSTANCE.apply("glasses", "appVersion", "");
+            DeviceStore.INSTANCE.apply("glasses", "besFwVersion", "");
+            DeviceStore.INSTANCE.apply("glasses", "mtkFwVersion", "");
             Bridge.log("LIVE: Cleared cached version_info fields for fresh session");
         }
         
         if (state.equals(ConnTypes.DISCONNECTED)) {
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
-            GlassesStore.INSTANCE.apply("glasses", "connected", false);
-            GlassesStore.INSTANCE.apply("glasses", "signalStrength", -1);
-            GlassesStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", 0L);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
+            DeviceStore.INSTANCE.apply("glasses", "connected", false);
+            DeviceStore.INSTANCE.apply("glasses", "signalStrength", -1);
+            DeviceStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", 0L);
             // Drop OTA caches when fully disconnected — avoids leaking session/step state
             // from a previous pairing into the next one.
             resetOtaCache();
@@ -825,7 +825,7 @@ public class MentraLive extends SGCManager {
         try {
             bluetoothScanner.stopScan(scanCallback);
             isScanning = false;
-            GlassesStore.INSTANCE.apply("core", "searching", false);
+            DeviceStore.INSTANCE.apply("bluetooth", "searching", false);
             Bridge.log("LIVE: BLE scan stopped");
 
             // Post event only if we haven't been destroyed
@@ -1101,7 +1101,7 @@ public class MentraLive extends SGCManager {
                 if (!isConnected && !isConnecting && !isKilled) {
                     // Prefer saved MAC for direct GATT connect (faster and more reliable than scanning).
                     // Falls back to name-based scan if no address is saved.
-                    String lastDeviceAddress = (String) GlassesStore.INSTANCE.get("core", "device_address");
+                    String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("bluetooth", "device_address");
                     if (lastDeviceAddress != null && !lastDeviceAddress.isEmpty() && bluetoothAdapter != null) {
                         try {
                             BluetoothDevice device = bluetoothAdapter.getRemoteDevice(lastDeviceAddress);
@@ -1164,10 +1164,10 @@ public class MentraLive extends SGCManager {
                     isConnecting = false;
                     isConnected = true;
                     connectedDevice = gatt.getDevice();
-                    GlassesStore.INSTANCE.apply("glasses", "bluetoothName", connectedDevice.getName());
+                    DeviceStore.INSTANCE.apply("glasses", "bluetoothName", connectedDevice.getName());
                     // Persist MAC so reconnection can use direct GATT instead of scanning
                     if (connectedDevice.getAddress() != null) {
-                        GlassesStore.INSTANCE.apply("core", "device_address", connectedDevice.getAddress());
+                        DeviceStore.INSTANCE.apply("bluetooth", "device_address", connectedDevice.getAddress());
                     }
 
                     // Save the connected device name for future reconnections
@@ -1313,7 +1313,7 @@ public class MentraLive extends SGCManager {
                         Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...");
 
                         // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
-                        // GlassesStore handles connected state based on fullyBooted
+                        // DeviceStore handles connected state based on fullyBooted
 
                         // Keep the state as CONNECTING until the glasses SOC responds
                         // connectionEvent(SmartGlassesConnectionState.CONNECTING);
@@ -2728,7 +2728,7 @@ public class MentraLive extends SGCManager {
                 // This check maintains platform parity with iOS
                 if (audioConnected) {
                     Bridge.log("LIVE: Audio: Both glasses_ready and audio connected - marking as fully connected");
-                    GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+                    DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
                     updateConnectionState(ConnTypes.CONNECTED);
                 } else {
                     Bridge.log("LIVE: Audio: Waiting for CTKD audio bonding before marking as fully connected");
@@ -2770,13 +2770,13 @@ public class MentraLive extends SGCManager {
                 String btMacAddressLegacy = json.optString("bt_mac_address", "");
 
                 // Update parent SGCManager fields
-                GlassesStore.INSTANCE.apply("glasses", "appVersion", appVersionLegacy);
-                GlassesStore.INSTANCE.apply("glasses", "buildNumber", buildNumberLegacy);
-                GlassesStore.INSTANCE.apply("glasses", "deviceModel", deviceModelLegacy);
-                GlassesStore.INSTANCE.apply("glasses", "androidVersion", androidVersionLegacy);
-                GlassesStore.INSTANCE.apply("glasses", "otaVersionUrl", otaVersionUrlLegacy != null ? otaVersionUrlLegacy : "");
-                GlassesStore.INSTANCE.apply("glasses", "firmwareVersion", firmwareVersionLegacy);
-                GlassesStore.INSTANCE.apply("glasses", "btMacAddress", btMacAddressLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "appVersion", appVersionLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "buildNumber", buildNumberLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "deviceModel", deviceModelLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "androidVersion", androidVersionLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "otaVersionUrl", otaVersionUrlLegacy != null ? otaVersionUrlLegacy : "");
+                DeviceStore.INSTANCE.apply("glasses", "firmwareVersion", firmwareVersionLegacy);
+                DeviceStore.INSTANCE.apply("glasses", "btMacAddress", btMacAddressLegacy);
 
                 // Parse build number as integer for version checks (local field)
                 try {
@@ -2929,13 +2929,13 @@ public class MentraLive extends SGCManager {
                         }
                     }
 
-                    // Update GlassesStore for any fields we recognize
+                    // Update DeviceStore for any fields we recognize
                     if (fields.containsKey("app_version")) {
-                        GlassesStore.INSTANCE.apply("glasses", "appVersion", (String) fields.get("app_version"));
+                        DeviceStore.INSTANCE.apply("glasses", "appVersion", (String) fields.get("app_version"));
                     }
                     if (fields.containsKey("build_number")) {
                         String buildNum = (String) fields.get("build_number");
-                        GlassesStore.INSTANCE.apply("glasses", "buildNumber", buildNum);
+                        DeviceStore.INSTANCE.apply("glasses", "buildNumber", buildNum);
                         // Parse build number as integer for version checks
                         try {
                             int buildNumInt = Integer.parseInt(buildNum);
@@ -2946,28 +2946,28 @@ public class MentraLive extends SGCManager {
                     }
                     if (fields.containsKey("device_model")) {
                         String deviceModel = (String) fields.get("device_model");
-                        GlassesStore.INSTANCE.apply("glasses", "deviceModel", deviceModel);
+                        DeviceStore.INSTANCE.apply("glasses", "deviceModel", deviceModel);
                         // Determine LC3 audio support: base K900 doesn't support LC3, variants do
                         boolean supportsLC3Audio = !"K900".equals(deviceModel);
                         Bridge.log("LIVE: 📱 LC3 audio support: " + supportsLC3Audio + " (device: " + deviceModel + ")");
                     }
                     if (fields.containsKey("android_version")) {
-                        GlassesStore.INSTANCE.apply("glasses", "androidVersion", (String) fields.get("android_version"));
+                        DeviceStore.INSTANCE.apply("glasses", "androidVersion", (String) fields.get("android_version"));
                     }
                     if (fields.containsKey("ota_version_url")) {
-                        GlassesStore.INSTANCE.apply("glasses", "otaVersionUrl", (String) fields.get("ota_version_url"));
+                        DeviceStore.INSTANCE.apply("glasses", "otaVersionUrl", (String) fields.get("ota_version_url"));
                     }
                     if (fields.containsKey("firmware_version")) {
-                        GlassesStore.INSTANCE.apply("glasses", "fwVersion", (String) fields.get("firmware_version"));
+                        DeviceStore.INSTANCE.apply("glasses", "fwVersion", (String) fields.get("firmware_version"));
                     }
                     if (fields.containsKey("bes_fw_version")) {
-                        GlassesStore.INSTANCE.apply("glasses", "besFwVersion", (String) fields.get("bes_fw_version"));
+                        DeviceStore.INSTANCE.apply("glasses", "besFwVersion", (String) fields.get("bes_fw_version"));
                     }
                     if (fields.containsKey("mtk_fw_version")) {
-                        GlassesStore.INSTANCE.apply("glasses", "mtkFwVersion", (String) fields.get("mtk_fw_version"));
+                        DeviceStore.INSTANCE.apply("glasses", "mtkFwVersion", (String) fields.get("mtk_fw_version"));
                     }
                     if (fields.containsKey("bt_mac_address")) {
-                        GlassesStore.INSTANCE.apply("glasses", "btMacAddress", (String) fields.get("bt_mac_address"));
+                        DeviceStore.INSTANCE.apply("glasses", "btMacAddress", (String) fields.get("bt_mac_address"));
                     }
 
 
@@ -3137,7 +3137,7 @@ public class MentraLive extends SGCManager {
                         int ready = bodyObj.optInt("ready", 0);
                         if (ready == 0) {
                             Bridge.log("LIVE: K900 SOC not ready (ready=0)");
-                            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
+                            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
                             Bridge.sendTypedMessage("glasses_not_ready", new HashMap<String, Object>() {});
                             if (batteryPercentage > 0 && batteryPercentage <= 20) {
                                 Bridge.log("LIVE: K900 battery percentage: " + batteryPercentage);
@@ -3354,7 +3354,7 @@ public class MentraLive extends SGCManager {
     /**
      * Send the coreToken to the ASG client for direct backend authentication.
      * Retries a few times with delay if token is empty (bridge may not have applied
-     * CoreModule.update yet when glasses_ready runs).
+     * BluetoothSdkModule.update yet when glasses_ready runs).
      */
     private void sendCoreTokenToAsgClient() {
         Bridge.log("LIVE: Preparing to send coreToken to ASG client");
@@ -3392,7 +3392,7 @@ public class MentraLive extends SGCManager {
      * Send stored user email to the ASG client for Sentry crash reporting
      */
     private void sendStoredUserEmailToAsgClient() {
-        Object emailObj = GlassesStore.INSTANCE.get("core", "auth_email");
+        Object emailObj = DeviceStore.INSTANCE.get("bluetooth", "auth_email");
         String storedEmail = emailObj instanceof String ? (String) emailObj : "";
 
         if (storedEmail == null || storedEmail.isEmpty()) {
@@ -3432,8 +3432,8 @@ public class MentraLive extends SGCManager {
      */
     private void updateBatteryStatus(int level, boolean isCharging) {
         // Update parent SGCManager fields
-        GlassesStore.INSTANCE.apply("glasses", "batteryLevel", level);
-        GlassesStore.INSTANCE.apply("glasses", "charging", isCharging);
+        DeviceStore.INSTANCE.apply("glasses", "batteryLevel", level);
+        DeviceStore.INSTANCE.apply("glasses", "charging", isCharging);
 
         if (level >= 0) {
             Bridge.sendBatteryStatus(level, isCharging);
@@ -3448,9 +3448,9 @@ public class MentraLive extends SGCManager {
         Bridge.log("LIVE: 🌐 Updating WiFi status - connected: " + connected + ", SSID: " + ssid);
 
         // Update parent SGCManager fields
-        GlassesStore.INSTANCE.apply("glasses", "wifiConnected", connected);
-        GlassesStore.INSTANCE.apply("glasses", "wifiSsid", ssid);
-        GlassesStore.INSTANCE.apply("glasses", "wifiLocalIp", localIp);
+        DeviceStore.INSTANCE.apply("glasses", "wifiConnected", connected);
+        DeviceStore.INSTANCE.apply("glasses", "wifiSsid", ssid);
+        DeviceStore.INSTANCE.apply("glasses", "wifiLocalIp", localIp);
 
         // Send event to bridge for cloud communication
         Bridge.sendWifiStatusChange(connected, ssid, localIp);
@@ -3464,10 +3464,10 @@ public class MentraLive extends SGCManager {
         Bridge.log("LIVE: 🔥 Updating hotspot status - enabled: " + enabled + ", SSID: " + ssid);
 
         // Update parent SGCManager fields
-        GlassesStore.INSTANCE.apply("glasses", "hotspotEnabled", enabled);
-        GlassesStore.INSTANCE.apply("glasses", "hotspotSsid", ssid);
-        GlassesStore.INSTANCE.apply("glasses", "hotspotPassword", password);
-        GlassesStore.INSTANCE.apply("glasses", "hotspotGatewayIp", gatewayIp);
+        DeviceStore.INSTANCE.apply("glasses", "hotspotEnabled", enabled);
+        DeviceStore.INSTANCE.apply("glasses", "hotspotSsid", ssid);
+        DeviceStore.INSTANCE.apply("glasses", "hotspotPassword", password);
+        DeviceStore.INSTANCE.apply("glasses", "hotspotGatewayIp", gatewayIp);
 
         // Send hotspot status change event (matches iOS emitHotspotStatusChange)
         Bridge.sendHotspotStatusChange(enabled, ssid, password, gatewayIp);
@@ -3625,7 +3625,7 @@ public class MentraLive extends SGCManager {
 
     @Override
     public void sendGalleryMode() {
-        boolean active = (Boolean) GlassesStore.INSTANCE.get("core", "gallery_mode");
+        boolean active = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "gallery_mode");
         Bridge.log("LIVE: 📸 Sending gallery mode active to glasses: " + active);
         try {
             JSONObject json = new JSONObject();
@@ -3734,8 +3734,8 @@ public class MentraLive extends SGCManager {
 
     private void updateSignalStrength(int rssi) {
         long now = System.currentTimeMillis();
-        GlassesStore.INSTANCE.apply("glasses", "signalStrength", rssi);
-        GlassesStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", now);
+        DeviceStore.INSTANCE.apply("glasses", "signalStrength", rssi);
+        DeviceStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", now);
         Bridge.log("LIVE: 📶 RSSI: " + rssi + " dBm");
     }
 
@@ -4002,7 +4002,7 @@ public class MentraLive extends SGCManager {
         // var context = Bridge.getContext();
         // SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         // String lastDeviceAddress = prefs.getString(PREF_DEVICE_NAME, null);
-        String lastDeviceAddress = (String) GlassesStore.INSTANCE.get("core", "device_address");
+        String lastDeviceAddress = (String) DeviceStore.INSTANCE.get("bluetooth", "device_address");
 
         if (lastDeviceAddress != null && lastDeviceAddress.length() > 0) {
             // Connect to last known device if available
@@ -4035,7 +4035,7 @@ public class MentraLive extends SGCManager {
         // Update the microphone state tracker
         isMicrophoneEnabled = enable;
 
-        GlassesStore.INSTANCE.apply("glasses", "micEnabled", enable);
+        DeviceStore.INSTANCE.apply("glasses", "micEnabled", enable);
 
         // Update the shouldUseGlassesMic flag to reflect the current state
         this.shouldUseGlassesMic = enable;
@@ -4327,7 +4327,7 @@ public class MentraLive extends SGCManager {
                                 // If glasses_ready was already received, now we're fully ready
                                 if (glassesReadyReceived) {
                                     Bridge.log("LIVE: Audio: Both audio and glasses_ready confirmed - marking as fully connected");
-                                    GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+                                    DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
                                     updateConnectionState(ConnTypes.CONNECTED);
                                 }
 
@@ -4556,7 +4556,7 @@ public class MentraLive extends SGCManager {
      */
     private void markAudioConnected(String deviceName) {
         if (isKilled) {
-            Bridge.log("LIVE: A2DP: Ignoring markAudioConnected — SGC destroyed (would confuse CoreManager)");
+            Bridge.log("LIVE: A2DP: Ignoring markAudioConnected — SGC destroyed (would confuse DeviceManager)");
             return;
         }
         isBtClassicConnected = true;
@@ -4564,7 +4564,7 @@ public class MentraLive extends SGCManager {
         Bridge.sendAudioConnected(deviceName);
         if (glassesReadyReceived) {
             Bridge.log("LIVE: A2DP: Both audio and glasses_ready confirmed - marking as fully connected");
-            GlassesStore.INSTANCE.apply("glasses", "fullyBooted", true);
+            DeviceStore.INSTANCE.apply("glasses", "fullyBooted", true);
             updateConnectionState(ConnTypes.CONNECTED);
         }
     }
@@ -4705,7 +4705,7 @@ public class MentraLive extends SGCManager {
         reconnectAttempts = 0;
         isReconnecting = false;
         glassesReady = false;
-        GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
+        DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
         updateConnectionState(ConnTypes.DISCONNECTED);
 
         // Note: We don't null context here to prevent race conditions with BLE callbacks
@@ -4750,7 +4750,7 @@ public class MentraLive extends SGCManager {
     @Override
     public void sendButtonVideoRecordingSettings() {
         try {
-            Object videoSettingsObj = GlassesStore.INSTANCE.get("core", "button_video_settings");
+            Object videoSettingsObj = DeviceStore.INSTANCE.get("bluetooth", "button_video_settings");
             int videoWidth = 1920;  // defaults
             int videoHeight = 1080;
             int videoFps = 30;
@@ -4761,9 +4761,9 @@ public class MentraLive extends SGCManager {
                 videoHeight = ((Number) videoSettings.getOrDefault("height", videoHeight)).intValue();
                 videoFps = ((Number) videoSettings.getOrDefault("fps", videoFps)).intValue();
             } else {
-                Object width = GlassesStore.INSTANCE.get("core", "button_video_width");
-                Object height = GlassesStore.INSTANCE.get("core", "button_video_height");
-                Object fps = GlassesStore.INSTANCE.get("core", "button_video_fps");
+                Object width = DeviceStore.INSTANCE.get("bluetooth", "button_video_width");
+                Object height = DeviceStore.INSTANCE.get("bluetooth", "button_video_height");
+                Object fps = DeviceStore.INSTANCE.get("bluetooth", "button_video_fps");
                 if (width instanceof Number) {
                     videoWidth = ((Number) width).intValue();
                 }
@@ -6361,11 +6361,11 @@ public class MentraLive extends SGCManager {
 
     /**
      * Get the core authentication token.
-     * Reads from GlassesStore first (synced from JS via CoreModule.update), then falls back to
+     * Reads from DeviceStore first (synced from JS via BluetoothSdkModule.update), then falls back to
      * SharedPreferences for backward compatibility.
      */
     private String getCoreToken() {
-        Object fromStore = GlassesStore.INSTANCE.get("core", "core_token");
+        Object fromStore = DeviceStore.INSTANCE.get("bluetooth", "core_token");
         if (fromStore instanceof String) {
             String token = (String) fromStore;
             if (token != null && !token.isEmpty()) {
@@ -6443,7 +6443,7 @@ public class MentraLive extends SGCManager {
      * Send button photo settings to glasses
      */
     public void sendButtonPhotoSettings() {
-        String size = (String) GlassesStore.INSTANCE.get("core", "button_photo_size");
+        String size = (String) DeviceStore.INSTANCE.get("bluetooth", "button_photo_size");
 
         Bridge.log("LIVE: Sending button photo setting: " + size);
 
@@ -6467,7 +6467,7 @@ public class MentraLive extends SGCManager {
      */
     @Override
     public void sendButtonCameraLedSetting() {
-        boolean enabled = (Boolean) GlassesStore.INSTANCE.get("core", "button_camera_led");
+        boolean enabled = (Boolean) DeviceStore.INSTANCE.get("bluetooth", "button_camera_led");
 
         Bridge.log("LIVE: Sending button camera LED setting: " + enabled);
 
@@ -6494,7 +6494,7 @@ public class MentraLive extends SGCManager {
         int fov = 118;
         int roiPosition = 0;
         try {
-            Object raw = GlassesStore.INSTANCE.get("core", "camera_fov");
+            Object raw = DeviceStore.INSTANCE.get("bluetooth", "camera_fov");
             if (raw instanceof java.util.Map) {
                 @SuppressWarnings("unchecked")
                 java.util.Map<String, Object> map = (java.util.Map<String, Object>) raw;
@@ -6540,7 +6540,7 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        Object rawMinutes = GlassesStore.INSTANCE.get("core", "button_max_recording_time");
+        Object rawMinutes = DeviceStore.INSTANCE.get("bluetooth", "button_max_recording_time");
         int minutes = (rawMinutes instanceof Number) ? ((Number) rawMinutes).intValue() : 10;
 
         try {
@@ -6654,9 +6654,9 @@ public class MentraLive extends SGCManager {
 
             // Bridge.log("LIVE: Received LC3 audio packet seq=" + sequenceNumber + ", size=" + lc3Data.length);
 
-            // Forward raw LC3 to CoreManager (matches iOS behavior)
+            // Forward raw LC3 to DeviceManager (matches iOS behavior)
             // MentraLive uses 40-byte LC3 frames
-            CoreManager.getInstance().handleGlassesMicData(lc3Data, LC3_FRAME_SIZE);
+            DeviceManager.getInstance().handleGlassesMicData(lc3Data, LC3_FRAME_SIZE);
 
             // Bridge.log("LIVE: 🔊 Audio playback enabled: " + audioPlaybackEnabled);
         // } else {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -1,7 +1,7 @@
-package com.mentra.core.sgcs
+package com.mentra.bluetoothsdk.sgcs
 
-import com.mentra.core.CoreManager
-import com.mentra.core.GlassesStore
+import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.DeviceStore
 
 import android.graphics.BitmapFactory
 import android.bluetooth.BluetoothAdapter
@@ -36,20 +36,20 @@ import mentraos.ble.MentraosBle.HeadUpAngleResponse
 import mentraos.ble.MentraosBle.HeadPosition
 import mentraos.ble.MentraosBle.DeviceInfo
 
-import com.mentra.core.sgcs.SGCManager
-import com.mentra.core.Bridge
-import com.mentra.core.utils.DeviceTypes
-import com.mentra.core.utils.NexProtobufUtils
-import com.mentra.core.utils.NexEventUtils
-import com.mentra.core.utils.NexBluetoothConstants
-import com.mentra.core.utils.NexDisplayConstants
-import com.mentra.core.utils.NexBluetoothPacketTypes
-import com.mentra.core.utils.BitmapJavaUtils
-import com.mentra.core.utils.G1FontLoaderKt
-import com.mentra.core.utils.G1Text
-import com.mentra.core.utils.ConnTypes
+import com.mentra.bluetoothsdk.sgcs.SGCManager
+import com.mentra.bluetoothsdk.Bridge
+import com.mentra.bluetoothsdk.utils.DeviceTypes
+import com.mentra.bluetoothsdk.utils.NexProtobufUtils
+import com.mentra.bluetoothsdk.utils.NexEventUtils
+import com.mentra.bluetoothsdk.utils.NexBluetoothConstants
+import com.mentra.bluetoothsdk.utils.NexDisplayConstants
+import com.mentra.bluetoothsdk.utils.NexBluetoothPacketTypes
+import com.mentra.bluetoothsdk.utils.BitmapJavaUtils
+import com.mentra.bluetoothsdk.utils.G1FontLoaderKt
+import com.mentra.bluetoothsdk.utils.G1Text
+import com.mentra.bluetoothsdk.utils.ConnTypes
 import com.mentra.lc3Lib.Lc3Cpp
-import com.mentra.core.utils.audio.Lc3Player
+import com.mentra.bluetoothsdk.utils.audio.Lc3Player
 
 import java.util.UUID
 import java.util.concurrent.LinkedBlockingQueue
@@ -201,8 +201,8 @@ class MentraNex : SGCManager() {
         // isDebug = isDebug(context)
         type = DeviceTypes.NEX
         hasMic = true
-        GlassesStore.apply("glasses", "micEnabled", false)
-        preferredMainDeviceId = CoreManager.getInstance().deviceName
+        DeviceStore.apply("glasses", "micEnabled", false)
+        preferredMainDeviceId = DeviceManager.getInstance().deviceName
         
         // Initialize LC3 audio player
         lc3AudioPlayer = Lc3Player(context)
@@ -390,12 +390,12 @@ class MentraNex : SGCManager() {
     }
 
     override fun disconnect() {
-        GlassesStore.apply("glasses", "fullyBooted", false)
+        DeviceStore.apply("glasses", "fullyBooted", false)
         destroy();
     }
 
     override fun forget() {
-        GlassesStore.apply("glasses", "fullyBooted", false)
+        DeviceStore.apply("glasses", "fullyBooted", false)
         destroy();
     }
 
@@ -973,7 +973,7 @@ class MentraNex : SGCManager() {
                             Bridge.log("LC3 player not available - skipping LC3 audio output")
                         }
 
-                        CoreManager.getInstance().handleGlassesMicData(lc3Data);
+                        DeviceManager.getInstance().handleGlassesMicData(lc3Data);
 
                         // Still decode for callback compatibility
                         // TODO: (Verify) Commenting because commented in G1
@@ -1015,7 +1015,7 @@ class MentraNex : SGCManager() {
 
         Bridge.log("attemptGattConnection called for device: $deviceName (${device.address})")
 
-        GlassesStore.apply("glasses", "connectionState", ConnTypes.CONNECTING)
+        DeviceStore.apply("glasses", "connectionState", ConnTypes.CONNECTING)
         Bridge.log("Setting connectionState to CONNECTING. Notifying connectionEvent.")
         // connectionEvent(connectionState)
 
@@ -1054,13 +1054,13 @@ class MentraNex : SGCManager() {
     }
 
     private fun connectToSmartGlasses() {
-        val deviceModelName = CoreManager.getInstance().deviceName
-        val deviceAddress = CoreManager.getInstance().deviceAddress
+        val deviceModelName = DeviceManager.getInstance().deviceName
+        val deviceAddress = DeviceManager.getInstance().deviceAddress
 
         // Register bonding receiver
         Bridge.log("connectToSmartGlasses start")
         Bridge.log("try to ConnectToSmartGlassesing deviceModelName: ${deviceModelName} deviceAddress: ${deviceAddress}")
-        preferredMainDeviceId = CoreManager.getInstance().deviceName
+        preferredMainDeviceId = DeviceManager.getInstance().deviceName
         if (!bluetoothAdapter.isEnabled) {
             return
         }
@@ -1077,7 +1077,7 @@ class MentraNex : SGCManager() {
             else -> {
                 // Start scanning for devices
                 stopScan()
-                GlassesStore.apply("glasses", "connectionState", ConnTypes.SCANNING)
+                DeviceStore.apply("glasses", "connectionState", ConnTypes.SCANNING)
                 // connectionEvent(connectionState) // TODO: Figure out where is connection event defined????
                 startScan()
             }
@@ -1164,7 +1164,7 @@ class MentraNex : SGCManager() {
         Bridge.log("CALL START SCAN - Started scanning for devices...")
 
         // Ensure scanning state is immediately communicated to UI
-        GlassesStore.apply("glasses", "connectionState", ConnTypes.SCANNING)
+        DeviceStore.apply("glasses", "connectionState", ConnTypes.SCANNING)
         // connectionEvent(connectionState)
 
         // Stop the scan after some time (e.g., 10-15s instead of 60 to avoid
@@ -1278,18 +1278,18 @@ class MentraNex : SGCManager() {
 
     private fun updateConnectionState() {
         if (isMainConnected) {
-            GlassesStore.apply("glasses", "connectionState", ConnTypes.CONNECTED)
+            DeviceStore.apply("glasses", "connectionState", ConnTypes.CONNECTED)
             Bridge.log("Nex: Main glasses connected")
             lastConnectionTimestamp = System.currentTimeMillis()
-            GlassesStore.apply("glasses", "fullyBooted", true)
-            GlassesStore.apply("glasses", "connected", true)
+            DeviceStore.apply("glasses", "fullyBooted", true)
+            DeviceStore.apply("glasses", "connected", true)
             // Removed commented sleep code as it's not needed
             // connectionEvent(it)
         } else {
-            GlassesStore.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)
+            DeviceStore.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)
             Bridge.log("Nex: No Main glasses connected")
-            GlassesStore.apply("glasses", "fullyBooted", false)
-            GlassesStore.apply("glasses", "connected", false)
+            DeviceStore.apply("glasses", "fullyBooted", false)
+            DeviceStore.apply("glasses", "connected", false)
             // connectionEvent(it)
         }
     }
@@ -1360,7 +1360,7 @@ class MentraNex : SGCManager() {
             when (glassesToPhone.payloadCase) {
                 GlassesToPhone.PayloadCase.BATTERY_STATUS -> {
                     val batteryStatus: BatteryStatus = glassesToPhone.batteryStatus
-                    GlassesStore.apply("glasses", "batteryLevel", batteryStatus.level)
+                    DeviceStore.apply("glasses", "batteryLevel", batteryStatus.level)
                     // EventBus.getDefault().post(BatteryLevelEvent(batteryStatus.level, batteryStatus.charging))
                     Bridge.log("batteryStatus: $batteryStatus")
                 }
@@ -1434,7 +1434,7 @@ class MentraNex : SGCManager() {
                     Bridge.log("=== RECEIVED GLASSES PROTOBUF VERSION RESPONSE ===")
                     Bridge.log("Glasses Protobuf Version: ${versionResponse.version}")
                     Bridge.log("Message ID: ${versionResponse.msgId}")
-                    GlassesStore.apply("glasses", "protobufVersion", versionResponse.version.toString())
+                    DeviceStore.apply("glasses", "protobufVersion", versionResponse.version.toString())
                     
                     if (versionResponse.commit.isNotEmpty()) {
                         Bridge.log("Commit: ${versionResponse.commit}")
@@ -1531,7 +1531,7 @@ class MentraNex : SGCManager() {
         Bridge.log("Nex: setMicEnabled called with enable: $enable and delay: $delay")
         Bridge.log("Nex: Running set mic enabled: $enable")
         isMicrophoneEnabled = enable // Update the state tracker
-        GlassesStore.apply("glasses", "micEnabled", enable)
+        DeviceStore.apply("glasses", "micEnabled", enable)
 
         micEnableHandler?.postDelayed({
             if (connectionState != ConnTypes.CONNECTED) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -1,7 +1,7 @@
-package com.mentra.core.sgcs
+package com.mentra.bluetoothsdk.sgcs
 
-import com.mentra.core.GlassesStore
-import com.mentra.core.utils.ConnTypes
+import com.mentra.bluetoothsdk.DeviceStore
+import com.mentra.bluetoothsdk.utils.ConnTypes
 
 abstract class SGCManager {
     // Hard coded device properties:
@@ -47,13 +47,13 @@ abstract class SGCManager {
 
     /** Default: full [setDashboardPosition] (e.g. G1 single command). Nex overrides to height protobuf only. */
     open fun setDashboardHeightOnly(height: Int) {
-        val depth = (GlassesStore.store.get("core", "dashboard_depth") as? Number)?.toInt() ?: 2
+        val depth = (DeviceStore.store.get("bluetooth", "dashboard_depth") as? Number)?.toInt() ?: 2
         setDashboardPosition(height, depth)
     }
 
     /** Default: full [setDashboardPosition]. Nex overrides to display_distance only. */
     open fun setDashboardDepthOnly(depth: Int) {
-        val height = (GlassesStore.store.get("core", "dashboard_height") as? Number)?.toInt() ?: 4
+        val height = (DeviceStore.store.get("bluetooth", "dashboard_height") as? Number)?.toInt() ?: 4
         setDashboardPosition(height, depth)
     }
 
@@ -112,91 +112,91 @@ abstract class SGCManager {
     // Version info
     abstract fun requestVersionInfo()
 
-    // GlassesStore-backed read-only getters for convenience
+    // DeviceStore-backed read-only getters for convenience
     val fullyBooted: Boolean
-        get() = GlassesStore.get("glasses", "fullyBooted") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "fullyBooted") as? Boolean ?: false
 
     val connected: Boolean
-        get() = GlassesStore.get("glasses", "connected") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "connected") as? Boolean ?: false
 
     val connectionState: String
-        get() = GlassesStore.get("glasses", "connectionState") as? String ?: ConnTypes.DISCONNECTED
+        get() = DeviceStore.get("glasses", "connectionState") as? String ?: ConnTypes.DISCONNECTED
 
     val appVersion: String
-        get() = GlassesStore.get("glasses", "appVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "appVersion") as? String ?: ""
 
     val buildNumber: String
-        get() = GlassesStore.get("glasses", "buildNumber") as? String ?: ""
+        get() = DeviceStore.get("glasses", "buildNumber") as? String ?: ""
 
     val deviceModel: String
-        get() = GlassesStore.get("glasses", "deviceModel") as? String ?: ""
+        get() = DeviceStore.get("glasses", "deviceModel") as? String ?: ""
 
     val androidVersion: String
-        get() = GlassesStore.get("glasses", "androidVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "androidVersion") as? String ?: ""
 
     val otaVersionUrl: String
-        get() = GlassesStore.get("glasses", "otaVersionUrl") as? String ?: ""
+        get() = DeviceStore.get("glasses", "otaVersionUrl") as? String ?: ""
 
     val firmwareVersion: String
-        get() = GlassesStore.get("glasses", "firmwareVersion") as? String ?: ""
+        get() = DeviceStore.get("glasses", "firmwareVersion") as? String ?: ""
 
     val btMacAddress: String
-        get() = GlassesStore.get("glasses", "btMacAddress") as? String ?: ""
+        get() = DeviceStore.get("glasses", "btMacAddress") as? String ?: ""
 
     val serialNumber: String
-        get() = GlassesStore.get("glasses", "serialNumber") as? String ?: ""
+        get() = DeviceStore.get("glasses", "serialNumber") as? String ?: ""
 
     val style: String
-        get() = GlassesStore.get("glasses", "style") as? String ?: ""
+        get() = DeviceStore.get("glasses", "style") as? String ?: ""
 
     val color: String
-        get() = GlassesStore.get("glasses", "color") as? String ?: ""
+        get() = DeviceStore.get("glasses", "color") as? String ?: ""
 
     val micEnabled: Boolean
-        get() = GlassesStore.get("glasses", "micEnabled") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "micEnabled") as? Boolean ?: false
 
     val vadEnabled: Boolean
-        get() = GlassesStore.get("glasses", "vadEnabled") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "vadEnabled") as? Boolean ?: false
 
     val batteryLevel: Int
-        get() = GlassesStore.get("glasses", "batteryLevel") as? Int ?: -1
+        get() = DeviceStore.get("glasses", "batteryLevel") as? Int ?: -1
 
     val headUp: Boolean
-        get() = GlassesStore.get("glasses", "headUp") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "headUp") as? Boolean ?: false
 
     val charging: Boolean
-        get() = GlassesStore.get("glasses", "charging") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "charging") as? Boolean ?: false
 
     val caseOpen: Boolean
-        get() = GlassesStore.get("glasses", "caseOpen") as? Boolean ?: true
+        get() = DeviceStore.get("glasses", "caseOpen") as? Boolean ?: true
 
     val caseRemoved: Boolean
-        get() = GlassesStore.get("glasses", "caseRemoved") as? Boolean ?: true
+        get() = DeviceStore.get("glasses", "caseRemoved") as? Boolean ?: true
 
     val caseCharging: Boolean
-        get() = GlassesStore.get("glasses", "caseCharging") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "caseCharging") as? Boolean ?: false
 
     val caseBatteryLevel: Int
-        get() = GlassesStore.get("glasses", "caseBatteryLevel") as? Int ?: -1
+        get() = DeviceStore.get("glasses", "caseBatteryLevel") as? Int ?: -1
 
     val wifiSsid: String
-        get() = GlassesStore.get("glasses", "wifiSsid") as? String ?: ""
+        get() = DeviceStore.get("glasses", "wifiSsid") as? String ?: ""
 
     val wifiConnected: Boolean
-        get() = GlassesStore.get("glasses", "wifiConnected") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "wifiConnected") as? Boolean ?: false
 
     val wifiLocalIp: String
-        get() = GlassesStore.get("glasses", "wifiLocalIp") as? String ?: ""
+        get() = DeviceStore.get("glasses", "wifiLocalIp") as? String ?: ""
 
     val hotspotEnabled: Boolean
-        get() = GlassesStore.get("glasses", "hotspotEnabled") as? Boolean ?: false
+        get() = DeviceStore.get("glasses", "hotspotEnabled") as? Boolean ?: false
 
     val hotspotSsid: String
-        get() = GlassesStore.get("glasses", "hotspotSsid") as? String ?: ""
+        get() = DeviceStore.get("glasses", "hotspotSsid") as? String ?: ""
 
     val hotspotPassword: String
-        get() = GlassesStore.get("glasses", "hotspotPassword") as? String ?: ""
+        get() = DeviceStore.get("glasses", "hotspotPassword") as? String ?: ""
 
     val hotspotGatewayIp: String
-        get() = GlassesStore.get("glasses", "hotspotGatewayIp") as? String ?: ""
+        get() = DeviceStore.get("glasses", "hotspotGatewayIp") as? String ?: ""
 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
@@ -1,19 +1,19 @@
-package com.mentra.core.sgcs
+package com.mentra.bluetoothsdk.sgcs
 
-import com.mentra.core.Bridge
-import com.mentra.core.CoreManager
-import com.mentra.core.utils.ConnTypes
-import com.mentra.core.utils.DeviceTypes
-import com.mentra.core.GlassesStore
+import com.mentra.bluetoothsdk.Bridge
+import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.utils.ConnTypes
+import com.mentra.bluetoothsdk.utils.DeviceTypes
+import com.mentra.bluetoothsdk.DeviceStore
 
 class Simulated : SGCManager() {
 
     init {
         type = DeviceTypes.SIMULATED
-        GlassesStore.apply("glasses", "fullyBooted", true)
-        GlassesStore.apply("glasses", "connected", true)
-        GlassesStore.apply("glasses", "connectionState", ConnTypes.CONNECTED)
-        GlassesStore.apply("glasses", "micEnabled", false)
+        DeviceStore.apply("glasses", "fullyBooted", true)
+        DeviceStore.apply("glasses", "connected", true)
+        DeviceStore.apply("glasses", "connectionState", ConnTypes.CONNECTED)
+        DeviceStore.apply("glasses", "micEnabled", false)
     }
 
     // Audio Control

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/STTTools.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/STTTools.kt
@@ -1,8 +1,8 @@
-package com.mentra.core.stt
+package com.mentra.bluetoothsdk.stt
 
 import android.content.Context
 import android.content.SharedPreferences
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.File

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/SherpaOnnxTranscriber.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/SherpaOnnxTranscriber.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.stt
+package com.mentra.bluetoothsdk.stt
 
 import android.content.Context
 import android.content.SharedPreferences
@@ -6,7 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import com.k2fsa.sherpa.onnx.*
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 import java.io.File
 import java.nio.ByteBuffer
 import java.nio.ByteOrder

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/VadGateSpeechPolicy.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/stt/VadGateSpeechPolicy.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.stt
+package com.mentra.bluetoothsdk.stt
 
 import android.content.Context
 import android.util.Log

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/AES.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/AES.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import android.util.Base64;
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/AudioSessionMonitor.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/AudioSessionMonitor.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.utils
+package com.mentra.bluetoothsdk.utils
 
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothDevice
@@ -7,7 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 
 /**
  * Android AudioSessionMonitor - maintains API parity with iOS implementation

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BitmapJavaUtils.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BitmapJavaUtils.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import java.io.File;
 import android.graphics.Bitmap;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/Constants.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/Constants.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.utils
+package com.mentra.bluetoothsdk.utils
 
 object DeviceTypes {
     const val SIMULATED = "Simulated Glasses"

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/G1Text.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/G1Text.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.utils
+package com.mentra.bluetoothsdk.utils
 
 class G1Text {
     companion object {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/IncidentLogBleRelayNaming.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/IncidentLogBleRelayNaming.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import java.util.Locale;
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/IncidentLogBleUploadService.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/IncidentLogBleUploadService.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import android.util.Log;
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import android.content.BroadcastReceiver;
 import android.content.Context;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/MessageChunker.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/MessageChunker.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 import android.util.Log;
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.utils
+package com.mentra.bluetoothsdk.utils
 
 import java.nio.ByteBuffer
 import java.io.IOException
@@ -7,7 +7,7 @@ import java.util.UUID
 import android.content.Context
 import android.util.Log
 
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 
 import mentraos.ble.MentraosBle.DisplayText
 import mentraos.ble.MentraosBle.ClearDisplay

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
@@ -1,4 +1,4 @@
-package com.mentra.core.utils
+package com.mentra.bluetoothsdk.utils
 
 import android.content.Context
 import android.media.AudioManager
@@ -6,7 +6,7 @@ import android.media.AudioPlaybackConfiguration
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
-import com.mentra.core.Bridge
+import com.mentra.bluetoothsdk.Bridge
 
 /**
  * PhoneAudioMonitor - Monitors system audio playback state

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/SmartGlassesConnectionState.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/SmartGlassesConnectionState.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils;
+package com.mentra.bluetoothsdk.utils;
 
 public enum SmartGlassesConnectionState {
     DISCONNECTED,

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/ByteUtilAudioPlayer.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/ByteUtilAudioPlayer.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils.audio;
+package com.mentra.bluetoothsdk.utils.audio;
 
 import android.util.Log;
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/Lc3Player.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/Lc3Player.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils.audio;
+package com.mentra.bluetoothsdk.utils.audio;
 
 import android.content.Context;
 import android.media.AudioFormat;
@@ -18,7 +18,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.mentra.lc3Lib.Lc3Cpp;
-import com.mentra.core.utils.audio.ByteUtilAudioPlayer;
+import com.mentra.bluetoothsdk.utils.audio.ByteUtilAudioPlayer;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/PCMAudioPlayer.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/audio/PCMAudioPlayer.java
@@ -1,4 +1,4 @@
-package com.mentra.core.utils.audio;
+package com.mentra.bluetoothsdk.utils.audio;
 
 import android.content.Context;
 import android.media.AudioDeviceInfo;

--- a/mobile/modules/bluetooth-sdk/expo-module.config.json
+++ b/mobile/modules/bluetooth-sdk/expo-module.config.json
@@ -1,9 +1,9 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": ["CoreModule"]
+    "modules": ["BluetoothSdkModule"]
   },
   "android": {
-    "modules": ["com.mentra.core.CoreModule"]
+    "modules": ["com.mentra.bluetoothsdk.BluetoothSdkModule"]
   }
 }

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -1,16 +1,16 @@
 import ExpoModulesCore
 import Foundation
 
-public class CoreModule: Module, MentraBluetoothSDKDelegate {
+public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
     private var sdk: MentraBluetoothSDK?
 
     public func definition() -> ModuleDefinition {
-        Name("Core")
+        Name("BluetoothSdk")
 
         // Define events that can be sent to JavaScript
         Events(
             "glasses_status",
-            "core_status",
+            "bluetooth_status",
             "log",
             "device_discovered",
             "default_device_changed",
@@ -79,7 +79,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
             }
         }
 
-        Function("getCoreStatus") { () -> [String: Any] in
+        Function("getBluetoothStatus") { () -> [String: Any] in
             self.readOnMainActor {
                 self.bluetoothSdk().bluetoothStatus.values
             }
@@ -96,7 +96,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
                 let normalizedCategory = ObservableStore.normalizeCategory(category)
                 for (key, value) in values {
                     if value is NSNull { continue }
-                    GlassesStore.shared.apply(normalizedCategory, key, value)
+                    DeviceStore.shared.apply(normalizedCategory, key, value)
                 }
             }
         }
@@ -159,7 +159,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         AsyncFunction("connectDefaultController") {
             await MainActor.run {
-                CoreManager.shared.connectDefaultController()
+                DeviceManager.shared.connectDefaultController()
             }
         }
 
@@ -177,7 +177,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         AsyncFunction("disconnectController") {
             await MainActor.run {
-                CoreManager.shared.disconnectController()
+                DeviceManager.shared.disconnectController()
             }
         }
 
@@ -189,7 +189,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         AsyncFunction("forgetController") {
             await MainActor.run {
-                CoreManager.shared.forgetController()
+                DeviceManager.shared.forgetController()
             }
         }
 
@@ -214,21 +214,21 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         AsyncFunction("ping") {
             await MainActor.run {
-                CoreManager.shared.ping()
+                DeviceManager.shared.ping()
             }
         }
 
         AsyncFunction("dbg1") {
             await MainActor.run {
-                CoreManager.shared.dbg1()
-                CoreManager.shared.sgc?.dbg1()
+                DeviceManager.shared.dbg1()
+                DeviceManager.shared.sgc?.dbg1()
             }
         }
 
         AsyncFunction("dbg2") {
             await MainActor.run {
-                CoreManager.shared.dbg2()
-                CoreManager.shared.sgc?.dbg2()
+                DeviceManager.shared.dbg2()
+                DeviceManager.shared.sgc?.dbg2()
             }
         }
 
@@ -417,11 +417,11 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
         }
 
         AsyncFunction("getGlassesMediaVolume") { () async throws -> [String: Any] in
-            try await CoreManager.shared.getGlassesMediaVolume()
+            try await DeviceManager.shared.getGlassesMediaVolume()
         }
 
         AsyncFunction("setGlassesMediaVolume") { (level: Int) async throws -> [String: Any] in
-            try await CoreManager.shared.setGlassesMediaVolume(level: level)
+            try await DeviceManager.shared.setGlassesMediaVolume(level: level)
         }
 
         // MARK: - RGB LED Control
@@ -462,7 +462,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         AsyncFunction("restartTranscriber") {
             await MainActor.run {
-                CoreManager.shared.restartTranscriber()
+                DeviceManager.shared.restartTranscriber()
             }
         }
 
@@ -542,7 +542,7 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
     @MainActor
     public func mentraBluetoothSDK(_: MentraBluetoothSDK, didUpdateBluetoothStatus status: BluetoothStatusUpdate) {
-        sendEvent("core_status", status.values)
+        sendEvent("bluetooth_status", status.values)
     }
 
     @MainActor

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -113,7 +113,7 @@ class Bridge {
     ) {
         Task {
             await MainActor.run {
-                let searchResults = GlassesStore.shared.get("core", "searchResults") as? [[String: Any]] ?? []
+                let searchResults = DeviceStore.shared.get("bluetooth", "searchResults") as? [[String: Any]] ?? []
                 let id = "\(deviceModel):\(deviceName)"
                 var newResult: [String: Any] = [
                     "id": id,
@@ -133,7 +133,7 @@ class Bridge {
                     guard let name = $0["name"] as? String ?? $0["deviceName"] as? String else { return false }
                     return seen.insert("\(model):\(name)").inserted
                 }.reversed()
-                GlassesStore.shared.set("core", "searchResults", Array(uniqueResults))
+                DeviceStore.shared.set("bluetooth", "searchResults", Array(uniqueResults))
             }
         }
     }
@@ -257,7 +257,7 @@ class Bridge {
         Task {
             await MainActor.run {
                 var storedNetworks: [[String: Any]] =
-                    GlassesStore.shared.get("core", "wifiScanResults") as? [[String: Any]] ?? []
+                    DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
                 // add the networks to the storedNetworks array, removing duplicates by ssid
                 for network in networks {
                     if !storedNetworks.contains(where: {
@@ -266,7 +266,7 @@ class Bridge {
                         storedNetworks.append(network)
                     }
                 }
-                GlassesStore.shared.apply("core", "wifiScanResults", storedNetworks)
+                DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
             }
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -22,11 +22,11 @@ struct ViewState {
 }
 
 @MainActor
-@objc(CoreManager) class CoreManager: NSObject {
-    static let shared = CoreManager()
+@objc(DeviceManager) class DeviceManager: NSObject {
+    static let shared = DeviceManager()
 
-    @objc static func getInstance() -> CoreManager {
-        return CoreManager.shared
+    @objc static func getInstance() -> DeviceManager {
+        return DeviceManager.shared
     }
 
     // MARK: - Unique (iOS)
@@ -103,172 +103,172 @@ struct ViewState {
 
     /// settings:
     private var defaultWearable: String {
-        get { GlassesStore.shared.get("core", "default_wearable") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "default_wearable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "default_wearable") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "default_wearable", newValue) }
     }
 
     private var pendingWearable: String {
-        get { GlassesStore.shared.get("core", "pending_wearable") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "pending_wearable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "pending_wearable") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "pending_wearable", newValue) }
     }
 
     private var deviceName: String {
-        get { GlassesStore.shared.get("core", "device_name") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "device_name", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "device_name") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "device_name", newValue) }
     }
 
     private var deviceAddress: String {
-        get { GlassesStore.shared.get("core", "device_address") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "device_address", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "device_address") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "device_address", newValue) }
     }
 
     private var defaultController: String {
-        get { GlassesStore.shared.get("core", "default_controller") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "default_controller", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "default_controller") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "default_controller", newValue) }
     }
 
     private var pendingController: String {
-        get { GlassesStore.shared.get("core", "pending_controller") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "pending_controller", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "pending_controller") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "pending_controller", newValue) }
     }
 
     private var controllerDeviceName: String {
-        get { GlassesStore.shared.get("core", "controller_device_name") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "controller_device_name", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "controller_device_name") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "controller_device_name", newValue) }
     }
 
     private var screenDisabled: Bool {
-        get { GlassesStore.shared.get("core", "screen_disabled") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "screen_disabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "screen_disabled") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "screen_disabled", newValue) }
     }
 
     private var preferredMic: String {
-        get { GlassesStore.shared.get("core", "preferred_mic") as? String ?? "auto" }
-        set { GlassesStore.shared.apply("core", "preferred_mic", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "preferred_mic") as? String ?? "auto" }
+        set { DeviceStore.shared.apply("bluetooth", "preferred_mic", newValue) }
     }
 
     private var autoBrightness: Bool {
-        get { GlassesStore.shared.get("core", "auto_brightness") as? Bool ?? true }
-        set { GlassesStore.shared.apply("core", "auto_brightness", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "auto_brightness") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "auto_brightness", newValue) }
     }
 
     private var brightness: Int {
-        get { GlassesStore.shared.get("core", "brightness") as? Int ?? 50 }
-        set { GlassesStore.shared.apply("core", "brightness", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "brightness") as? Int ?? 50 }
+        set { DeviceStore.shared.apply("bluetooth", "brightness", newValue) }
     }
 
     private var headUpAngle: Int {
-        get { GlassesStore.shared.get("core", "head_up_angle") as? Int ?? 30 }
-        set { GlassesStore.shared.apply("core", "head_up_angle", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "head_up_angle") as? Int ?? 30 }
+        set { DeviceStore.shared.apply("bluetooth", "head_up_angle", newValue) }
     }
 
     private var sensingEnabled: Bool {
-        get { GlassesStore.shared.get("core", "sensing_enabled") as? Bool ?? true }
-        set { GlassesStore.shared.apply("core", "sensing_enabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "sensing_enabled") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "sensing_enabled", newValue) }
     }
 
     private var bypassVad: Bool {
-        get { GlassesStore.shared.get("core", "bypass_vad") as? Bool ?? true }
-        set { GlassesStore.shared.apply("core", "bypass_vad", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "bypass_vad") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "bypass_vad", newValue) }
     }
 
     private var offlineCaptionsRunning: Bool {
-        get { GlassesStore.shared.get("core", "offline_captions_running") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "offline_captions_running", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "offline_captions_running") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "offline_captions_running", newValue) }
     }
 
     private var localSttFallbackActive: Bool {
-        get { GlassesStore.shared.get("core", "local_stt_fallback_active") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "local_stt_fallback_active", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "local_stt_fallback_active") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "local_stt_fallback_active", newValue) }
     }
 
     private var shouldSendPcm: Bool {
-        get { GlassesStore.shared.get("core", "should_send_pcm") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "should_send_pcm", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_pcm") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_pcm", newValue) }
     }
 
     private var shouldSendLc3: Bool {
-        get { GlassesStore.shared.get("core", "should_send_lc3") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "should_send_lc3", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_lc3") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_lc3", newValue) }
     }
 
     private var shouldSendTranscript: Bool {
-        get { GlassesStore.shared.get("core", "should_send_transcript") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "should_send_transcript", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "should_send_transcript") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "should_send_transcript", newValue) }
     }
 
     private var contextualDashboard: Bool {
-        get { GlassesStore.shared.get("core", "contextual_dashboard") as? Bool ?? true }
-        set { GlassesStore.shared.apply("core", "contextual_dashboard", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "contextual_dashboard") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "contextual_dashboard", newValue) }
     }
 
     // state:
 
     private var searching: Bool {
-        get { GlassesStore.shared.get("core", "searching") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "searching", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searching") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "searching", newValue) }
     }
 
     private var searchingController: Bool {
-        get { GlassesStore.shared.get("core", "searchingController") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "searchingController", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searchingController") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "searchingController", newValue) }
     }
 
     private var glassesBtcConnected: Bool {
-        get { GlassesStore.shared.get("glasses", "btcConnected") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "btcConnected", newValue) }
+        get { DeviceStore.shared.get("glasses", "btcConnected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "btcConnected", newValue) }
     }
 
     private var micRanking: [String] {
         get {
-            GlassesStore.shared.get("core", "micRanking") as? [String] ?? MicMap.map["auto"]!
+            DeviceStore.shared.get("bluetooth", "micRanking") as? [String] ?? MicMap.map["auto"]!
         }
-        set { GlassesStore.shared.apply("core", "micRanking", newValue) }
+        set { DeviceStore.shared.apply("bluetooth", "micRanking", newValue) }
     }
 
     private var shouldSendBootingMessage: Bool {
-        get { GlassesStore.shared.get("core", "shouldSendBootingMessage") as? Bool ?? true }
-        set { GlassesStore.shared.apply("core", "shouldSendBootingMessage", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "shouldSendBootingMessage") as? Bool ?? true }
+        set { DeviceStore.shared.apply("bluetooth", "shouldSendBootingMessage", newValue) }
     }
 
     private var systemMicUnavailable: Bool {
-        get { GlassesStore.shared.get("core", "systemMicUnavailable") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "systemMicUnavailable", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "systemMicUnavailable") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "systemMicUnavailable", newValue) }
     }
 
     private var headUp: Bool {
-        get { GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "headUp", newValue) }
+        get { DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "headUp", newValue) }
     }
 
     private var micEnabled: Bool {
-        get { GlassesStore.shared.get("core", "micEnabled") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "micEnabled", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "micEnabled") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "micEnabled", newValue) }
     }
 
     private var currentMic: String {
-        get { GlassesStore.shared.get("core", "currentMic") as? String ?? "" }
-        set { GlassesStore.shared.apply("core", "currentMic", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "currentMic") as? String ?? "" }
+        set { DeviceStore.shared.apply("bluetooth", "currentMic", newValue) }
     }
 
     private var searchResults: [[String: Any]] {
-        get { GlassesStore.shared.get("core", "searchResults") as? [[String: Any]] ?? [] }
-        set { GlassesStore.shared.apply("core", "searchResults", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "searchResults") as? [[String: Any]] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "searchResults", newValue) }
     }
 
     private var wifiScanResults: [[String: Any]] {
-        get { GlassesStore.shared.get("core", "wifiScanResults") as? [[String: Any]] ?? [] }
-        set { GlassesStore.shared.apply("core", "wifiScanResults", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "wifiScanResults", newValue) }
     }
 
     private var lastLog: [String] {
-        get { GlassesStore.shared.get("core", "lastLog") as? [String] ?? [] }
-        set { GlassesStore.shared.apply("core", "lastLog", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "lastLog") as? [String] ?? [] }
+        set { DeviceStore.shared.apply("bluetooth", "lastLog", newValue) }
     }
 
     private var otherBtConnected: Bool {
-        get { GlassesStore.shared.get("core", "otherBtConnected") as? Bool ?? false }
-        set { GlassesStore.shared.apply("core", "otherBtConnected", newValue) }
+        get { DeviceStore.shared.get("bluetooth", "otherBtConnected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("bluetooth", "otherBtConnected", newValue) }
     }
 
     /// LC3 Audio Encoding
@@ -374,7 +374,7 @@ struct ViewState {
             Bridge.log("MAN: ERROR - LC3 converter not initialized but format is LC3")
             return
         }
-        let frameSize = GlassesStore.shared.get("core", "lc3_frame_size") as! Int
+        let frameSize = DeviceStore.shared.get("bluetooth", "lc3_frame_size") as! Int
         let lc3Data = lc3Converter.encode(pcmData, frameSize: frameSize) as Data
         guard lc3Data.count > 0 else {
             Bridge.log("MAN: ERROR - LC3 encoding returned empty data")
@@ -413,7 +413,7 @@ struct ViewState {
     /**
      * Handle raw LC3 audio data from glasses.
      * Decodes the glasses LC3 to PCM, then forwards to handlePcm for processing.
-     * This matches Android behavior - glasses forward raw LC3, CoreManager handles encoding.
+     * This matches Android behavior - glasses forward raw LC3, DeviceManager handles encoding.
      */
     func handleGlassesMicData(_ lc3Data: Data, _ frameSize: Int = 20) {
         lastLc3Event = Date()
@@ -692,7 +692,7 @@ struct ViewState {
             // sgc = FrameManager()
         }
         // update device model:
-        GlassesStore.shared.apply("glasses", "deviceModel", sgc?.type ?? "")
+        DeviceStore.shared.apply("glasses", "deviceModel", sgc?.type ?? "")
     }
 
     func initController(_ controllerModel: String) {
@@ -816,8 +816,8 @@ struct ViewState {
 
     private func checkAndReinitGlassesMic() {
         // if the glasses mic is marked as enabled (and the glasses are connected), but our last known lc3 event is from > 5 seconds ago, reinitialize the mic:
-        let glassesMicEnabled = GlassesStore.shared.get("glasses", "micEnabled") as? Bool ?? false
-        let glassesConnected = GlassesStore.shared.get("glasses", "connected") as? Bool ?? false
+        let glassesMicEnabled = DeviceStore.shared.get("glasses", "micEnabled") as? Bool ?? false
+        let glassesConnected = DeviceStore.shared.get("glasses", "connected") as? Bool ?? false
         if !glassesMicEnabled || !glassesConnected {
             return
         }
@@ -962,9 +962,9 @@ struct ViewState {
         Bridge.saveSetting("device_address", deviceAddress)
 
         // Re-apply display height after reconnection
-        let h = GlassesStore.shared.get("core", "dashboard_height") as? Int ?? 4
+        let h = DeviceStore.shared.get("bluetooth", "dashboard_height") as? Int ?? 4
         let d = NexDashboardDisplayWire.clampDepthFromStore(
-            GlassesStore.shared.get("core", "dashboard_depth")
+            DeviceStore.shared.get("bluetooth", "dashboard_depth")
         )
         sgc.setDashboardPosition(h, d)
     }
@@ -1136,7 +1136,7 @@ struct ViewState {
 
     func requestWifiScan() {
         Bridge.log("MAN: Requesting wifi scan")
-        GlassesStore.shared.apply("core", "wifiScanResults", [])
+        DeviceStore.shared.apply("bluetooth", "wifiScanResults", [])
         sgc?.requestWifiScan()
     }
 
@@ -1242,7 +1242,7 @@ struct ViewState {
     func getGlassesMediaVolume() async throws -> [String: Any] {
         guard let live = sgc as? MentraLive else {
             throw NSError(
-                domain: "CoreManager",
+                domain: "DeviceManager",
                 code: 100,
                 userInfo: [NSLocalizedDescriptionKey: "unsupported_device"]
             )
@@ -1259,7 +1259,7 @@ struct ViewState {
     func setGlassesMediaVolume(level: Int) async throws -> [String: Any] {
         guard let live = sgc as? MentraLive else {
             throw NSError(
-                domain: "CoreManager",
+                domain: "DeviceManager",
                 code: 100,
                 userInfo: [NSLocalizedDescriptionKey: "unsupported_device"]
             )
@@ -1390,12 +1390,12 @@ struct ViewState {
         updateMicState()
         shouldSendBootingMessage = true // Reset for next first connect
         // clear glasses properties:
-        GlassesStore.shared.apply("glasses", "deviceModel", "")
-        GlassesStore.shared.apply("glasses", "fullyBooted", false)
-        GlassesStore.shared.apply("glasses", "connected", false)
+        DeviceStore.shared.apply("glasses", "deviceModel", "")
+        DeviceStore.shared.apply("glasses", "fullyBooted", false)
+        DeviceStore.shared.apply("glasses", "connected", false)
         // disconnect the controller as well:
         searchingController = false
-        GlassesStore.shared.apply("glasses", "controllerConnected", false)
+        DeviceStore.shared.apply("glasses", "controllerConnected", false)
         controller?.disconnect()
         controller = nil // Clear the controller reference after disconnect
     }
@@ -1431,7 +1431,7 @@ struct ViewState {
         controllerDeviceName = ""
         Bridge.saveSetting("controller_device_name", "")
         Bridge.saveSetting("default_controller", "")
-        GlassesStore.shared.apply("glasses", "controllerConnected", false)
+        DeviceStore.shared.apply("glasses", "controllerConnected", false)
     }
 
     func findCompatibleDevices(_ deviceModel: String) {
@@ -1461,8 +1461,8 @@ struct ViewState {
     func stopScan() {
         controller?.stopScan()
         sgc?.stopScan()
-        GlassesStore.shared.apply("core", "searching", false)
-        GlassesStore.shared.apply("core", "searchingController", false)
+        DeviceStore.shared.apply("bluetooth", "searching", false)
+        DeviceStore.shared.apply("bluetooth", "searchingController", false)
     }
 
     func cleanup() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 @MainActor
-class GlassesStore {
-    static let shared = GlassesStore()
+class DeviceStore {
+    static let shared = DeviceStore()
     let store = ObservableStore()
 
     private var dashboardHeightDebounceTask: Task<Void, Never>?
@@ -55,48 +55,48 @@ class GlassesStore {
         store.set("glasses", "ringSignalStrength", -1)
 
         // CORE STATE:
-        store.set("core", "systemMicUnavailable", false)
-        store.set("core", "searching", false)
-        store.set("core", "searchingController", false)
-        store.set("core", "micEnabled", false)
-        store.set("core", "currentMic", "")
-        store.set("core", "searchResults", [])
-        store.set("core", "wifiScanResults", [])
-        store.set("core", "micRanking", MicMap.map["auto"]!)
-        store.set("core", "lastLog", [])
-        store.set("core", "otherBtConnected", false)
+        store.set("bluetooth", "systemMicUnavailable", false)
+        store.set("bluetooth", "searching", false)
+        store.set("bluetooth", "searchingController", false)
+        store.set("bluetooth", "micEnabled", false)
+        store.set("bluetooth", "currentMic", "")
+        store.set("bluetooth", "searchResults", [])
+        store.set("bluetooth", "wifiScanResults", [])
+        store.set("bluetooth", "micRanking", MicMap.map["auto"]!)
+        store.set("bluetooth", "lastLog", [])
+        store.set("bluetooth", "otherBtConnected", false)
 
         // CORE SETTINGS:
-        store.set("core", "default_wearable", "")
-        store.set("core", "pending_wearable", "")
-        store.set("core", "device_name", "")
-        store.set("core", "device_address", "")
-        store.set("core", "screen_disabled", false)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "sensing_enabled", true)
-        store.set("core", "brightness", 50)
-        store.set("core", "auto_brightness", true)
-        store.set("core", "dashboard_height", 4)
-        store.set("core", "dashboard_depth", 2)
-        store.set("core", "head_up_angle", 30)
-        store.set("core", "contextual_dashboard", true)
-        store.set("core", "gallery_mode", true)
-        store.set("core", "screen_disabled", false)
-        store.set("core", "button_photo_size", "medium")
-        store.set("core", "button_camera_led", true)
-        store.set("core", "button_max_recording_time", 10)
-        store.set("core", "camera_fov", ["fov": 118, "roi_position": 0])
-        store.set("core", "button_video_width", 1280)
-        store.set("core", "button_video_height", 720)
-        store.set("core", "button_video_fps", 30)
-        store.set("core", "preferred_mic", "auto")
-        store.set("core", "lc3_frame_size", 60)
-        store.set("core", "auth_email", "")
-        store.set("core", "core_token", "")
-        store.set("core", "should_send_pcm", false)
-        store.set("core", "should_send_lc3", false)
-        store.set("core", "should_send_transcript", false)
-        store.set("core", "bypass_vad", false)
+        store.set("bluetooth", "default_wearable", "")
+        store.set("bluetooth", "pending_wearable", "")
+        store.set("bluetooth", "device_name", "")
+        store.set("bluetooth", "device_address", "")
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "sensing_enabled", true)
+        store.set("bluetooth", "brightness", 50)
+        store.set("bluetooth", "auto_brightness", true)
+        store.set("bluetooth", "dashboard_height", 4)
+        store.set("bluetooth", "dashboard_depth", 2)
+        store.set("bluetooth", "head_up_angle", 30)
+        store.set("bluetooth", "contextual_dashboard", true)
+        store.set("bluetooth", "gallery_mode", true)
+        store.set("bluetooth", "screen_disabled", false)
+        store.set("bluetooth", "button_photo_size", "medium")
+        store.set("bluetooth", "button_camera_led", true)
+        store.set("bluetooth", "button_max_recording_time", 10)
+        store.set("bluetooth", "camera_fov", ["fov": 118, "roi_position": 0])
+        store.set("bluetooth", "button_video_width", 1280)
+        store.set("bluetooth", "button_video_height", 720)
+        store.set("bluetooth", "button_video_fps", 30)
+        store.set("bluetooth", "preferred_mic", "auto")
+        store.set("bluetooth", "lc3_frame_size", 60)
+        store.set("bluetooth", "auth_email", "")
+        store.set("bluetooth", "core_token", "")
+        store.set("bluetooth", "should_send_pcm", false)
+        store.set("bluetooth", "should_send_lc3", false)
+        store.set("bluetooth", "should_send_transcript", false)
+        store.set("bluetooth", "bypass_vad", false)
     }
 
     func get(_ category: String, _ key: String) -> Any? {
@@ -111,8 +111,8 @@ class GlassesStore {
         dashboardHeightDebounceTask?.cancel()
         dashboardHeightDebounceTask = Task { @MainActor in
             try? await Task.yield()
-            let h = store.get("core", "dashboard_height") as? Int ?? 4
-            CoreManager.shared.sgc?.setDashboardHeightOnly(h)
+            let h = store.get("bluetooth", "dashboard_height") as? Int ?? 4
+            DeviceManager.shared.sgc?.setDashboardHeightOnly(h)
         }
     }
 
@@ -120,8 +120,8 @@ class GlassesStore {
         dashboardDepthDebounceTask?.cancel()
         dashboardDepthDebounceTask = Task { @MainActor in
             try? await Task.yield()
-            let d = store.get("core", "dashboard_depth") as? Int ?? 2
-            CoreManager.shared.sgc?.setDashboardDepthOnly(d)
+            let d = store.get("bluetooth", "dashboard_depth") as? Int ?? 2
+            DeviceManager.shared.sgc?.setDashboardDepthOnly(d)
         }
     }
 
@@ -140,9 +140,9 @@ class GlassesStore {
             }
             if let ready = value as? Bool {
                 if ready {
-                    CoreManager.shared.handleDeviceReady()
+                    DeviceManager.shared.handleDeviceReady()
                 } else {
-                    CoreManager.shared.handleDeviceDisconnected()
+                    DeviceManager.shared.handleDeviceDisconnected()
                 }
                 // we shouldn't call store.set in this function as this is only intended for side-effects, not driving state updates
             }
@@ -150,9 +150,9 @@ class GlassesStore {
         case ("glasses", "controllerFullyBooted"):
             if let ready = value as? Bool {
                 if ready {
-                    CoreManager.shared.handleControllerReady()
+                    DeviceManager.shared.handleControllerReady()
                 } else {
-                    CoreManager.shared.handleControllerDisconnected()
+                    DeviceManager.shared.handleControllerDisconnected()
                 }
             }
 
@@ -161,131 +161,131 @@ class GlassesStore {
                 Task {
                     // give the glasses some extra time to finish booting:
                     try? await Task.sleep(nanoseconds: 1_000_000_000)
-                    await CoreManager.shared.sgc?.connectController()
+                    await DeviceManager.shared.sgc?.connectController()
                 }
             }
 
         case ("glasses", "headUp"):
             if let headUp = value as? Bool {
-                CoreManager.shared.sendCurrentState()
+                DeviceManager.shared.sendCurrentState()
                 Bridge.sendHeadUp(headUp)
             }
 
         // BLUETOOTH:
 
-        case ("core", "brightness"):
+        case ("bluetooth", "brightness"):
             let b = value as? Int ?? 50
-            let auto = store.get("core", "auto_brightness") as? Bool ?? true
+            let auto = store.get("bluetooth", "auto_brightness") as? Bool ?? true
             Task {
-                CoreManager.shared.sgc?.setBrightness(b, autoMode: auto)
-                CoreManager.shared.sgc?.sendTextWall("Set brightness to \(b)%")
+                DeviceManager.shared.sgc?.setBrightness(b, autoMode: auto)
+                DeviceManager.shared.sgc?.sendTextWall("Set brightness to \(b)%")
                 try? await Task.sleep(nanoseconds: 800_000_000) // 0.8 seconds
-                CoreManager.shared.sgc?.clearDisplay()
+                DeviceManager.shared.sgc?.clearDisplay()
             }
 
-        case ("core", "auto_brightness"):
-            let b = store.get("core", "brightness") as? Int ?? 50
+        case ("bluetooth", "auto_brightness"):
+            let b = store.get("bluetooth", "brightness") as? Int ?? 50
             let auto = value as? Bool ?? true
             let autoBrightnessChanged = (oldValue as? Bool) != auto
             Task {
-                CoreManager.shared.sgc?.setBrightness(b, autoMode: auto)
+                DeviceManager.shared.sgc?.setBrightness(b, autoMode: auto)
                 if autoBrightnessChanged {
-                    CoreManager.shared.sgc?.sendTextWall(
+                    DeviceManager.shared.sgc?.sendTextWall(
                         auto ? "Enabled auto brightness" : "Disabled auto brightness"
                     )
                     try? await Task.sleep(nanoseconds: 800_000_000) // 0.8 seconds
-                    CoreManager.shared.sgc?.clearDisplay()
+                    DeviceManager.shared.sgc?.clearDisplay()
                 }
             }
 
-        case ("core", "dashboard_height"):
+        case ("bluetooth", "dashboard_height"):
             scheduleDashboardHeightToGlasses()
 
-        case ("core", "dashboard_depth"):
+        case ("bluetooth", "dashboard_depth"):
             scheduleDashboardDepthToGlasses()
 
-        case ("core", "head_up_angle"):
+        case ("bluetooth", "head_up_angle"):
             if let angle = value as? Int {
-                CoreManager.shared.sgc?.setHeadUpAngle(angle)
+                DeviceManager.shared.sgc?.setHeadUpAngle(angle)
             }
 
-        case ("core", "menu_apps"):
+        case ("bluetooth", "menu_apps"):
             if let items = value as? [[String: Any]] {
-                CoreManager.shared.sgc?.setDashboardMenu(items)
+                DeviceManager.shared.sgc?.setDashboardMenu(items)
             }
 
-        case ("core", "gallery_mode"):
-            CoreManager.shared.sgc?.sendGalleryMode()
+        case ("bluetooth", "gallery_mode"):
+            DeviceManager.shared.sgc?.sendGalleryMode()
 
-        case ("core", "screen_disabled"):
+        case ("bluetooth", "screen_disabled"):
             if let disabled = value as? Bool {
                 if disabled {
-                    CoreManager.shared.sgc?.exit()
+                    DeviceManager.shared.sgc?.exit()
                 } else {
-                    CoreManager.shared.sgc?.clearDisplay()
+                    DeviceManager.shared.sgc?.clearDisplay()
                 }
             }
 
-        case ("core", "button_photo_size"):
-            CoreManager.shared.sgc?.sendButtonPhotoSettings()
+        case ("bluetooth", "button_photo_size"):
+            DeviceManager.shared.sgc?.sendButtonPhotoSettings()
 
-        case ("core", "button_camera_led"):
-            CoreManager.shared.sgc?.sendButtonCameraLedSetting()
+        case ("bluetooth", "button_camera_led"):
+            DeviceManager.shared.sgc?.sendButtonCameraLedSetting()
 
-        case ("core", "button_max_recording_time"):
-            CoreManager.shared.sgc?.sendButtonMaxRecordingTime()
+        case ("bluetooth", "button_max_recording_time"):
+            DeviceManager.shared.sgc?.sendButtonMaxRecordingTime()
 
-        case ("core", "camera_fov"):
-            CoreManager.shared.sgc?.sendCameraFovSetting()
+        case ("bluetooth", "camera_fov"):
+            DeviceManager.shared.sgc?.sendCameraFovSetting()
 
-        case ("core", "button_video_width"), ("core", "button_video_height"),
-             ("core", "button_video_fps"):
-            CoreManager.shared.sgc?.sendButtonVideoRecordingSettings()
+        case ("bluetooth", "button_video_width"), ("bluetooth", "button_video_height"),
+             ("bluetooth", "button_video_fps"):
+            DeviceManager.shared.sgc?.sendButtonVideoRecordingSettings()
 
-        case ("core", "preferred_mic"):
+        case ("bluetooth", "preferred_mic"):
             if let mic = value as? String {
-                apply("core", "micRanking", MicMap.map[mic] ?? MicMap.map["auto"]!)
-                CoreManager.shared.setMicState()
+                apply("bluetooth", "micRanking", MicMap.map[mic] ?? MicMap.map["auto"]!)
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "offline_captions_running"):
+        case ("bluetooth", "offline_captions_running"):
             if let running = value as? Bool {
-                CoreManager.shared.setMicState()
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "local_stt_fallback_active"):
+        case ("bluetooth", "local_stt_fallback_active"):
             if let active = value as? Bool {
-                CoreManager.shared.setMicState()
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_pcm"):
+        case ("bluetooth", "should_send_pcm"):
             if let pcm = value as? Bool {
-                CoreManager.shared.setMicState()
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_lc3"):
+        case ("bluetooth", "should_send_lc3"):
             if let lc3 = value as? Bool {
-                CoreManager.shared.setMicState()
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "should_send_transcript"):
+        case ("bluetooth", "should_send_transcript"):
             if let transcript = value as? Bool {
-                CoreManager.shared.setMicState()
+                DeviceManager.shared.setMicState()
             }
 
-        case ("core", "default_wearable"):
+        case ("bluetooth", "default_wearable"):
             if let wearable = value as? String {
                 Bridge.saveSetting("default_wearable", wearable)
                 if wearable == DeviceTypes.SIMULATED {
-                    CoreManager.shared.initSGC(wearable)
+                    DeviceManager.shared.initSGC(wearable)
                 }
             }
 
-        case ("core", "device_name"):
+        case ("bluetooth", "device_name"):
             if let name = value as? String {
-                CoreManager.shared.checkCurrentAudioDevice()
+                DeviceManager.shared.checkCurrentAudioDevice()
                 // listen for when the audio device is paired and connected
-                // CoreManager.shared.setupAudioPairing(deviceName: name)
+                // DeviceManager.shared.setupAudioPairing(deviceName: name)
             }
 
         default:

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1932,7 +1932,7 @@ public final class MentraBluetoothSDK {
                 self?.dispatchBridgeEvent(eventName, data)
             }
         }
-        storeListenerId = GlassesStore.shared.store.addListener { [weak self] category, changes in
+        storeListenerId = DeviceStore.shared.store.addListener { [weak self] category, changes in
             Task { @MainActor [weak self] in
                 self?.dispatchStoreUpdate(category, changes)
             }
@@ -1940,11 +1940,11 @@ public final class MentraBluetoothSDK {
     }
 
     public var glassesStatus: GlassesStatus {
-        GlassesStatus(values: GlassesStore.shared.store.getCategory("glasses"))
+        GlassesStatus(values: DeviceStore.shared.store.getCategory("glasses"))
     }
 
     public var bluetoothStatus: BluetoothStatus {
-        BluetoothStatus(values: GlassesStore.shared.store.getCategory(ObservableStore.coreCategory))
+        BluetoothStatus(values: DeviceStore.shared.store.getCategory(ObservableStore.bluetoothCategory))
     }
 
     public var defaultDevice: Device? {
@@ -1963,9 +1963,9 @@ public final class MentraBluetoothSDK {
         defaultDeviceApplyGeneration += 1
         let generation = defaultDeviceApplyGeneration
         suppressDefaultDeviceEvents = true
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "default_wearable", device.model.deviceType)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "device_name", device.name)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "device_address", device.identifier ?? "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "default_wearable", device.model.deviceType)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "device_name", device.name)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "device_address", device.identifier ?? "")
         finishDefaultDeviceApply(generation: generation)
     }
 
@@ -1973,9 +1973,9 @@ public final class MentraBluetoothSDK {
         defaultDeviceApplyGeneration += 1
         let generation = defaultDeviceApplyGeneration
         suppressDefaultDeviceEvents = true
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "default_wearable", "")
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "device_name", "")
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "device_address", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "default_wearable", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "device_name", "")
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "device_address", "")
         finishDefaultDeviceApply(generation: generation)
     }
 
@@ -1984,13 +1984,13 @@ public final class MentraBluetoothSDK {
             try BluetoothAvailability.shared.requirePoweredOn(operation: "scan for glasses")
         }
         discoveredDeviceNames.removeAll()
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "searching", true)
-        CoreManager.shared.findCompatibleDevices(model.deviceType)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searching", true)
+        DeviceManager.shared.findCompatibleDevices(model.deviceType)
     }
 
     public func stopScan() {
-        CoreManager.shared.stopScan()
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "searching", false)
+        DeviceManager.shared.stopScan()
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searching", false)
         delegate?.mentraBluetoothSDK(self, didStopScan: .cancelled)
     }
 
@@ -2001,7 +2001,7 @@ public final class MentraBluetoothSDK {
         let isController = ControllerTypes.ALL.contains(device.model.deviceType)
         if options.cancelExistingConnectionAttempt {
             if isController {
-                CoreManager.shared.disconnectController()
+                DeviceManager.shared.disconnectController()
             } else {
                 cancelConnectionAttempt()
             }
@@ -2009,8 +2009,8 @@ public final class MentraBluetoothSDK {
         if options.saveAsDefault && !isController {
             setDefaultDevice(device)
         }
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "pending_wearable", device.model.deviceType)
-        CoreManager.shared.connectByName(device.name)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "pending_wearable", device.model.deviceType)
+        DeviceManager.shared.connectByName(device.name)
     }
 
     public func connectDefault(options: ConnectOptions = ConnectOptions()) throws {
@@ -2026,109 +2026,109 @@ public final class MentraBluetoothSDK {
         if options.cancelExistingConnectionAttempt {
             cancelConnectionAttempt()
         }
-        CoreManager.shared.connectDefault()
+        DeviceManager.shared.connectDefault()
     }
 
     public func cancelConnectionAttempt() {
-        CoreManager.shared.disconnect()
+        DeviceManager.shared.disconnect()
     }
 
     public func connectSimulated() {
-        CoreManager.shared.connectSimulated()
+        DeviceManager.shared.connectSimulated()
     }
 
     public func disconnect() {
-        CoreManager.shared.disconnect()
+        DeviceManager.shared.disconnect()
     }
 
     public func forget() {
-        CoreManager.shared.forget()
+        DeviceManager.shared.forget()
     }
 
     public func displayText(_ request: DisplayTextRequest) async throws {
-        CoreManager.shared.displayText(request.dictionary)
+        DeviceManager.shared.displayText(request.dictionary)
     }
 
     public func displayEvent(_ request: DisplayEventRequest) async throws {
-        CoreManager.shared.displayEvent(request.values)
+        DeviceManager.shared.displayEvent(request.values)
     }
 
     public func clearDisplay() async throws {
-        CoreManager.shared.sgc?.clearDisplay()
+        DeviceManager.shared.sgc?.clearDisplay()
     }
 
     public func showDashboard() {
-        CoreManager.shared.showDashboard()
+        DeviceManager.shared.showDashboard()
     }
 
     public func setBrightness(_ level: Int, autoMode: Bool? = nil) async throws {
         if let autoMode {
-            GlassesStore.shared.apply(ObservableStore.coreCategory, "auto_brightness", autoMode)
+            DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "auto_brightness", autoMode)
         }
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "brightness", level)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "brightness", level)
     }
 
     public func setAutoBrightness(enabled: Bool) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "auto_brightness", enabled)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "auto_brightness", enabled)
     }
 
     public func setDashboardPosition(_ request: DashboardPositionRequest) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "dashboard_height", request.height)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "dashboard_depth", request.depth)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "dashboard_height", request.height)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "dashboard_depth", request.depth)
     }
 
     public func setDashboardMenu(_ items: [DashboardMenuItem]) async throws {
-        GlassesStore.shared.apply(
-            ObservableStore.coreCategory,
+        DeviceStore.shared.apply(
+            ObservableStore.bluetoothCategory,
             "menu_apps",
             items.map(\.dictionary)
         )
     }
 
     public func setHeadUpAngle(_ angleDegrees: Int) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "head_up_angle", angleDegrees)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "head_up_angle", angleDegrees)
     }
 
     public func setScreenDisabled(_ disabled: Bool) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "screen_disabled", disabled)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "screen_disabled", disabled)
     }
 
     public func setGalleryMode(_ mode: GalleryMode) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "gallery_mode", mode == .auto)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "gallery_mode", mode == .auto)
     }
 
     public func setButtonPhotoSettings(_ settings: ButtonPhotoSettings) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_photo_size", settings.size.rawValue)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_photo_size", settings.size.rawValue)
     }
 
     public func setButtonVideoRecordingSettings(_ settings: ButtonVideoRecordingSettings) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_video_width", settings.width)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_video_height", settings.height)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_video_fps", settings.fps)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_video_width", settings.width)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_video_height", settings.height)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_video_fps", settings.fps)
     }
 
     public func setButtonCameraLed(enabled: Bool) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_camera_led", enabled)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_camera_led", enabled)
     }
 
     public func setButtonMaxRecordingTime(minutes: Int) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "button_max_recording_time", minutes)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_max_recording_time", minutes)
     }
 
     public func setCameraFov(_ fov: CameraFov) async throws {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "camera_fov", fov.value)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "camera_fov", fov.value)
     }
 
     public func setMicState(_ config: MicConfiguration) {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "should_send_pcm", config.sendPcmData)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "should_send_lc3", config.sendLc3Data)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "should_send_transcript", config.sendTranscript)
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "bypass_vad", config.bypassVad)
-        CoreManager.shared.setMicState()
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "should_send_pcm", config.sendPcmData)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "should_send_lc3", config.sendLc3Data)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "should_send_transcript", config.sendTranscript)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "bypass_vad", config.bypassVad)
+        DeviceManager.shared.setMicState()
     }
 
     public func setPreferredMic(_ preferredMic: MicPreference) {
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "preferred_mic", preferredMic.rawValue)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "preferred_mic", preferredMic.rawValue)
     }
 
     public func setOwnAppAudioPlaying(_ playing: Bool) {
@@ -2136,23 +2136,23 @@ public final class MentraBluetoothSDK {
     }
 
     public func requestWifiScan() {
-        CoreManager.shared.requestWifiScan()
+        DeviceManager.shared.requestWifiScan()
     }
 
     public func sendWifiCredentials(ssid: String, password: String) {
-        CoreManager.shared.sendWifiCredentials(ssid, password)
+        DeviceManager.shared.sendWifiCredentials(ssid, password)
     }
 
     public func forgetWifiNetwork(ssid: String) {
-        CoreManager.shared.forgetWifiNetwork(ssid)
+        DeviceManager.shared.forgetWifiNetwork(ssid)
     }
 
     public func setHotspotState(enabled: Bool) {
-        CoreManager.shared.setHotspotState(enabled)
+        DeviceManager.shared.setHotspotState(enabled)
     }
 
     public func requestPhoto(_ request: PhotoRequest) {
-        CoreManager.shared.photoRequest(
+        DeviceManager.shared.photoRequest(
             request.requestId,
             request.appId,
             request.size.rawValue,
@@ -2165,19 +2165,19 @@ public final class MentraBluetoothSDK {
     }
 
     public func queryGalleryStatus() {
-        CoreManager.shared.queryGalleryStatus()
+        DeviceManager.shared.queryGalleryStatus()
     }
 
     public func startStream(_ request: StreamRequest) {
-        CoreManager.shared.startStream(request.values)
+        DeviceManager.shared.startStream(request.values)
     }
 
     public func keepStreamAlive(_ request: StreamKeepAliveRequest) {
-        CoreManager.shared.keepStreamAlive(request.values)
+        DeviceManager.shared.keepStreamAlive(request.values)
     }
 
     public func rgbLedControl(_ request: RgbLedRequest) {
-        CoreManager.shared.rgbLedControl(
+        DeviceManager.shared.rgbLedControl(
             requestId: request.requestId,
             packageName: request.packageName,
             action: request.action.rawValue,
@@ -2189,11 +2189,11 @@ public final class MentraBluetoothSDK {
     }
 
     public func stopStream() {
-        CoreManager.shared.stopStream()
+        DeviceManager.shared.stopStream()
     }
 
     public func startVideoRecording(_ request: VideoRecordingRequest) {
-        CoreManager.shared.startVideoRecording(
+        DeviceManager.shared.startVideoRecording(
             request.requestId,
             request.save,
             request.flash,
@@ -2202,31 +2202,31 @@ public final class MentraBluetoothSDK {
     }
 
     public func stopVideoRecording(requestId: String) {
-        CoreManager.shared.stopVideoRecording(requestId)
+        DeviceManager.shared.stopVideoRecording(requestId)
     }
 
     public func requestVersionInfo() {
-        CoreManager.shared.requestVersionInfo()
+        DeviceManager.shared.requestVersionInfo()
     }
 
     public func sendOtaStart() {
-        CoreManager.shared.sendOtaStart()
+        DeviceManager.shared.sendOtaStart()
     }
 
     public func sendOtaQueryStatus() {
-        CoreManager.shared.sendOtaQueryStatus()
+        DeviceManager.shared.sendOtaQueryStatus()
     }
 
     public func sendShutdown() {
-        CoreManager.shared.sendShutdown()
+        DeviceManager.shared.sendShutdown()
     }
 
     public func sendReboot() {
-        CoreManager.shared.sendReboot()
+        DeviceManager.shared.sendReboot()
     }
 
     public func sendIncidentId(_ incidentId: String, apiBaseUrl: String? = nil) {
-        CoreManager.shared.sendIncidentId(incidentId, apiBaseUrl: apiBaseUrl)
+        DeviceManager.shared.sendIncidentId(incidentId, apiBaseUrl: apiBaseUrl)
     }
 
     public func invalidate() {
@@ -2235,7 +2235,7 @@ public final class MentraBluetoothSDK {
             self.bridgeEventSinkId = nil
         }
         if let storeListenerId {
-            GlassesStore.shared.store.removeListener(storeListenerId)
+            DeviceStore.shared.store.removeListener(storeListenerId)
             self.storeListenerId = nil
         }
         delegate = nil
@@ -2245,7 +2245,7 @@ public final class MentraBluetoothSDK {
         switch ObservableStore.normalizeCategory(category) {
         case "glasses":
             delegate?.mentraBluetoothSDK(self, didUpdateGlassesStatus: GlassesStatusUpdate(values: glassesStatusChanges(changes)))
-        case ObservableStore.coreCategory:
+        case ObservableStore.bluetoothCategory:
             delegate?.mentraBluetoothSDK(self, didUpdateBluetoothStatus: BluetoothStatusUpdate(values: changes))
             if !suppressDefaultDeviceEvents && changes.keys.contains(where: { defaultDeviceKeys.contains($0) }) {
                 dispatchDefaultDeviceChanged()
@@ -2260,13 +2260,13 @@ public final class MentraBluetoothSDK {
         var merged = changes
 
         if changes.keys.contains(where: { ["wifiConnected", "wifiSsid", "wifiLocalIp"].contains($0) }) {
-            merged["wifiConnected"] = GlassesStore.shared.get("glasses", "wifiConnected") as? Bool ?? false
-            merged["wifiSsid"] = GlassesStore.shared.get("glasses", "wifiSsid") as? String ?? ""
-            merged["wifiLocalIp"] = GlassesStore.shared.get("glasses", "wifiLocalIp") as? String ?? ""
+            merged["wifiConnected"] = DeviceStore.shared.get("glasses", "wifiConnected") as? Bool ?? false
+            merged["wifiSsid"] = DeviceStore.shared.get("glasses", "wifiSsid") as? String ?? ""
+            merged["wifiLocalIp"] = DeviceStore.shared.get("glasses", "wifiLocalIp") as? String ?? ""
         }
 
         if changes["signalStrengthUpdatedAt"] != nil, changes["signalStrength"] == nil {
-            merged["signalStrength"] = GlassesStore.shared.get("glasses", "signalStrength") as? Int ?? -1
+            merged["signalStrength"] = DeviceStore.shared.get("glasses", "signalStrength") as? Int ?? -1
         }
 
         return merged
@@ -2285,7 +2285,7 @@ public final class MentraBluetoothSDK {
     }
 
     private func currentDefaultDevice() -> Device? {
-        let core = GlassesStore.shared.store.getCategory(ObservableStore.coreCategory)
+        let core = DeviceStore.shared.store.getCategory(ObservableStore.bluetoothCategory)
         guard let model = core["default_wearable"] as? String, !model.isEmpty else { return nil }
         guard let name = core["device_name"] as? String, !name.isEmpty else { return nil }
         let identifier = (core["device_address"] as? String).flatMap { $0.isEmpty ? nil : $0 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -1,6 +1,6 @@
 //
 //  ObservableStore.swift
-//  Core
+//  BluetoothSdk
 //
 //  Observable state management with immediate event emission
 //
@@ -13,11 +13,11 @@ class ObservableStore {
     private var onEmit: ((String, [String: Any]) -> Void)?
     private var listeners: [String: (String, [String: Any]) -> Void] = [:]
 
-    nonisolated static let coreCategory = "core"
-    private nonisolated static let legacyBluetoothCategory = "bluetooth"
+    nonisolated static let bluetoothCategory = "bluetooth"
+    private nonisolated static let legacyCoreCategory = "core"
 
     nonisolated static func normalizeCategory(_ category: String) -> String {
-        category == legacyBluetoothCategory ? coreCategory : category
+        category == legacyCoreCategory ? bluetoothCategory : category
     }
 
     func configure(onEmit: @escaping (String, [String: Any]) -> Void) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/controllers/ControllerManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/controllers/ControllerManager.swift
@@ -99,89 +99,89 @@ protocol ControllerManager {
 /// doesn't seem to work for concurrency reasons :(
 /// we can make read-only getters for convienence though:
 extension ControllerManager {
-    // MARK: - Default GlassesStore-backed property implementations
+    // MARK: - Default DeviceStore-backed property implementations
 
     var fullyBooted: Bool {
-        GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
     }
 
     var connected: Bool {
-        GlassesStore.shared.get("glasses", "connected") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "connected") as? Bool ?? false
     }
 
     var appVersion: String {
-        GlassesStore.shared.get("glasses", "appVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "appVersion") as? String ?? ""
     }
 
     var buildNumber: String {
-        GlassesStore.shared.get("glasses", "buildNumber") as? String ?? ""
+        DeviceStore.shared.get("glasses", "buildNumber") as? String ?? ""
     }
 
     var deviceModel: String {
-        GlassesStore.shared.get("glasses", "deviceModel") as? String ?? ""
+        DeviceStore.shared.get("glasses", "deviceModel") as? String ?? ""
     }
 
     var androidVersion: String {
-        GlassesStore.shared.get("glasses", "androidVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "androidVersion") as? String ?? ""
     }
 
     var otaVersionUrl: String {
-        GlassesStore.shared.get("glasses", "otaVersionUrl") as? String ?? ""
+        DeviceStore.shared.get("glasses", "otaVersionUrl") as? String ?? ""
     }
 
     var firmwareVersion: String {
-        GlassesStore.shared.get("glasses", "fwVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "fwVersion") as? String ?? ""
     }
 
     var btMacAddress: String {
-        GlassesStore.shared.get("glasses", "btMacAddress") as? String ?? ""
+        DeviceStore.shared.get("glasses", "btMacAddress") as? String ?? ""
     }
 
     var serialNumber: String {
-        GlassesStore.shared.get("glasses", "serialNumber") as? String ?? ""
+        DeviceStore.shared.get("glasses", "serialNumber") as? String ?? ""
     }
 
     var style: String {
-        GlassesStore.shared.get("glasses", "style") as? String ?? ""
+        DeviceStore.shared.get("glasses", "style") as? String ?? ""
     }
 
     var color: String {
-        GlassesStore.shared.get("glasses", "color") as? String ?? ""
+        DeviceStore.shared.get("glasses", "color") as? String ?? ""
     }
 
     var micEnabled: Bool {
-        GlassesStore.shared.get("glasses", "micEnabled") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "micEnabled") as? Bool ?? false
     }
 
     var vadEnabled: Bool {
-        GlassesStore.shared.get("glasses", "vadEnabled") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "vadEnabled") as? Bool ?? false
     }
 
     var batteryLevel: Int {
-        GlassesStore.shared.get("glasses", "batteryLevel") as? Int ?? -1
+        DeviceStore.shared.get("glasses", "batteryLevel") as? Int ?? -1
     }
 
     var headUp: Bool {
-        GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
     }
 
     var charging: Bool {
-        GlassesStore.shared.get("glasses", "charging") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "charging") as? Bool ?? false
     }
 
     var caseOpen: Bool {
-        GlassesStore.shared.get("glasses", "caseOpen") as? Bool ?? true
+        DeviceStore.shared.get("glasses", "caseOpen") as? Bool ?? true
     }
 
     var caseRemoved: Bool {
-        GlassesStore.shared.get("glasses", "caseRemoved") as? Bool ?? true
+        DeviceStore.shared.get("glasses", "caseRemoved") as? Bool ?? true
     }
 
     var caseCharging: Bool {
-        GlassesStore.shared.get("glasses", "caseCharging") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "caseCharging") as? Bool ?? false
     }
 
     var caseBatteryLevel: Int {
-        GlassesStore.shared.get("glasses", "caseBatteryLevel") as? Int ?? -1
+        DeviceStore.shared.get("glasses", "caseBatteryLevel") as? Int ?? -1
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
@@ -131,7 +131,7 @@ class R1: NSObject, ControllerManager {
     @Published private var _batteryLevel: Int = -1 {
         didSet {
             if _batteryLevel != oldValue && _batteryLevel >= 0 {
-                GlassesStore.shared.apply("glasses", "controllerBatteryLevel", _batteryLevel)
+                DeviceStore.shared.apply("glasses", "controllerBatteryLevel", _batteryLevel)
                 // Bridge.sendBatteryStatus(level: _batteryLevel, charging: isCharging)
             }
         }
@@ -259,7 +259,7 @@ class R1: NSObject, ControllerManager {
     /// to WRITE_CHAR_2 (BAE80012-…). Reverse-engineered from the Even Realities mobile app
     /// (BleRing1CmdProto::advStart -> BleRing1CmdPublicExt.sendCmd).
     private func connectToGlasses() {
-        let glassesMac = (GlassesStore.shared.get("glasses", "btMacAddress") as? String)
+        let glassesMac = (DeviceStore.shared.get("glasses", "btMacAddress") as? String)
             ?? UserDefaults.standard.string(forKey: "glasses_btMacAddress")
 
         guard let glassesMac else {
@@ -307,17 +307,17 @@ class R1: NSObject, ControllerManager {
         Bridge.log("R1: Ring connected")
 
         if let name = ringPeripheral?.name, let id = extractRingId(name) {
-            GlassesStore.shared.apply("core", "controller_device_name", id)
+            DeviceStore.shared.apply("bluetooth", "controller_device_name", id)
         }
 
         guard let mac = ringMacAddress else {
             Bridge.log("R1: No ring MAC address found")
             return
         }
-        GlassesStore.shared.apply("glasses", "controllerMacAddress", mac)
+        DeviceStore.shared.apply("glasses", "controllerMacAddress", mac)
 
-        GlassesStore.shared.apply("glasses", "controllerConnected", true)
-        // GlassesStore.shared.apply("glasses", "controllerFullyBooted", true)
+        DeviceStore.shared.apply("glasses", "controllerConnected", true)
+        // DeviceStore.shared.apply("glasses", "controllerFullyBooted", true)
 
         // tell the ring to connect to the glasses if we have it's mac address:
         connectToGlasses()
@@ -325,7 +325,7 @@ class R1: NSObject, ControllerManager {
         // after a second, connect the glasses to the controller if needed:
         Task {
             try? await Task.sleep(nanoseconds: 1_000_000_000)
-            await CoreManager.shared.sgc?.connectController()
+            await DeviceManager.shared.sgc?.connectController()
         }
 
         startHeartbeat()
@@ -339,7 +339,7 @@ class R1: NSObject, ControllerManager {
         heartbeatTimer = Timer.scheduledTimer(withTimeInterval: 30.0, repeats: true) {
             [weak self] _ in
             DispatchQueue.main.async {
-                guard let self = self, GlassesStore.shared.get("glasses", "controllerConnected") as? Bool ?? false else { return }
+                guard let self = self, DeviceStore.shared.get("glasses", "controllerConnected") as? Bool ?? false else { return }
                 // Read battery if we have the standard battery char
                 if let char = self.batteryLevelChar {
                     self.ringPeripheral?.readValue(for: char)
@@ -421,8 +421,8 @@ class R1: NSObject, ControllerManager {
         notifySubscriptionCount = 0
         initSequenceRun = false
         ringMacAddress = nil
-        GlassesStore.shared.apply("glasses", "controllerConnected", false)
-        GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
+        DeviceStore.shared.apply("glasses", "controllerConnected", false)
+        DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
     }
 
     // MARK: - Reconnection
@@ -431,7 +431,7 @@ class R1: NSObject, ControllerManager {
         Task {
             await reconnectionManager.start { [weak self] in
                 guard let self else { return false }
-                if await MainActor.run(body: { GlassesStore.shared.get("glasses", "controllerConnected") as? Bool ?? false }) {
+                if await MainActor.run(body: { DeviceStore.shared.get("glasses", "controllerConnected") as? Bool ?? false }) {
                     return true // already connected
                 }
                 Bridge.log("R1: Attempting reconnection...")
@@ -626,9 +626,9 @@ extension R1: CBCentralManagerDelegate {
                 self.disconnect()
                 self.ringUUID = nil
                 // we are still searching!:
-                GlassesStore.shared.apply("glasses", "controllerConnected", false)
-                GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
-                GlassesStore.shared.apply("glasses", "controllerSearching", true)
+                DeviceStore.shared.apply("glasses", "controllerConnected", false)
+                DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
+                DeviceStore.shared.apply("glasses", "controllerSearching", true)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
                     self.startScan()
                 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/services/PhoneMic.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/services/PhoneMic.swift
@@ -332,14 +332,14 @@ class PhoneMic {
             if _isRecording {
                 _isRecording = false
                 currentMicMode = ""
-                CoreManager.shared.onInterruption(began: true)
+                DeviceManager.shared.onInterruption(began: true)
             }
         case .ended:
             Bridge.log("Audio session interruption ended")
             if let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt {
                 let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
                 if options.contains(.shouldResume) {
-                    CoreManager.shared.onInterruption(began: false)
+                    DeviceManager.shared.onInterruption(began: false)
                 }
             }
         @unknown default:
@@ -357,7 +357,7 @@ class PhoneMic {
         }
 
         Bridge.log("MIC: handleRouteChange: \(reason)")
-        CoreManager.shared.onRouteChange(
+        DeviceManager.shared.onRouteChange(
             reason: reason, availableInputs: audioSession?.availableInputs ?? []
         )
 
@@ -599,7 +599,7 @@ class PhoneMic {
             }
 
             let pcmData = self.extractInt16Data(from: convertedBuffer)
-            CoreManager.shared.handlePcm(pcmData)
+            DeviceManager.shared.handlePcm(pcmData)
         }
 
         // Start the audio engine

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -368,10 +368,10 @@ class G1: NSObject, SGCManager {
 
     private var _fullyBooted: Bool = false
     var fullyBooted: Bool {
-        get { GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
+        get { DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
         set {
-            let oldValue = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
-            GlassesStore.shared.apply("glasses", "fullyBooted", newValue)
+            let oldValue = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+            DeviceStore.shared.apply("glasses", "fullyBooted", newValue)
             if !newValue {
                 // Reset battery levels when disconnected
                 batteryLevel = -1
@@ -382,8 +382,8 @@ class G1: NSObject, SGCManager {
     }
 
     private var connected: Bool {
-        get { GlassesStore.shared.get("glasses", "connected") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "connected", newValue) }
+        get { DeviceStore.shared.get("glasses", "connected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "connected", newValue) }
     }
 
     var leftReady: Bool = false
@@ -396,23 +396,23 @@ class G1: NSObject, SGCManager {
     @Published var rightBatteryLevel: Int = -1
 
     private var batteryLevel: Int {
-        get { GlassesStore.shared.get("glasses", "batteryLevel") as? Int ?? -1 }
-        set { GlassesStore.shared.apply("glasses", "batteryLevel", newValue) }
+        get { DeviceStore.shared.get("glasses", "batteryLevel") as? Int ?? -1 }
+        set { DeviceStore.shared.apply("glasses", "batteryLevel", newValue) }
     }
 
     private var caseCharging: Bool {
-        get { GlassesStore.shared.get("glasses", "caseCharging") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "caseCharging", newValue) }
+        get { DeviceStore.shared.get("glasses", "caseCharging") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "caseCharging", newValue) }
     }
 
     private var caseOpen: Bool {
-        get { GlassesStore.shared.get("glasses", "caseOpen") as? Bool ?? true }
-        set { GlassesStore.shared.apply("glasses", "caseOpen", newValue) }
+        get { DeviceStore.shared.get("glasses", "caseOpen") as? Bool ?? true }
+        set { DeviceStore.shared.apply("glasses", "caseOpen", newValue) }
     }
 
     private var caseRemoved: Bool {
-        get { GlassesStore.shared.get("glasses", "caseRemoved") as? Bool ?? true }
-        set { GlassesStore.shared.apply("glasses", "caseRemoved", newValue) }
+        get { DeviceStore.shared.get("glasses", "caseRemoved") as? Bool ?? true }
+        set { DeviceStore.shared.apply("glasses", "caseRemoved", newValue) }
     }
 
     var isDisconnecting = false
@@ -1181,7 +1181,7 @@ class G1: NSObject, SGCManager {
             // compressedVoiceData = data
             // skip the first 2 bytes:
             let lc3Data = data.subdata(in: 2 ..< data.count)
-            CoreManager.shared.handleGlassesMicData(lc3Data)
+            DeviceManager.shared.handleGlassesMicData(lc3Data)
         //                CoreCommsService.log("G1: Got voice data: " + String(data.count))
         case .UNK_1:
             handleAck(from: peripheral, success: true)
@@ -1238,16 +1238,16 @@ class G1: NSObject, SGCManager {
             switch DeviceOrders(rawValue: order) {
             case .HEAD_UP:
                 Bridge.log("G1: HEAD_UP")
-                GlassesStore.shared.apply("glasses", "headUp", true)
+                DeviceStore.shared.apply("glasses", "headUp", true)
             case .HEAD_UP2:
                 Bridge.log("G1: HEAD_UP2")
-                GlassesStore.shared.apply("glasses", "headUp", true)
+                DeviceStore.shared.apply("glasses", "headUp", true)
             // case .HEAD_DOWN:
             //   CoreCommsService.log("HEAD_DOWN")
             //   break
             case .HEAD_DOWN2:
                 Bridge.log("G1: HEAD_DOWN2")
-                GlassesStore.shared.apply("glasses", "headUp", false)
+                DeviceStore.shared.apply("glasses", "headUp", false)
             case .ACTIVATED:
                 Bridge.log("G1: ACTIVATED")
             case .SILENCED:
@@ -1290,7 +1290,7 @@ class G1: NSObject, SGCManager {
                 guard data.count >= 3 else { break }
                 if Int(data[2]) != -1 {
                     let newCaseBatteryLevel = Int(data[2])
-                    GlassesStore.shared.apply("glasses", "caseBatteryLevel", newCaseBatteryLevel)
+                    DeviceStore.shared.apply("glasses", "caseBatteryLevel", newCaseBatteryLevel)
                     Bridge.log("G1: Case battery level: \(newCaseBatteryLevel)%")
                 } else {
                     Bridge.log("G1: Case battery level was -1")
@@ -1749,7 +1749,7 @@ extension G1 {
 
     func setMicEnabled(_ enabled: Bool) {
         Bridge.log("G1: setMicEnabled() \(enabled)")
-        GlassesStore.shared.apply("glasses", "micEnabled", enabled)
+        DeviceStore.shared.apply("glasses", "micEnabled", enabled)
         var micOnData = Data()
         micOnData.append(Commands.BLE_REQ_MIC_ON.rawValue)
         if enabled {
@@ -2238,9 +2238,9 @@ extension G1: CBCentralManagerDelegate, CBPeripheralDelegate {
                     Bridge.log("G1: 📱 Style: \(style), Color: \(color)")
 
                     // Store the information
-                    GlassesStore.shared.apply("glasses", "serialNumber", decodedSerial)
-                    GlassesStore.shared.apply("glasses", "style", decodedStyle)
-                    GlassesStore.shared.apply("glasses", "color", decodedColor)
+                    DeviceStore.shared.apply("glasses", "serialNumber", decodedSerial)
+                    DeviceStore.shared.apply("glasses", "style", decodedStyle)
+                    DeviceStore.shared.apply("glasses", "color", decodedColor)
                 } else {
                     Bridge.log("G1: 📱 Could not decode serial number from manufacturer data")
                 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1436,12 +1436,12 @@ class G2: NSObject, SGCManager {
                     Task { await self.reconnectionManager.stop() }
                     Bridge.log("G2: Auth sequence complete, glasses ready")
 
-                    // Set device_name so CoreManager can save it for reconnection
+                    // Set device_name so DeviceManager can save it for reconnection
                     if let peripheralName = self.rightPeripheral?.name
                         ?? self.leftPeripheral?.name,
                         let serialNumber = self.deviceNameToSerialNumber[peripheralName]
                     {
-                        GlassesStore.shared.apply("core", "device_name", serialNumber)
+                        DeviceStore.shared.apply("bluetooth", "device_name", serialNumber)
                         Bridge.log("G2: Set device_name to \(serialNumber)")
                     }
 
@@ -1449,11 +1449,11 @@ class G2: NSObject, SGCManager {
                     let btName =
                         self.rightPeripheral?.name
                             ?? self.leftPeripheral?.name ?? ""
-                    GlassesStore.shared.apply("glasses", "bluetoothName", btName)
-                    GlassesStore.shared.apply("glasses", "deviceModel", DeviceTypes.G2)
+                    DeviceStore.shared.apply("glasses", "bluetoothName", btName)
+                    DeviceStore.shared.apply("glasses", "deviceModel", DeviceTypes.G2)
 
-                    GlassesStore.shared.apply("glasses", "connected", true)
-                    GlassesStore.shared.apply("glasses", "fullyBooted", true)
+                    DeviceStore.shared.apply("glasses", "connected", true)
+                    DeviceStore.shared.apply("glasses", "fullyBooted", true)
 
                     // connnect a controller if we have one:
                     self.connectController()
@@ -1555,7 +1555,7 @@ class G2: NSObject, SGCManager {
     }
 
     private func sendEvenHubHeartbeat() {
-        let isFullyBooted = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        let isFullyBooted = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
         guard isFullyBooted else { return }
 
         let msg = EvenHubProto.heartbeatMessage()
@@ -1572,7 +1572,7 @@ class G2: NSObject, SGCManager {
     }
 
     private func sendDevSettingsHeartbeat() {
-        let isFullyBooted = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        let isFullyBooted = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
         guard isFullyBooted else { return }
         let msg = DevSettingsProto.baseHeartbeat(magicRandom: sendManager.nextMagicRandom())
         sendDevSettingsCommand(msg, left: true, right: true)
@@ -1586,7 +1586,7 @@ class G2: NSObject, SGCManager {
     }
 
     private func sendMenuApps() {
-        let menuItems = GlassesStore.shared.get("core", "menu_apps") as? [[String: Any]] ?? []
+        let menuItems = DeviceStore.shared.get("bluetooth", "menu_apps") as? [[String: Any]] ?? []
         if menuItems.isEmpty {
             return
         }
@@ -1599,7 +1599,7 @@ class G2: NSObject, SGCManager {
         // Bridge.log("G2: sendTextWall(\(text.prefix(50))...)")
 
         // ignore events while the dashboard is open:
-        // let isHeadUp = GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+        // let isHeadUp = DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
         // if isHeadUp {
         //     return
         // }
@@ -2306,10 +2306,10 @@ class G2: NSObject, SGCManager {
 
     func setMicEnabled(_ enabled: Bool) {
         Bridge.log("G2: setMicEnabled(\(enabled))")
-        let currentEnabled = GlassesStore.shared.get("glasses", "micEnabled") as? Bool ?? false
+        let currentEnabled = DeviceStore.shared.get("glasses", "micEnabled") as? Bool ?? false
         if currentEnabled && enabled {
             // if already enabled, set to disabled, then send enabled after 500ms:
-            GlassesStore.shared.apply("glasses", "micEnabled", true)
+            DeviceStore.shared.apply("glasses", "micEnabled", true)
             let msg = EvenHubProto.audioControlMessage(enable: false)
             sendEvenHubCommand(msg)
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
@@ -2320,7 +2320,7 @@ class G2: NSObject, SGCManager {
             return
         }
 
-        GlassesStore.shared.apply("glasses", "micEnabled", enabled)
+        DeviceStore.shared.apply("glasses", "micEnabled", enabled)
         let msg = EvenHubProto.audioControlMessage(enable: enabled)
         sendEvenHubCommand(msg)
     }
@@ -2392,8 +2392,8 @@ class G2: NSObject, SGCManager {
         pageCreated = false
         pageHasTextContainer = false
         heartbeatCounter = 0
-        GlassesStore.shared.apply("glasses", "connected", false)
-        GlassesStore.shared.apply("glasses", "fullyBooted", false)
+        DeviceStore.shared.apply("glasses", "connected", false)
+        DeviceStore.shared.apply("glasses", "fullyBooted", false)
     }
 
     func forget() {
@@ -2427,13 +2427,13 @@ class G2: NSObject, SGCManager {
     }
 
     func connectController() {
-        let isFullyBooted = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        let isFullyBooted = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
         guard isFullyBooted else {
             Bridge.log("G2: connectController - g2 not fully booted, ignoring")
             return
         }
 
-        guard let mac = GlassesStore.shared.get("glasses", "controllerMacAddress") as? String else {
+        guard let mac = DeviceStore.shared.get("glasses", "controllerMacAddress") as? String else {
             Bridge.log("G2: connectController - no MAC address found")
             return
         }
@@ -2456,13 +2456,13 @@ class G2: NSObject, SGCManager {
     }
 
     func disconnectController() {
-        let isFullyBooted = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        let isFullyBooted = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
         guard isFullyBooted else {
             Bridge.log("G2: disconnectController - g2 not fully booted, ignoring")
             return
         }
 
-        guard let mac = GlassesStore.shared.get("glasses", "controllerMacAddress") as? String else {
+        guard let mac = DeviceStore.shared.get("glasses", "controllerMacAddress") as? String else {
             Bridge.log("G2: disconnectController - no MAC address found")
             return
         }
@@ -2482,9 +2482,9 @@ class G2: NSObject, SGCManager {
         )
         sendDevSettingsCommand(msg)
 
-        // GlassesStore.shared.apply("glasses", "controllerMacAddress", "")
-        GlassesStore.shared.apply("glasses", "controllerConnected", false)
-        GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
+        // DeviceStore.shared.apply("glasses", "controllerMacAddress", "")
+        DeviceStore.shared.apply("glasses", "controllerConnected", false)
+        DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
         Bridge.log("G2: Sent RING_DISCONNECT_INFO for MAC \(mac)")
     }
 
@@ -2942,26 +2942,26 @@ class G2: NSObject, SGCManager {
     }
 
     private func setFullyConnected() {
-        let isFullyConnected = GlassesStore.shared.get("glasses", "connected") as? Bool ?? false
-        let isFullyBooted = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        let isFullyConnected = DeviceStore.shared.get("glasses", "connected") as? Bool ?? false
+        let isFullyBooted = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
         if !isFullyConnected {
-            GlassesStore.shared.apply("glasses", "connected", true)
+            DeviceStore.shared.apply("glasses", "connected", true)
         }
         if !isFullyBooted {
-            GlassesStore.shared.apply("glasses", "fullyBooted", true)
+            DeviceStore.shared.apply("glasses", "fullyBooted", true)
         }
     }
 
     private func setControllerFullyConnected() {
         let isControllerConnected =
-            GlassesStore.shared.get("glasses", "controllerConnected") as? Bool ?? false
+            DeviceStore.shared.get("glasses", "controllerConnected") as? Bool ?? false
         let isControllerFullyBooted =
-            GlassesStore.shared.get("glasses", "controllerFullyBooted") as? Bool ?? false
+            DeviceStore.shared.get("glasses", "controllerFullyBooted") as? Bool ?? false
         if !isControllerConnected {
-            GlassesStore.shared.apply("glasses", "controllerConnected", true)
+            DeviceStore.shared.apply("glasses", "controllerConnected", true)
         }
         if !isControllerFullyBooted {
-            GlassesStore.shared.apply("glasses", "controllerFullyBooted", true)
+            DeviceStore.shared.apply("glasses", "controllerFullyBooted", true)
         }
     }
 
@@ -3020,9 +3020,9 @@ class G2: NSObject, SGCManager {
 
             if eventType == .doubleClick {
                 // trigger dashboard:
-                let isHeadUp = GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+                let isHeadUp = DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
                 // toggle head up:
-                GlassesStore.shared.apply("glasses", "headUp", !isHeadUp)
+                DeviceStore.shared.apply("glasses", "headUp", !isHeadUp)
                 if isHeadUp {
                     // Bridge.log("G2: going back to home, clearing display")
                     // clear the display after a delay:
@@ -3033,7 +3033,7 @@ class G2: NSObject, SGCManager {
                 // sendDashboardCommand(DashboardCommand.trigger)
 
                 // toggle head up:
-                // GlassesStore.shared.apply("glasses", "headUp", true)
+                // DeviceStore.shared.apply("glasses", "headUp", true)
                 // runDashboardSequence()
             }
 
@@ -3057,8 +3057,8 @@ class G2: NSObject, SGCManager {
                 currentTextContent = ""
                 currentBitmapBase64 = ""
                 // Firmware kills the mic on system exit; re-arm it if it should be on
-                GlassesStore.shared.apply("glasses", "micEnabled", false)
-                CoreManager.shared.updateMicState()
+                DeviceStore.shared.apply("glasses", "micEnabled", false)
+                DeviceManager.shared.updateMicState()
                 // Force re-create the page to reclaim EvenHub focus
                 // Task {
                 //     try? await Task.sleep(nanoseconds: 1_000_000_000)  // 1000ms for glasses to finish transition
@@ -3123,7 +3123,7 @@ class G2: NSObject, SGCManager {
     }
 
     private func reconnectController() {
-        let mac = GlassesStore.shared.get("glasses", "controllerMacAddress") as? String ?? ""
+        let mac = DeviceStore.shared.get("glasses", "controllerMacAddress") as? String ?? ""
         guard !mac.isEmpty else {
             Bridge.log("G2: reconnectController - no MAC address found")
             return
@@ -3157,9 +3157,9 @@ class G2: NSObject, SGCManager {
             // // if it's 3c or 3d that's disconnected:
             // if connStat == 0x3c || connStat == 0x3d {
             //     Bridge.log("G2: Ring disconnected")
-            //     GlassesStore.shared.apply("glasses", "controllerConnected", false)
-            //     GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
-            //     GlassesStore.shared.apply("glasses", "controllerSearching", true)
+            //     DeviceStore.shared.apply("glasses", "controllerConnected", false)
+            //     DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
+            //     DeviceStore.shared.apply("glasses", "controllerSearching", true)
             // }
 
             // Bridge.log("G2: Ring connection status: connStat=\(connStat)")
@@ -3173,23 +3173,23 @@ class G2: NSObject, SGCManager {
 
                 if ringFields[1] as? Int32 ?? 0 == 1 {
                     Bridge.log("G2: Ring maybe connected?")
-                    // GlassesStore.shared.apply("glasses", "controllerConnected", true)
-                    GlassesStore.shared.apply("glasses", "controllerFullyBooted", true)
+                    // DeviceStore.shared.apply("glasses", "controllerConnected", true)
+                    DeviceStore.shared.apply("glasses", "controllerFullyBooted", true)
                 }
 
                 if ringFields[4] as? Int32 ?? 0 == 62 {
                     Bridge.log("G2: Ring maybe reconnected?")
-                    // GlassesStore.shared.apply("glasses", "controllerConnected", true)
-                    GlassesStore.shared.apply("glasses", "controllerFullyBooted", true)
+                    // DeviceStore.shared.apply("glasses", "controllerConnected", true)
+                    DeviceStore.shared.apply("glasses", "controllerFullyBooted", true)
                 }
             }
 
             // if the data ends in 2016 that's a disconnect?:
             // if data.suffix(4) == Data([0x20, 0x16]) {
             //     Bridge.log("G2: Ring disconnected")
-            //     GlassesStore.shared.apply("glasses", "controllerConnected", false)
-            //     GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
-            //     GlassesStore.shared.apply("glasses", "controllerSearching", true)
+            //     DeviceStore.shared.apply("glasses", "controllerConnected", false)
+            //     DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
+            //     DeviceStore.shared.apply("glasses", "controllerSearching", true)
             // }
 
             if let ringData = fields[5] as? Data { // field 5 = ringInfo
@@ -3202,19 +3202,19 @@ class G2: NSObject, SGCManager {
 
                 if connStatus == 22 {
                     Bridge.log("G2: Ring disconnected")
-                    GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
-                    GlassesStore.shared.apply("glasses", "controllerSearching", true)
+                    DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
+                    DeviceStore.shared.apply("glasses", "controllerSearching", true)
                     reconnectController()
                 }
 
                 if connStatus == 8 {
                     Bridge.log("G2: Ring maybe disconnected?")
-                    // GlassesStore.shared.apply("glasses", "controllerConnected", false)
-                    // GlassesStore.shared.apply("glasses", "controllerFullyBooted", false)
-                    // GlassesStore.shared.apply("glasses", "controllerSearching", true)
+                    // DeviceStore.shared.apply("glasses", "controllerConnected", false)
+                    // DeviceStore.shared.apply("glasses", "controllerFullyBooted", false)
+                    // DeviceStore.shared.apply("glasses", "controllerSearching", true)
                     // reconnectController()
                 }
-                // // GlassesStore.shared.apply("glasses", "ringConnectedToGlasses", connected)
+                // // DeviceStore.shared.apply("glasses", "ringConnectedToGlasses", connected)
             }
         }
 
@@ -3282,14 +3282,14 @@ class G2: NSObject, SGCManager {
             let level = Int(battery)
             if level >= 0 && level <= 100 {
                 // Bridge.log("G2: Battery level: \(level)%")
-                GlassesStore.shared.apply("glasses", "batteryLevel", level)
+                DeviceStore.shared.apply("glasses", "batteryLevel", level)
             }
         }
 
         // Charging status
         if let charging = fields[13] as? Int32 {
             let isCharging = charging != 0
-            GlassesStore.shared.apply("glasses", "charging", isCharging)
+            DeviceStore.shared.apply("glasses", "charging", isCharging)
             // Bridge.log("G2: Charging: \(isCharging)")
             // Re-send battery status with updated charging info
             if batteryLevel >= 0 {
@@ -3302,15 +3302,15 @@ class G2: NSObject, SGCManager {
            let leftVersion = String(data: leftVer, encoding: .utf8)
         {
             // Bridge.log("G2: Left firmware: \(leftVersion)")
-            GlassesStore.shared.apply("glasses", "leftFirmwareVersion", leftVersion)
+            DeviceStore.shared.apply("glasses", "leftFirmwareVersion", leftVersion)
         }
         if let rightVer = fields[6] as? Data,
            let rightVersion = String(data: rightVer, encoding: .utf8)
         {
             // Bridge.log("G2: Right firmware: \(rightVersion)")
-            GlassesStore.shared.apply("glasses", "rightFirmwareVersion", rightVersion)
+            DeviceStore.shared.apply("glasses", "rightFirmwareVersion", rightVersion)
             // Use right version as the main version
-            GlassesStore.shared.apply("glasses", "fwVersion", rightVersion)
+            DeviceStore.shared.apply("glasses", "fwVersion", rightVersion)
         }
     }
 
@@ -3375,14 +3375,14 @@ class G2: NSObject, SGCManager {
         if data == Data([0x08, 0x01, 0x1A, 0x00]) {
             Bridge.log("G2: gesture_ctrl response: dashboard closed")
             // re-send mic on / update mic state:
-            GlassesStore.shared.apply("glasses", "micEnabled", false)
-            CoreManager.shared.updateMicState() // should set the mic back on if it should be on
-            //     // let isHeadUp = GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+            DeviceStore.shared.apply("glasses", "micEnabled", false)
+            DeviceManager.shared.updateMicState() // should set the mic back on if it should be on
+            //     // let isHeadUp = DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
 
             //     // toggle head up:
-            //     GlassesStore.shared.apply("glasses", "headUp", false)
+            //     DeviceStore.shared.apply("glasses", "headUp", false)
             //     // send the current state to the glasses
-            //     CoreManager.shared.sendCurrentState()
+            //     DeviceManager.shared.sendCurrentState()
             // reset the text container (different from clearDisplay())
             sendTextWall(" ")
         }
@@ -3421,9 +3421,9 @@ class G2: NSObject, SGCManager {
         }
         lastAudioFrame = audioData
 
-        // Forward LC3 data to CoreManager for decoding
+        // Forward LC3 data to DeviceManager for decoding
         // G2 uses 40-byte frames (vs G1's 20-byte frames)
-        CoreManager.shared.handleGlassesMicData(audioData, 40)
+        DeviceManager.shared.handleGlassesMicData(audioData, 40)
     }
 }
 
@@ -3496,13 +3496,13 @@ extension G2: CBCentralManagerDelegate {
             // Save MAC per side; ring's advStart needs the left lens MAC.
             if let mac = extractMac(from: mfgData) {
                 if name.contains("_L_") {
-                    GlassesStore.shared.apply("glasses", "leftMacAddress", mac)
-                    GlassesStore.shared.apply("glasses", "btMacAddress", mac)
+                    DeviceStore.shared.apply("glasses", "leftMacAddress", mac)
+                    DeviceStore.shared.apply("glasses", "btMacAddress", mac)
                 } else if name.contains("_R_") {
-                    GlassesStore.shared.apply("glasses", "rightMacAddress", mac)
+                    DeviceStore.shared.apply("glasses", "rightMacAddress", mac)
                 }
             }
-            // GlassesStore.shared.apply("glasses", "signalStrength", RSSI.intValue)
+            // DeviceStore.shared.apply("glasses", "signalStrength", RSSI.intValue)
 
             // Always emit discovered device to frontend
             self.emitDiscoveredDevice(serialNumber)
@@ -3588,8 +3588,8 @@ extension G2: CBCentralManagerDelegate {
             self.startupPageCreated = false
             self.pageCreated = false
             self.pageHasTextContainer = false
-            GlassesStore.shared.apply("glasses", "connected", false)
-            GlassesStore.shared.apply("glasses", "fullyBooted", false)
+            DeviceStore.shared.apply("glasses", "connected", false)
+            DeviceStore.shared.apply("glasses", "fullyBooted", false)
 
             // Start persistent reconnection loop (every 30s, unlimited attempts)
             self.startReconnectionTimer()
@@ -3602,7 +3602,7 @@ extension G2: CBCentralManagerDelegate {
                 guard let self else { return false }
 
                 // Check if already connected
-                if await MainActor.run(body: { GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }) {
+                if await MainActor.run(body: { DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }) {
                     Bridge.log("G2: Already connected, stopping reconnection")
                     return true
                 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
@@ -124,16 +124,16 @@ class Mach1: UltraliteBaseViewController, SGCManager {
     @Published var batteryLevel: Int = -1
     @Published var isConnected: Bool = false
     var ready: Bool {
-        get { GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
+        get { DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
         set {
-            let oldValue = GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
-            GlassesStore.shared.apply("glasses", "fullyBooted", newValue)
+            let oldValue = DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+            DeviceStore.shared.apply("glasses", "fullyBooted", newValue)
         }
     }
 
     private var connected: Bool {
-        get { GlassesStore.shared.get("glasses", "connected") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "connected", newValue) }
+        get { DeviceStore.shared.get("glasses", "connected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "connected", newValue) }
     }
 
     /// Store discovered peripherals by their identifier
@@ -178,7 +178,7 @@ class Mach1: UltraliteBaseViewController, SGCManager {
             guard let self else { return }
             Bridge.log("MACH1: batteryLevelListener: \(value)")
             batteryLevel = value
-            GlassesStore.shared.apply("glasses", "batteryLevel", value)
+            DeviceStore.shared.apply("glasses", "batteryLevel", value)
             ready = true
             connected = true
         })
@@ -216,16 +216,16 @@ class Mach1: UltraliteBaseViewController, SGCManager {
         Bridge.log("MACH1: Tap detected! Count: \(tapNumberInt)")
 
         if tapNumberInt >= 2 {
-            let hUp = GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
-            GlassesStore.shared.apply("glasses", "headUp", !hUp)
+            let hUp = DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
+            DeviceStore.shared.apply("glasses", "headUp", !hUp)
 
             // start a timer and auto turn off the dashboard after 15 seconds:
             if !hUp {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 15) {
                     let currentHeadUp =
-                        GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+                        DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
                     if currentHeadUp {
-                        GlassesStore.shared.apply("glasses", "headUp", false)
+                        DeviceStore.shared.apply("glasses", "headUp", false)
                     }
                 }
             }
@@ -460,7 +460,7 @@ class Mach1: UltraliteBaseViewController, SGCManager {
 
         guard let device = UltraliteManager.shared.currentDevice else {
             Bridge.log("MACH1: No current device")
-            CoreManager.shared.forget()
+            DeviceManager.shared.forget()
             return false
         }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -620,10 +620,10 @@ extension MentraLive: CBCentralManagerDelegate {
         if let name = peripheral.name {
             UserDefaults.standard.set(name, forKey: PREFS_DEVICE_NAME)
             Bridge.log("Saved device name for future reconnection: \(name)")
-            GlassesStore.shared.apply("glasses", "bluetoothName", name)
+            DeviceStore.shared.apply("glasses", "bluetoothName", name)
         }
-        // Persist peripheral UUID so CoreManager can sync it to RN settings
-        GlassesStore.shared.apply("core", "device_address", peripheral.identifier.uuidString)
+        // Persist peripheral UUID so DeviceManager can sync it to RN settings
+        DeviceStore.shared.apply("bluetooth", "device_address", peripheral.identifier.uuidString)
 
         // Audio Pairing: Setup Bluetooth audio after BLE connection
         if let deviceName = peripheral.name {
@@ -763,7 +763,7 @@ extension MentraLive: CBPeripheralDelegate {
             Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...")
 
             // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
-            // GlassesStore handles connected state based on fullyBooted
+            // DeviceStore handles connected state based on fullyBooted
 
             // Keep state as connecting until glasses are ready
             updateConnectionState(ConnTypes.CONNECTING)
@@ -909,14 +909,14 @@ class MentraLive: NSObject, SGCManager {
     /// Mirrors Android `updateConnectionState` — RN home reads `glasses.connectionState` for reconnecting UI.
     private func updateConnectionState(_ state: String) {
         connectionState = state
-        GlassesStore.shared.apply("glasses", "connectionState", state)
+        DeviceStore.shared.apply("glasses", "connectionState", state)
         // Drop OTA caches when fully disconnected — avoids leaking session/step state from
         // a previous pairing into the next one (would otherwise surface as wrong overall_percent
         // or stale lastBesOtaProgress on the next OTA).
         if state == ConnTypes.DISCONNECTED {
             stopSignalStrengthPolling()
-            GlassesStore.shared.apply("glasses", "signalStrength", -1)
-            GlassesStore.shared.apply("glasses", "signalStrengthUpdatedAt", 0)
+            DeviceStore.shared.apply("glasses", "signalStrength", -1)
+            DeviceStore.shared.apply("glasses", "signalStrengthUpdatedAt", 0)
             resetOtaCache()
         }
     }
@@ -964,7 +964,7 @@ class MentraLive: NSObject, SGCManager {
 
     func setMicEnabled(_ enabled: Bool) {
         Bridge.log("LIVE: 🎤 Microphone state change requested: \(enabled)")
-        GlassesStore.shared.apply("glasses", "micEnabled", enabled)
+        DeviceStore.shared.apply("glasses", "micEnabled", enabled)
 
         // Only enable if device supports LC3 audio
         guard supportsLC3Audio else {
@@ -1083,13 +1083,13 @@ class MentraLive: NSObject, SGCManager {
     private var lastReceivedMessageId = 0
 
     private var fullyBooted: Bool {
-        get { GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "fullyBooted", newValue) }
+        get { DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "fullyBooted", newValue) }
     }
 
     private var connected: Bool {
-        get { GlassesStore.shared.get("glasses", "connected") as? Bool ?? false }
-        set { GlassesStore.shared.apply("glasses", "connected", newValue) }
+        get { DeviceStore.shared.get("glasses", "connected") as? Bool ?? false }
+        set { DeviceStore.shared.apply("glasses", "connected", newValue) }
     }
 
     // Queue Management
@@ -1559,7 +1559,7 @@ class MentraLive: NSObject, SGCManager {
             emitDiscoveredDevice(peripheral.name!)
         }
 
-        // var dName = CoreManager.shared.deviceName
+        // var dName = DeviceManager.shared.deviceName
         // if dName.isEmpty {
         //     dName = "MENTRA_LIVE"
         // }
@@ -1580,7 +1580,7 @@ class MentraLive: NSObject, SGCManager {
 
         centralManager?.stopScan()
         isScanning = false
-        GlassesStore.shared.apply(ObservableStore.coreCategory, "searching", false)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searching", false)
         Bridge.log("LIVE: BLE scan stopped")
     }
 
@@ -2061,34 +2061,34 @@ class MentraLive: NSObject, SGCManager {
 
                 // Update local fields for any we recognize
                 if let appVersion = fields["app_version"] as? String {
-                    GlassesStore.shared.apply("glasses", "appVersion", appVersion)
+                    DeviceStore.shared.apply("glasses", "appVersion", appVersion)
                 }
                 if let buildNumber = fields["build_number"] as? String {
                     isNewVersion = (Int(buildNumber) ?? 0) >= 5
-                    GlassesStore.shared.apply("glasses", "buildNumber", buildNumber)
+                    DeviceStore.shared.apply("glasses", "buildNumber", buildNumber)
                 }
                 if let deviceModel = fields["device_model"] as? String {
-                    GlassesStore.shared.apply("glasses", "deviceModel", deviceModel)
+                    DeviceStore.shared.apply("glasses", "deviceModel", deviceModel)
                 }
                 if let androidVersion = fields["android_version"] as? String {
-                    GlassesStore.shared.apply("glasses", "androidVersion", androidVersion)
+                    DeviceStore.shared.apply("glasses", "androidVersion", androidVersion)
                 }
                 if let otaVersionUrl = fields["ota_version_url"] as? String {
-                    GlassesStore.shared.apply("glasses", "otaVersionUrl", otaVersionUrl)
+                    DeviceStore.shared.apply("glasses", "otaVersionUrl", otaVersionUrl)
                 }
                 if let firmwareVersion = fields["firmware_version"] as? String {
-                    GlassesStore.shared.apply("glasses", "fwVersion", firmwareVersion)
+                    DeviceStore.shared.apply("glasses", "fwVersion", firmwareVersion)
                 }
                 if let besFwVersion = fields["bes_fw_version"] as? String {
-                    GlassesStore.shared.apply("glasses", "besFwVersion", besFwVersion)
+                    DeviceStore.shared.apply("glasses", "besFwVersion", besFwVersion)
                 }
                 if let mtkFwVersion = fields["mtk_fw_version"] as? String {
                     // MTK firmware version (e.g., "20241130")
                     // Note: Stored separately from BES version for OTA patch matching
-                    GlassesStore.shared.apply("glasses", "mtkFwVersion", mtkFwVersion)
+                    DeviceStore.shared.apply("glasses", "mtkFwVersion", mtkFwVersion)
                 }
                 if let btMacAddress = fields["bt_mac_address"] as? String {
-                    GlassesStore.shared.apply("glasses", "btMacAddress", btMacAddress)
+                    DeviceStore.shared.apply("glasses", "btMacAddress", btMacAddress)
                 }
 
                 // Send fields immediately to RN - no waiting for other chunks
@@ -2184,7 +2184,7 @@ class MentraLive: NSObject, SGCManager {
                 // SOC is still booting
                 if readyResponse == 0 {
                     Bridge.log("LIVE: K900 SOC not ready (ready=0)")
-                    GlassesStore.shared.apply("glasses", "fullyBooted", false)
+                    DeviceStore.shared.apply("glasses", "fullyBooted", false)
                     Bridge.sendTypedMessage("glasses_not_ready", body: [:])
 
                     // Check for low battery during pairing
@@ -2461,7 +2461,7 @@ class MentraLive: NSObject, SGCManager {
     }
 
     func sendGalleryMode() {
-        let active = GlassesStore.shared.get("core", "gallery_mode") as! Bool
+        let active = DeviceStore.shared.get("bluetooth", "gallery_mode") as! Bool
         Bridge.log("LIVE: 📸 Sending gallery mode active to glasses: \(active)")
 
         let json: [String: Any] = [
@@ -2518,10 +2518,10 @@ class MentraLive: NSObject, SGCManager {
 
         // Invalidate any version fields from a prior link session so the next version_info
         // cannot leave a stale build number in RN (ASG is source of truth for PackageInfo).
-        GlassesStore.shared.apply("glasses", "buildNumber", "")
-        GlassesStore.shared.apply("glasses", "appVersion", "")
-        GlassesStore.shared.apply("glasses", "besFwVersion", "")
-        GlassesStore.shared.apply("glasses", "mtkFwVersion", "")
+        DeviceStore.shared.apply("glasses", "buildNumber", "")
+        DeviceStore.shared.apply("glasses", "appVersion", "")
+        DeviceStore.shared.apply("glasses", "besFwVersion", "")
+        DeviceStore.shared.apply("glasses", "mtkFwVersion", "")
         Bridge.log("LIVE: Cleared cached version_info fields before refresh")
 
         // Perform SOC-dependent initialization
@@ -2589,14 +2589,14 @@ class MentraLive: NSObject, SGCManager {
         let firmwareVersion = json["firmware_version"] as? String ?? ""
         let btMacAddress = json["bt_mac_address"] as? String ?? ""
 
-        GlassesStore.shared.apply("glasses", "appVersion", appVersion)
-        GlassesStore.shared.apply("glasses", "buildNumber", buildNumber)
-        GlassesStore.shared.apply("glasses", "otaVersionUrl", otaVersionUrl)
-        GlassesStore.shared.apply("glasses", "fwVersion", firmwareVersion)
-        GlassesStore.shared.apply("glasses", "btMacAddress", btMacAddress)
+        DeviceStore.shared.apply("glasses", "appVersion", appVersion)
+        DeviceStore.shared.apply("glasses", "buildNumber", buildNumber)
+        DeviceStore.shared.apply("glasses", "otaVersionUrl", otaVersionUrl)
+        DeviceStore.shared.apply("glasses", "fwVersion", firmwareVersion)
+        DeviceStore.shared.apply("glasses", "btMacAddress", btMacAddress)
         isNewVersion = (Int(buildNumber) ?? 0) >= 5
-        GlassesStore.shared.apply("glasses", "deviceModel", deviceModel)
-        GlassesStore.shared.apply("glasses", "androidVersion", androidVersion)
+        DeviceStore.shared.apply("glasses", "deviceModel", deviceModel)
+        DeviceStore.shared.apply("glasses", "androidVersion", androidVersion)
 
         // Detect LC3 audio support: K901+ devices have microphone, K900 does not
         // supportsLC3Audio = deviceModel != "K900"
@@ -2656,13 +2656,13 @@ class MentraLive: NSObject, SGCManager {
         //     return
         // }
 
-        // // Forward PCM data to CoreManager for VAD and server transmission (same as Android)
-        // CoreManager.shared.handlePcm(pcmData)
+        // // Forward PCM data to DeviceManager for VAD and server transmission (same as Android)
+        // DeviceManager.shared.handlePcm(pcmData)
 
         // Bridge.log(
         //     "LIVE: Processed LC3 audio seq=\(sequenceNumber), \(lc3Data.count) bytes"
         // )
-        CoreManager.shared.handleGlassesMicData(lc3Data, 40)
+        DeviceManager.shared.handleGlassesMicData(lc3Data, 40)
 
         // Bridge.log(
         //     "LIVE: Processed LC3 audio seq=\(sequenceNumber), \(lc3Data.count)→\(pcmData.count) bytes"
@@ -3077,7 +3077,7 @@ class MentraLive: NSObject, SGCManager {
     private func uploadBleIncidentLogRelay(
         relay: BleIncidentLogRelayEntry, fileName: String, data: Data
     ) {
-        let token = GlassesStore.shared.get("core", "core_token") as? String ?? ""
+        let token = DeviceStore.shared.get("bluetooth", "core_token") as? String ?? ""
         guard !token.isEmpty else {
             sendTransferCompleteConfirmation(fileName: fileName, success: false)
             if let existing = bleIncidentLogRelays[relay.fileBaseKey] {
@@ -3278,7 +3278,7 @@ class MentraLive: NSObject, SGCManager {
     private func sendCoreTokenToAsgClient() {
         Bridge.log("Preparing to send coreToken to ASG client")
 
-        let coreToken = GlassesStore.shared.get("core", "core_token") as? String ?? ""
+        let coreToken = DeviceStore.shared.get("bluetooth", "core_token") as? String ?? ""
         if coreToken.isEmpty {
             Bridge.log("LIVE: No coreToken available to send to ASG client")
             return
@@ -3295,7 +3295,7 @@ class MentraLive: NSObject, SGCManager {
 
     /// Send stored user email to the ASG client for Sentry crash reporting
     private func sendStoredUserEmailToAsgClient() {
-        let storedEmail = GlassesStore.shared.store.get("core", "auth_email") as? String ?? ""
+        let storedEmail = DeviceStore.shared.store.get("bluetooth", "auth_email") as? String ?? ""
 
         guard !storedEmail.isEmpty else {
             Bridge.log("LIVE: No stored user email to send to ASG client")
@@ -3500,8 +3500,8 @@ class MentraLive: NSObject, SGCManager {
     // MARK: - Update Methods
 
     private func updateBatteryStatus(level: Int, isCharging: Bool) {
-        GlassesStore.shared.apply("glasses", "batteryLevel", level)
-        GlassesStore.shared.apply("glasses", "charging", isCharging)
+        DeviceStore.shared.apply("glasses", "batteryLevel", level)
+        DeviceStore.shared.apply("glasses", "charging", isCharging)
 
         if level >= 0 {
             Bridge.sendBatteryStatus(level: level, charging: isCharging)
@@ -3510,18 +3510,18 @@ class MentraLive: NSObject, SGCManager {
 
     private func updateWifiStatus(connected: Bool, ssid: String, ip: String) {
         Bridge.log("LIVE: 🌐 Updating WiFi status - connected: \(connected), ssid: \(ssid)")
-        GlassesStore.shared.apply("glasses", "wifiConnected", connected)
-        GlassesStore.shared.apply("glasses", "wifiSsid", ssid)
-        GlassesStore.shared.apply("glasses", "wifiLocalIp", ip)
+        DeviceStore.shared.apply("glasses", "wifiConnected", connected)
+        DeviceStore.shared.apply("glasses", "wifiSsid", ssid)
+        DeviceStore.shared.apply("glasses", "wifiLocalIp", ip)
         emitWifiStatusChange()
     }
 
     private func updateHotspotStatus(enabled: Bool, ssid: String, password: String, ip: String) {
         Bridge.log("LIVE: 🔥 Updating hotspot status - enabled: \(enabled), ssid: \(ssid)")
-        GlassesStore.shared.apply("glasses", "hotspotEnabled", enabled)
-        GlassesStore.shared.apply("glasses", "hotspotSsid", ssid)
-        GlassesStore.shared.apply("glasses", "hotspotPassword", password)
-        GlassesStore.shared.apply("glasses", "hotspotGatewayIp", ip) // This is the gateway IP from glasses
+        DeviceStore.shared.apply("glasses", "hotspotEnabled", enabled)
+        DeviceStore.shared.apply("glasses", "hotspotSsid", ssid)
+        DeviceStore.shared.apply("glasses", "hotspotPassword", password)
+        DeviceStore.shared.apply("glasses", "hotspotGatewayIp", ip) // This is the gateway IP from glasses
         emitHotspotStatusChange()
     }
 
@@ -3626,8 +3626,8 @@ class MentraLive: NSObject, SGCManager {
 
     private func updateSignalStrength(_ rssi: Int) {
         let now = Int(Date().timeIntervalSince1970 * 1000)
-        GlassesStore.shared.apply("glasses", "signalStrength", rssi)
-        GlassesStore.shared.apply("glasses", "signalStrengthUpdatedAt", now)
+        DeviceStore.shared.apply("glasses", "signalStrength", rssi)
+        DeviceStore.shared.apply("glasses", "signalStrengthUpdatedAt", now)
         Bridge.log("LIVE: 📶 RSSI: \(rssi) dBm")
     }
 
@@ -3855,15 +3855,15 @@ class MentraLive: NSObject, SGCManager {
             centralManager?.cancelPeripheralConnection(peripheral)
         }
 
-        GlassesStore.shared.apply("glasses", "connected", false)
-        GlassesStore.shared.apply("glasses", "fullyBooted", false)
-        GlassesStore.shared.apply("glasses", "wifiConnected", false)
-        GlassesStore.shared.apply("glasses", "wifiSsid", "")
-        GlassesStore.shared.apply("glasses", "wifiLocalIp", "")
-        GlassesStore.shared.apply("glasses", "hotspotEnabled", false)
-        GlassesStore.shared.apply("glasses", "hotspotSsid", "")
-        GlassesStore.shared.apply("glasses", "hotspotPassword", "")
-        GlassesStore.shared.apply("glasses", "hotspotGatewayIp", "")
+        DeviceStore.shared.apply("glasses", "connected", false)
+        DeviceStore.shared.apply("glasses", "fullyBooted", false)
+        DeviceStore.shared.apply("glasses", "wifiConnected", false)
+        DeviceStore.shared.apply("glasses", "wifiSsid", "")
+        DeviceStore.shared.apply("glasses", "wifiLocalIp", "")
+        DeviceStore.shared.apply("glasses", "hotspotEnabled", false)
+        DeviceStore.shared.apply("glasses", "hotspotSsid", "")
+        DeviceStore.shared.apply("glasses", "hotspotPassword", "")
+        DeviceStore.shared.apply("glasses", "hotspotGatewayIp", "")
 
         connectedPeripheral = nil
         centralManager?.delegate = nil
@@ -4481,7 +4481,7 @@ extension MentraLive {
         sendButtonVideoRecordingSettings()
 
         // Send button max recording time
-        let maxTime = GlassesStore.shared.get("core", "button_max_recording_time") as! Int
+        let maxTime = DeviceStore.shared.get("bluetooth", "button_max_recording_time") as! Int
         sendButtonMaxRecordingTime(maxTime)
 
         // Send button photo settings
@@ -4499,7 +4499,7 @@ extension MentraLive {
 
     func sendButtonVideoRecordingSettings() {
         let settings =
-            GlassesStore.shared.get("core", "button_video_settings") as? [String: Any] ?? [
+            DeviceStore.shared.get("bluetooth", "button_video_settings") as? [String: Any] ?? [
                 "width": 1280,
                 "height": 720,
                 "fps": 30,
@@ -4534,7 +4534,7 @@ extension MentraLive {
     }
 
     func sendButtonMaxRecordingTime() {
-        let maxTime = GlassesStore.shared.get("core", "button_max_recording_time") as? Int ?? 10
+        let maxTime = DeviceStore.shared.get("bluetooth", "button_max_recording_time") as? Int ?? 10
         Bridge.log("Sending button max recording time: \(maxTime) minutes")
 
         guard connectionState == ConnTypes.CONNECTED else {
@@ -4550,7 +4550,7 @@ extension MentraLive {
     }
 
     func sendButtonPhotoSettings() {
-        let size = GlassesStore.shared.get("core", "button_photo_size") as! String
+        let size = DeviceStore.shared.get("bluetooth", "button_photo_size") as! String
 
         Bridge.log("Sending button photo setting: \(size)")
 
@@ -4567,7 +4567,7 @@ extension MentraLive {
     }
 
     func sendButtonCameraLedSetting() {
-        let enabled = GlassesStore.shared.get("core", "button_camera_led") as! Bool
+        let enabled = DeviceStore.shared.get("bluetooth", "button_camera_led") as! Bool
 
         Bridge.log("Sending button camera LED setting: \(enabled)")
 
@@ -4584,7 +4584,7 @@ extension MentraLive {
     }
 
     func sendCameraFovSetting() {
-        let settings = GlassesStore.shared.get("core", "camera_fov") as? [String: Any] ?? ["fov": 118, "roi_position": 0]
+        let settings = DeviceStore.shared.get("bluetooth", "camera_fov") as? [String: Any] ?? ["fov": 118, "roi_position": 0]
         let fov = settings["fov"] as? Int ?? 118
         let roiPosition = settings["roi_position"] as? Int ?? 0
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -1418,8 +1418,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log("NEX: 🔋 Battery Status - Level: \(level)%, Charging: \(isCharging)")
 
         // Update @Published properties (G1-compatible approach)
-        GlassesStore.shared.apply("glasses", "batteryLevel", level)
-        GlassesStore.shared.apply("glasses", "charging", isCharging)
+        DeviceStore.shared.apply("glasses", "batteryLevel", level)
+        DeviceStore.shared.apply("glasses", "charging", isCharging)
     }
 
     private func handleChargingStateProtobuf(_ chargingState: Mentraos_Ble_ChargingState) {
@@ -1428,15 +1428,15 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log("NEX: 🔌 Charging State: \(chargingState ? "CHARGING" : "NOT_CHARGING")")
 
         // Update @Published property (G1-compatible approach)
-        GlassesStore.shared.apply("glasses", "charging", chargingState)
+        DeviceStore.shared.apply("glasses", "charging", chargingState)
     }
 
     private func handleDeviceInfoProtobuf(_ deviceInfo: Mentraos_Ble_DeviceInfo) {
         Bridge.log("NEX: 📱 Device Info: \(deviceInfo)")
 
         // Update @Published properties (G1-compatible approach)
-        GlassesStore.shared.apply("glasses", "deviceFirmwareVersion", deviceInfo.fwVersion)
-        GlassesStore.shared.apply("glasses", "deviceHardwareModel", deviceInfo.hwModel)
+        DeviceStore.shared.apply("glasses", "deviceFirmwareVersion", deviceInfo.fwVersion)
+        DeviceStore.shared.apply("glasses", "deviceHardwareModel", deviceInfo.hwModel)
     }
 
     private func handleHeadPositionProtobuf(_ headPosition: Mentraos_Ble_HeadPosition) {
@@ -1561,7 +1561,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Update @Published properties (G1-compatible approach)
         switch gestureType {
         case .headUp:
-            GlassesStore.shared.apply("glasses", "headUp", true)
+            DeviceStore.shared.apply("glasses", "headUp", true)
             lastHeadGesture = "headUp"
         case .nod:
             lastHeadGesture = "nod"
@@ -1582,8 +1582,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log("NEX: 🔋 JSON Battery Status - Level: \(level)%, Charging: \(charging)")
 
         // Update @Published properties (G1-compatible approach)
-        GlassesStore.shared.apply("glasses", "batteryLevel", level)
-        GlassesStore.shared.apply("glasses", "charging", isCharging)
+        DeviceStore.shared.apply("glasses", "batteryLevel", level)
+        DeviceStore.shared.apply("glasses", "charging", isCharging)
     }
 
     private func handleDeviceInfoJson(_ json: [String: Any]) {
@@ -2172,8 +2172,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         deviceReady = false
         // batteryLevel = -1
         // charging = false
-        GlassesStore.shared.apply("glasses", "batteryLevel", -1)
-        GlassesStore.shared.apply("glasses", "charging", false)
+        DeviceStore.shared.apply("glasses", "batteryLevel", -1)
+        DeviceStore.shared.apply("glasses", "charging", false)
         vadActive = false
         compressedVoiceData = .init()
         aiListening = false

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -114,12 +114,12 @@ extension SGCManager {
     // MARK: - Dashboard (default: combined wire format; Nex implements single-field)
 
     func setDashboardHeightOnly(_ height: Int) {
-        let d = GlassesStore.shared.get("core", "dashboard_depth") as? Int ?? 2
+        let d = DeviceStore.shared.get("bluetooth", "dashboard_depth") as? Int ?? 2
         setDashboardPosition(height, d)
     }
 
     func setDashboardDepthOnly(_ depth: Int) {
-        let h = GlassesStore.shared.get("core", "dashboard_height") as? Int ?? 4
+        let h = DeviceStore.shared.get("bluetooth", "dashboard_height") as? Int ?? 4
         setDashboardPosition(h, depth)
     }
 
@@ -127,117 +127,117 @@ extension SGCManager {
 
     func setDashboardMenu(_: [[String: Any]]) {}
 
-    // MARK: - Default GlassesStore-backed property implementations
+    // MARK: - Default DeviceStore-backed property implementations
 
     var fullyBooted: Bool {
-        GlassesStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "fullyBooted") as? Bool ?? false
     }
 
     var connected: Bool {
-        GlassesStore.shared.get("glasses", "connected") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "connected") as? Bool ?? false
     }
 
     var appVersion: String {
-        GlassesStore.shared.get("glasses", "appVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "appVersion") as? String ?? ""
     }
 
     var buildNumber: String {
-        GlassesStore.shared.get("glasses", "buildNumber") as? String ?? ""
+        DeviceStore.shared.get("glasses", "buildNumber") as? String ?? ""
     }
 
     var deviceModel: String {
-        GlassesStore.shared.get("glasses", "deviceModel") as? String ?? ""
+        DeviceStore.shared.get("glasses", "deviceModel") as? String ?? ""
     }
 
     var androidVersion: String {
-        GlassesStore.shared.get("glasses", "androidVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "androidVersion") as? String ?? ""
     }
 
     var otaVersionUrl: String {
-        GlassesStore.shared.get("glasses", "otaVersionUrl") as? String ?? ""
+        DeviceStore.shared.get("glasses", "otaVersionUrl") as? String ?? ""
     }
 
     var firmwareVersion: String {
-        GlassesStore.shared.get("glasses", "fwVersion") as? String ?? ""
+        DeviceStore.shared.get("glasses", "fwVersion") as? String ?? ""
     }
 
     var btMacAddress: String {
-        GlassesStore.shared.get("glasses", "btMacAddress") as? String ?? ""
+        DeviceStore.shared.get("glasses", "btMacAddress") as? String ?? ""
     }
 
     var serialNumber: String {
-        GlassesStore.shared.get("glasses", "serialNumber") as? String ?? ""
+        DeviceStore.shared.get("glasses", "serialNumber") as? String ?? ""
     }
 
     var style: String {
-        GlassesStore.shared.get("glasses", "style") as? String ?? ""
+        DeviceStore.shared.get("glasses", "style") as? String ?? ""
     }
 
     var color: String {
-        GlassesStore.shared.get("glasses", "color") as? String ?? ""
+        DeviceStore.shared.get("glasses", "color") as? String ?? ""
     }
 
     var micEnabled: Bool {
-        GlassesStore.shared.get("glasses", "micEnabled") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "micEnabled") as? Bool ?? false
     }
 
     var vadEnabled: Bool {
-        GlassesStore.shared.get("glasses", "vadEnabled") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "vadEnabled") as? Bool ?? false
     }
 
     var batteryLevel: Int {
-        GlassesStore.shared.get("glasses", "batteryLevel") as? Int ?? -1
+        DeviceStore.shared.get("glasses", "batteryLevel") as? Int ?? -1
     }
 
     var headUp: Bool {
-        GlassesStore.shared.get("glasses", "headUp") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "headUp") as? Bool ?? false
     }
 
     var charging: Bool {
-        GlassesStore.shared.get("glasses", "charging") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "charging") as? Bool ?? false
     }
 
     var caseOpen: Bool {
-        GlassesStore.shared.get("glasses", "caseOpen") as? Bool ?? true
+        DeviceStore.shared.get("glasses", "caseOpen") as? Bool ?? true
     }
 
     var caseRemoved: Bool {
-        GlassesStore.shared.get("glasses", "caseRemoved") as? Bool ?? true
+        DeviceStore.shared.get("glasses", "caseRemoved") as? Bool ?? true
     }
 
     var caseCharging: Bool {
-        GlassesStore.shared.get("glasses", "caseCharging") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "caseCharging") as? Bool ?? false
     }
 
     var caseBatteryLevel: Int {
-        GlassesStore.shared.get("glasses", "caseBatteryLevel") as? Int ?? -1
+        DeviceStore.shared.get("glasses", "caseBatteryLevel") as? Int ?? -1
     }
 
     var wifiSsid: String {
-        GlassesStore.shared.get("glasses", "wifiSsid") as? String ?? ""
+        DeviceStore.shared.get("glasses", "wifiSsid") as? String ?? ""
     }
 
     var wifiConnected: Bool {
-        GlassesStore.shared.get("glasses", "wifiConnected") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "wifiConnected") as? Bool ?? false
     }
 
     var wifiLocalIp: String {
-        GlassesStore.shared.get("glasses", "wifiLocalIp") as? String ?? ""
+        DeviceStore.shared.get("glasses", "wifiLocalIp") as? String ?? ""
     }
 
     var hotspotEnabled: Bool {
-        GlassesStore.shared.get("glasses", "hotspotEnabled") as? Bool ?? false
+        DeviceStore.shared.get("glasses", "hotspotEnabled") as? Bool ?? false
     }
 
     var hotspotSsid: String {
-        GlassesStore.shared.get("glasses", "hotspotSsid") as? String ?? ""
+        DeviceStore.shared.get("glasses", "hotspotSsid") as? String ?? ""
     }
 
     var hotspotPassword: String {
-        GlassesStore.shared.get("glasses", "hotspotPassword") as? String ?? ""
+        DeviceStore.shared.get("glasses", "hotspotPassword") as? String ?? ""
     }
 
     var hotspotGatewayIp: String {
-        GlassesStore.shared.get("glasses", "hotspotGatewayIp") as? String ?? ""
+        DeviceStore.shared.get("glasses", "hotspotGatewayIp") as? String ?? ""
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
@@ -8,12 +8,12 @@
 @MainActor
 class Simulated: SGCManager {
     init() {
-        GlassesStore.shared.apply("glasses", "fullyBooted", true)
-        GlassesStore.shared.apply("glasses", "connected", true)
-        GlassesStore.shared.apply("glasses", "connectionState", ConnTypes.CONNECTED)
-        GlassesStore.shared.apply("glasses", "micEnabled", false)
-        GlassesStore.shared.apply("glasses", "vadEnabled", false)
-        GlassesStore.shared.apply("glasses", "btcConnected", false)
+        DeviceStore.shared.apply("glasses", "fullyBooted", true)
+        DeviceStore.shared.apply("glasses", "connected", true)
+        DeviceStore.shared.apply("glasses", "connectionState", ConnTypes.CONNECTED)
+        DeviceStore.shared.apply("glasses", "micEnabled", false)
+        DeviceStore.shared.apply("glasses", "vadEnabled", false)
+        DeviceStore.shared.apply("glasses", "btcConnected", false)
     }
 
     // MARK: - Device Information

--- a/mobile/modules/bluetooth-sdk/plugin/src/withIos.ts
+++ b/mobile/modules/bluetooth-sdk/plugin/src/withIos.ts
@@ -13,7 +13,7 @@ const ensureBluetoothSdkExpoAdapterPodEnv = (podfile: string): string => {
   }
 
   const insertion = [
-    "  # Expo apps need the SDK's Expo module adapter so autolinking can register CoreModule.",
+    "  # Expo apps need the SDK's Expo module adapter so autolinking can register BluetoothSdk.",
     `  ${BLUETOOTH_SDK_EXPO_ADAPTER_LINE}`,
     "",
   ].join("\n")

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1,4 +1,4 @@
-// Core Event Types
+// Bluetooth SDK Event Types
 export type GlassesNotReadyEvent = {
   type: "glasses_not_ready"
   message: string
@@ -368,12 +368,12 @@ export type MiniappSelectedEvent = {
   packageName: string
 }
 
-// Union type of all core events
-export type CoreEvent = Parameters<CoreModuleEvents[keyof CoreModuleEvents]>[0]
+// Union type of all Bluetooth SDK events
+export type BluetoothSdkEvent = Parameters<BluetoothSdkModuleEvents[keyof BluetoothSdkModuleEvents]>[0]
 
-export type CoreModuleEvents = {
+export type BluetoothSdkModuleEvents = {
   glasses_status: (changed: Partial<GlassesStatus>) => void
-  core_status: (changed: Partial<CoreStatus>) => void
+  bluetooth_status: (changed: Partial<BluetoothStatus>) => void
   log: (event: LogEvent) => void
   device_discovered: (device: Device) => void
   default_device_changed: (event: {device?: Device}) => void
@@ -539,7 +539,7 @@ export interface WifiSearchResult {
   frequency?: number
 }
 
-export interface CoreStatus {
+export interface BluetoothStatus {
   // state:
   searching: boolean
   searchingController: boolean

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
@@ -2,8 +2,8 @@ import {NativeModule, requireNativeModule} from "expo"
 
 import {
   ConnectOptions,
-  CoreModuleEvents,
-  CoreStatus,
+  BluetoothSdkModuleEvents,
+  BluetoothStatus,
   DeviceScanRequest,
   GalleryMode,
   GlassesMediaVolumeGetResult,
@@ -19,13 +19,13 @@ import {
 } from "./BluetoothSdk.types"
 
 type GlassesListener = (changed: Partial<GlassesStatus>) => void
-type CoreStatusListener = (changed: Partial<CoreStatus>) => void
+type BluetoothStatusListener = (changed: Partial<BluetoothStatus>) => void
 type MaybePromise<T> = T | Promise<T>
 
-declare class CoreModule extends NativeModule<CoreModuleEvents> {
+declare class BluetoothSdkModule extends NativeModule<BluetoothSdkModuleEvents> {
   // Observable Store Functions (native)
   getGlassesStatus(): Promise<GlassesStatus>
-  getCoreStatus(): Promise<CoreStatus>
+  getBluetoothStatus(): Promise<BluetoothStatus>
   getDefaultDevice(): Promise<Device | null>
   update(category: string, values: Record<string, any>): Promise<void>
 
@@ -130,17 +130,17 @@ declare class CoreModule extends NativeModule<CoreModuleEvents> {
 
   // Helper methods for type-safe observable store access
   updateGlasses(values: Partial<GlassesStatus>): Promise<void>
-  updateCore(values: Record<string, any>): Promise<void>
+  updateBluetoothSettings(values: Record<string, any>): Promise<void>
   onGlassesStatus(callback: GlassesListener): () => void
-  onCoreStatus(callback: CoreStatusListener): () => void
+  onBluetoothStatus(callback: BluetoothStatusListener): () => void
 
   // Process resident-set-size in MB. iOS-only; Android stub returns 0.
   getMemoryMB(): number
 }
 
 // This call loads the native module object from the JSI.
-// NativeModule<CoreModuleEvents> already extends EventEmitter<CoreModuleEvents>
-const NativeCoreModule = requireNativeModule<CoreModule>("Core")
+// NativeModule<BluetoothSdkModuleEvents> already extends EventEmitter<BluetoothSdkModuleEvents>
+const NativeBluetoothSdkModule = requireNativeModule<BluetoothSdkModule>("BluetoothSdk")
 
 const DEFAULT_CONNECT_OPTIONS: Required<ConnectOptions> = {
   saveAsDefault: true,
@@ -186,53 +186,53 @@ function adaptGlassesUpdateToNative(values: Partial<GlassesStatus>): Record<stri
 }
 
 // Add helper methods to the module
-const nativeGetGlassesStatus = NativeCoreModule.getGlassesStatus.bind(
-  NativeCoreModule,
+const nativeGetGlassesStatus = NativeBluetoothSdkModule.getGlassesStatus.bind(
+  NativeBluetoothSdkModule,
 ) as () => MaybePromise<GlassesStatus>
-NativeCoreModule.getGlassesStatus = function () {
+NativeBluetoothSdkModule.getGlassesStatus = function () {
   return Promise.resolve(nativeGetGlassesStatus())
 }
 
-const nativeGetCoreStatus = NativeCoreModule.getCoreStatus.bind(NativeCoreModule) as () => MaybePromise<CoreStatus>
-NativeCoreModule.getCoreStatus = function () {
-  return Promise.resolve(nativeGetCoreStatus())
+const nativeGetBluetoothStatus = NativeBluetoothSdkModule.getBluetoothStatus.bind(NativeBluetoothSdkModule) as () => MaybePromise<BluetoothStatus>
+NativeBluetoothSdkModule.getBluetoothStatus = function () {
+  return Promise.resolve(nativeGetBluetoothStatus())
 }
 
-const nativeGetDefaultDevice = NativeCoreModule.getDefaultDevice.bind(
-  NativeCoreModule,
+const nativeGetDefaultDevice = NativeBluetoothSdkModule.getDefaultDevice.bind(
+  NativeBluetoothSdkModule,
 ) as () => MaybePromise<Device | null>
-NativeCoreModule.getDefaultDevice = function () {
+NativeBluetoothSdkModule.getDefaultDevice = function () {
   return Promise.resolve(nativeGetDefaultDevice())
 }
 
-NativeCoreModule.updateGlasses = function (values: Partial<GlassesStatus>) {
+NativeBluetoothSdkModule.updateGlasses = function (values: Partial<GlassesStatus>) {
   return this.update("glasses", adaptGlassesUpdateToNative(values))
 }
 
-NativeCoreModule.updateCore = function (values: Record<string, any>) {
-  return this.update("core", values)
+NativeBluetoothSdkModule.updateBluetoothSettings = function (values: Record<string, any>) {
+  return this.update("bluetooth", values)
 }
 
-NativeCoreModule.onGlassesStatus = function (callback: GlassesListener) {
+NativeBluetoothSdkModule.onGlassesStatus = function (callback: GlassesListener) {
   const subscription = this.addListener("glasses_status", callback)
   return () => subscription.remove()
 }
 
-NativeCoreModule.onCoreStatus = function (callback: CoreStatusListener) {
-  const subscription = this.addListener("core_status", callback)
+NativeBluetoothSdkModule.onBluetoothStatus = function (callback: BluetoothStatusListener) {
+  const subscription = this.addListener("bluetooth_status", callback)
   return () => subscription.remove()
 }
 
-const nativeConnectDefault = NativeCoreModule.connectDefault.bind(NativeCoreModule)
-NativeCoreModule.connectDefault = function (options?: ConnectOptions) {
+const nativeConnectDefault = NativeBluetoothSdkModule.connectDefault.bind(NativeBluetoothSdkModule)
+NativeBluetoothSdkModule.connectDefault = function (options?: ConnectOptions) {
   if (!options) {
     return nativeConnectDefault()
   }
   return this.connectDefaultWithOptions({...DEFAULT_CONNECT_OPTIONS, ...options})
 }
 
-NativeCoreModule.connect = function (device: Device, options?: ConnectOptions) {
+NativeBluetoothSdkModule.connect = function (device: Device, options?: ConnectOptions) {
   return this.connectWithOptions(device, {...DEFAULT_CONNECT_OPTIONS, ...options})
 }
 
-export default NativeCoreModule
+export default NativeBluetoothSdkModule

--- a/mobile/modules/island/src/services/DisplayProcessor.ts
+++ b/mobile/modules/island/src/services/DisplayProcessor.ts
@@ -27,7 +27,7 @@ import {
   type BreakMode,
 } from "../utils/display"
 
-import CoreModule, {GlassesStatus} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {GlassesStatus} from "@mentra/bluetooth-sdk"
 
 import {getRuntimeHooks, ISLAND_SETTINGS_KEYS} from "../runtime/config"
 
@@ -289,7 +289,7 @@ export class DisplayProcessor {
     }
 
     // subscribe to glasses status changes:
-    CoreModule.onGlassesStatus((changed: Partial<GlassesStatus>) => {
+    BluetoothSdk.onGlassesStatus((changed: Partial<GlassesStatus>) => {
       if (changed.deviceModel) {
         this.setDeviceModel(changed.deviceModel)
       }

--- a/mobile/modules/island/src/services/LocalDisplayManager.ts
+++ b/mobile/modules/island/src/services/LocalDisplayManager.ts
@@ -19,7 +19,7 @@
  * is off.
  */
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import displayProcessor from "./DisplayProcessor"
 import {getRuntimeHooks} from "../runtime/config"
@@ -373,7 +373,7 @@ class LocalDisplayManager {
     }
 
     try {
-      CoreModule.displayEvent(processedEvent)
+      BluetoothSdk.displayEvent(processedEvent)
       getRuntimeHooks().setDisplayEvent?.(JSON.stringify(processedEvent))
     } catch (err) {
       console.error(`${LOG_TAG}: native display failed:`, err)

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -15,7 +15,7 @@ import * as Battery from "expo-battery"
 import * as Clipboard from "expo-clipboard"
 import {File, Paths} from "expo-file-system"
 import * as Location from "expo-location"
-import CoreModule, {type RgbLedAction, type RgbLedColor} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {type RgbLedAction, type RgbLedColor} from "@mentra/bluetooth-sdk"
 
 import {
   MiniappErrorCode,
@@ -830,7 +830,7 @@ class LocalMiniappRuntime {
       }
 
       // Hand off to LocalDisplayManager — it owns boot/throttle/arbitration/
-      // expiry + the native CoreModule.displayEvent call + useDisplayStore.
+      // expiry + the native BluetoothSdk.displayEvent call + useDisplayStore.
       localDisplayManager.request(packageName, {
         view: (payload.view as DisplayPayload["view"]) ?? "main",
         layout: payload.layout as DisplayPayload["layout"],
@@ -970,7 +970,7 @@ class LocalMiniappRuntime {
     const action = normalizeRgbLedAction(payload.action)
     const color = normalizeRgbLedColor(payload.color)
 
-    CoreModule.rgbLedControl(
+    BluetoothSdk.rgbLedControl(
       ledRequestId,
       packageName,
       action,
@@ -1452,7 +1452,7 @@ class LocalMiniappRuntime {
    *
    * Cloud-dependent streams (transcription:*, translation:*) only flow if the
    * cloud knows the phone wants them. Local-only streams (button_press, etc.)
-   * are NOT sent — they come from CoreModule, not from cloud.
+   * are NOT sent — they come from the Bluetooth SDK, not from cloud.
    */
   private updateCloudSubscriptions(): void {
     const cloudStreams = new Set<string>()
@@ -1553,8 +1553,8 @@ class LocalMiniappRuntime {
    * Translate cloud event names to miniapp stream type values.
    */
   private normalizeStreamType(cloudEventName: string): string {
-    // Cloud / CoreModule → miniapp protocol translations.
-    // CoreModule event names don't always match the miniapp wire values.
+    // Cloud / Bluetooth SDK → miniapp protocol translations.
+    // Bluetooth SDK event names don't always match the miniapp wire values.
     switch (cloudEventName) {
       case "head_up":
         return MiniappStreamType.HEAD_POSITION // head_up → head_position

--- a/mobile/modules/island/src/services/LocalSttFallbackCoordinator.ts
+++ b/mobile/modules/island/src/services/LocalSttFallbackCoordinator.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {getRuntimeHooks, ISLAND_SETTINGS_KEYS} from "../runtime/config"
 
@@ -71,7 +71,7 @@ class LocalSttFallbackCoordinator {
   private async startLocalStt(): Promise<void> {
     this.log("starting local stt")
     try {
-      await CoreModule.restartTranscriber()
+      await BluetoothSdk.restartTranscriber()
     } catch (err) {
       this.log(`restartTranscriber failed: ${err}`)
     }

--- a/mobile/modules/island/src/services/MicStateCoordinator.ts
+++ b/mobile/modules/island/src/services/MicStateCoordinator.ts
@@ -6,10 +6,10 @@
  * The cloud sends mic state changes via SocketComms (e.g., "pcm", "transcription").
  * Local miniapps subscribe to audio_chunk / transcription streams.
  * This coordinator merges both sets of requirements and pushes the union to
- * CoreModule so the mic runs whenever at least one consumer needs it.
+ * BluetoothSdk so the mic runs whenever at least one consumer needs it.
  */
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 const LOG_TAG = "MIC_COORDINATOR"
 
@@ -62,7 +62,7 @@ class MicStateCoordinator {
   }
 
   /**
-   * Compute the union of cloud and local requirements and push to CoreModule.
+   * Compute the union of cloud and local requirements and push to BluetoothSdk.
    *
    * Wire-format note: the cloud only ever receives LC3 over the binary
    * WebSocket. Its `requiredData=["pcm"]` is a logical "I need audio"
@@ -81,7 +81,7 @@ class MicStateCoordinator {
     //   `${LOG_TAG}: applying union — pcm=${shouldSendPcm} lc3=${shouldSendLc3} transcript=${shouldSendTranscript} bypass_vad=${bypassVad}`,
     // )
 
-    CoreModule.update("core", {
+    BluetoothSdk.update("core", {
       should_send_pcm: shouldSendPcm,
       should_send_lc3: shouldSendLc3,
       should_send_transcript: shouldSendTranscript,

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -81,7 +81,7 @@ jest.mock("@/components/glasses/GlassesPairingLoader", () => {
 import {act, render, waitFor} from "@testing-library/react-native"
 import type {ReactNode} from "react"
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useRoute} from "@react-navigation/native"
 import {useNavigationStore} from "@/stores/navigation"
 import {submitAutomaticBugIncident} from "@/services/bugReport/automaticBugReport"
@@ -123,7 +123,7 @@ describe("pairing loading screen", () => {
     })
 
     await waitFor(() => {
-      expect(CoreModule.forget).toHaveBeenCalled()
+      expect(BluetoothSdk.forget).toHaveBeenCalled()
       expect(replace).toHaveBeenCalledWith("/pairing/failure", {
         error: "pairing:failed",
         deviceModel: "Mentra Live",

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -138,7 +138,7 @@ import {render, fireEvent, waitFor} from "@testing-library/react-native"
 import type {ReactNode} from "react"
 import {Platform} from "react-native"
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useLocalSearchParams} from "expo-router"
 import {usePushUnder} from "@/contexts/NavigationHistoryContext"
 import {useNavigationStore} from "@/stores/navigation"
@@ -189,7 +189,7 @@ describe("pairing scan screen", () => {
     const {getByText} = render(<SelectGlassesBluetoothScreen />)
 
     await waitFor(() => {
-      expect(CoreModule.startScan).toHaveBeenCalledWith({model: "Mentra Live"})
+      expect(BluetoothSdk.startScan).toHaveBeenCalledWith({model: "Mentra Live"})
     })
 
     fireEvent.press(getByText("001"))
@@ -202,7 +202,7 @@ describe("pairing scan screen", () => {
       })
     })
 
-    expect(CoreModule.setDefaultDevice).toHaveBeenCalledWith({
+    expect(BluetoothSdk.setDefaultDevice).toHaveBeenCalledWith({
       id: "a",
       model: "Mentra Live",
       name: "MENTRA_LIVE_BLE_001",

--- a/mobile/src/app/miniapps/settings/camera.tsx
+++ b/mobile/src/app/miniapps/settings/camera.tsx
@@ -91,7 +91,7 @@ export default function CameraSettingsScreen() {
       return
     }
     setPhotoSize(size)
-    CoreModule.updateCore({button_photo_size: size})
+    CoreModule.updateBluetoothSettings({button_photo_size: size})
   }
 
   const handleVideoResolutionChange = (resolution: VideoResolution) => {
@@ -103,7 +103,7 @@ export default function CameraSettingsScreen() {
     const height = resolution === "4K" ? 2160 : resolution === "1440p" ? 1920 : resolution === "1080p" ? 1080 : 720
     const fps = resolution === "4K" ? 15 : 30
     setVideoSettings({width, height, fps})
-    CoreModule.updateCore({button_video_width: width, button_video_height: height, button_video_fps: fps})
+    CoreModule.updateBluetoothSettings({button_video_width: width, button_video_height: height, button_video_fps: fps})
   }
 
   const _handleLedToggle = (enabled: boolean) => {
@@ -121,7 +121,7 @@ export default function CameraSettingsScreen() {
     }
     const minutes = parseInt(time.replace("m", ""))
     setMaxRecordingTime(minutes)
-    CoreModule.updateCore({button_max_recording_time: minutes})
+    CoreModule.updateBluetoothSettings({button_max_recording_time: minutes})
   }
 
   const handleCameraFovChange = (fov: number, roi_position: CameraRoiPosition) => {

--- a/mobile/src/app/miniapps/settings/camera.tsx
+++ b/mobile/src/app/miniapps/settings/camera.tsx
@@ -12,7 +12,7 @@ import Toast from "react-native-toast-message"
 import {useGlassesStore} from "@/stores/glasses"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import {spacing, ThemedStyle} from "@/theme"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 type PhotoSize = "small" | "medium" | "large"
 type VideoResolution = "720p" | "1080p" | "1440p" | "4K"
@@ -91,7 +91,7 @@ export default function CameraSettingsScreen() {
       return
     }
     setPhotoSize(size)
-    CoreModule.updateBluetoothSettings({button_photo_size: size})
+    BluetoothSdk.updateBluetoothSettings({button_photo_size: size})
   }
 
   const handleVideoResolutionChange = (resolution: VideoResolution) => {
@@ -103,7 +103,7 @@ export default function CameraSettingsScreen() {
     const height = resolution === "4K" ? 2160 : resolution === "1440p" ? 1920 : resolution === "1080p" ? 1080 : 720
     const fps = resolution === "4K" ? 15 : 30
     setVideoSettings({width, height, fps})
-    CoreModule.updateBluetoothSettings({button_video_width: width, button_video_height: height, button_video_fps: fps})
+    BluetoothSdk.updateBluetoothSettings({button_video_width: width, button_video_height: height, button_video_fps: fps})
   }
 
   const _handleLedToggle = (enabled: boolean) => {
@@ -121,7 +121,7 @@ export default function CameraSettingsScreen() {
     }
     const minutes = parseInt(time.replace("m", ""))
     setMaxRecordingTime(minutes)
-    CoreModule.updateBluetoothSettings({button_max_recording_time: minutes})
+    BluetoothSdk.updateBluetoothSettings({button_max_recording_time: minutes})
   }
 
   const handleCameraFovChange = (fov: number, roi_position: CameraRoiPosition) => {

--- a/mobile/src/app/miniapps/settings/controller.tsx
+++ b/mobile/src/app/miniapps/settings/controller.tsx
@@ -13,7 +13,7 @@ import {Group} from "@/components/ui"
 import {RouteButton} from "@/components/ui/RouteButton"
 
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {EmptyState} from "@/components/glasses/info/EmptyState"
 import {showAlert} from "@/contexts/ModalContext"
@@ -35,7 +35,7 @@ function DeviceSettings() {
     })
     if (result === 1) {
       try {
-        CoreModule.forgetController()
+        BluetoothSdk.forgetController()
       } catch (e) {
         console.log(e)
       }
@@ -55,7 +55,7 @@ function DeviceSettings() {
     })
 
     if (result === 1) {
-      CoreModule.disconnectController()
+      BluetoothSdk.disconnectController()
     }
   }
 

--- a/mobile/src/app/miniapps/settings/glasses.tsx
+++ b/mobile/src/app/miniapps/settings/glasses.tsx
@@ -14,7 +14,7 @@ import {Group} from "@/components/ui"
 import {RouteButton} from "@/components/ui/RouteButton"
 
 import {Capabilities, DeviceTypes, getModelCapabilities} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import OtaProgressSection from "@/components/glasses/OtaProgressSection"
 import {BatteryStatus} from "@/components/glasses/info/BatteryStatus"
@@ -56,7 +56,7 @@ function DeviceSettings() {
       options: {allowDismiss: false},
     })
     if (result === 1) {
-      CoreModule.forget()
+      BluetoothSdk.forget()
       // useAppletStatusStore.getState().stopAllApplets()
       // useAppletStatusStore.getState().refreshApplets()
       // // give us a second to forget the glasses before going back
@@ -75,7 +75,7 @@ function DeviceSettings() {
     })
 
     if (result === 1) {
-      CoreModule.disconnect()
+      BluetoothSdk.disconnect()
     }
   }
 

--- a/mobile/src/app/miniapps/settings/stress-test.tsx
+++ b/mobile/src/app/miniapps/settings/stress-test.tsx
@@ -15,7 +15,7 @@ import {miniappHost} from "@/components/miniapp/MiniappHost"
 import {useNavigationStore} from "@/stores/navigation"
 import {useStressTestStore} from "@/stores/stressTest"
 import {buildDummyMiniappHtml} from "@/utils/stressTest/dummyHtml"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {miniappRunningRegistry} from "@mentra/island"
 
 const DUMMY_PREFIX = "com.mentra.stress.dummy."
@@ -59,7 +59,7 @@ export default function StressTest() {
     let id: ReturnType<typeof setInterval> | null = null
     const tick = () => {
       try {
-        const mb = CoreModule.getMemoryMB()
+        const mb = BluetoothSdk.getMemoryMB()
         setResidentMB(mb)
         if (active) {
           // Single-line structured log so the CLI driver can grep
@@ -143,7 +143,7 @@ export default function StressTest() {
     // syslog, which IS reachable from idevicesyslog (unlike RN's
     // console.log in release builds).
     if (jscN > 0) {
-      ;(CoreModule as any).jscRunBenchmark()
+      ;(BluetoothSdk as any).jscRunBenchmark()
       return
     }
 
@@ -221,31 +221,31 @@ export default function StressTest() {
               label="Spawn 1 JSContext"
               subtitle="Measures per-context memory cost"
               onPress={async () => {
-                const baseline = CoreModule.getMemoryMB()
-                const result = (CoreModule as any).jscSpawnAndMeasure(1, baseline)
+                const baseline = BluetoothSdk.getMemoryMB()
+                const result = (BluetoothSdk as any).jscSpawnAndMeasure(1, baseline)
                 console.log("STRESS: jsc-spike", JSON.stringify(result))
               }}
             />
             <RouteButton
               label="Spawn 10 JSContexts"
               onPress={async () => {
-                const baseline = CoreModule.getMemoryMB()
-                const result = (CoreModule as any).jscSpawnAndMeasure(10, baseline)
+                const baseline = BluetoothSdk.getMemoryMB()
+                const result = (BluetoothSdk as any).jscSpawnAndMeasure(10, baseline)
                 console.log("STRESS: jsc-spike", JSON.stringify(result))
               }}
             />
             <RouteButton
               label="Spawn 50 JSContexts"
               onPress={async () => {
-                const baseline = CoreModule.getMemoryMB()
-                const result = (CoreModule as any).jscSpawnAndMeasure(50, baseline)
+                const baseline = BluetoothSdk.getMemoryMB()
+                const result = (BluetoothSdk as any).jscSpawnAndMeasure(50, baseline)
                 console.log("STRESS: jsc-spike", JSON.stringify(result))
               }}
             />
             <RouteButton
               label="Kill all JSContexts"
               onPress={() => {
-                (CoreModule as any).jscKillAll()
+                (BluetoothSdk as any).jscKillAll()
                 console.log("STRESS: jsc-killed-all")
               }}
             />

--- a/mobile/src/app/miniapps/settings/super.tsx
+++ b/mobile/src/app/miniapps/settings/super.tsx
@@ -1,5 +1,5 @@
 import {ScrollView, View} from "react-native"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {Header, Screen} from "@/components/ignite"
 import ToggleSetting from "@/components/settings/ToggleSetting"
@@ -45,8 +45,8 @@ export default function SuperSettingsScreen() {
           </Group>
 
           <Group title="Debug">
-            <RouteButton label="dbg1()" onPress={() => CoreModule.dbg1()} />
-            <RouteButton label="dbg2()" onPress={() => CoreModule.dbg2()} />
+            <RouteButton label="dbg1()" onPress={() => BluetoothSdk.dbg1()} />
+            <RouteButton label="dbg2()" onPress={() => BluetoothSdk.dbg2()} />
             <RouteButton label="Stress Test (Jetsam)" onPress={() => push("/miniapps/settings/stress-test")} />
           </Group>
 

--- a/mobile/src/app/miniapps/settings/transcription.tsx
+++ b/mobile/src/app/miniapps/settings/transcription.tsx
@@ -1,5 +1,5 @@
 import {useFocusEffect} from "@react-navigation/native"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useCallback, useEffect, useState} from "react"
 import {ActivityIndicator, BackHandler, Platform, ScrollView, View} from "react-native"
 
@@ -141,7 +141,7 @@ export default function TranscriptionSettingsScreen() {
     const now = Date.now()
     setLastRestartTime(now)
     await STTModelManager.activateModel(modelId)
-    await CoreModule.restartTranscriber()
+    await BluetoothSdk.restartTranscriber()
   }
 
   const handleModelChange = async (modelId: string) => {

--- a/mobile/src/app/onboarding/live.tsx
+++ b/mobile/src/app/onboarding/live.tsx
@@ -4,7 +4,7 @@ import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import showAlert from "@/utils/AlertUtils"
-import CoreModule, {TouchEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {TouchEvent} from "@mentra/bluetooth-sdk"
 import {Platform} from "react-native"
 
 const CDN_BASE = "https://mentra-videos-cdn.mentraglass.com/onboarding/mentra-live/light"
@@ -42,7 +42,7 @@ export default function MentraLiveOnboarding() {
       // wait for the action button to be pressed:
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("button_press", (data: any) => {
+          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
             if (data?.type === "button_press" && data?.pressType === "short") {
               unsub.remove()
               resolve()
@@ -64,7 +64,7 @@ export default function MentraLiveOnboarding() {
       info: translate("onboarding:liveLedFlashWarning"),
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("button_press", (data: any) => {
+          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
             if (data?.type === "button_press" && (data?.pressType === "long" || data?.pressType === "short")) {
               unsub.remove()
               resolve()
@@ -86,7 +86,7 @@ export default function MentraLiveOnboarding() {
       info: translate("onboarding:liveLedFlashWarning"),
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("button_press", (data: any) => {
+          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
             if (data?.type === "button_press" && (data?.pressType === "long" || data?.pressType === "short")) {
               unsub.remove()
               resolve()
@@ -119,7 +119,7 @@ export default function MentraLiveOnboarding() {
       subtitle: translate("onboarding:liveDoubleTapTouchpad"),
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("touch_event", (data: TouchEvent) => {
+          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
             if (data?.gesture_name === "double_tap") {
               unsub.remove()
               resolve()
@@ -141,7 +141,7 @@ export default function MentraLiveOnboarding() {
       // subtitle2: translate("onboarding:liveSwipeTouchpadDown"),
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("touch_event", (data: TouchEvent) => {
+          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
             if (data?.gesture_name === "forward_swipe" || data?.gesture_name === "backward_swipe") {
               unsub.remove()
               resolve()
@@ -162,7 +162,7 @@ export default function MentraLiveOnboarding() {
       subtitle: translate("onboarding:liveDoubleTapTouchpad"),
       waitFn: (): Promise<void> => {
         return new Promise<void>((resolve) => {
-          const unsub = CoreModule.addListener("touch_event", (data: TouchEvent) => {
+          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
             if (data?.gesture_name === "double_tap") {
               unsub.remove()
               resolve()

--- a/mobile/src/app/ota/__tests__/progress.test.tsx
+++ b/mobile/src/app/ota/__tests__/progress.test.tsx
@@ -54,15 +54,15 @@ import {MINIMUM_OTA_STATUS_BUILD, OtaProgressMessages} from "@/app/ota/otaProgre
 
 const sb = (n: number) => String(n)
 
-const CoreModule = require("@mentra/bluetooth-sdk").default
+const BluetoothSdk = require("@mentra/bluetooth-sdk").default
 
 beforeEach(() => {
   jest.useFakeTimers()
   useGlassesStore.getState().reset()
   useConnectionOverlayConfig.getState().clearConfig()
   mockReplace.mockClear()
-  CoreModule.sendOtaQueryStatus.mockClear()
-  CoreModule.sendOtaStart.mockClear()
+  BluetoothSdk.sendOtaQueryStatus.mockClear()
+  BluetoothSdk.sendOtaStart.mockClear()
 })
 
 afterEach(() => {
@@ -337,7 +337,7 @@ describe("progress.tsx watchdog timers", () => {
   it("delays sendOtaStart after reconnect when multi-step APK completed", async () => {
     useGlassesStore.getState().setGlassesInfo({buildNumber: sb(MINIMUM_OTA_STATUS_BUILD + 3), connected: true})
     render(<OtaProgressScreen />)
-    CoreModule.sendOtaStart.mockClear()
+    BluetoothSdk.sendOtaStart.mockClear()
 
     act(() => {
       useGlassesStore.getState().setOtaStatus({
@@ -359,19 +359,19 @@ describe("progress.tsx watchdog timers", () => {
       useGlassesStore.getState().setGlassesInfo({connected: true})
     })
 
-    expect(CoreModule.sendOtaStart).not.toHaveBeenCalled()
+    expect(BluetoothSdk.sendOtaStart).not.toHaveBeenCalled()
 
     await act(async () => {
       await jest.advanceTimersByTimeAsync(6000)
     })
 
-    expect(CoreModule.sendOtaStart).toHaveBeenCalled()
+    expect(BluetoothSdk.sendOtaStart).toHaveBeenCalled()
   })
 
   it("pings periodically while updating", async () => {
     useGlassesStore.getState().setGlassesInfo({connected: true})
     render(<OtaProgressScreen />)
-    CoreModule.ping.mockClear()
+    BluetoothSdk.ping.mockClear()
 
     act(() => {
       useGlassesStore.getState().setOtaStatus({
@@ -386,12 +386,12 @@ describe("progress.tsx watchdog timers", () => {
       })
     })
 
-    expect(CoreModule.ping).toHaveBeenCalled()
-    CoreModule.ping.mockClear()
+    expect(BluetoothSdk.ping).toHaveBeenCalled()
+    BluetoothSdk.ping.mockClear()
     await act(async () => {
       await jest.advanceTimersByTimeAsync(10_000)
     })
-    expect(CoreModule.ping).toHaveBeenCalled()
+    expect(BluetoothSdk.ping).toHaveBeenCalled()
   })
 })
 
@@ -440,7 +440,7 @@ describe("progress.tsx reconnect", () => {
   it("sends sendOtaStart on mount when connected (no session yet)", () => {
     useGlassesStore.getState().setGlassesInfo({connected: true})
     render(<OtaProgressScreen />)
-    expect(CoreModule.sendOtaStart).toHaveBeenCalled()
+    expect(BluetoothSdk.sendOtaStart).toHaveBeenCalled()
   })
 
   it("retry button calls sendOtaStart", () => {
@@ -462,7 +462,7 @@ describe("progress.tsx reconnect", () => {
     })
 
     fireEvent.press(getByTestId("button-Retry"))
-    expect(CoreModule.sendOtaStart).toHaveBeenCalled()
+    expect(BluetoothSdk.sendOtaStart).toHaveBeenCalled()
   })
 })
 

--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -1,7 +1,7 @@
 import {useFocusEffect} from "expo-router"
 import {useEffect, useState, useCallback, useRef} from "react"
 import {View, ActivityIndicator} from "react-native"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {MINIMUM_OTA_STATUS_BUILD} from "@/app/ota/otaProgressTimeouts"
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
@@ -100,7 +100,7 @@ export default function OtaCheckForUpdatesScreen() {
 
           // Request version info since we don't have it yet
           console.log("OTA: Requesting version_info from glasses")
-          CoreModule.requestVersionInfo()
+          BluetoothSdk.requestVersionInfo()
 
           versionInfoTimeoutRef.current = BgTimer.setTimeout(() => {
             if (checkCompletedRef.current) {
@@ -119,7 +119,7 @@ export default function OtaCheckForUpdatesScreen() {
       }
 
       // Match OtaUpdateChecker home path: BES often arrives late in version_info_3 (chip init after reflash).
-      void CoreModule.requestVersionInfo()
+      void BluetoothSdk.requestVersionInfo()
 
       let latestBesFwVersion = useGlassesStore.getState().besFwVersion
       if (!latestBesFwVersion) {
@@ -170,7 +170,7 @@ export default function OtaCheckForUpdatesScreen() {
         // Refresh version_info (build / fw) in case the store still held values from a prior session
         // before the native clear-on-connect + glasses_ready re-query completed.
         console.log("OTA: Requesting fresh version_info from glasses before HTTP compare")
-        void CoreModule.requestVersionInfo()
+        void BluetoothSdk.requestVersionInfo()
 
         const result = await checkForOtaUpdate(
           OTA_VERSION_URL_PROD,

--- a/mobile/src/app/ota/progress-legacy.tsx
+++ b/mobile/src/app/ota/progress-legacy.tsx
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useEffect, useState, useRef, useCallback} from "react"
 import {View, ActivityIndicator} from "react-native"
 
@@ -286,11 +286,11 @@ export default function OtaProgressScreen() {
 
     if (isOtaActive && glassesConnected) {
       // Send initial ping immediately
-      CoreModule.ping().catch((err) => console.log("OTA: ping failed:", err))
+      BluetoothSdk.ping().catch((err) => console.log("OTA: ping failed:", err))
 
       // Set up interval to ping (legacy: PING_INTERVAL_MS + LEGACY_EXTRA_TIMEOUT_MS)
       pingIntervalRef.current = window.setInterval(() => {
-        CoreModule.ping().catch((err) => console.log("OTA: ping failed:", err))
+        BluetoothSdk.ping().catch((err) => console.log("OTA: ping failed:", err))
       }, legacyPingIntervalMs)
 
       return () => {
@@ -587,7 +587,7 @@ export default function OtaProgressScreen() {
         "OTA_TRACK: send_ota_start",
         JSON.stringify({attempt: retryCount + 1, maxRetries: MAX_RETRIES, sequence: [...updateSequenceRef.current]}),
       )
-      await CoreModule.sendOtaStart()
+      await BluetoothSdk.sendOtaStart()
       setOtaStartTime(Date.now())
 
       // Start global session timeout once (covers whole multi-step OTA)
@@ -1529,7 +1529,7 @@ export default function OtaProgressScreen() {
     const completedUpdate = updateSequenceRef.current[currentUpdateIndex]
     if (completedUpdate === "apk") {
       // Clear native store so future version_info events aren't deduped by ObservableStore
-      CoreModule.updateGlasses({buildNumber: ""})
+      BluetoothSdk.updateGlasses({buildNumber: ""})
       // Clear RN store synchronously so check-for-updates sees empty buildNumber on mount
       // (the native bridge call is async and may not complete before navigation)
       useGlassesStore.getState().setGlassesInfo({buildNumber: ""})

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk"
 import {useCallback, useEffect, useRef, useState} from "react"
 import {View, ActivityIndicator} from "react-native"
@@ -308,7 +308,7 @@ export default function OtaProgressScreen() {
         console.log(
           `[OTA_PROGRESS] watchdog: no ack in ${RETRY_INTERVAL_MS}ms, retrying ota_start (attempt ${retryCountRef.current})`,
         )
-        void CoreModule.sendOtaStart()
+        void BluetoothSdk.sendOtaStart()
           .then(() => {
             armAckAndStuckWatchdogsOnly()
           })
@@ -339,7 +339,7 @@ export default function OtaProgressScreen() {
     hasReceivedAckRef.current = false
     armAckAndStuckWatchdogsOnly()
     try {
-      await CoreModule.sendOtaStart()
+      await BluetoothSdk.sendOtaStart()
     } catch (err) {
       console.warn("[OTA_PROGRESS] sendOtaStart threw", err)
       clearRetryTimeout()
@@ -447,7 +447,7 @@ export default function OtaProgressScreen() {
 
     if (becameConnected) {
       console.log("[OTA_PROGRESS] connect-edge: reconnected, sending ota_query_status")
-      void CoreModule.sendOtaQueryStatus()
+      void BluetoothSdk.sendOtaQueryStatus()
       armQueryReplyFallback("reconnect")
       return
     }
@@ -470,7 +470,7 @@ export default function OtaProgressScreen() {
       void sendOtaStartWithWatchdogs()
     } else {
       console.log("[OTA_PROGRESS] initial mount, session exists, sending ota_query_status")
-      void CoreModule.sendOtaQueryStatus()
+      void BluetoothSdk.sendOtaQueryStatus()
       armQueryReplyFallback("initial-mount")
     }
   }, [connected, sendOtaStartWithWatchdogs, clearPostApkDelay, armQueryReplyFallback])
@@ -493,7 +493,7 @@ export default function OtaProgressScreen() {
       clearProgressTimeout()
       onFirstActivity()
       onFirstNonZeroProgress()
-      void CoreModule.sendOtaQueryStatus()
+      void BluetoothSdk.sendOtaQueryStatus()
       useGlassesStore.getState().setMtkUpdatedThisSession(true)
     }
     GlobalEventEmitter.on("ota_start_ack", handleAck)
@@ -508,9 +508,9 @@ export default function OtaProgressScreen() {
   useEffect(() => {
     const active = connected && (displayState === "starting" || displayState === "updating")
     if (active) {
-      void CoreModule.ping().catch(() => {})
+      void BluetoothSdk.ping().catch(() => {})
       pingIntervalRef.current = setInterval(() => {
-        void CoreModule.ping().catch(() => {})
+        void BluetoothSdk.ping().catch(() => {})
       }, PING_INTERVAL_MS)
       return () => {
         clearPingInterval()

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -4,7 +4,7 @@ import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/Onboardin
 import {translate} from "@/i18n"
 import {focusEffectPreventBack, usePushPrevious} from "@/contexts/NavigationHistoryContext"
 import {useGlassesStore} from "@/stores/glasses"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import {SettingsNavigationUtils} from "@/utils/SettingsNavigationUtils"
 import {useCoreStore} from "@/stores/core"
@@ -24,7 +24,7 @@ export default function BtClassicPairingScreen() {
   focusEffectPreventBack()
 
   const handleSuccess = () => {
-    CoreModule.connectDefault().catch((error) => {
+    BluetoothSdk.connectDefault().catch((error) => {
       console.error("Failed to connect default glasses after Bluetooth Classic pairing:", error)
     })
     pushPrevious()

--- a/mobile/src/app/pairing/failure.tsx
+++ b/mobile/src/app/pairing/failure.tsx
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useLocalSearchParams} from "expo-router"
 import {useEffect} from "react"
 import {View} from "react-native"
@@ -30,7 +30,7 @@ export default function PairingFailureScreen() {
   }, [])
 
   const handleRetry = () => {
-    CoreModule.forget()
+    BluetoothSdk.forget()
     clearHistoryAndGoHome()
     push("/pairing/select-glasses-model")
   }

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -1,5 +1,5 @@
 import {useRoute} from "@react-navigation/native"
-import CoreModule, {PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
 import {useCallback, useEffect, useRef, useState} from "react"
 import {View} from "react-native"
 
@@ -34,7 +34,7 @@ export default function GlassesPairingLoadingScreen() {
   }, [])
 
   useEffect(() => {
-    let sub = CoreModule.addListener("glasses_not_ready", (_event: GlassesNotReadyEvent) => {
+    let sub = BluetoothSdk.addListener("glasses_not_ready", (_event: GlassesNotReadyEvent) => {
       setShowGlassesBooting(true)
     })
     return () => {
@@ -52,7 +52,7 @@ export default function GlassesPairingLoadingScreen() {
   const handlePairFailure = useCallback(
     (error: string) => {
       clearPairingTimeout()
-      CoreModule.forget()
+      BluetoothSdk.forget()
       if (error === "errors:pairNeedDisconnect") {
         replace("/pairing/unpair-even", {deviceModel: deviceModel})
         return
@@ -63,7 +63,7 @@ export default function GlassesPairingLoadingScreen() {
   )
 
   useEffect(() => {
-    let sub = CoreModule.addListener("pair_failure", (event: PairFailureEvent) => {
+    let sub = BluetoothSdk.addListener("pair_failure", (event: PairFailureEvent) => {
       handlePairFailure(event.error)
     })
     return () => {

--- a/mobile/src/app/pairing/prep-controller.tsx
+++ b/mobile/src/app/pairing/prep-controller.tsx
@@ -12,7 +12,7 @@ import {showAlert} from "@/utils/AlertUtils"
 import {PermissionFeatures, checkConnectivityRequirementsUI, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {useState} from "react"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
 
@@ -195,7 +195,7 @@ export default function PairingPrepScreen() {
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {
-      await CoreModule.connectSimulated()
+      await BluetoothSdk.connectSimulated()
       clearHistoryAndGoHome()
       return
     }

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -15,7 +15,7 @@ import {useState} from "react"
 import GlassesTroubleshootingModal from "@/components/glasses/GlassesTroubleshootingModal"
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
 import {useAppStatusStore} from "@mentra/island"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 type BluetoothPermission = Permission | "android.permission.BLUETOOTH" | "android.permission.BLUETOOTH_ADMIN"
 
@@ -198,7 +198,7 @@ export default function PairingPrepScreen() {
 
     // skip pairing for simulated glasses:
     if (deviceModel.startsWith(DeviceTypes.SIMULATED)) {
-      await CoreModule.connectSimulated()
+      await BluetoothSdk.connectSimulated()
       clearHistoryAndGoHome()
       return
     }

--- a/mobile/src/app/pairing/scan-controller.tsx
+++ b/mobile/src/app/pairing/scan-controller.tsx
@@ -1,4 +1,4 @@
-import CoreModule, {type Device} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {type Device} from "@mentra/bluetooth-sdk"
 import {useLocalSearchParams} from "expo-router"
 import {useEffect, useState} from "react"
 import {ActivityIndicator, Image, Platform, ScrollView, TouchableOpacity, View} from "react-native"
@@ -37,8 +37,8 @@ export default function SelectGlassesBluetoothScreen() {
     if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
       return
     }
-    CoreModule.disconnectController()
-    CoreModule.forgetController()
+    BluetoothSdk.disconnectController()
+    BluetoothSdk.forgetController()
     goBack()
   }, true)
 
@@ -53,7 +53,7 @@ export default function SelectGlassesBluetoothScreen() {
   useEffect(() => {
     const initializeAndSearchForDevices = async () => {
       try {
-        await CoreModule.startScan({model: deviceModel})
+        await BluetoothSdk.startScan({model: deviceModel})
       } catch (error) {
         console.error("Failed to start controller scan:", error)
       }
@@ -92,7 +92,7 @@ export default function SelectGlassesBluetoothScreen() {
 
   const startPairing = async (device: Device) => {
     setTimeout(() => {
-      CoreModule.connect(device).catch((error) => {
+      BluetoothSdk.connect(device).catch((error) => {
         console.error("Failed to connect to controller:", error)
       })
     }, 2000)

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -1,4 +1,4 @@
-import CoreModule, {type Device} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {type Device} from "@mentra/bluetooth-sdk"
 import {useLocalSearchParams} from "expo-router"
 import {useEffect, useState} from "react"
 import {ActivityIndicator, Image, Platform, ScrollView, TouchableOpacity, View} from "react-native"
@@ -44,8 +44,8 @@ export default function SelectGlassesBluetoothScreen() {
     if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
       return
     }
-    CoreModule.disconnect()
-    CoreModule.forget()
+    BluetoothSdk.disconnect()
+    BluetoothSdk.forget()
     goBack()
   }, true)
 
@@ -60,7 +60,7 @@ export default function SelectGlassesBluetoothScreen() {
   useEffect(() => {
     const initializeAndSearchForDevices = async () => {
       try {
-        await CoreModule.startScan({model: deviceModel})
+        await BluetoothSdk.startScan({model: deviceModel})
       } catch (error) {
         console.error("Failed to start glasses scan:", error)
       }
@@ -101,7 +101,7 @@ export default function SelectGlassesBluetoothScreen() {
     const deviceTypesWithBtClassic = [DeviceTypes.LIVE]
     if (Platform.OS === "android" || btcConnected || !deviceTypesWithBtClassic.includes(device.model as DeviceTypes)) {
       setTimeout(() => {
-        CoreModule.connect(device).catch((error) => {
+        BluetoothSdk.connect(device).catch((error) => {
           console.error("Failed to connect to glasses:", error)
         })
       }, 2000)
@@ -110,7 +110,7 @@ export default function SelectGlassesBluetoothScreen() {
       return
     }
 
-    await CoreModule.setDefaultDevice(device)
+    await BluetoothSdk.setDefaultDevice(device)
     setDeviceName(device.name)
     // pair bt classic first:
     replace("/pairing/btclassic")

--- a/mobile/src/app/pairing/select-controller.tsx
+++ b/mobile/src/app/pairing/select-controller.tsx
@@ -24,7 +24,7 @@ export default function SelectControllerScreen() {
   // when this screen is focused, forget any glasses that may be paired:
   useFocusEffect(
     useCallback(() => {
-      // CoreModule.forget()
+      // BluetoothSdk.forget()
       return () => {}
     }, []),
   )

--- a/mobile/src/app/pairing/select-glasses-model.tsx
+++ b/mobile/src/app/pairing/select-glasses-model.tsx
@@ -1,5 +1,5 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useFocusEffect} from "expo-router"
 import {useCallback} from "react"
 import {View, TouchableOpacity, Platform, ScrollView, Image} from "react-native"
@@ -27,7 +27,7 @@ export default function SelectGlassesModelScreen() {
   // when this screen is focused, forget any glasses that may be paired:
   useFocusEffect(
     useCallback(() => {
-      CoreModule.forget()
+      BluetoothSdk.forget()
       return () => {}
     }, []),
   )

--- a/mobile/src/app/pairing/unpair-even.tsx
+++ b/mobile/src/app/pairing/unpair-even.tsx
@@ -1,6 +1,6 @@
 import {useRoute} from "@react-navigation/native"
 import {View} from "react-native"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {Button, Screen} from "@/components/ignite"
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
@@ -24,7 +24,7 @@ export default function UnpairEvenScreen() {
   }
 
   const handleTryAgain = () => {
-    CoreModule.forget()
+    BluetoothSdk.forget()
     clearHistory()
     replace("/pairing/prep", {deviceModel})
   }

--- a/mobile/src/app/wifi/connecting.tsx
+++ b/mobile/src/app/wifi/connecting.tsx
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useLocalSearchParams} from "expo-router"
 import {useEffect, useRef, useState, useCallback} from "react"
 import {ActivityIndicator, View} from "react-native"
@@ -84,7 +84,7 @@ export default function WifiConnectingScreen() {
   const attemptConnection = async () => {
     try {
       console.log("Attempting to send wifi credentials to Core", ssid, password)
-      await CoreModule.sendWifiCredentials(ssid, password)
+      await BluetoothSdk.sendWifiCredentials(ssid, password)
 
       // Set timeout for connection attempt (20 seconds)
       connectionTimeoutRef.current = setTimeout(() => {

--- a/mobile/src/app/wifi/scan.tsx
+++ b/mobile/src/app/wifi/scan.tsx
@@ -1,4 +1,4 @@
-import CoreModule, {WifiSearchResult} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {WifiSearchResult} from "@mentra/bluetooth-sdk"
 import {useFocusEffect} from "expo-router"
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {ActivityIndicator, ScrollView, TouchableOpacity, View} from "react-native"
@@ -131,7 +131,7 @@ export default function WifiScanScreen() {
     }, 15000)
 
     try {
-      await CoreModule.requestWifiScan()
+      await BluetoothSdk.requestWifiScan()
       console.log("WIFI_SCAN: WiFi scan request sent successfully")
     } catch (error) {
       console.error("WIFI_SCAN: Error scanning for WiFi networks:", error)
@@ -163,7 +163,7 @@ export default function WifiScanScreen() {
             onPress: async () => {
               try {
                 console.log(`WIFI_SCAN: Forgetting network: ${selectedNetwork.ssid}`)
-                await CoreModule.forgetWifiNetwork(selectedNetwork.ssid)
+                await BluetoothSdk.forgetWifiNetwork(selectedNetwork.ssid)
                 // Also remove from local saved credentials
                 WifiCredentialsService.removeCredentials(selectedNetwork.ssid)
                 setSavedNetworks((prev) => prev.filter((ssid) => ssid !== selectedNetwork.ssid))

--- a/mobile/src/components/dev/CoreStatusBar.tsx
+++ b/mobile/src/components/dev/CoreStatusBar.tsx
@@ -8,7 +8,7 @@ import {useCoreStore} from "@/stores/core"
 import {useDebugStore} from "@/stores/debug"
 import {useGlassesStore} from "@/stores/glasses"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
-import CoreModule, {TouchEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {TouchEvent} from "@mentra/bluetooth-sdk"
 import {BgTimer} from "@mentra/island"
 
 function Tag({icon, label, bg}: {icon: IconTypes; label: string; bg: string}) {
@@ -38,7 +38,7 @@ export default function CoreStatusBar() {
 
   const touchEventTimer = useRef<number | null>(null)
   useEffect(() => {
-    let sub = CoreModule.addListener("touch_event", (event: TouchEvent) => {
+    let sub = BluetoothSdk.addListener("touch_event", (event: TouchEvent) => {
       setTouchEvent(event)
       BgTimer.clearTimeout(touchEventTimer.current ?? 0)
       touchEventTimer.current = BgTimer.setTimeout(() => {

--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -1,5 +1,5 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {ActivityIndicator, View} from "react-native"
 
 import {Button} from "@/components/ignite"
@@ -36,7 +36,7 @@ export const ConnectDeviceButton = () => {
         return
       }
 
-      await CoreModule.connectDefault()
+      await BluetoothSdk.connectDefault()
     } catch (err) {
       console.error("connect to glasses error:", err)
       showAlert("Connection Error", "Failed to connect to glasses. Please try again.", [{text: "OK"}])
@@ -46,7 +46,7 @@ export const ConnectDeviceButton = () => {
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
     if (isSearching) {
-      await CoreModule.disconnectController()
+      await BluetoothSdk.disconnectController()
     } else {
       await connectGlasses()
     }
@@ -123,7 +123,7 @@ export const ConnectControllerButton = () => {
         return
       }
 
-      await CoreModule.connectDefaultController()
+      await BluetoothSdk.connectDefaultController()
     } catch (err) {
       console.error("connect to glasses error:", err)
       showAlert("Connection Error", "Failed to connect to glasses. Please try again.", [{text: "OK"}])
@@ -133,7 +133,7 @@ export const ConnectControllerButton = () => {
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
     if (isSearching) {
-      await CoreModule.disconnect()
+      await BluetoothSdk.disconnect()
     } else {
       await connectController()
     }

--- a/mobile/src/components/glasses/NexDeveloperSettings.tsx
+++ b/mobile/src/components/glasses/NexDeveloperSettings.tsx
@@ -1,5 +1,5 @@
 import {Capabilities, getModelCapabilities} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useEffect, useState} from "react"
 import {ScrollView, TextInput, TextStyle, TouchableOpacity, View, ViewStyle} from "react-native"
 
@@ -338,7 +338,7 @@ export default function NexDeveloperSettings() {
         ])
         return
       }
-      await CoreModule.displayText({
+      await BluetoothSdk.displayText({
         text,
         x: parseInt(positionX, 0),
         y: parseInt(positionY, 0),
@@ -379,7 +379,7 @@ export default function NexDeveloperSettings() {
 
   const onClearDisplayClick = async () => {
     if (glassesConnected) {
-      await CoreModule.clearDisplay()
+      await BluetoothSdk.clearDisplay()
     } else {
       showAlert("Please connect to the device", "Please connect to the device", [
         {

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -1,5 +1,5 @@
 import {DeviceTypes, getModelCapabilities} from "@/../../cloud/packages/types/src"
-import CoreModule, {GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
 import {useState, useEffect} from "react"
 import {ActivityIndicator, Image, ImageSourcePropType, TouchableOpacity, View, ViewStyle} from "react-native"
 import type {ReactNode} from "react"
@@ -79,7 +79,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   // Listen for glasses_not_ready event to know when glasses are actually booting
   useEffect(() => {
-    const sub = CoreModule.addListener("glasses_not_ready", (_event: GlassesNotReadyEvent) => {
+    const sub = BluetoothSdk.addListener("glasses_not_ready", (_event: GlassesNotReadyEvent) => {
       setShowGlassesBooting(true)
     })
     return () => {
@@ -130,7 +130,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       if (!requirementsCheck) {
         return
       }
-      await CoreModule.connectDefault()
+      await BluetoothSdk.connectDefault()
     } catch (error) {
       console.error("connect to glasses error:", error)
       showAlert("Connection Error", "Failed to connect to glasses. Please try again.", [{text: "OK"}])
@@ -139,7 +139,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   const handleConnectOrDisconnect = async () => {
     if (searching || nativeLinkBusy) {
-      await CoreModule.disconnect()
+      await BluetoothSdk.disconnect()
       setIsCheckingConnectivity(false)
       resetSearching()
     } else {
@@ -259,9 +259,9 @@ export const ControllerStatus = ({style}: {style?: ViewStyle}) => {
 
   const handleConnectOrDisconnect = async () => {
     if (isSearching) {
-      await CoreModule.disconnectController()
+      await BluetoothSdk.disconnectController()
     } else {
-      await CoreModule.connectDefaultController()
+      await BluetoothSdk.connectDefaultController()
     }
   }
 

--- a/mobile/src/components/home/PairGlassesCard.tsx
+++ b/mobile/src/components/home/PairGlassesCard.tsx
@@ -4,7 +4,7 @@ import {Button, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import GlassView from "@/components/ui/GlassView"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useState} from "react"
 
 export const PairGlassesCard = ({style}: {style?: ViewStyle}) => {
@@ -46,7 +46,7 @@ export const PairGlassesCard = ({style}: {style?: ViewStyle}) => {
           tx="home:start"
           preset="primary"
           onPress={() => {
-            CoreModule.connectSimulated()
+            BluetoothSdk.connectSimulated()
           }}
         />
         <Button

--- a/mobile/src/effects/ButtonActions.tsx
+++ b/mobile/src/effects/ButtonActions.tsx
@@ -5,7 +5,7 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useApps, useStart} from "@mentra/island"
 import {SETTINGS, useSetting, useSettingsStore} from "@/stores/settings"
 import {askPermissionsUI} from "@/utils/PermissionsUtils"
-import CoreModule, {ButtonPressEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {ButtonPressEvent} from "@mentra/bluetooth-sdk"
 
 export function ButtonActions() {
   const applets = useApps()
@@ -127,7 +127,7 @@ export function ButtonActions() {
       startApplet(targetApp, {skipNavigation: true})
     }
 
-    let sub = CoreModule.addListener("button_press", onButtonPress)
+    let sub = BluetoothSdk.addListener("button_press", onButtonPress)
 
     return () => {
       sub.remove()

--- a/mobile/src/effects/Reconnect.tsx
+++ b/mobile/src/effects/Reconnect.tsx
@@ -3,7 +3,7 @@ import {AppState} from "react-native"
 
 import {SETTINGS, useSetting, useSettingsStore} from "@/stores/settings"
 import {checkConnectivityRequirementsUI} from "@/utils/PermissionsUtils"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {useGlassesStore} from "@/stores/glasses"
 import {useCoreStore} from "@/stores/core"
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
@@ -35,7 +35,7 @@ export async function attemptReconnectToDefaultWearable(): Promise<boolean> {
     return true
   }
   try {
-    await CoreModule.connectDefault()
+    await BluetoothSdk.connectDefault()
   } catch (error) {
     console.warn("RECONNECT: failed to connect default wearable:", error)
     return false

--- a/mobile/src/effects/WhisperTest.tsx
+++ b/mobile/src/effects/WhisperTest.tsx
@@ -1,7 +1,7 @@
 // import React, {useEffect, useState} from "react"
 // import {Text, Button, View} from "react-native"
 // import {useSpeechToText, WHISPER_TINY, WHISPER_TINY_EN} from "react-native-executorch"
-// import CoreModule from "@mentra/bluetooth-sdk"
+// import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 // // const decodePcm16Base64ToFloat32 = (base64: string): Float32Array => {
 // //   const binaryString = atob(base64)
@@ -59,7 +59,7 @@
 
 //     // console.log("COMPOSITOR: Is recording:", recorder.isRecording());
 
-//     await CoreModule.updateCore({
+//     await BluetoothSdk.updateCore({
 //       should_send_pcm: true,
 //     })
 
@@ -72,7 +72,7 @@
 //     //   console.log("COMPOSITOR: Transcription result:", model.downloadProgress)
 //     // }, 1000)
 
-//     const pcmSub = CoreModule.addListener("mic_pcm", (event) => {
+//     const pcmSub = BluetoothSdk.addListener("mic_pcm", (event) => {
 //       // console.log("COMPOSITOR: Received mic pcm:", event.base64)
 //       //   const samples = decodePcm16Base64ToFloat32(event.base64)
 //       //   let samples = new Float32Array(event.pcm)

--- a/mobile/src/services/AudioPlaybackService.test.ts
+++ b/mobile/src/services/AudioPlaybackService.test.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {createAudioPlayer, setAudioModeAsync} from "expo-audio"
 
 import audioPlaybackService from "@/services/AudioPlaybackService"
@@ -44,7 +44,7 @@ describe("AudioPlaybackService", () => {
     jest.clearAllMocks()
     resetCoreModuleMock()
     mockPlayer.volume = 1
-    ;(CoreModule.getGlassesMediaVolume as jest.Mock).mockResolvedValue({vol: 1, statusCode: 0})
+    ;(BluetoothSdk.getGlassesMediaVolume as jest.Mock).mockResolvedValue({vol: 1, statusCode: 0})
   })
 
   afterEach(() => {
@@ -70,21 +70,21 @@ describe("AudioPlaybackService", () => {
         shouldPlayInBackground: true,
       }),
     )
-    expect(CoreModule.setGlassesMediaVolume).toHaveBeenCalledWith(9)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenCalledWith(9)
     expect(mockPlayer.volume).toBe(0.25)
     expect(mockPlayer.replace).toHaveBeenCalledWith({uri: "https://example.com/audio.mp3"})
     expect(mockPlayer.play).toHaveBeenCalled()
-    expect(CoreModule.setOwnAppAudioPlaying).toHaveBeenCalledWith(true)
+    expect(BluetoothSdk.setOwnAppAudioPlaying).toHaveBeenCalledWith(true)
 
     const statusListener = getLatestStatusListener()
     statusListener({didJustFinish: true, duration: 2})
 
     expect(onComplete).toHaveBeenCalledWith("audio-1", true, null, 2000)
-    expect(CoreModule.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
 
     jest.advanceTimersByTime(500)
     await Promise.resolve()
-    expect(CoreModule.setOwnAppAudioPlaying).toHaveBeenLastCalledWith(false)
+    expect(BluetoothSdk.setOwnAppAudioPlaying).toHaveBeenLastCalledWith(false)
   })
 
   it("interrupts existing playback without restoring bumped volume until the replacement finishes", async () => {
@@ -95,13 +95,13 @@ describe("AudioPlaybackService", () => {
     await audioPlaybackService.play({requestId: "second", audioUrl: "https://example.com/two.mp3"}, secondComplete)
 
     expect(firstComplete).toHaveBeenCalledWith("first", true, null, expect.any(Number))
-    expect(CoreModule.setGlassesMediaVolume).toHaveBeenCalledTimes(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenCalledTimes(1)
     expect(createAudioPlayer).toHaveBeenCalledTimes(1)
 
     const statusListener = getLatestStatusListener()
     statusListener({didJustFinish: true, duration: 1})
 
     expect(secondComplete).toHaveBeenCalledWith("second", true, null, 1000)
-    expect(CoreModule.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
   })
 })

--- a/mobile/src/services/AudioPlaybackService.ts
+++ b/mobile/src/services/AudioPlaybackService.ts
@@ -1,5 +1,5 @@
 import {createAudioPlayer, AudioPlayer, AudioStatus, setAudioModeAsync} from "expo-audio"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {BgTimer} from "@mentra/island"
 
 interface AudioPlayRequest {
@@ -95,7 +95,7 @@ class AudioPlaybackService {
     }
 
     try {
-      const raw = await CoreModule.getGlassesMediaVolume()
+      const raw = await BluetoothSdk.getGlassesMediaVolume()
       const vol = Number(raw.vol)
       const statusCode = Number(raw.statusCode)
       if (!Number.isFinite(vol)) {
@@ -108,7 +108,7 @@ class AudioPlaybackService {
         return
       }
       console.log(`AUDIO: Raising glasses media volume (was ${vol})`)
-      await CoreModule.setGlassesMediaVolume(AudioPlaybackService.GLASSES_VOLUME_FLOOR)
+      await BluetoothSdk.setGlassesMediaVolume(AudioPlaybackService.GLASSES_VOLUME_FLOOR)
       this.glassesVolumeRestoreLevel = vol
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -127,7 +127,7 @@ class AudioPlaybackService {
 
     try {
       console.log(`AUDIO: Restoring glasses media volume to ${restoreLevel}`)
-      await CoreModule.setGlassesMediaVolume(restoreLevel)
+      await BluetoothSdk.setGlassesMediaVolume(restoreLevel)
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
       console.warn(`AUDIO: Failed to restore glasses volume to ${restoreLevel}:`, msg)
@@ -187,7 +187,7 @@ class AudioPlaybackService {
         BgTimer.clearTimeout(this.audioStopDebounceTimer)
         this.audioStopDebounceTimer = null
       }
-      CoreModule.setOwnAppAudioPlaying(true).catch((e) => {
+      BluetoothSdk.setOwnAppAudioPlaying(true).catch((e) => {
         console.warn("AUDIO: Failed to notify native of audio start:", e)
       })
 
@@ -297,7 +297,7 @@ class AudioPlaybackService {
     // Uses BgTimer to work reliably when app is backgrounded on Android
     this.audioStopDebounceTimer = BgTimer.setTimeout(() => {
       this.audioStopDebounceTimer = null
-      CoreModule.setOwnAppAudioPlaying(false).catch((e) => {
+      BluetoothSdk.setOwnAppAudioPlaying(false).catch((e) => {
         console.warn("AUDIO: Failed to notify native of audio stop:", e)
       })
     }, AudioPlaybackService.AUDIO_STOP_DEBOUNCE_MS)

--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -198,7 +198,7 @@ describe("MantleManager", () => {
   it("syncs native status, routes events, and forwards Bluetooth SDK setting changes", async () => {
     jest.advanceTimersByTime(1000)
 
-    expect(coreModuleMock.updateCore).toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         contextual_dashboard: true,
         core_token: "server-token",
@@ -206,13 +206,13 @@ describe("MantleManager", () => {
         power_saving_mode: false,
       }),
     )
-    expect(coreModuleMock.updateCore).not.toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({
         notifications_enabled: expect.anything(),
       }),
     )
     for (const nonSdkKey of ["always_on_status_bar", "metric_system"]) {
-      expect(coreModuleMock.updateCore).not.toHaveBeenCalledWith(
+      expect(coreModuleMock.updateBluetoothSettings).not.toHaveBeenCalledWith(
         expect.objectContaining({
           [nonSdkKey]: expect.anything(),
         }),
@@ -220,7 +220,7 @@ describe("MantleManager", () => {
     }
     expect(crustModuleMock.setNotificationConfig).toHaveBeenCalledWith(true, [])
 
-    emitCoreModuleEvent("core_status", {searching: true, otherBtConnected: true})
+    emitCoreModuleEvent("bluetooth_status", {searching: true, otherBtConnected: true})
     emitCoreModuleEvent("glasses_status", {connected: true, deviceModel: "Mentra Live", batteryLevel: 77})
 
     expect(useCoreStore.getState().searching).toBe(true)
@@ -283,9 +283,9 @@ describe("MantleManager", () => {
       timestamp: 123456,
     })
     expect(socketComms.sendBatteryStatus).toHaveBeenCalledWith(88, true, 123456)
-    ;(coreModuleMock.updateCore as jest.Mock).mockClear()
+    ;(coreModuleMock.updateBluetoothSettings as jest.Mock).mockClear()
     await useSettingsStore.getState().setSetting(SETTINGS.core_token.key, "new-token", false)
-    expect(coreModuleMock.updateCore).toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         core_token: "new-token",
       }),
@@ -293,7 +293,7 @@ describe("MantleManager", () => {
   })
 
   it("syncs notification enablement and blocklist settings to Crust only", async () => {
-    ;(coreModuleMock.updateCore as jest.Mock).mockClear()
+    ;(coreModuleMock.updateBluetoothSettings as jest.Mock).mockClear()
     ;(crustModuleMock.setNotificationConfig as jest.Mock).mockClear()
 
     await useSettingsStore.getState().setSetting(SETTINGS.notifications_enabled.key, false, false)
@@ -302,12 +302,12 @@ describe("MantleManager", () => {
     await waitFor(() => {
       expect(crustModuleMock.setNotificationConfig).toHaveBeenLastCalledWith(false, ["com.blocked"])
     })
-    expect(coreModuleMock.updateCore).not.toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({
         notifications_enabled: expect.anything(),
       }),
     )
-    expect(coreModuleMock.updateCore).not.toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({
         notifications_blocklist: expect.anything(),
       }),
@@ -329,7 +329,7 @@ describe("MantleManager", () => {
     for (const key of Object.keys(nonSdkSettings)) {
       expect(useSettingsStore.getState().getCoreSettings()).not.toHaveProperty(key)
     }
-    ;(coreModuleMock.updateCore as jest.Mock).mockClear()
+    ;(coreModuleMock.updateBluetoothSettings as jest.Mock).mockClear()
     for (const [key, value] of Object.entries(nonSdkSettings)) {
       await useSettingsStore.getState().setSetting(key, value, false)
     }
@@ -337,11 +337,11 @@ describe("MantleManager", () => {
     for (const key of Object.keys(nonSdkSettings)) {
       expect(useSettingsStore.getState().getCoreSettings()).not.toHaveProperty(key)
     }
-    expect(coreModuleMock.updateCore).not.toHaveBeenCalled()
+    expect(coreModuleMock.updateBluetoothSettings).not.toHaveBeenCalled()
 
     expect(useSettingsStore.getState().getCoreSettings()).toHaveProperty("power_saving_mode")
     await useSettingsStore.getState().setSetting(SETTINGS.power_saving_mode.key, true, false)
-    expect(coreModuleMock.updateCore).toHaveBeenCalledWith(
+    expect(coreModuleMock.updateBluetoothSettings).toHaveBeenCalledWith(
       expect.objectContaining({
         power_saving_mode: true,
       }),

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -1,4 +1,4 @@
-import CoreModule, {
+import BluetoothSdk, {
   ButtonPressEvent,
   BluetoothStatus,
   GlassesStatus,
@@ -195,7 +195,7 @@ class MantleManager {
     // give the core some time to boot before sending all the initial settings:
     BgTimer.setTimeout(() => {
       const initialCoreSettings = useSettingsStore.getState().getCoreSettings()
-      CoreModule.updateBluetoothSettings(initialCoreSettings) // send settings to core
+      BluetoothSdk.updateBluetoothSettings(initialCoreSettings) // send settings to core
       console.log("MANTLE: Settings sent to core")
       // settings are now in native; safe to attempt auto-connect
       attemptReconnectToDefaultWearable()
@@ -291,7 +291,7 @@ class MantleManager {
     //     }
     //     // give some time for the glasses to be fully ready:
     //     BgTimer.setTimeout(async () => {
-    //       await CoreModule.connectDefault()
+    //       await BluetoothSdk.connectDefault()
     //     }, 3000)
     //   } catch (error) {
     //     console.error("connect to glasses error:", error)
@@ -330,7 +330,7 @@ class MantleManager {
           }
         }
         // console.log("MANTLE: core settings changed", coreSettingsObj)
-        CoreModule.updateBluetoothSettings(coreSettingsObj)
+        BluetoothSdk.updateBluetoothSettings(coreSettingsObj)
       },
       {equalityFn: shallow},
     )
@@ -352,13 +352,13 @@ class MantleManager {
 
     // Forward core status changes to the zustand core store.
     this.subs.push(
-      CoreModule.onBluetoothStatus((changed: Partial<BluetoothStatus>) => {
+      BluetoothSdk.onBluetoothStatus((changed: Partial<BluetoothStatus>) => {
         // console.log("MANTLE: Core status changed", changed)
         useCoreStore.getState().setCoreInfo(changed)
       }),
     )
     this.subs.push(
-      CoreModule.onGlassesStatus((changed) => {
+      BluetoothSdk.onGlassesStatus((changed) => {
         // console.log("MANTLE: Glasses status changed", changed)
         useGlassesStore.getState().setGlassesInfo(changed)
         localMiniappRuntime.forwardEvent("glasses_connection_state", changed)
@@ -372,14 +372,14 @@ class MantleManager {
     // Subscribe to individual core events
     {
       this.subs.push(
-        CoreModule.addListener("log", (event) => {
+        BluetoothSdk.addListener("log", (event) => {
           console.log("CORE:", event.message)
         }),
       )
 
       // Keep the store in sync for standalone WiFi status events.
       this.subs.push(
-        CoreModule.addListener("wifi_status_change", (event) => {
+        BluetoothSdk.addListener("wifi_status_change", (event) => {
           const {type: _type, ...wifi} = event
           useGlassesStore.getState().setGlassesInfo({wifi})
         }),
@@ -387,7 +387,7 @@ class MantleManager {
 
       // TODO: remove since we can sub to the zustand store for hotspot info:
       this.subs.push(
-        CoreModule.addListener("hotspot_status_change", (event) => {
+        BluetoothSdk.addListener("hotspot_status_change", (event) => {
           const enabled = event.state === "enabled"
           const ssid = enabled ? event.ssid : ""
           const password = enabled ? event.password : ""
@@ -403,7 +403,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("hotspot_error", (event) => {
+        BluetoothSdk.addListener("hotspot_error", (event) => {
           GlobalEventEmitter.emit("hotspot_error", {
             error_message: event.error_message,
             timestamp: event.timestamp,
@@ -412,7 +412,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("gallery_status", (event) => {
+        BluetoothSdk.addListener("gallery_status", (event) => {
           GlobalEventEmitter.emit("gallery_status", {
             photos: event.photos,
             videos: event.videos,
@@ -424,13 +424,13 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("photo_response", (event) => {
+        BluetoothSdk.addListener("photo_response", (event) => {
           restComms.sendPhotoResponse(event)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("heartbeat_sent", (event) => {
+        BluetoothSdk.addListener("heartbeat_sent", (event) => {
           console.log("MANTLE: received heartbeat_sent event from Bluetooth SDK", event.heartbeat_sent)
           // TODO: remove the global event emitter and sub directly in the component where needed
           GlobalEventEmitter.emit("heartbeat_sent", {
@@ -440,7 +440,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("heartbeat_received", (event) => {
+        BluetoothSdk.addListener("heartbeat_received", (event) => {
           console.log("MANTLE: received heartbeat_received event from Bluetooth SDK", event.heartbeat_received)
           // TODO: remove the global event emitter and sub directly in the component where needed
           GlobalEventEmitter.emit("heartbeat_received", {
@@ -450,7 +450,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("button_press", (event) => {
+        BluetoothSdk.addListener("button_press", (event) => {
           console.log("MANTLE: BUTTON_PRESS event received:", event)
           this.handle_button_press(event)
           localMiniappRuntime.forwardEvent("button_press", event)
@@ -458,7 +458,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("touch_event", (event) => {
+        BluetoothSdk.addListener("touch_event", (event) => {
           const deviceModel = event.device_model ?? "Mentra Live"
           const gestureName = event.gesture_name ?? "unknown"
           const timestamp = typeof event.timestamp === "number" ? event.timestamp : Date.now()
@@ -472,7 +472,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("swipe_volume_status", (event) => {
+        BluetoothSdk.addListener("swipe_volume_status", (event) => {
           const enabled = !!event.enabled
           const timestamp = typeof event.timestamp === "number" ? event.timestamp : Date.now()
           socketComms.sendSwipeVolumeStatus(enabled, timestamp)
@@ -482,7 +482,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("switch_status", (event) => {
+        BluetoothSdk.addListener("switch_status", (event) => {
           const switchType = typeof event.switch_type === "number" ? event.switch_type : event.switchType ?? -1
           const switchValue = typeof event.switch_value === "number" ? event.switch_value : event.switchValue ?? -1
           const timestamp = typeof event.timestamp === "number" ? event.timestamp : Date.now()
@@ -493,7 +493,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("rgb_led_control_response", (event) => {
+        BluetoothSdk.addListener("rgb_led_control_response", (event) => {
           const requestId = event.requestId ?? ""
           const success = event.state === "success"
           const errorMessage = event.state === "error" ? event.errorCode : null
@@ -504,13 +504,13 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("pair_failure", (event) => {
+        BluetoothSdk.addListener("pair_failure", (event) => {
           GlobalEventEmitter.emit("pair_failure", event.error)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_pairing_needed", (event) => {
+        BluetoothSdk.addListener("audio_pairing_needed", (event) => {
           GlobalEventEmitter.emit("audio_pairing_needed", {
             deviceName: event.device_name,
           })
@@ -518,7 +518,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_connected", (event) => {
+        BluetoothSdk.addListener("audio_connected", (event) => {
           GlobalEventEmitter.emit("audio_connected", {
             deviceName: event.device_name,
           })
@@ -526,39 +526,39 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_disconnected", () => {
+        BluetoothSdk.addListener("audio_disconnected", () => {
           GlobalEventEmitter.emit("audio_disconnected", {})
         }),
       )
 
       // Allow core to persist hardware-originated setting changes.
       this.subs.push(
-        CoreModule.addListener("save_setting", async (event) => {
+        BluetoothSdk.addListener("save_setting", async (event) => {
           console.log("MANTLE: Received save_setting event from core:", event)
           await useSettingsStore.getState().setSetting(event.key, event.value)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("head_up", (event) => {
+        BluetoothSdk.addListener("head_up", (event) => {
           mantle.handle_head_up(event.up)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("vad_status", (event) => {
+        BluetoothSdk.addListener("vad_status", (event) => {
           socketComms.sendVadStatus(event.status)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("battery_status", (event) => {
+        BluetoothSdk.addListener("battery_status", (event) => {
           socketComms.sendBatteryStatus(event.level, event.charging, event.timestamp)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("local_transcription", (event) => {
+        BluetoothSdk.addListener("local_transcription", (event) => {
           mantle.handle_local_transcription(event)
         }),
       )
@@ -669,7 +669,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_pairing_needed", (event) => {
+        BluetoothSdk.addListener("audio_pairing_needed", (event) => {
           GlobalEventEmitter.emit("audio_pairing_needed", {
             deviceName: event.device_name,
           })
@@ -677,7 +677,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_connected", (event) => {
+        BluetoothSdk.addListener("audio_connected", (event) => {
           GlobalEventEmitter.emit("audio_connected", {
             deviceName: event.device_name,
           })
@@ -685,21 +685,21 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("audio_disconnected", () => {
+        BluetoothSdk.addListener("audio_disconnected", () => {
           GlobalEventEmitter.emit("audio_disconnected", {})
         }),
       )
 
       // allow the core to change settings so it can persist state:
       this.subs.push(
-        CoreModule.addListener("save_setting", async (event) => {
+        BluetoothSdk.addListener("save_setting", async (event) => {
           console.log("MANTLE: Received save_setting event from Core:", event)
           await useSettingsStore.getState().setSetting(event.key, event.value)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("head_up", (event) => {
+        BluetoothSdk.addListener("head_up", (event) => {
           mantle.handle_head_up(event.up)
           // Translate native {up: boolean} → cloud-SDK shape {position: "up" | "down"}
           localMiniappRuntime.forwardEvent("head_up", {
@@ -740,14 +740,14 @@ class MantleManager {
       // this.subs.push({remove: () => batteryStateSub.remove()})
 
       // this.subs.push(
-      //   CoreModule.addListener("vad", (event) => {
+      //   BluetoothSdk.addListener("vad", (event) => {
       //     localMiniappRuntime.forwardEvent("VAD", event)
       //     localSttFallbackCoordinator.onVad(!!event?.status)
       //   }),
       // )
 
       // this.subs.push(
-      //   CoreModule.addListener("audio_chunk", (event) => {
+      //   BluetoothSdk.addListener("audio_chunk", (event) => {
       //     localMiniappRuntime.forwardEvent("audio_chunk", event)
       //   }),
       // )
@@ -755,7 +755,7 @@ class MantleManager {
       // G2 dashboard menu: user selected a miniapp from the glasses swipe menu
       // G2.swift resolves the numeric appId → packageName before sending this event
       this.subs.push(
-        CoreModule.addListener("miniapp_selected", (event) => {
+        BluetoothSdk.addListener("miniapp_selected", (event) => {
           const packageName = event.packageName as string
           if (!packageName) return
           const app = useAppStatusStore.getState().apps.find((a) => a.packageName === packageName)
@@ -772,19 +772,19 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("local_transcription", (event) => {
+        BluetoothSdk.addListener("local_transcription", (event) => {
           mantle.handle_local_transcription(event)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("ws_text", (event) => {
+        BluetoothSdk.addListener("ws_text", (event) => {
           socketComms.sendText(event.text)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("ws_bin", (event) => {
+        BluetoothSdk.addListener("ws_bin", (event) => {
           const binaryString = atob(event.base64)
           const bytes = new Uint8Array(binaryString.length)
           for (let i = 0; i < binaryString.length; i++) {
@@ -795,7 +795,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("mic_lc3", (event) => {
+        BluetoothSdk.addListener("mic_lc3", (event) => {
           if (this.micDataTimeout) {
             BgTimer.clearTimeout(this.micDataTimeout)
           }
@@ -817,7 +817,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("mic_pcm", () => {
+        BluetoothSdk.addListener("mic_pcm", () => {
           // mic_pcm events are strictly on-device. Local miniapps consume
           // raw PCM via the `audio_chunk` listener; Sherpa-ONNX consumes
           // it via the local-STT path. The cloud only ever receives LC3
@@ -835,21 +835,21 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("stream_status", (event) => {
+        BluetoothSdk.addListener("stream_status", (event) => {
           console.log("MANTLE: Forwarding stream status to server:", event)
           socketComms.sendStreamStatus(event)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("keep_alive_ack", (event) => {
+        BluetoothSdk.addListener("keep_alive_ack", (event) => {
           console.log("MANTLE: Forwarding keep-alive ACK to server:", event)
           socketComms.sendKeepAliveAck(event)
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("ota_update_available", (event) => {
+        BluetoothSdk.addListener("ota_update_available", (event) => {
           if (!useGlassesStore.getState().connected) {
             console.log("📱 MANTLE: Ignoring ota_update_available - glasses not connected")
             return
@@ -873,7 +873,7 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("mtk_update_complete", (event) => {
+        BluetoothSdk.addListener("mtk_update_complete", (event) => {
           console.log("MANTLE: MTK firmware update complete:", event.message)
           GlobalEventEmitter.emit("mtk_update_complete", {
             message: event.message,
@@ -883,14 +883,14 @@ class MantleManager {
       )
 
       this.subs.push(
-        CoreModule.addListener("ota_start_ack", (event) => {
+        BluetoothSdk.addListener("ota_start_ack", (event) => {
           console.log("MANTLE: ota_start_ack received from glasses")
           GlobalEventEmitter.emit("ota_start_ack", {timestamp: event.timestamp})
         }),
       )
 
       this.subs.push(
-        CoreModule.addListener("ota_status", (event) => {
+        BluetoothSdk.addListener("ota_status", (event) => {
           const normalized = normalizeOtaStatusEvent(event as Record<string, unknown>)
           const status: OtaStatus = otaStatusFromNormalized(normalized)
           useGlassesStore.getState().setOtaStatus(status)
@@ -911,11 +911,11 @@ class MantleManager {
     }
 
     // one time get all:
-    const bluetoothStatus = await CoreModule.getBluetoothStatus()
+    const bluetoothStatus = await BluetoothSdk.getBluetoothStatus()
     // console.log("MANTLE: Bluetooth status:", bluetoothStatus)
     useCoreStore.getState().setCoreInfo(bluetoothStatus)
 
-    const glassesStatus = await CoreModule.getGlassesStatus()
+    const glassesStatus = await BluetoothSdk.getGlassesStatus()
     // console.log("MANTLE: glasses status:", glassesStatus)
     useGlassesStore.getState().setGlassesInfo(glassesStatus)
   }

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -1,4 +1,11 @@
-import CoreModule, {ButtonPressEvent, CoreStatus, GlassesStatus, OtaStatus, OtaProgress, OtaUpdateInfo} from "@mentra/bluetooth-sdk"
+import CoreModule, {
+  ButtonPressEvent,
+  BluetoothStatus as CoreStatus,
+  GlassesStatus,
+  OtaProgress,
+  OtaStatus,
+  OtaUpdateInfo,
+} from "@mentra/bluetooth-sdk"
 import CrustModule from "crust"
 import * as Calendar from "expo-calendar"
 import * as Location from "expo-location"
@@ -188,7 +195,7 @@ class MantleManager {
     // give the core some time to boot before sending all the initial settings:
     BgTimer.setTimeout(() => {
       const initialCoreSettings = useSettingsStore.getState().getCoreSettings()
-      CoreModule.updateCore(initialCoreSettings) // send settings to core
+      CoreModule.updateBluetoothSettings(initialCoreSettings) // send settings to core
       console.log("MANTLE: Settings sent to core")
       // settings are now in native; safe to attempt auto-connect
       attemptReconnectToDefaultWearable()
@@ -323,7 +330,7 @@ class MantleManager {
           }
         }
         // console.log("MANTLE: core settings changed", coreSettingsObj)
-        CoreModule.updateCore(coreSettingsObj)
+        CoreModule.updateBluetoothSettings(coreSettingsObj)
       },
       {equalityFn: shallow},
     )
@@ -345,7 +352,7 @@ class MantleManager {
 
     // Forward core status changes to the zustand core store.
     this.subs.push(
-      CoreModule.onCoreStatus((changed: Partial<CoreStatus>) => {
+      CoreModule.onBluetoothStatus((changed: Partial<CoreStatus>) => {
         // console.log("MANTLE: Core status changed", changed)
         useCoreStore.getState().setCoreInfo(changed)
       }),
@@ -904,7 +911,7 @@ class MantleManager {
     }
 
     // one time get all:
-    const coreStatus = await CoreModule.getCoreStatus()
+    const coreStatus = await CoreModule.getBluetoothStatus()
     // console.log("MANTLE: core status:", coreStatus)
     useCoreStore.getState().setCoreInfo(coreStatus)
 

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -1,6 +1,6 @@
 import CoreModule, {
   ButtonPressEvent,
-  BluetoothStatus as CoreStatus,
+  BluetoothStatus,
   GlassesStatus,
   OtaProgress,
   OtaStatus,
@@ -352,7 +352,7 @@ class MantleManager {
 
     // Forward core status changes to the zustand core store.
     this.subs.push(
-      CoreModule.onBluetoothStatus((changed: Partial<CoreStatus>) => {
+      CoreModule.onBluetoothStatus((changed: Partial<BluetoothStatus>) => {
         // console.log("MANTLE: Core status changed", changed)
         useCoreStore.getState().setCoreInfo(changed)
       }),
@@ -911,9 +911,9 @@ class MantleManager {
     }
 
     // one time get all:
-    const coreStatus = await CoreModule.getBluetoothStatus()
-    // console.log("MANTLE: core status:", coreStatus)
-    useCoreStore.getState().setCoreInfo(coreStatus)
+    const bluetoothStatus = await CoreModule.getBluetoothStatus()
+    // console.log("MANTLE: Bluetooth status:", bluetoothStatus)
+    useCoreStore.getState().setCoreInfo(bluetoothStatus)
 
     const glassesStatus = await CoreModule.getGlassesStatus()
     // console.log("MANTLE: glasses status:", glassesStatus)

--- a/mobile/src/services/RestComms.test.ts
+++ b/mobile/src/services/RestComms.test.ts
@@ -121,7 +121,7 @@ describe("RestComms", () => {
     const CoreModule = require("@mentra/bluetooth-sdk").default
     restComms.setCoreToken("new-core-token")
 
-    expect(CoreModule.updateCore).toHaveBeenCalledWith({core_token: "new-core-token"})
+    expect(CoreModule.updateBluetoothSettings).toHaveBeenCalledWith({core_token: "new-core-token"})
     expect(useSettingsStore.getState().getSetting(SETTINGS.core_token.key)).not.toBe("new-core-token")
   })
 })

--- a/mobile/src/services/RestComms.test.ts
+++ b/mobile/src/services/RestComms.test.ts
@@ -118,10 +118,10 @@ describe("RestComms", () => {
   })
 
   it("syncs core tokens to native state", () => {
-    const CoreModule = require("@mentra/bluetooth-sdk").default
+    const BluetoothSdk = require("@mentra/bluetooth-sdk").default
     restComms.setCoreToken("new-core-token")
 
-    expect(CoreModule.updateBluetoothSettings).toHaveBeenCalledWith({core_token: "new-core-token"})
+    expect(BluetoothSdk.updateBluetoothSettings).toHaveBeenCalledWith({core_token: "new-core-token"})
     expect(useSettingsStore.getState().getSetting(SETTINGS.core_token.key)).not.toBe("new-core-token")
   })
 })

--- a/mobile/src/services/RestComms.ts
+++ b/mobile/src/services/RestComms.ts
@@ -2,7 +2,7 @@ import {AppletInterface} from "@/../../cloud/packages/types/src"
 import axios, {AxiosInstance, AxiosRequestConfig} from "axios"
 import {AsyncResult, Result, result as Res} from "typesafe-ts"
 
-import CoreModule, {PhotoResponseEvent} from "@mentra/bluetooth-sdk"
+import BluetoothSdk, {PhotoResponseEvent} from "@mentra/bluetooth-sdk"
 import {SETTINGS, useSettingsStore} from "@/stores/settings"
 import {useConnectionStore} from "@/stores/connection"
 import {WebSocketStatus} from "@/services/ws-types"
@@ -50,7 +50,7 @@ class RestComms {
 
     // Sync to native DeviceStore (and persist to SharedPreferences in BluetoothSdkModule when bridge runs)
     const value = token ?? ""
-    const updateResult = CoreModule.updateBluetoothSettings({core_token: value})
+    const updateResult = BluetoothSdk.updateBluetoothSettings({core_token: value})
     if (updateResult != null && typeof (updateResult as Promise<void>).then === "function") {
       ;(updateResult as Promise<void>).catch(() => {})
     }

--- a/mobile/src/services/RestComms.ts
+++ b/mobile/src/services/RestComms.ts
@@ -48,9 +48,9 @@ class RestComms {
       }`,
     )
 
-    // Sync to native GlassesStore (and persist to SharedPreferences in CoreModule when bridge runs)
+    // Sync to native DeviceStore (and persist to SharedPreferences in BluetoothSdkModule when bridge runs)
     const value = token ?? ""
-    const updateResult = CoreModule.updateCore({core_token: value})
+    const updateResult = CoreModule.updateBluetoothSettings({core_token: value})
     if (updateResult != null && typeof (updateResult as Promise<void>).then === "function") {
       ;(updateResult as Promise<void>).catch(() => {})
     }

--- a/mobile/src/services/STTModelManager.ts
+++ b/mobile/src/services/STTModelManager.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {Platform} from "react-native"
 import * as RNFS from "@dr.pogodin/react-native-fs"
 
@@ -138,7 +138,7 @@ class STTModelManager {
 
   async getCurrentModelIdFromPreferences(): Promise<string> {
     try {
-      let path = await CoreModule.getSttModelPath()
+      let path = await BluetoothSdk.getSttModelPath()
       const modelId = path && path.length > 0 ? this.getModelIdFromPath(path) : ""
 
       this.setCurrentModelId(modelId)
@@ -216,7 +216,7 @@ class STTModelManager {
       }
 
       // Validate model with native module
-      const isValid = await CoreModule.validateSttModel(modelPath)
+      const isValid = await BluetoothSdk.validateSttModel(modelPath)
       return isValid
     } catch (error) {
       console.error("Error checking model availability:", error)
@@ -315,7 +315,7 @@ class STTModelManager {
       console.log(`Calling native extractTarBz2 for ${Platform.OS}...`)
       try {
         onExtractionProgress?.({percentage: 25})
-        const extractionResult = await CoreModule.extractTarBz2(tempPath, finalPath)
+        const extractionResult = await BluetoothSdk.extractTarBz2(tempPath, finalPath)
         if (!extractionResult) {
           throw new Error("Native extraction returned failure status")
         }
@@ -384,7 +384,7 @@ class STTModelManager {
   }
 
   private async setNativeModelPath(path: string, languageCode: string): Promise<void> {
-    CoreModule.setSttModelDetails(path, languageCode)
+    BluetoothSdk.setSttModelDetails(path, languageCode)
     return
   }
 

--- a/mobile/src/services/SocketComms.display.test.ts
+++ b/mobile/src/services/SocketComms.display.test.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {displayProcessor as MockDisplayProcessor} from "@mentra/island"
 
 import {useDisplayStore} from "@/stores/display"
@@ -74,7 +74,7 @@ describe("SocketComms display events", () => {
         view: "main",
       }),
     )
-    expect(CoreModule.displayEvent).toHaveBeenCalledWith(
+    expect(BluetoothSdk.displayEvent).toHaveBeenCalledWith(
       expect.objectContaining({
         _processed: true,
         view: "main",
@@ -105,7 +105,7 @@ describe("SocketComms display events", () => {
 
     socketComms.handle_display_event(rawEvent)
 
-    expect(CoreModule.displayEvent).toHaveBeenCalledWith(rawEvent)
+    expect(BluetoothSdk.displayEvent).toHaveBeenCalledWith(rawEvent)
     expect(useDisplayStore.getState().dashboardEvent).toEqual(rawEvent)
     expect(consoleErrorSpy).toHaveBeenCalledWith("SOCKET: DisplayProcessor error, using raw event:", expect.any(Error))
     consoleErrorSpy.mockRestore()

--- a/mobile/src/services/SocketComms.ts
+++ b/mobile/src/services/SocketComms.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {
   displayProcessor,
   localMiniappRuntime,
@@ -477,7 +477,7 @@ class SocketComms {
       }
     }
 
-    // CoreModule.updateCore({
+    // BluetoothSdk.updateCore({
     //   // should_send_pcm: shouldSendPcmData,
     //   should_send_lc3: shouldSendPcmData, // online apps always want lc3
     //   should_send_transcript: shouldSendTranscript,
@@ -505,7 +505,7 @@ class SocketComms {
       processedEvent = msg
     }
 
-    CoreModule.displayEvent(processedEvent)
+    BluetoothSdk.displayEvent(processedEvent)
     const displayEventStr = JSON.stringify(processedEvent)
     useDisplayStore.getState().setDisplayEvent(displayEventStr)
   }
@@ -563,25 +563,25 @@ class SocketComms {
       return
     }
     // Parameter order: requestId, appId, size, webhookUrl, authToken, compress, flash, sound
-    CoreModule.photoRequest(requestId, appId, size, webhookUrl, authToken, compress, flash, sound)
+    BluetoothSdk.photoRequest(requestId, appId, size, webhookUrl, authToken, compress, flash, sound)
   }
 
   private handle_start_stream(msg: any) {
     const streamUrl = msg.streamUrl
     if (streamUrl) {
-      CoreModule.startStream(msg)
+      BluetoothSdk.startStream(msg)
     } else {
       console.log("Invalid stream request: missing stream URL")
     }
   }
 
   private handle_stop_stream() {
-    CoreModule.stopStream()
+    BluetoothSdk.stopStream()
   }
 
   private handle_keep_stream_alive(msg: any) {
     console.log(`SOCKET: Received KEEP_STREAM_ALIVE: ${JSON.stringify(msg)}`)
-    CoreModule.keepStreamAlive(msg)
+    BluetoothSdk.keepStreamAlive(msg)
   }
 
   private handle_start_video_recording(msg: any) {
@@ -590,13 +590,13 @@ class SocketComms {
     const save = msg.save !== false
     const flash = msg.flash ?? true
     const sound = msg.sound ?? true
-    CoreModule.startVideoRecording(videoRequestId, save, flash, sound)
+    BluetoothSdk.startVideoRecording(videoRequestId, save, flash, sound)
   }
 
   private handle_stop_video_recording(msg: any) {
     console.log(`SOCKET: Received STOP_VIDEO_RECORDING: ${JSON.stringify(msg)}`)
     const stopRequestId = msg.requestId || ""
-    CoreModule.stopVideoRecording(stopRequestId)
+    BluetoothSdk.stopVideoRecording(stopRequestId)
   }
 
   private handle_rgb_led_control(msg: any) {
@@ -610,7 +610,7 @@ class SocketComms {
       return Number.isFinite(coerced) ? coerced : fallback
     }
 
-    CoreModule.rgbLedControl(
+    BluetoothSdk.rgbLedControl(
       msg.requestId,
       msg.packageName ?? null,
       normalizeRgbLedAction(msg.action),

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 
 import {gallerySyncNotifications} from "@/services/asg/gallerySyncNotifications"
 import {gallerySyncService} from "./gallerySyncService"
@@ -142,6 +142,6 @@ describe("GallerySyncService", () => {
 
     expect(useGallerySyncStore.getState().syncState).toBe("requesting_hotspot")
     expect(useGallerySyncStore.getState().syncServiceOpenedHotspot).toBe(true)
-    expect(CoreModule.setHotspotState).toHaveBeenCalledWith(true)
+    expect(BluetoothSdk.setHotspotState).toHaveBeenCalledWith(true)
   })
 })

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -5,7 +5,7 @@
 
 import * as RNFS from "@dr.pogodin/react-native-fs"
 import NetInfo from "@react-native-community/netinfo"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {AppState, AppStateStatus, Platform} from "react-native"
 import WifiManager from "react-native-wifi-reborn"
 
@@ -656,7 +656,7 @@ class GallerySyncService {
 
     try {
       console.log("[GallerySyncService]   📤 Sending hotspot enable command to glasses...")
-      await CoreModule.setHotspotState(true)
+      await BluetoothSdk.setHotspotState(true)
       console.log("[GallerySyncService]   ✅ Hotspot request sent successfully")
       console.log("[GallerySyncService]   ⏳ Waiting for hotspot_status_change event (timeout: 30s)...")
     } catch (error) {
@@ -915,7 +915,7 @@ class GallerySyncService {
             console.log(`[GallerySyncService] 📶 Final SSID check before download: "${finalSSID}"`)
             if (Platform.OS === "android") {
               // Some local builds can have stale generated typings for the Bluetooth SDK module.
-              ;(CoreModule as any).logCurrentWifiFrequency?.()
+              ;(BluetoothSdk as any).logCurrentWifiFrequency?.()
             }
             if (finalSSID !== hotspotInfo.ssid) {
               console.error(
@@ -1943,7 +1943,7 @@ class GallerySyncService {
 
     try {
       console.log("[GallerySyncService] Closing hotspot...")
-      await CoreModule.setHotspotState(false)
+      await BluetoothSdk.setHotspotState(false)
       store.setSyncServiceOpenedHotspot(false)
       store.setHotspotInfo(null)
       console.log("[GallerySyncService] Hotspot closed")
@@ -2002,7 +2002,7 @@ class GallerySyncService {
    */
   async queryGlassesGalleryStatus(): Promise<void> {
     try {
-      await CoreModule.queryGalleryStatus()
+      await BluetoothSdk.queryGalleryStatus()
     } catch (error) {
       console.error("[GallerySyncService] Failed to query gallery status:", error)
     }

--- a/mobile/src/services/bugReport/bugReportIncident.ts
+++ b/mobile/src/services/bugReport/bugReportIncident.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import NetInfo from "@react-native-community/netinfo"
 import Constants from "expo-constants"
 import * as ImagePicker from "expo-image-picker"
@@ -248,7 +248,7 @@ export async function submitBugIncident(
 
   const glassesConnected = useGlassesStore.getState().connected
   if (glassesConnected) {
-    CoreModule.sendIncidentId(incidentId, phoneBackendUrl)
+    BluetoothSdk.sendIncidentId(incidentId, phoneBackendUrl)
   }
 
   if (options?.screenshots && options.screenshots.length > 0) {

--- a/mobile/src/services/miniapps/MiniappCatalog.ts
+++ b/mobile/src/services/miniapps/MiniappCatalog.ts
@@ -1,7 +1,7 @@
 import {Platform} from "react-native"
 import * as Sentry from "@sentry/react-native"
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {
   appRegistry,
   BgTimer,
@@ -188,7 +188,7 @@ class MiniappCatalog {
         }
         return false
       }
-      await CoreModule.restartTranscriber()
+      await BluetoothSdk.restartTranscriber()
       useSettingsStore.getState().setSetting(SETTINGS.offline_captions_running.key, true)
     }
 

--- a/mobile/src/stores/core.ts
+++ b/mobile/src/stores/core.ts
@@ -1,6 +1,6 @@
 import {create} from "zustand"
 import {subscribeWithSelector} from "zustand/middleware"
-import {CoreStatus} from "@mentra/bluetooth-sdk"
+import {BluetoothStatus as CoreStatus} from "@mentra/bluetooth-sdk"
 
 interface CoreState extends CoreStatus {
   setCoreInfo: (info: Partial<CoreStatus>) => void

--- a/mobile/src/stores/core.ts
+++ b/mobile/src/stores/core.ts
@@ -1,13 +1,13 @@
 import {create} from "zustand"
 import {subscribeWithSelector} from "zustand/middleware"
-import {BluetoothStatus as CoreStatus} from "@mentra/bluetooth-sdk"
+import {BluetoothStatus} from "@mentra/bluetooth-sdk"
 
-interface CoreState extends CoreStatus {
-  setCoreInfo: (info: Partial<CoreStatus>) => void
+interface CoreState extends BluetoothStatus {
+  setCoreInfo: (info: Partial<BluetoothStatus>) => void
   reset: () => void
 }
 
-const initialState: CoreStatus = {
+const initialState: BluetoothStatus = {
   // state:
   searching: false,
   searchingController: false,

--- a/mobile/src/test-utils/mockCoreModule.ts
+++ b/mobile/src/test-utils/mockCoreModule.ts
@@ -18,7 +18,7 @@ const addListener = jest.fn((eventName: string, listener: Listener) => {
 export const coreModuleMock = {
   addListener,
   requestBluetoothPermissions: jest.fn(() => Promise.resolve(true)),
-  getCoreStatus: jest.fn(() =>
+  getBluetoothStatus: jest.fn(() =>
     Promise.resolve({
       searching: false,
       micRanking: ["glasses", "phone", "bluetooth"],
@@ -68,9 +68,9 @@ export const coreModuleMock = {
     }),
   ),
   update: jest.fn(() => Promise.resolve()),
-  updateCore: jest.fn(() => Promise.resolve()),
+  updateBluetoothSettings: jest.fn(() => Promise.resolve()),
   updateGlasses: jest.fn(() => Promise.resolve()),
-  onCoreStatus: jest.fn((listener: Listener) => addListener("core_status", listener).remove),
+  onBluetoothStatus: jest.fn((listener: Listener) => addListener("bluetooth_status", listener).remove),
   onGlassesStatus: jest.fn((listener: Listener) => addListener("glasses_status", listener).remove),
   displayEvent: jest.fn(() => Promise.resolve()),
   displayText: jest.fn(() => Promise.resolve()),

--- a/mobile/src/utils/LogoutUtils.ts
+++ b/mobile/src/utils/LogoutUtils.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import {Session} from "@supabase/supabase-js"
 
 import restComms from "@/services/RestComms"
@@ -51,7 +51,7 @@ export class LogoutUtils {
 
     try {
       // First try to disconnect any connected glasses
-      await CoreModule.disconnect()
+      await BluetoothSdk.disconnect()
       console.log(`${this.TAG}: Disconnected glasses`)
     } catch (error) {
       console.warn(`${this.TAG}: Error disconnecting glasses:`, error)
@@ -59,7 +59,7 @@ export class LogoutUtils {
 
     try {
       // Then forget the glasses completely
-      await CoreModule.forget()
+      await BluetoothSdk.forget()
       console.log(`${this.TAG}: Forgot glasses pairing`)
     } catch (error) {
       console.warn(`${this.TAG}: Error forgetting glasses:`, error)

--- a/mobile/src/utils/PermissionsUtils.tsx
+++ b/mobile/src/utils/PermissionsUtils.tsx
@@ -1,5 +1,5 @@
 import {AppletInterface, AppletPermission} from "@/../../cloud/packages/types/src"
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import CrustModule from "crust"
 import {Alert, Linking, PermissionsAndroid, Platform} from "react-native"
 import BleManager from "react-native-ble-manager"

--- a/mobile/src/utils/SettingsNavigationUtils.tsx
+++ b/mobile/src/utils/SettingsNavigationUtils.tsx
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
 import CrustModule from "crust"
 import {Linking, Platform} from "react-native"
 


### PR DESCRIPTION
## Summary

This PR reverts `f8ab48f19` (`Restore Core naming for review separation`) so the Bluetooth SDK naming cleanup can be reviewed and merged separately after the main feature branch lands.

It intentionally keeps the file/module move from the feature branch and re-applies only the code-facing rename layer, including the SDK-facing module/status/store naming that was temporarily undone to reduce review and merge-conflict noise.

## Why

The base feature branch now preserves the old Core-facing names to make the current PR easier to review and easier to merge alongside the parallel TypeScript work. This follow-up branch gives us a clean, isolated PR that can bring the SDK-facing names back later without mixing that rename churn into the larger refactor review.

## Validation

- `cd mobile && bun run test`
- `cd mobile/android && ./gradlew :mentra-bluetooth-sdk:compileDebugKotlin`
