### PR TITLE
[codex] Fix Mentra Live action button event id

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
@@ -162,18 +162,18 @@ public class K900CommandHandler {
     }
 
     /**
-     * Handle camera button short press 1. Immediately send RGB LED authority claim 2. After 5
+     * Handle action button short press 1. Immediately send RGB LED authority claim 2. After 5
      * seconds, activate blue LED
      */
     private void handleCameraButtonShortPress() {
-        Log.d(TAG, "📸 Camera button short pressed - handling with configurable mode");
+        Log.d(TAG, "📸 Action button short pressed - handling with configurable mode");
 
         handleConfigurableButtonPress(false); // false = short press
     }
 
-    /** Handle camera button long press */
+    /** Handle action button long press */
     private void handleCameraButtonLongPress() {
-        Log.d(TAG, "📹 Camera button long pressed - handling with configurable mode");
+        Log.d(TAG, "📹 Action button long pressed - handling with configurable mode");
         handleConfigurableButtonPress(true); // true = long press
     }
 
@@ -1023,7 +1023,7 @@ public class K900CommandHandler {
             try {
                 JSONObject buttonObject = new JSONObject();
                 buttonObject.put("type", "button_press");
-                buttonObject.put("buttonId", "camera");
+                buttonObject.put("buttonId", "action");
                 buttonObject.put("pressType", isLongPress ? "long" : "short");
                 buttonObject.put("timestamp", System.currentTimeMillis());
 
@@ -1108,7 +1108,7 @@ public class K900CommandHandler {
                                     commandStr.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
             if (sent) {
-                Log.i(TAG, "✅ 💙 Blue RGB LED activated successfully via camera button");
+                Log.i(TAG, "✅ 💙 Blue RGB LED activated successfully via action button");
             } else {
                 Log.e(TAG, "❌ 💙 Failed to activate blue RGB LED");
             }

--- a/cloud/packages/cloud-client/docs/protocol.md
+++ b/cloud/packages/cloud-client/docs/protocol.md
@@ -85,7 +85,7 @@ Messages that provide sensor data or user interactions.
 ```typescript
 {
   "type": "button_press",
-  "buttonId": "power",
+  "buttonId": "action",
   "pressType": "short",  // or "long"
   "timestamp": "2024-01-01T00:00:00.000Z"
 }

--- a/cloud/packages/sdk/src/session/managers/DeviceManager.ts
+++ b/cloud/packages/sdk/src/session/managers/DeviceManager.ts
@@ -57,7 +57,7 @@ import type { PermissionsManager } from "./PermissionsManager";
  * Button press event from the glasses hardware.
  */
 export interface ButtonPressEvent {
-  /** Identifier of the button that was pressed. */
+  /** Identifier of the button that was pressed. Mentra Live's right action button is "action". */
   buttonId: string;
   /** Whether the press was short or long. */
   pressType: "short" | "long";

--- a/cloud/packages/sdk/src/types/messages/glasses-to-cloud.ts
+++ b/cloud/packages/sdk/src/types/messages/glasses-to-cloud.ts
@@ -67,7 +67,7 @@ export interface OpenDashboard extends BaseMessage {
 //===========================================================
 
 /**
- * Button press event from glasses
+ * Button press event from glasses. Mentra Live's right action button is "action".
  */
 export interface ButtonPress extends BaseMessage {
   type: GlassesToCloudMessageType.BUTTON_PRESS;

--- a/docs-bluetooth-sdk/api-reference.mdx
+++ b/docs-bluetooth-sdk/api-reference.mdx
@@ -416,7 +416,7 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `device_discovered` | `Device` | A supported glasses device is discovered during scan. |
 | `default_device_changed` | `{device?: Device}` | The SDK default device changes. |
 | `glasses_not_ready` | `GlassesNotReadyEvent` | A command needs ready glasses but the connected device is not ready. |
-| `button_press` | `ButtonPressEvent` | Glasses button press. |
+| `button_press` | `ButtonPressEvent` | Glasses button press. Mentra Live uses `buttonId: "action"` for the right action button. |
 | `touch_event` | `TouchEvent` | Glasses touch or swipe gesture. |
 | `head_up` | `HeadUpEvent` | Head-up state changes. |
 | `voice_activity_detection_status` | `VoiceActivityDetectionStatusEvent` | Glasses-side Voice Activity Detection is enabled or disabled. |

--- a/docs-bluetooth-sdk/react-native-expo.mdx
+++ b/docs-bluetooth-sdk/react-native-expo.mdx
@@ -180,6 +180,7 @@ export function DeviceScreen() {
   });
 
   useBluetoothEvent('button_press', (event) => {
+    // Mentra Live's right action button reports event.buttonId === 'action'.
     console.log('Glasses button:', event.buttonId, event.pressType);
   });
 

--- a/docs/os-devs/asg-client/README.mdx
+++ b/docs/os-devs/asg-client/README.mdx
@@ -40,7 +40,7 @@ Currently, the primary supported device is **Mentra Live**.
 
 ### 🎮 Hardware Integration
 
-- Button press detection (camera button)
+- Button press detection (right action button)
 - Swipe gesture recognition
 - Battery status monitoring
 

--- a/docs/os-devs/asg-client/architecture.mdx
+++ b/docs/os-devs/asg-client/architecture.mdx
@@ -131,9 +131,9 @@ public class NetworkManagerFactory {
 Commands from the microcontroller (hardware events):
 
 ```java
-// Button press commands
-"cs_pho" → Short camera button press (photo)
-"cs_vdo" → Long camera button press (video)
+// Right action-button press commands
+"cs_pho" → Short action-button press (photo)
+"cs_vdo" → Long action-button press (video)
 
 // Other hardware commands
 "hm_batv" → Battery status update

--- a/docs/os-devs/asg-client/button-system.mdx
+++ b/docs/os-devs/asg-client/button-system.mdx
@@ -4,7 +4,7 @@ The button press system in ASG Client handles physical button interactions on th
 
 ## How It Works
 
-1. The user presses the camera button on the glasses.
+1. The user presses the right action button on the glasses.
 2. The BES microcontroller classifies the press and sends a K900 command:
    - `cs_pho` for short press
    - `cs_vdo` for long press
@@ -14,18 +14,18 @@ The button press system in ASG Client handles physical button interactions on th
 
 ## Button Press Event
 
-Every camera-button press is forwarded to the phone when Bluetooth is connected:
+Every action-button press is forwarded to the phone when Bluetooth is connected:
 
 ```json
 {
   "type": "button_press",
-  "buttonId": "camera",
+  "buttonId": "action",
   "pressType": "short",
   "timestamp": 1234567890
 }
 ```
 
-`pressType` is `"short"` or `"long"`. Apps can react to this event even when the glasses also capture locally.
+`buttonId` is `"action"` for the Mentra Live right action button. `pressType` is `"short"` or `"long"`. Apps can react to this event even when the glasses also capture locally.
 
 ## Local Capture Gate
 
@@ -58,7 +58,7 @@ Settings used:
 
 ## Other Button Commands
 
-Besides the camera button, ASG Client also handles:
+Besides the right action button, ASG Client also handles:
 
 - Swipe gestures from arm swipes
 - Battery status updates

--- a/docs/os-devs/asg-client/mentra-live.mdx
+++ b/docs/os-devs/asg-client/mentra-live.mdx
@@ -129,7 +129,7 @@ adb logcat -c
 
 ### Button Commands
 
-The MCU sends these commands for button presses:
+The MCU sends these commands for right action-button presses:
 
 | Action      | Command   | Description       |
 | ----------- | --------- | ----------------- |

--- a/docs/os-devs/contributing/mentraos-asg-client-guidelines.mdx
+++ b/docs/os-devs/contributing/mentraos-asg-client-guidelines.mdx
@@ -70,7 +70,7 @@ public interface IBluetoothManager {
 
 ### Media System
 
-The media system handles camera button presses and media capture:
+The media system handles right action-button presses and media capture:
 
 **Button Press Flow**:
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -168,6 +168,7 @@ export function DeviceScreen() {
   })
 
   useBluetoothEvent('button_press', (event) => {
+    // Mentra Live's right action button reports event.buttonId === 'action'.
     console.log('Glasses button:', event.buttonId, event.pressType)
   })
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -2597,7 +2597,7 @@ public class MentraLive extends SGCManager {
 
             case "button_press":
                 // Process button press event
-                String buttonId = json.optString("buttonId", "unknown");
+                String buttonId = normalizeButtonId(json.optString("buttonId", "unknown"));
                 String pressType = json.optString("pressType", "short");
 
                 Bridge.log("LIVE: Received button press - buttonId: " + buttonId + ", pressType: " + pressType);
@@ -7402,4 +7402,8 @@ public class MentraLive extends SGCManager {
              return "Error listing LC3 log files: " + e.getMessage();
          }
      }
+
+    private String normalizeButtonId(String buttonId) {
+        return "camera".equals(buttonId) ? "action" : buttonId;
+    }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2990,11 +2990,15 @@ class MentraLive: NSObject, SGCManager {
     }
 
     private func handleButtonPress(_ json: [String: Any]) {
-        let buttonId = json["buttonId"] as? String ?? "unknown"
+        let buttonId = normalizeButtonId(json["buttonId"] as? String ?? "unknown")
         let pressType = json["pressType"] as? String ?? "short"
 
         Bridge.log("LIVE: Received button press - buttonId: \(buttonId), pressType: \(pressType)")
         Bridge.sendButtonPress(buttonId: buttonId, pressType: pressType)
+    }
+
+    private func normalizeButtonId(_ buttonId: String) -> String {
+        buttonId == "camera" ? "action" : buttonId
     }
 
     private func handleVersionInfo(_ json: [String: Any]) {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -9,6 +9,7 @@ export type GlassesNotReadyEvent = {
 // timestamp} (see BluetoothSdkModule on both iOS and Android). Consumers must
 // filter on `pressType` / the "button_press" listener name, never `event.type`.
 export type ButtonPressEvent = {
+  /** Mentra Live reports its right action button as "action". */
   buttonId: string
   pressType: "long" | "short"
   timestamp: number

--- a/sdk/docs/input.md
+++ b/sdk/docs/input.md
@@ -58,6 +58,7 @@ Subscribes to physical button press events.
 
 ```ts
 interface ButtonPressData {
+  // Mentra Live's right action button reports "action".
   buttonId: string
   pressType: "short" | "long"
 }


### PR DESCRIPTION
## Summary

Fixes the public Mentra Live button identifier so the right action button is surfaced as `buttonId: "action"` instead of the stale camera-button label.

## Event-name mapping

| Surface | Current/corrected name | Origin / notes |
| --- | --- | --- |
| ASG BLE payload | `type: "button_press"`, `buttonId: "action"`, `pressType: "short" | "long"` | `K900CommandHandler` handles `cs_pho`, `cs_vdo`, and `hs_ntfy` button notifications, then forwards the event to the phone. |
| Bluetooth SDK React Native event | `button_press` with `ButtonPressEvent.buttonId === "action"` on Mentra Live | Android and iOS Mentra Live parsers now normalize legacy incoming `"camera"` IDs to `"action"` before emitting to the public SDK bridge. |
| Cloud SDK stream | `StreamType.BUTTON_PRESS` / `"button_press"` with opaque `buttonId`; Mentra Live documented as `"action"` | Stream/event name remains the generic button stream; the public button identifier is corrected. |
| Touch / swipe inputs | `touch_event` gesture names such as `single_tap`, `double_tap`, `forward_swipe`, etc. | Unchanged; these are separate related input events from K900 touch reports. |

## Scope

- Updated Mentra Live ASG event emission from `buttonId: "camera"` to `buttonId: "action"`.
- Added Bluetooth SDK Android/iOS normalization so older Mentra Live ASG payloads using `"camera"` still surface as `"action"` to public SDK consumers.
- Updated public docs and type comments to teach the action-button identifier.

## Compatibility notes

This intentionally changes the public Mentra Live button identifier from `"camera"` to `"action"`. The Bluetooth SDK parser compatibility path maps older glasses payloads from `"camera"` to `"action"`, so apps using current SDK builds will see the corrected identifier even before all glasses-side clients are updated.

## Validation

- `git diff --check`
- `cd asg_client && ./gradlew :app:compileDebugJavaWithJavac`

Mobile/cloud `node_modules` were not installed in the wrapper worktree, and the TypeScript changes are comments/docs only. The Bluetooth SDK native parser edits were statically inspected.