### PR TITLE
OTA Update for 2026-04-18 Mentra Live units

### DIFF
--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -192,8 +192,8 @@ android {
 
         minSdk 28
         targetSdk 33
-        versionCode 37
-        versionName "37.0"
+        versionCode 38
+        versionName "38.0"
 
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -179,6 +179,12 @@ public class OtaHelper {
     private static volatile boolean mtkUpdatedThisSession = false;
     private static volatile boolean isBackgroundPrefetchInProgress = false;
 
+    // True when the in-flight MTK install is the final firmware step (no BES update follows).
+    // BES installs power-cycle the device themselves; an MTK-only update has nothing to trigger
+    // the reboot its staged A/B image needs, so OtaService reboots on MTK success. Set at install
+    // kickoff so it is correct on both the session and legacy/no-session completion paths.
+    private volatile boolean rebootAfterMtkInstall = false;
+
     private volatile boolean pendingPhoneInstall = false;
 
     /** Snapshot for {@link #buildMinimalOtaStatusJson()} when no OTA session exists (aligns with {@link #sendMtkInstallProgress} shape). */
@@ -343,6 +349,16 @@ public class OtaHelper {
 
     public OtaSessionManager getSessionManager() {
         return sessionManager;
+    }
+
+    /**
+     * Whether the most recently started MTK install should trigger a self-reboot on success —
+     * i.e. it is an MTK-only update with no BES step to power-cycle the device. Set by
+     * {@link #checkAndUpdateMtkFirmware} at install kickoff and read by OtaService's MTK SUCCESS
+     * handler, so it works regardless of whether an OTA session is active.
+     */
+    public boolean shouldRebootAfterMtkInstall() {
+        return rebootAfterMtkInstall;
     }
 
     /**
@@ -1275,7 +1291,9 @@ public class OtaHelper {
                         // and start BES as a separate update round.
                         Log.i(TAG, "Both MTK and BES updates available - applying MTK first, phone will handle BES next");
 
-                        boolean mtkStarted = checkAndUpdateMtkFirmware(mtkPatch, context, true);
+                        // besUpdateFollows=true: the upcoming BES install will power-cycle the
+                        // device, so MTK must not self-reboot here (avoids a double reboot).
+                        boolean mtkStarted = checkAndUpdateMtkFirmware(mtkPatch, context, true, true);
                         if (mtkStarted) {
                             Log.i(TAG, "MTK firmware update started - BES will be handled by phone in next round");
                         } else {
@@ -2293,6 +2311,12 @@ public class OtaHelper {
     }
 
     private boolean checkAndUpdateMtkFirmware(JSONObject firmwareInfo, Context context, boolean installNow) {
+        // Default: treat as the final firmware step (MTK-only) so it self-reboots. Callers that
+        // know a BES update follows pass besUpdateFollows=true to suppress the reboot.
+        return checkAndUpdateMtkFirmware(firmwareInfo, context, installNow, false);
+    }
+
+    private boolean checkAndUpdateMtkFirmware(JSONObject firmwareInfo, Context context, boolean installNow, boolean besUpdateFollows) {
         try {
             // Check for mutual exclusion - don't start MTK update if other updates in progress
             if (isUpdating) {
@@ -2381,6 +2405,12 @@ public class OtaHelper {
             }
 
             Log.i(TAG, "✅ MTK firmware ready for install");
+
+            // Record whether this install should self-reboot on success. An MTK-only update
+            // (no BES update following) has nothing to power-cycle the device and apply the
+            // staged A/B image, so OtaService reboots on success. When a BES update follows,
+            // the BES install power-cycles the device for us, so we must not reboot here.
+            rebootAfterMtkInstall = !besUpdateFollows;
 
             // Set flag before starting update
             isMtkOtaInProgress = true;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -352,13 +352,16 @@ public class OtaHelper {
     }
 
     /**
-     * Whether the most recently started MTK install should trigger a self-reboot on success —
-     * i.e. it is an MTK-only update with no BES step to power-cycle the device. Set by
-     * {@link #checkAndUpdateMtkFirmware} at install kickoff and read by OtaService's MTK SUCCESS
-     * handler, so it works regardless of whether an OTA session is active.
+     * Returns whether the most recently started MTK install should trigger a self-reboot on
+     * success — i.e. it is an MTK-only update with no BES step to power-cycle the device — and
+     * atomically clears the flag. Read-and-clear so a duplicate or late MTK SUCCESS event cannot
+     * schedule a second/stale reboot; the flag is re-armed only at the next MTK install kickoff
+     * (see {@link #checkAndUpdateMtkFirmware}). Works regardless of whether an OTA session exists.
      */
-    public boolean shouldRebootAfterMtkInstall() {
-        return rebootAfterMtkInstall;
+    public synchronized boolean consumeRebootAfterMtkInstall() {
+        boolean reboot = rebootAfterMtkInstall;
+        rebootAfterMtkInstall = false;
+        return reboot;
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -236,8 +236,9 @@ public class OtaService extends Service {
                 //
                 // The decision is read from a flag OtaHelper set at install kickoff (based on
                 // whether a BES update follows), NOT from session state — so it is correct on both
-                // the session path and the legacy/no-session path below.
-                boolean shouldRebootAfterMtk = otaHelper != null && otaHelper.shouldRebootAfterMtkInstall();
+                // the session path and the legacy/no-session path below. consume*() clears the flag
+                // so a duplicate/late SUCCESS event can't schedule a second reboot.
+                boolean shouldRebootAfterMtk = otaHelper != null && otaHelper.consumeRebootAfterMtkInstall();
 
                 if (otaHelper != null) {
                     otaHelper.sendMtkInstallProgressToPhone("FINISHED", 100, null);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -229,21 +229,15 @@ public class OtaService extends Service {
                 updateNotification("MTK firmware updated successfully");
                 Log.i(TAG, "📱 MTK system SUCCESS received - staged for next reboot");
 
-                // Decide BEFORE advancing the session whether this MTK step is the final one.
-                // MTK A/B updates only take effect after a reboot. When a BES update follows,
-                // the BES install power-cycles the device and applies the staged MTK image as a
-                // side effect, so we must NOT reboot here. When MTK is the last/only step there
-                // is nothing to trigger that reboot, so we issue it ourselves (see below).
-                boolean mtkWasFinalStep = false;
-                if (otaHelper != null) {
-                    OtaSessionManager session = otaHelper.getSessionManager();
-                    if (session != null && session.hasActiveSession()) {
-                        int idx = session.getCurrentStepIndex();
-                        boolean mtkIsCurrentStep = "mtk".equals(session.getStepType(idx));
-                        boolean isLastStep = (idx + 1) >= session.getTotalSteps();
-                        mtkWasFinalStep = mtkIsCurrentStep && isLastStep;
-                    }
-                }
+                // MTK A/B updates only take effect after a reboot. When a BES update follows, the
+                // BES install power-cycles the device and applies the staged MTK image as a side
+                // effect, so we must NOT reboot here. For an MTK-only update nothing else triggers
+                // that reboot, so we issue it ourselves once the install reports success.
+                //
+                // The decision is read from a flag OtaHelper set at install kickoff (based on
+                // whether a BES update follows), NOT from session state — so it is correct on both
+                // the session path and the legacy/no-session path below.
+                boolean shouldRebootAfterMtk = otaHelper != null && otaHelper.shouldRebootAfterMtkInstall();
 
                 if (otaHelper != null) {
                     otaHelper.sendMtkInstallProgressToPhone("FINISHED", 100, null);
@@ -264,7 +258,7 @@ public class OtaService extends Service {
                 // firmware ourselves after a short delay (lets the phone receive the
                 // "complete" status first). Historically MTK was always bundled with a BES
                 // update, whose MCU-level install power-cycled the device automatically.
-                if (mtkWasFinalStep) {
+                if (shouldRebootAfterMtk) {
                     scheduleMtkRebootToApplyUpdate();
                 }
                 break;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -34,7 +34,13 @@ public class OtaService extends Service {
     private static final String TAG = OtaConstants.TAG;
     private static final String CHANNEL_ID = "ota_service_channel";
     private static final int NOTIFICATION_ID = 2001;
-    
+
+    // Delay before rebooting to apply a staged MTK-only update. Gives the BLE
+    // ota_status "complete" message time to reach the phone before we drop the
+    // connection, so the phone settles on its "complete" UI rather than a bare
+    // "disconnected" spinner during the reboot.
+    private static final long MTK_REBOOT_DELAY_MS = 3000;
+
     private OtaHelper otaHelper;
     
     @Override
@@ -223,6 +229,22 @@ public class OtaService extends Service {
                 updateNotification("MTK firmware updated successfully");
                 Log.i(TAG, "📱 MTK system SUCCESS received - staged for next reboot");
 
+                // Decide BEFORE advancing the session whether this MTK step is the final one.
+                // MTK A/B updates only take effect after a reboot. When a BES update follows,
+                // the BES install power-cycles the device and applies the staged MTK image as a
+                // side effect, so we must NOT reboot here. When MTK is the last/only step there
+                // is nothing to trigger that reboot, so we issue it ourselves (see below).
+                boolean mtkWasFinalStep = false;
+                if (otaHelper != null) {
+                    OtaSessionManager session = otaHelper.getSessionManager();
+                    if (session != null && session.hasActiveSession()) {
+                        int idx = session.getCurrentStepIndex();
+                        boolean mtkIsCurrentStep = "mtk".equals(session.getStepType(idx));
+                        boolean isLastStep = (idx + 1) >= session.getTotalSteps();
+                        mtkWasFinalStep = mtkIsCurrentStep && isLastStep;
+                    }
+                }
+
                 if (otaHelper != null) {
                     otaHelper.sendMtkInstallProgressToPhone("FINISHED", 100, null);
                     // Session-based path: auto-advance to the next step (e.g. BES) immediately
@@ -236,6 +258,14 @@ public class OtaService extends Service {
                     }
                 } else {
                     sendMtkUpdateCompleteMessage();
+                }
+
+                // MTK-only update: no BES step will reboot for us, so apply the staged
+                // firmware ourselves after a short delay (lets the phone receive the
+                // "complete" status first). Historically MTK was always bundled with a BES
+                // update, whose MCU-level install power-cycled the device automatically.
+                if (mtkWasFinalStep) {
+                    scheduleMtkRebootToApplyUpdate();
                 }
                 break;
             case ERROR:
@@ -253,6 +283,25 @@ public class OtaService extends Service {
         Log.i(TAG, "Sending MTK update complete broadcast");
         Intent intent = new Intent("com.mentra.asg_client.MTK_UPDATE_COMPLETE");
         sendBroadcast(intent);
+    }
+
+    /**
+     * Reboot the device to apply a staged MTK-only firmware update.
+     *
+     * MTK A/B updates do not change ro.custom.ota.version until the device reboots. When MTK is
+     * bundled with a BES update the BES install power-cycles the device for us; for an MTK-only
+     * update nothing else triggers the reboot, so the device would otherwise keep re-offering the
+     * same patch (current firmware still matches the patch's start_firmware) in a loop.
+     *
+     * Delayed so the phone receives the BLE "complete" status before the connection drops.
+     */
+    private void scheduleMtkRebootToApplyUpdate() {
+        Log.i(TAG, "🔄 MTK was the final OTA step (no BES update) - rebooting in "
+                + (MTK_REBOOT_DELAY_MS / 1000) + "s to apply staged firmware");
+        new Handler(Looper.getMainLooper()).postDelayed(() -> {
+            Log.i(TAG, "🔄 Rebooting now to apply staged MTK firmware update");
+            SysControl.reboot(getApplicationContext());
+        }, MTK_REBOOT_DELAY_MS);
     }
     
     @Subscribe(threadMode = ThreadMode.MAIN)

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 37,
-      "versionName": "37.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
-      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
+      "versionCode": 38,
+      "versionName": "38.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38.apk",
+      "sha256": "ccd334a658f1e6aa2d716dc5a2b2ea2751bead5bda25b8cf43be4faffa9e20a8"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -14,6 +14,24 @@
     }
   },
   "mtk_patches": [
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
+      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
+      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+    },
     {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 37,
-      "versionName": "37.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
-      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
+      "versionCode": 38,
+      "versionName": "38.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38.apk",
+      "sha256": "ccd334a658f1e6aa2d716dc5a2b2ea2751bead5bda25b8cf43be4faffa9e20a8"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,


### PR DESCRIPTION
## Problem

MTK A/B firmware updates only take effect **after a reboot**. Historically every MTK patch shipped bundled with a BES firmware update, and the BES install power-cycles the device at the MCU level — which applies the staged MTK image as a side effect. So we never needed to reboot ourselves.

We now need to ship an **MTK patch on its own** (no BES update). In that case nothing triggers the reboot, so:

- The device keeps reporting its pre-update MTK firmware version (`ro.custom.ota.version` doesn't change until reboot).
- The OTA manifest keeps matching the same patch (current firmware still equals the patch's `start_firmware`).
- The phone re-runs the "update available" → install → re-check cycle in an **infinite loop**.

## Fix

When the **final** OTA step in a session is MTK (i.e. no BES step follows), reboot the device once the MTK install reports `SUCCESS`, via the existing `SysControl.reboot()` path (the same broadcast already used by the phone-initiated reboot command). After reboot the device reports the new firmware version, the patch no longer matches, and the loop ends.

- The reboot decision is made **before** advancing the session, checking that the current step is `mtk` and is the last step. The order is always APK → MTK → BES, so "MTK is last" ⇔ "no BES follows".
- When a BES step **does** follow, behavior is unchanged — BES still triggers the power-cycle and we do **not** reboot.
- The reboot is delayed ~3s so the phone receives the BLE `complete` status before the connection drops, letting its UI settle on "complete" rather than a bare "disconnected" spinner.

All changes are confined to the MTK `SUCCESS` handler in `OtaService.java`; `SysControl`, `Handler`, `Looper`, and `OtaSessionManager` were already imported.

## Notes

- This is the glasses-side change only. A small, optional phone-side follow-up (`deriveOtaDisplayState.ts`) could give the MTK reboot the same polished "restarting → complete" UX that BES has; without it the phone still handles this gracefully (shows "complete" via the generic status rule, self-heals on reconnect if a message is missed). No false-failure risk: the stall watchdog is disabled while disconnected and the only remaining timer is the 20-min global cap.

## Testing

- [ ] Manual: ship to a Mentra Live on firmware matching an MTK-only patch; confirm it installs, auto-reboots once, comes back on the new firmware, and the phone no longer loops.
- [ ] Manual: MTK + BES bundled update still applies both with a single (BES-triggered) reboot and no double-reboot.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes firmware OTA completion to trigger a full device reboot via SysControl; incorrect flag handling could double-reboot or skip reboot, but logic is gated by install-time besUpdateFollows and consume-and-clear on SUCCESS.
> 
> **Overview**
> Fixes an **infinite OTA loop** when shipping an **MTK patch without BES**: staged MTK A/B firmware does not apply until reboot, so the device keeps matching the same manifest patch until something power-cycles it (previously that was always the bundled BES install).
> 
> **`OtaHelper`** arms a **`rebootAfterMtkInstall`** flag when MTK install starts (`rebootAfterMtkInstall = !besUpdateFollows`). Combined MTK+BES installs pass **`besUpdateFollows=true`** so the glasses do not self-reboot before BES. **`consumeRebootAfterMtkInstall()`** returns and clears the flag so duplicate SUCCESS events cannot schedule a second reboot.
> 
> **`OtaService`** on MTK **SUCCESS** reads that flag; when true it calls **`scheduleMtkRebootToApplyUpdate()`**, which waits **3s** (BLE `complete` to the phone) then **`SysControl.reboot()`**. MTK+BES behavior is unchanged (no self-reboot when BES follows).
> 
> Also bumps **ASG client to 38.0** and updates **`prod_live_version.json`** / test manifest with **38** APK metadata and **additional MTK patch** entries for more `start_firmware` paths to `MentraLive_20260525`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acb981c702ffb47bbec95bef65f83f3ea05982d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-reboots the device after a successful MTK-only OTA so the staged firmware applies and the update loop stops. Reboot is delayed ~3s so the phone receives the BLE “complete” status first.

- **Bug Fixes**
  - Reboot decision is now driven by an install-time flag `rebootAfterMtkInstall` set in `OtaHelper` at MTK kickoff, so it works for both session and legacy/no-session paths.
  - Combined MTK+BES updates pass `besUpdateFollows=true` to suppress self-reboot (BES power-cycles); MTK-only defaults to self-reboot.
  - On MTK `SUCCESS` in `OtaService`, send `FINISHED` to the phone and, if `consumeRebootAfterMtkInstall()` is true, schedule `SysControl.reboot()` after `MTK_REBOOT_DELAY_MS`; the read-and-clear avoids double reboots from duplicate/late events.

- **Dependencies**
  - Bumped app to `38 (38.0)` and updated OTA website manifests (`prod_live_version.json`, `test_bes_ota_prod_live_version.json`) to point to the 38 APK, add new MTK patch ranges, and refresh SHA256 hashes.

<sup>Written for commit acb981c702ffb47bbec95bef65f83f3ea05982d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

