### PR TITLE
chore: disable audio playback for mentra display

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -101,7 +101,8 @@ class MentraNex : SGCManager() {
 
     // Off by default; toggled from Nex Developer Settings via the nex_audio_playback flag.
     private val isLc3AudioEnabled: Boolean
-        get() = DeviceStore.get("bluetooth", "nex_audio_playback") as? Boolean ?: false
+        // get() = DeviceStore.get("bluetooth", "nex_audio_playback") as? Boolean ?: false
+        get() = false
     private var lc3AudioPlayer: Lc3Player? = null
 
     private var lc3DecoderPtr: Long = 0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small behavioral change that turns off optional local LC3 playback; mic forwarding logic is unchanged and risk is limited to users who relied on the dev toggle.
> 
> **Overview**
> **Mentra Nex** LC3 audio playback on the phone is **forced off** by hardcoding `isLc3AudioEnabled` to always return `false`, instead of reading the `nex_audio_playback` value from **Nex Developer Settings** via `DeviceStore`.
> 
> Incoming LC3 packets from the glasses will no longer be written to `Lc3Player` (init/`applyNexAudioPlaybackSetting` paths also treat playback as disabled). The previous `DeviceStore` getter is left commented for an easy revert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaab168186ac1b93db79cd32d9d5286f5d458e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->