### PR TITLE
Prevent reconnect storms from refreshing app state

### DIFF
--- a/.github/workflows/porter-debug.yml
+++ b/.github/workflows/porter-debug.yml
@@ -7,6 +7,7 @@ on:
       - cloud/issues-048
       - cloud/pod-loop-stall-cascade
       - cloud/104-soniox-eventqueue-leak-fix
+      - codex/issue-107-reconnect-storm
     paths:
       - "cloud/**"
       - ".github/workflows/porter-debug.yml"

--- a/cloud/issues/107-reconnect-storm-thundering-herd/design.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/design.md
@@ -1,0 +1,188 @@
+# Issue 107 Design: Cheap Reconnects Under WebSocket Storms
+
+## Plain-English Summary
+
+The cloud pod crashed because too many sockets reconnected at once and each reconnect repeated work that did not need to happen during reconnect.
+
+The fix is to make reconnect boring:
+
+> Reconnect should restore the wire, not rediscover the world.
+
+When a miniapp reconnects, cloud already knows the user's session, installed apps, running apps, and subscriptions in memory. Reconnect should attach the new WebSocket, send the app its acknowledgment, and reuse that known state. Database refreshes and broad app-state broadcasts should happen when state actually changes, such as install, uninstall, start, stop, or settings change.
+
+## Failure Mode
+
+On May 11, 2026, us-central prod saw a broad WebSocket drop:
+
+- 62 glasses/client sockets closed with code 1006 in one second.
+- 47-49 miniapp sockets closed with code 1006 in the same window.
+- 29 users reconnected about 6 seconds later.
+- 72 slow app-connect logs fired across 29 users and 11 packages.
+- The slow path was `connection_init -> broadcastAppState -> refreshInstalledApps`.
+- The pod stopped answering `/health` and `/livez`.
+- Kubernetes killed the container with exit 137 after liveness probe failures.
+
+This is a WebSocket reconnect storm with thundering-herd amplification. The original socket drop may be network or infrastructure related, but cloud made the recovery worse by doing too much repeated work at the same time.
+
+## Current Hot Path
+
+Today, app reconnect/init can do this:
+
+```text
+miniapp websocket connects
+  -> AppManager.handleAppInit()
+  -> attachAppSocket()
+  -> send ACK and state snapshot
+  -> broadcastAppState()
+  -> refreshInstalledApps()
+  -> appService.getAllApps(userId)
+  -> User.findOne(...)
+  -> App.find(...)
+```
+
+That DB-backed refresh is useful when the installed app list may have changed. It is wasteful during ordinary reconnect because the session already has `userSession.installedApps`, populated when the session was created.
+
+## Design Principles
+
+1. Reconnect must be cheap all the time, not only during storm mode.
+2. Refresh from the database only when state may actually be stale.
+3. Collapse duplicate app-state broadcasts for the same user.
+4. Preserve protocol behavior for apps and clients.
+5. Keep observability so the next storm proves whether the fix worked.
+
+## Proposed Fix
+
+### 1. Make Installed-App Refresh Explicit
+
+Change `broadcastAppState()` so it does not automatically call `refreshInstalledApps()`.
+
+Default behavior:
+
+```text
+broadcastAppState()
+  -> use cached userSession.installedApps
+  -> snapshot session
+  -> send APP_STATE_CHANGE
+```
+
+Explicit refresh behavior:
+
+```text
+broadcastAppState({ refreshInstalledApps: true })
+  -> refreshInstalledApps()
+  -> snapshot session
+  -> send APP_STATE_CHANGE
+```
+
+The fallback should still refresh if `userSession.installedApps` is empty, because an empty cache may mean the session failed to bootstrap correctly.
+
+### 2. Coalesce Duplicate Broadcasts
+
+Add a per-user-session scheduler:
+
+```text
+scheduleBroadcastAppState()
+  -> if one is already scheduled, do nothing
+  -> otherwise wait briefly, then call broadcastAppState()
+```
+
+Recommended delay: 150 ms.
+
+If any caller requests a refresh while a broadcast is pending, the scheduled broadcast does one refresh, not many.
+
+### 3. Treat Reconnect Differently From State Change
+
+For app `connection_init` and reconnect paths:
+
+```text
+attach socket
+send ACK
+send current device/session snapshot
+schedule a cheap app-state broadcast from cached state
+```
+
+Do not refresh installed apps from Mongo just because a socket reattached.
+
+### 4. Refresh on Real State Changes
+
+Callers that can change installed or running state should request an explicit refresh when needed.
+
+Examples:
+
+- install app: refresh before broadcasting
+- uninstall app: refresh before or after stop flow
+- start app: broadcast cached state, because start changes running state, not installed app list
+- stop app: broadcast cached state, because stop changes running state, not installed app list
+
+## Reconnect Storm Guard
+
+The storm guard is a backup fuse, not the primary fix.
+
+It should detect bursts like:
+
+```text
+50 socket closes with code 1006 in 10 seconds
+or
+25 reconnects in 10 seconds
+```
+
+During the guard window, reconnect work must stay in cheap mode:
+
+- no installed-app refresh
+- coalesced app-state broadcasts only
+- no best-effort cleanup or repair loops inline
+
+This PR can ship the cheap reconnect fix first. If the implementation already makes reconnect cheap in normal mode, the guard can be added as a smaller follow-up or included only as logging.
+
+## Test Strategy
+
+### Unit/Behavior Tests
+
+Add tests around `AppManager` behavior:
+
+1. `broadcastAppState()` does not call `refreshInstalledApps()` by default.
+2. `broadcastAppState({ refreshInstalledApps: true })` refreshes once.
+3. duplicate scheduled broadcasts collapse into one broadcast.
+4. app init schedules a cheap broadcast instead of awaiting a DB-backed refresh.
+
+### Local Harness
+
+Add or update a local harness that simulates:
+
+- many users
+- many apps per user
+- app WebSocket init/reconnect bursts
+- artificial delay inside installed-app refresh
+
+The before/after signal should be:
+
+```text
+before: reconnect burst runs one installed-app refresh per app connection
+after: reconnect burst runs zero refreshes on reconnect, or one coalesced refresh only when explicitly requested
+```
+
+The harness does not need to perfectly recreate Porter or AKS. It only needs to prove the cloud reconnect path no longer amplifies a socket storm into repeated DB-backed work.
+
+## Success Criteria
+
+Under a local reconnect burst comparable to the May 11 incident:
+
+- app reconnect ACKs are still sent
+- installed-app refresh count is near zero for reconnect-only traffic
+- duplicate app-state broadcasts collapse per user
+- event loop remains responsive enough for health checks
+- slow `connection_init` logs no longer show `refreshInstalledApps` as the dominant phase
+
+## Rollout
+
+1. Branch from `staging`.
+2. Ship to cloud-debug first.
+3. Simulate reconnect storms against debug if practical.
+4. Watch `slow-app-connect`, `event-loop-delay`, health checks, and reconnect logs.
+5. Promote through staging before main.
+
+## Open Questions
+
+1. Should uninstall call a second explicit broadcast after `stopApp()` so the installed app list refresh is guaranteed?
+2. Should `addRunningApp()` be made fully non-blocking during reconnect, or is the current no-op save behavior enough after removing the installed-app refresh?
+3. Should the storm guard be implemented now, or should this PR focus on making normal reconnect cheap and leave guard logging for the next PR?

--- a/cloud/issues/107-reconnect-storm-thundering-herd/design.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/design.md
@@ -103,7 +103,28 @@ schedule a cheap app-state broadcast from cached state
 
 Do not refresh installed apps from Mongo just because a socket reattached.
 
-### 4. Refresh on Real State Changes
+### 4. Reuse Per-App Settings After First Attach
+
+The app ACK includes app-specific settings. On first attach, cloud can read those settings from the user document and cache them in the active `AppManager`.
+
+On later reconnects for an app that was already running, cloud should reuse that cache instead of reading the user document again. If the user changes settings while the session is active, the settings route should update both Mongo and the active in-memory cache before sending the settings update.
+
+This keeps reconnect cheap while preserving correctness:
+
+```text
+first attach -> load settings from user document
+settings changed -> update document and active-session cache
+reconnect -> reuse active-session cache
+cache missing -> fall back to user document
+```
+
+### 5. Avoid Redundant Running-App Writes
+
+`addRunningApp(packageName)` should remain on the first real app attach/start path, but reconnect should skip it when in-memory app state already says the app is running, dormant, or in grace period.
+
+The database should record actual state changes. It should not be required for restoring a socket that cloud already expected to exist.
+
+### 6. Refresh on Real State Changes
 
 Callers that can change installed or running state should request an explicit refresh when needed.
 
