### PR TITLE
Cleanup automation + Slack improvements + Linux setup-runner support

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -48,6 +48,17 @@ jobs:
     # ASG client below stays unconstrained because it's a clean gradle build.
     runs-on: [self-hosted, macOS, ARM64]
 
+    # Surface release-status.json fields as job outputs so slack-notify can
+    # build a per-platform status section. See mobile/scripts/release-android.mjs.
+    outputs:
+      apk_name: ${{ steps.release-status.outputs.apk_name }}
+      apk_url: ${{ steps.release-status.outputs.apk_url }}
+      beta_number: ${{ steps.release-status.outputs.beta_number }}
+      tag: ${{ steps.release-status.outputs.tag }}
+      version: ${{ steps.release-status.outputs.version }}
+      google_play: ${{ steps.release-status.outputs.google_play }}
+      google_play_detail: ${{ steps.release-status.outputs.google_play_detail }}
+
     steps:
       - name: Get cache week number
         id: cache-week
@@ -163,9 +174,37 @@ jobs:
           name: mobile-staging
           path: mobile/android/app/build/outputs/apk/release/app-release.apk
 
+      # Read release-status.json (written by release-android.mjs) and expose
+      # its fields as step outputs the workflow's `outputs:` block references.
+      - name: Read release status
+        id: release-status
+        if: always() && hashFiles('mobile/build/release-status.json') != ''
+        run: |
+          STATUS=mobile/build/release-status.json
+          echo "apk_name=$(jq -r '.apk_name // ""' "$STATUS")"           >> $GITHUB_OUTPUT
+          echo "apk_url=$(jq -r '.apk_url // ""' "$STATUS")"             >> $GITHUB_OUTPUT
+          echo "beta_number=$(jq -r '.beta_number // ""' "$STATUS")"     >> $GITHUB_OUTPUT
+          echo "tag=$(jq -r '.tag // ""' "$STATUS")"                     >> $GITHUB_OUTPUT
+          echo "version=$(jq -r '.version // ""' "$STATUS")"             >> $GITHUB_OUTPUT
+          echo "google_play=$(jq -r '.google_play // ""' "$STATUS")"     >> $GITHUB_OUTPUT
+          # Detail strings can contain special chars; base64-encode to be
+          # safe across the GITHUB_OUTPUT round-trip, then slack-notify
+          # decodes.
+          DETAIL=$(jq -r '.google_play_detail // ""' "$STATUS" | base64)
+          echo "google_play_detail=$DETAIL"                              >> $GITHUB_OUTPUT
+
   build-mobile-ios:
     name: Build Mobile App (iOS)
     runs-on: [self-hosted, macOS, ARM64]
+
+    outputs:
+      ipa_name: ${{ steps.release-status.outputs.ipa_name }}
+      ipa_url: ${{ steps.release-status.outputs.ipa_url }}
+      beta_number: ${{ steps.release-status.outputs.beta_number }}
+      tag: ${{ steps.release-status.outputs.tag }}
+      version: ${{ steps.release-status.outputs.version }}
+      testflight: ${{ steps.release-status.outputs.testflight }}
+      testflight_detail: ${{ steps.release-status.outputs.testflight_detail }}
 
     steps:
       - name: Kill stale build processes
@@ -368,6 +407,20 @@ jobs:
         with:
           name: mobile-staging-ios
           path: mobile/build/ios-export/app-release.ipa
+
+      - name: Read release status
+        id: release-status
+        if: always() && hashFiles('mobile/build/release-status.json') != ''
+        run: |
+          STATUS=mobile/build/release-status.json
+          echo "ipa_name=$(jq -r '.ipa_name // ""' "$STATUS")"           >> $GITHUB_OUTPUT
+          echo "ipa_url=$(jq -r '.ipa_url // ""' "$STATUS")"             >> $GITHUB_OUTPUT
+          echo "beta_number=$(jq -r '.beta_number // ""' "$STATUS")"     >> $GITHUB_OUTPUT
+          echo "tag=$(jq -r '.tag // ""' "$STATUS")"                     >> $GITHUB_OUTPUT
+          echo "version=$(jq -r '.version // ""' "$STATUS")"             >> $GITHUB_OUTPUT
+          echo "testflight=$(jq -r '.testflight // ""' "$STATUS")"       >> $GITHUB_OUTPUT
+          DETAIL=$(jq -r '.testflight_detail // ""' "$STATUS" | base64)
+          echo "testflight_detail=$DETAIL"                               >> $GITHUB_OUTPUT
 
   build-asg:
     name: Build ASG Client
@@ -628,6 +681,20 @@ jobs:
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
           SHA: ${{ github.sha }}
+          # Per-platform release metadata from the build jobs' release-status.json.
+          # These come from steps.release-status.outputs.* surfaced as job outputs.
+          ANDROID_APK_NAME: ${{ needs.build-mobile-android.outputs.apk_name }}
+          ANDROID_APK_URL: ${{ needs.build-mobile-android.outputs.apk_url }}
+          ANDROID_BETA: ${{ needs.build-mobile-android.outputs.beta_number }}
+          ANDROID_VERSION: ${{ needs.build-mobile-android.outputs.version }}
+          ANDROID_PLAY: ${{ needs.build-mobile-android.outputs.google_play }}
+          ANDROID_PLAY_DETAIL_B64: ${{ needs.build-mobile-android.outputs.google_play_detail }}
+          IOS_IPA_NAME: ${{ needs.build-mobile-ios.outputs.ipa_name }}
+          IOS_IPA_URL: ${{ needs.build-mobile-ios.outputs.ipa_url }}
+          IOS_BETA: ${{ needs.build-mobile-ios.outputs.beta_number }}
+          IOS_VERSION: ${{ needs.build-mobile-ios.outputs.version }}
+          IOS_TESTFLIGHT: ${{ needs.build-mobile-ios.outputs.testflight }}
+          IOS_TESTFLIGHT_DETAIL_B64: ${{ needs.build-mobile-ios.outputs.testflight_detail }}
         # All shell here is pure ASCII. Status symbols use Slack mrkdwn
         # emoji codes (e.g. :white_check_mark:) instead of literal Unicode
         # so the shell parser never has to deal with non-ASCII bytes.
@@ -684,28 +751,74 @@ jobs:
 
           RUN_URL="https://github.com/${REPO}/actions/runs/${RUN_ID}"
           COMMIT_URL="https://github.com/${REPO}/commit/${SHA}"
-          RELEASE_BASE="https://github.com/${REPO}/releases/download/staging-builds"
-          ANDROID_URL="${RELEASE_BASE}/mobile-latest.apk"
-          IOS_URL="${RELEASE_BASE}/mobile-latest.ipa"
-          ASG_URL="${RELEASE_BASE}/asg-latest.apk"
 
-          android_detail() {
-            if [ "$ANDROID_RESULT" = "success" ]; then
-              echo "<${ANDROID_URL}|Download mobile-latest.apk>"
+          # Helper: emoji shortcode for a sub-status (TestFlight, Play).
+          substatus_icon() {
+            case "$1" in
+              success) echo ":white_check_mark:" ;;
+              failure) echo ":x:" ;;
+              skipped) echo ":fast_forward:" ;;
+              *) echo ":grey_question:" ;;
+            esac
+          }
+
+          # Helper: decode base64 detail, return empty if input is empty.
+          decode_b64() {
+            if [ -z "$1" ]; then
+              echo ""
             else
-              echo "<${RUN_URL}|See run logs>"
+              echo "$1" | base64 --decode 2>/dev/null || echo ""
             fi
           }
-          ios_detail() {
-            if [ "$IOS_RESULT" = "success" ]; then
-              echo "<${IOS_URL}|Download mobile-latest.ipa>"
+
+          # Per-platform detail lines built from the build jobs' outputs.
+          # Use the Beta_N versioned URL (not mobile-latest) so the link
+          # makes it clear which build this notification is about.
+          ANDROID_PLAY_DETAIL=$(decode_b64 "$ANDROID_PLAY_DETAIL_B64")
+          IOS_TESTFLIGHT_DETAIL=$(decode_b64 "$IOS_TESTFLIGHT_DETAIL_B64")
+          # ASG client doesn't write a release-status.json (no versioning logic
+          # in its job), so we just link to the rolling URL.
+          ASG_LATEST_URL="https://github.com/${REPO}/releases/download/staging-builds/asg-latest.apk"
+
+          android_detail() {
+            local lines=""
+            if [ "$ANDROID_RESULT" = "success" ] && [ -n "$ANDROID_APK_URL" ]; then
+              # Show version + Beta_N + APK link.
+              lines="*v${ANDROID_VERSION} Beta ${ANDROID_BETA}* - <${ANDROID_APK_URL}|${ANDROID_APK_NAME}>"
+              # Add Play upload sub-line.
+              local play_icon
+              play_icon=$(substatus_icon "$ANDROID_PLAY")
+              case "$ANDROID_PLAY" in
+                success) lines="${lines}\nGoogle Play internal: ${play_icon} uploaded" ;;
+                failure) lines="${lines}\nGoogle Play internal: ${play_icon} ${ANDROID_PLAY_DETAIL:-failed}" ;;
+                skipped) lines="${lines}\nGoogle Play internal: ${play_icon} skipped (${ANDROID_PLAY_DETAIL:-no creds})" ;;
+                *)       lines="${lines}\nGoogle Play internal: ${play_icon} ${ANDROID_PLAY:-unknown}" ;;
+              esac
             else
-              echo "<${RUN_URL}|See run logs>"
+              lines="<${RUN_URL}|See run logs>"
             fi
