### PR TITLE
Add crash-hunting observability for cloud restarts

### DIFF
--- a/cloud/issues/105-event-loop-cascade-investigation/design.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/design.md
@@ -1,6 +1,6 @@
 # Design: Phase-1.5 Cascade Diagnostic Instrumentation
 
-**Status:** Implemented on `cloud/issue-106` — pending cloud-debug deploy/soak
+**Status:** Implemented on `cloud/issue-106` — cloud-debug smoke passed; soak ongoing
 **Date:** 2026-05-05
 **Related:** [spike.md](./spike.md), [spec.md](./spec.md), [106 spike](../106-app-ws-storm-multi-app/spike.md)
 

--- a/cloud/issues/105-event-loop-cascade-investigation/design.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/design.md
@@ -1,0 +1,441 @@
+# Design: Phase-1.5 Cascade Diagnostic Instrumentation
+
+**Status:** Implemented on `cloud/issue-106` — pending cloud-debug deploy/soak
+**Date:** 2026-05-05
+**Related:** [spike.md](./spike.md), [spec.md](./spec.md), [106 spike](../106-app-ws-storm-multi-app/spike.md)
+
+---
+
+## Plain-English Mental Model
+
+Observability means "make production explain itself."
+
+For this incident, use this vocabulary:
+
+| Word | Simple definition | What we need here |
+|---|---|---|
+| Log | A timestamped event saying what happened | `slow-app-connect`, `ws-close`, `process-shutdown-started` |
+| Metric | A number tracked over time | event-loop max delay, app WS close count, active sessions |
+| Trace/phase timing | A breakdown of one operation | reconnect total time split across auth, session lookup, app refresh, broadcast |
+| Profile | CPU samples showing which code burned processor time | useful locally/debug, not the main production signal |
+
+Better Stack is the evidence warehouse: it collects logs/metrics, lets us query them, builds dashboards, and sends alerts. It is not a replacement for application-level breadcrumbs. It can tell us a pod restarted or HTTP latency rose, but our code must tell it whether the slow path was `CONNECTION_INIT`, `RECONNECT`, `subscription_update`, `refreshInstalledApps`, or app WS close cleanup.
+
+The design goal is therefore:
+
+```text
+Emit cheap, structured Mentra-specific facts.
+Let Better Stack store, graph, alert, and correlate them.
+Use the next cascade to choose one fix PR instead of guessing.
+```
+
+---
+
+## Overview
+
+This design describes how to add production-safe diagnostics for the app-message / reconnect cascade without changing runtime behavior.
+
+The goal is not to fix the cascade in this PR. The goal is to make the next staging or debug event produce enough evidence to choose the correct fix.
+
+The current evidence points at two mechanisms that existing telemetry conflates:
+
+1. **Async wall-time amplification:** app-message timers can grow to tens of seconds because they wrap awaited work. The event loop can remain responsive while `op_appMessage_ms` grows.
+2. **Synchronous storm amplification:** small sync segments in app init/reconnect/subscription paths can multiply across many simultaneous app sessions and miss `/livez`.
+
+The design instruments the boundary between those two mechanisms.
+
+---
+
+## Decision
+
+Ship a Phase-1.5 observability PR before any optimization PR.
+
+Ship the diagnostic surfaces together in one PR, not as three staged observability PRs. The cascade is intermittent; capturing the next event with only protocol timers but without connect/subscription/WS lifecycle context could leave us with another ambiguous incident and another wait cycle. The safer review strategy is to keep one PR but organize it into clear file-level sections matching S1-S8 in [spec.md](./spec.md), with cloud-debug soak as the blast-radius control.
+
+Do not keep broad-spiking before instrumentation. The spike has already narrowed the unknowns to paths and phases that can be measured safely:
+
+- app WS protocol: `CONNECTION_INIT`, `RECONNECT`, regular app messages;
+- app connect phases: `attachAppSocket`, `broadcastAppState`, `refreshInstalledApps`, app/user DB lookups;
+- subscription fanout phases: transcription, translation, stream ensure, microphone state;
+- event-loop delay and liveness lifecycle;
+- app WS close/backpressure facts.
+
+Keep this PR behavior-neutral:
+
+- no liveness/readiness changes;
+- no DB query changes;
+- no reconnect semantics changes;
+- no coalescing/debouncing yet;
+- no profiler enabled by default.
+
+Coordination note: if the original Phase 1 observability PR (#2626) lands on `main` before Phase 1.5 is implemented, rebase Phase 1.5 onto the branch that contains it. If staging promotes with Phase 1.5 first, treat Phase 1.5 as superseding the older Phase 1-only observability branch and avoid carrying divergent instrumentation forward.
+
+---
+
+## Architecture
+
+The diagnostics should be built from three small primitives:
+
+### 1. Windowed Operation Timers
+
+Use the existing `operationTimers` pattern so every `system-vitals` line gets bounded numeric totals for the prior 30s window.
+
+Examples:
+
+```text
+op_appProtocol_connectionInit_ms
+op_appConnect_refreshInstalledApps_ms
+op_subscription_syncManagers_ms
+op_appMsg_displayRequest_ms
+```
+
+These answer: "Where did wall-clock time accumulate in this 30s window?"
+
+Implementation detail: these diagnostic `op_*` fields are intentionally excluded from `opTotalMs`. `opTotalMs` remains the older coarse budget signal, while Phase 1.5 fields provide nested explanation without double-counting.
+
+### 2. Windowed Counters
+
+Add lightweight count accumulators for the same windows.
+
+Examples:
+
+```text
+appProtocol_connectionInit_count
+appConnect_broadcastAppState_count
+subscription_update_count
+wsSend_backpressure_count
+```
+
+These answer: "Was this slow because one call was huge, or because many small calls stacked up?"
+
+### 3. Slow Outlier Logs
+
+Emit structured warnings only above thresholds. These logs include phase breakdowns for one slow operation.
+
+Examples:
+
+```text
+slow-app-protocol
+slow-app-connect
+slow-subscription-update
+ws-close
+```
+
+These answer: "Which package/user-hash/path was slow, and what phase inside it was responsible?"
+
+---
+
+## Data Flow
+
+At runtime, every app WS event should pass through increasingly specific instrumentation:
+
+```text
+app-ws message
+  -> bun-websocket protocol timer
+      -> connection_init timer OR reconnect timer OR regular message timer
+          -> AppManager phase timers, if init/reconnect
+          -> AppMessageHandler per-type timers, if regular message
+              -> SubscriptionManager phase timers, if subscription_update
+  -> operationTimers snapshot in system-vitals
+  -> slow-* log only if threshold exceeded
+```
+
+Separately:
+
+```text
+app-ws close/send/drain
+  -> per-socket metadata in ws.data
+  -> ws-close structured log on close
+  -> ws send/backpressure/drain counters in system-vitals
+```
+
+And:
+
+```text
+process lifecycle
+  -> startup / sigterm / shutdown breadcrumbs
+  -> external porter kubectl describe pod check after restart
+```
+
+---
+
+## Diagnostic Surfaces
+
+### App Protocol Surface
+
+Instrument `bun-websocket.ts` before dispatching into session handlers.
+
+Required fields:
+
+- `op_appProtocol_connectionInit_ms`
+- `op_appProtocol_reconnect_ms`
+- `op_appProtocol_regularMessage_ms`
+- `op_appProtocol_parse_ms`
+- `op_appProtocol_sessionLookup_ms`
+- matching counts for each path
+
+This is necessary because `CONNECTION_INIT` and `RECONNECT` do not behave like normal app messages.
+
+### App Connect Surface
+
+Instrument `AppManager.ts` and `app.service.ts`.
+
+Required fields:
+
+- `op_appConnect_handleAppInit_ms`
+- `op_appConnect_handleReconnect_ms`
+- `op_appConnect_attachAppSocket_ms`
+- `op_appConnect_findOrCreateUser_ms`
+- `op_appConnect_broadcastAppState_ms`
+- `op_appConnect_refreshInstalledApps_ms`
+- `op_appService_getAllApps_ms`
+- `op_appService_getAllApps_userFindOne_ms`
+- `op_appService_getAllApps_appFind_ms`
+
+This directly tests the local-harness hypothesis that legacy init plus app-state refresh can create large wall-time and/or sync amplification.
+
+### Normal App Message Surface
+
+Instrument `app-message-handler.ts`.
+
+Required fields:
+
+- `op_appMsg_subscriptionUpdate_ms`
+- `op_appMsg_displayRequest_ms`
+- `op_appMsg_*_ms` for the remaining switch cases
+- matching counts
+
+This preserves the original 105 question: if regular messages dominate, which message type?
+
+### Subscription Fanout Surface
+
+Instrument `SubscriptionManager.ts` and the narrow downstream hooks that are easy to time.
+
+Required fields:
+
+- `op_subscription_updateSubscriptions_ms`
+- `op_subscription_processUpdate_ms`
+- `op_subscription_permissionCheck_ms`
+- `op_subscription_syncManagers_ms`
+- `op_subscription_transcriptionUpdate_ms`
+- `op_subscription_translationUpdate_ms`
+- `op_subscription_ensureStreamsExist_ms`
+- `op_subscription_microphoneHandleChange_ms`
+
+This tests whether multi-app subscription updates during a storm are the actual sync/async amplifier.
+
+### Event Loop Surface
+
+Keep the existing rolling lag samples and add Bun histogram delay.
+
+Local spike result on Bun `1.3.13`:
+
+- `perf_hooks.monitorEventLoopDelay` works.
+- `histogram.reset()` works.
+- `eventLoopDelayHistMaxMs` catches isolated 80ms and 250ms blocks.
+- `p99` can miss isolated blocks depending on sample count.
+- `performance.eventLoopUtilization()` exists but returned all zeros locally, so do not use ELU.
+
+Required vitals fields:
+
+- `eventLoopLagCurrentMs`
+- `eventLoopLagAvgMs`
+- `eventLoopLagP95Ms`
+- `eventLoopLagP99Ms`
+- `eventLoopLagMaxMs`
+- `eventLoopDelayHistP95Ms`
+- `eventLoopDelayHistP99Ms`
+- `eventLoopDelayHistMaxMs`
+- `eventLoopDelayHistMeanMs`
+
+Reset the histogram each vitals window. Treat `max` as the key field for isolated stalls.
+
+### WS Lifecycle Surface
+
+Track facts in `ws.data` and log on close.
+
+Current feasibility caveat: app sockets currently respond to SDK app-level `ping` messages, and `AppSession` sends protocol `ping()` heartbeats, but Bun app `pong` handling is not currently wired into app-session state. The first implementation should record what is directly observable (`lastMessageAt`, `lastSendAt`, ping send time, send return values, drain counts, close code). Add app `pong` timestamping only if it can be wired through `websocketHandlers.pong()` cleanly. If not, leave `lastPongReceivedAgoMs` null and keep `inferredCloseSource` conservative.
+
+Required `ws-close` fields:
+
+- `wsKind`
+- `packageName`
+- `userIdHash`
+- `code`
+- `connectionAgeMs`
+- `lastMessageAgoMs`
+- `lastSendAgoMs`
+- `lastPingSentAgoMs`
+- `lastPongReceivedAgoMs`
+- `sendBackpressureCount`
+- `drainCount`
+- `bytesIn`
+- `bytesOut`
+- `messagesIn`
+- `messagesOut`
+- `inferredCloseSource`
+
+Do not claim TCP-level details Bun does not expose. Use `inferredCloseSource`, not `closeSource`.
+
+### Process Lifecycle Surface
+
+Keep the existing fail-fast SIGTERM handler. Add or normalize small lifecycle breadcrumbs if needed:
+
+- startup;
+- SIGTERM received;
+- shutdown complete;
+- shutdown watchdog.
+
+Exit 137 analysis must include an external Kube check:
+
+```bash
+porter kubectl --cluster 4689 -- describe pod <pod> -n default
+```
+
+In-process logs cannot prove a final stall if the process is pinned until SIGKILL.
+
+### External Status Correlation
+
+Issue 106 still tracks W3: Cloudflare/Azure/Porter status correlation around known cascade timestamps. This is useful context but should not block the instrumentation PR, because public status pages are too coarse to distinguish pod-side missed pings from a local loop stall. Record any public incident matches in the spike, then rely on S7 to gather pod-local evidence during the next event.
+
+---
+
+## Privacy And Safety
+
+These diagnostics run in production-like environments, so they must be privacy-safe by construction.
+
+Rules:
+
+- Use `userIdHash`, never raw `userId` or email.
+- Do not log transcript text.
+- Do not log app message payloads.
+- Do not log API keys, JWTs, authorization headers, or query strings.
+- Do not log raw WebSocket close reasons; log `reasonLength` only if useful.
+- Log package names because package name is already operational metadata and is needed for debugging.
+- Keep all vitals fields numeric.
+
+Slow logs should include only:
+
+- feature name;
+- package name;
+- user hash;
+- message/protocol type;
+- duration;
+- phase timings;
+- bounded counts.
+
+---
+
+## Overhead Model
+
+Expected overhead is low because the common path uses counters and `performance.now()` brackets only.
+
+Costs:
+
+- one or two `performance.now()` calls around instrumented phases;
+- numeric accumulator updates;
+- slow log object allocation only when threshold is exceeded;
+- one event-loop histogram running with `resolution: 10`;
+- per-socket metadata counters in `ws.data`.
+
+Controls:
+
+- slow thresholds start at 100ms for app protocol/connect/subscription logs;
+- no per-message payload logging;
+- no stack traces for slow paths;
+- no continuous CPU/heap profiler outside debug;
+- add throttling if `slow-*` volume becomes noisy during cloud-debug soak.
+
+The debug soak must verify:
+
+- no meaningful RSS/heap increase;
+- no BetterStack volume spike;
+- no change in steady-state event-loop lag;
+- no warnings during idle traffic.
+
+---
+
+## Rollout
+
+1. Branch from `staging`.
+2. Implement S1-S8 from [spec.md](./spec.md).
+3. Run local typecheck and targeted tests.
+4. Run the local harness smoke against the instrumentation.
+5. Deploy to `cloud-debug` only.
+6. Soak for at least 30 minutes under normal traffic.
+7. Verify BetterStack field shape and log volume.
+8. PR to `staging`.
+9. Wait for one staging cascade or high-load window.
+10. Write a new numbered Phase 2 fix issue/spec from captured evidence.
+
+Do not deploy directly to staging from the local branch. Do not push to staging.
+
+---
+
+## Acceptance Criteria
+
+The next event should let us answer these seven questions:
+
+1. Did `CONNECTION_INIT`, `RECONNECT`, or regular app messages dominate?
+2. If regular app messages dominated, which message type dominated?
+3. If init/reconnect dominated, which phase dominated?
+4. If subscription dominated, which downstream manager phase dominated?
+5. Was the event loop actually pinned, or was the time async wall-time?
+6. Did app WSs show evidence of missed heartbeat or backpressure before close?
+7. Did the process run the SIGTERM handler, or did Kube SIGKILL before JS could respond?
+
+If those questions are answerable, the instrumentation succeeded even if the root cause is not fixed yet.
+
+---
+
+## Alternatives Considered
+
+### Keep Spiking Without Code
+
+Rejected. Existing logs have reached their limit. More aggregate queries can refine timelines but cannot split async wait from sync blockage or identify uninstrumented phases.
+
+### Enable Bun CPU Profiling In Staging/Prod
+
+Rejected as the default path. Bun profiling is useful, but it has higher operational complexity and artifact-retention problems. Keep it debug-only or one-off.
+
+### Only Add Per-Message-Type Timers
+
+Rejected. This was the original spec, but the local harness showed suspicious work in `CONNECTION_INIT`, `RECONNECT`, `broadcastAppState`, and subscription fanout. Those paths would be missed.
+
+### Fix The Suspected Hot Paths Immediately
+
+Rejected. We have plausible fixes, but choosing now risks optimizing the wrong path. Instrumentation should decide between app-state refresh coalescing, DB work reduction, subscription sync coalescing, WS heartbeat/backpressure work, or liveness tuning.
+
+### Use `performance.eventLoopUtilization`
+
+Rejected for now. Local Bun `1.3.13` returned zeros under idle and busy conditions. Revisit only after Bun behavior changes or is proven in the deployed runtime.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Log volume increases | Prefer vitals counters; slow logs only above threshold; add throttling if needed. |
+| Hot-path overhead | Use only `performance.now()` and numeric accumulators in common paths. |
+| Privacy leakage | Hash user IDs; do not log payloads, transcripts, tokens, or raw reasons. |
+| Misreading async wall-time as CPU | Pair phase timings with event-loop histogram max and vitals gaps. |
+| Missing final fatal stall | Use Kube pod state plus lifecycle breadcrumbs; in-process telemetry may die with the process. |
+| Bun API mismatch in deployment | Feature-detect histogram support and log unsupported state explicitly. |
+
+---
+
+## Phase 2 Decision Tree
+
+After one event with Phase 1.5:
+
+| Evidence | Likely fix |
+|---|---|
+| `op_appConnect_refreshInstalledApps_ms` dominates | Debounce/coalesce `broadcastAppState` and installed-app refresh during reconnect storms. |
+| `op_appConnect_findOrCreateUser_ms` or `appService` DB phases dominate async time | Cache or avoid DB-backed work on reconnect/init path. |
+| `op_subscription_syncManagers_ms` dominates | Coalesce subscription downstream sync per user/package. |
+| Event-loop max spikes while instrumented await time is low | Optimize or yield around sync CPU work. |
+| WS backpressure/drain spikes precede 1006 storm | Investigate Bun WS send/backpressure and heartbeat behavior. |
+| No SIGTERM breadcrumbs before 137 | Treat exit 137 as hard loop pin until Kube SIGKILL; do not blame missing graceful shutdown. |
+
+Do not select a Phase 2 fix before this evidence exists.

--- a/cloud/issues/105-event-loop-cascade-investigation/spec.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/spec.md
@@ -1,6 +1,6 @@
 # Spec: Phase-1.5 Cascade Diagnostic Instrumentation
 
-**Status:** Implemented on `cloud/issue-106` — pending cloud-debug deploy/soak
+**Status:** Implemented on `cloud/issue-106` — cloud-debug smoke passed; soak ongoing
 **Target branch:** staging-first; soak on cloud-debug before staging
 **Scope:** Observability only. No behavior changes, no cascade fix in this PR.
 **Design:** [design.md](./design.md) explains the production-safety rationale and rollout model.

--- a/cloud/issues/105-event-loop-cascade-investigation/spec.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/spec.md
@@ -1,0 +1,646 @@
+# Spec: Phase-1.5 Cascade Diagnostic Instrumentation
+
+**Status:** Implemented on `cloud/issue-106` — pending cloud-debug deploy/soak
+**Target branch:** staging-first; soak on cloud-debug before staging
+**Scope:** Observability only. No behavior changes, no cascade fix in this PR.
+**Design:** [design.md](./design.md) explains the production-safety rationale and rollout model.
+
+---
+
+## Plain-English Goal
+
+This PR is a flight recorder, not a fix.
+
+Today we know that `op_appMessage_ms` gets huge during cascade windows, but that number is too broad. It only says "app-message handling took wall-clock time." It does not tell us whether:
+
+- the event loop was blocked by synchronous JavaScript work;
+- the handler was waiting on MongoDB, app lookup, app server behavior, or another async resource;
+- dozens of reconnects/subscription updates each did a small amount of sync work that stacked up;
+- WebSocket close/backpressure behavior started the pile-up;
+- Kubernetes killed the pod before the process could run its shutdown handler.
+
+The instrumentation below adds the missing labels and phase timings. After the next event, the team should be able to answer:
+
+```text
+What path was slow?
+Which internal phase was slow?
+Was the event loop pinned or merely waiting on async work?
+Did the WS storm happen before, during, or after the slow path?
+Did the process receive and handle shutdown cleanly?
+```
+
+Better Stack will store, search, graph, and alert on these records. The application still has to emit the Mentra-specific facts because no vendor can infer `CONNECTION_INIT`, `RECONNECT`, `subscription_update`, or `broadcastAppState` from generic container metrics.
+
+---
+
+## Are We Done Spiking?
+
+We are done enough to instrument. We are **not** done enough to fix.
+
+The spike has narrowed the problem to a concrete proof gap:
+
+1. `op_appMessage_ms` dominates every known cascade window.
+2. `op_appMessage_ms` is wall-clock around awaits, so it conflates async wait with sync CPU.
+3. The staging 2026-05-04 event had a real multi-app WS storm plus an event-loop silence window.
+4. The earlier prod windows did not show the same staging-scale WS storm, so the storm is not a proven universal trigger.
+5. Local harnesses show both mechanisms are plausible:
+   - async DB/resource wait can create 69-92s aggregate app-message wall-time without pinning the loop;
+   - small sync work in reconnect/init/subscription paths can multiply across dozens of sessions and miss `/livez`.
+
+More unaided log spelunking will mostly recycle the same ambiguity. The next useful work is a tightly scoped instrumentation PR that lets the next event answer:
+
+- Which app protocol/message path is slow?
+- Which internal phase is slow?
+- Is the time async wait, sync loop blockage, WS backpressure, or process/liveness behavior?
+- Did the app WS storm come from pod-side missed pings or peer/network-side closure?
+
+---
+
+## Instrumentation Shape
+
+This PR should add **eight diagnostic surfaces**:
+
+1. Top-level app WS protocol timers: `CONNECTION_INIT`, `RECONNECT`, normal app messages.
+2. Per-message-type timers inside `handleAppMessage`.
+3. Reconnect/init phase timers around `attachAppSocket`, `broadcastAppState`, and DB-backed app refresh.
+4. Subscription fanout phase timers around `SubscriptionManager.syncManagers`.
+5. Slow outlier warnings with phase breakdowns.
+6. Continuous event-loop delay fields in every `system-vitals`.
+7. WS close, ping, send-return, and drain/backpressure telemetry.
+8. Process/liveness lifecycle breadcrumbs for exit-137 interpretation.
+
+This is more than the original four-item spec because the local harness changed the suspect set. In particular, instrumentation that only times message types would miss legacy `CONNECTION_INIT`, v3 `RECONNECT`, and the `broadcastAppState -> refreshInstalledApps -> appService.getAllApps` path.
+
+Implementation note: the detailed diagnostic timers are emitted as `op_*` fields for Better Stack query consistency, but they are excluded from `opTotalMs` so the existing coarse operation budget does not double-count nested phase timings.
+
+---
+
+## S1. Top-Level App WS Protocol Timers
+
+**File:** `cloud/packages/cloud/src/services/websocket/bun-websocket.ts`
+
+**Why:** `CONNECTION_INIT` and `RECONNECT` are handled in `bun-websocket.ts` before normal app messages reach `UserSession.handleAppMessage`. The existing per-message handler spec would miss the exact path the local harness made suspicious.
+
+Add operation timers:
+
+```text
+op_appProtocol_connectionInit_ms
+op_appProtocol_reconnect_ms
+op_appProtocol_regularMessage_ms
+op_appProtocol_ping_ms
+op_appProtocol_parse_ms
+op_appProtocol_sessionLookup_ms
+```
+
+Also emit counters in vitals:
+
+```text
+appProtocol_connectionInit_count
+appProtocol_reconnect_count
+appProtocol_regularMessage_count
+appProtocol_ping_count
+appProtocol_parseError_count
+appProtocol_sessionMissing_count
+```
+
+For slow protocol-level calls, log:
+
+```json
+{
+  "feature": "slow-app-protocol",
+  "protocolType": "connection_init",
+  "packageName": "com.mentra.captions.debug",
+  "userIdHash": 1514391467,
+  "durationMs": 412.3,
+  "phaseTimings": {
+    "parse": 0.2,
+    "validateApiKey": 102.1,
+    "handleAppInit": 309.4
+  }
+}
+```
+
+Thresholds:
+
+- `SLOW_APP_PROTOCOL_MS = 100`
+- Always include package and hashed user, never raw user ID.
+
+---
+
+## S2. Per-Message-Type Timers
+
+**File:** `cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts`
+
+Keep the existing outer `op_appMessage_ms` timer as a backstop, but add per-type timers for normal app messages:
+
+```text
+op_appMsg_subscriptionUpdate_ms
+op_appMsg_displayRequest_ms
+op_appMsg_dashboardContentUpdate_ms
+op_appMsg_dashboardModeChange_ms
+op_appMsg_dashboardSystemUpdate_ms
+op_appMsg_rgbLedControl_ms
+op_appMsg_cameraFovSet_ms
+op_appMsg_streamRequest_ms
+op_appMsg_streamStop_ms
+op_appMsg_streamStatusCheck_ms
+op_appMsg_locationPollRequest_ms
+op_appMsg_photoRequest_ms
+op_appMsg_audioPlayRequest_ms
+op_appMsg_audioStopRequest_ms
+op_appMsg_audioStreamStart_ms
+op_appMsg_audioStreamEnd_ms
+op_appMsg_managedStreamRequest_ms
+op_appMsg_managedStreamStop_ms
+op_appMsg_requestWifiSetup_ms
+op_appMsg_ownershipRelease_ms
+op_appMsg_unknown_ms
+```
+
+Also emit per-type counts:
+
+```text
+appMsg_subscriptionUpdate_count
+appMsg_displayRequest_count
+...
+```
+
+Counts matter because a window can be slow because one message took 2s, or because 600 messages each took 3ms.
+
+---
+
+## S3. App Init/Reconnect Phase Timers
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/session/AppManager.ts`
+- `cloud/packages/cloud/src/services/core/app.service.ts`
+
+**Why:** The local Mentra-path harness points at legacy `CONNECTION_INIT` and reconnect/init fanout. v3 `RECONNECT` is relatively light; legacy init calls `attachAppSocket`, then `broadcastAppState`, then `refreshInstalledApps`, which can do DB-backed app/user lookups.
+
+Add operation timers:
+
+```text
+op_appConnect_handleAppInit_ms
+op_appConnect_handleReconnect_ms
+op_appConnect_shouldDeferReconnect_ms
+op_appConnect_attachAppSocket_ms
+op_appConnect_findOrCreateUser_ms
+op_appConnect_addRunningApp_ms
+op_appConnect_sendAck_ms
+op_appConnect_sendFullStateSnapshot_ms
+op_appConnect_broadcastAppState_ms
+op_appConnect_refreshInstalledApps_ms
+op_appConnect_snapshotForClient_ms
+op_appService_getAllApps_ms
+op_appService_getAllApps_userFindOne_ms
+op_appService_getAllApps_appFind_ms
+```
+
+Add counters:
+
+```text
+appConnect_handleAppInit_count
+appConnect_handleReconnect_count
+appConnect_broadcastAppState_count
+appConnect_refreshInstalledApps_count
+```
+
+Slow log:
+
+```json
+{
+  "feature": "slow-app-connect",
+  "mode": "connection_init",
+  "packageName": "com.mentra.captions.debug",
+  "sdkVersion": "none",
+  "userIdHash": 1514391467,
+  "durationMs": 418.7,
+  "phaseTimings": {
+    "attachAppSocket": 103.2,
+    "broadcastAppState": 309.1,
+    "refreshInstalledApps": 205.0,
+    "snapshotForClient": 3.1
+  }
+}
+```
+
+Thresholds:
+
+- `SLOW_APP_CONNECT_MS = 100`
+- `SLOW_APP_CONNECT_PHASE_MS = 50`
+
+`SLOW_APP_CONNECT_PHASE_MS` should not create separate per-phase warning logs on the hot path. It should only annotate the parent `slow-app-connect` payload, for example with `slowPhases: ["refreshInstalledApps"]`, after the total connect/reconnect path has already crossed `SLOW_APP_CONNECT_MS`.
+
+This directly answers whether the 17:03 post-restart `op_appMessage_ms = 41s` shape is DB/app refresh wall-time, state snapshot work, or something else.
+
+---
+
+## S4. Subscription Fanout Timers
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts`
+- `cloud/packages/cloud/src/services/session/SubscriptionManager.ts`
+- `cloud/packages/cloud/src/services/session/MicrophoneManager.ts` if a narrow hook is easy
+
+**Why:** The staging storm produced many subscription updates across packages, and the harness showed that small sync work downstream can amplify across sessions.
+
+Add operation timers:
+
+```text
+op_subscription_updateSubscriptions_ms
+op_subscription_processUpdate_ms
+op_subscription_permissionCheck_ms
+op_subscription_permissionDbFallback_ms
+op_subscription_appSessionUpdate_ms
+op_subscription_syncManagers_ms
+op_subscription_transcriptionUpdate_ms
+op_subscription_translationUpdate_ms
+op_subscription_ensureStreamsExist_ms
+op_subscription_locationUpdate_ms
+op_subscription_calendarUpdate_ms
+op_subscription_microphoneHandleChange_ms
+```
+
+Add counters:
+
+```text
+subscription_update_count
+subscription_languageChanged_count
+subscription_debounceScheduled_count
+subscription_debounceApplied_count
+subscription_permissionDbFallback_count
+```
+
+Slow log:
+
+```json
+{
+  "feature": "slow-subscription-update",
+  "packageName": "com.mentra.ai",
+  "userIdHash": 1514391467,
+  "durationMs": 281.4,
+  "subscriptionCount": 3,
+  "languageChanged": true,
+  "phaseTimings": {
+    "permissionCheck": 0.8,
+    "appSessionUpdate": 0.3,
+    "syncManagers": 279.1,
+    "transcriptionUpdate": 140.0,
+    "ensureStreamsExist": 138.7
+  }
+}
+```
+
+Thresholds:
+
+- `SLOW_SUBSCRIPTION_UPDATE_MS = 100`
+- `SLOW_SUBSCRIPTION_PHASE_MS = 50`
+
+---
+
+## S5. Phase Breakdown Instead of Magical "SyncTimer"
+
+**Files:** same call sites as S1-S4
+
+The previous draft proposed a generic `SyncTimer`. That is directionally useful but too hand-wavy. Use explicit phase timing instead.
+
+For each slow log, include:
+
+```json
+{
+  "durationMs": 418.7,
+  "instrumentedAwaitMs": 412.0,
+  "unattributedSyncMs": 6.7,
+  "phaseTimings": {
+    "userFindOne": 101.2,
+    "appFind": 103.5,
+    "snapshotForClient": 3.1
+  }
+}
+```
+
+Definitions:
+
+- `durationMs`: wall-clock duration of the whole operation.
+- `instrumentedAwaitMs`: sum of known awaited phase wall-times.
+- `unattributedSyncMs`: `durationMs - instrumentedAwaitMs`, clamped at 0.
+- `phaseTimings`: named awaited or sync phases we care about.
+
+This does not magically prove CPU time by itself; it tells us which awaited phase consumed wall-time. Combine with S6 event-loop delay. If `durationMs` is huge, `instrumentedAwaitMs` is low, and event-loop delay is high, suspect sync CPU. If `instrumentedAwaitMs` is huge and event-loop delay stays low, suspect async resource wait.
+
+---
+
+## S6. Continuous Event-Loop Delay in Vitals
+
+**Files:**
+
+- `cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts`
+- `cloud/packages/cloud/src/services/metrics/MetricsService.ts`
+
+**Local Bun spike result (2026-05-05):**
+
+- Bun `1.3.13` exposes `perf_hooks.monitorEventLoopDelay`.
+- A controlled 250ms busy loop was detected as `maxMs ~= 241ms` and `p99Ms ~= 241ms` with `resolution: 10`.
+- A controlled 80ms busy loop was detected in `maxMs` across resolutions.
+- `p99Ms` can miss a single isolated block when there are many samples, especially at `resolution: 1`; `maxMs` is required.
+- Bun `performance.eventLoopUtilization()` exists but returned all zeros in the local spike. Do **not** use ELU for this instrumentation yet.
+
+Add fields to every `system-vitals` log:
+
+```json
+{
+  "eventLoopLagCurrentMs": 0.4,
+  "eventLoopLagAvgMs": 0.6,
+  "eventLoopLagP95Ms": 1.0,
+  "eventLoopLagP99Ms": 1.2,
+  "eventLoopLagMaxMs": 4.9,
+  "eventLoopSampleCount": 300,
+  "eventLoopDelayHistP95Ms": 1.0,
+  "eventLoopDelayHistP99Ms": 1.2,
+  "eventLoopDelayHistMaxMs": 4.9,
+  "eventLoopDelayHistMeanMs": 0.6
+}
+```
+
+Implementation:
+
+1. Start with the existing rolling-window lag samples.
+2. Add `perf_hooks.monitorEventLoopDelay({ resolution: 10 })` if supported.
+3. Reset the histogram after each `system-vitals` emission so each vitals line represents the prior 30s window.
+4. Treat histogram `maxMs` as the most important field for isolated stalls. Use p95/p99 for sustained jitter.
+5. If Bun does not support it or behaves unexpectedly, log one startup line:
+
+```json
+{ "feature": "event-loop-delay-histogram-unsupported", "runtime": "bun" }
+```
+
+Do not let unsupported histogram instrumentation silently produce zeros.
+Do not emit or rely on `eventLoopUtilization` until Bun returns nonzero local results.
+
+Important limitation: in a hard stall that ends in SIGKILL, in-process event-loop instrumentation may never emit the final gap. This is still valuable for buildup-phase analysis and for nonfatal prod cascades.
+
+---
+
+## S7. App WS Close, Heartbeat, Backpressure, and Drain Telemetry
+
+**File:** `cloud/packages/cloud/src/services/websocket/bun-websocket.ts`
+
+**Why:** 106 needs to distinguish network/peer closure from pod-side missed pings or WS backpressure. Bun may not expose raw TCP reset vs close-frame details, so record the facts we control and infer cautiously.
+
+On app WS open, track in `ws.data`:
+
+```text
+openedAt
+lastMessageAt
+lastSendAt
+lastPingSentAt
+lastPongReceivedAt
+lastSendResult
+sendBackpressureCount
+drainCount
+bytesIn
+bytesOut
+messagesIn
+messagesOut
+```
+
+On every app WS close, log:
+
+```json
+{
+  "feature": "ws-close",
+  "wsKind": "app",
+  "packageName": "com.mentra.captions.debug",
+  "userIdHash": 1514391467,
+  "code": 1006,
+  "reasonLength": 0,
+  "connectionAgeMs": 123456,
+  "lastMessageAgoMs": 4858,
+  "lastSendAgoMs": 1200,
+  "lastPingSentAgoMs": 30000,
+  "lastPongReceivedAgoMs": 61000,
+  "sendBackpressureCount": 2,
+  "drainCount": 2,
+  "bytesIn": 12345,
+  "bytesOut": 67890,
+  "messagesIn": 42,
+  "messagesOut": 41,
+  "inferredCloseSource": "unknown_no_close_frame"
+}
+```
+
+`inferredCloseSource` values:
+
+```text
+peer_clean_close
+our_shutdown
+our_error_close
+our_ping_timeout
+unknown_no_close_frame
+unknown
+```
+
+Do not claim TCP RST unless Bun exposes it directly.
+
+On `send()` calls to app/glasses sockets, record Bun's return value category:
+
+```text
+wsSend_success_count
+wsSend_queued_count
+wsSend_backpressure_count
+wsSend_failed_count
+```
+
+Bun `ServerWebSocket.send()` can signal backpressure via negative return values, and `drain` tells us when pressure clears. During the next storm, this will tell us whether the pod was falling behind on outbound WS writes.
+
+---
+
+## S8. Process and Kube Lifecycle Breadcrumbs
+
+**Files:**
+
+- `cloud/packages/cloud/src/index.ts`
+- `cloud/tools/bstack/runbooks/pod-crash.md` or a short query note in this issue
+
+Current code already has a SIGTERM handler with synchronous stderr logs. Keep it. Add only small breadcrumbs if missing:
+
+```json
+{ "feature": "process-lifecycle", "event": "startup", "pid": 123, "imageTag": "..." }
+{ "feature": "process-lifecycle", "event": "sigterm-received", "pid": 123 }
+{ "feature": "process-lifecycle", "event": "shutdown-complete", "elapsedMs": 412 }
+```
+
+If the next exit 137 has no `sigterm-received`, the interpretation is: Kube likely sent SIGTERM, but JS could not run the handler before SIGKILL.
+
+Also document the required external check:
+
+```bash
+porter kubectl --cluster 4689 -- describe pod <pod> -n default
+```
+
+Capture:
+
+- last state reason and exit code;
+- liveness timeout/period/failureThreshold;
+- old finished time and new started time;
+- restart count;
+- events, if present.
+
+In-process code cannot prove a gap while it is pinned and then killed. Kube state is part of the evidence.
+
+---
+
+## S9. Optional Debug-Only Bun Profiling Hooks
+
+**Scope:** debug only; do not enable on staging/prod by default.
+
+Bun supports CPU/heap profile flags such as:
+
+```bash
+bun --cpu-prof --cpu-prof-dir=/tmp/bun-profiles ...
+bun --heap-prof --heap-prof-dir=/tmp/bun-profiles ...
+```
+
+For cloud-debug only, create an operator note for running a profiling build or one-off debug command with:
+
+- CPU profiles written to `/tmp/bun-profiles`;
+- a way to copy profiles before pod deletion/restart;
+- no profiler enabled on staging/prod unless we explicitly decide the overhead and data retention are acceptable.
+
+This is not the primary proof mechanism. The structured logs above are more likely to survive and explain the next event.
+
+---
+
+## Non-Goals
+
+- Do not fix or optimize any hot path in this PR.
+- Do not change liveness/readiness settings in this PR.
+- Do not add new DB calls or app-server calls.
+- Do not log raw user IDs, transcript text, API keys, JWTs, raw close reasons, or request payloads.
+- Do not enable Bun CPU/heap profiling outside debug by default.
+- Do not replace the existing `op_appMessage_ms`; keep it as a backstop.
+
+---
+
+## Acceptance Queries
+
+After deploy to cloud-debug/staging, the next event should answer these with one BetterStack query set:
+
+1. Which protocol path dominated?
+   - `op_appProtocol_connectionInit_ms`
+   - `op_appProtocol_reconnect_ms`
+   - `op_appProtocol_regularMessage_ms`
+2. If normal messages dominated, which message type?
+   - `op_appMsg_subscriptionUpdate_ms`
+   - `op_appMsg_displayRequest_ms`
+   - etc.
+3. If init/reconnect dominated, which phase?
+   - `op_appConnect_refreshInstalledApps_ms`
+   - `op_appConnect_broadcastAppState_ms`
+   - `op_appConnect_findOrCreateUser_ms`
+   - `op_appService_getAllApps_*`
+4. If subscription dominated, which phase?
+   - `op_subscription_syncManagers_ms`
+   - `op_subscription_transcriptionUpdate_ms`
+   - `op_subscription_ensureStreamsExist_ms`
+5. Was the event loop pinned?
+   - `eventLoopLagP99Ms`, `eventLoopLagMaxMs`, `event-loop-gap`, `heartbeat-gap`, vitals gaps.
+6. Did app WSs close because we missed heartbeats/backpressure?
+   - `ws-close` last ping/pong ages, `inferredCloseSource`, send backpressure counters, drain counts.
+7. Did the process receive SIGTERM and exit cleanly?
+   - process lifecycle logs plus `porter kubectl describe pod`.
+
+If these seven questions are answerable for the next event, Phase 1.5 succeeded.
+
+---
+
+## Testing
+
+### Local
+
+1. `bunx tsc --noEmit`
+2. Relevant unit tests for any timing helper.
+3. Local harness smoke:
+
+```bash
+bun run tools/ws-storm-local/mentra-path-storm-harness.ts -- \
+  --users=56 \
+  --apps-per-user=1 \
+  --rounds=1 \
+  --message-handler=true \
+  --connect-mode=init \
+  --sdk-version=none \
+  --user-db-async-ms=100 \
+  --app-db-async-ms=100
+```
+
+Verify that local logs/vitals expose:
+
+- protocol timer fields;
+- app connect phase fields;
+- subscription phase fields;
+- no raw PII;
+- no warnings under idle load.
+
+### Cloud-Debug Smoke
+
+1. Branch from `staging`.
+2. Deploy/soak only on cloud-debug first.
+3. Verify in BetterStack:
+   - `system-vitals` includes new op fields and event-loop lag fields.
+   - `ws-close` logs include the new metadata.
+   - `slow-*` logs are rare under normal traffic.
+   - No meaningful RSS/heap/log-volume regression.
+
+### Staging Acceptance
+
+After staging deploy, wait for the next cascade or high-load window. The event should produce a clear attribution:
+
+```text
+Dominant path: connection_init vs reconnect vs regular message
+Dominant phase: refreshInstalledApps vs subscription sync vs display request vs other
+Timing type: async resource wait vs sync loop blockage
+WS storm source: likely pod-side heartbeat/backpressure vs peer/network-side unknown
+Lifecycle: graceful SIGTERM observed vs SIGKILL before handler could run
+```
+
+---
+
+## Rollout
+
+1. Branch off `staging`.
+2. Implement S1-S8. S9 is an operator note only unless debug profiling is explicitly requested.
+3. Soak on cloud-debug.
+4. PR to `staging`.
+5. Let staging capture one event.
+6. Write a Phase 2 fix spec from the captured evidence.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Vitals payload grows too much | Keep fields numeric and bounded; no labels or raw payloads. |
+| Slow warnings flood BetterStack | Start with 100ms thresholds, add per-feature throttling if needed. |
+| Phase timers add overhead | Use `performance.now()` and accumulator counters only; avoid allocations in hot paths where possible. |
+| Close-source overclaims | Use `inferredCloseSource` and avoid TCP-level claims Bun does not expose. |
+| In-process instrumentation misses fatal stalls | Combine with Kube pod state and startup/lifecycle breadcrumbs. |
+
+---
+
+## Summary
+
+We should stop broad spiking and spec/ship this instrumentation next. It is the smallest useful step that converts the current ambiguous evidence into a fixable answer.
+
+The likely fix will be one of:
+
+- coalesce/debounce `broadcastAppState` and installed-app refresh on reconnect/init storms;
+- reduce DB-backed work in `attachAppSocket` or `refreshInstalledApps`;
+- coalesce subscription downstream manager syncs;
+- address WS heartbeat/backpressure behavior;
+- tune liveness only after understanding which path is actually pinning or waiting.
+
+Do not choose among those fixes until this instrumentation captures the next event.

--- a/cloud/issues/105-event-loop-cascade-investigation/spike.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/spike.md
@@ -1,0 +1,359 @@
+# Spike: Event-Loop Cascade Investigation (Staging 2026-05-04, Multi-Cascade Analysis)
+
+**Status:** Open — investigation; spec.md proposes the instrumentation needed to close the gap
+**Date:** 2026-05-04
+**Last updated:** 2026-05-05 — Phase 1.5 observability implemented on `cloud/issue-106`; pending cloud-debug deploy/soak
+**Reporter:** Investigation conducted live during staging cascade event 17:02 UTC, then back-tested against three prior us-central prod cascades (04-30 15:40, 04-30 18:24, 05-01 11:38)
+**Related:**
+
+- [102-pod-loop-stall-cascade](../102-pod-loop-stall-cascade/) — Phase 1 instrumentation that produced the data this spike analyzes
+- [055-cloud-prod-oom-crashes](../055-cloud-prod-oom-crashes/) — original 2026-03 framing of liveness-probe-failure cascade
+- [061-crash-investigation](../061-crash-investigation/) — added GC + health-timing instrumentation
+- [076-aks-node-maintenance-pod-evictions](../076-aks-node-maintenance-pod-evictions/) — distinguishes infrastructure events from cascades; rules out 05-01 12:01 cluster event from cascade analysis
+- [104-soniox-eventqueue-leak](../104-soniox-eventqueue-leak/) — independently fixed memory leak; ruled out as a current cascade contributor
+- [106-app-ws-storm-multi-app](../106-app-ws-storm-multi-app/) — sister issue investigating the multi-app simultaneous WS-disconnect pattern that this spike identifies as the proximate cascade trigger
+
+---
+
+## Plain-English Observability Model
+
+This spike is trying to stop us from guessing. Production observability is just a way to leave enough breadcrumbs that, when the pod gets sick again, we can reconstruct what happened.
+
+There are four kinds of clues:
+
+| Clue type | Plain meaning | Example for this incident |
+|---|---|---|
+| Logs | "What happened?" | `slow-app-message` for `subscription_update` took 420 ms |
+| Metrics | "How much/how often?" | 56 app WS 1006 closes in one minute |
+| Traces/phase timings | "Where did one operation spend time?" | reconnect spent 310 ms in `refreshInstalledApps` |
+| Profiling | "What code burned CPU?" | CPU samples point at layout/rendering/JSON parsing |
+
+Better Stack is where we store, search, graph, and alert on these clues. But Better Stack cannot automatically know Mentra-specific concepts like `CONNECTION_INIT`, `RECONNECT`, `subscription_update`, `broadcastAppState`, or `com.mentra.captions.debug`. Our code has to emit those facts first.
+
+The core question is:
+
+```text
+Did app-message time grow because code was blocking the event loop,
+or because handlers were awaiting slow resources while the event loop stayed alive?
+```
+
+Those look similar in today's `op_appMessage_ms` number but require different fixes.
+
+---
+
+## Summary
+
+The staging pod cascaded at 2026-05-04 17:02 UTC and the container restarted in place. Phase 1 obs (issue 102) was running, and the BetterStack S3 historical log tier preserved enough data to reconstruct the lead-up minute-by-minute. We also re-queried three earlier us-central prod cascades the same way.
+
+The picture that emerges is **more nuanced than any single hypothesis**, and earlier first-pass conclusions in this investigation were wrong:
+
+- **Wrong Hypothesis #1:** "It's an lc3Decode cascade" — caught by Phase 1's `slow-audio-stage` warnings. Wrong: lc3Decode time inflation was a **measurement artifact**. The Phase 1 substage timer brackets the entire `decodeAudioChunk` call, including allocs and GC pauses landing inside it. When other work on the loop pressured GC, decode times appeared to spike. The actual time-eater was elsewhere.
+- **Wrong Hypothesis #2:** "It's heavy `op_appMessage_ms`" — confirmed at the gross level: every cascade across 4 events shows app_msg dominating opTotalMs at 95–98%. But high `op_appMessage_ms` alone doesn't trigger cascade — staging has spikes of 1500–2000 ms regularly without cascading.
+- **Wrong Hypothesis #3:** "It's `com.mentra.captions` display request volume" — staging right now is doing **2.4× more captions display requests** than during the cascade window, while remaining healthy. Volume isn't the trigger.
+
+What the data **does** show:
+
+1. Cascades are **two-phase** events: a slow-build phase (occasional `op_appMessage_ms` spikes accumulating over minutes) followed by a sudden burst-trigger (multi-app WS disconnect storm) that pushes the loop fully blocked.
+2. The proximate cascade trigger for staging 17:02 was a **104-event WebSocket close storm** in the minute immediately before the block: 49 distinct app WS connections from 5 different packages closed with code 1006 (abnormal closure) within ~60 seconds.
+3. The same `op_appMessage_ms` dominance signature appears in all three prior us-central prod cascades. We have weaker evidence for the WS storm pattern in those (Phase 1 wasn't on prod).
+4. Existing telemetry has reached its useful limit. Several questions can't be answered without instrumentation we don't have.
+
+**2026-05-05 refinement:** an independent follow-up pass strengthened the app-message thesis but weakened the claim that the staging WS storm explains all prod cascades. The updated view is:
+
+1. `op_appMessage_ms` dominance is still the common cross-cascade symptom.
+2. The staging 17:02 event had a real, unusually large app+glasses WS storm and an actual event-loop silence window.
+3. The three prior prod windows did **not** show a staging-scale simultaneous app 1006 storm. They may be related through the same app-message degradation path, but the proximate trigger appears different or weaker.
+4. Local reproduction shows two separate mechanisms that existing telemetry currently conflates:
+   - **Async wall-time amplification**: slow awaits can produce tens of seconds of aggregate `op_appMessage_ms` while the event loop remains responsive.
+   - **Synchronous storm amplification**: tiny synchronous work per reconnect/subscription can multiply across dozens of simultaneous app sessions and produce multi-second heartbeat gaps.
+
+---
+
+## The Cascade Pattern (staging 2026-05-04 17:02)
+
+### Timeline
+
+```
+Time     app_ms (30s)  WS 1006s  micActive  Notes
+─────    ────────────  ────────  ─────────  ─────
+16:30-39  87-131         0        17-22      Baseline (~0.3% of one core)
+16:40       326           0        20         Small spike, recovers same minute
+16:46     ★ 2142 ★         0        22         BIG spike (20× baseline), recovers
+16:48-49  1245-1309        0        22         Sustained spike, recovers
+16:51       331           0        24         Moderate
+16:54-58  49-280           0        25-28      Intermittent
+16:59     ★ 1425 ★         0        29         BIG spike
+17:00         82           0        29         Recovers
+17:01         72         ★104★+52   29         WS STORM (49 apps × 1006 in 60s)
+17:02       (none)          0        ?          ← LOOP BLOCK (vitals didn't fire)
+17:03         72           0        29         ← Container restart in place
+17:04        1504          0        28         Spike STILL happens post-restart
+17:05          74          0        29         Recovers
+17:06        1884          0        29         Spike STILL happens
+```
+
+### What was true throughout
+
+- Memory **flat** at 384–393 MB. Heap 70–95 MB. No memory cascade.
+- `wsDisconnects`/`wsReconnects` counters at near-zero except 17:01 (the storm).
+- Mongo blocking ms steady at ~150 ms per 30s. Not blocking.
+- **Zero `event-loop-lag` warnings fired** (threshold >100 ms), across the whole cascade window AND across all four cascade days.
+- Audio processing time (`op_audioProcessing_ms`) was steady 1000–1300 ms / 30s, scaling with mic-active count. Not anomalous.
+
+### The smoking-gun signal: vitals didn't fire at 17:02
+
+`SystemVitalsLogger` runs on a 30-second `setInterval`. Two consecutive emission slots produced no log (17:02:11 and 17:02:41 missing). The only way that happens is the event loop being blocked the entire interval. After the restart, the next vitals at 17:03:23 reported `opTotalMs: 41,836` with `op_appMessage_ms: 41,035` — that's the catch-up: the accumulator captured ~41s of app-message wall-time that elapsed during the block + recovery.
+
+### The proximate trigger: WS storm at 17:01
+
+In the 60-second window immediately preceding the loop block, **49 distinct app WS connections from 5 packages closed simultaneously**:
+
+| Package | Closes (code 1006) |
+|---|---|
+| com.mentra.captions | 16 |
+| com.mentra.ai | 10 |
+| cloud.augmentos.notify | 9 |
+| com.mentra.merge | 8 |
+| com.mentra.notes | 6 |
+
+Each close triggers cleanup work: close handler, grace-period timer, eventual reconnect (auth + session lookup + state sync + subscription re-establish + transcription re-attach), `mic state resync` (logged 20× in this minute), `app_state_change` broadcast to all glasses WSs.
+
+**Code 1006 = abnormal WebSocket closure.** No clean close-frame handshake. This is TCP-level disruption, not app-side `ws.close(1000, ...)`.
+
+49 simultaneous reconnect cycles is enough cleanup work to push the already-loaded loop over the liveness threshold (75 s of failed `/livez`).
+
+---
+
+## What's Consistent Across the Four Cascades
+
+I queried `s3Cluster(primary, t373499_mentracloud_prod_s3)` (full historical retention) for the three prior us-central cascades. Phase 1 obs is NOT on prod (#2626 wasn't merged), so I can't see `slow-audio-*` events there — but `op_*_ms` op timers, `system-vitals`, and standard log lines are all preserved.
+
+| Cascade | Peak op_appMessage_ms (30s) | % of opTotalMs | audio_ms during peak | Signature |
+|---|---|---|---|---|
+| Prod 04-30 15:40 | 2,901 ms | 97% | 92 ms | App-msg dominant |
+| Prod 04-30 18:24 | 7,616 ms | 96% | 291 ms | App-msg dominant |
+| Prod 05-01 11:38 | 4,686 ms | 99.9% | 0 ms (no mic) | App-msg dominant |
+| **Staging 05-04 17:02** | 41,035 ms | 98% | 398 ms | **App-msg dominant + WS storm + loop block** |
+
+**`op_appMessage_ms` dominates `opTotalMs` in all four.** `op_audioProcessing_ms` is normal-to-low in all four. Audio is consistently NOT the cascade time-eater.
+
+**The 4× prod cascades did NOT show a 17:02-style vitals gap.** The pod stayed responsive enough to keep emitting vitals every 30 s, even while `op_appMessage_ms` was bursting. K8s probes timed out (visible as BetterStack uptime incidents) but the pod survived without container restart for the 04-30 cascades; 05-01 11:38 did restart.
+
+So the prod cascades may have been **degraded responsiveness without full loop blockage**, while the staging cascade had **actual loop blockage**. Both have the same dominant signal (`op_appMessage_ms`) but different severity.
+
+### 2026-05-05 W4 re-query: prod did not have a staging-scale app WS storm
+
+The follow-up pass queried the S3 historical table for the three prior us-central prod windows at both minute and second granularity:
+
+```sql
+SELECT
+  toStartOfSecond(dt) AS second,
+  countIf(JSONExtractString(raw, 'service') = 'AppManager'
+    AND positionCaseInsensitive(JSONExtractString(raw, 'message'), '1006') > 0) AS app_1006,
+  countIf(positionCaseInsensitive(JSONExtractString(raw, 'message'), 'unexpectedly disconnected') > 0) AS unexpected,
+  uniqIf(JSONExtractString(raw, 'packageName'),
+    JSONExtractString(raw, 'service') = 'AppManager'
+    AND positionCaseInsensitive(JSONExtractString(raw, 'message'), '1006') > 0) AS distinct_packages
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND JSONExtractString(raw, 'region') = 'us-central'
+  AND <cascade-window predicates>
+GROUP BY second
+HAVING app_1006 > 0 OR unexpected > 0
+ORDER BY app_1006 DESC, unexpected DESC
+```
+
+Top results:
+
+| Window | Largest app 1006 second | Distinct packages | Timing vs cascade | Interpretation |
+|---|---:|---:|---|---|
+| Prod 04-30 15:40 | 2 | 1 | scattered before/during window | Not a multi-app storm |
+| Prod 04-30 18:24 | 2 | 1 | scattered before/during window | Not a multi-app storm |
+| Prod 05-01 11:38 | 12 | 5 | 11:20:34 UTC, ~18 min before listed cascade | Small multi-app burst, not staging-scale |
+| Staging 05-04 17:02 | 104 AppManager 1006 log lines, 52 unexpected app disconnects | 8 | 17:01:17 UTC, immediately before stall | Staging-scale storm |
+
+This refines issue 106: the staging storm is real and likely important for that restart, but it is **not currently proven as the universal prod cascade trigger**.
+
+### 2026-05-05 Porter/Kube confirmation of exit 137
+
+`porter kubectl --cluster 4689 -- describe pod cloud-staging-cloud-c9986c855-zqr9k -n default` showed:
+
+- Current staging pod last state: `Terminated`, `Reason: Error`, `Exit Code: 137`.
+- Old container finished at `2026-05-04 17:02:51 UTC`.
+- New container started at `2026-05-04 17:02:52 UTC`.
+- Generated liveness probe: `GET /livez`, `timeout=3s`, `period=5s`, `failureThreshold=15`.
+- Porter config sets `terminationGracePeriodSeconds: 10`.
+
+There were no `shutdown-started`, `shutdown-complete`, `SIGTERM`, or `shutdown-watchdog-fired` logs in BetterStack for the staging window.
+
+Interpretation: the code already has a fail-fast SIGTERM handler in `packages/cloud/src/index.ts`, including synchronous stderr logging. Exit 137 does **not** mean "we forgot graceful shutdown." It most likely means Kube sent SIGTERM after ~75s of failed liveness probes, but the JS event loop was not able to run the signal handler before the 10s grace expired, so Kube sent SIGKILL.
+
+Operational implication: if we want faster restart, adjust liveness timing/failure policy. If we want clean exit code 0, the JS loop must be able to run the signal handler; a hard-pinned loop cannot.
+
+### 2026-05-05 local harness findings
+
+A local-only harness was added under `cloud/tools/ws-storm-local/` to avoid deploying while still exercising the real Mentra session paths. It uses `com.mentra.captions.debug` whenever captions is included in a package pool.
+
+Two harnesses exist:
+
+- `bun-ws-storm-harness.ts` — raw Bun native WebSocket server/client storm.
+- `mentra-path-storm-harness.ts` — exercises real `AppManager`, `AppSession`, `SubscriptionManager`, and optionally `handleAppMessage`, with fake sockets and stubbed external services.
+
+Key results:
+
+| Scenario | Shape | Max heartbeat gap | Result |
+|---|---|---:|---|
+| Raw Bun WS, 112 simultaneous closes/reconnects | no artificial work | ~2ms | Bun WS close/reconnect alone did not reproduce stall |
+| Raw Bun WS, async reconnect delay 3000ms | awaits only | ~3ms | Huge wall-time without loop stall |
+| Real Mentra v3 reconnect, 56 apps × 10 rounds | `RECONNECT`, message handler on | 6ms | Clean |
+| Real Mentra legacy init, clean DB/resources | `CONNECTION_INIT` during grace | 5ms | Clean |
+| Legacy init + async 100ms DB-like delay, 56 apps × 3 rounds | fake async User/App queries | 12ms | Aggregate reconnect wall-time 69s, event loop responsive |
+| Legacy init + async 100ms DB-like delay, 112 apps × 2 rounds | fake async User/App queries | 11ms | Aggregate reconnect wall-time 92s, event loop responsive |
+| Legacy init + sync 5ms User/App DB-like work, 56 apps × 2 rounds | fake sync CPU around DB calls | 1120ms | Sync amplification visible |
+| Legacy init + sync 20ms User/App DB-like work, 56 apps × 1 round | fake sync CPU around DB calls | 4481ms | Crosses current `/livez` timeout |
+| v3 reconnect + subscription/transcription sync 20ms, 56 apps × 1 round | sync downstream manager work | 1119ms | Subscription fanout can amplify sync work |
+
+Main takeaways:
+
+1. A WS close/reconnect storm by itself is not enough to reproduce the 80s staging stall locally.
+2. Large aggregate `op_appMessage_ms` can be entirely async wall-time. This matches prod windows where vitals kept firing.
+3. The dangerous condition is many simultaneous app init/subscription paths plus small synchronous segments. The local harness shows how tens of milliseconds of sync work can become seconds of liveness-visible delay.
+4. The real code path difference matters:
+   - `handleReconnect()` for SDK v3 is relatively light.
+   - legacy `handleAppInit()` calls `attachAppSocket()`, then `broadcastAppState()`, then `refreshInstalledApps()`.
+   - `refreshInstalledApps()` calls `appService.getAllApps(userId)`, which does `User.findOne` and `App.find`.
+   - Subscription updates call `SubscriptionManager.syncManagers()`, which awaits transcription/translation update and stream ensure work.
+
+This makes `CONNECTION_INIT` during grace/reconnect and `subscription_update` fanout the most suspicious paths for Phase 1.5 instrumentation.
+
+### 2026-05-05 Bun event-loop histogram local spike
+
+Before committing `perf_hooks.monitorEventLoopDelay` to the instrumentation design, we tested it locally on Bun `1.3.13`.
+
+Support check:
+
+| API | Bun 1.3.13 local result | Decision |
+|---|---|---|
+| `perf_hooks.monitorEventLoopDelay` | Exists and reports useful delay histograms | Use it, with feature detection |
+| `histogram.reset()` | Exists | Reset after each vitals window |
+| `performance.eventLoopUtilization()` | Exists but returned all zeros during idle+busy test | Do not use yet |
+| `PerformanceObserver.supportedEntryTypes` | `["mark","measure","resource"]`; still no `gc` | No natural-GC observer |
+
+Controlled busy-loop results:
+
+| Test | Result |
+|---|---|
+| 250ms sync busy loop, `resolution: 10` | histogram `maxMs ~= 241ms`, `p99Ms ~= 241ms`; independent timer gap also `~241ms` |
+| 80ms sync busy loop, `resolution: 1` | histogram `maxMs ~= 79ms`, but p99 missed the isolated block |
+| 80ms sync busy loop, `resolution: 10` | histogram `maxMs ~= 77ms`, `p99Ms ~= 77ms` in the short test window |
+| 80ms sync busy loop, `resolution: 50` | histogram `maxMs ~= 77ms`, p95/p99 also caught it because sample count was small |
+
+Takeaways for the spec:
+
+- Include histogram `maxMs`; do not rely on p99 alone for isolated stalls.
+- Use `resolution: 10` as the first production candidate.
+- Reset the histogram each `system-vitals` window so the numbers describe the prior 30s.
+- Keep the existing heartbeat/vitals gap detection, because no in-process histogram can emit the final sample if the process is pinned until SIGKILL.
+
+---
+
+## What We Cannot Conclude
+
+### "op_appMessage_ms is sync CPU work"
+
+It might not be. The timer wraps an `await`:
+
+```ts
+// bun-websocket.ts:807
+const t0 = performance.now()
+try {
+  await userSession.handleAppMessage(ws as any, parsed)
+} finally {
+  operationTimers.addTiming("appMessage", performance.now() - t0)
+}
+```
+
+`performance.now() - t0` is **wall-clock**. Includes all awaits inside `handleAppMessage`. If a handler does `await db.findOne(...)` for 200 ms, that 200 ms counts toward `op_appMessage_ms` even though the loop was free during the I/O.
+
+Strong evidence that some of the time IS sync CPU:
+- Staging 17:02 vitals didn't fire = loop genuinely blocked.
+
+Strong counter-evidence that prod cascades were mostly NOT sync-CPU:
+- Vitals fired throughout prod cascades (loop kept ticking).
+- `op_audioProcessing_ms` (which IS sync work) stayed at normal levels — sync audio kept being scheduled.
+- Zero `event-loop-lag` warnings across all 4 cascades.
+
+So at minimum, prod cascades may be **async-bound degradation** (slow handlers awaiting on something) rather than CPU pinning. The staging cascade is the only one we have proof of actual loop blockage for, and that proof comes from a different signal (vitals gap), not from `op_appMessage_ms` itself.
+
+### "Captions display requests are the cause"
+
+Per-request analysis:
+
+| Window | app_msg / 30s | Display req / 30s | ms per request |
+|---|---|---|---|
+| Cascade peak (16:59:41) | 1,425 ms | ~370 | ~3.9 ms |
+| Cascade peak (17:00:11) | 1,467 ms | ~470 | ~3.1 ms |
+| Now (22:17, healthy spike) | 1,347 ms | ~600 | ~2.2 ms |
+| Now steady (22:21, healthy) | 177 ms | ~970 | ~0.18 ms |
+
+Per-request handler time during the cascade was **~17× slower** than current healthy steady state. But staging right now has higher captions display volume than the cascade window had — and is healthy. Volume isn't the trigger; per-request slowness is.
+
+We don't know what makes per-request handler time inflate from 0.18 ms to 3 ms. Could be GC pressure, app-server-side back-pressure, async resource contention, or a specific message type that's heavy.
+
+### "The WS storm is caused by the load buildup"
+
+The hypothesis is plausible: high `op_appMessage_ms` → loop busy → outbound WS pings delayed → multiple peers time out → cluster of 1006 closes. But:
+- The 16:46 spike (`app_msg=2142 ms`) was larger than the 17:00:11 spike (`1467 ms`) and recovered cleanly with no WS storm.
+- Spikes at 17:04 and 17:06 (post-restart) also didn't trigger storms.
+
+So the storm doesn't follow simply from a single spike's magnitude. Either there's a cumulative threshold we can't see, or the storm is partly caused by an external network event we can't observe from inside the pod.
+
+This is **the open question for [issue 106](../106-app-ws-storm-multi-app/)**.
+
+---
+
+## What Was Eliminated
+
+| Hypothesis | Evidence against |
+|---|---|
+| Memory leak / OOM | Flat memory throughout. Container `Reason: Error`, not `OOMKilled`. Heap+external didn't grow during cascade lead-up. The 104 soniox fix is in production and continues to hold. |
+| Wide audio fan-out | Zero `slow-audio-fanout` events in 30 min before staging cascade. Subscriber counts in normal range. |
+| Single pathological audio call | Zero `slow-audio-call` events (50 ms threshold on the per-batch UDP handler). |
+| MongoDB blocking | `mongoTotalBlockingMs` steady at ~150 ms per 30s. Not anomalous during cascades. |
+| Reorder-buffer batch flush | `slow-audio-call` would have caught it. Didn't fire. |
+| lc3Decode WASM execution | Caught by Phase 1 substage timer but the slowness is in the JS wrapper around the WASM call (alloc, GC interrupts), not the call itself. The WASM is fast. |
+| AKS node maintenance / cluster event | All 4 cascades happened without a cluster-event signature (no simultaneous staging/dev/debug restart). The 2026-05-01 12:01 restart WAS a cluster event and is excluded from this analysis. |
+| Raw Bun WS close/reconnect storm alone | Local Bun WS harness closed/reconnected 112–168 sockets simultaneously without meaningful heartbeat gaps. A storm needs additional sync work or another trigger to become fatal. |
+| Large `op_appMessage_ms` as proof of sync CPU | Local Mentra-path harness produced 69–92s aggregate reconnect wall-time with async DB-like delays while heartbeat gaps stayed ~11–12ms. `op_appMessage_ms` is wall-clock, not CPU. |
+| Exit 137 means shutdown handler is missing | Staging code already has a SIGTERM handler with synchronous stderr logs. Kube/Porter data plus absent shutdown logs instead suggests the loop was too pinned to run the handler before SIGKILL. |
+| Staging WS storm as universal prod trigger | W4 prod back-test did not find staging-scale simultaneous 1006 storms in the three prior prod cascade windows. The storm is staging-proven, prod-unproven. |
+
+---
+
+## Why Existing Telemetry Has Reached Its Limit
+
+To progress further on what's actually slow about app-message handlers during cascade conditions, the missing pieces are:
+
+1. **Per-message-type op timer breakdown.** We currently have `op_appMessage_ms` as one bucket for all 20+ message types (subscription_update, display_request, dashboard_*, photo_request, audio_*, location_*, stream_*, etc.). The 7,616 ms peak could be 95% display_request or 95% subscription_update — we can't tell.
+2. **Slow-handler outlier warnings**, same shape as `slow-audio-stage`. When a single `handleAppMessage` call exceeds N ms, log `{feature: "slow-app-message", messageType, packageName, userIdHash, durationMs}`. Catches the specific call that was slow, not just the aggregate window.
+3. **Sync-vs-async time split per handler.** Bracket each `await` in the handler chain to measure pure sync segments. Definitively answers whether the cascade is CPU pinning or async wait pile-up.
+4. **Always-emit event-loop-lag samples in every vitals.** Currently only emitted as a warning when >100 ms. If we always emit (current/avg/p99 from the rolling window), we can see if the loop is actually pinned during spikes that fall short of the warning threshold.
+5. **WS close categorization.** Distinguish "we received a close frame from peer" (peer initiated), "TCP RST" (network), "ping timeout from our side" (we failed to keep the connection alive), and "we initiated close." Tells us whether 1006 closes are external (network/peer) or self-induced (our pod missing pings).
+
+Items 1–4 are scoped in [spec.md](./spec.md).
+Item 5 is the focus of [106](../106-app-ws-storm-multi-app/).
+
+---
+
+## Open Follow-Ups
+
+- [ ] Ship the small Phase-1.5 instrumentation PR per spec.md (per-message-type timers, slow-app-message warnings, event-loop-lag in vitals).
+- [ ] After deploy, wait for next staging cascade (rate is ~daily). Re-analyze with new data.
+- [ ] Investigate 106 in parallel: does the multi-app simultaneous-1006 pattern correlate with anything observable from the pod side, or is it a network/Cloudflare/k8s-service-mesh signal?
+- [ ] Set up BetterStack alert on `feature: "slow-app-message"` (once it exists) with reasonable threshold to capture cascades in real time. The `s3Cluster(...)` historical table preserves data anyway, but a real-time alert lets us pull live diagnostics (heap snapshot, per-session state) before restart.
+
+## Where to use the runbook insight
+
+A self-criticism I want to capture for next time: my early queries against the cascade window used `remote(t373499_mentracloud_prod_logs)` (hot tier, ~1h retention) and concluded that pre-cascade diagnostic events had aged out. The runbook ([cloud/tools/bstack/runbooks/weekly-error-audit.md](../../tools/bstack/runbooks/weekly-error-audit.md)) explicitly documents that the historical table `s3Cluster(primary, t373499_mentracloud_prod_s3) WHERE _row_type = 1` has full retention. Using the right table from the start would have surfaced the data hours earlier.
+
+**Going forward: any cascade investigation more than ~30 minutes old should use the s3Cluster historical table.**

--- a/cloud/issues/105-event-loop-cascade-investigation/spike.md
+++ b/cloud/issues/105-event-loop-cascade-investigation/spike.md
@@ -2,7 +2,7 @@
 
 **Status:** Open — investigation; spec.md proposes the instrumentation needed to close the gap
 **Date:** 2026-05-04
-**Last updated:** 2026-05-05 — Phase 1.5 observability implemented on `cloud/issue-106`; pending cloud-debug deploy/soak
+**Last updated:** 2026-05-05 — Phase 1.5 observability implemented on `cloud/issue-106`; cloud-debug smoke passed; soak ongoing
 **Reporter:** Investigation conducted live during staging cascade event 17:02 UTC, then back-tested against three prior us-central prod cascades (04-30 15:40, 04-30 18:24, 05-01 11:38)
 **Related:**
 
@@ -345,10 +345,32 @@ Item 5 is the focus of [106](../106-app-ws-storm-multi-app/).
 
 ---
 
+## Cloud-Debug Validation
+
+Phase-1.5 is deployed to `cloud-debug` from branch `cloud/issue-106`.
+
+What passed on 2026-05-05:
+
+- Cloud package build passed.
+- Cloud package test suite passed: 6 suites, 6 passed.
+- GitHub Actions `porter-debug.yml` deployed commit `316e7db0a8c39631b801d779789b220e51dc3151`.
+- Kubernetes rollout completed; `cloud-debug-cloud` is `1/1 Running` with zero restarts.
+- `https://debug.augmentos.cloud/livez` returned `ok`.
+- Pod logs and BetterStack show `process-lifecycle` startup and `event-loop-delay-histogram` startup.
+- BetterStack hot table `remote(t373499_mentracloud_prod_logs)` shows new `system-vitals` fields: `eventLoopDelayMaxMs`, `eventLoopDelayP99Ms`, and `eventLoopDelayMeanMs`.
+- Synthetic `/app-ws` reconnect smoke used `com.mentra.captions.debug`, not production captions.
+- The smoke produced `feature: "app-ws-close"` with `packageName`, `userIdHash`, close code/reason, inferred close source, and send counters.
+- The same smoke produced the expected vitals counter: `appProtocol_reconnect_count = 1` and `op_appProtocol_reconnect_ms = 17`.
+- A pre-existing raw API-key debug log was removed; BetterStack confirmed the synthetic key was not present in the new log row.
+
+Soak is still ongoing. The next useful signal is either a natural cloud-debug/staging cascade or a controlled reconnect/subscription storm against cloud-debug.
+
 ## Open Follow-Ups
 
-- [ ] Ship the small Phase-1.5 instrumentation PR per spec.md (per-message-type timers, slow-app-message warnings, event-loop-lag in vitals).
-- [ ] After deploy, wait for next staging cascade (rate is ~daily). Re-analyze with new data.
+- [x] Ship Phase-1.5 instrumentation on `cloud/issue-106`.
+- [x] Deploy to cloud-debug and smoke-test BetterStack ingestion.
+- [ ] Soak on cloud-debug before staging.
+- [ ] After staging deploy, wait for next staging cascade (rate is ~daily). Re-analyze with new data.
 - [ ] Investigate 106 in parallel: does the multi-app simultaneous-1006 pattern correlate with anything observable from the pod side, or is it a network/Cloudflare/k8s-service-mesh signal?
 - [ ] Set up BetterStack alert on `feature: "slow-app-message"` (once it exists) with reasonable threshold to capture cascades in real time. The `s3Cluster(...)` historical table preserves data anyway, but a real-time alert lets us pull live diagnostics (heap snapshot, per-session state) before restart.
 

--- a/cloud/issues/106-app-ws-storm-multi-app/spike.md
+++ b/cloud/issues/106-app-ws-storm-multi-app/spike.md
@@ -1,0 +1,336 @@
+# Spike: Multi-App WebSocket Disconnect Storm — Cascade Trigger?
+
+**Status:** Open — investigation only, no fix proposed in this doc
+**Date:** 2026-05-04
+**Last updated:** 2026-05-05 — W4 prod back-test completed; local harness evidence added
+**Reporter:** Identified during analysis of staging 2026-05-04 17:02 UTC cascade
+**Related:**
+
+- [105-event-loop-cascade-investigation](../105-event-loop-cascade-investigation/) — parent investigation that identified this pattern as the proximate cascade trigger
+- [102-pod-loop-stall-cascade](../102-pod-loop-stall-cascade/) — original cascade framing
+- [076-aks-node-maintenance-pod-evictions](../076-aks-node-maintenance-pod-evictions/) — distinct pattern (Azure node rotation), explicitly NOT this
+- [055-cloud-prod-oom-crashes](../055-cloud-prod-oom-crashes/), [061-crash-investigation](../061-crash-investigation/) — historical cascade context
+
+---
+
+## Plain-English Goal
+
+This spike asks one narrow question:
+
+```text
+Did a burst of app WebSocket disconnects help trigger the pod cascade,
+and if yes, what made those sockets all close at nearly the same time?
+```
+
+A WebSocket close code `1006` means the connection disappeared without a clean close handshake. That can happen because the network broke, the peer gave up, or the pod was too busy to respond in time. The code alone does not tell us which one.
+
+The evidence we need is therefore simple:
+
+- when did each app socket last receive a message?
+- when did the pod last send a ping or app message?
+- did Bun report send backpressure or delayed drain events?
+- did many packages close in the same second?
+- did event-loop delay rise before the closes, or only after them?
+
+Better Stack can store and graph those facts, but our app has to emit them because generic container metrics cannot tell the difference between "network closed the socket" and "our pod missed heartbeat work while overloaded."
+
+---
+
+## Summary
+
+In the 60-second window immediately preceding the staging 2026-05-04 17:02 cascade, **49 distinct app WebSocket connections from 5 different package names closed simultaneously with code 1006** (abnormal closure, no clean WS frame handshake). Container restarted in place 60–90 seconds later.
+
+**2026-05-05 count refinement:** a follow-up per-second aggregate query found the same core storm plus three one-off packages. At 17:01:17 UTC, staging had `104` AppManager `1006` log lines, `56` UserSession/glasses `1006` lines, `52` "unexpectedly disconnected" app warnings, and `8` distinct app package names. The original "49 from 5 packages" count remains the core set; the wider query includes three single-disconnect packages.
+
+This pattern looks like the **proximate trigger** of the cascade: 49 simultaneous reconnect cycles (cleanup + auth + state-sync + subscription re-establishment + transcription re-attach + mic-state-resync + glasses-WS broadcasts) is enough cleanup work to push an already-loaded event loop over the K8s liveness probe threshold.
+
+**The open question this spike opens:** *what causes 49 unrelated app WS connections (across different mini-app servers, different deployment units) to close abnormally within 60 seconds?*
+
+We don't yet know if this is:
+- A network-layer event (Cloudflare hiccup, k8s service mesh blip, Azure VNet)
+- Pod-side missed pings (loop too busy → all peers time out independently within ~30s)
+- Bun WS server pathology under load
+- Something else
+
+This is open and worth investigating. It might or might not turn out to be the same root cause as issue 105's cascade slowness; could be independent.
+
+**2026-05-05 refinement:** this pattern is now best framed as **staging-proven, prod-unproven**. The staging event clearly had a large multi-app storm immediately before restart. The three earlier us-central prod cascade windows did not show a staging-scale simultaneous 1006 storm, so this is probably one trigger shape rather than the universal explanation for all app-message cascades.
+
+---
+
+## The Storm in 30 Seconds (Staging 2026-05-04 17:01)
+
+In the minute 17:01:00 → 17:02:00 UTC, AppManager logged 104 `1006`-related events (≈2 log lines per disconnect — close detection + grace-period start) and 52 distinct "App unexpectedly disconnected" warnings. Breakdown by package:
+
+| Package | Closes (code 1006) |
+|---|---|
+| com.mentra.captions | 16 |
+| com.mentra.ai | 10 |
+| cloud.augmentos.notify | 9 |
+| com.mentra.merge | 8 |
+| com.mentra.notes | 6 |
+| com.mentra.dash | 1 |
+| com.mentra.translation | 1 |
+| com.mentra.link | 1 |
+| **Total unexpected app disconnect warnings** | **52** |
+
+Plus glasses-side WS disconnects in the same minute:
+- "Glasses connection closed: code=1006" — multiple sessions, varying silent-time before detection (138 ms to 4858 ms).
+
+Each of the core 49 app disconnects produced:
+- "App disconnected" log
+- "Starting grace period for reconnection"
+- "Grace period started"
+- "✅ SDK reconnected during grace period - resurrection avoided!" (within ~1 second; the apps reconnected fast)
+- "Grace period cancelled"
+
+So the core 49 apps successfully reconnected within the grace window. No app stayed dead. But the cleanup + reconnect work for all of them simultaneously was substantial.
+
+---
+
+## Why This Pattern Matters
+
+### The cleanup cost per disconnect
+
+Each unexpected app WS disconnect triggers (in the cloud pod):
+
+1. **Close handler runs** — cleanup of WS event listeners, marking the AppSession as disconnected
+2. **Grace period timer scheduled** — `setTimeout(graceMs)` for resurrection deadline
+3. **Subscription cleanup** — current subscriptions are paused (transcription stream may unsubscribe)
+4. **Transcription stream re-evaluation** — does this app's missing subscription mean the underlying Soniox stream should be torn down?
+5. **`app_state_change` broadcast to all glasses WSs in the user session** — informs phone app the mini-app stopped
+6. **"Display request skipped - GLASSES_DISCONNECTED" cascading errors** if other apps are mid-flight to the now-disconnected user
+
+Then on reconnect (which happens in ~hundreds of milliseconds for SDK-mediated reconnects):
+
+1. **WS upgrade handshake** — auth, session lookup, attach handlers
+2. **State sync** — current display state, pending photo requests, settings
+3. **Subscription re-establishment** — app re-subscribes to its data streams
+4. **Transcription stream re-attach** — Soniox stream re-bound to this app's subscription
+5. **Mic state resync** — verify mic state matches current subscription requirements (logged 20× during the 17:01 storm)
+6. **Grace-period cancellation** — clear the timer scheduled in step 2 above
+
+Per disconnect+reconnect, that's tens of synchronous-and-asynchronous operations. Most are sub-millisecond, but combined across 49 simultaneous cycles in 60 seconds, we're plausibly looking at hundreds of milliseconds to several seconds of cumulative work, including allocations that pressure GC.
+
+### Why "simultaneous" matters
+
+If 49 disconnects were spread over an hour (one every ~73 seconds), the cleanup work would be background noise — never enough to notice. The cascade-triggering shape is **clustered**: 49 in 60 seconds = ~one every 1.2 seconds. The pod has no idle window to amortize the work.
+
+49 reconnect-state-sync chains running interleaved on the event loop is precisely the kind of bursty load that pushes a busy loop into "blocked" territory.
+
+---
+
+## What Caused 49 Apps to Close Simultaneously?
+
+### Hypothesis A: Network-layer event
+
+External infrastructure (Cloudflare, Azure VNet, Tailscale-via-Porter, k8s service mesh) briefly disrupted the TCP connections from the apps' Porter pods to the cloud pod.
+
+**Supporting evidence:**
+
+- 5 different packages from different deployment units (separate Porter apps) all dropped at the same time. They don't share infrastructure within their own pods, but they all ride through Porter → k8s service → cloud pod. A network event affecting that path could hit all of them.
+- Code 1006 = TCP-level disruption. App-side `ws.close(1000, ...)` would be code 1000 (clean). 1006 is "the connection just died without warning."
+- The 49 reconnects all succeeded fast (~hundreds of ms), suggesting the apps themselves were healthy and the TCP layer recovered quickly.
+
+**Counter-evidence:**
+
+- We have no direct signal from BetterStack or Porter about a network blip at 17:01 UTC. (Could check if alerts/Cloudflare/Azure status had anything around that time.)
+- Other regions / pods didn't show similar disconnect storms.
+
+### Hypothesis B: Pod-side missed pings
+
+The cloud pod's event loop was already busy (recall: `op_appMessage_ms` was sustained at 1,400–2,000 ms / 30 s for several minutes prior). WebSocket keepalive pings from cloud → app servers may have been delayed. Each app server has its own ping-timeout watchdog; when cloud's ping arrived too late, the app server closed the connection abnormally (1006 from app-server perspective, then the close propagates back to cloud as 1006 also).
+
+**Supporting evidence:**
+
+- Cascade buildup was visible in `op_appMessage_ms` for 4–5 minutes before the storm.
+- Bun and Node WS servers send periodic pings; if the loop is busy, pings can be delayed enough to trip the receiving side's timeout.
+- Multiple apps independently timing out makes sense if they share roughly the same ping-timeout (say, 30 s) — they'd all expire within a window.
+
+**Counter-evidence:**
+
+- The 16:46 spike (`op_appMessage_ms = 2,142 ms`) was larger than the 17:00:11 spike (1,467 ms) and didn't trigger a storm. Pure-load explanations need to also explain why the threshold was crossed at 17:01 specifically.
+- We have zero `event-loop-lag` warnings (>100 ms) across the whole 4-day window. If pings were delayed enough to time out, we'd expect lag samples to catch some of it.
+
+### Hypothesis C: Bun WS server pathology
+
+Bun's WebSocket server might have a behavior under specific load patterns where it batches close detection or holds onto connections in some pathological way that surfaces as a burst of `1006` events.
+
+**Supporting evidence:**
+
+- We're on a relatively recent Bun version. Bun's WS server has had behavioral changes in past releases.
+
+**Counter-evidence:**
+
+- This is speculation. We don't have concrete evidence of a Bun bug.
+- The same pod runs continuously without issue for many hours between cascades.
+
+### Hypothesis D: A specific app's reconnect logic triggered cross-pod pressure
+
+If e.g. `com.mentra.captions` reconnects with a tight retry loop, and 16 simultaneous user sessions of captions are all reconnecting simultaneously, that's 16 connections being established at once on the cloud pod. Each opens a new TCP/WS connection, runs the upgrade handshake, attaches handlers — all on the main event loop.
+
+**Supporting evidence:**
+
+- Captions had the largest single-package count (16) in the storm.
+- Captions runs as a service many users have installed; coordinated user-session reconnects could compound.
+
+**Counter-evidence:**
+
+- If this were captions-specific, we wouldn't see 5 different packages all storm-closing in the same minute. Other apps (ai, notify, merge, notes) close-closure at the same time strongly suggests an external trigger affecting all of them, not coordinated per-app reconnects.
+
+### Hypothesis E: Combination
+
+Most likely: **B + a triggering perturbation**. The pod is busy. Something small (a bigger-than-usual handler call, a brief network jitter, a single app server momentarily slow) tips the balance. The first peer times out and closes 1006. That close triggers cleanup work, which makes the loop slightly busier. The next peer times out. Cascade builds within 30–60 s.
+
+The 16:46 spike didn't cascade because the pod happened not to be near the critical threshold at that moment — different concurrent load, different queue state, slightly different mic count, different app population. The 17:01 storm hit a moment where the pod was right at the edge.
+
+---
+
+## What's Eliminated
+
+| Hypothesis | Evidence against |
+|---|---|
+| Cluster event (Azure node rotation, AKS upgrade) | [076 spike](../076-aks-node-maintenance-pod-evictions/) documents the cluster-event signature: simultaneous restarts across `cloud-prod`, `cloud-staging`, `cloud-dev`, `cloud-debug` on the same cluster within ~14 min. The 17:02 staging cascade had NO simultaneous restarts of other apps on cluster 4689. The 2026-05-01 12:01 incident WAS a cluster event and is excluded from this analysis. |
+| Single-app server crash and recovery | We see 5 different packages close simultaneously. Not one app server's lifecycle. |
+| Cloud pod restart causing the disconnects | The cloud pod restarted AFTER the 17:01 storm (at 17:02 from liveness failure). The disconnects came first. |
+| Memory/heap pressure causing WS layer to fail | Memory was flat at 384–393 MB throughout. Not a memory event. |
+| Raw Bun WebSocket storm alone | Local raw Bun WS harness closed/reconnected 112–168 sockets without meaningful heartbeat gaps. Bun WS close/reconnect alone did not reproduce the stall. |
+| This storm pattern as universal prod trigger | W4 found no staging-scale simultaneous 1006 storm in the three prior us-central prod cascade windows. This is a proven staging trigger candidate, not yet a universal cascade explanation. |
+
+---
+
+## What We Need to Know
+
+To distinguish A vs B vs E, we need:
+
+### W1. Per-WS close-source categorization
+
+When a WS closes with code 1006, log *why* the cloud pod believes the connection closed:
+
+- "Peer sent close frame" — clean close from the other side (would be code 1000 or 1001 typically, not 1006, but worth distinguishing if observed)
+- "Received close without close frame" — TCP-level close, peer didn't send WS close frame (typical 1006)
+- "TCP RST received" — explicit reset
+- "Our ping-pong watchdog fired" — we sent a ping, got no pong within timeout, we close the connection
+- "Underlying socket error" — write failed, etc.
+
+Bun's WS server may or may not expose these distinctions cleanly. Need to investigate. If it does, log the close-source as a structured field on every close event:
+
+```json
+{
+  feature: "ws-close",
+  packageName: "com.mentra.captions",
+  code: 1006,
+  closeSource: "ping-timeout-from-our-side",
+  durationMs: 32100,  // how long this connection lived
+  bytesIn: 12345,
+  bytesOut: 67890
+}
+```
+
+This single signal answers Hypothesis B definitively. If `closeSource: "ping-timeout-from-our-side"` dominates during the storm, the pod is missing pings — Hypothesis B is correct, fix is to keep the loop responsive enough to send pings on time (possibly the same fix as 105). If `closeSource: "received-close-without-frame"` dominates, the peer side sent the close — Hypothesis A is in play, we need to look at the network/proxy layer.
+
+### W2. WS keepalive ping timing
+
+Log when our pod sent its last ping to each app WS and when it received a pong. If pings are going out late during the buildup phase, that's pre-cascade evidence of Hypothesis B.
+
+This requires Bun WS internals access; might be a custom keepalive implementation rather than Bun's built-in ping/pong (which we may not be using).
+
+### W3. Cloudflare / Azure / Porter network event correlation
+
+For each cascade event, check at the same UTC time:
+
+- Cloudflare status page / network metrics
+- Azure status page for centralus region
+- Porter platform-level events (do we have an audit log?)
+- BetterStack collector data for the underlying nodes — were there node-level network blips?
+
+Manual today; could be partially automated with bstack runbook integrations.
+
+### W4. Cross-correlate WS storms across cascades
+
+If we have records of past cascades, do they all have a multi-app WS storm preceding? If yes, this pattern is the cascade trigger universally. If only some cascades, the WS storm is one of multiple possible triggers and we need to investigate the others.
+
+For the three prior us-central prod cascades (04-30 15:40, 04-30 18:24, 05-01 11:38), we could query for similar 1006-cluster patterns. Phase 1 obs wasn't on prod, but `AppManager` close logs are present.
+
+**Completed 2026-05-05:** W4 was run against S3 historical logs at minute and second granularity.
+
+Query shape:
+
+```sql
+SELECT
+  toStartOfSecond(dt) AS second,
+  countIf(JSONExtractString(raw, 'service') = 'AppManager'
+    AND positionCaseInsensitive(JSONExtractString(raw, 'message'), '1006') > 0) AS app_1006,
+  countIf(positionCaseInsensitive(JSONExtractString(raw, 'message'), 'unexpectedly disconnected') > 0) AS unexpected,
+  uniqIf(JSONExtractString(raw, 'packageName'),
+    JSONExtractString(raw, 'service') = 'AppManager'
+    AND positionCaseInsensitive(JSONExtractString(raw, 'message'), '1006') > 0) AS distinct_packages
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND JSONExtractString(raw, 'region') = 'us-central'
+  AND <cascade-window predicates>
+GROUP BY second
+HAVING app_1006 > 0 OR unexpected > 0
+ORDER BY app_1006 DESC, unexpected DESC
+```
+
+Findings:
+
+| Window | Largest app 1006 second | Distinct packages | Notes |
+|---|---:|---:|---|
+| Prod 04-30 15:40 | 2 | 1 | Small single-package trickles only |
+| Prod 04-30 18:24 | 2 | 1 | Small single-package trickles only |
+| Prod 05-01 11:38 | 12 | 5 | Small burst at 11:20:34 UTC, ~18 min before listed cascade |
+| Staging 05-04 17:02 | 104 AppManager 1006 log lines, 52 unexpected app disconnects | 8 | Immediate precursor at 17:01:17 UTC |
+
+Conclusion: the staging WS storm is real and large enough to be a plausible proximate trigger for that restart, but **prior prod cascades do not share the same storm signature**. 106 should remain a sibling investigation, not the sole explanation for 105.
+
+### W5. Local storm harnesses
+
+A local-only harness was added under `cloud/tools/ws-storm-local/` to test whether a storm can be reproduced without deploying. Any captions package in the harness package pool is `com.mentra.captions.debug`; the harness rewrites accidental `com.mentra.captions` arguments to debug.
+
+Harnesses:
+
+- `bun-ws-storm-harness.ts`: raw Bun native WebSocket server/client storm.
+- `mentra-path-storm-harness.ts`: real `AppManager`, `AppSession`, `SubscriptionManager`, and optionally `handleAppMessage`, with fake sockets and stubbed services.
+
+Results relevant to 106:
+
+| Scenario | Result |
+|---|---|
+| Raw Bun WS, 112 simultaneous app closes/reconnects | No stall; max heartbeat gap ~2ms |
+| Raw Bun WS, 168 simultaneous multi-app closes/reconnects | No stall; max heartbeat gap ~6ms |
+| Raw Bun WS with high stdout/log pressure | No stall locally; log volume alone did not reproduce the silence window |
+| Raw Bun WS with 3000ms async reconnect delay | Huge wall-time per message, but event loop stayed responsive |
+| Real Mentra v3 reconnect storm, 56 app sessions × 10 rounds | Clean; max heartbeat gap 6ms |
+| Real Mentra legacy init + async DB-like delay | Tens of seconds aggregate reconnect wall-time, but event loop stayed responsive |
+| Real Mentra legacy init + small synchronous DB-like work | Multi-second heartbeat gaps; 20ms sync work crossed current `/livez` timeout |
+
+Conclusion: raw Bun WS close/reconnect behavior is **not enough** to reproduce the staging stall on a laptop. The dangerous local reproduction requires the storm to amplify synchronous work in Mentra's reconnect/init/subscription paths.
+
+---
+
+## Proposed Investigation Plan (no code changes)
+
+1. **W4 first** — completed 2026-05-05. Result: staging-scale storm did not appear in the three prior prod windows.
+2. **W3 manual check** — look at Cloudflare and Azure status for the cascade timestamps. Quick.
+3. **W1 + W2 spec** — write a small spec adding the close-source and ping-timing instrumentation. Estimate ~50 LoC. Ships separately or alongside the [105 spec](../105-event-loop-cascade-investigation/spec.md) instrumentation.
+4. **Add storm-path timers** — for app `CONNECTION_INIT`, app `RECONNECT`, `attachAppSocket`, `broadcastAppState`, `refreshInstalledApps`, `SubscriptionManager.syncManagers`, transcription update, stream ensure, and Bun WS `send()` return values / `drain` counts.
+
+---
+
+## Open Follow-Ups
+
+- [x] Run W4 query and document findings here.
+- [ ] Run W3 status-page checks for the four known cascade timestamps.
+- [ ] Spec W1 + W2 (separate doc or fold into 105 spec).
+- [ ] Decide whether W1/W2 belongs in 106 or should be folded into the 105 Phase 1.5 instrumentation spec.
+- [ ] Once W1 + W2 ship, capture the next cascade and confirm or rule out Hypotheses A vs B.
+
+## Why This Is a Separate Issue (not part of 105)
+
+105 is asking "which app-message handler is consuming time during cascade?" — that's about CPU within message-handling code paths, fixable in our own code.
+
+106 is asking "what causes 49 simultaneous app WS disconnects, and is it actually the cascade trigger?" — that's about WS lifecycle behavior under load and possibly external infrastructure events. Different scope, different fix path.
+
+Both could share the same root cause (e.g., the loop is busy, missing pings) — but they could equally be independent (e.g., cascade busy from message handling, WS storm from network event). Keeping them as sibling issues lets us investigate in parallel without over-coupling the analyses or fixes.

--- a/cloud/packages/cloud/src/index.ts
+++ b/cloud/packages/cloud/src/index.ts
@@ -195,6 +195,17 @@ logger.info(`\n
     ☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️
     ☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️☁️\n`);
 
+logger.info(
+  {
+    feature: "process-lifecycle",
+    event: "process-started",
+    pid: process.pid,
+    bunVersion: Bun.version,
+    port: PORT,
+  },
+  "Process lifecycle: started",
+);
+
 // ---------------------------------------------------------------------------
 // Fail-fast shutdown on SIGTERM/SIGINT
 //
@@ -278,6 +289,7 @@ async function failFastShutdown(signal: string): Promise<void> {
   // Watchdog: if anything hangs, force-exit at the budget with a distinct code.
   const watchdog = setTimeout(() => {
     shutdownStderrLine({
+      feature: "process-lifecycle",
       event: "shutdown-watchdog-fired",
       signal,
       budgetMs: SHUTDOWN_BUDGET_MS,
@@ -291,6 +303,7 @@ async function failFastShutdown(signal: string): Promise<void> {
   // Step 1: announce via synchronous stderr (Pino logs may not flush in time).
   const sessions = UserSession.getAllSessions();
   shutdownStderrLine({
+    feature: "process-lifecycle",
     event: "shutdown-started",
     signal,
     pid: process.pid,
@@ -340,6 +353,7 @@ async function failFastShutdown(signal: string): Promise<void> {
 
   // Step 5: announce completion via synchronous stderr.
   shutdownStderrLine({
+    feature: "process-lifecycle",
     event: "shutdown-complete",
     signal,
     elapsedMs: Date.now() - t0,

--- a/cloud/packages/cloud/src/services/core/developer.service.ts
+++ b/cloud/packages/cloud/src/services/core/developer.service.ts
@@ -80,7 +80,7 @@ export async function validateApiKey(packageName: string, apiKey: string, userSe
     // Hash the provided API key and compare with stored hash
     const hashedKey = hashApiKey(apiKey);
 
-    _logger.debug({ hashedKey, apiKey }, `Validating API key for ${packageName}`);
+    _logger.debug({ hashedKey, hasApiKey: Boolean(apiKey) }, `Validating API key for ${packageName}`);
 
     // Compare the hashed API key with the stored hashed API key
     const isValid = hashedKey === app.hashedApiKey;

--- a/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
+++ b/cloud/packages/cloud/src/services/metrics/SystemVitalsLogger.ts
@@ -16,7 +16,7 @@
  * See: cloud/issues/069-ws-disconnect-observability/spike.md
  */
 
-import { PerformanceObserver } from "node:perf_hooks";
+import { PerformanceObserver, monitorEventLoopDelay } from "node:perf_hooks";
 import { heapStats } from "bun:jsc";
 import { logger as rootLogger } from "../logging/pino-logger";
 import { UserSession } from "../session/UserSession";
@@ -24,6 +24,7 @@ import { memoryLeakDetector } from "../debug/MemoryLeakDetector";
 import { mongoQueryStats } from "../../connections/mongodb.connection";
 import { udpAudioServer } from "../udp/UdpAudioServer";
 import { getDeviceStateCounters, resetDeviceStateCounters } from "./device-state-counters";
+import { cascadeDiagnostics } from "./cascade-diagnostics";
 
 const logger = rootLogger.child({ service: "SystemVitalsLogger" });
 
@@ -47,6 +48,7 @@ const VITALS_SELF_SLOW_MS = 500;
 // Natural minor GCs are typically <10ms; 100ms catches plausibly-relevant
 // pauses without flooding.
 const NATURAL_GC_THRESHOLD_MS = 100;
+const EVENT_LOOP_DELAY_HISTOGRAM_RESOLUTION_MS = 10;
 
 /**
  * Operation timing accumulator.
@@ -135,6 +137,7 @@ class SystemVitalsLogger {
   private heartbeatInterval?: NodeJS.Timeout;
   private lastHeartbeatTick: number = Date.now();
   private gcObserver?: PerformanceObserver;
+  private eventLoopDelayHistogram?: ReturnType<typeof monitorEventLoopDelay>;
   // Issue 102: previous UDP stats snapshot for delta calculation per vitals window.
   // Initialized to all-zeros (not null) so the first vitals window after pod
   // start captures the from-boot traffic as its delta instead of hardcoding 0.
@@ -179,9 +182,19 @@ class SystemVitalsLogger {
     // Issue 102: observe natural V8 GC pauses (not just our forced gc-probe).
     this.startGcObserver();
 
+    // Issue 105: continuous event-loop delay histogram. This catches isolated
+    // blocks that rolling p99 sampling can miss. Use maxMs as the primary
+    // cascade signal; local Bun 1.3.13 testing showed p99 may miss one-off
+    // stalls while maxMs catches them.
+    this.startEventLoopDelayHistogram();
+
     logger.info(
-      { vitalsIntervalMs: VITALS_INTERVAL_MS, gcProbeIntervalMs: GC_PROBE_INTERVAL_MS },
-      "SystemVitalsLogger started (vitals + GC probe + gap detector + heartbeat + natural-GC observer)",
+      {
+        vitalsIntervalMs: VITALS_INTERVAL_MS,
+        gcProbeIntervalMs: GC_PROBE_INTERVAL_MS,
+        eventLoopDelayHistogramResolutionMs: EVENT_LOOP_DELAY_HISTOGRAM_RESOLUTION_MS,
+      },
+      "SystemVitalsLogger started (vitals + GC probe + gap detector + heartbeat + natural-GC observer + event-loop histogram)",
     );
   }
 
@@ -206,7 +219,58 @@ class SystemVitalsLogger {
       this.gcObserver.disconnect();
       this.gcObserver = undefined;
     }
+    if (this.eventLoopDelayHistogram) {
+      this.eventLoopDelayHistogram.disable();
+      this.eventLoopDelayHistogram = undefined;
+    }
     logger.info("SystemVitalsLogger stopped");
+  }
+
+  private startEventLoopDelayHistogram(): void {
+    try {
+      this.eventLoopDelayHistogram = monitorEventLoopDelay({
+        resolution: EVENT_LOOP_DELAY_HISTOGRAM_RESOLUTION_MS,
+      });
+      this.eventLoopDelayHistogram.enable();
+      logger.info(
+        {
+          feature: "event-loop-delay-histogram",
+          resolutionMs: EVENT_LOOP_DELAY_HISTOGRAM_RESOLUTION_MS,
+        },
+        "Event-loop delay histogram started",
+      );
+    } catch (err) {
+      logger.warn(
+        {
+          feature: "event-loop-delay-histogram-unsupported",
+          err,
+        },
+        "Event-loop delay histogram NOT installed",
+      );
+    }
+  }
+
+  private getEventLoopDelayHistogramSnapshot(): Record<string, number> {
+    const histogram = this.eventLoopDelayHistogram;
+    if (!histogram) {
+      return {};
+    }
+
+    try {
+      const maxMs = histogram.max / 1_000_000;
+      const meanMs = histogram.mean / 1_000_000;
+      const p99Ms = histogram.percentile(99) / 1_000_000;
+      const snapshot = {
+        eventLoopDelayMaxMs: Math.round(maxMs * 10) / 10,
+        eventLoopDelayMeanMs: Number.isFinite(meanMs) ? Math.round(meanMs * 10) / 10 : 0,
+        eventLoopDelayP99Ms: Math.round(p99Ms * 10) / 10,
+      };
+      histogram.reset();
+      return snapshot;
+    } catch (err) {
+      logger.warn({ err }, "Failed to read event-loop delay histogram");
+      return {};
+    }
   }
 
   /**
@@ -445,6 +509,8 @@ class SystemVitalsLogger {
       const sessions = UserSession.getAllSessions();
       sessionCountForLog = sessions.length;
       const mongoStats = mongoQueryStats.getAndReset();
+      const cascadeSnapshot = cascadeDiagnostics.getAndReset();
+      const eventLoopDelaySnapshot = this.getEventLoopDelayHistogramSnapshot();
 
       // Issue 102: pod-level UDP counter deltas per 30s vitals window.
       // UdpAudioServer exposes cumulative counters; we compute deltas against
@@ -707,6 +773,19 @@ class SystemVitalsLogger {
           ...Object.fromEntries(Object.entries(operationSnapshot).map(([k, v]) => [`op_${k}_ms`, Math.round(v)])),
           opTotalMs: Math.round(totalOperationMs),
           opBudgetUsedPct: Math.round((totalOperationMs / VITALS_INTERVAL_MS) * 100),
+
+          // Issue 105 Phase 1.5 diagnostic timers/counters. These are logged
+          // as op_* fields for query consistency but excluded from opTotalMs so
+          // the long-lived coarse budget signal does not double-count nested
+          // phase timings.
+          ...Object.fromEntries(
+            Object.entries(cascadeSnapshot.timers).map(([k, v]) => [`op_${k}_ms`, Math.round(v)]),
+          ),
+          ...Object.fromEntries(Object.entries(cascadeSnapshot.counters).map(([k, v]) => [k, Math.round(v)])),
+
+          // Continuous event-loop delay histogram. maxMs is the main signal for
+          // isolated sync blocks; p99 is useful only for broader degradation.
+          ...eventLoopDelaySnapshot,
 
           // Issue 102: pod-level UDP load per 30s window. Quantifies the regime
           // where the cascade fires (per the independent spike, dangerous

--- a/cloud/packages/cloud/src/services/metrics/cascade-diagnostics.ts
+++ b/cloud/packages/cloud/src/services/metrics/cascade-diagnostics.ts
@@ -1,0 +1,407 @@
+import { logger as rootLogger } from "../logging/pino-logger";
+
+const logger = rootLogger.child({ service: "CascadeDiagnostics" });
+
+const SLOW_APP_PROTOCOL_MS = 100;
+const SLOW_APP_CONNECT_MS = 100;
+const SLOW_APP_CONNECT_PHASE_MS = 50;
+const SLOW_APP_MESSAGE_MS = 100;
+const SLOW_SUBSCRIPTION_UPDATE_MS = 100;
+const SLOW_SUBSCRIPTION_PHASE_MS = 50;
+
+type NumericSnapshot = Record<string, number>;
+
+export interface WebSocketObservation {
+  openedAt: number;
+  lastMessageAt?: number;
+  lastSendAt?: number;
+  lastPingSentAt?: number;
+  lastPongReceivedAt?: number;
+  sendCount: number;
+  sendReturnPositiveCount: number;
+  sendReturnZeroCount: number;
+  sendReturnNegativeCount: number;
+  sendReturnVoidCount: number;
+  drainCount: number;
+  lastSendReturn?: number;
+}
+
+interface SlowLogBase {
+  packageName?: string;
+  userIdHash?: number;
+  durationMs: number;
+  phaseTimings?: Record<string, number>;
+}
+
+class CascadeDiagnostics {
+  private timers: NumericSnapshot = {};
+  private counters: NumericSnapshot = {};
+
+  addTimer(name: string, durationMs: number): void {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      return;
+    }
+    this.timers[name] = (this.timers[name] ?? 0) + durationMs;
+  }
+
+  increment(name: string, amount = 1): void {
+    if (!Number.isFinite(amount) || amount === 0) {
+      return;
+    }
+    this.counters[name] = (this.counters[name] ?? 0) + amount;
+  }
+
+  getAndReset(): { timers: NumericSnapshot; counters: NumericSnapshot } {
+    const snapshot = {
+      timers: this.timers,
+      counters: this.counters,
+    };
+    this.timers = {};
+    this.counters = {};
+    return snapshot;
+  }
+}
+
+export const cascadeDiagnostics = new CascadeDiagnostics();
+
+export class PhaseTimer {
+  private readonly startedAt = performance.now();
+  private readonly phaseTimings: Record<string, number> = {};
+
+  get durationMs(): number {
+    return performance.now() - this.startedAt;
+  }
+
+  get timings(): Record<string, number> {
+    return { ...this.phaseTimings };
+  }
+
+  get instrumentedPhaseMs(): number {
+    return Object.values(this.phaseTimings).reduce((sum, value) => sum + value, 0);
+  }
+
+  get unattributedMs(): number {
+    return Math.max(0, this.durationMs - this.instrumentedPhaseMs);
+  }
+
+  async measure<T>(phase: string, operation: () => Promise<T>): Promise<T> {
+    const t0 = performance.now();
+    try {
+      return await operation();
+    } finally {
+      this.addPhase(phase, performance.now() - t0);
+    }
+  }
+
+  measureSync<T>(phase: string, operation: () => T): T {
+    const t0 = performance.now();
+    try {
+      return operation();
+    } finally {
+      this.addPhase(phase, performance.now() - t0);
+    }
+  }
+
+  private addPhase(phase: string, durationMs: number): void {
+    if (!Number.isFinite(durationMs) || durationMs < 0) {
+      return;
+    }
+    this.phaseTimings[phase] = (this.phaseTimings[phase] ?? 0) + durationMs;
+  }
+}
+
+export function createPhaseTimer(): PhaseTimer {
+  return new PhaseTimer();
+}
+
+export function hashUserId(userId: string | undefined | null): number | undefined {
+  if (!userId) {
+    return undefined;
+  }
+
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < userId.length; i++) {
+    hash ^= userId.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+export function roundMs(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+export function slowPhases(phaseTimings: Record<string, number>, thresholdMs: number): string[] {
+  return Object.entries(phaseTimings)
+    .filter(([, durationMs]) => durationMs >= thresholdMs)
+    .map(([phase]) => phase);
+}
+
+export function appMessageTimerName(messageType: string | undefined): string {
+  return `appMsg_${messageTypeSuffix(messageType)}`;
+}
+
+export function messageTypeSuffix(messageType: string | undefined): string {
+  const type = messageType || "unknown";
+  const known: Record<string, string> = {
+    subscription_update: "subscriptionUpdate",
+    display_request: "displayRequest",
+    dashboard_content_update: "dashboardContentUpdate",
+    dashboard_mode_change: "dashboardModeChange",
+    dashboard_system_update: "dashboardSystemUpdate",
+    rgb_led_control: "rgbLedControl",
+    camera_fov_set: "cameraFovSet",
+    stream_request: "streamRequest",
+    rtmp_stream_request: "streamRequest",
+    stream_stop: "streamStop",
+    rtmp_stream_stop: "streamStop",
+    stream_status_check: "streamStatusCheck",
+    location_poll_request: "locationPollRequest",
+    photo_request: "photoRequest",
+    audio_play_request: "audioPlayRequest",
+    audio_stop_request: "audioStopRequest",
+    audio_stream_start: "audioStreamStart",
+    audio_stream_end: "audioStreamEnd",
+    managed_stream_request: "managedStreamRequest",
+    managed_stream_stop: "managedStreamStop",
+    request_wifi_setup: "requestWifiSetup",
+    ownership_release: "ownershipRelease",
+  };
+
+  if (known[type]) {
+    return known[type];
+  }
+
+  return type
+    .replace(/[^a-zA-Z0-9]+(.)/g, (_, chr: string) => chr.toUpperCase())
+    .replace(/^[A-Z]/, (chr) => chr.toLowerCase())
+    .replace(/[^a-zA-Z0-9]/g, "") || "unknown";
+}
+
+export function logSlowAppProtocol(
+  protocolType: "connection_init" | "reconnect" | "regular_message" | "ping" | "parse",
+  data: SlowLogBase,
+): void {
+  if (data.durationMs < SLOW_APP_PROTOCOL_MS) {
+    return;
+  }
+
+  logger.warn(
+    {
+      feature: "slow-app-protocol",
+      protocolType,
+      packageName: data.packageName,
+      userIdHash: data.userIdHash,
+      durationMs: roundMs(data.durationMs),
+      phaseTimings: data.phaseTimings ? roundPhaseTimings(data.phaseTimings) : undefined,
+      instrumentedPhaseMs: data.phaseTimings ? roundMs(sumPhaseTimings(data.phaseTimings)) : undefined,
+      unattributedMs: data.phaseTimings ? roundMs(Math.max(0, data.durationMs - sumPhaseTimings(data.phaseTimings))) : undefined,
+    },
+    `Slow app protocol ${protocolType}: ${Math.round(data.durationMs)}ms`,
+  );
+}
+
+export function logSlowAppConnect(mode: "connection_init" | "reconnect" | "broadcast_app_state", data: SlowLogBase): void {
+  if (data.durationMs < SLOW_APP_CONNECT_MS) {
+    return;
+  }
+
+  const roundedPhases = data.phaseTimings ? roundPhaseTimings(data.phaseTimings) : undefined;
+  logger.warn(
+    {
+      feature: "slow-app-connect",
+      mode,
+      packageName: data.packageName,
+      userIdHash: data.userIdHash,
+      durationMs: roundMs(data.durationMs),
+      phaseTimings: roundedPhases,
+      slowPhases: roundedPhases ? slowPhases(roundedPhases, SLOW_APP_CONNECT_PHASE_MS) : undefined,
+      instrumentedPhaseMs: data.phaseTimings ? roundMs(sumPhaseTimings(data.phaseTimings)) : undefined,
+      unattributedMs: data.phaseTimings ? roundMs(Math.max(0, data.durationMs - sumPhaseTimings(data.phaseTimings))) : undefined,
+    },
+    `Slow app connect ${mode}: ${Math.round(data.durationMs)}ms`,
+  );
+}
+
+export function logSlowAppMessage(data: SlowLogBase & { messageType: string }): void {
+  if (data.durationMs < SLOW_APP_MESSAGE_MS) {
+    return;
+  }
+
+  logger.warn(
+    {
+      feature: "slow-app-message",
+      messageType: data.messageType,
+      packageName: data.packageName,
+      userIdHash: data.userIdHash,
+      durationMs: roundMs(data.durationMs),
+      phaseTimings: data.phaseTimings ? roundPhaseTimings(data.phaseTimings) : undefined,
+    },
+    `Slow app message ${data.messageType}: ${Math.round(data.durationMs)}ms`,
+  );
+}
+
+export function logSlowSubscriptionUpdate(data: SlowLogBase & { subscriptionCount: number }): void {
+  if (data.durationMs < SLOW_SUBSCRIPTION_UPDATE_MS) {
+    return;
+  }
+
+  const roundedPhases = data.phaseTimings ? roundPhaseTimings(data.phaseTimings) : undefined;
+  logger.warn(
+    {
+      feature: "slow-subscription-update",
+      packageName: data.packageName,
+      userIdHash: data.userIdHash,
+      subscriptionCount: data.subscriptionCount,
+      durationMs: roundMs(data.durationMs),
+      phaseTimings: roundedPhases,
+      slowPhases: roundedPhases ? slowPhases(roundedPhases, SLOW_SUBSCRIPTION_PHASE_MS) : undefined,
+      instrumentedPhaseMs: data.phaseTimings ? roundMs(sumPhaseTimings(data.phaseTimings)) : undefined,
+      unattributedMs: data.phaseTimings ? roundMs(Math.max(0, data.durationMs - sumPhaseTimings(data.phaseTimings))) : undefined,
+    },
+    `Slow subscription update: ${Math.round(data.durationMs)}ms`,
+  );
+}
+
+export function getOrCreateWsObservation(ws: unknown): WebSocketObservation {
+  const data = (ws as { data?: { obs?: WebSocketObservation } }).data;
+  if (!data) {
+    return {
+      openedAt: Date.now(),
+      sendCount: 0,
+      sendReturnPositiveCount: 0,
+      sendReturnZeroCount: 0,
+      sendReturnNegativeCount: 0,
+      sendReturnVoidCount: 0,
+      drainCount: 0,
+    };
+  }
+
+  if (!data.obs) {
+    data.obs = {
+      openedAt: Date.now(),
+      sendCount: 0,
+      sendReturnPositiveCount: 0,
+      sendReturnZeroCount: 0,
+      sendReturnNegativeCount: 0,
+      sendReturnVoidCount: 0,
+      drainCount: 0,
+    };
+  }
+  return data.obs;
+}
+
+export function markWebSocketOpened(ws: unknown): void {
+  const obs = getOrCreateWsObservation(ws);
+  obs.openedAt = Date.now();
+}
+
+export function markWebSocketMessageReceived(ws: unknown): void {
+  getOrCreateWsObservation(ws).lastMessageAt = Date.now();
+}
+
+export function markWebSocketPingSent(ws: unknown): void {
+  getOrCreateWsObservation(ws).lastPingSentAt = Date.now();
+  cascadeDiagnostics.increment("wsPingSent_count");
+}
+
+export function markWebSocketPongReceived(ws: unknown): void {
+  getOrCreateWsObservation(ws).lastPongReceivedAt = Date.now();
+  cascadeDiagnostics.increment("wsPongReceived_count");
+}
+
+export function markWebSocketDrain(ws: unknown): void {
+  const obs = getOrCreateWsObservation(ws);
+  obs.drainCount++;
+  cascadeDiagnostics.increment("wsDrain_count");
+}
+
+export function recordWebSocketSend(ws: unknown, direction: "app" | "glasses", sendReturn: number | void): void {
+  const obs = getOrCreateWsObservation(ws);
+  obs.lastSendAt = Date.now();
+  obs.sendCount++;
+
+  if (typeof sendReturn === "number") {
+    obs.lastSendReturn = sendReturn;
+    if (sendReturn > 0) {
+      obs.sendReturnPositiveCount++;
+      cascadeDiagnostics.increment(`wsSend_${direction}_returnPositive_count`);
+    } else if (sendReturn === 0) {
+      obs.sendReturnZeroCount++;
+      cascadeDiagnostics.increment(`wsSend_${direction}_returnZero_count`);
+    } else {
+      obs.sendReturnNegativeCount++;
+      cascadeDiagnostics.increment(`wsSend_${direction}_returnNegative_count`);
+    }
+  } else {
+    obs.sendReturnVoidCount++;
+    cascadeDiagnostics.increment(`wsSend_${direction}_returnVoid_count`);
+  }
+}
+
+export function buildAppWsCloseTelemetry(ws: unknown, code: number): Record<string, unknown> {
+  const data = (ws as {
+    data?: {
+      userId?: string;
+      packageName?: string;
+      sdkVersion?: string;
+      obs?: WebSocketObservation;
+    };
+  }).data;
+  const obs = data?.obs;
+  const now = Date.now();
+
+  cascadeDiagnostics.increment("appWsClose_count");
+  if (code === 1006) {
+    cascadeDiagnostics.increment("appWsClose_1006_count");
+  } else if (code === 1000 || code === 1001) {
+    cascadeDiagnostics.increment("appWsClose_clean_count");
+  } else {
+    cascadeDiagnostics.increment("appWsClose_other_count");
+  }
+
+  return {
+    feature: "app-ws-close",
+    userIdHash: hashUserId(data?.userId),
+    packageName: data?.packageName,
+    sdkVersion: data?.sdkVersion,
+    code,
+    inferredCloseSource: inferCloseSource(code, obs),
+    openDurationMs: obs?.openedAt ? now - obs.openedAt : undefined,
+    lastMessageAgoMs: obs?.lastMessageAt ? now - obs.lastMessageAt : undefined,
+    lastSendAgoMs: obs?.lastSendAt ? now - obs.lastSendAt : undefined,
+    lastPingSentAgoMs: obs?.lastPingSentAt ? now - obs.lastPingSentAt : undefined,
+    lastPongReceivedAgoMs: obs?.lastPongReceivedAt ? now - obs.lastPongReceivedAt : undefined,
+    sendCount: obs?.sendCount,
+    sendReturnPositiveCount: obs?.sendReturnPositiveCount,
+    sendReturnZeroCount: obs?.sendReturnZeroCount,
+    sendReturnNegativeCount: obs?.sendReturnNegativeCount,
+    sendReturnVoidCount: obs?.sendReturnVoidCount,
+    drainCount: obs?.drainCount,
+    lastSendReturn: obs?.lastSendReturn,
+  };
+}
+
+function inferCloseSource(code: number, obs: WebSocketObservation | undefined): string {
+  if (code === 1000 || code === 1001) {
+    return "clean_close";
+  }
+  if (code !== 1006) {
+    return "close_frame_or_local_close";
+  }
+  if (!obs) {
+    return "unknown_no_close_frame";
+  }
+  if (obs.lastPingSentAt && !obs.lastPongReceivedAt) {
+    return "unknown_no_close_frame_ping_sent_no_pong_recorded";
+  }
+  return "unknown_no_close_frame";
+}
+
+function roundPhaseTimings(phaseTimings: Record<string, number>): Record<string, number> {
+  return Object.fromEntries(Object.entries(phaseTimings).map(([phase, durationMs]) => [phase, roundMs(durationMs)]));
+}
+
+function sumPhaseTimings(phaseTimings: Record<string, number>): number {
+  return Object.values(phaseTimings).reduce((sum, value) => sum + value, 0);
+}

--- a/cloud/packages/cloud/src/services/session/AppManager.ts
+++ b/cloud/packages/cloud/src/services/session/AppManager.ts
@@ -29,6 +29,13 @@ import appService, { DEPRECATED_APPS } from "../core/app.service";
 import * as developerService from "../core/developer.service";
 import { logger as rootLogger } from "../logging/pino-logger";
 import { metricsService } from "../metrics";
+import {
+  cascadeDiagnostics,
+  createPhaseTimer,
+  hashUserId,
+  logSlowAppConnect,
+  recordWebSocketSend,
+} from "../metrics/cascade-diagnostics";
 import { PosthogService } from "../logging/posthog.service";
 import { IWebSocket, WebSocketReadyState } from "../websocket/types";
 import { deferredAppConnectionRegistry, type DeferredAppConnection } from "../websocket/DeferredAppConnectionRegistry";
@@ -1225,61 +1232,90 @@ export class AppManager {
     reconnectMessage: { sessionId: string; sdkVersion?: string },
     packageName: string,
   ): Promise<void> {
-    const appSession = this.apps.get(packageName);
-    const shouldDefer = await this.shouldDeferReconnect(packageName);
+    const phaseTimer = createPhaseTimer();
+    try {
+      const appSession = phaseTimer.measureSync("getAppSession", () => this.apps.get(packageName));
+      const shouldDefer = await phaseTimer.measure("shouldDeferReconnect", () => this.shouldDeferReconnect(packageName));
 
-    if (!appSession && shouldDefer) {
-      ws.send(
-        JSON.stringify({
-          type: CloudToAppMessageType.RECONNECT_DEFERRED,
-          code: "AWAITING_APP_RESTORE",
-          message: "Cloud is restoring app state",
-          timeoutMs: 30_000,
-          timestamp: new Date(),
+      if (!appSession && shouldDefer) {
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_DEFERRED,
+              code: "AWAITING_APP_RESTORE",
+              message: "Cloud is restoring app state",
+              timeoutMs: 30_000,
+              timestamp: new Date(),
+            }),
+          ),
+        );
+
+        phaseTimer.measureSync("deferRegister", () =>
+          deferredAppConnectionRegistry.register({
+            userId: this.userSession.userId,
+            packageName,
+            sdkVersion: reconnectMessage.sdkVersion ?? "3.0.0",
+            priorSessionId: reconnectMessage.sessionId,
+            websocket: ws as any,
+            reason: "awaiting_app_restore",
+          }),
+        );
+        return;
+      }
+
+      if (appSession && appSession.sessionId !== reconnectMessage.sessionId) {
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_REJECTED,
+              code: "SESSION_EXPIRED",
+              message: "Reconnect session identity does not match the active app session",
+              timestamp: new Date(),
+            }),
+          ),
+        );
+        ws.close(1008, "Session expired");
+        return;
+      }
+
+      if (!appSession || appSession.isStopped) {
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_REJECTED,
+              code: "NOT_RUNNING",
+              message: "App is not expected to run for this user session",
+              timestamp: new Date(),
+            }),
+          ),
+        );
+        ws.close(1008, "App not running");
+        return;
+      }
+
+      await phaseTimer.measure("attachAppSocket", () =>
+        this.attachAppSocket(packageName, ws, {
+          ackType: CloudToAppMessageType.RECONNECT_ACK,
+          sdkVersion: reconnectMessage.sdkVersion,
         }),
       );
-
-      deferredAppConnectionRegistry.register({
-        userId: this.userSession.userId,
+    } finally {
+      const durationMs = phaseTimer.durationMs;
+      cascadeDiagnostics.addTimer("appConnect_reconnect", durationMs);
+      cascadeDiagnostics.increment("appConnect_reconnect_count");
+      logSlowAppConnect("reconnect", {
         packageName,
-        sdkVersion: reconnectMessage.sdkVersion ?? "3.0.0",
-        priorSessionId: reconnectMessage.sessionId,
-        websocket: ws as any,
-        reason: "awaiting_app_restore",
+        userIdHash: hashUserId(this.userSession.userId),
+        durationMs,
+        phaseTimings: phaseTimer.timings,
       });
-      return;
     }
-
-    if (appSession && appSession.sessionId !== reconnectMessage.sessionId) {
-      ws.send(
-        JSON.stringify({
-          type: CloudToAppMessageType.RECONNECT_REJECTED,
-          code: "SESSION_EXPIRED",
-          message: "Reconnect session identity does not match the active app session",
-          timestamp: new Date(),
-        }),
-      );
-      ws.close(1008, "Session expired");
-      return;
-    }
-
-    if (!appSession || appSession.isStopped) {
-      ws.send(
-        JSON.stringify({
-          type: CloudToAppMessageType.RECONNECT_REJECTED,
-          code: "NOT_RUNNING",
-          message: "App is not expected to run for this user session",
-          timestamp: new Date(),
-        }),
-      );
-      ws.close(1008, "App not running");
-      return;
-    }
-
-    await this.attachAppSocket(packageName, ws, {
-      ackType: CloudToAppMessageType.RECONNECT_ACK,
-      sdkVersion: reconnectMessage.sdkVersion,
-    });
   }
 
   /**
@@ -1289,9 +1325,9 @@ export class AppManager {
    * @param initMessage App initialization message
    */
   async handleAppInit(ws: IWebSocket, initMessage: AppConnectionInit): Promise<void> {
+    const phaseTimer = createPhaseTimer();
+    const { packageName, apiKey } = initMessage;
     try {
-      const { packageName, apiKey } = initMessage;
-
       // Reject deprecated apps immediately.
       if (DEPRECATED_APPS.includes(packageName)) {
         this.logger.info(
@@ -1315,7 +1351,9 @@ export class AppManager {
       }
 
       // Validate the API key
-      const isValidApiKey = await developerService.validateApiKey(packageName, apiKey, this.userSession);
+      const isValidApiKey = await phaseTimer.measure("validateApiKey", () =>
+        developerService.validateApiKey(packageName, apiKey, this.userSession),
+      );
 
       if (!isValidApiKey) {
         this.logger.error(
@@ -1396,10 +1434,12 @@ export class AppManager {
         );
       }
 
-      await this.attachAppSocket(packageName, ws, {
-        ackType: CloudToAppMessageType.CONNECTION_ACK,
-        sdkVersion: initMessage.sdkVersion,
-      });
+      await phaseTimer.measure("attachAppSocket", () =>
+        this.attachAppSocket(packageName, ws, {
+          ackType: CloudToAppMessageType.CONNECTION_ACK,
+          sdkVersion: initMessage.sdkVersion,
+        }),
+      );
 
       // Resolve pending connection if it exists
       const pending = this.pendingConnections.get(packageName);
@@ -1424,11 +1464,13 @@ export class AppManager {
 
         // Track app_start event in PostHog
         try {
-          await PosthogService.trackEvent("app_start", this.userSession.userId, {
-            packageName,
-            userId: this.userSession.userId,
-            sessionId: this.userSession.sessionId,
-          });
+          await phaseTimer.measure("posthogAppStart", () =>
+            PosthogService.trackEvent("app_start", this.userSession.userId, {
+              packageName,
+              userId: this.userSession.userId,
+              sessionId: this.userSession.sessionId,
+            }),
+          );
         } catch (error) {
           const logger = this.logger.child({ packageName });
           logger.error(error, "Error tracking app_start event in PostHog");
@@ -1456,7 +1498,7 @@ export class AppManager {
       });
 
       // Broadcast app state change
-      await this.broadcastAppState();
+      await phaseTimer.measure("broadcastAppState", () => this.broadcastAppState());
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(
@@ -1486,6 +1528,16 @@ export class AppManager {
       } catch (sendError) {
         this.logger.error(sendError, `Error sending internal error to App:`);
       }
+    } finally {
+      const durationMs = phaseTimer.durationMs;
+      cascadeDiagnostics.addTimer("appConnect_connectionInit", durationMs);
+      cascadeDiagnostics.increment("appConnect_connectionInit_count");
+      logSlowAppConnect("connection_init", {
+        packageName,
+        userIdHash: hashUserId(this.userSession.userId),
+        durationMs,
+        phaseTimings: phaseTimer.timings,
+      });
     }
   }
 
@@ -1494,12 +1546,15 @@ export class AppManager {
    */
   async broadcastAppState(): Promise<AppStateChange | null> {
     this.logger.debug({ function: "broadcastAppState" }, `Broadcasting app state for user ${this.userSession.userId}`);
+    const phaseTimer = createPhaseTimer();
     try {
       // Refresh installed apps
-      await this.refreshInstalledApps();
+      await phaseTimer.measure("refreshInstalledApps", () => this.refreshInstalledApps());
 
       // Transform session for client
-      const clientSessionData = await this.userSession.snapshotForClient();
+      const clientSessionData = await phaseTimer.measure("snapshotForClient", () =>
+        this.userSession.snapshotForClient(),
+      );
       this.logger.debug({ clientSessionData }, `Transformed user session data for ${this.userSession.userId}`);
       // Create app state change message
       const appStateChange: AppStateChange = {
@@ -1515,12 +1570,23 @@ export class AppManager {
         return appStateChange;
       }
 
-      this.userSession.websocket.send(JSON.stringify(appStateChange));
+      const clientWebSocket = this.userSession.websocket;
+      phaseTimer.measureSync("sendClient", () =>
+        recordWebSocketSend(clientWebSocket, "glasses", clientWebSocket.send(JSON.stringify(appStateChange))),
+      );
       this.logger.debug({ appStateChange }, `Sent APP_STATE_CHANGE to ${this.userSession.userId}`);
       return appStateChange;
     } catch (error) {
       this.logger.error(error, `Error broadcasting app state for ${this.userSession.userId}`);
       return null;
+    } finally {
+      const durationMs = phaseTimer.durationMs;
+      cascadeDiagnostics.addTimer("appConnect_broadcastAppState", durationMs);
+      logSlowAppConnect("broadcast_app_state", {
+        userIdHash: hashUserId(this.userSession.userId),
+        durationMs,
+        phaseTimings: phaseTimer.timings,
+      });
     }
   }
 
@@ -1528,13 +1594,18 @@ export class AppManager {
    * Refresh the installed apps list
    */
   async refreshInstalledApps(): Promise<void> {
+    const phaseTimer = createPhaseTimer();
     try {
       // Fetch installed apps
-      const installedAppsList = await appService.getAllApps(this.userSession.userId);
+      const installedAppsList = await phaseTimer.measure("appServiceGetAllApps", () =>
+        appService.getAllApps(this.userSession.userId),
+      );
       const installedApps = new Map<string, AppI>();
-      for (const app of installedAppsList) {
-        installedApps.set(app.packageName, app);
-      }
+      phaseTimer.measureSync("mapInstalledApps", () => {
+        for (const app of installedAppsList) {
+          installedApps.set(app.packageName, app);
+        }
+      });
       this.logger.info(
         { installedAppsList: installedAppsList.map((app) => app.packageName) },
         `Fetched ${installedApps.size} installed apps for ${this.userSession.userId}`,
@@ -1546,6 +1617,8 @@ export class AppManager {
       this.logger.info(`Updated installed apps for ${this.userSession.userId}`);
     } catch (error) {
       this.logger.error(error, `Error refreshing installed apps:`);
+    } finally {
+      cascadeDiagnostics.addTimer("appConnect_refreshInstalledApps", phaseTimer.durationMs);
     }
   }
 
@@ -1765,7 +1838,10 @@ export class AppManager {
   }
 
   private async attachAppSocket(packageName: string, ws: IWebSocket, options: AppAttachOptions = {}): Promise<void> {
-    const connectedAppSession = this.getOrCreateAppSession(packageName);
+    const phaseTimer = createPhaseTimer();
+    const connectedAppSession = phaseTimer.measureSync("getOrCreateAppSession", () =>
+      this.getOrCreateAppSession(packageName),
+    );
     if (!connectedAppSession) {
       this.logger.warn({ packageName }, `[AppManager] Cannot attach app socket - AppManager disposed`);
       ws.close(1008, "Session ended");
@@ -1775,16 +1851,18 @@ export class AppManager {
     // Set SDK version before handleConnect so the disconnect handler
     // knows whether to use TRANSPORT_DOWN (v3) or GRACE_PERIOD (v2).
     if (options.sdkVersion) {
-      connectedAppSession.setSdkVersion(options.sdkVersion);
+      phaseTimer.measureSync("setSdkVersion", () => connectedAppSession.setSdkVersion(options.sdkVersion));
     }
 
-    connectedAppSession.handleConnect(ws);
+    phaseTimer.measureSync("handleConnect", () => connectedAppSession.handleConnect(ws));
     const sessionId = connectedAppSession.sessionId;
 
     const app = this.userSession.installedApps.get(packageName);
-    const user = await User.findOrCreateUser(this.userSession.userId);
+    const user = await phaseTimer.measure("findOrCreateUser", () => User.findOrCreateUser(this.userSession.userId));
     const userSettings = user.getAppSettings(packageName) || app?.settings || [];
-    const mentraosSettings = this.userSession.userSettingsManager.buildMentraosSettings();
+    const mentraosSettings = phaseTimer.measureSync("buildMentraosSettings", () =>
+      this.userSession.userSettingsManager.buildMentraosSettings(),
+    );
 
     const ackMessage = {
       type: options.ackType ?? CloudToAppMessageType.CONNECTION_ACK,
@@ -1797,9 +1875,9 @@ export class AppManager {
       timestamp: new Date(),
     };
 
-    ws.send(JSON.stringify(ackMessage));
+    phaseTimer.measureSync("sendAck", () => recordWebSocketSend(ws, "app", ws.send(JSON.stringify(ackMessage))));
     metricsService.incrementMiniappMessagesOut();
-    this.userSession.deviceManager.sendFullStateSnapshot(ws);
+    phaseTimer.measureSync("sendFullStateSnapshot", () => this.userSession.deviceManager.sendFullStateSnapshot(ws));
 
     // Issue 087: Clear dedup cache and deliver active stream state.
     // Issue 090: Only for v3 apps. v2 apps don't expect unsolicited
@@ -1807,17 +1885,19 @@ export class AppManager {
     // on the v2 SDK from stale data, blocking all new startManagedStream() calls.
     if (connectedAppSession.isV3) {
       this.userSession.managedStreamingExtension.clearLastSentStatus(packageName);
-      this.deliverActiveStreamState(packageName, ws);
+      phaseTimer.measureSync("deliverActiveStreamState", () => this.deliverActiveStreamState(packageName, ws));
     }
 
     try {
-      await user.addRunningApp(packageName);
+      await phaseTimer.measure("addRunningApp", () => user.addRunningApp(packageName));
     } catch (error) {
       this.logger.error(
         error,
         `Error updating user's running apps for ${this.userSession.userId} for app ${packageName}`,
       );
       this.logger.debug({ packageName, userId: this.userSession.userId }, "Failed to update user's running apps");
+    } finally {
+      cascadeDiagnostics.addTimer("appConnect_attachAppSocket", phaseTimer.durationMs);
     }
   }
 

--- a/cloud/packages/cloud/src/services/session/AppSession.ts
+++ b/cloud/packages/cloud/src/services/session/AppSession.ts
@@ -22,6 +22,7 @@ import { MemoryOwnerStat } from "../metrics/memory-census";
 import { estimateStringBytes, sumEstimatedBytes } from "../metrics/memory-estimate";
 import { ResourceTracker } from "../../utils/resource-tracker";
 import { metricsService } from "../metrics/MetricsService";
+import { markWebSocketPingSent, recordWebSocketSend } from "../metrics/cascade-diagnostics";
 import { IWebSocket, WebSocketReadyState, hasEventEmitter } from "../websocket/types";
 
 /**
@@ -526,7 +527,10 @@ export class AppSession {
     this.heartbeatInterval = setInterval(() => {
       if (this.disposed) return; // Guard against stale callback
       if (ws.readyState === WebSocketReadyState.OPEN) {
-        ws.ping?.();
+        if (typeof ws.ping === "function") {
+          ws.ping();
+          markWebSocketPingSent(ws);
+        }
         if (LOG_PING_PONG) {
           this.logger.debug("Sent ping");
         }
@@ -895,7 +899,7 @@ export class AppSession {
     }
 
     try {
-      this._webSocket.send(JSON.stringify(message));
+      recordWebSocketSend(this._webSocket, "app", this._webSocket.send(JSON.stringify(message)));
       metricsService.incrementMiniappMessagesOut();
       return true;
     } catch (error) {

--- a/cloud/packages/cloud/src/services/session/SubscriptionManager.ts
+++ b/cloud/packages/cloud/src/services/session/SubscriptionManager.ts
@@ -11,6 +11,13 @@ import {
 
 import App from "../../models/app.model";
 import { appCache } from "../core/app-cache.service";
+import {
+  cascadeDiagnostics,
+  createPhaseTimer,
+  hashUserId,
+  logSlowSubscriptionUpdate,
+  PhaseTimer,
+} from "../metrics/cascade-diagnostics";
 import { SimplePermissionChecker } from "../permissions/simple-permission-checker";
 
 import { AppSession, LocationRate } from "./AppSession";
@@ -218,8 +225,11 @@ export class SubscriptionManager {
    * conditions when multiple subscription updates arrive rapidly. See Issue 008.
    */
   async updateSubscriptions(packageName: string, subscriptions: SubscriptionRequest[]): Promise<void> {
+    const phaseTimer = createPhaseTimer();
     // Get or create AppSession for this app
-    const appSession = this.userSession.appManager.getOrCreateAppSession(packageName);
+    const appSession = phaseTimer.measureSync("getOrCreateAppSession", () =>
+      this.userSession.appManager.getOrCreateAppSession(packageName),
+    );
 
     // If AppManager is disposed, we can't update subscriptions
     if (!appSession) {
@@ -230,9 +240,24 @@ export class SubscriptionManager {
     // Serialize subscription updates per-app to prevent race conditions.
     // Multiple updates can arrive rapidly during startup and would otherwise
     // process concurrently, causing the wrong final state. See Issue 008.
-    await appSession.enqueue(async () => {
-      await this.processSubscriptionUpdate(appSession, packageName, subscriptions);
-    });
+    try {
+      await phaseTimer.measure("appSessionQueue", () =>
+        appSession.enqueue(async () => {
+          await this.processSubscriptionUpdate(appSession, packageName, subscriptions, phaseTimer);
+        }),
+      );
+    } finally {
+      const durationMs = phaseTimer.durationMs;
+      cascadeDiagnostics.addTimer("subscription_update", durationMs);
+      cascadeDiagnostics.increment("subscription_update_count");
+      logSlowSubscriptionUpdate({
+        packageName,
+        userIdHash: hashUserId(this.userSession.userId),
+        subscriptionCount: subscriptions.length,
+        durationMs,
+        phaseTimings: phaseTimer.timings,
+      });
+    }
   }
 
   /**
@@ -243,68 +268,76 @@ export class SubscriptionManager {
     appSession: AppSession,
     packageName: string,
     subscriptions: SubscriptionRequest[],
+    phaseTimer?: PhaseTimer,
   ): Promise<void> {
+    const timer = phaseTimer ?? createPhaseTimer();
     // Process incoming subscriptions array (strings and special location objects)
     const streamSubscriptions: ExtendedStreamType[] = [];
     let locationRate: LocationRate | null = null;
 
-    for (const sub of subscriptions) {
-      if (
-        typeof sub === "object" &&
-        sub !== null &&
-        "stream" in sub &&
-        (sub as any).stream === StreamType.LOCATION_STREAM
-      ) {
-        locationRate = (sub as any).rate || null;
-        streamSubscriptions.push(StreamType.LOCATION_STREAM);
-      } else if (typeof sub === "string") {
-        streamSubscriptions.push(sub as ExtendedStreamType);
+    timer.measureSync("parseSubscriptions", () => {
+      for (const sub of subscriptions) {
+        if (
+          typeof sub === "object" &&
+          sub !== null &&
+          "stream" in sub &&
+          (sub as any).stream === StreamType.LOCATION_STREAM
+        ) {
+          locationRate = (sub as any).rate || null;
+          streamSubscriptions.push(StreamType.LOCATION_STREAM);
+        } else if (typeof sub === "string") {
+          streamSubscriptions.push(sub as ExtendedStreamType);
+        }
       }
-    }
+    });
 
     // Convert bare TRANSCRIPTION to language-specific stream
-    const processed: ExtendedStreamType[] = streamSubscriptions.map((sub) =>
-      sub === StreamType.TRANSCRIPTION ? createTranscriptionStream("en-US") : sub,
+    const processed: ExtendedStreamType[] = timer.measureSync("normalizeSubscriptions", () =>
+      streamSubscriptions.map((sub) => (sub === StreamType.TRANSCRIPTION ? createTranscriptionStream("en-US") : sub)),
     );
 
     // Validate permissions (best-effort)
     let allowedProcessed: ExtendedStreamType[] = processed;
-    try {
-      const app = appCache.getByPackageName(packageName) || (await App.findOne({ packageName }).lean());
-      if (app) {
-        const { allowed, rejected } = SimplePermissionChecker.filterSubscriptions(app, processed);
-        if (rejected.length > 0) {
-          // Log at error level — a rejected subscription is a data-loss event.
-          // Include the app's actual permissions so we can diagnose *why* it was
-          // rejected without needing to query the DB separately. (Fix 044-1)
-          this.logger.error(
-            {
-              userId: this.userSession.userId,
-              packageName,
-              rejectedCount: rejected.length,
-              rejected,
-              appPermissions: app.permissions?.map((p: { type: string }) => p.type) ?? [],
-              requestedSubscriptions: processed,
-            },
-            "Rejected subscriptions due to missing permissions — app data stream interrupted",
+    await timer.measure("permissionValidation", async () => {
+      try {
+        const app = appCache.getByPackageName(packageName) || (await App.findOne({ packageName }).lean());
+        if (app) {
+          const { allowed, rejected } = SimplePermissionChecker.filterSubscriptions(app, processed);
+          if (rejected.length > 0) {
+            // Log at error level — a rejected subscription is a data-loss event.
+            // Include the app's actual permissions so we can diagnose *why* it was
+            // rejected without needing to query the DB separately. (Fix 044-1)
+            this.logger.error(
+              {
+                userId: this.userSession.userId,
+                packageName,
+                rejectedCount: rejected.length,
+                rejected,
+                appPermissions: app.permissions?.map((p: { type: string }) => p.type) ?? [],
+                requestedSubscriptions: processed,
+              },
+              "Rejected subscriptions due to missing permissions — app data stream interrupted",
+            );
+          }
+          allowedProcessed = allowed;
+        } else {
+          // App document not found in DB — allow all subscriptions but log it.
+          // This can happen if an app connects before its manifest is registered,
+          // or if the App collection is out of sync with the running apps.
+          this.logger.warn(
+            { packageName, userId: this.userSession.userId },
+            "App document not found in DB during permission check — allowing all requested subscriptions",
           );
         }
-        allowedProcessed = allowed;
-      } else {
-        // App document not found in DB — allow all subscriptions but log it.
-        // This can happen if an app connects before its manifest is registered,
-        // or if the App collection is out of sync with the running apps.
-        this.logger.warn(
-          { packageName, userId: this.userSession.userId },
-          "App document not found in DB during permission check — allowing all requested subscriptions",
-        );
+      } catch (error) {
+        this.logger.error({ packageName, error }, "Error validating subscriptions; continuing with all requested");
       }
-    } catch (error) {
-      this.logger.error({ packageName, error }, "Error validating subscriptions; continuing with all requested");
-    }
+    });
 
     // Delegate to AppSession for storage and grace period handling
-    const updateResult = appSession.updateSubscriptions(allowedProcessed, locationRate);
+    const updateResult = timer.measureSync("appSessionUpdateSubscriptions", () =>
+      appSession.updateSubscriptions(allowedProcessed, locationRate),
+    );
 
     if (!updateResult.applied) {
       this.logger.info(
@@ -329,8 +362,8 @@ export class SubscriptionManager {
     );
 
     // Sync downstream managers
-    await this.syncManagers();
-    this.userSession.microphoneManager?.handleSubscriptionChange();
+    await timer.measure("syncManagers", () => this.syncManagers());
+    timer.measureSync("microphoneHandleSubscriptionChange", () => this.userSession.microphoneManager?.handleSubscriptionChange());
   }
 
   /**
@@ -469,30 +502,47 @@ export class SubscriptionManager {
    * Sync all downstream managers with current subscription state
    */
   private async syncManagers(): Promise<void> {
+    const phaseTimer = createPhaseTimer();
     try {
       // Sync transcription
-      const transcriptionSubs = this.getTranscriptionSubscriptions();
-      await this.userSession.transcriptionManager.updateSubscriptions(transcriptionSubs);
+      const transcriptionSubs = phaseTimer.measureSync("getTranscriptionSubscriptions", () =>
+        this.getTranscriptionSubscriptions(),
+      );
+      await phaseTimer.measure("transcriptionUpdateSubscriptions", () =>
+        this.userSession.transcriptionManager.updateSubscriptions(transcriptionSubs),
+      );
 
       // Sync translation
-      const translationSubs = this.getTranslationSubscriptions();
-      await this.userSession.translationManager.updateSubscriptions(translationSubs);
+      const translationSubs = phaseTimer.measureSync("getTranslationSubscriptions", () =>
+        this.getTranslationSubscriptions(),
+      );
+      await phaseTimer.measure("translationUpdateSubscriptions", () =>
+        this.userSession.translationManager.updateSubscriptions(translationSubs),
+      );
 
       // Ensure streams exist
-      await Promise.all([
-        this.userSession.transcriptionManager.ensureStreamsExist(),
-        this.userSession.translationManager.ensureStreamsExist(),
-      ]);
+      await phaseTimer.measure("ensureStreamsExist", () =>
+        Promise.all([
+          this.userSession.transcriptionManager.ensureStreamsExist(),
+          this.userSession.translationManager.ensureStreamsExist(),
+        ]),
+      );
 
       // Sync location
-      const locationSubs = this.getLocationSubscriptions();
-      this.userSession.locationManager.handleSubscriptionUpdate(locationSubs);
+      const locationSubs = phaseTimer.measureSync("getLocationSubscriptions", () => this.getLocationSubscriptions());
+      phaseTimer.measureSync("locationHandleSubscriptionUpdate", () =>
+        this.userSession.locationManager.handleSubscriptionUpdate(locationSubs),
+      );
 
       // Sync calendar
-      const calendarSubs = this.getCalendarSubscriptions();
-      this.userSession.calendarManager.handleSubscriptionUpdate(calendarSubs);
+      const calendarSubs = phaseTimer.measureSync("getCalendarSubscriptions", () => this.getCalendarSubscriptions());
+      phaseTimer.measureSync("calendarHandleSubscriptionUpdate", () =>
+        this.userSession.calendarManager.handleSubscriptionUpdate(calendarSubs),
+      );
     } catch (error) {
       this.logger.error({ userId: this.userSession.userId, error }, "Error syncing managers with subscriptions");
+    } finally {
+      cascadeDiagnostics.addTimer("subscription_syncManagers", phaseTimer.durationMs);
     }
   }
 }

--- a/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
+++ b/cloud/packages/cloud/src/services/session/handlers/app-message-handler.ts
@@ -38,6 +38,12 @@ import {
 import App from "../../../models/app.model";
 import { appCache } from "../../core/app-cache.service";
 import { SimplePermissionChecker } from "../../permissions/simple-permission-checker";
+import {
+  appMessageTimerName,
+  cascadeDiagnostics,
+  hashUserId,
+  logSlowAppMessage,
+} from "../../metrics/cascade-diagnostics";
 import { metricsService } from "../../metrics/MetricsService";
 import { IWebSocket, WebSocketReadyState } from "../../websocket/types";
 import type UserSession from "../UserSession";
@@ -91,6 +97,9 @@ export async function handleAppMessage(
   message: AppToCloudMessage,
 ): Promise<void> {
   const logger = userSession.logger.child({ service: SERVICE_NAME });
+  const startedAt = performance.now();
+  const messageType = String((message as any)?.type ?? "unknown");
+  const timerName = appMessageTimerName(messageType);
 
   try {
     switch (message.type) {
@@ -193,6 +202,16 @@ export async function handleAppMessage(
   } catch (error) {
     logger.error({ error, type: message.type }, "Error handling App message");
     throw error;
+  } finally {
+    const durationMs = performance.now() - startedAt;
+    cascadeDiagnostics.addTimer(timerName, durationMs);
+    cascadeDiagnostics.increment(`${timerName}_count`);
+    logSlowAppMessage({
+      messageType,
+      packageName: (message as any)?.packageName,
+      userIdHash: hashUserId(userSession.userId),
+      durationMs,
+    });
   }
 }
 

--- a/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
+++ b/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
@@ -716,6 +716,9 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
       if (!parsedUserId) {
         logger.error({ sessionId: initMessage.sessionId }, "Unable to determine user ID for app init");
         ws.close(1008, "User session identity missing");
+        recordAppProtocolTiming("appProtocol_connectionInit", "connection_init", protocolTimer, {
+          packageName: initMessage.packageName,
+        });
         return;
       }
 
@@ -735,6 +738,10 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
           ),
         );
         ws.close(1008, "Session not found");
+        recordAppProtocolTiming("appProtocol_connectionInit", "connection_init", protocolTimer, {
+          packageName: initMessage.packageName,
+          userId: parsedUserId,
+        });
         return;
       }
 
@@ -784,6 +791,10 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
           ),
         );
         ws.close(1008, "Reconnect unsupported");
+        recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
+          packageName: reconnectPackageName,
+          userId: reconnectUserId,
+        });
         return;
       }
 
@@ -801,6 +812,10 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
           ),
         );
         ws.close(1008, "Reconnect identity missing");
+        recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
+          packageName: reconnectPackageName,
+          userId: reconnectUserId,
+        });
         return;
       }
 
@@ -825,6 +840,10 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
             ),
           );
           ws.close(1008, "Reconnect unauthenticated");
+          recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
+            packageName: reconnectPackageName,
+            userId: reconnectUserId,
+          });
           return;
         }
 
@@ -845,6 +864,10 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
             ),
           );
           ws.close(1008, "Invalid API key");
+          recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
+            packageName: reconnectPackageName,
+            userId: reconnectUserId,
+          });
           return;
         }
 
@@ -873,14 +896,9 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
             }),
           ),
         );
-        const durationMs = protocolTimer.durationMs;
-        cascadeDiagnostics.addTimer("appProtocol_reconnect", durationMs);
-        cascadeDiagnostics.increment("appProtocol_reconnect_count");
-        logSlowAppProtocol("reconnect", {
+        recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
           packageName: reconnectPackageName,
-          userIdHash: hashUserId(reconnectUserId),
-          durationMs,
-          phaseTimings: protocolTimer.timings,
+          userId: reconnectUserId,
         });
         return;
       }
@@ -888,14 +906,9 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
       await protocolTimer.measure("handleReconnect", () =>
         activeUserSession.appManager.handleReconnect(ws as any, reconnectMessage, reconnectPackageName),
       );
-      const durationMs = protocolTimer.durationMs;
-      cascadeDiagnostics.addTimer("appProtocol_reconnect", durationMs);
-      cascadeDiagnostics.increment("appProtocol_reconnect_count");
-      logSlowAppProtocol("reconnect", {
+      recordAppProtocolTiming("appProtocol_reconnect", "reconnect", protocolTimer, {
         packageName: reconnectPackageName,
-        userIdHash: hashUserId(reconnectUserId),
-        durationMs,
-        phaseTimings: protocolTimer.timings,
+        userId: reconnectUserId,
       });
       return;
     }
@@ -918,6 +931,11 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
           }),
         ),
       );
+      recordAppProtocolTiming("appProtocol_regularMessage", "regular_message", undefined, {
+        packageName: ws.data.packageName || packageName,
+        userId: userId || ws.data.userId,
+        durationMs: performance.now() - t0,
+      });
       return;
     }
 
@@ -956,6 +974,23 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
  */
 function isJsonBuffer(buf: Buffer | Uint8Array): boolean {
   return buf.length > 0 && buf[0] === 0x7b; // '{' character
+}
+
+function recordAppProtocolTiming(
+  timerName: "appProtocol_connectionInit" | "appProtocol_reconnect" | "appProtocol_regularMessage",
+  protocolType: Parameters<typeof logSlowAppProtocol>[0],
+  protocolTimer: ReturnType<typeof createPhaseTimer> | undefined,
+  data: { packageName?: string; userId?: string; durationMs?: number },
+): void {
+  const durationMs = data.durationMs ?? protocolTimer?.durationMs ?? 0;
+  cascadeDiagnostics.addTimer(timerName, durationMs);
+  cascadeDiagnostics.increment(`${timerName}_count`);
+  logSlowAppProtocol(protocolType, {
+    packageName: data.packageName,
+    userIdHash: hashUserId(data.userId),
+    durationMs,
+    phaseTimings: protocolTimer?.timings,
+  });
 }
 
 function handleAppClose(ws: AppServerWebSocket, code: number, reason: string): void {

--- a/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
+++ b/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
@@ -30,6 +30,18 @@ import { isShuttingDown } from "../shutdown";
 import { metricsService } from "../metrics";
 import { PosthogService } from "../logging/posthog.service";
 import UserSession from "../session/UserSession";
+import {
+  buildAppWsCloseTelemetry,
+  cascadeDiagnostics,
+  createPhaseTimer,
+  hashUserId,
+  logSlowAppProtocol,
+  markWebSocketDrain,
+  markWebSocketMessageReceived,
+  markWebSocketOpened,
+  markWebSocketPongReceived,
+  recordWebSocketSend,
+} from "../metrics/cascade-diagnostics";
 
 import type {
   GlassesWebSocketData,
@@ -120,6 +132,15 @@ function handleGlassesUpgrade(req: Request, server: any, url: URL): Response | u
         type: "glasses",
         userId,
         udpEncryptionRequested,
+        obs: {
+          openedAt: Date.now(),
+          sendCount: 0,
+          sendReturnPositiveCount: 0,
+          sendReturnZeroCount: 0,
+          sendReturnNegativeCount: 0,
+          sendReturnVoidCount: 0,
+          drainCount: 0,
+        },
       } as GlassesWebSocketData,
     });
 
