### PR TITLE
fix(bluetooth-sdk/ios): make ObservableStore thread-safe

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/ObservableStore.swift
@@ -13,6 +13,16 @@ class ObservableStore {
     private var onEmit: ((String, [String: Any]) -> Void)?
     private var listeners: [String: (String, [String: Any]) -> Void] = [:]
 
+    // Serialize every access to `values` / `listeners`. This type is annotated
+    // @MainActor, but it is reached from BLE background callbacks through the
+    // Obj-C/React Native bridge, which bypasses Swift actor isolation. The
+    // resulting data race corrupts the backing dictionary and crashes with
+    // "-[__NSTaggedDate countByEnumeratingWithState:objects:count:]: unrecognized
+    // selector" inside getCategory's enumeration. A recursive lock makes the
+    // dictionary access safe regardless of the calling thread (recursive so a
+    // listener firing on the same thread can safely re-enter).
+    private let lock = NSRecursiveLock()
+
     nonisolated static let bluetoothCategory = "bluetooth"
     private nonisolated static let legacyCoreCategory = "core"
 
@@ -26,45 +36,60 @@ class ObservableStore {
 
     func addListener(_ listener: @escaping (String, [String: Any]) -> Void) -> String {
         let id = UUID().uuidString
+        lock.lock()
         listeners[id] = listener
+        lock.unlock()
         return id
     }
 
     func removeListener(_ id: String) {
+        lock.lock()
         listeners.removeValue(forKey: id)
+        lock.unlock()
     }
 
     func set(_ category: String, _ key: String, _ value: Any) {
         let normalizedCategory = Self.normalizeCategory(category)
         let fullKey = "\(normalizedCategory).\(key)"
-        let oldValue = values[fullKey]
 
+        lock.lock()
+        let oldValue = values[fullKey]
         // Skip if unchanged
         if let old = oldValue, areEqual(old, value) {
+            lock.unlock()
             return
         }
-
         values[fullKey] = value
+        // Snapshot listeners under the lock, then release before emitting so a
+        // listener that re-enters the store on another thread cannot deadlock.
+        let listenersSnapshot = Array(listeners.values)
+        lock.unlock()
 
         // Emit immediately
         let changes = [key: value]
         onEmit?(normalizedCategory, changes)
-        for listener in Array(listeners.values) {
+        for listener in listenersSnapshot {
             listener(normalizedCategory, changes)
         }
     }
 
     func get(_ category: String, _ key: String) -> Any? {
-        values["\(Self.normalizeCategory(category)).\(key)"]
+        lock.lock()
+        defer { lock.unlock() }
+        return values["\(Self.normalizeCategory(category)).\(key)"]
     }
 
     func wouldSkipSet(_ category: String, _ key: String, _ value: Any) -> Bool {
         let fullKey = "\(Self.normalizeCategory(category)).\(key)"
+        lock.lock()
+        defer { lock.unlock() }
         guard let oldValue = values[fullKey] else { return false }
         return areEqual(oldValue, value)
     }
 
     func getCategory(_ category: String) -> [String: Any] {
+        lock.lock()
+        defer { lock.unlock() }
         var result: [String: Any] = [:]
         let prefix = "\(Self.normalizeCategory(category))."
         for (key, value) in values where key.hasPrefix(prefix) {


### PR DESCRIPTION
## Summary

`ObservableStore` (iOS) is annotated `@MainActor`, but it is reached from BLE background callbacks through the Obj-C / React Native bridge, which bypasses Swift actor isolation. The unsynchronized access races on the backing `values` dictionary and **intermittently crashes the app** with:

```
-[__NSTaggedDate countByEnumeratingWithState:objects:count:]: unrecognized selector sent to instance 0x8000000000000000
```

### Crash backtrace (observed in Xcode, main thread aborts)

```
__pthread_kill
...
ObservableStore.getCategory(_:)
MentraBluetoothSDK.bluetoothStatus.getter      // DeviceStore.shared.store.getCategory(.bluetoothCategory)
MentraBluetoothSDK.state.getter
MentraBluetoothSDK.dispatchStoreUpdate(_:)
closure #1 in closure #2 in MentraBluetoothSDK...
```

The crash surfaces inside `getCategory()`'s `for (key, value) in values` enumeration once the dictionary reference has been corrupted by the data race (the corrupted pointer `0x8000000000000000` is a tagged `NSDate`). Because it is a race, it is intermittent — it typically fires after the BLE link has been up for a while and status updates are flowing.

## Fix

Guard all reads/writes of `values` and `listeners` with an `NSRecursiveLock`:

- Recursive so a listener firing synchronously on the same thread can safely re-enter the store.
- In `set()`, listeners are snapshotted under the lock and the lock is released **before** emitting, so a cross-thread re-entrant listener cannot deadlock.
- Covers `set`, `get`, `getCategory`, `wouldSkipSet`, `addListener`, `removeListener`.

This makes the dictionary access safe regardless of the calling thread without changing the public API or the `@MainActor` annotation.

## Notes / scope

- iOS only. The Android `ObservableStore.kt` is out of scope for this PR.
- No behavior change beyond serialization; the emit path and skip-if-unchanged semantics are preserved.

## Test plan

- [x] Builds.
- [x] Ran on device (Mentra Live + iPhone, Expo 56 / RN 0.85, New Architecture). The `__NSTaggedDate` abort no longer reproduces over extended BLE status streaming where it previously crashed intermittently.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared BLE state used on every status update; locking changes concurrency semantics but is narrowly scoped and preserves existing emit behavior.
> 
> **Overview**
> Fixes intermittent iOS crashes from **unsynchronized access** to `ObservableStore`'s backing dictionaries when BLE / RN bridge callbacks hit the store off the main thread despite `@MainActor`.
> 
> The change adds an **`NSRecursiveLock`** around all reads and writes to `values` and `listeners` (`get`, `set`, `getCategory`, `wouldSkipSet`, `addListener`, `removeListener`). In **`set()`**, listeners are **snapshotted under the lock** and notifications run **after unlock** so cross-thread re-entry cannot deadlock. Public API and emit / skip-if-unchanged behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c0fbb5c90bae4511f00862d3ec39751fcf80798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the iOS `ObservableStore` thread-safe to stop intermittent crashes caused by BLE background callbacks bypassing `@MainActor`. Fixes the `-[__NSTaggedDate …]: unrecognized selector` crash during category enumeration.

- **Bug Fixes**
  - Guard all access to `values` and `listeners` with `NSRecursiveLock`.
  - In `set`, snapshot listeners under the lock and unlock before emitting to avoid re-entrant deadlocks.
  - Applies to `set`, `get`, `getCategory`, `wouldSkipSet`, `addListener`, `removeListener`; no API/behavior changes; iOS only.

<sup>Written for commit 0c0fbb5c90bae4511f00862d3ec39751fcf80798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

