### PR TITLE
sdk: pin npm publish to alpha tag while on 3.0.0-alpha.x

### DIFF
--- a/cloud/packages/sdk/package.json
+++ b/cloud/packages/sdk/package.json
@@ -2,6 +2,10 @@
   "name": "@mentra/sdk",
   "version": "3.0.0-alpha.1",
   "description": "Build apps for MentraOS smartglasses. This SDK provides everything you need to create real-time smartglasses applications.",
+  "publishConfig": {
+    "tag": "alpha",
+    "access": "public"
+  },
   "source": "src/index.ts",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary

- Adds `publishConfig.tag: "alpha"` to `cloud/packages/sdk/package.json` so any future `npm publish` (or `bun publish`) from this package.json defaults to the `alpha` dist-tag, not `latest`.
- Prevents an accidental clobbering of npm's `latest` dist-tag when publishing prereleases.

## Why

A recent alpha publish ran without \`--tag alpha\`, which pointed \`latest\` at \`3.0.0-alpha.4\` instead of the \`2.1.x\` stable line. For ~8 days, fresh \`npm install @mentra/sdk\` (no version pinned) resolved to a 3.x prerelease. Existing projects with \`"^2.1.x"\` ranges were unaffected, but new devs and unpinned scaffolds got a broken install.

The \`publishConfig.tag\` field is the package-level fix: even if someone forgets the CLI flag, npm tags the upload \`alpha\`. When \`3.0.0\` stabilizes, bump this field to \`"latest"\`.

## Separate manual step (not in this PR)

Re-point the dist-tags on npm — needs publish auth:

\`\`\`bash
npm dist-tag add @mentra/sdk@2.1.29 latest
npm dist-tag add @mentra/sdk@3.0.0-alpha.4 alpha
\`\`\`

## Test plan

- [ ] Inspect the diff — single field added, no other changes
- [ ] After merging + publishing, verify \`npm view @mentra/sdk dist-tags\` shows the next alpha goes to \`alpha\` tag automatically (without \`--tag\` flag)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins `@mentra/sdk` publishes to the `alpha` dist-tag and sets publish `access` to `public` in `cloud/packages/sdk/package.json` to prevent prereleases from overwriting `latest`. Switch to `latest` when `3.0.0` is stable.

- **Migration**
  - Re-point npm dist-tags: `npm dist-tag add @mentra/sdk@2.1.29 latest`, `npm dist-tag add @mentra/sdk@3.0.0-alpha.x alpha`
  - Verify: `npm view @mentra/sdk dist-tags`

<sup>Written for commit 83cdffb675f58f3ecc4eb7d372536df5762bda7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

