### PR TITLE
Staging

### DIFF
--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -4,7 +4,7 @@
       "versionCode": 38,
       "versionName": "38.0",
       "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk",
-      "sha256": "17c059983674706c627324cf5796659ac7eff54d1869ba2ee9a748709cfde7a0"
+      "sha256": "d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,

--- a/cloud/docker/Dockerfile.dev
+++ b/cloud/docker/Dockerfile.dev
@@ -21,6 +21,11 @@ COPY packages/sdk/package.json packages/sdk/tsconfig.json ./packages/sdk/
 COPY packages/utils/package.json packages/utils/tsconfig.json ./packages/utils/
 COPY packages/cloud/package.json packages/cloud/tsconfig.json ./packages/cloud/
 
+# Bun's patchedDependencies (cloud/package.json) requires the patch file to
+# exist at install time — without it, `bun install` errors with
+# "could not find patch file".
+COPY patches ./patches
+
 # Install dependencies only (skip prepare scripts that build SDK)
 # SDK will be built at runtime after volume mount
 RUN bun install --no-link --ignore-scripts

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -26,7 +26,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       // icon: "./assets/app-icons/ic_launcher.png",
       package: "com.mentra.mentra",
       googleServicesFile: "./google-services.json",
-      versionCode: 236,
+      versionCode: 240,
       adaptiveIcon: {
         foregroundImage: "./assets/app-icons/ic_launcher_foreground.png",
         // backgroundImage: "./assets/app-icons/ic_launcher.png",
@@ -64,7 +64,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       icon: "./assets/app-icons/ic_launcher.png",
       supportsTablet: false,
       requireFullScreen: true,
-      buildNumber: "236",
+      buildNumber: "240",
       bundleIdentifier: "com.mentra.mentra",
       googleServicesFile: "./GoogleService-Info.plist",
       associatedDomains: ["applinks:apps.mentra.glass", "applinks:apps.mentraglass.com"],

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -26,7 +26,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       // icon: "./assets/app-icons/ic_launcher.png",
       package: "com.mentra.mentra",
       googleServicesFile: "./google-services.json",
-      versionCode: 218,
+      versionCode: 236,
       adaptiveIcon: {
         foregroundImage: "./assets/app-icons/ic_launcher_foreground.png",
         // backgroundImage: "./assets/app-icons/ic_launcher.png",
@@ -64,7 +64,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       icon: "./assets/app-icons/ic_launcher.png",
       supportsTablet: false,
       requireFullScreen: true,
-      buildNumber: "218",
+      buildNumber: "236",
       bundleIdentifier: "com.mentra.mentra",
       googleServicesFile: "./GoogleService-Info.plist",
       associatedDomains: ["applinks:apps.mentra.glass", "applinks:apps.mentraglass.com"],

--- a/mobile/scripts/release-all.mjs
+++ b/mobile/scripts/release-all.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env zx
 
 import { setBuildEnv } from './set-build-env.mjs';
+import { withRetry } from './release-utils.mjs';
 import { readFile, writeFile, cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -68,6 +69,12 @@ process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures = 'arm64-v8a';
 await $({ stdio: 'inherit' })`rm -rf android`;
 await $({ stdio: 'inherit' })`bun expo prebuild --platform android`;
 await $({ stdio: 'inherit' })`bun expo export --platform android --clear`;
+
+// Prebuild can leave a stale autolinking.json with the wrong packageName
+// (com.mentra instead of com.mentra.mentra), which makes the generated
+// ReactNativeApplicationEntryPoint reference a non-existent BuildConfig.
+// Delete it so gradle's settings phase regenerates it against the final build.gradle.
+await $({ stdio: 'inherit' })`rm -rf android/build/generated/autolinking`;
 
 // ── Step 4: Copy fastlane config into android/ ────────────────────────────────
 
@@ -142,10 +149,14 @@ console.log('\n━━━ Step 7: Uploading APK to GitHub release ━━━');
 
 if (!releaseExists) {
   console.log(`Creating new pre-release: ${tag}`);
-  await $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`;
+  await withRetry('gh release create', () =>
+    $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`
+  );
 }
 
-await $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedApkPath} --clobber`;
+await withRetry('gh release upload (APK)', () =>
+  $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedApkPath} --clobber`
+);
 console.log(`Uploaded ${apkName} to release ${tag}`);
 
 // ── Step 8: Build AAB ─────────────────────────────────────────────────────────
