### PR TITLE
Refresh Bluetooth signal strength every 10 seconds

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -82,6 +82,8 @@ object GlassesStore {
         store.set("glasses", "hotspotPassword", "")
         store.set("glasses", "hotspotGatewayIp", "")
         store.set("glasses", "bluetoothName", "")
+        store.set("glasses", "signalStrength", -1)
+        store.set("glasses", "signalStrengthUpdatedAt", 0L)
         store.set("glasses", "controllerConnected", false)
         store.set("glasses", "controllerFullyBooted", false)
         store.set("glasses", "controllerMacAddress", "")

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothModels.kt
@@ -96,6 +96,7 @@ data class MentraGlassesStatus(
     val connectionState: String,
     val btcConnected: Boolean,
     val signalStrength: Int,
+    val signalStrengthUpdatedAt: Long,
     val deviceModel: String,
     val androidVersion: String,
     val firmwareVersion: String,
@@ -139,6 +140,7 @@ data class MentraGlassesStatus(
             "connectionState" to connectionState,
             "btcConnected" to btcConnected,
             "signalStrength" to signalStrength,
+            "signalStrengthUpdatedAt" to signalStrengthUpdatedAt,
             "deviceModel" to deviceModel,
             "androidVersion" to androidVersion,
             "fwVersion" to firmwareVersion,
@@ -186,6 +188,7 @@ data class MentraGlassesStatus(
                 connectionState = stringValue(values, "connectionState") ?: "disconnected",
                 btcConnected = boolValue(values, "btcConnected") ?: false,
                 signalStrength = numberValue(values, "signalStrength") ?: -1,
+                signalStrengthUpdatedAt = longValue(values, "signalStrengthUpdatedAt") ?: 0L,
                 deviceModel = stringValue(values, "deviceModel") ?: "",
                 androidVersion = stringValue(values, "androidVersion") ?: "",
                 firmwareVersion = stringValue(values, "firmwareVersion", "fwVersion") ?: "",
@@ -379,6 +382,7 @@ data class MentraGlassesStatusUpdate(
     val connectionState: String? = null,
     val btcConnected: Boolean? = null,
     val signalStrength: Int? = null,
+    val signalStrengthUpdatedAt: Long? = null,
     val deviceModel: String? = null,
     val androidVersion: String? = null,
     val firmwareVersion: String? = null,
@@ -422,6 +426,7 @@ data class MentraGlassesStatusUpdate(
             putIfNotNull("connectionState", connectionState)
             putIfNotNull("btcConnected", btcConnected)
             putIfNotNull("signalStrength", signalStrength)
+            putIfNotNull("signalStrengthUpdatedAt", signalStrengthUpdatedAt)
             putIfNotNull("deviceModel", deviceModel)
             putIfNotNull("androidVersion", androidVersion)
             putIfNotNull("fwVersion", firmwareVersion)
@@ -471,6 +476,7 @@ data class MentraGlassesStatusUpdate(
                 connectionState = optionalStringValue(values, "connectionState"),
                 btcConnected = optionalBoolValue(values, "btcConnected"),
                 signalStrength = optionalNumberValue(values, "signalStrength"),
+                signalStrengthUpdatedAt = optionalLongValue(values, "signalStrengthUpdatedAt"),
                 deviceModel = optionalStringValue(values, "deviceModel"),
                 androidVersion = optionalStringValue(values, "androidVersion"),
                 firmwareVersion = optionalStringValue(values, "firmwareVersion", "fwVersion"),
@@ -1151,8 +1157,11 @@ private fun boolValue(
 
 private fun longValue(
     values: Map<String, Any>,
-    key: String,
-): Long? = (values[key] as? Number)?.toLong()
+    vararg keys: String,
+): Long? =
+    keys.firstNotNullOfOrNull { key ->
+        (values[key] as? Number)?.toLong()
+    }
 
 private fun hasAnyKey(
     values: Map<String, Any>,
@@ -1165,6 +1174,16 @@ private fun optionalNumberValue(
 ): Int? =
     if (hasAnyKey(values, *keys)) {
         numberValue(values, *keys)
+    } else {
+        null
+    }
+
+private fun optionalLongValue(
+    values: Map<String, Any>,
+    vararg keys: String,
+): Long? =
+    if (hasAnyKey(values, *keys)) {
+        longValue(values, *keys)
     } else {
         null
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -331,7 +331,7 @@ class MentraBluetoothSdk private constructor(
         when (ObservableStore.normalizeCategory(category)) {
             "glasses" ->
                 dispatchToListeners {
-                    it.onGlassesStatusChanged(MentraGlassesStatusUpdate.fromMap(changes))
+                    it.onGlassesStatusChanged(MentraGlassesStatusUpdate.fromMap(glassesStatusChanges(changes)))
                 }
             ObservableStore.CORE_CATEGORY -> {
                 dispatchToListeners {
@@ -343,6 +343,15 @@ class MentraBluetoothSdk private constructor(
                 dispatchDiscoveredDevices(changes["searchResults"])
             }
         }
+    }
+
+    private fun glassesStatusChanges(changes: Map<String, Any>): Map<String, Any> {
+        if (!changes.containsKey("signalStrengthUpdatedAt") || changes.containsKey("signalStrength")) {
+            return changes
+        }
+
+        val signalStrength = (GlassesStore.get("glasses", "signalStrength") as? Number)?.toInt() ?: -1
+        return changes + ("signalStrength" to signalStrength)
     }
 
     private fun dispatchDefaultDeviceChanged() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -151,6 +151,7 @@ public class MentraLive extends SGCManager {
     // Heartbeat parameters
     private static final int HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
     private static final int BATTERY_REQUEST_EVERY_N_HEARTBEATS = 10; // Every 10 heartbeats (5 minutes)
+    private static final long RSSI_READ_INTERVAL_MS = 10000; // 10 seconds
 
     // Micbeat parameters - periodically enable custom audio TX
     private static final long MICBEAT_INTERVAL_MS = (1000 * 60) * 30; // micbeat every 30 minutes
@@ -454,6 +455,11 @@ public class MentraLive extends SGCManager {
     private Runnable heartbeatRunnable;
     private int heartbeatCounter = 0;
     private boolean glassesReady = false;
+
+    // RSSI tracking
+    private Handler rssiReadHandler = new Handler(Looper.getMainLooper());
+    private Runnable rssiReadRunnable;
+    private boolean rssiReadInProgress = false;
     
     // BES OTA progress tracking - only send to UI on 5% increments
     private int lastBesOtaProgress = -1;
@@ -565,6 +571,14 @@ public class MentraLive extends SGCManager {
                 sendHeartbeat();
                 // Schedule next heartbeat
                 heartbeatHandler.postDelayed(this, HEARTBEAT_INTERVAL_MS);
+            }
+        };
+
+        rssiReadRunnable = new Runnable() {
+            @Override
+            public void run() {
+                requestSignalStrength();
+                rssiReadHandler.postDelayed(this, RSSI_READ_INTERVAL_MS);
             }
         };
 
@@ -690,6 +704,8 @@ public class MentraLive extends SGCManager {
         if (state.equals(ConnTypes.DISCONNECTED)) {
             GlassesStore.INSTANCE.apply("glasses", "fullyBooted", false);
             GlassesStore.INSTANCE.apply("glasses", "connected", false);
+            GlassesStore.INSTANCE.apply("glasses", "signalStrength", -1);
+            GlassesStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", 0L);
             // Drop OTA caches when fully disconnected — avoids leaking session/step state
             // from a previous pairing into the next one.
             resetOtaCache();
@@ -1170,6 +1186,9 @@ public class MentraLive extends SGCManager {
                     // Stop heartbeat mechanism
                     stopHeartbeat();
 
+                    // Stop RSSI polling
+                    stopSignalStrengthPolling();
+
                     // Stop micbeat mechanism
                     stopMicBeat();
 
@@ -1210,6 +1229,9 @@ public class MentraLive extends SGCManager {
 
                 // Stop heartbeat mechanism
                 stopHeartbeat();
+
+                // Stop RSSI polling
+                stopSignalStrengthPolling();
 
                 // Stop micbeat mechanism
                 stopMicBeat();
@@ -1311,6 +1333,16 @@ public class MentraLive extends SGCManager {
                 // Process the read data if needed
             } else {
                 Log.e(TAG, "Characteristic read failed with status: " + status);
+            }
+        }
+
+        @Override
+        public void onReadRemoteRssi(BluetoothGatt gatt, int rssi, int status) {
+            rssiReadInProgress = false;
+            if (status == BluetoothGatt.GATT_SUCCESS) {
+                updateSignalStrength(rssi);
+            } else {
+                Log.e(TAG, "RSSI read failed with status: " + status);
             }
         }
 
@@ -1450,6 +1482,7 @@ public class MentraLive extends SGCManager {
 
             // Now that all GATT setup operations are complete, start data flow
             Bridge.log("LIVE: Starting send queue and readiness check loop");
+            startSignalStrengthPolling();
             handler.post(processSendQueueRunnable);
             startReadinessCheckLoop();
             return;
@@ -1602,6 +1635,7 @@ public class MentraLive extends SGCManager {
         } else {
             // No descriptors to write, start data flow immediately
             Bridge.log("LIVE: No descriptor writes needed, starting send queue and readiness check loop");
+            startSignalStrengthPolling();
             handler.post(processSendQueueRunnable);
             startReadinessCheckLoop();
         }
@@ -3622,6 +3656,48 @@ public class MentraLive extends SGCManager {
         // stopTestMessages();
     }
 
+    private void startSignalStrengthPolling() {
+        Bridge.log("LIVE: 📶 Starting RSSI polling");
+        rssiReadHandler.removeCallbacks(rssiReadRunnable);
+        requestSignalStrength();
+        rssiReadHandler.postDelayed(rssiReadRunnable, RSSI_READ_INTERVAL_MS);
+    }
+
+    private void stopSignalStrengthPolling() {
+        Bridge.log("LIVE: 📶 Stopping RSSI polling");
+        rssiReadHandler.removeCallbacks(rssiReadRunnable);
+        rssiReadInProgress = false;
+    }
+
+    private void requestSignalStrength() {
+        if (!isConnected || bluetoothGatt == null) {
+            return;
+        }
+
+        if (!hasPermissions()) {
+            Bridge.log("LIVE: 📶 Cannot read RSSI - missing Bluetooth permission");
+            return;
+        }
+
+        if (rssiReadInProgress) {
+            Bridge.log("LIVE: 📶 Skipping RSSI read - previous read still pending");
+            return;
+        }
+
+        boolean started = bluetoothGatt.readRemoteRssi();
+        rssiReadInProgress = started;
+        if (!started) {
+            Bridge.log("LIVE: 📶 RSSI read did not start");
+        }
+    }
+
+    private void updateSignalStrength(int rssi) {
+        long now = System.currentTimeMillis();
+        GlassesStore.INSTANCE.apply("glasses", "signalStrength", rssi);
+        GlassesStore.INSTANCE.apply("glasses", "signalStrengthUpdatedAt", now);
+        Bridge.log("LIVE: 📶 RSSI: " + rssi + " dBm");
+    }
+
     /**
      * Start the micbeat mechanism - periodically enable custom audio TX
      */
@@ -4528,6 +4604,9 @@ public class MentraLive extends SGCManager {
         // Stop heartbeat mechanism
         stopHeartbeat();
 
+        // Stop RSSI polling
+        stopSignalStrengthPolling();
+
         // Stop micbeat mechanism
         stopMicBeat();
 
@@ -4550,6 +4629,7 @@ public class MentraLive extends SGCManager {
         // Cancel any pending handlers
         handler.removeCallbacksAndMessages(null);
         heartbeatHandler.removeCallbacksAndMessages(null);
+        rssiReadHandler.removeCallbacksAndMessages(null);
         micBeatHandler.removeCallbacksAndMessages(null);
         connectionTimeoutHandler.removeCallbacksAndMessages(null);
         testMessageHandler.removeCallbacksAndMessages(null);

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -51,6 +51,7 @@ class GlassesStore {
         store.set("glasses", "controllerBatteryLevel", -1)
         store.set("glasses", "controllerSignalStrength", -1)
         store.set("glasses", "signalStrength", -1)
+        store.set("glasses", "signalStrengthUpdatedAt", 0)
         store.set("glasses", "ringSignalStrength", -1)
 
         // CORE STATE:

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -296,6 +296,8 @@ public struct MentraGlassesStatus: CustomStringConvertible {
             "wifiConnected": false,
             "wifiSsid": "",
             "wifiLocalIp": "",
+            "signalStrength": -1,
+            "signalStrengthUpdatedAt": 0,
         ]))
     }
 
@@ -305,6 +307,7 @@ public struct MentraGlassesStatus: CustomStringConvertible {
     public var connectionState: String { stringValue(values, "connectionState") ?? "disconnected" }
     public var btcConnected: Bool { boolValue(values, "btcConnected") ?? false }
     public var signalStrength: Int { intValue(values["signalStrength"]) ?? -1 }
+    public var signalStrengthUpdatedAt: Int { intValue(values["signalStrengthUpdatedAt"]) ?? 0 }
     public var deviceModel: String { stringValue(values, "deviceModel") ?? "" }
     public var androidVersion: String { stringValue(values, "androidVersion") ?? "" }
     public var firmwareVersion: String { stringValue(values, "firmwareVersion", "fwVersion") ?? "" }
@@ -439,6 +442,7 @@ public struct MentraGlassesStatusUpdate: CustomStringConvertible {
     public var connectionState: String? { optionalStringValue(values, "connectionState") }
     public var btcConnected: Bool? { optionalBoolValue(values, "btcConnected") }
     public var signalStrength: Int? { optionalIntValue(values, "signalStrength") }
+    public var signalStrengthUpdatedAt: Int? { optionalIntValue(values, "signalStrengthUpdatedAt") }
     public var deviceModel: String? { optionalStringValue(values, "deviceModel") }
     public var androidVersion: String? { optionalStringValue(values, "androidVersion") }
     public var firmwareVersion: String? { optionalStringValue(values, "firmwareVersion", "fwVersion") }
@@ -1557,7 +1561,7 @@ public final class MentraBluetoothSDK {
     private func dispatchStoreUpdate(_ category: String, _ changes: [String: Any]) {
         switch ObservableStore.normalizeCategory(category) {
         case "glasses":
-            delegate?.mentraBluetoothSDK(self, didUpdateGlassesStatus: MentraGlassesStatusUpdate(values: changes))
+            delegate?.mentraBluetoothSDK(self, didUpdateGlassesStatus: MentraGlassesStatusUpdate(values: glassesStatusChanges(changes)))
         case ObservableStore.coreCategory:
             delegate?.mentraBluetoothSDK(self, didUpdateBluetoothStatus: MentraBluetoothStatusUpdate(values: changes))
             if !suppressDefaultDeviceEvents && changes.keys.contains(where: { defaultDeviceKeys.contains($0) }) {
@@ -1567,6 +1571,16 @@ public final class MentraBluetoothSDK {
         default:
             break
         }
+    }
+
+    private func glassesStatusChanges(_ changes: [String: Any]) -> [String: Any] {
+        guard changes["signalStrengthUpdatedAt"] != nil, changes["signalStrength"] == nil else {
+            return changes
+        }
+
+        var merged = changes
+        merged["signalStrength"] = GlassesStore.shared.get("glasses", "signalStrength") as? Int ?? -1
+        return merged
     }
 
     private func dispatchDefaultDeviceChanged() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -683,10 +683,11 @@ extension MentraLive: CBCentralManagerDelegate {
 
 extension MentraLive: CBPeripheralDelegate {
     func peripheral(_: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        signalStrengthReadInFlight = false
         if let error {
             Bridge.log("LIVE: Error reading RSSI: \(error.localizedDescription)")
         } else {
-            Bridge.log("LIVE: RSSI: \(RSSI)")
+            updateSignalStrength(Int(truncating: RSSI))
         }
     }
 
@@ -768,7 +769,6 @@ extension MentraLive: CBPeripheralDelegate {
             updateConnectionState(ConnTypes.CONNECTING)
 
             // Request MTU size
-            peripheral.readRSSI()
             let mtuSize = peripheral.maximumWriteValueLength(for: .withResponse)
             Bridge.log("LIVE: Current MTU size: \(mtuSize + 3) bytes")
 
@@ -787,6 +787,7 @@ extension MentraLive: CBPeripheralDelegate {
             }
 
             // Start readiness check loop
+            startSignalStrengthPolling()
             startReadinessCheckLoop()
         } else {
             Bridge.log("LIVE: Required BLE characteristics not found")
@@ -913,6 +914,9 @@ class MentraLive: NSObject, SGCManager {
         // a previous pairing into the next one (would otherwise surface as wrong overall_percent
         // or stale lastBesOtaProgress on the next OTA).
         if state == ConnTypes.DISCONNECTED {
+            stopSignalStrengthPolling()
+            GlassesStore.shared.apply("glasses", "signalStrength", -1)
+            GlassesStore.shared.apply("glasses", "signalStrengthUpdatedAt", 0)
             resetOtaCache()
         }
     }
@@ -1047,6 +1051,7 @@ class MentraLive: NSObject, SGCManager {
     private let CONNECTION_TIMEOUT_MS: UInt64 = 100_000_000_000 // 100 seconds
     private let HEARTBEAT_INTERVAL_MS: TimeInterval = 30.0 // 30 seconds
     private let BATTERY_REQUEST_EVERY_N_HEARTBEATS = 10
+    private let SIGNAL_STRENGTH_READ_INTERVAL_MS: TimeInterval = 10.0
     private let MIN_SEND_DELAY_MS: UInt64 = 160_000_000 // 160ms in nanoseconds
     private let READINESS_CHECK_INTERVAL_MS: TimeInterval = 2.5 // 2.5 seconds
 
@@ -1094,6 +1099,8 @@ class MentraLive: NSObject, SGCManager {
     // Timers
     private var heartbeatTimer: Timer?
     private var heartbeatCounter = 0
+    private var signalStrengthTimer: DispatchSourceTimer?
+    private var signalStrengthReadInFlight = false
     private var readinessCheckTimer: Timer?
     private var readinessCheckCounter = 0
 
@@ -3582,6 +3589,49 @@ class MentraLive: NSObject, SGCManager {
         heartbeatCounter = 0
     }
 
+    private func startSignalStrengthPolling() {
+        Bridge.log("LIVE: 📶 Starting RSSI polling")
+        stopSignalStrengthPolling()
+
+        requestSignalStrength()
+
+        let interval = DispatchTimeInterval.milliseconds(Int(SIGNAL_STRENGTH_READ_INTERVAL_MS * 1000))
+        signalStrengthTimer = DispatchSource.makeTimerSource(queue: bluetoothQueue)
+        signalStrengthTimer?.schedule(
+            deadline: .now() + interval,
+            repeating: interval
+        )
+        signalStrengthTimer?.setEventHandler { [weak self] in
+            self?.requestSignalStrength()
+        }
+        signalStrengthTimer?.resume()
+    }
+
+    private func stopSignalStrengthPolling() {
+        signalStrengthTimer?.cancel()
+        signalStrengthTimer = nil
+        signalStrengthReadInFlight = false
+        Bridge.log("LIVE: 📶 Stopping RSSI polling")
+    }
+
+    private func requestSignalStrength() {
+        guard let peripheral = connectedPeripheral else { return }
+        guard !signalStrengthReadInFlight else {
+            Bridge.log("LIVE: 📶 Skipping RSSI read - previous read still pending")
+            return
+        }
+
+        signalStrengthReadInFlight = true
+        peripheral.readRSSI()
+    }
+
+    private func updateSignalStrength(_ rssi: Int) {
+        let now = Int(Date().timeIntervalSince1970 * 1000)
+        GlassesStore.shared.apply("glasses", "signalStrength", rssi)
+        GlassesStore.shared.apply("glasses", "signalStrengthUpdatedAt", now)
+        Bridge.log("LIVE: 📶 RSSI: \(rssi) dBm")
+    }
+
     private func sendHeartbeat() {
         guard fullyBooted, connectionState == ConnTypes.CONNECTED else {
             Bridge.log("LIVE: Skipping heartbeat - glasses not fully booted or not connected")
@@ -3695,6 +3745,7 @@ class MentraLive: NSObject, SGCManager {
 
     private func stopAllTimers() {
         stopHeartbeat()
+        stopSignalStrengthPolling()
         stopReadinessCheckLoop()
         stopConnectionTimeout()
         stopMicBeat() // Stop LC3 audio micbeat

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -382,6 +382,8 @@ export interface GlassesStatus {
   connectionState: string
   btcConnected: boolean
   signalStrength: number
+  /** Milliseconds since epoch when signalStrength was last refreshed by the phone BLE stack. */
+  signalStrengthUpdatedAt: number
   // device info
   deviceModel: string
   androidVersion: string


### PR DESCRIPTION
## Summary

This updates the Mentra Bluetooth SDK so the glasses-side `signalStrength` status is refreshed by the phone BLE stack on a 10-second timer instead of only being populated opportunistically during connection setup.

## What changed

- Starts periodic RSSI reads after the Mentra Live BLE GATT setup finishes on Android and iOS.
- Stops RSSI polling and resets `signalStrength` on disconnect/cleanup.
- Adds typed `signalStrengthUpdatedAt` to the Android, iOS, and TypeScript SDK surfaces so apps can tell when the value was last refreshed.
- Ensures status callbacks include the current `signalStrength` whenever `signalStrengthUpdatedAt` changes, so subscribers receive a real signal-strength refresh event even if Android/iOS report the same dBm value twice.

## Verification

- `./gradlew :mentra-bluetooth-sdk:publishToMavenLocal` from `mobile/android` completed successfully.
- Rebuilt and installed the Android partner-kit example on the connected Note 20 (`R5CN80W6MZA`).
- Verified the Device tab updated from `-54 dBm / updated 11:48:52` to later readings including `-61 dBm / updated 11:52:30`.
- `bun run build` in `mobile/modules/bluetooth-sdk` completed successfully and regenerated the SDK declaration output with `signalStrengthUpdatedAt`.

## Notes

- `bun run compile` in `mobile` still fails on existing repo-wide TypeScript errors outside this change, beginning with `e2e-tests/ui` dynamic import config and missing `bun:test`/Vite/Recharts types.
- The iOS example Swift compile path got through, but simulator linking still fails because the installed GStreamer framework is built for iOS device, not iOS Simulator.
