### PR TITLE
Update test BES OTA manifest (BES 17.26.05.22, asg-client v38, new MTK patches)

### DIFF
--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -3,8 +3,8 @@
     "com.mentra.asg_client": {
       "versionCode": 38,
       "versionName": "38.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk",
-      "sha256": "d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59"
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
+      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -15,15 +15,21 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
+      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
+    },
+    {
       "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260204",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_firmware_20260113_20260204.zip",
-      "sha256": "dac093bca108228c084963e58213e9db0c472c0d5d586203acdc19b48ab04abd"
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
+      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
     }
   ],
   "bes_firmware": {
-    "version": "17.26.04.01",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.04.01.bin",
-    "sha256": "67a7d1c48dd7fbed16fc1a94c9d221ebae2e817f493d0007a58e8d49028f4e82"
+    "version": "17.26.05.22",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
+    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
   }
 }


### PR DESCRIPTION
Updates the test BES OTA manifest (`asg_client/ota_website/test_bes_ota_prod_live_version.json`).

## Changes

### asg-client APK
- `versionCode` / `versionName` → **38** / **38.0**
- `apkUrl` points at `asg-client-37.apk` (the uploaded build)
- `sha256` updated to `a637d239…ae3564`

### BES firmware
- `version` → **17.26.05.22**
- `url` → `bes_firmware_17.26.05.22.bin`
- `sha256` → `9499b1d1…c5fa3c`

### MTK patches (now two entries)
| start | end | file | sha256 |
|---|---|---|---|
| MentraLive_20260204 | MentraLive_20260525 | `mtk_ota_update_20260204_20260525.zip` | `6078863f…c82bbd27` |
| MentraLive_20260113 | MentraLive_20260525 | `mtk_ota_update_20260113_20260525.zip` | `23b39198…d8d856a7` |

SHA256 hashes for the APK and BES `.bin` were computed by downloading the release assets; MTK hashes are as supplied.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the test BES OTA manifest to deliver BES firmware 17.26.05.22, `asg_client` v38, and two MTK patch entries; URLs and SHA-256s updated. The APK entry points to `asg-client-37.apk` (uploaded build).

<sup>Written for commit f375b4330057f1e4fa872365527242324926e9c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

