### PR TITLE
Add mtk OTA patch 20260418_20260525 to test OTA manifest

### DIFF
--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -15,6 +15,12 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+    },
+    {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -21,6 +21,18 @@
       "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
     },
     {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
+      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
+      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+    },
+    {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",


### PR DESCRIPTION
Adds the `mtk_ota_update_20260418_20260525.zip` patch (firmware 2026-04-18 → 2026-05-25) to the `mtk_patches` list in the test ASG OTA manifest.

- File: `asg_client/ota_website/test_bes_ota_prod_live_version.json`
- URL: https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip
- sha256: `169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256` (verified against downloaded artifact)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only manifest JSON with no application code changes; wrong hashes/URLs would affect test OTA flows only.
> 
> **Overview**
> Extends the **test ASG OTA manifest** (`test_bes_ota_prod_live_version.json`) by adding **three** new `mtk_patches` entries, each upgrading devices on intermediate `MentraLive_*` builds to **`MentraLive_20260525`** via GitHub-hosted zip artifacts with pinned **sha256** hashes.
> 
> The new paths cover **`MentraLive_20260418`**, **`MentraLive_20260421`**, and **`MentraLive_20260513`**; existing patches (e.g. `20260204` → `20260525`) are unchanged. The OTA client already selects a patch by matching `start_firmware` to `ro.custom.ota.version`, so this only expands which device versions the **test** manifest can offer for MTK incremental updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7d5b0e445e8fd043424d45bafe86ce6006b3cf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->