### PR TITLE
Fast-fail local photo receiver uploads

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -71,6 +71,8 @@ public class MediaCaptureService {
     // Debug flag: Enable detailed end-to-end photo capture timing logs
     // true = log timing from request to capture, false = suppress timing logs
     private static final boolean ENABLE_PHOTO_TIMING_LOGS = true;
+    private static final int DEFAULT_PHOTO_UPLOAD_CONNECT_TIMEOUT_SECONDS = 5;
+    private static final int LOCAL_PHOTO_UPLOAD_CONNECT_TIMEOUT_SECONDS = 1;
 
     private final Context mContext;
     private final MediaUploadQueueManager mMediaQueueManager;
@@ -2337,13 +2339,28 @@ public class MediaCaptureService {
                                 // - 5 seconds to connect (allows time for DNS+TCP+TLS over WiFi)
                                 // - 10 seconds to write the photo data
                                 // - 5 seconds to read the response
+                                int connectTimeoutSeconds =
+                                        isLocalNetworkWebhook(webhookUrl)
+                                                ? LOCAL_PHOTO_UPLOAD_CONNECT_TIMEOUT_SECONDS
+                                                : DEFAULT_PHOTO_UPLOAD_CONNECT_TIMEOUT_SECONDS;
+                                if (connectTimeoutSeconds
+                                        < DEFAULT_PHOTO_UPLOAD_CONNECT_TIMEOUT_SECONDS) {
+                                    Log.d(
+                                            TAG,
+                                            "⚡ Using fast local receiver connect timeout ("
+                                                    + connectTimeoutSeconds
+                                                    + "s) for webhook: "
+                                                    + webhookUrl);
+                                }
+
                                 OkHttpClient client =
                                         new OkHttpClient.Builder()
                                                 .connectTimeout(
-                                                        5,
+                                                        connectTimeoutSeconds,
                                                         java.util.concurrent.TimeUnit
-                                                                .SECONDS) // Allow time for
-                                                // DNS+TCP+TLS on WiFi
+                                                                .SECONDS) // Local receiver
+                                                // failures should fall back quickly; public
+                                                // webhooks keep the normal WiFi allowance.
                                                 .writeTimeout(
                                                         10,
                                                         java.util.concurrent.TimeUnit
@@ -2684,6 +2701,41 @@ public class MediaCaptureService {
                             }
                         })
                 .start();
+    }
+
+    private boolean isLocalNetworkWebhook(String webhookUrl) {
+        try {
+            URI uri = URI.create(webhookUrl);
+            String host = uri.getHost();
+            if (host == null || host.isEmpty()) {
+                return false;
+            }
+            return isLocalIpv4Literal(host) || "localhost".equalsIgnoreCase(host);
+        } catch (Exception ignored) {
+            return false;
+        }
+    }
+
+    private boolean isLocalIpv4Literal(String host) {
+        String[] parts = host.split("\\.");
+        if (parts.length != 4) {
+            return false;
+        }
+        int[] octets = new int[4];
+        for (int i = 0; i < parts.length; i++) {
+            try {
+                octets[i] = Integer.parseInt(parts[i]);
+            } catch (NumberFormatException e) {
+                return false;
+            }
+            if (octets[i] < 0 || octets[i] > 255) {
+                return false;
+            }
+        }
+        return octets[0] == 10
+                || (octets[0] == 172 && octets[1] >= 16 && octets[1] <= 31)
+                || (octets[0] == 192 && octets[1] == 168)
+                || octets[0] == 127;
     }
 
     /** Upload a video file to AugmentOS Cloud Currently a stub - videos are kept on device */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/photoreceiver/MentraPhotoReceiverModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/photoreceiver/MentraPhotoReceiverModule.kt
@@ -1,8 +1,11 @@
 package com.mentra.bluetoothsdk.photoreceiver
 
 import android.content.Context
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
 import android.net.Uri
 import android.util.Log
+import com.mentra.bluetoothsdk.DeviceStore
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
@@ -129,6 +132,10 @@ class MentraPhotoReceiverModule : Module() {
   }
 
   private fun bestLocalIpv4Address(): String? {
+    val glassesLocalIp = (DeviceStore.get("glasses", "wifiLocalIp") as? String)
+      ?.trim()
+      ?.takeIf { it.isNotEmpty() }
+    val activeNetworkAddress = activeNetworkIpv4Address()
     val wifiPrivateCandidates = mutableListOf<Inet4Address>()
     val wifiCandidates = mutableListOf<Inet4Address>()
     val privateCandidates = mutableListOf<Inet4Address>()
@@ -153,12 +160,55 @@ class MentraPhotoReceiverModule : Module() {
       }
     }
 
