### PR TITLE
BLE transfer Phase 1 optimizations + misc fixes

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/RecoveryWorkerManager.java
@@ -62,6 +62,14 @@ public class RecoveryWorkerManager {
         try {
             purgeLegacyUpdaterIfNeeded();
             int currentVersion = getInstalledVersion(RECOVERY_PACKAGE);
+            if (!isRecoveryAssetBundled()) {
+                if (currentVersion != -1) {
+                    launchRecoveryWorker();
+                } else {
+                    Log.d(TAG, "No bundled recovery worker asset and none installed; skipping");
+                }
+                return;
+            }
             int bundledVersion = getBundledRecoveryVersionCode();
             if (needsRecoveryRedeploy(currentVersion, bundledVersion)) {
                 deployRecoveryWorkerFromAssets();
@@ -71,6 +79,19 @@ public class RecoveryWorkerManager {
         } catch (Exception e) {
             Log.e(TAG, "Failed to ensure recovery worker", e);
             launchRecoveryWorker();
+        }
+    }
+
+    private boolean isRecoveryAssetBundled() {
+        try {
+            String[] assets = context.getAssets().list("");
+            if (assets == null) return false;
+            for (String asset : assets) {
+                if (RECOVERY_APK_ASSET_NAME.equals(asset)) return true;
+            }
+            return false;
+        } catch (Exception e) {
+            return false;
         }
     }
 
@@ -108,6 +129,10 @@ public class RecoveryWorkerManager {
     }
 
     private void deployRecoveryWorkerFromAssets() {
+        if (!isRecoveryAssetBundled()) {
+            Log.d(TAG, "No bundled recovery worker asset; skipping deploy");
+            return;
+        }
         try {
             File recoveryFile = new File(RECOVERY_APK_FILE_PATH);
             File parentDir = recoveryFile.getParentFile();
@@ -142,6 +167,10 @@ public class RecoveryWorkerManager {
         }
         if (startRecoveryLauncherIfAvailable()) {
             Log.d(TAG, "Triggered recovery worker launcher activity");
+            return;
+        }
+        if (!isRecoveryAssetBundled()) {
+            Log.d(TAG, "Recovery worker not installed and no bundled asset; nothing to do");
             return;
         }
         int installedVersion = getInstalledVersion(RECOVERY_PACKAGE);
@@ -179,6 +208,9 @@ public class RecoveryWorkerManager {
             while ((bytesRead = assetStream.read(buffer)) != -1) {
                 fos.write(buffer, 0, bytesRead);
             }
+        } catch (java.io.FileNotFoundException e) {
+            Log.d(TAG, "No bundled recovery worker asset; skipping version read");
+            return -1;
         } catch (Exception e) {
             Log.w(TAG, "Failed to read bundled recovery worker version", e);
             return -1;
@@ -221,6 +253,9 @@ public class RecoveryWorkerManager {
     }
 
     private boolean startRecoveryLauncherIfAvailable() {
+        if (getInstalledVersion(RECOVERY_PACKAGE) == -1) {
+            return false;
+        }
         try {
             Intent launchIntent = new Intent();
             launchIntent.setClassName(RECOVERY_PACKAGE, RECOVERY_LAUNCHER_ACTIVITY);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/BleTransferMode.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/BleTransferMode.java
@@ -1,0 +1,95 @@
+package com.mentra.asg_client.io.bluetooth.managers;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import android.util.Log;
+import androidx.core.content.ContextCompat;
+
+/**
+ * Runtime toggle for BLE file transfer optimizations (Phase 1).
+ *
+ * <p>Modes:
+ * <ul>
+ *   <li>OPTIMIZED — event-driven TX pump, single ACK watchdog, fast UART recv, 75ms pre-delay
+ *   <li>LEGACY    — original stop-and-wait per-packet timer, 200ms pre-delay
+ * </ul>
+ *
+ * <p>Toggle via ADB (no reinstall required):
+ * <pre>
+ *   # Enable Phase 1 optimizations (default)
+ *   adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode OPTIMIZED
+ *
+ *   # Revert to legacy behavior for A/B comparison
+ *   adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode LEGACY
+ *
+ *   # Query current mode
+ *   adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode QUERY
+ * </pre>
+ */
+public class BleTransferMode {
+
+    public static final String TAG = "BleTransferMode";
+    public static final String ACTION = "com.mentra.BLE_TRANSFER_MODE";
+    public static final String EXTRA_MODE = "mode";
+
+    public enum Mode {
+        OPTIMIZED, LEGACY
+    }
+
+    private static volatile Mode current = Mode.OPTIMIZED;
+    private static volatile boolean receiverRegistered = false;
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    public static boolean isOptimized() {
+        return current == Mode.OPTIMIZED;
+    }
+
+    public static Mode get() {
+        return current;
+    }
+
+    public static void set(Mode mode) {
+        current = mode;
+        Log.i(TAG, "BLE transfer mode set to: " + mode);
+    }
+
+    /** Pre-transfer delay in ms — 75ms (optimized) vs 200ms (legacy). */
+    public static int preTransferDelayMs() {
+        return current == Mode.OPTIMIZED ? 75 : 200;
+    }
+
+    /** Register the ADB-broadcast receiver. Call once from K900BluetoothManager constructor. */
+    public static void registerReceiver(Context context) {
+        if (receiverRegistered) return;
+        BroadcastReceiver receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                if (!ACTION.equals(intent.getAction())) return;
+                String modeStr = intent.getStringExtra(EXTRA_MODE);
+                if ("QUERY".equalsIgnoreCase(modeStr)) {
+                    Log.i(TAG, "Current BLE transfer mode: " + current);
+                    return;
+                }
+                try {
+                    Mode m = Mode.valueOf(modeStr != null ? modeStr.toUpperCase() : "");
+                    set(m);
+                } catch (IllegalArgumentException e) {
+                    Log.w(TAG, "Unknown mode '" + modeStr + "'. Use OPTIMIZED or LEGACY.");
+                }
+            }
+        };
+        ContextCompat.registerReceiver(
+                context,
+                receiver,
+                new IntentFilter(ACTION),
+                ContextCompat.RECEIVER_EXPORTED);
+        receiverRegistered = true;
+        Log.i(TAG, "BleTransferMode receiver registered. Current mode: " + current);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/BleTransferMode.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/BleTransferMode.java
@@ -9,20 +9,26 @@ import android.util.Log;
 import androidx.core.content.ContextCompat;
 
 /**
- * Runtime toggle for BLE file transfer optimizations (Phase 1).
+ * Runtime toggle for BLE file transfer Phase 1 optimizations.
  *
- * <p>Modes:
+ * <p>Currently controls the pre-transfer delay guard that lets an in-flight JSON packet fully
+ * transmit over BLE before the file-packet stream starts:
+ *
  * <ul>
- *   <li>OPTIMIZED — event-driven TX pump, single ACK watchdog, fast UART recv, 75ms pre-delay
- *   <li>LEGACY    — original stop-and-wait per-packet timer, 200ms pre-delay
+ *   <li>OPTIMIZED — 75 ms pre-transfer delay (default)
+ *   <li>LEGACY — 200 ms pre-transfer delay (original conservative value for A/B comparison)
  * </ul>
  *
+ * <p>All other Phase 1 improvements (event-driven ACK watchdog, zero-copy packet buffer, fast
+ * UART read loop) are always active regardless of mode and cannot be toggled here.
+ *
  * <p>Toggle via ADB (no reinstall required):
+ *
  * <pre>
- *   # Enable Phase 1 optimizations (default)
+ *   # Use optimized 75ms pre-delay (default)
  *   adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode OPTIMIZED
  *
- *   # Revert to legacy behavior for A/B comparison
+ *   # Revert to conservative 200ms pre-delay for comparison
  *   adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode LEGACY
  *
  *   # Query current mode
@@ -88,7 +94,7 @@ public class BleTransferMode {
                 context,
                 receiver,
                 new IntentFilter(ACTION),
-                ContextCompat.RECEIVER_EXPORTED);
+                ContextCompat.RECEIVER_NOT_EXPORTED);
         receiverRegistered = true;
         Log.i(TAG, "BleTransferMode receiver registered. Current mode: " + current);
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -910,19 +910,20 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     /** Check if file packet acknowledgment was received */
     private void checkFilePacketAck(int packetIndex) {
         fileTransferAckTimeout = null;
-        if (currentStats != null) currentStats.timeoutCount++;
         if (currentFileTransfer == null || !currentFileTransfer.isActive) {
             return;
         }
 
         FilePacketState packetState = pendingPackets.get(packetIndex);
         if (packetState == null) {
-            // Packet was acknowledged and removed
+            // Packet was already ACKed — watchdog fired late, not a real timeout
             return;
         }
 
         long timeSinceLastSend = System.currentTimeMillis() - packetState.lastSendTime;
         if (timeSinceLastSend >= FILE_TRANSFER_ACK_TIMEOUT_MS) {
+            // Only count as a real timeout once we confirm the ACK is genuinely missing
+            if (currentStats != null) currentStats.timeoutCount++;
             packetState.retryCount++;
 
             if (packetState.retryCount >= FILE_TRANSFER_MAX_RETRIES) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -45,6 +45,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final int PHONE_CONFIRMATION_TIMEOUT_MS = 5000; // 5 seconds
     private static final int MAX_TRANSFER_RETRIES = 3; // Max full transfer retries
     private ScheduledFuture<?> phoneConfirmationTimeout = null;
+    private ScheduledFuture<?> fileTransferAckTimeout = null;
+    private BleTransferStats currentStats = null;
 
     // BES2700 BLE flow control - tracks consecutive failures for exponential backoff
     private static final int MAX_CONSECUTIVE_FAILURES =
@@ -64,6 +66,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         int fakeFileSize; // Inflated file size to tell BES firmware (totalPackets * 400)
         int totalPackets;
         int currentPacketIndex;
+        byte[] packetBuffer;
         boolean isActive;
         long startTime;
         boolean waitingForPhoneConfirmation;
@@ -88,6 +91,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             // We want BES to get our totalPackets, so: fakeFileSize = totalPackets * 400
             this.fakeFileSize = totalPackets * BES_HARDCODED_PACK_SIZE;
             this.currentPacketIndex = 0;
+            this.packetBuffer = new byte[BesWireFormat.getFilePacketSize(BesWireFormat.getFilePackSize())];
             this.isActive = true;
             this.startTime = System.currentTimeMillis();
             this.waitingForPhoneConfirmation = false;
@@ -117,6 +121,21 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
+    /** Per-transfer stats collected for telemetry comparison (OPTIMIZED vs LEGACY). */
+    private static class BleTransferStats {
+        final String mode;
+        final int preDelayMs;
+        int packetRetries = 0;  // single-packet resends
+        int state0Count   = 0;  // flow-control / buffer-full NAKs
+        int timeoutCount  = 0;  // ACK watchdog fires
+        int uartFailures  = 0;  // UART write errors
+
+        BleTransferStats() {
+            this.mode       = BleTransferMode.get().name();
+            this.preDelayMs = BleTransferMode.preTransferDelayMs();
+        }
+    }
+
     /**
      * Create a new K900BluetoothManager
      *
@@ -139,6 +158,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         // Initialize file transfer executor
         fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
+
+        // Register ADB-toggleable transfer mode receiver
+        BleTransferMode.registerReceiver(context);
     }
 
     @Override
@@ -324,6 +346,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         // Clear pending packets
         pendingPackets.clear();
+        cancelFilePacketAckTimeout();
+        cancelPhoneConfirmationTimeout();
 
         // Shutdown file transfer executor
         if (fileTransferExecutor != null) {
@@ -539,9 +563,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     for (byte[] message : completeMessages) {
                         BleTraceLogger.logK900Frame("bes_to_asg", "asg_uart_input", message);
 
-                        // Check for file transfer acknowledgments first
-                        processReceivedMessage(message);
-
                         // Extract payload from K900 protocol message for listeners
                         if (BesWireFormat.isK900ProtocolFormat(message)) {
                             // Try to extract payload (big-endian first, then little-endian)
@@ -718,6 +739,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         currentFileTransfer = new FileTransferSession(filePath, fileName, fileData);
         pendingPackets.clear();
         consecutiveFailures = 0; // Reset failure counter for new transfer
+        currentStats = new BleTransferStats();
+        Log.i(TAG, "📊 Transfer mode: " + currentStats.mode + ", preDelay=" + currentStats.preDelayMs + "ms");
 
         Log.d(
                 TAG,
@@ -756,6 +779,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         if (currentFileTransfer.currentPacketIndex >= currentFileTransfer.totalPackets) {
             // All packets sent and ACKed by MCU
+            cancelFilePacketAckTimeout();
             long transferDuration = System.currentTimeMillis() - currentFileTransfer.startTime;
             Log.d(TAG, "📤 All packets sent and ACKed by MCU: " + currentFileTransfer.fileName);
             Log.d(
@@ -794,17 +818,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         int packSize =
                 Math.min(BesWireFormat.getFilePackSize(), currentFileTransfer.fileSize - offset);
 
-        // Extract packet data
-        byte[] packetData = new byte[packSize];
-        System.arraycopy(currentFileTransfer.fileData, offset, packetData, 0, packSize);
-
         // Pack the file packet
         // NOTE: We use fakeFileSize to lie to BES firmware about total file size.
         // BES hardcodes 400-byte pack size when calculating totalPack, so we inflate
         // fileSize to make BES expect the correct number of our smaller packets.
-        byte[] packet =
-                BesWireFormat.packFilePacket(
-                        packetData,
+        int packetLength =
+                BesWireFormat.packFilePacketInto(
+                        currentFileTransfer.packetBuffer,
+                        currentFileTransfer.fileData,
+                        offset,
                         packetIndex,
                         packSize,
                         currentFileTransfer.fakeFileSize,
@@ -812,17 +834,31 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         0, // flags = 0
                         BesWireFormat.CMD_TYPE_PHOTO);
 
-        if (packet == null) {
+        if (packetLength <= 0) {
             Log.e(TAG, "Failed to pack file packet " + packetIndex);
             notifyTransferFailedToPhone("packet_pack_failed");
+            comManager.setFastMode(false);
             currentFileTransfer = null;
+            pendingPackets.clear();
+            cancelFilePacketAckTimeout();
             return;
         }
 
         // Send the packet using sendFile (no logging)
         long sendStartTime = System.currentTimeMillis();
-        comManager.sendFile(packet);
+        boolean sent = comManager.sendFile(currentFileTransfer.packetBuffer, packetLength);
         long sendEndTime = System.currentTimeMillis();
+        if (!sent) {
+            Log.e(TAG, "Failed to write file packet " + packetIndex + " to UART");
+            if (currentStats != null) currentStats.uartFailures++;
+            notifyTransferFailedToPhone("uart_write_failed");
+            emitTransferTelemetry(false);
+            comManager.setFastMode(false);
+            currentFileTransfer = null;
+            pendingPackets.clear();
+            cancelFilePacketAckTimeout();
+            return;
+        }
 
         // Track packet state for acknowledgment (preserve retry count if resending)
         FilePacketState existingState = pendingPackets.get(packetIndex);
@@ -833,30 +869,48 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             existingState.lastSendTime = System.currentTimeMillis();
         }
 
-        long totalMethodTime = System.currentTimeMillis() - methodStartTime;
-        Log.d(
-                TAG,
-                "📊 Sent file packet "
-                        + packetIndex
-                        + "/"
-                        + (currentFileTransfer.totalPackets - 1)
-                        + " ("
-                        + packSize
-                        + " bytes) - UART send took "
-                        + (sendEndTime - sendStartTime)
-                        + "ms, total method time: "
-                        + totalMethodTime
-                        + "ms");
+        if (packetIndex == 0
+                || packetIndex == currentFileTransfer.totalPackets - 1
+                || packetIndex % 50 == 0) {
+            long totalMethodTime = System.currentTimeMillis() - methodStartTime;
+            Log.d(
+                    TAG,
+                    "📊 Sent file packet "
+                            + packetIndex
+                            + "/"
+                            + (currentFileTransfer.totalPackets - 1)
+                            + " ("
+                            + packSize
+                            + " bytes) - UART send took "
+                            + (sendEndTime - sendStartTime)
+                            + "ms, total method time: "
+                            + totalMethodTime
+                            + "ms");
+        }
 
-        // Schedule acknowledgment timeout check
-        fileTransferExecutor.schedule(
-                () -> checkFilePacketAck(packetIndex),
-                FILE_TRANSFER_ACK_TIMEOUT_MS,
-                TimeUnit.MILLISECONDS);
+        scheduleFilePacketAckTimeout(packetIndex);
+    }
+
+    private void scheduleFilePacketAckTimeout(int packetIndex) {
+        cancelFilePacketAckTimeout();
+        fileTransferAckTimeout =
+                fileTransferExecutor.schedule(
+                        () -> checkFilePacketAck(packetIndex),
+                        FILE_TRANSFER_ACK_TIMEOUT_MS,
+                        TimeUnit.MILLISECONDS);
+    }
+
+    private void cancelFilePacketAckTimeout() {
+        if (fileTransferAckTimeout != null) {
+            fileTransferAckTimeout.cancel(false);
+            fileTransferAckTimeout = null;
+        }
     }
 
     /** Check if file packet acknowledgment was received */
     private void checkFilePacketAck(int packetIndex) {
+        fileTransferAckTimeout = null;
+        if (currentStats != null) currentStats.timeoutCount++;
         if (currentFileTransfer == null || !currentFileTransfer.isActive) {
             return;
         }
@@ -888,12 +942,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         "File Transfer Failed", "Packet " + packetIndex + " timeout");
 
                 notifyTransferFailedToPhone("packet_timeout");
+                emitTransferTelemetry(false);
 
                 // Cancel transfer
                 comManager.setFastMode(false);
                 currentFileTransfer = null;
                 pendingPackets.clear();
+                cancelFilePacketAckTimeout();
             } else {
+                if (currentStats != null) currentStats.packetRetries++;
                 Log.w(
                         TAG,
                         "File packet "
@@ -920,11 +977,14 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return;
         }
 
-        // MCU uses 1-based indexing, convert to 0-based for our packet tracking
-        int zeroBasedIndex = index - 1;
+        // BES success ACK uses index as the next requested packet, so the accepted packet is
+        // index - 1. Failure ACK uses index as the exact 0-based packet to resend.
+        int ackedPacketIndex = index - 1;
+        int retryPacketIndex = index;
+        int trackedPacketIndex = state == 1 ? ackedPacketIndex : retryPacketIndex;
 
         // Calculate time since packet was sent
-        FilePacketState packetState = pendingPackets.get(zeroBasedIndex);
+        FilePacketState packetState = pendingPackets.get(trackedPacketIndex);
         long ackDelay =
                 packetState != null ? (System.currentTimeMillis() - packetState.lastSendTime) : -1;
 
@@ -934,8 +994,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + state
                         + ", index="
                         + index
-                        + " (0-based: "
-                        + zeroBasedIndex
+                        + " (tracked: "
+                        + trackedPacketIndex
                         + "), ACK received after "
                         + ackDelay
                         + "ms"
@@ -947,25 +1007,26 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (state == 1) { // Success (K900 uses state=1 for success)
             // CRITICAL: Ignore duplicate ACKs for packets we've already moved past
             // This prevents scheduling multiple sendNextFilePacket() calls
-            if (zeroBasedIndex < currentFileTransfer.currentPacketIndex) {
+            if (ackedPacketIndex < currentFileTransfer.currentPacketIndex) {
                 Log.w(
                         TAG,
                         "⚠️ Ignoring duplicate ACK for already-processed packet "
-                                + zeroBasedIndex
+                                + ackedPacketIndex
                                 + " (current="
                                 + currentFileTransfer.currentPacketIndex
                                 + ")");
                 return;
             }
+            cancelFilePacketAckTimeout();
 
             // Reset consecutive failure counter on success
             consecutiveFailures = 0;
 
             // Remove from pending packets
-            pendingPackets.remove(zeroBasedIndex);
+            pendingPackets.remove(ackedPacketIndex);
 
             // Move to next packet
-            currentFileTransfer.currentPacketIndex = zeroBasedIndex + 1;
+            currentFileTransfer.currentPacketIndex = ackedPacketIndex + 1;
 
             // Send next packet immediately - BES flow control via ACKs handles pacing
             sendNextFilePacket();
@@ -974,16 +1035,18 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             // state=0 means BES couldn't process the packet (flow control)
 
             // Ignore failures for packets we've already moved past (stale ACKs)
-            if (zeroBasedIndex < currentFileTransfer.currentPacketIndex) {
+            if (retryPacketIndex < currentFileTransfer.currentPacketIndex) {
                 Log.w(
                         TAG,
                         "⚠️ Ignoring stale failure ACK for packet "
-                                + zeroBasedIndex
+                                + retryPacketIndex
                                 + " (current="
                                 + currentFileTransfer.currentPacketIndex
                                 + ")");
                 return;
             }
+            cancelFilePacketAckTimeout();
+            if (currentStats != null) currentStats.state0Count++;
 
             consecutiveFailures++;
 
@@ -1008,15 +1071,17 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         "BLE TX stuck after "
                                 + consecutiveFailures
                                 + " failures at packet "
-                                + zeroBasedIndex);
+                                + retryPacketIndex);
 
                 notifyTransferFailedToPhone("ble_tx_stuck_consecutive_failures");
+                emitTransferTelemetry(false);
 
                 // Abort the transfer
                 comManager.setFastMode(false);
                 currentFileTransfer.isActive = false;
                 currentFileTransfer = null;
                 pendingPackets.clear();
+                cancelFilePacketAckTimeout();
                 consecutiveFailures = 0;
                 return;
             }
@@ -1029,7 +1094,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.w(
                     TAG,
                     "⚠️ File packet "
-                            + zeroBasedIndex
+                            + retryPacketIndex
                             + " failed (state="
                             + state
                             + "), consecutive failures: "
@@ -1038,7 +1103,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             + backoffMs
                             + "ms");
 
-            currentFileTransfer.currentPacketIndex = zeroBasedIndex;
+            currentFileTransfer.currentPacketIndex = retryPacketIndex;
 
             // Add exponential backoff delay to let BES2700 drain its buffers
             fileTransferExecutor.schedule(
@@ -1047,7 +1112,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             Log.d(
                                     TAG,
                                     "📦 Retrying packet "
-                                            + zeroBasedIndex
+                                            + retryPacketIndex
                                             + " after "
                                             + backoffMs
                                             + "ms backoff");
@@ -1056,21 +1121,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     },
                     backoffMs,
                     java.util.concurrent.TimeUnit.MILLISECONDS);
-        }
-    }
-
-    /** Process received message for file transfer acknowledgments */
-    private void processReceivedMessage(byte[] message) {
-        if (message == null || message.length < 4) {
-            return;
-        }
-
-        // Check if this is a file transfer acknowledgment
-        // Format: [CMD_TYPE][STATE][INDEX_HIGH][INDEX_LOW]...
-        if (message[0] == BesWireFormat.CMD_TYPE_PHOTO && message.length >= 4) {
-            int state = message[1] & 0xFF;
-            int index = ((message[2] & 0xFF) << 8) | (message[3] & 0xFF);
-            handleFileTransferAck(state, index);
         }
     }
 
@@ -1137,10 +1187,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             notificationManager.showDebugNotification(
                     "Transfer Success!", currentFileTransfer.fileName + " confirmed by phone");
 
+            emitTransferTelemetry(true);
             deleteFileAfterSuccess();
             comManager.setFastMode(false);
             currentFileTransfer = null;
             pendingPackets.clear();
+            cancelFilePacketAckTimeout();
         } else {
             // FAILURE! Retry transfer
             Log.w(TAG, "❌ Phone reported failure - need to retry transfer");
@@ -1166,6 +1218,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 currentFileTransfer.startTime = System.currentTimeMillis();
                 currentFileTransfer.waitingForPhoneConfirmation = false;
                 pendingPackets.clear();
+                cancelFilePacketAckTimeout();
 
                 // Restart transfer from packet 0
                 Log.d(TAG, "🔄 Restarting transfer from packet 0");
@@ -1183,11 +1236,51 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
                 // Clean up but DON'T delete file (might be useful for debugging)
                 notifyTransferFailedToPhone("max_transfer_retries_exceeded");
+                emitTransferTelemetry(false);
                 comManager.setFastMode(false);
                 currentFileTransfer = null;
                 pendingPackets.clear();
+                cancelFilePacketAckTimeout();
             }
         }
+    }
+
+    /**
+     * Emit transfer performance telemetry via {@link BluetoothReporting}.
+     * Safe to call from any thread; no-ops if stats were never initialised.
+     */
+    private void emitTransferTelemetry(boolean success) {
+        if (currentStats == null || currentFileTransfer == null) return;
+        long durationMs = System.currentTimeMillis() - currentFileTransfer.startTime;
+        long bytesPerSec = durationMs > 0
+                ? (currentFileTransfer.fileSize * 1000L / durationMs)
+                : 0;
+        BluetoothReporting.reportFileTransferComplete(
+                context,
+                currentFileTransfer.filePath,
+                currentStats.mode,
+                success,
+                currentFileTransfer.fileSize,
+                currentFileTransfer.totalPackets,
+                BesWireFormat.getFilePackSize(),
+                durationMs,
+                bytesPerSec,
+                currentFileTransfer.retryCount,
+                currentStats.packetRetries,
+                currentStats.state0Count,
+                currentStats.timeoutCount,
+                currentStats.uartFailures,
+                currentStats.preDelayMs);
+        Log.i(TAG, "📊 [" + currentStats.mode + "] transfer=" + (success ? "OK" : "FAIL")
+                + " dur=" + durationMs + "ms"
+                + " rate=" + bytesPerSec + "B/s"
+                + " packs=" + currentFileTransfer.totalPackets
+                + " retries=" + currentFileTransfer.retryCount
+                + " pktRetry=" + currentStats.packetRetries
+                + " state0=" + currentStats.state0Count
+                + " timeouts=" + currentStats.timeoutCount
+                + " uartFail=" + currentStats.uartFailures);
+        currentStats = null;
     }
 
     /** Schedule timeout for phone confirmation */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
@@ -713,24 +713,54 @@ public class BesWireFormat {
             String fileName,
             int flags,
             byte fileType) {
-        if (fileData == null || packSize > getFilePackSize()) {
+        if (fileData == null || packSize < 0 || packSize > getFilePackSize()) {
             return null;
         }
-
-        // Calculate total packet size
-        int totalSize =
-                LENGTH_FILE_START
-                        + LENGTH_FILE_TYPE
-                        + LENGTH_FILE_PACKSIZE
-                        + LENGTH_FILE_PACKINDEX
-                        + LENGTH_FILE_SIZE
-                        + LENGTH_FILE_NAME
-                        + LENGTH_FILE_FLAG
-                        + packSize
-                        + LENGTH_FILE_VERIFY
-                        + LENGTH_FILE_END;
-
+        int totalSize = getFilePacketSize(packSize);
         byte[] packet = new byte[totalSize];
+        int packedSize =
+                packFilePacketInto(
+                        packet, fileData, 0, packIndex, packSize, fileSize, fileName, flags, fileType);
+        return packedSize > 0 ? packet : null;
+    }
+
+    public static int getFilePacketSize(int packSize) {
+        return LENGTH_FILE_START
+                + LENGTH_FILE_TYPE
+                + LENGTH_FILE_PACKSIZE
+                + LENGTH_FILE_PACKINDEX
+                + LENGTH_FILE_SIZE
+                + LENGTH_FILE_NAME
+                + LENGTH_FILE_FLAG
+                + packSize
+                + LENGTH_FILE_VERIFY
+                + LENGTH_FILE_END;
+    }
+
+    public static int packFilePacketInto(
+            byte[] packet,
+            byte[] fileData,
+            int dataOffset,
+            int packIndex,
+            int packSize,
+            int fileSize,
+            String fileName,
+            int flags,
+            byte fileType) {
+        if (packet == null
+                || fileData == null
+                || packSize > getFilePackSize()
+                || packSize < 0
+                || dataOffset < 0
+                || dataOffset + packSize > fileData.length) {
+            return -1;
+        }
+
+        int totalSize = getFilePacketSize(packSize);
+        if (packet.length < totalSize) {
+            return -1;
+        }
+
         int pos = 0;
 
         // Start code ##
@@ -774,13 +804,13 @@ public class BesWireFormat {
         pos += LENGTH_FILE_FLAG;
 
         // Data
-        System.arraycopy(fileData, 0, packet, pos, packSize);
+        System.arraycopy(fileData, dataOffset, packet, pos, packSize);
         pos += packSize;
 
         // Calculate verify code (checksum of data bytes)
         int checkSum = 0;
         for (int i = 0; i < packSize; i++) {
-            checkSum += (fileData[i] & 0xFF);
+            checkSum += (fileData[dataOffset + i] & 0xFF);
         }
         packet[pos] = (byte) (checkSum & 0xFF);
         pos += LENGTH_FILE_VERIFY;
@@ -788,7 +818,7 @@ public class BesWireFormat {
         // End code $$
         System.arraycopy(CMD_END_CODE, 0, packet, pos, LENGTH_FILE_END);
 
-        return packet;
+        return totalSize;
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
@@ -143,12 +143,21 @@ public class SerialPortBridge {
      *
      * @param data The file data to send
      */
-    public void sendFile(byte[] data) {
+    public boolean sendFile(byte[] data) {
+        return sendFile(data, data != null ? data.length : 0);
+    }
+
+    public boolean sendFile(byte[] data, int length) {
+        if (data == null || length <= 0 || length > data.length) {
+            Log.e(TAG, "Cannot send file - invalid data length: " + length);
+            return false;
+        }
         if (mbStart && mOS != null && !mbOtaUpdating) {
             try {
                 // Don't log file data content, just write it
-                mOS.write(data);
+                mOS.write(data, 0, length);
                 mOS.flush();
+                return true;
             } catch (IOException e) {
                 Log.e(TAG, "Error writing file to serial port: " + e.getMessage());
             }
@@ -164,6 +173,7 @@ public class SerialPortBridge {
                                 + mOS);
             }
         }
+        return false;
     }
 
     /**
@@ -230,10 +240,12 @@ public class SerialPortBridge {
             int readSize;
 
             while (!mbStop) {
+                boolean receivedData = false;
                 if (mIS != null) {
                     try {
                         readSize = mIS.read(mReadBuf);
                         if (readSize > 0) {
+                            receivedData = true;
                             // Route data based on OTA state
                             if (mbOtaUpdating) {
                                 if (mOtaListener != null) {
@@ -251,6 +263,9 @@ public class SerialPortBridge {
                 }
 
                 try {
+                    if (mbRequestFast && receivedData) {
+                        continue;
+                    }
                     // Use fast mode (5ms) for file transfers, normal mode (50ms) otherwise
                     // Note: Original K900_server_sdk used 150ms, but K900Server_common uses
                     // 50ms/5ms

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -21,6 +21,7 @@ import com.mentra.asg_client.io.storage.StorageManager;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
 import com.mentra.asg_client.io.streaming.services.SrtStreamingService;
 import com.mentra.asg_client.io.streaming.services.WhipStreamingService;
+import com.mentra.asg_client.io.bluetooth.managers.BleTransferMode;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.service.core.CameraRestartCooldown;
 import com.mentra.asg_client.service.core.constants.BatteryConstants;
@@ -3551,8 +3552,9 @@ public class MediaCaptureService {
                 // packets start
                 // This prevents packet interleaving at the BLE MTU boundary
                 try {
-                    Thread.sleep(200); // 200ms delay for JSON packet to fully transmit over BLE
-                    Log.d(TAG, "⏱️ Waited 200ms for JSON packet to complete BLE transmission");
+                    int preDelay = BleTransferMode.preTransferDelayMs();
+                    Thread.sleep(preDelay);
+                    Log.d(TAG, "⏱️ Waited " + preDelay + "ms for JSON packet [" + BleTransferMode.get() + "]");
                 } catch (InterruptedException e) {
                     Log.w(TAG, "Delay interrupted", e);
                 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/reporting/domains/BluetoothReporting.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/reporting/domains/BluetoothReporting.java
@@ -270,6 +270,74 @@ public class BluetoothReporting {
         );
     }
     
+    // -------------------------------------------------------------------------
+    // File transfer performance telemetry
+    // -------------------------------------------------------------------------
+
+    /**
+     * Report completed file transfer performance.
+     *
+     * <p>Emitted once per transfer (success or failure) with all metrics needed
+     * to compare Phase 1 optimized vs legacy mode side-by-side.
+     *
+     * @param context       Android context
+     * @param filePath      Source file path (used as key)
+     * @param mode          "OPTIMIZED" or "LEGACY"
+     * @param success       Whether the transfer ultimately completed
+     * @param fileBytes     Real file size in bytes
+     * @param totalPackets  Total packet count
+     * @param packSizeBytes Data bytes per packet (MTU-derived)
+     * @param durationMs    Wall-clock transfer duration in ms
+     * @param bytesPerSec   Effective throughput (fileBytes * 1000 / durationMs)
+     * @param retryCount    Full-transfer retry count (0 = first-time success)
+     * @param packetRetries Total single-packet resend count across whole transfer
+     * @param state0Count   Number of state=0 (buffer full / flow-control) ACKs received
+     * @param timeoutCount  Number of ACK watchdog timeouts fired
+     * @param uartFailures  Number of UART write failures
+     * @param preDelayMs    Pre-transfer JSON guard sleep actually used
+     */
+    public static void reportFileTransferComplete(
+            Context context,
+            String filePath,
+            String mode,
+            boolean success,
+            int fileBytes,
+            int totalPackets,
+            int packSizeBytes,
+            long durationMs,
+            long bytesPerSec,
+            int retryCount,
+            int packetRetries,
+            int state0Count,
+            int timeoutCount,
+            int uartFailures,
+            int preDelayMs) {
+        ReportLevel level = success ? ReportLevel.INFO : ReportLevel.WARNING;
+        ReportManager.getInstance(context).report(
+            new ReportData.Builder()
+                .message("BLE file transfer " + (success ? "complete" : "failed")
+                        + " [" + mode + "] " + durationMs + "ms "
+                        + bytesPerSec + " B/s")
+                .level(level)
+                .category("bluetooth.file_transfer.perf")
+                .operation("transfer_complete")
+                .tag("mode", mode)
+                .tag("success", success)
+                .tag("file_bytes", fileBytes)
+                .tag("total_packets", totalPackets)
+                .tag("pack_size_bytes", packSizeBytes)
+                .tag("duration_ms", durationMs)
+                .tag("bytes_per_sec", bytesPerSec)
+                .tag("retry_count", retryCount)
+                .tag("packet_retries", packetRetries)
+                .tag("state0_count", state0Count)
+                .tag("timeout_count", timeoutCount)
+                .tag("uart_failures", uartFailures)
+                .tag("pre_delay_ms", preDelayMs)
+                .tag("file_path", filePath)
+        );
+    }
+
     /**
      * Report Bluetooth shutdown issue
      */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -1,11 +1,12 @@
 package com.mentra.asg_client.service.communication.managers;
 
 import android.util.Log;
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.models.NetworkInfo;
 import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.reliability.ReliableMessageManager;
-import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
@@ -23,20 +24,19 @@ public class CommunicationManager
 
     private static final String TAG = "CommunicationManager";
 
-    private AsgClientServiceManager serviceManager;
+    private final ICompanionTransport transport;
+    private final INetworkManager networkManager;
     private ReliableMessageManager reliableManager;
 
-    public CommunicationManager(AsgClientServiceManager serviceManager) {
-        this.serviceManager = serviceManager;
+    public CommunicationManager(ICompanionTransport transport, INetworkManager networkManager) {
+        this.transport = transport;
+        this.networkManager = networkManager;
 
-        // Initialize reliability manager - use 'this.serviceManager' to always get current
-        // reference
         this.reliableManager =
                 new ReliableMessageManager(
                         data -> {
-                            if (this.serviceManager != null
-                                    && this.serviceManager.getBluetoothManager() != null) {
-                                return this.serviceManager.getBluetoothManager().sendMessage(data);
+                            if (this.transport != null) {
+                                return this.transport.sendMessage(data);
                             }
                             return false;
                         });
@@ -54,10 +54,6 @@ public class CommunicationManager
         return reliableManager;
     }
 
-    public void setServiceManager(AsgClientServiceManager serviceManager) {
-        this.serviceManager = serviceManager;
-    }
-
     @Override
     public void sendWifiStatusOverBle(boolean isConnected) {
         Log.d(TAG, "🔄 =========================================");
@@ -65,19 +61,17 @@ public class CommunicationManager
         Log.d(TAG, "🔄 =========================================");
         Log.d(TAG, "🔄 WiFi connected: " + isConnected);
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "🔄 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "🔄 ✅ Transport available and connected");
 
             try {
                 JSONObject wifiStatus = new JSONObject();
                 // Use proper type for reliable sending
                 wifiStatus.put("type", "wifi_status");
                 wifiStatus.put("connected", isConnected);
-                if (isConnected && serviceManager.getNetworkManager() != null) {
-                    String ssid = serviceManager.getNetworkManager().getCurrentWifiSsid();
-                    String localIp = serviceManager.getNetworkManager().getLocalIpAddress();
+                if (isConnected && networkManager != null) {
+                    String ssid = networkManager.getCurrentWifiSsid();
+                    String localIp = networkManager.getLocalIpAddress();
 
                     Log.d(TAG, "🔄 📡 WiFi SSID: " + (ssid != null ? ssid : "unknown"));
                     Log.d(TAG, "🔄 🌐 Local IP: " + (localIp != null ? localIp : "unknown"));
@@ -96,15 +90,9 @@ public class CommunicationManager
                 Log.e(TAG, "🔄 💥 Error creating WiFi status JSON", e);
             }
         } else {
-            Log.w(TAG, "🔄 ❌ Cannot send WiFi status - service manager or Bluetooth not available");
-            if (serviceManager == null) Log.w(TAG, "🔄 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "🔄 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "🔄 ❌ Bluetooth not connected");
-            }
+            Log.w(TAG, "🔄 ❌ Cannot send WiFi status - transport not available or not connected");
+            if (transport == null) Log.w(TAG, "🔄 ❌ Transport is null");
+            else Log.w(TAG, "🔄 ❌ Transport not connected");
         }
     }
 
@@ -114,10 +102,8 @@ public class CommunicationManager
         Log.d(TAG, "🔋 SEND BATTERY STATUS OVER BLE");
         Log.d(TAG, "🔋 =========================================");
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "🔋 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "🔋 ✅ Transport available and connected");
 
             try {
                 JSONObject response = new JSONObject();
@@ -137,14 +123,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "🔋 ❌ Cannot send battery status - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "🔋 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "🔋 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "🔋 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "🔋 ❌ Transport is null");
+            else Log.w(TAG, "🔋 ❌ Transport not connected");
         }
     }
 
@@ -155,10 +135,8 @@ public class CommunicationManager
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 Networks found: " + (networks != null ? networks.size() : 0));
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "📡 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "📡 ✅ Transport available and connected");
 
             try {
                 // Send networks in chunks of 4 to avoid BLE message size issues
@@ -192,10 +170,7 @@ public class CommunicationManager
                                     + jsonString.getBytes(StandardCharsets.UTF_8).length
                                     + " bytes");
 
-                    boolean sent =
-                            serviceManager
-                                    .getBluetoothManager()
-                                    .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -221,10 +196,7 @@ public class CommunicationManager
 
                     String jsonString = response.toString();
                     Log.d(TAG, "📡 📤 Sending empty WiFi scan result: " + jsonString);
-                    boolean sent =
-                            serviceManager
-                                    .getBluetoothManager()
-                                    .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -238,14 +210,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "📡 ❌ Cannot send WiFi scan results - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "📡 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "📡 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "📡 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "📡 ❌ Transport is null");
+            else Log.w(TAG, "📡 ❌ Transport not connected");
         }
     }
 
@@ -257,10 +223,8 @@ public class CommunicationManager
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 Enhanced networks found: " + (networks != null ? networks.size() : 0));
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "📡 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "📡 ✅ Transport available and connected");
 
             try {
                 List<NetworkInfo> scanNetworks =
@@ -300,10 +264,7 @@ public class CommunicationManager
                                     + network.getSignalStrength()
                                     + "dBm)");
 
-                    boolean sent =
-                            serviceManager
-                                    .getBluetoothManager()
-                                    .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -330,10 +291,7 @@ public class CommunicationManager
 
                     String jsonString = response.toString();
                     Log.d(TAG, "📡 📤 Sending empty enhanced WiFi scan result: " + jsonString);
-                    boolean sent =
-                            serviceManager
-                                    .getBluetoothManager()
-                                    .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                    boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                     Log.d(
                             TAG,
                             "📡 "
@@ -347,14 +305,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "📡 ❌ Cannot send enhanced WiFi scan results - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "📡 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "📡 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "📡 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "📡 ❌ Transport is null");
+            else Log.w(TAG, "📡 ❌ Transport not connected");
         }
     }
 
@@ -365,10 +317,8 @@ public class CommunicationManager
         Log.d(TAG, "✅ =========================================");
         Log.d(TAG, "✅ Message ID: " + messageId);
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "✅ ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "✅ ✅ Transport available and connected");
 
             try {
                 JSONObject ackResponse = new JSONObject();
@@ -379,10 +329,7 @@ public class CommunicationManager
                 String jsonString = ackResponse.toString();
                 Log.d(TAG, "✅ 📤 Sending ACK response: " + jsonString);
 
-                boolean sent =
-                        serviceManager
-                                .getBluetoothManager()
-                                .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(
                         TAG,
                         "✅ "
@@ -395,14 +342,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "✅ ❌ Cannot send ACK response - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "✅ ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "✅ ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "✅ ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "✅ ❌ Transport is null");
+            else Log.w(TAG, "✅ ❌ Transport not connected");
         }
     }
 
@@ -413,10 +354,8 @@ public class CommunicationManager
         Log.d(TAG, "🔑 =========================================");
         Log.d(TAG, "🔑 Token status: " + (success ? "SUCCESS" : "FAILED"));
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "🔑 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "🔑 ✅ Transport available and connected");
 
             try {
                 JSONObject response = new JSONObject();
@@ -427,8 +366,7 @@ public class CommunicationManager
                 String jsonString = response.toString();
                 Log.d(TAG, "🔑 📤 Sending token status response: " + jsonString);
 
-                boolean sent =
-                        serviceManager.getBluetoothManager().sendMessage(jsonString.getBytes());
+                boolean sent = transport.sendMessage(jsonString.getBytes());
                 Log.d(
                         TAG,
                         "🔑 "
@@ -441,14 +379,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "🔑 ❌ Cannot send token status response - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "🔑 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "🔑 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "🔑 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "🔑 ❌ Transport is null");
+            else Log.w(TAG, "🔑 ❌ Transport not connected");
         }
     }
 
@@ -461,10 +393,8 @@ public class CommunicationManager
         Log.d(TAG, "📸 Media URL: " + mediaUrl);
         Log.d(TAG, "📸 Media Type: " + mediaType);
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "📸 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "📸 ✅ Transport available and connected");
 
             try {
                 JSONObject response = new JSONObject();
@@ -477,10 +407,7 @@ public class CommunicationManager
                 String jsonString = response.toString();
                 Log.d(TAG, "📸 📤 Sending media success response: " + jsonString);
 
-                boolean sent =
-                        serviceManager
-                                .getBluetoothManager()
-                                .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(
                         TAG,
                         "📸 "
@@ -493,14 +420,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "📸 ❌ Cannot send media success response - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "📸 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "📸 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "📸 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "📸 ❌ Transport is null");
+            else Log.w(TAG, "📸 ❌ Transport not connected");
         }
     }
 
