### PR TITLE
fix: align iOS MentraNex behavior with Android

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -595,6 +595,8 @@ struct ViewState {
             sgc = G2()
         } else if wearable.contains(DeviceTypes.LIVE) {
             sgc = MentraLive()
+        } else if wearable.contains(DeviceTypes.NEX) {
+            sgc = MentraNexSGC.getInstance()
         } else if wearable.contains(DeviceTypes.MACH1) {
             sgc = Mach1()
         } else if wearable.contains(DeviceTypes.Z100) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -96,7 +96,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             Bridge.log("NEX: Failed to convert UIImage to bitmap bytes")
             return false
         }
-        displayBitmapData(bmpData, width: Int(image.size.width), height: Int(image.size.height))
+        let pixelWidth = image.cgImage?.width ?? Int(image.size.width * image.scale)
+        let pixelHeight = image.cgImage?.height ?? Int(image.size.height * image.scale)
+        displayBitmapData(bmpData, width: pixelWidth, height: pixelHeight)
         return true
     }
 
@@ -321,9 +323,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     // MARK: - Singleton Access
 
     @objc static func getInstance() -> MentraNexSGC {
-        if instance == nil {
-            instance = MentraNexSGC()
+        if let existing = instance, existing.centralManager != nil {
+            return existing
         }
+        instance = MentraNexSGC()
         return instance!
     }
 
@@ -450,6 +453,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     private func setServicesReady(_ ready: Bool) {
         servicesReady = ready
+        guard ready else { return }
+        releaseServiceWaiters()
+    }
+
+    private func releaseServiceWaiters() {
         let waiters = serviceReadyWaiters
         serviceReadyWaiters.removeAll()
         waiters.forEach { $0.resume() }
@@ -814,6 +822,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             return "connecting"
         case ConnTypes.CONNECTED:
             return "connected"
+        case ConnTypes.SCANNING:
+            return "scanning"
         default:
             return "disconnected"
         }
@@ -1995,6 +2005,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             centralManager?.cancelPeripheralConnection(peripheral)
         }
         setServicesReady(false)
+        releaseServiceWaiters()
         Task { await commandQueue.clear() }
         resumePendingWrite()
         stopReconnectionTimer()
@@ -2037,6 +2048,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Clear discovery cache
         discoveredPeripherals.removeAll()
         setServicesReady(false)
+        releaseServiceWaiters()
         Task { await commandQueue.clear() }
         resumePendingWrite()
 
@@ -2300,6 +2312,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         isConnecting = false
         connectionState = ConnTypes.DISCONNECTED
         setServicesReady(false)
+        releaseServiceWaiters()
         Task { await commandQueue.clear() }
         resumePendingWrite()
         self.peripheral = nil // Reset peripheral on failure to allow reconnection
@@ -2325,6 +2338,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Save microphone state before disconnection (like Java implementation)
         saveMicrophoneStateBeforeDisconnection()
         setServicesReady(false)
+        releaseServiceWaiters()
         Task { await commandQueue.clear() }
         resumePendingWrite()
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -42,7 +42,14 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     func sendJson(_: [String: Any], wakeUp _: Bool, requireAck _: Bool) {}
 
