### PR TITLE
[codex] Preserve relative gallery metadata while saving files

### DIFF
--- a/mobile/src/services/asg/localStorageService.test.ts
+++ b/mobile/src/services/asg/localStorageService.test.ts
@@ -1,0 +1,58 @@
+import {storage} from "@/utils/storage"
+
+import {localStorageService} from "./localStorageService"
+
+const DOWNLOADED_FILES_KEY = "asg_downloaded_files"
+const DOCS = "/tmp/documents"
+
+function loadDownloadedFilesMetadata(): Record<string, {filePath: string; thumbnailPath?: string}> {
+  const result = storage.load<Record<string, {filePath: string; thumbnailPath?: string}>>(DOWNLOADED_FILES_KEY)
+  if (result.is_error()) {
+    throw result.error
+  }
+  return result.value
+}
+
+describe("LocalStorageService gallery metadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    storage.clearAll()
+  })
+
+  it("saves new files without rewriting existing relative metadata as absolute paths", async () => {
+    storage.save(DOWNLOADED_FILES_KEY, {
+      IMG_existing: {
+        name: "IMG_existing",
+        filePath: "MentraPhotos/IMG_existing/base.jpg",
+        size: 123,
+        modified: 1000,
+        mime_type: "image/jpeg",
+        is_video: false,
+        thumbnailPath: "MentraPhotos/IMG_existing/.thumb.jpg",
+        downloaded_at: 1000,
+      },
+    })
+
+    await localStorageService.saveDownloadedFile({
+      name: "IMG_new",
+      filePath: `${DOCS}/MentraPhotos/IMG_new/base.jpg`,
+      size: 456,
+      modified: 2000,
+      mime_type: "image/jpeg",
+      is_video: false,
+      thumbnailPath: `${DOCS}/MentraPhotos/IMG_new/.thumb.jpg`,
+      downloaded_at: 2000,
+    })
+
+    expect(loadDownloadedFilesMetadata()).toEqual({
+      IMG_existing: expect.objectContaining({
+        filePath: "MentraPhotos/IMG_existing/base.jpg",
+        thumbnailPath: "MentraPhotos/IMG_existing/.thumb.jpg",
+      }),
+      IMG_new: expect.objectContaining({
+        filePath: "MentraPhotos/IMG_new/base.jpg",
+        thumbnailPath: "MentraPhotos/IMG_new/.thumb.jpg",
+      }),
+    })
+  })
+})

--- a/mobile/src/services/asg/localStorageService.ts
+++ b/mobile/src/services/asg/localStorageService.ts
@@ -98,6 +98,14 @@ export class LocalStorageService {
     return `${this.ASG_THUMBNAILS_DIR}/${filename}_thumb.jpg`
   }
 
+  private loadRawDownloadedFiles(): Record<string, DownloadedFile> {
+    const res = storage.load<Record<string, DownloadedFile>>(this.DOWNLOADED_FILES_KEY)
+    if (res.is_error()) {
+      return {}
+    }
+    return res.value
+  }
+
   /**
    * Initialize client ID if not exists
    */
@@ -153,7 +161,7 @@ export class LocalStorageService {
    */
   async saveDownloadedFile(file: DownloadedFile): Promise<void> {
     try {
-      const files = await this.getDownloadedFiles()
+      const files = this.loadRawDownloadedFiles()
 
       // 🔍 DIAGNOSTIC: Check if file already exists
       // const existingFile = files[file.name]


### PR DESCRIPTION
## Summary

Separates a narrow gallery metadata preservation fix out of the release hotfix PR.

This PR prevents `saveDownloadedFile()` from rewriting existing relative gallery metadata paths as absolute iOS Documents paths when saving a newly downloaded file.

## Scope Boundary

This is intentionally **not** the multi-photo sharing hotfix. The release hotfix remains PR #3087 and should contain only the share-cache filename fix.

This PR also does **not** attempt to repair or migrate already-saved absolute paths. The earlier recovery/backport behavior was removed because we do not have enough evidence that released app state is already corrupted.

## Root Cause

`saveDownloadedFile()` loaded existing metadata through `getDownloadedFiles()`. That method is intended for runtime callers and reconstructs relative stored paths into absolute current Documents paths. Saving that hydrated map back can turn previously relative metadata into absolute paths.

## Changes

- Add a raw metadata load helper for `saveDownloadedFile()`.
- Use raw stored metadata when appending/replacing a downloaded file entry.
- Preserve the existing `getDownloadedFiles()` runtime path reconstruction behavior.
- Add a focused test that existing relative metadata stays relative after saving a new file.

## Validation

- `git diff --check origin/dev..HEAD`
- `cd mobile && bun run test -- src/services/asg/localStorageService.test.ts --runInBand`
- `cd mobile && bun run compile`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8c3405c54c3ffb17b0f4a8361fe73913d3603913. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->