### PR TITLE
Fix broken photo/video detection in Mentra Live onboarding

### DIFF
--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -4,8 +4,11 @@ export type GlassesNotReadyEvent = {
   message: string
 }
 
+// NOTE: unlike most events below, the native module does NOT include a `type`
+// field on the button_press payload — it sends only {buttonId, pressType,
+// timestamp} (see BluetoothSdkModule on both iOS and Android). Consumers must
+// filter on `pressType` / the "button_press" listener name, never `event.type`.
 export type ButtonPressEvent = {
-  type: "button_press"
   buttonId: string
   pressType: "long" | "short"
   timestamp: number

--- a/mobile/src/app/onboarding/live.tsx
+++ b/mobile/src/app/onboarding/live.tsx
@@ -1,59 +1,14 @@
 import {Screen} from "@/components/ignite"
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
+import {waitForButtonPress, waitForTouchGesture} from "@/components/onboarding/waitForGlassesEvent"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import showAlert from "@/utils/AlertUtils"
-import BluetoothSdk, {TouchEvent} from "@mentra/bluetooth-sdk"
 import {useMemo} from "react"
 import {Platform} from "react-native"
 
 const CDN_BASE = "https://mentra-videos-cdn.mentraglass.com/onboarding/mentra-live/light"
-
-// Resolve once a button press matching `pressTypes` arrives. The listener is
-// removed both when it fires AND when the step is left (signal aborts), so it
-// never leaks across re-renders.
-const waitForButtonPress = (signal: AbortSignal, pressTypes: string[]): Promise<void> => {
-  return new Promise<void>((resolve) => {
-    if (signal.aborted) {
-      resolve()
-      return
-    }
-    const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
-      if (data?.type === "button_press" && pressTypes.includes(data?.pressType)) {
-        unsub.remove()
-        signal.removeEventListener("abort", onAbort)
-        resolve()
-      }
-    })
-    const onAbort = () => {
-      unsub.remove()
-    }
-    signal.addEventListener("abort", onAbort)
-  })
-}
-
-// Resolve once a touch gesture in `gestureNames` arrives. Same abort-safe
-// cleanup contract as waitForButtonPress.
-const waitForTouchGesture = (signal: AbortSignal, gestureNames: string[]): Promise<void> => {
-  return new Promise<void>((resolve) => {
-    if (signal.aborted) {
-      resolve()
-      return
-    }
-    const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
-      if (data?.gestureName && gestureNames.includes(data.gestureName)) {
-        unsub.remove()
-        signal.removeEventListener("abort", onAbort)
-        resolve()
-      }
-    })
-    const onAbort = () => {
-      unsub.remove()
-    }
-    signal.addEventListener("abort", onAbort)
-  })
-}
 
 export default function MentraLiveOnboarding() {
   const {clearHistoryAndGoHome} = useNavigationStore.getState()

--- a/mobile/src/app/onboarding/live.tsx
+++ b/mobile/src/app/onboarding/live.tsx
@@ -5,225 +5,207 @@ import {translate} from "@/i18n"
 import {SETTINGS, useSetting} from "@/stores/settings"
 import showAlert from "@/utils/AlertUtils"
 import BluetoothSdk, {TouchEvent} from "@mentra/bluetooth-sdk"
+import {useMemo} from "react"
 import {Platform} from "react-native"
 
 const CDN_BASE = "https://mentra-videos-cdn.mentraglass.com/onboarding/mentra-live/light"
+
+// Resolve once a button press matching `pressTypes` arrives. The listener is
+// removed both when it fires AND when the step is left (signal aborts), so it
+// never leaks across re-renders.
+const waitForButtonPress = (signal: AbortSignal, pressTypes: string[]): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
+      if (data?.type === "button_press" && pressTypes.includes(data?.pressType)) {
+        unsub.remove()
+        signal.removeEventListener("abort", onAbort)
+        resolve()
+      }
+    })
+    const onAbort = () => {
+      unsub.remove()
+    }
+    signal.addEventListener("abort", onAbort)
+  })
+}
+
+// Resolve once a touch gesture in `gestureNames` arrives. Same abort-safe
+// cleanup contract as waitForButtonPress.
+const waitForTouchGesture = (signal: AbortSignal, gestureNames: string[]): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
+      if (data?.gestureName && gestureNames.includes(data.gestureName)) {
+        unsub.remove()
+        signal.removeEventListener("abort", onAbort)
+        resolve()
+      }
+    })
+    const onAbort = () => {
+      unsub.remove()
+    }
+    signal.addEventListener("abort", onAbort)
+  })
+}
 
 export default function MentraLiveOnboarding() {
   const {clearHistoryAndGoHome} = useNavigationStore.getState()
   const [_onboardingLiveCompleted, setOnboardingLiveCompleted] = useSetting(SETTINGS.onboarding_live_completed.key)
 
   // NOTE: you can't have 2 transition videos in a row or things will break:
-  let steps: OnboardingStep[] = [
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB0_start_onboarding.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB0_start_onboarding.jpg"),
-      name: "Start Onboarding",
-      playCount: 1,
-      transition: true,
-      fadeOut: true,
-      title: translate("onboarding:liveWelcomeTitle"),
-      subtitle: translate("onboarding:liveWelcomeSubtitle"),
-      titleCentered: true,
-      subtitleCentered: true,
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB4_action_button_click.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB4_action_button_click.jpg"),
-      name: "Action Button Click",
-      playCount: -1, //2,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:liveTakeAPhoto"),
-      subtitle: translate("onboarding:livePressActionButton"),
-      info: translate("onboarding:liveLedFlashWarning"),
-      // wait for the action button to be pressed:
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
-            if (data?.type === "button_press" && data?.pressType === "short") {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+  // Memoized so each step's `waitFn` keeps a stable identity across re-renders.
+  // OnboardingGuide's waitFn effect keys off `step.waitFn`; if these were rebuilt
+  // every render the effect would re-subscribe and leak a BLE listener each time,
+  // which broke photo/video detection during onboarding.
+  const steps: OnboardingStep[] = useMemo(() => {
+    const built: OnboardingStep[] = [
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB0_start_onboarding.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB0_start_onboarding.jpg"),
+        name: "Start Onboarding",
+        playCount: 1,
+        transition: true,
+        fadeOut: true,
+        title: translate("onboarding:liveWelcomeTitle"),
+        subtitle: translate("onboarding:liveWelcomeSubtitle"),
+        titleCentered: true,
+        subtitleCentered: true,
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB5_action_button_record.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB5_action_button_record.jpg"),
-      name: "Action Button Record",
-      playCount: -1, // 2,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:liveStartRecording"),
-      subtitle: translate("onboarding:livePressAndHold"),
-      info: translate("onboarding:liveLedFlashWarning"),
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
-            if (data?.type === "button_press" && (data?.pressType === "long" || data?.pressType === "short")) {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB4_action_button_click.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB4_action_button_click.jpg"),
+        name: "Action Button Click",
+        playCount: -1, //2,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:liveTakeAPhoto"),
+        subtitle: translate("onboarding:livePressActionButton"),
+        info: translate("onboarding:liveLedFlashWarning"),
+        // wait for the action button to be pressed:
+        waitFn: (signal: AbortSignal): Promise<void> => waitForButtonPress(signal, ["short"]),
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB5_action_button_record.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB5_action_button_record.jpg"),
-      name: "Action Button Stop Recording",
-      playCount: -1, // 2,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:liveStopRecording"),
-      subtitle: translate("onboarding:livePressAndHoldAgain"),
-      info: translate("onboarding:liveLedFlashWarning"),
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
-            if (data?.type === "button_press" && (data?.pressType === "long" || data?.pressType === "short")) {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB5_action_button_record.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB5_action_button_record.jpg"),
+        name: "Action Button Record",
+        playCount: -1, // 2,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:liveStartRecording"),
+        subtitle: translate("onboarding:livePressAndHold"),
+        info: translate("onboarding:liveLedFlashWarning"),
+        waitFn: (signal: AbortSignal): Promise<void> => waitForButtonPress(signal, ["long", "short"]),
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB6_transition_trackpad.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB6_transition_trackpad.jpg"),
-      name: "Transition Trackpad",
-      playCount: -1, // 1,
-      transition: true,
-      fadeOut: true,
-      // show next slide's title and subtitle:
-      title: translate("onboarding:livePlayMusic"),
-      subtitle: translate("onboarding:liveDoubleTapTouchpad"),
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB7_trackpad_tap.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB7_trackpad_tap.jpg"),
-      name: "Trackpad Tap",
-      playCount: -1, // 1,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:livePlayMusic"),
-      subtitle: translate("onboarding:liveDoubleTapTouchpad"),
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
-            if (data?.gestureName === "double_tap") {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB5_action_button_record.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB5_action_button_record.jpg"),
+        name: "Action Button Stop Recording",
+        playCount: -1, // 2,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:liveStopRecording"),
+        subtitle: translate("onboarding:livePressAndHoldAgain"),
+        info: translate("onboarding:liveLedFlashWarning"),
+        waitFn: (signal: AbortSignal): Promise<void> => waitForButtonPress(signal, ["long", "short"]),
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB8_trackpad_slide.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB8_trackpad_slide.jpg"),
-      name: "Trackpad Volume Slide",
-      playCount: -1, // 1,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:liveAdjustVolume"),
-      subtitle: translate("onboarding:liveSwipeTouchpadUp") + "\n" + translate("onboarding:liveSwipeTouchpadDown"),
-      // subtitle2: translate("onboarding:liveSwipeTouchpadDown"),
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
-            if (data?.gestureName === "forward_swipe" || data?.gestureName === "backward_swipe") {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB6_transition_trackpad.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB6_transition_trackpad.jpg"),
+        name: "Transition Trackpad",
+        playCount: -1, // 1,
+        transition: true,
+        fadeOut: true,
+        // show next slide's title and subtitle:
+        title: translate("onboarding:livePlayMusic"),
+        subtitle: translate("onboarding:liveDoubleTapTouchpad"),
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB9_trackpad_pause.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB9_trackpad_pause.jpg"),
-      name: "Trackpad Pause",
-      playCount: -1, // 1,
-      transition: false,
-      fadeOut: true,
-      title: translate("onboarding:livePauseMusic"),
-      subtitle: translate("onboarding:liveDoubleTapTouchpad"),
-      waitFn: (): Promise<void> => {
-        return new Promise<void>((resolve) => {
-          const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
-            if (data?.gestureName === "double_tap") {
-              unsub.remove()
-              resolve()
-            }
-          })
-        })
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB7_trackpad_tap.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB7_trackpad_tap.jpg"),
+        name: "Trackpad Tap",
+        playCount: -1, // 1,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:livePlayMusic"),
+        subtitle: translate("onboarding:liveDoubleTapTouchpad"),
+        waitFn: (signal: AbortSignal): Promise<void> => waitForTouchGesture(signal, ["double_tap"]),
       },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB10_cord.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB10_cord.jpg"),
-      name: "Cord",
-      playCount: 1,
-      transition: true,
-      // fadeOut: true,
-      title: " ",
-      // title: translate("onboarding:liveConnectCable"),
-      // subtitle: translate("onboarding:liveCableDescription"),
-      // info: translate("onboarding:liveCableInfo"),
-      replayable: false,
-      buttonTimeoutMs: 5000,
-      // waitFn: (): Promise<void> => {
-      //   return new Promise<void>((resolve) => {
-      //     // Check if already charging
-      //     if (useGlassesStore.getState().charging) {
-      //       resolve()
-      //       return
-      //     }
-      //     // Wait for charging state to become true
-      //     const unsub = useGlassesStore.subscribe(
-      //       (state) => state.charging,
-      //       (charging) => {
-      //         if (charging) {
-      //           unsub()
-      //           resolve()
-      //         }
-      //       },
-      //     )
-      //   })
-      // },
-    },
-    {
-      type: "video",
-      source: `${CDN_BASE}/ONB11_end.mp4`,
-      poster: require("@assets/onboarding/live/thumbnails/ONB11_end.jpg"),
-      name: "End",
-      playCount: 1,
-      transition: false,
-      replayable: false,
-      title: translate("onboarding:liveEndTitle"),
-      subtitle: translate("onboarding:liveEndMessage"),
-      titleCentered: true,
-      subtitleCentered: true,
-    },
-  ]
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB8_trackpad_slide.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB8_trackpad_slide.jpg"),
+        name: "Trackpad Volume Slide",
+        playCount: -1, // 1,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:liveAdjustVolume"),
+        subtitle: translate("onboarding:liveSwipeTouchpadUp") + "\n" + translate("onboarding:liveSwipeTouchpadDown"),
+        // subtitle2: translate("onboarding:liveSwipeTouchpadDown"),
+        waitFn: (signal: AbortSignal): Promise<void> =>
+          waitForTouchGesture(signal, ["forward_swipe", "backward_swipe"]),
+      },
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB9_trackpad_pause.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB9_trackpad_pause.jpg"),
+        name: "Trackpad Pause",
+        playCount: -1, // 1,
+        transition: false,
+        fadeOut: true,
+        title: translate("onboarding:livePauseMusic"),
+        subtitle: translate("onboarding:liveDoubleTapTouchpad"),
+        waitFn: (signal: AbortSignal): Promise<void> => waitForTouchGesture(signal, ["double_tap"]),
+      },
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB10_cord.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB10_cord.jpg"),
+        name: "Cord",
+        playCount: 1,
+        transition: true,
+        // fadeOut: true,
+        title: " ",
+        // title: translate("onboarding:liveConnectCable"),
+        // subtitle: translate("onboarding:liveCableDescription"),
+        // info: translate("onboarding:liveCableInfo"),
+        replayable: false,
+        buttonTimeoutMs: 5000,
+      },
+      {
+        type: "video",
+        source: `${CDN_BASE}/ONB11_end.mp4`,
+        poster: require("@assets/onboarding/live/thumbnails/ONB11_end.jpg"),
+        name: "End",
+        playCount: 1,
+        transition: false,
+        replayable: false,
+        title: translate("onboarding:liveEndTitle"),
+        subtitle: translate("onboarding:liveEndMessage"),
+        titleCentered: true,
+        subtitleCentered: true,
+      },
+    ]
 
-  // remove JUST index 4 on android because transitions are broken:
-  if (Platform.OS === "android") {
-    steps.splice(4, 1)
-  }
+    // remove JUST index 4 on android because transitions are broken:
+    if (Platform.OS === "android") {
+      built.splice(4, 1)
+    }
+
+    return built
+  }, [])
 
   // reduce down to 2 steps if __DEV__
   // if (__DEV__) {

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -25,7 +25,11 @@ interface BaseStep {
   bullets?: string[]
   numberedBullets?: string[]
   fadeOut?: boolean // if true, the step will fade out after the duration
-  waitFn?: () => Promise<void>
+  // Resolves when the step's required user action is detected. Receives an
+  // AbortSignal that fires when the step is left or the component re-renders;
+  // implementations MUST remove any event listeners they register when aborted,
+  // otherwise listeners leak across re-renders (see OnboardingGuide waitFn effect).
+  waitFn?: (signal: AbortSignal) => Promise<void>
 }
 
 interface VideoStep extends BaseStep {
@@ -756,20 +760,27 @@ export function OnboardingGuide({
   useEffect(() => {
     if (!step.waitFn) return
 
-    let cancelled = false
+    const controller = new AbortController()
+    let advanceTimer: number | null = null
     setWaitState(true)
 
-    step.waitFn().then(() => {
-      if (cancelled) return
+    step.waitFn(controller.signal).then(() => {
+      if (controller.signal.aborted) return
       setWaitState(false)
-      BgTimer.setTimeout(() => {
-        if (cancelled) return
+      advanceTimer = BgTimer.setTimeout(() => {
+        if (controller.signal.aborted) return
         handleNext(true)
       }, 1500)
     })
 
     return () => {
-      cancelled = true
+      // Abort signals the waitFn to remove its event listener(s); without this
+      // every re-render leaks a button_press/touch_event listener and the step
+      // can resolve from a stale subscription, breaking photo/video detection.
+      controller.abort()
+      if (advanceTimer != null) {
+        BgTimer.clearTimeout(advanceTimer)
+      }
     }
   }, [step.waitFn])
 

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -1,0 +1,148 @@
+import {render, act} from "@testing-library/react-native"
+
+import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
+import {getCoreModuleListenerCount, resetCoreModuleMock} from "@/test-utils/mockCoreModule"
+import BluetoothSdk from "@mentra/bluetooth-sdk"
+
+// --- Heavy / native deps that OnboardingGuide pulls in ---
+
+jest.mock("expo-video", () => {
+  const player = {
+    loop: false,
+    audioMixingMode: "mixWithOthers",
+    currentTime: 0,
+    duration: 1,
+    play: jest.fn(),
+    pause: jest.fn(),
+    replaceAsync: jest.fn(() => Promise.resolve()),
+    addListener: jest.fn(() => ({remove: jest.fn()})),
+  }
+  return {
+    __esModule: true,
+    useVideoPlayer: () => player,
+    VideoView: () => null,
+  }
+})
+
+jest.mock("expo-image", () => ({
+  __esModule: true,
+  Image: () => null,
+}))
+
+jest.mock("@/components/brands/MentraLogoStandalone", () => ({
+  MentraLogoStandalone: () => null,
+}))
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useAppTheme: () => ({
+    theme: {colors: {primary: "#000", foreground: "#000", background: "#fff", muted_foreground: "#888"}},
+  }),
+}))
+
+jest.mock("@/contexts/NavigationHistoryContext", () => ({
+  focusEffectPreventBack: jest.fn(),
+}))
+
+jest.mock("@/stores/navigation", () => ({
+  useNavigationStore: {getState: () => ({clearHistoryAndGoHome: jest.fn()})},
+}))
+
+jest.mock("@/stores/settings", () => ({
+  SETTINGS: {super_mode: {key: "super_mode"}},
+  useSetting: () => [false, jest.fn()],
+}))
+
+jest.mock("@/components/ignite", () => {
+  const {Text: RNText, TouchableOpacity} = require("react-native")
+  const React = require("react")
+  return {
+    Text: ({text, children}: any) => React.createElement(RNText, null, text ?? children),
+    Button: ({text, onPress}: any) =>
+      React.createElement(TouchableOpacity, {onPress}, React.createElement(RNText, null, text)),
+    Header: () => null,
+    Icon: () => null,
+  }
+})
+
+// Build a Mentra-Live-style step list: a video step whose waitFn resolves on a
+// short button_press, exactly like onboarding/live.tsx. Each call returns FRESH
+// inline arrow functions, mirroring live.tsx rebuilding `steps` every render.
+const buildSteps = (): OnboardingStep[] => [
+  {
+    type: "video",
+    source: "photo.mp4",
+    name: "Take a photo",
+    playCount: -1,
+    transition: false,
+    fadeOut: false,
+    title: "Take a photo",
+    // Mirrors the abort-safe waitFn contract used by onboarding/live.tsx: the
+    // button_press listener is removed both when it fires and when the step is
+    // left (signal aborts), so it must never leak across re-renders.
+    waitFn: (signal: AbortSignal): Promise<void> => {
+      return new Promise<void>((resolve) => {
+        if (signal.aborted) {
+          resolve()
+          return
+        }
+        const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
+          if (data?.type === "button_press" && data?.pressType === "short") {
+            unsub.remove()
+            signal.removeEventListener("abort", onAbort)
+            resolve()
+          }
+        })
+        const onAbort = () => {
+          unsub.remove()
+        }
+        signal.addEventListener("abort", onAbort)
+      })
+    },
+  },
+  {
+    type: "video",
+    source: "next.mp4",
+    name: "Next",
+    playCount: 1,
+    transition: false,
+    fadeOut: false,
+  },
+]
+
+describe("OnboardingGuide waitFn lifecycle", () => {
+  beforeEach(() => {
+    resetCoreModuleMock()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  const renderGuide = () =>
+    render(<OnboardingGuide steps={buildSteps()} autoStart={true} requiresGlassesConnection={false} />)
+
+  it("does not leak button_press listeners across re-renders while on a waitFn step", () => {
+    const {rerender} = renderGuide()
+
+    // Drive to the waitFn step (index 1). The intro is a transition that
+    // auto-advances; emit nothing, just let timers/effects settle.
+    act(() => {
+      jest.advanceTimersByTime(1000)
+    })
+
+    // Simulate the parent (live.tsx) re-rendering several times with a freshly
+    // built `steps` array (new waitFn identities each render). This is exactly
+    // what happens when any store/zustand selector updates during onboarding.
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        rerender(<OnboardingGuide steps={buildSteps()} autoStart={true} requiresGlassesConnection={false} />)
+      })
+    }
+
+    // BUG: each re-render registers a new button_press listener without removing
+    // the previous one, so the count grows unbounded. There should be at most
+    // one active listener for the current step.
+    expect(getCoreModuleListenerCount("button_press")).toBeLessThanOrEqual(1)
+  })
+})

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -86,7 +86,7 @@ const buildSteps = (): OnboardingStep[] => [
           return
         }
         const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
-          if (data?.type === "button_press" && data?.pressType === "short") {
+          if (data?.pressType === "short") {
             unsub.remove()
             signal.removeEventListener("abort", onAbort)
             resolve()

--- a/mobile/src/components/onboarding/__tests__/waitForGlassesEvent.test.ts
+++ b/mobile/src/components/onboarding/__tests__/waitForGlassesEvent.test.ts
@@ -1,0 +1,76 @@
+import {waitForButtonPress, waitForTouchGesture} from "@/components/onboarding/waitForGlassesEvent"
+import {emitCoreModuleEvent, getCoreModuleListenerCount, resetCoreModuleMock} from "@/test-utils/mockCoreModule"
+
+describe("waitForGlassesEvent", () => {
+  beforeEach(() => {
+    resetCoreModuleMock()
+  })
+
+  describe("waitForButtonPress", () => {
+    it("resolves on a real (type-less) button_press payload", async () => {
+      const controller = new AbortController()
+      const done = waitForButtonPress(controller.signal, ["short"])
+
+      // This is exactly what the native module sends to JS: NO `type` field.
+      // The old code gated on data.type === "button_press" and never resolved,
+      // leaving the "take a photo" step stuck.
+      emitCoreModuleEvent("button_press", {buttonId: "camera", pressType: "short", timestamp: 123})
+
+      await expect(done).resolves.toBeUndefined()
+      // Listener removed after resolving.
+      expect(getCoreModuleListenerCount("button_press")).toBe(0)
+    })
+
+    it("matches any of the accepted press types (long or short)", async () => {
+      const controller = new AbortController()
+      const done = waitForButtonPress(controller.signal, ["long", "short"])
+
+      emitCoreModuleEvent("button_press", {buttonId: "camera", pressType: "long", timestamp: 1})
+
+      await expect(done).resolves.toBeUndefined()
+    })
+
+    it("ignores press types that do not match", () => {
+      const controller = new AbortController()
+      let resolved = false
+      waitForButtonPress(controller.signal, ["short"]).then(() => {
+        resolved = true
+      })
+
+      emitCoreModuleEvent("button_press", {buttonId: "camera", pressType: "long", timestamp: 1})
+
+      expect(resolved).toBe(false)
+      expect(getCoreModuleListenerCount("button_press")).toBe(1)
+    })
+
+    it("removes its listener when the signal aborts (no leak)", () => {
+      const controller = new AbortController()
+      waitForButtonPress(controller.signal, ["short"])
+      expect(getCoreModuleListenerCount("button_press")).toBe(1)
+
+      controller.abort()
+      expect(getCoreModuleListenerCount("button_press")).toBe(0)
+    })
+  })
+
+  describe("waitForTouchGesture", () => {
+    it("resolves on a matching gesture and removes its listener", async () => {
+      const controller = new AbortController()
+      const done = waitForTouchGesture(controller.signal, ["double_tap"])
+
+      emitCoreModuleEvent("touch_event", {type: "touch_event", gestureName: "double_tap", timestamp: 1})
+
+      await expect(done).resolves.toBeUndefined()
+      expect(getCoreModuleListenerCount("touch_event")).toBe(0)
+    })
+
+    it("removes its listener when the signal aborts (no leak)", () => {
+      const controller = new AbortController()
+      waitForTouchGesture(controller.signal, ["double_tap"])
+      expect(getCoreModuleListenerCount("touch_event")).toBe(1)
+
+      controller.abort()
+      expect(getCoreModuleListenerCount("touch_event")).toBe(0)
+    })
+  })
+})

--- a/mobile/src/components/onboarding/waitForGlassesEvent.ts
+++ b/mobile/src/components/onboarding/waitForGlassesEvent.ts
@@ -1,0 +1,54 @@
+import BluetoothSdk, {TouchEvent} from "@mentra/bluetooth-sdk"
+
+// Helpers for onboarding steps that wait for a glasses interaction. Each takes
+// an AbortSignal and removes its listener both when it fires AND when the step
+// is left (signal aborts), so listeners never leak across re-renders.
+
+// Resolve once a button press matching `pressTypes` arrives.
+//
+// NOTE: the native button_press event delivered to JS is {buttonId, pressType,
+// timestamp} with NO `type` field (see BluetoothSdkModule on both iOS and
+// Android), so we must NOT gate on data.type — doing so silently never resolves
+// and the "take a photo" / recording onboarding steps get stuck. The listener
+// is already scoped to the "button_press" event name, so matching on pressType
+// alone is correct.
+export const waitForButtonPress = (signal: AbortSignal, pressTypes: string[]): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const unsub = BluetoothSdk.addListener("button_press", (data: any) => {
+      if (pressTypes.includes(data?.pressType)) {
+        unsub.remove()
+        signal.removeEventListener("abort", onAbort)
+        resolve()
+      }
+    })
+    const onAbort = () => {
+      unsub.remove()
+    }
+    signal.addEventListener("abort", onAbort)
+  })
+}
+
+// Resolve once a touch gesture in `gestureNames` arrives.
+export const waitForTouchGesture = (signal: AbortSignal, gestureNames: string[]): Promise<void> => {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve()
+      return
+    }
+    const unsub = BluetoothSdk.addListener("touch_event", (data: TouchEvent) => {
+      if (data?.gestureName && gestureNames.includes(data.gestureName)) {
+        unsub.remove()
+        signal.removeEventListener("abort", onAbort)
+        resolve()
+      }
+    })
+    const onAbort = () => {
+      unsub.remove()
+    }
+    signal.addEventListener("abort", onAbort)
+  })
+}

