### PR TITLE
Bump Bluetooth SDK to 0.1.10

### DIFF
--- a/docs-bluetooth-sdk/android.mdx
+++ b/docs-bluetooth-sdk/android.mdx
@@ -44,7 +44,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.7")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
 }
 ```
 

--- a/docs-bluetooth-sdk/ios.mdx
+++ b/docs-bluetooth-sdk/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.7` or newer, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.10` or newer, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.7"
+  from: "0.1.10"
 )
 ```
 

--- a/docs-bluetooth-sdk/quickstart.mdx
+++ b/docs-bluetooth-sdk/quickstart.mdx
@@ -94,7 +94,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.7")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
 }
 ```
 
@@ -111,14 +111,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.7` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Use version `0.1.10` or newer, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.7"
+  from: "0.1.10"
 )
 ```
 

--- a/docs-bluetooth-sdk/troubleshooting.mdx
+++ b/docs-bluetooth-sdk/troubleshooting.mdx
@@ -23,7 +23,7 @@ icon: "circle-question"
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.7` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.10` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -147,7 +147,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.8",
+      "version": "0.1.10",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -409,7 +409,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Add the `MentraBluetoothSDK` product to your app target at version `0.1.7` or newer.
+Add the `MentraBluetoothSDK` product to your app target at version `0.1.10` or newer.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_ANDROID_MAVEN.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_ANDROID_MAVEN.md
@@ -18,7 +18,7 @@ companion library expected in the public artifacts.
 
 The commands below assume the full MentraOS Android Gradle build layout, where
 the SDK module is included under `mobile/android` as `:mentra-bluetooth-sdk`.
-That is the layout used for the `0.1.7` Maven Central release.
+That is the layout used for Maven Central releases.
 
 ## Prerequisites
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -68,7 +68,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.8`
+Use the same version format as existing SwiftPM tags, for example `0.1.10`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.8",
+  "version": "0.1.10",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",


### PR DESCRIPTION
## Summary

- Bump `@mentra/bluetooth-sdk` package metadata and `mobile/bun.lock` from `0.1.8` to `0.1.10`.
- Update standalone Bluetooth SDK docs and module README install guidance to use `0.1.10` for Android Maven and iOS SwiftPM.
- Make release docs avoid stale old-version examples where possible.

## Validation

- `npm view @mentra/bluetooth-sdk@0.1.10 version`
- `curl -I https://repo.maven.apache.org/maven2/com/mentraglass/bluetooth-sdk/0.1.10/bluetooth-sdk-0.1.10.pom`
- `git ls-remote --tags https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git 0.1.10`
- `cd mobile && bun install --frozen-lockfile`
- `cd mobile/modules/bluetooth-sdk && bun run build`
- `cd mobile/modules/bluetooth-sdk && bun run build:plugin`
- `cd docs-bluetooth-sdk && bunx --bun mint export --output /tmp/mentra-bluetooth-sdk-docs-0.1.10-export.zip`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package metadata only; no runtime or API code changes.
> 
> **Overview**
> Bumps **Mentra Bluetooth SDK** consumer-facing version references from **0.1.7 / 0.1.8** to **0.1.10** across docs, the Expo module, and the lockfile.
> 
> **`@mentra/bluetooth-sdk`** is set to `0.1.10` in `mobile/modules/bluetooth-sdk/package.json`, with `mobile/bun.lock` updated to match. Standalone docs (`android.mdx`, `ios.mdx`, `quickstart.mdx`, `troubleshooting.mdx`) and the module README now point Android Gradle consumers at `com.mentraglass:bluetooth-sdk:0.1.10` and iOS consumers at SwiftPM **0.1.10** or newer.
> 
> Release maintainer docs drop pinned old-version examples (e.g. Maven layout tied to `0.1.7`, SwiftPM tag example `0.1.8` → `0.1.10`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed5717b2cccbab645704fa83df55c10fda5ce9ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->