### PR TITLE
Add developer OTA manifest URL setting

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -180,6 +180,7 @@ public class OtaHelper {
     private static volatile boolean isBackgroundPrefetchInProgress = false;
 
     private volatile boolean pendingPhoneInstall = false;
+    private volatile String pendingPhoneInstallVersionJsonUrl = null;
 
     /** Snapshot for {@link #buildMinimalOtaStatusJson()} when no OTA session exists (aligns with {@link #sendMtkInstallProgress} shape). */
     private String lastOtaPhoneStage;
@@ -551,30 +552,6 @@ public class OtaHelper {
 
     // Wakelock timeout for OTA process (10 minutes)
     private static final long OTA_WAKELOCK_TIMEOUT_MS = 600000;
-    private static final int REACHABILITY_TIMEOUT_MS = 5000;
-
-    /**
-     * Quick HEAD request to CDN to verify internet reachability before starting OTA.
-     * Returns true if the CDN is reachable, false otherwise.
-     */
-    private boolean checkInternetReachable() {
-        try {
-            // This is just a HEAD reachability probe so the actual URL doesn't matter for the
-            // probe to work, but it should be kept in sync with the manifest URL when that swaps.
-            HttpURLConnection conn = (HttpURLConnection)
-                new URL("https://ota.mentraglass.com/prod_live_version.json").openConnection();
-            conn.setConnectTimeout(REACHABILITY_TIMEOUT_MS);
-            conn.setReadTimeout(REACHABILITY_TIMEOUT_MS);
-            conn.setRequestMethod("HEAD");
-            conn.connect();
-            int code = conn.getResponseCode();
-            conn.disconnect();
-            return code >= 200 && code < 400;
-        } catch (Exception e) {
-            Log.w(TAG, "Internet reachability check failed: " + e.getMessage());
-            return false;
-        }
-    }
 
     private List<String> buildStepSequence(JSONObject rootJson, JSONObject apps, Context context) {
         List<String> steps = new ArrayList<>();
@@ -635,7 +612,15 @@ public class OtaHelper {
      * Called by OtaCommandHandler when phone sends ota_start command.
      */
     public void startOtaFromPhone() {
-        Log.i(TAG, "📱 Starting OTA from phone request");
+        startOtaFromPhone(OtaConstants.VERSION_JSON_URL);
+    }
+
+    /**
+     * Start OTA update from phone command using the phone-selected version manifest URL.
+     */
+    public void startOtaFromPhone(String versionJsonUrl) {
+        String requestedVersionJsonUrl = resolveVersionJsonUrl(versionJsonUrl);
+        Log.i(TAG, "📱 Starting OTA from phone request with versionJsonUrl=" + requestedVersionJsonUrl);
 
         // Immediately acknowledge receipt so the phone cancels its retry timer.
         sendOtaStartAck();
@@ -646,6 +631,7 @@ public class OtaHelper {
         if (versionCheckLock.isLocked()) {
             Log.i(TAG, "📱 OTA prefetch in progress - queuing install to fire after prefetch completes");
             pendingPhoneInstall = true;
+            pendingPhoneInstallVersionJsonUrl = requestedVersionJsonUrl;
             isPhoneInitiatedOta = true;
             // Acquire wakelock early so CPU stays awake for the queued install pass
             WakeLockManager.acquireCpuWakeLock(context, OTA_WAKELOCK_TIMEOUT_MS);
@@ -668,15 +654,18 @@ public class OtaHelper {
 
         // Fast-path: if background prefetch already fetched and cached the version JSON,
         // skip the network round-trip entirely and jump straight to install.
-        if (cachedVersionJson != null) {
+        if (cachedVersionJson != null && requestedVersionJsonUrl.equals(lastVersionJsonUrl)) {
             Log.i(TAG, "📱 Cache fast-path: reusing prefetched version JSON (skipping network re-fetch)");
             startInstallFromCachedJson(context, cachedVersionJson);
             return;
+        } else if (cachedVersionJson != null) {
+            Log.i(TAG, "📱 Ignoring prefetched version JSON because phone requested a different manifest: "
+                    + requestedVersionJsonUrl + " (cached=" + lastVersionJsonUrl + ")");
         }
 
         Log.i(TAG, "📱 Phone-initiated OTA: starting version check (download STARTED deferred)");
 
-        startVersionCheck(context);
+        startVersionCheckWithUrl(context, requestedVersionJsonUrl);
     }
 
     /**
@@ -689,7 +678,7 @@ public class OtaHelper {
             try {
                 if (!versionCheckLock.tryLock()) {
                     Log.w(TAG, "📱 Cache fast-path: version check lock held — falling back to full check");
-                    startVersionCheck(context);
+                    startVersionCheckWithUrl(context, lastVersionJsonUrl);
                     return;
                 }
                 try {
@@ -844,12 +833,25 @@ public class OtaHelper {
     }
 
     /**
+     * Resolve the optional phone-provided manifest URL.
+     * Older phone builds do not send one, and blank developer-setting values should fall back to production.
+     */
+    private String resolveVersionJsonUrl(String versionJsonUrl) {
+        if (versionJsonUrl == null) {
+            return OtaConstants.VERSION_JSON_URL;
+        }
+        String trimmed = versionJsonUrl.trim();
+        return trimmed.isEmpty() ? OtaConstants.VERSION_JSON_URL : trimmed;
+    }
+
+    /**
      * Start a version check using a custom version JSON URL.
      * Used by DebugApkOtaReceiver to test OTA with a local/custom URL.
      * @param context Application context
      * @param versionJsonUrl URL to fetch the version JSON from (http, https)
      */
     public void startVersionCheckWithUrl(Context context, String versionJsonUrl) {
+        String resolvedVersionJsonUrl = resolveVersionJsonUrl(versionJsonUrl);
         Log.d(TAG, "Check OTA update method init");
         Log.i(TAG, "OTA check trigger -> phoneInitiated=" + isPhoneInitiatedOta
                 + ", autonomousEnabled=" + AUTONOMOUS_OTA_ENABLED
@@ -857,7 +859,7 @@ public class OtaHelper {
                 + ", isUpdating=" + isUpdating
                 + ", mtkInProgress=" + isMtkOtaInProgress
                 + ", besInProgress=" + BesOtaManager.isBesOtaInProgress
-                + ", versionJsonUrl=" + versionJsonUrl);
+                + ", versionJsonUrl=" + resolvedVersionJsonUrl);
 
         // if (!isNetworkAvailable(context)) {
         //     Log.e(TAG, "No WiFi connection available. Skipping OTA check.");
@@ -884,7 +886,7 @@ public class OtaHelper {
 
             // Store the URL under the lock so a concurrent caller can't overwrite it
             // before this check finishes (used by the pendingPhoneInstall retry).
-            lastVersionJsonUrl = versionJsonUrl;
+            lastVersionJsonUrl = resolvedVersionJsonUrl;
 
             // Check if update is in progress (separate from version check)
             if (isUpdating) {
@@ -909,7 +911,7 @@ public class OtaHelper {
 
                 stage[0] = "fetch_version_info";
                 // Fetch version info from URL
-                String versionInfo = fetchVersionInfo(versionJsonUrl);
+                String versionInfo = fetchVersionInfo(resolvedVersionJsonUrl);
                 stage[0] = "parse_version_json";
                 JSONObject json = new JSONObject(versionInfo);
 
@@ -956,7 +958,7 @@ public class OtaHelper {
                 otaCheckReachedSuccessLog[0] = true;
                 Log.i(TAG, "OTA check completed successfully");
             } catch (Exception e) {
-                String urlForLog = versionJsonUrl != null ? versionJsonUrl : lastVersionJsonUrl;
+                String urlForLog = resolvedVersionJsonUrl != null ? resolvedVersionJsonUrl : lastVersionJsonUrl;
                 String rootMsg = e.getMessage() != null ? e.getMessage() : "";
                 String causeInfo = "";
                 if (e.getCause() != null) {
@@ -974,6 +976,7 @@ public class OtaHelper {
                 // Cancel any queued install — triggering an install pass after a failed prefetch
                 // would attempt to install a potentially corrupt or incomplete cache.
                 pendingPhoneInstall = false;
+                pendingPhoneInstallVersionJsonUrl = null;
                 // Send failure to phone with semantic error classification
                 String errorCode = classifyDownloadError(e);
                 if (isPhoneInitiatedOta) {
@@ -994,9 +997,13 @@ public class OtaHelper {
                 // Capture before resetting — if the user tapped Install while prefetch was running,
                 // we need to fire a fresh install pass now that the cache is fully populated.
                 boolean shouldInstallNow = pendingPhoneInstall;
+                String queuedVersionJsonUrl = pendingPhoneInstallVersionJsonUrl != null
+                        ? pendingPhoneInstallVersionJsonUrl
+                        : lastVersionJsonUrl;
                 isBackgroundPrefetchInProgress = false;
                 isPhoneInitiatedOta = false;
                 pendingPhoneInstall = false;
+                pendingPhoneInstallVersionJsonUrl = null;
                 versionCheckLock.unlock();
                 Log.d(TAG, "Version check thread finished (reachedSuccessLog=" + otaCheckReachedSuccessLog[0]
                         + ", lastStage=" + stage[0] + "), lock released, ready for next check");
@@ -1004,7 +1011,7 @@ public class OtaHelper {
                 if (shouldInstallNow) {
                     Log.i(TAG, "📱 Phone-initiated install was queued during prefetch - firing install pass now");
                     isPhoneInitiatedOta = true;
-                    startVersionCheckWithUrl(context, lastVersionJsonUrl); // fresh pass: same URL, installNow=true, files served from cache
+                    startVersionCheckWithUrl(context, queuedVersionJsonUrl); // fresh pass: same URL, installNow=true, files served from cache
                 }
             }
         }).start();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
@@ -6,8 +6,7 @@ package com.mentra.asg_client.io.ota.utils;
 public class OtaConstants {
     public static final String TAG = "ASGClientOTA";
 
-    // URLs
-    // Production OTA version JSON URL
+    // Default production manifest URL. Phone-initiated OTA can override this via ota_start.version_json_url.
     public static final String VERSION_JSON_URL = "https://ota.mentraglass.com/prod_live_version.json";
 
     // Test URLs (uncomment to use for testing)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
@@ -117,10 +117,13 @@ public class OtaCommandHandler implements ICommandHandler {
 
         // Reset retry counter on success
         otaStartRetryCount = 0;
-        
+
+        String versionJsonUrl = data.optString("version_json_url", data.optString("ota_version_url", null));
+
         // Start OTA from phone request
-        otaHelperInstance.startOtaFromPhone();
-        Log.i(TAG, "📱 OTA started from phone command");
+        otaHelperInstance.startOtaFromPhone(versionJsonUrl);
+        Log.i(TAG, "📱 OTA started from phone command"
+                + (versionJsonUrl != null && !versionJsonUrl.isEmpty() ? " using " + versionJsonUrl : ""));
         return true;
     }
 
@@ -184,11 +187,11 @@ public class OtaCommandHandler implements ICommandHandler {
             st.put("overall_percent", 0);
             st.put("status", "failed");
             st.put("error_message", errorMessage);
-            
+
             communicationManager.sendOtaStatus(st);
             Log.i(TAG, "📱 Sent OTA error to phone: " + errorMessage);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating OTA error message", e);
         }
     }
-} 
+}

--- a/asg_client/ota_updater/app/src/main/java/com/augmentos/otaupdater/helper/Constants.java
+++ b/asg_client/ota_updater/app/src/main/java/com/augmentos/otaupdater/helper/Constants.java
@@ -3,8 +3,8 @@ package com.mentra.otaupdater.helper;
 public class Constants {
     public static final String TAG = "OTAUpdater";
 
-    // URLs
-    public static final String VERSION_JSON_URL = "https://ota.mentraglass.com/prod_live_version.json"; // TODO: change with real server ip address
+    // Default production manifest URL used by the standalone OTA updater.
+    public static final String VERSION_JSON_URL = "https://ota.mentraglass.com/prod_live_version.json";
 
     // Heartbeat actions
     public static final String ACTION_HEARTBEAT = "com.augmentos.otaupdater.ACTION_HEARTBEAT";

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -390,7 +390,7 @@ class BluetoothSdkModule : Module() {
 
         // MARK: - OTA Commands
 
-        AsyncFunction("sendOtaStart") { sdk?.sendOtaStart() }
+        AsyncFunction("sendOtaStart") { versionJsonUrl: String? -> sdk?.sendOtaStart(versionJsonUrl) }
 
         AsyncFunction("sendOtaQueryStatus") { sdk?.sendOtaQueryStatus() }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1241,9 +1241,9 @@ class DeviceManager {
      * Send OTA start command to glasses. Called when user approves an update (onboarding or
      * background mode). Triggers glasses to begin download and installation.
      */
-    fun sendOtaStart() {
+    fun sendOtaStart(versionJsonUrl: String? = null) {
         Bridge.log("MAN: 📱 Sending OTA start command to glasses")
-        (sgc as? MentraLive)?.sendOtaStart()
+        (sgc as? MentraLive)?.sendOtaStart(versionJsonUrl)
     }
 
     fun sendOtaQueryStatus() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -470,8 +470,8 @@ class MentraBluetoothSdk private constructor(
         deviceManager.requestVersionInfo()
     }
 
-    internal fun sendOtaStart() {
-        deviceManager.sendOtaStart()
+    internal fun sendOtaStart(versionJsonUrl: String? = null) {
+        deviceManager.sendOtaStart(versionJsonUrl)
     }
 
     internal fun sendOtaQueryStatus() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -3652,10 +3652,17 @@ public class MentraLive extends SGCManager {
      * Triggers glasses to begin download and installation.
      */
     public void sendOtaStart() {
+        sendOtaStart(null);
+    }
+
+    public void sendOtaStart(String versionJsonUrl) {
         try {
             JSONObject json = new JSONObject();
             json.put("type", "ota_start");
             json.put("timestamp", System.currentTimeMillis());
+            if (versionJsonUrl != null && !versionJsonUrl.trim().isEmpty()) {
+                json.put("version_json_url", versionJsonUrl.trim());
+            }
             sendJson(json, true);
             Bridge.log("LIVE: 📱 Sending ota_start command to glasses");
         } catch (JSONException e) {

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -351,9 +351,9 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
 
         // MARK: - OTA Commands
 
-        AsyncFunction("sendOtaStart") {
+        AsyncFunction("sendOtaStart") { (versionJsonUrl: String?) in
             await MainActor.run {
-                self.bluetoothSdk().sendOtaStart()
+                self.bluetoothSdk().sendOtaStart(versionJsonUrl: versionJsonUrl)
             }
         }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1082,9 +1082,13 @@ struct ViewState {
     /// Send OTA start command to glasses.
     /// Called when user approves an update (onboarding or background mode).
     /// Triggers glasses to begin download and installation.
-    func sendOtaStart() {
+    func sendOtaStart(versionJsonUrl: String? = nil) {
         Bridge.log("MAN: 📱 Sending OTA start command to glasses")
-        sgc?.sendOtaStart()
+        if let live = sgc as? MentraLive {
+            live.sendOtaStart(versionJsonUrl: versionJsonUrl)
+        } else {
+            sgc?.sendOtaStart()
+        }
     }
 
     func sendOtaQueryStatus() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -436,8 +436,8 @@ public final class MentraBluetoothSDK {
         DeviceManager.shared.requestVersionInfo()
     }
 
-    func sendOtaStart() {
-        DeviceManager.shared.sendOtaStart()
+    func sendOtaStart(versionJsonUrl: String? = nil) {
+        DeviceManager.shared.sendOtaStart(versionJsonUrl: versionJsonUrl)
     }
 
     func sendOtaQueryStatus() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2514,12 +2514,19 @@ class MentraLive: NSObject, SGCManager {
     /// Called when user approves an update (onboarding or background mode).
     /// Triggers glasses to begin download and installation.
     func sendOtaStart() {
+        sendOtaStart(versionJsonUrl: nil)
+    }
+
+    func sendOtaStart(versionJsonUrl: String?) {
         Bridge.log("LIVE: 📱 Sending ota_start command to glasses")
 
-        let json: [String: Any] = [
+        var json: [String: Any] = [
             "type": "ota_start",
             "timestamp": Int(Date().timeIntervalSince1970 * 1000),
         ]
+        if let trimmedUrl = versionJsonUrl?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmedUrl.isEmpty {
+            json["version_json_url"] = trimmedUrl
+        }
 
         sendJson(json, wakeUp: true)
     }

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -105,7 +105,7 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   requestPhoto(params: PhotoRequestParams): Promise<void>
 
   // OTA Commands
-  sendOtaStart(): Promise<void>
+  sendOtaStart(versionJsonUrl?: string): Promise<void>
   sendOtaQueryStatus(): Promise<void>
 
   // Version Info Commands

--- a/mobile/src/app/miniapps/settings/developer.tsx
+++ b/mobile/src/app/miniapps/settings/developer.tsx
@@ -2,6 +2,7 @@ import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import {ScrollView, View} from "react-native"
 
 import BackendUrl from "@/components/dev/BackendUrl"
+import OtaVersionUrl from "@/components/dev/OtaVersionUrl"
 import StoreUrl from "@/components/dev/StoreUrl"
 import {Header, Icon, Screen, Text} from "@/components/ignite"
 import SelectSetting from "@/components/settings/SelectSetting"
@@ -228,6 +229,8 @@ export default function DeveloperSettingsScreen() {
           <BackendUrl />
 
           <StoreUrl />
+
+          <OtaVersionUrl />
 
           {superMode && <RouteButton label="Super Settings" onPress={() => push("/miniapps/settings/super")} />}
 

--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -9,7 +9,7 @@ import {Screen, Header, Button, Text, Icon} from "@/components/ignite"
 import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
-import {checkForOtaUpdate, OTA_VERSION_URL_PROD} from "@/effects/OtaUpdateChecker"
+import {checkForOtaUpdate} from "@/effects/OtaUpdateChecker"
 import {translate} from "@/i18n/translate"
 import {isGlassesConnected, selectGlassesConnected, useGlassesStore, waitForGlassesState} from "@/stores/glasses"
 import {SETTINGS, useSetting} from "@/stores/settings"
@@ -25,6 +25,7 @@ export default function OtaCheckForUpdatesScreen() {
   const besFirmwareVersion = useGlassesStore((state) => state.besFirmwareVersion)
   const glassesWifiConnected = useGlassesStore((state) => state.wifi.state === "connected")
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
+  const [otaVersionUrl] = useSetting<string>(SETTINGS.ota_version_url.key)
   const deviceName = defaultWearable || "Glasses"
   const glassesConnected = useGlassesStore(selectGlassesConnected)
   const [onboardingLiveCompleted] = useSetting(SETTINGS.onboarding_live_completed.key)
@@ -173,7 +174,7 @@ export default function OtaCheckForUpdatesScreen() {
         void BluetoothSdk.requestVersionInfo()
 
         const result = await checkForOtaUpdate(
-          OTA_VERSION_URL_PROD,
+          otaVersionUrl,
           currentBuildNumber,
           latestMtkFirmwareVersion,
           latestBesFirmwareVersion,
@@ -250,7 +251,7 @@ export default function OtaCheckForUpdatesScreen() {
       }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [checkKey, currentBuildNumber, mtkFirmwareVersion, besFirmwareVersion, glassesConnected])
+  }, [checkKey, currentBuildNumber, mtkFirmwareVersion, besFirmwareVersion, glassesConnected, otaVersionUrl])
 
   // Navigate to next step based on onboarding status
   const handleContinue = () => {

--- a/mobile/src/app/ota/progress-legacy.tsx
+++ b/mobile/src/app/ota/progress-legacy.tsx
@@ -8,7 +8,7 @@ import {Screen, Header, Button, Text, Icon} from "@/components/ignite"
 import {LoadingCoverVideo} from "@/components/ota/LoadingCoverVideo"
 import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
-import {checkBesUpdate, findMatchingMtkPatch, fetchVersionInfo, OTA_VERSION_URL_PROD} from "@/effects/OtaUpdateChecker"
+import {checkBesUpdate, findMatchingMtkPatch, fetchVersionInfo} from "@/effects/OtaUpdateChecker"
 import {selectGlassesConnected, useGlassesStore} from "@/stores/glasses"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import {logEvent} from "@/utils/analytics"
@@ -64,6 +64,7 @@ export default function OtaProgressScreen() {
   const {theme} = useAppTheme()
   const {replace, push} = useNavigationStore.getState()
   const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const [otaVersionUrl] = useSetting<string>(SETTINGS.ota_version_url.key)
   const otaProgress = useGlassesStore((state) => state.otaProgress)
   const otaUpdateAvailable = useGlassesStore((state) => state.otaUpdateAvailable)
   const glassesConnected = useGlassesStore(selectGlassesConnected)
@@ -378,7 +379,7 @@ export default function OtaProgressScreen() {
       if (updateSequenceRef.current.length === 0) return
 
       // Fetch the latest version.json to check against
-      const versionJson = await fetchVersionInfo(OTA_VERSION_URL_PROD)
+      const versionJson = await fetchVersionInfo(otaVersionUrl)
       if (!versionJson) {
         console.log("OTA REVALIDATE: Could not fetch version.json")
         return
@@ -447,7 +448,7 @@ export default function OtaProgressScreen() {
     }
 
     revalidateUpdateSequence()
-  }, [besFirmwareVersion, mtkFirmwareVersion])
+  }, [besFirmwareVersion, mtkFirmwareVersion, otaVersionUrl])
 
   // Fallback: detect APK install success via build number increase for older glasses firmware
   // that does not send the explicit ota_status apk/step_complete signal on reconnect.
@@ -584,7 +585,7 @@ export default function OtaProgressScreen() {
         "OTA_TRACK: send_ota_start",
         JSON.stringify({attempt: retryCount + 1, maxRetries: MAX_RETRIES, sequence: [...updateSequenceRef.current]}),
       )
-      await BluetoothSdk.sendOtaStart()
+      await BluetoothSdk.sendOtaStart(otaVersionUrl)
       setOtaStartTime(Date.now())
 
       // Start global session timeout once (covers whole multi-step OTA)
@@ -680,7 +681,7 @@ export default function OtaProgressScreen() {
         setProgressState("failed")
       }
     }
-  }, [retryCount, progressState])
+  }, [retryCount, progressState, otaVersionUrl])
 
   // When waitingForReconnectRef is true, watch for glasses to be ready then trigger ota_start.
   // After APK: requires BLE reconnect AND fresh buildNumber (version_info arrived), then waits

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -22,6 +22,7 @@ import {focusEffectPreventBack} from "@/contexts/NavigationHistoryContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useConnectionOverlayConfig} from "@/contexts/ConnectionOverlayContext"
 import {isGlassesConnected, selectGlassesConnected, useGlassesStore} from "@/stores/glasses"
+import {SETTINGS, useSetting} from "@/stores/settings"
 import {getOtaErrorMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import {useNavigationStore} from "@/stores/navigation"
@@ -77,6 +78,7 @@ export default function OtaProgressScreen() {
   const connected = useGlassesStore(selectGlassesConnected)
   const otaStatus = useGlassesStore((s) => s.otaStatus)
   const otaProgress = useGlassesStore((s) => s.otaProgress)
+  const [otaVersionUrl] = useSetting<string>(SETTINGS.ota_version_url.key)
 
   // Genuinely local UI state
   const [errorMsg, setErrorMsg] = useState("")
@@ -308,7 +310,7 @@ export default function OtaProgressScreen() {
         console.log(
           `[OTA_PROGRESS] watchdog: no ack in ${RETRY_INTERVAL_MS}ms, retrying ota_start (attempt ${retryCountRef.current})`,
         )
-        void BluetoothSdk.sendOtaStart()
+        void BluetoothSdk.sendOtaStart(otaVersionUrl)
           .then(() => {
             armAckAndStuckWatchdogsOnly()
           })
@@ -332,14 +334,14 @@ export default function OtaProgressScreen() {
       clearRetryTimeout()
       setErrorMsg(OtaProgressMessages.stalledOrStuck)
     }, DOWNLOAD_STUCK_TIMEOUT_MS)
-  }, [clearRetryTimeout, clearStuckTimeout, computeDisplayStateNow])
+  }, [clearRetryTimeout, clearStuckTimeout, computeDisplayStateNow, otaVersionUrl])
 
   const sendOtaStartWithWatchdogs = useCallback(async () => {
     maybeStartGlobalTimeout()
     hasReceivedAckRef.current = false
     armAckAndStuckWatchdogsOnly()
     try {
-      await BluetoothSdk.sendOtaStart()
+      await BluetoothSdk.sendOtaStart(otaVersionUrl)
     } catch (err) {
       console.warn("[OTA_PROGRESS] sendOtaStart threw", err)
       clearRetryTimeout()
@@ -355,7 +357,7 @@ export default function OtaProgressScreen() {
         setErrorMsg(OtaProgressMessages.sendOtaStartFailed)
       }
     }
-  }, [armAckAndStuckWatchdogsOnly, clearRetryTimeout, clearStuckTimeout, maybeStartGlobalTimeout])
+  }, [armAckAndStuckWatchdogsOnly, clearRetryTimeout, clearStuckTimeout, maybeStartGlobalTimeout, otaVersionUrl])
 
   sendOtaStartRef.current = sendOtaStartWithWatchdogs
 

--- a/mobile/src/components/dev/OtaVersionUrl.tsx
+++ b/mobile/src/components/dev/OtaVersionUrl.tsx
@@ -1,0 +1,301 @@
+import {useState} from "react"
+import {TextInput, TextStyle, TouchableOpacity, View, ViewStyle} from "react-native"
+
+import {Button, Text} from "@/components/ignite"
+import GlassView from "@/components/ui/GlassView"
+import {OTA_VERSION_URL_PROD} from "@/config/ota"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {SETTINGS, useSetting} from "@/stores/settings"
+import {ThemedStyle} from "@/theme"
+import showAlert from "@/utils/AlertUtils"
+
+interface SavedUrl {
+  label: string
+  url: string
+}
+
+export default function OtaVersionUrl() {
+  const {theme, themed} = useAppTheme()
+  const [customUrlInput, setCustomUrlInput] = useState("")
+  const [isSavingUrl, setIsSavingUrl] = useState(false)
+  const [otaVersionUrl, setOtaVersionUrl] = useSetting<string | null>(SETTINGS.ota_version_url.key)
+  const [savedUrls, setSavedUrls] = useSetting<SavedUrl[]>(SETTINGS.saved_ota_version_urls.key)
+
+  const bookmarks: SavedUrl[] = Array.isArray(savedUrls) ? savedUrls : []
+
+  const generateLabel = (url: string): string => {
+    try {
+      const parsed = new URL(url)
+      return parsed.host
+    } catch {
+      return url
+    }
+  }
+
+  const trimmedInputUrl = () => customUrlInput.trim()
+
+  const validateUrl = (url: string): boolean => {
+    if (!url) {
+      showAlert("Empty URL", "Please enter a URL or reset to default.", [{text: "OK"}])
+      return false
+    }
+
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      showAlert("Invalid URL", "Please enter a valid URL starting with http:// or https://", [{text: "OK"}])
+      return false
+    }
+
+    return true
+  }
+
+  const handleBookmark = () => {
+    const urlToSave = trimmedInputUrl()
+
+    if (!validateUrl(urlToSave)) {
+      return
+    }
+
+    if (bookmarks.some((bookmark) => bookmark.url === urlToSave)) {
+      showAlert("Already Bookmarked", "This URL is already in your saved list.", [{text: "OK"}])
+      return
+    }
+
+    const label = generateLabel(urlToSave)
+    setSavedUrls([...bookmarks, {label, url: urlToSave}])
+    showAlert("Bookmarked", `Saved "${label}" to your URLs.`, [{text: "OK"}])
+  }
+
+  const handleDeleteBookmark = (index: number) => {
+    const bookmark = bookmarks[index]
+    showAlert("Remove Bookmark", `Remove "${bookmark.label}" from your saved URLs?`, [
+      {text: "Cancel", style: "cancel"},
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: () => {
+          setSavedUrls(bookmarks.filter((_, i) => i !== index))
+        },
+      },
+    ])
+  }
+
+  const handleSaveUrl = async () => {
+    const urlToTest = trimmedInputUrl()
+
+    if (!validateUrl(urlToTest)) {
+      return
+    }
+
+    setIsSavingUrl(true)
+
+    try {
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+      try {
+        const response = await fetch(urlToTest, {
+          method: "GET",
+          signal: controller.signal,
+        })
+
+        clearTimeout(timeoutId)
+
+        if (!response.ok) {
+          showAlert("Verification Failed", `The server responded with status ${response.status}.`, [{text: "OK"}])
+          return
+        }
+
+        const data = await response.json()
+        if (!data || typeof data !== "object") {
+          showAlert("Verification Failed", "The URL did not return a JSON object.", [{text: "OK"}])
+          return
+        }
+
+        await setOtaVersionUrl(urlToTest)
+        showAlert("Success", "Custom OTA version URL saved. Future OTA checks will use this manifest.", [
+          {text: "OK"},
+        ])
+      } catch (fetchError: unknown) {
+        clearTimeout(timeoutId)
+        throw fetchError
+      }
+    } catch (error: unknown) {
+      console.error("OTA URL test failed:", error instanceof Error ? error.message : "Unknown error")
+
+      let errorMessage = "Could not load the OTA version manifest. Please check the URL and network connection."
+      if (error instanceof Error && error.name === "AbortError") {
+        errorMessage = "Connection timed out. Please check the URL and server status."
+      }
+
+      showAlert("Verification Failed", errorMessage, [{text: "OK"}])
+    } finally {
+      setIsSavingUrl(false)
+    }
+  }
+
+  const handleResetUrl = async () => {
+    await setOtaVersionUrl(null)
+    setCustomUrlInput("")
+    showAlert("Success", "Reset OTA version URL to default.", [{text: "OK"}])
+  }
+
+  return (
+    <GlassView className="bg-primary-foreground rounded-2xl" style={themed($container)}>
+      <View style={themed($textContainer)}>
+        <Text style={themed($label)}>Custom OTA Version URL</Text>
+        <Text style={themed($subtitle)}>
+          Override the OTA version manifest used for update checks and installs. Leave blank to use default.
+          {otaVersionUrl && `\nCurrently using: ${otaVersionUrl}`}
+        </Text>
+        <TextInput
+          style={themed($urlInput)}
+          placeholder="e.g., https://example.com/live_version.json"
+          placeholderTextColor={theme.colors.textDim}
+          value={customUrlInput}
+          onChangeText={setCustomUrlInput}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          editable={!isSavingUrl}
+        />
+        <View style={themed($buttonRow)}>
+          <Button
+            text={isSavingUrl ? "Testing..." : "Save & Test URL"}
+            onPress={handleSaveUrl}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+          <Button
+            tx="common:reset"
+            onPress={handleResetUrl}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+          <Button
+            text="Bookmark"
+            onPress={handleBookmark}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+        </View>
+
+        {bookmarks.length > 0 && (
+          <View style={themed($savedSection)}>
+            <Text style={themed($sectionLabel)}>My URLs</Text>
+            <View style={themed($chipContainer)}>
+              {bookmarks.map((bookmark, index) => (
+                <TouchableOpacity
+                  key={`${bookmark.url}-${index}`}
+                  style={themed($chip)}
+                  onPress={() => setCustomUrlInput(bookmark.url)}
+                  onLongPress={() => handleDeleteBookmark(index)}
+                  activeOpacity={0.7}>
+                  <Text style={themed($chipText)}>{bookmark.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text style={themed($chipHint)}>Tap to fill. Long-press to remove.</Text>
+          </View>
+        )}
+
+        <View style={themed($buttonColumn)}>
+          <Button
+            text="Production"
+            onPress={() => setCustomUrlInput(OTA_VERSION_URL_PROD)}
+            compact
+            flex
+            flexContainer={false}
+          />
+        </View>
+      </View>
+    </GlassView>
+  )
+}
+
+const $container: ThemedStyle<ViewStyle> = ({spacing}) => ({
+  paddingHorizontal: spacing.s6,
+  paddingVertical: spacing.s4,
+})
+
+const $textContainer: ThemedStyle<ViewStyle> = () => ({
+  flex: 1,
+})
+
+const $label: ThemedStyle<TextStyle> = ({colors}) => ({
+  flexWrap: "wrap",
+  fontSize: 16,
+  color: colors.text,
+})
+
+const $subtitle: ThemedStyle<TextStyle> = ({colors}) => ({
+  flexWrap: "wrap",
+  fontSize: 12,
+  marginTop: 5,
+  color: colors.textDim,
+})
+
+const $urlInput: ThemedStyle<TextStyle> = ({colors, spacing}) => ({
+  backgroundColor: colors.background,
+  borderColor: colors.primary,
+  borderRadius: spacing.s3,
+  paddingHorizontal: 12,
+  paddingVertical: 10,
+  fontSize: 14,
+  marginTop: 10,
+  marginBottom: 10,
+  color: colors.text,
+})
+
+const $buttonRow: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  marginTop: 10,
+})
+
+const $buttonColumn: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  gap: 12,
+  justifyContent: "space-between",
+  marginTop: 12,
+})
+
+const $savedSection: ThemedStyle<ViewStyle> = () => ({
+  marginTop: 14,
+  marginBottom: 4,
+})
+
+const $sectionLabel: ThemedStyle<TextStyle> = ({colors}) => ({
+  fontSize: 13,
+  fontWeight: "600",
+  color: colors.textDim,
+  marginBottom: 8,
+})
+
+const $chipContainer: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: 8,
+})
+
+const $chip: ThemedStyle<ViewStyle> = ({colors, spacing}) => ({
+  backgroundColor: colors.background,
+  borderWidth: 1,
+  borderColor: colors.border,
+  borderRadius: spacing.s3,
+  paddingHorizontal: 10,
+  paddingVertical: 6,
+})
+
+const $chipText: ThemedStyle<TextStyle> = ({colors}) => ({
+  color: colors.text,
+  fontSize: 13,
+})
+
+const $chipHint: ThemedStyle<TextStyle> = ({colors}) => ({
+  color: colors.textDim,
+  fontSize: 11,
+  marginTop: 6,
+})

--- a/mobile/src/config/ota.ts
+++ b/mobile/src/config/ota.ts
@@ -1,0 +1,1 @@
+export const OTA_VERSION_URL_PROD = "https://ota.mentraglass.com/prod_live_version.json"

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -47,9 +47,6 @@ interface VersionJson {
   releaseNotes?: string
 }
 
-// OTA version URL constant
-export const OTA_VERSION_URL_PROD = "https://ota.mentraglass.com/prod_live_version.json"
-
 function areGlassesConnectedNow(): boolean {
   return isGlassesConnected(useGlassesStore.getState().connection)
 }
@@ -391,6 +388,7 @@ export function OtaUpdateChecker() {
   // OTA check state from glasses store
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
   const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const [otaVersionUrl] = useSetting<string>(SETTINGS.ota_version_url.key)
   const glassesConnected = useGlassesStore(selectGlassesConnected)
   const buildNumber = useGlassesStore((state) => state.buildNumber)
   const glassesWifiConnected = useGlassesStore((state) => state.wifi.state === "connected")
@@ -634,7 +632,7 @@ export function OtaUpdateChecker() {
       )
       hasCheckedOta.current = true // Mark as checked to prevent duplicate checks
 
-      checkForOtaUpdate(OTA_VERSION_URL_PROD, buildNumber, latestMtkFirmwareVersion, latestBesFirmwareVersion)
+      checkForOtaUpdate(otaVersionUrl, buildNumber, latestMtkFirmwareVersion, latestBesFirmwareVersion)
         .then(({updateAvailable, latestVersionInfo, updates}) => {
           console.log(
             `OTA: check completed - updateAvailable: ${updateAvailable}, updates: ${updates?.join(", ") || "none"}`,
@@ -747,6 +745,7 @@ export function OtaUpdateChecker() {
     defaultWearable,
     pathname,
     push,
+    otaVersionUrl,
     superMode,
   ])
 

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -5,6 +5,7 @@ import {create} from "zustand"
 import {subscribeWithSelector} from "zustand/middleware"
 import * as Device from "expo-device"
 
+import {OTA_VERSION_URL_PROD} from "@/config/ota"
 import restComms from "@/services/RestComms"
 import {storage} from "@/utils/storage"
 
@@ -121,6 +122,17 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: false,
     persist: true,
   },
+  ota_version_url: {
+    key: "ota_version_url",
+    defaultValue: () => {
+      return process.env.EXPO_PUBLIC_OTA_VERSION_URL_OVERRIDE || OTA_VERSION_URL_PROD
+    },
+    // If env var is set, always use it (on every boot)
+    override: () => process.env.EXPO_PUBLIC_OTA_VERSION_URL_OVERRIDE,
+    writable: true,
+    saveOnServer: false,
+    persist: true,
+  },
   saved_backend_urls: {
     key: "saved_backend_urls",
     defaultValue: () => [],
@@ -133,6 +145,13 @@ export const SETTINGS: Record<string, Setting> = {
     defaultValue: () => [],
     writable: true,
     saveOnServer: true,
+    persist: true,
+  },
+  saved_ota_version_urls: {
+    key: "saved_ota_version_urls",
+    defaultValue: () => [],
+    writable: true,
+    saveOnServer: false,
     persist: true,
   },
   reconnect_on_app_foreground: {


### PR DESCRIPTION
## Summary
- add a developer setting for overriding the OTA version manifest URL
- thread the configured manifest URL through manual OTA checks, progress screens, and phone-initiated OTA start
- allow ASG/OTA updater code paths to receive the manifest URL override instead of always using the production default

## Why
This lets us test a local or tunneled OTA manifest while keeping the production URL as the normal default.

## Notes
- This PR is stacked on `codex/hackathon-feedback-fixes` to keep the diff limited to the OTA URL setting.
- The local BES manifest helper script is intentionally not included in this repo.

## Validation
- `git diff --check b247ed102..HEAD`
- inspected the committed diff for private BES source paths