--- a/mobile/src/test-utils/mockCoreModule.ts
+++ b/mobile/src/test-utils/mockCoreModule.ts
@@ -122,6 +122,8 @@ export const emitCoreModuleEvent = (eventName: string, payload: any) => {
   listeners.get(eventName)?.forEach((listener) => listener(payload))
 }
 
+export const getCoreModuleListenerCount = (eventName: string) => listeners.get(eventName)?.size ?? 0
+
 export const resetCoreModuleMock = () => {
   listeners.clear()
   Object.values(coreModuleMock).forEach((value) => {


### PR DESCRIPTION
## Scope

Fixes incident `e7f4b17d-0709-49b1-8075-a29fbed1590b` — *"Detection for taking photos and starting and stopping videos are broken during Mentra Live's onboarding flow"* (iOS, app 2.11.0).

## Root cause

The onboarding steps that wait for a glasses button press (take photo, start/stop recording) register a `button_press` listener inside a Promise in each step's `waitFn`. `OnboardingGuide`'s effect only set a `cancelled` flag on cleanup and **never removed that listener**:

```js
useEffect(() => {
  if (!step.waitFn) return
  let cancelled = false
  step.waitFn().then(() => { if (cancelled) return; ...handleNext(true) })
  return () => { cancelled = true }   // leaks the BLE listener
}, [step.waitFn])
```

Combined with `live.tsx` rebuilding `steps` (and every inline `waitFn`) on **every render** with no memoization, any re-render gave `step.waitFn` a new identity, re-ran the effect, leaked another listener, and re-armed the wait state. Stale subscriptions could then resolve the wrong step.

Incident phone logs confirmed the symptoms: button presses arrived correctly, but step advancement was delayed ~8s (vs the intended 1.5s) and the "Stop Recording" step auto-advanced via `handleNext(false)` with **no button press at all**.

## Changes

- **`OnboardingGuide.tsx`** — `waitFn` now receives an `AbortSignal`; the effect aborts on cleanup so listeners are removed even when no press arrives, and the pending advance timer is cleared.
- **`live.tsx`** — memoize `steps` for stable `waitFn` identities; replace the six duplicated inline `waitFn`s with abort-safe `waitForButtonPress` / `waitForTouchGesture` helpers.
- **Regression test** (`OnboardingGuide.waitFn.test.tsx`) — asserts `button_press` listeners do not leak across re-renders on a `waitFn` step.

## Test evidence

- Regression test red→green verified: leaky cleanup → **6 listeners** (fails, expected ≤1); fixed → **1 listener** (passes). Run with `npx jest` (note: `bun test` routes to bun's native runner and segfaults on this suite).
- `bun compile`: no new type errors in the changed files.
- `eslint`: 0 errors on changed files (only pre-existing-style warnings).
- 6 unrelated suites that fail on this branch fail identically on base `staging` (verified by stashing) — not caused by this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to onboarding UI and BLE event listeners; no auth, payments, or core connection logic changes.
> 
> **Overview**
> Fixes Mentra Live onboarding steps that wait for glasses button presses and touch gestures by stopping **leaked BLE listeners** and **incorrect button matching**.
> 
> **`OnboardingGuide`** now passes an **`AbortSignal`** into each step’s `waitFn` and **aborts on effect cleanup**, so `button_press` / `touch_event` subscriptions are torn down when the step changes or the parent re-renders; the pending auto-advance timer is cleared too.
> 
> **`live.tsx`** **memoizes** the step list so `waitFn` references stay stable, and routes waits through **`waitForButtonPress`** / **`waitForTouchGesture`** instead of duplicated inline listeners.
> 
> **Button detection** no longer checks `data.type === "button_press"` (native payloads are only `{buttonId, pressType, timestamp}`); matching uses **`pressType`** only, which unblocks photo and record steps that never advanced.
> 
> **`ButtonPressEvent`** typing and comments document the native shape; **unit tests** cover abort cleanup, listener counts, and type-less payloads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d21347ddd56763f5e0ee5326720928430eb67e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken photo/video detection in Mentra Live onboarding by stopping leaked BLE listeners, stabilizing wait functions, fixing event matching, and aligning event types with native. Resolves the delayed and phantom step advances seen in incident e7f4b17d (iOS 2.11.0).

- **Bug Fixes**
  - `OnboardingGuide`: `waitFn` now accepts an `AbortSignal`; cleanup aborts to remove `button_press`/`touch_event` listeners and clears the advance timer.
  - `live.tsx`: memoized `steps` to keep `waitFn` identities stable and avoid re-subscribing on each render.
  - Fixed `button_press` detection to match native payloads (no `type` field); now matches on `pressType` only so photo/recording steps advance.
  - `@mentra/bluetooth-sdk`: removed phantom `type` from `ButtonPressEvent` to match native and prevent future mischecks.

- **Refactors**
  - Replaced inline wait functions with abort-safe helpers: `waitForButtonPress` and `waitForTouchGesture` (in `waitForGlassesEvent`).
  - Added tests for wait cleanup and event matching; test utils include `getCoreModuleListenerCount`.

<sup>Written for commit d21347ddd56763f5e0ee5326720928430eb67e51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

