### PR TITLE
Add feedback receipt emails

### DIFF
--- a/cloud/packages/cloud/src/api/hono/client/incident-logs.api.ts
+++ b/cloud/packages/cloud/src/api/hono/client/incident-logs.api.ts
@@ -10,6 +10,7 @@ import { v4 as uuidv4 } from "uuid";
 import { incidentStorage, LogEntry } from "../../../services/storage/incident-storage.service";
 import { Incident } from "../../../models/incident.model";
 import appService from "../../../services/core/app.service";
+import { queueFeedbackReceipt } from "../../../services/client/feedback-receipt.service";
 import { logger as rootLogger } from "../../../services/logging/pino-logger";
 import { queueIncidentProcessing } from "../../../services/incidents/incident-processor.service";
 import type { AppEnv } from "../../../types/hono";
@@ -114,6 +115,8 @@ app.post("/", async (c) => {
     });
 
     logger.info({ incidentId, userId: userEmail }, "Created incident for bug report");
+
+    queueFeedbackReceipt(userEmail, body.feedback, { incidentId });
 
     // Queue background processing (cloud logs, Linear, notifications)
     queueIncidentProcessing(incidentId, userEmail);

--- a/cloud/packages/cloud/src/services/client/feedback-receipt.service.test.ts
+++ b/cloud/packages/cloud/src/services/client/feedback-receipt.service.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  getFeedbackReceiptDetails,
   getFeedbackReceiptType,
   queueFeedbackReceipt,
   resolveFeedbackReceiptRecipient,
