### PR TITLE
Post per-platform staging-build status to Slack

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -605,3 +605,153 @@ jobs:
             } catch (error) {
               console.log('Cleanup skipped:', error.message);
             }
+
+  slack-notify:
+    name: Notify Slack
+    needs: [build-mobile-android, build-mobile-ios, build-asg, upload-releases]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for commit metadata
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_NIGHTLY_BUILDS }}
+          ANDROID_RESULT: ${{ needs.build-mobile-android.result }}
+          IOS_RESULT: ${{ needs.build-mobile-ios.result }}
+          ASG_RESULT: ${{ needs.build-asg.result }}
+          UPLOAD_RESULT: ${{ needs.upload-releases.result }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_NIGHTLY_BUILDS secret not set — skipping Slack notification."
+            exit 0
+          fi
+
+          # Commit metadata for the message footer.
+          COMMIT_SHORT="${SHA:0:7}"
+          COMMIT_SUBJECT=$(git log -1 --pretty=%s "$SHA")
+          COMMIT_AUTHOR=$(git log -1 --pretty=%an "$SHA")
+
+          # Map GH Actions job conclusions → emoji + human label.
+          # success → ✅, failure → ❌, skipped → ⏭️, cancelled → 🚫, anything else → ⚠️
+          icon() {
+            case "$1" in
+              success) echo "✅" ;;
+              failure) echo "❌" ;;
+              skipped) echo "⏭️" ;;
+              cancelled) echo "🚫" ;;
+              *) echo "⚠️" ;;
+            esac
+          }
+          label() {
+            case "$1" in
+              success) echo "built and published" ;;
+              failure) echo "failed" ;;
+              skipped) echo "skipped" ;;
+              cancelled) echo "cancelled" ;;
+              *) echo "$1" ;;
+            esac
+          }
+
+          ANDROID_ICON=$(icon "$ANDROID_RESULT")
+          IOS_ICON=$(icon "$IOS_RESULT")
+          ASG_ICON=$(icon "$ASG_RESULT")
+          UPLOAD_ICON=$(icon "$UPLOAD_RESULT")
+
+          # Overall header: ✅ if upload succeeded AND all three built; ⚠️ if
+          # some platforms shipped but others failed; ❌ if nothing shipped.
+          if [ "$UPLOAD_RESULT" = "success" ] && \
+             [ "$ANDROID_RESULT" = "success" ] && \
+             [ "$IOS_RESULT" = "success" ] && \
+             [ "$ASG_RESULT" = "success" ]; then
+            HEADER_ICON="✅"
+            HEADER_TEXT="Staging build complete"
+          elif [ "$UPLOAD_RESULT" = "success" ]; then
+            HEADER_ICON="⚠️"
+            HEADER_TEXT="Staging build partial (some platforms failed)"
+          else
+            HEADER_ICON="❌"
+            HEADER_TEXT="Staging build failed"
+          fi
+
+          RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
+          COMMIT_URL="https://github.com/${REPO}/commit/${SHA}"
+          RELEASE_BASE="https://github.com/${REPO}/releases/download/staging-builds"
+          ANDROID_URL="${RELEASE_BASE}/mobile-latest.apk"
+          IOS_URL="${RELEASE_BASE}/mobile-latest.ipa"
+          ASG_URL="${RELEASE_BASE}/asg-latest.apk"
+
+          # Per-platform "details" line. For successes we link the latest
+          # artifact; for failures we point at the run log.
+          android_detail() {
+            if [ "$ANDROID_RESULT" = "success" ]; then
+              echo "<${ANDROID_URL}|Download mobile-latest.apk>"
+            else
+              echo "<${RUN_URL}|See run logs>"
+            fi
+          }
+          ios_detail() {
+            if [ "$IOS_RESULT" = "success" ]; then
+              echo "<${IOS_URL}|Download mobile-latest.ipa>"
+            else
+              echo "<${RUN_URL}|See run logs>"
+            fi
+          }
+          asg_detail() {
+            if [ "$ASG_RESULT" = "success" ]; then
+              echo "<${ASG_URL}|Download asg-latest.apk>"
+            else
+              echo "<${RUN_URL}|See run logs>"
+            fi
+          }
+
+          ANDROID_DETAIL=$(android_detail)
+          IOS_DETAIL=$(ios_detail)
+          ASG_DETAIL=$(asg_detail)
+          ANDROID_LABEL=$(label "$ANDROID_RESULT")
+          IOS_LABEL=$(label "$IOS_RESULT")
+          ASG_LABEL=$(label "$ASG_RESULT")
+
+          # Note: ${{ github.event.head_commit.message }} would be ideal but
+          # is only set on push events. We use git for both push and
+          # workflow_dispatch so the field is always populated.
+
+          # Build the JSON payload with jq so commit subjects with
+          # quotes/newlines don't break the message. `$'\n'` is bash's
+          # literal newline (Slack's mrkdwn doesn't interpret `\n`).
+          NL=$'\n'
+          PAYLOAD=$(jq -n \
+            --arg header "${HEADER_ICON} ${HEADER_TEXT}" \
+            --arg context "Commit <${COMMIT_URL}|\`${COMMIT_SHORT}\`> by ${COMMIT_AUTHOR} • <${RUN_URL}|View run>" \
+            --arg commit_msg "${COMMIT_SUBJECT}" \
+            --arg android "*${ANDROID_ICON} Android (mobile)* — ${ANDROID_LABEL}${NL}${ANDROID_DETAIL}" \
+            --arg ios "*${IOS_ICON} iOS (mobile)* — ${IOS_LABEL}${NL}${IOS_DETAIL}" \
+            --arg asg "*${ASG_ICON} ASG client* — ${ASG_LABEL}${NL}${ASG_DETAIL}" \
+            --arg upload "_Publishing step:_ ${UPLOAD_ICON} ${UPLOAD_RESULT}" \
+            '{
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: $header } },
+                { type: "section", text: { type: "mrkdwn", text: $commit_msg } },
+                { type: "divider" },
+                { type: "section", text: { type: "mrkdwn", text: $android } },
+                { type: "section", text: { type: "mrkdwn", text: $ios } },
+                { type: "section", text: { type: "mrkdwn", text: $asg } },
+                { type: "divider" },
+                { type: "context", elements: [
+                  { type: "mrkdwn", text: $upload },
+                  { type: "mrkdwn", text: $context }
+                ] }
+              ]
+            }')
+
+          echo "Posting to Slack…"
+          curl -fsS -X POST -H "Content-Type: application/json" \
+            --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+          echo


