### PR TITLE
Fix Android Linux-runner pickup + bundler version + setup-runner.sh

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -43,7 +43,10 @@ permissions:
 jobs:
   build-mobile-android:
     name: Build Mobile App (Android)
-    runs-on: self-hosted
+    # macOS-only: release-android.mjs assumes a Mac mini runner setup
+    # (per-runner git config, Mentra credentials at ~/.mentra/credentials).
+    # ASG client below stays unconstrained because it's a clean gradle build.
+    runs-on: [self-hosted, macOS, ARM64]
 
     steps:
       - name: Get cache week number
@@ -239,7 +242,15 @@ jobs:
         # Mentra-Community/match-certs, decrypts with MATCH_PASSWORD, installs
         # into the runner's login keychain. --readonly guarantees we never
         # accidentally regenerate certs from CI (only your laptop should).
-        run: bundle install && bundle exec fastlane match appstore --readonly
+        #
+        # `bundle update --bundler` retargets Gemfile.lock to whatever
+        # bundler the runner has, instead of requiring the exact 2.x.y the
+        # lockfile was generated against. Avoids "Could not find bundler
+        # (2.6.9) required by Gemfile.lock" on runners with older system Ruby.
+        run: |
+          bundle update --bundler
+          bundle install
+          bundle exec fastlane match appstore --readonly
 
       - name: Run release-ios (signed IPA + Beta_N upload + TestFlight)
         working-directory: ./mobile

--- a/mobile/scripts/setup-runner.sh
+++ b/mobile/scripts/setup-runner.sh
@@ -14,6 +14,20 @@
 #      runners — pass --runners 0 to skip runner registration entirely if
 #      you've already set them up by hand).
 #
+# Manual post-install steps (do these once after running this script):
+#   1. Copy ~/.mentra/credentials/ from an existing runner (or your laptop).
+#      Three files are required for the staging-builds workflow:
+#        - appstore-connect.env       (ASC API key id + issuer id)
+#        - AuthKey_<id>.p8             (ASC API private key)
+#        - google-play-key.json        (Play Store internal-track service acct)
+#      Auth proper to your team — these are NOT in this repo.
+#
+# What this script does NOT need to set up:
+#   - iOS signing identity / provisioning profile. The staging-builds workflow
+#     pulls the encrypted distribution cert + provisioning profile from
+#     Mentra-Community/match-certs via fastlane match on every build run, so
+#     each runner gets a fresh import per build. No per-runner Xcode bootstrap.
+#
 # Required env vars (only when registering runners):
 #   GH_RUNNER_TOKEN   - short-lived registration token from
 #                       Repo > Settings > Actions > Runners > New self-hosted runner
@@ -278,6 +292,17 @@ if ! command -v fastlane >/dev/null 2>&1; then
     gem install fastlane --no-document || sudo gem install fastlane --no-document
 fi
 
+# Required by mobile/scripts/set-build-env.mjs (called at the top of
+# release-android.mjs / release-ios.mjs). The script reads `git config
+# user.name` to label the build in the in-app debug menu. If unset,
+# release scripts crash at Step 1. Value is purely cosmetic; pick anything
+# that's safe to display in the app's debug overlay.
+if [[ -z "$(git config --global user.name 2>/dev/null)" ]]; then
+    git config --global user.name "Mentra CI"
+    git config --global user.email "ci@mentra.glass"
+    ok "Set global git identity (Mentra CI <ci@mentra.glass>)"
+fi
+
 ok "Core toolchain installed"
 
 # ---------------------------------------------------------------------------
@@ -498,5 +523,8 @@ cat <<EOF
     - System Settings > Lock Screen > Require password "Never"
     - Sign in to the Apple Developer account in Xcode (Settings > Accounts)
     - Confirm runner(s) appear at $GH_RUNNER_URL/settings/actions/runners
+    - Copy ~/.mentra/credentials/ from an existing runner (or your laptop):
+        scp ~/.mentra/credentials/{appstore-connect.env,AuthKey_*.p8,google-play-key.json} \\
+            user@$RUNNER_NAME_BASE:~/.mentra/credentials/
 ==========================================================================
 EOF


### PR DESCRIPTION
## What

Follow-up to #3021. The first post-merge staging-builds run failed for three reasons; this PR fixes all three.

## 1. Mobile Android job got picked up by a Linux runner

The build-mobile-android job had \`runs-on: self-hosted\` (no platform constraint). A Linux runner (\`actions-runner-4\` at \`/home/mentra/\`) was eligible and grabbed the job. The release-android.mjs script's \`setBuildEnv\` calls \`git config user.name\`, which only succeeds on machines where we've set the global identity. We had only done that on bob + bigbob (the Mac minis).

**Fix:** constrain to \`[self-hosted, macOS, ARM64]\`. Matches the iOS job's existing constraint. ASG stays bare because it's a clean gradle build that runs fine on either OS.

## 2. Match step failed with bundler version mismatch

\`Gemfile.lock\` was generated on a developer laptop with bundler 2.6.9. The runner's system bundler is older and refused to honor a Gemfile.lock pinned to 2.6.9: \`Could not find 'bundler' (2.6.9)\`.

**Fix:** add \`bundle update --bundler\` before \`bundle install\` in the match step. Retargets the lockfile to whatever bundler version the runner has.

## 3. setup-runner.sh missing two things needed for fresh runners

- No global git identity → \`setBuildEnv\` crashes
- No mention of credential copying

**Fix:** script now sets \`git config --global user.name "Mentra CI"\` + email if unset (only if unset — preserves whatever existing runners have), and documents the credential scp step in the "next steps" footer. Also adds a comment explaining why no Xcode bootstrap is needed (match handles it per-build).

## Test plan

- [ ] Merge → next staging push triggers workflow
- [ ] Confirm Android job runs on bob or bigbob (not actions-runner-4)
- [ ] Confirm iOS match step gets past \`bundle install\`
- [ ] Confirm full pipeline produces APK + IPA artifacts, and TestFlight + Play uploads work

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes staging mobile builds by forcing the Android job onto Mac runners, updating `bundler` before `bundle install`, and improving new runner setup to avoid git identity crashes.

- **Bug Fixes**
  - Constrain Android job to `[self-hosted, macOS, ARM64]` to avoid Linux runner pickup and ensure the expected Mac runner environment.
  - Run `bundle update --bundler` before `bundle install` in the iOS match step to resolve `Gemfile.lock` bundler version mismatches.
  - Update `mobile/scripts/setup-runner.sh` to set global git `user.name`/`user.email` if missing and document copying `~/.mentra/credentials/` files.

<sup>Written for commit 37a2a64bd9b5ff535719b094e60604c2d8db5d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3022?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

