### PR TITLE
Fix Soniox endpoint mid-utterance splits

### DIFF
--- a/.github/workflows/porter-debug.yml
+++ b/.github/workflows/porter-debug.yml
@@ -8,6 +8,7 @@ on:
       - cloud/pod-loop-stall-cascade
       - cloud/104-soniox-eventqueue-leak-fix
       - codex/issue-107-reconnect-storm
+      - cloud/fix-soniox-isfinal-split
     paths:
       - "cloud/**"
       - ".github/workflows/porter-debug.yml"

--- a/cloud/packages/cloud/src/scripts/soniox-repro-mock.ts
+++ b/cloud/packages/cloud/src/scripts/soniox-repro-mock.ts
@@ -1,0 +1,404 @@
+/**
+ * Deterministic Soniox bug reproduction via mock session.
+ *
+ * The real Soniox endpoint-mid-utterance bug is hard to provoke from TTS
+ * because v4's semantic endpoint detector is robust against clean audio.
+ * It DOES misfire on real speech in prod/staging (~5% of utterances).
+ *
+ * Rather than chase TTS audio that triggers the model, we replay the
+ * exact event sequence captured from a staging trace where the bug fired.
+ * This isolates the test to our handler code (SonioxSdkStream.handleResult/
+ * handleEndpoint/handleFinalized) where the fix lives.
+ *
+ * Bug pattern captured from staging (user said "You know? Come on, I'm right."):
+ *
+ *   interim "Come"
+ *   interim "Come on"
+ *   interim "Come on,"
+ *   interim "You know? Come on, I'"       ← rolling window jumped
+ *   FINAL   "You know? Come on, I'"       ← endpoint fired mid-word
+ *   ENDPT
+ *   interim "Come on, I'm"
+ *   interim "Come on, I'm right."
+ *   FINAL   "Come on, I'm right."
+ *   ENDPT
+ *
+ * Expected (after fix): one FINAL "You know? Come on, I'm right."
+ *
+ * Usage:
+ *   bun run src/scripts/soniox-repro-mock.ts
+ *
+ * Exit 0 if single-FINAL behavior observed, 1 if bug still present.
+ */
+
+import { EventEmitter } from "events";
+import pino from "pino";
+import type { RealtimeResult, RealtimeToken } from "@soniox/node";
+
+import { SonioxSdkStream } from "../services/session/transcription/providers/SonioxSdkStream";
+import type { StreamCallbacks } from "../services/session/transcription/types";
+
+// ---------------------------------------------------------------------------
+// Mock Soniox session: an EventEmitter that records sendAudio/finalize/pause
+// calls and lets us emit "result", "endpoint", "finalized" at will.
+// ---------------------------------------------------------------------------
+
+class MockSonioxSession extends EventEmitter {
+  state: "idle" | "connecting" | "connected" | "closed" = "idle";
+  sentAudio = 0;
+  finalizeCalls = 0;
+  pauseCalls = 0;
+  resumeCalls = 0;
+
+  async connect(): Promise<void> {
+    this.state = "connecting";
+    setImmediate(() => {
+      this.state = "connected";
+      this.emit("connected");
+    });
+  }
+
+  sendAudio(_data: Uint8Array): void {
+    this.sentAudio += _data.length;
+  }
+
+  finalize(): void {
+    this.finalizeCalls++;
+  }
+
+  pause(): void {
+    this.pauseCalls++;
+  }
+
+  resume(): void {
+    this.resumeCalls++;
+  }
+
+  async finish(): Promise<void> {
+    // no-op; emits handled separately
+  }
+
+  close(): void {
+    this.state = "closed";
+    this.emit("disconnected", "test");
+  }
+
+  // Helper to emit a fully-typed RealtimeResult
+  emitResult(tokens: Partial<RealtimeToken>[], finalAudioProcMs = 0, totalAudioProcMs = 0): void {
+    const fullTokens: RealtimeToken[] = tokens.map((t) => ({
+      text: t.text ?? "",
+      is_final: t.is_final ?? false,
+      confidence: t.confidence ?? 0.9,
+      start_ms: t.start_ms ?? 0,
+      end_ms: t.end_ms ?? 100,
+      speaker: t.speaker ?? "1",
+      language: t.language ?? "en",
+    }));
+    const result: RealtimeResult = {
+      tokens: fullTokens,
+      final_audio_proc_ms: finalAudioProcMs,
+      total_audio_proc_ms: totalAudioProcMs,
+    } as any;
+    this.emit("result", result);
+  }
+}
+
+class MockSonioxClient {
+  lastSession: MockSonioxSession | null = null;
+  realtime = {
+    stt: (_config: any) => {
+      const session = new MockSonioxSession();
+      this.lastSession = session;
+      return session as any;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const logger = pino({
+  level: process.env.SONIOX_REPRO_VERBOSE ? "debug" : "warn",
+  transport: {
+    target: "pino-pretty",
+    options: { colorize: true, ignore: "pid,hostname,time", singleLine: true },
+  },
+});
+
+const stubProvider: any = {
+  name: "soniox",
+  recordSuccess: () => {},
+  recordFailure: () => {},
+};
+
+type CapturedEvent = {
+  t: number;
+  kind: "interim" | "FINAL";
+  text: string;
+  utteranceId?: string;
+};
+
+const events: CapturedEvent[] = [];
+let t0 = 0;
+
+const callbacks: StreamCallbacks = {
+  onReady: () => {
+    console.log(`[${(Date.now() - t0).toString().padStart(5)}ms] READY`);
+  },
+  onData: (data: any) => {
+    const t = Date.now() - t0;
+    const kind = data.isFinal ? "FINAL" : "interim";
+    events.push({ t, kind, text: data.text, utteranceId: data.utteranceId });
+    const tag = kind === "FINAL" ? "\x1b[33mFINAL  \x1b[0m" : "interim";
+    console.log(`[${t.toString().padStart(5)}ms] ${tag} (${data.utteranceId?.slice(-6) ?? "------"}) "${data.text}"`);
+  },
+  onError: (err: Error) => console.error(`ERROR ${err.message}`),
+  onClosed: () => {},
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+// ---------------------------------------------------------------------------
+// Test scenarios
+// ---------------------------------------------------------------------------
+
+interface Scenario {
+  name: string;
+  /**
+   * Drive the session through a synthetic event sequence.
+   * Returns when the scenario is finished feeding events.
+   */
+  run: (session: MockSonioxSession) => Promise<void>;
+}
+
+const scenarios: Scenario[] = [
+  {
+    // Direct replay of the staging bug trace:
+    //   interim "Come"
+    //   interim "Come on"
+    //   interim "Come on,"
+    //   interim "You know? Come on, I'"   ← suddenly prefixed by "You know? "
+    //   FINAL   "You know? Come on, I'"   ← endpoint fired mid-word
+    //   ENDPT
+    //   interim "Come on, I'm"
+    //   interim "Come on, I'm right."
+    //   FINAL   "Come on, I'm right."
+    //   ENDPT
+    name: "staging-replay: 'You know? Come on, I\\'m right.' split mid-word",
+    run: async (s) => {
+      // Build up "Come on," with non-final tokens
+      s.emitResult([{ text: "Come", is_final: false }]);
+      await sleep(20);
+      s.emitResult([
+        { text: "Come", is_final: false },
+        { text: " on", is_final: false },
+      ]);
+      await sleep(20);
+      s.emitResult([
+        { text: "Come", is_final: false },
+        { text: " on", is_final: false },
+        { text: ",", is_final: false },
+      ]);
+      await sleep(20);
+
+      // Now Soniox commits "You know? " as finalized tokens (it had heard this
+      // earlier; the rolling window re-surfaces it). "Come on, I'" added.
+      s.emitResult([
+        { text: "You know?", is_final: true },
+        { text: " Come", is_final: true },
+        { text: " on,", is_final: true },
+        { text: " I'", is_final: false },
+      ]);
+      await sleep(20);
+
+      // Endpoint fires immediately — mid-word "I'"
+      s.emit("endpoint");
+      await sleep(50);
+
+      // After endpoint, audio keeps flowing. New utterance begins picking up
+      // the continuation. Note "Come on, I'm" duplicates "Come on, I'"
+      s.emitResult([{ text: "Come", is_final: false }]);
+      await sleep(20);
+      s.emitResult([
+        { text: "Come", is_final: false },
+        { text: " on", is_final: false },
+        { text: ",", is_final: false },
+        { text: " I'm", is_final: false },
+      ]);
+      await sleep(20);
+      s.emitResult([
+        { text: "Come", is_final: true },
+        { text: " on,", is_final: true },
+        { text: " I'm", is_final: true },
+        { text: " right.", is_final: false },
+      ]);
+      await sleep(20);
+      s.emitResult([
+        { text: "Come", is_final: true },
+        { text: " on,", is_final: true },
+        { text: " I'm", is_final: true },
+        { text: " right.", is_final: true },
+      ]);
+      await sleep(20);
+      s.emit("endpoint");
+    },
+  },
+  {
+    // Single clean utterance — should produce ONE final.
+    name: "clean utterance: 'Hello, how are you?'",
+    run: async (s) => {
+      s.emitResult([{ text: "Hello", is_final: false }]);
+      await sleep(30);
+      s.emitResult([
+        { text: "Hello", is_final: false },
+        { text: ",", is_final: false },
+        { text: " how", is_final: false },
+      ]);
+      await sleep(30);
+      s.emitResult([
+        { text: "Hello", is_final: true },
+        { text: ",", is_final: true },
+        { text: " how", is_final: true },
+        { text: " are", is_final: false },
+        { text: " you?", is_final: false },
+      ]);
+      await sleep(30);
+      s.emitResult([
+        { text: "Hello", is_final: true },
+        { text: ",", is_final: true },
+        { text: " how", is_final: true },
+        { text: " are", is_final: true },
+        { text: " you?", is_final: true },
+      ]);
+      await sleep(30);
+      s.emit("endpoint");
+    },
+  },
+  {
+    // Real "two separate utterances" — should produce TWO finals.
+    name: "two real utterances: 'Hello.' [pause] 'Goodbye.'",
+    run: async (s) => {
+      s.emitResult([
+        { text: "Hello", is_final: true },
+        { text: ".", is_final: true },
+      ]);
+      await sleep(30);
+      s.emit("endpoint");
+      // Real silence between utterances — long enough that any debounce
+      // should commit the first final
+      await sleep(1500);
+      s.emitResult([
+        { text: "Goodbye", is_final: true },
+        { text: ".", is_final: true },
+      ]);
+      await sleep(30);
+      s.emit("endpoint");
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+async function runScenario(scenario: Scenario): Promise<{ pass: boolean; finals: CapturedEvent[] }> {
+  console.log("\n" + "═".repeat(80));
+  console.log(`SCENARIO: ${scenario.name}`);
+  console.log("═".repeat(80));
+
+  events.length = 0;
+  t0 = Date.now();
+
+  const client = new MockSonioxClient();
+  const stream = new SonioxSdkStream(
+    "mock-" + Date.now(),
+    "transcription:en-US",
+    stubProvider,
+    "en-US",
+    undefined,
+    callbacks,
+    logger as any,
+    { model: "stt-rt-v4" } as any,
+    client as any,
+  );
+
+  await stream.initialize();
+  // Wait for the connected event to flow through
+  await sleep(50);
+
+  const session = client.lastSession!;
+  await scenario.run(session);
+
+  // Drain a bit so any deferred logic fires (the fix may include a debounce
+  // window). 1500ms covers up to a 1s debounce comfortably.
+  await sleep(1500);
+
+  // Close: flush any pending text
+  session.emit("finished");
+  await sleep(100);
+  await stream.close();
+  await sleep(100);
+
+  const finals = events.filter((e) => e.kind === "FINAL");
+  return { pass: true, finals };
+}
+
+interface Expectation {
+  name: string;
+  expectedFinalCount: number;
+  expectedFinalText?: string; // optional: substring match
+}
+
+const expectations: Expectation[] = [
+  {
+    name: scenarios[0].name,
+    expectedFinalCount: 1,
+    expectedFinalText: "right",
+  },
+  {
+    name: scenarios[1].name,
+    expectedFinalCount: 1,
+    expectedFinalText: "Hello",
+  },
+  {
+    name: scenarios[2].name,
+    expectedFinalCount: 2,
+  },
+];
+
+async function main() {
+  let allPass = true;
+  for (let i = 0; i < scenarios.length; i++) {
+    const result = await runScenario(scenarios[i]);
+    const expected = expectations[i];
+
+    console.log(`\nFinals (${result.finals.length}):`);
+    result.finals.forEach((f, j) => console.log(`  ${j + 1}. "${f.text}"`));
+
+    let pass = result.finals.length === expected.expectedFinalCount;
+    if (pass && expected.expectedFinalText) {
+      pass = result.finals.some((f) => f.text.includes(expected.expectedFinalText!));
+    }
+
+    if (pass) {
+      console.log(`\n\x1b[32m✓ PASS\x1b[0m: expected ${expected.expectedFinalCount} FINAL(s)`);
+    } else {
+      allPass = false;
+      console.log(
+        `\n\x1b[31m✗ FAIL\x1b[0m: expected ${expected.expectedFinalCount} FINAL(s)${expected.expectedFinalText ? ` containing "${expected.expectedFinalText}"` : ""}, got ${result.finals.length}`,
+      );
+    }
+  }
+
+  console.log("\n" + "═".repeat(80));
+  console.log(allPass ? "\x1b[32mAll scenarios passed.\x1b[0m" : "\x1b[31mFailures detected.\x1b[0m");
+  process.exit(allPass ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("fatal:", err);
+  process.exit(2);
+});

--- a/cloud/packages/cloud/src/scripts/soniox-repro.ts
+++ b/cloud/packages/cloud/src/scripts/soniox-repro.ts
@@ -1,0 +1,252 @@
+/**
+ * Soniox transcription bug reproduction harness.
+ *
+ * Feeds a pre-recorded WAV file (16kHz mono PCM) into the actual
+ * SonioxSdkStream and captures all interim/FINAL events. Used to reproduce
+ * the "endpoint fires mid-utterance, producing split FINALs" bug seen in
+ * staging and prod logs.
+ *
+ * Usage:
+ *   SONIOX_API_KEY=... bun run src/scripts/soniox-repro.ts <path-to-wav>
+ *
+ * Expected bug pattern:
+ *   - Multiple FINAL events close together for what is one logical utterance
+ *   - Some FINALs ending mid-word (e.g., "I'")
+ *
+ * Exit code 0 if no bug detected, 1 if bug pattern observed.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import pino from "pino";
+import { SonioxNodeClient } from "@soniox/node";
+
+import { SonioxSdkStream } from "../services/session/transcription/providers/SonioxSdkStream";
+import type { StreamCallbacks } from "../services/session/transcription/types";
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+const audioPath = process.argv[2];
+if (!audioPath) {
+  console.error("usage: bun run src/scripts/soniox-repro.ts <path-to-wav>");
+  process.exit(2);
+}
+if (!fs.existsSync(audioPath)) {
+  console.error(`audio file not found: ${audioPath}`);
+  process.exit(2);
+}
+
+const apiKey = process.env.SONIOX_API_KEY;
+if (!apiKey) {
+  console.error("SONIOX_API_KEY env var required");
+  process.exit(2);
+}
+
+// Pino logger - quiet by default; SONIOX_REPRO_VERBOSE=1 for debug
+const logger = pino({
+  level: process.env.SONIOX_REPRO_VERBOSE ? "debug" : "info",
+  transport: {
+    target: "pino-pretty",
+    options: { colorize: true, ignore: "pid,hostname,time", singleLine: true },
+  },
+});
+
+// Minimal stub for SonioxTranscriptionProvider — we only need recordSuccess /
+// recordFailure / name fields used by SonioxSdkStream.
+const stubProvider: any = {
+  name: "soniox",
+  recordSuccess: () => {},
+  recordFailure: () => {},
+};
+
+const client = new SonioxNodeClient({ apiKey });
+
+// ---------------------------------------------------------------------------
+// Event capture
+// ---------------------------------------------------------------------------
+
+type CapturedEvent = {
+  t: number;
+  kind: "interim" | "FINAL" | "ready" | "error" | "closed";
+  text?: string;
+  utteranceId?: string;
+  speakerId?: string;
+  msg?: string;
+};
+
+const events: CapturedEvent[] = [];
+let t0 = 0;
+
+const callbacks: StreamCallbacks = {
+  onReady: () => {
+    const t = Date.now() - t0;
+    events.push({ t, kind: "ready" });
+    console.log(`[${t.toString().padStart(5)}ms] READY`);
+  },
+  onData: (data: any) => {
+    const t = Date.now() - t0;
+    const kind = data.isFinal ? "FINAL" : "interim";
+    events.push({ t, kind, text: data.text, utteranceId: data.utteranceId, speakerId: data.speakerId });
+    const tag = kind === "FINAL" ? "\x1b[33mFINAL  \x1b[0m" : "interim";
+    console.log(`[${t.toString().padStart(5)}ms] ${tag} (${data.utteranceId?.slice(-6) ?? "------"}) "${data.text}"`);
+  },
+  onError: (err: Error) => {
+    const t = Date.now() - t0;
+    events.push({ t, kind: "error", msg: err.message });
+    console.error(`[${t.toString().padStart(5)}ms] ERROR ${err.message}`);
+  },
+  onClosed: (code: number) => {
+    const t = Date.now() - t0;
+    events.push({ t, kind: "closed", msg: String(code) });
+    console.log(`[${t.toString().padStart(5)}ms] CLOSED ${code}`);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// WAV reader
+// ---------------------------------------------------------------------------
+
+function readWavPcm16(filePath: string): { pcm: Buffer; sampleRate: number; channels: number } {
+  const buf = fs.readFileSync(filePath);
+  if (buf.slice(0, 4).toString() !== "RIFF" || buf.slice(8, 12).toString() !== "WAVE") {
+    throw new Error("not a WAV file");
+  }
+  // Walk chunks to find fmt and data
+  let offset = 12;
+  let sampleRate = 0;
+  let channels = 0;
+  let bitsPerSample = 0;
+  let dataOffset = 0;
+  let dataLength = 0;
+  while (offset < buf.length - 8) {
+    const chunkId = buf.slice(offset, offset + 4).toString();
+    const chunkSize = buf.readUInt32LE(offset + 4);
+    if (chunkId === "fmt ") {
+      channels = buf.readUInt16LE(offset + 10);
+      sampleRate = buf.readUInt32LE(offset + 12);
+      bitsPerSample = buf.readUInt16LE(offset + 22);
+    } else if (chunkId === "data") {
+      dataOffset = offset + 8;
+      dataLength = chunkSize;
+      break;
+    }
+    offset += 8 + chunkSize;
+  }
+  if (sampleRate !== 16000 || channels !== 1 || bitsPerSample !== 16) {
+    throw new Error(
+      `unsupported WAV (need 16000Hz mono 16-bit, got ${sampleRate}Hz ${channels}ch ${bitsPerSample}bit)`,
+    );
+  }
+  return { pcm: buf.subarray(dataOffset, dataOffset + dataLength), sampleRate, channels };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main() {
+  console.log(`Loading: ${path.resolve(audioPath)}`);
+  const { pcm, sampleRate, channels } = readWavPcm16(audioPath);
+  const durationMs = (pcm.length / 2 / sampleRate) * 1000;
+  console.log(`Audio: ${sampleRate}Hz ${channels}ch ${pcm.length} bytes (${durationMs.toFixed(0)}ms)`);
+
+  const stream = new SonioxSdkStream(
+    "repro-" + Date.now(),
+    "transcription:en-US",
+    stubProvider,
+    "en-US",
+    undefined,
+    callbacks,
+    logger as any,
+    {
+      model: "stt-rt-v4",
+      // Override Soniox's `max_endpoint_delay_ms` via env to simulate
+      // aggressive endpoint detection (500ms = min, 3000ms = max,
+      // Soniox default = 2000ms).
+      maxEndpointDelayMs: process.env.SONIOX_MAX_ENDPOINT_DELAY_MS
+        ? Number(process.env.SONIOX_MAX_ENDPOINT_DELAY_MS)
+        : undefined,
+      // Override the post-endpoint debounce window. Default in our code
+      // is 500ms.
+      endpointDebounceMs: process.env.SONIOX_ENDPOINT_DEBOUNCE_MS
+        ? Number(process.env.SONIOX_ENDPOINT_DEBOUNCE_MS)
+        : undefined,
+    } as any,
+    client,
+  );
+
+  t0 = Date.now();
+  console.log(`[${"0".padStart(5)}ms] init…`);
+  await stream.initialize();
+
+  // Feed audio in real-time chunks
+  // 16kHz mono 16-bit = 32000 bytes/sec = 1600 bytes per 50ms
+  const chunkSize = 1600; // 50ms of audio
+  const chunkInterval = 50; // ms
+
+  for (let i = 0; i < pcm.length; i += chunkSize) {
+    const chunk = pcm.subarray(i, Math.min(i + chunkSize, pcm.length));
+    // Copy into a new ArrayBuffer to satisfy writeAudio signature
+    const ab = new ArrayBuffer(chunk.length);
+    new Uint8Array(ab).set(chunk);
+    await stream.writeAudio(ab);
+    await sleep(chunkInterval);
+  }
+
+  // Drain: wait for any trailing events. 4 seconds is enough to let any
+  // pending Soniox endpoint / finalized events surface.
+  console.log(`[${(Date.now() - t0).toString().padStart(5)}ms] done feeding audio; draining 4s…`);
+  await sleep(4000);
+
+  await stream.close();
+  await sleep(500);
+
+  // -------------------------------------------------------------------------
+  // Analyze
+  // -------------------------------------------------------------------------
+  console.log("\n=== Summary ===");
+  const finals = events.filter((e) => e.kind === "FINAL");
+  const interims = events.filter((e) => e.kind === "interim");
+  console.log(`Total interims: ${interims.length}`);
+  console.log(`Total FINALs:   ${finals.length}`);
+  console.log();
+
+  // Detect bug: consecutive FINALs within 800ms of each other.
+  // This is the signature of a single utterance being split.
+  let bugDetected = false;
+  for (let i = 1; i < finals.length; i++) {
+    const gap = finals[i].t - finals[i - 1].t;
+    if (gap < 800) {
+      bugDetected = true;
+      console.log(`\x1b[31mBUG: FINAL #${i} at ${finals[i].t}ms is ${gap}ms after FINAL #${i - 1}\x1b[0m`);
+      console.log(`     prev: "${finals[i - 1].text}"`);
+      console.log(`     next: "${finals[i].text}"`);
+    }
+  }
+
+  // Also flag: any FINAL ending in incomplete-looking token (single letter + apostrophe, etc.)
+  for (const f of finals) {
+    const text = f.text ?? "";
+    if (/\b[A-Za-z]'$/.test(text) || /\b[A-Za-z]$/.test(text)) {
+      console.log(`\x1b[31mBUG: FINAL ends mid-word: "${text}"\x1b[0m`);
+      bugDetected = true;
+    }
+  }
+
+  console.log();
+  console.log("Final transcript chain:");
+  finals.forEach((f, i) => console.log(`  ${i + 1}. [${f.t}ms] "${f.text}"`));
+
+  process.exit(bugDetected ? 1 : 0);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+main().catch((err) => {
+  console.error("fatal:", err);
+  process.exit(2);
+});

--- a/cloud/packages/cloud/src/scripts/soniox-repro.ts
+++ b/cloud/packages/cloud/src/scripts/soniox-repro.ts
@@ -132,7 +132,9 @@ function readWavPcm16(filePath: string): { pcm: Buffer; sampleRate: number; chan
       dataLength = chunkSize;
       break;
     }
-    offset += 8 + chunkSize;
+    // RIFF requires odd-sized chunks to be followed by a pad byte to
+    // keep subsequent chunks word-aligned.
+    offset += 8 + chunkSize + (chunkSize % 2);
   }
   if (sampleRate !== 16000 || channels !== 1 || bitsPerSample !== 16) {
     throw new Error(
@@ -226,14 +228,11 @@ async function main() {
     }
   }
 
-  // Also flag: any FINAL ending in incomplete-looking token (single letter + apostrophe, etc.)
-  for (const f of finals) {
-    const text = f.text ?? "";
-    if (/\b[A-Za-z]'$/.test(text) || /\b[A-Za-z]$/.test(text)) {
-      console.log(`\x1b[31mBUG: FINAL ends mid-word: "${text}"\x1b[0m`);
-      bugDetected = true;
-    }
-  }
+  // The "consecutive FINALs within 800ms" check above is the load-bearing
+  // diagnostic. We deliberately don't try heuristics like "ends in single
+  // letter" or "ends in letter+apostrophe": those produce false positives
+  // on legitimate words ("I", "a") or transcribed hesitations ("uh, I'")
+  // and don't add coverage beyond the timing-based check.
 
   console.log();
   console.log("Final transcript chain:");

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
@@ -450,10 +450,12 @@ export class SonioxSdkStream implements StreamInstance {
     // Stop gap detection interval (Fix 044-3)
     this.stopGapDetection();
 
-    // Discard any in-flight pending FINAL so its debounce timer can't
-    // fire after close. (handleFinished will fire during finish() and
-    // emit a final if needed.)
-    this.cancelPendingFinal("stream closing");
+    // Commit any in-flight pending FINAL before shutdown. If we cancelled
+    // it instead, we'd silently drop the last utterance when close() lands
+    // inside the endpoint-debounce window (handleEndpoint clears
+    // lastEmittedInterimText, so pendingFinalText is the only copy of the
+    // text). After committing, the timer is cleared so it can't refire.
+    this.commitPendingFinal("stream closing");
 
     try {
       // Graceful shutdown: finish() waits for remaining results, then closes.

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
@@ -146,6 +146,39 @@ export class SonioxSdkStream implements StreamInstance {
   private stablePrefixText = "";
   private prevWindowFinalLen = 0;
 
+  // ── Endpoint debounce + merge ───────────────────────────────────────
+  // Soniox's semantic endpoint detector occasionally misfires mid-
+  // utterance, producing a chain of short FINALs that should have been
+  // one (~5% of utterances in staging traces). To prevent emitting
+  // multiple split FINALs per logical utterance, we:
+  //
+  //   1. On `endpoint`, capture the current candidate text as a
+  //      "pending FINAL" and reset utterance state (so Soniox's
+  //      internal rolling-window reset stays in sync).
+  //   2. Defer the actual FINAL emission by `endpointDebounceMs`.
+  //   3. If a second `endpoint` fires before the timer expires, attempt
+  //      to merge the new candidate text into the pending one using
+  //      suffix-prefix overlap detection. If they overlap, the second
+  //      endpoint was a continuation of the same utterance; if not,
+  //      they're genuinely separate (commit the first, hold the second).
+  //   4. When the timer expires, emit the pending FINAL.
+  //
+  // Trusted signals that bypass the debounce and emit immediately:
+  //   - `finalized` event (handleFinalized): only fires in response to
+  //     OUR `session.finalize()` or `session.pause()` calls, which are
+  //     driven by phone-VAD-stop or our 2s audio-gap detection. We
+  //     initiated them, so the utterance has truly ended.
+  //   - `finished` event (handleFinished): the session is ending; flush
+  //     immediately.
+  private pendingFinalText: string = "";
+  private pendingFinalUtteranceId: string | null = null;
+  private pendingFinalSpeakerId: string | undefined;
+  private pendingFinalLanguage: string | undefined;
+  private pendingFinalTimer: NodeJS.Timeout | null = null;
+  private endpointDebounceMs: number;
+  private static readonly DEFAULT_ENDPOINT_DEBOUNCE_MS = 500;
+  private static readonly MIN_OVERLAP_CHARS = 3;
+
   constructor(
     public readonly id: string,
     public readonly subscription: string,
@@ -157,6 +190,9 @@ export class SonioxSdkStream implements StreamInstance {
     private readonly config: SonioxProviderConfig,
     client: SonioxNodeClient,
   ) {
+    this.endpointDebounceMs =
+      config.endpointDebounceMs ?? SonioxSdkStream.DEFAULT_ENDPOINT_DEBOUNCE_MS;
+
     // ── Build session config ────────────────────────────────────────
     const sessionConfig = this.buildSessionConfig();
 
@@ -414,6 +450,11 @@ export class SonioxSdkStream implements StreamInstance {
     // Stop gap detection interval (Fix 044-3)
     this.stopGapDetection();
 
+    // Discard any in-flight pending FINAL so its debounce timer can't
+    // fire after close. (handleFinished will fire during finish() and
+    // emit a final if needed.)
+    this.cancelPendingFinal("stream closing");
+
     try {
       // Graceful shutdown: finish() waits for remaining results, then closes.
       // Keep listeners active through finish() so finalized/finished handlers
@@ -605,66 +646,176 @@ export class SonioxSdkStream implements StreamInstance {
   }
 
   /**
-   * Endpoint event: the server detected that the speaker stopped talking.
+   * Endpoint event: the server's semantic detector thinks the speaker
+   * stopped. Soft signal — misfires ~5% of the time, firing mid-
+   * utterance. We capture the current utterance's text as a pending
+   * FINAL and defer emission. A second endpoint that arrives before
+   * the timer expires is merged with this one if its text continues
+   * from where the pending text left off (suffix-prefix overlap).
    *
-   * Emit a final with the last emitted interim text (which is the most
-   * complete version of this utterance). Then rotate utteranceId so the
-   * next speech segment gets its own card.
+   * Critically, we DO reset utterance state immediately, because
+   * Soniox's internal rolling window also resets on endpoint. Keeping
+   * our `stablePrefixText` in sync prevents duplicated content in the
+   * next utterance's interims.
    */
   private handleEndpoint(): void {
     this.lastActivity = Date.now();
 
-    // The most complete text for this utterance is whatever we last emitted
-    // as an interim. Use that as the final, ensuring the frontend transitions
-    // the card from interim → final seamlessly (same utteranceId, same text).
-    if (this.lastEmittedInterimText.trim()) {
-      this.emitFinal(
-        this.lastEmittedInterimText,
-        this.currentSpeakerId,
-        this.currentLanguage,
-        undefined, // no token array needed for final
-      );
-    } else {
-      // Try the utterance buffer as a fallback
-      const utterance = this.utteranceBuffer.markEndpoint();
-      if (utterance && utterance.text.trim()) {
-        this.emitFinal(utterance.text, utterance.speaker, utterance.language, utterance.tokens);
+    const candidate = this.lastEmittedInterimText.trim();
+    if (candidate) {
+      if (this.pendingFinalText && this.pendingFinalTimer) {
+        const merged = this.tryMergeOverlap(this.pendingFinalText, candidate);
+        if (merged !== null) {
+          // Continuation of the prior utterance — merge texts, keep the
+          // original utteranceId so downstream can update the same card.
+          this.pendingFinalText = merged;
+          this.logger.debug(
+            { streamId: this.id, mergedLen: merged.length },
+            "🎙️ SONIOX SDK: endpoint merged with pending (continuation)",
+          );
+        } else {
+          // No overlap — these are genuinely separate utterances. Commit
+          // the prior, set this as the new pending candidate.
+          this.commitPendingFinal("non-overlapping next endpoint");
+          this.pendingFinalText = candidate;
+          this.pendingFinalUtteranceId = this.currentUtteranceId;
+          this.pendingFinalSpeakerId = this.currentSpeakerId;
+          this.pendingFinalLanguage = this.currentLanguage;
+        }
+      } else {
+        // First endpoint candidate — capture current state.
+        this.pendingFinalText = candidate;
+        this.pendingFinalUtteranceId = this.currentUtteranceId;
+        this.pendingFinalSpeakerId = this.currentSpeakerId;
+        this.pendingFinalLanguage = this.currentLanguage;
       }
+
+      // (Re)schedule commit.
+      if (this.pendingFinalTimer) clearTimeout(this.pendingFinalTimer);
+      this.pendingFinalTimer = setTimeout(() => {
+        this.commitPendingFinal("debounce expired");
+      }, this.endpointDebounceMs);
     }
 
-    // Rotate utterance ID and reset prefix for the next speech segment
+    // Reset utterance state so the next utterance starts fresh in sync
+    // with Soniox's internal rolling-window reset.
     this.currentUtteranceId = null;
     this.currentSpeakerId = undefined;
     this.currentLanguage = undefined;
     this.lastEmittedInterimText = "";
     this.stablePrefixText = "";
     this.prevWindowFinalLen = 0;
-
-    // Reset utterance buffer for the next utterance
     this.utteranceBuffer.reset();
 
-    this.logger.debug({ streamId: this.id }, "🎙️ SONIOX SDK: endpoint — rotated utterance");
+    this.logger.debug({ streamId: this.id }, "🎙️ SONIOX SDK: endpoint received (pending FINAL deferred)");
   }
 
   /**
-   * Finalized event: the server confirmed a manual `session.finalize()` call
-   * (triggered by VAD stop). Behaves like endpoint — emit final from the
-   * last known interim text, then reset for the next utterance.
+   * Suffix-prefix overlap merge. Returns the merged string if `b` starts
+   * with a suffix of `a` (at least `MIN_OVERLAP_CHARS`), otherwise null.
+   *
+   * Example: ("You know? Come on, I'", "Come on, I'm right.")
+   *   Suffix "Come on, I'" (11 chars) of `a` matches prefix of `b`.
+   *   → "You know? Come on, I'" + "m right." = "You know? Come on, I'm right."
+   */
+  private tryMergeOverlap(a: string, b: string): string | null {
+    const maxOverlap = Math.min(a.length, b.length);
+    for (let len = maxOverlap; len >= SonioxSdkStream.MIN_OVERLAP_CHARS; len--) {
+      if (a.endsWith(b.substring(0, len))) {
+        return a + b.substring(len);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Emit the pending FINAL and clear pending state. Called by:
+   *   - Debounce timer expiry (the happy path)
+   *   - Non-overlapping next endpoint (commit prior before storing new)
+   *   - Trusted signals (handleFinalized, handleFinished)
+   */
+  private commitPendingFinal(reason: string): void {
+    if (this.pendingFinalTimer) {
+      clearTimeout(this.pendingFinalTimer);
+      this.pendingFinalTimer = null;
+    }
+
+    if (!this.pendingFinalText) {
+      return;
+    }
+
+    // Restore the pending utterance's identity temporarily so emitFinal
+    // attaches the right utteranceId / speaker / language. The
+    // currentUtteranceId may have already advanced to a new utterance
+    // by the time the debounce fires.
+    const savedUtteranceId = this.currentUtteranceId;
+    const savedSpeakerId = this.currentSpeakerId;
+    const savedLanguage = this.currentLanguage;
+
+    this.currentUtteranceId = this.pendingFinalUtteranceId;
+    this.currentSpeakerId = this.pendingFinalSpeakerId;
+    this.currentLanguage = this.pendingFinalLanguage;
+
+    this.emitFinal(this.pendingFinalText, this.pendingFinalSpeakerId, this.pendingFinalLanguage, undefined);
+
+    this.currentUtteranceId = savedUtteranceId;
+    this.currentSpeakerId = savedSpeakerId;
+    this.currentLanguage = savedLanguage;
+
+    this.pendingFinalText = "";
+    this.pendingFinalUtteranceId = null;
+    this.pendingFinalSpeakerId = undefined;
+    this.pendingFinalLanguage = undefined;
+
+    this.logger.debug({ streamId: this.id, reason }, "🎙️ SONIOX SDK: pending FINAL committed");
+  }
+
+  /**
+   * Discard any pending FINAL without emitting (used on close/dispose
+   * where committing would be racy).
+   */
+  private cancelPendingFinal(reason: string): void {
+    if (this.pendingFinalTimer) {
+      clearTimeout(this.pendingFinalTimer);
+      this.pendingFinalTimer = null;
+    }
+    if (this.pendingFinalText) {
+      this.pendingFinalText = "";
+      this.pendingFinalUtteranceId = null;
+      this.pendingFinalSpeakerId = undefined;
+      this.pendingFinalLanguage = undefined;
+      this.logger.debug({ streamId: this.id, reason }, "🎙️ SONIOX SDK: pending FINAL discarded");
+    }
+  }
+
+  /**
+   * Finalized event: the server confirmed a manual `session.finalize()`
+   * call (triggered by VAD-stop or the 2s audio-gap auto-pause). Trusted
+   * signal — we initiated it, so the utterance has truly ended.
+   *
+   * Two pieces of work:
+   *   1. Commit any in-flight pending FINAL (from a prior endpoint that
+   *      hadn't yet expired its debounce).
+   *   2. Emit FINAL for the current utterance's text.
    */
   private handleFinalized(): void {
     this.lastActivity = Date.now();
 
+    // Step 1: flush any debounced pending FINAL.
+    this.commitPendingFinal("superseded by finalize");
+
+    // Step 2: emit FINAL for the current utterance directly, bypassing
+    // the debounce (this is a trusted signal).
     if (this.lastEmittedInterimText.trim()) {
       this.emitFinal(this.lastEmittedInterimText, this.currentSpeakerId, this.currentLanguage, undefined);
     } else {
-      // Fallback: flush utterance buffer
       const utterance = this.utteranceBuffer.markEndpoint();
       if (utterance && utterance.text.trim()) {
         this.emitFinal(utterance.text, utterance.speaker, utterance.language, utterance.tokens);
       }
     }
 
-    // Reset for next utterance
+    // Reset for next utterance.
     this.currentUtteranceId = null;
     this.currentSpeakerId = undefined;
     this.currentLanguage = undefined;
@@ -678,10 +829,12 @@ export class SonioxSdkStream implements StreamInstance {
 
   /**
    * Finished event: the session is ending (server signaled end of stream).
+   * Flush any pending debounced FINAL, then flush any current interim
+   * text as a final.
    */
   private handleFinished(): void {
     this.logger.debug({ streamId: this.id }, "Soniox SDK session finished");
-    // Flush any pending data as a final
+    this.commitPendingFinal("session finished");
     if (this.lastEmittedInterimText.trim()) {
       this.emitFinal(this.lastEmittedInterimText, this.currentSpeakerId, this.currentLanguage, undefined);
       this.lastEmittedInterimText = "";
@@ -813,6 +966,10 @@ export class SonioxSdkStream implements StreamInstance {
       enable_endpoint_detection: true,
       enable_speaker_diarization: true,
       language_hints: languageHints.length > 0 ? languageHints : undefined,
+      // Allowed 500–3000, Soniox default 2000. Higher gives the semantic
+      // model more time to retract premature endpoint decisions, reducing
+      // mid-utterance splits.
+      max_endpoint_delay_ms: this.config.maxEndpointDelayMs,
       context: {
         terms: ["Mentra", "MentraOS", "Hey Mentra"],
         text: "Mentra MentraOS, Hey Mentra (an AI assistant)",

--- a/cloud/packages/cloud/src/services/session/transcription/types.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/types.ts
@@ -75,6 +75,20 @@ export interface SonioxProviderConfig {
   endpoint: string;
   model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v4'
   maxConnections?: number;
+  /**
+   * Soniox `max_endpoint_delay_ms`. Allowed 500–3000, default 2000.
+   * Higher = Soniox waits longer before committing endpoint events,
+   * giving the semantic model more time to retract premature decisions.
+   * Useful for reducing mid-utterance endpoint splits.
+   */
+  maxEndpointDelayMs?: number;
+  /**
+   * How long to wait after a Soniox `endpoint` event before emitting
+   * the FINAL. If new tokens or new audio arrive within this window,
+   * the endpoint is treated as premature and discarded. Defaults to
+   * 500ms; tune higher for noisier signals.
+   */
+  endpointDebounceMs?: number;
 }
 
 export interface AlibabaProviderConfig {
@@ -347,6 +361,12 @@ export const DEFAULT_TRANSCRIPTION_CONFIG: TranscriptionConfig = {
     apiKey: SONIOX_API_KEY,
     endpoint: SONIOX_ENDPOINT,
     model: SONIOX_MODEL,
+    // 3000ms = Soniox's max. Higher = Soniox waits longer before
+    // committing endpoint events, giving the semantic model more time
+    // to retract premature decisions. Combined with our endpoint-
+    // debounce-and-merge logic in SonioxSdkStream, this reduces the
+    // rate of mid-utterance FINAL splits.
+    maxEndpointDelayMs: 3000,
   },
 
   alibaba: {


### PR DESCRIPTION
## Summary

Fixes the long-standing bug where transcripts arrive as multiple short FINALs (sometimes ending mid-word) instead of one complete utterance. Hits ~5% of utterances in staging traces; symptoms include "the final transcript drops content from the interim," "text changes/disappears around punctuation," and sentences appearing as two cards in Captions.

## Root cause

Soniox v4's semantic endpoint detector occasionally fires `endpoint` mid-utterance. Our previous code immediately emitted a FINAL on every endpoint event, so one logical sentence got split into multiple short FINALs.

Staging trace showing the bug:
```
01:02:54.562 FINAL "You know? Come on, I'"      ← endpoint mid-word
01:02:54.755 FINAL "Come on, I'm right."        ← continuation as new utterance
```

## Fix

In `SonioxSdkStream.ts`:

1. On `endpoint`, capture the candidate text and defer emission by 500ms (configurable via `endpointDebounceMs`). Utterance state still resets (to stay in sync with Soniox's internal rolling-window reset).
2. If a second `endpoint` arrives before the timer expires, attempt a suffix-prefix overlap merge:
   - Overlap found → continuation of same utterance; merge texts, reset timer.
   - No overlap → truly separate utterances; commit prior, hold new.
3. Trusted signals (`finalized` from VAD-stop / 2s audio-gap, `finished` from stream end) bypass the debounce and emit immediately.

Plus: set `max_endpoint_delay_ms: 3000` (Soniox's max, default is 2000ms) so the semantic model has more time to retract premature decisions before they reach us. Defense in depth.

## Reproduction + verification

Two new test harnesses in `src/scripts/`:

- **`soniox-repro-mock.ts`** — deterministic replay via mock Soniox session. Three scenarios:
  - Staging bug pattern → before fix: 2 FINALs; after fix: 1 FINAL `"You know? Come on, I'm right."` ✓
  - Clean single utterance → 1 FINAL ✓
  - Two genuinely separate utterances → 2 FINALs (no false merging) ✓
- **`soniox-repro.ts`** — real Soniox integration with TTS audio. Verifies multi-sentence audio still produces correct per-sentence FINALs.

Run locally:
```
bun run src/scripts/soniox-repro-mock.ts
SONIOX_API_KEY=... bun run src/scripts/soniox-repro.ts <path-to-wav>
```

## What this does NOT change

- The `is_final` token handling and rolling-window stable-prefix logic (`handleResult`).
- Multi-speaker / diarization output shape.
- Phone-VAD-stop and 2s audio-gap behavior on Mentra Live glasses (both trigger `finalized` which bypasses the debounce).

## Test plan

- [x] Mock-event repro of the staging bug → fix produces single merged FINAL
- [x] Multi-sentence real audio → still produces correct per-sentence FINALs
- [x] Clean utterance → single FINAL (no false latency)
- [x] Two real utterances with pause → two FINALs (no false merge)
- [x] Type check + lint clean on changed files
- [ ] Manual staging validation: deploy, replay `bstack` query for consecutive-FINAL pattern, expect the rate to drop materially

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Soniox mid-utterance splits so one complete FINAL is emitted per sentence, reducing dropped/duplicated text and double cards seen in ~5% of utterances on staging. Also enables cloud-debug deploys of this branch via `porter-debug` for easier validation.

- **Bug Fixes**
  - Debounces `endpoint` events (default 500ms) and merges consecutive endpoints via suffix–prefix overlap; trusted signals (`finalized`, `finished`) bypass the debounce; `close()` now commits any pending FINAL to prevent dropping the last utterance.
  - Sets Soniox `max_endpoint_delay_ms` to 3000 by default; adds `endpointDebounceMs` and `maxEndpointDelayMs` to config for tuning.
  - Adds `src/scripts/soniox-repro-mock.ts` and `src/scripts/soniox-repro.ts` for local repro; removes brittle mid-word heuristic and updates WAV parser to respect RIFF pad bytes.
  - CI: adds `cloud/fix-soniox-isfinal-split` to `.github/workflows/porter-debug.yml` to allow cloud-debug deploys.

<sup>Written for commit 5dd20186cd25392ed68e385d55c9a14cb70a8642. Summary will update on new commits. <a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/2846?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

