### PR TITLE
Improve OTA user messaging for TLS trust and captive portal failures

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -606,6 +607,33 @@ public class OtaHelper {
     }
 
     /**
+     * Detect TLS trust-chain failures (wrong device time, captive portal TLS MITM, etc.).
+     * Walks the full cause chain because {@link javax.net.ssl.SSLHandshakeException} often wraps
+     * {@link java.security.cert.CertPathValidatorException}.
+     */
+    private static boolean isTlsTrustFailure(Throwable e) {
+        for (Throwable t = e; t != null; t = t.getCause()) {
+            if (t instanceof java.security.cert.CertificateException) {
+                return true;
+            }
+            String cn = t.getClass().getName();
+            if (cn.contains("CertPathValidatorException")) {
+                return true;
+            }
+            String m = t.getMessage();
+            if (m != null) {
+                String lm = m.toLowerCase(Locale.US);
+                if (lm.contains("trust anchor")
+                        || lm.contains("certpathvalidator")
+                        || lm.contains("certification path not found")) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Classify download exceptions into semantic error codes for actionable user feedback.
      */
     private String classifyDownloadError(Exception e) {
@@ -613,6 +641,9 @@ public class OtaHelper {
             // Non-network failure (size cap, sha256 mismatch). Carry the stable code through
             // so the phone-side error mapping doesn't confuse this with a transient WiFi issue.
             return ((FirmwareDownloadException) e).getErrorCode();
+        } else if (isTlsTrustFailure(e)) {
+            // Distinct from generic ssl_error so the phone can show clock/captive-portal guidance.
+            return "ssl_trust_failure";
         } else if (e instanceof java.net.SocketTimeoutException) {
             return "no_internet";
         } else if (e instanceof java.net.UnknownHostException) {

--- a/mobile/src/app/ota/progress-legacy.tsx
+++ b/mobile/src/app/ota/progress-legacy.tsx
@@ -13,6 +13,7 @@ import {useGlassesStore} from "@/stores/glasses"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import {logEvent} from "@/utils/analytics"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
+import {getOtaErrorMessage} from "@/utils/otaErrorMapping"
 
 import {
   DOWNLOAD_STUCK_TIMEOUT_MS,
@@ -72,6 +73,7 @@ export default function OtaProgressScreen() {
   const buildNumber = useGlassesStore((state) => state.buildNumber)
   const besFwVersion = useGlassesStore((state) => state.besFwVersion)
   const mtkFwVersion = useGlassesStore((state) => state.mtkFwVersion)
+  const deviceModel = useGlassesStore((state) => state.deviceModel)
 
   const [progressState, setProgressState] = useState<ProgressState>("starting")
   const [retryCount, setRetryCount] = useState(0)
@@ -1905,7 +1907,10 @@ export default function OtaProgressScreen() {
           {errorMessage ? (
             <>
               <View className="h-2" />
-              <Text text={errorMessage} className="text-sm text-center text-secondary-foreground" />
+              <Text
+                text={getOtaErrorMessage(errorMessage, deviceModel)}
+                className="text-sm text-center text-secondary-foreground"
+              />
             </>
           ) : null}
           <View className="h-2" />

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -77,6 +77,7 @@ export default function OtaProgressScreen() {
   const connected = useGlassesStore((s) => s.connected)
   const otaStatus = useGlassesStore((s) => s.otaStatus)
   const otaProgress = useGlassesStore((s) => s.otaProgress)
+  const deviceModel = useGlassesStore((s) => s.deviceModel)
 
   // Genuinely local UI state
   const [errorMsg, setErrorMsg] = useState("")
@@ -749,7 +750,7 @@ export default function OtaProgressScreen() {
     }
 
     if (displayState === "failed") {
-      const displayedError = errorMsg || getOtaErrorMessage(otaStatus?.error)
+      const displayedError = errorMsg || getOtaErrorMessage(otaStatus?.error, deviceModel)
       const showChangeWifi = shouldShowChangeWifiForOtaDownloadFailure(otaStatus, otaProgress, errorMsg)
       return (
         <>

--- a/mobile/src/services/__tests__/mantle-ota-status.test.ts
+++ b/mobile/src/services/__tests__/mantle-ota-status.test.ts
@@ -96,6 +96,23 @@ describe("MantleManager ota_status handler", () => {
     expect(stored?.status).toBe("failed")
   })
 
+  it("maps abbreviated err field to error (glasses BLE short keys)", () => {
+    handleOtaStatusEvent({
+      session_id: "sess-err",
+      total_steps: 1,
+      current_step: 1,
+      step_type: "apk",
+      phase: "download",
+      step_percent: 0,
+      overall_percent: 0,
+      status: "failed",
+      err: "ssl_trust_failure",
+    })
+
+    const stored = useGlassesStore.getState().otaStatus
+    expect(stored?.error).toBe("ssl_trust_failure")
+  })
+
   it("emits via GlobalEventEmitter", () => {
     const emitted: any[] = []
     GlobalEventEmitter.on("ota_status", (s: any) => emitted.push(s))

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -2,7 +2,15 @@ import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk"
 
 import {OtaProgressMessages} from "@/app/ota/otaProgressTimeouts"
 
-import {getOtaErrorMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
+import {getOtaErrorMessage, otaTlsTrustUserMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
+
+const TLS_GUIDANCE_DEFAULT =
+  "Your Mentra Live can't reach the internet. Please restart your Mentra Live.\n\n" +
+  "Mentra Live does not work on captive portal WiFi networks. Please try a different WiFi network."
+
+const TLS_GUIDANCE_CUSTOM_MODEL =
+  "Your Spectacles can't reach the internet. Please restart your Mentra Live.\n\n" +
+  "Mentra Live does not work on captive portal WiFi networks. Please try a different WiFi network."
 
 function baseOtaStatus(overrides: Partial<OtaStatus> = {}): OtaStatus {
   return {
@@ -35,8 +43,30 @@ describe("getOtaErrorMessage", () => {
     expect(getOtaErrorMessage("no_internet")).toBe("Glasses WiFi has no internet connection")
   })
 
-  it("maps ssl_error to connection message", () => {
-    expect(getOtaErrorMessage("ssl_error")).toBe("Secure connection failed — try a different WiFi network")
+  it("maps ssl_error to TLS trust guidance", () => {
+    expect(getOtaErrorMessage("ssl_error")).toBe(TLS_GUIDANCE_DEFAULT)
+  })
+
+  it("maps ssl_trust_failure to TLS trust guidance", () => {
+    expect(getOtaErrorMessage("ssl_trust_failure")).toBe(TLS_GUIDANCE_DEFAULT)
+  })
+
+  it("uses device model in TLS trust guidance when provided", () => {
+    expect(getOtaErrorMessage("ssl_error", "Spectacles")).toBe(TLS_GUIDANCE_CUSTOM_MODEL)
+  })
+
+  it("sanitizes raw JVM cert path errors from older glasses builds", () => {
+    expect(
+      getOtaErrorMessage(
+        "java.security.cert.CertPathValidatorException: Trust anchor or certification path not found.",
+        "Spectacles",
+      ),
+    ).toBe(TLS_GUIDANCE_CUSTOM_MODEL)
+  })
+
+  it("exposes otaTlsTrustUserMessage helper", () => {
+    expect(otaTlsTrustUserMessage()).toBe(TLS_GUIDANCE_DEFAULT)
+    expect(otaTlsTrustUserMessage("  Spectacles  ")).toBe(TLS_GUIDANCE_CUSTOM_MODEL)
   })
 
   it("maps download_failed to download message", () => {

--- a/mobile/src/utils/otaErrorMapping.ts
+++ b/mobile/src/utils/otaErrorMapping.ts
@@ -1,5 +1,28 @@
 import type {OtaProgress, OtaStatus} from "@mentra/bluetooth-sdk"
 
+const DEFAULT_GLASSES_DISPLAY_NAME = "Mentra Live"
+
+function looksLikeRawJvmTlsTrustError(msg: string): boolean {
+  const m = msg.toLowerCase()
+  return (
+    m.includes("certpathvalidator") ||
+    m.includes("trust anchor") ||
+    m.includes("certification path not found")
+  )
+}
+
+/**
+ * Copy for TLS trust / clock / captive-portal style failures. We cannot reliably tell
+ * wrong time vs captive portal on the phone, so both common fixes are included.
+ */
+export function otaTlsTrustUserMessage(glassesDisplayName?: string): string {
+  const name = (glassesDisplayName ?? "").trim() || DEFAULT_GLASSES_DISPLAY_NAME
+  return (
+    `Your ${name} can't reach the internet. Please restart your Mentra Live.\n\n` +
+    `Mentra Live does not work on captive portal WiFi networks. Please try a different WiFi network.`
+  )
+}
+
 function isDownloadPhaseSnapshot(
   otaStatus: OtaStatus | null | undefined,
   otaProgress: OtaProgress | null | undefined,
@@ -37,12 +60,17 @@ export function shouldShowChangeWifiForOtaDownloadFailure(
   return false
 }
 
-export function getOtaErrorMessage(error?: string): string {
+export function getOtaErrorMessage(error?: string, glassesDisplayName?: string): string {
+  if (!error) {
+    return "Update failed"
+  }
+
   switch (error) {
     case "no_internet":
       return "Glasses WiFi has no internet connection"
     case "ssl_error":
-      return "Secure connection failed — try a different WiFi network"
+    case "ssl_trust_failure":
+      return otaTlsTrustUserMessage(glassesDisplayName)
     case "download_failed":
       return "Download failed — check glasses WiFi connection"
     case "firmware_too_large":
@@ -52,6 +80,9 @@ export function getOtaErrorMessage(error?: string): string {
     case "install_failed":
       return "Install failed — please try again"
     default:
+      if (looksLikeRawJvmTlsTrustError(error)) {
+        return otaTlsTrustUserMessage(glassesDisplayName)
+      }
       return error || "Update failed"
   }
 }

--- a/mobile/src/utils/otaLegacyMapping.ts
+++ b/mobile/src/utils/otaLegacyMapping.ts
@@ -20,7 +20,7 @@ export type NormalizedOtaStatusEvent = {
 export function normalizeOtaStatusEvent(event: Record<string, unknown>): NormalizedOtaStatusEvent {
   const e = event as Record<string, any>
   const phase: "download" | "install" = e?.phase === "install" ? "install" : "download"
-  const err = e?.error_message ?? e?.errorMessage
+  const err = e?.error_message ?? e?.errorMessage ?? e?.err
   return {
     session_id: String(e?.session_id ?? e?.sessionId ?? ""),
     total_steps: Number(e?.total_steps ?? e?.totalSteps ?? 0),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users saw raw JVM text such as `CertPathValidatorException: Trust anchor or certification path not found` on the OTA failure screen. That string is now replaced with actionable copy that covers the two common causes we cannot distinguish on the device alone: glasses connectivity/time issues and captive portal WiFi.

## Changes

- **asg_client (`OtaHelper`)**: Walk the exception cause chain and classify certificate path / trust-anchor style failures as a stable `ssl_trust_failure` code (before the generic `download_failed` bucket).
- **mobile**: Map `ssl_error`, `ssl_trust_failure`, and raw JVM TLS-looking strings to user-facing guidance that (1) asks the user to restart Mentra Live and (2) explains captive portal limitations. Uses the connected glasses `deviceModel` in the first sentence when available. Legacy OTA progress screen runs errors through the same mapper. `normalizeOtaStatusEvent` now reads the abbreviated `err` field from glasses BLE payloads in addition to `error_message`.

## Testing

- `asg_client`: `./gradlew :app:compileDebugJavaWithJavac` was not run here (no Android SDK in the agent environment).
- `mobile`: Jest was not executed here (`node_modules` not present; `npm install` hit a peer dependency conflict without `--legacy-peer-deps`). Please run `npm test -- --testPathPattern='otaErrorMapping|mantle-ota-status'` (or `bun test` with the same filter) locally after install.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8b4b4b87-d4a9-4813-a2ca-fcb38b9f0ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8b4b4b87-d4a9-4813-a2ca-fcb38b9f0ac2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

