### PR TITLE
fix: write without response to android ble

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -70,6 +70,10 @@ class MentraNex : SGCManager() {
         
         private const val MAX_CHUNK_SIZE_DEFAULT: Int = 176 // Maximum chunk size for BLE packets
         private const val DELAY_BETWEEN_CHUNKS_SEND: Long = 10 // Adjust this value as needed
+        // Upper bound on waiting for onCharacteristicWrite. A no-response write's
+        // callback is normally near-instant; this only guards against a callback that
+        // never arrives, so a dropped write can't wedge the send queue forever.
+        private const val WRITE_CALLBACK_TIMEOUT_MS: Long = 2000
 
         private const val INITIAL_CONNECTION_DELAY_MS = 350L // Adjust this value as needed
         // Window to let a queued DisconnectRequest flush to the glasses before we close GATT.
@@ -275,6 +279,17 @@ class MentraNex : SGCManager() {
         fun waitWhileTrue() {
             while (flag) {
                 (this as Object).wait()
+            }
+        }
+
+        /** Bounded wait: returns early if the flag is still set after [timeoutMs]. */
+        @Synchronized
+        fun waitWhileTrue(timeoutMs: Long) {
+            val deadline = System.currentTimeMillis() + timeoutMs
+            while (flag) {
+                val remaining = deadline - System.currentTimeMillis()
+                if (remaining <= 0) break
+                (this as Object).wait(remaining)
             }
         }
 
@@ -942,9 +957,13 @@ class MentraNex : SGCManager() {
         val result = gatt.setCharacteristicNotification(characteristic, true)
         Bridge.log("Nex: PROC_QUEUE - setCharacteristicNotification result: $result")
 
-        // Set write type for the characteristic
-        characteristic.writeType = BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT
-        Bridge.log("Nex: PROC_QUEUE - write type set")
+        // Write-without-response: the onCharacteristicWrite callback fires when the
+        // local stack accepts the buffer, not after a remote ATT round-trip, so TX is
+        // no longer throttled to ~1 packet per connection interval. This is what keeps
+        // captions flowing when the phone is asleep and the interval is relaxed (the
+        // firmware RX characteristic advertises WRITE_WITHOUT_RESP). Matches G1.
+        characteristic.writeType = BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+        Bridge.log("Nex: PROC_QUEUE - write type set (NO_RESPONSE)")
 
         // Add delay
         Bridge.log("Nex: PROC_QUEUE - waiting to enable notification...")
@@ -1656,17 +1675,30 @@ class MentraNex : SGCManager() {
                         // Send to main glass
                         val canSend = mainGlassGatt != null && mainWriteChar != null && isMainConnected
                         Bridge.log("[BLE] PROC_QUEUE send check: gatt=${mainGlassGatt != null} writeChar=${mainWriteChar != null} connected=$isMainConnected → canSend=$canSend len=${request.data.size}")
+                        var writeStarted = false
                         if (canSend) {
                             mainWaiter.setTrue()
                             mainWriteChar?.value = request.data
-                            mainGlassGatt?.writeCharacteristic(mainWriteChar)
-                            lastSendTimestamp = System.currentTimeMillis()
-                            Bridge.log("[BLE] PROC_QUEUE writeCharacteristic issued, waiting for onCharacteristicWrite callback")
+                            // Honor the return value: writeCharacteristic returns false when the
+                            // stack is busy / out of buffers, and in that case no callback fires.
+                            // Only wait for the callback if the write actually started, otherwise
+                            // the waiter would block until the next disconnect.
+                            val issued = mainGlassGatt?.writeCharacteristic(mainWriteChar) ?: false
+                            if (issued) {
+                                writeStarted = true
+                                lastSendTimestamp = System.currentTimeMillis()
+                                Bridge.log("[BLE] PROC_QUEUE writeCharacteristic issued, awaiting onCharacteristicWrite")
+                            } else {
+                                mainWaiter.setFalse()
+                                Log.e(TAG, "[BLE] PROC_QUEUE writeCharacteristic returned false — stack busy, dropping fragment")
+                            }
                         } else {
                             Bridge.log("[BLE] PROC_QUEUE skipping write — not ready, packet dropped")
                         }
 
-                        mainWaiter.waitWhileTrue()
+                        if (writeStarted) {
+                            mainWaiter.waitWhileTrue(WRITE_CALLBACK_TIMEOUT_MS)
+                        }
 
                         Thread.sleep(DELAY_BETWEEN_CHUNKS_SEND)
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -464,7 +464,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         waiters.forEach { $0.resume() }
     }
 
-    private func waitForWriteAck() async {
+    /// Suspends until CoreBluetooth signals it can accept another write-without-response
+    /// (resumed by peripheralIsReady(toSendWriteWithoutResponse:), or by the disconnect
+    /// handlers so an in-flight send can't wedge the queue across a drop).
+    private func waitUntilReadyToWrite() async {
         await withCheckedContinuation { continuation in
             pendingWriteContinuation = continuation
         }
@@ -567,8 +570,18 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
                 "NEX: 📦 Sending chunk \(index) of \(command.chunks.count) to \(peripheral.name ?? "Unknown")"
             )
             Bridge.log("NEX: 📦 Chunk data: \(data.toHexString())")
-            peripheral.writeValue(data, for: writeCharacteristic, type: .withResponse)
-            await waitForWriteAck()
+            // Write WITHOUT response: a write-with-response is one outstanding request at a
+            // time gated on a remote round trip, which puts the (screen-off-throttled) app
+            // thread in the path of every fragment and makes captions crawl in the background.
+            // .withoutResponse lets CoreBluetooth batch fragments into connection events.
+            // CoreBluetooth does NOT call didWriteValueFor for .withoutResponse, so we use its
+            // flow-control flag instead of an ack — gating prevents dropped fragments (which
+            // would make the firmware discard the whole reassembled caption). See
+            // docs/ble-disconnects-during-captions.md in the firmware repo.
+            if !peripheral.canSendWriteWithoutResponse {
+                await waitUntilReadyToWrite()
+            }
+            peripheral.writeValue(data, for: writeCharacteristic, type: .withoutResponse)
 
             // Delay between chunks except maybe after the last chunk if waitTime will handle it
             if index < command.chunks.count - 1 {
@@ -2425,8 +2438,10 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // iOS MTU is automatically negotiated - we can only discover the current value
         // No manual MTU request available on iOS (platform limitation)
 
-        // Get current MTU capability (iOS-specific approach)
-        let maxWriteLength = peripheral.maximumWriteValueLength(for: .withResponse)
+        // Get current MTU capability (iOS-specific approach). Query for .withoutResponse
+        // since that's the write type the caption path uses; its limit can differ from
+        // .withResponse, and sizing chunks to it avoids oversized writes being dropped.
+        let maxWriteLength = peripheral.maximumWriteValueLength(for: .withoutResponse)
         let actualMTU = maxWriteLength + 3 // Add L2CAP header size
 
         Bridge.log("NEX: 📊 iOS MTU Discovery Results:")
@@ -2656,6 +2671,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             resumePendingWrite()
             return
         }
+        resumePendingWrite()
+    }
+
+    func peripheralIsReady(toSendWriteWithoutResponse _: CBPeripheral) {
+        // CoreBluetooth can accept more write-without-response data; unblock the sender.
         resumePendingWrite()
     }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core BLE send pacing for all Nex outbound traffic; mis-handled flow control or dropped fragments could affect caption reassembly, though behavior mirrors G1 and adds explicit timeouts/guards.
> 
> **Overview**
> Nex phone→glasses BLE TX on **Android** and **iOS** now uses **write without response** instead of write-with-response, so caption/protobuf fragments are not gated on a remote ATT round-trip per packet (especially when the app is backgrounded and connection intervals stretch). This aligns Nex with the existing **G1** pattern and the firmware RX characteristic that advertises `WRITE_WITHOUT_RESP`.
> 
> On **Android** (`MentraNex.kt`), the TX characteristic is set to `WRITE_TYPE_NO_RESPONSE`; the send worker only waits on `onCharacteristicWrite` when `writeCharacteristic` actually returns true, with a **2s** bounded wait so a missing callback cannot wedge the queue; failed/busy writes drop the fragment instead of blocking forever.
> 
> On **iOS** (`MentraNex.swift`), chunks use `.withoutResponse` with **`canSendWriteWithoutResponse`** / **`peripheralIsReady(toSendWriteWithoutResponse:)`** flow control instead of `didWriteValueFor` acks; MTU chunk sizing uses **`maximumWriteValueLength(for: .withoutResponse)`** so fragments match the path in use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27660a8140e6444f28bd89e79a115cf36ccf8561. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->