### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,3 +166,45 @@ export MENTRA_AGENT_API_KEY=your-api-key
 
 - Architecture specs and design docs: `/docs/`
 - Module-specific implementation details: See module-specific `AGENTS.md` files
+
+## Cursor Cloud specific instructions
+
+### Docker limitation
+
+Docker `docker compose up` does **not** work in Cloud Agent VMs due to cgroup v2 "threaded mode" conflicts in the nested container environment. Run the cloud backend directly instead:
+
+```bash
+cd cloud/packages/cloud && bun run dev
+```
+
+This uses `bun --watch` for hot reloading, matching the Docker dev behavior.
+
+### Cloud backend direct run (non-Docker)
+
+When running the cloud backend directly (without Docker), you need:
+
+1. **Symlink `.env`**: `ln -sf /workspace/cloud/.env /workspace/cloud/packages/cloud/.env` -- `dotenv.config()` reads from cwd, and `bun run dev` runs from `packages/cloud/`.
+2. **Set `PORT=8002`** in `cloud/.env` (the default `PORT=80` requires root).
+3. **Add required secrets** to `cloud/.env` beyond `.env.example` defaults:
+   - `AUGMENTOS_AUTH_JWT_SECRET` (any string for local dev)
+   - `RESEND_API_KEY` (any placeholder)
+   - `SUPABASE_SERVICE_KEY` (any placeholder; real key needed for auth flows)
+4. MongoDB timeouts are expected without a real MongoDB instance -- the server still starts and serves HTTP/WebSocket traffic.
+
+### Running services
+
+| Service | Command | Port | Notes |
+|---|---|---|---|
+| Cloud backend | `cd cloud/packages/cloud && bun run dev` | 8002 | Requires `.env` symlink and secrets above |
+| MentraOS Store | `cd cloud/websites/store && bun run dev` | 5173 | Pure frontend, works out of box |
+| Developer Console | `cd cloud/websites/console && bun run dev` | 5174 | Pure frontend, works out of box |
+| Account Portal | `cd cloud/websites/account && bun run dev` | 5175 | Pure frontend |
+
+### Key commands reference
+
+- **Build cloud packages**: `cd cloud && bun run build`
+- **Lint cloud backend**: `cd cloud/packages/cloud && bun run lint` (pre-existing warnings/errors expected)
+- **Lint store**: `cd cloud/websites/store && bun run lint`
+- **Lint console**: `cd cloud/websites/console && bun run lint`
+- **Run cloud tests**: `cd cloud && bun run test`
+- **Copy env files**: Copy `.env.example` to `.env` in `cloud/`, `cloud/websites/store/`, `cloud/websites/console/`

--- a/cloud/bun.lock
+++ b/cloud/bun.lock
@@ -3816,6 +3816,8 @@
 
     "@mentra/v3-smoke-test/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "@mentra/v3-stream-example/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@mentra/v3-stream-example/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@mentra/v3-stream-example/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -4318,6 +4320,8 @@
 
     "@mentra/v3-smoke-test/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "@mentra/v3-stream-example/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@mentra/v3-stream-example/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-radio-group/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ=="],
@@ -4621,6 +4625,8 @@
     "@mentra/debugger/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@mentra/sdk/jsonwebtoken/jws/jwa": ["jwa@1.4.2", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw=="],
+
+    "@mentra/v3-stream-example/@types/bun/bun-types/@types/node": ["@types/node@22.19.17", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q=="],
 
     "@radix-ui/react-radio-group/@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "AugmentOS",
+  "name": "workspace",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -24,6 +24,7 @@
         "lint-staged": "^16.2.1",
         "prettier": "^3.6.2",
         "typesafe-ts": "^1.7.0",
+        "typescript": "^6.0.2",
         "typescript-eslint": "^8.44.1"
       }
     },
@@ -5330,6 +5331,20 @@
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/utils": "^8.39.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-eslint": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to the root `AGENTS.md` with practical guidance for future cloud agents working in this monorepo.

### What's included

- **Docker limitation**: Documents that `docker compose up` fails in Cloud Agent VMs due to cgroup v2 nested-container conflicts, and provides the direct `bun run dev` alternative.
- **Cloud backend direct run**: Step-by-step for running the backend without Docker, including the `.env` symlink requirement, port override, and minimum secrets needed.
- **Services table**: Quick reference for starting Store, Console, Account, and Cloud backend with ports.
- **Key commands**: Consolidated lint/build/test commands for all cloud modules.

### Evidence of working environment

[mentraos_dev_environment_demo.mp4](https://cursor.com/agents/bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmentraos_dev_environment_demo.mp4)

Demo showing Store app browsing and Console sign-in page interaction.

[MentraOS Store landing page](https://cursor.com/agents/bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstore_landing_page.webp)
[Developer Console landing page](https://cursor.com/agents/bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconsole_landing_page.webp)
[Cloud backend health endpoint](https://cursor.com/agents/bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcloud_health_endpoint.webp)

All services verified operational: Cloud backend (port 8002), Store (port 5173), Console (port 5174).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b6945e-4eb7-4df6-bb15-0a6d4937e91c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