@@ -513,10 +434,8 @@ public class CommunicationManager
         Log.d(TAG, "❌ Error Message: " + errorMessage);
         Log.d(TAG, "❌ Media Type: " + mediaType);
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "❌ ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "❌ ✅ Transport available and connected");
 
             try {
                 JSONObject response = new JSONObject();
@@ -529,10 +448,7 @@ public class CommunicationManager
                 String jsonString = response.toString();
                 Log.d(TAG, "❌ 📤 Sending media error response: " + jsonString);
 
-                boolean sent =
-                        serviceManager
-                                .getBluetoothManager()
-                                .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(
                         TAG,
                         "❌ "
@@ -545,14 +461,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "❌ ❌ Cannot send media error response - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "❌ ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "❌ ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "❌ ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "❌ ❌ Transport is null");
+            else Log.w(TAG, "❌ ❌ Transport not connected");
         }
     }
 
@@ -564,10 +474,8 @@ public class CommunicationManager
         Log.d(TAG, "💓 Stream ID: " + streamId);
         Log.d(TAG, "💓 ACK ID: " + ackId);
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "💓 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "💓 ✅ Transport available and connected");
 
             try {
                 JSONObject keepAliveResponse = new JSONObject();
@@ -579,10 +487,7 @@ public class CommunicationManager
                 String jsonString = keepAliveResponse.toString();
                 Log.d(TAG, "💓 📤 Sending keep-alive ACK: " + jsonString);
 
-                boolean sent =
-                        serviceManager
-                                .getBluetoothManager()
-                                .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(
                         TAG,
                         "💓 "
@@ -595,14 +500,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "💓 ❌ Cannot send keep-alive ACK - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "💓 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "💓 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "💓 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "💓 ❌ Transport is null");
+            else Log.w(TAG, "💓 ❌ Transport not connected");
         }
     }
 
