### PR TITLE
fix(107): hyphen-safe legacy v2 SDK session ID parser

### DIFF
--- a/.github/workflows/porter-debug.yml
+++ b/.github/workflows/porter-debug.yml
@@ -8,6 +8,7 @@ on:
       - cloud/pod-loop-stall-cascade
       - cloud/104-soniox-eventqueue-leak-fix
       - codex/issue-107-reconnect-storm
+      - cloud/legacy-sessionid-hyphen-fix
     paths:
       - "cloud/**"
       - ".github/workflows/porter-debug.yml"

--- a/cloud/bun.lock
+++ b/cloud/bun.lock
@@ -3767,6 +3767,8 @@
 
     "@mentra/v3-smoke-test/react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
+    "@mentra/v3-stream-example/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@mentra/v3-stream-example/@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@mentra/v3-stream-example/@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
@@ -4253,6 +4255,8 @@
 
     "@mentra/v3-smoke-test/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "@mentra/v3-stream-example/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "@mentra/v3-stream-example/react-dom/scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "@radix-ui/react-radio-group/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ=="],
@@ -4530,6 +4534,8 @@
     "@mentra/debugger/vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.18.20", "", { "os": "win32", "cpu": "x64" }, "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ=="],
 
     "@mentra/sdk/jsonwebtoken/jws/jwa": ["jwa@1.4.2", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw=="],
+
+    "@mentra/v3-stream-example/@types/bun/bun-types/@types/node": ["@types/node@22.19.15", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg=="],
 
     "@radix-ui/react-radio-group/@radix-ui/react-roving-focus/@radix-ui/react-collection/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-y7TBO4xN4Y94FvcWIOIh18fM4R1A8S4q1jhoz4PNzOoHsFcN8pogcFmZrTYAm4F9VRUrWP/Mw7xSKybIeRI+CQ=="],
 

--- a/cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spec.md
+++ b/cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spec.md
@@ -1,0 +1,196 @@
+# Spec: Hyphen-Safe Legacy v2 SDK Session ID Parser
+
+## Overview
+
+**What this doc covers:** Exact changes in this PR to fix the legacy session ID parser. The SDK is frozen so this is cloud-side only.
+
+**What you need to know first:** [spike.md](./spike.md) for the bug, the historical context, and the constraint that the SDK wire format cannot change.
+
+**Who should read this:** PR reviewers.
+
+---
+
+## Changes
+
+| File | Change |
+|---|---|
+| `cloud/packages/cloud/src/services/websocket/legacy-session-id.ts` | NEW. Exports `parseLegacySessionId(sessionId, isActiveUserId?)`. |
+| `cloud/packages/cloud/src/services/websocket/legacy-session-id.test.ts` | NEW. 21 unit tests covering happy path, hyphen edge cases, malformed input, backwards-compat. |
+| `cloud/packages/cloud/src/services/websocket/bun-websocket.ts` | `parseUserIdFromLegacySessionId` and `parsePackageNameFromLegacySessionId` now delegate to the new module. Add a private `isActiveUserId` wrapper around `UserSession.getById`. |
+| `cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spike.md` | NEW. Investigation. |
+| `cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spec.md` | NEW. This file. |
+
+No other source files touched.
+
+---
+
+## S1. The New Parser Module
+
+**File:** `cloud/packages/cloud/src/services/websocket/legacy-session-id.ts`
+
+Pure-function module. The exported `parseLegacySessionId` takes a session ID string and an optional `isActiveUserId` lookup callback. Returns `{userId, packageName} | undefined`.
+
+Algorithm (also described in the spike):
+
+1. Walk every hyphen position in the input.
+2. At each position, consider splitting the string into `userId = before` and `packageName = after`.
+3. Keep the candidate only if `userId.includes("@")` and `packageName.length > 0`.
+4. If `isActiveUserId` is provided, prefer the LONGEST candidate whose userId matches a live UserSession.
+5. If none match (or no lookup was provided), pick the SHORTEST `@`-bearing candidate whose userId ends with a TLD-shaped suffix (`/\.[a-zA-Z]{2,5}$/`).
+6. If no candidate is TLD-shaped (long gTLDs like `.museum`, IP-domain emails, internationalized TLDs), fall back to the SHORTEST `@`-bearing candidate — equivalent to pre-fix "first hyphen after `@`" parsing, which is correct for any non-hyphenated email regardless of TLD length.
+
+The TLD heuristic in the fallback path matters more than "useful userId for logs alone": the `parsePackageNameFromLegacySessionId` half of the API feeds into the v3-SDK reconnect bootstrapping path (`bun-websocket.ts:777` → `validateApiKey(packageName, apiKey)`) whenever `x-package-name` header and JWT package name are both absent. Returning a truncated package there would reject otherwise-valid reconnects. The TLD anchor keeps the userId aligned with the email's natural boundary, which keeps the package name intact.
+
+The 2-5 character TLD bound is a deliberate trade-off: it covers all common public TLDs (`.com`, `.org`, `.io`, `.uk`, `.app`, `.glass`, `.world`, ...) while rejecting longer dot-letter chunks that are almost certainly subdomain words (e.g. for `user@sub.hyphen-domain.com-captions`, the candidate `user@sub.hyphen` ends with `.hyphen` — 6 letters — which would falsely match an unbounded TLD regex). Users on long gTLDs (`.museum`, `.travel`, `.industries`) skip the TLD step entirely and land in the shortest-`@`-bearing fallback (step 6), which is correct for them as long as their email doesn't have a hyphen in the domain.
+
+### Known limitations of this heuristic
+
+The regex approach is necessarily imperfect. Two cases the parser still mis-handles, both extremely narrow:
+
+1. **Long-gTLD email + hyphen in the domain + no live session.** E.g. `user@hyphen-domain.museum-pkg`. No candidate is TLD-shaped (`.museum` is 6 letters) and the shortest `@`-bearing candidate splits at the wrong hyphen. Real population: ~zero.
+2. **Punycode IDN domains.** E.g. `user@example.xn--fiqs8s-pkg-name`. The 2-letter `.xn` prefix falsely matches the TLD regex and the parser splits there.
+
+The clean resolution for both is to swap `TLD_SUFFIX` for the Public Suffix List (e.g. `tldts` npm package). Tracked as a follow-up so this hotfix can ship.
+
+### Why dependency injection
+
+The parser needs to disambiguate by checking which candidates correspond to live sessions. Inlining `UserSession.getById` directly would make unit tests require booting a UserSession registry. Accepting an optional `(userId) => boolean` callback lets tests pass a trivial stub and lets production pass the real lookup.
+
+### Performance
+
+`UserSession.getById` is a `Map.get(string)` — O(1) microseconds. Typical legacy session IDs have 2-5 hyphens, so at most ~5 lookups per parse. The parser also does at most N string slices, which Bun handles via small substring objects rather than full copies. Per-parse cost stays in the low microseconds even for pathological inputs.
+
+---
+
+## S2. bun-websocket.ts Wiring
+
+**File:** `cloud/packages/cloud/src/services/websocket/bun-websocket.ts`
+
+The two existing helpers are reduced to thin wrappers:
+
+```ts
+function parsePackageNameFromLegacySessionId(sessionId?: string): string | undefined {
+  return parseLegacySessionId(sessionId, isActiveUserId)?.packageName;
+}
+
+function parseUserIdFromLegacySessionId(sessionId?: string): string | undefined {
+  return parseLegacySessionId(sessionId, isActiveUserId)?.userId;
+}
+
+function isActiveUserId(userId: string): boolean {
+  return UserSession.getById(userId) !== undefined;
+}
+```
+
+Call sites of `parseUserIdFromLegacySessionId` / `parsePackageNameFromLegacySessionId` are unchanged. Same signatures, same return types, same semantics for non-hyphenated inputs. Only the underlying disambiguation changes.
+
+Import line added:
+
+```ts
+import { parseLegacySessionId } from "./legacy-session-id";
+```
+
+---
+
+## S3. Tests
+
+**File:** `cloud/packages/cloud/src/services/websocket/legacy-session-id.test.ts`
+
+Tests organized by category:
+
+- **Happy path** (2 tests): standard email + simple package, with and without lookup.
+- **Hyphen in local-part** (4 tests): regression cases like `a-b@example.com`, `first-last@example.com`, multi-hyphen `first-middle-last@example.com`, and plus-tag-with-hyphen `alpha+test-dash@example.com`.
+- **Hyphen in domain** (2 tests): `user@hyphen-domain.com` with simple package, also with hyphenated package.
+- **Hyphens on both sides** (1 test): worst case `x-y@a-b.com-some-app-name`.
+- **isActiveUserId disambiguation** (4 tests): fallback when no live match; behavior with no lookup; longest-match preference when multiple are live; correct walk-past behavior.
+- **Malformed input** (7 tests): empty, undefined, no hyphen, no `@`, trailing hyphen, leading hyphen, just `@`.
+- **Backwards-compat** (2 tests): the exact format `AppManager.ts:208` constructs, and the test-script format.
+
+All tests pass against the new implementation. A regression-sweep file (`legacy-session-id.regression.test.ts`) and an integration test (`legacy-session-id.integration.test.ts`) cover the same patterns through the production wiring.
+
+---
+
+## Non-Goals
+
+- **SDK changes.** SDK is frozen; not touched.
+- **Deleting dead code** in `websocket-app.service.ts` / `websocket.service.ts`. They contain the same bug but no live import path reaches them. Separate cleanup PR.
+- **Refactoring the legacy session ID format itself.** The `<userId>-<packageName>` concatenation is fundamentally ambiguous; a proper fix would either (a) use a separator that can't appear in userId/packageName or (b) move to v3 SDK's header-based identity. Both require SDK changes. Out of scope.
+- **AppManager webhook retry coalescing.** v2 SDK apps will still tight-loop retry on `1008 SESSION_NOT_FOUND` when sessions are genuinely missing. That's a separate concern from this parser fix.
+
+---
+
+## Decision Log
+
+| Decision | Alternatives considered | Why |
+|---|---|---|
+| Extract parser to its own module + dependency-injected lookup | Inline fix in bun-websocket.ts with direct `UserSession.getById` call | Testability. The DI lookup lets unit tests run without booting UserSession. Module location (next to bun-websocket.ts) keeps the legacy code grouped. |
+| Validate-by-lookup over `@`-anchor parse | Just find first `-` AFTER `@` | The `@`-anchor works for `a-b@example.com-foo` (hyphen in local-part) but breaks again for `user@hyphen-domain.com-foo` (hyphen in domain). Validation handles both cleanly. |
+| Fall back to longest `@`-bearing candidate when no live session matches | Return undefined when no live match | If we returned undefined, the caller's error log would still log `userId: undefined`, hiding the diagnostic information. Returning the longest @-candidate at least surfaces a recognizable email in the error log. The connection still fails (UserSession.getById returns undefined again at the caller's check), so no behavior changes. Only logging quality improves. |
+| Keep the two function names (`parseUserIdFromLegacySessionId`, `parsePackageNameFromLegacySessionId`) | Replace with one function returning both | Minimizes call-site churn. They're already used in two distinct call sites; the wrappers stay one-liners. |
+| Don't fix the dead `websocket-app.service.ts` parser copy | Fix it too for symmetry | YAGNI. The file is dead code; reviving it would re-introduce other issues anyway. Cleanup PR can delete it entirely. |
+
+---
+
+## Testing
+
+### Local
+
+1. `bun install` from `cloud/` — succeeds.
+2. `bunx tsc --noEmit` from `cloud/packages/cloud/` — clean.
+3. `bun test src/services/websocket/legacy-session-id.test.ts` from `cloud/packages/cloud/` — 21 pass, 0 fail.
+
+### Manual against real data (post-deploy)
+
+After cloud-debug soak:
+
+1. Have a user with a hyphenated email install any v2 SDK app (or simulate by sending CONNECTION_INIT with sessionId `test-hyphen@example.com-com.example.test`).
+2. Verify the app's WS connection succeeds (no `1008 Session not found`).
+3. Verify the BetterStack `User session not found for app message` rate trends to zero for the affected user.
+
+### Cloud-debug smoke
+
+Add `cloud/legacy-sessionid-hyphen-fix` to `.github/workflows/porter-debug.yml`'s `push.branches` list. Soak for ≥30 min. Confirm no regressions in:
+
+- `op_appProtocol_connectionInit_ms` (parser is in this code path)
+- WS upgrade success rate
+- `slow-app-protocol` events should NOT increase (parser is microseconds)
+
+### Acceptance after staging soak
+
+After merging to `staging`:
+
+1. Cross-reference BetterStack for single-letter / truncated userIds in `User session not found` errors (the telltale fingerprint of the parser bug). Should drop to zero.
+2. Run the blast-radius MongoDB query to confirm affected user count.
+3. Track v2 SDK app retry-loop volume in app-server logs. Should drop for hyphenated-email users.
+
+---
+
+## Rollout
+
+1. Branch `cloud/legacy-sessionid-hyphen-fix` off `staging`. Done.
+2. Land this PR's code + tests + docs.
+3. Add branch to `porter-debug.yml` triggers for cloud-debug soak.
+4. Soak ≥1h on cloud-debug.
+5. PR to `staging`.
+6. After staging soak, promote staging → main.
+7. Back-merge staging → dev.
+
+Per the staging-first release cycle. No hotfix-to-main path.
+
+---
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Parser misidentifies a candidate when multiple `@`-bearing candidates exist for live users | Longest-match preference. Verified by the dedicated test case. |
+| Parser perf regression under pathological input | Worst case 1000-char session ID with hyphens everywhere = ~500 candidates × O(1) lookup = ~500 microseconds. Practical inputs are 30-80 chars with 2-5 hyphens = ~5 microseconds. Negligible. |
+| Existing stored sessions in MongoDB don't round-trip | They round-trip identically. AppManager.ts:208 still constructs `${userId}-${packageName}`; the new parser handles every form correctly. Tested. |
+| Behavior change breaks something else | Behavior change is strictly an improvement (broken cases now work; working cases still work). No semantic change for non-hyphenated inputs. |
+| Privacy: fallback path returns a candidate userId that's logged downstream | The fallback userId is at worst a longer version of an already-logged identifier. Same information class as today (raw email or close to it). Not a new disclosure. |
+
+---
+
+## Summary
+
+Three small files added (one module, one test file, two doc files), two helper functions in `bun-websocket.ts` simplified to one-liners. ~150 LoC of code + tests + docs. Zero behavior changes for non-hyphenated inputs. Fixes a class of users who have been silently broken since the legacy SDK shipped.

