### PR TITLE
chore: add graceful disconnect

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -71,6 +71,8 @@ class MentraNex : SGCManager() {
         private const val DELAY_BETWEEN_CHUNKS_SEND: Long = 10 // Adjust this value as needed
 
         private const val INITIAL_CONNECTION_DELAY_MS = 350L // Adjust this value as needed
+        // Window to let a queued DisconnectRequest flush to the glasses before we close GATT.
+        private const val DISCONNECT_FLUSH_DELAY_MS = 250L
         private const val MICBEAT_INTERVAL_MS: Long = (1000 * 60) * 30; // micbeat every 30 minutes
 
         private const val MAIN_TASK_HANDLER_CODE_GATT_STATUS_CHANGED: Int = 110
@@ -150,8 +152,6 @@ class MentraNex : SGCManager() {
     private var isScanning: Boolean = false
 
     private var protobufVersionPosted: Boolean = false
-
-    private var hasConnectedThisSession: Boolean = false
 
     private var bleScanCallback: ScanCallback? = null
 
@@ -418,12 +418,12 @@ class MentraNex : SGCManager() {
 
     override fun disconnect() {
         DeviceStore.apply("glasses", "fullyBooted", false)
-        destroy();
+        destroy()
     }
 
     override fun forget() {
         DeviceStore.apply("glasses", "fullyBooted", false)
-        destroy();
+        destroy()
     }
 
     override fun cleanup() {
@@ -908,14 +908,6 @@ class MentraNex : SGCManager() {
                 showHomeScreen() // Turn on the NexGlasses display
                 updateConnectionState()
 
-                if (hasConnectedThisSession) {
-                    Bridge.log("Nex: BLE reconnect detected — showing reconnected banner")
-                    sendTextWall("// MentraOS Reconnected")
-                    mainTaskHandler.postDelayed({ clearDisplay() }, 3000)
-                } else {
-                    hasConnectedThisSession = true
-                }
-
                 // Post protobuf schema version information (only once)
                 if (!protobufVersionPosted) {
                     postProtobufSchemaVersionInfo()
@@ -1129,6 +1121,21 @@ class MentraNex : SGCManager() {
     }
 
     private fun destroy() {
+        // Tell the glasses this teardown is intentional so they return to the welcome
+        // screen immediately instead of holding the last frame through the firmware's
+        // unexpected-disconnect grace period. Best-effort: if the write can't be sent
+        // or doesn't flush in time, the firmware grace period is the safety net.
+        val canSend = mainGlassGatt != null && mainWriteChar != null && isMainConnected
+        if (!canSend) {
+            performDestroy()
+            return
+        }
+        Bridge.log("Nex: Sending DisconnectRequest before teardown")
+        sendProtobuf(NexProtobufUtils.generateDisconnectRequestCommandBytes(), 100)
+        mainTaskHandler.postDelayed({ performDestroy() }, DISCONNECT_FLUSH_DELAY_MS)
+    }
+
+    private fun performDestroy() {
         Bridge.log("Nex: MentraNexSGC ONDESTROY")
         showHomeScreen()
         isKilled = true
@@ -1180,7 +1187,6 @@ class MentraNex : SGCManager() {
         sendQueue.offer(emptyArray()) // is this needed?
         isWorkerRunning = false
         isMainConnected = false
-        hasConnectedThisSession = false
         Bridge.log("Nex: MentraNexSGC cleanup complete")
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/NexSGCUtils.kt
@@ -12,6 +12,7 @@ import com.mentra.bluetoothsdk.DeviceStore
 
 import mentraos.ble.MentraosBle.DisplayText
 import mentraos.ble.MentraosBle.ClearDisplay
+import mentraos.ble.MentraosBle.DisconnectRequest
 import mentraos.ble.MentraosBle.PhoneToGlasses
 import mentraos.ble.MentraosBle.DisplayImage
 import mentraos.ble.MentraosBle.BatteryStateRequest
@@ -195,6 +196,14 @@ object NexProtobufUtils {
         // VersionRequest/VersionResponse removed from the BLE schema; fw_version now comes via DeviceInfo.
         Bridge.log("Nex: generateVersionRequestCommandBytes is a no-op after schema removal")
         return ByteArray(0)
+    }
+
+    fun generateDisconnectRequestCommandBytes(): ByteArray {
+        val disconnectRequest = DisconnectRequest.newBuilder().build()
+        val phoneToGlasses = PhoneToGlasses.newBuilder()
+            .setDisconnect(disconnectRequest)
+            .build()
+        return generateProtobufCommandBytes(phoneToGlasses)
     }
 
     fun generateBatteryStateRequestCommandBytes(): ByteArray {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -236,7 +236,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     /// Device discovery cache (like MentraLive)
     private var discoveredPeripherals = [String: CBPeripheral]() // name -> peripheral
-    private var hasConnectedThisSession = false
     private var lastConnectionTimestamp: TimeInterval = 0
     private var lastReceivedLc3Sequence = -1
     private var currentImageChunks: [[UInt8]] = []
@@ -1968,6 +1967,38 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     @objc func disconnect() {
         Bridge.log("NEX: 🔌 User-initiated disconnect")
+        // Light teardown: drop the link but stay able to reconnect.
+        sendIntentionalDisconnectThen { [weak self] in self?.finalizeDisconnect() }
+    }
+
+    /// Best-effort: tell the glasses this disconnect is intentional so they return to
+    /// the welcome screen immediately rather than holding the last frame through the
+    /// firmware's unexpected-disconnect grace period, then run `teardown` after a short
+    /// window to let the write flush. Falls straight through if nothing is connected.
+    private func sendIntentionalDisconnectThen(_ teardown: @escaping () -> Void) {
+        isDisconnecting = true
+        stopReconnectionTimer()
+        guard peripheral != nil, servicesReady else {
+            teardown()
+            return
+        }
+        sendDisconnectRequest()
+        MentraNexSGC._bluetoothQueue.asyncAfter(deadline: .now() + 0.25, execute: teardown)
+    }
+
+    private func sendDisconnectRequest() {
+        let phoneToGlasses = Mentraos_Ble_PhoneToGlasses.with {
+            $0.disconnect = Mentraos_Ble_DisconnectRequest()
+        }
+        guard let protobufData = try? phoneToGlasses.serializedData() else {
+            Bridge.log("NEX: ⚠️ Failed to serialize DisconnectRequest")
+            return
+        }
+        Bridge.log("NEX: 📤 Sending DisconnectRequest before teardown")
+        queueDataWithOptimalChunking(protobufData, packetType: PACKET_TYPE_PROTOBUF)
+    }
+
+    private func finalizeDisconnect() {
         if let peripheral {
             // Save microphone state before disconnection (like Java implementation)
             saveMicrophoneStateBeforeDisconnection()
@@ -1975,7 +2006,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             // Stop mic beat system
             stopMicBeat()
 
-            isDisconnecting = true
             connectionState = ConnTypes.DISCONNECTED
             centralManager?.cancelPeripheralConnection(peripheral)
         }
@@ -1989,6 +2019,12 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     // MARK: - Lifecycle Management (ported from Java)
 
     @objc func destroy() {
+        // Route through the shared path so forget()/cleanup() also signal an
+        // intentional disconnect to the glasses before the link goes down.
+        sendIntentionalDisconnectThen { [weak self] in self?.performDestroy() }
+    }
+
+    private func performDestroy() {
         Bridge.log("NEX: 💥 Destroying MentraNexSGC instance")
 
         isKilled = true
@@ -2031,7 +2067,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // Reset initialization flags
         whiteListedAlready = false
         protobufVersionPosted = false
-        hasConnectedThisSession = false
         currentImageChunks.removeAll()
         isImageSendProgressing = false
         currentMTU = MTU_DEFAULT
@@ -2068,7 +2103,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         micBeatCount = 0
         shouldUseGlassesMic = true
         microphoneStateBeforeDisconnection = false
-        hasConnectedThisSession = false
         currentImageChunks.removeAll()
         isImageSendProgressing = false
         updateConnectedState(isConnected: false)
@@ -2352,7 +2386,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         bmpChunkSize = MTU_DEFAULT - 20
         currentImageChunks.removeAll()
         isImageSendProgressing = false
-        hasConnectedThisSession = false
         updateConnectedState(isConnected: false)
 
         // Clear command queue if needed
@@ -2500,17 +2533,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // 4. Show home screen to turn on the NexGlasses display (Java line 673)
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) { // 50ms delay
             self.showHomeScreen()
-        }
-
-        if hasConnectedThisSession {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.08) {
-                self.sendTextWall("// MentraOS Reconnected")
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3.08) {
-                self.clearDisplay()
-            }
-        } else {
-            hasConnectedThisSession = true
         }
 
         // 5. Post protobuf schema version information (Java lines 684-687)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes intentional vs accidental disconnect signaling and timing before GATT close; wrong timing could still leave stale UI on glasses, but scope is Nex-only and best-effort with firmware fallback.
> 
> **Overview**
> Nex BLE teardown now sends a protobuf **`DisconnectRequest`** before closing GATT on **Android** and **iOS**, with a short flush delay (~250ms) so firmware can treat the drop as intentional and return to the welcome screen instead of holding the last frame through the unexpected-disconnect grace period. **`NexProtobufUtils.generateDisconnectRequestCommandBytes()`** was added on Android; iOS builds the same message inline.
> 
> **`destroy()`** / disconnect paths were split so the request runs first when the link is up, then existing cleanup runs in **`performDestroy()`** (or **`finalizeDisconnect()`** on iOS for user disconnect). If nothing is connected, teardown is unchanged.
> 
> The **“MentraOS Reconnected”** banner on BLE reconnect and **`hasConnectedThisSession`** tracking were **removed** on both platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30ef4c8e91d78551e2bef8ff69d09a7e0c669905. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->