### PR TITLE
[codex] Fix gallery multi-photo share cache names

### DIFF
--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -610,7 +610,7 @@ export function GalleryScreen() {
       const cacheDir = `${RNFS.CachesDirectoryPath}/share`
       await RNFS.mkdir(cacheDir)
 
-      for (const photo of photosToShare) {
+      for (const [index, photo] of photosToShare.entries()) {
         let filePath = ""
         if (photo.filePath) {
           filePath = photo.filePath.startsWith("file://") ? photo.filePath.replace("file://", "") : photo.filePath
@@ -623,7 +623,7 @@ export function GalleryScreen() {
         if (!exists) continue
 
         const basename = filePath.split("/").pop() || photo.name
-        const cachePath = `${cacheDir}/${basename}`
+        const cachePath = `${cacheDir}/${String(index + 1).padStart(3, "0")}-${basename}`
         await RNFS.unlink(cachePath).catch(() => {})
         await RNFS.copyFile(filePath, cachePath)
         shareUrls.push(`file://${cachePath}`)


### PR DESCRIPTION
## Summary

Hotfix for gallery multi-photo sharing when selected photos have the same source basename, such as capture-aware synced images stored as separate `.../base.jpg` files.

This PR is intentionally limited to the release-safe sharing fix: selecting N photos should share N distinct cache files, not N URLs that all point at the final copied cache file.

## Scope Boundary

This hotfix does **not** include the gallery persistence/path migration work noticed during device verification. That riskier disappearance-adjacent behavior has been split into draft PR #3088.

## Root Cause

The multi-select share flow copied each selected file into the shared cache directory using only the source basename. When multiple selected photos resolved to the same basename, each copy overwrote the previous cache file, and the share sheet received multiple URLs pointing at the final copied photo.

## Changes

- Prefix each multi-share cache filename with its selection index before copying it into the share cache directory.
- Preserve the existing share flow and cleanup behavior otherwise.

## Validation

- `git diff --check origin/dev..HEAD`
- `cd mobile && bun run compile`
- Earlier before the split: iOS Debug build installed/launched on Philippe's connected iPhone 15 and the fixed gallery share path was manually exercised as far as iOS share-sheet automation allowed.

## Test Note

This version deliberately keeps the production hotfix as a direct existing-code edit instead of adding a new test-only helper. The focused helper unit test was removed with that simplification; the behavior is covered by the minimal cache filename change and device/manual validation path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to share-cache naming in the gallery screen with no auth, sync, or persistence logic touched.
> 
> **Overview**
> Fixes **multi-select gallery share** when several selected items copy into the share cache with the **same source basename** (e.g. capture-aware sync paths ending in the same `base.jpg`). Each selection is now copied to a **distinct cache file** by prefixing the cache name with a zero-padded selection index (`001-`, `002-`, …) before the basename, so `Share.open({ urls })` receives one URL per photo instead of duplicates pointing at the last overwrite.
> 
> Single-photo share and post-share cache cleanup are unchanged; scope is limited to `handleShareSelectedPhotos` in `GalleryScreen.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f05161a1d514b39831dea20ec0382feec147d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->