### PR TITLE
fix: fix ios flashing iisues

### DIFF
--- a/mobile/scripts/ios-release.mjs
+++ b/mobile/scripts/ios-release.mjs
@@ -14,11 +14,11 @@ await $({stdio: "inherit"})`cp .env ios/.xcode.env.local`
 await $({stdio: "inherit", cwd: "ios"})`pod install`
 
 function isConnectedIphone(device) {
-  return (
-    (device.capabilities?.some((c) => c.name === "iPhone") ||
-      device.deviceProperties?.marketingName?.includes("iPhone")) &&
-    device.connectionProperties?.tunnelState === "connected"
-  )
+  const isIphone =
+    device.hardwareProperties?.deviceType === "iPhone" ||
+    device.capabilities?.some((c) => c.name === "iPhone") ||
+    device.deviceProperties?.marketingName?.includes("iPhone")
+  return isIphone && device.connectionProperties?.tunnelState === "connected"
 }
 
 async function listDevicesViaDevicectl() {

--- a/mobile/scripts/ios.mjs
+++ b/mobile/scripts/ios.mjs
@@ -14,15 +14,14 @@ await $`xcrun devicectl list devices --json-output ${tmpFile} --timeout 5`
 const json = JSON.parse(await fs.readFile(tmpFile, "utf-8"))
 await fs.remove(tmpFile)
 
-const device =
-  json.result?.devices?.find(
-    (d) => d.capabilities?.some((c) => c.name === "iPhone") || d.deviceProperties?.marketingName?.includes("iPhone"),
-  ) &&
-  json.result.devices.find(
-    (d) =>
-      (d.capabilities?.some((c) => c.name === "iPhone") || d.deviceProperties?.marketingName?.includes("iPhone")) &&
-      d.connectionProperties?.tunnelState === "connected",
-  )
+const isIphone = (d) =>
+  d.hardwareProperties?.deviceType === "iPhone" ||
+  d.capabilities?.some((c) => c.name === "iPhone") ||
+  d.deviceProperties?.marketingName?.includes("iPhone")
+
+const device = json.result?.devices?.find(
+  (d) => isIphone(d) && d.connectionProperties?.tunnelState === "connected",
+)
 
 if (!device) {
   // Fallback: find any available paired iPhone


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Local build-script-only changes; no app runtime, auth, or backend impact.
> 
> **Overview**
> Fixes **physical iPhone selection** for `bun` iOS dev and release scripts by aligning how `devicectl` JSON is interpreted.
> 
> Both `ios.mjs` and `ios-release.mjs` now treat a device as an iPhone when `hardwareProperties.deviceType === "iPhone"` (in addition to capability name and marketing name), and require `connectionProperties.tunnelState === "connected"` for the primary pick. **`ios.mjs`** replaces a broken two-step `.find()` (which could miss the right connected phone) with a single `isIphone` helper and one connected-device lookup; the existing paired-iPhone fallback is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a5eeb4f4eb3ad1d8e116df8ce5ab62aca37610e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->