### PR TITLE
feat: add support for text chunking in mentra display

### DIFF
--- a/cloud/packages/display-utils/src/profiles/nex.ts
+++ b/cloud/packages/display-utils/src/profiles/nex.ts
@@ -127,7 +127,7 @@ export const NEX_PROFILE: DisplayProfile = {
   displayWidthPx: 440,
   maxLines: 5,
 
-  maxPayloadBytes: 226,
+  maxPayloadBytes: 450, // Matches firmware MAX_TEXT_LEN / DisplayText.text cap; delivered via fragmented BLE transport
   bleChunkSize: 176,
 
   // Font metrics

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -133,6 +133,7 @@ class MentraNex : SGCManager() {
 
     private var maxChunkSize: Int = MAX_CHUNK_SIZE_DEFAULT // Maximum chunk size for BLE packets
     private var bmpChunkSize: Int = 194 // BMP chunk size
+    private var protobufSeq: Int = 0 // Rolling sequence for fragmented control messages
 
     @Volatile private var isWorkerRunning = false
     // Queue to hold pending requests
@@ -437,7 +438,7 @@ class MentraNex : SGCManager() {
         Bridge.log("Nex: === SENDING HEAD UP ANGLE COMMAND TO GLASSES ===")
         Bridge.log("Nex: Head Up Angle: $validatedAngle degrees (validated range: 0-60)")
         val cmdBytes = NexProtobufUtils.generateHeadUpAngleConfigCommandBytes(angle)
-        sendDataSequentially(cmdBytes, 10)
+        sendProtobuf(cmdBytes, 10)
     }
 
     override fun getBatteryStatus() {
@@ -470,16 +471,16 @@ class MentraNex : SGCManager() {
         // TODO: test this logic. Is it correct? Should we send both or just one?
         Bridge.log("Nex: setBrightness() - level: " + level + "%, autoMode: " + autoMode);
         val brightnessCmdBytes = NexProtobufUtils.generateBrightnessConfigCommandBytes(level)
-        sendDataSequentially(brightnessCmdBytes, 10)
+        sendProtobuf(brightnessCmdBytes, 10)
 
         val autoBrightnessCmdBytes = NexProtobufUtils.generateAutoBrightnessConfigCommandBytes(autoMode)
-        sendDataSequentially(autoBrightnessCmdBytes, 10)
+        sendProtobuf(autoBrightnessCmdBytes, 10)
     }
 
     override fun clearDisplay() { 
         Bridge.log("Nex: clearDisplay() - sending clear display request command bytes");
         val clearDisplayPackets = NexProtobufUtils.generateClearDisplayRequestCommandBytes()
-        sendDataSequentially(clearDisplayPackets, 10)
+        sendProtobuf(clearDisplayPackets, 10)
         // sendTextWall(" ")
         Bridge.log("Nex: clearDisplay() - sent clear display request command bytes");
     }
@@ -487,7 +488,7 @@ class MentraNex : SGCManager() {
     override fun sendTextWall(text: String) {
         Bridge.log("Nex: sendTextWall() - text: " + text);
         val textChunks: ByteArray = createTextWallChunksForNex(text)
-        sendDataSequentially(textChunks);
+        sendProtobuf(textChunks)
     }
 
     override fun sendDoubleTextWall(top: String, bottom: String) {
@@ -498,7 +499,7 @@ class MentraNex : SGCManager() {
             bottom?.let { append(it) }
         }
         val textChunks = createTextWallChunksForNex(finalText)
-        sendDataSequentially(textChunks)
+        sendProtobuf(textChunks)
     }
 
     override fun displayBitmap(
@@ -533,23 +534,23 @@ class MentraNex : SGCManager() {
         Bridge.log("Nex: setDashboardPosition() - height: " + height + ", depth: " + depth)
         // Send display_height then display_distance; adjust order if Nex firmware requires otherwise.
         val heightBytes = NexProtobufUtils.generateDisplayHeightCommandBytes(height)
-        sendDataSequentially(heightBytes, 10)
+        sendProtobuf(heightBytes, 10)
         val distanceCm = NexProtobufUtils.dashboardDepthToDistanceCm(depth)
         val distanceBytes = NexProtobufUtils.generateDisplayDistanceCommandBytes(distanceCm)
-        sendDataSequentially(distanceBytes, 10)
+        sendProtobuf(distanceBytes, 10)
     }
 
     override fun setDashboardHeightOnly(height: Int) {
         Bridge.log("Nex: setDashboardHeightOnly() - height: $height")
         val heightBytes = NexProtobufUtils.generateDisplayHeightCommandBytes(height)
-        sendDataSequentially(heightBytes, 10)
+        sendProtobuf(heightBytes, 10)
     }
 
     override fun setDashboardDepthOnly(depth: Int) {
         Bridge.log("Nex: setDashboardDepthOnly() - depth: $depth")
         val distanceCm = NexProtobufUtils.dashboardDepthToDistanceCm(depth)
         val distanceBytes = NexProtobufUtils.generateDisplayDistanceCommandBytes(distanceCm)
-        sendDataSequentially(distanceBytes, 10)
+        sendProtobuf(distanceBytes, 10)
     }
 
     override fun ping() {
@@ -736,12 +737,16 @@ class MentraNex : SGCManager() {
                     val packetHex = values.joinToString("") { "%02X".format(it) }
                     Bridge.log("onCharacteristicWrite Values - $packetHex")
 
-                    if (values.isNotEmpty()) {
-                        val packetType = values[0]
-                        val protobufData = values.copyOfRange(1, values.size)
-
-                        if (packetType == NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF) {
-                            // just for test
+                    if (values.size >= 4 && values[0] == NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF) {
+                        // Debug-only re-decode of our own outgoing write. Frames are now
+                        // [0x02][seq][total][index] + protobuf, so strip the full 4-byte
+                        // transport header. Only a single-fragment write (total==1) holds a
+                        // complete, independently decodable protobuf; fragments of a
+                        // multi-part message are partial and would fail to decode.
+                        val total = values[2].toInt() and 0xFF
+                        val index = values[3].toInt() and 0xFF
+                        if (total == 1 && index == 0) {
+                            val protobufData = values.copyOfRange(4, values.size)
                             decodeProtobufsByWrite(protobufData, packetHex)
                         }
                     }
@@ -921,7 +926,7 @@ class MentraNex : SGCManager() {
                 Bridge.log("=== SENDING GLASSES PROTOBUF VERSION REQUEST ===")
                 val versionQueryPacket = NexProtobufUtils.generateVersionRequestCommandBytes()
                 if (versionQueryPacket.isNotEmpty()) {
-                    sendDataSequentially(versionQueryPacket, 100)
+                    sendProtobuf(versionQueryPacket, 100)
                     Bridge.log("Sent glasses protobuf version request")
                 } else {
                     Bridge.log("Skipping version request: schema removed VersionRequest")
@@ -1239,7 +1244,7 @@ class MentraNex : SGCManager() {
             val streamId = "%04X".format(random.nextInt(0x10000)) // 4-digit hex format
             
             val startImageSendingBytes = NexProtobufUtils.generateDisplayImageCommandBytes(streamId, totalChunks, width, height)
-            sendDataSequentially(startImageSendingBytes)
+            sendProtobuf(startImageSendingBytes)
 
             // Send all chunks with proper stream ID parsing
             val chunks = NexProtobufUtils.createBmpChunksForNexGlasses(streamId, bmpData, totalChunks, bmpChunkSize)
@@ -1520,14 +1525,14 @@ class MentraNex : SGCManager() {
             }
             Bridge.log("Nex: === SENDING MICROPHONE STATE COMMAND TO GLASSES ===")
             val micConfigBytes = NexProtobufUtils.generateMicStateConfigCommandBytes(enable)
-            sendDataSequentially(micConfigBytes, 10) // wait some time to setup the mic
+            sendProtobuf(micConfigBytes, 10) // wait some time to setup the mic
             Bridge.log("Nex: Sent MIC command: ${micConfigBytes.joinToString("") { "%02x".format(it) }}")
         }, delay)
     }
 
     private fun queryBatteryStatus() {
         val batteryQueryPacket = NexProtobufUtils.generateBatteryStateRequestCommandBytes()
-        sendDataSequentially(batteryQueryPacket, 250)
+        sendProtobuf(batteryQueryPacket, 250)
     }
 
     ///// PROCESSING THREAD /////////////////
@@ -1558,6 +1563,51 @@ class MentraNex : SGCManager() {
     private fun sendDataSequentially(data: List<ByteArray>) {
         val chunks = Array(data.size) { i -> SendRequest(data[i]) }
         sendQueue.offer(chunks)
+        startWorkerIfNeeded()
+    }
+
+    /**
+     * Frames a serialized protobuf message onto the 0x02 control channel and sends it.
+     *
+     * The message is split into fragments that each fit the negotiated MTU, prefixed with a
+     * 4-byte transport header: [0x02][seq][totalChunks][chunkIndex]. The firmware reassembles
+     * fragments by seq/index before decoding. Single-fragment messages (totalChunks == 1) are
+     * decoded directly by the firmware fast path.
+     *
+     * @param protobufBytes raw serialized PhoneToGlasses bytes (no framing)
+     * @param waitTime optional post-message delay in ms applied after the last fragment (-1 = none)
+     */
+    private fun sendProtobuf(protobufBytes: ByteArray, waitTime: Int = -1) {
+        val headerSize = 4 // [0x02][seq][totalChunks][chunkIndex]
+        val maxFragment = (maxChunkSize - headerSize).coerceAtLeast(1)
+        val totalChunks =
+            if (protobufBytes.isEmpty()) 1 else (protobufBytes.size + maxFragment - 1) / maxFragment
+
+        if (totalChunks > 255) {
+            Log.e(TAG, "Nex: Protobuf message too large to fragment ($totalChunks chunks) - dropping")
+            return
+        }
+
+        val seq = protobufSeq
+        protobufSeq = (protobufSeq + 1) and 0xFF
+
+        val frames = Array(totalChunks) { index ->
+            val start = index * maxFragment
+            val end = minOf(start + maxFragment, protobufBytes.size)
+            val fragLen = end - start
+            val frame = ByteArray(headerSize + fragLen)
+            frame[0] = NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF
+            frame[1] = seq.toByte()
+            frame[2] = totalChunks.toByte()
+            frame[3] = index.toByte()
+            if (fragLen > 0) {
+                System.arraycopy(protobufBytes, start, frame, headerSize, fragLen)
+            }
+            // Carry the post-message delay on the final fragment only.
+            SendRequest(frame, if (index == totalChunks - 1) waitTime else -1)
+        }
+
+        sendQueue.offer(frames)
         startWorkerIfNeeded()
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
@@ -425,18 +425,18 @@ object NexProtobufUtils {
         }
     }
 
+    /**
+     * Returns the raw serialized PhoneToGlasses protobuf bytes.
+     *
+     * Transport framing (the 0x02 packet type and the [seq][totalChunks][chunkIndex]
+     * fragmentation header) is applied at send time by MentraNexSGC.sendProtobuf(),
+     * which owns the negotiated MTU / chunk size. Keeping framing out of here lets a
+     * single chunker handle every control command uniformly.
+     */
     private fun generateProtobufCommandBytes(phoneToGlasses: PhoneToGlasses): ByteArray {
         val contentBytes = phoneToGlasses.toByteArray()
-        val chunk = ByteBuffer.allocate(contentBytes.size + 1)
-
-        chunk.put(NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF)
-        chunk.put(contentBytes)
-
-        // Enhanced logging for protobuf messages
-        val result = chunk.array()
-        logProtobufMessage(phoneToGlasses, result)
-
-        return result
+        logProtobufMessage(phoneToGlasses, contentBytes)
+        return contentBytes
     }
 
     private fun logProtobufMessage(phoneToGlasses: PhoneToGlasses, fullMessage: ByteArray) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -349,6 +349,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     private var deviceMaxMTU = 23 // Device's maximum capability
     private var maxChunkSize = 176 // Calculated optimal chunk size
     private var bmpChunkSize = 176 // Image chunk size (iOS-optimized)
+    private var protobufSeq: UInt8 = 0 // Rolling sequence for fragmented control messages
 
     // MARK: - Command Queue (modeled after ERG1Manager)
 
@@ -500,16 +501,51 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         ])
     }
 
+    /// Splits a serialized protobuf message into BLE-sized fragments, each prefixed with a
+    /// 4-byte transport header [packetType][seq][totalChunks][chunkIndex] so the firmware can
+    /// reassemble messages larger than one MTU. Single-fragment messages set totalChunks = 1
+    /// and are decoded directly by the firmware's fast path.
     private func queueDataWithOptimalChunking(
         _ data: Data, packetType: UInt8 = 0x02, waitTimeMs: Int = 0
     ) {
+        // Telemetry: report the full logical command (type byte + protobuf) before fragmenting.
         var packetData = Data([packetType])
         packetData.append(data)
-        if packetData.count > maxChunkSize {
-            Bridge.log("NEX: protobuf packet (\(packetData.count) bytes) exceeds maxChunkSize (\(maxChunkSize)); sending single write for protocol compatibility")
-        }
         emitBleCommandSent(packetData)
-        queueChunks([Array(packetData)], waitTimeMs: waitTimeMs, chunkDelayMs: Int(DELAY_BETWEEN_CHUNKS_SEND_MS))
+
+        let headerSize = 4 // [packetType][seq][totalChunks][chunkIndex]
+        let effectiveChunkSize = max(1, maxChunkSize - headerSize)
+        let totalChunks = data.isEmpty
+            ? 1 : Int(ceil(Double(data.count) / Double(effectiveChunkSize)))
+
+        guard totalChunks <= 255 else {
+            Bridge.log(
+                "NEX: ❌ Protobuf message too large to fragment (\(totalChunks) chunks) - dropping"
+            )
+            return
+        }
+
+        let seq = protobufSeq
+        protobufSeq = protobufSeq &+ 1
+
+        var chunks: [[UInt8]] = []
+        var offset = 0
+        var index = 0
+        while offset < data.count || (index == 0 && data.isEmpty) {
+            let end = min(offset + effectiveChunkSize, data.count)
+            var frame: [UInt8] = [packetType, seq, UInt8(totalChunks), UInt8(index)]
+            if end > offset {
+                frame.append(contentsOf: data.subdata(in: offset ..< end))
+            }
+            chunks.append(frame)
+            offset = end
+            index += 1
+        }
+
+        Bridge.log(
+            "NEX: 📦 Fragmented protobuf into \(chunks.count) chunk(s) (seq=\(seq), max payload \(effectiveChunkSize) bytes)"
+        )
+        queueChunks(chunks, waitTimeMs: waitTimeMs)
     }
 
     private func processCommand(_ command: BufferedCommand) async {

--- a/mobile/modules/island/src/utils/display/profiles/nex.ts
+++ b/mobile/modules/island/src/utils/display/profiles/nex.ts
@@ -127,7 +127,7 @@ export const NEX_PROFILE: DisplayProfile = {
   displayWidthPx: 440,
   maxLines: 5,
 
-  maxPayloadBytes: 226,
+  maxPayloadBytes: 450, // Matches firmware MAX_TEXT_LEN / DisplayText.text cap; delivered via fragmented BLE transport
   bleChunkSize: 176,
 
   // Font metrics


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core Nex BLE/protobuf transport for most glasses commands; mis-fragmentation or firmware mismatch could break display and device control until validated on hardware.
> 
> **Overview**
> This PR enables **longer Mentra Nex display text** and the **BLE transport** needed to deliver it.
> 
> **Display limits:** `NEX_PROFILE.maxPayloadBytes` is raised from **226 → 450** in both `cloud/packages/display-utils` and `mobile/modules/island`, aligned with firmware `MAX_TEXT_LEN` / `DisplayText.text`, with the comment that delivery uses fragmented BLE.
> 
> **Protobuf BLE framing (Android + iOS):** Control messages no longer assume a single MTU-sized write. `NexProtobufUtils` / helpers return **raw serialized `PhoneToGlasses` bytes**; **`sendProtobuf`** (Android) and **`queueDataWithOptimalChunking`** (iOS) add a **4-byte header** `[0x02][seq][totalChunks][chunkIndex]`, split payload by negotiated MTU, and queue fragments with a rolling **seq** (drops if &gt;255 chunks). Display, brightness, mic, battery, dashboard, image start, etc. route through this path instead of undivided `sendDataSequentially` for protobuf.
> 
> **Debug:** Android `onCharacteristicWrite` only re-decodes outgoing protobuf when **totalChunks == 1** and **index == 0**, matching the new header layout.
> 
> Non-protobuf traffic (e.g. `0x18` exit, image `0xB0` chunks, whitelist) still uses the existing sequential send path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e42fcc2795f8e72e36c04ff884b9ce0df1b0dbed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->