### PR TITLE
Fix asg-client-38-test.apk sha256 in test OTA manifest

### DIFF
--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -4,7 +4,7 @@
       "versionCode": 38,
       "versionName": "38.0",
       "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk",
-      "sha256": "17c059983674706c627324cf5796659ac7eff54d1869ba2ee9a748709cfde7a0"
+      "sha256": "d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,


### PR DESCRIPTION
## Summary

- The `asg-client-38-test.apk` artifact at the `apkUrl` was re-uploaded but `test_bes_ota_prod_live_version.json` still carries the old `sha256`.
- Verified live: `curl -L https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk | shasum -a 256` returns `d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59`, but the manifest claims `17c059...`.
- v27 OTA clients pointed at this manifest download the APK successfully, then fail verification and delete it. Logs from a real v27→v38 OTA test on a Mentra Live show `Expected SHA256: 17c059...` vs `Calculated SHA256: d504e1f1...` followed by `Downloaded APK hash does not match expected value! Deleting APK.`

This PR updates the manifest's `sha256` to match what's actually hosted.

## Test plan

- [ ] After merge + deploy, `curl https://ota.mentraglass.com/test_bes_ota_prod_live_version.json` returns the new sha256.
- [ ] On a v27 device pointed at this manifest, OTA download passes the SHA256 check and proceeds to install.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update test OTA manifest to correct sha256 for `asg-client-38-test.apk`, matching the current artifact at the apkUrl. Fixes OTA verification failures on v27 devices by aligning the manifest hash with the downloaded APK.

<sup>Written for commit 661ad115906144cbedcdca5273cb87b360ec95c6. Summary will update on new commits. <a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/2692?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

