### PR TITLE
bluetooth-sdk: declare FOREGROUND_SERVICE_DATA_SYNC permission

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -24,9 +24,10 @@
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
   <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
 
-  <!-- Foreground service permissions -->
+  <!-- Foreground service permissions (must match foregroundServiceType bits on the service) -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
   <!-- Other permissions -->


### PR DESCRIPTION
## Summary

Adds the missing `android.permission.FOREGROUND_SERVICE_DATA_SYNC` to `mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml`. Without it, every host app targeting Android 14+ (targetSdk 34+) crashes on first launch.

## Why

The library's `ForegroundService` is declared with three foreground-service types:

```xml
<service android:name="com.mentra.core.services.ForegroundService"
         android:foregroundServiceType="dataSync|connectedDevice|microphone"/>
```

But the manifest only declares two of the three matching `uses-permission` entries — `FOREGROUND_SERVICE_DATA_SYNC` is missing. On Android 14+, `startForeground()` validates that the **runtime type the service starts with** has a matching app-level permission, regardless of which sibling types are also declared. The SDK calls `startForegroundWithAutoDetectedType(...)` which can pick `dataSync`, and that path throws:

```
java.lang.SecurityException: Starting FGS with type dataSync
    callerApp=ProcessRecord{...:com.example.host/u0a117} targetSDK=36
    requires permissions: all of the permissions [android.permission.FOREGROUND_SERVICE_DATA_SYNC]
  at android.app.Service.startForeground(Service.java:862)
  at com.mentra.core.services.ForegroundService.startForegroundWithAutoDetectedType(Foreground.kt:52)
  at com.mentra.core.services.ForegroundService.onCreate(Foreground.kt:24)
```

…which propagates up as `RuntimeException: Unable to create service com.mentra.core.services.ForegroundService` and kills the host process.

## Repro

Running the partner kit's `examples/react-native` app on a Pixel 8 (Android 15, targetSdk 36):

1. `expo run:android` builds and installs cleanly.
2. App opens to the dev launcher, JS bundle loads (727 modules in 312ms).
3. App immediately crashes — `RuntimeException: Unable to create service ... Caused by SecurityException`.
4. Stuck on "Reloading…" forever because RN reload tries to recreate the service.

With this one-line manifest change applied, same APK boots through to the Device tab and shows the disconnected Mentra Live, Scan/Connect/Display Hello/Clear actions, and the Camera/Stream/System/Console tabs.

## Risk

- One additional `<uses-permission>` declaration. No code change.
- Permission is normal-protection (granted at install time). No runtime prompt impact.
- Brings the manifest in line with what the service already declares it needs at runtime.

## Test plan

- [x] `examples/react-native` builds, installs, and launches without the SecurityException on Android 15
- [ ] Verify the same on a partner-targeted Android 14 device
- [ ] Confirm partner sample apps (`examples/android`) inherit the permission via manifest merging — they should, since this declaration lives in the library manifest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Declare missing `android.permission.FOREGROUND_SERVICE_DATA_SYNC` in the Bluetooth SDK manifest to match the service’s `foregroundServiceType`. This prevents a SecurityException and first‑launch crash on Android 14+ apps.

- **Bug Fixes**
  - Added `FOREGROUND_SERVICE_DATA_SYNC` to align with `dataSync|connectedDevice|microphone`.
  - Fixes `startForeground()` SecurityException on Android 14+ (targetSdk 34+).
  - No runtime prompt; permission is install-time and merges into host apps.

<sup>Written for commit 8a4320c2a9fe9b9a14659dff840547bd07feeab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