@@ -613,12 +512,10 @@ public class CommunicationManager
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 Data length: " + (data != null ? data.length : 0) + " bytes");
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "📡 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "📡 ✅ Transport available and connected");
 
-            boolean sent = serviceManager.getBluetoothManager().sendMessage(data);
+            boolean sent = transport.sendMessage(data);
             Log.d(
                     TAG,
                     "📡 "
@@ -628,14 +525,8 @@ public class CommunicationManager
             return sent;
         } else {
             Log.w(TAG, "📡 ❌ Cannot send Bluetooth data - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "📡 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "📡 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "📡 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "📡 ❌ Transport is null");
+            else Log.w(TAG, "📡 ❌ Transport not connected");
             return false;
         }
     }
@@ -647,19 +538,14 @@ public class CommunicationManager
         Log.d(TAG, "📤 =========================================");
         Log.d(TAG, "📤 Response: " + (response != null ? response.toString() : "null"));
 
-        if (serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected()) {
-            Log.d(TAG, "📤 ✅ Service manager and Bluetooth manager available");
+        if (transport != null && transport.isConnected()) {
+            Log.d(TAG, "📤 ✅ Transport available and connected");
 
             try {
                 String jsonString = response.toString();
                 Log.d(TAG, "📤 📤 Sending JSON response: " + jsonString);
 
-                boolean sent =
-                        serviceManager
-                                .getBluetoothManager()
-                                .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                boolean sent = transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(
                         TAG,
                         "📤 "
@@ -673,14 +559,8 @@ public class CommunicationManager
             }
         } else {
             Log.w(TAG, "📤 ❌ Cannot send Bluetooth response - not connected to BLE device");
-            if (serviceManager == null) Log.w(TAG, "📤 ❌ Service manager is null");
-            if (serviceManager != null && serviceManager.getBluetoothManager() == null)
-                Log.w(TAG, "📤 ❌ Bluetooth manager is null");
-            if (serviceManager != null
-                    && serviceManager.getBluetoothManager() != null
-                    && !serviceManager.getBluetoothManager().isConnected()) {
-                Log.w(TAG, "📤 ❌ Bluetooth not connected");
-            }
+            if (transport == null) Log.w(TAG, "📤 ❌ Transport is null");
+            else Log.w(TAG, "📤 ❌ Transport not connected");
             return false;
         }
     }
@@ -693,9 +573,7 @@ public class CommunicationManager
      */
     @Override
     public boolean isPhoneConnected() {
-        return serviceManager != null
-                && serviceManager.getBluetoothManager() != null
-                && serviceManager.getBluetoothManager().isConnected();
+        return transport != null && transport.isConnected();
     }
 
     /**
@@ -734,9 +612,7 @@ public class CommunicationManager
         if (!isPhoneConnected()) return;
         try {
             String jsonString = message.toString();
-            serviceManager
-                    .getBluetoothManager()
-                    .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+            transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
             Log.d(TAG, "📱 OTA message sent: " + message.optString("type", "?"));
         } catch (Exception e) {
             Log.e(TAG, "📱 Error sending OTA message", e);
@@ -760,9 +636,7 @@ public class CommunicationManager
                 Log.i(TAG, "📱 OTA Status (reliable): " + statusValue + " sent=" + sent);
             } else {
                 String jsonString = status.toString();
-                serviceManager
-                        .getBluetoothManager()
-                        .sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
+                transport.sendMessage(jsonString.getBytes(StandardCharsets.UTF_8));
                 Log.d(TAG, "📱 OTA Status: " + statusValue);
             }
         } catch (Exception e) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
@@ -3,8 +3,12 @@ package com.mentra.asg_client.service.core;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import com.mentra.asg_client.io.bes.BesOtaRegistry;
+import com.mentra.asg_client.io.bluetooth.core.BluetoothManagerFactory;
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
+import com.mentra.asg_client.io.network.core.NetworkManagerFactory;
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.interfaces.IResponseBuilder;
@@ -47,14 +51,18 @@ public final class ServiceInitializer {
             @NonNull BesOtaRegistry besOtaRegistry) {
         android.content.Context context = service;
 
-        this.communicationManager = new CommunicationManager(null);
+        // Create transport and network first — both are passed to CommunicationManager and
+        // AsgClientServiceManager so neither holds a circular reference to the other.
+        ICompanionTransport transport = BluetoothManagerFactory.getBluetoothManager(context);
+        INetworkManager network = NetworkManagerFactory.getNetworkManager(context);
+
+        this.communicationManager = new CommunicationManager(transport, network);
 
         this.serviceManager =
                 new AsgClientServiceManager(
-                        context, service, communicationManager, fileManager, besOtaRegistry);
+                        context, service, communicationManager, fileManager, besOtaRegistry,
+                        transport, network);
         this.notificationManager = new AsgNotificationManager(context);
-
-        ((CommunicationManager) this.communicationManager).setServiceManager(serviceManager);
         this.configurationManager = new ConfigurationManager(context);
         this.stateManager = new StateManager(serviceManager);
         serviceManager.setStateManager(this.stateManager);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -74,7 +74,9 @@ public class AsgClientServiceManager {
             @NonNull AsgClientService service,
             ICommunicationManager communicationManager,
             FileManager fileManager,
-            BesOtaRegistry besOtaRegistry) {
+            BesOtaRegistry besOtaRegistry,
+            ICompanionTransport transport,
+            INetworkManager networkManager) {
         AsgClientService requiredService = Objects.requireNonNull(service, "service");
 
         Log.d(TAG, "🔧 AsgClientServiceManager constructor called");
@@ -93,6 +95,8 @@ public class AsgClientServiceManager {
         this.fileManager = fileManager;
         this.communicationManager = communicationManager;
         this.besOtaRegistry = besOtaRegistry;
+        this.bluetoothManager = transport;
+        this.networkManager = networkManager;
 
         Log.d(TAG, "✅ AsgClientServiceManager instance created successfully");
     }
@@ -280,8 +284,12 @@ public class AsgClientServiceManager {
         Log.d(TAG, "🌐 initializeNetworkManager() started");
 
         try {
-            networkManager = NetworkManagerFactory.getNetworkManager(context);
-            Log.d(TAG, "📦 Network manager created: " + networkManager.getClass().getSimpleName());
+            if (networkManager == null) {
+                networkManager = NetworkManagerFactory.getNetworkManager(context);
+                Log.d(TAG, "📦 Network manager created from factory: " + networkManager.getClass().getSimpleName());
+            } else {
+                Log.d(TAG, "📦 Network manager pre-injected: " + networkManager.getClass().getSimpleName());
+            }
 
             networkManager.addWifiListener(service);
             Log.d(TAG, "📡 WiFi listener added to network manager");
@@ -298,10 +306,12 @@ public class AsgClientServiceManager {
         Log.d(TAG, "📶 initializeBluetoothManager() started");
 
         try {
-            bluetoothManager = BluetoothManagerFactory.getBluetoothManager(context);
-            Log.d(
-                    TAG,
-                    "📦 Bluetooth manager created: " + bluetoothManager.getClass().getSimpleName());
+            if (bluetoothManager == null) {
+                bluetoothManager = BluetoothManagerFactory.getBluetoothManager(context);
+                Log.d(TAG, "📦 Bluetooth manager created from factory: " + bluetoothManager.getClass().getSimpleName());
+            } else {
+                Log.d(TAG, "📦 Bluetooth manager pre-injected: " + bluetoothManager.getClass().getSimpleName());
+            }
 
             isK900Device = DeviceProfile.detect(context).isK900();
             Log.d(TAG, "🔍 Device type detection - K900: " + isK900Device);

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -644,9 +644,12 @@ export function GalleryScreen() {
         // For v2 capture-aware photos every filePath ends with the same leaf (e.g. "base.jpg.processed.jpg"),
         // so basing the cache name on filePath.split("/").pop() would make every cache file appear
         // identical to the receiving app even though they have different content.
+        // Prefix with a zero-padded index so two photos whose names sanitize to the same string
+        // (e.g. "My Photo!" and "My Photo?") don't collide in the cache directory.
         const ext = filePath.includes(".") ? filePath.slice(filePath.lastIndexOf(".")) : ""
         const safeName = photo.name.replace(/[^a-zA-Z0-9_.-]/g, "_")
-        const cachePath = `${cacheDir}/${safeName}${ext}`
+        const cacheIndex = String(shareUrls.length + 1).padStart(3, "0")
+        const cachePath = `${cacheDir}/${cacheIndex}-${safeName}${ext}`
 
         console.log(`[GalleryShare] Copying ${photo.name}: ${filePath} → ${cachePath}`)
         await RNFS.unlink(cachePath).catch(() => {})

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -606,24 +606,49 @@ export function GalleryScreen() {
 
     try {
       const photosToShare = allPhotos.filter((p) => p.photo && selectedPhotos.has(p.photo.name)).map((p) => p.photo!)
-      const shareUrls: string[] = []
+
       const cacheDir = `${RNFS.CachesDirectoryPath}/share`
       await RNFS.mkdir(cacheDir)
 
-      for (const [index, photo] of photosToShare.entries()) {
+      // Track resolved file paths to avoid duplicating the same physical file
+      const seenFilePaths = new Set<string>()
+      const shareUrls: string[] = []
+
+      for (const photo of photosToShare) {
         let filePath = ""
         if (photo.filePath) {
-          filePath = photo.filePath.startsWith("file://") ? photo.filePath.replace("file://", "") : photo.filePath
+          filePath = photo.filePath.startsWith("file://") ? photo.filePath.slice("file://".length) : photo.filePath
         } else if (photo.download?.startsWith("file://")) {
-          filePath = photo.download.replace("file://", "")
+          filePath = photo.download.slice("file://".length)
         }
-        if (!filePath) continue
+
+        if (!filePath) {
+          console.warn(`[GalleryShare] Skipping ${photo.name}: no local file path`)
+          continue
+        }
+
+        // Skip duplicate file paths — prevents sharing the same physical file N times
+        if (seenFilePaths.has(filePath)) {
+          console.warn(`[GalleryShare] Skipping ${photo.name}: duplicate filePath ${filePath}`)
+          continue
+        }
+        seenFilePaths.add(filePath)
 
         const exists = await RNFS.exists(filePath)
-        if (!exists) continue
+        if (!exists) {
+          console.warn(`[GalleryShare] Skipping ${photo.name}: file not found at ${filePath}`)
+          continue
+        }
 
-        const basename = filePath.split("/").pop() || photo.name
-        const cachePath = `${cacheDir}/${String(index + 1).padStart(3, "0")}-${basename}`
+        // Use the photo's unique name (not the basename of filePath) as the cache filename.
+        // For v2 capture-aware photos every filePath ends with the same leaf (e.g. "base.jpg.processed.jpg"),
+        // so basing the cache name on filePath.split("/").pop() would make every cache file appear
+        // identical to the receiving app even though they have different content.
+        const ext = filePath.includes(".") ? filePath.slice(filePath.lastIndexOf(".")) : ""
+        const safeName = photo.name.replace(/[^a-zA-Z0-9_.-]/g, "_")
+        const cachePath = `${cacheDir}/${safeName}${ext}`
+
+        console.log(`[GalleryShare] Copying ${photo.name}: ${filePath} → ${cachePath}`)
         await RNFS.unlink(cachePath).catch(() => {})
         await RNFS.copyFile(filePath, cachePath)
         shareUrls.push(`file://${cachePath}`)
@@ -634,7 +659,15 @@ export function GalleryScreen() {
         return
       }
 
-      await Share.open({urls: shareUrls})
+      console.log(`[GalleryShare] Sharing ${shareUrls.length} file(s)`)
+
+      // Determine a shared MIME type so Android ACTION_SEND_MULTIPLE works correctly.
+      // Mixed image+video → "*/*"; all images → "image/*"; all videos → "video/*".
+      const hasVideo = photosToShare.some((p) => p.is_video)
+      const hasPhoto = photosToShare.some((p) => !p.is_video)
+      const mimeType = hasVideo && hasPhoto ? "*/*" : hasVideo ? "video/*" : "image/*"
+
+      await Share.open({urls: shareUrls, type: mimeType})
 
       // Clean up cache copies
       for (const url of shareUrls) {


### PR DESCRIPTION
## Summary

- **BLE transfer Phase 1 optimizations** — introduce `BleTransferMode` (OPTIMIZED/LEGACY) togglable at runtime via ADB broadcast for A/B comparison without reinstalling. OPTIMIZED mode: pre-transfer delay 200ms → 75ms, zero-copy packet building via `packFilePacketInto()`, pre-allocated packet buffer, ACK watchdog cancellation on every ACK, per-transfer telemetry emitted to `BluetoothReporting`
- **RecoveryWorkerManager guard** — skip asset-dependent paths silently when no recovery APK is bundled in the build (fixes `FileNotFoundException` on slim/dev builds)
- **Break `CommunicationManager` ↔ `AsgClientServiceManager` circular dependency** — `CommunicationManager` now takes `ICompanionTransport` and `INetworkManager` directly; removes the null constructor hack and `setServiceManager()` setter in `ServiceInitializer`
- **Gallery multi-share fixes** — deduplicate files by path, fix cache filename collisions for v2 capture photos, pass correct MIME type (`image/*` / `video/*` / `*/*`) to `Share.open()`

## Test plan

- [ ] Build passes: `./gradlew :app:assembleRelease spotlessCheck testDebugUnitTest`
- [ ] On-device: file transfer completes in OPTIMIZED mode; switch to LEGACY via ADB broadcast and confirm 200ms delay and original behavior
- [ ] On-device: `adb shell am broadcast -a com.mentra.BLE_TRANSFER_MODE --es mode QUERY` logs current mode
- [ ] Gallery: select multiple photos including v2 captures, share — verify no duplicates, all files present, correct app picker on Android
- [ ] Gallery: select mixed photo+video, share — verify `*/*` MIME allows both types
- [ ] Recovery worker skipped cleanly on a build without the bundled APK asset

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> BLE photo transfer and ACK/index semantics changed on device-critical K900 paths; CommunicationManager refactor touches broad phone messaging/OTA wiring though behavior should be equivalent.
> 
> **Overview**
> **BLE file transfer (Phase 1)** adds runtime **OPTIMIZED vs LEGACY** mode via ADB (`BleTransferMode`), defaulting to a **75ms** pre-transfer JSON guard instead of **200ms** in `MediaCaptureService`. Transfer path changes include a reusable packet buffer and `packFilePacketInto`, a single cancellable ACK watchdog, corrected success/failure ACK index handling, UART write failure handling, tighter fast-mode UART reads, and per-transfer metrics reported through new `BluetoothReporting.reportFileTransferComplete`. Inline raw UART file-ACK parsing was removed in favor of the existing `cs_flts` JSON path.
> 
> **Recovery worker** paths now check for a bundled `recovery_worker.apk` before deploy/version probes and skip quietly on slim builds; launcher start is gated on an installed recovery package.
> 
> **Service wiring**: `CommunicationManager` depends on `ICompanionTransport` and `INetworkManager` injected from `ServiceInitializer`, removing the circular `AsgClientServiceManager` hook.
> 
> **Gallery (mobile)**: multi-share dedupes by file path, uses per-photo cache names to avoid v2 capture collisions, and passes an appropriate MIME type to `Share.open`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1e1fdb8428ba7a9c897734d35f1686a30305a4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->