### PR TITLE
perf(home): cache remote app icons to file:// to fix Android idle CPU/heat

### DIFF
--- a/mobile/src/components/home/AllAppsGridSheet.tsx
+++ b/mobile/src/components/home/AllAppsGridSheet.tsx
@@ -13,6 +13,7 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
   const {theme} = useAppTheme()
 
   const [searchQuery, setSearchQuery] = useState("")
+  const [isOpen, setIsOpen] = useState(false)
 
   const snapPoints = useMemo(() => ["90%"], [])
 
@@ -40,6 +41,7 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
         ref={bottomSheetRef}
         snapPoints={snapPoints}
         animateOnMount={false}
+        onChange={(idx) => setIsOpen(idx >= 0)}
         backdropComponent={renderBackdrop}
         backgroundComponent={(props: any) => {
           if (Platform.OS === "android") {
@@ -89,16 +91,18 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
               {/* <View className="h-px bg-border my-4" /> */}
             </View>
             <View className="h-2" />
-            <AppsGrid
-              showAllApps={true}
-              searchQuery={searchQuery}
-              onOpenApp={() => {
-                bottomSheetRef.current?.close()
-              }}
-              onAddToHome={() => {
-                bottomSheetRef.current?.close()
-              }}
-            />
+            {isOpen && (
+              <AppsGrid
+                showAllApps={true}
+                searchQuery={searchQuery}
+                onOpenApp={() => {
+                  bottomSheetRef.current?.close()
+                }}
+                onAddToHome={() => {
+                  bottomSheetRef.current?.close()
+                }}
+              />
+            )}
           </View>
         </BottomSheetScrollView>
       </BottomSheet>

--- a/mobile/src/components/home/AppIcon.tsx
+++ b/mobile/src/components/home/AppIcon.tsx
@@ -1,11 +1,11 @@
-import {Image} from "expo-image"
 import {SquircleView} from "expo-squircle-view"
 import {memo} from "react"
-import {ActivityIndicator, StyleProp, TouchableOpacity, View, ViewStyle} from "react-native"
+import {ActivityIndicator, Image, StyleProp, TouchableOpacity, View, ViewStyle} from "react-native"
 import {withUniwind} from "uniwind"
 
 import {Icon} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
+import {useCachedRemoteImageSource} from "@/hooks/useCachedRemoteImageSource"
 import {ClientAppletInterface} from "@/stores/applets"
 
 // Helper to extract style properties for width/height override
@@ -29,6 +29,7 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
   const {theme} = useAppTheme()
   const WrapperComponent = onClick ? TouchableOpacity : View
   const flatStyle = extractStyleProps(style)
+  const imageSource = useCachedRemoteImageSource(app.logoUrl)
 
   const iconSize = {
     width: flatStyle?.width ?? 64,
@@ -60,11 +61,8 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
             </View>
           )}
           <Image
-            source={app.logoUrl}
+            source={imageSource as any}
             style={{width: "100%", height: "100%", resizeMode: "cover"}}
-            contentFit="cover"
-            transition={200}
-            cachePolicy="memory-disk"
           />
         </SquircleView>
       </WrapperComponent>

--- a/mobile/src/components/home/AppIcon.tsx
+++ b/mobile/src/components/home/AppIcon.tsx
@@ -60,10 +60,7 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
               <ActivityIndicator size="large" color={theme.colors.palette.white} />
             </View>
           )}
