### PR TITLE
[codex] Investigate Mentra Live scan fallback

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -736,7 +736,15 @@ public class MentraLive extends SGCManager {
      * Starts BLE scanning for Mentra Live glasses
      */
     private void startScan() {
-        if (bluetoothAdapter == null || isScanning) {
+        if (bluetoothAdapter == null) {
+            return;
+        }
+
+        if (isScanning) {
+            if (!isReconnecting) {
+                updateConnectionState(ConnTypes.SCANNING);
+                emitBondedMentraLiveDevices();
+            }
             return;
         }
 
@@ -779,6 +787,10 @@ public class MentraLive extends SGCManager {
             }
             
             isScanning = true;
+            if (!isReconnecting && !isConnecting && !isConnected) {
+                updateConnectionState(ConnTypes.SCANNING);
+            }
+            emitBondedMentraLiveDevices();
             bluetoothScanner.startScan(filters, settings, scanCallback);
 
             // Set a timeout to stop scanning
@@ -839,6 +851,64 @@ public class MentraLive extends SGCManager {
         }
     }
 
+    private boolean isCompatibleMentraLiveDeviceName(String deviceName) {
+        if (deviceName == null || deviceName.isEmpty()) {
+            return false;
+        }
+
+        String normalizedName = deviceName.toLowerCase(Locale.US);
+        return deviceName.equals("Xy_A") ||
+                deviceName.startsWith("XyBLE_") ||
+                deviceName.startsWith("MENTRA_LIVE_BLE") ||
+                deviceName.startsWith("MENTRA_LIVE_BT") ||
+                normalizedName.startsWith("mentra_live") ||
+                normalizedName.startsWith("mentra live");
+    }
+
+    private void emitBondedMentraLiveDevices() {
+        if (bluetoothAdapter == null || !hasPermissions()) {
+            return;
+        }
+
+        Set<BluetoothDevice> bondedDevices;
+        try {
+            bondedDevices = bluetoothAdapter.getBondedDevices();
+        } catch (SecurityException e) {
+            Bridge.log("LIVE: Missing permission to read bonded devices: " + e.getMessage());
+            return;
+        } catch (Exception e) {
+            Log.w(TAG, "Unable to read bonded devices", e);
+            return;
+        }
+
+        if (bondedDevices == null || bondedDevices.isEmpty()) {
+            return;
+        }
+
+        int compatibleCount = 0;
+        for (BluetoothDevice bondedDevice : bondedDevices) {
+            String deviceName = safeDeviceName(bondedDevice);
+            if (!isCompatibleMentraLiveDeviceName(deviceName)) {
+                continue;
+            }
+
+            String deviceAddress = "";
+            try {
+                deviceAddress = bondedDevice.getAddress();
+            } catch (Exception e) {
+                Log.w(TAG, "Unable to read bonded device address", e);
+            }
+
+            Bridge.sendDiscoveredDevice(DeviceTypes.LIVE, deviceName, deviceAddress);
+            compatibleCount++;
+        }
+
+        if (compatibleCount > 0) {
+            Bridge.log("LIVE: Found " + compatibleCount + " already paired Mentra Live device" +
+                    (compatibleCount == 1 ? "" : "s"));
+        }
+    }
+
     private void emitStopScanEvent() {
         Map<String, Object> body = new HashMap<>();
         body.put("device_model", DeviceTypes.LIVE);
@@ -891,7 +961,7 @@ public class MentraLive extends SGCManager {
 
             // Post the discovered device to the event bus ONLY
             // Don't automatically connect - wait for explicit connect request from UI
-            if (deviceName.equals("Xy_A") || deviceName.startsWith("XyBLE_") || deviceName.startsWith("MENTRA_LIVE_BLE") || deviceName.startsWith("MENTRA_LIVE_BT") || deviceName.toLowerCase().startsWith("mentra_live")) {
+            if (isCompatibleMentraLiveDeviceName(deviceName)) {
                 String glassType = deviceName.equals("Xy_A") ? "Standard" : "K900";
                 Bridge.log("LIVE: Found compatible " + glassType + " glasses device: " + deviceName);
                 // EventBus.getDefault().post(new GlassesBluetoothSearchDiscoverEvent(
@@ -3880,6 +3950,15 @@ public class MentraLive extends SGCManager {
         
         // Clear reconnection mode when user manually scans
         isReconnecting = false;
+        if (!isConnected) {
+            isConnecting = false;
+            if (connectionTimeoutRunnable != null) {
+                connectionTimeoutHandler.removeCallbacks(connectionTimeoutRunnable);
+                connectionTimeoutRunnable = null;
+            }
+            closeGattQuietly(true);
+            updateConnectionState(ConnTypes.SCANNING);
+        }
 
         if (bluetoothAdapter == null) {
             Log.e(TAG, "Bluetooth not available");


### PR DESCRIPTION
**Not for review yet.** This draft PR is an investigation artifact so the Mentra Live scan behavior can be reproduced, validated on hardware, and either accepted or replaced with a better product-level fix.

## Symptoms observed

- On the connected Android phone, the React Native example was in Mentra Live mode and scan showed `Scanning · 0 results`.
- The connection row stayed stuck on `CONNECTING` while the user was trying to scan.
- Android Location was initially off, which blocked BLE scanning at the OS level. After Location was enabled, BLE scan callbacks started, but the SDK still did not surface the target glasses.
- The glasses were clearly paired over Bluetooth audio: Spotify audio played through the glasses and Android Bluetooth state showed `Mentra_Live_E87D` connected over audio profiles.
- The plugged glasses were not the usual E613 pair, so the relevant target during investigation was the audio-connected `Mentra_Live_E87D` device.

## Repro shape to validate

1. Use an Android phone with a Mentra Live device already paired or connected for Bluetooth audio.
2. Open the React Native Bluetooth SDK example.
3. Select Mentra Live and start scanning.
4. Observe whether the SDK scan result list remains empty and whether the connection status stays on `CONNECTING` instead of moving to `SCANNING`.
5. Confirm whether Android Bluetooth shows the same Mentra Live device connected for audio while SDK discovery remains empty.

## Investigation notes

- Audio Bluetooth and SDK control BLE are separate paths. Audio can be connected while the SDK still has no BLE/GATT control connection.
- `MentraLive.startScan()` performs an unfiltered BLE scan and only emits devices that appear through scan results with compatible names.
- Already bonded/audio-connected Mentra Live devices may not appear as normal advertising scan results at the moment the example scans.
- Manual scan cleared `isReconnecting`, but it did not clear a stale `isConnecting` state or publish `SCANNING`, so the UI could keep showing `CONNECTING` during a scan attempt.

## What this patch changes

- When a manual scan starts and the SDK is not connected, clear stale connecting state, cancel the connection timeout, close the old GATT quietly, and publish `SCANNING`.
- Emit already bonded devices whose names match Mentra Live naming patterns before starting scan and when scan is already active.
- Reuse one compatibility matcher for both scan-result names and bonded-device names, including `Mentra_Live_*` / `mentra live*` variants.

## What this gives us if validated

- The scan UI can surface already paired or audio-connected Mentra Live devices instead of showing zero results.
- The connection row should stop presenting stale `CONNECTING` state while the user is actively scanning.
- Users can select a known paired Mentra Live device such as `Mentra_Live_E87D` even if it is not currently visible through normal BLE advertising.

## Validation performed

- `git diff --check`
- `./android/gradlew -p android :mentra-bluetooth-sdk:compileDebugJavaWithJavac` from the React Native starter kit example
- Rebuilt and installed the React Native example on the connected Android phone during investigation. After explicit install/launch, the UI showed `CONNECTED` to `Mentra_Live_E87D` with battery, firmware, and RSSI populated.

## Caveats / follow-up questions

- The phone dropped off ADB after UI verification, so final logcat for the successful connected state was not captured.
- This fallback may surface multiple previously bonded Mentra Live devices on phones with a large Bluetooth history. That may be useful for recovery, but it should be validated against expected production UX.
