### PR TITLE
Bump CI version to 2.11.0 + document drift hazard

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -1,5 +1,5 @@
 # Version
-EXPO_PUBLIC_MENTRAOS_VERSION=2.10.0
+EXPO_PUBLIC_MENTRAOS_VERSION=2.11.0
 
 # Apple Developer team identifier — required by scripts/release-ios.mjs.
 # Not a secret (visible in every IPA's embedded provisioning profile).

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -23,6 +23,21 @@ MentraOS Manager is a React Native app built with Expo and expo-router for file-
 - Upload to Google Play: `bun upload:google:play` (builds AAB and uploads to Play Store)
 - Build iOS archive: `bun build:ios:archive`
 
+### Versioning
+
+The user-facing app version (`CFBundleShortVersionString` on iOS,
+`versionName` on Android) comes from `EXPO_PUBLIC_MENTRAOS_VERSION` in
+`.env`. **The CI staging-builds workflow uses `.env.example`** (it does
+`cp .env.example .env` on each runner), so:
+
+- Bump `EXPO_PUBLIC_MENTRAOS_VERSION` in **both `.env` and `.env.example`**
+  whenever starting work on a new version (e.g. 2.10 → 2.11). Otherwise
+  CI keeps building the old train and TestFlight will reject with
+  "train is closed for new build submissions" once that train is approved.
+- The build number (`CFBundleVersion` / `versionCode`) is derived at
+  build time from wall-clock seconds — see `mobile/scripts/build-number.mjs`.
+  Nothing to bump manually; just don't downgrade `EXPO_PUBLIC_MENTRAOS_VERSION`.
+
 ### Testing
 
 - Run tests: `bun test`


### PR DESCRIPTION
## What

\`mobile/.env.example\` was at 2.10.0 while \`mobile/.env\` (developer-local) was at 2.11.0. CI workflow copies \`.env.example\` → \`.env\` on each runner, so every CI iOS build tried to push a 2.10.0 IPA to TestFlight — which Apple rejected because the 2.10 train is closed.

Two changes:

1. **\`.env.example\`**: \`2.10.0\` → \`2.11.0\` to match the developer-local \`.env\`.
2. **\`mobile/AGENTS.md\`**: new Versioning subsection under "Build and Test Commands" calling out that \`.env.example\` is the CI source of truth and must be bumped alongside the local \`.env\`, so this drift doesn't happen again.

## After merge

- Next staging-builds run produces \`v2.11/Mentra_2p11_Beta_N.{apk,ipa}\` instead of v2.10.
- TestFlight upload should succeed (assuming 2.11 isn't already approved+closed; if it is, bump again to 2.12).
- Rolling-latest URLs (\`mobile-latest.apk\`/\`.ipa\`, \`asg-latest.apk\`) are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned CI build version to 2.11.0 by bumping `EXPO_PUBLIC_MENTRAOS_VERSION` in `mobile/.env.example` so TestFlight uploads target the correct train. Added a Versioning note in `mobile/AGENTS.md` to make `.env.example` the CI source of truth and prevent drift with local `.env`.

<sup>Written for commit 1a492db5494711b40b3bc5e6dd2421ff58a0d4b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3029?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