+            printf '%b' "$lines"
+          }
+          ios_detail() {
+            local lines=""
+            if [ "$IOS_RESULT" = "success" ] && [ -n "$IOS_IPA_URL" ]; then
+              lines="*v${IOS_VERSION} Beta ${IOS_BETA}* - <${IOS_IPA_URL}|${IOS_IPA_NAME}>"
+              local tf_icon
+              tf_icon=$(substatus_icon "$IOS_TESTFLIGHT")
+              case "$IOS_TESTFLIGHT" in
+                success) lines="${lines}\nTestFlight: ${tf_icon} uploaded" ;;
+                failure) lines="${lines}\nTestFlight: ${tf_icon} ${IOS_TESTFLIGHT_DETAIL:-failed}" ;;
+                skipped) lines="${lines}\nTestFlight: ${tf_icon} skipped (${IOS_TESTFLIGHT_DETAIL:-no creds})" ;;
+                *)       lines="${lines}\nTestFlight: ${tf_icon} ${IOS_TESTFLIGHT:-unknown}" ;;
+              esac
+            else
+              lines="<${RUN_URL}|See run logs>"
+            fi
+            printf '%b' "$lines"
           }
           asg_detail() {
             if [ "$ASG_RESULT" = "success" ]; then
-              echo "<${ASG_URL}|Download asg-latest.apk>"
+              echo "<${ASG_LATEST_URL}|Download asg-latest.apk>"
             else
               echo "<${RUN_URL}|See run logs>"
             fi

--- a/mobile/scripts/README.md
+++ b/mobile/scripts/README.md
@@ -170,4 +170,21 @@ Both tiers are run by the weekly scheduler.
 
 ## Linux runner support
 
-Not implemented yet. The cleanup script (`runner-cleanup.sh`) is already cross-platform and the systemd unit files (`runner-cleanup.service.template`, `runner-cleanup.timer.template`) are ready. `setup-runner.sh` itself currently bails on Linux. When we onboard a Linux build box, expect to do ~half a day of platform-branch work in setup-runner.sh covering: apt-get instead of brew, Android SDK manual download, GitHub Actions runner Linux tarball, systemd unit install instead of launchd plist. The pieces are all here; just needs to be wired up and tested on actual hardware.
+**Status: best-effort, untested.** `setup-runner.sh` has been extended with `case "$(uname -s)"` branches for Ubuntu/Debian (apt-get instead of brew, Linux Android SDK install, systemd timer instead of launchd plist for the cleanup scheduler, Linux-x64/arm64 GitHub Actions runner tarball, etc.) but nothing has been exercised on a real Linux box yet. Expect to fix bugs the first time you actually onboard a Linux runner.
+
+A Linux runner only supports the Android + ASG client jobs, not iOS (Xcode-only). The `staging-builds.yml` Android job has `runs-on: [self-hosted, macOS, ARM64]` which currently excludes Linux — change to bare `self-hosted` once you have a working Linux runner and want it to pick up Android load.
+
+Onboarding a Linux runner (after merge):
+
+```bash
+# On the Linux box:
+git clone https://github.com/Mentra-Community/MentraOS.git
+cd MentraOS/mobile/scripts
+GH_RUNNER_TOKEN=ghs_xxx ./setup-runner.sh
+
+# Then on your laptop:
+scp ~/.mentra/credentials/google-play-key.json <user>@<linux-runner>:~/.mentra/credentials/
+scp ~/.gradle/gradle.properties <user>@<linux-runner>:~/.gradle/gradle.properties
+```
+
+(No `appstore-connect.env` or `AuthKey_*.p8` needed since Linux doesn't do iOS.)

--- a/mobile/scripts/README.md
+++ b/mobile/scripts/README.md
@@ -1,0 +1,173 @@
+# mobile/scripts
+
+Build, release, dev, runner-bootstrap, and log-tooling scripts for the MentraOS mobile app.
+
+Most are invoked via `bun` (see `mobile/package.json` `scripts:` section) and are NOT meant to be run directly — but they're also self-contained enough to run with `zx ./scripts/foo.mjs` if you know what you're doing.
+
+## Quick reference
+
+### Dev / day-to-day
+
+| Script | Purpose |
+|---|---|
+| `start.mjs` | Wrapper around `expo start`. Sets `EXPO_PUBLIC_BUILD_*` env vars from git first. Invoked via `bun start`. |
+| `android.mjs` | Build + install + launch the app on a USB-connected Android device. `bun android`. |
+| `ios.mjs` | Same for iOS Simulator. `bun ios`. |
+| `android-wireless.mjs` | Switch a USB-connected Android device to wireless adb. |
+| `android-dbg.sh` | Set up adb reverse proxies for local-network dev. |
+| `android-flash-prebuilt.mjs` | Flash a prebuilt APK to a device without rebuilding. |
+| `android-internal.mjs` | Build for the Play Store "internal" track without uploading. |
+| `set-build-env.mjs` | Helper: reads `git config user.name`, current branch, etc., and exports them as `EXPO_PUBLIC_BUILD_*` env vars so the in-app debug overlay can show "built by X on Y commit". Required by every release script. |
+
+### Release pipeline
+
+These get wired into the staging-builds CI workflow (`.github/workflows/staging-builds.yml`) and can also be invoked manually from your laptop.
+
+| Script | Purpose |
+|---|---|
+| `release-all.mjs` | Convenience wrapper: runs `release-android.mjs` then `release-ios.mjs`. `bun run release:all`. |
+| `release-android.mjs` | Build signed APK + AAB → upload APK to GitHub release as `Mentra_<X>p<Y>_Beta_N.apk` → upload AAB to Google Play internal track via fastlane. `bun run release:android`. |
+| `release-ios.mjs` | Build signed IPA → upload to GitHub release as `Mentra_iOS_<X>p<Y>_Beta_N.ipa` → upload to TestFlight via `xcrun altool`. `bun run release:ios`. |
+| `release-utils.mjs` | Shared helpers: `withRetry` (network ops), `isSentryTransientError` (Sentry retry predicate), `writeSummary` (per-platform release summary files). |
+| `build-number.mjs` | Single source of truth for `CFBundleVersion` / `versionCode`. Derives from `Date.now()` so it's strictly monotonic across CI + local without needing a committed counter. |
+| `build-google-play.mjs` | Standalone AAB build (no upload). Rarely used directly. |
+| `ios-release.mjs` | Older iOS release path (pre-fastlane-match). Kept for now; prefer `release-ios.mjs`. |
+| `build-number.d.mts` | TypeScript declarations for `build-number.mjs` so `app.config.ts` can import it cleanly. |
+
+### Self-hosted runner setup + maintenance
+
+| Script | Purpose |
+|---|---|
+| `setup-runner.sh` | Bootstrap a Mac mini into a working GitHub Actions self-hosted runner. **See [New runner setup guide](#new-runner-setup-guide) below.** |
+| `runner-cleanup.sh` | Cross-platform cache cleanup. Scheduled by setup-runner.sh to run weekly. Also invokable manually for deep clean. See [Cleanup script](#runner-cleanup-script) below. |
+| `runner-cleanup.plist.template` | macOS launchd unit installed by setup-runner.sh. |
+| `runner-cleanup.service.template` | Linux systemd unit (not yet installed automatically; for when Linux runner support lands). |
+| `runner-cleanup.timer.template` | Linux systemd timer that triggers the cleanup service. |
+| `setup-ios.sh` | One-time `pod install` + Xcode setup for a fresh laptop checkout. Independent of CI. |
+| `setup-sherpa-onnx-optional.sh` | Downloads the Sherpa ONNX model bundle. Optional; only needed if you're working on the on-device speech feature. |
+
+### Log / debug tooling
+
+| Script | Purpose |
+|---|---|
+| `log-viewer.sh` | Pretty-print + color the firehose from `bun start`. `bun dev:logs`. |
+| `log-dashboard.sh` | Real-time stats + counters from the firehose. `bun dev:logs-dashboard`. |
+| `log-filter.sh` | Grep-style filter by subsystem (BLE, audio, etc.). |
+| `sherpa-download.js` | Re-fetches the Sherpa ONNX models if they got nuked or corrupted. |
+| `preinstall.mjs` / `postinstall.mjs` | Hooks bun runs around `bun install`. Currently mostly no-ops with logging. |
+| `model-download-config.json` | Config for `sherpa-download.js` listing which models to fetch + checksums. |
+
+### Subdirectories
+
+- **`old/`** — abandoned scripts kept for reference. Includes pre-Expo-migration build scripts. Do not edit.
+- **`stress-test/`** — Maestro-driven stress testing runs. Per-run output dirs (`runs/<timestamp>-<scenario>/`) accumulate; periodically prune them.
+
+---
+
+## New runner setup guide
+
+A short, opinionated walk-through for onboarding a new Mac mini into the build fleet. Assumes the reader knows what a GitHub Actions self-hosted runner is.
+
+### Prerequisites
+
+1. **Hardware**: Apple Silicon Mac mini. (Intel works but isn't tested.)
+2. **macOS user account**: a dedicated user, not your personal one. Convention: name it for the machine (e.g. `bigbob`).
+3. **Xcode**: installed from the App Store, launched once, license accepted. Sign into the Mentra Apple Developer account in Xcode → Settings → Accounts so the runner can do signed iOS archives.
+4. **Network**: machine should be reachable on Tailscale (`tag:ci`) for remote debugging.
+5. **A short-lived runner registration token**: visit https://github.com/Mentra-Community/MentraOS/settings/actions/runners/new and copy the `ghs_xxx` token from the displayed `./config.sh` command. Token expires in ~1 hour.
+
+### Optional but recommended before running the script
+
+- Disable "Prevent automatic login" in System Settings so the machine can reboot unattended.
+- Disable screen lock / FileVault password prompts.
+
+### Run the script
+
+From this directory on the runner (clone the repo first):
+
+```bash
+git clone https://github.com/Mentra-Community/MentraOS.git
+cd MentraOS/mobile/scripts
+GH_RUNNER_TOKEN=ghs_xxx ./setup-runner.sh
+```
+
+The script is idempotent — re-running is safe and gets you the latest config (Ruby version, cleanup schedule, etc.).
+
+To also install Tailscale and join the tailnet:
+
+```bash
+ENABLE_TAILSCALE=1 TAILSCALE_AUTHKEY=tskey-auth-xxx \
+GH_RUNNER_TOKEN=ghs_xxx ./setup-runner.sh
+```
+
+Get a Tailscale auth key from https://login.tailscale.com/admin/settings/keys (single-use, tagged `tag:ci`, ephemeral).
+
+### After the script finishes
+
+Three manual steps the script can't automate:
+
+1. **Copy credentials.** From an existing runner or your laptop:
+
+   ```bash
+   scp ~/.mentra/credentials/{appstore-connect.env,AuthKey_*.p8,google-play-key.json} \
+       <user>@<new-runner>:~/.mentra/credentials/
+   ```
+
+   Also copy `~/.gradle/gradle.properties` if it has the `MENTRAOS_UPLOAD_*` keys (needed for Android release signing):
+
+   ```bash
+   scp ~/.gradle/gradle.properties <user>@<new-runner>:~/.gradle/gradle.properties
+   ```
+
+2. **Enable auto-login** in System Settings > Users & Groups so the machine recovers from power cuts without human intervention.
+
+3. **Verify the runner shows up** at https://github.com/Mentra-Community/MentraOS/settings/actions/runners with the labels `self-hosted, macOS, ARM64`. If you used custom labels, also confirm those.
+
+### Verify it actually works
+
+Trigger a manual workflow run:
+
+```bash
+gh workflow run staging-builds.yml --ref staging
+```
+
+Watch the run and confirm a job picks the new runner.
+
+---
+
+## Runner cleanup script
+
+`runner-cleanup.sh` is scheduled by `setup-runner.sh` to run weekly (Sundays 03:00 local). It defers automatically if a build process (gradle, xcodebuild, Xcode, bun, node, java, cmake) is detected.
+
+### Tiers
+
+- **Tier 1** (cheap caches): bun install cache, gradle build-cache + transforms, Android emulator system images, stale `_work` dirs older than 7 days. Next build is *not* noticeably slower.
+- **Tier 2** (expensive caches): everything in Tier 1, plus the whole `~/.gradle/caches`, the user cache dir (`~/Library/Caches` on macOS, `~/.cache` on Linux), `~/.android/avd`, and `~/Library/Developer/Xcode/DerivedData/Mentra-*`. First build after Tier 2 is *significantly* slower (5-15 min cold gradle, ~10 min cold iOS archive).
+
+Both tiers are run by the weekly scheduler.
+
+### Manual invocations
+
+```bash
+# Default: --tier all, with build-process guard
+~/mentra/runner-cleanup.sh
+
+# Just Tier 1
+~/mentra/runner-cleanup.sh --tier 1
+
+# Force run even if a build is in progress (DANGEROUS — only if you're sure)
+~/mentra/runner-cleanup.sh --force
+
+# Dry-run: see what would be deleted without changing anything
+~/mentra/runner-cleanup.sh --dry-run
+```
+
+### Logs
+
+`~/mentra/runner-cleanup.log` — appended to on every run, trimmed to the last 500 lines automatically.
+
+---
+
+## Linux runner support
+
+Not implemented yet. The cleanup script (`runner-cleanup.sh`) is already cross-platform and the systemd unit files (`runner-cleanup.service.template`, `runner-cleanup.timer.template`) are ready. `setup-runner.sh` itself currently bails on Linux. When we onboard a Linux build box, expect to do ~half a day of platform-branch work in setup-runner.sh covering: apt-get instead of brew, Android SDK manual download, GitHub Actions runner Linux tarball, systemd unit install instead of launchd plist. The pieces are all here; just needs to be wired up and tested on actual hardware.

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -187,19 +187,45 @@ console.log('\n━━━ Step 9: Uploading AAB to Google Play ━━━');
 
 const keyPath = process.env.GOOGLE_PLAY_JSON_KEY || path.join(os.homedir(), '.mentra', 'credentials', 'google-play-key.json');
 
+// Track Play Store upload result so we can surface it in the release-status
+// JSON consumed by the staging-builds workflow Slack notification.
+let playStatus = 'skipped';
+let playDetail = null;
+
 if (!existsSync(keyPath)) {
   console.log(`⚠️  Google Play key not found at ${keyPath}`);
   console.log('   Skipping Google Play upload.');
   console.log('   To enable: place service account key at ~/.mentra/credentials/google-play-key.json');
   console.log('   or set GOOGLE_PLAY_JSON_KEY env var.');
+  playDetail = 'credentials missing on runner';
 } else {
   process.env.GOOGLE_PLAY_JSON_KEY = keyPath;
   // Install gems and run fastlane
   await $({ stdio: 'inherit', cwd: 'android' })`bundle install`;
-  await withRetry('fastlane google_play', () =>
-    $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`
-  );
-  console.log('AAB uploaded to Google Play (internal track)');
+  try {
+    await withRetry('fastlane google_play', () =>
+      $({ stdio: 'inherit', cwd: 'android' })`bundle exec fastlane google_play`
+    );
+    console.log('AAB uploaded to Google Play (internal track)');
+    playStatus = 'success';
+  } catch (err) {
+    // Same philosophy as iOS TestFlight: Play upload is a publish-side
+    // concern. The signed APK + AAB are already on the GH release. Don't
+    // fail the build over a transient Play API outage or a previously-
+    // uploaded versionCode collision; warn loud and continue.
+    console.warn('\n⚠️  Google Play upload failed — continuing because the signed APK + AAB');
+    console.warn('   were still published to the GitHub release.');
+    console.warn('   Original error:', err?.message || err);
+    playStatus = 'failure';
+    const msg = String(err?.message || err || '');
+    if (/wrong key|signed with the wrong/i.test(msg)) {
+      playDetail = 'AAB signed with wrong key (check upload-keystore)';
+    } else if (/version code|already.+used/i.test(msg)) {
+      playDetail = 'versionCode already used (bump build number)';
+    } else {
+      playDetail = msg.split('\n')[0].slice(0, 200);
+    }
+  }
 }
 
 // ── Done ──────────────────────────────────────────────────────────────────────
@@ -212,7 +238,35 @@ const summaryLines = [
   `  Version: ${version} (versionCode ${versionCode})`,
   `  APK: ${apkUrl}`,
 ];
-if (existsSync(keyPath)) {
+if (playStatus === 'success') {
   summaryLines.push('  Google Play: AAB uploaded (internal track)');
+} else if (playStatus === 'failure') {
+  summaryLines.push(`  Google Play: FAILED (${playDetail || 'see logs'})`);
+} else {
+  summaryLines.push('  Google Play: skipped (no credentials on runner)');
 }
 await writeSummary('android', summaryLines);
+
+// Structured status file for the staging-builds workflow's Slack notification.
+const statusPath = path.resolve('build/release-status.json');
+const { writeFile: writeStatusFile, mkdir: mkdirP } = await import('fs/promises');
+await mkdirP(path.dirname(statusPath), { recursive: true });
+await writeStatusFile(
+  statusPath,
+  JSON.stringify(
+    {
+      platform: 'android',
+      version,
+      versionCode,
+      beta_number: betaNumber,
+      apk_name: apkName,
+      apk_url: apkUrl,
+      tag,
+      google_play: playStatus, // 'success' | 'failure' | 'skipped'
+      google_play_detail: playDetail,
+    },
+    null,
+    2,
+  ),
+);
+console.log(`Wrote release status: ${statusPath}`);

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -181,10 +181,16 @@ console.log('\n━━━ Step 6: Uploading to App Store Connect ━━━');
 
 const ascConfig = loadASCConfig();
 
+// Track TestFlight result so we can surface it in the summary file
+// release-status.json (consumed by the workflow's Slack notification).
+let testflightStatus = 'skipped';
+let testflightDetail = null;
+
 if (!ascConfig || !ascConfig.ASC_API_KEY_ID || !ascConfig.ASC_API_ISSUER_ID || !existsSync(ascConfig.ASC_API_KEY_PATH || '')) {
   console.log('⚠️  App Store Connect credentials not found at ~/.mentra/credentials/appstore-connect.env');
   console.log('   Skipping TestFlight upload.');
   console.log('   To enable: create ~/.mentra/credentials/appstore-connect.env with ASC_API_KEY_ID, ASC_API_ISSUER_ID, ASC_API_KEY_PATH');
+  testflightDetail = 'credentials missing on runner';
 } else {
   // altool looks for AuthKey_<id>.p8 in $API_PRIVATE_KEYS_DIR
   const keyDir = path.dirname(ascConfig.ASC_API_KEY_PATH);
@@ -193,6 +199,7 @@ if (!ascConfig || !ascConfig.ASC_API_KEY_ID || !ascConfig.ASC_API_ISSUER_ID || !
       $({ stdio: 'inherit', env: { ...process.env, API_PRIVATE_KEYS_DIR: keyDir } })`xcrun altool --upload-app -f ${ipaPath} -t ios --apiKey ${ascConfig.ASC_API_KEY_ID} --apiIssuer ${ascConfig.ASC_API_ISSUER_ID}`
     );
     console.log('IPA uploaded to App Store Connect (TestFlight)');
+    testflightStatus = 'success';
   } catch (err) {
     // TestFlight upload is a publish-side concern, not a build-correctness
     // check. The signed IPA itself is valid and has already been published
@@ -205,6 +212,15 @@ if (!ascConfig || !ascConfig.ASC_API_KEY_ID || !ascConfig.ASC_API_ISSUER_ID || !
     console.warn('   Common cause: EXPO_PUBLIC_MENTRAOS_VERSION matches a previously');
     console.warn('   approved/closed TestFlight train. Bump it to enable TestFlight.');
     console.warn('   Original error:', err?.message || err);
+    testflightStatus = 'failure';
+    // Heuristic: if the error mentions the closed-train pattern, surface that;
+    // otherwise show the first line of the error.
+    const msg = String(err?.message || err || '');
+    if (/closed for new build submissions|must contain a higher version|Invalid Pre-Release Train/i.test(msg)) {
+      testflightDetail = 'version closed (bump EXPO_PUBLIC_MENTRAOS_VERSION)';
+    } else {
+      testflightDetail = msg.split('\n')[0].slice(0, 200);
+    }
   }
 }
 
@@ -272,7 +288,36 @@ const summaryLines = [
   `  Version: ${version} (buildNumber ${buildNumber})`,
   `  IPA: ${ipaUrl}`,
 ];
-if (ascConfig && existsSync(ascConfig.ASC_API_KEY_PATH || '')) {
+if (testflightStatus === 'success') {
   summaryLines.push('  TestFlight: uploaded');
+} else if (testflightStatus === 'failure') {
+  summaryLines.push(`  TestFlight: FAILED (${testflightDetail || 'see logs'})`);
+} else {
+  summaryLines.push('  TestFlight: skipped (no credentials on runner)');
 }
 await writeSummary('ios', summaryLines);
+
+// Structured status file for the staging-builds workflow's Slack notification.
+// Consumed by the "Build Mobile App (iOS)" job's post-script step which emits
+// these values as job outputs that slack-notify reads.
+const statusPath = path.resolve('build/release-status.json');
+const { writeFile: writeStatusFile } = await import('fs/promises');
+await writeStatusFile(
+  statusPath,
+  JSON.stringify(
+    {
+      platform: 'ios',
+      version,
+      buildNumber,
+      beta_number: betaNumber,
+      ipa_name: ipaName,
+      ipa_url: ipaUrl,
+      tag,
+      testflight: testflightStatus, // 'success' | 'failure' | 'skipped'
+      testflight_detail: testflightDetail,
+    },
+    null,
+    2,
+  ),
+);
+console.log(`Wrote release status: ${statusPath}`);

--- a/mobile/scripts/runner-cleanup.plist.template
+++ b/mobile/scripts/runner-cleanup.plist.template
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+        "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  MentraOS runner cache cleanup launchd unit.
+  Installed by mobile/scripts/setup-runner.sh into
+    ~/Library/LaunchAgents/com.mentra.runner-cleanup.plist
+  with @@HOME_DIR@@ substituted to the absolute path of $HOME.
+
+  Schedule: every Sunday at 03:00 local time.
+  Behavior: runs the cleanup script with tier=all (Tier 1 + Tier 2).
+  If a build is active, the script auto-defers and exits 0.
+-->
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.mentra.runner-cleanup</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/bin/bash</string>
+      <string>@@HOME_DIR@@/mentra/runner-cleanup.sh</string>
+      <string>--tier</string>
+      <string>all</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+      <!-- Sunday = weekday 0 in launchd's StartCalendarInterval scheme. -->
+      <key>Weekday</key><integer>0</integer>
+      <key>Hour</key><integer>3</integer>
+      <key>Minute</key><integer>0</integer>
+    </dict>
+
+    <!-- Run at next opportunity if the Mac was asleep at the scheduled time. -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <!-- Capture stdout/stderr into the log file the script itself appends to,
+         so we get the launchd-level "ran at this time" markers too. -->
+    <key>StandardOutPath</key>
+    <string>@@HOME_DIR@@/mentra/runner-cleanup.log</string>
+    <key>StandardErrorPath</key>
+    <string>@@HOME_DIR@@/mentra/runner-cleanup.log</string>
+
+    <!-- Nice value: 10 (lower than build processes so cleanup never starves a build). -->
+    <key>Nice</key>
+    <integer>10</integer>
+  </dict>
+</plist>

--- a/mobile/scripts/runner-cleanup.service.template
+++ b/mobile/scripts/runner-cleanup.service.template
@@ -1,0 +1,26 @@
+# MentraOS runner cache cleanup systemd service.
+# Installed by mobile/scripts/setup-runner.sh into
+#   ~/.config/systemd/user/runner-cleanup.service
+# with @@HOME_DIR@@ substituted to the absolute path of $HOME.
+#
+# Triggered weekly by runner-cleanup.timer (Sunday 03:00 local).
+# Behavior: runs the cleanup script with `--tier all`. If a build is
+# active, the script auto-defers and exits 0.
+
+[Unit]
+Description=MentraOS runner cache cleanup
+# Don't run during system shutdown.
+DefaultDependencies=no
+After=default.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/bash @@HOME_DIR@@/mentra/runner-cleanup.sh --tier all
+StandardOutput=append:@@HOME_DIR@@/mentra/runner-cleanup.log
+StandardError=append:@@HOME_DIR@@/mentra/runner-cleanup.log
+# Lower priority than build processes so cleanup never starves a build.
+Nice=10
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=default.target

--- a/mobile/scripts/runner-cleanup.sh
+++ b/mobile/scripts/runner-cleanup.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+#
+# MentraOS self-hosted runner cache cleanup.
+#
+# Frees disk on a runner by deleting cacheable artifacts. Designed to be
+# scheduled weekly via launchd (macOS) or systemd timer (Linux); set up by
+# mobile/scripts/setup-runner.sh.
+#
+# Tiers (cumulative — Tier 2 includes Tier 1):
+#   Tier 1 — Cheap caches that re-fill from local computation or fast
+#            downloads on the next build:
+#              * ~/.bun/install/cache/*
+#              * ~/.gradle/caches/build-cache-* and transforms-*
+#              * Android emulator system images (we don't run emulators in CI)
+#              * stale _work checkouts older than 7 days
+#   Tier 2 — Expensive caches; first build after wipe costs 5-15 min:
+#              * everything in Tier 1
+#              * ~/.gradle/caches in full (Maven deps re-download)
+#              * ~/Library/Caches/* (macOS) / ~/.cache/* (Linux), minus dirs
+#                we know are not safe to wipe (gh, dotnet)
+#              * ~/.android/avd (any configured emulators)
+#              * ~/Library/Developer/Xcode/DerivedData/Mentra-* (macOS only)
+#
+# Concurrency: if a build is running (gradle, xcodebuild, Xcode, bun, node
+# processes owned by the current user) the cleanup defers and exits 0. The
+# scheduler retries on its normal cadence (weekly) so no spinning.
+#
+# Logs to ~/mentra/runner-cleanup.log, self-trimmed to last 500 lines.
+#
+# Usage:
+#   runner-cleanup.sh                # default: --tier all
+#   runner-cleanup.sh --tier 1       # quick cleanup
+#   runner-cleanup.sh --tier 2       # deep cleanup (includes Tier 1)
+#   runner-cleanup.sh --tier all     # same as --tier 2
+#   runner-cleanup.sh --dry-run      # print what would be deleted, change nothing
+#   runner-cleanup.sh --force        # skip the build-process check
+
+set -u
+LC_ALL=C
+
+# --- Parse args --------------------------------------------------------------
+
+TIER="all"
+DRY_RUN=0
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tier)
+            TIER="${2:-}"
+            shift 2
+            ;;
+        --tier=*)
+            TIER="${1#*=}"
+            shift
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        --force)
+            FORCE=1
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,/^set -u/p' "$0" | sed 's/^# \{0,1\}//; $d'
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$TIER" in
+    1|2|all) ;;
+    *) echo "Invalid --tier '$TIER' (expected 1, 2, or all)" >&2; exit 2 ;;
+esac
+
+# --- Logging -----------------------------------------------------------------
+
+LOG_DIR="$HOME/mentra"
+LOG_FILE="$LOG_DIR/runner-cleanup.log"
+mkdir -p "$LOG_DIR"
+
+# All output (stdout + stderr) goes to the log file AND to the terminal.
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+trim_log() {
+    # Trim the log to the most recent 500 lines so it can't grow unbounded.
+    if [[ -f "$LOG_FILE" ]]; then
+        local tmp
+        tmp=$(mktemp)
+        tail -n 500 "$LOG_FILE" > "$tmp" && mv "$tmp" "$LOG_FILE"
+    fi
+}
+# Trim on exit, success or failure.
+trap trim_log EXIT
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { echo "[$(ts)] $*"; }
+
+# --- Platform detection ------------------------------------------------------
+
+case "$(uname -s)" in
+    Darwin) PLATFORM=mac ;;
+    Linux)  PLATFORM=linux ;;
+    *)      log "ERROR: unsupported platform '$(uname -s)' — exiting."; exit 1 ;;
+esac
+
+log "Starting cleanup tier=$TIER platform=$PLATFORM dry_run=$DRY_RUN force=$FORCE"
+
+# --- Build-in-progress check -------------------------------------------------
+
+# `pgrep -u "$USER"` matches processes owned by the current user only, so
+# we don't trip on system services with similar names.
+BUILD_PROCS_REGEX="gradle|xcodebuild|Xcode|bun|node|java|cmake"
+
+if [[ "$FORCE" -ne 1 ]]; then
+    if pgrep -u "$USER" -fl "$BUILD_PROCS_REGEX" >/dev/null 2>&1; then
+        log "Build process detected (pgrep matched against /$BUILD_PROCS_REGEX/) — deferring cleanup."
+        log "Active processes:"
+        pgrep -u "$USER" -fl "$BUILD_PROCS_REGEX" | sed 's/^/  /' | head -20
+        # Exit 0 so the scheduler doesn't treat this as a failure that should
+        # be retried immediately. Cleanup just runs at its next regular slot.
+        exit 0
+    fi
+fi
+
+# --- Disk usage helpers ------------------------------------------------------
+
+# Return free bytes on the root filesystem. Cross-platform: BSD `df` (mac) and
+# GNU `df` (linux) both support `-k` (1KiB blocks). We multiply by 1024.
+free_bytes() {
+    local kib
+    kib=$(df -k / | awk 'NR==2 {print $4}')
+    echo "$(( kib * 1024 ))"
+}
+
+human_bytes() {
+    # 18446744073709551615 → 16 EiB; awk handles up to ~10^15 fine.
+    awk -v b="$1" 'BEGIN {
+        units[0]="B"; units[1]="KiB"; units[2]="MiB"; units[3]="GiB"; units[4]="TiB";
+        v=b; i=0;
+        while (v >= 1024 && i < 4) { v /= 1024; i++ }
+        printf "%.2f %s\n", v, units[i];
+    }'
+}
+
+START_FREE=$(free_bytes)
+log "Before cleanup: $(human_bytes "$START_FREE") free on /"
+
+# --- rm helper that respects --dry-run ---------------------------------------
+
+# Resolve a glob safely. Bash with nullglob/nocaseglob can produce
+# unexpected results; we use `find` + `-prune` for predictable behaviour.
+nuke() {
+    local target="$1"
+    if [[ ! -e "$target" && ! -L "$target" ]]; then
+        log "  skip (not present): $target"
+        return 0
+    fi
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        local size
+        size=$(du -sk "$target" 2>/dev/null | awk '{print $1*1024}')
+        log "  would delete: $target ($(human_bytes "${size:-0}"))"
+        return 0
+    fi
+    local size
+    size=$(du -sk "$target" 2>/dev/null | awk '{print $1*1024}')
+    rm -rf -- "$target"
+    log "  deleted: $target ($(human_bytes "${size:-0}"))"
+}
+
+# Like nuke but accepts a glob pattern and operates on each match.
+# Logs one aggregate line per pattern instead of per match, so a cache with
+# thousands of entries doesn't drown the log.
+nuke_glob() {
+    local pattern="$1"
+    local matches=()
+    # shellcheck disable=SC2206
+    matches=( $pattern )
+    if [[ ${#matches[@]} -eq 0 || ( ${#matches[@]} -eq 1 && ! -e "${matches[0]}" ) ]]; then
+        log "  skip (no matches): $pattern"
+        return 0
+    fi
+
+    # Sum sizes of all matches.
+    local total_kb=0
+    for m in "${matches[@]}"; do
+        local kb
+        kb=$(du -sk "$m" 2>/dev/null | awk '{print $1}')
+        total_kb=$(( total_kb + ${kb:-0} ))
+    done
+    local total_bytes=$(( total_kb * 1024 ))
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        log "  would delete: $pattern (${#matches[@]} entries, $(human_bytes "$total_bytes"))"
+        return 0
+    fi
+
+    for m in "${matches[@]}"; do
+        rm -rf -- "$m"
+    done
+    log "  deleted: $pattern (${#matches[@]} entries, $(human_bytes "$total_bytes"))"
+}
+
+# --- Tier 1 ------------------------------------------------------------------
+
+log "Running Tier 1 (cheap caches)..."
+
+# Bun's install cache — re-fetched from the registry on next bun install.
+nuke_glob "$HOME/.bun/install/cache/*"
+
+# Gradle build cache + transforms. modules-2 (downloaded Maven deps) is
+# deliberately NOT here; that's Tier 2.
+nuke_glob "$HOME/.gradle/caches/build-cache-*"
+nuke_glob "$HOME/.gradle/caches/transforms-*"
+
+# Android emulator system images. We don't run emulators in CI; setup-runner.sh
+# doesn't install AVDs by default. If a future developer sshs in and creates
+# one this will nuke it, which is acceptable for a build server.
+if [[ "$PLATFORM" == "mac" ]]; then
+    nuke_glob "$HOME/Library/Android/sdk/system-images"
+else
+    nuke_glob "$HOME/Android/Sdk/system-images"
+fi
+
+# Stale per-runner workdirs. Each runner-N has a _work dir containing one
+# subdir per repo it's checked out. We don't try to nuke a runner's currently
+# active checkout — the build-process guard above already excludes that case.
+# Anything older than 7 days that we wouldn't touch on a typical week.
+if [[ -d "$HOME/mentra" ]]; then
+    while IFS= read -r dir; do
+        nuke "$dir"
+    done < <(find "$HOME/mentra"/actions-runner-*/_work -mindepth 2 -maxdepth 2 -type d -mtime +7 2>/dev/null)
+fi
+
+# --- Tier 2 ------------------------------------------------------------------
+
+if [[ "$TIER" == "2" || "$TIER" == "all" ]]; then
+    log "Running Tier 2 (expensive caches)..."
+
+    # Gradle: everything. Modules-2 (downloaded JARs/AARs) is the big one;
+    # next build will re-download from Maven Central (~hundreds of MB,
+    # 2-5 min on a fast pipe).
+    nuke "$HOME/.gradle/caches"
+
+    # User-level cache dir. On Mac this is ~/Library/Caches; on Linux ~/.cache.
+    # We explicitly skip a few subdirs that aren't really caches:
+    #   - gh: GH CLI auth state ("hosts.yml" → re-auth required if nuked)
+    #   - rbenv: holds downloaded Ruby tarballs but also build dirs in progress
+    if [[ "$PLATFORM" == "mac" ]]; then
+        CACHE_ROOT="$HOME/Library/Caches"
+    else
+        CACHE_ROOT="$HOME/.cache"
+    fi
+    if [[ -d "$CACHE_ROOT" ]]; then
+        # find ... -prune to skip whitelisted dirs.
+        while IFS= read -r entry; do
+            nuke "$entry"
+        done < <(find "$CACHE_ROOT" -mindepth 1 -maxdepth 1 \
+                    ! -name "gh" \
+                    ! -name "rbenv" \
+                    2>/dev/null)
+    fi
+
+    # Android emulators (state, snapshots, custom AVD configs).
+    nuke "$HOME/.android/avd"
+
+    # macOS-only: Xcode DerivedData for the Mentra project. Major disk hog
+    # (~20-50 GB after a few builds). Next iOS archive is slow (~10 min cold
+    # compile) but that's what a deep clean is for.
+    if [[ "$PLATFORM" == "mac" ]]; then
+        nuke_glob "$HOME/Library/Developer/Xcode/DerivedData/Mentra-*"
+    fi
+fi
+
+# --- Summary -----------------------------------------------------------------
+
+END_FREE=$(free_bytes)
+DELTA=$(( END_FREE - START_FREE ))
+
+log "After cleanup: $(human_bytes "$END_FREE") free on /"
+if [[ "$DELTA" -ge 0 ]]; then
+    log "Freed: $(human_bytes "$DELTA")"
+else
+    # Possible if a build wrote new files during cleanup. Rare but real.
+    log "Net change: -$(human_bytes "$(( -DELTA ))") (disk shrank during cleanup — likely build wrote new artifacts)"
+fi
+
+log "Done."

--- a/mobile/scripts/runner-cleanup.timer.template
+++ b/mobile/scripts/runner-cleanup.timer.template
@@ -1,0 +1,19 @@
+# MentraOS runner cache cleanup systemd timer.
+# Installed by mobile/scripts/setup-runner.sh into
+#   ~/.config/systemd/user/runner-cleanup.timer
+#
+# Fires the runner-cleanup.service every Sunday at 03:00 local time.
+
+[Unit]
+Description=Weekly trigger for MentraOS runner cache cleanup
+Requires=runner-cleanup.service
+
+[Timer]
+OnCalendar=Sun *-*-* 03:00:00
+# If the machine was off at 03:00, run as soon as it's available again.
+Persistent=true
+# Don't fire multiple times concurrently if the service is somehow still running.
+Unit=runner-cleanup.service
+
+[Install]
+WantedBy=timers.target

--- a/mobile/scripts/setup-runner.sh
+++ b/mobile/scripts/setup-runner.sh
@@ -477,6 +477,44 @@ sudo mdutil -i off "$HOME/Library/Caches/CocoaPods" 2>/dev/null || true
 ok "Spotlight indexing disabled for build artifact directories"
 
 # ---------------------------------------------------------------------------
+# Weekly cache cleanup scheduler
+# ---------------------------------------------------------------------------
+# Runs runner-cleanup.sh every Sunday at 03:00 local. The script auto-defers
+# if a build is active, so this never interrupts work. See
+# mobile/scripts/runner-cleanup.sh + .plist.template for the moving parts.
+
+info "Installing weekly cache cleanup scheduler"
+
+SCRIPT_DIR_ABS="$(cd "$(dirname "$0")" && pwd)"
+CLEANUP_SCRIPT_SRC="$SCRIPT_DIR_ABS/runner-cleanup.sh"
+CLEANUP_PLIST_SRC="$SCRIPT_DIR_ABS/runner-cleanup.plist.template"
+CLEANUP_SCRIPT_DST="$RUNNER_BASE_DIR/runner-cleanup.sh"
+CLEANUP_PLIST_DST="$HOME/Library/LaunchAgents/com.mentra.runner-cleanup.plist"
+
+if [[ ! -f "$CLEANUP_SCRIPT_SRC" ]]; then
+    warn "runner-cleanup.sh not found next to setup-runner.sh — skipping cleanup scheduler install."
+elif [[ ! -f "$CLEANUP_PLIST_SRC" ]]; then
+    warn "runner-cleanup.plist.template not found — skipping cleanup scheduler install."
+else
+    # Copy the script to a stable location (the in-repo path is volatile —
+    # workflow runs check out fresh into _work/.../scripts/). The plist
+    # references the stable copy.
+    mkdir -p "$RUNNER_BASE_DIR"
+    cp "$CLEANUP_SCRIPT_SRC" "$CLEANUP_SCRIPT_DST"
+    chmod +x "$CLEANUP_SCRIPT_DST"
+
+    # Render the plist with $HOME substituted into the @@HOME_DIR@@ placeholder.
+    mkdir -p "$(dirname "$CLEANUP_PLIST_DST")"
+    sed "s|@@HOME_DIR@@|$HOME|g" "$CLEANUP_PLIST_SRC" > "$CLEANUP_PLIST_DST"
+
+    # Reload the plist (unload then load) so config changes take effect.
+    launchctl unload "$CLEANUP_PLIST_DST" 2>/dev/null || true
+    launchctl load -w "$CLEANUP_PLIST_DST" 2>/dev/null || true
+
+    ok "Weekly cleanup scheduled: Sundays 03:00 (script: $CLEANUP_SCRIPT_DST)"
+fi
+
+# ---------------------------------------------------------------------------
 # GitHub Actions runner(s)
 # ---------------------------------------------------------------------------
 
@@ -566,5 +604,10 @@ cat <<EOF
     - Copy ~/.mentra/credentials/ from an existing runner (or your laptop):
         scp ~/.mentra/credentials/{appstore-connect.env,AuthKey_*.p8,google-play-key.json} \\
             user@$RUNNER_NAME_BASE:~/.mentra/credentials/
+
+  Automated maintenance:
+    - Weekly cache cleanup runs Sundays at 03:00 (defers if a build is active).
+      Logs: $RUNNER_BASE_DIR/runner-cleanup.log
+      Manual deep clean: $RUNNER_BASE_DIR/runner-cleanup.sh --tier all --force
 ==========================================================================
 EOF

--- a/mobile/scripts/setup-runner.sh
+++ b/mobile/scripts/setup-runner.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 #
-# MentraOS Mac mini self-hosted runner bootstrap.
+# MentraOS self-hosted runner bootstrap (macOS + Linux).
 #
-# Bootstraps a fresh Mac mini into a working GitHub Actions runner host for
-# the MentraOS iOS + Android pipelines. Run once per new machine. Re-running
-# is safe — every step is idempotent.
+# Bootstraps a fresh Mac mini OR a Linux box (Ubuntu/Debian) into a working
+# GitHub Actions runner host for the MentraOS pipelines. Re-running is safe —
+# every step is idempotent.
+#
+# Platform support:
+#   macOS  — full support: mobile iOS + mobile Android + ASG client
+#   Linux  — partial: mobile Android + ASG client only (no iOS). Use a Linux
+#            runner to take Android/ASG load off the Mac minis once you have
+#            >2 macOS runners.
+#
+# NOTE: The Linux paths in this script are not yet exercised in CI. Treat
+# them as "best effort, will fix when we actually onboard a Linux box."
 #
 # Manual prerequisites (do these once before running this script):
 #   1. Sign in to the Mac with the dedicated CI Apple ID.
@@ -107,8 +116,15 @@ fi
 # Preflight
 # ---------------------------------------------------------------------------
 
-[[ "$(uname -s)" == "Darwin" ]] || fail "This script only runs on macOS."
-[[ "$(uname -m)" == "arm64" ]]  || fail "Apple Silicon required (arm64)."
+case "$(uname -s)" in
+    Darwin) PLATFORM=mac ;;
+    Linux)  PLATFORM=linux ;;
+    *)      fail "This script supports macOS and Linux only (got $(uname -s))." ;;
+esac
+
+if [[ "$PLATFORM" == "mac" ]]; then
+    [[ "$(uname -m)" == "arm64" ]] || fail "Apple Silicon required on macOS (arm64)."
+fi
 
 GH_RUNNER_URL="${GH_RUNNER_URL:-https://github.com/Mentra-Community/MentraOS}"
 
@@ -188,65 +204,102 @@ fi
 # Xcode license + CLI tools
 # ---------------------------------------------------------------------------
 
-info "Ensuring Xcode CLI tools are installed"
-if ! xcode-select -p >/dev/null 2>&1; then
-    xcode-select --install || true
-    warn "Xcode CLI tools were missing. Re-run this script after the GUI install completes."
-    exit 1
-fi
+if [[ "$PLATFORM" == "mac" ]]; then
+    info "Ensuring Xcode CLI tools are installed"
+    if ! xcode-select -p >/dev/null 2>&1; then
+        xcode-select --install || true
+        warn "Xcode CLI tools were missing. Re-run this script after the GUI install completes."
+        exit 1
+    fi
 
-if [[ -d "/Applications/Xcode.app" ]]; then
-    sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
-    sudo xcodebuild -license accept || true
-    sudo xcodebuild -runFirstLaunch || true
-    ok "Xcode pointed at /Applications/Xcode.app"
+    if [[ -d "/Applications/Xcode.app" ]]; then
+        sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
+        sudo xcodebuild -license accept || true
+        sudo xcodebuild -runFirstLaunch || true
+        ok "Xcode pointed at /Applications/Xcode.app"
+    else
+        fail "Xcode.app not found in /Applications. Install Xcode from the App Store first."
+    fi
 else
-    fail "Xcode.app not found in /Applications. Install Xcode from the App Store first."
+    info "Skipping Xcode setup (Linux runner — Android + ASG only)."
 fi
 
 # ---------------------------------------------------------------------------
 # Homebrew
 # ---------------------------------------------------------------------------
 
-if ! command -v brew >/dev/null 2>&1; then
-    info "Installing Homebrew"
-    NONINTERACTIVE=1 /bin/bash -c \
-        "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-fi
+if [[ "$PLATFORM" == "mac" ]]; then
+    if ! command -v brew >/dev/null 2>&1; then
+        info "Installing Homebrew"
+        NONINTERACTIVE=1 /bin/bash -c \
+            "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    fi
 
-# Ensure brew is on PATH for the rest of this script + future shells.
-BREW_PREFIX="/opt/homebrew"
-eval "$($BREW_PREFIX/bin/brew shellenv)"
+    # Ensure brew is on PATH for the rest of this script + future shells.
+    BREW_PREFIX="/opt/homebrew"
+    eval "$($BREW_PREFIX/bin/brew shellenv)"
 
-ZPROFILE="$HOME/.zprofile"
-if ! grep -q 'brew shellenv' "$ZPROFILE" 2>/dev/null; then
-    echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$ZPROFILE"
+    ZPROFILE="$HOME/.zprofile"
+    if ! grep -q 'brew shellenv' "$ZPROFILE" 2>/dev/null; then
+        echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> "$ZPROFILE"
+    fi
+    ok "Homebrew ready"
+else
+    BREW_PREFIX=""  # not used on Linux but referenced in env-var setup
+    ZPROFILE="$HOME/.profile"
+    info "Updating apt package index"
+    sudo apt-get update -qq
+    ok "apt ready"
 fi
-ok "Homebrew ready"
 
 # ---------------------------------------------------------------------------
 # Core toolchain
 # ---------------------------------------------------------------------------
 
 info "Installing core toolchain"
-brew update
+if [[ "$PLATFORM" == "mac" ]]; then
+    brew update
 
-# applesimutils lives in the wix tap.
-brew tap wix/brew >/dev/null 2>&1 || true
+    # applesimutils lives in the wix tap.
+    brew tap wix/brew >/dev/null 2>&1 || true
 
-brew install \
-    git \
-    git-lfs \
-    gh \
-    cocoapods \
-    watchman \
-    swiftformat \
-    openjdk@17 \
-    xcbeautify \
-    coreutils \
-    jq \
-    wix/brew/applesimutils \
-    xcodesorg/made/xcodes
+    brew install \
+        git \
+        git-lfs \
+        gh \
+        cocoapods \
+        watchman \
+        swiftformat \
+        openjdk@17 \
+        xcbeautify \
+        coreutils \
+        jq \
+        wix/brew/applesimutils \
+        xcodesorg/made/xcodes
+else
+    # Linux: install gh via GitHub's apt repo (not in default Ubuntu repos).
+    if ! command -v gh >/dev/null 2>&1; then
+        sudo apt-get install -y curl gnupg
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+            sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+            | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt-get update -qq
+    fi
+    sudo apt-get install -y \
+        git \
+        git-lfs \
+        gh \
+        openjdk-17-jdk \
+        jq \
+        build-essential \
+        autoconf bison patch rustc libssl-dev libyaml-dev libreadline-dev \
+        zlib1g-dev libgmp-dev libncurses-dev libffi-dev libgdbm6 libgdbm-dev \
+        libdb-dev uuid-dev
+    # ^ that long list is ruby-build's recommended deps for compiling Ruby
+    # 3.4 from source via rbenv. Without them, `rbenv install` will fail.
+fi
 
 # Bun: installed via the official script (not in homebrew-core; the oven-sh
 # tap exists but the upstream-recommended install path is curl|bash).
@@ -276,11 +329,14 @@ if ! grep -q '\.maestro/bin' "$ZPROFILE" 2>/dev/null; then
 fi
 export PATH="$HOME/.maestro/bin:$PATH"
 
-# Java 17 needs a symlink to be picked up by /usr/libexec/java_home.
-if [[ ! -L "/Library/Java/JavaVirtualMachines/openjdk-17.jdk" ]]; then
-    sudo ln -sfn \
-        "$BREW_PREFIX/opt/openjdk@17/libexec/openjdk.jdk" \
-        "/Library/Java/JavaVirtualMachines/openjdk-17.jdk"
+# Java 17 needs a symlink to be picked up by /usr/libexec/java_home (Mac).
+# On Linux, openjdk-17-jdk installs to a known path that JAVA_HOME can point to.
+if [[ "$PLATFORM" == "mac" ]]; then
+    if [[ ! -L "/Library/Java/JavaVirtualMachines/openjdk-17.jdk" ]]; then
+        sudo ln -sfn \
+            "$BREW_PREFIX/opt/openjdk@17/libexec/openjdk.jdk" \
+            "/Library/Java/JavaVirtualMachines/openjdk-17.jdk"
+    fi
 fi
 
 # Ruby via rbenv. macOS ships an Apple-deprecated Ruby 2.6 whose
@@ -292,7 +348,14 @@ RUBY_VERSION="3.4.2"
 
 if ! command -v rbenv >/dev/null 2>&1; then
     info "Installing rbenv + ruby-build"
-    brew install rbenv ruby-build
+    if [[ "$PLATFORM" == "mac" ]]; then
+        brew install rbenv ruby-build
+    else
+        # Linux: rbenv via git clone (it's not in apt). Idempotent thanks
+        # to the `command -v` check above.
+        git clone https://github.com/rbenv/rbenv.git "$HOME/.rbenv"
+        git clone https://github.com/rbenv/ruby-build.git "$HOME/.rbenv/plugins/ruby-build"
+    fi
 fi
 
 # Persist rbenv shims on PATH for future shells AND the runner service.
@@ -349,14 +412,31 @@ ok "Core toolchain installed"
 
 if [[ "${SKIP_ANDROID:-0}" != "1" ]]; then
     info "Installing Android SDK"
-    brew install --cask android-commandlinetools || true
 
-    ANDROID_HOME="$HOME/Library/Android/sdk"
+    if [[ "$PLATFORM" == "mac" ]]; then
+        brew install --cask android-commandlinetools || true
+        ANDROID_HOME="$HOME/Library/Android/sdk"
+        SDKMANAGER="$BREW_PREFIX/share/android-commandlinetools/cmdline-tools/latest/bin/sdkmanager"
+    else
+        # Linux: manual cmdline-tools install.
+        ANDROID_HOME="$HOME/Android/Sdk"
+        mkdir -p "$ANDROID_HOME/cmdline-tools"
+        if [[ ! -d "$ANDROID_HOME/cmdline-tools/latest" ]]; then
+            TMP_DIR=$(mktemp -d)
+            CMD_TOOLS_VERSION="11076708"  # known-good version; bump as needed
+            curl -fsSL -o "$TMP_DIR/cmdtools.zip" \
+                "https://dl.google.com/android/repository/commandlinetools-linux-${CMD_TOOLS_VERSION}_latest.zip"
+            (cd "$TMP_DIR" && unzip -q cmdtools.zip)
+            mv "$TMP_DIR/cmdline-tools" "$ANDROID_HOME/cmdline-tools/latest"
+            rm -rf "$TMP_DIR"
+        fi
+        SDKMANAGER="$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager"
+    fi
+
     mkdir -p "$ANDROID_HOME"
     export ANDROID_HOME
     export ANDROID_SDK_ROOT="$ANDROID_HOME"
 
-    SDKMANAGER="$BREW_PREFIX/share/android-commandlinetools/cmdline-tools/latest/bin/sdkmanager"
     if [[ -x "$SDKMANAGER" ]]; then
         yes | "$SDKMANAGER" --sdk_root="$ANDROID_HOME" --licenses >/dev/null || true
         "$SDKMANAGER" --sdk_root="$ANDROID_HOME" \
@@ -374,12 +454,12 @@ if [[ "${SKIP_ANDROID:-0}" != "1" ]]; then
         cat >> "$ZPROFILE" <<EOF
 
 # Android SDK (added by setup-runner.sh)
-export ANDROID_HOME="\$HOME/Library/Android/sdk"
+export ANDROID_HOME="$ANDROID_HOME"
 export ANDROID_SDK_ROOT="\$ANDROID_HOME"
 export PATH="\$ANDROID_HOME/platform-tools:\$ANDROID_HOME/cmdline-tools/latest/bin:\$PATH"
 EOF
     fi
-    ok "Android SDK installed"
+    ok "Android SDK installed at $ANDROID_HOME"
 else
     info "Skipping Android SDK (SKIP_ANDROID=1)"
 fi
@@ -390,14 +470,19 @@ fi
 
 if [[ "${ENABLE_TAILSCALE:-0}" == "1" ]]; then
     info "Installing Tailscale"
-    if ! command -v tailscale >/dev/null 2>&1; then
-        brew install --cask tailscale
+    if [[ "$PLATFORM" == "mac" ]]; then
+        if ! command -v tailscale >/dev/null 2>&1; then
+            brew install --cask tailscale
+        fi
+        # The cask installs the GUI app. Launching it once registers the system
+        # extension so the CLI works.
+        open -a "Tailscale" || true
+        sleep 5
+    else
+        if ! command -v tailscale >/dev/null 2>&1; then
+            curl -fsSL https://tailscale.com/install.sh | sudo sh
+        fi
     fi
-
-    # The cask installs the GUI app. Launching it once registers the system
-    # extension so the CLI works.
-    open -a "Tailscale" || true
-    sleep 5
 
     info "Joining tailnet"
     sudo tailscale up \
@@ -414,20 +499,24 @@ fi
 # Power + auto-login behavior for a headless build box
 # ---------------------------------------------------------------------------
 
-info "Disabling sleep and enabling auto-restart"
-sudo pmset -a sleep 0
-sudo pmset -a disksleep 0
-sudo pmset -a displaysleep 30
-sudo pmset -a autorestart 1
-sudo pmset -a powernap 0
-sudo systemsetup -setrestartfreeze on >/dev/null 2>&1 || true
-sudo systemsetup -setrestartpowerfailure on >/dev/null 2>&1 || true
-ok "Power settings tuned for unattended use"
+if [[ "$PLATFORM" == "mac" ]]; then
+    info "Disabling sleep and enabling auto-restart"
+    sudo pmset -a sleep 0
+    sudo pmset -a disksleep 0
+    sudo pmset -a displaysleep 30
+    sudo pmset -a autorestart 1
+    sudo pmset -a powernap 0
+    sudo systemsetup -setrestartfreeze on >/dev/null 2>&1 || true
+    sudo systemsetup -setrestartpowerfailure on >/dev/null 2>&1 || true
+    ok "Power settings tuned for unattended use"
 
-# Auto-login is set in System Settings > Users & Groups (requires GUI + the
-# user's password). The runner uses launchd anyway, so we don't strictly need
-# auto-login — but it makes recovering from a power-cut faster.
-warn "Auto-login is GUI-only on modern macOS. Set it once in System Settings > Users & Groups."
+    # Auto-login is set in System Settings > Users & Groups (requires GUI + the
+    # user's password). The runner uses launchd anyway, so we don't strictly need
+    # auto-login — but it makes recovering from a power-cut faster.
+    warn "Auto-login is GUI-only on modern macOS. Set it once in System Settings > Users & Groups."
+else
+    info "Linux power management: assumes the box stays on (e.g. ATX desktop, VM). Skipping."
+fi
 
 # ---------------------------------------------------------------------------
 # File descriptor limits
@@ -437,6 +526,7 @@ warn "Auto-login is GUI-only on modern macOS. Set it once in System Settings > U
 # look like build flakes but are pure config. Bump system-wide limits.
 
 info "Raising file descriptor limits"
+if [[ "$PLATFORM" == "mac" ]]; then
 sudo tee /Library/LaunchDaemons/limit.maxfiles.plist >/dev/null <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -461,6 +551,18 @@ sudo chown root:wheel /Library/LaunchDaemons/limit.maxfiles.plist
 sudo chmod 644 /Library/LaunchDaemons/limit.maxfiles.plist
 sudo launchctl load -w /Library/LaunchDaemons/limit.maxfiles.plist 2>/dev/null || true
 ok "File descriptor limit raised to 524288 (system-wide)"
+else
+    # Linux: bump via systemd user limits + /etc/security/limits.conf.
+    if ! grep -q "MentraOS runner" /etc/security/limits.conf 2>/dev/null; then
+        sudo tee -a /etc/security/limits.conf >/dev/null <<'EOF'
+
+# MentraOS runner (added by setup-runner.sh)
+* soft nofile 524288
+* hard nofile 524288
+EOF
+    fi
+    ok "File descriptor limit raised to 524288 (effective after next login)"
+fi
 
 # ---------------------------------------------------------------------------
 # Spotlight exclusions
@@ -468,13 +570,17 @@ ok "File descriptor limit raised to 524288 (system-wide)"
 # Spotlight indexing Xcode DerivedData and the runner workspace burns 5-10%
 # CPU during builds and contends with the SSD. Exclude them.
 
-info "Excluding build dirs from Spotlight"
-mkdir -p "$RUNNER_BASE_DIR"
-mkdir -p "$HOME/Library/Developer/Xcode/DerivedData"
-sudo mdutil -i off "$RUNNER_BASE_DIR" 2>/dev/null || true
-sudo mdutil -i off "$HOME/Library/Developer/Xcode/DerivedData" 2>/dev/null || true
-sudo mdutil -i off "$HOME/Library/Caches/CocoaPods" 2>/dev/null || true
-ok "Spotlight indexing disabled for build artifact directories"
+if [[ "$PLATFORM" == "mac" ]]; then
+    info "Excluding build dirs from Spotlight"
+    mkdir -p "$RUNNER_BASE_DIR"
+    mkdir -p "$HOME/Library/Developer/Xcode/DerivedData"
+    sudo mdutil -i off "$RUNNER_BASE_DIR" 2>/dev/null || true
+    sudo mdutil -i off "$HOME/Library/Developer/Xcode/DerivedData" 2>/dev/null || true
+    sudo mdutil -i off "$HOME/Library/Caches/CocoaPods" 2>/dev/null || true
+    ok "Spotlight indexing disabled for build artifact directories"
+else
+    mkdir -p "$RUNNER_BASE_DIR"
+fi
 
 # ---------------------------------------------------------------------------
 # Weekly cache cleanup scheduler
@@ -487,31 +593,47 @@ info "Installing weekly cache cleanup scheduler"
 
 SCRIPT_DIR_ABS="$(cd "$(dirname "$0")" && pwd)"
 CLEANUP_SCRIPT_SRC="$SCRIPT_DIR_ABS/runner-cleanup.sh"
-CLEANUP_PLIST_SRC="$SCRIPT_DIR_ABS/runner-cleanup.plist.template"
 CLEANUP_SCRIPT_DST="$RUNNER_BASE_DIR/runner-cleanup.sh"
-CLEANUP_PLIST_DST="$HOME/Library/LaunchAgents/com.mentra.runner-cleanup.plist"
 
 if [[ ! -f "$CLEANUP_SCRIPT_SRC" ]]; then
     warn "runner-cleanup.sh not found next to setup-runner.sh — skipping cleanup scheduler install."
-elif [[ ! -f "$CLEANUP_PLIST_SRC" ]]; then
-    warn "runner-cleanup.plist.template not found — skipping cleanup scheduler install."
 else
-    # Copy the script to a stable location (the in-repo path is volatile —
-    # workflow runs check out fresh into _work/.../scripts/). The plist
-    # references the stable copy.
     mkdir -p "$RUNNER_BASE_DIR"
     cp "$CLEANUP_SCRIPT_SRC" "$CLEANUP_SCRIPT_DST"
     chmod +x "$CLEANUP_SCRIPT_DST"
 
-    # Render the plist with $HOME substituted into the @@HOME_DIR@@ placeholder.
-    mkdir -p "$(dirname "$CLEANUP_PLIST_DST")"
-    sed "s|@@HOME_DIR@@|$HOME|g" "$CLEANUP_PLIST_SRC" > "$CLEANUP_PLIST_DST"
-
-    # Reload the plist (unload then load) so config changes take effect.
-    launchctl unload "$CLEANUP_PLIST_DST" 2>/dev/null || true
-    launchctl load -w "$CLEANUP_PLIST_DST" 2>/dev/null || true
-
-    ok "Weekly cleanup scheduled: Sundays 03:00 (script: $CLEANUP_SCRIPT_DST)"
+    if [[ "$PLATFORM" == "mac" ]]; then
+        CLEANUP_PLIST_SRC="$SCRIPT_DIR_ABS/runner-cleanup.plist.template"
+        CLEANUP_PLIST_DST="$HOME/Library/LaunchAgents/com.mentra.runner-cleanup.plist"
+        if [[ ! -f "$CLEANUP_PLIST_SRC" ]]; then
+            warn "runner-cleanup.plist.template not found — cleanup install skipped."
+        else
+            mkdir -p "$(dirname "$CLEANUP_PLIST_DST")"
+            sed "s|@@HOME_DIR@@|$HOME|g" "$CLEANUP_PLIST_SRC" > "$CLEANUP_PLIST_DST"
+            launchctl unload "$CLEANUP_PLIST_DST" 2>/dev/null || true
+            launchctl load -w "$CLEANUP_PLIST_DST" 2>/dev/null || true
+            ok "Weekly cleanup scheduled (launchd): Sundays 03:00"
+        fi
+    else
+        # Linux: systemd --user units. Need lingering enabled so they fire
+        # without an interactive session.
+        SVC_SRC="$SCRIPT_DIR_ABS/runner-cleanup.service.template"
+        TIMER_SRC="$SCRIPT_DIR_ABS/runner-cleanup.timer.template"
+        UNIT_DIR="$HOME/.config/systemd/user"
+        if [[ ! -f "$SVC_SRC" || ! -f "$TIMER_SRC" ]]; then
+            warn "Cleanup service/timer templates missing — skipping Linux cleanup install."
+        else
+            mkdir -p "$UNIT_DIR"
+            sed "s|@@HOME_DIR@@|$HOME|g" "$SVC_SRC" > "$UNIT_DIR/runner-cleanup.service"
+            sed "s|@@HOME_DIR@@|$HOME|g" "$TIMER_SRC" > "$UNIT_DIR/runner-cleanup.timer"
+            # `loginctl enable-linger` keeps user systemd units alive without
+            # an interactive login. Idempotent.
+            sudo loginctl enable-linger "$USER" || true
+            systemctl --user daemon-reload || true
+            systemctl --user enable --now runner-cleanup.timer || true
+            ok "Weekly cleanup scheduled (systemd): Sundays 03:00"
+        fi
+    fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -523,7 +645,15 @@ if [[ "$SKIP_RUNNER_REGISTRATION" -eq 1 ]]; then
 elif [[ "$RUNNER_COUNT" -eq 0 ]]; then
     info "Runner registration skipped (--runners 0)."
 else
-    LABELS="self-hosted,macOS,ARM64"
+    if [[ "$PLATFORM" == "mac" ]]; then
+        LABELS="self-hosted,macOS,ARM64"
+    else
+        # uname -m → x86_64 / aarch64 → arch labels x64 / arm64
+        case "$(uname -m)" in
+            x86_64)  LABELS="self-hosted,linux,x64" ;;
+            aarch64) LABELS="self-hosted,linux,arm64" ;;
+        esac
+    fi
     if [[ -n "$RUNNER_LABELS_EXTRA" ]]; then
         LABELS="$LABELS,$RUNNER_LABELS_EXTRA"
     fi
@@ -538,7 +668,14 @@ else
         cd "$RUNNER_HOME"
 
         if [[ ! -f ./config.sh ]]; then
-            RUNNER_TARBALL="actions-runner-osx-arm64-${RUNNER_VERSION}.tar.gz"
+            # Pick the right tarball for the platform.
+            case "$PLATFORM-$(uname -m)" in
+                mac-arm64)     RUNNER_OS_ARCH="osx-arm64" ;;
+                linux-x86_64)  RUNNER_OS_ARCH="linux-x64" ;;
+                linux-aarch64) RUNNER_OS_ARCH="linux-arm64" ;;
+                *) fail "Unsupported platform-arch combo: $PLATFORM $(uname -m)" ;;
+            esac
+            RUNNER_TARBALL="actions-runner-${RUNNER_OS_ARCH}-${RUNNER_VERSION}.tar.gz"
             curl -fL -o "$RUNNER_TARBALL" \
                 "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_TARBALL}"
             tar xzf "$RUNNER_TARBALL"
@@ -563,24 +700,37 @@ else
         # rbenv shims must come first on PATH so `ruby` / `bundle` / `gem`
         # resolve to the rbenv-installed 3.4.x, not Apple's system 2.6.
         {
-            echo "PATH=$HOME/.rbenv/shims:$HOME/.bun/bin:$HOME/.maestro/bin:$BREW_PREFIX/bin:$BREW_PREFIX/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+            if [[ "$PLATFORM" == "mac" ]]; then
+                echo "PATH=$HOME/.rbenv/shims:$HOME/.bun/bin:$HOME/.maestro/bin:$BREW_PREFIX/bin:$BREW_PREFIX/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+                echo "JAVA_HOME=$BREW_PREFIX/opt/openjdk@17"
+            else
+                echo "PATH=$HOME/.rbenv/shims:$HOME/.rbenv/bin:$HOME/.bun/bin:$HOME/.maestro/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+                echo "JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64"
+            fi
             echo "LANG=en_US.UTF-8"
-            echo "JAVA_HOME=$BREW_PREFIX/opt/openjdk@17"
             if [[ "${SKIP_ANDROID:-0}" != "1" ]]; then
-                echo "ANDROID_HOME=$HOME/Library/Android/sdk"
-                echo "ANDROID_SDK_ROOT=$HOME/Library/Android/sdk"
+                echo "ANDROID_HOME=$ANDROID_HOME"
+                echo "ANDROID_SDK_ROOT=$ANDROID_HOME"
             fi
         } > "$RUNNER_HOME/.env"
 
-        # Install + start the launchd service so the runner survives reboots.
-        # svc.sh's plist lives in ~/Library/LaunchAgents — check that rather
-        # than relying on `svc.sh status` exit codes (which vary by version).
-        SVC_PLIST="$HOME/Library/LaunchAgents/actions.runner.$(printf '%s' "$GH_RUNNER_URL" | sed 's|https://github.com/||; s|/|-|g').${RUNNER_NAME}.plist"
-        if [[ ! -f "$SVC_PLIST" ]]; then
-            sudo ./svc.sh install "$USER"
+        # Install + start the runner as a service so it survives reboots.
+        # On macOS svc.sh writes a launchd plist; on Linux it writes a
+        # systemd unit. Both ship in the GH Actions runner tarball.
+        if [[ "$PLATFORM" == "mac" ]]; then
+            SVC_PLIST="$HOME/Library/LaunchAgents/actions.runner.$(printf '%s' "$GH_RUNNER_URL" | sed 's|https://github.com/||; s|/|-|g').${RUNNER_NAME}.plist"
+            if [[ ! -f "$SVC_PLIST" ]]; then
+                sudo ./svc.sh install "$USER"
+            fi
+            sudo ./svc.sh start || true
+        else
+            # svc.sh on Linux uses systemd by default. Needs root to install
+            # because the unit goes in /etc/systemd/system. Runs as the
+            # invoking user via User= directive.
+            sudo ./svc.sh install "$USER" || true
+            sudo ./svc.sh start || true
         fi
-        sudo ./svc.sh start || true
-        ok "Runner $RUNNER_NAME registered and running as a launchd service"
+        ok "Runner $RUNNER_NAME registered and running as a service"
     done
 fi
 
@@ -591,19 +741,23 @@ fi
 cat <<EOF
 
 ==========================================================================
-  Host '$RUNNER_NAME_BASE' bootstrapped.
+  Host '$RUNNER_NAME_BASE' bootstrapped ($PLATFORM).
 
   GitHub URL: $GH_RUNNER_URL
   Runner home(s): $RUNNER_BASE_DIR/actions-runner-*
 
   Next steps you should do manually once:
+$([ "$PLATFORM" = mac ] && cat <<MAC_STEPS
     - System Settings > Users & Groups > set this user to auto-login
     - System Settings > Lock Screen > Require password "Never"
     - Sign in to the Apple Developer account in Xcode (Settings > Accounts)
+MAC_STEPS
+)
     - Confirm runner(s) appear at $GH_RUNNER_URL/settings/actions/runners
     - Copy ~/.mentra/credentials/ from an existing runner (or your laptop):
         scp ~/.mentra/credentials/{appstore-connect.env,AuthKey_*.p8,google-play-key.json} \\
             user@$RUNNER_NAME_BASE:~/.mentra/credentials/
+$([ "$PLATFORM" = mac ] && echo "    - For Android signing: also copy ~/.gradle/gradle.properties (has MENTRAOS_UPLOAD_* keys).")
 
   Automated maintenance:
     - Weekly cache cleanup runs Sundays at 03:00 (defers if a build is active).


### PR DESCRIPTION
## What

Bundles four changes (originally just cleanup; expanded based on feedback):

### 1. Weekly runner cache cleanup

\`mobile/scripts/runner-cleanup.sh\` is cross-platform (macOS + Linux), two-tiered:
- **Tier 1**: bun cache, gradle build-cache + transforms, Android emulator system images, stale \`_work\` dirs >7d. Frees ~12 GiB on a typical Mac mini with no rebuild cost.
- **Tier 2**: Tier 1 + full \`~/.gradle/caches\`, OS user caches, AVDs, Xcode DerivedData. Frees ~30 GiB more but next build is slower (~10 min cold gradle, ~10 min cold iOS archive).

Both tiers run by the weekly scheduler (Sundays 03:00 local). Auto-defers if a build is detected (gradle, xcodebuild, Xcode, bun, node, java, cmake).

\`setup-runner.sh\` installs the launchd plist (macOS) or systemd timer (Linux) automatically.

### 2. mobile/scripts/README.md

Inventory of every script in the directory + a senior-eng-focused onboarding guide for setting up a new Mac mini runner.

### 3. Slack notification fixes (from earlier feedback)

The Slack message now shows:
- Versioned **Beta_N** URLs (e.g. \`v2.11/Mentra_iOS_2p11_Beta_17.ipa\`) instead of the rolling \`mobile-latest\` URLs, so it's clear which build the link is for.
- TestFlight upload status on iOS (\`success\` / \`failure\` / \`skipped\` + reason).
- Google Play internal-track upload status on Android (\`success\` / \`failure\` / \`skipped\` + reason).

Protocol: \`release-{ios,android}.mjs\` write \`mobile/build/release-status.json\` → a per-job \"Read release status\" step parses it → job declares the values as outputs → \`slack-notify\` consumes them.

### 4. setup-runner.sh: Linux best-effort

Added platform branches throughout: apt-get, Linux Android SDK install, linux-x64/arm64 GH Actions runner tarballs, systemd timer for cleanup, Tailscale curl-installer. Linux runners are Android + ASG only (no iOS — Xcode requirement).

**Untested on actual Linux hardware.** README flags this. Expect to fix bugs on first real onboarding.

## Test plan

- [ ] Merge → next staging push → Slack message now shows Beta_N URLs + per-platform TestFlight/Play status.
- [ ] Re-run \`setup-runner.sh\` on bob + bigbob (idempotent) — should install the launchd plist + copy the cleanup script.
- [ ] \`launchctl list | grep mentra\` to verify cleanup unit loaded.
- [ ] Dry-run cleanup: \`~/mentra/runner-cleanup.sh --tier 1 --dry-run --force\`.
- [ ] (When you onboard a Linux runner) — verify the platform branches work; expect bugs.