@@ -163,12 +184,23 @@ after: reconnect burst runs zero refreshes on reconnect, or one coalesced refres
 
 The harness does not need to perfectly recreate Porter or AKS. It only needs to prove the cloud reconnect path no longer amplifies a socket storm into repeated DB-backed work.
 
+The local sync-pressure comparison added for this issue showed:
+
+```text
+origin/staging: 56 reconnects caused a 2737 ms event-loop heartbeat gap
+cheap reconnect, realistic warm reconnect: 56 reconnects caused about a 230 ms max round heartbeat gap
+```
+
+That is enough to show we reproduced the process-level health-check failure shape locally and removed the specific reconnect amplification we saw in prod logs.
+
 ## Success Criteria
 
 Under a local reconnect burst comparable to the May 11 incident:
 
 - app reconnect ACKs are still sent
 - installed-app refresh count is near zero for reconnect-only traffic
+- already-running reconnects do not reread user settings
+- already-running reconnects do not rewrite running-app state
 - duplicate app-state broadcasts collapse per user
 - event loop remains responsive enough for health checks
 - slow `connection_init` logs no longer show `refreshInstalledApps` as the dominant phase
@@ -184,5 +216,5 @@ Under a local reconnect burst comparable to the May 11 incident:
 ## Open Questions
 
 1. Should uninstall call a second explicit broadcast after `stopApp()` so the installed app list refresh is guaranteed?
-2. Should `addRunningApp()` be made fully non-blocking during reconnect, or is the current no-op save behavior enough after removing the installed-app refresh?
+2. Should `validateApiKey` get a per-package cache if debug/staging shows it becomes the next storm bottleneck?
 3. Should the storm guard be implemented now, or should this PR focus on making normal reconnect cheap and leave guard logging for the next PR?

--- a/cloud/issues/107-reconnect-storm-thundering-herd/spec.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/spec.md
@@ -164,6 +164,31 @@ Option B:
 
 Preferred: A where easy, B where correctness requires eventual persistence.
 
+Implementation note for this PR:
+
+- compute whether the app was already expected to be running before calling `handleConnect(ws)`
+- skip `addRunningApp(packageName)` when the app was already running, dormant, or in grace period
+- keep the write on the first real attach/start path
+
+### S4.5: Reuse App-Specific Settings on Reconnect
+
+`attachAppSocket()` also reads the user document to get app-specific settings before sending `CONNECTION_ACK`.
+
+During reconnect, the active session can reuse settings it already loaded for that app. Keep an in-memory per-`AppManager` settings cache:
+
+```text
+first attach for package -> read user settings and cache them
+settings update route -> update user settings and refresh the active session cache
+already-running reconnect -> reuse cached settings
+```
+
+Fallback behavior:
+
+- if settings are missing from the cache, read from the user document
+- if app settings are updated while a session is active, update the cache before sending the settings update message
+
+This keeps reconnect cheap without changing the settings protocol.
+
 ### S5: Keep `refreshInstalledApps()` But Make Its Use Intentional
 
 Do not delete `refreshInstalledApps()`. It is still useful when the app list may be stale.
@@ -239,6 +264,8 @@ Add tests for `AppManager` behavior:
 4. if any coalesced call requests refresh, the final broadcast refreshes once.
 5. reconnect attach does not block on installed-app refresh.
 6. reconnect attach does not call `addRunningApp` if app is already running.
+7. reconnect attach reuses cached app-specific settings after the first successful attach.
+8. active-session settings cache updates when the app settings route saves new settings.
 
 ### Integration / Harness Tests
 
@@ -257,6 +284,7 @@ Acceptance:
 - no multi-minute vitals gap
 - slow `connection_init` count drops sharply
 - no repeated `refreshInstalledApps` per app reconnect
+- no repeated user settings read per already-running app reconnect
 - app state is eventually correct
 
 ### Production Verification
@@ -329,4 +357,3 @@ Mitigation: clear timers in `AppManager.dispose()` / `UserSession.dispose()`.
 3. Should `refreshInstalledApps` have its own slow diagnostic with user hash and call-site reason?
 4. Should app reconnect ACK be sent before any persistence work?
 5. Should app WebSocket reconnects have jitter/backoff guidance in the SDK?
-

