### PR TITLE
fix: send requestId instead of request_id for iOS video recording

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -4739,7 +4739,7 @@ extension MentraLive {
 
         var json: [String: Any] = [
             "type": "start_video_recording",
-            "request_id": requestId,
+            "requestId": requestId,
             "save": save,
             "flash": flash,
             "sound": sound,
@@ -4766,7 +4766,7 @@ extension MentraLive {
 
         let json: [String: Any] = [
             "type": "stop_video_recording",
-            "request_id": requestId,
+            "requestId": requestId,
         ]
         sendJson(json)
     }


### PR DESCRIPTION
Summary: Fixes the iOS Bluetooth SDK video recording payloads to send requestId instead of request_id, matching Android and the Mentra Live command handler.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
iOS Bluetooth SDK now sends `requestId` (camelCase) in start/stop video recording payloads instead of `request_id`. This matches Android and the Mentra Live command handler so recording commands are processed correctly.

<sup>Written for commit 5866e15798c0be6f6d29134d0257c8996e2d0191. Summary will update on new commits. <a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/2866?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