+    if (activeNetworkAddress != null) {
+      val activeHost = activeNetworkAddress.hostAddress
+      if (sameIpv4Slash24(activeHost, glassesLocalIp)) {
+        emitStatus("Using active phone Wi-Fi address $activeHost for glasses $glassesLocalIp")
+        return activeHost
+      }
+    }
+
+    val sameSubnetCandidate = (
+      wifiPrivateCandidates +
+        wifiCandidates +
+        privateCandidates +
+        otherCandidates
+      ).firstOrNull { sameIpv4Slash24(it.hostAddress, glassesLocalIp) }
+    if (sameSubnetCandidate != null) {
+      emitStatus("Using same-subnet phone address ${sameSubnetCandidate.hostAddress} for glasses $glassesLocalIp")
+      return sameSubnetCandidate.hostAddress
+    }
+
+    if (activeNetworkAddress != null && isPrivateIpv4(activeNetworkAddress.hostAddress.orEmpty())) {
+      emitStatus("Using active phone network address ${activeNetworkAddress.hostAddress}")
+      return activeNetworkAddress.hostAddress
+    }
+
     return (
       wifiPrivateCandidates.firstOrNull() ?:
         wifiCandidates.firstOrNull() ?:
         privateCandidates.firstOrNull() ?:
         otherCandidates.firstOrNull()
       )?.hostAddress
+  }
+
+  private fun activeNetworkIpv4Address(): Inet4Address? {
+    val connectivityManager = reactContext()
+      .getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager ?: return null
+    val activeNetwork = connectivityManager.activeNetwork ?: return null
+    val capabilities = connectivityManager.getNetworkCapabilities(activeNetwork) ?: return null
+    val isLanNetwork = capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) ||
+      capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)
+    if (!isLanNetwork) return null
+    val linkProperties = connectivityManager.getLinkProperties(activeNetwork) ?: return null
+    return linkProperties.linkAddresses
+      .map { it.address }
+      .filterIsInstance<Inet4Address>()
+      .firstOrNull { address ->
+        !address.isLoopbackAddress &&
+          !address.isLinkLocalAddress &&
+          isPrivateIpv4(address.hostAddress.orEmpty())
+      }
   }
 
   private fun receiverEndpoint(host: String, port: Int): ReceiverEndpoint {
@@ -188,6 +238,16 @@ class MentraPhotoReceiverModule : Module() {
     return host.startsWith("192.168.") ||
       host.startsWith("10.") ||
       host.matches(Regex("^172\\.(1[6-9]|2[0-9]|3[0-1])\\..*"))
+  }
+
+  private fun sameIpv4Slash24(first: String?, second: String?): Boolean {
+    if (first.isNullOrBlank() || second.isNullOrBlank()) return false
+    val firstParts = first.split(".")
+    val secondParts = second.split(".")
+    if (firstParts.size != 4 || secondParts.size != 4) return false
+    return firstParts[0] == secondParts[0] &&
+      firstParts[1] == secondParts[1] &&
+      firstParts[2] == secondParts[2]
   }
 
   private companion object {


### PR DESCRIPTION
## Summary

- Prefer the phone's active LAN IPv4 address, and when known, an address on the same `/24` as the glasses Wi-Fi IP, when the Android photo receiver publishes its upload URL.
- Keep public webhook behavior unchanged, but use a 1s connect timeout for local/private photo receiver URLs so unreachable direct phone uploads fall back to BLE quickly instead of waiting the full 5s connect timeout.

## Root Cause

Live logs showed the photo receiver and stream receiver were both advertising the phone LAN address `192.168.50.176`, while the glasses were on `192.168.50.43`. The photo path sent:

```text
MentraPhotoReceiver: Photo receiver ready at http://192.168.50.176:8787/upload
BLE_TRACE ... type=take_photo ... "webhookUrl":"http:\/\/192.168.50.176:8787\/upload"
```

The photo then fell back through BLE:

```text
photo_status ... "status":"ble_fallback_compression"
BlePhotoUploadService: Uploading BLE fallback photo to local receiver via loopback: http://127.0.0.1:8787/upload
photo_relay_upload_end ... "success":true,"outcome":"uploaded"
```

After app restart, stream failed with the same destination:

```text
MentraGStreamer: GStreamer WHIP receiver PLAYING
BLE_TRACE ... type=start_stream ... "streamUrl":"http:\/\/192.168.50.176:8190\/whip\/endpoint"
WHIP request failed: failed to connect to /192.168.50.176 (port 8190) from /192.168.50.43 ... after 10000ms
```

Direct reachability checks confirmed both devices were on `192.168.50.0/24`, but the glasses could not reach the phone:

```text
phone wlan0:   192.168.50.176/24
asg wlan0:     192.168.50.43/24
ping 192.168.50.176: 2 packets transmitted, 0 received
phone nc -l -p 9999 + glasses nc -w 3 192.168.50.176 9999: nc: Timeout
```

So the current field failure is not photo-specific. The LAN path is unreachable for both photo upload and WHIP streaming. This PR does not pretend to fix an isolated/AP-client-isolation network; it makes the photo path choose a better receiver address when multiple interfaces exist and avoid the avoidable 5s wait before BLE fallback for local receiver URLs that cannot be reached.

## Validation

- `git diff --check`
- `cd asg_client && ./gradlew :app:compileDebugJavaWithJavac`
- `cd mobile/modules/bluetooth-sdk && bun run build`
- `cd asg_client && ANDROID_SERIAL=0123456789ABCDEF ./gradlew :app:installDebug`
- Live device log capture from phone `RFCX71TH0CR` and glasses `0123456789ABCDEF`

`cd mobile && bun compile` was also run after dependency install, but it is currently blocked by unrelated existing TypeScript errors in `src/services/asg/gallerySyncService.test.ts` at the `resolveConnectivity?.()` calls.