### PR TITLE
A0: Un-short-circuit BT/Network factories with DeviceProfile

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BluetoothManagerFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BluetoothManagerFactory.java
@@ -2,47 +2,49 @@ package com.mentra.asg_client.io.bluetooth.core;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
 import com.mentra.asg_client.io.bluetooth.managers.StandardBluetoothManager;
+import com.mentra.asg_client.service.utils.DeviceProfile;
 import com.mentra.asg_client.service.utils.ServiceUtils;
 
 /**
- * Factory class to create the appropriate bluetooth manager implementation
- * based on the device type.
+ * Factory class to create the appropriate bluetooth manager implementation based on the device
+ * type.
  */
 public class BluetoothManagerFactory {
     private static final String TAG = "BluetoothManagerFactory";
 
     /**
      * Get a bluetooth manager implementation based on the device type
+     *
      * @param context The application context
      * @return An implementation of IBluetoothManager appropriate for the device
      */
     public static IBluetoothManager getBluetoothManager(Context context) {
         Context appContext = context.getApplicationContext();
-        
-        // Switched back to StandardBluetoothManager due to issues with NordicBluetoothManager
-        //Log.i(TAG, "Using StandardBluetoothManager instead of NordicBluetoothManager");
-        //Log.i(TAG, "Implementation class: " + StandardBluetoothManager.class.getName());
-        //return new StandardBluetoothManager(appContext);
-        
-        Log.d(TAG, "[FORCING K900 IMPLEMENTATION OF BLUETOOTH MANAGER]");
-        if (true || ServiceUtils.isK900Device(appContext)) {
-            Log.i(TAG, "Creating K900BluetoothManager - K900 device detected");
-            Log.d(TAG, "Device type: " + ServiceUtils.getDeviceTypeString(appContext));
+
+        DeviceProfile profile = DeviceProfile.detect(appContext);
+        Log.d(
+                TAG,
+                "Device profile: "
+                        + profile
+                        + " ("
+                        + ServiceUtils.getDeviceTypeString(appContext)
+                        + ")");
+
+        if (profile.isK900()) {
+            Log.i(TAG, "Creating K900BluetoothManager");
             return new K900BluetoothManager(appContext);
-        } else {
-            Log.i(TAG, "Creating StandardBluetoothManager - standard device detected");
-            Log.d(TAG, "Device type: " + ServiceUtils.getDeviceTypeString(appContext));
-            return new StandardBluetoothManager(appContext);
         }
 
+        Log.i(TAG, "Creating StandardBluetoothManager");
+        return new StandardBluetoothManager(appContext);
     }
-    
+
     /**
      * Check if the device is a K900
+     *
      * @param context The application context
      * @return true if the device is a K900, false otherwise
      * @deprecated Use ServiceUtils.isK900Device() instead - centralized implementation
@@ -52,4 +54,4 @@ public class BluetoothManagerFactory {
         Log.w(TAG, "⚠️ Using deprecated isK900Device() - switch to ServiceUtils.isK900Device()");
         return ServiceUtils.isK900Device(context);
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/NetworkManagerFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/NetworkManagerFactory.java
@@ -2,42 +2,38 @@ package com.mentra.asg_client.io.network.core;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.managers.FallbackNetworkManager;
 import com.mentra.asg_client.io.network.managers.K900NetworkManager;
-import com.mentra.asg_client.service.utils.ServiceUtils;
 import com.mentra.asg_client.io.network.managers.SystemNetworkManager;
 import com.mentra.asg_client.io.network.utils.DebugNotificationManager;
+import com.mentra.asg_client.service.utils.DeviceProfile;
+import com.mentra.asg_client.service.utils.ServiceUtils;
 
-/**
- * Factory class that creates the appropriate network manager based on device type.
- */
+/** Factory class that creates the appropriate network manager based on device type. */
 public class NetworkManagerFactory {
     private static final String TAG = "NetworkManagerFactory";
-    
+
     // K900-specific constants
     private static final String K900_BROADCAST_ACTION = "com.xy.xsetting.action";
     private static final String K900_SYSTEM_UI_PACKAGE = "com.android.systemui";
-    
+
     /**
      * Get the appropriate network manager for the current device
+     *
      * @param context The application context
      * @return The appropriate network manager
      */
     public static INetworkManager getNetworkManager(Context context) {
         DebugNotificationManager notificationManager = new DebugNotificationManager(context);
-        
-        // First check if this is a K900 device
-        // TODO: Should we remove this?
-        Log.d(TAG, "[FORCING k900 DEVICE TYPE FOR TESTING]");
-        if (true || ServiceUtils.isK900Device(context)) {
+
+        if (DeviceProfile.detect(context).isK900()) {
             Log.i(TAG, "K900 device detected, using K900NetworkManager");
             Log.d(TAG, "Device type: " + ServiceUtils.getDeviceTypeString(context));
             notificationManager.showDeviceTypeNotification(true);
             return new K900NetworkManager(context);
         }
-        
+
         // Then check if we have system permissions
         if (hasSystemPermissions(context)) {
             Log.i(TAG, "Device has system permissions, using SystemNetworkManager");
@@ -50,13 +46,14 @@ public class NetworkManagerFactory {
         Log.i(TAG, "Using FallbackNetworkManager with possible K900 enhancements");
         notificationManager.showDeviceTypeNotification(false);
         notificationManager.showDebugNotification(
-                "Limited Network Functionality", 
+                "Limited Network Functionality",
                 "This app is running without system permissions. Network functionality will depend on the device type.");
         return new FallbackNetworkManager(context, notificationManager);
     }
-    
+
     /**
      * Check if the device is a K900
+     *
      * @param context The application context
      * @return true if the device is a K900, false otherwise
      * @deprecated Use ServiceUtils.isK900Device() instead - centralized implementation
@@ -66,22 +63,23 @@ public class NetworkManagerFactory {
         Log.w(TAG, "⚠️ Using deprecated isK900Device() - switch to ServiceUtils.isK900Device()");
         return ServiceUtils.isK900Device(context);
     }
-    
+
     /**
      * Check if the app has system permissions
+     *
      * @param context The application context
      * @return true if the app has system permissions, false otherwise
      */
     private static boolean hasSystemPermissions(Context context) {
         return false;
-//
-//        try {
-//            // Check if the app is installed in a system location
-//            String appPath = context.getPackageCodePath();
-//            return appPath.startsWith("/system/") || appPath.contains("/priv-app/");
-//        } catch (Exception e) {
-//            Log.e(TAG, "Error checking for system permissions", e);
-//            return false;
-//        }
+        //
+        //        try {
+        //            // Check if the app is installed in a system location
+        //            String appPath = context.getPackageCodePath();
+        //            return appPath.startsWith("/system/") || appPath.contains("/priv-app/");
+        //        } catch (Exception e) {
+        //            Log.e(TAG, "Error checking for system permissions", e);
+        //            return false;
+        //        }
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/utils/DeviceProfile.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/utils/DeviceProfile.java
@@ -1,0 +1,17 @@
+package com.mentra.asg_client.service.utils;
+
+import android.content.Context;
+
+/** High-level device profile for factory selection (Mentra Live vs generic Android). */
+public enum DeviceProfile {
+    MENTRA_LIVE,
+    GENERIC_ANDROID;
+
+    public static DeviceProfile detect(Context context) {
+        return ServiceUtils.isK900Device(context) ? MENTRA_LIVE : GENERIC_ANDROID;
+    }
+
+    public boolean isK900() {
+        return this == MENTRA_LIVE;
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/utils/DeviceProfileTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/utils/DeviceProfileTest.java
@@ -1,0 +1,63 @@
+package com.mentra.asg_client.service.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.content.Context;
+import androidx.test.core.app.ApplicationProvider;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowBuild;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class DeviceProfileTest {
+
+    @Test
+    public void detect_returnsMentraLive_forMentraLiveModel() {
+        ShadowBuild.setModel("MentraLive");
+        Context context = ApplicationProvider.getApplicationContext();
+
+        assertThat(DeviceProfile.detect(context)).isEqualTo(DeviceProfile.MENTRA_LIVE);
+        assertThat(DeviceProfile.detect(context).isK900()).isTrue();
+    }
+
+    @Test
+    public void detect_returnsMentraLive_forK900Model() {
+        ShadowBuild.setModel("K900Plus");
+        Context context = ApplicationProvider.getApplicationContext();
+
+        assertThat(DeviceProfile.detect(context)).isEqualTo(DeviceProfile.MENTRA_LIVE);
+    }
+
+    @Test
+    public void detect_returnsMentraLive_forXyGlassesProduct() {
+        ShadowBuild.setModel("generic");
+        ShadowBuild.setProduct("xyglasses");
+        Context context = ApplicationProvider.getApplicationContext();
+
+        assertThat(DeviceProfile.detect(context)).isEqualTo(DeviceProfile.MENTRA_LIVE);
+    }
+
+    @Test
+    public void detect_returnsMentraLive_forXyAiGlassesFingerprint() {
+        ShadowBuild.setModel("device");
+        ShadowBuild.setFingerprint("xyaiglasses/release-keys");
+        Context context = ApplicationProvider.getApplicationContext();
+
+        assertThat(DeviceProfile.detect(context)).isEqualTo(DeviceProfile.MENTRA_LIVE);
+    }
+
+    @Test
+    public void detect_returnsGenericAndroid_forPixelLikeDevice() {
+        ShadowBuild.setModel("Pixel 7");
+        ShadowBuild.setProduct("pixel_7");
+        ShadowBuild.setDevice("panther");
+        ShadowBuild.setManufacturer("Google");
+        Context context = ApplicationProvider.getApplicationContext();
+
+        assertThat(DeviceProfile.detect(context)).isEqualTo(DeviceProfile.GENERIC_ANDROID);
+        assertThat(DeviceProfile.detect(context).isK900()).isFalse();
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes the forced K900 test short-circuits (`if (true || ...)`) in `BluetoothManagerFactory` and `NetworkManagerFactory`. Adds a thin `DeviceProfile` enum that wraps existing `ServiceUtils.isK900Device()` detection for typed factory selection.

## Changes

- New `DeviceProfile` enum (`MENTRA_LIVE` / `GENERIC_ANDROID`) with `detect()` and `isK900()`
- `BluetoothManagerFactory` selects `K900BluetoothManager` vs `StandardBluetoothManager` based on profile
- `NetworkManagerFactory` K900 branch uses `DeviceProfile`; `hasSystemPermissions()` unchanged (A4 follow-up)
- Robolectric `DeviceProfileTest` locks mentralive, k900, xyglasses, xyaiglasses tokens

## Out of scope

- `HardwareManagerFactory` (already uses `ServiceUtils.isK900Device()`)
- Migrating other K900 call sites
- Fixing `hasSystemPermissions()` (A4)

## Test evidence

- `./gradlew spotlessCheck` not required on this PR (B0 adds CI gate)
- JVM: `DeviceProfileTest` (Robolectric) — run locally with `./gradlew :app:testDebugUnitTest` when SDK available

## Mentra Live validation (required before merge)

On physical Mentra Live hardware:

1. Boot logs show `K900BluetoothManager` and `K900NetworkManager` selected
2. `AsgClientServiceManager` BES OTA init runs (`BES OTA Manager initialized and registered`)
3. Phone pairs; BLE commands and photo transfer work
4. WiFi/hotspot setup still works

If detection fails on a unit, add the matching token to `ServiceUtils.isK900Device()` — do not revert to `true || ...`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4bb7f5c-8f97-4057-8202-e0180f8860ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4bb7f5c-8f97-4057-8202-e0180f8860ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