@@ -54,6 +55,84 @@ describe("feedback receipt helpers", () => {
     queueFeedbackReceipt("user@example.com", { type: "feature" }, { sender });
 
     expect(calls).toBe(1);
+  });
+
+  test("extracts bug report details for echo", () => {
+    expect(
+      getFeedbackReceiptDetails({
+        type: "bug",
+        expectedBehavior: "  it should work  ",
+        actualBehavior: "it crashed",
+        severityRating: 4,
+      }),
+    ).toEqual({
+      expectedBehavior: "it should work",
+      actualBehavior: "it crashed",
+      severityRating: 4,
+    });
+  });
+
+  test("extracts feature request details for echo", () => {
+    expect(
+      getFeedbackReceiptDetails({
+        type: "feature",
+        feedbackText: "add dark mode",
+        experienceRating: 5,
+      }),
+    ).toEqual({
+      feedbackText: "add dark mode",
+      experienceRating: 5,
+    });
+  });
+
+  test("extracts legacy string feedback as echo", () => {
+    expect(getFeedbackReceiptDetails("  please fix the thing  ")).toEqual({
+      legacyText: "please fix the thing",
+    });
+  });
+
+  test("returns undefined when no echo content is present", () => {
+    expect(getFeedbackReceiptDetails({ type: "bug" })).toBeUndefined();
+    expect(getFeedbackReceiptDetails("")).toBeUndefined();
+  });
+
+  test("ignores out-of-range ratings", () => {
+    expect(
+      getFeedbackReceiptDetails({
+        type: "feature",
+        feedbackText: "hi",
+        experienceRating: 12,
+      }),
+    ).toEqual({ feedbackText: "hi" });
+  });
+
+  test("passes echo details through to the sender", async () => {
+    let received: { details?: unknown } = {};
+    const sender: FeedbackReceiptSender = {
+      sendFeedbackReceipt: async (_email, _type, _incidentId, details) => {
+        received.details = details;
+        return {};
+      },
+    };
+
+    queueFeedbackReceipt(
+      "user@example.com",
+      {
+        type: "bug",
+        expectedBehavior: "should work",
+        actualBehavior: "broken",
+        severityRating: 3,
+      },
+      { sender },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(received.details).toEqual({
+      expectedBehavior: "should work",
+      actualBehavior: "broken",
+      severityRating: 3,
+    });
   });
 
   test("does not call sender for automatic bug reports", () => {

--- a/cloud/packages/cloud/src/services/client/feedback-receipt.service.test.ts
+++ b/cloud/packages/cloud/src/services/client/feedback-receipt.service.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getFeedbackReceiptType,
+  queueFeedbackReceipt,
+  resolveFeedbackReceiptRecipient,
+  shouldSendFeedbackReceipt,
+  type FeedbackReceiptSender,
+} from "./feedback-receipt.service";
+
+describe("feedback receipt helpers", () => {
+  test("uses contactEmail when provided and valid", () => {
+    expect(
+      resolveFeedbackReceiptRecipient("relay@example.com", {
+        type: "bug",
+        contactEmail: "  followup@example.com  ",
+      }),
+    ).toBe("followup@example.com");
+  });
+
+  test("falls back to auth email when contactEmail is invalid", () => {
+    expect(
+      resolveFeedbackReceiptRecipient("user@example.com", {
+        type: "feature",
+        contactEmail: "not-an-email",
+      }),
+    ).toBe("user@example.com");
+  });
+
+  test("classifies structured and legacy feedback", () => {
+    expect(getFeedbackReceiptType({ type: "bug" })).toBe("bug");
+    expect(getFeedbackReceiptType({ type: "feature" })).toBe("feature");
+    expect(getFeedbackReceiptType("legacy feedback")).toBe("feedback");
+  });
+
+  test("skips automatic bug report receipts", () => {
+    expect(
+      shouldSendFeedbackReceipt({
+        type: "bug",
+        submissionMode: "AUTOMATIC",
+      }),
+    ).toBe(false);
+  });
+
+  test("queues receipts without awaiting delivery", () => {
+    let calls = 0;
+    const sender: FeedbackReceiptSender = {
+      sendFeedbackReceipt: () => {
+        calls += 1;
+        return new Promise(() => {});
+      },
+    };
+
+    queueFeedbackReceipt("user@example.com", { type: "feature" }, { sender });
+
+    expect(calls).toBe(1);
+  });
+
+  test("does not call sender for automatic bug reports", () => {
+    let calls = 0;
+    const sender: FeedbackReceiptSender = {
+      sendFeedbackReceipt: async () => {
+        calls += 1;
+        return {};
+      },
+    };
+
+    queueFeedbackReceipt(
+      "user@example.com",
+      {
+        type: "bug",
+        submissionMode: "AUTOMATIC",
+      },
+      { sender },
+    );
+
+    expect(calls).toBe(0);
+  });
+});

--- a/cloud/packages/cloud/src/services/client/feedback-receipt.service.ts
+++ b/cloud/packages/cloud/src/services/client/feedback-receipt.service.ts
@@ -1,7 +1,11 @@
 // services/client/feedback-receipt.service.ts
 // Queues user-facing receipts for submitted feedback and bug reports.
 
-import type { FeedbackData, FeedbackReceiptType } from "../../types/feedback.types";
+import type {
+  FeedbackData,
+  FeedbackReceiptDetails,
+  FeedbackReceiptType,
+} from "../../types/feedback.types";
 import { logger as rootLogger } from "../logging/pino-logger";
 
 const logger = rootLogger.child({ service: "feedback-receipt.service" });
@@ -13,6 +17,7 @@ export interface FeedbackReceiptSender {
     recipientEmail: string,
     feedbackType: FeedbackReceiptType,
     incidentId?: string,
+    details?: FeedbackReceiptDetails,
   ): Promise<{ id?: string; error?: unknown }>;
 }
 
@@ -59,6 +64,46 @@ export function shouldSendFeedbackReceipt(feedback: string | FeedbackData): bool
   return !(isStructuredFeedback(feedback) && feedback.type === "bug" && feedback.submissionMode === "AUTOMATIC");
 }
 
