### PR TITLE
Fix glasses clock skew during gallery sync and OTA (rebased onto staging)

### DIFF
--- a/agents/asg-photo-gallery-system.md
+++ b/agents/asg-photo-gallery-system.md
@@ -282,6 +282,7 @@ if (isAvifFile(fileContent)) {
 3. Monitor network requests in mobile app logs
 4. Check sync state in AsyncStorage
 5. Verify file permissions on glasses
+6. **Clock skew**: If `/api/sync` returns `changed_files: []` but `gallery_status` still shows items, compare phone `last_sync_time` with glasses `server_time`. When the watermark is ahead of glasses clock, the phone retries with `last_sync_time=0` and may send BLE `set_system_time` (only when skew is detected—not on every connect). Glasses firmware also clamps a future `last_sync_time` to full sync.
 
 ### Testing Checklist
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -608,6 +608,22 @@ public class OtaHelper {
     /**
      * Classify download exceptions into semantic error codes for actionable user feedback.
      */
+    private boolean isClockSkewSslError(Throwable e) {
+        Throwable t = e;
+        while (t != null) {
+            if (t instanceof java.security.cert.CertificateNotYetValidException) {
+                return true;
+            }
+            String msg = t.getMessage();
+            if (msg != null && (msg.contains("Certificate not yet valid")
+                    || msg.contains("timestamp check failed"))) {
+                return true;
+            }
+            t = t.getCause();
+        }
+        return false;
+    }
+
     private String classifyDownloadError(Exception e) {
         if (e instanceof FirmwareDownloadException) {
             // Non-network failure (size cap, sha256 mismatch). Carry the stable code through
@@ -619,7 +635,12 @@ public class OtaHelper {
             return "no_internet";
         } else if (e instanceof java.net.ConnectException) {
             return "no_internet";
-        } else if (e instanceof javax.net.ssl.SSLException) {
+        } else if (e instanceof javax.net.ssl.SSLException || isClockSkewSslError(e)) {
+            if (isClockSkewSslError(e)) {
+                Log.w(TAG, "⏰ OTA failure likely due to glasses clock skew (TLS cert validity): "
+                        + e.getMessage());
+                return "clock_skew";
+            }
             return "ssl_error";
         } else if (e instanceof java.net.SocketException) {
             // Mid-download link loss, RST, or "Software caused connection abort" — not worth retrying
@@ -837,6 +858,18 @@ public class OtaHelper {
         }
         Log.e(TAG, "No WiFi connection detected");
         return false;
+    }
+
+    /**
+     * Re-run background OTA version check (e.g. after phone fixes glasses clock via BLE).
+     */
+    public void retryBackgroundVersionCheck() {
+        if (context == null) {
+            Log.w(TAG, "⏰ Cannot retry OTA version check — no context");
+            return;
+        }
+        Log.i(TAG, "⏰ Retrying OTA version check after clock sync from phone");
+        startVersionCheck(context);
     }
 
     public void startVersionCheck(Context context) {
@@ -2958,6 +2991,9 @@ public class OtaHelper {
             // Phone bridge (MentraLive.java) reads all fields from the top level of the JSON
             // object, so we add "type" directly to sessionState rather than nesting it under "data".
             sessionState.put("type", "ota_status");
+            if ("failed".equals(sessionState.optString("status"))) {
+                sessionState.put("glasses_time_ms", System.currentTimeMillis());
+            }
             phoneConnectionProvider.sendOtaStatus(sessionState);
         } catch (JSONException e) {
             Log.e(TAG, "Failed to send OTA status", e);
@@ -2985,6 +3021,7 @@ public class OtaHelper {
             if ("FAILED".equals(ev)) {
                 o.put("status", "failed");
                 o.put("error_message", lastOtaPhoneError != null ? lastOtaPhoneError : "Update failed");
+                o.put("glasses_time_ms", System.currentTimeMillis());
             } else if ("FINISHED".equals(ev)) {
                 if ("install".equals(lastOtaPhoneStage)) {
                     o.put("status", "complete");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
@@ -62,7 +62,7 @@ public class OtaCommandHandler implements ICommandHandler {
 
     @Override
     public Set<String> getSupportedCommandTypes() {
-        return Set.of("ota_start", "ota_update_response", "ota_query_status");
+        return Set.of("ota_start", "ota_update_response", "ota_query_status", "ota_retry_version_check");
     }
 
     @Override
@@ -75,6 +75,8 @@ public class OtaCommandHandler implements ICommandHandler {
                     return handleOtaUpdateResponse(data);
                 case "ota_query_status":
                     return handleOtaQueryStatus();
+                case "ota_retry_version_check":
+                    return handleOtaRetryVersionCheck();
                 default:
                     Log.e(TAG, "Unsupported OTA command: " + commandType);
                     return false;
@@ -160,6 +162,16 @@ public class OtaCommandHandler implements ICommandHandler {
             String statusStr = data != null ? data.optString("status", "?") : "?";
             Log.i(TAG, "📱 Sent ota_status response: " + statusStr);
         }
+        return true;
+    }
+
+    private boolean handleOtaRetryVersionCheck() {
+        Log.i(TAG, "📱 Received ota_retry_version_check from phone");
+        if (otaHelperInstance == null) {
+            Log.w(TAG, "OtaHelper not initialized — cannot retry version check");
+            return false;
+        }
+        otaHelperInstance.retryBackgroundVersionCheck();
         return true;
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PowerCommandHandler.java
@@ -7,6 +7,7 @@ import com.mentra.asg_client.SysControl;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.service.legacy.interfaces.ICommandHandler;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
+import com.mentra.asg_client.service.utils.ServiceConstants;
 
 import org.json.JSONObject;
 
@@ -23,6 +24,7 @@ public class PowerCommandHandler implements ICommandHandler {
 
     private static final String CMD_SHUTDOWN = "shutdown";
     private static final String CMD_REBOOT = "reboot";
+    private static final String CMD_SET_SYSTEM_TIME = ServiceConstants.COMMAND_SET_SYSTEM_TIME;
 
     private final Context context;
     private final AsgClientServiceManager serviceManager;
@@ -34,7 +36,7 @@ public class PowerCommandHandler implements ICommandHandler {
 
     @Override
     public Set<String> getSupportedCommandTypes() {
-        return Set.of(CMD_SHUTDOWN, CMD_REBOOT);
+        return Set.of(CMD_SHUTDOWN, CMD_REBOOT, CMD_SET_SYSTEM_TIME);
     }
 
     @Override
@@ -45,6 +47,8 @@ public class PowerCommandHandler implements ICommandHandler {
                     return handleShutdown();
                 case CMD_REBOOT:
                     return handleReboot();
+                case CMD_SET_SYSTEM_TIME:
+                    return handleSetSystemTime(data);
                 default:
                     Log.e(TAG, "Unsupported power command: " + commandType);
                     return false;
@@ -85,6 +89,25 @@ public class PowerCommandHandler implements ICommandHandler {
             return true;
         } catch (Exception e) {
             Log.e(TAG, "❌ Error initiating reboot", e);
+            return false;
+        }
+    }
+
+    /**
+     * Set glasses system clock from phone (only sent when phone detects clock skew during gallery sync).
+     */
+    private boolean handleSetSystemTime(JSONObject data) {
+        long timestampMs = data != null ? data.optLong("timestamp_ms", 0L) : 0L;
+        if (timestampMs <= 0L) {
+            Log.w(TAG, "set_system_time ignored: missing or invalid timestamp_ms");
+            return false;
+        }
+        Log.i(TAG, "⏰ Setting system time from phone: " + timestampMs);
+        try {
+            SysControl.setSystemTime(context, timestampMs);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "❌ Error setting system time", e);
             return false;
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/utils/ServiceConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/utils/ServiceConstants.java
@@ -50,6 +50,7 @@ public final class ServiceConstants {
     public static final String COMMAND_REQUEST_WIFI_STATUS = "request_wifi_status";
     public static final String COMMAND_REQUEST_WIFI_SCAN = "request_wifi_scan";
     public static final String COMMAND_SET_HOTSPOT_STATE = "set_hotspot_state";
+    public static final String COMMAND_SET_SYSTEM_TIME = "set_system_time";
     public static final String COMMAND_PING = "ping";
     public static final String COMMAND_BATTERY_STATUS = "battery_status";
     public static final String COMMAND_REQUEST_VERSION = "request_version";

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -321,7 +321,7 @@ Response:
 
 #### `set_system_time`
 
-Sets the glasses system clock from the phone. Sent only when the phone detects clock skew during gallery sync (not on every BLE connect).
+Sets the glasses system clock from the phone. Sent only when the phone detects clock skew during gallery sync or OTA version checks (not on every BLE connect).
 
 ```json
 {"type": "set_system_time", "timestamp_ms": 1710000000000}

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -319,6 +319,16 @@ Response:
 }
 ```
 
+#### `set_system_time`
+
+Sets the glasses system clock from the phone. Sent only when the phone detects clock skew during gallery sync (not on every BLE connect).
+
+```json
+{"type": "set_system_time", "timestamp_ms": 1710000000000}
+```
+
+No response is required for V1 (fire-and-forget).
+
 #### `disconnect_wifi`
 
 ```json

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -356,6 +356,10 @@ class BluetoothSdkModule : Module() {
             sdk?.setHotspotState(enabled)
         }
 
+        AsyncFunction("setSystemTime") { timestampMs: Double ->
+            sdk?.setSystemTime(timestampMs.toLong())
+        }
+
         // MARK: - Gallery Commands
 
         AsyncFunction("setGalleryModeEnabled") { enabled: Boolean ->
@@ -393,6 +397,8 @@ class BluetoothSdkModule : Module() {
         AsyncFunction("sendOtaStart") { sdk?.sendOtaStart() }
 
         AsyncFunction("sendOtaQueryStatus") { sdk?.sendOtaQueryStatus() }
+
+        AsyncFunction("retryOtaVersionCheck") { sdk?.retryOtaVersionCheck() }
 
         // MARK: - Version Info Commands
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -534,6 +534,7 @@ public class Bridge private constructor() {
         }
 
         @JvmStatic
+        @JvmOverloads
         fun sendOtaStatus(
                 sessionId: String,
                 totalSteps: Int,
@@ -543,7 +544,8 @@ public class Bridge private constructor() {
                 stepPercent: Int,
                 overallPercent: Int,
                 status: String,
-                errorMessage: String?
+                errorMessage: String? = null,
+                glassesTimeMs: Long? = null,
         ) {
             val eventBody = HashMap<String, Any>()
             eventBody["session_id"] = sessionId
@@ -555,6 +557,9 @@ public class Bridge private constructor() {
             eventBody["overall_percent"] = overallPercent
             eventBody["status"] = status
             errorMessage?.let { eventBody["error_message"] = it }
+            if (glassesTimeMs != null && glassesTimeMs > 0) {
+                eventBody["glasses_time_ms"] = glassesTimeMs
+            }
 
             Log.d(TAG, "Bridge: sendOtaStatus: $eventBody")
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1232,6 +1232,11 @@ class DeviceManager {
         sgc?.sendHotspotState(enabled)
     }
 
+    fun setSystemTime(timestampMs: Long) {
+        Bridge.log("MAN: Setting glasses system time: $timestampMs")
+        sgc?.sendSetSystemTime(timestampMs)
+    }
+
     fun queryGalleryStatus() {
         Bridge.log("MAN: Querying gallery status from glasses")
         sgc?.queryGalleryStatus()
@@ -1249,6 +1254,11 @@ class DeviceManager {
     fun sendOtaQueryStatus() {
         Bridge.log("MAN: 📱 Sending OTA query status command to glasses")
         (sgc as? MentraLive)?.sendOtaQueryStatus()
+    }
+
+    fun retryOtaVersionCheck() {
+        Bridge.log("MAN: ⏰ Retrying glasses OTA version check after clock sync")
+        (sgc as? MentraLive)?.sendOtaRetryVersionCheck()
     }
 
     /**

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -192,6 +192,7 @@ class DeviceManager {
     // Guard against duplicate ready callbacks firing back-to-back.
     private var lastReadyHandledAtMs: Long = 0L
     private var lastReadyHandledKey: String = ""
+    private var lastSystemTimeSyncConnectionKey: String = ""
 
     private var systemMicUnavailable: Boolean
         get() = DeviceStore.store.get("bluetooth", "systemMicUnavailable") as? Boolean ?: false
@@ -974,6 +975,7 @@ class DeviceManager {
             Bridge.log("MAN: Cleaning up previous sgc type: ${sgc?.type}")
             sgc?.cleanup()
             sgc = null
+            lastSystemTimeSyncConnectionKey = ""
         }
 
         if (sgc != null) {
@@ -1048,6 +1050,8 @@ class DeviceManager {
         defaultWearable = sgc?.type ?: ""
         searching = false
 
+        syncSystemTimeOnceForConnection(readyKey)
+
         // Apply dashboard position before any boot text so content doesn't jump.
         sgc?.setDashboardPosition(dashboardHeight, dashboardDepth)
 
@@ -1084,6 +1088,21 @@ class DeviceManager {
         Bridge.saveSetting("device_address", deviceAddress)
     }
 
+    private fun syncSystemTimeOnceForConnection(connectionKey: String) {
+        val activeSgc = sgc ?: return
+        if (activeSgc.type.contains(DeviceTypes.SIMULATED)) {
+            return
+        }
+        if (connectionKey == lastSystemTimeSyncConnectionKey) {
+            return
+        }
+
+        lastSystemTimeSyncConnectionKey = connectionKey
+        val timestampMs = System.currentTimeMillis()
+        Bridge.log("MAN: Syncing glasses system time once for connection: $timestampMs")
+        activeSgc.sendSetSystemTime(timestampMs)
+    }
+
     private fun handleG1Ready() {
         // G1-specific setup (if any needed in the future)
         // Note: G1-specific settings like silent mode, battery status,
@@ -1096,6 +1115,7 @@ class DeviceManager {
 
     fun handleDeviceDisconnected() {
         Bridge.log("MAN: Device disconnected")
+        lastSystemTimeSyncConnectionKey = ""
         DeviceStore.apply("glasses", "headUp", false)
         DeviceStore.apply("glasses", "voiceActivityDetectionEnabled", true)
     }
@@ -1503,6 +1523,7 @@ class DeviceManager {
         sgc?.clearDisplay()
         sgc?.disconnect()
         sgc = null // Clear the SGC reference after disconnect
+        lastSystemTimeSyncConnectionKey = ""
         searching = false
         micEnabled = false
         updateMicState()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -413,6 +413,10 @@ class MentraBluetoothSdk private constructor(
         deviceManager.setHotspotState(enabled)
     }
 
+    fun setSystemTime(timestampMs: Long) {
+        deviceManager.setSystemTime(timestampMs)
+    }
+
     fun requestPhoto(request: PhotoRequest) {
         Bridge.log(
             "NATIVE: PHOTO PIPELINE [3b/6] MentraBluetoothSdk.requestPhoto requestId=${request.requestId} appId=${request.appId}"
@@ -476,6 +480,10 @@ class MentraBluetoothSdk private constructor(
 
     internal fun sendOtaQueryStatus() {
         deviceManager.sendOtaQueryStatus()
+    }
+
+    internal fun retryOtaVersionCheck() {
+        deviceManager.retryOtaVersionCheck()
     }
 
     internal fun sendShutdown() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -2532,8 +2532,10 @@ public class MentraLive extends SGCManager {
                 Bridge.log("LIVE: 📱 OTA status - step " + osCurrentStep + "/" + osTotalSteps +
                       " " + osPhase + " " + osStatus + " " + osOverallPercent + "%");
 
+                long glassesTimeMs = json.optLong("glasses_time_ms", 0);
                 Bridge.sendOtaStatus(osSessionId, osTotalSteps, osCurrentStep, osStepType,
-                    osPhase, osStepPercent, osOverallPercent, osStatus, osErrorMessage);
+                    osPhase, osStepPercent, osOverallPercent, osStatus, osErrorMessage,
+                    glassesTimeMs > 0 ? glassesTimeMs : null);
                 break;
 
             case "ota_progress":
@@ -2984,7 +2986,12 @@ public class MentraLive extends SGCManager {
                     if (fields.containsKey("bt_mac_address")) {
                         DeviceStore.INSTANCE.apply("glasses", "bluetoothMacAddress", (String) fields.get("bt_mac_address"));
                     }
-
+                    if (fields.containsKey("system_time_ms")) {
+                        Object v = fields.get("system_time_ms");
+                        if (v instanceof Number) {
+                            GlassesStore.INSTANCE.apply("glasses", "systemTimeMs", ((Number) v).longValue());
+                        }
+                    }
 
                     Bridge.log("LIVE: Processed version_info fields and sent to RN");
                 } else {
@@ -3672,6 +3679,18 @@ public class MentraLive extends SGCManager {
             Bridge.log("LIVE: 📱 Sending ota_query_status command to glasses");
         } catch (JSONException e) {
             Log.e(TAG, "📱 Error creating ota_query_status command", e);
+        }
+    }
+
+    public void sendOtaRetryVersionCheck() {
+        try {
+            JSONObject json = new JSONObject();
+            json.put("type", "ota_retry_version_check");
+            json.put("timestamp", System.currentTimeMillis());
+            sendJson(json, true);
+            Bridge.log("LIVE: ⏰ Sending ota_retry_version_check command to glasses");
+        } catch (JSONException e) {
+            Log.e(TAG, "⏰ Error creating ota_retry_version_check command", e);
         }
     }
 
@@ -5838,6 +5857,19 @@ public class MentraLive extends SGCManager {
             Bridge.log("LIVE: 🔥 ✅ Hotspot state command sent successfully");
         } catch (JSONException e) {
             Log.e(TAG, "🔥 💥 Error creating hotspot state JSON", e);
+        }
+    }
+
+    @Override
+    public void sendSetSystemTime(long timestampMs) {
+        Bridge.log("LIVE: ⏰ Sending set_system_time to glasses: " + timestampMs);
+        try {
+            JSONObject command = new JSONObject();
+            command.put("type", "set_system_time");
+            command.put("timestamp_ms", timestampMs);
+            sendJson(command, true);
+        } catch (JSONException e) {
+            Log.e(TAG, "⏰ Error creating set_system_time JSON", e);
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -2989,7 +2989,7 @@ public class MentraLive extends SGCManager {
                     if (fields.containsKey("system_time_ms")) {
                         Object v = fields.get("system_time_ms");
                         if (v instanceof Number) {
-                            GlassesStore.INSTANCE.apply("glasses", "systemTimeMs", ((Number) v).longValue());
+                            DeviceStore.INSTANCE.apply("glasses", "systemTimeMs", ((Number) v).longValue());
                         }
                     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -1,5 +1,6 @@
 package com.mentra.bluetoothsdk.sgcs
 
+import com.mentra.bluetoothsdk.Bridge
 import com.mentra.bluetoothsdk.DeviceStore
 import com.mentra.bluetoothsdk.utils.ConnTypes
 
@@ -99,6 +100,11 @@ abstract class SGCManager {
     abstract fun sendWifiCredentials(ssid: String, password: String)
     abstract fun forgetWifiNetwork(ssid: String)
     abstract fun sendHotspotState(enabled: Boolean)
+
+    /** Set glasses system clock (Mentra Live only; no-op on other devices). */
+    open fun sendSetSystemTime(timestampMs: Long) {
+        Bridge.log("SGC: sendSetSystemTime not supported on $type")
+    }
 
     // User Context (for crash reporting)
     abstract fun sendUserEmailToGlasses(email: String)

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -290,6 +290,12 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
             }
         }
 
+        AsyncFunction("setSystemTime") { (timestampMs: Double) in
+            await MainActor.run {
+                self.bluetoothSdk().setSystemTime(timestampMs: Int64(timestampMs))
+            }
+        }
+
         // MARK: - Gallery Commands
 
         AsyncFunction("setGalleryModeEnabled") { (enabled: Bool) in
@@ -360,6 +366,12 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
         AsyncFunction("sendOtaQueryStatus") {
             await MainActor.run {
                 self.bluetoothSdk().sendOtaQueryStatus()
+            }
+        }
+
+        AsyncFunction("retryOtaVersionCheck") {
+            await MainActor.run {
+                self.bluetoothSdk().retryOtaVersionCheck()
             }
         }
 

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -291,8 +291,19 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
         }
 
         AsyncFunction("setSystemTime") { (timestampMs: Double) in
+            let maxTimestamp = Double(Int64.max).nextDown
+            guard timestampMs.isFinite,
+                  timestampMs >= Double(Int64.min),
+                  timestampMs <= maxTimestamp
+            else {
+                throw BluetoothError(
+                    code: "invalid_timestamp",
+                    message: "setSystemTime timestampMs must be a finite Int64 millisecond timestamp."
+                )
+            }
+            let timestamp = Int64(timestampMs)
             await MainActor.run {
-                self.bluetoothSdk().setSystemTime(timestampMs: Int64(timestampMs))
+                self.bluetoothSdk().setSystemTime(timestampMs: timestamp)
             }
         }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -389,7 +389,8 @@ class Bridge {
         stepPercent: Int,
         overallPercent: Int,
         status: String,
-        errorMessage: String?
+        errorMessage: String?,
+        glassesTimeMs: Int64? = nil
     ) {
         var eventBody: [String: Any] = [
             "session_id": sessionId,
@@ -403,6 +404,9 @@ class Bridge {
         ]
         if let error = errorMessage {
             eventBody["error_message"] = error
+        }
+        if let glassesTimeMs, glassesTimeMs > 0 {
+            eventBody["glasses_time_ms"] = glassesTimeMs
         }
         Bridge.sendTypedMessage("ota_status", body: eventBody)
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1075,6 +1075,11 @@ struct ViewState {
         sgc?.sendHotspotState(enabled)
     }
 
+    func setSystemTime(_ timestampMs: Int64) {
+        Bridge.log("MAN: Setting glasses system time: \(timestampMs)")
+        sgc?.sendSetSystemTime(timestampMs)
+    }
+
     func queryGalleryStatus() {
         Bridge.log("MAN: 📸 Querying gallery status from glasses")
         sgc?.queryGalleryStatus()
@@ -1091,6 +1096,11 @@ struct ViewState {
     func sendOtaQueryStatus() {
         Bridge.log("MAN: 📱 Sending OTA query status command to glasses")
         (sgc as? MentraLive)?.sendOtaQueryStatus()
+    }
+
+    func retryOtaVersionCheck() {
+        Bridge.log("MAN: ⏰ Retrying glasses OTA version check after clock sync")
+        (sgc as? MentraLive)?.sendOtaRetryVersionCheck()
     }
 
     /// Request version info from glasses.

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -225,6 +225,7 @@ struct ViewState {
         get { DeviceStore.shared.get("bluetooth", "shouldSendBootingMessage") as? Bool ?? true }
         set { DeviceStore.shared.apply("bluetooth", "shouldSendBootingMessage", newValue) }
     }
+    private var lastSystemTimeSyncConnectionKey = ""
 
     private var systemMicUnavailable: Bool {
         get { DeviceStore.shared.get("bluetooth", "systemMicUnavailable") as? Bool ?? false }
@@ -581,6 +582,7 @@ struct ViewState {
             Bridge.log("MAN: Manager already initialized, cleaning up previous sgc")
             sgc?.cleanup()
             sgc = nil
+            lastSystemTimeSyncConnectionKey = ""
         }
 
         if sgc != nil {
@@ -844,6 +846,9 @@ struct ViewState {
         defaultWearable = sgc.type
         searching = false
 
+        let connectionKey = "\(sgc.type):\(deviceName)"
+        syncSystemTimeOnceForConnection(sgc, connectionKey: connectionKey)
+
         // Show welcome message on first connect for all display glasses
         if shouldSendBootingMessage {
             Task {
@@ -879,6 +884,20 @@ struct ViewState {
             DeviceStore.shared.get("bluetooth", "dashboard_depth")
         )
         sgc.setDashboardPosition(h, d)
+    }
+
+    private func syncSystemTimeOnceForConnection(_ sgc: SGCManager, connectionKey: String) {
+        if sgc.type.contains(DeviceTypes.SIMULATED) {
+            return
+        }
+        if connectionKey == lastSystemTimeSyncConnectionKey {
+            return
+        }
+
+        lastSystemTimeSyncConnectionKey = connectionKey
+        let timestampMs = Int64(Date().timeIntervalSince1970 * 1000)
+        Bridge.log("MAN: Syncing glasses system time once for connection: \(timestampMs)")
+        sgc.sendSetSystemTime(timestampMs)
     }
 
     func handleControllerReady() {
@@ -925,6 +944,7 @@ struct ViewState {
 
     func handleDeviceDisconnected() {
         Bridge.log("MAN: Device disconnected")
+        lastSystemTimeSyncConnectionKey = ""
         DeviceStore.shared.apply("glasses", "headUp", false)
         DeviceStore.shared.apply("glasses", "voiceActivityDetectionEnabled", true)
         // shouldSendBootingMessage = true  // Reset for next first connect
@@ -1317,6 +1337,7 @@ struct ViewState {
         sgc?.clearDisplay() // clear the screen
         sgc?.disconnect()
         sgc = nil // Clear the SGC reference after disconnect
+        lastSystemTimeSyncConnectionKey = ""
         searching = false
         micEnabled = false
         updateMicState()

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -375,6 +375,10 @@ public final class MentraBluetoothSDK {
         DeviceManager.shared.setHotspotState(enabled)
     }
 
+    func setSystemTime(timestampMs: Int64) {
+        DeviceManager.shared.setSystemTime(timestampMs)
+    }
+
     public func requestPhoto(_ request: PhotoRequest) {
         Bridge.log(
             "NATIVE: PHOTO PIPELINE [3b/6] MentraBluetoothSdk.requestPhoto requestId=\(request.requestId) appId=\(request.appId)"
@@ -442,6 +446,10 @@ public final class MentraBluetoothSDK {
 
     func sendOtaQueryStatus() {
         DeviceManager.shared.sendOtaQueryStatus()
+    }
+
+    func retryOtaVersionCheck() {
+        DeviceManager.shared.retryOtaVersionCheck()
     }
 
     func sendShutdown() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2018,6 +2018,7 @@ class MentraLive: NSObject, SGCManager {
 
             Bridge.log("LIVE: 📱 OTA status - step \(osCurrentStep)/\(osTotalSteps) \(osPhase) \(osStatus) \(osOverallPercent)%")
 
+            let glassesTimeMs = (json["glasses_time_ms"] as? NSNumber)?.int64Value ?? 0
             Bridge.sendOtaStatus(
                 sessionId: osSessionId,
                 totalSteps: osTotalSteps,
@@ -2027,7 +2028,8 @@ class MentraLive: NSObject, SGCManager {
                 stepPercent: osStepPercent,
                 overallPercent: osOverallPercent,
                 status: osStatus,
-                errorMessage: osErrorMessage
+                errorMessage: osErrorMessage,
+                glassesTimeMs: glassesTimeMs > 0 ? glassesTimeMs : nil
             )
 
         case "ota_progress":
@@ -2107,6 +2109,9 @@ class MentraLive: NSObject, SGCManager {
                 }
                 if let bluetoothMacAddress = fields["bt_mac_address"] as? String {
                     DeviceStore.shared.apply("glasses", "bluetoothMacAddress", bluetoothMacAddress)
+                }
+                if let systemTimeMs = fields["system_time_ms"] as? NSNumber {
+                    GlassesStore.shared.apply("glasses", "systemTimeMs", systemTimeMs.int64Value)
                 }
 
                 // Send fields immediately to RN - no waiting for other chunks
@@ -2424,6 +2429,17 @@ class MentraLive: NSObject, SGCManager {
         sendJson(json, wakeUp: true)
     }
 
+    func sendSetSystemTime(_ timestampMs: Int64) {
+        Bridge.log("LIVE: ⏰ Sending set_system_time: \(timestampMs)")
+
+        let json: [String: Any] = [
+            "type": "set_system_time",
+            "timestamp_ms": timestampMs,
+        ]
+
+        sendJson(json, wakeUp: true)
+    }
+
     func sendUserEmailToGlasses(_ email: String) {
         Bridge.log("LIVE: Sending user email to glasses for crash reporting")
 
@@ -2529,6 +2545,17 @@ class MentraLive: NSObject, SGCManager {
 
         let json: [String: Any] = [
             "type": "ota_query_status",
+            "timestamp": Int(Date().timeIntervalSince1970 * 1000),
+        ]
+
+        sendJson(json, wakeUp: true)
+    }
+
+    func sendOtaRetryVersionCheck() {
+        Bridge.log("LIVE: ⏰ Sending ota_retry_version_check command to glasses")
+
+        let json: [String: Any] = [
+            "type": "ota_retry_version_check",
             "timestamp": Int(Date().timeIntervalSince1970 * 1000),
         ]
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2111,7 +2111,7 @@ class MentraLive: NSObject, SGCManager {
                     DeviceStore.shared.apply("glasses", "bluetoothMacAddress", bluetoothMacAddress)
                 }
                 if let systemTimeMs = fields["system_time_ms"] as? NSNumber {
-                    GlassesStore.shared.apply("glasses", "systemTimeMs", systemTimeMs.int64Value)
+                    DeviceStore.shared.apply("glasses", "systemTimeMs", systemTimeMs.int64Value)
                 }
 
                 // Send fields immediately to RN - no waiting for other chunks

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -89,6 +89,7 @@ protocol SGCManager {
     func sendHotspotState(_ enabled: Bool)
     func sendOtaStart()
     func sendOtaQueryStatus()
+    func sendSetSystemTime(_ timestampMs: Int64)
     func sendOtaRetryVersionCheck()
 
     // MARK: - User Context (for crash reporting)

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -89,6 +89,7 @@ protocol SGCManager {
     func sendHotspotState(_ enabled: Bool)
     func sendOtaStart()
     func sendOtaQueryStatus()
+    func sendOtaRetryVersionCheck()
 
     // MARK: - User Context (for crash reporting)
 
@@ -134,6 +135,15 @@ extension SGCManager {
     // MARK: - Voice Activity Detection (default no-op — Mentra Live supports this)
 
     func sendVoiceActivityDetectionSetting() {}
+
+    /// Default no-op; Mentra Live overrides when phone detects clock skew during gallery sync.
+    func sendSetSystemTime(_: Int64) {
+        Bridge.log("SGC: sendSetSystemTime not supported")
+    }
+
+    func sendOtaRetryVersionCheck() {
+        Bridge.log("SGC: sendOtaRetryVersionCheck not supported")
+    }
 
     // MARK: - Default DeviceStore-backed property implementations
 

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -694,6 +694,8 @@ export interface GlassesStatus {
   leftMacAddress: string
   rightMacAddress: string
   buildNumber: string
+  /** Glasses System.currentTimeMillis() from last version_info (clock skew detection). */
+  systemTimeMs?: number
   otaVersionUrl: string
   appVersion: string
   bluetoothName: string

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -90,6 +90,8 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   sendWifiCredentials(ssid: string, password: string): Promise<void>
   forgetWifiNetwork(ssid: string): Promise<void>
   setHotspotState(enabled: boolean): Promise<void>
+  /** Set glasses system clock (Mentra Live only) when phone detects clock skew. */
+  setSystemTime(timestampMs: number): Promise<void>
   /** Logs current WiFi frequency (MHz) and 5 GHz band to Android logcat. */
   logCurrentWifiFrequency(): Promise<void>
 
@@ -107,6 +109,8 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   // OTA Commands
   sendOtaStart(): Promise<void>
   sendOtaQueryStatus(): Promise<void>
+  /** Re-run glasses-side OTA version check (called after a clock fix invalidates a TLS failure). */
+  retryOtaVersionCheck(): Promise<void>
 
   // Version Info Commands
   requestVersionInfo(): Promise<void>

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -125,12 +125,7 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   keepStreamAlive(params: StreamKeepAliveRequest): Promise<void>
 
   // Microphone Commands
-  setMicState(
-    enabled: boolean,
-    useGlassesMic?: boolean,
-    sendTranscript?: boolean,
-    sendLc3Data?: boolean,
-  ): Promise<void>
+  setMicState(enabled: boolean, useGlassesMic?: boolean, sendTranscript?: boolean, sendLc3Data?: boolean): Promise<void>
   setPreferredMic(preferredMic: MicPreference): Promise<void>
   restartTranscriber(): Promise<void>
 
@@ -280,7 +275,9 @@ NativeBluetoothSdkModule.getGlassesStatus = function () {
   return Promise.resolve(nativeGetGlassesStatus())
 }
 
-const nativeGetBluetoothStatus = NativeBluetoothSdkModule.getBluetoothStatus.bind(NativeBluetoothSdkModule) as () => MaybePromise<BluetoothStatus>
+const nativeGetBluetoothStatus = NativeBluetoothSdkModule.getBluetoothStatus.bind(
+  NativeBluetoothSdkModule,
+) as () => MaybePromise<BluetoothStatus>
 NativeBluetoothSdkModule.getBluetoothStatus = function () {
   return Promise.resolve(nativeGetBluetoothStatus())
 }
@@ -390,12 +387,7 @@ NativeBluetoothSdkModule.setMicState = function (
   sendLc3Data?: boolean,
 ) {
   return Promise.resolve(
-    nativeSetMicState(
-      enabled,
-      useGlassesMic ?? true,
-      sendTranscript ?? false,
-      sendLc3Data ?? false,
-    ),
+    nativeSetMicState(enabled, useGlassesMic ?? true, sendTranscript ?? false, sendLc3Data ?? false),
   )
 }
 
@@ -425,10 +417,7 @@ NativeBluetoothSdkModule.connect = function (device: Device, options?: ConnectOp
   return this.connectWithOptions(device, {...DEFAULT_CONNECT_OPTIONS, ...options})
 }
 
-NativeBluetoothSdkModule.scan = async function (
-  modelOrOptions: DeviceModel | ScanOptions,
-  options?: ScanModelOptions,
-) {
+NativeBluetoothSdkModule.scan = async function (modelOrOptions: DeviceModel | ScanOptions, options?: ScanModelOptions) {
   const scanOptions = normalizeScanArgs(modelOrOptions, options)
   const timeoutMs = normalizeTimeoutMs(scanOptions.timeoutMs ?? scanOptions.timeout, DEFAULT_SCAN_TIMEOUT_MS)
   let latestResults: Device[] = []

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -4,7 +4,14 @@ import type {OtaUpdateInfo} from "@mentra/bluetooth-sdk-internal"
 import {useEffect, useRef} from "react"
 
 import {useNavigationStore} from "@/stores/navigation"
-import {isGlassesConnected, selectGlassesConnected, useGlassesStore, waitForGlassesState} from "@/stores/glasses"
+import {maybeFixGlassesClockFromVersionInfo} from "@/services/asg/glassesClockSync"
+import {
+  getGlassesSystemTimeMs,
+  isGlassesConnected,
+  selectGlassesConnected,
+  useGlassesStore,
+  waitForGlassesState,
+} from "@/stores/glasses"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import showAlert from "@/utils/AlertUtils"
 import {translate} from "@/i18n/translate"
@@ -161,7 +168,7 @@ export function findMatchingMtkPatch(
 /**
  * Check if BES firmware update is available.
  * BES does not require sequential updates - can install any newer version directly.
- * If current version is unknown, skip BES comparison for this pass.
+ * If current version is unknown, assume update is needed (matches glasses OtaHelper).
  */
 export function checkBesUpdate(besFirmware: BesFirmware | undefined, currentVersion: string | undefined): boolean {
   if (!besFirmware) {
@@ -169,8 +176,10 @@ export function checkBesUpdate(besFirmware: BesFirmware | undefined, currentVers
   }
 
   if (!currentVersion) {
-    console.log("📱 BES current version unknown - skipping BES update check")
-    return false
+    console.log(
+      `📱 BES current version unknown - assuming update needed (server: ${besFirmware.version})`,
+    )
+    return true
   }
   // BES does not require sequential updates - can install any newer version directly
   return compareVersions(besFirmware.version, currentVersion) > 0
@@ -620,7 +629,7 @@ export function OtaUpdateChecker() {
           latestBesFirmwareVersion = useGlassesStore.getState().besFirmwareVersion
           console.log(`OTA: BES version arrived: ${latestBesFirmwareVersion}`)
         } else {
-          console.log("OTA: BES version still unknown after extended wait - proceeding without it")
+          console.log("OTA: BES version still unknown after extended wait - will assume BES update if published")
         }
         connected = areGlassesConnectedNow()
         if (!connected) {
@@ -633,6 +642,9 @@ export function OtaUpdateChecker() {
         `OTA: check starting (MTK: ${latestMtkFirmwareVersion || "unknown"}, BES: ${latestBesFirmwareVersion || "unknown"})`,
       )
       hasCheckedOta.current = true // Mark as checked to prevent duplicate checks
+
+      const systemTimeMs = getGlassesSystemTimeMs()
+      await maybeFixGlassesClockFromVersionInfo(systemTimeMs > 0 ? systemTimeMs : undefined)
 
       checkForOtaUpdate(OTA_VERSION_URL_PROD, buildNumber, latestMtkFirmwareVersion, latestBesFirmwareVersion)
         .then(({updateAvailable, latestVersionInfo, updates}) => {

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -176,9 +176,7 @@ export function checkBesUpdate(besFirmware: BesFirmware | undefined, currentVers
   }
 
   if (!currentVersion) {
-    console.log(
-      `📱 BES current version unknown - assuming update needed (server: ${besFirmware.version})`,
-    )
+    console.log(`📱 BES current version unknown - assuming update needed (server: ${besFirmware.version})`)
     return true
   }
   // BES does not require sequential updates - can install any newer version directly
@@ -644,7 +642,9 @@ export function OtaUpdateChecker() {
       hasCheckedOta.current = true // Mark as checked to prevent duplicate checks
 
       const systemTimeMs = getGlassesSystemTimeMs()
-      await maybeFixGlassesClockFromVersionInfo(systemTimeMs > 0 ? systemTimeMs : undefined)
+      await maybeFixGlassesClockFromVersionInfo(systemTimeMs > 0 ? systemTimeMs : undefined).catch((error) => {
+        console.warn("OTA: clock fix attempt failed; continuing OTA check", error)
+      })
 
       checkForOtaUpdate(OTA_VERSION_URL_PROD, buildNumber, latestMtkFirmwareVersion, latestBesFirmwareVersion)
         .then(({updateAvailable, latestVersionInfo, updates}) => {

--- a/mobile/src/effects/__tests__/OtaUpdateChecker.test.ts
+++ b/mobile/src/effects/__tests__/OtaUpdateChecker.test.ts
@@ -49,9 +49,9 @@ describe("checkBesUpdate", () => {
     expect(checkBesUpdate(undefined, "17.26.1.14")).toBe(false)
   })
 
-  it("returns false when current version is unknown", () => {
-    expect(checkBesUpdate(firmware, undefined)).toBe(false)
-    expect(checkBesUpdate(firmware, "")).toBe(false)
+  it("returns true when current version is unknown (assume update needed)", () => {
+    expect(checkBesUpdate(firmware, undefined)).toBe(true)
+    expect(checkBesUpdate(firmware, "")).toBe(true)
   })
 
   it("returns true when server version is newer", () => {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -19,6 +19,7 @@ import {migrate} from "@/services/Migrations"
 import restComms from "@/services/RestComms"
 import socketComms from "@/services/SocketComms"
 import {gallerySyncService} from "@/services/asg/gallerySyncService"
+import {handleOtaClockSkewFromGlasses} from "@/services/asg/glassesClockSync"
 import {submitAutomaticBugIncident} from "@/services/bugReport/automaticBugReport"
 import {
   appRegistry,
@@ -919,6 +920,12 @@ class MantleManager {
             useGlassesStore.getState().setOtaProgress(legacyOtaProgressFromOtaStatusEvent(normalized))
           } catch (err) {
             console.warn("MANTLE: ota_status legacy otaProgress mapping failed", err)
+          }
+
+          if (status.status === "failed") {
+            const raw = event as Record<string, unknown>
+            const glassesTimeMs = Number(raw.glasses_time_ms ?? raw.glassesTimeMs ?? 0) || undefined
+            void handleOtaClockSkewFromGlasses(normalized.error_message, glassesTimeMs)
           }
 
           if (status.status === "complete" || status.status === "failed") {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -925,7 +925,15 @@ class MantleManager {
           if (status.status === "failed") {
             const raw = event as Record<string, unknown>
             const glassesTimeMs = Number(raw.glasses_time_ms ?? raw.glassesTimeMs ?? 0) || undefined
-            void handleOtaClockSkewFromGlasses(normalized.error_message, glassesTimeMs)
+            const errorCode = normalized.error_message
+            if (
+              errorCode === "clock_skew" ||
+              (errorCode === "ssl_error" && typeof glassesTimeMs === "number" && Number.isFinite(glassesTimeMs))
+            ) {
+              handleOtaClockSkewFromGlasses(errorCode, glassesTimeMs).catch((err) => {
+                console.warn("MANTLE: OTA clock skew auto-fix failed", err)
+              })
+            }
           }
 
           if (status.status === "complete" || status.status === "failed") {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -1,11 +1,4 @@
-import BluetoothSdk, {
-  ButtonPressEvent,
-  BluetoothStatus,
-  GlassesStatus,
-  OtaStatus,
-  OtaProgress,
-  OtaUpdateInfo,
-} from "@mentra/bluetooth-sdk-internal"
+import BluetoothSdk, {ButtonPressEvent, BluetoothStatus, OtaStatus} from "@mentra/bluetooth-sdk-internal"
 import CrustModule from "crust"
 import * as Calendar from "expo-calendar"
 import * as Location from "expo-location"

--- a/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
+++ b/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
@@ -1,4 +1,4 @@
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 
 import {detectClockSkew} from "@/services/asg/gallerySyncClock"
 import {
@@ -8,7 +8,7 @@ import {
   resetOtaClockFixCooldownForTests,
 } from "@/services/asg/glassesClockSync"
 
-jest.mock("@mentra/bluetooth-sdk", () => ({
+jest.mock("@mentra/bluetooth-sdk-internal", () => ({
   __esModule: true,
   default: {
     setSystemTime: jest.fn().mockResolvedValue(undefined),
@@ -25,8 +25,8 @@ jest.mock("@mentra/island", () => ({
   },
 }))
 
-const mockSetSystemTime = CoreModule.setSystemTime as jest.Mock
-const mockRetryOta = CoreModule.retryOtaVersionCheck as jest.Mock
+const mockSetSystemTime = BluetoothSdk.setSystemTime as jest.Mock
+const mockRetryOta = BluetoothSdk.retryOtaVersionCheck as jest.Mock
 
 jest.mock("@/stores/glasses", () => ({
   useGlassesStore: {

--- a/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
+++ b/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
@@ -89,4 +89,18 @@ describe("glassesClockSync", () => {
     expect(fixed).toBe(true)
     expect(mockRetryOta).toHaveBeenCalled()
   })
+
+  it("handleOtaClockSkewFromGlasses coalesces concurrent calls into one fix", async () => {
+    // Regression for cubic P2: glasses can emit two clock_skew events back-to-back during BLE
+    // handshake. Without coalescing, both calls would pass the cooldown guard and double-fix.
+    const glassesTime = Date.now() - 365 * 24 * 60 * 60 * 1000
+    const [a, b] = await Promise.all([
+      handleOtaClockSkewFromGlasses("clock_skew", glassesTime),
+      handleOtaClockSkewFromGlasses("clock_skew", glassesTime),
+    ])
+    expect(a).toBe(true)
+    expect(b).toBe(true)
+    expect(mockSetSystemTime).toHaveBeenCalledTimes(1)
+    expect(mockRetryOta).toHaveBeenCalledTimes(1)
+  })
 })

--- a/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
+++ b/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
@@ -1,0 +1,85 @@
+import CoreModule from "@mentra/bluetooth-sdk"
+
+import {detectClockSkew} from "../gallerySyncClock"
+import {
+  fixGlassesClockIfSkewed,
+  handleOtaClockSkewFromGlasses,
+  maybeFixGlassesClockFromVersionInfo,
+  resetOtaClockFixCooldownForTests,
+} from "../glassesClockSync"
+
+jest.mock("@mentra/bluetooth-sdk", () => ({
+  __esModule: true,
+  default: {
+    setSystemTime: jest.fn().mockResolvedValue(undefined),
+    retryOtaVersionCheck: jest.fn().mockResolvedValue(undefined),
+  },
+}))
+
+jest.mock("@mentra/island", () => ({
+  BgTimer: {
+    setTimeout: (fn: () => void) => {
+      fn()
+      return 0
+    },
+  },
+}))
+
+const mockSetSystemTime = CoreModule.setSystemTime as jest.Mock
+const mockRetryOta = CoreModule.retryOtaVersionCheck as jest.Mock
+
+jest.mock("@/stores/glasses", () => ({
+  useGlassesStore: {
+    getState: jest.fn(() => ({
+      wifi: {state: "connected"},
+    })),
+  },
+}))
+
+describe("glassesClockSync", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    resetOtaClockFixCooldownForTests()
+    jest.spyOn(Date, "now").mockReturnValue(1_700_000_000_000)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it("fixGlassesClockIfSkewed sets time when wall clock drifts", async () => {
+    const glassesTime = Date.now() - 365 * 24 * 60 * 60 * 1000
+    const fixed = await fixGlassesClockIfSkewed(glassesTime, 0)
+    expect(fixed).toBe(true)
+    expect(mockSetSystemTime).toHaveBeenCalledWith(Date.now())
+  })
+
+  it("fixGlassesClockIfSkewed is a no-op when clocks agree", async () => {
+    const fixed = await fixGlassesClockIfSkewed(Date.now(), 0)
+    expect(fixed).toBe(false)
+    expect(mockSetSystemTime).not.toHaveBeenCalled()
+  })
+
+  it("handleOtaClockSkewFromGlasses fixes and retries on clock_skew", async () => {
+    const glassesTime = Date.now() - 365 * 24 * 60 * 60 * 1000
+    const fixed = await handleOtaClockSkewFromGlasses("clock_skew", glassesTime)
+    expect(fixed).toBe(true)
+    expect(mockSetSystemTime).toHaveBeenCalled()
+    expect(mockRetryOta).toHaveBeenCalled()
+  })
+
+  it("handleOtaClockSkewFromGlasses maps ssl_error with drift to clock fix", async () => {
+    const glassesTime = Date.now() - 365 * 24 * 60 * 60 * 1000
+    expect(detectClockSkew(Date.now(), glassesTime, 0).skewed).toBe(true)
+    const fixed = await handleOtaClockSkewFromGlasses("ssl_error", glassesTime)
+    expect(fixed).toBe(true)
+    expect(mockRetryOta).toHaveBeenCalled()
+  })
+
+  it("maybeFixGlassesClockFromVersionInfo retries OTA when WiFi connected", async () => {
+    const glassesTime = Date.now() - 365 * 24 * 60 * 60 * 1000
+    const fixed = await maybeFixGlassesClockFromVersionInfo(glassesTime)
+    expect(fixed).toBe(true)
+    expect(mockRetryOta).toHaveBeenCalled()
+  })
+})

--- a/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
+++ b/mobile/src/services/asg/__tests__/glassesClockSync.test.ts
@@ -1,12 +1,12 @@
 import CoreModule from "@mentra/bluetooth-sdk"
 
-import {detectClockSkew} from "../gallerySyncClock"
+import {detectClockSkew} from "@/services/asg/gallerySyncClock"
 import {
   fixGlassesClockIfSkewed,
   handleOtaClockSkewFromGlasses,
   maybeFixGlassesClockFromVersionInfo,
   resetOtaClockFixCooldownForTests,
-} from "../glassesClockSync"
+} from "@/services/asg/glassesClockSync"
 
 jest.mock("@mentra/bluetooth-sdk", () => ({
   __esModule: true,
@@ -74,6 +74,13 @@ describe("glassesClockSync", () => {
     const fixed = await handleOtaClockSkewFromGlasses("ssl_error", glassesTime)
     expect(fixed).toBe(true)
     expect(mockRetryOta).toHaveBeenCalled()
+  })
+
+  it("handleOtaClockSkewFromGlasses ignores ssl_error without glasses time", async () => {
+    const fixed = await handleOtaClockSkewFromGlasses("ssl_error")
+    expect(fixed).toBe(false)
+    expect(mockSetSystemTime).not.toHaveBeenCalled()
+    expect(mockRetryOta).not.toHaveBeenCalled()
   })
 
   it("maybeFixGlassesClockFromVersionInfo retries OTA when WiFi connected", async () => {

--- a/mobile/src/services/asg/gallerySyncClock.test.ts
+++ b/mobile/src/services/asg/gallerySyncClock.test.ts
@@ -1,0 +1,47 @@
+import {CLOCK_SKEW_TOLERANCE_MS, detectClockSkew, isSyncManifestEmpty} from "./gallerySyncClock"
+
+describe("gallerySyncClock", () => {
+  const phoneNow = 1_700_000_000_000
+  const glassesTime = phoneNow
+
+  describe("detectClockSkew", () => {
+    it("detects watermark ahead of glasses server time", () => {
+      const lastSyncTime = glassesTime + CLOCK_SKEW_TOLERANCE_MS + 1
+      expect(detectClockSkew(phoneNow, glassesTime, lastSyncTime)).toEqual({
+        skewed: true,
+        reason: "watermark_ahead_of_glasses",
+      })
+    })
+
+    it("detects wall clock drift between phone and glasses", () => {
+      const driftedGlassesTime = phoneNow - CLOCK_SKEW_TOLERANCE_MS - 1
+      expect(detectClockSkew(phoneNow, driftedGlassesTime, 0)).toEqual({
+        skewed: true,
+        reason: "wall_clock_drift",
+      })
+    })
+
+    it("reports no skew when clocks and watermark align", () => {
+      expect(detectClockSkew(phoneNow, glassesTime, glassesTime - 1000)).toEqual({
+        skewed: false,
+        reason: "",
+      })
+    })
+  })
+
+  describe("isSyncManifestEmpty", () => {
+    it("returns true when legacy changed_files is empty", () => {
+      expect(isSyncManifestEmpty({changed_files: []})).toBe(true)
+    })
+
+    it("returns false when captures are present (api v2)", () => {
+      expect(
+        isSyncManifestEmpty({
+          api_version: 2,
+          captures: [{capture_id: "IMG_1"}],
+          changed_files: [],
+        }),
+      ).toBe(false)
+    })
+  })
+})

--- a/mobile/src/services/asg/gallerySyncClock.ts
+++ b/mobile/src/services/asg/gallerySyncClock.ts
@@ -1,0 +1,39 @@
+/**
+ * Clock skew detection for gallery sync (phone vs glasses).
+ * Phone pushes time to glasses only when skew is detected during sync.
+ */
+
+export const CLOCK_SKEW_TOLERANCE_MS = 60_000
+
+export type ClockSkewReason = "watermark_ahead_of_glasses" | "wall_clock_drift" | ""
+
+export interface ClockSkewResult {
+  skewed: boolean
+  reason: ClockSkewReason
+}
+
+export function detectClockSkew(
+  phoneNow: number,
+  glassesServerTime: number,
+  lastSyncTime: number,
+  toleranceMs: number = CLOCK_SKEW_TOLERANCE_MS,
+): ClockSkewResult {
+  if (lastSyncTime > glassesServerTime + toleranceMs) {
+    return {skewed: true, reason: "watermark_ahead_of_glasses"}
+  }
+  if (Math.abs(phoneNow - glassesServerTime) > toleranceMs) {
+    return {skewed: true, reason: "wall_clock_drift"}
+  }
+  return {skewed: false, reason: ""}
+}
+
+export function isSyncManifestEmpty(syncData: {
+  api_version?: number
+  captures?: unknown[]
+  changed_files?: unknown[]
+}): boolean {
+  if (syncData.api_version === 2 && syncData.captures && syncData.captures.length > 0) {
+    return false
+  }
+  return !syncData.changed_files || syncData.changed_files.length === 0
+}

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -1,4 +1,4 @@
-import BluetoothSdk from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 
 import {asgCameraApi} from "@/services/asg/asgCameraApi"
 import {gallerySyncNotifications} from "@/services/asg/gallerySyncNotifications"
@@ -146,14 +146,16 @@ const CAPTURE_SYNC_RESPONSE = {
 const HOTSPOT_INFO = {ssid: "MentraLive_test", password: "00001111", ip: "192.168.43.1"}
 
 async function startFileDownload(): Promise<void> {
-  await (gallerySyncService as unknown as {startFileDownload: (info: typeof HOTSPOT_INFO) => Promise<void>}).startFileDownload(
-    HOTSPOT_INFO,
-  )
+  await (
+    gallerySyncService as unknown as {startFileDownload: (info: typeof HOTSPOT_INFO) => Promise<void>}
+  ).startFileDownload(HOTSPOT_INFO)
 }
 
 describe("GallerySyncService", () => {
   beforeEach(() => {
-    jest.useFakeTimers()
+    // Pin Date.now() to match EMPTY_SYNC_RESPONSE.server_time so detectClockSkew stays quiet
+    // in tests that don't explicitly want to trigger clock-skew recovery.
+    jest.useFakeTimers({now: 2000})
     jest.clearAllMocks()
     useGallerySyncStore.getState().reset()
     useGlassesStore.getState().reset()
@@ -271,6 +273,7 @@ describe("GallerySyncService", () => {
   describe("startFileDownload /api/sync desync recovery", () => {
     let executeCaptureDownloadSpy: jest.SpyInstance
     let consoleWarnSpy: jest.SpyInstance
+    let consoleLogSpy: jest.SpyInstance
 
     beforeEach(() => {
       useGallerySyncStore.getState().setGlassesGalleryStatus(3, 5, 8, true)
@@ -285,16 +288,18 @@ describe("GallerySyncService", () => {
         .mockResolvedValue(undefined)
 
       consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+      consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {})
     })
 
     afterEach(() => {
       executeCaptureDownloadSpy.mockRestore()
       consoleWarnSpy.mockRestore()
+      consoleLogSpy.mockRestore()
     })
 
     it("retries with last_sync_time=0 when glasses have content but incremental sync is empty", async () => {
       mockGetSyncState.mockResolvedValue({
-        last_sync_time: 1778211091355,
+        last_sync_time: 1500,
         client_id: "test_client",
         total_downloaded: 27,
         total_size: 1000,
@@ -304,18 +309,18 @@ describe("GallerySyncService", () => {
       await startFileDownload()
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(2)
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "test_client", 1778211091355, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "test_client", 1500, true)
       expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "test_client", 0, true)
       expect(executeCaptureDownloadSpy).toHaveBeenCalledWith([FAKE_CAPTURE], 2000)
-      expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Desync detected: glasses report content but /api/sync returned empty"),
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Empty sync but glasses report content — retrying with last_sync_time=0"),
       )
     })
 
     it("does not retry when glasses report no content", async () => {
       useGallerySyncStore.getState().setGlassesGalleryStatus(0, 0, 0, false)
       mockGetSyncState.mockResolvedValue({
-        last_sync_time: 1778211091355,
+        last_sync_time: 1500,
         client_id: "test_client",
         total_downloaded: 27,
         total_size: 1000,
@@ -325,7 +330,7 @@ describe("GallerySyncService", () => {
       await startFileDownload()
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
-      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 1778211091355, true)
+      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 1500, true)
       expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
       expect(useGallerySyncStore.getState().syncState).toBe("complete")
     })
@@ -348,7 +353,7 @@ describe("GallerySyncService", () => {
 
     it("retries at most once when full-sync retry is also empty", async () => {
       mockGetSyncState.mockResolvedValue({
-        last_sync_time: 1778211091355,
+        last_sync_time: 1500,
         client_id: "test_client",
         total_downloaded: 27,
         total_size: 1000,
@@ -359,15 +364,17 @@ describe("GallerySyncService", () => {
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(2)
       expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
-      expect(useGallerySyncStore.getState().syncState).toBe("complete")
+      // PR's resolveSyncManifest surfaces an error when glasses still report content after retry —
+      // this is the loud failure mode for "leftover files on glasses that we can't see".
+      expect(useGallerySyncStore.getState().syncState).toBe("error")
       expect(consoleWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Full-sync retry also returned empty"),
+        expect.stringContaining("Empty sync while glasses still report gallery content"),
       )
     })
 
     it("does not retry when the first /api/sync response already has captures", async () => {
       mockGetSyncState.mockResolvedValue({
-        last_sync_time: 1778211091355,
+        last_sync_time: 1500,
         client_id: "test_client",
         total_downloaded: 27,
         total_size: 1000,
@@ -386,7 +393,7 @@ describe("GallerySyncService", () => {
       // `has_content` stays true and /api/sync stays empty for the same watermark. Without
       // a guard, every sync would retry with last_sync_time=0 and re-download the whole gallery.
       mockGetSyncState.mockResolvedValue({
-        last_sync_time: 1778211091355,
+        last_sync_time: 1500,
         client_id: "test_client",
         total_downloaded: 27,
         total_size: 1000,

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -410,4 +410,102 @@ describe("GallerySyncService", () => {
       )
     })
   })
+
+  describe("resolveSyncManifest (clock skew)", () => {
+    const resolveSyncManifest = (clientId: string, lastSyncTime: number) =>
+      (gallerySyncService as any).resolveSyncManifest(clientId, lastSyncTime)
+
+    beforeEach(() => {
+      mockSyncWithServer.mockReset()
+    })
+
+    it("fixes glasses clock and retries full sync when watermark is ahead of server time", async () => {
+      const phoneNow = Date.now()
+      const glassesServerTime = phoneNow - 32 * 24 * 60 * 60 * 1000
+      const futureWatermark = phoneNow
+
+      mockSyncWithServer
+        .mockResolvedValueOnce({
+          data: {server_time: glassesServerTime, changed_files: [], client_id: "c1"},
+        })
+        .mockResolvedValueOnce({
+          data: {
+            server_time: phoneNow,
+            changed_files: [{name: "IMG_1.jpg", size: 1, modified: glassesServerTime}],
+            client_id: "c1",
+          },
+        })
+
+      const resultPromise = resolveSyncManifest("c1", futureWatermark)
+      await jest.advanceTimersByTimeAsync(600)
+      const result = await resultPromise
+
+      expect(BluetoothSdk.setSystemTime).toHaveBeenCalledTimes(1)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "c1", futureWatermark, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, true)
+      expect(result).not.toBeNull()
+      expect(result?.syncData.changed_files).toHaveLength(1)
+    })
+
+    it("does not call setSystemTime when clocks are aligned", async () => {
+      const now = Date.now()
+      mockSyncWithServer.mockResolvedValue({
+        data: {
+          server_time: now,
+          changed_files: [{name: "a.jpg", size: 1}],
+          client_id: "c1",
+        },
+      })
+
+      await resolveSyncManifest("c1", now - 1000)
+
+      expect(BluetoothSdk.setSystemTime).not.toHaveBeenCalled()
+    })
+
+    it("retries with last_sync_time=0 when empty but glasses have content", async () => {
+      const now = Date.now()
+      useGallerySyncStore.getState().setGlassesGalleryStatus(2, 1, 3, true)
+
+      mockSyncWithServer
+        .mockResolvedValueOnce({
+          data: {server_time: now, changed_files: [], client_id: "c1"},
+        })
+        .mockResolvedValueOnce({
+          data: {server_time: now, changed_files: [{name: "b.jpg", size: 1}], client_id: "c1"},
+        })
+
+      const result = await resolveSyncManifest("c1", now - 5000)
+
+      expect(BluetoothSdk.setSystemTime).not.toHaveBeenCalled()
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, true)
+      expect(result?.syncData.changed_files).toHaveLength(1)
+    })
+
+    it("returns null when still empty and glasses report content", async () => {
+      const now = Date.now()
+      useGallerySyncStore.getState().setGlassesGalleryStatus(1, 0, 1, true)
+
+      mockSyncWithServer.mockResolvedValue({
+        data: {server_time: now, changed_files: [], client_id: "c1"},
+      })
+
+      const result = await resolveSyncManifest("c1", now - 5000)
+
+      expect(result).toBeNull()
+    })
+
+    it("allows legitimate empty sync when glasses have no content", async () => {
+      const now = Date.now()
+      useGallerySyncStore.getState().setGlassesGalleryStatus(0, 0, 0, false)
+
+      mockSyncWithServer.mockResolvedValue({
+        data: {server_time: now, changed_files: [], client_id: "c1"},
+      })
+
+      const result = await resolveSyncManifest("c1", now - 5000)
+
+      expect(result).not.toBeNull()
+      expect(result?.syncData.changed_files).toHaveLength(0)
+    })
+  })
 })

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -1618,7 +1618,10 @@ class GallerySyncService {
       }
       console.log("[GallerySyncService]   💾 Updating sync state in local storage...")
       const currentSyncState = await localStorageService.getSyncState()
-      if (downloadedCount > 0) {
+      // Persist if we downloaded anything OR if a failure needs the watermark rolled back.
+      // (Otherwise a clock-skew-triggered full sync where every legacy file fails would
+      // leave the stale future watermark on disk and never retry those files.)
+      if (downloadedCount > 0 || downloadResult.failed.length > 0) {
         await localStorageService.updateSyncState({
           last_sync_time: syncWatermark,
           total_downloaded: currentSyncState.total_downloaded + downloadedCount,

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -21,6 +21,8 @@ import {MediaLibraryPermissions} from "@/utils/permissions/MediaLibraryPermissio
 
 import {translate} from "@/i18n"
 import {asgCameraApi} from "./asgCameraApi"
+import {fixGlassesClockIfSkewed} from "./glassesClockSync"
+import {detectClockSkew, isSyncManifestEmpty} from "./gallerySyncClock"
 import {gallerySettingsService} from "./gallerySettingsService"
 import {gallerySyncNotifications} from "./gallerySyncNotifications"
 import {localStorageService} from "./localStorageService"
@@ -51,6 +53,17 @@ const TIMING = {
 /** True when /api/sync has nothing to download (api_version=2 captures and legacy changed_files both empty). */
 function isSyncResponseEmpty(data: {captures?: CaptureGroup[]; changed_files?: PhotoInfo[]}): boolean {
   return (!data.captures || data.captures.length === 0) && (!data.changed_files || data.changed_files.length === 0)
+}
+
+type SyncManifestData = {
+  api_version?: number
+  client_id: string
+  captures?: CaptureGroup[]
+  changed_files: PhotoInfo[]
+  deleted_files?: string[]
+  server_time: number
+  total_changed?: number
+  total_size?: number
 }
 
 class GallerySyncService {
@@ -1163,6 +1176,63 @@ class GallerySyncService {
     }
   }
 
+  private async fetchSyncManifest(clientId: string, lastSyncTime: number): Promise<SyncManifestData> {
+    const syncResponse = await asgCameraApi.syncWithServer(clientId, lastSyncTime, true)
+    return (syncResponse.data || syncResponse) as SyncManifestData
+  }
+
+  /**
+   * Resolve sync manifest: detect skew, optionally fix clock, retry full sync when needed.
+   */
+  private async resolveSyncManifest(
+    clientId: string,
+    lastSyncTime: number,
+  ): Promise<{syncData: SyncManifestData; usedFullSync: boolean} | null> {
+    const store = useGallerySyncStore.getState()
+    let syncData = await this.fetchSyncManifest(clientId, lastSyncTime)
+    let clockFixed = false
+
+    const skewOnFirst = detectClockSkew(Date.now(), syncData.server_time, lastSyncTime)
+    if (skewOnFirst.skewed) {
+      clockFixed = await fixGlassesClockIfSkewed(syncData.server_time, lastSyncTime)
+      if (clockFixed) {
+        console.log("[GallerySyncService]   🔄 Retrying /api/sync with last_sync_time=0 after clock fix")
+        syncData = await this.fetchSyncManifest(clientId, 0)
+      }
+    }
+
+    if (!isSyncManifestEmpty(syncData)) {
+      return {syncData, usedFullSync: clockFixed || lastSyncTime === 0}
+    }
+
+    // Guard against re-firing the full-sync retry every sync when glasses retain leftover files
+    // from a failed delete-from-glasses: at most one retry per (client_id, last_sync_time) pair
+    // per process lifetime. Without this, we'd re-download the entire gallery on every sync.
+    const retryKey = `${clientId}:${lastSyncTime}`
+    const alreadyRetriedForThisWatermark = this.lastFullSyncRetryKey === retryKey
+    if (!clockFixed && store.glassesHasContent && lastSyncTime !== 0 && !alreadyRetriedForThisWatermark) {
+      this.lastFullSyncRetryKey = retryKey
+      console.log(
+        "[GallerySyncService]   🔄 Empty sync but glasses report content — retrying with last_sync_time=0",
+      )
+      syncData = await this.fetchSyncManifest(clientId, 0)
+      if (!isSyncManifestEmpty(syncData)) {
+        return {syncData, usedFullSync: true}
+      }
+    } else if (!clockFixed && store.glassesHasContent && lastSyncTime !== 0 && alreadyRetriedForThisWatermark) {
+      console.warn(
+        "[GallerySyncService]   ⚠️ Glasses still report content but /api/sync empty — already retried this watermark, skipping to avoid re-download loop",
+      )
+    }
+
+    if (store.glassesHasContent) {
+      console.warn("[GallerySyncService]   ⚠️ Empty sync while glasses still report gallery content")
+      return null
+    }
+
+    return {syncData, usedFullSync: false}
+  }
+
   /**
    * Start downloading files
    */
@@ -1195,52 +1265,33 @@ class GallerySyncService {
 
       console.log("[GallerySyncService]   📡 Calling /api/sync endpoint...")
       const syncStartTime = Date.now()
-      let syncResponse = await asgCameraApi.syncWithServer(syncState.client_id, syncState.last_sync_time, true)
-      let _syncDuration = Date.now() - syncStartTime
+      const resolved = await this.resolveSyncManifest(syncState.client_id, syncState.last_sync_time)
+      const _syncDuration = Date.now() - syncStartTime
       console.log(`[GallerySyncService]   ✅ /api/sync completed in ${_syncDuration}ms`)
 
-      let syncData = syncResponse.data || syncResponse
-
-      // BLE gallery_status counts all files on glasses; /api/sync is incremental by last_sync_time.
-      // If the phone watermark is ahead of file mtimes (clock skew, deleted locals, etc.), retry once as full sync.
-      // Guard against re-firing every sync when glasses retain leftover files from a failed delete:
-      // only one retry per (client_id, last_sync_time) pair per process lifetime.
-      const retryKey = `${syncState.client_id}:${syncState.last_sync_time}`
-      if (
-        isSyncResponseEmpty(syncData) &&
-        syncState.last_sync_time > 0 &&
-        useGallerySyncStore.getState().glassesHasContent &&
-        this.lastFullSyncRetryKey !== retryKey
-      ) {
-        this.lastFullSyncRetryKey = retryKey
-        console.warn(
-          "[GallerySyncService] Desync detected: glasses report content but /api/sync returned empty. " +
-            `Retrying with last_sync_time=0 (was ${syncState.last_sync_time}).`,
-        )
-        const retryStartTime = Date.now()
-        syncResponse = await asgCameraApi.syncWithServer(syncState.client_id, 0, true)
-        _syncDuration = Date.now() - retryStartTime
-        console.log(`[GallerySyncService]   ✅ /api/sync full-sync retry completed in ${_syncDuration}ms`)
-        syncData = syncResponse.data || syncResponse
-        if (isSyncResponseEmpty(syncData)) {
-          console.warn("[GallerySyncService] Full-sync retry also returned empty — falling through to up-to-date path.")
-        } else {
-          console.log("[GallerySyncService] Full-sync retry succeeded — proceeding with download.")
+      if (!resolved) {
+        const syncErrorMessage = "Could not sync gallery — try again"
+        store.setSyncError(syncErrorMessage)
+        await gallerySyncNotifications.showSyncError(syncErrorMessage)
+        if (store.syncServiceOpenedHotspot) {
+          await this.closeHotspot()
         }
-      } else if (
-        isSyncResponseEmpty(syncData) &&
-        syncState.last_sync_time > 0 &&
-        useGallerySyncStore.getState().glassesHasContent &&
-        this.lastFullSyncRetryKey === retryKey
-      ) {
-        console.warn(
-          "[GallerySyncService] Glasses still report content but /api/sync empty — already retried this watermark, skipping to avoid re-download loop.",
-        )
+        return
       }
+
+      const {syncData} = resolved
 
       console.log("[GallerySyncService]   📋 Sync response received:")
       console.log(`[GallerySyncService]      - Server time: ${syncData.server_time}`)
       console.log(`[GallerySyncService]      - Changed files: ${syncData.changed_files?.length || 0}`)
+      console.log(`[GallerySyncService]      - Captures: ${syncData.captures?.length || 0}`)
+
+      if (isSyncManifestEmpty(syncData)) {
+        console.log("[GallerySyncService]   ✅ No new files to sync - already up to date!")
+        store.setSyncComplete()
+        await this.onSyncComplete(0, 0)
+        return
+      }
 
       // Detect API version and route to appropriate download path
       const useCaptures = syncData.api_version === 2 && syncData.captures && syncData.captures.length > 0
@@ -1289,11 +1340,6 @@ class GallerySyncService {
 
         console.log("[GallerySyncService]   🚀 Beginning capture download execution...")
         await this.executeCaptureDownload(captures, syncData.server_time)
-      } else if (!syncData.changed_files || syncData.changed_files.length === 0) {
-        console.log("[GallerySyncService]   ✅ No new files to sync - already up to date!")
-        store.setSyncComplete()
-        await this.onSyncComplete(0, 0)
-        return
       } else {
         // Legacy flat file sync path
         const filesToSync = syncData.changed_files
@@ -1543,10 +1589,14 @@ class GallerySyncService {
       await mediaProcessingQueue.waitUntilDrained()
       console.log("[GallerySyncService]   ✅ Processing queue drained")
 
-      // Update sync state — only advance watermark if all files succeeded.
+      // Update sync state — only advance watermark if files were downloaded.
       // If any failed, set it before the oldest failure so they get retried.
       let syncWatermark = serverTime
-      if (downloadResult.failed.length > 0) {
+      if (downloadedCount === 0) {
+        const currentSyncState = await localStorageService.getSyncState()
+        syncWatermark = currentSyncState.last_sync_time
+        console.log("[GallerySyncService]   ℹ️ No files downloaded — last_sync_time unchanged")
+      } else if (downloadResult.failed.length > 0) {
         const failedSet = new Set(downloadResult.failed)
         let oldestFailed = Infinity
         for (const f of files) {
@@ -1561,14 +1611,27 @@ class GallerySyncService {
             `[GallerySyncService]   ⚠️ ${downloadResult.failed.length} files failed — sync watermark set to ${syncWatermark} instead of ${serverTime}`,
           )
         }
+      } else {
+        let maxModified = 0
+        const failedSet = new Set(downloadResult.failed)
+        for (const f of files) {
+          if (failedSet.has(f.name)) continue
+          const ts = typeof f.modified === "number" ? f.modified : parseInt(String(f.modified), 10)
+          if (!isNaN(ts)) maxModified = Math.max(maxModified, ts)
+        }
+        if (maxModified > 0) {
+          syncWatermark = maxModified
+        }
       }
       console.log("[GallerySyncService]   💾 Updating sync state in local storage...")
       const currentSyncState = await localStorageService.getSyncState()
-      await localStorageService.updateSyncState({
-        last_sync_time: syncWatermark,
-        total_downloaded: currentSyncState.total_downloaded + downloadedCount,
-        total_size: currentSyncState.total_size + downloadResult.total_size,
-      })
+      if (downloadedCount > 0) {
+        await localStorageService.updateSyncState({
+          last_sync_time: syncWatermark,
+          total_downloaded: currentSyncState.total_downloaded + downloadedCount,
+          total_size: currentSyncState.total_size + downloadResult.total_size,
+        })
+      }
       console.log("[GallerySyncService]   ✅ Sync state updated:")
       console.log(
         `[GallerySyncService]      - New last_sync_time: ${syncWatermark} (${new Date(syncWatermark).toISOString()})`,
@@ -1626,6 +1689,7 @@ class GallerySyncService {
     let failedCount = 0
     let totalSizeDownloaded = 0
     let oldestFailedTimestamp = Infinity // Track for sync watermark
+    let maxSuccessfulTimestamp = 0
 
     const shouldAutoSave = await gallerySettingsService.getAutoSaveToCameraRoll()
     const shouldProcessImages = useSettingsStore.getState().getSetting(SETTINGS.media_post_processing.key)
@@ -1675,6 +1739,9 @@ class GallerySyncService {
 
           totalSizeDownloaded += capture.total_size
           downloadedCount++
+          if (capture.timestamp > maxSuccessfulTimestamp) {
+            maxSuccessfulTimestamp = capture.timestamp
+          }
 
           // Enqueue for processing (runs concurrently with next download)
           // Delete from glasses happens after processing completes to avoid data loss on crash
@@ -1755,21 +1822,26 @@ class GallerySyncService {
         failedCount = failedFromThisBatch
       }
 
-      // Update sync state — only advance the watermark to serverTime if all
-      // captures succeeded. If any failed, set it just before the oldest failure
-      // so those captures are retried on the next sync.
-      const syncWatermark =
-        failedCount > 0 && oldestFailedTimestamp < Infinity ? Math.max(0, oldestFailedTimestamp - 1) : serverTime
+      // Update sync state — only advance watermark when captures were downloaded.
+      let syncWatermark = serverTime
       const currentSyncState = await localStorageService.getSyncState()
-      await localStorageService.updateSyncState({
-        last_sync_time: syncWatermark,
-        total_downloaded: currentSyncState.total_downloaded + downloadedCount,
-        total_size: currentSyncState.total_size + totalSizeDownloaded,
-      })
-      if (failedCount > 0) {
+      if (downloadedCount === 0) {
+        syncWatermark = currentSyncState.last_sync_time
+        console.log("[GallerySyncService]   ℹ️ No captures downloaded — last_sync_time unchanged")
+      } else if (failedCount > 0 && oldestFailedTimestamp < Infinity) {
+        syncWatermark = Math.max(0, oldestFailedTimestamp - 1)
         console.log(
           `[GallerySyncService]   ⚠️ ${failedCount} captures failed — sync watermark set to ${syncWatermark} instead of ${serverTime} so they will be retried`,
         )
+      } else if (maxSuccessfulTimestamp > 0) {
+        syncWatermark = maxSuccessfulTimestamp
+      }
+      if (downloadedCount > 0) {
+        await localStorageService.updateSyncState({
+          last_sync_time: syncWatermark,
+          total_downloaded: currentSyncState.total_downloaded + downloadedCount,
+          total_size: currentSyncState.total_size + totalSizeDownloaded,
+        })
       }
 
       store.setSyncComplete()

--- a/mobile/src/services/asg/gallerySyncService.ts
+++ b/mobile/src/services/asg/gallerySyncService.ts
@@ -50,11 +50,6 @@ const TIMING = {
   WIFI_COOLDOWN_MS: 3000, // Wait 3 seconds after user visits WiFi settings before showing alert again
 } as const
 
-/** True when /api/sync has nothing to download (api_version=2 captures and legacy changed_files both empty). */
-function isSyncResponseEmpty(data: {captures?: CaptureGroup[]; changed_files?: PhotoInfo[]}): boolean {
-  return (!data.captures || data.captures.length === 0) && (!data.changed_files || data.changed_files.length === 0)
-}
-
 type SyncManifestData = {
   api_version?: number
   client_id: string
@@ -1212,9 +1207,7 @@ class GallerySyncService {
     const alreadyRetriedForThisWatermark = this.lastFullSyncRetryKey === retryKey
     if (!clockFixed && store.glassesHasContent && lastSyncTime !== 0 && !alreadyRetriedForThisWatermark) {
       this.lastFullSyncRetryKey = retryKey
-      console.log(
-        "[GallerySyncService]   🔄 Empty sync but glasses report content — retrying with last_sync_time=0",
-      )
+      console.log("[GallerySyncService]   🔄 Empty sync but glasses report content — retrying with last_sync_time=0")
       syncData = await this.fetchSyncManifest(clientId, 0)
       if (!isSyncManifestEmpty(syncData)) {
         return {syncData, usedFullSync: true}
@@ -1825,18 +1818,22 @@ class GallerySyncService {
       // Update sync state — only advance watermark when captures were downloaded.
       let syncWatermark = serverTime
       const currentSyncState = await localStorageService.getSyncState()
-      if (downloadedCount === 0) {
-        syncWatermark = currentSyncState.last_sync_time
-        console.log("[GallerySyncService]   ℹ️ No captures downloaded — last_sync_time unchanged")
-      } else if (failedCount > 0 && oldestFailedTimestamp < Infinity) {
+      if (failedCount > 0 && oldestFailedTimestamp < Infinity) {
+        // Failures take priority — roll the watermark back before the oldest failure so it
+        // gets retried, regardless of whether anything else succeeded in this batch.
         syncWatermark = Math.max(0, oldestFailedTimestamp - 1)
         console.log(
           `[GallerySyncService]   ⚠️ ${failedCount} captures failed — sync watermark set to ${syncWatermark} instead of ${serverTime} so they will be retried`,
         )
+      } else if (downloadedCount === 0) {
+        syncWatermark = currentSyncState.last_sync_time
+        console.log("[GallerySyncService]   ℹ️ No captures downloaded — last_sync_time unchanged")
       } else if (maxSuccessfulTimestamp > 0) {
         syncWatermark = maxSuccessfulTimestamp
       }
-      if (downloadedCount > 0) {
+      // Persist if we downloaded anything OR if a failure needs the watermark rolled back
+      // (zero-byte / validation failures otherwise leave a stale watermark on disk).
+      if (downloadedCount > 0 || (failedCount > 0 && oldestFailedTimestamp < Infinity)) {
         await localStorageService.updateSyncState({
           last_sync_time: syncWatermark,
           total_downloaded: currentSyncState.total_downloaded + downloadedCount,

--- a/mobile/src/services/asg/glassesClockSync.ts
+++ b/mobile/src/services/asg/glassesClockSync.ts
@@ -2,7 +2,7 @@
  * Push phone time to glasses only when clock skew is detected (gallery sync, OTA, etc.).
  */
 
-import CoreModule from "@mentra/bluetooth-sdk"
+import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 import {BgTimer} from "@mentra/island"
 
 import {useGlassesStore} from "@/stores/glasses"
@@ -32,7 +32,7 @@ export async function fixGlassesClockIfSkewed(glassesServerTime: number, lastSyn
     return false
   }
   console.log(`[GlassesClockSync] ⏰ Clock skew detected (${reason}) — setting glasses time from phone`)
-  await CoreModule.setSystemTime(Date.now())
+  await BluetoothSdk.setSystemTime(Date.now())
   await delay(CLOCK_SETTLE_MS)
   return true
 }
@@ -72,7 +72,7 @@ export async function handleOtaClockSkewFromGlasses(
 
   lastOtaClockFixAt = Date.now()
   console.log("[GlassesClockSync] ⏰ Retrying glasses OTA version check after clock fix")
-  await CoreModule.retryOtaVersionCheck()
+  await BluetoothSdk.retryOtaVersionCheck()
   return true
 }
 
@@ -91,7 +91,7 @@ export async function maybeFixGlassesClockFromVersionInfo(systemTimeMs: number |
 
   if (useGlassesStore.getState().wifi.state === "connected") {
     console.log("[GlassesClockSync] ⏰ Glasses on WiFi — retrying OTA version check after clock fix")
-    await CoreModule.retryOtaVersionCheck()
+    await BluetoothSdk.retryOtaVersionCheck()
   }
 
   return true

--- a/mobile/src/services/asg/glassesClockSync.ts
+++ b/mobile/src/services/asg/glassesClockSync.ts
@@ -13,10 +13,15 @@ export const CLOCK_SETTLE_MS = 500
 
 const OTA_CLOCK_FIX_COOLDOWN_MS = 30_000
 let lastOtaClockFixAt = 0
+// Coalesce concurrent OTA clock-fix attempts. Glasses can emit two clock_skew events
+// back-to-back during BLE handshake; without this guard both would await the BLE fix
+// + retry pair before either updated `lastOtaClockFixAt`.
+let inflightOtaClockFix: Promise<boolean> | null = null
 
 /** @internal test-only */
 export function resetOtaClockFixCooldownForTests(): void {
   lastOtaClockFixAt = 0
+  inflightOtaClockFix = null
 }
 
 function delay(ms: number): Promise<void> {
@@ -63,17 +68,31 @@ export async function handleOtaClockSkewFromGlasses(
     return false
   }
 
-  const glassesTime = hasGlassesTime ? glassesTimeMs : Date.now() - 86_400_000
-
-  const fixed = await fixGlassesClockIfSkewed(glassesTime, 0)
-  if (!fixed) {
-    return false
+  // Coalesce concurrent attempts: if a fix is already in flight, await its result instead
+  // of racing it through the cooldown guard.
+  if (inflightOtaClockFix) {
+    return inflightOtaClockFix
   }
 
-  lastOtaClockFixAt = Date.now()
-  console.log("[GlassesClockSync] ⏰ Retrying glasses OTA version check after clock fix")
-  await BluetoothSdk.retryOtaVersionCheck()
-  return true
+  const glassesTime = hasGlassesTime ? glassesTimeMs : Date.now() - 86_400_000
+
+  inflightOtaClockFix = (async () => {
+    try {
+      const fixed = await fixGlassesClockIfSkewed(glassesTime, 0)
+      if (!fixed) {
+        return false
+      }
+
+      lastOtaClockFixAt = Date.now()
+      console.log("[GlassesClockSync] ⏰ Retrying glasses OTA version check after clock fix")
+      await BluetoothSdk.retryOtaVersionCheck()
+      return true
+    } finally {
+      inflightOtaClockFix = null
+    }
+  })()
+
+  return inflightOtaClockFix
 }
 
 /**

--- a/mobile/src/services/asg/glassesClockSync.ts
+++ b/mobile/src/services/asg/glassesClockSync.ts
@@ -1,0 +1,97 @@
+/**
+ * Push phone time to glasses only when clock skew is detected (gallery sync, OTA, etc.).
+ */
+
+import CoreModule from "@mentra/bluetooth-sdk"
+import {BgTimer} from "@mentra/island"
+
+import {useGlassesStore} from "@/stores/glasses"
+
+import {detectClockSkew} from "./gallerySyncClock"
+
+export const CLOCK_SETTLE_MS = 500
+
+const OTA_CLOCK_FIX_COOLDOWN_MS = 30_000
+let lastOtaClockFixAt = 0
+
+/** @internal test-only */
+export function resetOtaClockFixCooldownForTests(): void {
+  lastOtaClockFixAt = 0
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => BgTimer.setTimeout(resolve, ms))
+}
+
+/**
+ * Set glasses system clock from phone when skew is detected.
+ */
+export async function fixGlassesClockIfSkewed(
+  glassesServerTime: number,
+  lastSyncTime = 0,
+): Promise<boolean> {
+  const {skewed, reason} = detectClockSkew(Date.now(), glassesServerTime, lastSyncTime)
+  if (!skewed) {
+    return false
+  }
+  console.log(`[GlassesClockSync] ⏰ Clock skew detected (${reason}) — setting glasses time from phone`)
+  await CoreModule.setSystemTime(Date.now())
+  await delay(CLOCK_SETTLE_MS)
+  return true
+}
+
+/**
+ * After glasses report OTA failure due to clock skew, fix time and re-run background version check.
+ */
+export async function handleOtaClockSkewFromGlasses(
+  errorCode: string | undefined,
+  glassesTimeMs?: number,
+): Promise<boolean> {
+  if (Date.now() - lastOtaClockFixAt < OTA_CLOCK_FIX_COOLDOWN_MS) {
+    return false
+  }
+
+  const glassesTime =
+    typeof glassesTimeMs === "number" && glassesTimeMs > 0 ? glassesTimeMs : Date.now() - 86_400_000
+
+  if (errorCode === "ssl_error") {
+    const {skewed} = detectClockSkew(Date.now(), glassesTime, 0)
+    if (!skewed) {
+      return false
+    }
+    console.log("[GlassesClockSync] ⏰ OTA ssl_error with wall-clock drift — treating as clock skew")
+  } else if (errorCode !== "clock_skew") {
+    return false
+  }
+
+  const fixed = await fixGlassesClockIfSkewed(glassesTime, 0)
+  if (!fixed) {
+    return false
+  }
+
+  lastOtaClockFixAt = Date.now()
+  console.log("[GlassesClockSync] ⏰ Retrying glasses OTA version check after clock fix")
+  await CoreModule.retryOtaVersionCheck()
+  return true
+}
+
+/**
+ * Proactive fix when version_info includes glasses system_time_ms (e.g. before background OTA prefetch).
+ */
+export async function maybeFixGlassesClockFromVersionInfo(systemTimeMs: number | undefined): Promise<boolean> {
+  if (typeof systemTimeMs !== "number" || systemTimeMs <= 0) {
+    return false
+  }
+
+  const fixed = await fixGlassesClockIfSkewed(systemTimeMs, 0)
+  if (!fixed) {
+    return false
+  }
+
+  if (useGlassesStore.getState().wifi.state === "connected") {
+    console.log("[GlassesClockSync] ⏰ Glasses on WiFi — retrying OTA version check after clock fix")
+    await CoreModule.retryOtaVersionCheck()
+  }
+
+  return true
+}

--- a/mobile/src/services/asg/glassesClockSync.ts
+++ b/mobile/src/services/asg/glassesClockSync.ts
@@ -26,10 +26,7 @@ function delay(ms: number): Promise<void> {
 /**
  * Set glasses system clock from phone when skew is detected.
  */
-export async function fixGlassesClockIfSkewed(
-  glassesServerTime: number,
-  lastSyncTime = 0,
-): Promise<boolean> {
+export async function fixGlassesClockIfSkewed(glassesServerTime: number, lastSyncTime = 0): Promise<boolean> {
   const {skewed, reason} = detectClockSkew(Date.now(), glassesServerTime, lastSyncTime)
   if (!skewed) {
     return false
@@ -51,11 +48,13 @@ export async function handleOtaClockSkewFromGlasses(
     return false
   }
 
-  const glassesTime =
-    typeof glassesTimeMs === "number" && glassesTimeMs > 0 ? glassesTimeMs : Date.now() - 86_400_000
+  const hasGlassesTime = typeof glassesTimeMs === "number" && Number.isFinite(glassesTimeMs) && glassesTimeMs > 0
 
   if (errorCode === "ssl_error") {
-    const {skewed} = detectClockSkew(Date.now(), glassesTime, 0)
+    if (!hasGlassesTime) {
+      return false
+    }
+    const {skewed} = detectClockSkew(Date.now(), glassesTimeMs, 0)
     if (!skewed) {
       return false
     }
@@ -63,6 +62,8 @@ export async function handleOtaClockSkewFromGlasses(
   } else if (errorCode !== "clock_skew") {
     return false
   }
+
+  const glassesTime = hasGlassesTime ? glassesTimeMs : Date.now() - 86_400_000
 
   const fixed = await fixGlassesClockIfSkewed(glassesTime, 0)
   if (!fixed) {

--- a/mobile/src/stores/glasses.ts
+++ b/mobile/src/stores/glasses.ts
@@ -28,6 +28,7 @@ export const selectGlassesConnected = (state: {connection: GlassesConnectionStat
 export const selectGlassesReady = (state: {connection: GlassesConnectionStatus}) => isGlassesReady(state.connection)
 
 interface GlassesState extends GlassesStatus {
+  systemTimeMs: number
   wifiStatusKnown: boolean
   setGlassesInfo: (info: GlassesInfoUpdate) => void
   setBatteryInfo: (batteryLevel: number, charging: boolean, caseBatteryLevel: number, caseCharging: boolean) => void
@@ -105,6 +106,7 @@ export const getGlasesInfoPartial = (state: GlassesStatus) => {
 }
 
 interface GlassesStore extends GlassesStatus {
+  systemTimeMs: number
   mtkUpdatedThisSession: boolean
   wifiStatusKnown: boolean
   otaStatus: OtaStatus | null
@@ -126,6 +128,7 @@ const initialState: GlassesStore = {
   leftMacAddress: "",
   rightMacAddress: "",
   buildNumber: "",
+  systemTimeMs: 0,
   otaVersionUrl: "",
   appVersion: "",
   bluetoothName: "",
@@ -278,6 +281,10 @@ export const useGlassesStore = create<GlassesState>()(
     reset: () => set(initialState),
   })),
 )
+
+export function getGlassesSystemTimeMs(): number {
+  return useGlassesStore.getState().systemTimeMs ?? 0
+}
 
 export const waitForGlassesState = <K extends keyof GlassesState>(
   key: K,

--- a/mobile/src/test-utils/mockCoreModule.ts
+++ b/mobile/src/test-utils/mockCoreModule.ts
@@ -93,6 +93,7 @@ export const coreModuleMock = {
   sendWifiCredentials: jest.fn(() => Promise.resolve()),
   forgetWifiNetwork: jest.fn(() => Promise.resolve()),
   setHotspotState: jest.fn(() => Promise.resolve()),
+  setSystemTime: jest.fn(() => Promise.resolve()),
   logCurrentWifiFrequency: jest.fn(() => Promise.resolve()),
   queryGalleryStatus: jest.fn(() => Promise.resolve()),
   requestPhoto: jest.fn(() => Promise.resolve()),

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -35,6 +35,10 @@ describe("getOtaErrorMessage", () => {
     expect(getOtaErrorMessage("no_internet")).toBe("Glasses WiFi has no internet connection")
   })
 
+  it("maps clock_skew to time-sync message", () => {
+    expect(getOtaErrorMessage("clock_skew")).toContain("clock")
+  })
+
   it("maps ssl_error to connection message", () => {
     expect(getOtaErrorMessage("ssl_error")).toBe("Secure connection failed — try a different WiFi network")
   })

--- a/mobile/src/utils/__tests__/otaErrorMapping.test.ts
+++ b/mobile/src/utils/__tests__/otaErrorMapping.test.ts
@@ -36,7 +36,9 @@ describe("getOtaErrorMessage", () => {
   })
 
   it("maps clock_skew to time-sync message", () => {
-    expect(getOtaErrorMessage("clock_skew")).toContain("clock")
+    expect(getOtaErrorMessage("clock_skew")).toBe(
+      "Glasses clock is wrong — syncing time from your phone, then retrying update check",
+    )
   })
 
   it("maps ssl_error to connection message", () => {

--- a/mobile/src/utils/otaErrorMapping.ts
+++ b/mobile/src/utils/otaErrorMapping.ts
@@ -41,6 +41,8 @@ export function getOtaErrorMessage(error?: string): string {
   switch (error) {
     case "no_internet":
       return "Glasses WiFi has no internet connection"
+    case "clock_skew":
+      return "Glasses clock is wrong — syncing time from your phone, then retrying update check"
     case "ssl_error":
       return "Secure connection failed — try a different WiFi network"
     case "download_failed":


### PR DESCRIPTION
## Summary

Rebase of #2842 onto current staging. Original PR's branch was based off `81c394d22` (May 17) and developed against an older SDK shape (`CoreModule` from `@mentra/bluetooth-sdk`, `GlassesStore`). Staging has since moved that surface: the public `@mentra/bluetooth-sdk` no longer exposes private methods like `setSystemTime`/`retryOtaVersionCheck`, those now live on `@mentra/bluetooth-sdk-internal`. Plus #2879's gallery-sync work landed in `resolveSyncManifest`'s lap and needed merging in.

## Original PR

#2842 by @nic-olo — same feature, same authorship preserved via rebase. Recommend closing #2842 and merging this one.

## What's in here

All 4 commits from #2842 preserved with original authorship, plus one fixup commit covering the rebase reconciliation:

1. `Fix glasses clock skew during gallery sync and OTA` — phone-side detection, `resolveSyncManifest` flow
2. `Wire BLE set_system_time and OTA clock-skew handling` — native modules on Android + iOS
3. `Address clock skew review feedback` — MantleManager wiring
4. `Implement system time synchronization for connections in DeviceManager` — auto-sync on connect
5. **`Adjust clock-sync wiring for new SDK surface + reconcile staging tests`** (new) — see commit message

## Notable conflict resolutions

- **`resolveSyncManifest`**: PR's clock-skew + empty-but-content retry now also carries #2879's `(client_id, last_sync_time)` retry-guard so we don't re-download the gallery every sync when glasses retain leftover files from a failed delete-from-glasses.
- **Watermark write-back**: kept staging's failure reconciliation block (zero-byte / validation failure tracking) AND PR's `let syncWatermark` decision tree. Also persist `updateSyncState` when there are failures even with 0 downloads, otherwise the staging zero-byte test regresses.
- **`MentraBluetoothSdk.kt` / `MentraBluetoothSDK.swift`**: kept staging's `internal`/`func` visibility convention; new `retryOtaVersionCheck` matches the surrounding OTA functions' visibility.
- **`SGCManager.kt`/`.swift`**: kept staging's package paths (`com.mentra.bluetoothsdk`, `DeviceStore`); added `Bridge` import that the PR needed.
- **`OtaUpdateChecker.tsx`**: kept staging's variable names (`latestMtkFirmwareVersion`); added PR's `maybeFixGlassesClockFromVersionInfo` prologue and `getGlassesSystemTimeMs` import.
- **`MantleManager.ts`**: switched PR's `CoreModule`/`switchType` accessors to staging's `BluetoothSdk`/`event.switchType` (the typed event shape on staging only has camelCase).
- **`BluetoothSdkModule.ts`**: PR modified the top-level file but staging moved it into `_private/`. Added `setSystemTime` and `retryOtaVersionCheck` to the new `_private/BluetoothSdkModule.ts` type; deleted the stale top-level file.

## Verification

- `bun compile` clean
- `npx jest src/services/asg/gallerySyncService.test.ts src/services/asg/__tests__/glassesClockSync.test.ts` → 22/22 pass (5 staging desync tests + 5 PR clock-skew tests + 6 glassesClockSync tests + originals)
- Full jest run: same pre-existing failures as #2879's branch (MantleManager 'Super expression', BluetoothSdk module-not-found in jest-expo for some test suites — pre-existing on staging, not introduced here)
- Lint: cleaned up the 3 new "unused import" errors I would've introduced in MantleManager
- Native Kotlin/Swift compile: NOT verified locally. Mechanical edits only (added 1 function per file, matched surrounding visibility) — CI's Android + iOS build jobs will catch any wiring miss.

## Test plan

- [ ] CI green on `rebase/glasses-clock-sync`
- [ ] Smoke test gallery sync on glasses with intentionally-skewed clock to confirm the auto-fix flow still works end-to-end
- [ ] If CI iOS/Android build is green, close #2842 with a link here

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically detects and fixes phone ↔ glasses clock skew during gallery sync and OTA to prevent empty syncs and TLS “not yet valid” errors. Adds BLE time sync, safer watermark writes, and robust OTA retry handling across mobile, SDK, and ASG.

- **New Features**
  - Gallery sync: new `resolveSyncManifest` flow with `gallerySyncClock.*` helpers; detect skew via `server_time` vs `last_sync_time`, send `set_system_time` only when needed, then retry with `last_sync_time=0`.
  - OTA: propagate `glasses_time_ms` in `ota_status`, add `ota_retry_version_check`, map `ssl_error`+time to `clock_skew`, and proactively fix using `version_info.system_time_ms`.
  - SDK/Native: expose `setSystemTime` and `retryOtaVersionCheck` in `@mentra/bluetooth-sdk-internal`; DeviceManager syncs time once per connection; MentraLive/ASG implement `set_system_time` and retry commands; API docs updated.

- **Bug Fixes**
  - Prevent gallery re-download loops with a per-`(client_id, last_sync_time)` full-sync retry guard; surface error when sync stays empty while glasses report content.
  - Watermark writes: don’t advance when nothing downloaded; roll back before oldest failure; persist when downloads > 0 or any failures occur.
  - Coalesce concurrent OTA clock-fix attempts; BES check assumes update when current version is unknown; fix MentraLive `GlassesStore` → `DeviceStore` rename so release builds succeed.

<sup>Written for commit e08bf177de992c3f1ef1b06facd6cd2393755c7a. Summary will update on new commits. <a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/2885?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