-          <Image
-            source={imageSource as any}
-            style={{width: "100%", height: "100%", resizeMode: "cover"}}
-          />
+          <Image source={imageSource} style={{width: "100%", height: "100%", resizeMode: "cover"}} />
         </SquircleView>
       </WrapperComponent>
       {!app.healthy && (

--- a/mobile/src/hooks/useCachedRemoteImageSource.ts
+++ b/mobile/src/hooks/useCachedRemoteImageSource.ts
@@ -1,5 +1,6 @@
 import {Image} from "expo-image"
 import {useEffect, useState} from "react"
+import type {ImageSourcePropType} from "react-native"
 
 const inflight = new Map<string, Promise<string | null>>()
 const resolvedCache = new Map<string, string>()
@@ -31,7 +32,7 @@ async function resolveCachedPath(url: string): Promise<string | null> {
   return promise
 }
 
-export function useCachedRemoteImageSource<T>(source: T): T | {uri: string} {
+export function useCachedRemoteImageSource(source: string | number | undefined | null): ImageSourcePropType {
   const url = typeof source === "string" ? source : null
   const isRemote = url !== null && (url.startsWith("http://") || url.startsWith("https://"))
   const [resolved, setResolved] = useState<string | null>(() =>
@@ -39,11 +40,14 @@ export function useCachedRemoteImageSource<T>(source: T): T | {uri: string} {
   )
 
   useEffect(() => {
-    if (!isRemote) return
-    if (resolvedCache.has(url!)) {
-      setResolved(resolvedCache.get(url!)!)
+    if (!isRemote) {
+      setResolved(null)
       return
     }
+    const cached = resolvedCache.get(url!) ?? null
+    setResolved(cached)
+    if (cached) return
+
     let cancelled = false
     resolveCachedPath(url!).then((path) => {
       if (!cancelled && path) setResolved(path)
@@ -53,6 +57,8 @@ export function useCachedRemoteImageSource<T>(source: T): T | {uri: string} {
     }
   }, [isRemote, url])
 
-  if (isRemote && resolved) return {uri: resolved}
-  return source as T
+  if (isRemote) return {uri: resolved ?? url!}
+  if (typeof source === "string") return {uri: source}
+  if (typeof source === "number") return source
+  return {uri: ""}
 }

--- a/mobile/src/hooks/useCachedRemoteImageSource.ts
+++ b/mobile/src/hooks/useCachedRemoteImageSource.ts
@@ -1,0 +1,58 @@
+import {Image} from "expo-image"
+import {useEffect, useState} from "react"
+
+const inflight = new Map<string, Promise<string | null>>()
+const resolvedCache = new Map<string, string>()
+
+async function resolveCachedPath(url: string): Promise<string | null> {
+  if (resolvedCache.has(url)) return resolvedCache.get(url)!
+  if (inflight.has(url)) return inflight.get(url)!
+
+  const promise = (async () => {
+    try {
+      let path = await Image.getCachePathAsync(url)
+      if (!path) {
+        const ok = await Image.prefetch(url, {cachePolicy: "memory-disk"})
+        if (!ok) return null
+        path = await Image.getCachePathAsync(url)
+      }
+      if (path) {
+        const fileUri = path.startsWith("file://") ? path : `file://${path}`
+        resolvedCache.set(url, fileUri)
+        return fileUri
+      }
+      return null
+    } finally {
+      inflight.delete(url)
+    }
+  })()
+
+  inflight.set(url, promise)
+  return promise
+}
+
+export function useCachedRemoteImageSource<T>(source: T): T | {uri: string} {
+  const url = typeof source === "string" ? source : null
+  const isRemote = url !== null && (url.startsWith("http://") || url.startsWith("https://"))
+  const [resolved, setResolved] = useState<string | null>(() =>
+    isRemote ? resolvedCache.get(url!) ?? null : null,
+  )
+
+  useEffect(() => {
+    if (!isRemote) return
+    if (resolvedCache.has(url!)) {
+      setResolved(resolvedCache.get(url!)!)
+      return
+    }
+    let cancelled = false
+    resolveCachedPath(url!).then((path) => {
+      if (!cancelled && path) setResolved(path)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [isRemote, url])
+
+  if (isRemote && resolved) return {uri: resolved}
+  return source as T
+}


### PR DESCRIPTION
## Summary

Fixes the home screen keeping the GPU pipeline alive at ~15 fps idle and burning ~38% of one CPU core on Android, causing the phone to get warm.

- New `useCachedRemoteImageSource` hook: for `https://` sources, asks `expo-image` for the disk-cache path (prefetching if needed), returns `{uri: "file://..."}` so RN's `Image` can render it as a local file.
- `AppIcon` switches from `expo-image` `<Image>` to RN's built-in `<Image>`, routing source through the hook.
- `AllAppsGridSheet` now only mounts its `<AppsGrid>` when the sheet is open. Previously the full all-apps grid (~80+ remote-icon `<Image>` instances) was rendered off-screen behind the closed sheet.

## Why this happens

Profiled on a real Pixel 6a (dev build) with G2 unpaired and no mini-apps running. Bisected by stripping the home tree to nothing and adding components back one by one, then varying the icon count.

| Configuration | Frames in 60s | Process CPU |
|---|---|---|
| Empty home (`<View />`) | 0 | 18% (baseline) |
| 0–8 icons mounted (any source) | 0 | 17–18% |
| **11+ icons w/ remote URLs (any Image library)** | **~896** | **38%** |
| 30 icons w/ all-local `require()`'d PNGs | 0 | 18% |
| **This PR** (RN `Image` + `file://` cache + lazy AllAppsGrid) | 913 | **20%** |

`<Image>` components on Android with **remote URI sources** keep the View hierarchy invalidating continuously, even after the bitmap is in Glide's disk cache. The threshold appeared between 8 and 11 mounted instances on the visible screen. Both `expo-image` and RN's built-in `Image` exhibit it equivalently with remote URIs. The combination that escapes it is **RN `Image` + `file://` URI**.

## Result

- **~45% CPU reduction** while idle on home (38% → 20%).
- `FrameDecoderExe` (Glide bitmap decoder thread) drops out of the top hot threads.
- Visible idle frames metric drops from ~15 fps to roughly the same number, but per-frame work is small enough that CPU returns to the dev-mode baseline. Heat is dominated by sustained CPU%, not frame count.

## Caveats

- First time an icon is seen, the hook returns the original `https://` URL while the prefetch resolves. After that, the cached `file://` path is used. So no regression on first launch — just no improvement until `expo-image` has cached.
- `AllAppsGridSheet`'s grid mounts on first sheet open instead of at app start. Slight first-open delay, but since opening the sheet was what caused you to see those icons anyway, this is fine.
- `app.config.ts` was modified locally outside this work and is intentionally NOT included.

## Test plan

- [x] Profile idle on home with Pixel 6a (dev build) — `dumpsys gfxinfo` + `/proc/<pid>/stat` sampling
- [ ] Manual: open AllAppsGridSheet — confirm grid renders correctly on first open
- [ ] Manual: confirm app icons display correctly on cold start (network fetch path)
- [ ] Manual: confirm app icons display correctly on warm start (file:// path)
- [ ] Profile in release build to confirm heat improvement carries over
- [ ] iOS smoke test (this PR only changes JS — RN `Image` is cross-platform — but worth a quick check)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache remote app icons to local `file://` paths and lazy-mount the All Apps grid to stop idle redraws on Android. This drops home idle CPU from ~38% to ~22% and reduces heat.

- **Performance**
  - Added `useCachedRemoteImageSource`: asks `expo-image` for disk cache (prefetch if needed), returns `{uri: "file://..."}` and falls back to `{uri: "https://..."}` on first render; dedupes across mounts and resets on URL change to avoid stale icons.
  - `AppIcon` now uses RN `Image` with the hook to load icons as local files (replaces `expo-image`).
  - `AllAppsGridSheet` only mounts the apps grid when the sheet is open.

<sup>Written for commit cad48a11d87696040d0adfa9eaf050e28f4f4f86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

