### PR TITLE
[codex] Disable gallery capture for background apps

### DIFF
--- a/mobile/src/effects/ButtonActions.tsx
+++ b/mobile/src/effects/ButtonActions.tsx
@@ -85,13 +85,20 @@ export function ButtonActions() {
         return
       }
 
-      // Check if any foreground app is running
-      const activeForegroundApp = applets.find((app) => app.type === "standard" && app.running)
+      // Check if any standard or background app is running. A running background app
+      // (e.g. one that listens for hardware button presses) already receives this event
+      // server-side, so it owns the button. Launching the default app here would also
+      // re-enable gallery mode (camera running), recreating the duplicate native-capture +
+      // SDK requestPhoto() race that GalleryModeSync suppresses. Keep this predicate in sync
+      // with GalleryModeSync.
+      const activeButtonHandlingApp = applets.find(
+        (app) => (app.type === "standard" || app.type === "background") && app.running,
+      )
 
-      if (activeForegroundApp) {
+      if (activeButtonHandlingApp) {
         console.log(
-          "BUTTON_ACTION: Foreground app is running - button event already sent to server for app:",
-          activeForegroundApp.name,
+          "BUTTON_ACTION: App is running - button event already sent to server for app:",
+          activeButtonHandlingApp.name,
         )
         return
       }

--- a/mobile/src/effects/GalleryModeSync.tsx
+++ b/mobile/src/effects/GalleryModeSync.tsx
@@ -6,11 +6,11 @@ import {cameraPackageName} from "@/constants/miniapps"
 import {SETTINGS, useSetting} from "@/stores/settings"
 
 /**
- * Syncs gallery mode state to glasses based on foreground app status.
+ * Syncs gallery mode state to glasses based on app status.
  *
  * Gallery mode (capture enabled) is TRUE when:
  * - Camera app is running, OR
- * - No foreground apps are running
+ * - No standard/background apps are running
  *
  * This allows button press to capture photos when no apps are active,
  * while preventing capture when other apps are handling button events.
@@ -29,25 +29,19 @@ export function GalleryModeSync() {
     //   runningApps.map((app) => `${app.name} (${app.type}, ${app.packageName})`).join(", ") || "NONE",
     // )
 
-    // Find camera app if running
     const cameraApp = applets.find((app) => app.packageName === cameraPackageName && app.running)
-
-    // Find any other foreground app (excluding camera)
-    const otherForegroundApp = applets.find(
-      (app) => app.type === "standard" && app.running && app.packageName !== cameraPackageName,
+    const otherButtonHandlingApp = applets.find(
+      (app) =>
+        (app.type === "standard" || app.type === "background") &&
+        app.running &&
+        app.packageName !== cameraPackageName,
     )
 
-    // Determine capture state based on app states
-    // - If camera app running: TRUE (camera wants to capture)
-    // - If other foreground app running: FALSE (let app handle button)
-    // - If no apps running: TRUE (allow capture anyway)
-    const shouldEnableCapture = !!cameraApp || !otherForegroundApp
+    const shouldEnableCapture = !!cameraApp || !otherButtonHandlingApp
 
     // console.log(
-    //   `[GalleryModeSync] Camera: ${cameraApp ? `RUNNING` : "NOT RUNNING"}, ` +
-    //     `OtherApp: ${otherForegroundApp ? `RUNNING (${otherForegroundApp.name}, ${otherForegroundApp.packageName})` : "NOT RUNNING"}, ` +
-    //     `Capture: ${shouldEnableCapture ? "ENABLED" : "DISABLED"} ` +
-    //     `(Setting gallery_mode to ${shouldEnableCapture})`,
+    //   `[GalleryModeSync] Capture: ${shouldEnableCapture ? "ENABLED" : "DISABLED"} ` +
+    //     `(setting gallery_mode to ${shouldEnableCapture})`,
     // )
 
     if (galleryMode !== shouldEnableCapture) {


### PR DESCRIPTION
## Summary

- Disable native gallery capture when a running non-camera miniapp is either `standard` or `background`.
- Keep native gallery capture enabled when the camera app itself is running.
- Keep the gallery-mode decision inline in `GalleryModeSync`.

## Root Cause

`GalleryModeSync` only treated running `standard` apps as button-handling apps. Background miniapps that listen for hardware button presses, such as Led AI, left native gallery mode enabled, so the glasses native capture path and the miniapp SDK `requestPhoto()` path could both react to the same physical button press.

## Validation

Not rerun after inlining the same rule and removing the helper/test files per request.

## Notes

The local repro miniapp and cloud lockfile changes are not included in this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware button and gallery-mode behavior for all running background miniapps; misclassification could block default camera launch or leave capture enabled when it should not be.
> 
> **Overview**
> **Treats running `background` miniapps the same as `standard` apps for hardware button ownership and gallery capture.**
> 
> `GalleryModeSync` now disables native gallery capture when any running non-camera app is `standard` or `background`, not only foreground `standard` apps. That stops native capture from staying on while a background listener (e.g. Led AI) handles the same press via SDK `requestPhoto()`.
> 
> `ButtonActions` uses the same running-app predicate before auto-launching the default app, with an explicit note to keep it aligned with `GalleryModeSync` so gallery mode is not re-enabled and the duplicate-capture race does not return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92d2c110a89ee3511f521f685f9d1fa02ae662da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->