### PR TITLE
Use rbenv Ruby 3.4.2 on runners instead of system Ruby 2.6

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -242,13 +242,9 @@ jobs:
         # Mentra-Community/match-certs, decrypts with MATCH_PASSWORD, installs
         # into the runner's login keychain. --readonly guarantees we never
         # accidentally regenerate certs from CI (only your laptop should).
-        #
-        # `bundle update --bundler` retargets Gemfile.lock to whatever
-        # bundler the runner has, instead of requiring the exact 2.x.y the
-        # lockfile was generated against. Avoids "Could not find bundler
-        # (2.6.9) required by Gemfile.lock" on runners with older system Ruby.
+        # Assumes the runner has rbenv-managed Ruby 3.4+ on PATH (handled by
+        # setup-runner.sh); macOS's system Ruby 2.6 + bundler <2 won't work.
         run: |
-          bundle update --bundler
           bundle install
           bundle exec fastlane match appstore --readonly
 

--- a/mobile/scripts/setup-runner.sh
+++ b/mobile/scripts/setup-runner.sh
@@ -283,14 +283,52 @@ if [[ ! -L "/Library/Java/JavaVirtualMachines/openjdk-17.jdk" ]]; then
         "/Library/Java/JavaVirtualMachines/openjdk-17.jdk"
 fi
 
-# Ruby for fastlane / cocoapods. Use system Ruby + bundler.
+# Ruby via rbenv. macOS ships an Apple-deprecated Ruby 2.6 whose
+# bundler is too old (<2.0) to read modern Gemfile.lock files. Modern
+# fastlane and bundler require Ruby >=3. Pin to RUBY_VERSION so every
+# runner matches what developers use locally — avoids "works on my
+# machine" version drift in CI.
+RUBY_VERSION="3.4.2"
+
+if ! command -v rbenv >/dev/null 2>&1; then
+    info "Installing rbenv + ruby-build"
+    brew install rbenv ruby-build
+fi
+
+# Persist rbenv shims on PATH for future shells AND the runner service.
+# Use raw PATH prepend instead of `eval rbenv init` here to avoid a
+# `complete: command not found` zsh-completion warning under bash (which
+# tripped `set -e` when first written).
+if ! grep -q 'rbenv init' "$ZPROFILE" 2>/dev/null; then
+    cat >> "$ZPROFILE" <<'EOF'
+
+# rbenv (added by setup-runner.sh)
+eval "$(rbenv init - --no-rehash zsh)"
+EOF
+fi
+export PATH="$HOME/.rbenv/shims:$HOME/.rbenv/bin:$PATH"
+
+if ! rbenv versions --bare 2>/dev/null | grep -qx "$RUBY_VERSION"; then
+    info "Installing Ruby $RUBY_VERSION (this can take ~5 minutes)"
+    rbenv install -s "$RUBY_VERSION"
+fi
+rbenv global "$RUBY_VERSION"
+rbenv rehash
+
+ok "Ruby $(ruby -v)"
+
+# Bundler matching the one used to generate mobile/Gemfile.lock. Modern
+# rbenv-installed Rubies ship a recent bundler by default; gem install is
+# idempotent and brings it forward if needed.
 gem install bundler --no-document || true
 
-# fastlane is gem-installed (no longer in homebrew-core).
+# fastlane is gem-installed (no longer in homebrew-core). With rbenv
+# managing Ruby we never need sudo here.
 if ! command -v fastlane >/dev/null 2>&1; then
     info "Installing fastlane via RubyGems"
-    gem install fastlane --no-document || sudo gem install fastlane --no-document
+    gem install fastlane --no-document
 fi
+rbenv rehash
 
 # Required by mobile/scripts/set-build-env.mjs (called at the top of
 # release-android.mjs / release-ios.mjs). The script reads `git config
@@ -484,8 +522,10 @@ else
 
         # Bake env vars the runner should see at job time. The runner reads
         # ./.env on startup. Keep this in sync with what the workflows expect.
+        # rbenv shims must come first on PATH so `ruby` / `bundle` / `gem`
+        # resolve to the rbenv-installed 3.4.x, not Apple's system 2.6.
         {
-            echo "PATH=$HOME/.bun/bin:$HOME/.maestro/bin:$BREW_PREFIX/bin:$BREW_PREFIX/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            echo "PATH=$HOME/.rbenv/shims:$HOME/.bun/bin:$HOME/.maestro/bin:$BREW_PREFIX/bin:$BREW_PREFIX/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
             echo "LANG=en_US.UTF-8"
             echo "JAVA_HOME=$BREW_PREFIX/opt/openjdk@17"
             if [[ "${SKIP_ANDROID:-0}" != "1" ]]; then


### PR DESCRIPTION
## Why

This commit was supposed to land in #3022 but I pushed it ~5 min after that PR was merged, so it got orphaned on the (already-merged) branch. Re-opening here.

## What

System Ruby 2.6 on the Mac mini runners ships with a pre-2.0 bundler that can't even parse a modern Gemfile.lock — \`bundle update --bundler\` (the workaround in #3022) needs bundler ≥2 to run in the first place. Real fix: install a modern Ruby.

- \`setup-runner.sh\` now installs rbenv + Ruby 3.4.2 (matching what developers use locally), updates PATH and the runner-service .env to put \`$HOME/.rbenv/shims\` first.
- \`staging-builds.yml\` drops the \`bundle update --bundler\` workaround; the match step just runs \`bundle install\` now that runners have a modern Ruby + bundler that can resolve the lockfile.

## Already done by hand on bob + bigbob

I've SSH'd to both Mac mini runners and:
- Installed rbenv + Ruby 3.4.2 + bundler 4.0.12 + fastlane 2.235.0
- Patched each runner's \`.env\` file to put \`$HOME/.rbenv/shims\` first on PATH

Runner services may need to be restarted (\`sudo svc.sh stop && sudo svc.sh start\`) for the .env change to take effect. They didn't restart cleanly via non-interactive ssh (sudo password prompt). May or may not be needed — modern runner versions re-read .env per-job.

## Test plan

- [ ] Merge → next staging push triggers workflow
- [ ] iOS match step actually runs to completion (\`bundle install\` succeeds → match clones match-certs → cert + profile installed)
- [ ] iOS archive succeeds with the installed provisioning profile
- [ ] Android job uses modern Ruby for the android/fastlane Gemfile too (the \`bundle install\` happening inside release-android.mjs)

If the runner services didn't pick up the new .env, this PR's build will likely fail again with system Ruby. Fix is to restart the runner services manually.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Mac mini runners to `rbenv` Ruby 3.4.2 and remove the bundler workaround. This fixes Gemfile.lock parsing and makes `bundle install`/`fastlane` run reliably in CI.

- **Dependencies**
  - `mobile/scripts/setup-runner.sh`: install `rbenv` + Ruby 3.4.2, put `$HOME/.rbenv/shims` first on PATH and in runner `.env`, install `bundler` and `fastlane`, `rbenv rehash`.
  - `.github/workflows/staging-builds.yml`: remove `bundle update --bundler`; run `bundle install` before `fastlane match`.

- **Migration**
  - `bob` and `bigbob` are already updated. If a job still uses system Ruby, restart the runner service to reload `.env`.

<sup>Written for commit bac3aeaa53dc8f320ae66a2584e7f4818fe89391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3023?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

