### PR TITLE
[codex] Fix gallery mode during first 30s after ASG connect

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -1261,6 +1261,14 @@ public class AsgClientService extends Service implements NetworkStateListener, B
     }
 
     /**
+     * Handle the phone_ready/glasses_ready handshake completing over Bluetooth.
+     */
+    public void onPhoneReadyHandshakeComplete() {
+        Log.d(TAG, "📱 Phone ready handshake complete - marking phone connection active");
+        resetHeartbeatTimeout();
+    }
+
+    /**
      * Handle service heartbeat received from MentraLiveSGC
      */
     public void onServiceHeartbeatReceived() {
@@ -1599,4 +1607,4 @@ public class AsgClientService extends Service implements NetworkStateListener, B
             Log.e(TAG, "🗑️ Error cleaning up orphaned BLE transfers", e);
         }
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceContainer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceContainer.java
@@ -3,6 +3,7 @@ package com.mentra.asg_client.service.core;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.file.core.FileManagerFactory;
@@ -47,7 +48,7 @@ public class ServiceContainer {
 
     private final FileManager fileManager;
 
-    public ServiceContainer(Context context, AsgClientService service) {
+    public ServiceContainer(Context context, @NonNull AsgClientService service) {
         this.context = context;
 
         this.fileManager = FileManagerFactory.getInstance();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandler.java
@@ -82,6 +82,10 @@ public class PhoneReadyCommandHandler implements ICommandHandler {
             boolean sent = communicationManager.sendBluetoothResponse(response);
             Log.d(TAG, "📱 " + (sent ? "✅ Glasses ready response sent successfully" : "❌ Failed to send glasses ready response"));
 
+            if (sent && serviceManager != null) {
+                serviceManager.onPhoneReadyHandshakeComplete();
+            }
+
             // Auto-send WiFi status after glasses_ready
             Log.d(TAG, "📱 🔄 Scheduling WiFi status check in 500ms...");
             new Handler(Looper.getMainLooper()).postDelayed(() -> {
@@ -189,4 +193,4 @@ public class PhoneReadyCommandHandler implements ICommandHandler {
             Log.e(TAG, "💥 Error sending RGB LED authority command", e);
         }
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -3,6 +3,8 @@ package com.mentra.asg_client.service.legacy.managers;
 import android.content.Context;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+
 import com.mentra.asg_client.io.bes.BesOtaManager;
 import com.mentra.asg_client.io.bluetooth.core.BluetoothManagerFactory;
 import com.mentra.asg_client.io.bluetooth.core.ComManager;
@@ -22,6 +24,7 @@ import com.mentra.asg_client.service.core.handlers.RgbLedCommandHandler;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.settings.AsgSettings;
 
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -33,6 +36,7 @@ public class AsgClientServiceManager {
     private static final String TAG = "AsgClientServiceManager";
 
     private final Context context;
+    @NonNull
     private final AsgClientService service;
     private final ICommunicationManager communicationManager;
 
@@ -59,15 +63,17 @@ public class AsgClientServiceManager {
     // StateManager for battery monitoring (set after construction)
     private IStateManager stateManager;
 
-    public AsgClientServiceManager(Context context, AsgClientService service, ICommunicationManager communicationManager, FileManager fileManager) {
+    public AsgClientServiceManager(Context context, @NonNull AsgClientService service, ICommunicationManager communicationManager, FileManager fileManager) {
+        AsgClientService requiredService = Objects.requireNonNull(service, "service");
+
         Log.d(TAG, "🔧 AsgClientServiceManager constructor called");
         Log.d(TAG, "📋 Parameters - Context: " + (context != null ? "valid" : "null") +
-                ", Service: " + (service != null ? "valid" : "null") +
+                ", Service: valid" +
                 ", CommunicationManager: " + (communicationManager != null ? "valid" : "null") +
                 ", FileManager: " + (fileManager != null ? "valid" : "null"));
 
         this.context = context;
-        this.service = service;
+        this.service = requiredService;
         this.fileManager = fileManager;
         this.communicationManager = communicationManager;
 
@@ -292,16 +298,16 @@ public class AsgClientServiceManager {
             // Request BES system version now that BluetoothManager is ready
             // This queries sh_syvr to get firmware version and MAC addresses
             Log.d(TAG, "🔍 Checking conditions for BES system version request - isK900Device: " + isK900Device + 
-                      ", service: " + (service != null ? service.getClass().getSimpleName() : "null"));
+                      ", service: " + service.getClass().getSimpleName());
             
-            if (isK900Device && service != null && service instanceof com.mentra.asg_client.service.core.AsgClientService) {
+            if (isK900Device) {
                 Log.d(TAG, "✅ Conditions met - scheduling BES system version request");
                 // Delay slightly to ensure CommandProcessor is initialized
                 new android.os.Handler(android.os.Looper.getMainLooper()).postDelayed(() -> {
                     try {
                         Log.d(TAG, "🔧 Attempting to get CommandProcessor for BES system version request");
-                        com.mentra.asg_client.service.core.processors.CommandProcessor commandProcessor = 
-                            ((com.mentra.asg_client.service.core.AsgClientService) service).getCommandProcessor();
+                        com.mentra.asg_client.service.core.processors.CommandProcessor commandProcessor =
+                            service.getCommandProcessor();
                         if (commandProcessor != null) {
                             Log.d(TAG, "🔧 Requesting BES system version via CommandProcessor");
                             commandProcessor.requestSystemVersion();
@@ -314,8 +320,7 @@ public class AsgClientServiceManager {
                 }, 1000); // 1 second delay to ensure CommandProcessor is initialized
             } else {
                 Log.d(TAG, "⚠️ Conditions not met for BES system version request - isK900Device: " + isK900Device + 
-                          ", service null: " + (service == null) + 
-                          ", is AsgClientService: " + (service != null && service instanceof com.mentra.asg_client.service.core.AsgClientService));
+                          ", service: " + service.getClass().getSimpleName());
             }
         } catch (Exception e) {
             Log.e(TAG, "💥 Error initializing bluetooth manager", e);
@@ -638,14 +643,9 @@ public class AsgClientServiceManager {
      * @return true if connected to phone, false if disconnected
      */
     public boolean isConnected() {
-        if (service != null) {
-            boolean connected = service.isConnected();
-            Log.d(TAG, "🔌 Connection status: " + (connected ? "CONNECTED" : "DISCONNECTED"));
-            return connected;
-        } else {
-            Log.w(TAG, "⚠️ AsgClientService reference is null - assuming disconnected");
-            return false;
-        }
+        boolean connected = service.isConnected();
+        Log.d(TAG, "🔌 Connection status: " + (connected ? "CONNECTED" : "DISCONNECTED"));
+        return connected;
     }
 
     /**
@@ -653,12 +653,7 @@ public class AsgClientServiceManager {
      */
     public void onPhoneReadyHandshakeComplete() {
         Log.d(TAG, "📱 Phone ready handshake complete");
-
-        if (service != null) {
-            service.onPhoneReadyHandshakeComplete();
-        } else {
-            Log.w(TAG, "⚠️ AsgClientService reference is null - cannot mark phone ready handshake complete");
-        }
+        service.onPhoneReadyHandshakeComplete();
     }
 
     /**
@@ -666,12 +661,6 @@ public class AsgClientServiceManager {
      */
     public void onServiceHeartbeatReceived() {
         Log.d(TAG, "💓 Service heartbeat received from MentraLiveSGC");
-        
-        // Notify AsgClientService about the heartbeat
-        if (service != null) {
-            service.onServiceHeartbeatReceived();
-        } else {
-            Log.w(TAG, "⚠️ AsgClientService reference is null - cannot notify about heartbeat");
-        }
+        service.onServiceHeartbeatReceived();
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -649,6 +649,19 @@ public class AsgClientServiceManager {
     }
 
     /**
+     * Mark the phone connection active after the phone_ready/glasses_ready handshake completes.
+     */
+    public void onPhoneReadyHandshakeComplete() {
+        Log.d(TAG, "📱 Phone ready handshake complete");
+
+        if (service != null) {
+            service.onPhoneReadyHandshakeComplete();
+        } else {
+            Log.w(TAG, "⚠️ AsgClientService reference is null - cannot mark phone ready handshake complete");
+        }
+    }
+
+    /**
      * Handle service heartbeat received from MentraLiveSGC
      */
     public void onServiceHeartbeatReceived() {
@@ -661,4 +674,4 @@ public class AsgClientServiceManager {
             Log.w(TAG, "⚠️ AsgClientService reference is null - cannot notify about heartbeat");
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary

Fixes gallery mode for the first 30 seconds after ASG connects to the phone.

Before this change, ASG always initialized its phone connection state as `isConnected=false` and waited for the first phone heartbeat to flip it to true. The phone heartbeat interval is 30 seconds, but the phone sends user settings immediately after the `phone_ready` -> `glasses_ready` handshake. That meant ASG received `save_in_gallery_mode=false` while still believing the phone was disconnected.

The camera-button handler only suppresses local capture when both conditions are true:

```java
!isSaveInGalleryMode && isConnected
```

Because `isConnected` was still false during that first 30-second window, the handler took the disconnected fallback path and saved media locally even though gallery mode was inactive.

## Pre-existing behavior

1. ASG starts heartbeat monitoring and sets `isConnected=false`.
2. Phone sends `phone_ready`.
3. ASG responds with `glasses_ready`.
4. Phone starts the heartbeat scheduler, but the first ping is delayed by 30 seconds.
5. Phone immediately sends user settings, including `save_in_gallery_mode`.
6. For the first 30 seconds after connect, ASG can have `save_in_gallery_mode=false` and `isConnected=false` at the same time.
7. A camera-button press during that window saves locally via the disconnected fallback path.

For reconnects, this same first-30-seconds behavior happens whenever ASG has reset or expired its connection state before the new handshake. If ASG is still inside the previous 35-second heartbeat timeout window and still has `isConnected=true`, then the specific false-state window is already avoided by the old state.

## New behavior

ASG marks the phone connection active as soon as the explicit handshake completes: after handling `phone_ready` and successfully sending `glasses_ready`.

Heartbeat still owns ongoing liveness after that point. It continues to refresh the timeout on each ping and marks the phone disconnected if pings stop.

The result is that `save_in_gallery_mode=false` suppresses local button capture immediately after connection, without waiting for the first scheduled heartbeat.

## Other cleanup

- Tightened `AsgClientServiceManager` so its `AsgClientService` reference is a required constructor invariant instead of carrying unreachable null branches.

## Validation

- Built ASG debug APK with `./gradlew assembleDebug --no-daemon`.
- Installed the updated ASG APK on a connected Mentra Live.
- Connected the Partner Kit Android example on a Samsung Note 20.
- Verified before the first 30-second heartbeat that ASG logs `save_in_gallery_mode` inactive and a synthetic camera-button press reports `Gallery Mode: INACTIVE, Connection State: CONNECTED`.
- Ran `git diff --check` clean before committing.