### PR TITLE
Track BLE transport state in ASG

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -114,6 +114,7 @@ public class AsgClientService extends Service
     private static AsgClientService instance;
     private boolean lastI2sPlaying = false;
     private boolean isConnected = false; // Track connection state based on heartbeat
+    private boolean isBleTransportConnected = false; // Track phone BLE datapath state reported by BES
 
     // ---------------------------------------------
     // WiFi State Management
@@ -1374,6 +1375,30 @@ public class AsgClientService extends Service
     /** Get current connection state */
     public boolean isConnected() {
         return isConnected;
+    }
+
+    /** Get current phone BLE datapath state as reported by BES. */
+    public boolean isBleTransportConnected() {
+        return isBleTransportConnected;
+    }
+
+    /** Handle phone BLE datapath state updates forwarded by BES. */
+    public void onBleTransportStateChanged(boolean connected) {
+        boolean changed = isBleTransportConnected != connected;
+        isBleTransportConnected = connected;
+
+        if (!connected) {
+            isConnected = false;
+            if (heartbeatTimeoutHandler != null && heartbeatTimeoutRunnable != null) {
+                heartbeatTimeoutHandler.removeCallbacks(heartbeatTimeoutRunnable);
+            }
+        }
+
+        Log.i(
+                TAG,
+                "🔌 BLE transport state reported by BES: "
+                        + (connected ? "CONNECTED" : "DISCONNECTED")
+                        + (changed ? "" : " (unchanged)"));
     }
 
     /** Handle the phone_ready/glasses_ready handshake completing over Bluetooth. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
@@ -144,6 +144,11 @@ public class K900CommandHandler {
                     handleBesLogPacket(bData);
                     break;
 
+                case "ble_transport_state":
+                    // Phone BLE datapath state forwarded by BES
+                    handleBleTransportState(bData);
+                    break;
+
                 case "cs_shut":
                     // BES requesting graceful shutdown - send acknowledgment and shutdown MTK
                     handleShutdownCommand();
@@ -223,6 +228,69 @@ public class K900CommandHandler {
         } else {
             Log.d(TAG, "🎤 Voice Activity Detection event received");
         }
+    }
+
+    /** Handle phone BLE datapath state reports forwarded by BES. */
+    private void handleBleTransportState(JSONObject bData) {
+        if (bData == null) {
+            Log.w(TAG, "🔌 BLE transport state received without body");
+            return;
+        }
+
+        boolean connected = optBooleanLike(bData, "connected", false);
+        int conidx = bData.optInt("conidx", -1);
+        String source = bData.optString("source", "datapath");
+        boolean heartbeatConnected = serviceManager != null && serviceManager.isConnected();
+
+        if (serviceManager != null) {
+            serviceManager.onBleTransportStateChanged(connected);
+        }
+
+        Log.i(
+                TAG,
+                "🔌 BES BLE transport state: "
+                        + (connected ? "CONNECTED" : "DISCONNECTED")
+                        + ", source="
+                        + source
+                        + ", conidx="
+                        + conidx
+                        + ", heartbeat="
+                        + (heartbeatConnected ? "CONNECTED" : "DISCONNECTED"));
+
+        try {
+            JSONObject payload = new JSONObject();
+            payload.put("connected", connected);
+            payload.put("source", source);
+            payload.put("conidx", conidx);
+            payload.put("heartbeatConnected", heartbeatConnected);
+            BleTraceLogger.logEvent(
+                    "bes_to_asg",
+                    "ble_transport_state",
+                    connected ? "connected" : "disconnected",
+                    payload);
+        } catch (JSONException e) {
+            Log.d(TAG, "BLE transport trace log failed", e);
+        }
+    }
+
+    private boolean optBooleanLike(JSONObject data, String key, boolean defaultValue) {
+        Object value = data.opt(key);
+        if (value instanceof Boolean) {
+            return (Boolean) value;
+        }
+        if (value instanceof Number) {
+            return ((Number) value).intValue() != 0;
+        }
+        if (value instanceof String) {
+            String normalized = ((String) value).trim().toLowerCase();
+            if ("true".equals(normalized) || "1".equals(normalized) || "yes".equals(normalized)) {
+                return true;
+            }
+            if ("false".equals(normalized) || "0".equals(normalized) || "no".equals(normalized)) {
+                return false;
+            }
+        }
+        return defaultValue;
     }
 
     /**
@@ -894,9 +962,7 @@ public class K900CommandHandler {
             .getAsgSettings()
             .isSaveInGalleryMode();
 
-        boolean isBluetoothConnected =
-                serviceManager.getBluetoothManager() != null
-                        && serviceManager.getBluetoothManager().isConnected();
+        boolean isBluetoothConnected = serviceManager.isBleTransportConnected();
         boolean isHeartbeatConnected = serviceManager.isConnected();
         boolean isConnected = isBluetoothConnected || isHeartbeatConnected;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -649,6 +649,24 @@ public class AsgClientServiceManager {
     }
 
     /**
+     * Get the current phone BLE datapath status reported by BES.
+     * @return true if the phone BLE datapath is connected, false otherwise
+     */
+    public boolean isBleTransportConnected() {
+        boolean connected = service.isBleTransportConnected();
+        Log.d(TAG, "🔌 BLE transport status: " + (connected ? "CONNECTED" : "DISCONNECTED"));
+        return connected;
+    }
+
+    /**
+     * Update the phone BLE datapath status reported by BES.
+     */
+    public void onBleTransportStateChanged(boolean connected) {
+        Log.d(TAG, "🔌 BLE transport state update from BES: " + (connected ? "CONNECTED" : "DISCONNECTED"));
+        service.onBleTransportStateChanged(connected);
+    }
+
+    /**
      * Mark the phone connection active after the phone_ready/glasses_ready handshake completes.
      */
     public void onPhoneReadyHandshakeComplete() {

--- a/scripts/ble-trace-pretty.mjs
+++ b/scripts/ble-trace-pretty.mjs
@@ -207,6 +207,16 @@ function summarize(trace) {
     return parts.join(' ');
   }
 
+  if (trace.layer === 'ble_transport_state') {
+    const parts = [];
+    for (const key of ['connected', 'source', 'conidx', 'heartbeatConnected']) {
+      if (trace.payload[key] != null) {
+        parts.push(`${key}=${singleLine(trace.payload[key])}`);
+      }
+    }
+    return parts.join(' ');
+  }
+
   if (
     trace.layer === 'wifi_http_output' ||
     trace.layer === 'wifi_http_input' ||


### PR DESCRIPTION
We'd want to replace the current unreliable heartbeat system by using the known BES BLE state, if available.
This is a draft of a possible ASG Client side

Handle a ble_transport_state event that would be forwarded by the BES and keep the phone BLE datapath state separate from heartbeat liveness. Use that transport bit for button photo capture gating so local fallback decisions are based on the actual phone datapath, not merely the Android serial bridge state. Also teach the MentraBleTrace pretty-printer to render the new semantic transport-state event for the log trace system.

This PR does not remove the current heartbeat system