-    func setMicEnabled(_: Bool) {}
+    func setMicEnabled(_ enabled: Bool) {
+        shouldUseGlassesMic = enabled
+        if enabled {
+            startMicBeat()
+        } else {
+            stopMicBeat()
+        }
+    }
 
     func requestPhoto(
         _: String, appId _: String, size _: String?, webhookUrl _: String?, authToken _: String?,
@@ -69,15 +76,33 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     func sendCameraFovSetting() {}
 
-    func setBrightness(_: Int, autoMode _: Bool) {}
-
-    func sendDoubleTextWall(_: String, _: String) {}
-
-    func displayBitmap(base64ImageData _: String) async -> Bool {
-        return false
+    func setBrightness(_ level: Int, autoMode: Bool) {
+        updateGlassesBrightness(level)
+        updateGlassesAutoBrightness(autoMode)
     }
 
-    func showDashboard() {}
+    func sendDoubleTextWall(_ top: String, _ bottom: String) {
+        sendTextWall("\(top)\n\(bottom)")
+    }
+
+    func displayBitmap(base64ImageData: String) async -> Bool {
+        guard let imageData = Data(base64Encoded: base64ImageData),
+              let image = UIImage(data: imageData)
+        else {
+            Bridge.log("NEX: Failed to decode base64 image payload")
+            return false
+        }
+        guard let bmpData = convertUIImageToBmpData(image) else {
+            Bridge.log("NEX: Failed to convert UIImage to bitmap bytes")
+            return false
+        }
+        displayBitmapData(bmpData, width: Int(image.size.width), height: Int(image.size.height))
+        return true
+    }
+
+    func showDashboard() {
+        exit()
+    }
 
     func setDashboardPosition(_ height: Int, _ depth: Int) {
         // Same order as Android MentraNex: display_height then display_distance.
@@ -93,13 +118,19 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         updateGlassesDisplayDistance(depth: depth)
     }
 
-    func setHeadUpAngle(_: Int) {}
+    func setHeadUpAngle(_ angle: Int) {
+        updateGlassesHeadUpAngle(angle)
+    }
 
-    func getBatteryStatus() {}
+    func getBatteryStatus() {
+        queryBatteryStatus()
+    }
 
     func setSilentMode(_: Bool) {}
 
-    func exit() {}
+    func exit() {
+        queueChunks([[0x18]], waitTimeMs: 100)
+    }
 
     func sendShutdown() {}
 
@@ -110,17 +141,26 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         offDurationMs _: Int, count _: Int
     ) {}
 
-    func forget() {}
-
-    func connectById(_: String) {}
-
-    func getConnectedBluetoothName() -> String? {
-        return nil
+    func forget() {
+        destroy()
     }
 
-    func cleanup() {}
+    func connectById(_ id: String) {
+        savePreferredDeviceId(id)
+        connect(name: id)
+    }
 
-    func ping() {}
+    func getConnectedBluetoothName() -> String? {
+        peripheral?.name
+    }
+
+    func cleanup() {
+        destroy()
+    }
+
+    func ping() {
+        Bridge.log("NEX: ping() is host-side no-op for this transport")
+    }
     func connectController() {}
     func disconnectController() {}
 
@@ -165,10 +205,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     private var isDisconnecting = false
     private var reconnectionTimer: Timer?
     private var reconnectionAttempts = 0
-    // TODO: change this
     private let maxReconnectionAttempts = -1 // -1 for unlimited
-    private let reconnectionInterval: TimeInterval = 5.0 // 5 seconds
+    private let reconnectionInterval: TimeInterval = 2.0
     private var peripheralToConnectName: String?
+    private let INITIAL_CONNECTION_DELAY_MS: UInt64 = 350
+    private let DELAY_BETWEEN_CHUNKS_SEND_MS: UInt64 = 10
 
     // Heartbeat tracking (like Java implementation)
     private var heartbeatCount = 0
@@ -180,6 +221,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     private var micBeatCount = 0
     private let MICBEAT_INTERVAL_MS: TimeInterval = 30 * 60 // 30 minutes like Java
     private var shouldUseGlassesMic = true
+    private var isMicrophoneEnabled = true
     private var microphoneStateBeforeDisconnection = false
 
     // Whitelist system (like Java implementation)
@@ -191,6 +233,14 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     /// Device discovery cache (like MentraLive)
     private var discoveredPeripherals = [String: CBPeripheral]() // name -> peripheral
+    private var hasConnectedThisSession = false
+    private var lastConnectionTimestamp: TimeInterval = 0
+    private var lastReceivedLc3Sequence = -1
+    private var currentImageChunks: [[UInt8]] = []
+    private var isImageSendProgressing = false
+    private var servicesReady = false
+    private var serviceReadyWaiters: [CheckedContinuation<Void, Never>] = []
+    private var pendingWriteContinuation: CheckedContinuation<Void, Never>?
 
     // MARK: - Published Properties (G1-compatible)
 
@@ -333,6 +383,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
                 continuations.append(continuation)
             }
         }
+
+        func clear() {
+            commands.removeAll()
+        }
     }
 
     private let commandQueue = CommandQueue()
@@ -360,6 +414,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log(
             "NEX: 💾 Loaded saved device - Name: \(savedDeviceName ?? "None"), Address: \(savedDeviceAddress ?? "None")"
         )
+        DeviceStore.shared.apply("glasses", "micEnabled", false)
     }
 
     private func setupCommandQueue() {
@@ -375,7 +430,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         }
     }
 
-    private func queueChunks(_ chunks: [[UInt8]], waitTimeMs: Int = 0, chunkDelayMs: Int = 8) {
+    private func queueChunks(_ chunks: [[UInt8]], waitTimeMs: Int = 0, chunkDelayMs: Int = 10) {
         let cmd = BufferedCommand(
             chunks: chunks, waitTimeMs: waitTimeMs, chunkDelayMs: chunkDelayMs
         )
@@ -384,48 +439,68 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         }
     }
 
