### PR TITLE
Fix IMU sidecar capture for video recordings

### DIFF
--- a/asg_client/app/src/main/AndroidManifest.xml
+++ b/asg_client/app/src/main/AndroidManifest.xml
@@ -157,6 +157,16 @@
             </intent-filter>
         </receiver>
 
+        <!-- Debug receiver for testing MTK OTA via adb -->
+        <receiver
+            android:name="com.mentra.asg_client.receiver.DebugMtkOtaReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.mentra.DEBUG_MTK_OTA" />
+            </intent-filter>
+        </receiver>
+
         <!-- Intent IPC receiver for third-party app commands -->
         <receiver
             android:name="com.mentra.asg_client.receiver.IntentCommandReceiver"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -943,6 +943,10 @@ public class CameraNeoService extends LifecycleService {
             }
             closeCamera();
             stopBackgroundThread();
+            if (mImuRecorder != null) {
+                mImuRecorder.release();
+                mImuRecorder = null;
+            }
             releaseWakeLocks();
             
             sInstance = null;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -766,7 +766,8 @@ public final class PhotoSession {
             shotState = AeStateMachine.ShotState.SHOOTING;
 
             ImuRecorder imu = hooks.ensureImuRecorder();
-            imu.startRecording();
+            String imuStartPath = (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
+            imu.startRecording(imuStartPath);
 
             CaptureRequest.Builder stillBuilder =
                     activeCameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_STILL_CAPTURE);
@@ -916,7 +917,8 @@ public final class PhotoSession {
             shotState = AeStateMachine.ShotState.SHOOTING;
 
             ImuRecorder imu = hooks.ensureImuRecorder();
-            imu.startRecording();
+            String imuStartPath = (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
+            imu.startRecording(imuStartPath);
 
             Log.i(TAG, "HDR: Starting burst capture with brackets "
                     + java.util.Arrays.toString(HdrBurstBuilder.HDR_EV_BRACKETS));

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
@@ -240,7 +240,7 @@ public final class VideoRecordingSession {
 
                 ImuRecorder imu = hooks.ensureImuRecorder();
                 if (imu != null) {
-                    imu.startRecording();
+                    imu.startRecording(currentVideoPath);
                 }
 
                 pendingSettings = null;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
@@ -276,6 +276,12 @@ public final class VideoRecordingSession {
                 Log.e(TAG, "Failed to start recording after delay", e);
                 notifyError(currentVideoId, "Failed to start recording: " + e.getMessage());
                 isRecording = false;
+                // IMU may already be recording (started above); stop it so the sensor listener and
+                // partial stream don't keep running after a failed start.
+                ImuRecorder imu = hooks.currentImuRecorder();
+                if (imu != null) {
+                    imu.cancel();
+                }
             }
         }, VideoRecorderPolicy.RECORDER_SURFACE_WARMUP_MS);
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
@@ -242,12 +242,17 @@ public final class VideoRecordingSession {
                 }
 
                 mediaRecorder.start();
+                // Anchor for the video timeline on the IMU clock (elapsedRealtimeNanos), captured as
+                // close to recorder start as possible. Written to the IMU sidecar so the consumer can
+                // align frames (relative MP4 PTS) to IMU samples and subtract the fixed startup offset.
+                long videoStartElapsedRealtimeNs = android.os.SystemClock.elapsedRealtimeNanos();
                 isRecording = true;
                 recordingStartTime = System.currentTimeMillis();
 
                 ImuRecorder imu = hooks.ensureImuRecorder();
                 if (imu != null) {
                     imu.startRecording(currentVideoPath);
+                    imu.setVideoStartAnchor(videoStartElapsedRealtimeNs);
                 }
 
                 pendingSettings = null;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/VideoRecordingSession.java
@@ -184,6 +184,13 @@ public final class VideoRecordingSession {
             Log.e(TAG, "MediaRecorder error: what=" + what + ", extra=" + extra);
             isRecording = false;
             String errorMsg = VideoRecorderPolicy.mediaRecorderErrorMessage(what);
+            // Stop IMU first: it unregisters the sensor listener and closes/discards the partial.
+            // Otherwise the listener keeps running and writing into a directory deleteCorruptCapture
+            // is about to wipe. Mirrors the stop()-failure path.
+            ImuRecorder imu = hooks.currentImuRecorder();
+            if (imu != null) {
+                imu.cancel();
+            }
             deleteCorruptCapture(currentVideoPath);
             notifyError(currentVideoId, errorMsg);
             try {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -317,6 +317,13 @@ public class FileManagerImpl implements FileManager {
         if (items != null) {
             for (File item : items) {
                 if (item.isFile()) {
+                    // Skip transient *.partial sidecars (e.g. imu.jsonl.partial). These are in-flight
+                    // or retained-on-error recovery files; they must never be counted or advertised
+                    // for Wi-Fi sync, where unknown leaf names are treated as primary capture files.
+                    if (item.getName().endsWith(".partial")) {
+                        Log.d(TAG, "⏭️ Skipping .partial file from listing: " + item.getAbsolutePath());
+                        continue;
+                    }
                     // Add file to metadata list
                     String mimeType = new MimeTypeRegistry().getMimeType(item.getName());
                     String relativePath = getRelativePath(rootDir, item);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugMtkOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugMtkOtaReceiver.java
@@ -1,0 +1,36 @@
+package com.mentra.asg_client.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * Debug receiver for testing MTK OTA updates via adb.
+ *
+ * Usage:
+ *   adb shell am broadcast -a com.mentra.DEBUG_MTK_OTA \
+ *       --es url "http://localhost:8080/version.json" \
+ *       -n com.mentra.asg_client/.receiver.DebugMtkOtaReceiver
+ *
+ * The version JSON URL should point to a server hosting the generated version.json
+ * and MTK patch zip. Use test-mtk-ota.sh to automate this with ADB reverse
+ * port forwarding.
+ *
+ * FOR DEVELOPMENT/TESTING ONLY.
+ */
+public class DebugMtkOtaReceiver extends BroadcastReceiver {
+  private static final String TAG = "DebugMtkOtaReceiver";
+  public static final String ACTION_DEBUG_MTK_OTA = "com.mentra.DEBUG_MTK_OTA";
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    DebugOtaReceiverSupport.triggerOtaFromUrl(
+        context,
+        intent,
+        ACTION_DEBUG_MTK_OTA,
+        TAG,
+        "MTK OTA",
+        ".receiver.DebugMtkOtaReceiver"
+    );
+  }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugOtaReceiverSupport.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/receiver/DebugOtaReceiverSupport.java
@@ -1,0 +1,51 @@
+package com.mentra.asg_client.receiver;
+
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+
+import com.mentra.asg_client.io.ota.helpers.OtaHelper;
+
+final class DebugOtaReceiverSupport {
+  private DebugOtaReceiverSupport() {
+  }
+
+  static void triggerOtaFromUrl(
+      Context context,
+      Intent intent,
+      String expectedAction,
+      String tag,
+      String flowLabel,
+      String receiverComponent
+  ) {
+    if (!expectedAction.equals(intent.getAction())) {
+      return;
+    }
+
+    Log.w(tag, "========================================");
+    Log.w(tag, "⚠️ DEBUG " + flowLabel + " TRIGGERED VIA ADB ⚠️");
+    Log.w(tag, "========================================");
+
+    String url = intent.getStringExtra("url");
+    if (url == null || url.isEmpty()) {
+      Log.e(tag, "❌ Missing 'url' extra. Usage:");
+      Log.e(tag, "  adb shell am broadcast -a " + expectedAction
+          + " --es url \"http://localhost:8080/version.json\" "
+          + "-n " + context.getPackageName() + "/" + receiverComponent);
+      return;
+    }
+
+    Log.i(tag, "Version JSON URL: " + url);
+
+    OtaHelper helper = OtaHelper.getInstance();
+    if (helper == null) {
+      Log.e(tag, "❌ OtaHelper not initialized - is OtaService running?");
+      return;
+    }
+
+    Log.i(tag, "🚀 Starting " + flowLabel + " with custom OTA URL...");
+    helper.setPhoneInitiatedOta(true);
+    helper.startVersionCheckWithUrl(context, url);
+    Log.i(tag, "✅ " + flowLabel + " trigger dispatched - monitor logcat for progress");
+  }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -7,6 +7,7 @@ import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
 import android.os.Handler;
 import android.os.HandlerThread;
+import android.os.SystemClock;
 import android.util.Log;
 
 import org.json.JSONArray;
@@ -57,7 +58,17 @@ public class ImuRecorder implements SensorEventListener {
   private final Handler mSensorHandler;
 
   private volatile boolean mRecording = false;
-  private long mStartTimeNs = 0;
+  // Baseline for the zero-based relative sample times in the JSON. Set lazily from the FIRST sensor
+  // event's timestamp so the math stays within a single clock domain — SensorEvent.timestamp is
+  // elapsedRealtimeNanos (time since boot), NOT System.nanoTime(); mixing them previously produced a
+  // bogus multi-hundred-second durationMs and a large constant per-sample offset. -1 = unset.
+  private long mBaseTimestampNs = -1;
+  // Absolute capture anchor in the elapsedRealtimeNanos clock, captured at startRecording(). This is
+  // the SAME clock Android's camera2 reports in SENSOR_TIMESTAMP when SENSOR_INFO_TIMESTAMP_SOURCE is
+  // REALTIME. Recording it lets the phone correlate IMU samples to video frames to sub-ms once the
+  // MTK HAL advertises REALTIME frame timestamps. Today the camera reports UNKNOWN, so this is the
+  // forward-compatible anchor — the IMU side is already on the correct clock and needs no rework.
+  private long mStartElapsedRealtimeNs = 0;
 
   // Latest values (updated independently by each sensor). Touched only on the sensor thread.
   private final float[] mLatestAccel = new float[3];
@@ -107,7 +118,8 @@ public class ImuRecorder implements SensorEventListener {
     mTargetDir = parentDir;
     mPartialFile = new File(parentDir, PARTIAL_NAME);
     mSampleCount = 0;
-    mStartTimeNs = System.nanoTime();
+    mBaseTimestampNs = -1; // baselined off the first event below
+    mStartElapsedRealtimeNs = SystemClock.elapsedRealtimeNanos();
 
     try {
       mStreamWriter = new BufferedWriter(new FileWriter(mPartialFile, false));
@@ -211,9 +223,13 @@ public class ImuRecorder implements SensorEventListener {
   /** Append one compact sample line: [relativeTimeMs, ax, ay, az, gx, gy, gz]. Sensor thread only. */
   private void writeSampleLine(long timestampNs) {
     if (mStreamWriter == null) return;
+    if (mBaseTimestampNs < 0) {
+      // First event seen: this becomes t=0 so relative times start at ~0 within the event clock.
+      mBaseTimestampNs = timestampNs;
+    }
     try {
       JSONArray sample = new JSONArray();
-      sample.put(Math.round((timestampNs - mStartTimeNs) / 1_000_000.0));
+      sample.put(Math.round((timestampNs - mBaseTimestampNs) / 1_000_000.0));
       sample.put(round4(mLatestAccel[0]));
       sample.put(round4(mLatestAccel[1]));
       sample.put(round4(mLatestAccel[2]));
@@ -292,10 +308,19 @@ public class ImuRecorder implements SensorEventListener {
     }
 
     JSONObject root = new JSONObject();
-    root.put("version", 1);
+    root.put("version", 2);
     root.put("sampleCount", samples.length());
     root.put("samplingRateHz", 100);
-    root.put("startTimeNs", mStartTimeNs);
+    // clockSource documents the time base of the absolute timestamps below: Android's
+    // elapsedRealtimeNanos (boot-monotonic). This is the clock camera2 SENSOR_TIMESTAMP uses when
+    // the camera advertises SENSOR_INFO_TIMESTAMP_SOURCE = REALTIME, enabling IMU↔video correlation.
+    root.put("clockSource", "elapsedRealtimeNanos");
+    // Absolute elapsedRealtimeNanos of each sample's relative t=0 (the first sensor event).
+    // sampleAbsoluteNs = startTimeNs + relativeMs * 1_000_000.
+    root.put("startTimeNs", mBaseTimestampNs);
+    // Absolute elapsedRealtimeNanos captured at startRecording() (≈ MediaRecorder.start()), before
+    // the first sensor event arrived. Lets the consumer bound the IMU window against video start.
+    root.put("recordingStartElapsedRealtimeNs", mStartElapsedRealtimeNs);
     root.put("durationMs", lastRelMs);
     root.put("samples", samples);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -37,11 +37,12 @@ import java.io.IOException;
  * caller's thread (the previous code silently captured zero samples on longer video recordings —
  * registration succeeded but no {@code onSensorChanged} ever fired).
  *
- * <h3>Crash safety</h3>
+ * <h3>Streaming</h3>
  * Samples are streamed to a {@code imu.jsonl.partial} file as they arrive rather than buffered in
- * memory and written only at stop. A non-graceful termination (process kill, MediaRecorder.stop()
- * throw) therefore leaves the captured samples on disk for recovery instead of losing the whole
- * track. At graceful stop the partial is assembled into the canonical {@code imu.json} object.
+ * memory, bounding memory use on long recordings. At graceful stop the partial is assembled into the
+ * canonical {@code imu.json} object and removed. On any failure or cancel the partial is discarded:
+ * the camera pipeline's {@code deleteCorruptCapture} wipes the whole capture directory on a failed
+ * recording anyway, so there is no surviving media for an orphaned sidecar to belong to.
  */
 public class ImuRecorder implements SensorEventListener {
   private static final String TAG = "ImuRecorder";
@@ -77,8 +78,6 @@ public class ImuRecorder implements SensorEventListener {
   // Streaming sink for the in-progress capture. Touched only on the sensor thread.
   private BufferedWriter mStreamWriter;
   private File mPartialFile;
-  private File mTargetDir;
-  private int mSampleCount;
 
   public ImuRecorder(Context context) {
     mSensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -115,9 +114,7 @@ public class ImuRecorder implements SensorEventListener {
       return;
     }
 
-    mTargetDir = parentDir;
     mPartialFile = new File(parentDir, PARTIAL_NAME);
-    mSampleCount = 0;
     mBaseTimestampNs = -1; // baselined off the first event below
     mStartElapsedRealtimeNs = SystemClock.elapsedRealtimeNanos();
 
@@ -155,28 +152,31 @@ public class ImuRecorder implements SensorEventListener {
     // then continue assembly on the caller's thread once the sink is quiesced.
     flushAndCloseStreamSync();
 
-    File parentDir = new File(mediaFilePath).getParentFile();
-    File partial = new File(parentDir, PARTIAL_NAME);
-    if (!partial.exists()) {
+    File partial = mPartialFile;
+    if (partial == null || !partial.exists()) {
       Log.w(TAG, "No IMU samples captured");
       return null;
     }
 
+    // Sidecar lands next to the media file; the partial lives in the same dir but use the stored
+    // reference for it so stop and cancel always agree on the path.
+    File parentDir = new File(mediaFilePath).getParentFile();
     String sidecarPath = new File(parentDir, SIDECAR_NAME).getAbsolutePath();
     try {
       int written = assembleSidecar(partial, new File(sidecarPath));
       if (written == 0) {
         Log.w(TAG, "No IMU samples captured");
-        partial.delete();
         return null;
       }
-      partial.delete();
       Log.d(TAG, "IMU sidecar written: " + sidecarPath + " (" + written + " samples)");
       return sidecarPath;
     } catch (JSONException | IOException e) {
-      // Leave the partial in place — it still holds the raw samples for later recovery.
-      Log.e(TAG, "Failed to assemble IMU sidecar; partial retained at " + partial.getAbsolutePath(), e);
+      Log.e(TAG, "Failed to assemble IMU sidecar", e);
       return null;
+    } finally {
+      // Always discard the partial — a failed capture's directory is wiped by the camera pipeline,
+      // and a successful assembly no longer needs it. Never leave it to be served by gallery sync.
+      partial.delete();
     }
   }
 
@@ -238,7 +238,6 @@ public class ImuRecorder implements SensorEventListener {
       sample.put(round4(mLatestGyro[2]));
       mStreamWriter.write(sample.toString());
       mStreamWriter.write('\n');
-      mSampleCount++;
     } catch (IOException | JSONException e) {
       Log.e(TAG, "Failed to write IMU sample", e);
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -125,6 +125,11 @@ public class ImuRecorder implements SensorEventListener {
     } catch (IOException e) {
       Log.e(TAG, "Failed to open IMU stream file", e);
       mStreamWriter = null;
+      // FileWriter may have created a zero-byte file before failing; don't leave it behind.
+      if (mPartialFile.exists()) {
+        mPartialFile.delete();
+      }
+      mPartialFile = null;
       return;
     }
 
@@ -186,19 +191,29 @@ public class ImuRecorder implements SensorEventListener {
     }
   }
 
-  /** Cancel recording without saving; discards the partial stream. */
-  public void cancel() {
+  /** Stop sensor delivery and close the stream, leaving the partial file untouched. */
+  private void stopSensors() {
     mRecording = false;
     mSensorManager.unregisterListener(this);
     flushAndCloseStreamSync();
+  }
+
+  /** Cancel recording without saving; discards the partial stream. */
+  public void cancel() {
+    stopSensors();
     if (mPartialFile != null && mPartialFile.exists()) {
       mPartialFile.delete();
     }
   }
 
-  /** Release the sensor thread. Call when the recorder is no longer needed. */
+  /**
+   * Release the sensor thread. Call when the recorder is no longer needed. Stops sensor delivery but
+   * does NOT delete a retained partial: a graceful stop whose imu.json assembly failed keeps the
+   * partial as the only copy of the IMU data, and the camera service calls release() on teardown
+   * shortly after every recording — deleting here would destroy that recovery copy.
+   */
   public void release() {
-    cancel();
+    stopSensors();
     mSensorThread.quitSafely();
   }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -72,6 +72,13 @@ public class ImuRecorder implements SensorEventListener {
   // MTK HAL advertises REALTIME frame timestamps. Today the camera reports UNKNOWN, so this is the
   // forward-compatible anchor — the IMU side is already on the correct clock and needs no rework.
   private long mStartElapsedRealtimeNs = 0;
+  // Absolute elapsedRealtimeNanos captured by the video pipeline right after MediaRecorder.start(),
+  // i.e. the wall-clock anchor for the video timeline on the SAME clock as the IMU samples. The MP4
+  // itself only carries relative PTS, so this is what lets the consumer place frame N at
+  // videoStart + PTS_N and subtract the fixed camera/IMU startup offset (the ~100ms the data partner
+  // measured). It is recorder-start, not per-frame start-of-exposure, so it removes the constant
+  // offset but is not a sub-ms hardware sync. 0 = not set (e.g. photo captures, which have no video).
+  private long mVideoStartElapsedRealtimeNs = 0;
 
   // Latest values (updated independently by each sensor). Touched only on the sensor thread.
   private final float[] mLatestAccel = new float[3];
@@ -119,6 +126,7 @@ public class ImuRecorder implements SensorEventListener {
     mPartialFile = new File(parentDir, PARTIAL_NAME);
     mBaseTimestampNs = -1; // baselined off the first event below
     mStartElapsedRealtimeNs = SystemClock.elapsedRealtimeNanos();
+    mVideoStartElapsedRealtimeNs = 0; // set by the video pipeline via setVideoStartAnchor()
 
     try {
       mStreamWriter = new BufferedWriter(new FileWriter(mPartialFile, false));
@@ -143,6 +151,17 @@ public class ImuRecorder implements SensorEventListener {
     }
 
     Log.d(TAG, "IMU recording started (streaming to " + mPartialFile.getAbsolutePath() + ")");
+  }
+
+  /**
+   * Record the video timeline's absolute anchor on the elapsedRealtimeNanos clock. Call from the
+   * video pipeline immediately after {@code MediaRecorder.start()}, passing
+   * {@code SystemClock.elapsedRealtimeNanos()}. Written to the sidecar as
+   * {@code videoStartElapsedRealtimeNs} so the consumer can align frame N (relative PTS) to IMU
+   * samples and subtract the fixed camera/IMU startup offset. No-op for photo captures.
+   */
+  public void setVideoStartAnchor(long elapsedRealtimeNs) {
+    mVideoStartElapsedRealtimeNs = elapsedRealtimeNs;
   }
 
   /**
@@ -341,6 +360,13 @@ public class ImuRecorder implements SensorEventListener {
     // Absolute elapsedRealtimeNanos captured at startRecording() (≈ MediaRecorder.start()), before
     // the first sensor event arrived. Lets the consumer bound the IMU window against video start.
     root.put("recordingStartElapsedRealtimeNs", mStartElapsedRealtimeNs);
+    // Absolute elapsedRealtimeNanos anchor for the video timeline (recorder start). Present only for
+    // video captures. Frame N's absolute time ≈ videoStartElapsedRealtimeNs + framePtsNs; align that
+    // against the IMU samples (same clock) to remove the fixed camera/IMU startup offset. Omitted
+    // when 0 (e.g. photo captures, or if the video pipeline did not set it).
+    if (mVideoStartElapsedRealtimeNs > 0) {
+      root.put("videoStartElapsedRealtimeNs", mVideoStartElapsedRealtimeNs);
+    }
     root.put("durationMs", lastRelMs);
     root.put("samples", samples);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -5,52 +5,69 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 import android.hardware.SensorManager;
+import android.os.Handler;
+import android.os.HandlerThread;
 import android.util.Log;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * Records IMU (accelerometer + gyroscope) data during photo/video capture.
  * Writes a sidecar JSON file alongside the media file for phone-side
  * post-processing (e.g., gyro-based video stabilization).
  *
- * Sampling at ~100Hz, captures timestamp + accel[3] + gyro[3] per sample.
+ * <p>Sampling at ~100Hz, captures timestamp + accel[3] + gyro[3] per sample.
+ *
+ * <h3>Threading</h3>
+ * Sensor callbacks are delivered on a dedicated {@link HandlerThread} owned by this recorder, NOT
+ * the thread that calls {@link #startRecording()}. This matters: the camera pipeline calls
+ * {@code startRecording()} from a background {@code HandlerThread} that has a Looper but never
+ * pumps sensor events, and the no-Handler {@code registerListener} overload posts to the
+ * <em>main</em> looper. Registering against our own handler guarantees delivery regardless of the
+ * caller's thread (the previous code silently captured zero samples on longer video recordings —
+ * registration succeeded but no {@code onSensorChanged} ever fired).
+ *
+ * <h3>Crash safety</h3>
+ * Samples are streamed to a {@code imu.jsonl.partial} file as they arrive rather than buffered in
+ * memory and written only at stop. A non-graceful termination (process kill, MediaRecorder.stop()
+ * throw) therefore leaves the captured samples on disk for recovery instead of losing the whole
+ * track. At graceful stop the partial is assembled into the canonical {@code imu.json} object.
  */
 public class ImuRecorder implements SensorEventListener {
   private static final String TAG = "ImuRecorder";
   private static final int SAMPLING_PERIOD_US = 10000; // 100Hz
+  private static final String PARTIAL_NAME = "imu.jsonl.partial";
+  private static final String SIDECAR_NAME = "imu.json";
 
   private final SensorManager mSensorManager;
   private final Sensor mAccelerometer;
   private final Sensor mGyroscope;
 
+  // Dedicated thread so sensor callbacks are delivered independently of the caller's thread.
+  private final HandlerThread mSensorThread;
+  private final Handler mSensorHandler;
+
   private volatile boolean mRecording = false;
-  private final List<ImuSample> mSamples = new ArrayList<>();
   private long mStartTimeNs = 0;
 
-  // Latest values (updated independently by each sensor)
+  // Latest values (updated independently by each sensor). Touched only on the sensor thread.
   private final float[] mLatestAccel = new float[3];
   private final float[] mLatestGyro = new float[3];
 
-  private static class ImuSample {
-    final long timestampNs;
-    final float[] accel;
-    final float[] gyro;
-
-    ImuSample(long ts, float[] a, float[] g) {
-      this.timestampNs = ts;
-      this.accel = a.clone();
-      this.gyro = g.clone();
-    }
-  }
+  // Streaming sink for the in-progress capture. Touched only on the sensor thread.
+  private BufferedWriter mStreamWriter;
+  private File mPartialFile;
+  private File mTargetDir;
+  private int mSampleCount;
 
   public ImuRecorder(Context context) {
     mSensorManager = (SensorManager) context.getSystemService(Context.SENSOR_SERVICE);
@@ -63,35 +80,58 @@ public class ImuRecorder implements SensorEventListener {
     if (mGyroscope == null) {
       Log.w(TAG, "Gyroscope not available");
     }
+
+    mSensorThread = new HandlerThread("ImuRecorder");
+    mSensorThread.start();
+    mSensorHandler = new Handler(mSensorThread.getLooper());
   }
 
   /**
    * Start recording IMU data. Call this when photo/video capture begins.
+   *
+   * @param mediaFilePath Path to the media file being captured; the sidecar is written next to it.
+   *     The parent directory must already exist (the media file lives there).
    */
-  public void startRecording() {
+  public void startRecording(String mediaFilePath) {
     if (mRecording) {
       Log.w(TAG, "Already recording");
       return;
     }
 
-    synchronized (mSamples) {
-      mSamples.clear();
+    File parentDir = new File(mediaFilePath).getParentFile();
+    if (parentDir == null) {
+      Log.w(TAG, "Cannot resolve capture directory for " + mediaFilePath + "; IMU not recorded");
+      return;
     }
+
+    mTargetDir = parentDir;
+    mPartialFile = new File(parentDir, PARTIAL_NAME);
+    mSampleCount = 0;
     mStartTimeNs = System.nanoTime();
+
+    try {
+      mStreamWriter = new BufferedWriter(new FileWriter(mPartialFile, false));
+    } catch (IOException e) {
+      Log.e(TAG, "Failed to open IMU stream file", e);
+      mStreamWriter = null;
+      return;
+    }
+
     mRecording = true;
 
     if (mAccelerometer != null) {
-      mSensorManager.registerListener(this, mAccelerometer, SAMPLING_PERIOD_US);
+      mSensorManager.registerListener(this, mAccelerometer, SAMPLING_PERIOD_US, mSensorHandler);
     }
     if (mGyroscope != null) {
-      mSensorManager.registerListener(this, mGyroscope, SAMPLING_PERIOD_US);
+      mSensorManager.registerListener(this, mGyroscope, SAMPLING_PERIOD_US, mSensorHandler);
     }
 
-    Log.d(TAG, "IMU recording started");
+    Log.d(TAG, "IMU recording started (streaming to " + mPartialFile.getAbsolutePath() + ")");
   }
 
   /**
-   * Stop recording and write the sidecar JSON file.
+   * Stop recording and assemble the sidecar JSON file from the streamed samples.
+   *
    * @param mediaFilePath Path to the media file (e.g., IMG_xxx.jpg or VID_xxx.mp4)
    * @return Path to the sidecar JSON file, or null on failure
    */
@@ -99,81 +139,66 @@ public class ImuRecorder implements SensorEventListener {
     mRecording = false;
     mSensorManager.unregisterListener(this);
 
-    List<ImuSample> captured;
-    synchronized (mSamples) {
-      captured = new ArrayList<>(mSamples);
-      mSamples.clear();
-    }
+    // Flush + close the stream on the sensor thread so it can't race with a late onSensorChanged,
+    // then continue assembly on the caller's thread once the sink is quiesced.
+    flushAndCloseStreamSync();
 
-    if (captured.isEmpty()) {
+    File parentDir = new File(mediaFilePath).getParentFile();
+    File partial = new File(parentDir, PARTIAL_NAME);
+    if (!partial.exists()) {
       Log.w(TAG, "No IMU samples captured");
       return null;
     }
 
-    // Generate sidecar path: save imu.json inside the capture folder
-    File parentDir = new File(mediaFilePath).getParentFile();
-    String sidecarPath = new File(parentDir, "imu.json").getAbsolutePath();
-
+    String sidecarPath = new File(parentDir, SIDECAR_NAME).getAbsolutePath();
     try {
-      JSONObject root = new JSONObject();
-      root.put("version", 1);
-      root.put("sampleCount", captured.size());
-      root.put("samplingRateHz", 100);
-      root.put("startTimeNs", mStartTimeNs);
-      root.put("durationMs", (captured.get(captured.size() - 1).timestampNs - mStartTimeNs) / 1_000_000);
-
-      JSONArray samples = new JSONArray();
-      for (ImuSample s : captured) {
-        JSONArray sample = new JSONArray();
-        // Compact format: [relativeTimeMs, ax, ay, az, gx, gy, gz]
-        sample.put(Math.round((s.timestampNs - mStartTimeNs) / 1_000_000.0));
-        sample.put(round4(s.accel[0]));
-        sample.put(round4(s.accel[1]));
-        sample.put(round4(s.accel[2]));
-        sample.put(round4(s.gyro[0]));
-        sample.put(round4(s.gyro[1]));
-        sample.put(round4(s.gyro[2]));
-        samples.put(sample);
+      int written = assembleSidecar(partial, new File(sidecarPath));
+      if (written == 0) {
+        Log.w(TAG, "No IMU samples captured");
+        partial.delete();
+        return null;
       }
-      root.put("samples", samples);
-
-      File sidecarFile = new File(sidecarPath);
-      try (FileWriter writer = new FileWriter(sidecarFile)) {
-        writer.write(root.toString());
-      }
-
-      Log.d(TAG, "IMU sidecar written: " + sidecarPath + " (" + captured.size() + " samples)");
+      partial.delete();
+      Log.d(TAG, "IMU sidecar written: " + sidecarPath + " (" + written + " samples)");
       return sidecarPath;
-
     } catch (JSONException | IOException e) {
-      Log.e(TAG, "Failed to write IMU sidecar", e);
+      // Leave the partial in place — it still holds the raw samples for later recovery.
+      Log.e(TAG, "Failed to assemble IMU sidecar; partial retained at " + partial.getAbsolutePath(), e);
       return null;
     }
   }
 
-  /** Cancel recording without saving. */
+  /** Cancel recording without saving; discards the partial stream. */
   public void cancel() {
     mRecording = false;
     mSensorManager.unregisterListener(this);
-    synchronized (mSamples) {
-      mSamples.clear();
+    flushAndCloseStreamSync();
+    if (mPartialFile != null && mPartialFile.exists()) {
+      mPartialFile.delete();
     }
+  }
+
+  /** Release the sensor thread. Call when the recorder is no longer needed. */
+  public void release() {
+    cancel();
+    mSensorThread.quitSafely();
   }
 
   @Override
   public void onSensorChanged(SensorEvent event) {
+    // Runs on mSensorThread.
     if (!mRecording) return;
 
     switch (event.sensor.getType()) {
       case Sensor.TYPE_ACCELEROMETER:
         System.arraycopy(event.values, 0, mLatestAccel, 0, 3);
-        // Record a combined sample on each accel event (accel drives the sampling rate)
-        synchronized (mSamples) {
-          mSamples.add(new ImuSample(event.timestamp, mLatestAccel, mLatestGyro));
-        }
+        // Accel drives the sampling rate: emit one combined sample per accel event.
+        writeSampleLine(event.timestamp);
         break;
       case Sensor.TYPE_GYROSCOPE:
         System.arraycopy(event.values, 0, mLatestGyro, 0, 3);
+        break;
+      default:
         break;
     }
   }
@@ -181,6 +206,103 @@ public class ImuRecorder implements SensorEventListener {
   @Override
   public void onAccuracyChanged(Sensor sensor, int accuracy) {
     // Not needed
+  }
+
+  /** Append one compact sample line: [relativeTimeMs, ax, ay, az, gx, gy, gz]. Sensor thread only. */
+  private void writeSampleLine(long timestampNs) {
+    if (mStreamWriter == null) return;
+    try {
+      JSONArray sample = new JSONArray();
+      sample.put(Math.round((timestampNs - mStartTimeNs) / 1_000_000.0));
+      sample.put(round4(mLatestAccel[0]));
+      sample.put(round4(mLatestAccel[1]));
+      sample.put(round4(mLatestAccel[2]));
+      sample.put(round4(mLatestGyro[0]));
+      sample.put(round4(mLatestGyro[1]));
+      sample.put(round4(mLatestGyro[2]));
+      mStreamWriter.write(sample.toString());
+      mStreamWriter.write('\n');
+      mSampleCount++;
+    } catch (IOException | JSONException e) {
+      Log.e(TAG, "Failed to write IMU sample", e);
+    }
+  }
+
+  /** Quiesce the sensor sink: run flush+close on the sensor thread and block until done. */
+  private void flushAndCloseStreamSync() {
+    final Object lock = new Object();
+    final boolean[] done = {false};
+    boolean posted = mSensorHandler.post(() -> {
+      closeStreamOnSensorThread();
+      synchronized (lock) {
+        done[0] = true;
+        lock.notifyAll();
+      }
+    });
+    if (!posted) {
+      // Looper already gone; close inline as a best effort.
+      closeStreamOnSensorThread();
+      return;
+    }
+    synchronized (lock) {
+      while (!done[0]) {
+        try {
+          lock.wait();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+    }
+  }
+
+  private void closeStreamOnSensorThread() {
+    if (mStreamWriter == null) return;
+    try {
+      mStreamWriter.flush();
+      mStreamWriter.close();
+    } catch (IOException e) {
+      Log.e(TAG, "Failed to close IMU stream", e);
+    } finally {
+      mStreamWriter = null;
+    }
+  }
+
+  /**
+   * Read the streamed JSONL partial and write the canonical {@code imu.json} object. Keeps the
+   * exact same on-disk schema the previous in-memory implementation produced.
+   *
+   * @return number of samples written.
+   */
+  private int assembleSidecar(File partial, File sidecar) throws IOException, JSONException {
+    JSONArray samples = new JSONArray();
+    long lastRelMs = 0;
+    try (BufferedReader reader = new BufferedReader(new FileReader(partial))) {
+      String line;
+      while ((line = reader.readLine()) != null) {
+        if (line.isEmpty()) continue;
+        JSONArray sample = new JSONArray(line);
+        lastRelMs = sample.getLong(0);
+        samples.put(sample);
+      }
+    }
+
+    if (samples.length() == 0) {
+      return 0;
+    }
+
+    JSONObject root = new JSONObject();
+    root.put("version", 1);
+    root.put("sampleCount", samples.length());
+    root.put("samplingRateHz", 100);
+    root.put("startTimeNs", mStartTimeNs);
+    root.put("durationMs", lastRelMs);
+    root.put("samples", samples);
+
+    try (FileWriter writer = new FileWriter(sidecar)) {
+      writer.write(root.toString());
+    }
+    return samples.length();
   }
 
   private static double round4(float v) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/sensors/ImuRecorder.java
@@ -40,9 +40,11 @@ import java.io.IOException;
  * <h3>Streaming</h3>
  * Samples are streamed to a {@code imu.jsonl.partial} file as they arrive rather than buffered in
  * memory, bounding memory use on long recordings. At graceful stop the partial is assembled into the
- * canonical {@code imu.json} object and removed. On any failure or cancel the partial is discarded:
- * the camera pipeline's {@code deleteCorruptCapture} wipes the whole capture directory on a failed
- * recording anyway, so there is no surviving media for an orphaned sidecar to belong to.
+ * canonical {@code imu.json} object and removed. If assembly fails on an otherwise-successful stop
+ * the partial is retained (it is the only copy of the IMU data and the media file survives), so it
+ * can be recovered/retried; {@code .partial} files are excluded from gallery/Wi-Fi sync. On a
+ * capture failure or {@link #cancel()} the partial is deleted — there the camera pipeline wipes the
+ * whole capture directory, so there is no surviving media for a sidecar to belong to.
  */
 public class ImuRecorder implements SensorEventListener {
   private static final String TAG = "ImuRecorder";
@@ -166,17 +168,21 @@ public class ImuRecorder implements SensorEventListener {
       int written = assembleSidecar(partial, new File(sidecarPath));
       if (written == 0) {
         Log.w(TAG, "No IMU samples captured");
+        partial.delete();
         return null;
       }
+      partial.delete();
       Log.d(TAG, "IMU sidecar written: " + sidecarPath + " (" + written + " samples)");
       return sidecarPath;
     } catch (JSONException | IOException e) {
-      Log.e(TAG, "Failed to assemble IMU sidecar", e);
+      // Retain the partial. On a graceful stop the media file survives even when sidecar
+      // assembly fails (this method swallows the error rather than propagating it, so the camera
+      // pipeline does NOT wipe the directory), so the partial is the only copy of the IMU data —
+      // keep it for recovery/retry. It is excluded from gallery/Wi-Fi sync by the .partial filter
+      // in FileManagerImpl, so retaining it can't leak a bogus capture file. The cancel() path
+      // (used on capture failure, where the directory IS wiped) still deletes it.
+      Log.e(TAG, "Failed to assemble IMU sidecar; retaining partial at " + partial.getAbsolutePath(), e);
       return null;
-    } finally {
-      // Always discard the partial — a failed capture's directory is wiped by the camera pipeline,
-      // and a successful assembly no longer needs it. Never leave it to be served by gallery sync.
-      partial.delete();
     }
   }
 

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 36,
-      "versionName": "36.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-36.apk",
-      "sha256": "b086b93fee34219d3dc6e2f563a8d7e7d31f7690365b76076a111d564a51ebe4"
+      "versionCode": 37,
+      "versionName": "37.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
+      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -15,14 +15,21 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
+      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
+    },
+    {
       "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260204",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_firmware_20260113_20260204.zip"
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
+      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
     }
   ],
   "bes_firmware": {
-    "version": "17.26.04.01",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.04.01.bin",
-    "sha256": "67a7d1c48dd7fbed16fc1a94c9d221ebae2e817f493d0007a58e8d49028f4e82"
+    "version": "17.26.05.22",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
+    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
   }
 }


### PR DESCRIPTION
## Problem

The IMU sidecar (`imu.json`) was missing from longer video recordings. Short (~1s) clips had it; every longer clip (14s/31s/38s observed) did not.

## Root cause

`ImuRecorder` registered its `SensorEventListener` with the no-`Handler` `registerListener()` overload, which delivers events on the **main thread's Looper**. `startRecording()` is invoked from the camera's background `HandlerThread` — which has a Looper that never pumps sensor events — so `onSensorChanged` never fired. Registration succeeded and unregistered cleanly, but **zero samples were captured**, so `stopRecordingAndSave()` found an empty buffer and skipped the file.

Confirmed on-device:
- `dumpsys sensorservice` showed the `ImuRecorder` listener registered for the full recording duration and unregistered cleanly.
- `logcat` showed `Video recording stopped` (clean stop) immediately followed by `W ImuRecorder: No IMU samples captured`.

The early short clips happened to work because they ran from a thread/state where a live Looper was available.

## Fix

- **Handler-bound registration** — register the sensor listener against a dedicated `HandlerThread` owned by `ImuRecorder`, so delivery is independent of the caller's thread. *This is the fix for the missing data.*
- **Stream to disk** — samples are written to `imu.jsonl.partial` as they arrive instead of buffered in memory and written only on the graceful-stop path. A process kill or `MediaRecorder.stop()` throw mid-recording now leaves captured samples on disk for recovery. The graceful stop assembles the **same canonical `imu.json` object** (downstream gallery sync keys on the filename, verified — on-disk schema unchanged).
- **Thread lifecycle** — release the sensor thread in `CameraNeoService.onDestroy()`.

`startRecording()` now takes the media path so the stream file can be opened immediately; video and photo call sites updated accordingly.

## Test evidence

- `./gradlew :app:compileDebugJavaWithJavac` — BUILD SUCCESSFUL.
- `VideoRecordingSessionTest` and `PhotoSessionTest` pass.

### Suggested on-device verification

Flash this build, record a 30s+ video, then:
- `adb logcat | grep ImuRecorder` → expect `IMU sidecar written: ... (N samples)` with N>0
- confirm `imu.json` is present in the capture folder

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live photo/video capture path and changes IMU on-disk format (v2); prod OTA manifest updates affect field updates if merged as-is.
> 
> **Overview**
> Fixes **missing `imu.json` on longer video recordings** by changing how IMU data is captured and written, plus small camera/OTA housekeeping.
> 
> **IMU pipeline (`ImuRecorder` + camera sessions):** Sensor listeners are registered on a **dedicated `HandlerThread`** so callbacks run even when capture starts from the camera background thread (the prior no-`Handler` registration could register successfully but deliver **zero samples** on long clips). Samples **stream to `imu.jsonl.partial`** instead of an in-memory list; stop assembles **`imu.json` (schema v2)** with **`elapsedRealtimeNanos`**-based anchors (`recordingStartElapsedRealtimeNs`, optional **`videoStartElapsedRealtimeNs`** after `MediaRecorder.start()`). **`startRecording` now takes the media path**; photo/video/HDR call sites pass it. **`cancel()`** on recorder/video errors runs **before** corrupt capture cleanup so the sensor listener does not keep writing into a deleted folder; **`CameraNeoService.onDestroy()`** calls **`ImuRecorder.release()`**.
> 
> **Sync/listing:** **`FileManagerImpl`** skips `*.partial` files so in-flight or recovery sidecars are not advertised for Wi‑Fi sync.
> 
> **Dev / release config:** Adds **`DebugMtkOtaReceiver`** + shared **`DebugOtaReceiverSupport`** (adb MTK OTA URL trigger). Bumps **`prod_live_version.json`** to ASG client **v37** and updates MTK/BES firmware patch entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 548ff4ebe62473663d09ad8f86c50446479481ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing IMU sidecar files on longer video recordings and adds a video-start anchor to align frames to IMU samples. IMU is now captured on a dedicated thread and streamed with `elapsedRealtime`-based timestamps.

- **Bug Fixes**
  - Register accelerometer/gyro on a dedicated `HandlerThread` (`registerListener(..., handler)`) so sampling continues during recording.
  - Stream to `imu.jsonl.partial`; on stop assemble `imu.json` (schema v2: zero-based times, `clockSource: elapsedRealtimeNanos`, `startTimeNs`, `recordingStartElapsedRealtimeNs`, `videoStartElapsedRealtimeNs`). Delete the partial on success/zero samples; retain it if sidecar assembly fails. Exclude `*.partial` from file listings and Wi‑Fi sync.
  - Change `ImuRecorder.startRecording` to `startRecording(mediaPath)` from photo/video/HDR; clean up any zero‑byte partial if opening the stream fails. `VideoRecordingSession` sets the `videoStartElapsedRealtimeNs` anchor right after `MediaRecorder.start()`.
  - Flush/close the stream on the sensor thread; `release()` only stops sensors (does not delete a retained partial). Also release in `CameraNeoService.onDestroy()`.
  - On errors, stop IMU before cleanup: in `MediaRecorder.onError` cancel IMU before `deleteCorruptCapture`, and cancel IMU on delayed start failures in `VideoRecordingSession`.

- **New Features**
  - Add `DebugMtkOtaReceiver` and shared `DebugOtaReceiverSupport` for adb-triggered MTK OTA checks.
  - Update `ota_website/prod_live_version.json` to app v37 and new MTK/BES firmware entries.

<sup>Written for commit 548ff4ebe62473663d09ad8f86c50446479481ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