@@ -207,6 +228,15 @@ function handleAppUpgrade(req: Request, server: any, _url: URL): Response | unde
       apiKey,
       sdkVersion,
       appJwtPayload,
+      obs: {
+        openedAt: Date.now(),
+        sendCount: 0,
+        sendReturnPositiveCount: 0,
+        sendReturnZeroCount: 0,
+        sendReturnNegativeCount: 0,
+        sendReturnVoidCount: 0,
+        drainCount: 0,
+      },
     } as AppWebSocketData,
   });
 
@@ -259,6 +289,7 @@ export const websocketHandlers = {
    * Called when backpressure is relieved (can resume sending)
    */
   drain(ws: CloudServerWebSocket) {
+    markWebSocketDrain(ws);
     logger.debug({ userId: ws.data.userId, type: ws.data.type }, "WebSocket drain - backpressure relieved");
   },
 
@@ -268,8 +299,9 @@ export const websocketHandlers = {
   pong(ws: CloudServerWebSocket, _data: Buffer) {
     if (ws.data.type === "glasses") {
       handleGlassesPong(ws as GlassesServerWebSocket);
+    } else if (ws.data.type === "app") {
+      markWebSocketPongReceived(ws);
     }
-    // Apps don't need pong handling currently
   },
 
   // WebSocket configuration
@@ -286,6 +318,7 @@ export const websocketHandlers = {
  * Handle glasses WebSocket connection open
  */
 async function handleGlassesOpen(ws: GlassesServerWebSocket): Promise<void> {
+  markWebSocketOpened(ws);
   const { userId, udpEncryptionRequested } = ws.data;
 
   try {
@@ -397,7 +430,7 @@ async function handleGlassesConnectionInit(
     }
   }
 
-  ws.send(JSON.stringify(ackMessage));
+  recordWebSocketSend(ws, "glasses", ws.send(JSON.stringify(ackMessage)));
   metricsService.incrementClientMessagesOut();
 }
 
@@ -407,6 +440,7 @@ async function handleGlassesConnectionInit(
 async function handleGlassesMessage(ws: GlassesServerWebSocket, message: string | Buffer): Promise<void> {
   const t0 = performance.now();
   metricsService.incrementClientMessagesIn();
+  markWebSocketMessageReceived(ws);
   const { userId } = ws.data;
   const userSession = UserSession.getById(userId);
 
@@ -435,7 +469,7 @@ async function handleGlassesMessage(ws: GlassesServerWebSocket, message: string 
     // Application-level ping/pong for client liveness detection.
     // Respond immediately — don't log, don't relay, don't touch session state.
     if (parsed.type === "ping") {
-      ws.send(JSON.stringify({ type: "pong" }));
+      recordWebSocketSend(ws, "glasses", ws.send(JSON.stringify({ type: "pong" })));
       return;
     }
 
@@ -571,6 +605,7 @@ function handleGlassesClose(ws: GlassesServerWebSocket, code: number, reason: st
  * Handle app WebSocket connection open
  */
 async function handleAppOpen(ws: AppServerWebSocket): Promise<void> {
+  markWebSocketOpened(ws);
   const { userId, sessionId, appJwtPayload } = ws.data;
 
   logger.info({ userId, hasJwt: !!appJwtPayload }, "App WebSocket connection opened");
@@ -602,7 +637,16 @@ async function handleAppOpen(ws: AppServerWebSocket): Promise<void> {
     };
 
     try {
+      const phaseTimer = createPhaseTimer();
       await userSession.appManager.handleAppInit(ws as any, initMessage);
+      const durationMs = phaseTimer.durationMs;
+      cascadeDiagnostics.addTimer("appProtocol_connectionInit", durationMs);
+      cascadeDiagnostics.increment("appProtocol_connectionInit_count");
+      logSlowAppProtocol("connection_init", {
+        packageName: appJwtPayload.packageName,
+        userIdHash: hashUserId(userId),
+        durationMs,
+      });
       // Store package name in ws.data for later use
       ws.data.packageName = appJwtPayload.packageName;
     } catch (error) {
@@ -619,6 +663,7 @@ async function handleAppOpen(ws: AppServerWebSocket): Promise<void> {
 async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer): Promise<void> {
   const t0 = performance.now();
   metricsService.incrementMiniappMessagesIn();
+  markWebSocketMessageReceived(ws);
   const { userId, packageName } = ws.data;
 
   try {
@@ -636,43 +681,58 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
       return;
     }
 
+    const parseStart = performance.now();
     const parsed = JSON.parse(message.toString()) as AppToCloudMessage;
+    cascadeDiagnostics.addTimer("appProtocol_parse", performance.now() - parseStart);
 
     // App-level ping from SDK — respond immediately, don't touch session state.
     // Only new SDK versions (3.x hono+) send these. Old 2.x apps never send pings
     // so this branch is never hit for legacy apps — fully backwards compatible.
     // See: cloud/issues/046-sdk-app-ws-liveness
     if ((parsed as any).type === "ping") {
-      ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() }));
+      const pingStart = performance.now();
+      recordWebSocketSend(ws, "app", ws.send(JSON.stringify({ type: "pong", timestamp: Date.now() })));
+      const pingDurationMs = performance.now() - pingStart;
+      cascadeDiagnostics.addTimer("appProtocol_ping", pingDurationMs);
+      cascadeDiagnostics.increment("appProtocol_ping_count");
       return;
     }
 
     // App-level pong (future: SDK responding to cloud-initiated ping) — consume silently.
     if ((parsed as any).type === "pong") {
+      markWebSocketPongReceived(ws);
       return;
     }
 
     // Handle CONNECTION_INIT for legacy apps
     if (parsed.type === AppToCloudMessageType.CONNECTION_INIT) {
+      const protocolTimer = createPhaseTimer();
       const initMessage = parsed as AppConnectionInit;
 
-      const parsedUserId = userId || ws.data.userId || parseUserIdFromLegacySessionId(initMessage.sessionId);
+      const parsedUserId = protocolTimer.measureSync(
+        "sessionIdParse",
+        () => userId || ws.data.userId || parseUserIdFromLegacySessionId(initMessage.sessionId),
+      );
       if (!parsedUserId) {
         logger.error({ sessionId: initMessage.sessionId }, "Unable to determine user ID for app init");
         ws.close(1008, "User session identity missing");
         return;
       }
 
-      const userSession = UserSession.getById(parsedUserId);
+      const userSession = protocolTimer.measureSync("sessionLookup", () => UserSession.getById(parsedUserId));
       if (!userSession) {
         logger.error({ userId: parsedUserId }, "User session not found for app message");
-        ws.send(
-          JSON.stringify({
-            type: CloudToAppMessageType.CONNECTION_ERROR,
-            code: "SESSION_NOT_FOUND",
-            message: "Session not found",
-            timestamp: new Date(),
-          }),
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.CONNECTION_ERROR,
+              code: "SESSION_NOT_FOUND",
+              message: "Session not found",
+              timestamp: new Date(),
+            }),
+          ),
         );
         ws.close(1008, "Session not found");
         return;
@@ -684,40 +744,61 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
       ws.data.sdkVersion = initMessage.sdkVersion;
       ws.data.apiKey = initMessage.apiKey;
 
-      await userSession.appManager.handleAppInit(ws as any, initMessage);
+      await protocolTimer.measure("handleAppInit", () => userSession.appManager.handleAppInit(ws as any, initMessage));
+      const durationMs = protocolTimer.durationMs;
+      cascadeDiagnostics.addTimer("appProtocol_connectionInit", durationMs);
+      cascadeDiagnostics.increment("appProtocol_connectionInit_count");
+      logSlowAppProtocol("connection_init", {
+        packageName: initMessage.packageName,
+        userIdHash: hashUserId(parsedUserId),
+        durationMs,
+        phaseTimings: protocolTimer.timings,
+      });
       return;
     }
 
     if (parsed.type === AppToCloudMessageType.RECONNECT) {
+      const protocolTimer = createPhaseTimer();
       const reconnectMessage = parsed as any;
-      const reconnectUserId = userId || ws.data.userId;
-      const reconnectPackageName =
-        ws.data.packageName ||
-        ws.data.appJwtPayload?.packageName ||
-        parsePackageNameFromLegacySessionId(reconnectMessage.sessionId);
+      const reconnectUserId = protocolTimer.measureSync("sessionIdentity", () => userId || ws.data.userId);
+      const reconnectPackageName = protocolTimer.measureSync(
+        "packageIdentity",
+        () =>
+          ws.data.packageName ||
+          ws.data.appJwtPayload?.packageName ||
+          parsePackageNameFromLegacySessionId(reconnectMessage.sessionId),
+      );
       const reconnectSdkVersion = reconnectMessage.sdkVersion || ws.data.sdkVersion;
 
       if (!isV3Sdk(reconnectSdkVersion)) {
-        ws.send(
-          JSON.stringify({
-            type: CloudToAppMessageType.RECONNECT_REJECTED,
-            code: "SESSION_NOT_FOUND",
-            message: "Reconnect is only supported for SDK v3",
-            timestamp: new Date(),
-          }),
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_REJECTED,
+              code: "SESSION_NOT_FOUND",
+              message: "Reconnect is only supported for SDK v3",
+              timestamp: new Date(),
+            }),
+          ),
         );
         ws.close(1008, "Reconnect unsupported");
         return;
       }
 
       if (!reconnectUserId || !reconnectPackageName) {
-        ws.send(
-          JSON.stringify({
-            type: CloudToAppMessageType.RECONNECT_REJECTED,
-            code: "SESSION_NOT_FOUND",
-            message: "Reconnect missing user or package identity",
-            timestamp: new Date(),
-          }),
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_REJECTED,
+              code: "SESSION_NOT_FOUND",
+              message: "Reconnect missing user or package identity",
+              timestamp: new Date(),
+            }),
+          ),
         );
         ws.close(1008, "Reconnect identity missing");
         return;
@@ -727,79 +808,129 @@ async function handleAppMessage(ws: AppServerWebSocket, message: string | Buffer
       ws.data.packageName = reconnectPackageName;
       ws.data.sdkVersion = reconnectSdkVersion;
 
-      const activeUserSession = UserSession.getById(reconnectUserId);
+      const activeUserSession = protocolTimer.measureSync("sessionLookup", () => UserSession.getById(reconnectUserId));
       if (!activeUserSession) {
         const apiKey = ws.data.appJwtPayload?.apiKey || ws.data.apiKey;
         if (!apiKey) {
-          ws.send(
-            JSON.stringify({
-              type: CloudToAppMessageType.RECONNECT_REJECTED,
-              code: "SESSION_NOT_FOUND",
-              message: "Reconnect requires apiKey when cloud state is unavailable",
-              timestamp: new Date(),
-            }),
+          recordWebSocketSend(
+            ws,
+            "app",
+            ws.send(
+              JSON.stringify({
+                type: CloudToAppMessageType.RECONNECT_REJECTED,
+                code: "SESSION_NOT_FOUND",
+                message: "Reconnect requires apiKey when cloud state is unavailable",
+                timestamp: new Date(),
+              }),
+            ),
           );
           ws.close(1008, "Reconnect unauthenticated");
           return;
         }
 
-        const isValidApiKey = await developerService.validateApiKey(reconnectPackageName, apiKey);
+        const isValidApiKey = await protocolTimer.measure("validateApiKey", () =>
+          developerService.validateApiKey(reconnectPackageName, apiKey),
+        );
         if (!isValidApiKey) {
-          ws.send(
-            JSON.stringify({
-              type: CloudToAppMessageType.CONNECTION_ERROR,
-              code: "INVALID_API_KEY",
-              message: "Invalid API key",
-              timestamp: new Date(),
-            }),
+          recordWebSocketSend(
+            ws,
+            "app",
+            ws.send(
+              JSON.stringify({
+                type: CloudToAppMessageType.CONNECTION_ERROR,
+                code: "INVALID_API_KEY",
+                message: "Invalid API key",
+                timestamp: new Date(),
+              }),
+            ),
           );
           ws.close(1008, "Invalid API key");
           return;
         }
 
-        deferredAppConnectionRegistry.register({
-          userId: reconnectUserId,
-          packageName: reconnectPackageName,
-          sdkVersion: reconnectSdkVersion,
-          apiKey,
-          priorSessionId: reconnectMessage.sessionId,
-          websocket: ws,
-          reason: "booting",
-        });
-
-        ws.send(
-          JSON.stringify({
-            type: CloudToAppMessageType.RECONNECT_DEFERRED,
-            code: "BOOTING",
-            message: "Cloud is still restoring user session state",
-            timeoutMs: 30_000,
-            timestamp: new Date(),
+        protocolTimer.measureSync("deferRegister", () =>
+          deferredAppConnectionRegistry.register({
+            userId: reconnectUserId,
+            packageName: reconnectPackageName,
+            sdkVersion: reconnectSdkVersion,
+            apiKey,
+            priorSessionId: reconnectMessage.sessionId,
+            websocket: ws,
+            reason: "booting",
           }),
         );
+
+        recordWebSocketSend(
+          ws,
+          "app",
+          ws.send(
+            JSON.stringify({
+              type: CloudToAppMessageType.RECONNECT_DEFERRED,
+              code: "BOOTING",
+              message: "Cloud is still restoring user session state",
+              timeoutMs: 30_000,
+              timestamp: new Date(),
+            }),
+          ),
+        );
+        const durationMs = protocolTimer.durationMs;
+        cascadeDiagnostics.addTimer("appProtocol_reconnect", durationMs);
+        cascadeDiagnostics.increment("appProtocol_reconnect_count");
+        logSlowAppProtocol("reconnect", {
+          packageName: reconnectPackageName,
+          userIdHash: hashUserId(reconnectUserId),
+          durationMs,
+          phaseTimings: protocolTimer.timings,
+        });
         return;
       }
 
-      await activeUserSession.appManager.handleReconnect(ws as any, reconnectMessage, reconnectPackageName);
+      await protocolTimer.measure("handleReconnect", () =>
+        activeUserSession.appManager.handleReconnect(ws as any, reconnectMessage, reconnectPackageName),
+      );
+      const durationMs = protocolTimer.durationMs;
+      cascadeDiagnostics.addTimer("appProtocol_reconnect", durationMs);
+      cascadeDiagnostics.increment("appProtocol_reconnect_count");
+      logSlowAppProtocol("reconnect", {
+        packageName: reconnectPackageName,
+        userIdHash: hashUserId(reconnectUserId),
+        durationMs,
+        phaseTimings: protocolTimer.timings,
+      });
       return;
     }
 
     // For other messages, we need an existing session
+    const sessionLookupStart = performance.now();
     const userSession = UserSession.getById(userId || ws.data.userId);
+    cascadeDiagnostics.addTimer("appProtocol_sessionLookup", performance.now() - sessionLookupStart);
     if (!userSession) {
       logger.error({ userId }, "User session not found for app message");
-      ws.send(
-        JSON.stringify({
-          type: CloudToAppMessageType.CONNECTION_ERROR,
-          code: "SESSION_NOT_FOUND",
-          message: "Session not found",
-          timestamp: new Date(),
-        }),
+      recordWebSocketSend(
+        ws,
+        "app",
+        ws.send(
+          JSON.stringify({
+            type: CloudToAppMessageType.CONNECTION_ERROR,
+            code: "SESSION_NOT_FOUND",
+            message: "Session not found",
+            timestamp: new Date(),
+          }),
+        ),
       );
       return;
     }
 
     // Delegate message handling to UserSession
     await userSession.handleAppMessage(ws as any, parsed);
+    const regularDurationMs = performance.now() - t0;
+    cascadeDiagnostics.addTimer("appProtocol_regularMessage", regularDurationMs);
+    cascadeDiagnostics.increment("appProtocol_regularMessage_count");
+    logSlowAppProtocol("regular_message", {
+      packageName: ws.data.packageName || packageName,
+      userIdHash: hashUserId(userId || ws.data.userId),
+      durationMs: regularDurationMs,
+    });
   } catch (error) {
     logger.error({ error, userId, packageName }, "Error processing app message");
     ws.close(1011, "Internal server error");
@@ -831,6 +962,12 @@ function handleAppClose(ws: AppServerWebSocket, code: number, reason: string): v
   const { userId, packageName } = ws.data;
 
   logger.info({ userId, packageName, code, reason }, "App WebSocket closed");
+  const closeTelemetry = { ...buildAppWsCloseTelemetry(ws, code), reason: reason || undefined };
+  if (code === 1006) {
+    logger.warn(closeTelemetry, "App WebSocket close telemetry");
+  } else {
+    logger.info(closeTelemetry, "App WebSocket close telemetry");
+  }
 
   deferredAppConnectionRegistry.removeSocket(ws);
 

--- a/cloud/packages/cloud/src/services/websocket/types.ts
+++ b/cloud/packages/cloud/src/services/websocket/types.ts
@@ -8,6 +8,8 @@
 
 import type { ServerWebSocket } from "bun";
 
+import type { WebSocketObservation } from "../metrics/cascade-diagnostics";
+
 /**
  * Data attached to glasses WebSocket connections
  */
@@ -15,6 +17,7 @@ export interface GlassesWebSocketData {
   type: "glasses";
   userId: string;
   udpEncryptionRequested: boolean;
+  obs?: WebSocketObservation;
 }
 
 /**
@@ -27,6 +30,7 @@ export interface AppWebSocketData {
   packageName?: string;
   apiKey?: string;
   sdkVersion?: string;
+  obs?: WebSocketObservation;
   appJwtPayload?: {
     packageName: string;
     apiKey: string;

--- a/cloud/tools/ws-storm-local/bun-ws-storm-harness.ts
+++ b/cloud/tools/ws-storm-local/bun-ws-storm-harness.ts
@@ -1,0 +1,397 @@
+#!/usr/bin/env bun
+
+import WebSocket from "ws";
+
+type ConnKind = "glasses" | "app";
+
+interface ClientRecord {
+  id: number;
+  kind: ConnKind;
+  userId: string;
+  packageName?: string;
+  ws: WebSocket;
+}
+
+interface ServerData {
+  id?: number;
+  kind?: ConnKind;
+  userId?: string;
+  packageName?: string;
+}
+
+const DEFAULT_PACKAGES = [
+  "com.mentra.captions.debug",
+  "com.mentra.ai",
+  "cloud.augmentos.notify",
+  "com.mentra.merge",
+  "com.mentra.notes",
+  "com.mentra.translation",
+  "com.mentra.dash",
+  "com.mentra.link",
+];
+
+const args = new Map<string, string>();
+for (let i = 2; i < process.argv.length; i++) {
+  const raw = process.argv[i];
+  if (!raw.startsWith("--")) continue;
+  const [key, value] = raw.slice(2).split("=", 2);
+  args.set(key, value ?? "true");
+}
+
+const port = numberArg("port", 8899);
+const users = numberArg("users", 56);
+const appsPerUser = numberArg("apps-per-user", 1);
+const rounds = numberArg("rounds", 1);
+const reconnectDelayMs = numberArg("reconnect-delay-ms", 6000);
+const postReconnectSubscriptionUpdates = numberArg("subscription-updates", 1);
+const closeSyncWorkMs = numberArg("close-sync-ms", 0);
+const reconnectSyncWorkMs = numberArg("reconnect-sync-ms", 0);
+const subscriptionSyncWorkMs = numberArg("subscription-sync-ms", 0);
+const reconnectAsyncWorkMs = numberArg("reconnect-async-ms", 0);
+const subscriptionAsyncWorkMs = numberArg("subscription-async-ms", 0);
+const logsPerClose = numberArg("logs-per-close", 0);
+const logsPerSubscription = numberArg("logs-per-subscription", 0);
+const logBytes = numberArg("log-bytes", 256);
+const runLabel = args.get("label") ?? "local-bun-ws-storm";
+const packages = (args.get("packages")?.split(",").filter(Boolean) ?? DEFAULT_PACKAGES).map((p) =>
+  p === "com.mentra.captions" ? "com.mentra.captions.debug" : p,
+);
+
+const metrics = {
+  serverOpen: 0,
+  serverClose: 0,
+  serverMessages: 0,
+  clientOpen: 0,
+  clientClose: 0,
+  reconnectOpen: 0,
+  subscriptionsSent: 0,
+  maxHeartbeatGapMs: 0,
+  heartbeatGapsOver1s: 0,
+  maxMessageWallMs: 0,
+  messageWallTimesOver1s: 0,
+  closeBatchSpans: [] as number[],
+};
+
+const closeTimes: number[] = [];
+const activeClients = new Map<number, ClientRecord>();
+let nextClientId = 1;
+let lastHeartbeat = performance.now();
+
+const heartbeat = setInterval(() => {
+  const now = performance.now();
+  const gap = now - lastHeartbeat - 100;
+  if (gap > metrics.maxHeartbeatGapMs) metrics.maxHeartbeatGapMs = gap;
+  if (gap > 1000) metrics.heartbeatGapsOver1s++;
+  lastHeartbeat = now;
+}, 100);
+heartbeat.unref();
+
+const server = Bun.serve<ServerData>({
+  port,
+  fetch(req, server) {
+    const url = new URL(req.url);
+    if (url.pathname !== "/ws") {
+      return new Response("ok");
+    }
+
+    const upgraded = server.upgrade(req, {
+      data: {},
+    });
+    return upgraded ? undefined : new Response("upgrade failed", { status: 500 });
+  },
+  websocket: {
+    idleTimeout: 120,
+    sendPings: true,
+    open(ws) {
+      metrics.serverOpen++;
+    },
+    message(ws, raw) {
+      void handleMessage(ws, raw);
+    },
+    close(ws, code, reason) {
+      metrics.serverClose++;
+      closeTimes.push(performance.now());
+      if (closeSyncWorkMs > 0) busyWork(closeSyncWorkMs);
+      mimicCloseFanout(ws.data, code, reason);
+    },
+  },
+});
+
+console.log(
+  JSON.stringify({
+    event: "harness-started",
+    runLabel,
+    port,
+    users,
+    appsPerUser,
+    rounds,
+    reconnectDelayMs,
+    packages,
+    closeSyncWorkMs,
+    reconnectSyncWorkMs,
+    subscriptionSyncWorkMs,
+    reconnectAsyncWorkMs,
+    subscriptionAsyncWorkMs,
+    logsPerClose,
+    logsPerSubscription,
+    logBytes,
+  }),
+);
+
+await run();
+
+async function run(): Promise<void> {
+  const initial = await openPopulation("initial");
+  await sleep(500);
+
+  for (let round = 1; round <= rounds; round++) {
+    const roundClients = [...activeClients.values()];
+    const t0 = performance.now();
+    for (const client of roundClients) {
+      client.ws.terminate();
+    }
+    await waitFor(() => metrics.serverClose >= roundClients.length * round, 10_000);
+    const t1 = performance.now();
+
+    const closesForRound = closeTimes.slice(-roundClients.length);
+    metrics.closeBatchSpans.push(max(closesForRound) - min(closesForRound));
+
+    console.log(
+      JSON.stringify({
+        event: "storm-round-closed",
+        round,
+        clientsTerminated: roundClients.length,
+        observedCloseMs: Math.round(t1 - t0),
+        serverCloseCount: metrics.serverClose,
+        closeCallbackSpanMs: Math.round(metrics.closeBatchSpans.at(-1) ?? 0),
+      }),
+    );
+
+    await sleep(reconnectDelayMs);
+
+    const reconnected = await openPopulation(`round-${round}-reconnect`);
+    metrics.reconnectOpen += reconnected.length;
+
+    for (const client of reconnected) {
+      if (client.kind !== "app") continue;
+      for (let i = 0; i < postReconnectSubscriptionUpdates; i++) {
+        client.ws.send(
+          JSON.stringify({
+            type: "subscription_update",
+            packageName: client.packageName,
+            subscriptions: ["transcription:en-US", "microphone", "location"],
+          }),
+        );
+        metrics.subscriptionsSent++;
+      }
+    }
+
+    await sleep(1000);
+  }
+
+  for (const client of activeClients.values()) {
+    client.ws.close();
+  }
+  await sleep(250);
+  server.stop(true);
+
+  console.log(
+    JSON.stringify({
+      event: "harness-complete",
+      runLabel,
+      initialClients: initial.length,
+      metrics: {
+        ...metrics,
+        maxHeartbeatGapMs: Math.round(metrics.maxHeartbeatGapMs),
+        maxMessageWallMs: Math.round(metrics.maxMessageWallMs),
+        closeBatchSpans: metrics.closeBatchSpans.map((v) => Math.round(v)),
+      },
+    }),
+  );
+}
+
+async function handleMessage(ws: any, raw: string | Buffer): Promise<void> {
+  const t0 = performance.now();
+  metrics.serverMessages++;
+
+  try {
+    let message: any;
+    try {
+      message = JSON.parse(String(raw));
+    } catch {
+      return;
+    }
+
+    if (message.type === "init") {
+      ws.data.id = message.id;
+      ws.data.kind = message.kind;
+      ws.data.userId = message.userId;
+      ws.data.packageName = message.packageName;
+      if (reconnectSyncWorkMs > 0) busyWork(reconnectSyncWorkMs);
+      if (reconnectAsyncWorkMs > 0) await sleep(reconnectAsyncWorkMs);
+      ws.send(JSON.stringify({ type: "ack", id: message.id, kind: message.kind }));
+      return;
+    }
+
+    if (message.type === "subscription_update") {
+      if (subscriptionSyncWorkMs > 0) busyWork(subscriptionSyncWorkMs);
+      if (subscriptionAsyncWorkMs > 0) await sleep(subscriptionAsyncWorkMs);
+      mimicSubscriptionFanout(message);
+      ws.send(JSON.stringify({ type: "subscription_ack", id: ws.data.id }));
+    }
+  } finally {
+    const wallMs = performance.now() - t0;
+    if (wallMs > metrics.maxMessageWallMs) metrics.maxMessageWallMs = wallMs;
+    if (wallMs > 1000) metrics.messageWallTimesOver1s++;
+  }
+}
+
+async function openPopulation(phase: string): Promise<ClientRecord[]> {
+  activeClients.clear();
+  const records: ClientRecord[] = [];
+  const openPromises: Promise<void>[] = [];
+
+  for (let i = 0; i < users; i++) {
+    const userId = `storm-user-${i}@local.test`;
+    records.push(createClient("glasses", userId));
+
+    for (let appIndex = 0; appIndex < appsPerUser; appIndex++) {
+      const packageName = packages[(i + appIndex) % packages.length];
+      records.push(createClient("app", userId, packageName));
+    }
+  }
+
+  for (const record of records) {
+    openPromises.push(openClient(record, phase));
+  }
+
+  await Promise.all(openPromises);
+  return records;
+}
+
+function createClient(kind: ConnKind, userId: string, packageName?: string): ClientRecord {
+  return {
+    id: nextClientId++,
+    kind,
+    userId,
+    packageName,
+    ws: new WebSocket(`ws://127.0.0.1:${port}/ws`),
+  };
+}
+
+function openClient(record: ClientRecord, phase: string): Promise<void> {
+  activeClients.set(record.id, record);
+
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`open timeout ${record.id}`)), 5000);
+    record.ws.once("open", () => {
+      metrics.clientOpen++;
+      record.ws.send(
+        JSON.stringify({
+          type: "init",
+          phase,
+          id: record.id,
+          kind: record.kind,
+          userId: record.userId,
+          packageName: record.packageName,
+        }),
+      );
+    });
+    record.ws.once("message", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    record.ws.on("close", () => {
+      metrics.clientClose++;
+      activeClients.delete(record.id);
+    });
+    record.ws.once("error", reject);
+  });
+}
+
+function mimicCloseFanout(data: ServerData, code: number, reason: string): void {
+  const payload = {
+    id: data.id,
+    kind: data.kind,
+    userId: data.userId,
+    packageName: data.packageName,
+    code,
+    reason,
+    stateTransitions: ["running", "transport_down", "grace_period"],
+  };
+
+  JSON.stringify(payload);
+  emitSyntheticLogs("close", logsPerClose, payload);
+  for (let i = 0; i < 25; i++) {
+    Math.sqrt((data.id ?? 0) * i + code);
+  }
+}
+
+function mimicSubscriptionFanout(message: any): void {
+  const packageName = message.packageName === "com.mentra.captions" ? "com.mentra.captions.debug" : message.packageName;
+  const snapshot = {
+    packageName,
+    subscriptions: message.subscriptions,
+    managers: ["subscription", "transcription", "translation", "microphone", "app-state"],
+    installedApps: packages,
+  };
+
+  for (let i = 0; i < 50; i++) {
+    JSON.stringify(snapshot);
+  }
+  emitSyntheticLogs("subscription", logsPerSubscription, snapshot);
+}
+
+function emitSyntheticLogs(event: string, count: number, payload: Record<string, unknown>): void {
+  if (count <= 0) return;
+  const padding = "x".repeat(Math.max(0, logBytes));
+  for (let i = 0; i < count; i++) {
+    process.stdout.write(
+      JSON.stringify({
+        ts: new Date().toISOString(),
+        event,
+        i,
+        ...payload,
+        padding,
+      }) + "\n",
+    );
+  }
+}
+
+function busyWork(ms: number): void {
+  const end = performance.now() + ms;
+  let x = 0;
+  while (performance.now() < end) {
+    x += Math.sqrt(x + 1);
+  }
+  if (x === Number.MIN_SAFE_INTEGER) console.log(x);
+}
+
+function numberArg(name: string, fallback: number): number {
+  const raw = args.get(name);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > timeoutMs) {
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    }
+    await sleep(10);
+  }
+}
+
+function min(values: number[]): number {
+  return values.reduce((a, b) => Math.min(a, b), Number.POSITIVE_INFINITY);
+}
+
+function max(values: number[]): number {
+  return values.reduce((a, b) => Math.max(a, b), Number.NEGATIVE_INFINITY);
+}

--- a/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
+++ b/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
@@ -1,0 +1,584 @@
+#!/usr/bin/env bun
+
+import crypto from "node:crypto";
+
+type AnyFn = (...args: any[]) => any;
+
+interface HarnessArgs {
+  users: number;
+  appsPerUser: number;
+  rounds: number;
+  reconnectDelayMs: number;
+  roundPauseMs: number;
+  subscriptionUpdates: number;
+  userDbAsyncMs: number;
+  userDbSyncMs: number;
+  appDbAsyncMs: number;
+  appDbSyncMs: number;
+  transcriptionAsyncMs: number;
+  transcriptionSyncMs: number;
+  translationAsyncMs: number;
+  translationSyncMs: number;
+  ensureAsyncMs: number;
+  ensureSyncMs: number;
+  useMessageHandler: boolean;
+  connectMode: "reconnect" | "init";
+  sdkVersion: string | null;
+  label: string;
+  packages: string[];
+}
+
+interface OperationStats {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+  samples: number[];
+}
+
+interface AppRef {
+  userIndex: number;
+  packageName: string;
+  session: any;
+  appSession: any;
+  ws: FakeBunWebSocket;
+}
+
+const DEFAULT_PACKAGES = [
+  "com.mentra.captions.debug",
+  "com.mentra.ai",
+  "cloud.augmentos.notify",
+  "com.mentra.merge",
+  "com.mentra.notes",
+  "com.mentra.translation",
+  "com.mentra.dash",
+  "com.mentra.link",
+];
+
+const rawArgs = new Map<string, string>();
+for (let i = 2; i < process.argv.length; i++) {
+  const raw = process.argv[i];
+  if (!raw.startsWith("--")) continue;
+  const [key, value] = raw.slice(2).split("=", 2);
+  rawArgs.set(key, value ?? "true");
+}
+
+const args: HarnessArgs = {
+  users: numberArg("users", 56),
+  appsPerUser: numberArg("apps-per-user", 1),
+  rounds: numberArg("rounds", 5),
+  reconnectDelayMs: numberArg("reconnect-delay-ms", 1000),
+  roundPauseMs: numberArg("round-pause-ms", 250),
+  subscriptionUpdates: numberArg("subscription-updates", 1),
+  userDbAsyncMs: numberArg("user-db-async-ms", 0),
+  userDbSyncMs: numberArg("user-db-sync-ms", 0),
+  appDbAsyncMs: numberArg("app-db-async-ms", 0),
+  appDbSyncMs: numberArg("app-db-sync-ms", 0),
+  transcriptionAsyncMs: numberArg("transcription-async-ms", 0),
+  transcriptionSyncMs: numberArg("transcription-sync-ms", 0),
+  translationAsyncMs: numberArg("translation-async-ms", 0),
+  translationSyncMs: numberArg("translation-sync-ms", 0),
+  ensureAsyncMs: numberArg("ensure-async-ms", 0),
+  ensureSyncMs: numberArg("ensure-sync-ms", 0),
+  useMessageHandler: boolArg("message-handler", false),
+  connectMode: enumArg("connect-mode", "reconnect", ["reconnect", "init"]),
+  sdkVersion: nullableStringArg("sdk-version", "3.0.0"),
+  label: rawArgs.get("label") ?? "mentra-path-storm",
+  packages: (rawArgs.get("packages")?.split(",").filter(Boolean) ?? DEFAULT_PACKAGES).map((packageName) =>
+    packageName === "com.mentra.captions" ? "com.mentra.captions.debug" : packageName,
+  ),
+};
+
+process.env.NODE_ENV ??= "test";
+process.env.CLOUD_PUBLIC_HOST_NAME ??= "localhost";
+process.env.CLOUD_LOCAL_HOST_NAME ??= "localhost";
+process.env.AUGMENTOS_AUTH_JWT_SECRET ??= "local-harness-secret";
+
+const operationStats = new Map<string, OperationStats>();
+const metrics = {
+  maxHeartbeatGapMs: 0,
+  heartbeatGapsOver1s: 0,
+  socketsCreated: 0,
+  socketSends: 0,
+  socketBytesSent: 0,
+};
+
+const { default: AppModel } = await import("../../packages/cloud/src/models/app.model");
+patchAppModel(AppModel);
+const { default: AppManager } = await import("../../packages/cloud/src/services/session/AppManager");
+const { default: SubscriptionManager } = await import("../../packages/cloud/src/services/session/SubscriptionManager");
+const { handleAppMessage } = await import("../../packages/cloud/src/services/session/handlers/app-message-handler");
+const { appCache } = await import("../../packages/cloud/src/services/core/app-cache.service");
+const { User } = await import("../../packages/cloud/src/models/user.model");
+const { WebSocketReadyState } = await import("../../packages/cloud/src/services/websocket/types");
+
+const silentLogger = makeSilentLogger();
+let lastHeartbeat = performance.now();
+
+const heartbeat = setInterval(() => {
+  const now = performance.now();
+  const gap = now - lastHeartbeat - 100;
+  if (gap > metrics.maxHeartbeatGapMs) metrics.maxHeartbeatGapMs = gap;
+  if (gap > 1000) metrics.heartbeatGapsOver1s++;
+  lastHeartbeat = now;
+}, 100);
+heartbeat.unref();
+
+patchExternalServices();
+
+console.log(
+  JSON.stringify({
+    event: "mentra-harness-started",
+    ...args,
+  }),
+);
+
+const appRefs = await timed("setup", () => setupSessions());
+
+for (let round = 1; round <= args.rounds; round++) {
+  const startCloseCount = getStat("close").count;
+  const startReconnectCount = getStat("reconnect").count;
+  const startSubscriptionCount = getStat("subscription").count;
+
+  await timed("round", async () => {
+    await Promise.all(
+      appRefs.map((ref) =>
+        timed("close", () => ref.session.appManager.handleAppConnectionClosed(ref.packageName, 1006, "local storm")),
+      ),
+    );
+
+    await sleep(args.reconnectDelayMs);
+
+    await Promise.all(
+      appRefs.map(async (ref) => {
+        const ws = new FakeBunWebSocket(`${ref.session.userId}:${ref.packageName}:r${round}`);
+        ref.ws = ws;
+        await timed("reconnect", () => reconnectApp(ref, ws));
+      }),
+    );
+
+    for (let i = 0; i < args.subscriptionUpdates; i++) {
+      await Promise.all(
+        appRefs.map((ref) =>
+          timed("subscription", () => applySubscriptionUpdate(ref)),
+        ),
+      );
+    }
+  });
+
+  console.log(
+    JSON.stringify({
+      event: "round-complete",
+      round,
+      closeOps: getStat("close").count - startCloseCount,
+      reconnectOps: getStat("reconnect").count - startReconnectCount,
+      subscriptionOps: getStat("subscription").count - startSubscriptionCount,
+      maxHeartbeatGapMs: Math.round(metrics.maxHeartbeatGapMs),
+      heartbeatGapsOver1s: metrics.heartbeatGapsOver1s,
+      stats: snapshotStats(["round", "close", "reconnect", "subscription"]),
+    }),
+  );
+
+  await sleep(args.roundPauseMs);
+}
+
+for (const ref of appRefs) {
+  ref.session.appManager.removeAppSession(ref.packageName);
+}
+clearInterval(heartbeat);
+
+console.log(
+  JSON.stringify({
+    event: "mentra-harness-complete",
+    label: args.label,
+    appConnections: appRefs.length,
+    metrics: {
+      ...metrics,
+      maxHeartbeatGapMs: Math.round(metrics.maxHeartbeatGapMs),
+    },
+    stats: snapshotStats([...operationStats.keys()].sort()),
+  }),
+);
+
+  process.exit(0);
+
+async function reconnectApp(ref: AppRef, ws: FakeBunWebSocket): Promise<void> {
+  if (args.connectMode === "init") {
+    await ref.session.appManager.handleAppInit(ws as any, {
+      type: "tpa_connection_init",
+      packageName: ref.packageName,
+      apiKey: "local-api-key",
+      sdkVersion: args.sdkVersion ?? undefined,
+    });
+    return;
+  }
+
+  await ref.session.appManager.handleReconnect(
+    ws as any,
+    {
+      sessionId: ref.appSession.sessionId,
+      sdkVersion: args.sdkVersion ?? undefined,
+    },
+    ref.packageName,
+  );
+}
+
+async function setupSessions(): Promise<AppRef[]> {
+  const refs: AppRef[] = [];
+
+  for (let userIndex = 0; userIndex < args.users; userIndex++) {
+    const session = createFakeUserSession(userIndex);
+
+    for (let appIndex = 0; appIndex < args.appsPerUser; appIndex++) {
+      const packageName = args.packages[(userIndex + appIndex) % args.packages.length];
+      session.installedApps.set(packageName, fakeApp(packageName));
+
+      const appSession = session.appManager.getOrCreateAppSession(packageName);
+      if (args.sdkVersion) {
+        appSession.setSdkVersion(args.sdkVersion);
+      }
+      appSession.startConnecting();
+
+      const ws = new FakeBunWebSocket(`${session.userId}:${packageName}:initial`);
+      appSession.handleConnect(ws);
+
+      refs.push({
+        userIndex,
+        packageName,
+        session,
+        appSession,
+        ws,
+      });
+    }
+  }
+
+  await Promise.all(
+    refs.map((ref) =>
+      timed("initialSubscription", () => applySubscriptionUpdate(ref)),
+    ),
+  );
+
+  return refs;
+}
+
+async function applySubscriptionUpdate(ref: AppRef): Promise<void> {
+  const message = {
+    type: "subscription_update",
+    packageName: ref.packageName,
+    subscriptions: defaultSubscriptions(ref.packageName),
+    timestamp: new Date(),
+  };
+
+  if (args.useMessageHandler) {
+    await handleAppMessage(ref.ws as any, ref.session, message as any);
+    return;
+  }
+
+  await ref.session.subscriptionManager.updateSubscriptions(ref.packageName, message.subscriptions);
+}
+
+function createFakeUserSession(userIndex: number): any {
+  const userId = `storm-user-${userIndex}@local.test`;
+  const session: any = {
+    userId,
+    sessionId: `local-session-${userIndex}`,
+    logger: silentLogger.child({ userId }),
+    installedApps: new Map(),
+    websocket: new FakeBunWebSocket(`${userId}:glasses`),
+    userSettingsManager: {
+      buildMentraosSettings: () => [],
+    },
+    deviceManager: {
+      sendFullStateSnapshot: (ws: FakeBunWebSocket) => {
+        ws.send(JSON.stringify({ type: "full_state_snapshot", localHarness: true }));
+      },
+    },
+    managedStreamingExtension: {
+      clearLastSentStatus: () => {},
+      getUserStreamState: () => null,
+    },
+    unmanagedStreamingExtension: {
+      getActiveStreamInfo: () => null,
+    },
+    displayManager: {
+      handleAppStop: () => {},
+    },
+    locationManager: {
+      handleSubscriptionUpdate: () => {},
+      handleUnsubscribe: () => {},
+    },
+    calendarManager: {
+      handleSubscriptionUpdate: () => {},
+      handleUnsubscribe: () => {},
+    },
+    microphoneManager: {
+      handleSubscriptionChange: () => {},
+    },
+    transcriptionManager: makeTimedManager("transcription", args.transcriptionSyncMs, args.transcriptionAsyncMs),
+    translationManager: makeTimedManager("translation", args.translationSyncMs, args.translationAsyncMs),
+    getCapabilities: () => ({ model: "local-harness" }),
+    snapshotForClient: async () => ({ userId, localHarness: true }),
+  };
+
+  session.appManager = new AppManager(session);
+  session.subscriptionManager = new SubscriptionManager(session);
+  return session;
+}
+
+function makeTimedManager(name: string, syncMs: number, asyncMs: number): any {
+  return {
+    updateSubscriptions: (subscriptions: string[]) =>
+      timed(`${name}.updateSubscriptions`, async () => {
+        if (syncMs > 0) busyWork(syncMs);
+        if (asyncMs > 0) await sleep(asyncMs);
+        return subscriptions;
+      }),
+    ensureStreamsExist: () =>
+      timed(`${name}.ensureStreamsExist`, async () => {
+        if (args.ensureSyncMs > 0) busyWork(args.ensureSyncMs);
+        if (args.ensureAsyncMs > 0) await sleep(args.ensureAsyncMs);
+      }),
+  };
+}
+
+function patchExternalServices(): void {
+  (appCache as any).getByPackageName = (packageName: string) => fakeApp(packageName);
+
+  (User as any).findOrCreateUser = async (userId: string) =>
+    timed("user.findOrCreateUser", async () => {
+      if (args.userDbSyncMs > 0) busyWork(args.userDbSyncMs);
+      if (args.userDbAsyncMs > 0) await sleep(args.userDbAsyncMs);
+      return {
+        userId,
+        runningApps: [...args.packages],
+        getAppSettings: () => [],
+        addRunningApp: async (_packageName: string) => {},
+      };
+    });
+
+  (User as any).findOne = () =>
+    delayedQuery(
+      "user.findOne",
+      {
+        installedApps: args.packages.map((packageName) => ({
+          packageName,
+          installedDate: new Date(),
+        })),
+      },
+      args.userDbSyncMs,
+      args.userDbAsyncMs,
+    );
+}
+
+function patchAppModel(AppModel: any): void {
+  AppModel.find = (query: any) => {
+    const packageNames = query?.packageName?.$in;
+    if (Array.isArray(packageNames)) {
+      return delayedQuery(
+        "app.find",
+        packageNames.map((packageName) => fakeApp(packageName)),
+        args.appDbSyncMs,
+        args.appDbAsyncMs,
+      );
+    }
+    return delayedQuery(
+      "app.find",
+      args.packages.map((packageName) => fakeApp(packageName)),
+      args.appDbSyncMs,
+      args.appDbAsyncMs,
+    );
+  };
+  AppModel.findOne = (query: any) =>
+    delayedQuery("app.findOne", fakeApp(query?.packageName ?? "local.app"), args.appDbSyncMs, args.appDbAsyncMs);
+}
+
+function resolvedQuery<T>(value: T): Promise<T> & { lean: () => Promise<T>; exec: () => Promise<T> } {
+  const promise = Promise.resolve(value) as Promise<T> & { lean: () => Promise<T>; exec: () => Promise<T> };
+  promise.lean = () => Promise.resolve(value);
+  promise.exec = () => Promise.resolve(value);
+  return promise;
+}
+
+function delayedQuery<T>(
+  statName: string,
+  value: T,
+  syncMs: number,
+  asyncMs: number,
+): Promise<T> & { lean: () => Promise<T>; exec: () => Promise<T> } {
+  const makePromise = () =>
+    timed(statName, async () => {
+      if (syncMs > 0) busyWork(syncMs);
+      if (asyncMs > 0) await sleep(asyncMs);
+      return value;
+    });
+  const promise = makePromise() as Promise<T> & { lean: () => Promise<T>; exec: () => Promise<T> };
+  promise.lean = makePromise;
+  promise.exec = makePromise;
+  return promise;
+}
+
+function fakeApp(packageName: string): Record<string, unknown> {
+  return {
+    packageName,
+    name: packageName,
+    publicUrl: "http://localhost",
+    logoURL: "",
+    appType: "standard",
+    hashedApiKey: crypto.createHash("sha256").update("local-api-key").digest("hex"),
+    permissions: [{ type: "ALL" }],
+    settings: [],
+  };
+}
+
+function defaultSubscriptions(packageName: string): string[] {
+  if (packageName === "com.mentra.captions") {
+    packageName = "com.mentra.captions.debug";
+  }
+  if (packageName.includes("caption") || packageName.includes("translation")) {
+    return ["transcription:en-US"];
+  }
+  return ["transcription:en-US", "location_update", "phone_notification"];
+}
+
+class FakeBunWebSocket {
+  public readyState = WebSocketReadyState.OPEN;
+  public sentMessages = 0;
+  public bytesSent = 0;
+
+  constructor(public readonly id: string) {
+    metrics.socketsCreated++;
+  }
+
+  send(data: string | Buffer | ArrayBuffer | Uint8Array): void {
+    this.sentMessages++;
+    metrics.socketSends++;
+    if (typeof data === "string") {
+      this.bytesSent += data.length;
+      metrics.socketBytesSent += data.length;
+    } else {
+      this.bytesSent += data.byteLength;
+      metrics.socketBytesSent += data.byteLength;
+    }
+  }
+
+  close(_code?: number, _reason?: string): void {
+    this.readyState = WebSocketReadyState.CLOSED;
+  }
+
+  ping(): void {}
+}
+
+async function timed<T>(name: string, fn: () => T | Promise<T>): Promise<T> {
+  const t0 = performance.now();
+  try {
+    return await fn();
+  } finally {
+    recordStat(name, performance.now() - t0);
+  }
+}
+
+function recordStat(name: string, ms: number): void {
+  let stat = operationStats.get(name);
+  if (!stat) {
+    stat = {
+      count: 0,
+      totalMs: 0,
+      maxMs: 0,
+      samples: [],
+    };
+    operationStats.set(name, stat);
+  }
+
+  stat.count++;
+  stat.totalMs += ms;
+  if (ms > stat.maxMs) stat.maxMs = ms;
+  stat.samples.push(ms);
+}
+
+function snapshotStats(names: string[]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const name of names) {
+    const stat = operationStats.get(name);
+    if (!stat) continue;
+    const sorted = [...stat.samples].sort((a, b) => a - b);
+    out[name] = {
+      count: stat.count,
+      totalMs: round(stat.totalMs),
+      avgMs: round(stat.totalMs / stat.count),
+      p50Ms: round(percentile(sorted, 50)),
+      p95Ms: round(percentile(sorted, 95)),
+      p99Ms: round(percentile(sorted, 99)),
+      maxMs: round(stat.maxMs),
+    };
+  }
+  return out;
+}
+
+function getStat(name: string): OperationStats {
+  let stat = operationStats.get(name);
+  if (!stat) {
+    stat = { count: 0, totalMs: 0, maxMs: 0, samples: [] };
+    operationStats.set(name, stat);
+  }
+  return stat;
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const index = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index];
+}
+
+function round(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function busyWork(ms: number): void {
+  const end = performance.now() + ms;
+  let x = 0;
+  while (performance.now() < end) {
+    x += Math.sqrt(x + 1);
+  }
+  if (x === Number.MIN_SAFE_INTEGER) console.log(x);
+}
+
+function numberArg(name: string, fallback: number): number {
+  const raw = rawArgs.get(name);
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function boolArg(name: string, fallback: boolean): boolean {
+  const raw = rawArgs.get(name);
+  if (!raw) return fallback;
+  return raw === "true" || raw === "1" || raw === "yes";
+}
+
+function enumArg<T extends string>(name: string, fallback: T, allowed: T[]): T {
+  const raw = rawArgs.get(name) as T | undefined;
+  if (!raw) return fallback;
+  return allowed.includes(raw) ? raw : fallback;
+}
+
+function nullableStringArg(name: string, fallback: string | null): string | null {
+  const raw = rawArgs.get(name);
+  if (!raw) return fallback;
+  return raw === "none" || raw === "null" ? null : raw;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function makeSilentLogger(): Record<string, AnyFn> {
+  const logger: Record<string, AnyFn> = {
+    child: () => logger,
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+  };
+  return logger;
+}


### PR DESCRIPTION
## Why

The cloud server has been periodically freezing and getting restarted. Memory does not look like the cause.

Before this PR, we could see that app and websocket work got slower before some crashes, but we could not tell exactly what part of the server got stuck. This PR adds the extra breadcrumbs we need so the next event is easier to diagnose.

This PR is not intended to fix the crash directly. It is the logging and measurement pass that should let us make one focused fix after we catch the next bad event.

## What changed

- Added event loop delay measurements to the regular server health logs.
- Added timing around app websocket connection, reconnect, and regular message paths.
- Added timing around app message handling, split by message type.
- Added timing around subscription update work, since reconnect storms may amplify that path.
- Added app websocket close telemetry so we can see close code, package, send counts, and whether the close looks local or external.
- Added process startup and shutdown breadcrumbs so we can tell whether the server had time to shut down cleanly before Kubernetes killed it.
- Added local storm harnesses for reproducing websocket/reconnect pressure without using the production captions app.
- Updated the investigation docs with what we tried, what we ruled out, and how to interpret the new logs.

## What we have observed so far

- The crash pattern does not look memory-related.
- The server appears to freeze or fall behind badly enough that health checks fail.
- The strongest suspect is app/websocket handling getting too slow during certain bursts.
- Debug is healthy right now. The new observability is live there and confirmed in BetterStack.
- A live debug session showed normal event loop delay and no slow app-message warnings, so we have not reproduced the bad state yet.

## How this helps the next crash

When this happens again, the new logs should help answer:

1. Was the server actually blocked, or was it waiting on slow async work?
2. Which app message type was slow?
3. Did a reconnect or subscription-update burst happen right before the freeze?
4. Did many app websocket connections close at the same time?
5. Did Kubernetes kill the pod before our shutdown handler could run?

Once we have those answers, the next PR should be the actual fix.

## Validation

- `bun run build` passed in `cloud/packages/cloud`.
- `bun run test` passed in `cloud/packages/cloud`: 6 suites, 6 passed.
- `git diff --check` passed.
- Deployed to `cloud-debug` with `porter-debug.yml`.
- Verified `cloud-debug` rollout completed and `/livez` returned `ok`.
- Verified BetterStack receives the new `system-vitals` event loop fields.
- Verified a synthetic debug app websocket close emits `app-ws-close` telemetry.
- Verified reconnect attempts are counted in the new protocol metrics.

Known caveat: `bun run lint` is blocked in this checkout because `eslint-config-prettier` is missing from the local dependency environment.

## Docs

- [105 spike](cloud/issues/105-event-loop-cascade-investigation/spike.md)
- [105 spec](cloud/issues/105-event-loop-cascade-investigation/spec.md)
- [105 design](cloud/issues/105-event-loop-cascade-investigation/design.md)
- [106 app websocket storm spike](cloud/issues/106-app-ws-storm-multi-app/spike.md)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused observability to pinpoint cloud freeze/restart causes without changing behavior. Helps diagnose reconnect storms and event‑loop stalls tied to Linear issue 106.

- **New Features**
  - Event loop delay metrics added to system health logs.
  - Phase timings for app WebSocket connect/reconnect and per‑message handling; slow paths flagged by type.
  - Subscription update timing with phase breakdown and slow‑path logging.
  - WebSocket telemetry: open/ping/pong/drain/send counters, and close events with code and origin.
  - Process lifecycle breadcrumbs: startup, graceful shutdown, and watchdog timeouts.
  - Local WS‑storm harnesses to reproduce reconnect/subscription pressure.
  - Debug log hygiene: avoid logging raw API keys.
  - Investigation docs added for 105/106 with guidance on interpreting new logs.

<sup>Written for commit bd1fd9686be768d26a8cec5c956cec1d86833655. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