@@ -175,7 +186,9 @@ if (!existsSync(keyPath)) {
   process.env.GOOGLE_PLAY_JSON_KEY = keyPath;
   // Install gems and run fastlane
   await $({ stdio: 'inherit', cwd: 'android' })`bundle install`;
-  await $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`;
+  await withRetry('fastlane google_play', () =>
+    $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`
+  );
   console.log('AAB uploaded to Google Play (internal track)');
 }
 

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env zx
 
 import { setBuildEnv } from './set-build-env.mjs';
+import { withRetry } from './release-utils.mjs';
 import { readFile, writeFile, cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -68,6 +69,12 @@ process.env.ORG_GRADLE_PROJECT_reactNativeArchitectures = 'arm64-v8a';
 await $({ stdio: 'inherit' })`rm -rf android`;
 await $({ stdio: 'inherit' })`bun expo prebuild --platform android`;
 await $({ stdio: 'inherit' })`bun expo export --platform android --clear`;
+
+// Prebuild can leave a stale autolinking.json with the wrong packageName
+// (com.mentra instead of com.mentra.mentra), which makes the generated
+// ReactNativeApplicationEntryPoint reference a non-existent BuildConfig.
+// Delete it so gradle's settings phase regenerates it against the final build.gradle.
+await $({ stdio: 'inherit' })`rm -rf android/build/generated/autolinking`;
 
 // ── Step 4: Copy fastlane config into android/ ────────────────────────────────
 
@@ -142,10 +149,14 @@ console.log('\n━━━ Step 7: Uploading APK to GitHub release ━━━');
 
 if (!releaseExists) {
   console.log(`Creating new pre-release: ${tag}`);
-  await $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`;
+  await withRetry('gh release create', () =>
+    $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`
+  );
 }
 
-await $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedApkPath} --clobber`;
+await withRetry('gh release upload (APK)', () =>
+  $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedApkPath} --clobber`
+);
 console.log(`Uploaded ${apkName} to release ${tag}`);
 
 // ── Step 8: Build AAB ─────────────────────────────────────────────────────────
@@ -175,7 +186,9 @@ if (!existsSync(keyPath)) {
   process.env.GOOGLE_PLAY_JSON_KEY = keyPath;
   // Install gems and run fastlane
   await $({ stdio: 'inherit', cwd: 'android' })`bundle install`;
-  await $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`;
+  await withRetry('fastlane google_play', () =>
+    $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`
+  );
   console.log('AAB uploaded to Google Play (internal track)');
 }
 

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env zx
 
 import { setBuildEnv } from './set-build-env.mjs';
+import { withRetry } from './release-utils.mjs';
 import { readFile, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -146,7 +147,9 @@ if (!ascConfig || !ascConfig.ASC_API_KEY_ID || !ascConfig.ASC_API_ISSUER_ID || !
 } else {
   // altool looks for AuthKey_<id>.p8 in $API_PRIVATE_KEYS_DIR
   const keyDir = path.dirname(ascConfig.ASC_API_KEY_PATH);
-  await $({ stdio: 'inherit', env: { ...process.env, API_PRIVATE_KEYS_DIR: keyDir } })`xcrun altool --upload-app -f ${ipaPath} -t ios --apiKey ${ascConfig.ASC_API_KEY_ID} --apiIssuer ${ascConfig.ASC_API_ISSUER_ID}`;
+  await withRetry('altool TestFlight upload', () =>
+    $({ stdio: 'inherit', env: { ...process.env, API_PRIVATE_KEYS_DIR: keyDir } })`xcrun altool --upload-app -f ${ipaPath} -t ios --apiKey ${ascConfig.ASC_API_KEY_ID} --apiIssuer ${ascConfig.ASC_API_ISSUER_ID}`
+  );
   console.log('IPA uploaded to App Store Connect (TestFlight)');
 }
 
@@ -194,10 +197,14 @@ console.log(`IPA renamed to: ${ipaName} (Beta ${betaNumber})`);
 
 if (!releaseExists) {
   console.log(`Creating new pre-release: ${tag}`);
-  await $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`;
+  await withRetry('gh release create', () =>
+    $({ stdio: 'inherit' })`gh release create ${tag} --prerelease --title ${tag} --notes ${'Pre-release ' + tag}`
+  );
 }
 
-await $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedIpaPath} --clobber`;
+await withRetry('gh release upload (IPA)', () =>
+  $({ stdio: 'inherit' })`gh release upload ${tag} ${renamedIpaPath} --clobber`
+);
 console.log(`Uploaded ${ipaName} to release ${tag}`);
 
 // ── Done ──────────────────────────────────────────────────────────────────────

--- a/mobile/scripts/release-utils.mjs
+++ b/mobile/scripts/release-utils.mjs
@@ -1,0 +1,29 @@
+// Shared helpers for release scripts.
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run an async fn with retries and exponential backoff. Designed for network
+ * calls (gh release upload, fastlane google_play, altool, sentry-cli) that
+ * occasionally fail with transient TLS/connection errors.
+ *
+ * Usage:
+ *   await withRetry('Upload APK', () => $`gh release upload ...`);
+ */
+export async function withRetry(label, fn, { attempts = 4, baseDelayMs = 3000 } = {}) {
+  let lastErr;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (attempt === attempts) break;
+      const delay = baseDelayMs * Math.pow(2, attempt - 1);
+      console.warn(`\n⚠️  ${label} failed (attempt ${attempt}/${attempts}): ${err?.message || err}`);
+      console.warn(`   Retrying in ${Math.round(delay / 1000)}s...`);
+      await sleep(delay);
+    }
+  }
+  console.error(`\n❌ ${label} failed after ${attempts} attempts.`);
+  throw lastErr;
+}

