### PR TITLE
Handle MTK UVC streaming and drive privacy LEDs

### DIFF
--- a/asg_client/app/src/main/AndroidManifest.xml
+++ b/asg_client/app/src/main/AndroidManifest.xml
@@ -127,6 +127,16 @@
             </intent-filter>
         </receiver>
 
+        <!-- MTK USB UVC (webcam) streaming state -->
+        <receiver
+            android:name="com.mentra.asg_client.receiver.UvcStreamingBroadcastReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.uvc.action.UVC_STREAMING_CHANGED" />
+            </intent-filter>
+        </receiver>
+
         <!-- Debug receiver for testing BES OTA via adb -->
         <receiver
             android:name="com.mentra.asg_client.receiver.DebugBesOtaReceiver"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/UvcStreamingState.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/UvcStreamingState.java
@@ -1,0 +1,25 @@
+package com.mentra.asg_client.camera;
+
+/**
+ * Tracks USB UVC (webcam) streaming state from MTK firmware broadcasts.
+ *
+ * @see com.mentra.asg_client.receiver.UvcStreamingBroadcastReceiver
+ */
+public final class UvcStreamingState {
+
+    public static final String ACTION_UVC_STREAMING_CHANGED =
+            "com.uvc.action.UVC_STREAMING_CHANGED";
+    public static final String EXTRA_STREAMING = "streaming";
+
+    private static volatile boolean sStreaming;
+
+    private UvcStreamingState() {}
+
+    public static void setStreaming(boolean streaming) {
+        sStreaming = streaming;
+    }
+
+    public static boolean isStreaming() {
+        return sStreaming;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/UvcStreamingBroadcastReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/UvcStreamingBroadcastReceiver.java
@@ -1,0 +1,56 @@
+package com.mentra.asg_client.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.util.Log;
+
+import com.mentra.asg_client.camera.UvcStreamingState;
+import com.mentra.asg_client.service.core.AsgClientService;
+
+/**
+ * Receives UVC streaming state from MTK when USB webcam mode starts or stops.
+ *
+ * <p>Broadcast format (from MTK):
+ *
+ * <pre>
+ * action: com.uvc.action.UVC_STREAMING_CHANGED
+ * package: com.mentra.asg_client
+ * extra: streaming (boolean)
+ * </pre>
+ */
+public class UvcStreamingBroadcastReceiver extends BroadcastReceiver {
+
+    private static final String TAG = "UvcStreamingReceiver";
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (intent == null) {
+            return;
+        }
+
+        if (!UvcStreamingState.ACTION_UVC_STREAMING_CHANGED.equals(intent.getAction())) {
+            return;
+        }
+
+        boolean streaming = intent.getBooleanExtra(UvcStreamingState.EXTRA_STREAMING, false);
+        Log.i(TAG, "MTK UVC streaming changed: streaming=" + streaming);
+
+        UvcStreamingState.setStreaming(streaming);
+
+        Intent serviceIntent = new Intent(context, AsgClientService.class);
+        serviceIntent.setAction(AsgClientService.ACTION_UVC_STREAMING_CHANGED);
+        serviceIntent.putExtra(AsgClientService.EXTRA_UVC_STREAMING, streaming);
+
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent);
+            } else {
+                context.startService(serviceIntent);
+            }
+        } catch (IllegalStateException e) {
+            Log.e(TAG, "Failed to start service for UVC state", e);
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -20,7 +20,11 @@ import android.util.Size;
 
 import com.dev.api.DevApi;
 import com.mentra.asg_client.SysControl;
+import com.mentra.asg_client.camera.UvcStreamingState;
+import com.mentra.asg_client.hardware.K900RgbLedController;
 import com.mentra.asg_client.io.bluetooth.interfaces.BluetoothStateListener;
+import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
+import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.io.media.interfaces.ServiceCallbackInterface;
 import com.mentra.asg_client.io.media.managers.MediaUploadQueueManager;
@@ -75,6 +79,9 @@ public class AsgClientService extends Service implements NetworkStateListener, B
     public static final String ACTION_RESTART_CAMERA = "com.mentra.asg_client.ACTION_RESTART_CAMERA";
     public static final String ACTION_I2S_AUDIO_STATE = "com.mentra.asg_client.ACTION_I2S_AUDIO_STATE";
     public static final String EXTRA_I2S_AUDIO_PLAYING = "extra_i2s_audio_playing";
+    public static final String ACTION_UVC_STREAMING_CHANGED =
+            "com.mentra.asg_client.ACTION_UVC_STREAMING_CHANGED";
+    public static final String EXTRA_UVC_STREAMING = "extra_uvc_streaming";
     public static final String ACTION_START_OTA_UPDATER = "ACTION_START_OTA_UPDATER";
 
     // OTA Update progress actions
@@ -86,6 +93,8 @@ public class AsgClientService extends Service implements NetworkStateListener, B
     private static final String ACTION_HEARTBEAT = "com.mentra.asg_client.ACTION_HEARTBEAT";
     private static final String ACTION_HEARTBEAT_ACK = "com.mentra.asg_client.ACTION_HEARTBEAT_ACK";
     private static final long HEARTBEAT_TIMEOUT_MS = 35000; // 35 seconds timeout
+    /** Solid white RGB LED duration while USB UVC streaming (same as video recording). */
+    private static final int UVC_STREAMING_LED_DURATION_MS = 1_800_000;
 
     // ---------------------------------------------
     // Dependency Injection Container
@@ -109,6 +118,7 @@ public class AsgClientService extends Service implements NetworkStateListener, B
     // private boolean isAugmentosBound = false;
     private static AsgClientService instance;
     private boolean lastI2sPlaying = false;
+    private boolean lastUvcStreaming = false;
     private boolean isConnected = false; // Track connection state based on heartbeat
 
     // ---------------------------------------------
@@ -283,6 +293,12 @@ public class AsgClientService extends Service implements NetworkStateListener, B
                 return START_STICKY;
             }
 