--- a/cloud/issues/107-reconnect-storm-thundering-herd/spec.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/spec.md
@@ -1,0 +1,332 @@
+# Issue 107 Spec: Prevent Reconnect Storm Crashes
+
+## Goal
+
+Prevent the cloud pod from becoming unresponsive when many glasses/client and miniapp WebSockets reconnect at the same time.
+
+The primary strategy is simple:
+
+> Reconnect should reattach transport, not recompute session truth.
+
+The reconnect path should use already-known session state wherever possible. Expensive refreshes should happen on actual state changes, not on every reconnect.
+
+## Non-Goals
+
+- Do not solve the root cause of the initial code-1006 socket drop in this PR.
+- Do not redesign the entire AppManager.
+- Do not change miniapp protocol semantics unless required for correctness.
+- Do not remove existing observability.
+- Do not make Kubernetes liveness much looser as the primary fix.
+
+## Current Problem
+
+During the May 11, 2026 prod incident, a broad socket drop was followed by reconnect work:
+
+- 62 glasses/client socket closes with code 1006 in one second
+- 47-49 app socket closes with code 1006
+- 29 users reconnected roughly 6 seconds later
+- 72 slow app-connect logs fired across 29 users and 11 packages
+- slow phase was dominated by `connection_init -> broadcastAppState -> refreshInstalledApps`
+- pod stopped answering `/health` and `/livez`
+- Kubernetes restarted the container with exit 137 after liveness failures
+
+The expensive path today:
+
+```text
+app reconnect
+  -> attachAppSocket()
+  -> connection ack
+  -> broadcastAppState()
+  -> refreshInstalledApps()
+  -> appService.getAllApps(userId)
+  -> User.findOne(...)
+  -> App.find(...)
+```
+
+That is too much work to repeat during reconnect storms.
+
+## Design Principles
+
+1. Reconnect must be idempotent.
+2. Reconnect must avoid DB reads unless state is actually missing.
+3. Reconnect must avoid DB writes unless state changed.
+4. Duplicate app-state broadcasts should collapse into one.
+5. Health checks must remain responsive during reconnect storms.
+6. Storm protection should be a safety net, not the first line of defense.
+
+## Proposed Changes
+
+### S1: Stop Refreshing Installed Apps on Every App-State Broadcast
+
+Change `AppManager.broadcastAppState()` so it does not automatically call `refreshInstalledApps()`.
+
+Instead, `broadcastAppState()` should use `userSession.installedApps`, which is already populated on session creation.
+
+Allowed refresh points:
+
+- session creation
+- app install
+- app uninstall
+- app settings changes that affect app list/state
+- explicit client refresh route if one exists
+- fallback if `userSession.installedApps` is empty or clearly uninitialized
+
+Implementation shape:
+
+```ts
+async broadcastAppState(options?: { refreshInstalledApps?: boolean }): Promise<AppStateChange | null> {
+  if (options?.refreshInstalledApps || this.userSession.installedApps.size === 0) {
+    await this.refreshInstalledApps();
+  }
+
+  ...
+}
+```
+
+Default behavior should be no refresh.
+
+Call sites that actually mutate installed apps should pass `refreshInstalledApps: true` or call `refreshInstalledApps()` before broadcasting.
+
+### S2: Coalesce App-State Broadcasts Per User Session
+
+Add a per-`AppManager` broadcast scheduler so repeated calls collapse into one broadcast over a short window.
+
+Recommended window: 100-250ms.
+
+Behavior:
+
+- first call schedules a broadcast
+- duplicate calls while scheduled do not start new work
+- if a refresh is requested by any caller, the scheduled broadcast includes one refresh
+- callers do not need to await unless they need a return value
+
+Implementation shape:
+
+```ts
+private appStateBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
+private pendingAppStateRefresh = false;
+
+scheduleBroadcastAppState(options?: { refreshInstalledApps?: boolean }): void {
+  this.pendingAppStateRefresh ||= Boolean(options?.refreshInstalledApps);
+  if (this.appStateBroadcastTimer) return;
+
+  this.appStateBroadcastTimer = setTimeout(async () => {
+    this.appStateBroadcastTimer = null;
+    const refreshInstalledApps = this.pendingAppStateRefresh;
+    this.pendingAppStateRefresh = false;
+    await this.broadcastAppState({ refreshInstalledApps });
+  }, 150);
+}
+```
+
+Use `unref()` where available so timers do not block shutdown.
+
+### S3: Make App Reconnect Avoid App-State Refresh
+
+For `connection_init` and other reconnect attach paths:
+
+- attach the socket
+- send ACK
+- send device/session snapshot as needed
+- do not refresh installed apps
+- schedule a coalesced app-state broadcast using cached state
+
+If app state did not actually change, consider skipping the broadcast entirely.
+
+Rule of thumb:
+
+```text
+new app started -> broadcast app state
+existing app socket reattached -> do not recompute app state
+```
+
+### S4: Make `addRunningApp(packageName)` Idempotent or Backgrounded
+
+`attachAppSocket()` currently calls:
+
+```ts
+await user.addRunningApp(packageName);
+```
+
+During reconnect, this is likely unnecessary if the app is already known running.
+
+Change behavior so reconnect does not block on this write:
+
+Option A:
+
+- check in-memory session/app state first
+- only call `addRunningApp` if the app was not already running
+
+Option B:
+
+- fire-and-log in the background after ACK
+- keep the socket attach path fast
+
+Preferred: A where easy, B where correctness requires eventual persistence.
+
+### S5: Keep `refreshInstalledApps()` But Make Its Use Intentional
+
+Do not delete `refreshInstalledApps()`. It is still useful when the app list may be stale.
+
+Add call-site comments or function names to make intent clear:
+
+- `refreshInstalledAppsFromDb()`
+- `broadcastAppState({ refreshInstalledApps: true })`
+- `scheduleBroadcastAppState({ refreshInstalledApps: true })`
+
+The goal is to make accidental DB refresh on reconnect hard to reintroduce.
+
+### S6: Add Reconnect Storm Safety Net
+
+After S1-S5, add a lightweight safety guard.
+
+Track per-pod reconnect pressure over a short rolling window:
+
+- app WebSocket reconnects
+- glasses/client reconnects
+- app WebSocket closes with 1006
+- glasses/client closes with 1006
+
+If thresholds are exceeded, log `reconnect-storm-detected` and force reconnect work into cheap mode:
+
+- no installed-app refresh
+- coalesced app-state broadcasts only
+- no blocking DB writes in reconnect path
+
+Suggested initial thresholds:
+
+```text
+50 socket closes with code 1006 in 10 seconds
+or
+25 reconnects in 10 seconds
+```
+
+This should be a belt-and-suspenders guard. The normal reconnect path should already be cheap without it.
+
+### S7: Keep Health Checks Minimal
+
+Do not make liveness do app/session work.
+
+Verify:
+
+- `/livez` is a minimal process-alive check
+- `/health` can include slightly richer checks, but should not block behind reconnect processing
+
+If needed, tune liveness only after S1-S6:
+
+- readiness can fail during short pressure
+- liveness should only fail when the process is truly wedged
+
+## Files Likely Touched
+
+Expected implementation files:
+
+- `cloud/packages/cloud/src/services/session/AppManager.ts`
+- `cloud/packages/cloud/src/services/core/app.service.ts` only if helper naming or caching changes are needed
+- app install/uninstall/settings route files that call `broadcastAppState()`
+- tests under `cloud/tests/` or existing cloud package test location
+- local harness under `cloud/tools/ws-storm-local/` if committed/available
+
+## Test Plan
+
+### Unit Tests
+
+Add tests for `AppManager` behavior:
+
+1. `broadcastAppState()` does not call `refreshInstalledApps()` by default.
+2. `broadcastAppState({ refreshInstalledApps: true })` calls refresh once.
+3. repeated scheduled broadcasts coalesce into one.
+4. if any coalesced call requests refresh, the final broadcast refreshes once.
+5. reconnect attach does not block on installed-app refresh.
+6. reconnect attach does not call `addRunningApp` if app is already running.
+
+### Integration / Harness Tests
+
+Use or add a reconnect-storm harness:
+
+1. start cloud locally or in debug
+2. create 50-100 app/glasses WebSocket connections
+3. close them with code 1006 or abrupt socket termination
+4. reconnect them within 5-10 seconds
+5. poll `/livez` and `/health` during the storm
+
+Acceptance:
+
+- `/livez` remains responsive
+- no container restart
+- no multi-minute vitals gap
+- slow `connection_init` count drops sharply
+- no repeated `refreshInstalledApps` per app reconnect
+- app state is eventually correct
+
+### Production Verification
+
+After deployment to debug/staging:
+
+Run BetterStack queries during natural reconnects and synthetic debug tests.
+
+Expected improvements:
+
+- `slow-app-connect` decreases in count and duration
+- `broadcast_app_state` is no longer dominated by `refreshInstalledApps` during reconnect
+- no health timeout during reconnect bursts
+- DB slow-query volume does not spike during reconnect
+
+## Rollout Plan
+
+1. Branch from `staging`.
+2. Implement S1-S5 first.
+3. Add S6 storm guard only after reconnect path is cheap.
+4. Deploy to cloud-debug.
+5. Run reconnect-storm harness.
+6. Soak on cloud-debug.
+7. PR to `staging`.
+8. Soak staging.
+9. Promote staging to main.
+10. Back-merge staging to dev.
+
+## Acceptance Criteria
+
+This issue is done when:
+
+- reconnect no longer refreshes installed apps unless explicitly requested
+- duplicate app-state broadcasts are coalesced
+- app reconnect does not block on unnecessary DB writes
+- reconnect storm harness cannot make `/livez` time out
+- BetterStack shows reconnect storms as degraded/recovering, not pod-killing
+- the next natural 1006 storm does not restart the pod
+
+## Risks
+
+### Stale installed apps
+
+Risk: if installed apps are not refreshed on reconnect, app state may be stale after install/uninstall.
+
+Mitigation: refresh on actual install/uninstall/settings mutation paths, not reconnect.
+
+### Missing app-state broadcast
+
+Risk: if reconnect skips or coalesces broadcasts too aggressively, the client may not learn current state.
+
+Mitigation: use cached state and send one coalesced broadcast after reconnect settles.
+
+### Background DB write failure
+
+Risk: if `addRunningApp` is backgrounded, persistence failures could be missed.
+
+Mitigation: log failures and keep in-memory session state as source of truth during active session.
+
+### Timer lifecycle leaks
+
+Risk: coalescing timers could survive disposed sessions.
+
+Mitigation: clear timers in `AppManager.dispose()` / `UserSession.dispose()`.
+
+## Follow-Up Questions
+
+1. Should `broadcastAppState()` be renamed so it is clear whether it reads DB?
+2. Should app-state broadcast include a reason field for observability?
+3. Should `refreshInstalledApps` have its own slow diagnostic with user hash and call-site reason?
+4. Should app reconnect ACK be sent before any persistence work?
+5. Should app WebSocket reconnects have jitter/backoff guidance in the SDK?
+

--- a/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
@@ -303,10 +303,17 @@ Prototype changes tried:
 - callers can still request `broadcastAppState({ refreshInstalledApps: true })` for real app-list changes.
 - `AppManager.scheduleBroadcastAppState()` coalesces duplicate broadcasts over a short 150 ms window.
 - app `connection_init` schedules a cheap app-state broadcast instead of awaiting a DB-backed installed-app refresh inline.
+- app `connection_init` reuses cached app-specific settings when the app was already expected to be running.
+- app `connection_init` skips `addRunningApp(packageName)` when in-memory state already says the app is running, dormant, or in its grace period.
+- the app settings route updates the in-session settings cache when settings change.
 - install and uninstall routes request an explicit installed-app refresh.
-- the local Mentra-path storm harness waits for scheduled broadcasts and reports installed-app lookup counts.
+- the local Mentra-path storm harness waits for scheduled broadcasts and reports installed-app lookup counts and per-round event-loop heartbeat gaps.
 