--- a/mobile/src/app/miniapps/settings/camera.tsx
+++ b/mobile/src/app/miniapps/settings/camera.tsx
@@ -91,9 +91,7 @@ export default function CameraSettingsScreen() {
       return
     }
     setPhotoSize(size)
-    CoreModule.updateCore({button_photo_size: size}).catch((error: any) => {
-      console.error("Failed to update photo size on glasses:", error)
-    })
+    CoreModule.updateCore({button_photo_size: size})
   }
 
   const handleVideoResolutionChange = (resolution: VideoResolution) => {
@@ -105,11 +103,7 @@ export default function CameraSettingsScreen() {
     const height = resolution === "4K" ? 2160 : resolution === "1440p" ? 1920 : resolution === "1080p" ? 1080 : 720
     const fps = resolution === "4K" ? 15 : 30
     setVideoSettings({width, height, fps})
-    CoreModule.updateCore({button_video_width: width, button_video_height: height, button_video_fps: fps}).catch(
-      (error: any) => {
-        console.error("Failed to update video settings on glasses:", error)
-      },
-    )
+    CoreModule.updateCore({button_video_width: width, button_video_height: height, button_video_fps: fps})
   }
 
   const _handleLedToggle = (enabled: boolean) => {
@@ -127,9 +121,7 @@ export default function CameraSettingsScreen() {
     }
     const minutes = parseInt(time.replace("m", ""))
     setMaxRecordingTime(minutes)
-    CoreModule.updateCore({button_max_recording_time: minutes}).catch((error: any) => {
-      console.error("Failed to update max recording time on glasses:", error)
-    })
+    CoreModule.updateCore({button_max_recording_time: minutes})
   }
 
   const handleCameraFovChange = (fov: number, roi_position: CameraRoiPosition) => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes the mobile release pipeline with retry/backoff and fixes an Android prebuild autolinking issue that broke builds. Bumps iOS/Android build numbers, updates the OTA APK checksum, and ensures dev Docker installs work with `patchedDependencies`.

- **Bug Fixes**
  - Remove stale `android/build/generated/autolinking` after `expo prebuild` to fix wrong package name causing `BuildConfig` errors.
  - Copy `./patches` in `cloud/docker/Dockerfile.dev` so `bun install` works with `patchedDependencies`.
  - Update OTA JSON `sha256` to match the new APK.

- **Refactors**
  - Add `withRetry` helper and wrap flaky steps (`gh release create/upload`, `fastlane google_play`, `altool`) with exponential backoff.
  - Bump Android `versionCode` and iOS `buildNumber` to `240`.
  - Simplify camera settings by removing redundant `.catch` logs on `CoreModule.updateCore`.

<sup>Written for commit 33860c33c215227832b1cdc1637f2563ca486af7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

