### PR TITLE
Fix iOS Bluetooth SDK state isolation races

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @MainActor
 class ObservableStore {
-    private nonisolated(unsafe) var values: [String: Any] = [:]
+    private var values: [String: Any] = [:]
     private var onEmit: ((String, [String: Any]) -> Void)?
     private var listeners: [String: (String, [String: Any]) -> Void] = [:]
 
@@ -54,7 +54,7 @@ class ObservableStore {
         }
     }
 
-    nonisolated func get(_ category: String, _ key: String) -> Any? {
+    func get(_ category: String, _ key: String) -> Any? {
         values["\(Self.normalizeCategory(category)).\(key)"]
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -546,31 +546,36 @@ private final class BleIncidentLogRelayEntry {
 // MARK: - CBCentralManagerDelegate
 
 extension MentraLive: CBCentralManagerDelegate {
-    func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        switch central.state {
-        case .poweredOn:
-            Bridge.log("LIVE: Bluetooth powered on")
-            // If we have a saved device, try to reconnect
-            if let savedDeviceName = UserDefaults.standard.string(forKey: PREFS_DEVICE_NAME),
-               !savedDeviceName.isEmpty
-            {
-                startScan()
+    // CoreBluetooth delivers these callbacks on `bluetoothQueue`; hop back before touching MainActor state.
+    nonisolated func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        let state = central.state
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            switch state {
+            case .poweredOn:
+                Bridge.log("LIVE: Bluetooth powered on")
+                // If we have a saved device, try to reconnect
+                if let savedDeviceName = UserDefaults.standard.string(forKey: PREFS_DEVICE_NAME),
+                   !savedDeviceName.isEmpty
+                {
+                    self.startScan()
+                }
+
+            case .poweredOff:
+                Bridge.log("LIVE: Bluetooth is powered off")
+                self.updateConnectionState(ConnTypes.DISCONNECTED)
+
+            case .unauthorized:
+                Bridge.log("LIVE: Bluetooth is unauthorized")
+                self.updateConnectionState(ConnTypes.DISCONNECTED)
+
+            case .unsupported:
+                Bridge.log("LIVE: Bluetooth is unsupported")
+                self.updateConnectionState(ConnTypes.DISCONNECTED)
+
+            default:
+                Bridge.log("LIVE: Bluetooth state: \(state.rawValue)")
             }
-
-        case .poweredOff:
-            Bridge.log("LIVE: Bluetooth is powered off")
-            updateConnectionState(ConnTypes.DISCONNECTED)
-
-        case .unauthorized:
-            Bridge.log("LIVE: Bluetooth is unauthorized")
-            updateConnectionState(ConnTypes.DISCONNECTED)
-
-        case .unsupported:
-            Bridge.log("LIVE: Bluetooth is unsupported")
-            updateConnectionState(ConnTypes.DISCONNECTED)
-
-        default:
-            Bridge.log("LIVE: Bluetooth state: \(central.state.rawValue)")
         }
     }
 
@@ -602,79 +607,89 @@ extension MentraLive: CBCentralManagerDelegate {
         }
     }
 
-    func centralManager(
+    nonisolated func centralManager(
         _: CBCentralManager, didDiscover peripheral: CBPeripheral,
         advertisementData _: [String: Any], rssi: NSNumber
     ) {
-        handleDiscoveredPeripheral(peripheral, rssi: rssi)
+        DispatchQueue.main.async { [weak self] in
+            self?.handleDiscoveredPeripheral(peripheral, rssi: rssi)
+        }
     }
 
-    func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        Bridge.log("Connected to GATT server, discovering services...")
+    nonisolated func centralManager(_: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            Bridge.log("Connected to GATT server, discovering services...")
 
-        stopConnectionTimeout()
-        isConnecting = false
-        connectedPeripheral = peripheral
+            self.stopConnectionTimeout()
+            self.isConnecting = false
+            self.connectedPeripheral = peripheral
 
-        // Save device name and address for future reconnection
-        if let name = peripheral.name {
-            UserDefaults.standard.set(name, forKey: PREFS_DEVICE_NAME)
-            Bridge.log("Saved device name for future reconnection: \(name)")
-            DeviceStore.shared.apply("glasses", "bluetoothName", name)
+            // Save device name and address for future reconnection
+            if let name = peripheral.name {
+                UserDefaults.standard.set(name, forKey: PREFS_DEVICE_NAME)
+                Bridge.log("Saved device name for future reconnection: \(name)")
+                DeviceStore.shared.apply("glasses", "bluetoothName", name)
+            }
+            // Persist peripheral UUID so DeviceManager can sync it to RN settings
+            DeviceStore.shared.apply("bluetooth", "device_address", peripheral.identifier.uuidString)
+
+            // Audio Pairing: Setup Bluetooth audio after BLE connection
+            if let deviceName = peripheral.name {
+                Bridge.log("BLE connection established, setting up audio...")
+                // setupAudioPairing(deviceName: deviceName)
+            }
+
+            // Discover services
+            peripheral.discoverServices([SERVICE_UUID])
+
+            // Reset reconnect attempts
+            self.reconnectAttempts = 0
         }
-        // Persist peripheral UUID so DeviceManager can sync it to RN settings
-        DeviceStore.shared.apply("bluetooth", "device_address", peripheral.identifier.uuidString)
-
-        // Audio Pairing: Setup Bluetooth audio after BLE connection
-        if let deviceName = peripheral.name {
-            Bridge.log("BLE connection established, setting up audio...")
-            // setupAudioPairing(deviceName: deviceName)
-        }
-
-        // Discover services
-        peripheral.discoverServices([SERVICE_UUID])
-
-        // Reset reconnect attempts
-        reconnectAttempts = 0
     }
 
-    func centralManager(
+    nonisolated func centralManager(
         _: CBCentralManager, didDisconnectPeripheral _: CBPeripheral, error _: Error?
     ) {
-        Bridge.log("LIVE: Disconnected from GATT server")
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            Bridge.log("LIVE: Disconnected from GATT server")
 
-        isConnecting = false
+            self.isConnecting = false
 
-        connectedPeripheral = nil
-        fullyBooted = false
-        connected = false
-        updateConnectionState(ConnTypes.DISCONNECTED)
-        rgbLedAuthorityClaimed = false
+            self.connectedPeripheral = nil
+            self.fullyBooted = false
+            self.connected = false
+            self.updateConnectionState(ConnTypes.DISCONNECTED)
+            self.rgbLedAuthorityClaimed = false
 
-        stopAllTimers()
+            self.stopAllTimers()
 
-        // Clean up characteristics
-        txCharacteristic = nil
-        rxCharacteristic = nil
+            // Clean up characteristics
+            self.txCharacteristic = nil
+            self.rxCharacteristic = nil
 
-        // Attempt reconnection if not killed
-        if !isKilled {
-            handleReconnection()
+            // Attempt reconnection if not killed
+            if !self.isKilled {
+                self.handleReconnection()
+            }
         }
     }
 
-    func centralManager(_: CBCentralManager, didFailToConnect _: CBPeripheral, error: Error?) {
-        Bridge.log(
-            "LIVE: Failed to connect to peripheral: \(error?.localizedDescription ?? "Unknown error")"
-        )
+    nonisolated func centralManager(_: CBCentralManager, didFailToConnect _: CBPeripheral, error: Error?) {
+        let errorDescription = error?.localizedDescription ?? "Unknown error"
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            Bridge.log("LIVE: Failed to connect to peripheral: \(errorDescription)")
 
-        stopConnectionTimeout()
-        isConnecting = false
-        connectedPeripheral = nil
-        updateConnectionState(ConnTypes.DISCONNECTED)
+            self.stopConnectionTimeout()
+            self.isConnecting = false
+            self.connectedPeripheral = nil
+            self.updateConnectionState(ConnTypes.DISCONNECTED)
 
-        if !isKilled {
-            handleReconnection()
+            if !self.isKilled {
+                self.handleReconnection()
+            }
         }
     }
 }
@@ -682,198 +697,228 @@ extension MentraLive: CBCentralManagerDelegate {
 // MARK: - CBPeripheralDelegate
 
 extension MentraLive: CBPeripheralDelegate {
-    func peripheral(_: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
-        signalStrengthReadInFlight = false
-        if let error {
-            Bridge.log("LIVE: Error reading RSSI: \(error.localizedDescription)")
-        } else {
-            updateSignalStrength(Int(truncating: RSSI))
+    nonisolated func peripheral(_: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.signalStrengthReadInFlight = false
+            if let errorDescription {
+                Bridge.log("LIVE: Error reading RSSI: \(errorDescription)")
+            } else {
+                self.updateSignalStrength(Int(truncating: RSSI))
+            }
         }
     }
 
-    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
-        if let error {
-            Bridge.log("LIVE: Error discovering services: \(error.localizedDescription)")
-            centralManager?.cancelPeripheralConnection(peripheral)
-            return
-        }
+    nonisolated func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let errorDescription {
+                Bridge.log("LIVE: Error discovering services: \(errorDescription)")
+                self.centralManager?.cancelPeripheralConnection(peripheral)
+                return
+            }
 
-        guard let services = peripheral.services else { return }
+            guard let services = peripheral.services else { return }
 
-        for service in services where service.uuid == SERVICE_UUID {
-            Bridge.log("LIVE: Found UART service, discovering characteristics...")
-            peripheral.discoverCharacteristics(
-                [
-                    TX_CHAR_UUID, RX_CHAR_UUID, FILE_READ_UUID, FILE_WRITE_UUID, LC3_READ_UUID,
-                    LC3_WRITE_UUID,
-                ], for: service
-            )
+            for service in services where service.uuid == SERVICE_UUID {
+                Bridge.log("LIVE: Found UART service, discovering characteristics...")
+                peripheral.discoverCharacteristics(
+                    [
+                        TX_CHAR_UUID, RX_CHAR_UUID, FILE_READ_UUID, FILE_WRITE_UUID, LC3_READ_UUID,
+                        LC3_WRITE_UUID,
+                    ], for: service
+                )
+            }
         }
     }
 
-    func peripheral(
+    nonisolated func peripheral(
         _ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?
     ) {
-        if let error {
-            Bridge.log("LIVE: Error discovering characteristics: \(error.localizedDescription)")
-            centralManager?.cancelPeripheralConnection(peripheral)
-            return
-        }
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let errorDescription {
+                Bridge.log("LIVE: Error discovering characteristics: \(errorDescription)")
+                self.centralManager?.cancelPeripheralConnection(peripheral)
+                return
+            }
 
-        guard let characteristics = service.characteristics else { return }
+            guard let characteristics = service.characteristics else { return }
 
-        for characteristic in characteristics {
-            // Log characteristic properties for debugging
-            let props = characteristic.properties
-            let propsStr = [
-                props.contains(.notify) ? "NOTIFY" : nil,
-                props.contains(.indicate) ? "INDICATE" : nil,
-                props.contains(.read) ? "READ" : nil,
-                props.contains(.write) ? "WRITE" : nil,
-                props.contains(.writeWithoutResponse) ? "WRITE_NO_RESPONSE" : nil,
-            ].compactMap { $0 }.joined(separator: " ")
-            Bridge.log("📋 Characteristic \(characteristic.uuid): properties=[\(propsStr)]")
+            for characteristic in characteristics {
+                // Log characteristic properties for debugging
+                let props = characteristic.properties
+                let propsStr = [
+                    props.contains(.notify) ? "NOTIFY" : nil,
+                    props.contains(.indicate) ? "INDICATE" : nil,
+                    props.contains(.read) ? "READ" : nil,
+                    props.contains(.write) ? "WRITE" : nil,
+                    props.contains(.writeWithoutResponse) ? "WRITE_NO_RESPONSE" : nil,
+                ].compactMap { $0 }.joined(separator: " ")
+                Bridge.log("📋 Characteristic \(characteristic.uuid): properties=[\(propsStr)]")
 
-            if characteristic.uuid == TX_CHAR_UUID {
-                txCharacteristic = characteristic
-                Bridge.log("LIVE: ✅ Found TX characteristic")
-            } else if characteristic.uuid == RX_CHAR_UUID {
-                rxCharacteristic = characteristic
+                if characteristic.uuid == TX_CHAR_UUID {
+                    self.txCharacteristic = characteristic
+                    Bridge.log("LIVE: ✅ Found TX characteristic")
+                } else if characteristic.uuid == RX_CHAR_UUID {
+                    self.rxCharacteristic = characteristic
+                    Bridge.log(
+                        "LIVE: ✅ Found RX characteristic - hasNotify=\(props.contains(.notify)), hasIndicate=\(props.contains(.indicate))"
+                    )
+                } else if characteristic.uuid == FILE_READ_UUID {
+                    self.fileReadCharacteristic = characteristic
+                    Bridge.log("LIVE: 📁 Found FILE_READ characteristic (72FF)!")
+                } else if characteristic.uuid == FILE_WRITE_UUID {
+                    self.fileWriteCharacteristic = characteristic
+                    Bridge.log("LIVE: 📁 Found FILE_WRITE characteristic (73FF)!")
+                } else if characteristic.uuid == LC3_READ_UUID {
+                    self.lc3ReadCharacteristic = characteristic
+                    Bridge.log("LIVE: 🎤 Found LC3_READ characteristic (audio input)!")
+                } else if characteristic.uuid == LC3_WRITE_UUID {
+                    self.lc3WriteCharacteristic = characteristic
+                    Bridge.log("LIVE: 🎤 Found LC3_WRITE characteristic (audio output)!")
+                }
+            }
+
+            // Check if we have both characteristics
+            if self.txCharacteristic != nil, let rx = self.rxCharacteristic {
+                Bridge.log("LIVE: ✅ Both TX and RX characteristics found - BLE connection ready")
+                Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...")
+
+                // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
+                // DeviceStore handles connected state based on fullyBooted
+
+                // Keep state as connecting until glasses are ready
+                self.updateConnectionState(ConnTypes.CONNECTING)
+
+                let withResponseMtu = peripheral.maximumWriteValueLength(for: .withResponse) + 3
+                let withoutResponseMtu = peripheral.maximumWriteValueLength(for: .withoutResponse) + 3
+                self.currentMtu = max(23, min(withResponseMtu, withoutResponseMtu))
                 Bridge.log(
-                    "LIVE: ✅ Found RX characteristic - hasNotify=\(props.contains(.notify)), hasIndicate=\(props.contains(.indicate))"
+                    "LIVE: Current MTU estimate: withResponse=\(withResponseMtu), withoutResponse=\(withoutResponseMtu), selected=\(self.currentMtu)"
                 )
-            } else if characteristic.uuid == FILE_READ_UUID {
-                fileReadCharacteristic = characteristic
-                Bridge.log("LIVE: 📁 Found FILE_READ characteristic (72FF)!")
-            } else if characteristic.uuid == FILE_WRITE_UUID {
-                fileWriteCharacteristic = characteristic
-                Bridge.log("LIVE: 📁 Found FILE_WRITE characteristic (73FF)!")
-            } else if characteristic.uuid == LC3_READ_UUID {
-                lc3ReadCharacteristic = characteristic
-                Bridge.log("LIVE: 🎤 Found LC3_READ characteristic (audio input)!")
-            } else if characteristic.uuid == LC3_WRITE_UUID {
-                lc3WriteCharacteristic = characteristic
-                Bridge.log("LIVE: 🎤 Found LC3_WRITE characteristic (audio output)!")
+
+                // Enable notifications on RX characteristic
+                peripheral.setNotifyValue(true, for: rx)
+
+                // Enable notifications on file characteristics if available
+                if let fileRead = self.fileReadCharacteristic {
+                    peripheral.setNotifyValue(true, for: fileRead)
+                }
+
+                // Enable notifications on LC3 audio characteristic if device supports it
+                if self.supportsLC3Audio, let lc3Read = self.lc3ReadCharacteristic {
+                    peripheral.setNotifyValue(true, for: lc3Read)
+                    Bridge.log("LIVE: 🎤 Enabled LC3 audio notifications")
+                }
+
+                // Start readiness check loop
+                self.startSignalStrengthPolling()
+                self.startReadinessCheckLoop()
+            } else {
+                Bridge.log("LIVE: Required BLE characteristics not found")
+                if self.txCharacteristic == nil {
+                    Bridge.log("LIVE: TX characteristic not found")
+                }
+                if self.rxCharacteristic == nil {
+                    Bridge.log("LIVE: RX characteristic not found")
+                }
+                self.centralManager?.cancelPeripheralConnection(peripheral)
             }
-        }
-
-        // Check if we have both characteristics
-        if let tx = txCharacteristic, let rx = rxCharacteristic {
-            Bridge.log("LIVE: ✅ Both TX and RX characteristics found - BLE connection ready")
-            Bridge.log("LIVE: 🔄 Waiting for glasses SOC to become ready...")
-
-            // Don't set connected=true here - wait for SOC to be ready (fullyBooted=true)
-            // DeviceStore handles connected state based on fullyBooted
-
-            // Keep state as connecting until glasses are ready
-            updateConnectionState(ConnTypes.CONNECTING)
-
-            // Request MTU size
-            let mtuSize = peripheral.maximumWriteValueLength(for: .withResponse)
-            Bridge.log("LIVE: Current MTU size: \(mtuSize + 3) bytes")
-
-            // Enable notifications on RX characteristic
-            peripheral.setNotifyValue(true, for: rx)
-
-            // Enable notifications on file characteristics if available
-            if let fileRead = fileReadCharacteristic {
-                peripheral.setNotifyValue(true, for: fileRead)
-            }
-
-            // Enable notifications on LC3 audio characteristic if device supports it
-            if supportsLC3Audio, let lc3Read = lc3ReadCharacteristic {
-                peripheral.setNotifyValue(true, for: lc3Read)
-                Bridge.log("LIVE: 🎤 Enabled LC3 audio notifications")
-            }
-
-            // Start readiness check loop
-            startSignalStrengthPolling()
-            startReadinessCheckLoop()
-        } else {
-            Bridge.log("LIVE: Required BLE characteristics not found")
-            if txCharacteristic == nil {
-                Bridge.log("LIVE: TX characteristic not found")
-            }
-            if rxCharacteristic == nil {
-                Bridge.log("LIVE: RX characteristic not found")
-            }
-            centralManager?.cancelPeripheralConnection(peripheral)
         }
     }
 
-    func peripheral(
+    nonisolated func peripheral(
         _: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?
     ) {
-        // Bridge.log("LIVE: DEBUG: didUpdateValueFor CALLED - characteristic: \(characteristic.uuid), dataSize: \(characteristic.value?.count ?? 0)")
-        // Log raw hex for debugging glasses_ready issue
-        if let data = characteristic.value {
-            let hexString = data.prefix(50).map { String(format: "%02X ", $0) }.joined()
-            // Bridge.log("LIVE: DEBUG: RAW HEX (first 50): \(hexString)")
-        }
-        if let error {
-            Bridge.log(
-                "LIVE: Error updating value for characteristic: \(error.localizedDescription)"
-            )
-            return
-        }
-
-        guard let data = characteristic.value else {
-            Bridge.log("LIVE: Characteristic value is nil")
-            return
-        }
-
-        let threadId = Thread.current.hash
         let uuid = characteristic.uuid
+        let data = characteristic.value
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            // Bridge.log("LIVE: DEBUG: didUpdateValueFor CALLED - characteristic: \(uuid), dataSize: \(data?.count ?? 0)")
+            // Log raw hex for debugging glasses_ready issue
+            if let data {
+                let hexString = data.prefix(50).map { String(format: "%02X ", $0) }.joined()
+                _ = hexString
+                // Bridge.log("LIVE: DEBUG: RAW HEX (first 50): \(hexString)")
+            }
+            if let errorDescription {
+                Bridge.log("LIVE: Error updating value for characteristic: \(errorDescription)")
+                return
+            }
 
-        // Bridge.log("Thread-\(threadId): 🎉 didUpdateValueFor CALLBACK TRIGGERED! Characteristic: \(uuid)")
-        // if uuid == RX_CHAR_UUID {
-        //   Bridge.log("Thread-\(threadId): 🎯 RECEIVED DATA ON RX CHARACTERISTIC (Peripheral's TX)")
-        // } else if uuid == TX_CHAR_UUID {
-        //   Bridge.log("Thread-\(threadId): 🎯 RECEIVED DATA ON TX CHARACTERISTIC (Peripheral's RX)")
-        // }
-        // Bridge.log("Thread-\(threadId): 🔍 Processing received data - \(data.count) bytes")
+            guard let data else {
+                Bridge.log("LIVE: Characteristic value is nil")
+                return
+            }
 
-        // Handle LC3 audio data separately (dedicated characteristic for LC3-capable devices)
-        if uuid == LC3_READ_UUID && supportsLC3Audio {
-            // Bridge.log("LIVE: Received data on LC3_READ characteristic (audio input)")
-            processLc3AudioPacket(data)
-            return
+            let threadId = Thread.current.hash
+            _ = threadId
+
+            // Bridge.log("Thread-\(threadId): 🎉 didUpdateValueFor CALLBACK TRIGGERED! Characteristic: \(uuid)")
+            // if uuid == RX_CHAR_UUID {
+            //   Bridge.log("Thread-\(threadId): 🎯 RECEIVED DATA ON RX CHARACTERISTIC (Peripheral's TX)")
+            // } else if uuid == TX_CHAR_UUID {
+            //   Bridge.log("Thread-\(threadId): 🎯 RECEIVED DATA ON TX CHARACTERISTIC (Peripheral's RX)")
+            // }
+            // Bridge.log("Thread-\(threadId): 🔍 Processing received data - \(data.count) bytes")
+
+            // Handle LC3 audio data separately (dedicated characteristic for LC3-capable devices)
+            if uuid == LC3_READ_UUID && self.supportsLC3Audio {
+                // Bridge.log("LIVE: Received data on LC3_READ characteristic (audio input)")
+                self.processLc3AudioPacket(data)
+                return
+            }
+
+            // Handle regular data (JSON messages, file transfers, etc.)
+            self.processReceivedData(data)
         }
-
-        // Handle regular data (JSON messages, file transfers, etc.)
-        processReceivedData(data)
     }
 
-    func peripheral(_: CBPeripheral, didWriteValueFor _: CBCharacteristic, error: Error?) {
-        if let error {
-            Bridge.log("LIVE: Error writing characteristic: \(error.localizedDescription)")
-        } else {
-            Bridge.log("LIVE: Characteristic write successful")
+    nonisolated func peripheral(_: CBPeripheral, didWriteValueFor _: CBCharacteristic, error: Error?) {
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async {
+            if let errorDescription {
+                Bridge.log("LIVE: Error writing characteristic: \(errorDescription)")
+            } else {
+                Bridge.log("LIVE: Characteristic write successful")
+            }
         }
     }
 
-    func peripheral(
+    nonisolated func peripheral(
         _: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic,
         error: Error?
     ) {
-        if let error {
-            Bridge.log("LIVE: Error updating notification state: \(error.localizedDescription)")
-        } else {
-            Bridge.log(
-                "Notification state updated for \(characteristic.uuid): \(characteristic.isNotifying ? "ON" : "OFF")"
-            )
+        let uuid = characteristic.uuid
+        let isNotifying = characteristic.isNotifying
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            if let errorDescription {
+                Bridge.log("LIVE: Error updating notification state: \(errorDescription)")
+            } else {
+                Bridge.log("Notification state updated for \(uuid): \(isNotifying ? "ON" : "OFF")")
 
-            if characteristic.uuid == RX_CHAR_UUID, characteristic.isNotifying {
-                Bridge.log("LIVE: 🔔 Ready to receive data via notifications")
+                if uuid == self.RX_CHAR_UUID, isNotifying {
+                    Bridge.log("LIVE: 🔔 Ready to receive data via notifications")
+                }
             }
         }
     }
 
-    func peripheralDidUpdateRSSI(_ peripheral: CBPeripheral, error: Error?) {
-        if let error {
-            Bridge.log("LIVE: Error reading RSSI: \(error.localizedDescription)")
-        } else {
-            Bridge.log("LIVE: RSSI: \(peripheral.readRSSI())")
+    nonisolated func peripheralDidUpdateRSSI(_ peripheral: CBPeripheral, error: Error?) {
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async {
+            if let errorDescription {
+                Bridge.log("LIVE: Error reading RSSI: \(errorDescription)")
+            } else {
+                Bridge.log("LIVE: RSSI: \(peripheral.readRSSI())")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- make the Bluetooth SDK observable store read/write path stay on the main actor instead of marking the backing dictionary unsafe
- hop CoreBluetooth central/peripheral callbacks back to the main queue before touching `MentraLive` state
- preserve current `dev` MTU estimation and characteristic setup behavior while applying the isolation fix

## Included commits

- `7a71730de` Fix iOS Bluetooth SDK store isolation
- `cb050615a` Fix Mentra Live iOS BLE callback isolation

## Bug being solved

Restore MainActor isolation for the iOS ObservableStore backing dictionary so native state reads cannot race dictionary mutation during startup. This fixes the React Native example startup crash observed after JS bundle evaluation.

The React Native starter app was intermittently crashing on iPhone during startup immediately after the Metro JS bundle began evaluating. The iOS crash reports showed ObservableStore.getCategory iterating the SDK state dictionary while MentraBluetoothSDK.dispatchStoreUpdate was building bluetoothStatus, with Objective-C exceptions/SIGSEGV around dictionary iteration.

MentraLive creates CBCentralManager with the dedicated MentraLiveBluetooth queue, so its CoreBluetooth delegate callbacks can arrive off the main actor. Those callbacks were directly updating DeviceStore and other MainActor SDK state, unlike the G2/R1 implementations that hop back to the main queue first.

Make the Mentra Live CoreBluetooth delegate methods nonisolated and dispatch their stateful work to the main queue before touching DeviceStore, connection state, characteristics, or incoming packet processing. This keeps ObservableStore mutations and reads on the same actor boundary and removes the startup race.

Verified by rebuilding/installing the React Native starter iOS app on device with bun run ios -- --device 00008120-001619E102E1A01E, relaunching com.mentra.bluetoothsdk.example, and confirming no new MentraExample crash report appeared after the patched launch.

## Conflict notes

- Resolved package version conflicts by keeping the current `dev` package and lockfile versions out of this concurrency-focused split.
- Resolved `MentraLive.swift` around characteristic discovery by keeping `dev`'s current MTU estimation behavior and applying the nonisolated callback/main-queue handoff.

## Validation

- `git diff --check origin/dev..HEAD`
- verified no conflict markers remain in the touched Swift/package files

Full iOS build was not run from this split worktree because this branch does not include a standalone SwiftPM package or generated Xcode project for the Bluetooth SDK module.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes threading for all Mentra Live BLE lifecycle and data paths; behavior should match prior logic but regressions in connect/reconnect or packet handling are possible if main-queue ordering differs.
> 
> **Overview**
> Fixes **MainActor isolation** in the iOS Bluetooth SDK so native state is not read and written from different threads during startup.
> 
> **`ObservableStore`** drops `nonisolated(unsafe)` on its backing dictionary and makes **`get`** main-actor-only, so reads like `getCategory` no longer race concurrent `set` / `DeviceStore` updates.
> 
> **`MentraLive`** marks CoreBluetooth **central and peripheral delegate** callbacks `nonisolated` (they run on `bluetoothQueue`) and **dispatches** connection, discovery, disconnect, characteristic setup, and incoming packet handling to the **main queue** before updating `DeviceStore`, connection state, or processing data. Characteristic discovery also keeps the current **MTU estimate** logic (min of with/without-response sizes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb050615af4b38ddc8aec253723e7f21612b2544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->