### PR TITLE
fix: change SDK default WebSocket URL to production endpoint

### DIFF
--- a/cloud/docs/api-reference/websocket/app-connection.mdx
+++ b/cloud/docs/api-reference/websocket/app-connection.mdx
@@ -14,7 +14,7 @@ wss://api.mentra.glass/app-ws
 wss://devapi.mentra.glass/app-ws
 ```
 
-```bash Local
+```bash Local Development
 ws://localhost:8002/app-ws
 ```
 </CodeGroup>

--- a/cloud/packages/sdk/src/app/session/index.ts
+++ b/cloud/packages/sdk/src/app/session/index.ts
@@ -256,7 +256,7 @@ export class AppSession {
   constructor(private config: AppSessionConfig) {
     // Set defaults and merge with provided config
     this.config = {
-      mentraOSWebsocketUrl: `ws://localhost:8002/app-ws`, // Use localhost as default
+      mentraOSWebsocketUrl: `wss://api.mentra.glass/app-ws`, // Production WebSocket URL
       autoReconnect: true, // Enable auto-reconnection by default for better reliability
       maxReconnectAttempts: 3, // Default to 3 reconnection attempts for better resilience
       reconnectDelay: 1000, // Start with 1 second delay (uses exponential backoff)

--- a/docs/app-devs/reference/app-session.mdx
+++ b/docs/app-devs/reference/app-session.mdx
@@ -285,7 +285,7 @@ interface AppSessionConfig {
   /** Your API key for authentication. */
   apiKey: string;
 
-  /** The WebSocket URL provided by MentraOS Cloud. Defaults to 'ws://localhost:8002/app-ws'. */
+  /** The WebSocket URL provided by MentraOS Cloud. Defaults to 'wss://api.mentra.glass/app-ws.
   mentraOSWebsocketUrl?: string;
 
   /** Whether the session should automatically attempt to reconnect if the connection drops. Defaults to `false`. */


### PR DESCRIPTION
## Summary

The SDK `AppSession` was defaulting to `ws://localhost:8002/app-ws` (local dev server) instead of the production endpoint. This caused third-party apps to fail connecting with **"Connection timeout after 5000ms"** errors when deployed outside the local dev environment.

## Changes

Changed default from `ws://localhost:8002/app-ws` to `wss://api.mentra.glass/app-ws` in:

- `cloud/packages/sdk/src/app/session/index.ts` — SDK source code
- `cloud/docs/api-reference/websocket/app-connection.mdx` — API reference docs
- `docs/app-devs/reference/app-session.mdx` — AppSession reference docs

## Impact

- Third-party apps will now connect to the production MentraOS Cloud by default
- Local development still works — devs can override with `mentraOSWebsocketUrl: 'ws://localhost:8002/app-ws'` in their app config
- Fixes the common "couldn't connect" error when deploying apps to production

## Testing

Verified by deploying the camera app to SCARRED — sessions now connect successfully instead of timing out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the SDK default affects all apps that omit `mentraOSWebsocketUrl`, so local workflows must override explicitly; connection behavior is core to app runtime.
> 
> **Overview**
> **`AppSession`** now defaults **`mentraOSWebsocketUrl`** to **`wss://api.mentra.glass/app-ws`** instead of **`ws://localhost:8002/app-ws`**, so deployed third-party apps connect to production MentraOS Cloud without setting the URL explicitly. Local dev can still override with the localhost endpoint.
> 
> Docs are aligned: the app WebSocket API reference renames the local tab to **Local Development**, and the **`AppSessionConfig`** reference documents the new production default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93fc6b0cfcc6748429fa7db86aebd10ee79e3870. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the SDK `AppSession` default WebSocket to `wss://api.mentra.glass/app-ws` to prevent connection timeouts in deployed apps. Local dev can still override with `mentraOSWebsocketUrl: 'ws://localhost:8002/app-ws'`.

- **Bug Fixes**
  - Updated default in `cloud/packages/sdk/src/app/session/index.ts`.
  - Synced docs in `cloud/docs/api-reference/websocket/app-connection.mdx` and `docs/app-devs/reference/app-session.mdx`.

<sup>Written for commit 93fc6b0cfcc6748429fa7db86aebd10ee79e3870. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

