### PR TITLE
[codex] Align video recording runtime types

### DIFF
--- a/mobile/modules/island/src/runtime/config.ts
+++ b/mobile/modules/island/src/runtime/config.ts
@@ -321,17 +321,20 @@ export interface RuntimeHooks {
  * the bluetooth-sdk startVideoRecording/stopVideoRecording). Unlike photo, this
  * is fire-and-forget start/stop — no uploaded URL is returned.
  */
+export interface VideoRecordingOptions {
+  width?: number
+  height?: number
+  fps?: number
+  sound?: boolean
+  save?: boolean
+}
+
+export interface VideoRecordingStarted {
+  recordingId: string
+}
+
 export interface VideoRecordingAdapter {
-  startRecording: (
-    packageName: string,
-    opts: {
-      width?: number
-      height?: number
-      fps?: number
-      sound?: boolean
-      save?: boolean
-    },
-  ) => Promise<{recordingId: string}>
+  startRecording: (packageName: string, opts: VideoRecordingOptions) => Promise<VideoRecordingStarted>
   stopRecording: (packageName: string, recordingId?: string) => Promise<void>
   /**
    * Stop any recordings still owned by an app (e.g. on miniapp disconnect/crash)

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -35,7 +35,7 @@ import localDisplayManager from "./LocalDisplayManager"
 import type {DisplayPayload} from "./LocalDisplayManager"
 import localSttFallbackCoordinator from "./LocalSttFallbackCoordinator"
 import micStateCoordinator from "./MicStateCoordinator"
-import {getRuntimeHooks, ISLAND_SETTINGS_KEYS, type TtsSynthesisResult} from "../runtime/config"
+import {getRuntimeHooks, ISLAND_SETTINGS_KEYS, type TtsSynthesisResult, type VideoRecordingOptions} from "../runtime/config"
 import ttsModelManager from "./TTSModelManager"
 import {NavigationHandlers} from "./NavigationHandlers"
 
@@ -1771,13 +1771,14 @@ class LocalMiniappRuntime {
     }
 
     try {
-      const result = await video.startRecording(packageName, {
-        width: payload.width as number | undefined,
-        height: payload.height as number | undefined,
-        fps: payload.fps as number | undefined,
-        sound: payload.sound as boolean | undefined,
-        save: payload.save as boolean | undefined,
-      })
+      const opts: VideoRecordingOptions = {}
+      if (typeof payload.width === "number") opts.width = payload.width
+      if (typeof payload.height === "number") opts.height = payload.height
+      if (typeof payload.fps === "number") opts.fps = payload.fps
+      if (typeof payload.sound === "boolean") opts.sound = payload.sound
+      if (typeof payload.save === "boolean") opts.save = payload.save
+
+      const result = await video.startRecording(packageName, opts)
       this.sendResult(packageName, requestId, true, result)
     } catch (err) {
       this.sendResult(packageName, requestId, false, undefined, {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -31,6 +31,7 @@ import {
   micStateCoordinator,
   offlineSpeechModelService,
   BgTimer,
+  type RuntimeHooks,
   useAppStatusStore,
 } from "@mentra/island"
 import {useConnectionStore} from "@/stores/connection"
@@ -174,6 +175,12 @@ class MantleManager {
     // island service that reads settings / glasses status / sockets / audio
     // (LocalMiniappRuntime, LocalDisplayManager, LocalSttFallbackCoordinator,
     // DisplayProcessor) is touched.
+    const videoRecording: NonNullable<RuntimeHooks["videoRecording"]> = {
+      startRecording: (pkg, opts) => phoneVideoCoordinator.startRecording(pkg, opts),
+      stopRecording: (pkg, recordingId) => phoneVideoCoordinator.stopRecording(pkg, recordingId),
+      stopForApp: (pkg) => phoneVideoCoordinator.stopForApp(pkg),
+    }
+
     configureRuntime({
       socketComms: {
         sendMessage: (message) => socketComms.sendMessage(message as Parameters<typeof socketComms.sendMessage>[0]),
@@ -237,11 +244,7 @@ class MantleManager {
       photo: {
         takePhoto: (pkg, opts) => phonePhotoCoordinator.takePhoto(pkg, opts),
       },
-      videoRecording: {
-        startRecording: (pkg, opts) => phoneVideoCoordinator.startRecording(pkg, opts),
-        stopRecording: (pkg, recordingId) => phoneVideoCoordinator.stopRecording(pkg, recordingId),
-        stopForApp: (pkg) => phoneVideoCoordinator.stopForApp(pkg),
-      },
+      videoRecording,
       // Google Nav SDK adapter — the island runtime fan-outs nav events to
       // miniapps subscribed to navigation_*. Delegates straight to the host's
       // singleton NavigationService.

--- a/mobile/src/services/video/PhoneVideoCoordinator.ts
+++ b/mobile/src/services/video/PhoneVideoCoordinator.ts
@@ -17,19 +17,12 @@
  */
 
 import BluetoothSdk from "@mentra/bluetooth-sdk"
-import {getRuntimeHooks} from "@mentra/island"
+import {getRuntimeHooks, type RuntimeHooks} from "@mentra/island"
 
-export interface VideoRecordingOpts {
-  width?: number
-  height?: number
-  fps?: number
-  sound?: boolean
-  save?: boolean
-}
+type VideoRecordingAdapter = NonNullable<RuntimeHooks["videoRecording"]>
 
-export interface VideoRecordingStarted {
-  recordingId: string
-}
+export type VideoRecordingOpts = Parameters<VideoRecordingAdapter["startRecording"]>[1]
+export type VideoRecordingStarted = Awaited<ReturnType<VideoRecordingAdapter["startRecording"]>>
 
 export class VideoError extends Error {
   constructor(


### PR DESCRIPTION
## Summary

This keeps the local-miniapp video-recording path on a single shared runtime contract instead of duplicating inline option/result shapes between the island runtime and the Manager host.

## Root Cause

The video-recording adapter shape was duplicated at the island runtime boundary and in the phone coordinator. That makes the `LocalMiniappRuntime` payload, `MantleManager` adapter wiring, and `PhoneVideoCoordinator` implementation easy to drift when adjacent work touches generated island types or Bluetooth settings. The source on current `origin/dev` now compiles, but this removes the contract mismatch vector observed while validating the VAD-default PR.

## Changes

- Adds named `VideoRecordingOptions` and `VideoRecordingStarted` types to the island runtime config.
- Normalizes the video-recording payload in `LocalMiniappRuntime` into that shared options type before calling the host adapter.
- Derives `PhoneVideoCoordinator` option/result types from `RuntimeHooks["videoRecording"]`.
- Annotates the `MantleManager` video adapter with the shared runtime-hook type.

## Validation

- `cd mobile/modules/island && bun run build`
- `cd mobile && bun compile`
- `git diff --check`

## VAD PR Separation

This PR is intentionally separate from the VAD-default branch. It only aligns the existing video-recording type contract on top of `dev` and does not include VAD setting behavior changes.