-    /// Enhanced method that uses MTU-optimized chunking
+    private func waitUntilServicesReady() async {
+        if servicesReady {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            serviceReadyWaiters.append(continuation)
+        }
+    }
+
+    private func setServicesReady(_ ready: Bool) {
+        servicesReady = ready
+        let waiters = serviceReadyWaiters
+        serviceReadyWaiters.removeAll()
+        waiters.forEach { $0.resume() }
+    }
+
+    private func waitForWriteAck() async {
+        await withCheckedContinuation { continuation in
+            pendingWriteContinuation = continuation
+        }
+    }
+
+    private func resumePendingWrite() {
+        pendingWriteContinuation?.resume()
+        pendingWriteContinuation = nil
+    }
+
+    private func emitBleCommandSent(_ packetData: Data) {
+        guard packetData.first == PACKET_TYPE_PROTOBUF else { return }
+        guard packetData.count > 1 else { return }
+        let payload = packetData.subdata(in: 1 ..< packetData.count)
+        let commandName: String
+        if let phoneToGlasses = try? Mentraos_Ble_PhoneToGlasses(serializedData: payload) {
+            commandName = String(describing: phoneToGlasses.payload)
+        } else {
+            commandName = "UNKNOWN"
+        }
+        Bridge.sendTypedMessage("send_command_to_ble", body: [
+            "command": commandName,
+            "commandText": packetData.toHexString(),
+            "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
+        ])
+    }
+
+    private func emitBleCommandReceived(_ packetData: Data, payloadDescription: String) {
+        Bridge.sendTypedMessage("receive_command_from_ble", body: [
+            "command": payloadDescription,
+            "commandText": packetData.toHexString(),
+            "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
+        ])
+    }
+
     private func queueDataWithOptimalChunking(
         _ data: Data, packetType: UInt8 = 0x02, waitTimeMs: Int = 0
     ) {
-        // Emit BLE trace for debug overlays (mirrors Android NexEventUtils.sendBleCommandSentEvent).
-        if packetType == PACKET_TYPE_PROTOBUF,
-           let phoneToGlasses = try? Mentraos_Ble_PhoneToGlasses(serializedData: data) {
-            Bridge.sendTypedMessage("send_command_to_ble", body: [
-                "command": String(describing: phoneToGlasses.payload),
-                "commandText": data.toHexString(),
-                "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
-            ])
-        }
-
-        var chunks: [[UInt8]] = []
-        let effectiveChunkSize = maxChunkSize - 1 // Reserve 1 byte for packet type
-
-        // Add packet type as first byte
         var packetData = Data([packetType])
         packetData.append(data)
-
-        // Split into MTU-optimized chunks
-        var offset = 0
-        while offset < packetData.count {
-            let chunkSize = min(effectiveChunkSize, packetData.count - offset)
-            let chunkData = packetData.subdata(in: offset ..< (offset + chunkSize))
-            chunks.append(Array(chunkData))
-            offset += chunkSize
+        if packetData.count > maxChunkSize {
+            Bridge.log("NEX: protobuf packet (\(packetData.count) bytes) exceeds maxChunkSize (\(maxChunkSize)); sending single write for protocol compatibility")
         }
-
-        Bridge.log(
-            "NEX: 📦 Created \(chunks.count) MTU-optimized chunks (max size: \(effectiveChunkSize) bytes)"
-        )
-        queueChunks(chunks, waitTimeMs: waitTimeMs)
-    }
-
-    /// Helper method for queueing chunks with optional wait time
-    private func queueChunks(_ chunks: [[UInt8]], waitTimeMs: Int = 0) {
-        let cmd = BufferedCommand(chunks: chunks, waitTimeMs: waitTimeMs, chunkDelayMs: 8)
-        Task { [weak self] in
-            await self?.commandQueue.enqueue(cmd)
-        }
+        emitBleCommandSent(packetData)
+        queueChunks([Array(packetData)], waitTimeMs: waitTimeMs, chunkDelayMs: Int(DELAY_BETWEEN_CHUNKS_SEND_MS))
     }
 
     private func processCommand(_ command: BufferedCommand) async {
@@ -434,19 +509,28 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             return
         }
 
+        await waitUntilServicesReady()
+
         // Send each chunk sequentially
         for (index, chunk) in command.chunks.enumerated() {
+            let timeSinceConnection = Date().timeIntervalSince1970 * 1000 - lastConnectionTimestamp
+            if timeSinceConnection < Double(INITIAL_CONNECTION_DELAY_MS) {
+                let remainingMs = UInt64(Double(INITIAL_CONNECTION_DELAY_MS) - timeSinceConnection)
+                try? await Task.sleep(nanoseconds: remainingMs * 1_000_000)
+            }
             let data = Data(chunk)
             Bridge.log(
                 "NEX: 📦 Sending chunk \(index) of \(command.chunks.count) to \(peripheral.name ?? "Unknown")"
             )
             Bridge.log("NEX: 📦 Chunk data: \(data.toHexString())")
             peripheral.writeValue(data, for: writeCharacteristic, type: .withResponse)
+            await waitForWriteAck()
 
             // Delay between chunks except maybe after the last chunk if waitTime will handle it
             if index < command.chunks.count - 1 {
                 try? await Task.sleep(nanoseconds: UInt64(command.chunkDelayMs) * 1_000_000)
             }
+            try? await Task.sleep(nanoseconds: DELAY_BETWEEN_CHUNKS_SEND_MS * 1_000_000)
         }
 
         // Optional wait after the command
@@ -503,21 +587,14 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     // MARK: - Enhanced Device Filtering (ported from Java)
 
     private func isCompatibleNexDevice(_ deviceName: String) -> Bool {
-        // Enhanced filtering logic from Java implementation
+        // Keep in parity with Android MentraNex.kt scan filter.
         let compatiblePrefixes = [
-            "NexSim",
-            // "MENTRA",
-            // "NEX",
-            // "Nex",
-            // "MentraNex",
-            // "MENTRA_NEX",
-            // "Xy_A", // Legacy support
-            // "XyBLE_", // Legacy support
-            // "MENTRA_LIVE", // Cross-compatibility
+            "Nex1-",
+            "MENTRA_DISPLAY_",
         ]
 
         for prefix in compatiblePrefixes {
-            if deviceName.hasPrefix(prefix) || deviceName.contains(prefix) {
+            if deviceName.contains(prefix) {
                 Bridge.log("NEX: ✅ Device '\(deviceName)' matches compatible prefix: \(prefix)")
                 return true
             }
@@ -689,6 +766,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
         Bridge.log("NEX-CONN: ✅ Bluetooth is powered on, starting scan...")
         _isScanning = true
+        connectionState = ConnTypes.SCANNING
+        DeviceStore.shared.apply("glasses", "connectionState", ConnTypes.SCANNING)
 
         // Scan for ALL devices, not just those with specific services
         // Use same options as G1 scanner for consistency
@@ -765,11 +844,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     }
 
     @objc func findCompatibleDevices() {
-        Bridge.log("NEX-DISCOVERY: Finding compatible devices. Clearing connection targets.")
+        Bridge.log("NEX-DISCOVERY: Finding compatible devices.")
 
-        // Clear any specific device targets to ensure we are only discovering
+        // Clear specific connect target, but keep saved pairing data like Android.
         peripheralToConnectName = nil
-        clearSavedDeviceInfo() // This clears UserDefaults and our in-memory cache of saved/preferred devices.
 
         Task {
             if centralManager == nil {
@@ -783,11 +861,20 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
             if centralManager?.state == .poweredOn {
                 startScan()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10.0) { [weak self] in
+                    self?.stopScan()
+                }
             } else {
                 Bridge.log("NEX-DISCOVERY: Bluetooth not ready, will scan on power on.")
                 scanOnPowerOn = true
             }
         }
+    }
+
+    private func sanitizeDisplayText(_ text: String) -> String {
+        let normalized = text.replacingOccurrences(of: "—", with: "-")
+        let pattern = #"[^A-Za-z0-9 \r\n\.,!\?;:\-\[\]\(\)\{\}'"\+=/]"#
+        return normalized.replacingOccurrences(of: pattern, with: "", options: .regularExpression)
     }
 
     func sendTextWall(_ text: String) {
@@ -796,10 +883,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             return
         }
 
-        Bridge.log("NEX: Displaying text wall: '\(text)'")
+        let sanitizedText = sanitizeDisplayText(text)
+        Bridge.log("NEX: Displaying text wall: '\(sanitizedText)'")
 
         let displayText = Mentraos_Ble_DisplayText.with {
-            $0.text = text
+            $0.text = sanitizedText
             $0.size = 48
             $0.x = 20
             $0.y = 260
@@ -819,7 +907,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     }
 
     @objc func displayDoubleTextWall(_ textTop: String, textBottom: String) {
-        let combinedText = "\(textTop)\n\n\(textBottom)"
+        let combinedText = "\(textTop)\n\(textBottom)"
         sendTextWall(combinedText)
     }
 
@@ -954,6 +1042,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         }
 
         Bridge.log("NEX: Sending \(chunks.count) image chunks")
+        currentImageChunks = chunks
+        isImageSendProgressing = true
         queueChunks(chunks, waitTimeMs: 50)
     }
 
@@ -1016,11 +1106,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     @objc func showHomeScreen() {
         Bridge.log("NEX: Showing home screen")
         clearDisplay()
-
-        // Send a simple home screen text
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.sendTextWall("MentraOS Ready")
-        }
     }
 
     @objc func exitAllFunctions() {
@@ -1044,9 +1129,13 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             return
         }
 
