### PR TITLE
Add typed Bluetooth SDK status models

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -9,11 +9,11 @@ class CoreModule : Module() {
     private val sdkListener =
             object : MentraBluetoothSdkListener {
                 override fun onGlassesStatusChanged(status: MentraGlassesStatusUpdate) {
-                    sendEvent("glasses_status", status.values)
+                    sendEvent("glasses_status", status.toMap())
                 }
 
                 override fun onBluetoothStatusChanged(status: MentraBluetoothStatusUpdate) {
-                    sendEvent("core_status", status.values)
+                    sendEvent("core_status", status.toMap())
                 }
 
                 override fun onScanStopped(reason: MentraScanStopReason) {
@@ -165,10 +165,10 @@ class CoreModule : Module() {
 
         // MARK: - Observable Store Functions
 
-        Function("getGlassesStatus") { sdk?.getGlassesStatus()?.values ?: GlassesStore.store.getCategory("glasses") }
+        Function("getGlassesStatus") { sdk?.getGlassesStatus()?.toMap() ?: GlassesStore.store.getCategory("glasses") }
 
         Function("getCoreStatus") {
-            sdk?.getBluetoothStatus()?.values ?: GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY)
+            sdk?.getBluetoothStatus()?.toMap() ?: GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY)
         }
 
         Function("getDefaultDevice") { sdk?.getDefaultDevice()?.toMap() }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -341,11 +341,12 @@ public class Bridge private constructor() {
         /** Send WiFi status change */
         @JvmStatic
         fun sendWifiStatusChange(connected: Boolean, ssid: String?, localIp: String?) {
-            val event = HashMap<String, Any?>()
-            event["connected"] = connected
-            event["ssid"] = ssid
-            event["local_ip"] = localIp
-            sendTypedMessage("wifi_status_change", event as Map<String, Any>)
+            val status = MentraWifiStatus(
+                connected = connected,
+                ssid = ssid.orEmpty(),
+                localIp = localIp.orEmpty(),
+            )
+            sendTypedMessage("wifi_status_change", status.toMap())
         }
 
         /** Send WiFi scan results */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
@@ -370,12 +370,42 @@ data class MentraBatteryStatusEvent(
     val values: Map<String, Any>,
 )
 
-data class MentraWifiStatusEvent(
-    val values: Map<String, Any>,
+data class MentraWifiStatus(
+    val connected: Boolean,
+    val ssid: String,
+    val localIp: String,
 ) {
-    val connected: Boolean? get() = boolValue(values, "connected")
-    val ssid: String? get() = stringValue(values, "ssid", "wifiSsid")
-    val localIp: String? get() = stringValue(values, "local_ip", "localIp", "wifiLocalIp")
+    fun toMap(): Map<String, Any> =
+        mapOf(
+            "connected" to connected,
+            "ssid" to ssid,
+            "localIp" to localIp,
+        )
+
+    fun toEventMap(): Map<String, Any> =
+        toMap() + mapOf("type" to "wifi_status_change")
+
+    companion object {
+        @JvmStatic
+        fun fromMap(values: Map<String, Any>): MentraWifiStatus =
+            MentraWifiStatus(
+                connected = boolValue(values, "connected") ?: boolValue(values, "wifiConnected") ?: false,
+                ssid = stringValue(values, "ssid", "wifiSsid") ?: "",
+                localIp = stringValue(values, "localIp", "local_ip", "wifiLocalIp") ?: "",
+            )
+    }
+}
+
+data class MentraWifiStatusEvent(
+    val status: MentraWifiStatus,
+) {
+    constructor(values: Map<String, Any>) : this(MentraWifiStatus.fromMap(values))
+    constructor(connected: Boolean, ssid: String, localIp: String) : this(MentraWifiStatus(connected, ssid, localIp))
+
+    val connected: Boolean get() = status.connected
+    val ssid: String get() = status.ssid
+    val localIp: String get() = status.localIp
+    val values: Map<String, Any> get() = status.toEventMap()
 }
 
 data class MentraHotspotStatusEvent(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
@@ -38,21 +38,622 @@ data class MentraPairedDevice(
     val address: String? = null,
 )
 
+data class MentraDeviceSearchResult(
+    val deviceModel: String,
+    val deviceName: String,
+    val deviceAddress: String = "",
+) {
+    internal fun toMap(): Map<String, Any> =
+        mapOf(
+            "deviceModel" to deviceModel,
+            "deviceName" to deviceName,
+            "deviceAddress" to deviceAddress,
+        )
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraDeviceSearchResult =
+            MentraDeviceSearchResult(
+                deviceModel = stringValue(values, "deviceModel", "device_model") ?: "",
+                deviceName = stringValue(values, "deviceName", "device_name") ?: "",
+                deviceAddress = stringValue(values, "deviceAddress", "device_address") ?: "",
+            )
+    }
+}
+
+data class MentraWifiScanResult(
+    val ssid: String,
+    val requiresPassword: Boolean,
+    val signalStrength: Int,
+    val frequency: Int? = null,
+) {
+    internal fun toMap(): Map<String, Any> {
+        val map =
+            mutableMapOf<String, Any>(
+                "ssid" to ssid,
+                "requiresPassword" to requiresPassword,
+                "signalStrength" to signalStrength,
+            )
+        frequency?.let { map["frequency"] = it }
+        return map
+    }
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraWifiScanResult =
+            MentraWifiScanResult(
+                ssid = stringValue(values, "ssid") ?: "",
+                requiresPassword =
+                    boolValue(values, "requiresPassword", "requires_password", "auth_required") ?: false,
+                signalStrength = numberValue(values, "signalStrength", "signal_strength", "rssi") ?: -1,
+                frequency = numberValue(values, "frequency"),
+            )
+    }
+}
+
 data class MentraGlassesStatus(
-    val values: Map<String, Any>,
-)
+    val fullyBooted: Boolean,
+    val connected: Boolean,
+    val micEnabled: Boolean,
+    val connectionState: String,
+    val btcConnected: Boolean,
+    val signalStrength: Int,
+    val deviceModel: String,
+    val androidVersion: String,
+    val firmwareVersion: String,
+    val besFirmwareVersion: String,
+    val mtkFirmwareVersion: String,
+    val btMacAddress: String,
+    val leftMacAddress: String,
+    val rightMacAddress: String,
+    val macAddress: String,
+    val buildNumber: String,
+    val otaVersionUrl: String,
+    val appVersion: String,
+    val bluetoothName: String,
+    val serialNumber: String,
+    val style: String,
+    val color: String,
+    val wifi: MentraWifiStatus,
+    val batteryLevel: Int,
+    val charging: Boolean,
+    val caseBatteryLevel: Int,
+    val caseCharging: Boolean,
+    val caseOpen: Boolean,
+    val caseRemoved: Boolean,
+    val hotspotEnabled: Boolean,
+    val hotspotSsid: String,
+    val hotspotPassword: String,
+    val hotspotGatewayIp: String,
+    val headUp: Boolean,
+    val controllerConnected: Boolean,
+    val controllerFullyBooted: Boolean,
+    val controllerMacAddress: String,
+    val controllerBatteryLevel: Int,
+    val controllerSignalStrength: Int,
+    val ringSignalStrength: Int,
+) {
+    internal fun toMap(): Map<String, Any> =
+        mapOf(
+            "fullyBooted" to fullyBooted,
+            "connected" to connected,
+            "micEnabled" to micEnabled,
+            "connectionState" to connectionState,
+            "btcConnected" to btcConnected,
+            "signalStrength" to signalStrength,
+            "deviceModel" to deviceModel,
+            "androidVersion" to androidVersion,
+            "fwVersion" to firmwareVersion,
+            "besFwVersion" to besFirmwareVersion,
+            "mtkFwVersion" to mtkFirmwareVersion,
+            "btMacAddress" to btMacAddress,
+            "leftMacAddress" to leftMacAddress,
+            "rightMacAddress" to rightMacAddress,
+            "macAddress" to macAddress,
+            "buildNumber" to buildNumber,
+            "otaVersionUrl" to otaVersionUrl,
+            "appVersion" to appVersion,
+            "bluetoothName" to bluetoothName,
+            "serialNumber" to serialNumber,
+            "style" to style,
+            "color" to color,
+            "wifiConnected" to wifi.connected,
+            "wifiSsid" to wifi.ssid,
+            "wifiLocalIp" to wifi.localIp,
+            "batteryLevel" to batteryLevel,
+            "charging" to charging,
+            "caseBatteryLevel" to caseBatteryLevel,
+            "caseCharging" to caseCharging,
+            "caseOpen" to caseOpen,
+            "caseRemoved" to caseRemoved,
+            "hotspotEnabled" to hotspotEnabled,
+            "hotspotSsid" to hotspotSsid,
+            "hotspotPassword" to hotspotPassword,
+            "hotspotGatewayIp" to hotspotGatewayIp,
+            "headUp" to headUp,
+            "controllerConnected" to controllerConnected,
+            "controllerFullyBooted" to controllerFullyBooted,
+            "controllerMacAddress" to controllerMacAddress,
+            "controllerBatteryLevel" to controllerBatteryLevel,
+            "controllerSignalStrength" to controllerSignalStrength,
+            "ringSignalStrength" to ringSignalStrength,
+        )
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraGlassesStatus =
+            MentraGlassesStatus(
+                fullyBooted = boolValue(values, "fullyBooted") ?: false,
+                connected = boolValue(values, "connected") ?: false,
+                micEnabled = boolValue(values, "micEnabled") ?: false,
+                connectionState = stringValue(values, "connectionState") ?: "disconnected",
+                btcConnected = boolValue(values, "btcConnected") ?: false,
+                signalStrength = numberValue(values, "signalStrength") ?: -1,
+                deviceModel = stringValue(values, "deviceModel") ?: "",
+                androidVersion = stringValue(values, "androidVersion") ?: "",
+                firmwareVersion = stringValue(values, "firmwareVersion", "fwVersion") ?: "",
+                besFirmwareVersion = stringValue(values, "besFwVersion", "besFirmwareVersion") ?: "",
+                mtkFirmwareVersion = stringValue(values, "mtkFwVersion", "mtkFirmwareVersion") ?: "",
+                btMacAddress = stringValue(values, "btMacAddress") ?: "",
+                leftMacAddress = stringValue(values, "leftMacAddress") ?: "",
+                rightMacAddress = stringValue(values, "rightMacAddress") ?: "",
+                macAddress = stringValue(values, "macAddress") ?: "",
+                buildNumber = stringValue(values, "buildNumber") ?: "",
+                otaVersionUrl = stringValue(values, "otaVersionUrl") ?: "",
+                appVersion = stringValue(values, "appVersion") ?: "",
+                bluetoothName = stringValue(values, "bluetoothName") ?: "",
+                serialNumber = stringValue(values, "serialNumber") ?: "",
+                style = stringValue(values, "style") ?: "",
+                color = stringValue(values, "color") ?: "",
+                wifi = MentraWifiStatus.fromMap(values),
+                batteryLevel = numberValue(values, "batteryLevel") ?: -1,
+                charging = boolValue(values, "charging") ?: false,
+                caseBatteryLevel = numberValue(values, "caseBatteryLevel") ?: -1,
+                caseCharging = boolValue(values, "caseCharging") ?: false,
+                caseOpen = boolValue(values, "caseOpen") ?: true,
+                caseRemoved = boolValue(values, "caseRemoved") ?: true,
+                hotspotEnabled = boolValue(values, "hotspotEnabled") ?: false,
+                hotspotSsid = stringValue(values, "hotspotSsid") ?: "",
+                hotspotPassword = stringValue(values, "hotspotPassword") ?: "",
+                hotspotGatewayIp = stringValue(values, "hotspotGatewayIp", "hotspotLocalIp") ?: "",
+                headUp = boolValue(values, "headUp") ?: false,
+                controllerConnected = boolValue(values, "controllerConnected") ?: false,
+                controllerFullyBooted = boolValue(values, "controllerFullyBooted") ?: false,
+                controllerMacAddress = stringValue(values, "controllerMacAddress") ?: "",
+                controllerBatteryLevel = numberValue(values, "controllerBatteryLevel") ?: -1,
+                controllerSignalStrength = numberValue(values, "controllerSignalStrength") ?: -1,
+                ringSignalStrength = numberValue(values, "ringSignalStrength") ?: -1,
+            )
+    }
+}
 
 data class MentraBluetoothStatus(
-    val values: Map<String, Any>,
-)
+    val searching: Boolean,
+    val searchingController: Boolean,
+    val systemMicUnavailable: Boolean,
+    val micEnabled: Boolean,
+    val currentMic: String,
+    val micRanking: List<String>,
+    val searchResults: List<MentraDeviceSearchResult>,
+    val wifiScanResults: List<MentraWifiScanResult>,
+    val lastLog: List<String>,
+    val otherBtConnected: Boolean,
+    val defaultWearable: String,
+    val pendingWearable: String,
+    val deviceName: String,
+    val deviceAddress: String,
+    val defaultController: String,
+    val pendingController: String,
+    val controllerDeviceName: String,
+    val screenDisabled: Boolean,
+    val preferredMic: String,
+    val sensingEnabled: Boolean,
+    val powerSavingMode: Boolean,
+    val brightness: Int,
+    val autoBrightness: Boolean,
+    val dashboardHeight: Int,
+    val dashboardDepth: Int,
+    val headUpAngle: Int,
+    val contextualDashboard: Boolean,
+    val galleryModeAuto: Boolean,
+    val buttonPhotoSize: MentraButtonPhotoSize,
+    val buttonCameraLed: Boolean,
+    val buttonMaxRecordingTime: Int,
+    val buttonVideoWidth: Int,
+    val buttonVideoHeight: Int,
+    val buttonVideoFps: Int,
+    val shouldSendPcm: Boolean,
+    val shouldSendLc3: Boolean,
+    val shouldSendTranscript: Boolean,
+    val bypassVad: Boolean,
+    val offlineCaptionsRunning: Boolean,
+    val localSttFallbackActive: Boolean,
+    val shouldSendBootingMessage: Boolean,
+) {
+    val defaultDevice: MentraPairedDevice?
+        get() =
+            defaultWearable.takeIf { it.isNotBlank() }?.let {
+                MentraPairedDevice(
+                    model = MentraDeviceModel.fromDeviceType(it),
+                    name = deviceName,
+                    address = deviceAddress.takeIf(String::isNotBlank),
+                )
+            }
+
+    internal fun toMap(): Map<String, Any> =
+        mapOf(
+            "searching" to searching,
+            "searchingController" to searchingController,
+            "systemMicUnavailable" to systemMicUnavailable,
+            "micEnabled" to micEnabled,
+            "currentMic" to currentMic,
+            "micRanking" to micRanking,
+            "searchResults" to searchResults.map { it.toMap() },
+            "wifiScanResults" to wifiScanResults.map { it.toMap() },
+            "lastLog" to lastLog,
+            "otherBtConnected" to otherBtConnected,
+            "default_wearable" to defaultWearable,
+            "pending_wearable" to pendingWearable,
+            "device_name" to deviceName,
+            "device_address" to deviceAddress,
+            "default_controller" to defaultController,
+            "pending_controller" to pendingController,
+            "controller_device_name" to controllerDeviceName,
+            "screen_disabled" to screenDisabled,
+            "preferred_mic" to preferredMic,
+            "sensing_enabled" to sensingEnabled,
+            "power_saving_mode" to powerSavingMode,
+            "brightness" to brightness,
+            "auto_brightness" to autoBrightness,
+            "dashboard_height" to dashboardHeight,
+            "dashboard_depth" to dashboardDepth,
+            "head_up_angle" to headUpAngle,
+            "contextual_dashboard" to contextualDashboard,
+            "gallery_mode" to galleryModeAuto,
+            "button_photo_size" to buttonPhotoSize.value,
+            "button_camera_led" to buttonCameraLed,
+            "button_max_recording_time" to buttonMaxRecordingTime,
+            "button_video_width" to buttonVideoWidth,
+            "button_video_height" to buttonVideoHeight,
+            "button_video_fps" to buttonVideoFps,
+            "should_send_pcm" to shouldSendPcm,
+            "should_send_lc3" to shouldSendLc3,
+            "should_send_transcript" to shouldSendTranscript,
+            "bypass_vad" to bypassVad,
+            "offline_captions_running" to offlineCaptionsRunning,
+            "local_stt_fallback_active" to localSttFallbackActive,
+            "shouldSendBootingMessage" to shouldSendBootingMessage,
+        )
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraBluetoothStatus =
+            MentraBluetoothStatus(
+                searching = boolValue(values, "searching") ?: false,
+                searchingController = boolValue(values, "searchingController") ?: false,
+                systemMicUnavailable = boolValue(values, "systemMicUnavailable") ?: false,
+                micEnabled = boolValue(values, "micEnabled") ?: false,
+                currentMic = stringValue(values, "currentMic") ?: "",
+                micRanking = stringListValue(values, "micRanking"),
+                searchResults =
+                    mapListValue(values, "searchResults").map(MentraDeviceSearchResult::fromMap),
+                wifiScanResults =
+                    mapListValue(values, "wifiScanResults").map(MentraWifiScanResult::fromMap),
+                lastLog = stringListValue(values, "lastLog"),
+                otherBtConnected = boolValue(values, "otherBtConnected") ?: false,
+                defaultWearable = stringValue(values, "default_wearable") ?: "",
+                pendingWearable = stringValue(values, "pending_wearable") ?: "",
+                deviceName = stringValue(values, "device_name") ?: "",
+                deviceAddress = stringValue(values, "device_address") ?: "",
+                defaultController = stringValue(values, "default_controller") ?: "",
+                pendingController = stringValue(values, "pending_controller") ?: "",
+                controllerDeviceName = stringValue(values, "controller_device_name") ?: "",
+                screenDisabled = boolValue(values, "screen_disabled") ?: false,
+                preferredMic = stringValue(values, "preferred_mic") ?: "auto",
+                sensingEnabled = boolValue(values, "sensing_enabled") ?: true,
+                powerSavingMode = boolValue(values, "power_saving_mode") ?: false,
+                brightness = numberValue(values, "brightness") ?: 50,
+                autoBrightness = boolValue(values, "auto_brightness") ?: true,
+                dashboardHeight = numberValue(values, "dashboard_height") ?: 4,
+                dashboardDepth = numberValue(values, "dashboard_depth") ?: 2,
+                headUpAngle = numberValue(values, "head_up_angle") ?: 30,
+                contextualDashboard = boolValue(values, "contextual_dashboard") ?: true,
+                galleryModeAuto = boolValue(values, "gallery_mode") ?: false,
+                buttonPhotoSize = MentraButtonPhotoSize.fromValue(stringValue(values, "button_photo_size")),
+                buttonCameraLed = boolValue(values, "button_camera_led") ?: true,
+                buttonMaxRecordingTime = numberValue(values, "button_max_recording_time") ?: 10,
+                buttonVideoWidth = numberValue(values, "button_video_width") ?: 1280,
+                buttonVideoHeight = numberValue(values, "button_video_height") ?: 720,
+                buttonVideoFps = numberValue(values, "button_video_fps") ?: 30,
+                shouldSendPcm = boolValue(values, "should_send_pcm") ?: false,
+                shouldSendLc3 = boolValue(values, "should_send_lc3") ?: false,
+                shouldSendTranscript = boolValue(values, "should_send_transcript") ?: false,
+                bypassVad = boolValue(values, "bypass_vad") ?: false,
+                offlineCaptionsRunning = boolValue(values, "offline_captions_running") ?: false,
+                localSttFallbackActive = boolValue(values, "local_stt_fallback_active") ?: false,
+                shouldSendBootingMessage = boolValue(values, "shouldSendBootingMessage") ?: true,
+            )
+    }
+}
 
 data class MentraGlassesStatusUpdate(
-    val values: Map<String, Any>,
-)
+    val fullyBooted: Boolean? = null,
+    val connected: Boolean? = null,
+    val micEnabled: Boolean? = null,
+    val connectionState: String? = null,
+    val btcConnected: Boolean? = null,
+    val signalStrength: Int? = null,
+    val deviceModel: String? = null,
+    val androidVersion: String? = null,
+    val firmwareVersion: String? = null,
+    val besFirmwareVersion: String? = null,
+    val mtkFirmwareVersion: String? = null,
+    val btMacAddress: String? = null,
+    val leftMacAddress: String? = null,
+    val rightMacAddress: String? = null,
+    val macAddress: String? = null,
+    val buildNumber: String? = null,
+    val otaVersionUrl: String? = null,
+    val appVersion: String? = null,
+    val bluetoothName: String? = null,
+    val serialNumber: String? = null,
+    val style: String? = null,
+    val color: String? = null,
+    val wifi: MentraWifiStatus? = null,
+    val batteryLevel: Int? = null,
+    val charging: Boolean? = null,
+    val caseBatteryLevel: Int? = null,
+    val caseCharging: Boolean? = null,
+    val caseOpen: Boolean? = null,
+    val caseRemoved: Boolean? = null,
+    val hotspotEnabled: Boolean? = null,
+    val hotspotSsid: String? = null,
+    val hotspotPassword: String? = null,
+    val hotspotGatewayIp: String? = null,
+    val headUp: Boolean? = null,
+    val controllerConnected: Boolean? = null,
+    val controllerFullyBooted: Boolean? = null,
+    val controllerMacAddress: String? = null,
+    val controllerBatteryLevel: Int? = null,
+    val controllerSignalStrength: Int? = null,
+    val ringSignalStrength: Int? = null,
+) {
+    internal fun toMap(): Map<String, Any> =
+        buildMap {
+            putIfNotNull("fullyBooted", fullyBooted)
+            putIfNotNull("connected", connected)
+            putIfNotNull("micEnabled", micEnabled)
+            putIfNotNull("connectionState", connectionState)
+            putIfNotNull("btcConnected", btcConnected)
+            putIfNotNull("signalStrength", signalStrength)
+            putIfNotNull("deviceModel", deviceModel)
+            putIfNotNull("androidVersion", androidVersion)
+            putIfNotNull("fwVersion", firmwareVersion)
+            putIfNotNull("besFwVersion", besFirmwareVersion)
+            putIfNotNull("mtkFwVersion", mtkFirmwareVersion)
+            putIfNotNull("btMacAddress", btMacAddress)
+            putIfNotNull("leftMacAddress", leftMacAddress)
+            putIfNotNull("rightMacAddress", rightMacAddress)
+            putIfNotNull("macAddress", macAddress)
+            putIfNotNull("buildNumber", buildNumber)
+            putIfNotNull("otaVersionUrl", otaVersionUrl)
+            putIfNotNull("appVersion", appVersion)
+            putIfNotNull("bluetoothName", bluetoothName)
+            putIfNotNull("serialNumber", serialNumber)
+            putIfNotNull("style", style)
+            putIfNotNull("color", color)
+            wifi?.let {
+                put("wifiConnected", it.connected)
+                put("wifiSsid", it.ssid)
+                put("wifiLocalIp", it.localIp)
+            }
+            putIfNotNull("batteryLevel", batteryLevel)
+            putIfNotNull("charging", charging)
+            putIfNotNull("caseBatteryLevel", caseBatteryLevel)
+            putIfNotNull("caseCharging", caseCharging)
+            putIfNotNull("caseOpen", caseOpen)
+            putIfNotNull("caseRemoved", caseRemoved)
+            putIfNotNull("hotspotEnabled", hotspotEnabled)
+            putIfNotNull("hotspotSsid", hotspotSsid)
+            putIfNotNull("hotspotPassword", hotspotPassword)
+            putIfNotNull("hotspotGatewayIp", hotspotGatewayIp)
+            putIfNotNull("headUp", headUp)
+            putIfNotNull("controllerConnected", controllerConnected)
+            putIfNotNull("controllerFullyBooted", controllerFullyBooted)
+            putIfNotNull("controllerMacAddress", controllerMacAddress)
+            putIfNotNull("controllerBatteryLevel", controllerBatteryLevel)
+            putIfNotNull("controllerSignalStrength", controllerSignalStrength)
+            putIfNotNull("ringSignalStrength", ringSignalStrength)
+        }
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraGlassesStatusUpdate =
+            MentraGlassesStatusUpdate(
+                fullyBooted = optionalBoolValue(values, "fullyBooted"),
+                connected = optionalBoolValue(values, "connected"),
+                micEnabled = optionalBoolValue(values, "micEnabled"),
+                connectionState = optionalStringValue(values, "connectionState"),
+                btcConnected = optionalBoolValue(values, "btcConnected"),
+                signalStrength = optionalNumberValue(values, "signalStrength"),
+                deviceModel = optionalStringValue(values, "deviceModel"),
+                androidVersion = optionalStringValue(values, "androidVersion"),
+                firmwareVersion = optionalStringValue(values, "firmwareVersion", "fwVersion"),
+                besFirmwareVersion = optionalStringValue(values, "besFwVersion", "besFirmwareVersion"),
+                mtkFirmwareVersion = optionalStringValue(values, "mtkFwVersion", "mtkFirmwareVersion"),
+                btMacAddress = optionalStringValue(values, "btMacAddress"),
+                leftMacAddress = optionalStringValue(values, "leftMacAddress"),
+                rightMacAddress = optionalStringValue(values, "rightMacAddress"),
+                macAddress = optionalStringValue(values, "macAddress"),
+                buildNumber = optionalStringValue(values, "buildNumber"),
+                otaVersionUrl = optionalStringValue(values, "otaVersionUrl"),
+                appVersion = optionalStringValue(values, "appVersion"),
+                bluetoothName = optionalStringValue(values, "bluetoothName"),
+                serialNumber = optionalStringValue(values, "serialNumber"),
+                style = optionalStringValue(values, "style"),
+                color = optionalStringValue(values, "color"),
+                wifi =
+                    if (hasAnyKey(values, "wifiConnected", "wifiSsid", "wifiLocalIp")) {
+                        MentraWifiStatus.fromMap(values)
+                    } else {
+                        null
+                    },
+                batteryLevel = optionalNumberValue(values, "batteryLevel"),
+                charging = optionalBoolValue(values, "charging"),
+                caseBatteryLevel = optionalNumberValue(values, "caseBatteryLevel"),
+                caseCharging = optionalBoolValue(values, "caseCharging"),
+                caseOpen = optionalBoolValue(values, "caseOpen"),
+                caseRemoved = optionalBoolValue(values, "caseRemoved"),
+                hotspotEnabled = optionalBoolValue(values, "hotspotEnabled"),
+                hotspotSsid = optionalStringValue(values, "hotspotSsid"),
+                hotspotPassword = optionalStringValue(values, "hotspotPassword"),
+                hotspotGatewayIp = optionalStringValue(values, "hotspotGatewayIp", "hotspotLocalIp"),
+                headUp = optionalBoolValue(values, "headUp"),
+                controllerConnected = optionalBoolValue(values, "controllerConnected"),
+                controllerFullyBooted = optionalBoolValue(values, "controllerFullyBooted"),
+                controllerMacAddress = optionalStringValue(values, "controllerMacAddress"),
+                controllerBatteryLevel = optionalNumberValue(values, "controllerBatteryLevel"),
+                controllerSignalStrength = optionalNumberValue(values, "controllerSignalStrength"),
+                ringSignalStrength = optionalNumberValue(values, "ringSignalStrength"),
+            )
+    }
+}
 
 data class MentraBluetoothStatusUpdate(
-    val values: Map<String, Any>,
-)
+    val searching: Boolean? = null,
+    val searchingController: Boolean? = null,
+    val systemMicUnavailable: Boolean? = null,
+    val micEnabled: Boolean? = null,
+    val currentMic: String? = null,
+    val micRanking: List<String>? = null,
+    val searchResults: List<MentraDeviceSearchResult>? = null,
+    val wifiScanResults: List<MentraWifiScanResult>? = null,
+    val lastLog: List<String>? = null,
+    val otherBtConnected: Boolean? = null,
+    val defaultWearable: String? = null,
+    val pendingWearable: String? = null,
+    val deviceName: String? = null,
+    val deviceAddress: String? = null,
+    val defaultController: String? = null,
+    val pendingController: String? = null,
+    val controllerDeviceName: String? = null,
+    val screenDisabled: Boolean? = null,
+    val preferredMic: String? = null,
+    val sensingEnabled: Boolean? = null,
+    val powerSavingMode: Boolean? = null,
+    val brightness: Int? = null,
+    val autoBrightness: Boolean? = null,
+    val dashboardHeight: Int? = null,
+    val dashboardDepth: Int? = null,
+    val headUpAngle: Int? = null,
+    val contextualDashboard: Boolean? = null,
+    val galleryModeAuto: Boolean? = null,
+    val buttonPhotoSize: MentraButtonPhotoSize? = null,
+    val buttonCameraLed: Boolean? = null,
+    val buttonMaxRecordingTime: Int? = null,
+    val buttonVideoWidth: Int? = null,
+    val buttonVideoHeight: Int? = null,
+    val buttonVideoFps: Int? = null,
+    val shouldSendPcm: Boolean? = null,
+    val shouldSendLc3: Boolean? = null,
+    val shouldSendTranscript: Boolean? = null,
+    val bypassVad: Boolean? = null,
+    val offlineCaptionsRunning: Boolean? = null,
+    val localSttFallbackActive: Boolean? = null,
+    val shouldSendBootingMessage: Boolean? = null,
+) {
+    internal fun toMap(): Map<String, Any> =
+        buildMap {
+            putIfNotNull("searching", searching)
+            putIfNotNull("searchingController", searchingController)
+            putIfNotNull("systemMicUnavailable", systemMicUnavailable)
+            putIfNotNull("micEnabled", micEnabled)
+            putIfNotNull("currentMic", currentMic)
+            putIfNotNull("micRanking", micRanking)
+            searchResults?.let { put("searchResults", it.map(MentraDeviceSearchResult::toMap)) }
+            wifiScanResults?.let { put("wifiScanResults", it.map(MentraWifiScanResult::toMap)) }
+            putIfNotNull("lastLog", lastLog)
+            putIfNotNull("otherBtConnected", otherBtConnected)
+            putIfNotNull("default_wearable", defaultWearable)
+            putIfNotNull("pending_wearable", pendingWearable)
+            putIfNotNull("device_name", deviceName)
+            putIfNotNull("device_address", deviceAddress)
+            putIfNotNull("default_controller", defaultController)
+            putIfNotNull("pending_controller", pendingController)
+            putIfNotNull("controller_device_name", controllerDeviceName)
+            putIfNotNull("screen_disabled", screenDisabled)
+            putIfNotNull("preferred_mic", preferredMic)
+            putIfNotNull("sensing_enabled", sensingEnabled)
+            putIfNotNull("power_saving_mode", powerSavingMode)
+            putIfNotNull("brightness", brightness)
+            putIfNotNull("auto_brightness", autoBrightness)
+            putIfNotNull("dashboard_height", dashboardHeight)
+            putIfNotNull("dashboard_depth", dashboardDepth)
+            putIfNotNull("head_up_angle", headUpAngle)
+            putIfNotNull("contextual_dashboard", contextualDashboard)
+            putIfNotNull("gallery_mode", galleryModeAuto)
+            buttonPhotoSize?.let { put("button_photo_size", it.value) }
+            putIfNotNull("button_camera_led", buttonCameraLed)
+            putIfNotNull("button_max_recording_time", buttonMaxRecordingTime)
+            putIfNotNull("button_video_width", buttonVideoWidth)
+            putIfNotNull("button_video_height", buttonVideoHeight)
+            putIfNotNull("button_video_fps", buttonVideoFps)
+            putIfNotNull("should_send_pcm", shouldSendPcm)
+            putIfNotNull("should_send_lc3", shouldSendLc3)
+            putIfNotNull("should_send_transcript", shouldSendTranscript)
+            putIfNotNull("bypass_vad", bypassVad)
+            putIfNotNull("offline_captions_running", offlineCaptionsRunning)
+            putIfNotNull("local_stt_fallback_active", localSttFallbackActive)
+            putIfNotNull("shouldSendBootingMessage", shouldSendBootingMessage)
+        }
+
+    companion object {
+        internal fun fromMap(values: Map<String, Any>): MentraBluetoothStatusUpdate =
+            MentraBluetoothStatusUpdate(
+                searching = optionalBoolValue(values, "searching"),
+                searchingController = optionalBoolValue(values, "searchingController"),
+                systemMicUnavailable = optionalBoolValue(values, "systemMicUnavailable"),
+                micEnabled = optionalBoolValue(values, "micEnabled"),
+                currentMic = optionalStringValue(values, "currentMic"),
+                micRanking = optionalStringListValue(values, "micRanking"),
+                searchResults =
+                    optionalMapListValue(values, "searchResults")
+                        ?.map(MentraDeviceSearchResult::fromMap),
+                wifiScanResults =
+                    optionalMapListValue(values, "wifiScanResults")
+                        ?.map(MentraWifiScanResult::fromMap),
+                lastLog = optionalStringListValue(values, "lastLog"),
+                otherBtConnected = optionalBoolValue(values, "otherBtConnected"),
+                defaultWearable = optionalStringValue(values, "default_wearable"),
+                pendingWearable = optionalStringValue(values, "pending_wearable"),
+                deviceName = optionalStringValue(values, "device_name"),
+                deviceAddress = optionalStringValue(values, "device_address"),
+                defaultController = optionalStringValue(values, "default_controller"),
+                pendingController = optionalStringValue(values, "pending_controller"),
+                controllerDeviceName = optionalStringValue(values, "controller_device_name"),
+                screenDisabled = optionalBoolValue(values, "screen_disabled"),
+                preferredMic = optionalStringValue(values, "preferred_mic"),
+                sensingEnabled = optionalBoolValue(values, "sensing_enabled"),
+                powerSavingMode = optionalBoolValue(values, "power_saving_mode"),
+                brightness = optionalNumberValue(values, "brightness"),
+                autoBrightness = optionalBoolValue(values, "auto_brightness"),
+                dashboardHeight = optionalNumberValue(values, "dashboard_height"),
+                dashboardDepth = optionalNumberValue(values, "dashboard_depth"),
+                headUpAngle = optionalNumberValue(values, "head_up_angle"),
+                contextualDashboard = optionalBoolValue(values, "contextual_dashboard"),
+                galleryModeAuto = optionalBoolValue(values, "gallery_mode"),
+                buttonPhotoSize =
+                    optionalStringValue(values, "button_photo_size")?.let(MentraButtonPhotoSize::fromValue),
+                buttonCameraLed = optionalBoolValue(values, "button_camera_led"),
+                buttonMaxRecordingTime = optionalNumberValue(values, "button_max_recording_time"),
+                buttonVideoWidth = optionalNumberValue(values, "button_video_width"),
+                buttonVideoHeight = optionalNumberValue(values, "button_video_height"),
+                buttonVideoFps = optionalNumberValue(values, "button_video_fps"),
+                shouldSendPcm = optionalBoolValue(values, "should_send_pcm"),
+                shouldSendLc3 = optionalBoolValue(values, "should_send_lc3"),
+                shouldSendTranscript = optionalBoolValue(values, "should_send_transcript"),
+                bypassVad = optionalBoolValue(values, "bypass_vad"),
+                offlineCaptionsRunning = optionalBoolValue(values, "offline_captions_running"),
+                localSttFallbackActive = optionalBoolValue(values, "local_stt_fallback_active"),
+                shouldSendBootingMessage = optionalBoolValue(values, "shouldSendBootingMessage"),
+            )
+    }
+}
 
 data class MentraDisplayTextRequest(
     val text: String,
@@ -524,6 +1125,14 @@ private fun numberValue(
     compactKey: String,
 ): Int? = ((values[fullKey] ?: values[compactKey]) as? Number)?.toInt()
 
+private fun numberValue(
+    values: Map<String, Any>,
+    vararg keys: String,
+): Int? =
+    keys.firstNotNullOfOrNull { key ->
+        (values[key] as? Number)?.toInt()
+    }
+
 private fun stringValue(
     values: Map<String, Any>,
     vararg keys: String,
@@ -534,10 +1143,95 @@ private fun stringValue(
 
 private fun boolValue(
     values: Map<String, Any>,
-    key: String,
-): Boolean? = values[key] as? Boolean
+    vararg keys: String,
+): Boolean? =
+    keys.firstNotNullOfOrNull { key ->
+        values[key] as? Boolean
+    }
 
 private fun longValue(
     values: Map<String, Any>,
     key: String,
 ): Long? = (values[key] as? Number)?.toLong()
+
+private fun hasAnyKey(
+    values: Map<String, Any>,
+    vararg keys: String,
+): Boolean = keys.any(values::containsKey)
+
+private fun optionalNumberValue(
+    values: Map<String, Any>,
+    vararg keys: String,
+): Int? =
+    if (hasAnyKey(values, *keys)) {
+        numberValue(values, *keys)
+    } else {
+        null
+    }
+
+private fun optionalStringValue(
+    values: Map<String, Any>,
+    vararg keys: String,
+): String? =
+    if (hasAnyKey(values, *keys)) {
+        stringValue(values, *keys) ?: ""
+    } else {
+        null
+    }
+
+private fun optionalBoolValue(
+    values: Map<String, Any>,
+    vararg keys: String,
+): Boolean? =
+    if (hasAnyKey(values, *keys)) {
+        boolValue(values, *keys) ?: false
+    } else {
+        null
+    }
+
+private fun stringListValue(
+    values: Map<String, Any>,
+    key: String,
+): List<String> = (values[key] as? List<*>)?.mapNotNull { it as? String } ?: emptyList()
+
+private fun optionalStringListValue(
+    values: Map<String, Any>,
+    key: String,
+): List<String>? =
+    if (values.containsKey(key)) {
+        stringListValue(values, key)
+    } else {
+        null
+    }
+
+private fun mapListValue(
+    values: Map<String, Any>,
+    key: String,
+): List<Map<String, Any>> =
+    (values[key] as? List<*>)?.mapNotNull(::stringMapValue) ?: emptyList()
+
+private fun optionalMapListValue(
+    values: Map<String, Any>,
+    key: String,
+): List<Map<String, Any>>? =
+    if (values.containsKey(key)) {
+        mapListValue(values, key)
+    } else {
+        null
+    }
+
+private fun stringMapValue(value: Any?): Map<String, Any>? =
+    (value as? Map<*, *>)?.entries?.mapNotNull { (key, mapValue) ->
+        val stringKey = key as? String ?: return@mapNotNull null
+        val nonNullValue = mapValue ?: return@mapNotNull null
+        stringKey to nonNullValue
+    }?.toMap()
+
+private fun MutableMap<String, Any>.putIfNotNull(
+    key: String,
+    value: Any?,
+) {
+    if (value != null) {
+        put(key, value)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -55,10 +55,10 @@ class MentraBluetoothSdk private constructor(
     }
 
     fun getGlassesStatus(): MentraGlassesStatus =
-        MentraGlassesStatus(GlassesStore.store.getCategory("glasses"))
+        MentraGlassesStatus.fromMap(GlassesStore.store.getCategory("glasses"))
 
     fun getBluetoothStatus(): MentraBluetoothStatus =
-        MentraBluetoothStatus(GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY))
+        MentraBluetoothStatus.fromMap(GlassesStore.store.getCategory(ObservableStore.CORE_CATEGORY))
 
     fun getDefaultDevice(): MentraPairedDevice? = currentDefaultDevice()
 
@@ -331,11 +331,11 @@ class MentraBluetoothSdk private constructor(
         when (ObservableStore.normalizeCategory(category)) {
             "glasses" ->
                 dispatchToListeners {
-                    it.onGlassesStatusChanged(MentraGlassesStatusUpdate(changes))
+                    it.onGlassesStatusChanged(MentraGlassesStatusUpdate.fromMap(changes))
                 }
             ObservableStore.CORE_CATEGORY -> {
                 dispatchToListeners {
-                    it.onBluetoothStatusChanged(MentraBluetoothStatusUpdate(changes))
+                    it.onBluetoothStatusChanged(MentraBluetoothStatusUpdate.fromMap(changes))
                 }
                 if (!suppressDefaultDeviceEvents && changes.keys.any { it in DEFAULT_DEVICE_KEYS }) {
                     dispatchDefaultDeviceChanged()

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -538,6 +538,8 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
             )
         case let .touch(touch):
             sendEvent("touch_event", touch.values)
+        case let .wifiStatus(status):
+            sendEvent("wifi_status_change", status.values)
         case let .hotspotStatus(status):
             sendEvent("hotspot_status_change", status.values)
         case let .hotspotError(error):

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -230,12 +230,12 @@ class Bridge {
     }
 
     static func sendWifiStatusChange(connected: Bool, ssid: String?, localIp: String?) {
-        let event: [String: Any] = [
-            "connected": connected,
-            "ssid": ssid,
-            "local_ip": localIp,
-        ]
-        Bridge.sendTypedMessage("wifi_status_change", body: event)
+        let status = MentraWifiStatus(
+            connected: connected,
+            ssid: ssid ?? "",
+            localIp: localIp ?? ""
+        )
+        Bridge.sendTypedMessage("wifi_status_change", body: status.values)
     }
 
     static func updateWifiScanResults(_ networks: [[String: Any]]) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -620,6 +620,72 @@ public struct MentraTouchEvent: CustomStringConvertible {
     }
 }
 
+public struct MentraWifiStatus: CustomStringConvertible {
+    public let connected: Bool
+    public let ssid: String
+    public let localIp: String
+
+    public init(connected: Bool, ssid: String, localIp: String) {
+        self.connected = connected
+        self.ssid = ssid
+        self.localIp = localIp
+    }
+
+    public init(values: [String: Any]) {
+        self.connected = boolValue(values, "connected") ?? boolValue(values, "wifiConnected") ?? false
+        self.ssid = stringValue(values, "ssid", "wifiSsid") ?? ""
+        self.localIp = stringValue(values, "localIp", "local_ip", "wifiLocalIp") ?? ""
+    }
+
+    public var values: [String: Any] {
+        [
+            "connected": connected,
+            "ssid": ssid,
+            "localIp": localIp,
+        ]
+    }
+
+    public var description: String {
+        "MentraWifiStatus(connected: \(connected), ssid: \(ssid.isEmpty ? "none" : ssid), localIp: \(localIp.isEmpty ? "none" : localIp))"
+    }
+}
+
+public struct MentraWifiStatusEvent: CustomStringConvertible {
+    public let status: MentraWifiStatus
+
+    public init(status: MentraWifiStatus) {
+        self.status = status
+    }
+
+    public init(connected: Bool, ssid: String, localIp: String) {
+        self.status = MentraWifiStatus(connected: connected, ssid: ssid, localIp: localIp)
+    }
+
+    public init(values: [String: Any]) {
+        self.status = MentraWifiStatus(values: values)
+    }
+
+    public var connected: Bool {
+        status.connected
+    }
+
+    public var ssid: String {
+        status.ssid
+    }
+
+    public var localIp: String {
+        status.localIp
+    }
+
+    public var values: [String: Any] {
+        status.values.merging(["type": "wifi_status_change"]) { _, new in new }
+    }
+
+    public var description: String {
+        "MentraWifiStatusEvent(\(status))"
+    }
+}
+
 public struct MentraHotspotStatusEvent: CustomStringConvertible {
     public let values: [String: Any]
 
@@ -759,6 +825,7 @@ public struct MentraLocalTranscriptionEvent: CustomStringConvertible {
 public enum MentraBluetoothEvent: CustomStringConvertible {
     case buttonPress(MentraButtonPressEvent)
     case touch(MentraTouchEvent)
+    case wifiStatus(MentraWifiStatusEvent)
     case hotspotStatus(MentraHotspotStatusEvent)
     case hotspotError(MentraHotspotErrorEvent)
     case photoResponse(MentraPhotoResponseEvent)
@@ -771,6 +838,8 @@ public enum MentraBluetoothEvent: CustomStringConvertible {
         case let .buttonPress(event):
             event.description
         case let .touch(event):
+            event.description
+        case let .wifiStatus(event):
             event.description
         case let .hotspotStatus(event):
             event.description
@@ -1199,6 +1268,8 @@ public final class MentraBluetoothSDK {
             delegate?.mentraBluetoothSDK(self, didReceive: .localTranscription(event))
         case "hotspot_status_change":
             delegate?.mentraBluetoothSDK(self, didReceive: .hotspotStatus(MentraHotspotStatusEvent(values: data)))
+        case "wifi_status_change":
+            delegate?.mentraBluetoothSDK(self, didReceive: .wifiStatus(MentraWifiStatusEvent(values: data)))
         case "hotspot_error":
             delegate?.mentraBluetoothSDK(self, didReceive: .hotspotError(MentraHotspotErrorEvent(values: data)))
         case "photo_response":

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -8,6 +8,10 @@ private func intValue(_ value: Any?) -> Int? {
 }
 
 private func stringValue(_ values: [String: Any], _ keys: String...) -> String? {
+    stringValue(values, keys)
+}
+
+private func stringValue(_ values: [String: Any], _ keys: [String]) -> String? {
     for key in keys {
         if let value = values[key] as? String {
             return value
@@ -16,10 +20,62 @@ private func stringValue(_ values: [String: Any], _ keys: String...) -> String? 
     return nil
 }
 
-private func boolValue(_ values: [String: Any], _ key: String) -> Bool? {
-    if let value = values[key] as? Bool { return value }
-    if let value = values[key] as? NSNumber { return value.boolValue }
+private func boolValue(_ values: [String: Any], _ keys: String...) -> Bool? {
+    boolValue(values, keys)
+}
+
+private func boolValue(_ values: [String: Any], _ keys: [String]) -> Bool? {
+    for key in keys {
+        if let value = values[key] as? Bool { return value }
+        if let value = values[key] as? NSNumber { return value.boolValue }
+    }
     return nil
+}
+
+private func hasAnyKey(_ values: [String: Any], _ keys: String...) -> Bool {
+    hasAnyKey(values, keys)
+}
+
+private func hasAnyKey(_ values: [String: Any], _ keys: [String]) -> Bool {
+    keys.contains { values.keys.contains($0) }
+}
+
+private func optionalStringValue(_ values: [String: Any], _ keys: String...) -> String? {
+    hasAnyKey(values, keys) ? (stringValue(values, keys) ?? "") : nil
+}
+
+private func optionalIntValue(_ values: [String: Any], _ keys: String...) -> Int? {
+    guard hasAnyKey(values, keys) else { return nil }
+    for key in keys {
+        if let value = intValue(values[key]) { return value }
+    }
+    return nil
+}
+
+private func optionalBoolValue(_ values: [String: Any], _ keys: String...) -> Bool? {
+    hasAnyKey(values, keys) ? (boolValue(values, keys) ?? false) : nil
+}
+
+private func stringListValue(_ values: [String: Any], _ key: String) -> [String] {
+    values[key] as? [String] ?? []
+}
+
+private func optionalStringListValue(_ values: [String: Any], _ key: String) -> [String]? {
+    values.keys.contains(key) ? stringListValue(values, key) : nil
+}
+
+private func dictionaryListValue(_ values: [String: Any], _ key: String) -> [[String: Any]] {
+    values[key] as? [[String: Any]] ?? []
+}
+
+private func optionalDictionaryListValue(_ values: [String: Any], _ key: String) -> [[String: Any]]? {
+    values.keys.contains(key) ? dictionaryListValue(values, key) : nil
+}
+
+private func putIfNotNil(_ map: inout [String: Any], _ key: String, _ value: Any?) {
+    if let value {
+        map[key] = value
+    }
 }
 
 public struct MentraBluetoothSDKConfiguration {
@@ -127,12 +183,162 @@ public struct MentraPairedDevice: CustomStringConvertible {
     }
 }
 
-public struct MentraGlassesStatus: CustomStringConvertible {
-    public let values: [String: Any]
+public struct MentraDeviceSearchResult: CustomStringConvertible {
+    public let deviceModel: String
+    public let deviceName: String
+    public let deviceAddress: String
 
-    public init(values: [String: Any]) {
+    public init(deviceModel: String, deviceName: String, deviceAddress: String = "") {
+        self.deviceModel = deviceModel
+        self.deviceName = deviceName
+        self.deviceAddress = deviceAddress
+    }
+
+    init(values: [String: Any]) {
+        deviceModel = stringValue(values, "deviceModel", "device_model") ?? ""
+        deviceName = stringValue(values, "deviceName", "device_name") ?? ""
+        deviceAddress = stringValue(values, "deviceAddress", "device_address") ?? ""
+    }
+
+    var dictionary: [String: Any] {
+        [
+            "deviceModel": deviceModel,
+            "deviceName": deviceName,
+            "deviceAddress": deviceAddress,
+        ]
+    }
+
+    public var description: String {
+        "MentraDeviceSearchResult(deviceModel: \(deviceModel), deviceName: \(deviceName))"
+    }
+}
+
+public struct MentraWifiScanResult: CustomStringConvertible {
+    public let ssid: String
+    public let requiresPassword: Bool
+    public let signalStrength: Int
+    public let frequency: Int?
+
+    public init(ssid: String, requiresPassword: Bool, signalStrength: Int, frequency: Int? = nil) {
+        self.ssid = ssid
+        self.requiresPassword = requiresPassword
+        self.signalStrength = signalStrength
+        self.frequency = frequency
+    }
+
+    init(values: [String: Any]) {
+        ssid = stringValue(values, "ssid") ?? ""
+        requiresPassword = boolValue(values, "requiresPassword", "requires_password", "auth_required") ?? false
+        signalStrength = intValue(values["signalStrength"] ?? values["signal_strength"] ?? values["rssi"]) ?? -1
+        frequency = intValue(values["frequency"])
+    }
+
+    var dictionary: [String: Any] {
+        var values: [String: Any] = [
+            "ssid": ssid,
+            "requiresPassword": requiresPassword,
+            "signalStrength": signalStrength,
+        ]
+        if let frequency {
+            values["frequency"] = frequency
+        }
+        return values
+    }
+
+    public var description: String {
+        "MentraWifiScanResult(ssid: \(ssid), signalStrength: \(signalStrength))"
+    }
+}
+
+public struct MentraGlassesStatus: CustomStringConvertible {
+    let values: [String: Any]
+
+    init(values: [String: Any]) {
         self.values = values
     }
+
+    public func applying(_ update: MentraGlassesStatusUpdate) -> MentraGlassesStatus {
+        MentraGlassesStatus(values: values.merging(update.values) { _, new in new })
+    }
+
+    public func withBattery(level: Int, charging: Bool) -> MentraGlassesStatus {
+        applying(MentraGlassesStatusUpdate(values: ["batteryLevel": level, "charging": charging]))
+    }
+
+    public func withWifi(_ wifi: MentraWifiStatus) -> MentraGlassesStatus {
+        applying(MentraGlassesStatusUpdate(values: [
+            "wifiConnected": wifi.connected,
+            "wifiSsid": wifi.ssid,
+            "wifiLocalIp": wifi.localIp,
+        ]))
+    }
+
+    public func withHotspot(enabled: Bool, ssid: String, password: String, gatewayIp: String) -> MentraGlassesStatus {
+        applying(MentraGlassesStatusUpdate(values: [
+            "hotspotEnabled": enabled,
+            "hotspotSsid": ssid,
+            "hotspotPassword": password,
+            "hotspotGatewayIp": gatewayIp,
+        ]))
+    }
+
+    public func disconnected() -> MentraGlassesStatus {
+        applying(MentraGlassesStatusUpdate(values: [
+            "connected": false,
+            "connectionState": "DISCONNECTED",
+            "fullyBooted": false,
+            "batteryLevel": -1,
+            "charging": false,
+            "hotspotEnabled": false,
+            "hotspotGatewayIp": "",
+            "hotspotPassword": "",
+            "hotspotSsid": "",
+            "wifiConnected": false,
+            "wifiSsid": "",
+            "wifiLocalIp": "",
+        ]))
+    }
+
+    public var fullyBooted: Bool { boolValue(values, "fullyBooted") ?? false }
+    public var connected: Bool { boolValue(values, "connected") ?? false }
+    public var micEnabled: Bool { boolValue(values, "micEnabled") ?? false }
+    public var connectionState: String { stringValue(values, "connectionState") ?? "disconnected" }
+    public var btcConnected: Bool { boolValue(values, "btcConnected") ?? false }
+    public var signalStrength: Int { intValue(values["signalStrength"]) ?? -1 }
+    public var deviceModel: String { stringValue(values, "deviceModel") ?? "" }
+    public var androidVersion: String { stringValue(values, "androidVersion") ?? "" }
+    public var firmwareVersion: String { stringValue(values, "firmwareVersion", "fwVersion") ?? "" }
+    public var besFirmwareVersion: String { stringValue(values, "besFwVersion", "besFirmwareVersion") ?? "" }
+    public var mtkFirmwareVersion: String { stringValue(values, "mtkFwVersion", "mtkFirmwareVersion") ?? "" }
+    public var btMacAddress: String { stringValue(values, "btMacAddress") ?? "" }
+    public var leftMacAddress: String { stringValue(values, "leftMacAddress") ?? "" }
+    public var rightMacAddress: String { stringValue(values, "rightMacAddress") ?? "" }
+    public var macAddress: String { stringValue(values, "macAddress") ?? "" }
+    public var buildNumber: String { stringValue(values, "buildNumber") ?? "" }
+    public var otaVersionUrl: String { stringValue(values, "otaVersionUrl") ?? "" }
+    public var appVersion: String { stringValue(values, "appVersion") ?? "" }
+    public var bluetoothName: String { stringValue(values, "bluetoothName") ?? "" }
+    public var serialNumber: String { stringValue(values, "serialNumber") ?? "" }
+    public var style: String { stringValue(values, "style") ?? "" }
+    public var color: String { stringValue(values, "color") ?? "" }
+    public var wifi: MentraWifiStatus { MentraWifiStatus(values: values) }
+    public var batteryLevel: Int { intValue(values["batteryLevel"]) ?? -1 }
+    public var charging: Bool { boolValue(values, "charging") ?? false }
+    public var caseBatteryLevel: Int { intValue(values["caseBatteryLevel"]) ?? -1 }
+    public var caseCharging: Bool { boolValue(values, "caseCharging") ?? false }
+    public var caseOpen: Bool { boolValue(values, "caseOpen") ?? true }
+    public var caseRemoved: Bool { boolValue(values, "caseRemoved") ?? true }
+    public var hotspotEnabled: Bool { boolValue(values, "hotspotEnabled") ?? false }
+    public var hotspotSsid: String { stringValue(values, "hotspotSsid") ?? "" }
+    public var hotspotPassword: String { stringValue(values, "hotspotPassword") ?? "" }
+    public var hotspotGatewayIp: String { stringValue(values, "hotspotGatewayIp", "hotspotLocalIp") ?? "" }
+    public var headUp: Bool { boolValue(values, "headUp") ?? false }
+    public var controllerConnected: Bool { boolValue(values, "controllerConnected") ?? false }
+    public var controllerFullyBooted: Bool { boolValue(values, "controllerFullyBooted") ?? false }
+    public var controllerMacAddress: String { stringValue(values, "controllerMacAddress") ?? "" }
+    public var controllerBatteryLevel: Int { intValue(values["controllerBatteryLevel"]) ?? -1 }
+    public var controllerSignalStrength: Int { intValue(values["controllerSignalStrength"]) ?? -1 }
+    public var ringSignalStrength: Int { intValue(values["ringSignalStrength"]) ?? -1 }
 
     public var description: String {
         values.description
@@ -140,10 +346,79 @@ public struct MentraGlassesStatus: CustomStringConvertible {
 }
 
 public struct MentraBluetoothStatus: CustomStringConvertible {
-    public let values: [String: Any]
+    let values: [String: Any]
 
-    public init(values: [String: Any]) {
+    init(values: [String: Any]) {
         self.values = values
+    }
+
+    public func applying(_ update: MentraBluetoothStatusUpdate) -> MentraBluetoothStatus {
+        MentraBluetoothStatus(values: values.merging(update.values) { _, new in new })
+    }
+
+    public func withDefaultDevice(_ device: MentraPairedDevice?) -> MentraBluetoothStatus {
+        applying(MentraBluetoothStatusUpdate(values: [
+            "default_wearable": device?.model.deviceType ?? "",
+            "device_name": device?.name ?? "",
+            "device_address": device?.identifier ?? "",
+        ]))
+    }
+
+    public var searching: Bool { boolValue(values, "searching") ?? false }
+    public var searchingController: Bool { boolValue(values, "searchingController") ?? false }
+    public var systemMicUnavailable: Bool { boolValue(values, "systemMicUnavailable") ?? false }
+    public var micEnabled: Bool { boolValue(values, "micEnabled") ?? false }
+    public var currentMic: String { stringValue(values, "currentMic") ?? "" }
+    public var micRanking: [String] { stringListValue(values, "micRanking") }
+    public var searchResults: [MentraDeviceSearchResult] {
+        dictionaryListValue(values, "searchResults").map(MentraDeviceSearchResult.init(values:))
+    }
+    public var wifiScanResults: [MentraWifiScanResult] {
+        dictionaryListValue(values, "wifiScanResults").map(MentraWifiScanResult.init(values:))
+    }
+    public var lastLog: [String] { stringListValue(values, "lastLog") }
+    public var otherBtConnected: Bool { boolValue(values, "otherBtConnected") ?? false }
+    public var defaultWearable: String { stringValue(values, "default_wearable") ?? "" }
+    public var pendingWearable: String { stringValue(values, "pending_wearable") ?? "" }
+    public var deviceName: String { stringValue(values, "device_name") ?? "" }
+    public var deviceAddress: String { stringValue(values, "device_address") ?? "" }
+    public var defaultController: String { stringValue(values, "default_controller") ?? "" }
+    public var pendingController: String { stringValue(values, "pending_controller") ?? "" }
+    public var controllerDeviceName: String { stringValue(values, "controller_device_name") ?? "" }
+    public var screenDisabled: Bool { boolValue(values, "screen_disabled") ?? false }
+    public var preferredMic: String { stringValue(values, "preferred_mic") ?? "auto" }
+    public var sensingEnabled: Bool { boolValue(values, "sensing_enabled") ?? true }
+    public var powerSavingMode: Bool { boolValue(values, "power_saving_mode") ?? false }
+    public var brightness: Int { intValue(values["brightness"]) ?? 50 }
+    public var autoBrightness: Bool { boolValue(values, "auto_brightness") ?? true }
+    public var dashboardHeight: Int { intValue(values["dashboard_height"]) ?? 4 }
+    public var dashboardDepth: Int { intValue(values["dashboard_depth"]) ?? 2 }
+    public var headUpAngle: Int { intValue(values["head_up_angle"]) ?? 30 }
+    public var contextualDashboard: Bool { boolValue(values, "contextual_dashboard") ?? true }
+    public var galleryModeAuto: Bool { boolValue(values, "gallery_mode") ?? false }
+    public var buttonPhotoSize: MentraButtonPhotoSize {
+        MentraButtonPhotoSize(rawValue: stringValue(values, "button_photo_size") ?? "") ?? .medium
+    }
+    public var buttonCameraLed: Bool { boolValue(values, "button_camera_led") ?? true }
+    public var buttonMaxRecordingTime: Int { intValue(values["button_max_recording_time"]) ?? 10 }
+    public var buttonVideoWidth: Int { intValue(values["button_video_width"]) ?? 1280 }
+    public var buttonVideoHeight: Int { intValue(values["button_video_height"]) ?? 720 }
+    public var buttonVideoFps: Int { intValue(values["button_video_fps"]) ?? 30 }
+    public var shouldSendPcm: Bool { boolValue(values, "should_send_pcm") ?? false }
+    public var shouldSendLc3: Bool { boolValue(values, "should_send_lc3") ?? false }
+    public var shouldSendTranscript: Bool { boolValue(values, "should_send_transcript") ?? false }
+    public var bypassVad: Bool { boolValue(values, "bypass_vad") ?? false }
+    public var offlineCaptionsRunning: Bool { boolValue(values, "offline_captions_running") ?? false }
+    public var localSttFallbackActive: Bool { boolValue(values, "local_stt_fallback_active") ?? false }
+    public var shouldSendBootingMessage: Bool { boolValue(values, "shouldSendBootingMessage") ?? true }
+
+    public var defaultDevice: MentraPairedDevice? {
+        guard !defaultWearable.isEmpty else { return nil }
+        return MentraPairedDevice(
+            model: MentraDeviceModel.fromDeviceType(defaultWearable),
+            name: deviceName,
+            identifier: deviceAddress.isEmpty ? nil : deviceAddress
+        )
     }
 
     public var description: String {
@@ -152,11 +427,54 @@ public struct MentraBluetoothStatus: CustomStringConvertible {
 }
 
 public struct MentraGlassesStatusUpdate: CustomStringConvertible {
-    public let values: [String: Any]
+    let values: [String: Any]
 
-    public init(values: [String: Any]) {
+    init(values: [String: Any]) {
         self.values = values
     }
+
+    public var fullyBooted: Bool? { optionalBoolValue(values, "fullyBooted") }
+    public var connected: Bool? { optionalBoolValue(values, "connected") }
+    public var micEnabled: Bool? { optionalBoolValue(values, "micEnabled") }
+    public var connectionState: String? { optionalStringValue(values, "connectionState") }
+    public var btcConnected: Bool? { optionalBoolValue(values, "btcConnected") }
+    public var signalStrength: Int? { optionalIntValue(values, "signalStrength") }
+    public var deviceModel: String? { optionalStringValue(values, "deviceModel") }
+    public var androidVersion: String? { optionalStringValue(values, "androidVersion") }
+    public var firmwareVersion: String? { optionalStringValue(values, "firmwareVersion", "fwVersion") }
+    public var besFirmwareVersion: String? { optionalStringValue(values, "besFwVersion", "besFirmwareVersion") }
+    public var mtkFirmwareVersion: String? { optionalStringValue(values, "mtkFwVersion", "mtkFirmwareVersion") }
+    public var btMacAddress: String? { optionalStringValue(values, "btMacAddress") }
+    public var leftMacAddress: String? { optionalStringValue(values, "leftMacAddress") }
+    public var rightMacAddress: String? { optionalStringValue(values, "rightMacAddress") }
+    public var macAddress: String? { optionalStringValue(values, "macAddress") }
+    public var buildNumber: String? { optionalStringValue(values, "buildNumber") }
+    public var otaVersionUrl: String? { optionalStringValue(values, "otaVersionUrl") }
+    public var appVersion: String? { optionalStringValue(values, "appVersion") }
+    public var bluetoothName: String? { optionalStringValue(values, "bluetoothName") }
+    public var serialNumber: String? { optionalStringValue(values, "serialNumber") }
+    public var style: String? { optionalStringValue(values, "style") }
+    public var color: String? { optionalStringValue(values, "color") }
+    public var wifi: MentraWifiStatus? {
+        hasAnyKey(values, "wifiConnected", "wifiSsid", "wifiLocalIp") ? MentraWifiStatus(values: values) : nil
+    }
+    public var batteryLevel: Int? { optionalIntValue(values, "batteryLevel") }
+    public var charging: Bool? { optionalBoolValue(values, "charging") }
+    public var caseBatteryLevel: Int? { optionalIntValue(values, "caseBatteryLevel") }
+    public var caseCharging: Bool? { optionalBoolValue(values, "caseCharging") }
+    public var caseOpen: Bool? { optionalBoolValue(values, "caseOpen") }
+    public var caseRemoved: Bool? { optionalBoolValue(values, "caseRemoved") }
+    public var hotspotEnabled: Bool? { optionalBoolValue(values, "hotspotEnabled") }
+    public var hotspotSsid: String? { optionalStringValue(values, "hotspotSsid") }
+    public var hotspotPassword: String? { optionalStringValue(values, "hotspotPassword") }
+    public var hotspotGatewayIp: String? { optionalStringValue(values, "hotspotGatewayIp", "hotspotLocalIp") }
+    public var headUp: Bool? { optionalBoolValue(values, "headUp") }
+    public var controllerConnected: Bool? { optionalBoolValue(values, "controllerConnected") }
+    public var controllerFullyBooted: Bool? { optionalBoolValue(values, "controllerFullyBooted") }
+    public var controllerMacAddress: String? { optionalStringValue(values, "controllerMacAddress") }
+    public var controllerBatteryLevel: Int? { optionalIntValue(values, "controllerBatteryLevel") }
+    public var controllerSignalStrength: Int? { optionalIntValue(values, "controllerSignalStrength") }
+    public var ringSignalStrength: Int? { optionalIntValue(values, "ringSignalStrength") }
 
     public var description: String {
         values.description
@@ -164,11 +482,59 @@ public struct MentraGlassesStatusUpdate: CustomStringConvertible {
 }
 
 public struct MentraBluetoothStatusUpdate: CustomStringConvertible {
-    public let values: [String: Any]
+    let values: [String: Any]
 
-    public init(values: [String: Any]) {
+    init(values: [String: Any]) {
         self.values = values
     }
+
+    public var searching: Bool? { optionalBoolValue(values, "searching") }
+    public var searchingController: Bool? { optionalBoolValue(values, "searchingController") }
+    public var systemMicUnavailable: Bool? { optionalBoolValue(values, "systemMicUnavailable") }
+    public var micEnabled: Bool? { optionalBoolValue(values, "micEnabled") }
+    public var currentMic: String? { optionalStringValue(values, "currentMic") }
+    public var micRanking: [String]? { optionalStringListValue(values, "micRanking") }
+    public var searchResults: [MentraDeviceSearchResult]? {
+        optionalDictionaryListValue(values, "searchResults")?.map(MentraDeviceSearchResult.init(values:))
+    }
+    public var wifiScanResults: [MentraWifiScanResult]? {
+        optionalDictionaryListValue(values, "wifiScanResults")?.map(MentraWifiScanResult.init(values:))
+    }
+    public var lastLog: [String]? { optionalStringListValue(values, "lastLog") }
+    public var otherBtConnected: Bool? { optionalBoolValue(values, "otherBtConnected") }
+    public var defaultWearable: String? { optionalStringValue(values, "default_wearable") }
+    public var pendingWearable: String? { optionalStringValue(values, "pending_wearable") }
+    public var deviceName: String? { optionalStringValue(values, "device_name") }
+    public var deviceAddress: String? { optionalStringValue(values, "device_address") }
+    public var defaultController: String? { optionalStringValue(values, "default_controller") }
+    public var pendingController: String? { optionalStringValue(values, "pending_controller") }
+    public var controllerDeviceName: String? { optionalStringValue(values, "controller_device_name") }
+    public var screenDisabled: Bool? { optionalBoolValue(values, "screen_disabled") }
+    public var preferredMic: String? { optionalStringValue(values, "preferred_mic") }
+    public var sensingEnabled: Bool? { optionalBoolValue(values, "sensing_enabled") }
+    public var powerSavingMode: Bool? { optionalBoolValue(values, "power_saving_mode") }
+    public var brightness: Int? { optionalIntValue(values, "brightness") }
+    public var autoBrightness: Bool? { optionalBoolValue(values, "auto_brightness") }
+    public var dashboardHeight: Int? { optionalIntValue(values, "dashboard_height") }
+    public var dashboardDepth: Int? { optionalIntValue(values, "dashboard_depth") }
+    public var headUpAngle: Int? { optionalIntValue(values, "head_up_angle") }
+    public var contextualDashboard: Bool? { optionalBoolValue(values, "contextual_dashboard") }
+    public var galleryModeAuto: Bool? { optionalBoolValue(values, "gallery_mode") }
+    public var buttonPhotoSize: MentraButtonPhotoSize? {
+        optionalStringValue(values, "button_photo_size").flatMap(MentraButtonPhotoSize.init(rawValue:))
+    }
+    public var buttonCameraLed: Bool? { optionalBoolValue(values, "button_camera_led") }
+    public var buttonMaxRecordingTime: Int? { optionalIntValue(values, "button_max_recording_time") }
+    public var buttonVideoWidth: Int? { optionalIntValue(values, "button_video_width") }
+    public var buttonVideoHeight: Int? { optionalIntValue(values, "button_video_height") }
+    public var buttonVideoFps: Int? { optionalIntValue(values, "button_video_fps") }
+    public var shouldSendPcm: Bool? { optionalBoolValue(values, "should_send_pcm") }
+    public var shouldSendLc3: Bool? { optionalBoolValue(values, "should_send_lc3") }
+    public var shouldSendTranscript: Bool? { optionalBoolValue(values, "should_send_transcript") }
+    public var bypassVad: Bool? { optionalBoolValue(values, "bypass_vad") }
+    public var offlineCaptionsRunning: Bool? { optionalBoolValue(values, "offline_captions_running") }
+    public var localSttFallbackActive: Bool? { optionalBoolValue(values, "local_stt_fallback_active") }
+    public var shouldSendBootingMessage: Bool? { optionalBoolValue(values, "shouldSendBootingMessage") }
 
     public var description: String {
         values.description

--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -11,16 +11,32 @@ import Foundation
 class ObservableStore {
     private nonisolated(unsafe) var values: [String: Any] = [:]
     private var onEmit: ((String, [String: Any]) -> Void)?
+    private var listeners: [String: (String, [String: Any]) -> Void] = [:]
 
     nonisolated static let coreCategory = "core"
     private nonisolated static let legacyBluetoothCategory = "bluetooth"
+
+    nonisolated static func normalizeCategory(_ category: String) -> String {
+        category == legacyBluetoothCategory ? coreCategory : category
+    }
 
     func configure(onEmit: @escaping (String, [String: Any]) -> Void) {
         self.onEmit = onEmit
     }
 
+    func addListener(_ listener: @escaping (String, [String: Any]) -> Void) -> String {
+        let id = UUID().uuidString
+        listeners[id] = listener
+        return id
+    }
+
+    func removeListener(_ id: String) {
+        listeners.removeValue(forKey: id)
+    }
+
     func set(_ category: String, _ key: String, _ value: Any) {
-        let fullKey = "\(category).\(key)"
+        let normalizedCategory = Self.normalizeCategory(category)
+        let fullKey = "\(normalizedCategory).\(key)"
         let oldValue = values[fullKey]
 
         // Skip if unchanged
@@ -31,16 +47,20 @@ class ObservableStore {
         values[fullKey] = value
 
         // Emit immediately
-        onEmit?(category, [key: value])
+        let changes = [key: value]
+        onEmit?(normalizedCategory, changes)
+        for listener in listeners.values {
+            listener(normalizedCategory, changes)
+        }
     }
 
     nonisolated func get(_ category: String, _ key: String) -> Any? {
-        values["\(category).\(key)"]
+        values["\(Self.normalizeCategory(category)).\(key)"]
     }
 
     func getCategory(_ category: String) -> [String: Any] {
         var result: [String: Any] = [:]
-        let prefix = "\(category)."
+        let prefix = "\(Self.normalizeCategory(category))."
         for (key, value) in values where key.hasPrefix(prefix) {
             let shortKey = String(key.dropFirst(prefix.count))
             result[shortKey] = value

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -3736,11 +3736,6 @@ class MentraLive: NSObject, SGCManager {
     // }
 
     private func emitWifiStatusChange() {
-        let eventBody: [String: Any] = [
-            "connected": wifiConnected,
-            "ssid": wifiSsid,
-            "local_ip": wifiLocalIp,
-        ]
         Bridge.sendWifiStatusChange(connected: wifiConnected, ssid: wifiSsid, localIp: wifiLocalIp)
     }
 

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -55,10 +55,14 @@ export type LogEvent = {
   message: string
 }
 
-export type WifiStatusChangeEvent = {
-  type: "wifi_status_change"
+export type WifiStatus = {
   connected: boolean
   ssid: string
+  localIp: string
+}
+
+export type WifiStatusChangeEvent = WifiStatus & {
+  type: "wifi_status_change"
 }
 
 export type HotspotStatusChangeEvent = {


### PR DESCRIPTION
## Summary

This PR adds typed status models to the Bluetooth SDK after the gallery-mode connection fix branch.

It replaces public native SDK access to string-keyed status dictionaries for the stable glasses/Bluetooth status surfaces with typed Android and iOS models, while keeping map serialization internal for the React Native bridge.

## Changes

- Add typed Android status snapshots and partial update models for glasses and Bluetooth state.
- Add typed iOS status accessors and update helpers for the same status surfaces.
- Keep React Native bridge payloads compatible by converting typed models back to maps internally.
- Add typed Wi-Fi scan/device search result models used by status APIs.

## Validation

- `cd mobile && bun install --frozen-lockfile`
- Android SDK Kotlin compile was run before pushing this stack.
- Partner Kit Android example was rebuilt, installed, and launched on the Note 20 after the typed SDK changes.
