### PR TITLE
Fix gallery sync desync recovery (clean cherry-pick of #2877)

### DIFF
--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -8,8 +8,17 @@ import {gallerySyncService} from "./gallerySyncService"
 import {useGallerySyncStore} from "@/stores/gallerySync"
 import {useGlassesStore} from "@/stores/glasses"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
+import type {CaptureGroup} from "@/types/asg"
 
 jest.mock("@mentra/bluetooth-sdk", () => {
+  const {coreModuleMock} = require("@/test-utils/mockCoreModule")
+  return {
+    __esModule: true,
+    default: coreModuleMock,
+  }
+})
+
+jest.mock("@mentra/bluetooth-sdk-internal", () => {
   const {coreModuleMock} = require("@/test-utils/mockCoreModule")
   return {
     __esModule: true,
@@ -66,6 +75,8 @@ jest.mock("@/services/asg/gallerySyncNotifications", () => ({
   gallerySyncNotifications: {
     requestPermissions: jest.fn(() => Promise.resolve()),
     showSyncError: jest.fn(),
+    showSyncStarted: jest.fn(() => Promise.resolve()),
+    showSyncComplete: jest.fn(() => Promise.resolve()),
   },
 }))
 
@@ -76,6 +87,7 @@ jest.mock("@/services/asg/localStorageService", () => ({
     updateSyncQueueIndex: jest.fn(() => Promise.resolve()),
     getSyncState: jest.fn(() => Promise.resolve({total_downloaded: 0, total_size: 0})),
     updateSyncState: jest.fn(() => Promise.resolve()),
+    saveSyncQueue: jest.fn(() => Promise.resolve()),
     clearSyncQueue: jest.fn(() => Promise.resolve()),
   },
 }))
@@ -100,6 +112,44 @@ jest.mock("@/services/asg/asgCameraApi", () => ({
 jest.mock("@/i18n", () => ({
   translate: jest.fn((key: string) => key),
 }))
+
+const mockGetSyncState = localStorageService.getSyncState as jest.Mock
+const mockSyncWithServer = asgCameraApi.syncWithServer as jest.Mock
+const mockSetServer = asgCameraApi.setServer as jest.Mock
+
+const EMPTY_SYNC_RESPONSE = {
+  data: {
+    api_version: 2,
+    server_time: 2000,
+    captures: [] as CaptureGroup[],
+    changed_files: [],
+  },
+}
+
+const FAKE_CAPTURE: CaptureGroup = {
+  capture_id: "IMG_20260205_163852_546_480",
+  type: "video",
+  timestamp: 1000,
+  total_size: 1000,
+  files: [{name: "IMG_20260205_163852_546_480/base.mp4", size: 1000, role: "primary"}],
+}
+
+const CAPTURE_SYNC_RESPONSE = {
+  data: {
+    api_version: 2,
+    server_time: 2000,
+    captures: [FAKE_CAPTURE],
+    changed_files: [],
+  },
+}
+
+const HOTSPOT_INFO = {ssid: "MentraLive_test", password: "00001111", ip: "192.168.43.1"}
+
+async function startFileDownload(): Promise<void> {
+  await (gallerySyncService as unknown as {startFileDownload: (info: typeof HOTSPOT_INFO) => Promise<void>}).startFileDownload(
+    HOTSPOT_INFO,
+  )
+}
 
 describe("GallerySyncService", () => {
   beforeEach(() => {
@@ -215,6 +265,118 @@ describe("GallerySyncService", () => {
       last_sync_time: failedTimestamp - 1,
       total_downloaded: 1,
       total_size: 100,
+    })
+  })
+
+  describe("startFileDownload /api/sync desync recovery", () => {
+    let executeCaptureDownloadSpy: jest.SpyInstance
+    let consoleWarnSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      useGallerySyncStore.getState().setGlassesGalleryStatus(3, 5, 8, true)
+
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+      mockSetServer.mockImplementation(() => {})
+
+      executeCaptureDownloadSpy = jest
+        .spyOn(gallerySyncService as unknown as {executeCaptureDownload: () => Promise<void>}, "executeCaptureDownload")
+        .mockResolvedValue(undefined)
+
+      consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+    })
+
+    afterEach(() => {
+      executeCaptureDownloadSpy.mockRestore()
+      consoleWarnSpy.mockRestore()
+    })
+
+    it("retries with last_sync_time=0 when glasses have content but incremental sync is empty", async () => {
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1778211091355,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValueOnce(EMPTY_SYNC_RESPONSE).mockResolvedValueOnce(CAPTURE_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(2)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "test_client", 1778211091355, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "test_client", 0, true)
+      expect(executeCaptureDownloadSpy).toHaveBeenCalledWith([FAKE_CAPTURE], 2000)
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Desync detected: glasses report content but /api/sync returned empty"),
+      )
+    })
+
+    it("does not retry when glasses report no content", async () => {
+      useGallerySyncStore.getState().setGlassesGalleryStatus(0, 0, 0, false)
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1778211091355,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
+      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 1778211091355, true)
+      expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
+      expect(useGallerySyncStore.getState().syncState).toBe("complete")
+    })
+
+    it("does not retry on first sync when last_sync_time is 0", async () => {
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 0,
+        client_id: "test_client",
+        total_downloaded: 0,
+        total_size: 0,
+      })
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
+      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 0, true)
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Desync detected"))
+    })
+
+    it("retries at most once when full-sync retry is also empty", async () => {
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1778211091355,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(2)
+      expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
+      expect(useGallerySyncStore.getState().syncState).toBe("complete")
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Full-sync retry also returned empty"),
+      )
+    })
+
+    it("does not retry when the first /api/sync response already has captures", async () => {
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1778211091355,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValue(CAPTURE_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
+      expect(executeCaptureDownloadSpy).toHaveBeenCalledWith([FAKE_CAPTURE], 2000)
+      expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Desync detected"))
     })
   })
 })

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -274,6 +274,8 @@ describe("GallerySyncService", () => {
 
     beforeEach(() => {
       useGallerySyncStore.getState().setGlassesGalleryStatus(3, 5, 8, true)
+      // Reset the singleton's full-sync guard between tests so each test starts fresh.
+      ;(gallerySyncService as unknown as {lastFullSyncRetryKey: string | null}).lastFullSyncRetryKey = null
 
       mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
       mockSetServer.mockImplementation(() => {})
@@ -377,6 +379,35 @@ describe("GallerySyncService", () => {
       expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
       expect(executeCaptureDownloadSpy).toHaveBeenCalledWith([FAKE_CAPTURE], 2000)
       expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Desync detected"))
+    })
+
+    it("does not retry full-sync twice for the same (client_id, last_sync_time) pair", async () => {
+      // Regression: if glasses retain leftover files from a failed delete-from-glasses,
+      // `has_content` stays true and /api/sync stays empty for the same watermark. Without
+      // a guard, every sync would retry with last_sync_time=0 and re-download the whole gallery.
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1778211091355,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+
+      await startFileDownload()
+
+      // onSyncComplete clears glassesHasContent; re-set it to simulate glasses still
+      // reporting leftover files (the exact desync condition the guard protects against).
+      useGallerySyncStore.getState().setGlassesGalleryStatus(3, 5, 8, true)
+
+      await startFileDownload()
+
+      // First call: incremental + full-sync retry = 2 calls.
+      // Second call: incremental only — guard suppresses the retry.
+      expect(mockSyncWithServer).toHaveBeenCalledTimes(3)
+      expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("already retried this watermark, skipping to avoid re-download loop"),
+      )
     })
   })
 })

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -48,6 +48,11 @@ const TIMING = {
   WIFI_COOLDOWN_MS: 3000, // Wait 3 seconds after user visits WiFi settings before showing alert again
 } as const
 