-        // Validate brightness range (0-100)
-        let validBrightness = max(0, min(100, brightness))
-        Bridge.log("NEX: Setting brightness to \(validBrightness)%")
+        let validBrightness: Int
+        if brightness != -1 {
+            validBrightness = (max(0, min(100, brightness)) * 63) / 100
+        } else {
+            validBrightness = (30 * 63) / 100
+        }
+        Bridge.log("NEX: Setting brightness to wire value \(validBrightness)")
 
         let brightnessConfig = Mentraos_Ble_BrightnessConfig.with {
             $0.value = UInt32(validBrightness)
@@ -1168,6 +1257,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     }
 
     @objc func setMicrophoneEnabled(_ enabled: Bool) {
+        isMicrophoneEnabled = enabled
+        DeviceStore.shared.apply("glasses", "micEnabled", enabled)
+
         guard nexReady else {
             Bridge.log("NEX: Not ready to set microphone state. Device not initialized.")
             return
@@ -1252,10 +1344,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         let timestamp = Date().timeIntervalSince1970 * 1000
         Bridge.log("NEX: Sending pong response (Time: \(timestamp))")
 
-        let pongResponse = Mentraos_Ble_PongResponse()
+        let pingRequest = Mentraos_Ble_PingRequest()
 
         let phoneToGlasses = Mentraos_Ble_PhoneToGlasses.with {
-            $0.pong = pongResponse
+            $0.ping = pingRequest
         }
 
         let protobufData = try! phoneToGlasses.serializedData()
@@ -1374,12 +1466,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             let glassesToPhone = try Mentraos_Ble_GlassesToPhone(serializedData: protobufData)
             Bridge.log("NEX: Processing protobuf payload case: \(glassesToPhone.payload)")
 
-            // Emit BLE trace for debug overlays (mirrors Android NexEventUtils.sendBleCommandReceivedEvent).
-            Bridge.sendTypedMessage("receive_command_from_ble", body: [
-                "command": String(describing: glassesToPhone.payload),
-                "commandText": protobufData.toHexString(),
-                "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
-            ])
+            let fullPacket = Data([PACKET_TYPE_PROTOBUF]) + protobufData
+            emitBleCommandReceived(fullPacket, payloadDescription: String(describing: glassesToPhone.payload))
 
             switch glassesToPhone.payload {
             case let .batteryStatus(batteryStatus):
@@ -1397,8 +1485,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             case let .headUpAngleSet(headUpAngleResponse):
                 handleHeadUpAngleResponseProtobuf(headUpAngleResponse)
 
-            case let .ping(pingRequest):
-                handlePingProtobuf(pingRequest)
+            case let .pong(pongResponse):
+                handlePongProtobuf(pongResponse)
 
             case let .vadEvent(vadEvent):
                 handleVadEventProtobuf(vadEvent)
@@ -1434,6 +1522,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             "NEX: Received audio data - sequence: \(sequenceNumber), size: \(audioData.count) bytes"
         )
 
+        if lastReceivedLc3Sequence != -1, UInt8((lastReceivedLc3Sequence + 1) & 0xFF) != sequenceNumber {
+            Bridge.log("NEX: LC3 packet sequence mismatch. Expected \((lastReceivedLc3Sequence + 1) & 0xFF), got \(sequenceNumber)")
+        }
+        lastReceivedLc3Sequence = Int(sequenceNumber)
+
         // Update @Published property (G1-compatible approach)
         // Create packet with sequence number prefix like G1 expects
         var packetData = Data()
@@ -1441,6 +1534,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         packetData.append(audioData)
 
         compressedVoiceData = packetData
+        DeviceManager.shared.handleGlassesMicData(audioData, 40)
     }
 
     private func processImageData(_ imageData: Data) {
@@ -1502,27 +1596,19 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         emitEvent("HeadUpAngleResponseEvent", body: eventBody)
     }
 
-    private func handlePingProtobuf(_: Mentraos_Ble_PingRequest) {
+    private func handlePongProtobuf(_: Mentraos_Ble_PongResponse) {
         let timestamp = Date().timeIntervalSince1970 * 1000
 
-        Bridge.log("NEX: 💓 Received PING from glasses (Time: \(timestamp))")
+        Bridge.log("NEX: 💓 Received PONG from glasses (Time: \(timestamp))")
+        notifyHeartbeatReceived(timestamp)
 
         // Automatically send pong response
         sendPongResponse()
 
-        // Emit heartbeat received event
-        let eventBody: [String: Any] = [
-            "heartbeat_received": [
-                "timestamp": timestamp,
-                "device_model": "Mentra Display",
-            ],
-        ]
-
-        emitEvent("HeartbeatReceivedEvent", body: eventBody)
-
         // Query battery status periodically (every 10 pings like Java implementation)
         heartbeatCount += 1
-        if heartbeatCount % 10 == 0 {
+        let batteryLevel = DeviceStore.shared.get("glasses", "batteryLevel") as? Int ?? -1
+        if batteryLevel == -1 || heartbeatCount % 10 == 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 self.queryBatteryStatus()
             }
@@ -1550,11 +1636,12 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         switch status {
         case .ok:
             Bridge.log("NEX: Image transfer completed successfully")
-        // Clear any pending image chunks
+            currentImageChunks.removeAll()
+            isImageSendProgressing = false
 
         case .incomplete:
             Bridge.log("NEX: Image transfer incomplete - Missing chunks: \(missingChunks)")
-        // Could implement chunk retransmission here
+            resendImageMissingChunks(missingChunks)
 
         default:
             Bridge.log("NEX: Unknown image transfer status")
@@ -1570,6 +1657,21 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         ]
 
         emitEvent("ImageTransferCompleteEvent", body: eventBody)
+    }
+
+    private func resendImageMissingChunks(_ missingChunks: [UInt32]) {
+        guard isImageSendProgressing, !currentImageChunks.isEmpty, !missingChunks.isEmpty else {
+            return
+        }
+        let retransmit = missingChunks.compactMap { index -> [UInt8]? in
+            let i = Int(index)
+            guard i >= 0, i < currentImageChunks.count else { return nil }
+            return currentImageChunks[i]
+        }
+        if !retransmit.isEmpty {
+            Bridge.log("NEX: Resending \(retransmit.count) missing image chunks")
+            queueChunks(retransmit)
+        }
     }
 
     private func handleImuDataProtobuf(_ imuData: Mentraos_Ble_ImuData) {
@@ -1618,7 +1720,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         let level = json["level"] as? Int ?? -1
         let isCharging = json["charging"] as? Bool ?? false
 
-        Bridge.log("NEX: 🔋 JSON Battery Status - Level: \(level)%, Charging: \(charging)")
+        Bridge.log("NEX: 🔋 JSON Battery Status - Level: \(level)%, Charging: \(isCharging)")
 
         // Update @Published properties (G1-compatible approach)
         DeviceStore.shared.apply("glasses", "batteryLevel", level)
@@ -1721,28 +1823,16 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     private func notifyHeartbeatSent(_ timestamp: TimeInterval) {
         lastHeartbeatSentTime = timestamp
-
-        let eventBody: [String: Any] = [
-            "heartbeat_sent": [
-                "timestamp": timestamp,
-                "device_model": "Mentra Display",
-            ],
-        ]
-
-        emitEvent("HeartbeatSentEvent", body: eventBody)
+        Bridge.sendTypedMessage("heartbeat_sent", body: [
+            "timestamp": timestamp,
+        ])
     }
 
     private func notifyHeartbeatReceived(_ timestamp: TimeInterval) {
         lastHeartbeatReceivedTime = timestamp
-
-        let eventBody: [String: Any] = [
-            "heartbeat_received": [
-                "timestamp": timestamp,
-                "device_model": "Mentra Display",
-            ],
-        ]
-
-        emitEvent("HeartbeatReceivedEvent", body: eventBody)
+        Bridge.sendTypedMessage("heartbeat_received", body: [
+            "timestamp": timestamp,
+        ])
     }
 
     @objc func getLastHeartbeatSentTime() -> TimeInterval {
@@ -1762,8 +1852,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             stopMicBeat()
         }
 
-        // Set mic enabled first (like Java line 1751)
-        setMicrophoneEnabled(true)
+        sendSetMicEnabled(true, delaySeconds: 0.01)
         micBeatCount += 1
 
         // Schedule periodic mic beat (like Java lines 1753-1762)
@@ -1771,16 +1860,22 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             [weak self] _ in
             guard let self else { return }
             Bridge.log("NEX: SENDING MIC BEAT")
-            self.setMicrophoneEnabled(self.shouldUseGlassesMic)
+            self.sendSetMicEnabled(self.shouldUseGlassesMic, delaySeconds: 0.001)
         }
     }
 
     private func stopMicBeat() {
-        setMicrophoneEnabled(false)
+        sendSetMicEnabled(false, delaySeconds: 0.01)
         micBeatTimer?.invalidate()
         micBeatTimer = nil
         micBeatCount = 0
         Bridge.log("NEX: Stopped mic beat")
+    }
+
+    private func sendSetMicEnabled(_ enabled: Bool, delaySeconds: TimeInterval) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delaySeconds) { [weak self] in
+            self?.setMicrophoneEnabled(enabled)
+        }
     }
 
     private func sendWhiteListCommand() {
@@ -1881,9 +1976,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     /// Save microphone state before disconnection (like Java implementation)
     private func saveMicrophoneStateBeforeDisconnection() {
-        UserDefaults.standard.set(shouldUseGlassesMic, forKey: "microphoneStateBeforeDisconnection")
-        microphoneStateBeforeDisconnection = shouldUseGlassesMic
-        Bridge.log("NEX: Saved microphone state before disconnection: \(shouldUseGlassesMic)")
+        UserDefaults.standard.set(isMicrophoneEnabled, forKey: "microphoneStateBeforeDisconnection")
+        microphoneStateBeforeDisconnection = isMicrophoneEnabled
+        Bridge.log("NEX: Saved microphone state before disconnection: \(isMicrophoneEnabled)")
     }
 
     @objc func disconnect() {
@@ -1899,6 +1994,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             connectionState = ConnTypes.DISCONNECTED
             centralManager?.cancelPeripheralConnection(peripheral)
         }
+        setServicesReady(false)
+        Task { await commandQueue.clear() }
+        resumePendingWrite()
         stopReconnectionTimer()
     }
 