+function trimToString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function clampRating(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const rounded = Math.round(value);
+  if (rounded < 1 || rounded > 5) {
+    return undefined;
+  }
+
+  return rounded;
+}
+
+export function getFeedbackReceiptDetails(feedback: string | FeedbackData): FeedbackReceiptDetails | undefined {
+  if (!isStructuredFeedback(feedback)) {
+    const legacyText = trimToString(feedback);
+    return legacyText ? { legacyText } : undefined;
+  }
+
+  const details: FeedbackReceiptDetails = {
+    expectedBehavior: trimToString(feedback.expectedBehavior),
+    actualBehavior: trimToString(feedback.actualBehavior),
+    severityRating: clampRating(feedback.severityRating),
+    feedbackText: trimToString(feedback.feedbackText),
+    experienceRating: clampRating(feedback.experienceRating),
+  };
+
+  const hasAny = Object.values(details).some((value) => value !== undefined);
+  return hasAny ? details : undefined;
+}
+
 async function getDefaultSender(): Promise<FeedbackReceiptSender> {
   const { emailService } = await import("../email/resend.service");
   return emailService;
@@ -76,10 +121,16 @@ export function queueFeedbackReceipt(
   const receiptLogger = options.logger || logger;
   const recipientEmail = resolveFeedbackReceiptRecipient(authEmail, feedback);
   const feedbackType = getFeedbackReceiptType(feedback);
+  const details = getFeedbackReceiptDetails(feedback);
 
   const sendReceipt = async () => {
     const sender = options.sender || (await getDefaultSender());
-    const result = await sender.sendFeedbackReceipt(recipientEmail, feedbackType, options.incidentId);
+    const result = await sender.sendFeedbackReceipt(
+      recipientEmail,
+      feedbackType,
+      options.incidentId,
+      details,
+    );
 
     if (result.error) {
       receiptLogger.warn(

--- a/cloud/packages/cloud/src/services/client/feedback-receipt.service.ts
+++ b/cloud/packages/cloud/src/services/client/feedback-receipt.service.ts
@@ -1,0 +1,108 @@
+// services/client/feedback-receipt.service.ts
+// Queues user-facing receipts for submitted feedback and bug reports.
+
+import type { FeedbackData, FeedbackReceiptType } from "../../types/feedback.types";
+import { logger as rootLogger } from "../logging/pino-logger";
+
+const logger = rootLogger.child({ service: "feedback-receipt.service" });
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export interface FeedbackReceiptSender {
+  sendFeedbackReceipt(
+    recipientEmail: string,
+    feedbackType: FeedbackReceiptType,
+    incidentId?: string,
+  ): Promise<{ id?: string; error?: unknown }>;
+}
+
+interface FeedbackReceiptLogger {
+  warn: (metadata: Record<string, unknown>, message: string) => void;
+}
+
+export interface QueueFeedbackReceiptOptions {
+  incidentId?: string;
+  logger?: FeedbackReceiptLogger;
+  sender?: FeedbackReceiptSender;
+}
+
+function isStructuredFeedback(feedback: string | FeedbackData): feedback is FeedbackData {
+  return typeof feedback === "object" && feedback !== null;
+}
+
+function normalizeEmail(email: unknown): string | undefined {
+  if (typeof email !== "string") {
+    return undefined;
+  }
+
+  const trimmed = email.trim();
+  return EMAIL_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+export function resolveFeedbackReceiptRecipient(authEmail: string, feedback: string | FeedbackData): string {
+  if (isStructuredFeedback(feedback)) {
+    return normalizeEmail(feedback.contactEmail) || authEmail;
+  }
+
+  return authEmail;
+}
+
+export function getFeedbackReceiptType(feedback: string | FeedbackData): FeedbackReceiptType {
+  if (isStructuredFeedback(feedback)) {
+    return feedback.type;
+  }
+
+  return "feedback";
+}
+
+export function shouldSendFeedbackReceipt(feedback: string | FeedbackData): boolean {
+  return !(isStructuredFeedback(feedback) && feedback.type === "bug" && feedback.submissionMode === "AUTOMATIC");
+}
+
+async function getDefaultSender(): Promise<FeedbackReceiptSender> {
+  const { emailService } = await import("../email/resend.service");
+  return emailService;
+}
+
+export function queueFeedbackReceipt(
+  authEmail: string,
+  feedback: string | FeedbackData,
+  options: QueueFeedbackReceiptOptions = {},
+): void {
+  if (!shouldSendFeedbackReceipt(feedback)) {
+    return;
+  }
+
+  const receiptLogger = options.logger || logger;
+  const recipientEmail = resolveFeedbackReceiptRecipient(authEmail, feedback);
+  const feedbackType = getFeedbackReceiptType(feedback);
+
+  const sendReceipt = async () => {
+    const sender = options.sender || (await getDefaultSender());
+    const result = await sender.sendFeedbackReceipt(recipientEmail, feedbackType, options.incidentId);
+
+    if (result.error) {
+      receiptLogger.warn(
+        {
+          error: result.error,
+          feedbackType,
+          incidentId: options.incidentId,
+          recipientEmail,
+        },
+        "Feedback receipt email returned an error",
+      );
+    }
+  };
+
+  sendReceipt().catch((error) => {
+    receiptLogger.warn(
+      {
+        error,
+        feedbackType,
+        incidentId: options.incidentId,
+        recipientEmail,
+      },
+      "Feedback receipt email failed",
+    );
+  });
+}

--- a/cloud/packages/cloud/src/services/client/feedback.service.ts
+++ b/cloud/packages/cloud/src/services/client/feedback.service.ts
@@ -5,7 +5,7 @@
 // New clients should use POST /api/incidents for bug reports instead.
 
 import { Feedback } from "../../models/feedback.model";
-import { emailService } from "../email/resend.service";
+import { queueFeedbackReceipt } from "./feedback-receipt.service";
 import { slackService } from "../notifications/slack.service";
 import type { FeedbackData, PhoneStateSnapshot, FeedbackResponse } from "../../types/feedback.types";
 import { logger as rootLogger } from "../logging/pino-logger";
@@ -52,6 +52,8 @@ export async function submitFeedback(
     // Legacy format - just send as plain text
     slackService.notifyUserFeedbackLegacy(email, feedback).catch(() => {});
   }
+
+  queueFeedbackReceipt(email, feedback);
 
   return {
     success: true,

--- a/cloud/packages/cloud/src/services/email/resend.service.ts
+++ b/cloud/packages/cloud/src/services/email/resend.service.ts
@@ -1,4 +1,5 @@
 import { Resend } from "resend";
+import type { FeedbackReceiptType } from "../../types/feedback.types";
 
 /**
  * Email service using Resend API for sending transactional emails
@@ -588,6 +589,101 @@ export class ResendEmailService {
       console.error("[resend.service] Error sending incident notification:", error);
       return { error };
     }
+  }
+
+  /**
+   * Sends a user-facing receipt for submitted feedback or bug reports.
+   */
+  async sendFeedbackReceipt(
+    recipientEmail: string,
+    feedbackType: FeedbackReceiptType,
+    incidentId?: string,
+  ): Promise<{ id?: string; error?: any }> {
+    const feedbackLabel = this.getFeedbackReceiptLabel(feedbackType);
+    const { html, text } = this.generateFeedbackReceiptEmail(feedbackLabel, incidentId);
+
+    try {
+      const { data, error } = await this.resend.emails.send({
+        from: this.defaultSender,
+        to: [recipientEmail],
+        subject: `Thanks for your MentraOS ${feedbackLabel}`,
+        html,
+        text,
+      });
+
+      if (error) {
+        console.error("[resend.service] Failed to send feedback receipt:", error);
+        return { error };
+      }
+
+      return { id: data?.id };
+    } catch (error) {
+      console.error("[resend.service] Error sending feedback receipt:", error);
+      return { error };
+    }
+  }
+
+  private getFeedbackReceiptLabel(feedbackType: FeedbackReceiptType): string {
+    if (feedbackType === "bug") {
+      return "bug report";
+    }
+
+    if (feedbackType === "feature") {
+      return "feature request";
+    }
+
+    return "feedback";
+  }
+
+  private generateFeedbackReceiptEmail(feedbackLabel: string, incidentId?: string): { html: string; text: string } {
+    const escapedFeedbackLabel = this.escapeHtml(feedbackLabel);
+    const escapedIncidentId = incidentId ? this.escapeHtml(incidentId) : undefined;
+    const referenceHtml = escapedIncidentId
+      ? `<p class="reference">Reference ID: <code>${escapedIncidentId}</code></p>`
+      : "";
+    const referenceText = incidentId ? [`Reference ID: ${incidentId}`] : [];
+
+    return {
+      html: `
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Thanks for your MentraOS ${escapedFeedbackLabel}</title>
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; background-color: #f6f7f9; margin: 0; padding: 0; }
+              .container { max-width: 600px; margin: 20px auto; background: #fff; border: 1px solid #e1e4e8; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
+              .header { background-color: #1f7a6d; color: #fff; padding: 24px; text-align: center; }
+              .content { padding: 24px; }
+              .reference { background: #f1f5f9; border: 1px solid #e2e8f0; padding: 12px; border-radius: 6px; }
+              .footer { background: #f8fafc; padding: 16px; text-align: center; color: #64748b; font-size: 13px; border-top: 1px solid #e2e8f0; }
+            </style>
+          </head>
+          <body>
+            <div class="container">
+              <div class="header">
+                <h2>Thanks for your ${escapedFeedbackLabel}</h2>
+              </div>
+              <div class="content">
+                <p>Thanks a ton for sending this in. Reports and requests like this are very helpful for us, and we read every one.</p>
+                <p>If we need to follow up, our team will reach out by email.</p>
+                ${referenceHtml}
+                <p>Thanks again,<br>The MentraOS Team</p>
+              </div>
+              <div class="footer">&copy; ${new Date().getFullYear()} Mentra Labs</div>
+            </div>
+          </body>
+        </html>
+      `,
+      text: [
+        `Thanks for your MentraOS ${feedbackLabel}.`,
+        "Thanks a ton for sending this in. Reports and requests like this are very helpful for us, and we read every one.",
+        "If we need to follow up, our team will reach out by email.",
+        ...referenceText,
+        "Thanks again,\nThe MentraOS Team",
+      ].join("\n\n"),
+    };
   }
 
   /**

--- a/cloud/packages/cloud/src/services/email/resend.service.ts
+++ b/cloud/packages/cloud/src/services/email/resend.service.ts
@@ -1,5 +1,8 @@
 import { Resend } from "resend";
-import type { FeedbackReceiptType } from "../../types/feedback.types";
+import type {
+  FeedbackReceiptDetails,
+  FeedbackReceiptType,
+} from "../../types/feedback.types";
 
 /**
  * Email service using Resend API for sending transactional emails
@@ -598,15 +601,16 @@ export class ResendEmailService {
     recipientEmail: string,
     feedbackType: FeedbackReceiptType,
     incidentId?: string,
+    details?: FeedbackReceiptDetails,
   ): Promise<{ id?: string; error?: any }> {
     const feedbackLabel = this.getFeedbackReceiptLabel(feedbackType);
-    const { html, text } = this.generateFeedbackReceiptEmail(feedbackLabel, incidentId);
+    const { html, text } = this.generateFeedbackReceiptEmail(feedbackLabel, incidentId, details);
 
     try {
       const { data, error } = await this.resend.emails.send({
         from: this.defaultSender,
         to: [recipientEmail],
-        subject: `Thanks for your MentraOS ${feedbackLabel}`,
+        subject: `Thanks for your Mentra ${feedbackLabel}`,
         html,
         text,
       });
@@ -635,13 +639,36 @@ export class ResendEmailService {
     return "feedback";
   }
 
-  private generateFeedbackReceiptEmail(feedbackLabel: string, incidentId?: string): { html: string; text: string } {
+  private generateFeedbackReceiptEmail(
+    feedbackLabel: string,
+    incidentId?: string,
+    details?: FeedbackReceiptDetails,
+  ): { html: string; text: string } {
     const escapedFeedbackLabel = this.escapeHtml(feedbackLabel);
     const escapedIncidentId = incidentId ? this.escapeHtml(incidentId) : undefined;
     const referenceHtml = escapedIncidentId
       ? `<p class="reference">Reference ID: <code>${escapedIncidentId}</code></p>`
       : "";
     const referenceText = incidentId ? [`Reference ID: ${incidentId}`] : [];
+
+    const echoRows = this.buildFeedbackReceiptEchoRows(details);
+    const echoHtml = echoRows.length
+      ? `
+        <div class="echo">
+          <div class="echo-title">What you sent us</div>
+          <dl class="echo-list">
+            ${echoRows
+              .map(
+                (row) =>
+                  `<dt>${this.escapeHtml(row.label)}</dt><dd>${row.isMultiline ? `<pre>${this.escapeHtml(row.value)}</pre>` : this.escapeHtml(row.value)}</dd>`,
+              )
+              .join("")}
+          </dl>
+        </div>`
+      : "";
+    const echoText = echoRows.length
+      ? ["What you sent us:", ...echoRows.map((row) => `${row.label}: ${row.value}`)]
+      : [];
 
     return {
       html: `
@@ -650,13 +677,19 @@ export class ResendEmailService {
           <head>
             <meta charset="utf-8">
             <meta name="viewport" content="width=device-width, initial-scale=1">
-            <title>Thanks for your MentraOS ${escapedFeedbackLabel}</title>
+            <title>Thanks for your Mentra ${escapedFeedbackLabel}</title>
             <style>
               body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; background-color: #f6f7f9; margin: 0; padding: 0; }
               .container { max-width: 600px; margin: 20px auto; background: #fff; border: 1px solid #e1e4e8; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
-              .header { background-color: #1f7a6d; color: #fff; padding: 24px; text-align: center; }
+              .header { background-color: #00b869; color: #fff; padding: 24px; text-align: center; }
               .content { padding: 24px; }
               .reference { background: #f1f5f9; border: 1px solid #e2e8f0; padding: 12px; border-radius: 6px; }
+              .echo { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 16px; margin: 16px 0; }
+              .echo-title { font-weight: 600; color: #475569; font-size: 13px; text-transform: uppercase; letter-spacing: 0.4px; margin-bottom: 8px; }
+              .echo-list { margin: 0; }
+              .echo-list dt { font-weight: 600; color: #334155; margin-top: 8px; font-size: 14px; }
+              .echo-list dd { margin: 4px 0 0 0; color: #1f2937; }
+              .echo-list pre { font-family: inherit; white-space: pre-wrap; margin: 0; }
               .footer { background: #f8fafc; padding: 16px; text-align: center; color: #64748b; font-size: 13px; border-top: 1px solid #e2e8f0; }
             </style>
           </head>
@@ -668,8 +701,9 @@ export class ResendEmailService {
               <div class="content">
                 <p>Thanks a ton for sending this in. Reports and requests like this are very helpful for us, and we read every one.</p>
                 <p>If we need to follow up, our team will reach out by email.</p>
+                ${echoHtml}
                 ${referenceHtml}
-                <p>Thanks again,<br>The MentraOS Team</p>
+                <p>Thanks again,<br>The Mentra Team</p>
               </div>
               <div class="footer">&copy; ${new Date().getFullYear()} Mentra Labs</div>
             </div>
@@ -677,13 +711,45 @@ export class ResendEmailService {
         </html>
       `,
       text: [
-        `Thanks for your MentraOS ${feedbackLabel}.`,
+        `Thanks for your Mentra ${feedbackLabel}.`,
         "Thanks a ton for sending this in. Reports and requests like this are very helpful for us, and we read every one.",
         "If we need to follow up, our team will reach out by email.",
+        ...echoText,
         ...referenceText,
-        "Thanks again,\nThe MentraOS Team",
+        "Thanks again,\nThe Mentra Team",
       ].join("\n\n"),
     };
+  }
+
+  private buildFeedbackReceiptEchoRows(
+    details?: FeedbackReceiptDetails,
+  ): Array<{ label: string; value: string; isMultiline: boolean }> {
+    if (!details) {
+      return [];
+    }
+
+    const rows: Array<{ label: string; value: string; isMultiline: boolean }> = [];
+
+    if (details.expectedBehavior) {
+      rows.push({ label: "Expected behavior", value: details.expectedBehavior, isMultiline: true });
+    }
+    if (details.actualBehavior) {
+      rows.push({ label: "What happened", value: details.actualBehavior, isMultiline: true });
+    }
+    if (details.severityRating !== undefined) {
+      rows.push({ label: "Severity", value: `${details.severityRating}/5`, isMultiline: false });
+    }
+    if (details.feedbackText) {
+      rows.push({ label: "Your message", value: details.feedbackText, isMultiline: true });
+    }
+    if (details.experienceRating !== undefined) {
+      rows.push({ label: "Rating", value: `${details.experienceRating}/5`, isMultiline: false });
+    }
+    if (details.legacyText) {
+      rows.push({ label: "Your message", value: details.legacyText, isMultiline: true });
+    }
+
+    return rows;
   }
 
   /**

--- a/cloud/packages/cloud/src/services/email/resend.service.ts
+++ b/cloud/packages/cloud/src/services/email/resend.service.ts
@@ -682,6 +682,8 @@ export class ResendEmailService {
               body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; background-color: #f6f7f9; margin: 0; padding: 0; }
               .container { max-width: 600px; margin: 20px auto; background: #fff; border: 1px solid #e1e4e8; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 8px rgba(0,0,0,0.06); }
               .header { background-color: #00b869; color: #fff; padding: 24px; text-align: center; }
+              .header img { display: block; margin: 0 auto 12px; height: 32px; max-width: 200px; }
+              .header h2 { margin: 0; font-weight: 500; font-size: 20px; }
               .content { padding: 24px; }
               .reference { background: #f1f5f9; border: 1px solid #e2e8f0; padding: 12px; border-radius: 6px; }
               .echo { background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 16px; margin: 16px 0; }
@@ -696,6 +698,7 @@ export class ResendEmailService {
           <body>
             <div class="container">
               <div class="header">
+                <img src="https://mentra-store-cdn.mentraglass.com/mentra_store_assets/Mentra_Logo/PNG/Full/Full%20-%20W.png" alt="Mentra" />
                 <h2>Thanks for your ${escapedFeedbackLabel}</h2>
               </div>
               <div class="content">

--- a/cloud/packages/cloud/src/types/feedback.types.ts
+++ b/cloud/packages/cloud/src/types/feedback.types.ts
@@ -54,6 +54,8 @@ export interface FeedbackResponse {
   success: boolean;
 }
 
+export type FeedbackReceiptType = "bug" | "feature" | "feedback";
+
 // ============================================================================
 // Shared Types
 // ============================================================================

--- a/cloud/packages/cloud/src/types/feedback.types.ts
+++ b/cloud/packages/cloud/src/types/feedback.types.ts
@@ -56,6 +56,19 @@ export interface FeedbackResponse {
 
 export type FeedbackReceiptType = "bug" | "feature" | "feedback";
 
+/**
+ * The user-visible portion of a feedback submission, echoed back in receipt
+ * emails so the submitter can see their report did not vanish.
+ */
+export interface FeedbackReceiptDetails {
+  expectedBehavior?: string;
+  actualBehavior?: string;
+  severityRating?: number;
+  feedbackText?: string;
+  experienceRating?: number;
+  legacyText?: string;
+}
+
 // ============================================================================
 // Shared Types
 // ============================================================================


### PR DESCRIPTION
## Summary

- Add a feedback receipt queue that sends user-facing emails after successful feedback or incident persistence.
- Send receipts for feature requests, legacy feedback, and user-initiated bug reports, using `contactEmail` when provided and valid.
- Skip receipts for automatic bug incidents and keep email delivery fire-and-forget so submissions are not blocked by Resend failures.

## Validation

- `bun test packages/cloud/src/services/client/feedback-receipt.service.test.ts`
- `bun run build` in `cloud/packages/cloud`
- `bun x prettier --check packages/cloud/src/services/client/feedback-receipt.service.ts packages/cloud/src/services/client/feedback-receipt.service.test.ts`

## Notes

- `bun run lint -- --quiet` is currently blocked in this checkout because `eslint-config-prettier` is missing from the installed lint dependency graph.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Send user-facing receipt emails after feedback submissions and user-initiated bug reports. Emails echo what the user sent, pick a validated contact email, include the incident ID when present, and never block submissions.

- **New Features**
  - Added `queueFeedbackReceipt` with recipient resolution, type detection, and skip for automatic bug incidents.
  - Hooked into legacy feedback submission and incident creation; passes `incidentId` when present.
  - Implemented delivery via `resend` (fire-and-forget with warning logs on errors).
  - Updated email template: brand green `#00b869`, Mentra logo in header, and "Mentra" copy; echoes bug expected/actual/severity, feature message/rating, and legacy text.
  - Introduced `FeedbackReceiptType` and detail extraction; tests cover recipient choice, type classification, skip behavior, echo extraction/rating clamp, and non-blocking send.

<sup>Written for commit d70e927a6453d30c438196c279d4dc8c30fabe78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