### PR DESCRIPTION
## What

Adds a \`slack-notify\` job at the end of the staging-builds workflow that posts a Block Kit message to Slack on every run completion (success, partial-success, or failure).

## Message shape

```
[Header] ✅/⚠️/❌  Staging build complete / partial / failed
[Section] commit subject
─────────
[Section] ✅ Android (mobile) — built and published
          <Download mobile-latest.apk>
[Section] ✅ iOS (mobile) — built and published
          <Download mobile-latest.ipa>
[Section] ⚠️ ASG client — failed
          <See run logs>
─────────
[Context] Publishing step: ✅ success  •  Commit \`abc1234\` by Alex Israelov  •  View run
```

For each platform:
- ✅ success → download link to the rolling-latest URL
- ❌ failure → link to the failed run for log inspection
- ⏭️ skipped / 🚫 cancelled → labeled accordingly, link to run

Overall verdict:
- ✅ if everything succeeded
- ⚠️ if upload-releases succeeded but at least one platform failed (partial publish)
- ❌ if nothing shipped

## Secret

Re-uses the existing \`SLACK_WEBHOOK_NIGHTLY_BUILDS\` secret in the repo. It was provisioned at some point but never wired into a workflow (\`nightly-builds.yml\` was deleted, and nothing else referenced it). This is the first actual user.

If the secret is unset for any reason, the step logs and skips — won't fail the workflow.

## Why always-fire

You explicitly wanted visibility into "iOS shipped to GH release but TestFlight failed because of XYZ" — that exact case is now a single Slack message with per-platform status and a link to investigate.

## Test plan

- [ ] Merge → next staging push triggers workflow
- [ ] Verify Slack message arrives in the configured channel
- [ ] Verify ✅/⚠️/❌ status icons match actual job outcomes
- [ ] Verify download links resolve to the latest artifacts
- [ ] Force a synthetic failure (e.g. break a build) → verify the message renders failure state correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts per-platform staging build results to Slack after every workflow run. Adds a `slack-notify` job to `.github/workflows/staging-builds.yml` with an overall verdict and links to artifacts or logs.

- New Features
  - Always runs (`if: always()`), reporting success/partial/failure with ✅/⚠️/❌.
  - Shows commit subject plus Android/iOS/ASG sections with status and labels (built and published/failed/skipped/cancelled).
  - Success links to rolling-latest artifacts; failures link to the run.
  - Reuses `SLACK_WEBHOOK_NIGHTLY_BUILDS`; missing secret logs and skips without failing.

<sup>Written for commit 8ef6af4f111f7709eb37e83a5810201278abf16c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3030?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