@@ -1938,11 +2036,22 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
         // Clear discovery cache
         discoveredPeripherals.removeAll()
+        setServicesReady(false)
+        Task { await commandQueue.clear() }
+        resumePendingWrite()
 
         Bridge.log("NEX: ✅ MentraNexSGC destroyed successfully")
         // Reset initialization flags
         whiteListedAlready = false
         protobufVersionPosted = false
+        hasConnectedThisSession = false
+        currentImageChunks.removeAll()
+        isImageSendProgressing = false
+        currentMTU = MTU_DEFAULT
+        deviceMaxMTU = MTU_DEFAULT
+        maxChunkSize = MTU_DEFAULT - 10
+        bmpChunkSize = MTU_DEFAULT - 20
+        updateConnectedState(isConnected: false)
     }
 
     @objc func reset() {
@@ -1972,6 +2081,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         micBeatCount = 0
         shouldUseGlassesMic = true
         microphoneStateBeforeDisconnection = false
+        hasConnectedThisSession = false
+        currentImageChunks.removeAll()
+        isImageSendProgressing = false
+        updateConnectedState(isConnected: false)
     }
 
     // MARK: - Helper Methods (like G1)
@@ -1986,6 +2099,13 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Emit device discovery event using standardized typed message function
         Bridge.log("NEX: 📡 Emitting discovered device: \(name)")
         Bridge.sendDiscoveredDevice(DeviceTypes.NEX, name)