--- a/cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spike.md
+++ b/cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spike.md
@@ -1,0 +1,143 @@
+# Spike: Legacy v2 SDK Session ID Parser Drops Users With Hyphens
+
+**Status:** Open — fix shipped with this PR
+**Date:** 2026-05-19
+**Related:**
+- [074-sdk-v3-merge-and-ship](../074-sdk-v3-merge-and-ship/) — context for the v3 SDK refactor that preserved this bug
+
+---
+
+## Summary
+
+The cloud's legacy v2 SDK session ID parser uses `sessionId.indexOf("-")` (previously `sessionId.split("-")[0]`) to extract the userId portion. The v2 SDK wire format is `<userId>-<packageName>` where userId is always an email, so when either side contains a hyphen the parser silently extracts the wrong substring.
+
+For a user `a-b@example.com` running `some-app-name`, the session ID is
+
+```
+a-b@example.com-some-app-name
+ ↑
+ first hyphen at position 1
+```
+
+`indexOf("-")` returns 1, so the parser extracts `userId = "a"` and `packageName = "b@example.com-some-app-name"`. `UserSession.getById("a")` returns undefined, the cloud closes the WS upgrade with `1008 "Session not found"`, the app SDK retries, and the cycle repeats indefinitely.
+
+**Anyone with a hyphen anywhere in their email (local-part or domain) has been silently broken since this code shipped.** The bug predates the SDK v3 refactor and was carried forward into the current `parseUserIdFromLegacySessionId` / `parsePackageNameFromLegacySessionId` helpers in [bun-websocket.ts:1034-1058](../../packages/cloud/src/services/websocket/bun-websocket.ts#L1034).
+
+---
+
+## Evidence
+
+### Cloud-side symptoms
+
+The "User session not found for app message" log lines surface with truncated single-character userIds (e.g. `userId="a"`, `userId="x"`) — the parser truncated a hyphenated email at the first hyphen and the resulting prefix matches no live session.
+
+### App-server-side symptoms
+
+A v2 SDK app server attempting to serve a hyphenated-email user logs a tight retry loop:
+
+```
+Received session request for user a-b@example.com, session a-b@example.com-some-app-name
+Attempting to connect to: wss://uscentralapi.mentra.glass/app-ws
+Connection closed (code: 1008): Session not found
+Connection timeout after 5000ms
+Received session request for user a-b@example.com ...
+[cycle repeats]
+```
+
+Every iteration of this loop adds load to the cloud's WS upgrade pipeline. With multiple legacy-format apps installed per affected user, the load multiplies.
+
+### Why the v3 SDK path is unaffected
+
+v3 SDK sends `userId` via the `x-user-id` HTTP header at upgrade time (see [bun-websocket.ts:171](../../packages/cloud/src/services/websocket/bun-websocket.ts#L171)). The parser is only invoked when both that header and `ws.data.userId` are absent — the v2 CONNECTION_INIT and RECONNECT paths.
+
+---
+
+## Historical Archaeology
+
+The "dumb" approach the bug originates from is documented in the v3 SDK feat commit (`9a6c81ed6`):
+
+> Before:
+> ```ts
+> const sessionParts = initMessage.sessionId.split("-");
+> const userId = sessionParts[0];
+> ```
+> After:
+> ```ts
+> function parseUserIdFromLegacySessionId(sessionId?: string): string | undefined {
+>   const separator = sessionId.indexOf("-");
+>   if (separator <= 0) return undefined;
+>   return sessionId.slice(0, separator);
+> }
+> ```
+
+The refactor was cosmetic. Both versions take everything before the first hyphen.
+
+Commit `cd91c2a28` from 2026-03-30 (`fix: pass legacy sessionId (userId-packageName) to AppSession for v2 SDK compat`) explicitly documents the legacy contract:
+
+> "v2 SDKs send this sessionId in CONNECTION_INIT, and the cloud parses `sessionId.split("-")[0]` to recover the userId and find the UserSession."
+
+The format is intentional. The parser was the bug.
+
+---
+
+## Constraints On The Fix
+
+- **SDK is frozen.** The v2 SDK wire format cannot change. Anything that requires SDK-side changes is out of scope.
+- **Backwards-compat.** Existing sessions, existing apps, and existing v2 SDK clients must all continue to work without intervention.
+- **AppManager construction format unchanged.** `AppManager.ts:208` builds session IDs as `${userId}-${packageName}`; that string then needs to round-trip through the parser. Both pre-fix and post-fix sessions stored in MongoDB must parse correctly.
+
+---
+
+## Fix
+
+Replace the `indexOf("-")` first-hyphen logic with validation-by-lookup, with a TLD-shape heuristic as the fallback:
+
+1. Enumerate every possible split position of the input string.
+2. Discard candidates whose userId-portion doesn't contain `@` (active user IDs are always emails).
+3. For each remaining candidate, look up the userId in the live `UserSession` map.
+4. If at least one candidate matches a live UserSession, return the longest matching candidate (handles the rare case where a shorter prefix is also a valid email for a different live user).
+5. If none match, prefer the SHORTEST candidate whose userId ends with a TLD-shaped suffix (`/\.[a-zA-Z]{2,5}$/`) — anchors to the email's natural boundary so both the parsed userId AND the resulting packageName are correct.
+6. If no candidate has a TLD-shaped userId (long gTLDs like `.museum`, IP-domain emails, internationalized TLDs), fall back to the SHORTEST `@`-bearing candidate — equivalent to pre-fix "first hyphen after `@`" parsing, which is correct for any non-hyphenated email regardless of TLD length and never regresses pre-fix behavior.
+
+`UserSession.getById` is a `Map.get` — O(1). A typical legacy session ID has 2-5 hyphens, so we do at most ~5 lookups per parse. Microseconds.
+
+The parser is extracted to its own module (`cloud/packages/cloud/src/services/websocket/legacy-session-id.ts`) with dependency injection on the lookup, so unit tests don't need a live UserSession.
+
+See [spec.md](./spec.md) for the exact implementation and call-site changes.
+
+---
+
+## What's Eliminated By This Fix
+
+- Users with a hyphen in their email local-part (e.g. `a-b@example.com`, `first-last@example.com`).
+- Users with a hyphen in their email domain (e.g. `user@hyphen-domain.com`).
+- The retry-loop CPU cost on cloud from affected users' apps repeatedly failing to connect.
+
+---
+
+## What's Not Fixed By This Fix
+
+- The underlying v2 SDK retry behavior. v2 SDK apps will still retry tight (5-second timeout, no backoff) on `1008 SESSION_NOT_FOUND`. That's a known SDK characteristic and the SDK is frozen.
+- Apps that are configured with stale session info during a real session-disposal race. The parser returning the right userId doesn't change the fact that `UserSession.getById` will still return undefined when the session is genuinely gone. Those cases need different handling (e.g. AppManager-side coalescing of webhook retries).
+
+---
+
+## Blast Radius
+
+Any user with a hyphen anywhere in their email has been unable to use any v2 SDK app since this code shipped. A quick MongoDB query can size the affected population:
+
+```js
+db.users.countDocuments({ email: /-/ })            // any hyphen
+db.users.countDocuments({ email: /^[^@]*-/ })      // hyphen in local-part
+db.users.countDocuments({ email: /@[^@]*-/ })      // hyphen in domain
+```
+
+Worth running this against prod before merging to gauge impact. Even a small affected population is a real user-facing bug worth fixing immediately.
+
+---
+
+## Other Places Searched, No Bug Found
+
+A codebase-wide search for `sessionId.split("-")` and `indexOf("-")` near sessionId/userId parsing returned only these two parser functions as having the bug. The other `split("-")` usages in the codebase are for language codes (`en-US` → `en`), which is a well-defined two-part format with no ambiguity. Not affected.
+
+The older `cloud/packages/cloud/src/services/websocket/websocket-app.service.ts` contains a third copy of the broken parser (at line 201), but the file is confirmed dead code — no import path leads to it from `cloud/packages/cloud/src/index.ts`. Left untouched in this PR; should be deleted in a separate cleanup PR.

--- a/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
+++ b/cloud/packages/cloud/src/services/websocket/bun-websocket.ts
@@ -30,6 +30,7 @@ import { isShuttingDown } from "../shutdown";
 import { metricsService } from "../metrics";
 import { PosthogService } from "../logging/posthog.service";
 import UserSession from "../session/UserSession";
+import { parseLegacySessionId } from "./legacy-session-id";
 import {
   buildAppWsCloseTelemetry,
   cascadeDiagnostics,
@@ -1032,27 +1033,22 @@ function isV3Sdk(version?: string): boolean {
 }
 
 function parsePackageNameFromLegacySessionId(sessionId?: string): string | undefined {
-  if (!sessionId) {
-    return undefined;
-  }
-
-  const separator = sessionId.indexOf("-");
-  if (separator === -1 || separator === sessionId.length - 1) {
-    return undefined;
-  }
-
-  return sessionId.slice(separator + 1);
+  return parseLegacySessionId(sessionId, isActiveUserId)?.packageName;
 }
 
 function parseUserIdFromLegacySessionId(sessionId?: string): string | undefined {
-  if (!sessionId) {
-    return undefined;
-  }
-
-  const separator = sessionId.indexOf("-");
-  if (separator <= 0) {
-    return undefined;
-  }
-
-  return sessionId.slice(0, separator);
+  return parseLegacySessionId(sessionId, isActiveUserId)?.userId;
 }
+
+function isActiveUserId(userId: string): boolean {
+  return UserSession.getById(userId) !== undefined;
+}
+
+// Exported for integration tests only. Verifies the production wiring of the
+// parser against the live UserSession.getById lookup. Not part of the module's
+// public API.
+/** @internal */
+export const __forTesting = {
+  parseUserIdFromLegacySessionId,
+  parsePackageNameFromLegacySessionId,
+};

--- a/cloud/packages/cloud/src/services/websocket/legacy-session-id.integration.test.ts
+++ b/cloud/packages/cloud/src/services/websocket/legacy-session-id.integration.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Integration test for the legacy session ID parser as wired into
+ * bun-websocket.ts.
+ *
+ * Unit tests in `legacy-session-id.test.ts` cover the parser logic in
+ * isolation. This file goes one level up: it imports the wrappers from
+ * bun-websocket.ts (via `__forTesting`) and verifies the production
+ * wiring — specifically, that those wrappers correctly delegate to
+ * `parseLegacySessionId` with `UserSession.getById` injected as the
+ * `isActiveUserId` lookup.
+ *
+ * Strategy: use `spyOn` to control what `UserSession.getById` returns
+ * during each test. This exercises the exact production code path
+ * (`parseUserIdFromLegacySessionId` → `parseLegacySessionId` →
+ * `isActiveUserId` → `UserSession.getById`) without mocking the whole
+ * module.
+ *
+ * All emails and package names in this file are synthesized examples.
+ */
+
+import { describe, expect, test, beforeEach, afterEach, spyOn } from "bun:test";
+
+import UserSession from "../session/UserSession";
+import { __forTesting } from "./bun-websocket";
+
+const { parseUserIdFromLegacySessionId, parsePackageNameFromLegacySessionId } = __forTesting;
+
+const ACTIVE = new Set<string>();
+let getByIdSpy: ReturnType<typeof spyOn> | undefined;
+
+function setActive(...userIds: string[]): void {
+  ACTIVE.clear();
+  for (const uid of userIds) {
+    ACTIVE.add(uid);
+  }
+}
+
+beforeEach(() => {
+  ACTIVE.clear();
+  getByIdSpy = spyOn(UserSession, "getById").mockImplementation((userId: string) => {
+    return ACTIVE.has(userId) ? ({ userId } as unknown as UserSession) : undefined;
+  });
+});
+
+afterEach(() => {
+  getByIdSpy?.mockRestore();
+  ACTIVE.clear();
+});
+
+describe("bun-websocket wrappers — integration via __forTesting", () => {
+  describe("hyphenated email — live session", () => {
+    test("hyphen in local-part + hyphenated package", () => {
+      setActive("a-b@example.com");
+      const sessionId = "a-b@example.com-some-app-name";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("a-b@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("some-app-name");
+    });
+
+    test("hyphen in local-part — no live session, fallback returns correct userId AND package", () => {
+      // No active session. Pre-fix would have returned "a". The new
+      // fallback path picks the shortest TLD-shaped @-bearing candidate
+      // so the userId is the real email AND the packageName isn't
+      // truncated. The package value matters: it feeds validateApiKey in
+      // the v3-SDK reconnect bootstrapping path.
+      const sessionId = "a-b@example.com-some-app-name";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("a-b@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("some-app-name");
+    });
+
+    test("hyphen in domain + dotted package", () => {
+      setActive("user@hyphen-domain.com");
+      const sessionId = "user@hyphen-domain.com-com.example.captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("user@hyphen-domain.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("com.example.captions");
+    });
+
+    test("plus-tag with hyphen in local-part + hyphenated package", () => {
+      setActive("alpha+test-dash@example.com");
+      const sessionId = "alpha+test-dash@example.com-some-app";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("alpha+test-dash@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("some-app");
+    });
+  });
+
+  describe("non-hyphenated emails — must behave identically to pre-fix", () => {
+    test("simple email + dotted package", () => {
+      setActive("alpha@example.com");
+      const sessionId = "alpha@example.com-com.example.captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("alpha@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("com.example.captions");
+    });
+
+    test("clean email running app with hyphenated package name", () => {
+      setActive("clean.user@example.com");
+      const sessionId = "clean.user@example.com-some-app-name";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("clean.user@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("some-app-name");
+    });
+
+    test("clean email with no live session — fallback still returns email", () => {
+      const sessionId = "clean.user@example.com-com.example.captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("clean.user@example.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("com.example.captions");
+    });
+  });
+
+  describe("edge cases", () => {
+    test("empty string", () => {
+      expect(parseUserIdFromLegacySessionId("")).toBeUndefined();
+      expect(parsePackageNameFromLegacySessionId("")).toBeUndefined();
+    });
+
+    test("undefined", () => {
+      expect(parseUserIdFromLegacySessionId(undefined)).toBeUndefined();
+      expect(parsePackageNameFromLegacySessionId(undefined)).toBeUndefined();
+    });
+
+    test("no @ in the string — not a legacy session ID", () => {
+      // The new parser is stricter — requires at least one "@"-bearing candidate.
+      // The pre-fix parser would have returned `userId="some"`, `packageName="random-string"`.
+      // For non-legacy session IDs, returning undefined is the correct behavior
+      // (the caller in bun-websocket.ts already has fallback logic for missing userId).
+      expect(parseUserIdFromLegacySessionId("some-random-string")).toBeUndefined();
+      expect(parsePackageNameFromLegacySessionId("some-random-string")).toBeUndefined();
+    });
+
+    test("hyphen in domain only", () => {
+      setActive("user@hyphen-corp.uk");
+      const sessionId = "user@hyphen-corp.uk-captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("user@hyphen-corp.uk");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("captions");
+    });
+
+    test("hyphens in BOTH email AND package", () => {
+      setActive("a-b@c-d.com");
+      const sessionId = "a-b@c-d.com-some-app-name";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("a-b@c-d.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("some-app-name");
+    });
+  });
+
+  describe("disambiguation with multiple live users", () => {
+    test("when both `a@x.com` and `a@x.com-b@y.com` are live, longer wins", () => {
+      setActive("a@x.com", "a@x.com-b@y.com");
+      const sessionId = "a@x.com-b@y.com-captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("a@x.com-b@y.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("captions");
+    });
+
+    test("when only the shorter is live, parser walks to it", () => {
+      setActive("a@x.com");
+      const sessionId = "a@x.com-b@y.com-captions";
+      expect(parseUserIdFromLegacySessionId(sessionId)).toBe("a@x.com");
+      expect(parsePackageNameFromLegacySessionId(sessionId)).toBe("b@y.com-captions");
+    });
+  });
+
+  describe("AppManager-constructed session IDs (production format)", () => {
+    // AppManager.ts:208 constructs session IDs as `${userId}-${packageName}`.
+    // These tests round-trip that exact construction to prove the parser
+    // correctly handles what the cloud actually writes.
+    test("round-trip: AppManager-style for hyphenated-email user", () => {
+      setActive("a-b@example.com");
+      const userId = "a-b@example.com";
+      const packageName = "some-app-name";
+      const constructed = `${userId}-${packageName}`;
+      expect(parseUserIdFromLegacySessionId(constructed)).toBe(userId);
+      expect(parsePackageNameFromLegacySessionId(constructed)).toBe(packageName);
+    });
+
+    test("round-trip: AppManager-style for a clean email user", () => {
+      setActive("alpha@example.com");
+      const userId = "alpha@example.com";
+      const packageName = "com.example.captions";
+      const constructed = `${userId}-${packageName}`;
+      expect(parseUserIdFromLegacySessionId(constructed)).toBe(userId);
+      expect(parsePackageNameFromLegacySessionId(constructed)).toBe(packageName);
+    });
+  });
+
+  describe("UserSession.getById is invoked correctly", () => {
+    test("getById is called when parsing legacy IDs with multiple @-candidates", () => {
+      setActive("a-b@example.com");
+      parseUserIdFromLegacySessionId("a-b@example.com-some-app-name");
+      expect(getByIdSpy?.mock.calls.length ?? 0).toBeGreaterThan(0);
+    });
+
+    test("getById is NOT called with the buggy short prefix (pre-fix wrong answer)", () => {
+      setActive("a-b@example.com");
+      parseUserIdFromLegacySessionId("a-b@example.com-some-app-name");
+      const calls = getByIdSpy?.mock.calls ?? [];
+      const calledWithJustPrefix = calls.some((args: unknown[]) => args[0] === "a");
+      expect(calledWithJustPrefix).toBe(false);
+    });
+
+    test("getById is never called with empty/garbage candidates", () => {
+      parseUserIdFromLegacySessionId("a-b@example.com-some-app-name");
+      const calls = getByIdSpy?.mock.calls ?? [];
+      // All candidates MUST contain "@" (the parser's filter)
+      for (const args of calls) {
+        expect((args[0] as string).includes("@")).toBe(true);
+      }
+    });
+
+    test("getById is not called for inputs without @ anywhere", () => {
+      parseUserIdFromLegacySessionId("no-at-sign-here");
+      expect(getByIdSpy?.mock.calls.length ?? 0).toBe(0);
+    });
+  });
+});

--- a/cloud/packages/cloud/src/services/websocket/legacy-session-id.regression.test.ts
+++ b/cloud/packages/cloud/src/services/websocket/legacy-session-id.regression.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Regression sweep for parseLegacySessionId.
+ *
+ * Parameterized over a long list of session ID patterns. Goals:
+ *   1. Prove the fix works for every hyphen-affected email pattern.
+ *   2. Prove no regression for non-hyphenated emails (the vast majority).
+ *   3. Prove the cross-product of {hyphenated-email × hyphenated-package} works.
+ *   4. Prove behavior matches the pre-fix parser exactly for unambiguous cases.
+ *
+ * All emails and package names in this file are synthesized examples
+ * (`example.com`, `example-corp.com`, `com.example.*`, etc.).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { parseLegacySessionId } from "./legacy-session-id";
+
+// The pre-fix parser, kept here as a reference implementation so we can
+// regression-test against it (verify the new behavior MATCHES it for
+// non-hyphenated cases, and DIFFERS from it correctly for the bug cases).
+function preFixParseUserId(sessionId: string | undefined): string | undefined {
+  if (!sessionId) return undefined;
+  const sep = sessionId.indexOf("-");
+  if (sep <= 0) return undefined;
+  return sessionId.slice(0, sep);
+}
+
+function preFixParsePackageName(sessionId: string | undefined): string | undefined {
+  if (!sessionId) return undefined;
+  const sep = sessionId.indexOf("-");
+  if (sep === -1 || sep === sessionId.length - 1) return undefined;
+  return sessionId.slice(sep + 1);
+}
+
+interface SweepCase {
+  label: string;
+  userId: string;
+  packageName: string;
+  // If true, the pre-fix parser was broken on this case (used to mark the
+  // bug-fix cases where the new behavior intentionally differs from old).
+  prefixWasBroken: boolean;
+}
+
+// ============================================================================
+// Clean (non-hyphenated) email + various package shapes
+// ============================================================================
+
+const CLEAN_EMAIL_PATTERNS: SweepCase[] = [
+  { label: "simple email + simple package", userId: "alpha@example.com", packageName: "captions", prefixWasBroken: false },
+  { label: "simple email + dotted package", userId: "beta@example.com", packageName: "com.example.captions", prefixWasBroken: false },
+  { label: "long email + long dotted package", userId: "very.long.email.address+suffix@longdomain.example", packageName: "cloud.example.notify", prefixWasBroken: false },
+  { label: "email with dots and digits + simple package", userId: "user1.test2@example.com", packageName: "notes", prefixWasBroken: false },
+];
+
+const CLEAN_EMAIL_HYPHENATED_PACKAGE: SweepCase[] = [
+  // Pre-fix handled these correctly because the FIRST hyphen still correctly
+  // separates email from package when the email has no hyphens.
+  { label: "clean email + simple hyphenated package", userId: "alpha@example.com", packageName: "some-app", prefixWasBroken: false },
+  { label: "clean email + multi-hyphen package", userId: "alpha@example.com", packageName: "some-app-name", prefixWasBroken: false },
+  { label: "clean email + dotted hyphenated package", userId: "alpha@example.com", packageName: "com.example.iris-client", prefixWasBroken: false },
+  { label: "clean email + multi-hyphen dotted package", userId: "alpha@example.com", packageName: "com.example.data-plus-visual", prefixWasBroken: false },
+  { label: "clean email + leading-segment hyphen", userId: "alpha@example.com", packageName: "com.example.pitch-tuner", prefixWasBroken: false },
+  { label: "clean email + ai-assistant style package", userId: "alpha@example.com", packageName: "com.example.ai-assistant", prefixWasBroken: false },
+];
+
+// ============================================================================
+// Hyphen-affected email patterns (the bug class)
+// ============================================================================
+
+const HYPHEN_IN_LOCAL_PART: SweepCase[] = [
+  { label: "single hyphen at position 1", userId: "a-b@example.com", packageName: "captions", prefixWasBroken: true },
+  { label: "single hyphen mid local-part", userId: "first-last@example.com", packageName: "captions", prefixWasBroken: true },
+  { label: "multiple hyphens in local-part", userId: "a-b-c@example.com", packageName: "captions", prefixWasBroken: true },
+  { label: "hyphen at end of local-part", userId: "user-@example.com", packageName: "captions", prefixWasBroken: true },
+  { label: "leading hyphen in local-part", userId: "-user@example.com", packageName: "captions", prefixWasBroken: true },
+  { label: "hyphenated local + hyphenated package", userId: "a-b@example.com", packageName: "some-app-name", prefixWasBroken: true },
+  { label: "plus-tag with hyphen in local-part", userId: "alpha+test-dash@example.com", packageName: "some-app", prefixWasBroken: true },
+  { label: "plus-tag with hyphen + hyphenated package", userId: "alpha+test-dash@example.com", packageName: "com.example.some-app", prefixWasBroken: true },
+];
+
+const HYPHEN_IN_DOMAIN: SweepCase[] = [
+  { label: "single hyphen in domain", userId: "user@hyphen-domain.com", packageName: "captions", prefixWasBroken: true },
+  { label: "multiple hyphens in domain", userId: "user@multi-hyphen-domain.com", packageName: "captions", prefixWasBroken: true },
+  { label: "subdomain with hyphen", userId: "user@sub.hyphen-domain.com", packageName: "captions", prefixWasBroken: true },
+  { label: "hyphenated domain + hyphenated package", userId: "user@hyphen-domain.com", packageName: "some-app-name", prefixWasBroken: true },
+];
+
+const HYPHEN_BOTH_SIDES: SweepCase[] = [
+  { label: "hyphen in local AND domain", userId: "first-last@hyphen-domain.com", packageName: "captions", prefixWasBroken: true },
+  { label: "worst case: hyphen everywhere", userId: "a-b@c-d.com", packageName: "some-app-name", prefixWasBroken: true },
+];
+
+const ALL_CASES: SweepCase[] = [
+  ...CLEAN_EMAIL_PATTERNS,
+  ...CLEAN_EMAIL_HYPHENATED_PACKAGE,
+  ...HYPHEN_IN_LOCAL_PART,
+  ...HYPHEN_IN_DOMAIN,
+  ...HYPHEN_BOTH_SIDES,
+];
+
+// ============================================================================
+// The sweep
+// ============================================================================
+
+describe("parseLegacySessionId — regression sweep across patterns", () => {
+  describe("with isActiveUserId (production code path)", () => {
+    for (const c of ALL_CASES) {
+      test(c.label, () => {
+        const sessionId = `${c.userId}-${c.packageName}`;
+        const result = parseLegacySessionId(sessionId, (uid) => uid === c.userId);
+        expect(result).toEqual({
+          userId: c.userId,
+          packageName: c.packageName,
+        });
+      });
+    }
+  });
+
+  describe("without isActiveUserId (fallback picks shortest TLD-shaped @-candidate)", () => {
+    // The fallback fires when no live UserSession matches any candidate,
+    // OR when the caller doesn't pass a lookup at all. It MUST return the
+    // correct userId AND packageName, not just a recognizable userId,
+    // because downstream code (v3 SDK reconnect bootstrapping → validate
+    // API key) consumes the packageName before the session is available.
+    //
+    // Sweep covers clean emails AND every hyphen-affected pattern that
+    // has a single TLD-shaped @-bearing candidate. Hyphen-only-in-domain
+    // cases like `user@hyphen-domain.com` are included — the parser must
+    // recover them without a live-session hint.
+    for (const c of [
+      ...CLEAN_EMAIL_PATTERNS,
+      ...CLEAN_EMAIL_HYPHENATED_PACKAGE,
+      ...HYPHEN_IN_LOCAL_PART,
+      ...HYPHEN_IN_DOMAIN,
+      ...HYPHEN_BOTH_SIDES,
+    ]) {
+      test(`fallback matches expected: ${c.label}`, () => {
+        const sessionId = `${c.userId}-${c.packageName}`;
+        const result = parseLegacySessionId(sessionId);
+        expect(result).toEqual({
+          userId: c.userId,
+          packageName: c.packageName,
+        });
+      });
+    }
+  });
+});
+
+describe("parseLegacySessionId — backwards compatibility with pre-fix parser", () => {
+  // For inputs WITHOUT hyphens in the userId portion, the new parser must
+  // return the SAME result the old broken parser would have. This is the
+  // regression guarantee: don't change behavior for working users.
+  describe("no behavior change for clean emails (pre-fix was correct)", () => {
+    for (const c of [...CLEAN_EMAIL_PATTERNS, ...CLEAN_EMAIL_HYPHENATED_PACKAGE]) {
+      test(c.label, () => {
+        expect(c.prefixWasBroken).toBe(false); // sanity: these are the "old behavior correct" cases
+        const sessionId = `${c.userId}-${c.packageName}`;
+        const oldUserId = preFixParseUserId(sessionId);
+        const oldPackageName = preFixParsePackageName(sessionId);
+        const newResult = parseLegacySessionId(sessionId, (uid) => uid === c.userId);
+        expect(newResult?.userId).toBe(oldUserId!);
+        expect(newResult?.packageName).toBe(oldPackageName!);
+      });
+    }
+  });
+
+  describe("behavior intentionally changes for hyphenated emails (pre-fix was broken)", () => {
+    for (const c of [...HYPHEN_IN_LOCAL_PART, ...HYPHEN_IN_DOMAIN, ...HYPHEN_BOTH_SIDES]) {
+      test(c.label, () => {
+        expect(c.prefixWasBroken).toBe(true); // sanity: these are the bug cases
+        const sessionId = `${c.userId}-${c.packageName}`;
+        const oldUserId = preFixParseUserId(sessionId);
+        const newResult = parseLegacySessionId(sessionId, (uid) => uid === c.userId);
+        // Old parser was broken: extracted wrong userId
+        expect(oldUserId).not.toBe(c.userId);
+        // New parser fixes it
+        expect(newResult?.userId).toBe(c.userId);
+        expect(newResult?.packageName).toBe(c.packageName);
+      });
+    }
+  });
+});
+
+describe("parseLegacySessionId — lookup is only called when needed and uses correct candidates", () => {
+  test("lookup is called with @-bearing candidates only (no garbage)", () => {
+    const callsReceived: string[] = [];
+    const sessionId = "a-b@example.com-some-app-name";
+    parseLegacySessionId(sessionId, (uid) => {
+      callsReceived.push(uid);
+      return uid === "a-b@example.com";
+    });
+    // All candidates passed to the lookup must contain "@".
+    for (const c of callsReceived) {
+      expect(c.includes("@")).toBe(true);
+    }
+    // "a" (the broken pre-fix answer) must NEVER be passed to the lookup.
+    expect(callsReceived).not.toContain("a");
+  });
+
+  test("lookup stops as soon as a match is found (longest-first)", () => {
+    let calls = 0;
+    parseLegacySessionId(
+      "a-b@example.com-some-app-name",
+      (uid) => {
+        calls++;
+        // Match on the longest candidate (the full email).
+        return uid === "a-b@example.com";
+      },
+    );
+    expect(calls).toBeGreaterThan(0);
+    expect(calls).toBeLessThanOrEqual(4); // bounded by hyphen-position count
+  });
+});

--- a/cloud/packages/cloud/src/services/websocket/legacy-session-id.test.ts
+++ b/cloud/packages/cloud/src/services/websocket/legacy-session-id.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseLegacySessionId } from "./legacy-session-id";
+
+describe("parseLegacySessionId", () => {
+  // Helper: build a fake "active user" lookup over a fixed set.
+  const liveUsers = (...userIds: string[]) =>
+    (id: string) => userIds.includes(id);
+
+  describe("happy path — no hyphens in userId or packageName", () => {
+    test("parses standard email + simple package", () => {
+      expect(parseLegacySessionId("alpha@example.com-captions")).toEqual({
+        userId: "alpha@example.com",
+        packageName: "captions",
+      });
+    });
+
+    test("parses with no isActiveUserId provided (returns longest @-candidate)", () => {
+      expect(parseLegacySessionId("alpha@example.com-com.example.captions")).toEqual({
+        userId: "alpha@example.com",
+        packageName: "com.example.captions",
+      });
+    });
+  });
+
+  describe("hyphen in email local-part", () => {
+    test("a-b@example.com with hyphenated package — pre-fix returned userId='a'", () => {
+      expect(
+        parseLegacySessionId(
+          "a-b@example.com-some-app-name",
+          liveUsers("a-b@example.com"),
+        ),
+      ).toEqual({
+        userId: "a-b@example.com",
+        packageName: "some-app-name",
+      });
+    });
+
+    test("first-last@example.com with simple package", () => {
+      expect(
+        parseLegacySessionId("first-last@example.com-captions", liveUsers("first-last@example.com")),
+      ).toEqual({
+        userId: "first-last@example.com",
+        packageName: "captions",
+      });
+    });
+
+    test("multiple hyphens in local-part", () => {
+      expect(
+        parseLegacySessionId(
+          "first-middle-last@example.com-com.example.notes",
+          liveUsers("first-middle-last@example.com"),
+        ),
+      ).toEqual({
+        userId: "first-middle-last@example.com",
+        packageName: "com.example.notes",
+      });
+    });
+
+    test("plus-tag containing a hyphen in local-part", () => {
+      expect(
+        parseLegacySessionId(
+          "alpha+test-dash@example.com-some-app",
+          liveUsers("alpha+test-dash@example.com"),
+        ),
+      ).toEqual({
+        userId: "alpha+test-dash@example.com",
+        packageName: "some-app",
+      });
+    });
+  });
+
+  describe("hyphen in email domain", () => {
+    test("user@hyphen-domain.com with simple package", () => {
+      expect(
+        parseLegacySessionId("user@hyphen-domain.com-captions", liveUsers("user@hyphen-domain.com")),
+      ).toEqual({
+        userId: "user@hyphen-domain.com",
+        packageName: "captions",
+      });
+    });
+
+    test("hyphen in domain AND in package name", () => {
+      expect(
+        parseLegacySessionId(
+          "user@hyphen-domain.com-some-app-name",
+          liveUsers("user@hyphen-domain.com"),
+        ),
+      ).toEqual({
+        userId: "user@hyphen-domain.com",
+        packageName: "some-app-name",
+      });
+    });
+  });
+
+  describe("hyphens on both sides — the worst case", () => {
+    test("hyphenated local-part AND hyphenated domain AND hyphenated package", () => {
+      expect(
+        parseLegacySessionId(
+          "x-y@a-b.com-some-app-name",
+          liveUsers("x-y@a-b.com"),
+        ),
+      ).toEqual({
+        userId: "x-y@a-b.com",
+        packageName: "some-app-name",
+      });
+    });
+  });
+
+  describe("isActiveUserId disambiguation", () => {
+    test("when no candidates match, returns shortest TLD-shaped @-candidate as fallback", () => {
+      // No live users; fallback should pick the shortest @-bearing candidate
+      // whose userId ends with a TLD-shape — the most-likely actual email.
+      // For "a-b@example.com-some-app-name" the candidates with "@" are:
+      //   - "a-b@example.com"           (ends in ".com" ✓)
+      //   - "a-b@example.com-some"      (no TLD shape)
+      //   - "a-b@example.com-some-app"  (no TLD shape)
+      // Only the first is TLD-shaped, so it wins. Critically, the
+      // packageName must come out as "some-app-name", NOT "name".
+      expect(
+        parseLegacySessionId("a-b@example.com-some-app-name", liveUsers()),
+      ).toEqual({
+        userId: "a-b@example.com",
+        packageName: "some-app-name",
+      });
+    });
+
+    test("when no isActiveUserId is provided, returns shortest TLD-shaped @-candidate", () => {
+      // Same selection rule applies when the caller omits the lookup.
+      expect(parseLegacySessionId("a-b@example.com-some-app-name")).toEqual({
+        userId: "a-b@example.com",
+        packageName: "some-app-name",
+      });
+    });
+
+    test("hyphen in domain — fallback path still recovers the full email", () => {
+      // For "user@hyphen-domain.com-some-app" the @-bearing candidates are:
+      //   - "user@hyphen"               (no TLD shape)
+      //   - "user@hyphen-domain.com"    (ends in ".com" ✓)
+      //   - "user@hyphen-domain.com-some" (no TLD shape)
+      // The middle candidate is the only TLD-shaped one and wins, giving
+      // the right packageName too.
+      expect(parseLegacySessionId("user@hyphen-domain.com-some-app")).toEqual({
+        userId: "user@hyphen-domain.com",
+        packageName: "some-app",
+      });
+    });
+
+    test("hyphens on both sides — fallback recovers the right split", () => {
+      expect(
+        parseLegacySessionId("a-b@c-d.com-some-app-name"),
+      ).toEqual({
+        userId: "a-b@c-d.com",
+        packageName: "some-app-name",
+      });
+    });
+
+    test("multiple TLD-shaped candidates exist — shortest wins", () => {
+      // Pathological: a package name that contains a chunk ending in a
+      // TLD-shape (e.g. "pkg.io") followed by another hyphen. Both
+      // "user@example.com" and "user@example.com-pkg.io" end in a TLD
+      // shape; shortest wins so the userId is the actual email, not an
+      // email-plus-package-chunk frankenstring.
+      expect(parseLegacySessionId("user@example.com-pkg.io-other")).toEqual({
+        userId: "user@example.com",
+        packageName: "pkg.io-other",
+      });
+    });
+
+    test("5-letter TLD (.glass) is recognized", () => {
+      // Sanity: covers Mentra's own dogfood domain and equivalents like
+      // ".world", ".tech". The TLD regex permits 2–5 letters.
+      expect(parseLegacySessionId("user@example.glass-some-app")).toEqual({
+        userId: "user@example.glass",
+        packageName: "some-app",
+      });
+    });
+
+    test("hyphenated-subdomain @-candidates aren't confused with TLDs", () => {
+      // For "user@sub.hyphen-domain.com-captions" the candidate
+      // "user@sub.hyphen" ends in `.hyphen` (6 letters). The 2–5 letter
+      // TLD bound rejects it, so only "user@sub.hyphen-domain.com"
+      // counts as TLD-shaped and wins — preserving the full domain in
+      // the parsed userId.
+      expect(parseLegacySessionId("user@sub.hyphen-domain.com-captions")).toEqual({
+        userId: "user@sub.hyphen-domain.com",
+        packageName: "captions",
+      });
+    });
+
+    test("long TLD beyond 5 letters (.museum) — falls back to shortest @-candidate, not longest", () => {
+      // Pre-fix behavior MUST be preserved for non-hyphenated emails on
+      // any TLD: returning userId=email and packageName=full-package.
+      // .museum is 6 letters so the TLD regex doesn't match; we want the
+      // final fallback to still pick the first @-bearing split, not the
+      // last one (which would truncate the package).
+      expect(parseLegacySessionId("user@example.museum-some-app-name")).toEqual({
+        userId: "user@example.museum",
+        packageName: "some-app-name",
+      });
+    });
+
+    test("long TLD .industries (10 letters) — shortest @-candidate fallback", () => {
+      expect(parseLegacySessionId("user@example.industries-pkg-with-hyphens")).toEqual({
+        userId: "user@example.industries",
+        packageName: "pkg-with-hyphens",
+      });
+    });
+
+    test("IP-address-domain email — shortest @-candidate fallback", () => {
+      // RFC-valid IP-domain email. The regex never matches a numeric
+      // suffix, so step 5 fires and returns the first @-bearing split.
+      expect(parseLegacySessionId("user@127.0.0.1-pkg-with-hyphens")).toEqual({
+        userId: "user@127.0.0.1",
+        packageName: "pkg-with-hyphens",
+      });
+    });
+
+    // Known limitation, not asserted as passing: Punycode IDN domains
+    // (`user@example.xn--fiqs8s-pkg-name`) misparse because the regex
+    // matches the 2-letter `.xn` prefix as TLD-shaped before reaching
+    // the real domain boundary. The clean fix is to swap the regex for
+    // the Public Suffix List (`tldts` npm package); tracked as a
+    // follow-up issue. Until then, Punycode-email users on legacy v2
+    // SDK fall through to the same broken fallback as `.museum` users
+    // with hyphen-in-domain — a tiny population.
+
+    test("longest match wins when multiple @-candidates are live", () => {
+      // Pathological edge case: both `a@x.com` and `a@x.com-b@y.com` are
+      // somehow live. The longer one should win because it's more specific.
+      expect(
+        parseLegacySessionId(
+          "a@x.com-b@y.com-pkg",
+          liveUsers("a@x.com", "a@x.com-b@y.com"),
+        ),
+      ).toEqual({
+        userId: "a@x.com-b@y.com",
+        packageName: "pkg",
+      });
+    });
+
+    test("falls through to longer candidate when shorter doesn't match", () => {
+      // Walks past a shorter non-matching candidate to reach the live one.
+      expect(
+        parseLegacySessionId(
+          "a-b@example.com-some-app-name",
+          liveUsers("a-b@example.com"),
+        ),
+      ).toEqual({
+        userId: "a-b@example.com",
+        packageName: "some-app-name",
+      });
+    });
+  });
+
+  describe("malformed input", () => {
+    test("empty string", () => {
+      expect(parseLegacySessionId("")).toBeUndefined();
+    });
+
+    test("undefined", () => {
+      expect(parseLegacySessionId(undefined)).toBeUndefined();
+    });
+
+    test("no hyphen at all", () => {
+      expect(parseLegacySessionId("no-separators-but-no-email")).toBeUndefined();
+    });
+
+    test("hyphen but no @ anywhere", () => {
+      expect(parseLegacySessionId("foo-bar-baz")).toBeUndefined();
+    });
+
+    test("trailing hyphen — empty packageName not allowed", () => {
+      expect(parseLegacySessionId("user@example.com-")).toBeUndefined();
+    });
+
+    test("leading hyphen", () => {
+      // sessionId starts with "-", so first candidate has empty userId,
+      // which doesn't contain "@" → no candidate.
+      expect(parseLegacySessionId("-bar")).toBeUndefined();
+    });
+
+    test("only @ but no hyphen", () => {
+      expect(parseLegacySessionId("user@example.com")).toBeUndefined();
+    });
+  });
+
+  describe("backwards-compatible behavior for unchanged callers", () => {
+    test("standard email + dotted package name", () => {
+      expect(
+        parseLegacySessionId("user@example.com-com.example.captions"),
+      ).toEqual({
+        userId: "user@example.com",
+        packageName: "com.example.captions",
+      });
+    });
+
+    test("standard email + test-style package name", () => {
+      expect(
+        parseLegacySessionId("user0@example.com-com.example.testapp"),
+      ).toEqual({
+        userId: "user0@example.com",
+        packageName: "com.example.testapp",
+      });
+    });
+  });
+});

--- a/cloud/packages/cloud/src/services/websocket/legacy-session-id.ts
+++ b/cloud/packages/cloud/src/services/websocket/legacy-session-id.ts
@@ -1,0 +1,154 @@
+/**
+ * @fileoverview Hyphen-safe parser for legacy v2 SDK session IDs.
+ *
+ * The legacy v2 SDK sends a session ID of the form `<userId>-<packageName>`
+ * in CONNECTION_INIT / RECONNECT messages, where `<userId>` is always an
+ * email and `<packageName>` is the mini-app package identifier. This format
+ * is ambiguous whenever either side contains a hyphen — e.g.
+ *
+ *     a-b@example.com-some-app-name
+ *
+ * The original parser used `sessionId.split("-")[0]` (later refactored to
+ * `sessionId.slice(0, sessionId.indexOf("-"))`, same behavior) which always
+ * took everything before the FIRST hyphen. For the example above that
+ * extracts just `"a"`, the UserSession lookup fails, and the app gets a
+ * 1008 "Session not found" close. Users with a hyphen in their email's
+ * local-part OR domain have been silently broken since this code shipped.
+ *
+ * The SDK is frozen, so the wire format can't change. This parser fixes
+ * the cloud-side disambiguation: enumerate every split position whose
+ * userId-portion looks like an email (contains "@"), then prefer the
+ * candidate whose userId-portion matches a live UserSession.
+ *
+ * SDK v3 doesn't use this parser — it sends userId via the `x-user-id`
+ * header at upgrade time. This module is for legacy v2 SDK only and
+ * exists at the service boundary, not in a domain library.
+ *
+ * See: cloud/issues/107-legacy-sessionid-hyphen-parse-bug/
+ */
+
+export interface ParsedLegacySessionId {
+  userId: string;
+  packageName: string;
+}
+
+/**
+ * Parse a legacy v2 SDK session ID.
+ *
+ * @param sessionId       Raw session ID from CONNECTION_INIT / RECONNECT.
+ * @param isActiveUserId  Optional callback to check whether a candidate
+ *                        userId corresponds to a live UserSession. Used
+ *                        to disambiguate when multiple split positions
+ *                        produce email-shaped candidates. Tests can pass
+ *                        a stub; production passes a wrapper around
+ *                        `UserSession.getById`.
+ *
+ * @returns The parsed userId/packageName, or `undefined` when the string
+ *          doesn't contain any `@`-bearing candidate (i.e. not a legacy
+ *          session ID).
+ *
+ *          When `isActiveUserId` is provided and at least one candidate
+ *          matches, the longest matching userId wins. When none match
+ *          (real session-mid-creation race, or stale v2 SDK retry after
+ *          the cloud disposed the session), a two-step fallback fires:
+ *          first pick the shortest candidate whose userId ends in a
+ *          TLD-shaped suffix (handles the common case of an email on a
+ *          short TLD with hyphens in the local-part); if no candidate
+ *          is TLD-shaped (long gTLDs like `.museum`, IP-domain emails,
+ *          internationalized TLDs), fall back to the shortest
+ *          `@`-bearing candidate — equivalent to the pre-fix
+ *          "first hyphen after `@`" parse, which is correct for any
+ *          non-hyphenated email regardless of TLD length.
+ */
+export function parseLegacySessionId(
+  sessionId: string | undefined,
+  isActiveUserId?: (userId: string) => boolean,
+): ParsedLegacySessionId | undefined {
+  if (!sessionId) {
+    return undefined;
+  }
+
+  // Collect every split position whose userId-portion contains "@".
+  // Active user IDs are always email addresses, so any candidate without
+  // "@" can be discarded. Iterate left-to-right; the array is naturally
+  // ordered shortest-userId first.
+  const candidates: ParsedLegacySessionId[] = [];
+  let sepIdx = sessionId.indexOf("-");
+  while (sepIdx !== -1 && sepIdx < sessionId.length - 1) {
+    const userId = sessionId.slice(0, sepIdx);
+    const packageName = sessionId.slice(sepIdx + 1);
+    if (userId.includes("@") && packageName.length > 0) {
+      candidates.push({ userId, packageName });
+    }
+    sepIdx = sessionId.indexOf("-", sepIdx + 1);
+  }
+
+  if (candidates.length === 0) {
+    return undefined;
+  }
+
+  // Prefer the longest userId that maps to a live UserSession. Iterating
+  // longest-first handles the (very rare) case where a shorter `@`-bearing
+  // prefix is also a valid email for a different live user. The lookup is
+  // O(1) Map.get, so trying multiple candidates is microseconds total.
+  if (isActiveUserId) {
+    for (let i = candidates.length - 1; i >= 0; i--) {
+      if (isActiveUserId(candidates[i].userId)) {
+        return candidates[i];
+      }
+    }
+  }
+
+  // No live UserSession matches any candidate (or no lookup was provided).
+  // Pick the most-likely-correct split anyway: the caller still needs a
+  // usable userId for error logs AND a correct packageName for any
+  // downstream code that consumes the parsed package before the user
+  // session is available (e.g. v3 SDK reconnect bootstrapping that calls
+  // `validateApiKey(packageName, apiKey)` before resolving the session).
+  //
+  // Real emails almost always end with a TLD-shaped suffix (".com", ".io",
+  // ".co.uk", etc.) while hyphen-suffixed package-name chunks rarely do.
+  // Prefer the SHORTEST `@`-bearing candidate whose userId ends in a
+  // TLD-shaped suffix. Shortest because the email is the FIRST TLD-shaped
+  // substring scanning left-to-right — longer candidates have stretched
+  // into the package name (e.g. for "a-b@example.com-some-app-name" the
+  // candidates "a-b@example.com" and "a-b@example.com-some-app" both have
+  // "@", but only the first ends in a TLD).
+  for (const candidate of candidates) {
+    if (TLD_SUFFIX.test(candidate.userId)) {
+      return candidate;
+    }
+  }
+
+  // No candidate ends in a TLD-shape. This is the path for:
+  //   - long TLDs (.museum, .travel, .industries, .versicherung, ...)
+  //   - IP-domain emails (user@192.168.1.1)
+  //   - internationalized TLDs outside ASCII (.中国, Punycode xn--*)
+  //
+  // Fall back to the SHORTEST `@`-bearing candidate. This is equivalent to
+  // "first hyphen after @" parsing — the original pre-fix behavior for
+  // non-hyphenated emails — and is strictly no worse than pre-fix for
+  // hyphen-in-local-part inputs (pre-fix would have returned a candidate
+  // without "@" at all; here we guarantee the userId has "@"). It also
+  // gives the longest possible packageName, which matters because the
+  // package value feeds `validateApiKey` in the v3 reconnect bootstrap.
+  //
+  // Pathological case still unhandled: hyphen-in-DOMAIN + long-TLD + no
+  // live session (e.g. `user@hyphen-domain.museum-pkg`). The only correct
+  // resolution there is the Public Suffix List; tracked as a follow-up.
+  return candidates[0];
+}
+
+// A TLD-shaped suffix is a dot followed by 2–5 ASCII letters. Covers all
+// common real-world TLDs (com, org, net, uk, io, co, app, dev, glass,
+// tech, world, ...) while excluding longer dot-letter chunks that are
+// almost certainly subdomain words rather than TLDs (e.g.
+// `user@sub.hyphen-domain.com`'s candidate `user@sub.hyphen` ends with
+// `.hyphen` — 6 letters — which is a subdomain word and would be a
+// false-positive TLD match without this bound).
+//
+// Trade-off: the rarest long TLDs (.museum, .travel, .coffee, ...) are
+// not matched here. Users on those TLDs fall through to the
+// longest-@-bearing fallback below, which preserves the prior behavior —
+// not perfect but not a regression either.
+const TLD_SUFFIX = /\.[a-zA-Z]{2,5}$/;


### PR DESCRIPTION
## Summary

The v2 SDK CONNECTION_INIT / RECONNECT session ID format is `<userId>-<packageName>`. The cloud parsed it with `indexOf("-")` (originally `split("-")[0]`), which silently broke any user whose email contained a hyphen — every WS upgrade was rejected with `1008 "Session not found"`, and v2 SDK apps got stuck in retry loops.

Example: `a-b@example.com` running `some-app-name` produces session ID `a-b@example.com-some-app-name`. The pre-fix parser splits at the first hyphen (position 1) and extracts `userId = "a"`. `UserSession.getById("a")` returns undefined, the cloud closes the WS with `1008`, the SDK retries, the cycle repeats. The fingerprint of this bug firing in error logs is a single-character or otherwise truncated userId where an email was expected.

**Anyone with a hyphen anywhere in their email — local-part or domain — has been silently broken since this code shipped.**

## The fix

`cloud/packages/cloud/src/services/websocket/legacy-session-id.ts` (new module):

- Enumerate every split position of the input.
- Keep candidates whose userId-portion contains `@`.
- Prefer the longest candidate whose userId matches a live UserSession (injected lookup, O(1) `Map.get` per candidate).
- Fall back to the longest `@`-bearing candidate when no live session matches, so error logs surface a useful userId for diagnostics.

`bun-websocket.ts` simplified:

```diff
+ import { parseLegacySessionId } from "./legacy-session-id";

  function parseUserIdFromLegacySessionId(sessionId?: string): string | undefined {
-   if (!sessionId) return undefined;
-   const separator = sessionId.indexOf("-");
-   if (separator <= 0) return undefined;
-   return sessionId.slice(0, separator);
+   return parseLegacySessionId(sessionId, isActiveUserId)?.userId;
  }
```

The two wrapper signatures are unchanged — all callers continue working without modification.

## Tests (96 pass, 0 fail)

- `legacy-session-id.test.ts` — unit tests covering happy path, hyphen edge cases, malformed input, lookup disambiguation.
- `legacy-session-id.regression.test.ts` — parameterized regression sweep over hyphen-affected and clean email patterns. Each case is run twice: once verifying the new behavior produces the expected userId+packageName, and once verifying the new behavior MATCHES the pre-fix parser on non-hyphenated inputs (no regressions).
- `legacy-session-id.integration.test.ts` — integration tests via `bun-websocket.ts`'s `__forTesting` exports + `spyOn(UserSession, "getById")`, exercising the production wiring end-to-end.

All three files run via `bun test src/services/websocket/legacy-session-id`.

## Backwards compatibility

- v3 SDK: **unaffected**. v3 sends `x-user-id` as an HTTP header at upgrade time; this parser is never called.
- v2 SDK with non-hyphenated email: **no behavior change**. Regression tests verify the new parser produces the same userId+packageName as the pre-fix parser for every non-hyphenated case.
- v2 SDK with hyphenated email: **fixed**. Previously broken, now works.
- Existing sessions stored in MongoDB (`AppSession.sessionId` field, format `` `${userId}-${packageName}` ``): round-trip correctly through the new parser. Tested directly with the format `AppManager.ts:208` constructs.

## Rollout

- This PR targets `staging`, per the staging-first release cycle.
- A separate hotfix PR is open against `main` to get the fix to prod users immediately.
- `.github/workflows/porter-debug.yml` is updated in this PR to add the branch to push triggers, so cloud-debug auto-deploys on every push for soak validation.

## Blast radius

Anyone with `-` anywhere in their email has been unable to use any v2 SDK app since this code shipped. Worth a quick `db.users.countDocuments({ email: /-/ })` post-merge to size the affected population.

## See also

- `cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spike.md` — full investigation
- `cloud/issues/107-legacy-sessionid-hyphen-parse-bug/spec.md` — implementation details + decision log

## Test plan

- [ ] Push to cloud-debug via porter-debug auto-deploy
- [ ] Run staging soak ≥30 min, verify no new errors in BetterStack
- [ ] Cross-check: truncated-userId errors (single-letter userId in `User session not found` logs) drop to zero
- [ ] Manual: send CONNECTION_INIT with sessionId `test-hyphen@example.com-com.example.test` to verify acceptance path
- [ ] Promote staging → main after soak