+/** True when /api/sync has nothing to download (api_version=2 captures and legacy changed_files both empty). */
+function isSyncResponseEmpty(data: {captures?: CaptureGroup[]; changed_files?: PhotoInfo[]}): boolean {
+  return (!data.captures || data.captures.length === 0) && (!data.changed_files || data.changed_files.length === 0)
+}
+
 class GallerySyncService {
   private static instance: GallerySyncService
   private hotspotListenerRegistered = false
@@ -1186,11 +1191,34 @@ class GallerySyncService {
 
       console.log("[GallerySyncService]   📡 Calling /api/sync endpoint...")
       const syncStartTime = Date.now()
-      const syncResponse = await asgCameraApi.syncWithServer(syncState.client_id, syncState.last_sync_time, true)
-      const _syncDuration = Date.now() - syncStartTime
+      let syncResponse = await asgCameraApi.syncWithServer(syncState.client_id, syncState.last_sync_time, true)
+      let _syncDuration = Date.now() - syncStartTime
       console.log(`[GallerySyncService]   ✅ /api/sync completed in ${_syncDuration}ms`)
 
-      const syncData = syncResponse.data || syncResponse
+      let syncData = syncResponse.data || syncResponse
+
+      // BLE gallery_status counts all files on glasses; /api/sync is incremental by last_sync_time.
+      // If the phone watermark is ahead of file mtimes (clock skew, deleted locals, etc.), retry once as full sync.
+      if (
+        isSyncResponseEmpty(syncData) &&
+        syncState.last_sync_time > 0 &&
+        useGallerySyncStore.getState().glassesHasContent
+      ) {
+        console.warn(
+          "[GallerySyncService] Desync detected: glasses report content but /api/sync returned empty. " +
+            `Retrying with last_sync_time=0 (was ${syncState.last_sync_time}).`,
+        )
+        const retryStartTime = Date.now()
+        syncResponse = await asgCameraApi.syncWithServer(syncState.client_id, 0, true)
+        _syncDuration = Date.now() - retryStartTime
+        console.log(`[GallerySyncService]   ✅ /api/sync full-sync retry completed in ${_syncDuration}ms`)
+        syncData = syncResponse.data || syncResponse
+        if (isSyncResponseEmpty(syncData)) {
+          console.warn("[GallerySyncService] Full-sync retry also returned empty — falling through to up-to-date path.")
+        } else {
+          console.log("[GallerySyncService] Full-sync retry succeeded — proceeding with download.")
+        }
+      }
 
       console.log("[GallerySyncService]   📋 Sync response received:")
       console.log(`[GallerySyncService]      - Server time: ${syncData.server_time}`)

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -63,6 +63,10 @@ class GallerySyncService {
   private glassesStoreUnsubscribe: (() => void) | null = null
   private appStateSubscription: ReturnType<typeof AppState.addEventListener> | null = null
   private waitingForWifiRetry = false
+  // Guards full-sync recovery so we don't re-download the entire gallery every sync
+  // when glasses retain leftover files (e.g. a previous delete-from-glasses failed).
+  // Keyed by `${client_id}:${last_sync_time}` — same pair = already tried, skip.
+  private lastFullSyncRetryKey: string | null = null
   private wifiSettingsOpenedAt: number | null = null // Timestamp when user was sent to WiFi settings
 
   private constructor() {}
@@ -1199,11 +1203,16 @@ class GallerySyncService {
 
       // BLE gallery_status counts all files on glasses; /api/sync is incremental by last_sync_time.
       // If the phone watermark is ahead of file mtimes (clock skew, deleted locals, etc.), retry once as full sync.
+      // Guard against re-firing every sync when glasses retain leftover files from a failed delete:
+      // only one retry per (client_id, last_sync_time) pair per process lifetime.
+      const retryKey = `${syncState.client_id}:${syncState.last_sync_time}`
       if (
         isSyncResponseEmpty(syncData) &&
         syncState.last_sync_time > 0 &&
-        useGallerySyncStore.getState().glassesHasContent
+        useGallerySyncStore.getState().glassesHasContent &&
+        this.lastFullSyncRetryKey !== retryKey
       ) {
+        this.lastFullSyncRetryKey = retryKey
         console.warn(
           "[GallerySyncService] Desync detected: glasses report content but /api/sync returned empty. " +
             `Retrying with last_sync_time=0 (was ${syncState.last_sync_time}).`,
@@ -1218,6 +1227,15 @@ class GallerySyncService {
         } else {
           console.log("[GallerySyncService] Full-sync retry succeeded — proceeding with download.")
         }
+      } else if (
+        isSyncResponseEmpty(syncData) &&
+        syncState.last_sync_time > 0 &&
+        useGallerySyncStore.getState().glassesHasContent &&
+        this.lastFullSyncRetryKey === retryKey
+      ) {
+        console.warn(
+          "[GallerySyncService] Glasses still report content but /api/sync empty — already retried this watermark, skipping to avoid re-download loop.",
+        )
       }
 
       console.log("[GallerySyncService]   📋 Sync response received:")


### PR DESCRIPTION
## Summary

Cherry-picks the gallery-sync desync recovery fix from #2877 onto a clean branch off `staging`.

The original PR (#2877) accidentally pulled in 27 unrelated commits from the `asg-client-consolidated` merge (Spotless config, MediaCaptureService reformat, OtaHelper rewrite, DeviceProfile, hotspot landing page, etc.) — 25 files / +5017/-3029. This PR is just the fix: 2 files, +193/-3.

## What the fix does

When the glasses report having content (`gallery_status.has_content == true`) but `/api/sync` returns no captures with a non-zero `last_sync_time`, retry once with `last_sync_time=0` (full sync). This handles desync from clock skew, deleted local files, or watermark drift.

- Guards: only triggers on incremental syncs (`last_sync_time > 0`) with `glassesHasContent` true
- Retries at most once; falls through cleanly to "up to date" on second empty response

## Merge conflict resolution

The cherry-pick had a real conflict in `gallerySyncService.test.ts` because `staging` already had the data-loss / validator fixes from #2862 (commit `7875a5526`). Resolution unions all mocks (`mediaProcessingQueue.enqueue/abort`, `asgCameraApi.downloadCapture`, `localStorageService.updateSyncQueueIndex`) and keeps both test suites side-by-side. The new `executeCaptureDownload` spy was scoped to the inner `describe` block so it doesn't interfere with `staging`'s existing `executeCaptureDownload` tests.

## Test plan

- [x] `npx jest src/services/asg/gallerySyncService.test.ts` — 10/10 tests pass locally (5 staging tests + 5 new desync recovery tests)
- [ ] CI green on this branch
- [ ] Close #2877 with a link to this PR

## Original author

Original commit by @nic-olo (Nicolo Micheletti) — preserved via cherry-pick.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes gallery sync desync by retrying with a full sync when glasses report content but incremental `/api/sync` returns no captures, and adds a guard to avoid repeating the retry for the same watermark. Prevents false “up to date” states and re-download loops from clock skew, deleted locals, or leftover files.

- **Bug Fixes**
  - Detects empty incremental syncs when `last_sync_time > 0` and `glassesHasContent` is true, then retries once with `last_sync_time=0`.
  - Skips the full-sync retry if the same `(client_id, last_sync_time)` was already retried in this session to prevent re-download loops.
  - Adds tests for retry behavior, no-content cases, first sync (no retry), non-empty responses, single-retry cap, and the repeat-retry guard.

<sup>Written for commit b4a43bb15244ee8eee8ec0bb0fc9709cbcb06f31. Summary will update on new commits. <a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/2879?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