+    }
+
+    private func updateConnectedState(isConnected: Bool) {
+        connectionState = isConnected ? ConnTypes.CONNECTED : ConnTypes.DISCONNECTED
+        DeviceStore.shared.apply("glasses", "connected", isConnected)
+        DeviceStore.shared.apply("glasses", "fullyBooted", isConnected)
+        DeviceStore.shared.apply("glasses", "connectionState", isConnected ? ConnTypes.CONNECTED : ConnTypes.DISCONNECTED)
     }
 
     @objc func checkBluetoothState() {
@@ -2064,10 +2184,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             return
         }
 
-        // guard isCompatibleNexDevice(deviceName) else {
-        //     // Bridge.log("NEX-CONN: 🚫 Ignoring incompatible device: \(deviceName)")
-        //     return
-        // }
+        guard isCompatibleNexDevice(deviceName) else {
+            return
+        }
 
         Bridge.log("NEX-CONN: 🎯 === Compatible Nex Device Found ===")
         Bridge.log("NEX-CONN: 📱 Device Name: \(deviceName)")
@@ -2129,6 +2248,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         self.peripheral = peripheral
         isConnecting = true
         connectionState = ConnTypes.CONNECTING
+        DeviceStore.shared.apply("glasses", "connectionState", ConnTypes.CONNECTING)
 
         // Use connection options for better reliability (from Java implementation)
         let connectionOptions: [String: Any] = [
@@ -2163,6 +2283,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log("NEX-CONN: 💾 Device information saved for reliable reconnection")
         peripheral.delegate = self
         Bridge.log("NEX-CONN: 🔍 Discovering services...")
+        setServicesReady(false)
         peripheral.discoverServices([MAIN_SERVICE_UUID])
 
         // Reset any failed connection attempt counters
@@ -2178,6 +2299,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         )
         isConnecting = false
         connectionState = ConnTypes.DISCONNECTED