-Local harness command:
+### Async DB Delay Test
+
+This test injected async DB-like delay. It proves the reconnect path stopped repeating installed-app refreshes and that async wait time alone does not pin the loop.
+
+Command:
 
 ```bash
 cd cloud
@@ -333,5 +340,73 @@ Interpretation:
 
 - The reconnect burst no longer repeats `refreshInstalledApps()` per app connection.
 - The event loop stayed responsive in the local harness.
-- The remaining dominant phase is `attachAppSocket`, mostly because it still reads the user document for legacy app-specific settings and running-app persistence. That is async DB work, not the loop-pinning installed-app refresh fanout seen in the incident logs.
-- Avoiding the legacy settings DB read may be possible later, but it is a broader behavior change and should not be mixed into this crash-prevention PR unless debug/staging still shows reconnect pressure after this fix.
+- The first prototype still had extra `attachAppSocket` work from legacy app-specific settings and running-app persistence.
+- The follow-up prototype below removes that extra work for already-running app reconnects by caching settings in the active `AppManager` and skipping `addRunningApp()` when in-memory state already says the app is running.
+
+### Sync Pressure Before/After Test
+
+This test injected short synchronous pauses into the same DB call sites. It is not claiming Mongo is synchronous in production. It is a local way to model what happens when reconnect fanout causes enough CPU, GC, or blocking work to make health-check timers late.
+
+Before fix, running the harness against `origin/staging` produced a liveness-like event-loop gap:
+
+```bash
+cd /tmp/mentraos-107-staging/cloud
+bun run tools/ws-storm-local/mentra-path-storm-harness.ts \
+  --connect-mode=init \
+  --users=56 \
+  --apps-per-user=1 \
+  --rounds=1 \
+  --subscription-updates=0 \
+  --user-db-sync-ms=20 \
+  --app-db-sync-ms=5 \
+  --reconnect-delay-ms=100 \
+  --label=issue-107-before-staging-sync-pressure
+```
+
+Result:
+
+```text
+reconnect avg: about 2691 ms
+reconnect p95: about 2819 ms
+max heartbeat gap: 2737 ms
+heartbeat gaps over 1s: 1
+installed-app User.findOne lookups: 56
+App.find queries: 57
+dominant slow phase: broadcastAppState -> refreshInstalledApps
+```
+
+After the cheap-reconnect changes, the same sync-pressure shape still has a first-round cache warmup artifact in the harness because the harness creates fake already-running app sessions without going through the real first attach path. The second round is the realistic already-running reconnect shape:
+
+```bash
+cd cloud
+bun run tools/ws-storm-local/mentra-path-storm-harness.ts \
+  --connect-mode=init \
+  --users=56 \
+  --apps-per-user=1 \
+  --rounds=2 \
+  --subscription-updates=0 \
+  --user-db-sync-ms=20 \
+  --app-db-sync-ms=5 \
+  --reconnect-delay-ms=100 \
+  --broadcast-settle-ms=300 \
+  --label=issue-107-after-pr-per-round-heartbeat
+```
+
+Result:
+
+```text
+round 1 max heartbeat gap: 1310 ms
+round 1 heartbeat gaps over 1s: 1
+round 2 max heartbeat gap: about 230 ms
+round 2 heartbeat gaps over 1s: 0
+round 2 installed-app User.findOne lookups: 0
+round 2 attachAppSocket phase: about 0.2-0.4 ms per reconnect
+round 2 scheduleBroadcastAppState phase: 0 ms
+```
+
+Interpretation:
+
+- The old code can locally reproduce the process-level shape that makes Kubernetes health checks time out.
+- The new code removes the confirmed `refreshInstalledApps()` amplification during reconnect.
+- The new code also avoids the app-specific settings read and `addRunningApp()` write once the app has already attached once.
+- The remaining synthetic slow phase is `validateApiKey`, which does an `App.findOne({ packageName })`. It was around 9.9 ms in the sampled prod incident logs, while the confirmed incident slow phase was `broadcastAppState -> refreshInstalledApps`. Keep watching it, but do not widen this PR unless debug/staging shows it becoming the new bottleneck.

--- a/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
@@ -410,3 +410,71 @@ Interpretation:
 - The new code removes the confirmed `refreshInstalledApps()` amplification during reconnect.
 - The new code also avoids the app-specific settings read and `addRunningApp()` write once the app has already attached once.
 - The remaining synthetic slow phase is `validateApiKey`, which does an `App.findOne({ packageName })`. It was around 9.9 ms in the sampled prod incident logs, while the confirmed incident slow phase was `broadcastAppState -> refreshInstalledApps`. Keep watching it, but do not widen this PR unless debug/staging shows it becoming the new bottleneck.
+
+## Cloud-Debug Validation
+
+Date: May 11, 2026.
+
+PR branch `codex/issue-107-reconnect-storm` was deployed to `cloud-debug` using the manual `Deploy cloud-debug` GitHub workflow.
+
+Deployed image:
+
+```text
+p15081loccentralussub83c25aaff6.azurecr.io/cloud-debug:94236545dc53b88dad06b97b16d42b46a97a22f3
+```
+
+The rollout initially created the new pod but left it pending because the 5 CPU request could not fit while the old debug pod was still running. Cloud-debug had 0 active sessions, so the old pod was deleted to free the slot. The new pod then became ready with 0 restarts.
+
+Post-deploy health:
+
+```text
+status: ok
+activeSessions: 0
+eventLoopLagMs: about 1 ms
+rssMB: about 234 MB
+```
+
+BetterStack hot-tier logs showed `system-vitals` from `cloud-debug` after deployment and no `event-loop-delay` warnings:
+
+```text
+22:20 UTC: vitals=2, event_loop_delay=0, max_event_loop_delay_ms=19.3
+22:21 UTC: vitals=2, event_loop_delay=0, max_event_loop_delay_ms=24.0
+22:22 UTC: vitals=2, event_loop_delay=0, max_event_loop_delay_ms=40.6
+```
+
+The storm harness was also run inside the deployed cloud-debug container to verify the exact Porter image/runtime:
+
+```bash
+porter kubectl --cluster 4689 -- exec -n default cloud-debug-cloud-7bbf467cdf-2jc2q -- bash -lc '
+  cd /app &&
+  bun run tools/ws-storm-local/mentra-path-storm-harness.ts \
+    --connect-mode=init \
+    --users=56 \
+    --apps-per-user=1 \
+    --rounds=2 \
+    --subscription-updates=0 \
+    --user-db-sync-ms=20 \
+    --app-db-sync-ms=5 \
+    --reconnect-delay-ms=100 \
+    --broadcast-settle-ms=300 \
+    --label=issue-107-cloud-debug-in-pod-sync-pressure
+'
+```
+
+Result:
+
+```text
+round 1 max heartbeat gap: 1326 ms
+round 1 heartbeat gaps over 1s: 1
+round 2 max heartbeat gap: 232 ms
+round 2 heartbeat gaps over 1s: 0
+round 2 installed-app User.findOne lookups: 0
+round 2 installed-app App.find queries: 0
+```
+
+Interpretation:
+
+- The deployed cloud-debug image contains the cheap reconnect fix.
+- The image-level harness result matches local validation.
+- `/health` stayed responsive during and after the in-pod harness run.
+- This is still not a full live remote reconnect-storm test, because cloud-debug had no active user sessions and no real miniapp traffic at the time. A true remote test needs active debug sessions plus valid miniapp connections, or a purpose-built debug-only synthetic session endpoint/harness.

--- a/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
+++ b/cloud/issues/107-reconnect-storm-thundering-herd/spike.md
@@ -1,0 +1,337 @@
+# Issue 107 Spike: Reconnect Storm Thundering-Herd Crash
+
+## Summary
+
+On May 11, 2026, the us-central production cloud pod restarted after a broad WebSocket disconnect and reconnect storm. The restart was not caused by memory growth. The container was killed by Kubernetes after health checks timed out.
+
+The failure mode is best described as:
+
+> WebSocket reconnect storm with thundering-herd amplification.
+
+A large number of client and miniapp WebSockets disappeared at almost the same time. Clients and miniapps then reconnected in a tight burst. Each reconnect triggered repeated app initialization work, including database-backed installed-app refreshes and app-state broadcasts. That work appears to have overwhelmed the cloud process long enough that `/health` and `/livez` stopped responding, causing Kubernetes to restart the container.
+
+The important fix is not fancy storm-mode logic first. The reconnect path should stop doing nonessential work all the time.
+
+## Incident Timeline
+
+All times are May 11, 2026.
+
+| Time | Event |
+| --- | --- |
+| 10:27 PM PDT, May 10 / 05:27 UTC | BetterStack host-memory alerts fired across many AKS nodes. |
+| 04:53 AM PDT / 11:53 UTC | Host-memory alerts resolved together. |
+| 10:46:02 AM PDT / 17:46:02 UTC | Last normal pre-crash `system-vitals` log from us-central prod. RSS about 401 MB, active sessions about 74. |
+| 10:46:10 AM PDT / 17:46:10 UTC | 62 glasses/client WebSockets closed with code 1006 in one second. 49 app WebSockets also closed with code 1006 in the same window. |
+| 10:46:11-10:46:13 AM PDT / 17:46:11-17:46:13 UTC | 72 slow app-connect diagnostics emitted across 29 users and 11 packages. |
+| 10:46:15-10:46:16 AM PDT / 17:46:15-17:46:16 UTC | 29 users reconnected, all after code 1006 closes, with downtime around 5.5-6.3 seconds. |
+| 10:47:06 AM PDT / 17:47:06 UTC | BetterStack uptime incident started: `prod.augmentos.cloud/health` timeout. |
+| 10:47:41 AM PDT / 17:47:41 UTC | Kubernetes killed and restarted the container in place. |
+| 10:48:13 AM PDT / 17:48:13 UTC | New container emitted post-restart `system-vitals`. |
+| 10:51:36 AM PDT / 17:51:36 UTC | BetterStack uptime incident resolved. |
+
+## What We Confirmed
+
+### This was not a Cloud memory leak
+
+Kubernetes showed the previous container state as:
+
+```text
+Last State: Terminated
+Reason: Error
+Exit Code: 137
+Started: Sun, 10 May 2026 10:29:58 -0700
+Finished: Mon, 11 May 2026 10:47:41 -0700
+```
+
+The pod events showed repeated readiness and liveness probe timeouts before the kill:
+
+```text
+Readiness probe failed: /health context deadline exceeded
+Liveness probe failed: /livez context deadline exceeded
+Container cloud-prod-cloud failed liveness probe, will be restarted
+```
+
+The container was not marked `OOMKilled`. RSS before the stall was roughly 400 MB, far below the 4096 MB container limit.
+
+### This was a same-pod container restart, not pod rescheduling
+
+The pod name stayed the same:
+
+```text
+cloud-prod-cloud-97cd59c8f-tz6cv
+```
+
+Only the container restarted. That means this was not a node eviction or a pod replacement.
+
+### The host-memory BetterStack emails were a separate infrastructure alert
+
+The host-memory emails started around 05:27 UTC and resolved around 11:53 UTC. They affected many AKS nodes at nearly the same time. The old node from the email, `aks-u4689eahyt4-84412711-vmss00001h`, was no longer in the cluster when checked.
+
+Those alerts are worth tracking as AKS/Porter infrastructure noise, but they were not the direct cause of the 17:47 UTC prod restart.
+
+### Both Cloud-to-client and Cloud-to-miniapp sockets were affected
+
+At 17:46:10 UTC:
+
+| Socket type | Count | Distinct users | Distinct packages | Close code |
+| --- | ---: | ---: | ---: | --- |
+| Glasses/client WebSockets | 62 | 62 | N/A | 1006 |
+| App WebSockets | 47-49 | 31-34 depending on log field | 12-14 | 1006 |
+
+Code 1006 means the socket disappeared without a normal close frame. That points to a network-shaped or transport-shaped interruption, not a clean application shutdown.
+
+Affected app packages included:
+
+- `com.mentra.captions`
+- `com.mentra.ai`
+- `cloud.augmentos.notify`
+- `com.mentra.notes`
+- `com.mentra.merge`
+- `com.mentra.streamer`
+- `com.mentra.translation`
+- `com.kai.glasses`
+- `com.youfeng.dashboard`
+- `com.youfeng.g2-orchestrator`
+- `napa-xccelerator-prod`
+
+### The reconnect work was expensive
+
+After the socket drop, the new diagnostics showed 72 slow app-connect logs across 29 users and 11 packages.
+
+The raw slow-connect logs showed this shape:
+
+```json
+{
+  "feature": "slow-app-connect",
+  "mode": "connection_init",
+  "durationMs": 119.7,
+  "packageName": "com.mentra.captions",
+  "phaseTimings": {
+    "attachAppSocket": 12.7,
+    "broadcastAppState": 97.1,
+    "validateApiKey": 9.9
+  },
+  "slowPhases": ["broadcastAppState"]
+}
+```
+
+And:
+
+```json
+{
+  "feature": "slow-app-connect",
+  "mode": "broadcast_app_state",
+  "durationMs": 111.4,
+  "phaseTimings": {
+    "refreshInstalledApps": 111.3,
+    "snapshotForClient": 0
+  },
+  "slowPhases": ["refreshInstalledApps"]
+}
+```
+
+This says the hot path is:
+
+```text
+connection_init -> broadcastAppState -> refreshInstalledApps
+```
+
+## Relevant Code Path
+
+In `cloud/packages/cloud/src/services/session/AppManager.ts`, `broadcastAppState()` always calls `refreshInstalledApps()`:
+
+```ts
+async broadcastAppState(): Promise<AppStateChange | null> {
+  await this.refreshInstalledApps();
+  const clientSessionData = await this.userSession.snapshotForClient();
+  ...
+  this.userSession.websocket.send(JSON.stringify(appStateChange));
+}
+```
+
+`refreshInstalledApps()` calls:
+
+```ts
+const installedAppsList = await appService.getAllApps(this.userSession.userId);
+```
+
+In `cloud/packages/cloud/src/services/core/app.service.ts`, `getAllApps(userId)` does:
+
+```ts
+const user = await User.findOne({ email: userId });
+const _appstoreApps = await App.find({ packageName: { $in: _installedApps } });
+```
+
+So reconnect can perform database-backed installed-app refreshes even when the installed app list has no reason to be stale.
+
+## Working Hypothesis
+
+The crash is not caused by the socket drops alone. The crash is caused by the server work triggered after the drops.
+
+The sequence appears to be:
+
+1. A network-shaped event causes many client and app WebSockets to close with code 1006.
+2. Clients and apps reconnect almost together.
+3. Reconnect runs too much per-user and per-app initialization work.
+4. `connection_init` calls `broadcastAppState`.
+5. `broadcastAppState` refreshes installed apps from Mongo.
+6. Many reconnects do this at once.
+7. The event loop stops responding to `/health` and `/livez`.
+8. Kubernetes kills the container after repeated liveness failures.
+
+## Why This Is a Thundering Herd
+
+This is a thundering herd because many clients wake up from the same event and perform the same expensive work at the same time.
+
+In this case, the herd is:
+
+- app and glasses WebSockets reconnecting together
+- each reconnect doing state refresh and broadcast work
+- DB reads and session updates multiplying across users and apps
+
+The fix is to make reconnect cheap and idempotent.
+
+## What We Should Not Do First
+
+Do not start with a complicated special-case "storm mode" as the primary fix.
+
+Storm mode may still be useful as a safety net, but the first-order problem is that normal reconnect does unnecessary work. If work is not needed on a normal reconnect, it should not run during any reconnect.
+
+## Open Questions
+
+1. What caused the initial 1006 socket drop?
+   - Public Cloudflare/Azure status did not show a matching obvious incident.
+   - The close pattern still looks network-shaped or transport-shaped.
+
+2. How many previous prod restarts show the same pattern?
+   - Back-test prior incidents for `1006` close burst followed by slow `connection_init` / `broadcastAppState` / `refreshInstalledApps`.
+
+3. Is `user.addRunningApp(packageName)` also a meaningful contributor?
+   - `attachAppSocket()` calls it after ACK.
+   - It may be unnecessary or backgroundable if the app is already running.
+
+4. Is `validateApiKey` ever slow enough to matter during storms?
+   - In the sampled raw logs it was smaller than `broadcastAppState`, but should stay in diagnostics.
+
+5. Are app WebSocket reconnects and glasses reconnects triggered by the same upstream event?
+   - Both closed with 1006 in the same second.
+   - That strongly suggests common transport or pod-facing network disruption, but does not prove where.
+
+## Evidence Queries
+
+### Per-second storm shape
+
+```sql
+SELECT toStartOfSecond(dt) AS second,
+  count() AS rows,
+  countIf(JSONExtractString(raw,'feature')='ws-close') AS ws_close,
+  countIf(JSONExtractString(raw,'feature')='ws-reconnect') AS ws_reconnect,
+  countIf(JSONExtractString(raw,'feature')='app-ws-close') AS app_ws_close,
+  countIf(JSONExtractString(raw,'feature')='slow-app-connect') AS slow_app_connect,
+  countIf(JSONExtractString(raw,'feature')='slow-app-message') AS slow_app_message,
+  uniqExact(JSONExtractString(raw,'userId')) AS users
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND dt >= '2026-05-11 17:45:30'
+  AND dt <= '2026-05-11 17:47:00'
+  AND JSONExtractString(raw,'server') = 'cloud-prod'
+  AND JSONExtractString(raw,'region') = 'us-central'
+GROUP BY second
+ORDER BY second;
+```
+
+### App WebSocket close package breakdown
+
+```sql
+SELECT JSONExtractString(raw,'packageName') AS packageName,
+  JSONExtractInt(raw,'code') AS code,
+  JSONExtractString(raw,'inferredCloseSource') AS inferred,
+  count() AS closes,
+  uniqExact(JSONExtractString(raw,'userId')) AS users
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND dt >= '2026-05-11 17:46:09'
+  AND dt <= '2026-05-11 17:46:12'
+  AND JSONExtractString(raw,'server') = 'cloud-prod'
+  AND JSONExtractString(raw,'region') = 'us-central'
+  AND JSONExtractString(raw,'feature') = 'app-ws-close'
+GROUP BY packageName, code, inferred
+ORDER BY closes DESC;
+```
+
+### Slow app-connect breakdown
+
+```sql
+SELECT JSONExtractString(raw,'packageName') AS packageName,
+  JSONExtractString(raw,'message') AS message,
+  count() AS c,
+  round(avg(JSONExtractFloat(raw,'durationMs')),1) AS avg_ms,
+  max(JSONExtractFloat(raw,'durationMs')) AS max_ms,
+  uniqExact(JSONExtractString(raw,'userIdHash')) AS users
+FROM s3Cluster(primary, t373499_mentracloud_prod_s3)
+WHERE _row_type = 1
+  AND dt >= '2026-05-11 17:46:08'
+  AND dt <= '2026-05-11 17:46:14'
+  AND JSONExtractString(raw,'server') = 'cloud-prod'
+  AND JSONExtractString(raw,'region') = 'us-central'
+  AND JSONExtractString(raw,'feature') IN ('slow-app-connect','slow-app-message','slow-subscription-fanout')
+GROUP BY packageName, message
+ORDER BY c DESC, max_ms DESC;
+```
+
+## Conclusion
+
+The observed crash is preventable even if the original socket drop is outside our control.
+
+We do not need to guarantee that all WebSockets stay connected forever. We need to guarantee that a reconnect storm does not make the cloud process stop answering health checks.
+
+The fix should make reconnect cheap:
+
+- no installed-app refresh on every reconnect
+- no duplicate app-state broadcast per app reconnect
+- no DB write on reconnect when state is already true
+- bounded/coalesced reconnect work
+- reconnect-path tests that prove `/livez` stays responsive under a 50-100 connection burst
+
+## Implementation Spike: Cheap Reconnect Prototype
+
+Branch: `codex/issue-107-reconnect-storm`, based on `origin/staging`.
+
+Prototype changes tried:
+
+- `AppManager.broadcastAppState()` uses cached `userSession.installedApps` by default.
+- callers can still request `broadcastAppState({ refreshInstalledApps: true })` for real app-list changes.
+- `AppManager.scheduleBroadcastAppState()` coalesces duplicate broadcasts over a short 150 ms window.
+- app `connection_init` schedules a cheap app-state broadcast instead of awaiting a DB-backed installed-app refresh inline.
+- install and uninstall routes request an explicit installed-app refresh.
+- the local Mentra-path storm harness waits for scheduled broadcasts and reports installed-app lookup counts.
+
+Local harness command:
+
+```bash
+cd cloud
+bun run tools/ws-storm-local/mentra-path-storm-harness.ts \
+  --connect-mode=init \
+  --users=56 \
+  --apps-per-user=1 \
+  --rounds=2 \
+  --subscription-updates=1 \
+  --user-db-async-ms=100 \
+  --app-db-async-ms=20 \
+  --broadcast-settle-ms=400 \
+  --label=issue-107-incident-shaped-after
+```
+
+Result:
+
+```text
+round 1: 56 reconnects, 0 installed-app User.findOne lookups, 1 App.find query, max heartbeat gap 2 ms
+round 2: 56 reconnects, 0 installed-app User.findOne lookups, 0 App.find queries, max heartbeat gap 2 ms
+```
+
+Interpretation:
+
+- The reconnect burst no longer repeats `refreshInstalledApps()` per app connection.
+- The event loop stayed responsive in the local harness.
+- The remaining dominant phase is `attachAppSocket`, mostly because it still reads the user document for legacy app-specific settings and running-app persistence. That is async DB work, not the loop-pinning installed-app refresh fanout seen in the incident logs.
+- Avoiding the legacy settings DB read may be possible later, but it is a broader behavior change and should not be mixed into this crash-prevention PR unless debug/staging still shows reconnect pressure after this fix.

--- a/cloud/packages/cloud/src/api/hono/routes/app-settings.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/app-settings.routes.ts
@@ -335,7 +335,8 @@ async function updateAppSettings(c: AppContext) {
     const user = await User.findOrCreateUser(userId);
 
     // Update the settings for this app
-    const updatedSettings = await user.updateAppSettings(appName, settingsArray);
+    await user.updateAppSettings(appName, settingsArray);
+    const updatedSettings = user.getAppSettings(appName) || settingsArray;
 
     logger.info(`Updated settings for app "${appName}" for user ${userId}`);
 
@@ -344,6 +345,8 @@ async function updateAppSettings(c: AppContext) {
 
     // If user has active sessions, send them settings updates via WebSocket
     if (userSession) {
+      userSession.appManager.updateCachedAppSettings(appName, updatedSettings);
+
       const settingsUpdate = {
         type: CloudToAppMessageType.SETTINGS_UPDATE,
         packageName: appName,

--- a/cloud/packages/cloud/src/api/hono/routes/apps.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/apps.routes.ts
@@ -363,7 +363,7 @@ async function startApp(c: AppContext) {
 
     // Broadcast state change
     try {
-      userSession.appManager.broadcastAppState();
+      userSession.appManager.scheduleBroadcastAppState();
     } catch (e) {
       logger.warn({ e }, "Failed to broadcast app state");
     }
@@ -468,7 +468,7 @@ async function installApp(c: AppContext) {
     // Broadcast state change if session exists
     if (userSession) {
       try {
-        userSession.appManager.broadcastAppState();
+        userSession.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
       } catch (e) {
         logger.warn({ e }, "Failed to broadcast app state");
       }
@@ -507,12 +507,12 @@ async function uninstallApp(c: AppContext) {
     user.installedApps = user.installedApps.filter((a: { packageName: string }) => a.packageName !== packageName);
     await user.save();
 
-    // Stop the app if running
-    // NOTE: stopApp() already calls broadcastAppState() internally,
-    // so we do NOT call it again here to avoid duplicate APP_STATE_CHANGE messages.
+    // Stop the app if running, then refresh the installed-app cache because
+    // uninstall changes the app list, not just running state.
     if (userSession) {
       try {
         await userSession.appManager.stopApp(packageName);
+        userSession.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
       } catch (e) {
         logger.warn(e, "Error stopping app during uninstall");
       }

--- a/cloud/packages/cloud/src/api/hono/routes/developer.routes.ts
+++ b/cloud/packages/cloud/src/api/hono/routes/developer.routes.ts
@@ -14,6 +14,7 @@ import { OrganizationService } from "../../../services/core/organization.service
 import { isMentraAdmin } from "../../../services/core/admin.utils";
 import App from "../../../models/app.model";
 import { appCache } from "../../../services/core/app-cache.service";
+import UserSession from "../../../services/session/UserSession";
 import type { AppEnv, AppContext } from "../../../types/hono";
 
 const logger = rootLogger.child({ service: "developer.routes" });
@@ -128,6 +129,7 @@ async function autoInstallAppForDeveloper(email: string, packageName: string): P
         installedDate: new Date(),
       });
       await user.save();
+      UserSession.getById(email)?.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
       logger.info({ email, packageName }, "Auto-installed app for developer");
     }
   } catch (error) {

--- a/cloud/packages/cloud/src/api/hono/store/store.apps.api.ts
+++ b/cloud/packages/cloud/src/api/hono/store/store.apps.api.ts
@@ -338,6 +338,9 @@ async function installApp(c: AppContext) {
       return c.json({ success: true, message: "App already installed" });
     }
 
+    const userSession = UserSession.getById(email);
+    userSession?.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
+
     return c.json({ success: true, message: "App installed successfully" });
   } catch (e: unknown) {
     const error = e as Error;
@@ -392,6 +395,7 @@ async function uninstallApp(c: AppContext) {
 
     // Uninstall app using service
     await storeService.uninstallAppForUser(user, packageName);
+    userSession?.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
 
     return c.json({ success: true, message: "App uninstalled successfully" });
   } catch (e: unknown) {

--- a/cloud/packages/cloud/src/services/console/console.apps.service.ts
+++ b/cloud/packages/cloud/src/services/console/console.apps.service.ts
@@ -7,6 +7,7 @@ import { isMentraAdmin } from "../core/admin.utils";
 import { slackService } from "../notifications/slack.service";
 import { logger as rootLogger } from "../logging/pino-logger";
 import { appCache } from "../core/app-cache.service";
+import UserSession from "../session/UserSession";
 const logger = rootLogger.child({ service: "console.apps.service" });
 
 const DEFAULT_MICROPHONE_PERMISSION = {
@@ -28,6 +29,7 @@ async function autoInstallAppForDeveloper(packageName: string, user: UserI): Pro
     }
     user.installedApps.push({ packageName, installedDate: new Date() });
     await user.save();
+    UserSession.getById(user.email)?.appManager.scheduleBroadcastAppState({ refreshInstalledApps: true });
     logger.info({ packageName, email: user.email }, "Auto-installed app for developer");
   } catch (error) {
     logger.error({ error, packageName, email: user.email }, "Error auto-installing app for developer");

--- a/cloud/packages/cloud/src/services/session/AppManager.ts
+++ b/cloud/packages/cloud/src/services/session/AppManager.ts
@@ -15,6 +15,7 @@ import {
   AppConnectionInit,
   AppStateChange,
   AppI,
+  AppSetting,
   WebhookRequestType,
   SessionWebhookRequest,
   AppType,
@@ -148,6 +149,7 @@ export class AppManager {
 
   private appStateBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
   private pendingAppStateRefresh = false;
+  private appSettingsByPackage = new Map<string, AppSetting[]>();
 
   // Cache of installed apps
   // private installedApps: AppI[] = [];
@@ -1622,6 +1624,14 @@ export class AppManager {
     timer.unref?.();
   }
 
+  updateCachedAppSettings(packageName: string, settings: AppSetting[] | undefined): void {
+    if (settings) {
+      this.appSettingsByPackage.set(packageName, settings);
+    } else {
+      this.appSettingsByPackage.delete(packageName);
+    }
+  }
+
   /**
    * Refresh the installed apps list
    */
@@ -1886,12 +1896,22 @@ export class AppManager {
       phaseTimer.measureSync("setSdkVersion", () => connectedAppSession.setSdkVersion(options.sdkVersion));
     }
 
+    const wasExpectedRunning =
+      connectedAppSession.isRunning || connectedAppSession.isInGracePeriod || connectedAppSession.isDormant;
+
     phaseTimer.measureSync("handleConnect", () => connectedAppSession.handleConnect(ws));
     const sessionId = connectedAppSession.sessionId;
 
     const app = this.userSession.installedApps.get(packageName);
-    const user = await phaseTimer.measure("findOrCreateUser", () => User.findOrCreateUser(this.userSession.userId));
-    const userSettings = user.getAppSettings(packageName) || app?.settings || [];
+    let userSettings = this.appSettingsByPackage.get(packageName);
+    let user: Awaited<ReturnType<typeof User.findOrCreateUser>> | null = null;
+
+    if (!userSettings || !wasExpectedRunning) {
+      user = await phaseTimer.measure("findOrCreateUser", () => User.findOrCreateUser(this.userSession.userId));
+      userSettings = user.getAppSettings(packageName) || app?.settings || [];
+      this.appSettingsByPackage.set(packageName, userSettings);
+    }
+
     const mentraosSettings = phaseTimer.measureSync("buildMentraosSettings", () =>
       this.userSession.userSettingsManager.buildMentraosSettings(),
     );
@@ -1920,17 +1940,22 @@ export class AppManager {
       phaseTimer.measureSync("deliverActiveStreamState", () => this.deliverActiveStreamState(packageName, ws));
     }
 
-    try {
-      await phaseTimer.measure("addRunningApp", () => user.addRunningApp(packageName));
-    } catch (error) {
-      this.logger.error(
-        error,
-        `Error updating user's running apps for ${this.userSession.userId} for app ${packageName}`,
-      );
-      this.logger.debug({ packageName, userId: this.userSession.userId }, "Failed to update user's running apps");
-    } finally {
-      cascadeDiagnostics.addTimer("appConnect_attachAppSocket", phaseTimer.durationMs);
+    if (!wasExpectedRunning) {
+      try {
+        await phaseTimer.measure("addRunningApp", async () => {
+          const userForUpdate = user ?? (await User.findOrCreateUser(this.userSession.userId));
+          await userForUpdate.addRunningApp(packageName);
+        });
+      } catch (error) {
+        this.logger.error(
+          error,
+          `Error updating user's running apps for ${this.userSession.userId} for app ${packageName}`,
+        );
+        this.logger.debug({ packageName, userId: this.userSession.userId }, "Failed to update user's running apps");
+      }
     }
+
+    cascadeDiagnostics.addTimer("appConnect_attachAppSocket", phaseTimer.durationMs);
   }
 
   private async attachDeferredConnection(

--- a/cloud/packages/cloud/src/services/session/AppManager.ts
+++ b/cloud/packages/cloud/src/services/session/AppManager.ts
@@ -100,6 +100,10 @@ interface AppAttachOptions {
   sdkVersion?: string;
 }
 
+interface BroadcastAppStateOptions {
+  refreshInstalledApps?: boolean;
+}
+
 // ── Hot-path allocation reduction ──────────────────────────────────────────────
 // Pre-allocated, frozen result objects for sendMessageToApp to avoid per-call
 // heap allocations on the hot path.  Reduces GC pressure / heap fragmentation
@@ -141,6 +145,9 @@ export class AppManager {
 
   // Track pending app start operations
   private pendingConnections = new Map<string, PendingConnection>();
+
+  private appStateBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingAppStateRefresh = false;
 
   // Cache of installed apps
   // private installedApps: AppI[] = [];
@@ -532,7 +539,7 @@ export class AppManager {
 
     // Broadcast updated app state to mobile
     if (resurrected.length > 0) {
-      await this.broadcastAppState();
+      this.scheduleBroadcastAppState();
     }
 
     return resurrected;
@@ -1145,7 +1152,7 @@ export class AppManager {
       }
 
       // Broadcast app state change
-      await this.broadcastAppState();
+      this.scheduleBroadcastAppState();
 
       // Close WebSocket connection via AppSession
       if (appSession) {
@@ -1497,8 +1504,8 @@ export class AppManager {
         timestamp: new Date().toISOString(),
       });
 
-      // Broadcast app state change
-      await phaseTimer.measure("broadcastAppState", () => this.broadcastAppState());
+      // Reconnect/init should reattach the socket, not refresh installed apps.
+      phaseTimer.measureSync("scheduleBroadcastAppState", () => this.scheduleBroadcastAppState());
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(
@@ -1544,12 +1551,14 @@ export class AppManager {
   /**
    * Broadcast app state to connected clients
    */
-  async broadcastAppState(): Promise<AppStateChange | null> {
+  async broadcastAppState(options: BroadcastAppStateOptions = {}): Promise<AppStateChange | null> {
     this.logger.debug({ function: "broadcastAppState" }, `Broadcasting app state for user ${this.userSession.userId}`);
     const phaseTimer = createPhaseTimer();
     try {
-      // Refresh installed apps
-      await phaseTimer.measure("refreshInstalledApps", () => this.refreshInstalledApps());
+      const shouldRefreshInstalledApps = options.refreshInstalledApps || this.userSession.installedApps.size === 0;
+      if (shouldRefreshInstalledApps) {
+        await phaseTimer.measure("refreshInstalledApps", () => this.refreshInstalledApps());
+      }
 
       // Transform session for client
       const clientSessionData = await phaseTimer.measure("snapshotForClient", () =>
@@ -1588,6 +1597,29 @@ export class AppManager {
         phaseTimings: phaseTimer.timings,
       });
     }
+  }
+
+  scheduleBroadcastAppState(options: BroadcastAppStateOptions = {}): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.pendingAppStateRefresh = this.pendingAppStateRefresh || Boolean(options.refreshInstalledApps);
+    if (this.appStateBroadcastTimer) {
+      return;
+    }
+
+    this.appStateBroadcastTimer = setTimeout(() => {
+      this.appStateBroadcastTimer = null;
+      const refreshInstalledApps = this.pendingAppStateRefresh;
+      this.pendingAppStateRefresh = false;
+
+      this.broadcastAppState({ refreshInstalledApps }).catch((error) => {
+        this.logger.error(error, `Error in scheduled app state broadcast for ${this.userSession.userId}`);
+      });
+    }, 150);
+    const timer = this.appStateBroadcastTimer as ReturnType<typeof setTimeout> & { unref?: () => void };
+    timer.unref?.();
   }
 
   /**
@@ -2129,6 +2161,12 @@ export class AppManager {
         });
       }
       this.pendingConnections.clear();
+
+      if (this.appStateBroadcastTimer) {
+        clearTimeout(this.appStateBroadcastTimer);
+        this.appStateBroadcastTimer = null;
+      }
+      this.pendingAppStateRefresh = false;
 
       // Track app_stop events for all running apps during disposal (using AppSession)
       const currentTime = Date.now();

--- a/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
+++ b/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
@@ -9,6 +9,7 @@ interface HarnessArgs {
   appsPerUser: number;
   rounds: number;
   reconnectDelayMs: number;
+  broadcastSettleMs: number;
   roundPauseMs: number;
   subscriptionUpdates: number;
   userDbAsyncMs: number;
@@ -67,6 +68,7 @@ const args: HarnessArgs = {
   appsPerUser: numberArg("apps-per-user", 1),
   rounds: numberArg("rounds", 5),
   reconnectDelayMs: numberArg("reconnect-delay-ms", 1000),
+  broadcastSettleMs: numberArg("broadcast-settle-ms", 300),
   roundPauseMs: numberArg("round-pause-ms", 250),
   subscriptionUpdates: numberArg("subscription-updates", 1),
   userDbAsyncMs: numberArg("user-db-async-ms", 0),
@@ -138,6 +140,8 @@ for (let round = 1; round <= args.rounds; round++) {
   const startCloseCount = getStat("close").count;
   const startReconnectCount = getStat("reconnect").count;
   const startSubscriptionCount = getStat("subscription").count;
+  const startUserFindOneCount = getStat("user.findOne").count;
+  const startAppFindCount = getStat("app.find").count;
 
   await timed("round", async () => {
     await Promise.all(
@@ -156,6 +160,8 @@ for (let round = 1; round <= args.rounds; round++) {
       }),
     );
 
+    await sleep(args.broadcastSettleMs);
+
     for (let i = 0; i < args.subscriptionUpdates; i++) {
       await Promise.all(
         appRefs.map((ref) =>
@@ -172,9 +178,11 @@ for (let round = 1; round <= args.rounds; round++) {
       closeOps: getStat("close").count - startCloseCount,
       reconnectOps: getStat("reconnect").count - startReconnectCount,
       subscriptionOps: getStat("subscription").count - startSubscriptionCount,
+      installedAppUserLookups: getStat("user.findOne").count - startUserFindOneCount,
+      installedAppQueries: getStat("app.find").count - startAppFindCount,
       maxHeartbeatGapMs: Math.round(metrics.maxHeartbeatGapMs),
       heartbeatGapsOver1s: metrics.heartbeatGapsOver1s,
-      stats: snapshotStats(["round", "close", "reconnect", "subscription"]),
+      stats: snapshotStats(["round", "close", "reconnect", "subscription", "user.findOne", "app.find"]),
     }),
   );
 

--- a/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
+++ b/cloud/tools/ws-storm-local/mentra-path-storm-harness.ts
@@ -115,11 +115,13 @@ const { WebSocketReadyState } = await import("../../packages/cloud/src/services/
 
 const silentLogger = makeSilentLogger();
 let lastHeartbeat = performance.now();
+let currentRoundMaxHeartbeatGapMs = 0;
 
 const heartbeat = setInterval(() => {
   const now = performance.now();
   const gap = now - lastHeartbeat - 100;
   if (gap > metrics.maxHeartbeatGapMs) metrics.maxHeartbeatGapMs = gap;
+  if (gap > currentRoundMaxHeartbeatGapMs) currentRoundMaxHeartbeatGapMs = gap;
   if (gap > 1000) metrics.heartbeatGapsOver1s++;
   lastHeartbeat = now;
 }, 100);
@@ -142,6 +144,8 @@ for (let round = 1; round <= args.rounds; round++) {
   const startSubscriptionCount = getStat("subscription").count;
   const startUserFindOneCount = getStat("user.findOne").count;
   const startAppFindCount = getStat("app.find").count;
+  const startHeartbeatGapsOver1s = metrics.heartbeatGapsOver1s;
+  currentRoundMaxHeartbeatGapMs = 0;
 
   await timed("round", async () => {
     await Promise.all(
@@ -180,6 +184,8 @@ for (let round = 1; round <= args.rounds; round++) {
       subscriptionOps: getStat("subscription").count - startSubscriptionCount,
       installedAppUserLookups: getStat("user.findOne").count - startUserFindOneCount,
       installedAppQueries: getStat("app.find").count - startAppFindCount,
+      roundMaxHeartbeatGapMs: Math.round(currentRoundMaxHeartbeatGapMs),
+      roundHeartbeatGapsOver1s: metrics.heartbeatGapsOver1s - startHeartbeatGapsOver1s,
       maxHeartbeatGapMs: Math.round(metrics.maxHeartbeatGapMs),
       heartbeatGapsOver1s: metrics.heartbeatGapsOver1s,
       stats: snapshotStats(["round", "close", "reconnect", "subscription", "user.findOne", "app.find"]),


### PR DESCRIPTION
## Summary
This PR targets the May 11 us-central crash pattern where many client and miniapp WebSockets disconnected, then reconnected together. The logs showed reconnect/init work repeatedly refreshing installed apps from the database through `broadcastAppState -> refreshInstalledApps`, which made recovery more expensive exactly when the pod was under pressure.

The fix makes reconnect cheaper: app reconnect now reattaches the socket and schedules a cached app-state broadcast instead of doing a DB-backed installed-app refresh inline. Installed-app refreshes still happen when the app list can actually change, such as install and uninstall. Duplicate app-state broadcasts for one user are coalesced over a short window.

## Docs
- Spike: `cloud/issues/107-reconnect-storm-thundering-herd/spike.md`
- Spec: `cloud/issues/107-reconnect-storm-thundering-herd/spec.md`
- Design: `cloud/issues/107-reconnect-storm-thundering-herd/design.md`

## Local test evidence
- `cd cloud/packages/cloud && bun run build` passed
- Local storm harness with 56 users, 2 reconnect rounds, artificial DB delay:
  - round 1: 56 reconnects, 0 installed-app `User.findOne` lookups, 1 `App.find` query, max heartbeat gap 2 ms
  - round 2: 56 reconnects, 0 installed-app `User.findOne` lookups, 0 `App.find` queries, max heartbeat gap 2 ms

Command used:
```bash
cd cloud
bun run tools/ws-storm-local/mentra-path-storm-harness.ts \
  --connect-mode=init \
  --users=56 \
  --apps-per-user=1 \
  --rounds=2 \
  --subscription-updates=1 \
  --user-db-async-ms=100 \
  --app-db-async-ms=20 \
  --broadcast-settle-ms=400 \
  --label=issue-107-incident-shaped-after
```

## Note
`bun run lint` is currently blocked in this checkout because `eslint-config-prettier` is missing from the installed dependencies. TypeScript build passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make app reconnects cheap to stop reconnect storms from triggering DB work and stalling the pod. Reconnect now schedules a cached app-state broadcast, reuses cached per-app settings, skips redundant DB writes/reads, and only refreshes installed apps on real list changes; validated on `cloud-debug`.

- **Bug Fixes**
  - Stopped default DB refresh in `broadcastAppState`; added `broadcastAppState({ refreshInstalledApps })` with a fallback if the cache is empty.
  - Added `scheduleBroadcastAppState()` to coalesce per-user broadcasts (~150ms); merges refresh requests, uses `unref()`, and clears timers on dispose.
  - Updated app `connection_init` to call `scheduleBroadcastAppState()` instead of awaiting `broadcastAppState()`.
  - Routes: `startApp` uses the scheduler; `installApp`/`uninstallApp` schedule `scheduleBroadcastAppState({ refreshInstalledApps: true })` (uninstall schedules after `stopApp()`); dev-console auto-install and store install/uninstall paths now also schedule a refresh-backed broadcast for live sessions.
  - Reconnect attach: reuse cached per-app settings (updated via `updateCachedAppSettings` on settings save); avoid re-reading settings on reconnect when cached; skip `addRunningApp()` when the app was already running/dormant/in grace period.
  - Local storm harness and docs: added `--broadcast-settle-ms`, per-round heartbeat metrics, installed-app lookup counters, and spike/spec/design docs; deployed to and validated on `cloud-debug` (round 2 max heartbeat gap ~232ms, zero installed-app refreshes on reconnect; health checks stayed responsive). 
  - CI: included `codex/issue-107-reconnect-storm` in the `porter-debug` workflow to enable easy `cloud-debug` deployments for validation.

<sup>Written for commit aaf6bc010bd470e587cd592cdf7828983ce1ca35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Cloud-debug validation plan

I am deploying this PR to `cloud-debug` before staging. The goal is to prove the fix in the real Porter/Bun/container environment, not only in the local harness.

Plan:
1. Capture current `cloud-debug` health as the before baseline.
2. Deploy this PR branch to `cloud-debug` using the manual `Deploy cloud-debug` workflow.
3. Confirm the new pod is healthy and running commit `94236545d`.
4. Run the same reconnect-storm style validation against debug where practical, then compare logs for `slow-app-connect`, `broadcast_app_state`, `refreshInstalledApps`, event-loop delay, `/health`, and `/livez` responsiveness.

Current caveat: true before/after on the same remote environment requires either testing the currently deployed old debug build before deployment or intentionally redeploying staging to debug first. Since debug currently has 0 active sessions, I am treating the pre-deploy health/log snapshot as baseline and the synthetic/local staging harness as the stronger old-code reproduction.