+            if (ACTION_UVC_STREAMING_CHANGED.equals(action)) {
+                boolean streaming = intent.getBooleanExtra(EXTRA_UVC_STREAMING, false);
+                handleUvcStreamingState(streaming);
+                return START_STICKY;
+            }
+
             // Delegate action handling to lifecycle manager
             lifecycleManager.handleAction(action, intent.getExtras());
             Log.d(TAG, "✅ Action processed successfully");
@@ -374,6 +390,70 @@ public class AsgClientService extends Service implements NetworkStateListener, B
 
     public static AsgClientService getInstance() {
         return instance;
+    }
+
+    /** Handle MTK UVC streaming state forwarded from {@link com.mentra.asg_client.receiver.UvcStreamingBroadcastReceiver}. */
+    public void handleUvcStreamingState(boolean streaming) {
+        if (streaming == lastUvcStreaming) {
+            Log.d(TAG, "UVC streaming state unchanged (" + streaming + "), skipping LED update");
+            return;
+        }
+
+        lastUvcStreaming = streaming;
+        Log.i(TAG, "UVC streaming state: " + (streaming ? "active" : "inactive"));
+        UvcStreamingState.setStreaming(streaming);
+        applyUvcStreamingLed(streaming);
+    }
+
+    /**
+     * Drive privacy indicators while USB UVC webcam mode is active — same pairing as video
+     * recording: local MTK front-facing flash LED plus BES RGB ring (solid white).
+     */
+    private void applyUvcStreamingLed(boolean streaming) {
+        IHardwareManager hardwareManager = getHardwareManagerForLed();
+        if (hardwareManager == null) {
+            Log.w(TAG, "Hardware manager not available; skipping UVC streaming LED update");
+            return;
+        }
+
+        if (streaming) {
+            if (hardwareManager.supportsRecordingLed()) {
+                hardwareManager.setRecordingLedOn();
+                Log.i(TAG, "UVC streaming front-facing recording flash LED on");
+            } else {
+                Log.w(TAG, "Recording flash LED not supported on this device");
+            }
+
+            if (hardwareManager.supportsRgbLed()) {
+                sendRgbLedControlAuthority(true);
+                hardwareManager.setRgbLedSolidWhite(
+                        UVC_STREAMING_LED_DURATION_MS,
+                        K900RgbLedController.DEFAULT_RGB_LED_BRIGHTNESS);
+                Log.i(TAG, "UVC streaming RGB ring LED on (solid white)");
+            } else {
+                Log.w(TAG, "RGB LED not supported on this device");
+            }
+        } else {
+            if (hardwareManager.supportsRecordingLed()) {
+                hardwareManager.setRecordingLedOff();
+                Log.i(TAG, "UVC streaming front-facing recording flash LED off");
+            }
+            if (hardwareManager.supportsRgbLed()) {
+                hardwareManager.setRgbLedOff();
+                Log.i(TAG, "UVC streaming RGB ring LED off");
+            }
+        }
+    }
+
+    private IHardwareManager getHardwareManagerForLed() {
+        IHardwareManager hardwareManager = HardwareManagerFactory.getInstance(this);
+        if (serviceContainer != null && serviceContainer.getServiceManager() != null) {
+            var bluetoothManager = serviceContainer.getServiceManager().getBluetoothManager();
+            if (bluetoothManager != null) {
+                hardwareManager.setBluetoothManager(bluetoothManager);
+            }
+        }
+        return hardwareManager;
     }
 
     public void handleI2SAudioState(boolean playing) {


### PR DESCRIPTION
## Summary
- Listen for MTK `com.uvc.action.UVC_STREAMING_CHANGED` broadcasts (package-targeted to `com.mentra.asg_client`) and track `streaming` state in `UvcStreamingState`.
- Forward UVC state through `AsgClientService` and turn on both privacy indicators when USB webcam mode starts: local MTK front-facing recording flash LED plus BES RGB ring (solid white). Turn both off when streaming stops.

## Test plan
- [ ] On Mentra Live glasses: `adb shell am broadcast -a com.uvc.action.UVC_STREAMING_CHANGED --ez streaming true com.mentra.asg_client` — front flash LED and RGB ring on
- [ ] Same with `--ez streaming false` — both LEDs off
- [ ] Real USB UVC session from a host PC — MTK broadcast fires and LEDs follow
- [ ] Confirm logs: `UvcStreamingReceiver`, `UVC streaming front-facing recording flash LED on`, `UVC streaming RGB ring LED on`


Made with [Cursor](https://cursor.com)