+        setServicesReady(false)
+        Task { await commandQueue.clear() }
+        resumePendingWrite()
         self.peripheral = nil // Reset peripheral on failure to allow reconnection
         // Optionally, start reconnection attempts here
         if !isDisconnecting, !isKilled {
@@ -2200,6 +2324,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Reset connection state
         // Save microphone state before disconnection (like Java implementation)
         saveMicrophoneStateBeforeDisconnection()
+        setServicesReady(false)
+        Task { await commandQueue.clear() }
+        resumePendingWrite()
 
         // Reset protobuf version posted flag for next connection (like Java implementation)
         protobufVersionPosted = false
@@ -2230,6 +2357,14 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         writeCharacteristic = nil
         notifyCharacteristic = nil
         connectionState = ConnTypes.DISCONNECTED
+        currentMTU = MTU_DEFAULT
+        deviceMaxMTU = MTU_DEFAULT
+        maxChunkSize = MTU_DEFAULT - 10
+        bmpChunkSize = MTU_DEFAULT - 20
+        currentImageChunks.removeAll()
+        isImageSendProgressing = false
+        hasConnectedThisSession = false
+        updateConnectedState(isConnected: false)
 
         // Clear command queue if needed
         if isQueueWorkerRunning {
@@ -2304,7 +2439,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
             // Calculate optimal chunk sizes based on iOS MTU constraints
             maxChunkSize = currentMTU - 10 // Reserve 10 bytes for headers
-            bmpChunkSize = currentMTU - 6 // Reserve 6 bytes for image headers
+            bmpChunkSize = currentMTU - 20
 
             Bridge.log("NEX: 📦 Optimized Chunk Sizes:")
             Bridge.log("NEX:    📄 Data Chunk Size: \(maxChunkSize) bytes")
@@ -2328,6 +2463,8 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Bridge.log("NEX-CONN: ✅ Device initialization complete - ready for communication")
         nexReady = true
         connectionState = ConnTypes.CONNECTED
+        lastConnectionTimestamp = Date().timeIntervalSince1970 * 1000
+        updateConnectedState(isConnected: true)
 
         // Update @Published property for device ready state
         deviceReady = true
@@ -2376,14 +2513,25 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             self.showHomeScreen()
         }
 
+        if hasConnectedThisSession {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
+                self.sendTextWall("// MentraOS Reconnected")
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.08) {
+                self.clearDisplay()
+            }
+        } else {
+            hasConnectedThisSession = true
+        }
+
         // 5. Post protobuf schema version information (Java lines 684-687)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { // 100ms delay
             self.postProtobufSchemaVersionInfo()
         }
 
