### PR TITLE
Fix AsgClientService foreground startup

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -35,6 +35,7 @@ import com.mentra.asg_client.service.media.interfaces.IMediaManager;
 import com.mentra.asg_client.service.system.interfaces.IConfigurationManager;
 import com.mentra.asg_client.service.system.interfaces.IServiceLifecycle;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.service.system.managers.AsgNotificationManager;
 import com.mentra.asg_client.service.utils.ServiceUtils;
 import com.mentra.asg_client.service.utils.SysProp;
 import java.nio.charset.StandardCharsets;
@@ -113,6 +114,13 @@ public class AsgClientService extends Service
     private static AsgClientService instance;
     private boolean lastI2sPlaying = false;
     private boolean isConnected = false; // Track connection state based on heartbeat
+
+    /**
+     * Used before {@link ServiceContainer} exists so FGS promotion is not delayed by heavy init.
+     */
+    private AsgNotificationManager mEarlyNotificationManager;
+
+    private boolean mForegroundStarted;
 
     // ---------------------------------------------
     // WiFi State Management
@@ -200,6 +208,10 @@ public class AsgClientService extends Service
 
         instance = this;
 
+        // Must run before heavy onCreate() work: startForegroundService() deadline (~5s) is
+        // measured until startForeground(), and onStartCommand() only runs after onCreate().
+        ensureForegroundStarted();
+
         try {
             // Register for EventBus events
             Log.d(TAG, "📡 Registering for EventBus events");
@@ -264,17 +276,7 @@ public class AsgClientService extends Service
         super.onStartCommand(intent, flags, startId);
 
         try {
-            // Ensure foreground service on API 26+
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                Log.d(TAG, "📱 API 26+ detected - setting up foreground service");
-                serviceContainer.getNotificationManager().createNotificationChannel();
-                startForeground(
-                        serviceContainer.getNotificationManager().getDefaultNotificationId(),
-                        serviceContainer.getNotificationManager().createForegroundNotification());
-                Log.d(TAG, "✅ Foreground service started");
-            } else {
-                Log.d(TAG, "📱 API < 26 - skipping foreground service setup");
-            }
+            ensureForegroundStarted();
 
             if (intent == null || intent.getAction() == null) {
                 Log.w(TAG, "⚠️ Received null intent or null action");
@@ -551,6 +553,35 @@ public class AsgClientService extends Service
     // ---------------------------------------------
     // Initialization Methods
     // ---------------------------------------------
+
+    /**
+     * Promote to a foreground service. Idempotent; safe from {@link #onCreate()} and {@link
+     * #onStartCommand()}. Not wrapped in onCreate's catch-all so AMS failures are visible.
+     */
+    private void ensureForegroundStarted() {
+        if (mForegroundStarted || Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            return;
+        }
+
+        AsgNotificationManager notificationManager = resolveNotificationManager();
+        notificationManager.createNotificationChannel();
+        startForeground(
+                notificationManager.getDefaultNotificationId(),
+                notificationManager.createForegroundNotification());
+        mForegroundStarted = true;
+        Log.d(TAG, "✅ Foreground service started");
+    }
+
+    private AsgNotificationManager resolveNotificationManager() {
+        if (serviceContainer != null) {
+            return serviceContainer.getNotificationManager();
+        }
+        if (mEarlyNotificationManager == null) {
+            mEarlyNotificationManager = new AsgNotificationManager(this);
+        }
+        return mEarlyNotificationManager;
+    }
+
     private void initializeServiceContainer() {
         Log.d(TAG, "🔧 initializeServiceContainer() started");
 


### PR DESCRIPTION
## Summary
- Reapply the AsgClientService foreground-startup fix directly on `dev`.
- Promote the service to foreground in `onCreate()` before heavy initialization starts.
- Keep foreground promotion idempotent from both `onCreate()` and `onStartCommand()` using an early `AsgNotificationManager` before `ServiceContainer` exists.

## Why
The original PR branch was based on `staging`, then retargeted to `dev`, which pulled unrelated staging history into the PR. This is the clean dev-based cherry-pick containing only the OS-1395 foreground-service deadline fix.

## Validation
- `git diff --cached --check`
- Checked for unresolved conflict markers in `AsgClientService.java`
- Confirmed diff is one file and one commit on top of `origin/dev`

Runtime validation still needed on Mentra Live: cold start / boot / OTA restart should no longer hit the Android foreground-service start deadline crash.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promote the service to foreground in onCreate() before heavy init to meet the 5s deadline and stop RemoteServiceException crashes on cold start/boot/OTA. Addresses Linear OS-1395.

- **Bug Fixes**
  - Added ensureForegroundStarted(), called at the top of onCreate() and safe to call again from onStartCommand().
  - Introduced an early AsgNotificationManager fallback when ServiceContainer is not ready to create the channel and minimal notification.
  - Tracked mForegroundStarted and skipped setup on API < 26 to keep behavior safe and idempotent.

<sup>Written for commit 04448803139dc43860cfa7e0a606aa44e9dc7e9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3032?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

