### PR TITLE
Make Bluetooth SDK status getters synchronous

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -73,22 +73,16 @@ public class CoreModule: Module, MentraBluetoothSDKDelegate {
 
         // MARK: - Observable Store Functions
 
-        AsyncFunction("getGlassesStatus") {
-            await MainActor.run {
-                self.bluetoothSdk().glassesStatus.dictionary
-            }
+        Function("getGlassesStatus") {
+            MentraGlassesStatus(values: GlassesStore.shared.store.getCategory("glasses")).dictionary
         }
 
-        AsyncFunction("getCoreStatus") {
-            await MainActor.run {
-                self.bluetoothSdk().bluetoothStatus.values
-            }
+        Function("getCoreStatus") {
+            MentraBluetoothStatus(values: GlassesStore.shared.store.getCategory(ObservableStore.coreCategory)).values
         }
 
-        AsyncFunction("getDefaultDevice") {
-            await MainActor.run {
-                self.bluetoothSdk().getDefaultDevice()?.dictionary
-            }
+        Function("getDefaultDevice") {
+            MentraBluetoothSDK.defaultDevice(from: GlassesStore.shared.store.getCategory(ObservableStore.coreCategory))?.dictionary
         }
 
         AsyncFunction("update") { (category: String, values: [String: Any]) in

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@MainActor
 class GlassesStore {
     static let shared = GlassesStore()
     let store = ObservableStore()
@@ -107,6 +106,7 @@ class GlassesStore {
         store.set(category, key, value)
     }
 
+    @MainActor
     private func scheduleDashboardHeightToGlasses() {
         dashboardHeightDebounceTask?.cancel()
         dashboardHeightDebounceTask = Task { @MainActor in
@@ -116,6 +116,7 @@ class GlassesStore {
         }
     }
 
+    @MainActor
     private func scheduleDashboardDepthToGlasses() {
         dashboardDepthDebounceTask?.cancel()
         dashboardDepthDebounceTask = Task { @MainActor in
@@ -126,6 +127,7 @@ class GlassesStore {
     }
 
     /// Apply changes with side effects
+    @MainActor
     func apply(_ category: String, _ key: String, _ value: Any) {
         let oldValue = store.get(category, key)
         store.set(category, key, value)

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -2285,6 +2285,10 @@ public final class MentraBluetoothSDK {
 
     private func currentDefaultDevice() -> MentraDevice? {
         let core = GlassesStore.shared.store.getCategory(ObservableStore.coreCategory)
+        return Self.defaultDevice(from: core)
+    }
+
+    nonisolated static func defaultDevice(from core: [String: Any]) -> MentraDevice? {
         guard let model = core["default_wearable"] as? String, !model.isEmpty else { return nil }
         guard let name = core["device_name"] as? String, !name.isEmpty else { return nil }
         let identifier = (core["device_address"] as? String).flatMap { $0.isEmpty ? nil : $0 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -7,58 +7,77 @@
 
 import Foundation
 
-@MainActor
 class ObservableStore {
-    private nonisolated(unsafe) var values: [String: Any] = [:]
+    private let lock = NSLock()
+    private var values: [String: Any] = [:]
     private var onEmit: ((String, [String: Any]) -> Void)?
     private var listeners: [String: (String, [String: Any]) -> Void] = [:]
 
-    nonisolated static let coreCategory = "core"
-    private nonisolated static let legacyBluetoothCategory = "bluetooth"
+    static let coreCategory = "core"
+    private static let legacyBluetoothCategory = "bluetooth"
 
-    nonisolated static func normalizeCategory(_ category: String) -> String {
+    static func normalizeCategory(_ category: String) -> String {
         category == legacyBluetoothCategory ? coreCategory : category
     }
 
     func configure(onEmit: @escaping (String, [String: Any]) -> Void) {
+        lock.lock()
         self.onEmit = onEmit
+        lock.unlock()
     }
 
     func addListener(_ listener: @escaping (String, [String: Any]) -> Void) -> String {
         let id = UUID().uuidString
+        lock.lock()
         listeners[id] = listener
+        lock.unlock()
         return id
     }
 
     func removeListener(_ id: String) {
+        lock.lock()
         listeners.removeValue(forKey: id)
+        lock.unlock()
     }
 
     func set(_ category: String, _ key: String, _ value: Any) {
         let normalizedCategory = Self.normalizeCategory(category)
         let fullKey = "\(normalizedCategory).\(key)"
+        let changes = [key: value]
+        let emitter: ((String, [String: Any]) -> Void)?
+        let activeListeners: [(String, [String: Any]) -> Void]
+
+        lock.lock()
         let oldValue = values[fullKey]
 
         // Skip if unchanged
         if let old = oldValue, areEqual(old, value) {
+            lock.unlock()
             return
         }
 
         values[fullKey] = value
+        emitter = onEmit
+        activeListeners = Array(listeners.values)
+        lock.unlock()
 
         // Emit immediately
-        let changes = [key: value]
-        onEmit?(normalizedCategory, changes)
-        for listener in listeners.values {
+        emitter?(normalizedCategory, changes)
+        for listener in activeListeners {
             listener(normalizedCategory, changes)
         }
     }
 
-    nonisolated func get(_ category: String, _ key: String) -> Any? {
-        values["\(Self.normalizeCategory(category)).\(key)"]
+    func get(_ category: String, _ key: String) -> Any? {
+        lock.lock()
+        defer { lock.unlock() }
+        return values["\(Self.normalizeCategory(category)).\(key)"]
     }
 
     func getCategory(_ category: String) -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
+
         var result: [String: Any] = [:]
         let prefix = "\(Self.normalizeCategory(category))."
         for (key, value) in values where key.hasPrefix(prefix) {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdkModule.ts
@@ -20,13 +20,12 @@ import {
 
 type GlassesListener = (changed: Partial<GlassesStatus>) => void
 type CoreStatusListener = (changed: Partial<CoreStatus>) => void
-type MaybePromise<T> = T | Promise<T>
 
 declare class CoreModule extends NativeModule<CoreModuleEvents> {
   // Observable Store Functions (native)
-  getGlassesStatus(): Promise<GlassesStatus>
-  getCoreStatus(): Promise<CoreStatus>
-  getDefaultDevice(): Promise<MentraDevice | null>
+  getGlassesStatus(): GlassesStatus
+  getCoreStatus(): CoreStatus
+  getDefaultDevice(): MentraDevice | null
   update(category: string, values: Record<string, any>): Promise<void>
 
   // Display Commands
@@ -181,26 +180,6 @@ function adaptGlassesUpdateToNative(values: Partial<GlassesStatus>): Record<stri
     }
   }
   return update
-}
-
-// Add helper methods to the module
-const nativeGetGlassesStatus = NativeCoreModule.getGlassesStatus.bind(
-  NativeCoreModule,
-) as () => MaybePromise<GlassesStatus>
-NativeCoreModule.getGlassesStatus = function () {
-  return Promise.resolve(nativeGetGlassesStatus())
-}
-
-const nativeGetCoreStatus = NativeCoreModule.getCoreStatus.bind(NativeCoreModule) as () => MaybePromise<CoreStatus>
-NativeCoreModule.getCoreStatus = function () {
-  return Promise.resolve(nativeGetCoreStatus())
-}
-
-const nativeGetDefaultDevice = NativeCoreModule.getDefaultDevice.bind(
-  NativeCoreModule,
-) as () => MaybePromise<MentraDevice | null>
-NativeCoreModule.getDefaultDevice = function () {
-  return Promise.resolve(nativeGetDefaultDevice())
 }
 
 NativeCoreModule.updateGlasses = function (values: Partial<GlassesStatus>) {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -918,11 +918,11 @@ class MantleManager {
     }
 
     // one time get all:
-    const coreStatus = await CoreModule.getCoreStatus()
+    const coreStatus = CoreModule.getCoreStatus()
     // console.log("MANTLE: core status:", coreStatus)
     useCoreStore.getState().setCoreInfo(coreStatus)
 
-    const glassesStatus = await CoreModule.getGlassesStatus()
+    const glassesStatus = CoreModule.getGlassesStatus()
     // console.log("MANTLE: glasses status:", glassesStatus)
     useGlassesStore.getState().setGlassesInfo(glassesStatus)
   }


### PR DESCRIPTION
## Summary

It makes the React Native Bluetooth SDK homogeneous across Android and Swift for cached status reads:

- Android already exposes `getGlassesStatus`, `getCoreStatus`, and `getDefaultDevice` as synchronous Expo `Function`s.
- Swift now does the same instead of exposing cached snapshots through `AsyncFunction`.
- The TypeScript SDK surface returns plain values again, rather than wrapping the native result in `Promise.resolve(...)`.

## How it works

The iOS issue was not that the data itself required async work. These getters read cached store snapshots. The async shape came from routing those reads through `MainActor.run` because the whole store was main-actor isolated.

This PR makes the cached store safe to read synchronously by protecting `ObservableStore` with a lock. `GlassesStore` itself is no longer globally main-actor isolated, but `apply(...)` and the dashboard hardware side effects remain `@MainActor`, because those paths can drive CoreManager / glasses side effects.

That keeps the real control plane actor-isolated while allowing snapshot getters to be synchronous on both Android and iOS.

## MentraOS impact

MentraOS previously used `await CoreModule.getCoreStatus()` and `await CoreModule.getGlassesStatus()` even when Android returned plain values. This PR removes those awaits to match the SDK contract. This is a pre-existing MentraOS call-site shape change, which is why it is separated into this PR instead of staying bundled into `codex/bluetooth-sdk-device-target-api`.

## Verification

- `bun run build` in `mobile/modules/bluetooth-sdk`
- `./gradlew :mentra-bluetooth-sdk:compileDebugKotlin --console=plain` in `mobile/android`
- `xcodebuild -workspace ios/Mentra.xcworkspace -scheme MentraBluetoothSDK -configuration Debug -sdk iphonesimulator -destination generic/platform=iOS\ Simulator build CODE_SIGNING_ALLOWED=NO` in `mobile`
- `git diff --check`

Note: repo-wide `bun compile` still fails with the existing broad mobile typecheck error set; no SDK getter-specific errors were observed.