-        // 6. Query glasses protobuf version from firmware (Java line 690)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { // 150ms delay
-            self.queryGlassesInfo()
+        // 6. Version request is removed in current schema; Android sends no-op.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            Bridge.log("NEX: Skipping version request; schema removed VersionRequest")
         }
 
         // 7. Push current glasses-side Voice Activity Detection setting
@@ -2493,10 +2641,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             Bridge.log(
                 "NEX-CONN: ❌ Error writing value to \(characteristic.uuid): \(error.localizedDescription)"
             )
+            resumePendingWrite()
             return
         }
-        // This log can be very noisy, so it's commented out.
-        // Bridge.log("NEX-CONN: 📤 Successfully wrote value to \(characteristic.uuid).")
+        resumePendingWrite()
     }
 
     func peripheral(
@@ -2514,10 +2662,16 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             Bridge.log(
                 "NEX-CONN: ✅ Successfully subscribed to notifications for characteristic \(characteristic.uuid.uuidString)."
             )
+            if characteristic.uuid == NOTIFY_CHAR_UUID {
+                setServicesReady(true)
+            }
         } else {
             Bridge.log(
                 "NEX-CONN:  unsubscribed from notifications for characteristic \(characteristic.uuid.uuidString)."
             )
+            if characteristic.uuid == NOTIFY_CHAR_UUID {
+                setServicesReady(false)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- wire iOS `MentraNexSGC` into `DeviceManager.initSGC` for `DeviceTypes.NEX` and replace no-op `SGCManager` surface methods with real Nex command paths
- fix Nex heartbeat protocol parity by handling `GlassesToPhone.pong` and replying with `PhoneToGlasses.ping`, and align heartbeat telemetry event names with Android
- align iOS Nex lifecycle/transport behavior with Android: scan filtering, connect-by-id, command queue gating, mic/audio forwarding, image retransmit, brightness/text command semantics, and reconnect state handling

## Test plan
- [x] Verified changed files are limited to iOS Nex manager and iOS DeviceManager wiring
- [x] Ran `bun compile` in `mobile` (fails in this environment due missing type dependencies in worktree setup)
- [x] Ran static parity checks for key signatures and protobuf field usage (`.pong` inbound, `.ping` outbound, NEX manager initialization path)
- [ ] Run full iOS build and on-device Nex BLE smoke test (scan/connect, battery query, mic/VAD, dashboard commands, heartbeat loop, reconnect)
- [ ] Run Android + iOS side-by-side parity smoke verification for shared Nex flows


Made with [Cursor](https://cursor.com)