### PR TITLE
Integrate VAD bypass query for Mentra Live

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -162,7 +162,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
                 // If looks like JSON but not C-wrapped, use the full formatting function
                 if (originalData.startsWith("{") && !K900ProtocolUtils.isCWrappedJson(originalData)) {
-                    Log.d(TAG, "📡 🔧 JSON data detected, applying C-wrapping and protocol formatting...");
                     Log.d(TAG, "📡 📦 JSON DATA BEFORE C-WRAPPING: " + originalData);
                     data = K900ProtocolUtils.formatMessageForTransmission(originalData);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
@@ -27,6 +27,8 @@ import com.mentra.asg_client.SysControl;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Handles K900 protocol commands.
  * Follows Single Responsibility Principle by handling only K900 protocol commands.
@@ -34,6 +36,7 @@ import org.json.JSONObject;
  */
 public class K900CommandHandler {
     private static final String TAG = "K900CommandHandler";
+    private static final int VOICE_ACTIVITY_DETECTION_SWITCH_TYPE = 8;
 
     private final AsgClientServiceManager serviceManager;
     private final IStateManager stateManager;
@@ -61,7 +64,7 @@ public class K900CommandHandler {
     public void processK900Command(JSONObject json) {
         try {
             String command = json.optString("C", "");
-            JSONObject bData = json.optJSONObject("B");
+            JSONObject bData = optK900Body(json);
             Log.d(TAG, "📦 Received K900 command: " + command);
 
             switch (command) {
@@ -92,7 +95,8 @@ public class K900CommandHandler {
                 // ---------------------------------------------
                 
                 case "sr_swst":
-                    // Switch status report (touch events)
+                case "sr_swit":
+                    // Switch status report (touch, VAD type 8, etc.)
                     handleSwitchStatusReport(bData);
                     break;
 
@@ -146,10 +150,15 @@ public class K900CommandHandler {
                     handleShutdownCommand();
                     break;
 
-                case "android_control_led":
+                // Phone → BES (tunneled via MTK UART). Forward to BES; do not treat as BES→MTK events.
+                case "cs_swst":
                 case "cs_swit":
                 case "cs_fbvol":
                 case "cs_batv":
+                    forwardK900CommandToBes(json);
+                    break;
+
+                case "android_control_led":
                 case "sr_ledon":
                     Log.d(TAG, "📦 Ignoring mirrored K900 command: " + command);
                     break;
@@ -554,6 +563,56 @@ public class K900CommandHandler {
             if (relayFirmwareJson != null) {
                 relayFirmwareJson.accept(BesLogManager.buildFirmwareUploadJson(""));
             }
+        }
+    }
+
+    private JSONObject optK900Body(JSONObject json) {
+        if (json == null) {
+            return null;
+        }
+        JSONObject bData = json.optJSONObject("B");
+        if (bData != null) {
+            return bData;
+        }
+        String bField = json.optString("B", "");
+        if (bField.isEmpty()) {
+            return null;
+        }
+        try {
+            return new JSONObject(bField);
+        } catch (JSONException e) {
+            Log.w(TAG, "Failed to parse K900 B field as JSON: " + bField);
+            return null;
+        }
+    }
+
+    /**
+     * Forward a phone-originated K900 client command to the BES chip over UART.
+     * On K900 glasses the phone sends commands to BES; BES tunnels a copy to MTK and expects
+     * MTK to relay the same JSON to BES for execution (e.g. cs_swst query, cs_swit type 8 VAD).
+     */
+    private void forwardK900CommandToBes(JSONObject json) {
+        if (serviceManager == null || serviceManager.getBluetoothManager() == null) {
+            Log.w(TAG, "Cannot forward K900 command to BES - Bluetooth manager unavailable");
+            return;
+        }
+
+        if (!serviceManager.getBluetoothManager().isConnected()) {
+            Log.w(TAG, "Cannot forward K900 command to BES - serial not connected");
+            return;
+        }
+
+        String commandStr = json.toString();
+
+        boolean sent =
+                serviceManager
+                        .getBluetoothManager()
+                        .sendData(commandStr.getBytes(StandardCharsets.UTF_8));
+
+        if (sent) {
+            Log.i(TAG, "✅ Forwarded K900 command to BES");
+        } else {
+            Log.e(TAG, "❌ Failed to forward K900 command to BES");
         }
     }
 
@@ -1018,13 +1077,17 @@ public class K900CommandHandler {
      */
     private void handleSwitchStatusReport(JSONObject bData) {
         Log.d(TAG, "📦 Processing switch status report");
-        
+
         if (bData != null) {
             int type = bData.optInt("type", -1);
             int switchValue = bData.optInt("switch", -1);
-            
-            Log.i(TAG, "📦 Switch status - Type: " + type + ", Switch: " + switchValue);
-            
+
+            if (type == VOICE_ACTIVITY_DETECTION_SWITCH_TYPE) {
+                Log.i(TAG, "📦 VAD switch status - enabled: " + (switchValue == 1));
+            } else {
+                Log.i(TAG, "📦 Switch status - Type: " + type + ", Switch: " + switchValue);
+            }
+
             // Send switch status over BLE
             sendSwitchStatusOverBle(type, switchValue);
         } else {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/smartglasses/K900ProtocolUtils.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/smartglasses/K900ProtocolUtils.java
@@ -328,7 +328,16 @@ public class K900ProtocolUtils {
             if (json.has(FIELD_C) && json.has(FIELD_V) && json.has(FIELD_B)) {
                 return true;
             }
-            
+
+            // Native K900 command envelope (cs_*, sr_*): C is a command name, not embedded JSON.
+            // B may be omitted when tunneled phone→MTK; must not run formatMessageForTransmission.
+            if (json.has(FIELD_C) && json.has(FIELD_V)) {
+                String command = json.optString(FIELD_C, "");
+                if (!command.isEmpty() && !command.startsWith("{")) {
+                    return true;
+                }
+            }
+
             return false;
         } catch (JSONException e) {
             return false;

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -253,7 +253,7 @@ await BluetoothSdk.rgbLedControl(
 )
 ```
 
-`setMicState(true)` defaults to continuous microphone PCM from the glasses. The SDK does not apply phone-side Voice Activity Detection gating to microphone audio events. Use `setVoiceActivityDetectionEnabled(false)` when you want glasses-side Voice Activity Detection disabled for continuous external STT, recording, or playback. `voice_activity_detection_status` reports whether glasses-side Voice Activity Detection is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone events include the latest `voiceActivityDetectionEnabled` value.
+`setMicState(true)` defaults to continuous microphone PCM from the glasses. The SDK does not apply phone-side Voice Activity Detection gating to microphone audio events. Use `setVoiceActivityDetectionEnabled(false)` when you want glasses-side Voice Activity Detection disabled for continuous external STT, recording, or playback (Mentra Live sends K900 `cs_swit` type 8). Use `queryVoiceActivityDetectionEnabled()` to read the current switch state (K900 `cs_swst`; responses arrive as `voice_activity_detection_status` and/or `switch_status` with type 8). `voice_activity_detection_status` reports whether glasses-side Voice Activity Detection is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone events include the latest `voiceActivityDetectionEnabled` value.
 
 ## Photo Upload
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -366,6 +366,10 @@ class BluetoothSdkModule : Module() {
             sdk?.setVoiceActivityDetectionEnabled(enabled)
         }
 
+        AsyncFunction("queryVoiceActivityDetectionEnabled") {
+            sdk?.queryVoiceActivityDetectionEnabled()
+        }
+
         AsyncFunction("queryGalleryStatus") { sdk?.queryGalleryStatus() }
 
         AsyncFunction("requestPhoto") { params: Map<String, Any?> ->

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1237,6 +1237,11 @@ class DeviceManager {
         sgc?.queryGalleryStatus()
     }
 
+    fun queryVoiceActivityDetectionEnabled() {
+        Bridge.log("MAN: Querying Voice Activity Detection switch state from glasses")
+        sgc?.queryVoiceActivityDetectionEnabled()
+    }
+
     /**
      * Send OTA start command to glasses. Called when user approves an update (onboarding or
      * background mode). Triggers glasses to begin download and installation.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -316,6 +316,10 @@ class MentraBluetoothSdk private constructor(
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "voice_activity_detection_enabled", enabled)
     }
 
+    fun queryVoiceActivityDetectionEnabled() {
+        deviceManager.queryVoiceActivityDetectionEnabled()
+    }
+
     fun setButtonPhotoSettings(size: ButtonPhotoSize) {
         DeviceStore.apply(ObservableStore.BLUETOOTH_CATEGORY, "button_photo_size", size.value)
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -1443,6 +1443,9 @@ public class MentraLive extends SGCManager {
 
             if (isRxCharacteristic) {
                 Bridge.log("LIVE: Received data on RX characteristic");
+                // #region agent log [810da2] Hypothesis A+C: capture data.length vs negotiated MTU
+                Bridge.log("LIVE: [DEBUG-810da2-HypAC] RX dataLen=" + data.length + " mtu=" + currentMtu + " firstByte=0x" + String.format("%02X", data[0]) + " second=0x" + (data.length > 1 ? String.format("%02X", data[1]) : "??"));
+                // #endregion
             } else if (isTxCharacteristic) {
                 Bridge.log("LIVE: Received data on TX characteristic");
             } else if (isLc3ReadCharacteristic) {
@@ -2199,6 +2202,10 @@ public class MentraLive extends SGCManager {
                 processJsonMessage(json);
             } else {
                 Log.w(TAG, "Thread-" + threadId + ": Failed to parse K900 protocol data");
+                // #region agent log [810da2] Hypothesis A+B: log header-declared length vs actual data length
+                int declaredPayloadLen = (data.length >= 5) ? (((data[3] & 0xFF) << 8) | (data[4] & 0xFF)) : -1;
+                Bridge.log("LIVE: [DEBUG-810da2-HypAB] K900 PARSE FAILED thread=" + threadId + " dataLen=" + data.length + " mtu=" + currentMtu + " declaredPayloadLen=" + declaredPayloadLen + " expectedTotal=" + (declaredPayloadLen + 7));
+                // #endregion
             }
 
             return; // Exit after processing K900 protocol format
@@ -3225,31 +3232,16 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
-            case "sr_swst":
             case "sr_swit":
                 try {
                     JSONObject bodyObj = optK900Body(json);
                     if (bodyObj != null) {
                         int type = bodyObj.optInt("type", -1);
                         int value = bodyObj.optInt("switch", -1);
-                        if (type == -1 && bodyObj.has("status")) {
-                            Log.w(
-                                    TAG,
-                                    "RX "
-                                            + command
-                                            + " firmware status body (not type/switch): "
-                                            + bodyObj
-                                            + " full="
-                                            + json);
-                        }
-                        if (type != -1) {
-                            handleSwitchStatus(type, value, System.currentTimeMillis());
-                        }
-                    } else {
-                        Log.w(TAG, "RX " + command + " with no parseable B field: " + json);
+                        handleSwitchStatus(type, value, System.currentTimeMillis());
                     }
                 } catch (Exception e) {
-                    Log.e(TAG, "Error parsing " + command + " response", e);
+                    Log.e(TAG, "Error parsing sr_swit response", e);
                 }
                 break;
 
@@ -3350,11 +3342,6 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
-            case "cs_swst":
-            case "cs_swit":
-                // Echo of our own TX (e.g. MTK forward loopback); not a glasses response.
-                break;
-
             default:
                 Log.d(TAG, "Unknown K900 command: " + command);
 
@@ -3364,15 +3351,6 @@ public class MentraLive extends SGCManager {
                 try {
                     // Try to parse the "C" field as JSON
                     JSONObject innerJson = new JSONObject(command);
-
-                    // Nested K900 JSON (double C-wrap from glasses MTK forward path)
-                    if (innerJson.has("C") && innerJson.optString("C", "").length() > 0) {
-                        String innerCommand = innerJson.optString("C", "");
-                        if (!innerCommand.startsWith("{")) {
-                            processK900JsonMessage(innerJson);
-                            return;
-                        }
-                    }
 
                     // If it has a "type" field, it's a standard message that got C-wrapped
                     if (innerJson.has("type")) {
@@ -5000,7 +4978,7 @@ public class MentraLive extends SGCManager {
             String jsonStr = cmd.toString();
             Bridge.log("LIVE: Sending hrt command: " + jsonStr);
             byte[] packedData = K900ProtocolUtils.packDataToK900(jsonStr.getBytes(StandardCharsets.UTF_8), K900ProtocolUtils.CMD_TYPE_STRING);
-
+            
             queueData(packedData);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating enable_custom_audio_tx command", e);
@@ -6582,43 +6560,12 @@ public class MentraLive extends SGCManager {
         sendVoiceActivityDetectionSetting();
     }
 
-    /** Logcat (tag Live): {@code adb logcat -s Live:I} */
-    /**
-     * Send a native K900 client command (cs_*) to glasses. Uses packDataToK900 on the full
-     * {"C","V","B"} envelope — never packJsonToK900, which is only for Mentra app JSON.
-     */
-    private boolean sendK900ClientCommand(String command, String bodyJson) {
-        if (!isConnected) {
-            Log.w(TAG, "TX K900 " + command + " skipped - not connected");
-            return false;
-        }
-        try {
-            JSONObject cmdObject = new JSONObject();
-            cmdObject.put("C", command);
-            cmdObject.put("V", 1);
-            cmdObject.put("B", bodyJson != null ? bodyJson : "");
-
-            String jsonStr = cmdObject.toString();
-            byte[] packedData =
-                    K900ProtocolUtils.packDataToK900(
-                            jsonStr.getBytes(StandardCharsets.UTF_8),
-                            K900ProtocolUtils.CMD_TYPE_STRING);
-            if (packedData == null) {
-                Log.e(TAG, "TX K900 " + command + " failed - pack returned null");
-                return false;
-            }
-            queueData(packedData);
-            return true;
-        } catch (JSONException e) {
-            Log.e(TAG, "Error creating K900 client command " + command, e);
-            return false;
-        }
-    }
-
     @Override
     public void sendVoiceActivityDetectionSetting() {
         Object value = DeviceStore.INSTANCE.get("bluetooth", "voice_activity_detection_enabled");
         boolean enabled = value instanceof Boolean ? (Boolean) value : true;
+
+        Bridge.log("LIVE: 🎤 Sending Voice Activity Detection setting to glasses: " + enabled);
 
         if (!isConnected) {
             Bridge.log("LIVE: Cannot send Voice Activity Detection setting - not connected");
@@ -6630,10 +6577,20 @@ public class MentraLive extends SGCManager {
             body.put("type", VOICE_ACTIVITY_DETECTION_SWITCH_TYPE);
             body.put("switch", enabled ? 1 : 0);
 
-            if (!sendK900ClientCommand("cs_swit", body.toString())) {
-                Bridge.log("LIVE: Failed to send Voice Activity Detection setting command");
+            JSONObject cmdObject = new JSONObject();
+            cmdObject.put("C", "cs_swit");
+            cmdObject.put("V", 1);
+            cmdObject.put("B", body.toString());
+
+            byte[] packedData =
+                    K900ProtocolUtils.packDataToK900(
+                            cmdObject.toString().getBytes(StandardCharsets.UTF_8),
+                            K900ProtocolUtils.CMD_TYPE_STRING);
+            if (packedData == null) {
+                Bridge.log("LIVE: Failed to pack Voice Activity Detection setting command");
                 return;
             }
+            queueData(packedData);
             Bridge.sendVoiceActivityDetectionStatus(enabled);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating Voice Activity Detection setting command", e);
@@ -6647,13 +6604,8 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        try {
-            if (!sendK900ClientCommand("cs_swst", "")) {
-                Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
-                return;
-            }
-        } catch (JSONException e) {
-            Log.e(TAG, "Error creating cs_swst command", e);
+        if (!sendK900ClientCommand("cs_swst", "")) {
+            Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -1443,9 +1443,6 @@ public class MentraLive extends SGCManager {
 
             if (isRxCharacteristic) {
                 Bridge.log("LIVE: Received data on RX characteristic");
-                // #region agent log [810da2] Hypothesis A+C: capture data.length vs negotiated MTU
-                Bridge.log("LIVE: [DEBUG-810da2-HypAC] RX dataLen=" + data.length + " mtu=" + currentMtu + " firstByte=0x" + String.format("%02X", data[0]) + " second=0x" + (data.length > 1 ? String.format("%02X", data[1]) : "??"));
-                // #endregion
             } else if (isTxCharacteristic) {
                 Bridge.log("LIVE: Received data on TX characteristic");
             } else if (isLc3ReadCharacteristic) {
@@ -2202,10 +2199,6 @@ public class MentraLive extends SGCManager {
                 processJsonMessage(json);
             } else {
                 Log.w(TAG, "Thread-" + threadId + ": Failed to parse K900 protocol data");
-                // #region agent log [810da2] Hypothesis A+B: log header-declared length vs actual data length
-                int declaredPayloadLen = (data.length >= 5) ? (((data[3] & 0xFF) << 8) | (data[4] & 0xFF)) : -1;
-                Bridge.log("LIVE: [DEBUG-810da2-HypAB] K900 PARSE FAILED thread=" + threadId + " dataLen=" + data.length + " mtu=" + currentMtu + " declaredPayloadLen=" + declaredPayloadLen + " expectedTotal=" + (declaredPayloadLen + 7));
-                // #endregion
             }
 
             return; // Exit after processing K900 protocol format
@@ -3232,16 +3225,31 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
+            case "sr_swst":
             case "sr_swit":
                 try {
                     JSONObject bodyObj = optK900Body(json);
                     if (bodyObj != null) {
                         int type = bodyObj.optInt("type", -1);
                         int value = bodyObj.optInt("switch", -1);
-                        handleSwitchStatus(type, value, System.currentTimeMillis());
+                        if (type == -1 && bodyObj.has("status")) {
+                            Log.w(
+                                    TAG,
+                                    "RX "
+                                            + command
+                                            + " firmware status body (not type/switch): "
+                                            + bodyObj
+                                            + " full="
+                                            + json);
+                        }
+                        if (type != -1) {
+                            handleSwitchStatus(type, value, System.currentTimeMillis());
+                        }
+                    } else {
+                        Log.w(TAG, "RX " + command + " with no parseable B field: " + json);
                     }
                 } catch (Exception e) {
-                    Log.e(TAG, "Error parsing sr_swit response", e);
+                    Log.e(TAG, "Error parsing " + command + " response", e);
                 }
                 break;
 
@@ -3342,6 +3350,11 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
+            case "cs_swst":
+            case "cs_swit":
+                // Echo of our own TX (e.g. MTK forward loopback); not a glasses response.
+                break;
+
             default:
                 Log.d(TAG, "Unknown K900 command: " + command);
 
@@ -3351,6 +3364,15 @@ public class MentraLive extends SGCManager {
                 try {
                     // Try to parse the "C" field as JSON
                     JSONObject innerJson = new JSONObject(command);
+
+                    // Nested K900 JSON (double C-wrap from glasses MTK forward path)
+                    if (innerJson.has("C") && innerJson.optString("C", "").length() > 0) {
+                        String innerCommand = innerJson.optString("C", "");
+                        if (!innerCommand.startsWith("{")) {
+                            processK900JsonMessage(innerJson);
+                            return;
+                        }
+                    }
 
                     // If it has a "type" field, it's a standard message that got C-wrapped
                     if (innerJson.has("type")) {
@@ -4978,7 +5000,7 @@ public class MentraLive extends SGCManager {
             String jsonStr = cmd.toString();
             Bridge.log("LIVE: Sending hrt command: " + jsonStr);
             byte[] packedData = K900ProtocolUtils.packDataToK900(jsonStr.getBytes(StandardCharsets.UTF_8), K900ProtocolUtils.CMD_TYPE_STRING);
-            
+
             queueData(packedData);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating enable_custom_audio_tx command", e);
@@ -6560,12 +6582,43 @@ public class MentraLive extends SGCManager {
         sendVoiceActivityDetectionSetting();
     }
 
+    /** Logcat (tag Live): {@code adb logcat -s Live:I} */
+    /**
+     * Send a native K900 client command (cs_*) to glasses. Uses packDataToK900 on the full
+     * {"C","V","B"} envelope — never packJsonToK900, which is only for Mentra app JSON.
+     */
+    private boolean sendK900ClientCommand(String command, String bodyJson) {
+        if (!isConnected) {
+            Log.w(TAG, "TX K900 " + command + " skipped - not connected");
+            return false;
+        }
+        try {
+            JSONObject cmdObject = new JSONObject();
+            cmdObject.put("C", command);
+            cmdObject.put("V", 1);
+            cmdObject.put("B", bodyJson != null ? bodyJson : "");
+
+            String jsonStr = cmdObject.toString();
+            byte[] packedData =
+                    K900ProtocolUtils.packDataToK900(
+                            jsonStr.getBytes(StandardCharsets.UTF_8),
+                            K900ProtocolUtils.CMD_TYPE_STRING);
+            if (packedData == null) {
+                Log.e(TAG, "TX K900 " + command + " failed - pack returned null");
+                return false;
+            }
+            queueData(packedData);
+            return true;
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating K900 client command " + command, e);
+            return false;
+        }
+    }
+
     @Override
     public void sendVoiceActivityDetectionSetting() {
         Object value = DeviceStore.INSTANCE.get("bluetooth", "voice_activity_detection_enabled");
         boolean enabled = value instanceof Boolean ? (Boolean) value : true;
-
-        Bridge.log("LIVE: 🎤 Sending Voice Activity Detection setting to glasses: " + enabled);
 
         if (!isConnected) {
             Bridge.log("LIVE: Cannot send Voice Activity Detection setting - not connected");
@@ -6577,23 +6630,30 @@ public class MentraLive extends SGCManager {
             body.put("type", VOICE_ACTIVITY_DETECTION_SWITCH_TYPE);
             body.put("switch", enabled ? 1 : 0);
 
-            JSONObject cmdObject = new JSONObject();
-            cmdObject.put("C", "cs_swit");
-            cmdObject.put("V", 1);
-            cmdObject.put("B", body.toString());
-
-            byte[] packedData =
-                    K900ProtocolUtils.packDataToK900(
-                            cmdObject.toString().getBytes(StandardCharsets.UTF_8),
-                            K900ProtocolUtils.CMD_TYPE_STRING);
-            if (packedData == null) {
-                Bridge.log("LIVE: Failed to pack Voice Activity Detection setting command");
+            if (!sendK900ClientCommand("cs_swit", body.toString())) {
+                Bridge.log("LIVE: Failed to send Voice Activity Detection setting command");
                 return;
             }
-            queueData(packedData);
             Bridge.sendVoiceActivityDetectionStatus(enabled);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating Voice Activity Detection setting command", e);
+        }
+    }
+
+    @Override
+    public void queryVoiceActivityDetectionEnabled() {
+        if (!isConnected) {
+            Bridge.log("LIVE: Cannot query Voice Activity Detection - not connected");
+            return;
+        }
+
+        try {
+            if (!sendK900ClientCommand("cs_swst", "")) {
+                Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
+                return;
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating cs_swst command", e);
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -6647,13 +6647,8 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        try {
-            if (!sendK900ClientCommand("cs_swst", "")) {
-                Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
-                return;
-            }
-        } catch (JSONException e) {
-            Log.e(TAG, "Error creating cs_swst command", e);
+        if (!sendK900ClientCommand("cs_swst", "")) {
+            Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -1443,9 +1443,6 @@ public class MentraLive extends SGCManager {
 
             if (isRxCharacteristic) {
                 Bridge.log("LIVE: Received data on RX characteristic");
-                // #region agent log [810da2] Hypothesis A+C: capture data.length vs negotiated MTU
-                Bridge.log("LIVE: [DEBUG-810da2-HypAC] RX dataLen=" + data.length + " mtu=" + currentMtu + " firstByte=0x" + String.format("%02X", data[0]) + " second=0x" + (data.length > 1 ? String.format("%02X", data[1]) : "??"));
-                // #endregion
             } else if (isTxCharacteristic) {
                 Bridge.log("LIVE: Received data on TX characteristic");
             } else if (isLc3ReadCharacteristic) {
@@ -2202,10 +2199,6 @@ public class MentraLive extends SGCManager {
                 processJsonMessage(json);
             } else {
                 Log.w(TAG, "Thread-" + threadId + ": Failed to parse K900 protocol data");
-                // #region agent log [810da2] Hypothesis A+B: log header-declared length vs actual data length
-                int declaredPayloadLen = (data.length >= 5) ? (((data[3] & 0xFF) << 8) | (data[4] & 0xFF)) : -1;
-                Bridge.log("LIVE: [DEBUG-810da2-HypAB] K900 PARSE FAILED thread=" + threadId + " dataLen=" + data.length + " mtu=" + currentMtu + " declaredPayloadLen=" + declaredPayloadLen + " expectedTotal=" + (declaredPayloadLen + 7));
-                // #endregion
             }
 
             return; // Exit after processing K900 protocol format
@@ -3232,16 +3225,31 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
+            case "sr_swst":
             case "sr_swit":
                 try {
                     JSONObject bodyObj = optK900Body(json);
                     if (bodyObj != null) {
                         int type = bodyObj.optInt("type", -1);
                         int value = bodyObj.optInt("switch", -1);
-                        handleSwitchStatus(type, value, System.currentTimeMillis());
+                        if (type == -1 && bodyObj.has("status")) {
+                            Log.w(
+                                    TAG,
+                                    "RX "
+                                            + command
+                                            + " firmware status body (not type/switch): "
+                                            + bodyObj
+                                            + " full="
+                                            + json);
+                        }
+                        if (type != -1) {
+                            handleSwitchStatus(type, value, System.currentTimeMillis());
+                        }
+                    } else {
+                        Log.w(TAG, "RX " + command + " with no parseable B field: " + json);
                     }
                 } catch (Exception e) {
-                    Log.e(TAG, "Error parsing sr_swit response", e);
+                    Log.e(TAG, "Error parsing " + command + " response", e);
                 }
                 break;
 
@@ -3342,6 +3350,11 @@ public class MentraLive extends SGCManager {
                 }
                 break;
 
+            case "cs_swst":
+            case "cs_swit":
+                // Echo of our own TX (e.g. MTK forward loopback); not a glasses response.
+                break;
+
             default:
                 Log.d(TAG, "Unknown K900 command: " + command);
 
@@ -3351,6 +3364,15 @@ public class MentraLive extends SGCManager {
                 try {
                     // Try to parse the "C" field as JSON
                     JSONObject innerJson = new JSONObject(command);
+
+                    // Nested K900 JSON (double C-wrap from glasses MTK forward path)
+                    if (innerJson.has("C") && innerJson.optString("C", "").length() > 0) {
+                        String innerCommand = innerJson.optString("C", "");
+                        if (!innerCommand.startsWith("{")) {
+                            processK900JsonMessage(innerJson);
+                            return;
+                        }
+                    }
 
                     // If it has a "type" field, it's a standard message that got C-wrapped
                     if (innerJson.has("type")) {
@@ -4978,7 +5000,7 @@ public class MentraLive extends SGCManager {
             String jsonStr = cmd.toString();
             Bridge.log("LIVE: Sending hrt command: " + jsonStr);
             byte[] packedData = K900ProtocolUtils.packDataToK900(jsonStr.getBytes(StandardCharsets.UTF_8), K900ProtocolUtils.CMD_TYPE_STRING);
-            
+
             queueData(packedData);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating enable_custom_audio_tx command", e);
@@ -6560,12 +6582,43 @@ public class MentraLive extends SGCManager {
         sendVoiceActivityDetectionSetting();
     }
 
+    /** Logcat (tag Live): {@code adb logcat -s Live:I} */
+    /**
+     * Send a native K900 client command (cs_*) to glasses. Uses packDataToK900 on the full
+     * {"C","V","B"} envelope — never packJsonToK900, which is only for Mentra app JSON.
+     */
+    private boolean sendK900ClientCommand(String command, String bodyJson) {
+        if (!isConnected) {
+            Log.w(TAG, "TX K900 " + command + " skipped - not connected");
+            return false;
+        }
+        try {
+            JSONObject cmdObject = new JSONObject();
+            cmdObject.put("C", command);
+            cmdObject.put("V", 1);
+            cmdObject.put("B", bodyJson != null ? bodyJson : "");
+
+            String jsonStr = cmdObject.toString();
+            byte[] packedData =
+                    K900ProtocolUtils.packDataToK900(
+                            jsonStr.getBytes(StandardCharsets.UTF_8),
+                            K900ProtocolUtils.CMD_TYPE_STRING);
+            if (packedData == null) {
+                Log.e(TAG, "TX K900 " + command + " failed - pack returned null");
+                return false;
+            }
+            queueData(packedData);
+            return true;
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating K900 client command " + command, e);
+            return false;
+        }
+    }
+
     @Override
     public void sendVoiceActivityDetectionSetting() {
         Object value = DeviceStore.INSTANCE.get("bluetooth", "voice_activity_detection_enabled");
         boolean enabled = value instanceof Boolean ? (Boolean) value : true;
-
-        Bridge.log("LIVE: 🎤 Sending Voice Activity Detection setting to glasses: " + enabled);
 
         if (!isConnected) {
             Bridge.log("LIVE: Cannot send Voice Activity Detection setting - not connected");
@@ -6577,20 +6630,10 @@ public class MentraLive extends SGCManager {
             body.put("type", VOICE_ACTIVITY_DETECTION_SWITCH_TYPE);
             body.put("switch", enabled ? 1 : 0);
 
-            JSONObject cmdObject = new JSONObject();
-            cmdObject.put("C", "cs_swit");
-            cmdObject.put("V", 1);
-            cmdObject.put("B", body.toString());
-
-            byte[] packedData =
-                    K900ProtocolUtils.packDataToK900(
-                            cmdObject.toString().getBytes(StandardCharsets.UTF_8),
-                            K900ProtocolUtils.CMD_TYPE_STRING);
-            if (packedData == null) {
-                Bridge.log("LIVE: Failed to pack Voice Activity Detection setting command");
+            if (!sendK900ClientCommand("cs_swit", body.toString())) {
+                Bridge.log("LIVE: Failed to send Voice Activity Detection setting command");
                 return;
             }
-            queueData(packedData);
             Bridge.sendVoiceActivityDetectionStatus(enabled);
         } catch (JSONException e) {
             Log.e(TAG, "Error creating Voice Activity Detection setting command", e);
@@ -6604,8 +6647,13 @@ public class MentraLive extends SGCManager {
             return;
         }
 
-        if (!sendK900ClientCommand("cs_swst", "")) {
-            Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
+        try {
+            if (!sendK900ClientCommand("cs_swst", "")) {
+                Bridge.log("LIVE: Failed to send Voice Activity Detection query command");
+                return;
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating cs_swst command", e);
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -113,6 +113,8 @@ abstract class SGCManager {
     // Voice Activity Detection
     open fun sendVoiceActivityDetectionSetting() {}
 
+    open fun queryVoiceActivityDetectionEnabled() {}
+
     // Version info
     abstract fun requestVersionInfo()
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -112,7 +112,6 @@ abstract class SGCManager {
 
     // Voice Activity Detection
     open fun sendVoiceActivityDetectionSetting() {}
-
     open fun queryVoiceActivityDetectionEnabled() {}
 
     // Version info

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
@@ -293,6 +293,14 @@ public class K900ProtocolUtils {
                 return true;
             }
 
+            // Native K900 command name in C (not Mentra JSON embedded in C)
+            if (json.has(FIELD_C) && json.has(FIELD_V)) {
+                String command = json.optString(FIELD_C, "");
+                if (!command.isEmpty() && !command.startsWith("{")) {
+                    return true;
+                }
+            }
+
             return false;
         } catch (JSONException e) {
             return false;
@@ -431,15 +439,24 @@ public class K900ProtocolUtils {
             // Check if this is C-wrapped format {"C": "..."}
             if (json.has(FIELD_C)) {
                 String innerContent = json.optString(FIELD_C, "");
-                android.util.Log.d("K900ProtocolUtils", "Detected C-wrapped format, inner content: " + innerContent);
 
-                // Try to parse the inner content as JSON
+                // Mentra app JSON-in-C: C holds a JSON object string. Native K900: C is cs_*/sr_* name.
+                if (!innerContent.startsWith("{")) {
+                    android.util.Log.d(
+                            "K900ProtocolUtils",
+                            "Native K900 envelope (C=" + innerContent + "), not unwrapping");
+                    return json;
+                }
+
+                android.util.Log.d("K900ProtocolUtils", "Detected JSON-in-C wrap, inner: " + innerContent);
+
                 try {
                     JSONObject innerJson = new JSONObject(innerContent);
                     return innerJson;
                 } catch (JSONException e) {
-                    android.util.Log.d("K900ProtocolUtils", "Inner content is not JSON, returning outer JSON object");
-                    // If inner content is not JSON, return the outer JSON
+                    android.util.Log.d(
+                            "K900ProtocolUtils",
+                            "Inner content is not JSON, returning outer: " + payloadStr);
                     return json;
                 }
             } else {

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -302,6 +302,12 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
             try await sdk.setVoiceActivityDetectionEnabled(enabled)
         }
 
+        AsyncFunction("queryVoiceActivityDetectionEnabled") {
+            await MainActor.run {
+                self.bluetoothSdk().queryVoiceActivityDetectionEnabled()
+            }
+        }
+
         AsyncFunction("queryGalleryStatus") {
             await MainActor.run {
                 self.bluetoothSdk().queryGalleryStatus()

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1080,6 +1080,11 @@ struct ViewState {
         sgc?.queryGalleryStatus()
     }
 
+    func queryVoiceActivityDetectionEnabled() {
+        Bridge.log("MAN: Querying Voice Activity Detection switch state from glasses")
+        sgc?.queryVoiceActivityDetectionEnabled()
+    }
+
     /// Send OTA start command to glasses.
     /// Called when user approves an update (onboarding or background mode).
     /// Triggers glasses to begin download and installation.

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -276,6 +276,10 @@ public final class MentraBluetoothSDK {
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "voice_activity_detection_enabled", enabled)
     }
 
+    public func queryVoiceActivityDetectionEnabled() {
+        DeviceManager.shared.queryVoiceActivityDetectionEnabled()
+    }
+
     public func setButtonPhotoSettings(size: ButtonPhotoSize) async throws {
         DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "button_photo_size", size.rawValue)
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2267,7 +2267,7 @@ class MentraLive: NSObject, SGCManager {
                 handleSpeakingStatus(speaking: on == 1)
             }
 
-        case "sr_swit":
+        case "sr_swst", "sr_swit":
             if let body = k900ParseBody(json["B"]) {
                 let switchType = k900JsonInt(body, "type") ?? -1
                 let switchValue = k900JsonInt(body, "switch") ?? -1
@@ -4561,7 +4561,6 @@ extension MentraLive {
 
     func sendVoiceActivityDetectionSetting() {
         let enabled = DeviceStore.shared.get("bluetooth", "voice_activity_detection_enabled") as? Bool ?? true
-        Bridge.log("LIVE: 🎤 Sending Voice Activity Detection setting to glasses: \(enabled)")
 
         guard connectedPeripheral != nil, txCharacteristic != nil else {
             Bridge.log("Cannot send Voice Activity Detection setting - BLE write path not ready")
@@ -4589,6 +4588,22 @@ extension MentraLive {
             }
         } catch {
             Bridge.log("LIVE: Error encoding Voice Activity Detection payload: \(error)")
+        }
+    }
+
+    func queryVoiceActivityDetectionEnabled() {
+        guard connectedPeripheral != nil, txCharacteristic != nil else {
+            Bridge.log("Cannot query Voice Activity Detection - BLE write path not ready")
+            return
+        }
+
+        let command: [String: Any] = [
+            "C": "cs_swst",
+            "V": 1,
+            "B": "",
+        ]
+        if !sendRawK900Command(command, wakeUp: true) {
+            Bridge.log("LIVE: Failed to send Voice Activity Detection query command")
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -107,6 +107,8 @@ protocol SGCManager {
 
     func sendVoiceActivityDetectionSetting()
 
+    func queryVoiceActivityDetectionEnabled()
+
     // MARK: - Version Info
 
     func requestVersionInfo()
@@ -134,6 +136,8 @@ extension SGCManager {
     // MARK: - Voice Activity Detection (default no-op — Mentra Live supports this)
 
     func sendVoiceActivityDetectionSetting() {}
+
+    func queryVoiceActivityDetectionEnabled() {}
 
     // MARK: - Default DeviceStore-backed property implementations
 

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -602,6 +602,8 @@ export interface BluetoothSdkPublicModule {
 
   setGalleryModeEnabled(enabled: boolean): Promise<void>
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
+  /** Mentra Live only: K900 `cs_swst`; listen for `voice_activity_detection_status` / `switch_status` (type 8). */
+  queryVoiceActivityDetectionEnabled(): Promise<void>
   setButtonPhotoSettings(size: ButtonPhotoSize): Promise<void>
   setButtonVideoRecordingSettings(width: number, height: number, fps: number): Promise<void>
   setButtonCameraLed(enabled: boolean): Promise<void>

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -96,6 +96,7 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   // Gallery Commands
   setGalleryModeEnabled(enabled: boolean): Promise<void>
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
+  queryVoiceActivityDetectionEnabled(): Promise<void>
   setButtonPhotoSettings(size: ButtonPhotoSize): Promise<void>
   setButtonVideoRecordingSettings(width: number, height: number, fps: number): Promise<void>
   setButtonCameraLed(enabled: boolean): Promise<void>
@@ -350,6 +351,28 @@ NativeBluetoothSdkModule.setGalleryModeEnabled = function (enabled: boolean) {
 
 NativeBluetoothSdkModule.setVoiceActivityDetectionEnabled = function (enabled: boolean) {
   return this.updateBluetoothSettings({voice_activity_detection_enabled: enabled})
+}
+
+type NativeQueryVadSwitchState = () => Promise<void>
+
+const nativeQueryVoiceActivityDetectionEnabled =
+  typeof NativeBluetoothSdkModule.queryVoiceActivityDetectionEnabled === "function"
+    ? NativeBluetoothSdkModule.queryVoiceActivityDetectionEnabled.bind(NativeBluetoothSdkModule)
+    : typeof (NativeBluetoothSdkModule as {queryVadSwitchState?: NativeQueryVadSwitchState}).queryVadSwitchState ===
+        "function"
+      ? (NativeBluetoothSdkModule as {queryVadSwitchState: NativeQueryVadSwitchState}).queryVadSwitchState.bind(
+          NativeBluetoothSdkModule,
+        )
+      : undefined
+
+NativeBluetoothSdkModule.queryVoiceActivityDetectionEnabled = function () {
+  if (nativeQueryVoiceActivityDetectionEnabled) {
+    return nativeQueryVoiceActivityDetectionEnabled()
+  }
+  console.warn(
+    "[@mentra/bluetooth-sdk] queryVoiceActivityDetectionEnabled is unavailable. Rebuild the native app (expo prebuild && expo run:android).",
+  )
+  return Promise.resolve()
 }
 
 NativeBluetoothSdkModule.setButtonPhotoSettings = function (size: ButtonPhotoSize) {

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -73,6 +73,9 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
   setHotspotState: PrivateBluetoothSdkModule.setHotspotState.bind(PrivateBluetoothSdkModule),
   setGalleryModeEnabled: PrivateBluetoothSdkModule.setGalleryModeEnabled.bind(PrivateBluetoothSdkModule),
   setVoiceActivityDetectionEnabled: PrivateBluetoothSdkModule.setVoiceActivityDetectionEnabled.bind(PrivateBluetoothSdkModule),
+  queryVoiceActivityDetectionEnabled: PrivateBluetoothSdkModule.queryVoiceActivityDetectionEnabled.bind(
+    PrivateBluetoothSdkModule,
+  ),
   setButtonPhotoSettings: PrivateBluetoothSdkModule.setButtonPhotoSettings.bind(PrivateBluetoothSdkModule),
   setButtonVideoRecordingSettings: PrivateBluetoothSdkModule.setButtonVideoRecordingSettings.bind(PrivateBluetoothSdkModule),
   setButtonCameraLed: PrivateBluetoothSdkModule.setButtonCameraLed.bind(PrivateBluetoothSdkModule),

--- a/mobile/modules/bluetooth-sdk/src/react/useMentraBluetooth.ts
+++ b/mobile/modules/bluetooth-sdk/src/react/useMentraBluetooth.ts
@@ -136,6 +136,7 @@ export type MentraBluetoothSession = {
   setDefaultDevice: (device: Device | null) => Promise<void>
   setGalleryModeEnabled: (enabled: boolean) => Promise<void>
   setVoiceActivityDetectionEnabled: (enabled: boolean) => Promise<void>
+  queryVoiceActivityDetectionEnabled: () => Promise<void>
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -294,6 +295,15 @@ export function useMentraBluetooth(options: UseMentraBluetoothOptions = {}): Men
     }
   }
 
+  async function queryVoiceActivityDetectionEnabled() {
+    try {
+      await BluetoothSdk.queryVoiceActivityDetectionEnabled()
+    } catch (error) {
+      options.onError?.(error)
+      throw error
+    }
+  }
+
   const galleryMode: GalleryModeState = {
     applying: galleryModeApplying,
     enabled: connection.bluetoothStatus.galleryModeEnabled !== false,
@@ -315,5 +325,6 @@ export function useMentraBluetooth(options: UseMentraBluetoothOptions = {}): Men
     setDefaultDevice: connection.setDefaultDevice,
     setGalleryModeEnabled,
     setVoiceActivityDetectionEnabled,
+    queryVoiceActivityDetectionEnabled,
   }
 }


### PR DESCRIPTION
## Summary

- Rebase `integrate-vad-bypass-1` onto `staging` with only the VAD-related commits (cherry-picked; full rebase conflicted on unrelated ASG/dev history).
- Add `queryVoiceActivityDetectionEnabled` across the Bluetooth SDK (Android, iOS, TypeScript/React).
- Improve K900 command handling and MentraLive VAD command processing on glasses.

## Test plan

- [ ] Pair Mentra Live glasses and confirm VAD state can be queried from the mobile app
- [ ] Verify `queryVoiceActivityDetectionEnabled` returns expected values on Android and iOS
- [ ] Exercise K900 VAD-related commands and confirm logging/error handling behaves as expected
- [ ] Smoke test unrelated staging flows (pairing, mic) for regressions


Made with [Cursor](https://cursor.com)