### PR TITLE
Fix Android SDK settings Gradle generation

### DIFF
--- a/mobile/modules/bluetooth-sdk/plugin/src/withAndroid.ts
+++ b/mobile/modules/bluetooth-sdk/plugin/src/withAndroid.ts
@@ -23,20 +23,12 @@ function withSettingsGradleModifications(config: any) {
   return withSettingsGradle(config, (config) => {
     let settingsGradle = config.modResults.contents
     const bluetoothSdkRoot = getBluetoothSdkRoot()
-
-    if (!settingsGradle.includes("def mentraBluetoothSdkRoot =")) {
-      settingsGradle = `
-def mentraBluetoothSdkRoot = System.getenv("MENTRA_BLUETOOTH_SDK_PACKAGE_PATH")
-if (!mentraBluetoothSdkRoot) {
-  mentraBluetoothSdkRoot = ${toGroovyString(bluetoothSdkRoot)}
-}
-${settingsGradle}`
-    }
+    const bluetoothSdkRootExpression = `System.getenv("MENTRA_BLUETOOTH_SDK_PACKAGE_PATH") ?: ${toGroovyString(bluetoothSdkRoot)}`
 
     if (!settingsGradle.includes("project(':mentra-bluetooth-sdk').projectDir")) {
       const bluetoothSdkProjectBlock = `
   if (findProject(':mentra-bluetooth-sdk') != null) {
-    project(':mentra-bluetooth-sdk').projectDir = new File(mentraBluetoothSdkRoot, 'android')
+    project(':mentra-bluetooth-sdk').projectDir = new File(${bluetoothSdkRootExpression}, 'android')
   }
 `
       const lc3Include = "  include ':lc3Lib'"
@@ -53,7 +45,7 @@ ${settingsGradle}`
 
     if (!settingsGradle.includes("project(':lc3Lib').projectDir")) {
       settingsGradle += `
-  project(':lc3Lib').projectDir = new File(mentraBluetoothSdkRoot, 'android/lc3Lib')
+  project(':lc3Lib').projectDir = new File(${bluetoothSdkRootExpression}, 'android/lc3Lib')
   `
     }
 
@@ -65,7 +57,7 @@ ${settingsGradle}`
 
     if (!settingsGradle.includes("project(':silero').projectDir")) {
       settingsGradle += `
-  project(':silero').projectDir = new File(mentraBluetoothSdkRoot, 'android/silero')
+  project(':silero').projectDir = new File(${bluetoothSdkRootExpression}, 'android/silero')
   `
     }
 


### PR DESCRIPTION
## Summary
- Follow-up to merged #3046.
- Fix the Bluetooth SDK Expo config plugin so it no longer emits ordinary Groovy statements before Gradle's required top-level pluginManagement block.
- Preserve MENTRA_BLUETOOTH_SDK_PACKAGE_PATH support by inlining the SDK-root expression in generated projectDir paths.
- Add a focused Bun test for settings.gradle ordering and legacy generated output cleanup.

## Validation
- bun test plugin/src/__tests__/withAndroid.test.ts
- bun run build:plugin
- EXPO_PUBLIC_GOOGLE_NAV_API_KEY=local-build-placeholder bun expo prebuild --platform android
- inspected mobile/android/settings.gradle: first non-comment line is pluginManagement {, no legacy def mentraBluetoothSdkRoot, env override still present
- EXPO_PUBLIC_GOOGLE_NAV_API_KEY=local-build-placeholder ./gradlew :app:assembleDebug
- git diff --check

This fixes the generated Gradle ordering regression that broke Android CI in downstream PRs after #3046.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time Expo/Gradle plugin output only; no runtime app logic, auth, or data handling changes.
> 
> **Overview**
> Fixes the Bluetooth SDK Expo config plugin so generated **`settings.gradle`** no longer prepends a **`def mentraBluetoothSdkRoot`** block ahead of Gradle’s required **`pluginManagement`** section (regression after #3046 that broke Android CI).
> 
> SDK root resolution is unchanged in behavior: **`MENTRA_BLUETOOTH_SDK_PACKAGE_PATH`** still wins, with a package-relative fallback, but the root is now an **inlined** `System.getenv(...) ?: "..."` expression on each **`projectDir`** line for **`:mentra-bluetooth-sdk`**, **`:lc3Lib`**, and **`:silero`** instead of a shared top-level variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32472e53de58049045aec3ff0917c3a8553537c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->