### PR TITLE
B0: Spotless formatting gate and asg_client AGENTS.md fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{java,kt,kts,gradle}]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,json,md}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/mentraos-asg-client-build.yml
+++ b/.github/workflows/mentraos-asg-client-build.yml
@@ -108,6 +108,10 @@ jobs:
             asg-gradle-${{ runner.os }}-${{ steps.cache-week.outputs.week }}-
             asg-gradle-${{ runner.os }}-
 
+      - name: Spotless check
+        working-directory: ./asg_client
+        run: ./gradlew spotlessCheck
+
       - name: Build Release APK
         id: gradle-build
         working-directory: ./asg_client

--- a/asg_client/AGENTS.md
+++ b/asg_client/AGENTS.md
@@ -1,6 +1,6 @@
 # ASG Client (Android Smart Glasses Client)
 
-Android application that runs on Android-based smart glasses like Mentra Live. Connects to MentraOS Cloud via WebSocket and manages hardware interfaces (camera, microphone, LED control, sensors).
+Android application that runs on Android-based smart glasses like Mentra Live. Primary transport is BLE to the paired phone (the phone forwards to MentraOS Cloud). Manages hardware interfaces (camera, microphone, LED control, sensors).
 
 ## Compatible Devices
 
@@ -114,7 +114,7 @@ This removes your custom build and restores the factory app.
 ```
 asg_client/
 ├── app/src/main/java/com/mentra/asg_client/
-│   ├── service/        # Main services (WebSocket, foreground service)
+│   ├── service/        # Main services (BLE bridge, foreground service)
 │   ├── camera/         # Camera capture and streaming
 │   ├── audio/          # Audio capture and processing
 │   ├── hardware/       # Hardware interfaces (LED, sensors)
@@ -142,7 +142,7 @@ asg_client/
 - **Methods**: camelCase (e.g., `connectToCloud()`)
 - **Constants**: UPPER_SNAKE_CASE (e.g., `MAX_RETRY_ATTEMPTS`)
 - **Member Variables**: mCamelCase with 'm' prefix (e.g., `mWebSocketClient`)
-- **Indentation**: 2 spaces
+- **Indentation**: 4 spaces
 - **Braces**: Opening brace on same line
 
 ### Documentation
@@ -153,7 +153,7 @@ asg_client/
 
 ### Architecture
 
-- **Dependency Injection**: Use Dagger/Hilt patterns in `/di` package
+- **Dependency Injection**: Manual factories under `io/*/core/*Factory.java` and `service/utils/DeviceProfile`. No Dagger/Hilt today (`/di` only has `AppModule.java`).
 - **Error Reporting**: Use Sentry via reporting package
 - **Logging**: Use Android Logcat with appropriate tags
 - **Services**: Follow Android foreground service best practices
@@ -169,7 +169,7 @@ asg_client/
 
 ### Cloud Communication
 
-- **WebSocket**: Persistent connection to MentraOS Cloud
+- **Phone bridge**: Primary transport is BLE to the paired phone; the phone forwards to MentraOS Cloud. Some ancillary HTTP/WebSocket paths exist (see `BuildConfig.MENTRAOS_HOST`).
 - **Media Streaming**: RTMP streaming via StreamPackLite
 - **Event Handling**: Camera button events, sensor data
 

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -5,6 +5,19 @@ plugins {
     id 'io.sentry.android.gradle' version '5.8.0'
 }
 
+apply plugin: 'com.diffplug.spotless'
+
+spotless {
+    java {
+        target 'src/**/*.java'
+        googleJavaFormat('1.17.0').aosp()
+        ratchetFrom 'origin/dev'
+        toggleOffOn()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
 // 1. Import classes for file/stream and properties
 import java.util.Properties
 

--- a/asg_client/build.gradle
+++ b/asg_client/build.gradle
@@ -42,6 +42,7 @@ plugins {
     //id 'com.google.gms.google-services' version '4.4.0' apply false
     id 'org.jetbrains.dokka' version '1.9.20' apply false
     id 'org.jetbrains.kotlin.android' version '1.9.24' apply false
+    id 'com.diffplug.spotless' version '6.25.0' apply false
 }
 
 tasks.register('clean') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds formatting infrastructure for `asg_client` without mass-reformatting the tree, and corrects factually wrong sections of `asg_client/AGENTS.md`.

## Changes

- Repo-root `.editorconfig` (4-space Java, 2-space yaml/md)
- Spotless 6.25.0 with `googleJavaFormat().aosp()` and `ratchetFrom 'origin/dev'` (only files changed vs `dev` are checked/reformatted)
- CI: `./gradlew spotlessCheck` in `mentraos-asg-client-build.yml` before `assembleRelease`
- `AGENTS.md`: 4-space indent, manual factories + `DeviceProfile` (no Hilt), BLE phone bridge as primary cloud transport

## Out of scope

- Mass reformat of all Java files (`ratchetFrom` prevents this)
- Lint baseline / `abortOnError` (P0)
- Introducing Hilt

## Test evidence

- `./gradlew spotlessCheck` passes locally on this branch (no Java source changes vs `dev`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4bb7f5c-8f97-4057-8202-e0180f8860ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4bb7f5c-8f97-4057-8202-e0180f8860ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

