### PR TITLE
Embed Mentra Live Bluetooth SDK docs

### DIFF
--- a/docs/app-devs/getting-started/ai-ide-integration.mdx
+++ b/docs/app-devs/getting-started/ai-ide-integration.mdx
@@ -37,8 +37,8 @@ Add this to your `settings.json` (open with `Cmd+,` or `zed: open settings`):
 {
   "context_servers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"],
       "env": {}
     }
   }
@@ -61,8 +61,8 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -114,8 +114,8 @@ Add to your VS Code `settings.json`:
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -149,7 +149,7 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
 
 ```bash
-bunx mcp-remote https://docs.mentraglass.com/mcp
+npx -y mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 Or if your tool supports HTTP MCP servers directly, use the URL:
@@ -177,19 +177,19 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Bun installed. The `mcp-remote` package runs through `bunx`.
-
+    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
+    
     ```bash
-    bun --version
+    node --version  # Should be v18.0.0 or higher
     ```
   </Accordion>
-
-  <Accordion title="bunx command not found">
-    Install Bun from [bun.sh](https://bun.sh/).
+  
+  <Accordion title="npx command not found">
+    Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
   </Accordion>
-
+  
   <Accordion title="Permission errors">
-    Try running the `bunx` command from a terminal where Bun is on your `PATH`.
+    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/app-devs/getting-started/ai-ide-integration.mdx
+++ b/docs/app-devs/getting-started/ai-ide-integration.mdx
@@ -37,8 +37,8 @@ Add this to your `settings.json` (open with `Cmd+,` or `zed: open settings`):
 {
   "context_servers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"],
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"],
       "env": {}
     }
   }
@@ -61,8 +61,8 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -114,8 +114,8 @@ Add to your VS Code `settings.json`:
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -149,7 +149,7 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
 
 ```bash
-npx -y mcp-remote https://docs.mentraglass.com/mcp
+bunx mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 Or if your tool supports HTTP MCP servers directly, use the URL:
@@ -177,19 +177,19 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
-    
+    Make sure you have Bun installed. The `mcp-remote` package runs through `bunx`.
+
     ```bash
-    node --version  # Should be v18.0.0 or higher
+    bun --version
     ```
   </Accordion>
-  
-  <Accordion title="npx command not found">
-    Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
+
+  <Accordion title="bunx command not found">
+    Install Bun from [bun.sh](https://bun.sh/).
   </Accordion>
-  
+
   <Accordion title="Permission errors">
-    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
+    Try running the `bunx` command from a terminal where Bun is on your `PATH`.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/app-devs/getting-started/ai-ide-integration.mdx
+++ b/docs/app-devs/getting-started/ai-ide-integration.mdx
@@ -61,14 +61,13 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "url": "https://docs.mentraglass.com/mcp"
     }
   }
 }
 ```
 
-Then **restart Cursor**.
+Then **restart Cursor** and approve the MCP server if prompted.
 
 <Accordion title="Alternative: Project-level config">
 You can also create `.cursor/mcp.json` in your project root to enable MentraOS docs only for that project.
@@ -87,11 +86,11 @@ VS Code 1.99+ has built-in MCP support with GitHub Copilot.
 5. Name it `mentraos-docs`
 
 <Accordion title="Manual configuration">
-Add to your VS Code `settings.json`:
+Create `.vscode/mcp.json` in your project and add:
 
 ```json
 {
-  "mcp.servers": {
+  "servers": {
     "mentraos-docs": {
       "type": "http",
       "url": "https://docs.mentraglass.com/mcp"
@@ -135,7 +134,7 @@ Add to your VS Code `settings.json`:
 Run this in your terminal:
 
 ```bash
-claude mcp add mentraos-docs --transport http https://docs.mentraglass.com/mcp
+claude mcp add --transport http mentraos-docs https://docs.mentraglass.com/mcp
 ```
 
 <Accordion title="Verify it worked">
@@ -146,16 +145,16 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 
 ### Other MCP-Compatible Tools
 
-For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
-
-```bash
-npx -y mcp-remote https://docs.mentraglass.com/mcp
-```
-
-Or if your tool supports HTTP MCP servers directly, use the URL:
+For tools that support remote HTTP MCP servers, use this URL directly:
 
 ```
 https://docs.mentraglass.com/mcp
+```
+
+If your tool only supports command-based local MCP servers, use `mcp-remote`:
+
+```bash
+npx -y mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 ---
@@ -177,7 +176,7 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
+    If your setup uses `mcp-remote`, make sure you have Node.js 18+ installed.
     
     ```bash
     node --version  # Should be v18.0.0 or higher

--- a/docs/app-devs/getting-started/overview.mdx
+++ b/docs/app-devs/getting-started/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Overview"
-description: "Build production-ready display smart glasses apps in minutes. Works with Even Realities, NIMO and Vuzix Z100 display smart glasses. If you're building for Mentra Live, read the [Bluetooth SDK docs](/app-devs/core-concepts/camera)."
+description: "Build production-ready display smart glasses apps in minutes. Works with Even Realities, NIMO and Vuzix Z100 display smart glasses. If you're building for Mentra Live, read the [Bluetooth SDK docs](/mentra-live)."
 icon: glasses
 ---
 
@@ -12,7 +12,7 @@ Users install the Mentra app on their phone, connect their glasses, and run apps
 
 Developers build apps that users can install (from a web link or the Mentra Store).
 
-If you're building for Mentra Live, read the [Bluetooth SDK docs](/app-devs/core-concepts/camera).
+If you're building for Mentra Live, read the [Bluetooth SDK docs](/mentra-live).
 
 Third party apps run in the cloud and have a low-latency connection to all the smart glasses hardware. Developers can call functions in their web application to take a picture, listen to microphone data, or display information on users' smart glasses.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,7 +144,7 @@
             "icon": "bluetooth",
             "pages": [
               "mentra-live/index",
-              "app-devs/getting-started/ai-ide-integration",
+              "mentra-live/ai-ide-integration",
               "mentra-live/quickstart",
               "mentra-live/examples"
             ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -138,7 +138,39 @@
       },
       {
         "tab": "Mentra Live",
-        "pages": ["app-devs/core-concepts/camera/README"]
+        "groups": [
+          {
+            "group": "Getting Started",
+            "icon": "bluetooth",
+            "pages": [
+              "mentra-live/index",
+              "app-devs/getting-started/ai-ide-integration",
+              "mentra-live/quickstart",
+              "mentra-live/examples"
+            ]
+          },
+          {
+            "group": "Platform Setup",
+            "icon": "mobile",
+            "pages": ["mentra-live/react-native-expo", "mentra-live/android", "mentra-live/ios"]
+          },
+          {
+            "group": "Core APIs",
+            "icon": "glasses",
+            "pages": [
+              "mentra-live/api-reference",
+              "mentra-live/display",
+              "mentra-live/audio",
+              "mentra-live/camera-streaming",
+              "mentra-live/hardware"
+            ]
+          },
+          {
+            "group": "Release",
+            "icon": "clipboard-check",
+            "pages": ["mentra-live/troubleshooting", "mentra-live/production-checklist"]
+          }
+        ]
       },
       {
         "tab": "OS Devs",

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -27,7 +27,7 @@ mode: "custom"
     <Card
       title="Build a Mentra Live App"
       icon="camera"
-      href="/app-devs/core-concepts/camera"
+      href="/mentra-live"
     >
       Use the Mentra Bluetooth SDK to build apps for camera glasses like Mentra Live.
     </Card>

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -1,0 +1,207 @@
+---
+title: "AI IDE Integration"
+description: "Connect your AI coding assistant to MentraOS docs for smarter development"
+icon: "robot"
+---
+
+<Info>
+**TL;DR** - Get your AI coding assistant to understand MentraOS instantly. Works with Zed, Cursor, VS Code, Windsurf, Claude Code, and more.
+</Info>
+
+## Why Connect Your AI IDE?
+
+When you connect your AI coding assistant to MentraOS docs, it can:
+
+- Answer questions about the MentraOS SDK
+- Help you write smart glasses apps faster
+- Look up API references automatically
+- Debug your code with context about how MentraOS works
+
+## MCP Server URL
+
+All setups below use this URL:
+
+```
+https://docs.mentraglass.com/mcp
+```
+
+---
+
+## Setup by IDE
+
+### Zed
+
+Add this to your `settings.json` (open with `Cmd+,` or `zed: open settings`):
+
+```json
+{
+  "context_servers": {
+    "mentraos-docs": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Restart Zed and you're done.
+
+<Accordion title="How to verify it's working">
+Open the Agent Panel and check the MCP servers indicator in settings. A green dot means the server is active. You can also type `/` in a chat to see available prompts from the server.
+</Accordion>
+
+---
+
+### Cursor
+
+Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it doesn't exist):
+
+```json
+{
+  "mcpServers": {
+    "mentraos-docs": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+    }
+  }
+}
+```
+
+Then **restart Cursor**.
+
+<Accordion title="Alternative: Project-level config">
+You can also create `.cursor/mcp.json` in your project root to enable MentraOS docs only for that project.
+</Accordion>
+
+---
+
+### VS Code (with GitHub Copilot)
+
+VS Code 1.99+ has built-in MCP support with GitHub Copilot.
+
+1. Open Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+2. Run **"MCP: Add Server"**
+3. Select **"HTTP"** as the transport type
+4. Enter URL: `https://docs.mentraglass.com/mcp`
+5. Name it `mentraos-docs`
+
+<Accordion title="Manual configuration">
+Add to your VS Code `settings.json`:
+
+```json
+{
+  "mcp.servers": {
+    "mentraos-docs": {
+      "type": "http",
+      "url": "https://docs.mentraglass.com/mcp"
+    }
+  }
+}
+```
+</Accordion>
+
+---
+
+### Windsurf
+
+1. Open Windsurf Settings (`Cmd+,` / `Ctrl+,`)
+2. Search for "MCP" and click to open the Manage Plugins panel
+3. Click **"View raw config"** to open `mcp_config.json`
+4. Add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "mentraos-docs": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+    }
+  }
+}
+```
+
+5. Click **Refresh** in the Manage Plugins panel
+
+<Accordion title="Config file location">
+- **macOS**: `~/.codeium/windsurf/mcp_config.json`
+- **Windows**: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
+</Accordion>
+
+---
+
+### Claude Code (CLI)
+
+Run this in your terminal:
+
+```bash
+claude mcp add mentraos-docs --transport http https://docs.mentraglass.com/mcp
+```
+
+<Accordion title="Verify it worked">
+Run `claude mcp list` to see your connected servers. You should see `mentraos-docs` in the list.
+</Accordion>
+
+---
+
+### Other MCP-Compatible Tools
+
+For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
+
+```bash
+npx -y mcp-remote https://docs.mentraglass.com/mcp
+```
+
+Or if your tool supports HTTP MCP servers directly, use the URL:
+
+```
+https://docs.mentraglass.com/mcp
+```
+
+---
+
+## Test It Out
+
+After setup, try asking your AI assistant:
+
+- *"How do I display text on smart glasses with MentraOS?"*
+- *"Show me how to use the camera API"*
+- *"What events can I listen to in an AppSession?"*
+- *"How do I listen for metric system setting changes?"*
+
+Your AI should now give you accurate, up-to-date answers using our docs.
+
+---
+
+## Troubleshooting
+
+<AccordionGroup>
+  <Accordion title="Server not connecting">
+    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
+    
+    ```bash
+    node --version  # Should be v18.0.0 or higher
+    ```
+  </Accordion>
+  
+  <Accordion title="npx command not found">
+    Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
+  </Accordion>
+  
+  <Accordion title="Permission errors">
+    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## What's Next?
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/app-devs/getting-started/quickstart">
+    Build your first smart glasses app in 15 minutes
+  </Card>
+  <Card title="Example Apps" icon="code" href="/app-devs/getting-started/example-apps">
+    Clone a working example and start hacking
+  </Card>
+</CardGroup>

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -37,8 +37,8 @@ Add this to your `settings.json` (open with `Cmd+,` or `zed: open settings`):
 {
   "context_servers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"],
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"],
       "env": {}
     }
   }
@@ -61,8 +61,8 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -114,8 +114,8 @@ Add to your VS Code `settings.json`:
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "bunx",
-      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "npx",
+      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -149,7 +149,7 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
 
 ```bash
-bunx mcp-remote https://docs.mentraglass.com/mcp
+npx -y mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 Or if your tool supports HTTP MCP servers directly, use the URL:
@@ -177,19 +177,19 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Bun installed. The `mcp-remote` package runs through `bunx`.
+    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
 
     ```bash
-    bun --version
+    node --version  # Should be v18.0.0 or higher
     ```
   </Accordion>
 
-  <Accordion title="bunx command not found">
-    Install Bun from [bun.sh](https://bun.sh/).
+  <Accordion title="npx command not found">
+    Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
   </Accordion>
 
   <Accordion title="Permission errors">
-    Try running the `bunx` command from a terminal where Bun is on your `PATH`.
+    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -189,7 +189,7 @@ Your AI should now give you accurate, up-to-date answers using our docs.
   </Accordion>
 
   <Accordion title="Permission errors">
-    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
+    Fix your Node.js package permissions with a version manager or npm prefix configuration instead of running downloaded packages with `sudo`.
   </Accordion>
 </AccordionGroup>
 
@@ -198,10 +198,10 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 ## What's Next?
 
 <CardGroup cols={2}>
-  <Card title="Quickstart" icon="rocket" href="/app-devs/getting-started/quickstart">
-    Build your first smart glasses app in 15 minutes
+  <Card title="Quickstart" icon="rocket" href="/mentra-live/quickstart">
+    Connect to Mentra Live and read glasses status
   </Card>
-  <Card title="Example Apps" icon="code" href="/app-devs/getting-started/example-apps">
-    Clone a working example and start hacking
+  <Card title="Example Apps" icon="code" href="/mentra-live/examples">
+    Run the Android, iOS, and React Native starter apps
   </Card>
 </CardGroup>

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -178,16 +178,16 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 <AccordionGroup>
   <Accordion title="Server not connecting">
     Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
-    
+
     ```bash
     node --version  # Should be v18.0.0 or higher
     ```
   </Accordion>
-  
+
   <Accordion title="npx command not found">
     Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
   </Accordion>
-  
+
   <Accordion title="Permission errors">
     Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
   </Accordion>

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -37,8 +37,8 @@ Add this to your `settings.json` (open with `Cmd+,` or `zed: open settings`):
 {
   "context_servers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"],
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"],
       "env": {}
     }
   }
@@ -61,8 +61,8 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -114,8 +114,8 @@ Add to your VS Code `settings.json`:
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "command": "bunx",
+      "args": ["mcp-remote", "https://docs.mentraglass.com/mcp"]
     }
   }
 }
@@ -149,7 +149,7 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
 
 ```bash
-npx -y mcp-remote https://docs.mentraglass.com/mcp
+bunx mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 Or if your tool supports HTTP MCP servers directly, use the URL:
@@ -177,19 +177,19 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
+    Make sure you have Bun installed. The `mcp-remote` package runs through `bunx`.
 
     ```bash
-    node --version  # Should be v18.0.0 or higher
+    bun --version
     ```
   </Accordion>
 
-  <Accordion title="npx command not found">
-    Install Node.js from [nodejs.org](https://nodejs.org/) which includes npm and npx.
+  <Accordion title="bunx command not found">
+    Install Bun from [bun.sh](https://bun.sh/).
   </Accordion>
 
   <Accordion title="Permission errors">
-    Try running the npx command with `sudo` on macOS/Linux, or run your terminal as Administrator on Windows.
+    Try running the `bunx` command from a terminal where Bun is on your `PATH`.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/mentra-live/ai-ide-integration.mdx
+++ b/docs/mentra-live/ai-ide-integration.mdx
@@ -61,14 +61,13 @@ Add this to your Cursor MCP config file at `~/.cursor/mcp.json` (create it if it
 {
   "mcpServers": {
     "mentraos-docs": {
-      "command": "npx",
-      "args": ["-y", "mcp-remote", "https://docs.mentraglass.com/mcp"]
+      "url": "https://docs.mentraglass.com/mcp"
     }
   }
 }
 ```
 
-Then **restart Cursor**.
+Then **restart Cursor** and approve the MCP server if prompted.
 
 <Accordion title="Alternative: Project-level config">
 You can also create `.cursor/mcp.json` in your project root to enable MentraOS docs only for that project.
@@ -87,11 +86,11 @@ VS Code 1.99+ has built-in MCP support with GitHub Copilot.
 5. Name it `mentraos-docs`
 
 <Accordion title="Manual configuration">
-Add to your VS Code `settings.json`:
+Create `.vscode/mcp.json` in your project and add:
 
 ```json
 {
-  "mcp.servers": {
+  "servers": {
     "mentraos-docs": {
       "type": "http",
       "url": "https://docs.mentraglass.com/mcp"
@@ -135,7 +134,7 @@ Add to your VS Code `settings.json`:
 Run this in your terminal:
 
 ```bash
-claude mcp add mentraos-docs --transport http https://docs.mentraglass.com/mcp
+claude mcp add --transport http mentraos-docs https://docs.mentraglass.com/mcp
 ```
 
 <Accordion title="Verify it worked">
@@ -146,16 +145,16 @@ Run `claude mcp list` to see your connected servers. You should see `mentraos-do
 
 ### Other MCP-Compatible Tools
 
-For any tool that supports MCP, use `mcp-remote` to connect to our HTTP endpoint:
-
-```bash
-npx -y mcp-remote https://docs.mentraglass.com/mcp
-```
-
-Or if your tool supports HTTP MCP servers directly, use the URL:
+For tools that support remote HTTP MCP servers, use this URL directly:
 
 ```
 https://docs.mentraglass.com/mcp
+```
+
+If your tool only supports command-based local MCP servers, use `mcp-remote`:
+
+```bash
+npx -y mcp-remote https://docs.mentraglass.com/mcp
 ```
 
 ---
@@ -177,7 +176,7 @@ Your AI should now give you accurate, up-to-date answers using our docs.
 
 <AccordionGroup>
   <Accordion title="Server not connecting">
-    Make sure you have Node.js 18+ installed. The `mcp-remote` package requires it.
+    If your setup uses `mcp-remote`, make sure you have Node.js 18+ installed.
 
     ```bash
     node --version  # Should be v18.0.0 or higher

--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -117,7 +117,7 @@ class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
 
 ## Local SDK Override
 
-Use this when testing SDK source changes locally:
+Use this when testing SDK source changes from a local MentraOS checkout. Run the publish command from the MentraOS source tree, then consume the Maven-local artifact from your app:
 
 ```bash
 cd /path/to/MentraOS/mobile/android

--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -120,7 +120,7 @@ class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
 Use this when testing SDK source changes from a local MentraOS checkout. Run the publish command from the MentraOS source tree, then consume the Maven-local artifact from your app:
 
 ```bash
-cd /path/to/MentraOS/mobile/android
+cd /path/to/MentraOS/mobile/modules/bluetooth-sdk/android
 ./gradlew :lc3Lib:publishToMavenLocal :mentra-bluetooth-sdk:publishToMavenLocal -PmentraPublicSdk=true
 ```
 

--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -1,0 +1,127 @@
+---
+title: "Android"
+description: "Use the Mentra Bluetooth SDK from a native Android app."
+icon: "android"
+---
+
+Native Android apps use the Maven artifact `com.mentraglass:bluetooth-sdk`.
+
+## Requirements
+
+- Android min SDK `28` or newer.
+- Java 17.
+- Android Studio or Gradle.
+- A physical Android phone for Bluetooth, camera, microphone, direct phone photo, and direct phone WebRTC testing.
+
+## Gradle Setup
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+```
+
+```kotlin
+// app/build.gradle.kts
+android {
+    defaultConfig {
+        minSdk = 28
+    }
+
+    packaging {
+        jniLibs {
+            pickFirsts += "**/libc++_shared.so"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
+}
+```
+
+The SDK is published to Maven Central. Keep `google()` and `mavenCentral()` configured. The SDK POM pulls in the companion `com.mentraglass:lc3Lib` codec artifact automatically; do not add it manually unless you have a specific override reason.
+
+The packaging rule avoids duplicate `libc++_shared.so` conflicts when your app also includes native media or camera dependencies.
+
+## Permissions
+
+Declare the platform permissions your app uses:
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+Request runtime permissions before scanning. Some Android 12+ devices require Location permission and Location services before BLE scan callbacks are delivered.
+
+## Basic Flow
+
+```kotlin
+import android.content.Context
+import com.mentra.bluetoothsdk.Device
+import com.mentra.bluetoothsdk.DeviceModel
+import com.mentra.bluetoothsdk.GlassesRuntimeState
+import com.mentra.bluetoothsdk.MentraBluetoothSdk
+import com.mentra.bluetoothsdk.MentraBluetoothSdkCallback
+
+class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
+    private val sdk = MentraBluetoothSdk.create(
+        context = context.applicationContext,
+        listener = this,
+    )
+    private var selectedDevice: Device? = null
+
+    fun scan() {
+        sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { devices ->
+            renderDevicePicker(devices, onSelect = { selectedDevice = it })
+        }
+    }
+
+    fun connect() {
+        selectedDevice?.let { sdk.connect(it) }
+    }
+
+    fun refreshStatus() {
+        sdk.requestVersionInfo()
+        val glasses = sdk.getGlasses()
+        if (glasses is GlassesRuntimeState.Connected) {
+            val model = glasses.device.deviceModel?.deviceType ?: "glasses"
+            val battery = glasses.battery.level?.toString() ?: "unknown"
+            println("Connected to $model, battery=$battery%")
+        }
+    }
+
+    override fun onGlassesChanged(glasses: GlassesRuntimeState) {
+        // Keep app UI derived from SDK status.
+        println("Glasses changed: $glasses")
+    }
+
+    private fun renderDevicePicker(devices: List<Device>, onSelect: (Device) -> Unit) {
+        // Render devices in SDK-provided order and call onSelect with the user's choice.
+    }
+
+    fun close() {
+        sdk.close()
+    }
+}
+```
+
+## Local SDK Override
+
+Use this when testing SDK source changes locally:
+
+```bash
+cd /path/to/MentraOS/mobile/android
+./gradlew :lc3Lib:publishToMavenLocal :mentra-bluetooth-sdk:publishToMavenLocal -PmentraPublicSdk=true
+```
+
+Then include `mavenLocal()` before `mavenCentral()` in the app's repositories while testing the local artifact.

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -106,7 +106,7 @@ val scanSession = sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDe
     renderDevicePicker(nextDevices)
 }
 
-val device = chooseDevice(devices)
+val device = waitForUserSelection()
 sdk.connect(device)
 sdk.setDefaultDevice(device)
 val defaultDevice = sdk.getDefaultDevice()
@@ -128,7 +128,7 @@ let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     renderDevicePicker(nextDevices)
 }
 
-let device = chooseDevice(devices)
+let device = await waitForUserSelection()
 try sdk.connect(to: device)
 sdk.setDefaultDevice(device)
 let defaultDevice = sdk.getDefaultDevice()

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -1,0 +1,496 @@
+---
+title: "API Reference"
+description: "Lifecycle, status, commands, events, and shared types for the Mentra Bluetooth SDK."
+icon: "book"
+---
+
+The Mentra Bluetooth SDK exposes the same core glasses lifecycle across Android, iOS, and React Native:
+
+- Scan for a supported glasses model.
+- Connect to a discovered `Device` or an app-restored default device.
+- Read typed lifecycle state through the public surface for your platform.
+- Subscribe to typed hardware events.
+- Send display, camera, stream, audio, Wi-Fi, hotspot, LED, and settings commands where supported by the connected model.
+
+## Packages And Imports
+
+| Platform | Install package | Import |
+| --- | --- | --- |
+| Android | `com.mentraglass:bluetooth-sdk` | `import com.mentra.bluetoothsdk.*` |
+| iOS | `MentraBluetoothSDK` Swift package | `import MentraBluetoothSDK` |
+| React Native / Expo | `@mentra/bluetooth-sdk` | `import BluetoothSdk, {DeviceModels} from '@mentra/bluetooth-sdk'` |
+| React Native hooks | `@mentra/bluetooth-sdk` | `import {useMentraBluetooth} from '@mentra/bluetooth-sdk/react'` |
+| React Native photo receiver | `@mentra/bluetooth-sdk` | `import MentraPhotoReceiver from '@mentra/bluetooth-sdk/photo-receiver'` |
+
+Only documented imports are part of the supported app developer API. Undocumented package subpaths or symbols with a leading underscore can change without notice.
+
+## Lifecycle
+
+<Tabs>
+  <Tab title="React Native">
+
+```tsx
+import {useBluetoothEvent, useMentraBluetooth} from '@mentra/bluetooth-sdk/react';
+
+function DeviceScreen() {
+  const mentra = useMentraBluetooth();
+  useBluetoothEvent('button_press', (event) => {
+    console.log(event.buttonId, event.pressType);
+  });
+
+  console.log(mentra.glasses.connection.state);
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val sdk = MentraBluetoothSdk.create(
+    context = applicationContext,
+    config = MentraBluetoothSdkConfig(),
+    listener = listener,
+)
+
+sdk.close()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let sdk = MentraBluetoothSDK(configuration: .default)
+sdk.delegate = delegate
+
+sdk.invalidate()
+```
+
+  </Tab>
+</Tabs>
+
+Keep one SDK instance per active app session. The SDK owns Bluetooth connection state, native event delivery, and cleanup. Your app owns user identity, UI state, and whether a default device record is persisted across app restarts.
+
+## Connection
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+const devices = await BluetoothSdk.scan(DeviceModels.MentraLive, {
+  timeoutMs: 10_000,
+  onResults: (nextDevices) => renderDevicePicker(nextDevices),
+});
+
+const device = await chooseDevice(devices);
+await BluetoothSdk.connect(device, {saveAsDefault: false});
+
+await BluetoothSdk.setDefaultDevice(device);
+
+const defaultDevice = await BluetoothSdk.getDefaultDevice();
+await BluetoothSdk.connectDefault();
+await BluetoothSdk.clearDefaultDevice();
+
+await BluetoothSdk.cancelConnectionAttempt();
+await BluetoothSdk.disconnect();
+await BluetoothSdk.forget();
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val devices = mutableListOf<Device>()
+val scanSession = sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
+    devices.clear()
+    devices.addAll(nextDevices)
+    renderDevicePicker(nextDevices)
+}
+
+val device = chooseDevice(devices)
+sdk.connect(device)
+sdk.setDefaultDevice(device)
+val defaultDevice = sdk.getDefaultDevice()
+sdk.connectDefault()
+sdk.clearDefaultDevice()
+
+sdk.cancelConnectionAttempt()
+sdk.disconnect()
+sdk.forget()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+var devices: [Device] = []
+let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
+    devices = nextDevices
+    renderDevicePicker(nextDevices)
+}
+
+let device = chooseDevice(devices)
+try sdk.connect(to: device)
+sdk.setDefaultDevice(device)
+let defaultDevice = sdk.getDefaultDevice()
+try sdk.connectDefault()
+sdk.clearDefaultDevice()
+
+sdk.cancelConnectionAttempt()
+sdk.disconnect()
+sdk.forget()
+```
+
+  </Tab>
+</Tabs>
+
+Prefer connecting to a `Device` returned by SDK scan callbacks. If your app wants `connectDefault()` to work after restart, persist a small default-device record in app storage and restore it with `setDefaultDevice()` before calling `connectDefault()`.
+
+Use `scan()` for user-facing device pickers. The progressive result callback is for UI: render the nearby-device list every time it changes during scanning. The returned final result is for control flow: after the timeout/completion, choose a device from the last list and connect. In multi-device environments, do not auto-connect to the first nearby glasses; present an explicit picker.
+
+## Device Identity
+
+`Device.id` is the stable app-facing key for a scan result, within the limits of the platform identifier available to the SDK. Use it as a list key, selected-device key, and persisted default-device key.
+
+Do not parse `id` for model, name, or address information. Use the typed fields instead:
+
+| Field | Meaning |
+| --- | --- |
+| `model` | Supported glasses family, such as Mentra Live or G2. |
+| `name` | Bluetooth/display name reported during scan. |
+| `address` / `identifier` | Platform device handle when available. Android commonly provides a Bluetooth address. iOS commonly provides a CoreBluetooth identifier. React Native exposes this value as `address`. |
+| `rssi` | Optional signal strength from scan results. It may be undefined at first discovery and appear in a later scan update when the platform reports RSSI metadata. |
+
+When the platform does not provide an address or identifier, the SDK falls back to a `model:name` key.
+
+Do not require `rssi` for picker rows. Use SDK-provided stable discovery order by default, and treat RSSI as supplemental signal-strength metadata when it is present.
+
+## Status
+
+<Tabs>
+  <Tab title="React Native">
+
+```tsx
+import {useMentraBluetooth} from '@mentra/bluetooth-sdk/react';
+
+const mentra = useMentraBluetooth();
+```
+
+React Native exposes `mentra.glasses.connection` as a discriminated union:
+
+```ts
+type GlassesConnectionStatus =
+  | {state: 'disconnected'}
+  | {state: 'scanning'}
+  | {state: 'connecting'}
+  | {state: 'bonding'}
+  | {state: 'connected'; fullyBooted: boolean};
+```
+
+Use `mentra.glasses.connection.state` for link-layer progress. `fullyBooted` only exists when `state === 'connected'`. The hook exposes the React app state as `glasses`, `sdk`, and `scan`.
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val state = sdk.getState()
+val glasses = sdk.getGlasses()
+val sdkState = sdk.getSdkState()
+val scan = sdk.getScanState()
+```
+
+Android exposes `GlassesRuntimeState` as `Connected` or `Disconnected`. The full state is grouped as `MentraBluetoothState(glasses, sdk, scan)`.
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let state = sdk.state
+let glasses = sdk.glasses
+let sdkState = sdk.sdkState
+let scan = sdk.scanState
+```
+
+iOS exposes `GlassesRuntimeState` as `.connected(...)` or `.disconnected(...)`. The full state is grouped as `MentraBluetoothState(glasses, sdk, scan)`.
+
+  </Tab>
+</Tabs>
+
+Status snapshots are safe to read at any time. For continuous subsystems, keep UI state derived from status callbacks or hook state. Request/response commands document their exact promise resolution and error criteria below.
+
+Public status is grouped the same way across platforms:
+
+| Field | Meaning |
+| --- | --- |
+| `glasses` | Connected-glasses runtime state. Includes connection/readiness, connected device identity, battery, firmware, Wi-Fi, hotspot, and signal metadata when connected. |
+| `sdk` | Phone-side SDK runtime state. Includes default device, gallery mode, microphone route, mic ranking, Wi-Fi scan results, scan activity, system mic availability, other Bluetooth audio status, and recent SDK log lines. |
+| `scan` | User-facing scan state. Includes whether a scan is active, whether controller scanning is active, and the stable-order discovered `Device[]` list. |
+
+Use `glasses.connected` / `mentra.glasses.connected` before reading connected-only fields. Native Android uses `GlassesRuntimeState.Connected`; native iOS uses `GlassesRuntimeState.connected(...)`; React Native exposes `mentra.glasses` with the same grouped concepts in React-friendly objects.
+
+## React Native Public Surface
+
+These are the supported React Native app developer entrypoints:
+
+| Area | Methods |
+| --- | --- |
+| Status and subscriptions | `useMentraBluetooth`, `useBluetoothScan`, and `useBluetoothEvent` for React components; `addListener` is available as the lower-level non-React subscription API |
+| Default device | `getDefaultDevice`, `setDefaultDevice`, `clearDefaultDevice` |
+| Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
+| Display | `displayText`, `clearDisplay`, `showDashboard`, `setDashboardPosition`, `setHeadUpAngle`, `setScreenDisabled` |
+| Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
+| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setButtonPhotoSettings`, `setButtonVideoRecordingSettings`, `setButtonCameraLed`, `setButtonMaxRecordingTime`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
+| Streaming | `startStream`, `stopStream` |
+| Audio | `setMicState`, `setVoiceActivityDetectionEnabled`, `setPreferredMic`, `setOwnAppAudioPlaying`, `getGlassesMediaVolume`, `setGlassesMediaVolume` |
+| LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate`, `retryOtaVersionCheck` |
+
+React Native helper exports include `DeviceModels`, `isConnectedGlassesConnectionStatus`, `isReadyGlassesConnectionStatus`, `isBusyGlassesConnectionStatus`, `isConnectedWifiStatus`, and `isEnabledHotspotStatus`. The React subpath exports `useMentraBluetooth`, `useBluetoothScan`, and `useBluetoothEvent`.
+
+For React Native status UI, use `useMentraBluetooth()` from `@mentra/bluetooth-sdk/react`. It returns `mentra.glasses`, `mentra.sdk`, and `mentra.scan` for connection, battery, Wi-Fi, hotspot, scan, and SDK runtime state.
+
+Important defaults:
+
+- `scan(model, options)` reports progressive results through `options.onResults`, resolves with the final matching `Device[]`, and times out after 15 seconds unless `options.timeoutMs` is set.
+- `connect` and `connectDefault` default `saveAsDefault` and `cancelExistingConnectionAttempt` to `true`.
+- `displayText(text, x, y, size)` defaults to `x = 0`, `y = 0`, and `size = 24`.
+- `setMicState(enabled)` defaults to glasses microphone on, transcript events off, and LC3 events off. Microphone audio events are continuous while capture is enabled. Use `setVoiceActivityDetectionEnabled(...)` for glasses-side Voice Activity Detection; `voice_activity_detection_status` reports whether it is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone audio events include the latest `voiceActivityDetectionEnabled` value.
+- `requestPhoto({authToken, ...})` omits the `Authorization` header when `authToken` is `null` or empty.
+- `requestPhoto({exposureTimeNs, ...})` uses auto exposure when `exposureTimeNs` is omitted or `null`; pass a positive nanosecond value for one-shot manual exposure.
+- `requestPhoto({exposureTimeNs, iso, ...})` uses `iso` only when `exposureTimeNs` enables one-shot manual exposure. Omit `iso` / pass `null` for auto ISO selection.
+- Request/response commands now resolve from the glasses response rather than only updating local SDK state. React Native returns success-only values for commands whose raw events can also carry errors: `requestPhoto(...)` returns terminal `PhotoSuccessResponseEvent` after capture and delivery finish, `startVideoRecording(...)` returns `VideoRecordingStartedStatusEvent`, `stopVideoRecording(...)` returns `VideoRecordingStoppedStatusEvent`, and `rgbLedControl(...)` returns `RgbLedControlSuccessResponseEvent`. The corresponding raw events still include error variants for listeners.
+- `setCameraFov({fov, roiPosition})` clamps `fov` to 62-118 degrees and accepts `roiPosition` as `"center"`, `"bottom"`, or `"top"`. You can also call `setCameraFov({preset: "narrow" | "standard" | "wide"})`; presets map to 82, 102, and 118 degrees with center ROI. On Mentra Live this persists the setting, restarts the camera, and resolves with `CameraFovResult` only after the ASG client reports the setting was applied to camera hardware after the restart cooldown. The promise rejects if the glasses report an error, persist the setting without hardware application, or time out. Treat FOV as a framing/ROI control; output resolution and effective detail can vary by capture path, firmware, and camera mode.
+- `startStream` optional `video` and `audio` configs are omitted unless supplied, so the connected glasses use their model defaults. The SDK sends stream keep-alives automatically and reports timeout/error state through `stream_status`.
+- Photo capture, video recording, and streaming always enable the camera light as a privacy indicator.
+
+## Promise Results And Errors
+
+One-shot commands resolve only after the matching ASG client response arrives. They reject/throw when the ASG response is an error, when the SDK cannot send the command, when an incompatible command is already in flight, or when the matching response times out. Keep listeners for streaming progress and status; use the returned value for the one-shot decision.
+
+React Native exposes the narrowest return types for clear branching after `await`. Android and iOS async APIs throw `BluetoothException` / `BluetoothError` for the same error cases, so successful calls return the success payload even when the native event struct can also represent raw listener errors.
+
+| API | Resolves With | Rejection / Throw Criteria |
+| --- | --- | --- |
+| `requestWifiScan()` | Final `WifiSearchResult[]` from `wifi_scan_result` where `scanComplete: true`, including `[]` when no networks are found. | Scan response timeout, send failure, or another Wi-Fi scan already in flight. |
+| `sendWifiCredentials(ssid, password)` | `WifiStatusChangeEvent` whose state is `connected` for the requested SSID. | Wi-Fi disconnect/error state, timeout, send failure, or another Wi-Fi status command in flight. |
+| `forgetWifiNetwork(ssid)` | `WifiStatusChangeEvent` once the requested SSID is no longer connected. | Timeout, send failure, or another Wi-Fi status command in flight. |
+| `setHotspotState(enabled)` | `HotspotStatusChangeEvent` matching the requested enabled/disabled state. | `hotspot_error`, timeout, send failure, or another hotspot command in flight. |
+| `requestVersionInfo()` | `VersionInfoResult` from the ASG `version_info` response. | Timeout, send failure, or another version query in flight. |
+| Gallery/button settings | `SettingsAckSuccessEvent` with a non-failure status such as `applied` or `ready`; the SDK local settings store updates only after this ASG ack resolves. | `settings_ack.status` of `error`, `failed`, `failure`, or `rejected`; timeout; or send failure. |
+| `setCameraFov(...)` | `CameraFovResult` with `fov`, `roiPosition`, `requestId`, and `timestamp` after the ASG client reports the setting was applied to camera hardware after the restart cooldown; the SDK local FOV setting updates only after this result resolves. | Glasses-side FOV/settings error, persist-only/no hardware-application ack, timeout, or send failure. |
+| `queryGalleryStatus()` | `GalleryStatusEvent`, including `cameraBusy` and optional `cameraBusyReason`. | Timeout, send failure, or another gallery status query in flight. |
+| `requestPhoto(...)` | Terminal response after capture and delivery finish: React Native `PhotoSuccessResponseEvent`; Android/iOS successful `PhotoResponseEvent`. The success includes `uploadUrl`, and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`. Progress follows through `photo_status`. | Raw `photo_response.state === "error"` from glasses/phone, fallback upload failure, terminal response timeout, or send failure. |
+| `startVideoRecording(...)` | React Native `VideoRecordingStartedStatusEvent` with `status: "recording_started"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_started"`. | `success: false` statuses such as `already_recording`, timeout, send failure, or duplicate request ID. |
+| `stopVideoRecording(requestId)` | React Native `VideoRecordingStoppedStatusEvent` with `status: "recording_stopped"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_stopped"`. | `success: false` statuses such as `not_recording`, timeout, send failure, or duplicate request ID. |
+| `startStream(...)` | `StreamStatusEvent` for the requested stream once `status` is `streaming`. | `stream_status` error/reconnect failure, timeout, or send failure. |
+| `stopStream()` | `StreamStatusEvent` once `status` is `stopped`; an already-stopped / not-streaming glasses reply resolves as a normalized stopped event. | Real stop error, timeout, send failure, or another stream stop in flight. |
+| `rgbLedControl(...)` | React Native `RgbLedControlSuccessResponseEvent`; Android/iOS successful `RgbLedControlResponseEvent`. | Raw `rgb_led_control_response.state === "error"`, timeout, or send failure. |
+| `checkForOtaUpdate()` / `retryOtaVersionCheck()` | `OtaQueryResult`: either `ota_update_available` or the current `ota_status`. | Command response timeout, send failure, or another OTA query in flight. A returned `ota_status.status === "failed"` is a glasses OTA state to show in UI, not a command transport rejection. |
+| `startOtaUpdate()` | `OtaStartAckEvent` from `ota_start_ack`. | Start-ack timeout, send failure, or another OTA start in flight. |
+
+## Gallery Mode
+
+Mentra Live has a gallery mode for the right action button. When gallery mode is enabled, a short press takes a photo, a long press starts video recording, and a short press stops the active video recording. Button and touch events are still reported to the SDK.
+
+Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGalleryModeEnabled(false)` to report button events without triggering local gallery capture while the glasses are connected. These setting calls return `SettingsAckSuccessEvent` from the ASG client and reject on failure statuses. Raw `settings_ack` listeners still receive `SettingsAckEvent` because listener events can include both success and failure statuses. The SDK can also configure the capture settings used by gallery mode:
+
+| Setting | API |
+| --- | --- |
+| Photo size | `setButtonPhotoSettings(...)` |
+| Video resolution and frame rate | `setButtonVideoRecordingSettings(width, height, fps)` |
+| Maximum video length | `setButtonMaxRecordingTime(minutes)` |
+| Camera field of view | `setCameraFov(...)` |
+| Camera LED preference | `setButtonCameraLed(...)` |
+
+## Common Commands
+
+| Area | Commands |
+| --- | --- |
+| Display | `displayText`, `clearDisplay`, `showDashboard` |
+| Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `disconnect`, `forget` |
+| Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
+| Camera | `requestPhoto`, gallery mode, button photo settings, button video settings, camera field of view |
+| Streaming | `startStream`, `stopStream` |
+| Audio | `setMicState`, Voice Activity Detection setting and events, audio callbacks, local transcription, media volume |
+| Settings | Brightness, dashboard position, head-up angle, screen disabled, gallery mode |
+| LEDs | `rgbLedControl` on supported glasses |
+| System | `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate`, `retryOtaVersionCheck` |
+
+Mentra Live has camera, microphone, and speaker hardware, but no display. G2 has display and microphone hardware, but no camera or speaker. Gate UI for display, camera, and speaker features by the connected model.
+
+## OTA Updates
+
+Mentra Live OTA is glasses-owned. The SDK exposes the same command and event semantics used by the MentraOS app:
+
+| API | Glasses command | Purpose |
+| --- | --- | --- |
+| `checkForOtaUpdate()` | `ota_query_status` | Ask the glasses to report update availability or current progress. Resolves with `OtaQueryResult` from the ASG client. |
+| `startOtaUpdate()` | `ota_start` | Start OTA after your app presents the update and the user accepts it. Resolves with `OtaStartAckEvent` from the ASG client. |
+| `retryOtaVersionCheck()` | `ota_retry_version_check` | Re-run the glasses-side version check after a known clock-skew/TLS failure. |
+
+Use the returned query/start values for one-shot UI. Keep `ota_status` listeners/delegates for install progress and terminal `complete` / `failed` state. React Native still receives `ota_update_available`, `ota_start_ack`, and `ota_status` events for low-level integrations; Android listeners receive `onOtaUpdateAvailable`, `onOtaStartAck`, and `onOtaStatus`; iOS delegates receive `.otaUpdateAvailable`, `.otaStartAck`, and `.otaStatus` through `BluetoothEvent`.
+
+OTA requires Mentra Live glasses firmware that supports the ASG OTA protocol and network access from the glasses. During install, normal BLE traffic can be interrupted and the glasses may restart; keep the app connected and avoid sending unrelated commands until `ota_status.status` is `complete` or `failed`.
+
+## Events
+
+React Native components should use `useBluetoothEvent()` for hardware events. The hook keeps the callback typed and removes the native subscription when the component unmounts. Native apps receive the same event categories through listener/delegate methods:
+
+<Tabs>
+  <Tab title="React Native">
+
+```tsx
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+export function HardwareEventLogger() {
+  useBluetoothEvent('button_press', (event) => console.log(event));
+  useBluetoothEvent('touch_event', (event) => console.log(event));
+  useBluetoothEvent('photo_status', (event) => console.log(event.status, event.resolvedConfig));
+  useBluetoothEvent('stream_status', (event) => console.log(event.resolvedConfig?.video?.fps));
+  useBluetoothEvent('ota_status', (event) => console.log(event.overall_percent));
+  useBluetoothEvent('speaking_status', (event) => console.log(event.speaking));
+  useBluetoothEvent('mic_pcm', (event) => {
+    console.log(event.sampleRate, event.bitsPerSample, event.channels, event.encoding);
+    console.log(event.pcm);
+  });
+
+  return null;
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+class GlassesEvents : MentraBluetoothSdkCallback() {
+    override fun onButtonPress(event: ButtonPressEvent) {
+        Log.d("Mentra", "${event.buttonId} ${event.pressType}")
+    }
+
+    override fun onPhotoResponse(event: PhotoResponseEvent) {
+        Log.d("Mentra", "Photo request ${event.requestId}: ${event.response.state}")
+    }
+
+    override fun onMicPcm(event: MicPcmEvent) {
+        Log.d("Mentra", "${event.sampleRate} Hz ${event.bitsPerSample}-bit PCM")
+    }
+
+    override fun onOtaStatus(event: OtaStatusEvent) {
+        Log.d("Mentra", "OTA ${event.status}: ${event.overallPercent}%")
+    }
+}
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+final class GlassesEvents: MentraBluetoothSDKDelegate {
+    func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didReceive event: BluetoothEvent) {
+        switch event {
+        case let .buttonPress(button):
+            print("\(button.buttonId) \(button.pressType)")
+        case let .photoResponse(photo):
+            print("Photo request \(photo.requestId): \(photo.response.state.rawValue)")
+        case let .otaStatus(status):
+            print("OTA \(status.status): \(status.overallPercent)%")
+        default:
+            break
+        }
+    }
+
+    func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didReceiveMicPcm event: MicPcmEvent) {
+        print("\(event.sampleRate) Hz \(event.bitsPerSample)-bit PCM")
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
+For non-React modules, `BluetoothSdk.addListener(...)` is the low-level subscription API. Keep the returned subscription and call `remove()` when the listener is no longer needed.
+
+The React Native event surface is typed through `BluetoothSdkEventMap`. These are the public event names accepted by `useBluetoothEvent()` and `BluetoothSdk.addListener()`:
+
+| Event name | Payload type | When it fires |
+| --- | --- | --- |
+| `log` | `LogEvent` | SDK diagnostic log line. |
+| `device_discovered` | `Device` | A supported glasses device is discovered during scan. |
+| `default_device_changed` | `{device?: Device}` | The SDK default device changes. |
+| `glasses_not_ready` | `GlassesNotReadyEvent` | A command needs ready glasses but the connected device is not ready. |
+| `button_press` | `ButtonPressEvent` | Glasses button press. |
+| `touch_event` | `TouchEvent` | Glasses touch or swipe gesture. |
+| `head_up` | `HeadUpEvent` | Head-up state changes. |
+| `voice_activity_detection_status` | `VoiceActivityDetectionStatusEvent` | Glasses-side Voice Activity Detection is enabled or disabled. |
+| `speaking_status` | `SpeakingStatusEvent` | Glasses-side Voice Activity Detection reports speaking or not speaking. |
+| `battery_status` | `BatteryStatusEvent` | Battery update from glasses. |
+| `local_transcription` | `LocalTranscriptionEvent` | SDK local transcription text update. |
+| `wifi_status_change` | `WifiStatusChangeEvent` | Glasses Wi-Fi connection state changes. |
+| `wifi_scan_result` | `WifiScanResultEvent` | Wi-Fi scan results. Intermediate events can have `scanComplete: false`; the final event has `scanComplete: true` and is what `requestWifiScan()` awaits. |
+| `version_info` | `VersionInfoEvent` | Glasses version metadata response. Also returned by `requestVersionInfo()`. |
+| `hotspot_status_change` | `HotspotStatusChangeEvent` | Glasses hotspot state changes. |
+| `hotspot_error` | `HotspotErrorEvent` | Hotspot operation fails. |
+| `photo_response` | `PhotoResponseEvent` | Terminal photo result. Success means capture and webhook delivery completed; error means the glasses or phone rejected/failed the request. `requestPhoto(...)` resolves with the success case and rejects on the error case; progress follows through `photo_status`. |
+| `photo_status` | `PhotoStatusEvent` | Photo capture progress changes. May include `resolvedConfig`, `requestedCaptureConfig`, `meteredPreview`, or `captureMetadata` depending on status. |
+| `video_recording_status` | `VideoRecordingStatusEvent` | Video recording start/stop succeeds or fails, or a status query reports `status: "recording_status"` with `data.recording`. `startVideoRecording(...)` and `stopVideoRecording(...)` resolve only from their matching terminal statuses (`recording_started` / `recording_stopped`); unsuccessful statuses such as `already_recording` reject the promise. |
+| `gallery_status` | `GalleryStatusEvent` | Gallery content/camera-busy status changes. `cameraBusyReason` is included when the glasses report a busy camera reason such as `video` or `stream`. |
+| `settings_ack` | `SettingsAckEvent` | Raw gallery/button/FOV setting acknowledgements from the glasses. Gallery and button setting methods return `SettingsAckSuccessEvent` and reject failure statuses; `setCameraFov(...)` resolves a friendlier `CameraFovResult` after the raw ack reports camera hardware application. |
+| `compatible_glasses_search_stop` | `CompatibleGlassesSearchStopEvent` | Compatible-glasses search stops for a model. |
+| `swipe_volume_status` | `SwipeVolumeStatusEvent` | Swipe-volume setting changes. |
+| `switch_status` | `SwitchStatusEvent` | Glasses switch status changes. |
+| `rgb_led_control_response` | `RgbLedControlResponseEvent` | RGB LED command succeeds or fails. `rgbLedControl(...)` resolves with the success case and rejects on the error case. |
+| `pair_failure` | `PairFailureEvent` | Bluetooth pairing fails. |
+| `audio_pairing_needed` | `AudioPairingNeededEvent` | The phone needs Bluetooth audio pairing for the device. |
+| `audio_connected` | `AudioConnectedEvent` | Bluetooth audio connects. |
+| `audio_disconnected` | `AudioDisconnectedEvent` | Bluetooth audio disconnects. |
+| `mic_pcm` | `MicPcmEvent` | PCM microphone frame arrives. |
+| `mic_lc3` | `MicLc3Event` | LC3 microphone frame arrives. |
+| `stream_status` | `StreamStatusEvent` | Camera stream lifecycle, reconnect, or error state changes. May include `resolvedConfig` with effective stream settings: encoded output size in `video.width` / `video.height`, native camera capture size in `video.captureWidth` / `video.captureHeight`, video bitrate and `fps`, plus audio bitrate, sample rate, echo cancellation, and noise suppression. |
+| `ota_update_available` | `OtaUpdateAvailableEvent` | Mentra Live reports an available OTA package. Also returned by `checkForOtaUpdate()` when an update is available. |
+| `ota_start_ack` | `OtaStartAckEvent` | Mentra Live acknowledges `startOtaUpdate()`. Also returned by `startOtaUpdate()`. |
+| `ota_status` | `OtaStatusEvent` | OTA step, phase, status, progress, or error changes. |
+
+For request/response commands, prefer the returned value from the method, such as the `PhotoSuccessResponseEvent` returned by React Native `requestPhoto(...)` or the operation-specific video result returned by React Native `startVideoRecording(...)` / `stopVideoRecording(...)`. `requestPhoto(...)` waits for the terminal `photo_response`: it resolves after the photo is captured and delivered to the webhook, and rejects if the glasses reject the request, the phone-side fallback upload fails, or the terminal response times out. Capture/upload/Bluetooth fallback progress follows through `photo_status`. Use event listeners for ongoing hardware streams and status updates: for example, `useBluetoothEvent('mic_pcm', ...)` receives a `MicPcmEvent`. `MicPcmEvent` includes `sampleRate`, `bitsPerSample`, `channels`, `encoding`, and `voiceActivityDetectionEnabled`; `MicLc3Event` includes `sampleRate`, `channels`, `encoding`, `frameDurationMs`, `frameSizeBytes`, `bitrate`, `packetizedFromGlasses`, and `voiceActivityDetectionEnabled`. `speaking_status` is separate from microphone audio frames so apps can use continuous audio while still reacting to speech activity.
+
+Public React Native event payload fields usually use camelCase. OTA events intentionally mirror the glasses firmware field names, such as `overall_percent` and `version_name`. For example, touch events expose `deviceModel` and `gestureName`, successful photo responses expose `uploadUrl` and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, and `fileSizeBytes`, hotspot errors expose `errorMessage`, Wi-Fi scan events expose `scanComplete`, and gallery status exposes `hasContent`, `cameraBusy`, and optional `cameraBusyReason`.
+
+### Photo Status Metadata
+
+`PhotoStatusEvent` reports progress through capture and transfer. Capture metadata is attached to the stage where the glasses know that data:
+
+| Status | Optional field | Description |
+| --- | --- | --- |
+| `configuring` | `resolvedConfig` | Effective JPEG dimensions, quality, requested size, source (`sdk` or `button`), transfer method, compression, and manual exposure fields when present. |
+| `capturing` | `requestedCaptureConfig` | Camera2 still request values submitted to the HAL, such as exposure time, ISO, frame duration, AE mode, AE lock, exposure compensation, target FPS range, AF mode, and ZSL. |
+| `capturing` | `meteredPreview` | Latest preview auto-exposure estimate before the still capture, including exposure time, ISO, and a light proxy when available. |
+| `captured` | `captureMetadata` | Actual still capture result returned by the HAL, including applied exposure time, ISO, frame duration, AE state/name, noise reduction mode, edge mode, sensor timestamp, and MFNR hint when available. |
+
+Transport statuses such as `uploading`, `compressing`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring` describe upload or BLE progress only and do not carry capture metadata. `ble_fallback_compression` means the direct Wi-Fi/webhook upload failed and the glasses are compressing the already-captured photo for Bluetooth fallback delivery. Apps should read actual capture values from `event.captureMetadata` on the `captured` status, not from upload statuses.
+
+Local action-button photos emitted by the glasses use the same `photo_status` shape when the phone SDK is connected. Those local captures set `resolvedConfig.source` to `button` and `resolvedConfig.transferMethod` to `local`.
+
+Android and iOS expose typed callbacks/delegate methods instead of the React Native string event API. Android uses `MentraBluetoothSdkListener` methods such as `onStateChanged`, `onGlassesChanged`, `onSdkStateChanged`, `onScanChanged`, `onDeviceDiscovered`, `onButtonPress`, `onSpeakingStatus`, `onPhotoResponse`, `onPhotoStatus`, `onMicPcm`, `onStreamStatus`, and `onOtaStatus`. iOS uses `MentraBluetoothSDKDelegate` methods such as `mentraBluetoothSDK(_:didUpdate:)`, `mentraBluetoothSDK(_:didUpdateGlasses:)`, `mentraBluetoothSDK(_:didUpdateSdkState:)`, `mentraBluetoothSDK(_:didUpdateScan:)`, `mentraBluetoothSDK(_:didDiscover:)`, `mentraBluetoothSDK(_:didReceive:)`, `mentraBluetoothSDK(_:didReceiveMicPcm:)`, and `mentraBluetoothSDK(_:didReceiveMicLc3:)`; OTA arrives through `didReceive` as `.otaUpdateAvailable`, `.otaStartAck`, or `.otaStatus`. Microphone audio callbacks use `MicPcmEvent` and `MicLc3Event` objects with the same metadata as React Native.
+
+| Event area | Examples |
+| --- | --- |
+| Input | Button press, touch, swipe, head-up |
+| Device state | Battery, case, Wi-Fi, hotspot, connection, RSSI |
+| Camera | Photo request result, gallery state, camera settings |
+| Streaming | Stream initializing, active, stopped, error |
+| OTA | Update available, start acknowledged, step/progress status |
+| Audio | Microphone PCM, LC3, local transcription, audio route state |
+| Diagnostics | SDK log events |
+
+## Version Fields
+
+Call `requestVersionInfo()` after connection when your app wants the glasses to refresh version metadata. Updated values arrive through the normal glasses-status callback and are also available in the next status snapshot.
+
+| Field | Meaning |
+| --- | --- |
+| `firmwareVersion` | Generic glasses firmware version when the connected model reports one. |
+| `deviceFirmwareVersion` | Device firmware version for models that report device info as a structured payload. |
+| `leftFirmwareVersion` / `rightFirmwareVersion` | Per-side firmware versions for glasses that report left/right firmware separately. |
+| `besFirmwareVersion` | Mentra Live BES firmware version. |
+| `mtkFirmwareVersion` | Mentra Live MTK/system OTA firmware version. |
+| `appVersion` | Glasses-side companion app version. On Mentra Live this is the ASG client APK version, not firmware. |
+| `androidVersion` | Android OS version on Android-based glasses. This is not firmware. |
+
+Different glasses models expose different version fields, so apps should prefer the generic firmware field when present, then fall back to model-specific firmware fields. Keep app and OS versions visibly labeled as app/OS versions.

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -100,13 +100,14 @@ await BluetoothSdk.forget();
 
 ```kotlin
 val devices = mutableListOf<Device>()
+var selectedDevice: Device? = null
 val scanSession = sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
     devices.clear()
     devices.addAll(nextDevices)
-    renderDevicePicker(nextDevices)
+    renderDevicePicker(nextDevices, onSelect = { selectedDevice = it })
 }
 
-val device = waitForUserSelection()
+val device = selectedDevice ?: return
 sdk.connect(device)
 sdk.setDefaultDevice(device)
 val defaultDevice = sdk.getDefaultDevice()
@@ -123,12 +124,15 @@ sdk.forget()
 
 ```swift
 var devices: [Device] = []
+var selectedDevice: Device? = nil
 let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     devices = nextDevices
-    renderDevicePicker(nextDevices)
+    renderDevicePicker(nextDevices) { device in
+        selectedDevice = device
+    }
 }
 
-let device = await waitForUserSelection()
+guard let device = selectedDevice else { return }
 try sdk.connect(to: device)
 sdk.setDefaultDevice(device)
 let defaultDevice = sdk.getDefaultDevice()

--- a/docs/mentra-live/audio.mdx
+++ b/docs/mentra-live/audio.mdx
@@ -1,0 +1,248 @@
+---
+title: "Audio"
+description: "Use microphone input and route normal phone audio playback to supported glasses speakers."
+icon: "microphone"
+---
+
+The Bluetooth SDK exposes microphone input controls, microphone audio callbacks, local transcription events, and Mentra Live media-volume helpers. Speaker playback is separate: your app plays audio with normal Android, iOS, or React Native audio APIs, and the phone OS routes that audio to Mentra Live when the glasses are connected as the Bluetooth media output.
+
+<Info>
+Mentra Live and G2 both have microphones. Mentra Live has a speaker; G2 does not.
+</Info>
+
+## Microphone Input
+
+Use `setMicState` when your app wants microphone audio from the connected glasses or phone microphone path.
+
+`enabled` turns microphone capture on or off. `useGlassesMic` selects the glasses microphone when `true`, or the phone microphone when `false`.
+
+Microphone audio events are emitted continuously from the selected microphone path while capture is enabled. The SDK does not apply phone-side Voice Activity Detection gating to PCM or LC3 events. Glasses-side Voice Activity Detection can be enabled or disabled with `setVoiceActivityDetectionEnabled(...)`; the current setting is reported through `voice_activity_detection_status`. When supported by the connected glasses, `speaking_status` reports whether the glasses currently detect speech. Microphone events also include the latest `voiceActivityDetectionEnabled` value.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.setMicState(true);
+await BluetoothSdk.setVoiceActivityDetectionEnabled(false);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.setMicState(enabled = true)
+sdk.setVoiceActivityDetectionEnabled(false)
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+sdk.setMicState(enabled: true)
+try await sdk.setVoiceActivityDetectionEnabled(false)
+```
+
+  </Tab>
+</Tabs>
+
+Your app owns user-facing microphone permission copy, should ask for microphone access only when the feature needs it, and should provide a visible way to disable microphone streaming.
+
+## Local Transcription
+
+<Tabs>
+  <Tab title="React Native">
+
+```tsx
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+export function TranscriptLogger() {
+  useBluetoothEvent('local_transcription', (event) => {
+    console.log(`${event.text} final=${event.isFinal}`);
+  });
+
+  return null;
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+override fun onLocalTranscription(event: LocalTranscriptionEvent) {
+    Log.d("Mentra", "${event.text} final=${event.isFinal}")
+}
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didReceive event: BluetoothEvent) {
+    if case let .localTranscription(transcription) = event {
+        print("\(transcription.text) final=\(transcription.isFinal)")
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
+## Microphone Audio Events
+
+React Native can listen for microphone PCM events. PCM events are self-describing so apps can pass the buffer directly to STT, WAV writing, or playback code without reading native SDK sources:
+
+```tsx
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+export function MicPcmLogger() {
+  useBluetoothEvent('mic_pcm', (event) => {
+    console.log(event.sampleRate, event.bitsPerSample, event.channels, event.encoding);
+    console.log(event.voiceActivityDetectionEnabled);
+    console.log(event.pcm);
+  });
+
+  return null;
+}
+```
+
+`mic_pcm` emits continuous 16 kHz, 16-bit, mono, signed little-endian PCM while microphone capture is enabled.
+
+`mic_lc3` emits SDK-encoded LC3 frames with `sampleRate`, `channels`, `frameDurationMs`, `frameSizeBytes`, `bitrate`, `packetizedFromGlasses`, and `voiceActivityDetectionEnabled`. For SDK-encoded LC3 events, `packetizedFromGlasses` is `false`: the SDK decodes glasses microphone LC3 and re-encodes it to the SDK's canonical LC3 output format before emitting app-facing LC3 events.
+
+Native Android and iOS apps receive `MicPcmEvent` and `MicLc3Event` objects with the same metadata through the SDK listener/delegate surfaces. Disable microphone audio callbacks when the app finishes using them.
+
+## Voice Activity Detection
+
+Voice Activity Detection means the glasses firmware is detecting whether the microphone signal currently contains speech. Use it as a signal, not as a replacement for microphone capture:
+
+- `setVoiceActivityDetectionEnabled(false)` keeps app-facing PCM and LC3 audio continuous for external STT, recording, and playback.
+- `voice_activity_detection_status` reports whether glasses-side Voice Activity Detection is enabled.
+- `speaking_status` reports the current speaking/not-speaking state when the connected glasses provide it.
+
+```tsx
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+export function SpeakingLogger() {
+  useBluetoothEvent('speaking_status', (event) => {
+    console.log(event.speaking ? 'speaking' : 'not speaking');
+  });
+
+  return null;
+}
+```
+
+## Mentra Live Speaker Playback
+
+Mentra Live uses two Bluetooth paths:
+
+- The SDK's BLE connection controls glasses features and receives device events.
+- The phone OS's Bluetooth media connection carries speaker audio from the phone to the glasses.
+
+There is no special Bluetooth SDK method for "play this sound through the speaker." Play audio the same way you would play audio from any mobile app. If Mentra Live is the active Bluetooth media output, the sound comes from the glasses.
+
+On Android, the system usually creates the Bluetooth audio bond after the BLE connection flow. If the phone shows a pairing dialog, the user should accept it. On iOS, apps cannot programmatically pair or select the Bluetooth media output; ask the user to open Settings > Bluetooth and connect/select Mentra Live before playback.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+import {createAudioPlayer, setAudioModeAsync} from 'expo-audio';
+
+await setAudioModeAsync({
+  playsInSilentMode: true,
+  interruptionMode: 'duckOthers',
+});
+
+const player = createAudioPlayer({uri: 'https://example.com/reply.wav'});
+
+await BluetoothSdk.setOwnAppAudioPlaying(true);
+player.addListener('playbackStatusUpdate', (status) => {
+  if (status.didJustFinish) {
+    void BluetoothSdk.setOwnAppAudioPlaying(false);
+  }
+});
+player.play();
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val player = MediaPlayer().apply {
+    setAudioAttributes(
+        AudioAttributes.Builder()
+            .setUsage(AudioAttributes.USAGE_MEDIA)
+            .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+            .build()
+    )
+    setDataSource(audioUrl)
+    prepare()
+}
+
+sdk.setOwnAppAudioPlaying(true)
+player.setOnCompletionListener {
+    sdk.setOwnAppAudioPlaying(false)
+    it.release()
+}
+player.start()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let session = AVAudioSession.sharedInstance()
+try session.setCategory(.playback, mode: .default, options: [.duckOthers])
+try session.setActive(true)
+
+let player = AVPlayer(url: audioUrl)
+sdk.setOwnAppAudioPlaying(true)
+player.play()
+```
+
+  </Tab>
+</Tabs>
+
+`setOwnAppAudioPlaying(true)` does not route audio by itself. It tells the SDK that your app is playing audio so the Mentra Live microphone path can avoid conflicting with speaker playback. Set it back to `false` when playback finishes or stops.
+
+## Mentra Live Media Volume
+
+Mentra Live exposes step-based media volume helpers where supported:
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+const current = await BluetoothSdk.getGlassesMediaVolume();
+console.log(current.level); // 0-15
+
+await BluetoothSdk.setGlassesMediaVolume(8);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val current = sdk.getGlassesMediaVolume()
+sdk.setGlassesMediaVolume(8)
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let current = try await sdk.getGlassesMediaVolume()
+try await sdk.setGlassesMediaVolume(8)
+```
+
+  </Tab>
+</Tabs>
+
+## Production Notes
+
+- Always provide a user-visible microphone permission explanation.
+- Let users disable microphone streaming.
+- For Mentra Live speaker features, explain that users may need to pair/select the glasses as the phone's Bluetooth media output.
+- Expect model availability to differ by platform, locale, and app configuration.
+- Keep cloud upload and retention policies explicit in your privacy disclosures.
+- Disable microphone audio callbacks when the app finishes using them.

--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -196,14 +196,14 @@ sdk.stopStream()
 ```swift
 let streamId = "stream-\(Date().timeIntervalSince1970)"
 
-sdk.startStream(
+try await sdk.startStream(
     StreamRequest(
         streamUrl: "http://192.168.1.42:8889/mentra-live/whip",
         streamId: streamId
     )
 )
 
-sdk.stopStream()
+try await sdk.stopStream()
 ```
 
   </Tab>

--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -1,0 +1,327 @@
+---
+title: "Camera And Streaming"
+description: "Request photos and start RTMP, SRT, or WebRTC streams from supported smart glasses."
+icon: "camera"
+---
+
+Camera and streaming features depend on the connected glasses model. Mentra Live has a camera; G2 does not. Gate UI by SDK status and model capability before exposing photo, video, or stream controls.
+
+## Photo Upload
+
+Photo upload sends a JPEG from supported glasses to a webhook URL. In the starter apps, the default Camera flow starts a receiver on the phone and sends the photo from the glasses to that phone URL. Turn on **Use cloud server** only when you want to send the upload to an external endpoint, such as your production API, a staging API, or the optional starter-kit helper.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+const photo = await BluetoothSdk.requestPhoto({
+  requestId: `photo-${Date.now()}`,
+  appId: 'com.example.app',
+  size: 'medium',
+  webhookUrl: 'https://api.example.com/mentra/photo',
+  authToken: 'optional-token',
+  compress: 'medium',
+  sound: true,
+  exposureTimeNs: null,
+  iso: null,
+});
+console.log('photo delivered', photo.photoUrl ?? photo.uploadUrl);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val photo = sdk.requestPhoto(
+    PhotoRequest(
+        requestId = "photo-${System.currentTimeMillis()}",
+        appId = "com.example.app",
+        size = PhotoSize.MEDIUM,
+        webhookUrl = "https://api.example.com/mentra/photo",
+        authToken = "optional-token",
+        compress = PhotoCompression.MEDIUM,
+        sound = true,
+        exposureTimeNs = null,
+        iso = null,
+    )
+)
+println("photo delivered: ${photo.requestId}")
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let photo = try await sdk.requestPhoto(
+    PhotoRequest(
+        requestId: "photo-\(Date().timeIntervalSince1970)",
+        appId: "com.example.app",
+        size: .medium,
+        webhookUrl: "https://api.example.com/mentra/photo",
+        authToken: "optional-token",
+        compress: .medium,
+        sound: true,
+        exposureTimeNs: nil,
+        iso: nil
+    )
+)
+print("photo delivered: \(photo.requestId)")
+```
+
+  </Tab>
+</Tabs>
+
+`requestPhoto(...)` resolves when the full photo action reaches terminal success: capture completed and the JPEG was delivered to the webhook, either directly from the glasses over Wi-Fi or through the phone's Bluetooth fallback relay. It rejects or throws when the glasses report a terminal `photo_response` error, when phone-side fallback upload fails, when the SDK cannot send the command, or when no terminal response arrives before the command timeout. Use `photo_status` for intermediate progress such as `accepted`, `configuring`, `capturing`, `captured`, `uploading`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring`; `photo_response` is the final success/error result. The returned success includes `uploadUrl`, and may include webhook-returned metadata such as `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`.
+
+The webhook should accept multipart form data with a `photo` file and `requestId`. If `authToken` is provided, the uploader adds `Authorization: Bearer <token>`. The camera light is always enabled for photo capture.
+
+For one-shot manual capture tuning, pass `exposureTimeNs` and `iso` together. `exposureTimeNs` is sensor exposure time in nanoseconds; `iso` is sensor ISO. If `exposureTimeNs` is omitted, `null` / `nil`, invalid, or unsupported by the connected glasses, the camera uses auto exposure and ignores `iso`.
+
+Listen for `photo_status` to render progress and inspect the effective settings the glasses used:
+
+```ts
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+useBluetoothEvent('photo_status', (event) => {
+  if (event.status === 'configuring') {
+    console.log('effective JPEG config', event.resolvedConfig);
+  }
+  if (event.status === 'capturing') {
+    console.log('requested still config', event.requestedCaptureConfig);
+    console.log('latest metered preview', event.meteredPreview);
+  }
+  if (event.status === 'captured') {
+    console.log('actual still capture', event.captureMetadata);
+  }
+});
+```
+
+`photo_status` metadata is stage-specific:
+
+| Status | Optional metadata | When to use it |
+| --- | --- | --- |
+| `configuring` | `resolvedConfig` | Show the effective JPEG dimensions, quality, requested size, source, transfer method, compression, and manual exposure fields when present. |
+| `capturing` | `requestedCaptureConfig`, `meteredPreview` | Compare the Camera2 still request with the latest auto-exposure preview estimate before the capture is fired. |
+| `captured` | `captureMetadata` | Read the actual HAL-applied still capture values, including exposure time, ISO, frame duration, AE state/name, noise reduction mode, edge mode, sensor timestamp, and MFNR hint when available. |
+
+Upload and BLE transfer statuses such as `uploading`, `compressing`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring` are transport progress only. They do not carry capture metadata, so use the `captured` event when you need the actual exposure/ISO/frame data for debugging or UI. `ble_fallback_compression` means the direct Wi-Fi/webhook upload failed and the glasses are compressing the already-captured photo for Bluetooth fallback delivery.
+
+## Gallery Mode
+
+Mentra Live has gallery mode for the right action button. When gallery mode is enabled, a short press takes a photo, a long press starts video recording, and a short press stops the active video recording. Button and touch events are still reported to your app.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.setGalleryModeEnabled(true);
+await BluetoothSdk.setButtonPhotoSettings('medium');
+await BluetoothSdk.setButtonVideoRecordingSettings(1280, 720, 30);
+await BluetoothSdk.setButtonMaxRecordingTime(3);
+const cameraFov = await BluetoothSdk.setCameraFov({fov: 102, roiPosition: 'center'});
+console.log(`Camera ready at ${cameraFov.fov}°`);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.setGalleryModeEnabled(true)
+sdk.setButtonPhotoSettings(size = ButtonPhotoSize.MEDIUM)
+sdk.setButtonVideoRecordingSettings(width = 1280, height = 720, fps = 30)
+sdk.setButtonMaxRecordingTime(minutes = 3)
+val cameraFov = sdk.setCameraFov(CameraFov(fov = 102, roiPosition = CameraRoiPosition.CENTER))
+println("Camera ready at ${cameraFov.fov}°")
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+try await sdk.setGalleryModeEnabled(true)
+try await sdk.setButtonPhotoSettings(size: .medium)
+try await sdk.setButtonVideoRecordingSettings(width: 1280, height: 720, fps: 30)
+try await sdk.setButtonMaxRecordingTime(minutes: 3)
+let cameraFov = try await sdk.setCameraFov(CameraFov(fov: 102, roiPosition: .center))
+print("Camera ready at \(cameraFov.fov)°")
+```
+
+  </Tab>
+</Tabs>
+
+Use `setGalleryModeEnabled(false)` when you want the action button to report events without triggering local gallery capture while the glasses are connected.
+
+Action-button photos emitted by the glasses use the same `photo_status` metadata shape when the phone SDK is connected. These local captures report `resolvedConfig.source: "button"` and `resolvedConfig.transferMethod: "local"`, then expose `requestedCaptureConfig` / `meteredPreview` on `capturing` and `captureMetadata` on `captured`.
+
+`setCameraFov` accepts FOV degrees from 62 to 118 and ROI position `"center"`, `"bottom"`, or `"top"` on React Native, `CameraRoiPosition` on Android, and `CameraRoiPosition` on iOS. React Native also accepts `{preset: "narrow" | "standard" | "wide"}`; presets map to 82, 102, and 118 degrees with center ROI. On Mentra Live, applying FOV/ROI restarts the camera; the returned `CameraFovResult` resolves from the ASG client only when the setting has been applied to camera hardware after the restart cooldown, and the promise rejects on glasses-side error, persist-only/no hardware-application ack, or timeout. Treat FOV as a framing/ROI control; output resolution and effective detail can vary by capture path, firmware, and camera mode.
+
+## Streaming
+
+Streaming sends camera video from supported glasses to an ingest URL. In the starter apps, the default Stream flow uses the phone as the receiver where the platform example supports it. Turn on **Use cloud server** when you want the glasses to stream to an external RTMP, SRT, or WHIP/WebRTC ingest endpoint. Use your own server in production; the local helper below is only a demo convenience for testing external endpoints from the starter apps.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+const streamId = `stream-${Date.now()}`;
+
+await BluetoothSdk.startStream({
+  type: 'start_stream',
+  streamUrl: 'http://192.168.1.42:8889/mentra-live/whip',
+  streamId,
+});
+
+await BluetoothSdk.stopStream();
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val streamId = "stream-${System.currentTimeMillis()}"
+
+sdk.startStream(
+    StreamRequest(
+        streamUrl = "http://192.168.1.42:8889/mentra-live/whip",
+        streamId = streamId,
+    )
+)
+
+sdk.stopStream()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let streamId = "stream-\(Date().timeIntervalSince1970)"
+
+sdk.startStream(
+    StreamRequest(
+        streamUrl: "http://192.168.1.42:8889/mentra-live/whip",
+        streamId: streamId
+    )
+)
+
+sdk.stopStream()
+```
+
+  </Tab>
+</Tabs>
+
+Use `rtmp://` or `rtmps://` for RTMP, `srt://` for SRT, and `http://` or `https://` for WHIP/WebRTC ingest. `startStream()` resolves once glasses report `status: "streaming"`; `stopStream()` resolves once glasses report `status: "stopped"` and also resolves with a normalized stopped event when glasses report that no stream was active. The SDK sends stream keep-alives automatically while streaming and reports keep-alive failures through `stream_status`. The camera light is always enabled while streaming.
+
+## Optional Local Demo Helper
+
+The starter kit includes a local helper server so developers can try the **Use cloud server** path without first deploying their own webhook or streaming service:
+
+```bash
+git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git
+cd Mentra-Bluetooth-SDK-Starter-Kit
+python3 examples/local-demo-cloud/server.py
+```
+
+In the starter apps, leave **Use cloud server** off for the default glasses-to-phone flow. Turn it on when you want to test an external endpoint, then paste the printed LAN `/upload` URL into the Camera screen or the printed RTMP, SRT, or WHIP publish URL into the Stream screen. You can skip this helper entirely when you already have reachable upload and streaming endpoints.
+
+<Warning>
+Do not use `localhost` from the mobile app. The glasses, phone, and computer must be on a network where the glasses can reach the printed LAN address.
+</Warning>
+
+## Direct Phone Capture And Streaming
+
+The starter kit examples also include direct phone photo and WebRTC receive flows:
+
+- Android can receive photos directly on the phone and host a GStreamer WHIP receiver.
+- iOS can receive photos directly on the phone and host a GStreamer WHIP receiver.
+- React Native includes local native companion modules for Android and iOS direct phone photo and WebRTC demos.
+
+Use real hardware for these flows. Keep the glasses Wi-Fi active and make sure the phone and glasses are on a reachable local network.
+
+For direct phone photo upload in React Native, start the phone receiver first and pass its `uploadUrl` as the photo webhook:
+
+```ts
+import BluetoothSdk from '@mentra/bluetooth-sdk';
+import MentraPhotoReceiver from '@mentra/bluetooth-sdk/photo-receiver';
+
+const receiver = await MentraPhotoReceiver.startPhotoReceiver();
+
+const uploadSubscription = MentraPhotoReceiver.addListener('photoUpload', (event) => {
+  console.log(event.requestId, event.fileUri, event.byteCount);
+});
+
+try {
+  const photo = await BluetoothSdk.requestPhoto({
+    requestId: `photo-${Date.now()}`,
+    appId: 'com.example.app',
+    size: 'medium',
+    webhookUrl: receiver.uploadUrl,
+    authToken: null,
+    compress: 'medium',
+    sound: true,
+  });
+  console.log('photo delivered', photo.photoUrl ?? photo.uploadUrl);
+} catch (error) {
+  uploadSubscription.remove();
+  await MentraPhotoReceiver.stopPhotoReceiver();
+  throw error;
+}
+
+// Later:
+uploadSubscription.remove();
+await MentraPhotoReceiver.stopPhotoReceiver();
+```
+
+## Stream Status
+
+Subscribe to stream status before starting a stream. Treat stream start as accepted, then drive UI from status events:
+
+<Tabs>
+  <Tab title="React Native">
+
+```tsx
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+export function StreamStatusLogger() {
+  useBluetoothEvent('stream_status', (event) => {
+    console.log(event);
+    console.log(event.resolvedConfig?.video?.fps);
+  });
+
+  return null;
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+override fun onStreamStatus(event: StreamStatusEvent) {
+    Log.d("Mentra", "Stream status: ${event.status}")
+    Log.d("Mentra", "Resolved FPS: ${event.resolvedConfig?.video?.fps}")
+}
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didReceive event: BluetoothEvent) {
+    if case let .streamStatus(status) = event {
+        print("Stream status: \(status)")
+        print("Resolved FPS: \(status.resolvedConfig?.video?.fps ?? -1)")
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
+Status values include initializing, streaming, stopped, reconnecting, and error states.
+When a status event includes `resolvedConfig`, it contains the effective settings
+used by the glasses after defaults, clamps, and camera-mode selection. In
+`resolvedConfig.video`, `width` and `height` are the encoded output dimensions,
+`captureWidth` and `captureHeight` are the native camera buffer dimensions before
+crop or downscale, `bitrate` is the encoded video bitrate in bits per second, and
+`fps` is the resolved capture/encode frame rate. `resolvedConfig.audio` reports
+the audio bitrate, sample rate, echo cancellation, and noise suppression settings
+when audio is active.

--- a/docs/mentra-live/display.mdx
+++ b/docs/mentra-live/display.mdx
@@ -1,0 +1,133 @@
+---
+title: "Display"
+description: "Send text, clear the display, open the dashboard, and manage display-related settings."
+icon: "display"
+---
+
+The display API sends glanceable, user-visible information to supported smart glasses.
+
+<Info>
+Mentra Live does not have a display. Use display APIs only on display-equipped models such as G2.
+</Info>
+
+## Basic Text
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.displayText('Turn left in 100 ft', 0, 0, 24);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.displayText(text = "Turn left in 100 ft", x = 0, y = 0, size = 24)
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+try await sdk.displayText("Turn left in 100 ft", x: 0, y: 0, size: 24)
+```
+
+  </Tab>
+</Tabs>
+
+## Clear Display
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.clearDisplay();
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.clearDisplay()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+try await sdk.clearDisplay()
+```
+
+  </Tab>
+</Tabs>
+
+## Dashboard
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.showDashboard();
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.showDashboard()
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+sdk.showDashboard()
+```
+
+  </Tab>
+</Tabs>
+
+Dashboard support depends on the connected glasses model and firmware.
+
+## Display Settings
+
+Display-related settings include dashboard position, head-up angle, and screen enable/disable state.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.setDashboardPosition(4, 6);
+await BluetoothSdk.setHeadUpAngle(20);
+await BluetoothSdk.setScreenDisabled(false);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.setDashboardPosition(height = 4, depth = 6)
+sdk.setHeadUpAngle(angleDegrees = 20)
+sdk.setScreenDisabled(false)
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+try await sdk.setDashboardPosition(height: 4, depth: 6)
+try await sdk.setHeadUpAngle(20)
+try await sdk.setScreenDisabled(false)
+```
+
+  </Tab>
+</Tabs>
+
+## Guidelines
+
+- Keep text short. Glasses displays are glanceable, not phone screens.
+- Prefer one primary message at a time.
+- Avoid rapid display churn. Debounce frequent updates.
+- Clear the display when information is stale.
+- Handle disconnected, not-ready, and unsupported-capability states gracefully.

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -1,0 +1,80 @@
+---
+title: "Example Apps"
+description: "Run the Android, iOS, and React Native starter apps from a fresh clone."
+icon: "mobile"
+---
+
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
+
+```bash
+git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git
+cd Mentra-Bluetooth-SDK-Starter-Kit
+```
+
+## What The Examples Demonstrate
+
+- Scanning for supported Mentra glasses, connecting, disconnecting, and reconnecting to a saved/default device.
+- Reading typed glasses and Bluetooth status snapshots.
+- Displaying text, clearing the display, and opening the dashboard where supported.
+- Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, audio, and SDK log events.
+- Controlling model-supported features such as dashboard position, head-up angle, gallery mode, button photo/video settings, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
+- Running the default glasses-to-phone photo and streaming demos, plus optional cloud-server demos for external upload and streaming endpoints.
+
+## Android
+
+```bash
+cd examples/android
+./gradlew installDebug
+```
+
+The Android example is a Kotlin / Jetpack Compose app. It installs the SDK as `com.mentraglass:bluetooth-sdk`.
+
+## iOS
+
+```bash
+cd examples/ios
+open MentraExample.xcodeproj
+```
+
+The iOS example is a SwiftUI app. It installs the SDK as the `MentraBluetoothSDK` Swift package.
+
+## React Native / Expo
+
+```bash
+cd examples/react-native
+bun install
+bunx expo prebuild
+bunx expo run:ios
+# or
+bun run android:dev
+```
+
+The React Native example installs the SDK as `@mentra/bluetooth-sdk` and demonstrates the same Device, Camera, Stream, System, and Console flows as the native examples.
+
+## Optional Local Photo And Streaming Helper
+
+The Camera and Stream screens default to a glasses-to-phone flow where the example app starts a receiver on the phone and sends the glasses output there. You do not need this helper for that default path.
+
+Use this helper only when you turn on **Use cloud server** in the example app and want to test an external endpoint without deploying your own photo webhook or streaming server. Production apps can use any reachable HTTPS upload endpoint and any reachable RTMP, SRT, or WHIP ingest URL.
+
+From the repo root:
+
+```bash
+python3 examples/local-demo-cloud/server.py
+```
+
+After enabling **Use cloud server**, paste the printed LAN `/upload` URL into the Camera screen, or paste the printed RTMP, SRT, or WHIP publish URL into the Stream screen. If Docker is not installed or not running, the helper starts the photo webhook and skips streaming with a warning.
+
+<Warning>
+Do not use `localhost` in the app. The glasses, phone, and computer must be on a network where the glasses can reach the printed LAN address.
+</Warning>
+
+## Local SDK Development
+
+Package-manager installs are the normal SDK path. Use local overrides only when testing SDK source changes:
+
+- Android: publish `com.mentraglass:bluetooth-sdk` and its companion artifacts to Maven local, then build the example with `mavenLocal()` enabled.
+- iOS: point Xcode at a local Swift package checkout when testing unpublished Swift SDK source changes.
+- React Native: install a local `@mentra/bluetooth-sdk` package path and set `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH` so Metro and native builds resolve the same package.
+
+Do not bake machine-specific paths into committed app config.

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -40,7 +40,7 @@ sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
     renderDevicePicker(nextDevices)
 }
 
-sdk.connect(chooseDevice(devices))
+sdk.connect(waitForUserSelection())
 ```
 
   </Tab>
@@ -53,7 +53,7 @@ try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     renderDevicePicker(nextDevices)
 }
 
-try sdk.connect(to: chooseDevice(devices))
+try sdk.connect(to: await waitForUserSelection())
 ```
 
   </Tab>

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -33,22 +33,28 @@ await BluetoothSdk.connect(await chooseDevice(devices));
   <Tab title="Android">
 
 ```kotlin
+var selectedDevice: Device? = null
 sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
-    renderDevicePicker(nextDevices)
+    renderDevicePicker(nextDevices, onSelect = { selectedDevice = it })
 }
 
-sdk.connect(waitForUserSelection())
+selectedDevice?.let { sdk.connect(it) }
 ```
 
   </Tab>
   <Tab title="iOS">
 
 ```swift
+var selectedDevice: Device? = nil
 try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
-    renderDevicePicker(nextDevices)
+    renderDevicePicker(nextDevices) { device in
+        selectedDevice = device
+    }
 }
 
-try sdk.connect(to: await waitForUserSelection())
+if let selectedDevice {
+    try sdk.connect(to: selectedDevice)
+}
 ```
 
   </Tab>

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -1,0 +1,115 @@
+---
+title: "Hardware Integration"
+description: "Handle model differences and optional capabilities across smart glasses."
+icon: "microchip"
+---
+
+The SDK presents a common native API over multiple glasses models. Capabilities differ by model and firmware, so apps should treat advanced features as optional.
+
+## Recommended Flow
+
+1. Ask the user which glasses model they are pairing.
+2. Call `scan()` for that model.
+3. Present typed discovered devices from the progressive scan results.
+4. Connect using the discovered device or default-device helper.
+5. Read shaped glasses state, firmware fields, and capability-related status before enabling advanced features.
+6. Keep app UI derived from SDK status rather than from command success alone.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+import BluetoothSdk, {DeviceModels} from '@mentra/bluetooth-sdk';
+
+const devices = await BluetoothSdk.scan(DeviceModels.MentraLive, {
+  timeoutMs: 10_000,
+  onResults: (nextDevices) => renderDevicePicker(nextDevices),
+});
+
+await BluetoothSdk.connect(await chooseDevice(devices));
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val devices = mutableListOf<Device>()
+sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
+    devices.clear()
+    devices.addAll(nextDevices)
+    renderDevicePicker(nextDevices)
+}
+
+sdk.connect(chooseDevice(devices))
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+var devices: [Device] = []
+try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
+    devices = nextDevices
+    renderDevicePicker(nextDevices)
+}
+
+try sdk.connect(to: chooseDevice(devices))
+```
+
+  </Tab>
+</Tabs>
+
+In multi-device environments, keep the picker explicit. Do not auto-connect to the first scan result; let the user choose the glasses they expect.
+
+## Capability Areas
+
+- Display: text, dashboard, head-up angle, and screen enable/disable commands.
+- Input: button, touch, head-up, and switch events.
+- Audio: PCM, LC3, audio pairing, preferred microphone, and local transcription.
+- Camera: photo, gallery, video recording, and streaming.
+- Network: Wi-Fi scan, credentials, and hotspot state.
+- Maintenance: model-specific version info.
+
+## Model Differences
+
+Treat each advanced feature as optional. Your app should degrade gracefully if a model does not support camera, Wi-Fi, display batching, local transcription, streaming, RGB LEDs, or controller pairing.
+
+| Model | Display | Camera | Microphone | Speaker | Primary strengths |
+| --- | --- | --- | --- | --- | --- |
+| Mentra Live | No | Yes | Yes | Yes | Camera, microphone, speaker, Wi-Fi, streaming, phone-connected workflows |
+| G2 | Yes | No | Yes | No | Display and glanceable UI workflows |
+
+## Mentra Live Hardware
+
+Mentra Live is the camera glasses model supported by the Bluetooth SDK. It is built for visual capture, streaming, and audio-first interactions rather than display output.
+
+- Camera: 1080p with streaming support.
+- Display: no display.
+- Microphone: yes.
+- Speaker: yes.
+- Buttons: yes, including press, double press, and long press events.
+- LEDs: RGB feedback plus white privacy light.
+- Wi-Fi: yes.
+
+```ts
+{
+  modelName: "Mentra Live",
+  hasCamera: true,
+  hasDisplay: false,
+  hasMicrophone: true,
+  hasSpeaker: true,
+  hasButton: true,
+  hasLight: true,
+  hasWifi: true
+}
+```
+
+Unsupported operations are recoverable SDK errors. Reconcile command failures with the latest status snapshot before showing destructive UI.
+
+## Connection Resilience
+
+- Subscribe to status callbacks before connecting.
+- Retry scans manually from the UI instead of scanning forever in the background.
+- On mobile OS background transitions, expect Bluetooth behavior to vary by platform.
+- Provide a visible "forget device" path that clears both the SDK default device and any app-persisted default-device record.
+- If your app persists a default device, restore it with `setDefaultDevice()` before calling `connectDefault()`.

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -33,10 +33,7 @@ await BluetoothSdk.connect(await chooseDevice(devices));
   <Tab title="Android">
 
 ```kotlin
-val devices = mutableListOf<Device>()
 sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
-    devices.clear()
-    devices.addAll(nextDevices)
     renderDevicePicker(nextDevices)
 }
 
@@ -47,9 +44,7 @@ sdk.connect(waitForUserSelection())
   <Tab title="iOS">
 
 ```swift
-var devices: [Device] = []
 try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
-    devices = nextDevices
     renderDevicePicker(nextDevices)
 }
 

--- a/docs/mentra-live/index.mdx
+++ b/docs/mentra-live/index.mdx
@@ -8,11 +8,7 @@ The Mentra Bluetooth SDK is the base SDK for building mobile apps that control s
 
 Use this SDK when your app owns the mobile experience and needs a direct phone-to-glasses connection.
 
-In Summer 2026, we'll release MentraOS 3.0, a new SDK that combines the speed and ease of the cloud SDK with the speed, privacy, and control of the Bluetooth SDK. Learn more in the [MentraOS Roadmap June blogpost](https://mentraglass.com/blogs/blog/mentra-roadmap-update-moving-to-miniapps-on-the-phone).
-
-<Info>
-If you are building a cloud Mini App that runs through MentraOS, start with the [MentraOS App Devs docs](/app-devs/getting-started/overview) and the Mentra Cloud SDK (`@mentra/sdk`). If you are building a mobile app that talks to glasses over Bluetooth, use this Bluetooth SDK.
-</Info>
+In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run on the phone. Learn more in the [MentraOS Roadmap June blogpost](https://mentraglass.com/blogs/blog/mentra-roadmap-update-moving-to-miniapps-on-the-phone).
 
 ## Packages
 
@@ -29,15 +25,6 @@ If you are building a cloud Mini App that runs through MentraOS, start with the 
 - Apps that receive button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, audio, and SDK log events.
 - Apps that control model-supported features such as dashboard position, head-up angle, gallery mode, camera settings, speaker playback, RGB LEDs, Wi-Fi, hotspot, microphone, camera, and streaming.
 - Photo upload to your own webhook and RTMP, SRT, or WebRTC streaming to your own ingest endpoint. The starter kit also includes optional local demo helpers for trying these flows on a LAN.
-
-## Bluetooth SDK vs Cloud SDK
-
-| Use case | SDK |
-| --- | --- |
-| Build a mobile app that connects directly to glasses over Bluetooth | Mentra Bluetooth SDK |
-| Build a cloud Mini App that users launch from MentraOS | Mentra Cloud SDK (`@mentra/sdk`) |
-| Need CoreBluetooth, Android BLE, native permissions, and mobile lifecycle control | Mentra Bluetooth SDK |
-| Need server-side sessions, webhooks, app store distribution, and MentraOS relay features | Mentra Cloud SDK (`@mentra/sdk`) |
 
 ## Requirements
 

--- a/docs/mentra-live/index.mdx
+++ b/docs/mentra-live/index.mdx
@@ -1,0 +1,63 @@
+---
+title: "Mentra Live"
+description: "Build mobile apps that connect directly to Mentra Live over Bluetooth."
+icon: "bluetooth"
+---
+
+The Mentra Bluetooth SDK is the base SDK for building mobile apps that control smart glasses directly over Bluetooth. It gives Android, iOS, and React Native apps access to scanning, pairing, device status, microphone audio, camera capture on camera-equipped models, speaker playback on speaker-equipped models, streaming, Wi-Fi, hardware events, and display commands on display-equipped models.
+
+Use this SDK when your app owns the mobile experience and needs a direct phone-to-glasses connection.
+
+In Summer 2026, we'll release MentraOS 3.0, a new SDK that combines the speed and ease of the cloud SDK with the speed, privacy, and control of the Bluetooth SDK. Learn more in the [MentraOS Roadmap June blogpost](https://mentraglass.com/blogs/blog/mentra-roadmap-update-moving-to-miniapps-on-the-phone).
+
+<Info>
+If you are building a cloud Mini App that runs through MentraOS, start with the [MentraOS App Devs docs](/app-devs/getting-started/overview) and the Mentra Cloud SDK (`@mentra/sdk`). If you are building a mobile app that talks to glasses over Bluetooth, use this Bluetooth SDK.
+</Info>
+
+## Packages
+
+| Platform | Package | Import |
+| --- | --- | --- |
+| Android | `com.mentraglass:bluetooth-sdk` | `import com.mentra.bluetoothsdk.*` |
+| iOS | `MentraBluetoothSDK` Swift package | `import MentraBluetoothSDK` |
+| React Native / Expo | `@mentra/bluetooth-sdk` | `import BluetoothSdk from '@mentra/bluetooth-sdk'` |
+
+## What You Can Build
+
+- Native Android, iOS, or React Native apps that scan for and connect to MentraOS-compatible glasses.
+- Apps that display text, clear the display, and open the dashboard on display-equipped glasses such as G2.
+- Apps that receive button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, audio, and SDK log events.
+- Apps that control model-supported features such as dashboard position, head-up angle, gallery mode, camera settings, speaker playback, RGB LEDs, Wi-Fi, hotspot, microphone, camera, and streaming.
+- Photo upload to your own webhook and RTMP, SRT, or WebRTC streaming to your own ingest endpoint. The starter kit also includes optional local demo helpers for trying these flows on a LAN.
+
+## Bluetooth SDK vs Cloud SDK
+
+| Use case | SDK |
+| --- | --- |
+| Build a mobile app that connects directly to glasses over Bluetooth | Mentra Bluetooth SDK |
+| Build a cloud Mini App that users launch from MentraOS | Mentra Cloud SDK (`@mentra/sdk`) |
+| Need CoreBluetooth, Android BLE, native permissions, and mobile lifecycle control | Mentra Bluetooth SDK |
+| Need server-side sessions, webhooks, app store distribution, and MentraOS relay features | Mentra Cloud SDK (`@mentra/sdk`) |
+
+## Requirements
+
+- A physical Android phone or iPhone for real Bluetooth testing.
+- Android min SDK `28` or newer.
+- iOS deployment target `15.1` or newer.
+- React Native / Expo apps must use a development build or production native build. Expo Go cannot load the native SDK.
+- Bluetooth permissions, plus Android location permission where BLE scanning requires it.
+
+<CardGroup cols={2}>
+  <Card title="Quickstart" icon="rocket" href="/mentra-live/quickstart">
+    Install the SDK, connect to Mentra Live, and read glasses status.
+  </Card>
+  <Card title="Example Apps" icon="mobile" href="/mentra-live/examples">
+    Run the Android, iOS, and React Native starter apps from a fresh clone.
+  </Card>
+  <Card title="API Reference" icon="book" href="/mentra-live/api-reference">
+    Review lifecycle, commands, events, status fields, and model differences.
+  </Card>
+  <Card title="Troubleshooting" icon="circle-question" href="/mentra-live/troubleshooting">
+    Fix native build, permission, scan, stream, and Expo issues.
+  </Card>
+</CardGroup>

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -1,0 +1,159 @@
+---
+title: "iOS"
+description: "Use the Mentra Bluetooth SDK from a native iOS app."
+icon: "apple"
+---
+
+Native iOS apps use the `MentraBluetoothSDK` Swift package.
+
+## Requirements
+
+- iOS deployment target `15.1` or newer.
+- Xcode 15 or newer.
+- Swift Package Manager.
+- A physical iPhone for Bluetooth, camera, microphone, direct phone photo, and direct phone WebRTC testing.
+
+## Install
+
+The public SwiftPM repository is:
+
+```text
+https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
+```
+
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.10` or newer, and add the `MentraBluetoothSDK` product to your app target.
+
+For `Package.swift` consumers:
+
+```swift
+.package(
+  url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
+  from: "0.1.10"
+)
+```
+
+Then add the product to your target:
+
+```swift
+.product(name: "MentraBluetoothSDK", package: "mentra-bluetooth-sdk-ios")
+```
+
+For local SDK development, add the package folder directly in Xcode:
+
+```text
+/path/to/MentraOS/mobile/modules/bluetooth-sdk
+```
+
+<Warning>
+The SwiftPM package currently builds the core Bluetooth SDK only. It does not build the optional local STT, Nex/SwiftProtobuf, Vuzix/Ultralite, or tar.bz2 extraction code paths.
+</Warning>
+
+## Permissions
+
+Add usage descriptions to `Info.plist`:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app connects to your smart glasses over Bluetooth.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>This app uses the microphone when you enable audio features.</string>
+<key>NSLocalNetworkUsageDescription</key>
+<string>This app can connect to optional local demo servers on your network.</string>
+```
+
+## Background Operation
+
+If your iOS app needs to keep the glasses BLE link alive while the phone is locked or the app is backgrounded, enable Core Bluetooth background mode:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+  <string>bluetooth-central</string>
+</array>
+```
+
+If your app also keeps microphone capture or an audio session active in the background, add `audio` as well:
+
+```xml
+<key>UIBackgroundModes</key>
+<array>
+  <string>bluetooth-central</string>
+  <string>audio</string>
+</array>
+```
+
+Configure your `AVAudioSession` before starting continuous microphone or playback work. Start continuous microphone capture while the app is foregrounded; iOS background mode lets an active session continue, but the SDK does not start the phone microphone from the background. For example:
+
+```swift
+let session = AVAudioSession.sharedInstance()
+try session.setCategory(.playAndRecord, mode: .default, options: [.allowBluetooth, .defaultToSpeaker])
+try session.setActive(true)
+```
+
+`bluetooth-central` allows iOS to continue BLE central activity in the background, subject to iOS scheduling and power-management limits. `audio` is required only for apps that intentionally keep recording or audio playback active after backgrounding.
+
+<Warning>
+This SDK version does not enable terminated-app Core Bluetooth state restoration with `CBCentralManagerOptionRestoreIdentifierKey`. If iOS terminates the app, relaunch the app and reconnect from your normal startup flow.
+</Warning>
+
+## Basic Flow
+
+```swift
+import MentraBluetoothSDK
+
+@MainActor
+final class GlassesController: NSObject, MentraBluetoothSDKDelegate {
+    private let sdk = MentraBluetoothSDK()
+    private var selectedDevice: Device?
+
+    override init() {
+        super.init()
+        sdk.delegate = self
+    }
+
+    func scan() throws {
+        try sdk.scan(model: .mentraLive, timeout: 10) { [weak self] devices in
+            self?.renderDevicePicker(devices) { device in
+                self?.selectedDevice = device
+            }
+        }
+    }
+
+    func connect() throws {
+        guard let selectedDevice else { return }
+        try sdk.connect(to: selectedDevice)
+    }
+
+    func refreshStatus() {
+        sdk.requestVersionInfo()
+        let glasses = sdk.glasses
+        if let device = glasses.device {
+            let battery = glasses.battery?.level.map(String.init) ?? "unknown"
+            print("Connected to \(device.deviceModel?.deviceType ?? "glasses"), battery=\(battery)%")
+        }
+    }
+
+    func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didUpdateGlasses glasses: GlassesRuntimeState) {
+        // Keep app UI derived from SDK status.
+        print("Glasses changed: \(glasses)")
+    }
+
+    private func renderDevicePicker(_ devices: [Device], onSelect: @escaping (Device) -> Void) {
+        // Render devices in SDK-provided order and call onSelect with the user's choice.
+    }
+
+    deinit {
+        sdk.invalidate()
+    }
+}
+```
+
+## Local SDK Override
+
+Use this when testing native Swift SDK source changes locally:
+
+```text
+/path/to/MentraOS/mobile/modules/bluetooth-sdk
+```
+
+Add that folder as a local Swift package in Xcode. Keep local paths in your workspace settings or CI environment, not in committed project settings.

--- a/docs/mentra-live/production-checklist.mdx
+++ b/docs/mentra-live/production-checklist.mdx
@@ -1,0 +1,57 @@
+---
+title: "Production Checklist"
+description: "Validate a mobile app before shipping with the Mentra Bluetooth SDK."
+icon: "clipboard-check"
+---
+
+Use this checklist before shipping an app with the Mentra Bluetooth SDK.
+
+## App Setup
+
+- Android, iOS, and/or React Native native builds are configured for the app stack you ship.
+- iOS deployment target is `15.1` or newer.
+- Android min SDK is `28` or newer.
+- Android builds use Java 17.
+- Android native packaging includes any `pickFirst` rules required by the app's own native dependencies.
+- Bluetooth permission copy is user-friendly and specific.
+- Microphone, camera, local network, notification, and location permissions are requested only when needed.
+- The app integrates through the documented Android, iOS, or React Native SDK APIs.
+
+## SDK Integration
+
+- App subscribes to typed glasses and Bluetooth status callbacks.
+- App handles disconnect, reconnect, scan stopped, and pair failure states.
+- App does not assume every model supports every feature.
+- App cleans up SDK listeners/delegates and calls `close()` / `invalidate()` when sessions end.
+- React Native apps remove every SDK event subscription when screens/session owners unmount.
+- App avoids sending rapid display updates without debouncing.
+- App uses typed settings APIs for dashboard, gallery mode, camera, LED, Wi-Fi, streaming, and microphone settings.
+- Advanced controls are gated behind SDK capability/status checks.
+
+## Privacy And Compliance
+
+- Audio capture behavior is clearly disclosed.
+- Camera capture behavior is clearly disclosed.
+- Bluetooth and location permission copy explains device discovery.
+- Cloud upload behavior is documented in the app privacy policy.
+- Logs avoid sensitive user data.
+
+## Release Validation
+
+- Fresh bare Android app install using the published Maven artifact.
+- Fresh bare iOS app install using the published Swift package.
+- Fresh React Native development or production build using the published JavaScript package, if shipping React Native.
+- Android sample app in the Starter Kit builds.
+- iOS sample app in the Starter Kit resolves SwiftPM dependencies and builds.
+- React Native sample app in the Starter Kit runs `bun install`, `bunx expo prebuild`, and at least one native platform build.
+- Fresh install test on iOS.
+- Fresh install test on Android.
+- Pairing test with each supported glasses model.
+- Reconnect test after app restart.
+- Reconnect test after Bluetooth toggle.
+- Display command test, if shipping display-equipped models such as G2.
+- Camera/gallery/streaming test, if shipping camera-equipped models such as Mentra Live.
+- Speaker playback test, if shipping speaker-equipped models such as Mentra Live.
+- Hardware settings test for dashboard where supported, save-in-gallery mode, camera options, LED color/pattern, Wi-Fi, and hotspot behavior.
+- Button/touch event test.
+- Microphone audio/transcription test if enabled.

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -1,0 +1,358 @@
+---
+title: "Quickstart"
+description: "Install the Mentra Bluetooth SDK and connect a mobile app to smart glasses."
+icon: "rocket"
+---
+
+This quickstart shows the shortest path from package install to connecting to Mentra Live and reading glasses status.
+
+<Warning>
+Use a physical phone for Bluetooth testing. Simulators and emulators are useful for UI and compile checks, but they do not provide the real Bluetooth path.
+</Warning>
+
+## Step 1: Install The SDK
+
+<Tabs>
+  <Tab title="React Native / Expo">
+
+```bash
+bun add @mentra/bluetooth-sdk
+bunx expo install expo-build-properties
+```
+
+Add the config plugin to your Expo app config. In most Expo apps this is the root `app.json`; in TypeScript-configured apps it is usually the root `app.config.ts`. Merge these keys into the existing top-level `expo` object instead of creating a second config file or replacing unrelated settings:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@mentra/bluetooth-sdk",
+        {
+          "node": true
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "minSdkVersion": 28,
+            "packagingOptions": {
+              "pickFirst": [
+                "**/libc++_shared.so",
+                "**/libonnxruntime.so",
+                "**/libonnxruntime4j_jni.so"
+              ]
+            }
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+Then generate and run a native build:
+
+```bash
+bunx expo prebuild
+bunx expo run:ios
+# or
+bunx expo run:android
+```
+
+  </Tab>
+  <Tab title="Android">
+
+Add the Android package:
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+```
+
+```kotlin
+// app/build.gradle.kts
+android {
+    defaultConfig {
+        minSdk = 28
+    }
+    packaging {
+        jniLibs {
+            pickFirsts += "**/libc++_shared.so"
+        }
+    }
+}
+
+dependencies {
+    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
+}
+```
+
+The Android artifact is published on Maven Central. Keep `google()` and `mavenCentral()` in `repositories`. The companion LC3 codec artifact resolves transitively as `com.mentraglass:lc3Lib`.
+
+  </Tab>
+  <Tab title="iOS">
+
+Add the Swift package.
+
+In Xcode, add this package URL:
+
+```text
+https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
+```
+
+Use version `0.1.10` or newer, then add the `MentraBluetoothSDK` product to your app target.
+
+For `Package.swift` consumers:
+
+```swift
+.package(
+  url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
+  from: "0.1.10"
+)
+```
+
+Then add the product to your target:
+
+```swift
+.product(name: "MentraBluetoothSDK", package: "mentra-bluetooth-sdk-ios")
+```
+
+  </Tab>
+</Tabs>
+
+## Step 2: Add Permissions
+
+<Tabs>
+  <Tab title="React Native / Expo">
+
+Configure permissions in the same root Expo app config. If your app already has `android.permissions` or `ios.infoPlist`, append or merge these values:
+
+```json
+{
+  "expo": {
+    "android": {
+      "permissions": [
+        "android.permission.BLUETOOTH_SCAN",
+        "android.permission.BLUETOOTH_CONNECT",
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.POST_NOTIFICATIONS"
+      ]
+    },
+    "ios": {
+      "infoPlist": {
+        "NSBluetoothAlwaysUsageDescription": "This app connects to your smart glasses over Bluetooth.",
+        "NSMicrophoneUsageDescription": "This app uses the microphone when you enable audio features.",
+        "NSLocalNetworkUsageDescription": "This app can connect to optional local demo servers on your network."
+      }
+    }
+  }
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+Declare the platform permissions your app uses:
+
+```xml
+<uses-permission android:name="android.permission.BLUETOOTH_SCAN" />
+<uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+<uses-permission android:name="android.permission.RECORD_AUDIO" />
+<uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+```
+
+Some Android 12+ devices require runtime location permission and Location services before BLE scan callbacks arrive.
+
+  </Tab>
+  <Tab title="iOS">
+
+Add usage descriptions to `Info.plist`:
+
+```xml
+<key>NSBluetoothAlwaysUsageDescription</key>
+<string>This app connects to your smart glasses over Bluetooth.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>This app uses the microphone when you enable audio features.</string>
+<key>NSLocalNetworkUsageDescription</key>
+<string>This app can connect to optional local demo servers on your network.</string>
+```
+
+  </Tab>
+</Tabs>
+
+## Step 3: Connect And Read Status
+
+<Tabs>
+  <Tab title="React Native / Expo">
+
+```ts
+import BluetoothSdk, {DeviceModels} from '@mentra/bluetooth-sdk';
+
+const devices = await BluetoothSdk.scan(DeviceModels.MentraLive, {
+  timeoutMs: 10_000,
+  onResults: (nextDevices) => {
+    console.log('Nearby glasses:', nextDevices);
+  },
+});
+
+const device = await chooseDevice(devices);
+if (!device) {
+  throw new Error('No Mentra Live glasses selected');
+}
+
+await BluetoothSdk.connect(device);
+await BluetoothSdk.requestVersionInfo();
+```
+
+`onResults` is the live UI path while scanning is in progress. The returned `devices` array is the final list after the scan timeout/completion, which is the right place for final selection, fallback behavior, or "connect to this device" logic. In rooms with multiple pairs of glasses, present an explicit picker instead of auto-connecting to the first nearby device.
+
+Use `Device.id` as the stable app-facing key for scan rows, selected devices, and persisted default devices. Do not parse it for model, name, or address information; use the typed `model`, `name`, `address` / `identifier`, and `rssi` fields instead. Android commonly uses a Bluetooth address when available, iOS commonly uses a CoreBluetooth identifier when available, and the SDK falls back to `model:name` when no platform identifier is available.
+
+`Device.rssi` is optional. A device can appear in scan results before the platform reports RSSI, so picker UI should handle `undefined` and avoid reordering rows just because RSSI metadata arrives later.
+
+In React components, use `useMentraBluetooth()` to render the current connection and status state:
+
+```tsx
+import {Text} from 'react-native';
+import {useMentraBluetooth} from '@mentra/bluetooth-sdk/react';
+
+export function GlassesConnectionLabel() {
+  const mentra = useMentraBluetooth();
+
+  if (!mentra.glasses.connected) {
+    return <Text>Disconnected</Text>;
+  }
+
+  return <Text>Connected to {mentra.glasses.device.deviceModel || 'Mentra Live'}</Text>;
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+import android.content.Context
+import com.mentra.bluetoothsdk.Device
+import com.mentra.bluetoothsdk.DeviceModel
+import com.mentra.bluetoothsdk.GlassesRuntimeState
+import com.mentra.bluetoothsdk.MentraBluetoothSdk
+import com.mentra.bluetoothsdk.MentraBluetoothSdkCallback
+
+class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
+    private val sdk = MentraBluetoothSdk.create(
+        context = context.applicationContext,
+        listener = this,
+    )
+    private var selectedDevice: Device? = null
+
+    fun scan() {
+        sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { devices ->
+            renderDevicePicker(devices, onSelect = { selectedDevice = it })
+        }
+    }
+
+    fun connect() {
+        selectedDevice?.let { sdk.connect(it) }
+    }
+
+    fun refreshStatus() {
+        sdk.requestVersionInfo()
+        val glasses = sdk.getGlasses()
+        if (glasses is GlassesRuntimeState.Connected) {
+            val model = glasses.device.deviceModel?.deviceType ?: "glasses"
+            val battery = glasses.battery.level?.toString() ?: "unknown"
+            println("Connected to $model, battery=$battery%")
+        }
+    }
+
+    override fun onGlassesChanged(glasses: GlassesRuntimeState) {
+        // Keep app UI derived from SDK status.
+        println("Glasses changed: $glasses")
+    }
+
+    private fun renderDevicePicker(devices: List<Device>, onSelect: (Device) -> Unit) {
+        // Render devices in SDK-provided order and call onSelect with the user's choice.
+    }
+
+    fun close() {
+        sdk.close()
+    }
+}
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+import MentraBluetoothSDK
+
+@MainActor
+final class GlassesController: NSObject, MentraBluetoothSDKDelegate {
+    private let sdk = MentraBluetoothSDK()
+    private var selectedDevice: Device?
+
+    override init() {
+        super.init()
+        sdk.delegate = self
+    }
+
+    func scan() throws {
+        try sdk.scan(model: .mentraLive, timeout: 10) { [weak self] devices in
+            self?.renderDevicePicker(devices) { device in
+                self?.selectedDevice = device
+            }
+        }
+    }
+
+    func connect() throws {
+        guard let selectedDevice else { return }
+        try sdk.connect(to: selectedDevice)
+    }
+
+    func refreshStatus() {
+        sdk.requestVersionInfo()
+        let glasses = sdk.glasses
+        if let device = glasses.device {
+            let battery = glasses.battery?.level.map(String.init) ?? "unknown"
+            print("Connected to \(device.deviceModel?.deviceType ?? "glasses"), battery=\(battery)%")
+        }
+    }
+
+    func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didUpdateGlasses glasses: GlassesRuntimeState) {
+        // Keep app UI derived from SDK status.
+        print("Glasses changed: \(glasses)")
+    }
+
+    private func renderDevicePicker(_ devices: [Device], onSelect: @escaping (Device) -> Void) {
+        // Render devices in SDK-provided order and call onSelect with the user's choice.
+    }
+
+    deinit {
+        sdk.invalidate()
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Run Example Apps" icon="mobile" href="/mentra-live/examples">
+    Start from complete Android, iOS, and React Native examples.
+  </Card>
+  <Card title="API Reference" icon="book" href="/mentra-live/api-reference">
+    Learn the lifecycle, commands, status fields, and events.
+  </Card>
+</CardGroup>

--- a/docs/mentra-live/react-native-expo.mdx
+++ b/docs/mentra-live/react-native-expo.mdx
@@ -1,0 +1,280 @@
+---
+title: "React Native / Expo"
+description: "Use @mentra/bluetooth-sdk from a React Native or Expo development build."
+icon: "mobile-screen-button"
+---
+
+React Native apps use the JavaScript package `@mentra/bluetooth-sdk`. The package contains native Android and iOS code, so it must run in a development build or production native build.
+
+<Warning>
+Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the SDK's native modules.
+</Warning>
+
+## Install
+
+```bash
+bun add @mentra/bluetooth-sdk
+bunx expo install expo-build-properties
+```
+
+## Configure The Expo Plugin
+
+Add the SDK plugin and Android native-library packaging rules to your Expo app config. In most Expo apps this is the root `app.json`; in TypeScript-configured apps it is usually the root `app.config.ts`. Merge these keys into the existing top-level `expo` object instead of creating a second config file or replacing unrelated settings:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@mentra/bluetooth-sdk",
+        {
+          "node": true
+        }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "minSdkVersion": 28,
+            "packagingOptions": {
+              "pickFirst": [
+                "**/libc++_shared.so",
+                "**/libonnxruntime.so",
+                "**/libonnxruntime4j_jni.so"
+              ]
+            }
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+The plugin configures native module registration and the companion Android `lc3Lib` module during prebuild.
+
+## Run
+
+```bash
+bunx expo prebuild
+bunx expo run:ios
+# or
+bunx expo run:android
+```
+
+Use a physical phone for Bluetooth, camera, microphone, direct phone photo, and direct phone WebRTC testing.
+
+## Permissions
+
+Configure permissions in the same root Expo app config. If your app already has `android.permissions` or `ios.infoPlist`, append or merge these values:
+
+```json
+{
+  "expo": {
+    "android": {
+      "permissions": [
+        "android.permission.BLUETOOTH_SCAN",
+        "android.permission.BLUETOOTH_CONNECT",
+        "android.permission.ACCESS_FINE_LOCATION",
+        "android.permission.RECORD_AUDIO",
+        "android.permission.POST_NOTIFICATIONS"
+      ]
+    },
+    "ios": {
+      "infoPlist": {
+        "NSBluetoothAlwaysUsageDescription": "This app connects to your smart glasses over Bluetooth.",
+        "NSMicrophoneUsageDescription": "This app uses the microphone when you enable audio features.",
+        "NSLocalNetworkUsageDescription": "This app can connect to optional local demo servers on your network."
+      }
+    }
+  }
+}
+```
+
+## Background Operation On iOS
+
+If your React Native app needs BLE to keep running while the phone is locked or the app is backgrounded, add `bluetooth-central` to `ios.infoPlist.UIBackgroundModes`. If the app also keeps microphone capture or an audio session active in the background, add `audio` too:
+
+```json
+{
+  "expo": {
+    "ios": {
+      "infoPlist": {
+        "UIBackgroundModes": [
+          "bluetooth-central",
+          "audio"
+        ],
+        "NSBluetoothAlwaysUsageDescription": "This app connects to your smart glasses over Bluetooth.",
+        "NSMicrophoneUsageDescription": "This app uses the microphone when you enable audio features."
+      }
+    }
+  }
+}
+```
+
+Configure the iOS audio session before continuous mic capture. If your app does not already depend on `expo-audio`, install it with `bunx expo install expo-audio`. Then call `setAudioModeAsync` once during app startup or before enabling the microphone:
+
+```ts
+import {setAudioModeAsync} from 'expo-audio';
+
+await setAudioModeAsync({
+  allowsRecording: true,
+  allowsBackgroundRecording: true,
+  shouldPlayInBackground: true,
+  playsInSilentMode: true,
+  interruptionMode: 'duckOthers',
+});
+```
+
+Start continuous microphone capture while the app is foregrounded; iOS background mode lets an active session continue, but the SDK does not start the phone microphone from the background.
+
+Use `audio` background mode only when the app genuinely records or plays audio in the background. `bluetooth-central` is the BLE requirement; `audio` is the audio-session requirement for continuous mic/audio behavior.
+
+<Warning>
+This SDK version does not enable terminated-app Core Bluetooth state restoration with `CBCentralManagerOptionRestoreIdentifierKey`. If iOS terminates the app, relaunch the app and reconnect from your normal startup flow.
+</Warning>
+
+## Basic Usage
+
+```ts
+import BluetoothSdk, {DeviceModels} from '@mentra/bluetooth-sdk';
+
+const devices = await BluetoothSdk.scan(DeviceModels.MentraLive, {
+  timeoutMs: 10_000,
+  onResults: (nextDevices) => {
+    console.log('Nearby glasses:', nextDevices);
+  },
+});
+
+const device = await chooseDevice(devices);
+if (!device) {
+  throw new Error('No Mentra Live glasses selected');
+}
+
+await BluetoothSdk.connect(device);
+await BluetoothSdk.requestVersionInfo();
+```
+
+Use the React hooks below to render connection and status state in components. Mentra Live does not have a display; use display commands only after gating by model capability.
+
+## React Hooks
+
+React Native apps can use the optional hooks subpath for common lifecycle
+plumbing while keeping the root SDK available for direct commands:
+
+| Hook | Use when |
+| --- | --- |
+| `useMentraBluetooth` | You want one React session object for status, scan, connect/disconnect, default-device state, and gallery mode. |
+| `useBluetoothScan` | You want a focused scan picker without the full connection/session helper. |
+| `useBluetoothEvent` | You want React-managed subscription cleanup for hardware events such as button presses, touch, battery, Wi-Fi, hotspot, photo, stream, speaking, or microphone events. |
+
+```tsx
+import {Button, Text, View} from 'react-native';
+import {DeviceModels} from '@mentra/bluetooth-sdk';
+import {useBluetoothEvent, useMentraBluetooth} from '@mentra/bluetooth-sdk/react';
+
+export function DeviceScreen() {
+  const mentra = useMentraBluetooth({
+    defaultModel: DeviceModels.MentraLive,
+    scanTimeoutMs: 10_000,
+  });
+
+  useBluetoothEvent('button_press', (event) => {
+    console.log('Glasses button:', event.buttonId, event.pressType);
+  });
+
+  useBluetoothEvent('speaking_status', (event) => {
+    console.log('Speaking:', event.speaking);
+  });
+
+  return (
+    <View>
+      <Text>{mentra.glasses.connected ? 'Connected' : 'Disconnected'}</Text>
+      <Button disabled={mentra.busy} title="Scan" onPress={() => mentra.scan.start()} />
+      {mentra.scan.devices.map((device) => (
+        <Button key={device.id} title={device.name} onPress={() => mentra.connect(device)} />
+      ))}
+      <Button
+        disabled={!mentra.glasses.connected || mentra.sdk.galleryMode.applying}
+        title={mentra.sdk.galleryMode.enabled ? 'Disable gallery mode' : 'Enable gallery mode'}
+        onPress={() => {
+          void mentra.setGalleryModeEnabled(!mentra.sdk.galleryMode.enabled);
+        }}
+      />
+      <Button disabled={!mentra.glasses.connected} title="Disconnect" onPress={mentra.disconnect} />
+    </View>
+  );
+}
+```
+
+For a standalone picker, use `useBluetoothScan()` directly:
+
+```tsx
+import {Button, Text, View} from 'react-native';
+import {DeviceModels, type Device} from '@mentra/bluetooth-sdk';
+import {useBluetoothScan} from '@mentra/bluetooth-sdk/react';
+
+export function ScanPicker({onConnect}: {onConnect: (device: Device) => void}) {
+  const scan = useBluetoothScan({
+    model: DeviceModels.MentraLive,
+    timeoutMs: 10_000,
+  });
+
+  return (
+    <View>
+      <Button disabled={scan.scanning} title="Scan" onPress={() => scan.startScan()} />
+      {scan.error ? <Text>Scan failed</Text> : null}
+      {scan.devices.map((device) => (
+        <Button key={device.id} title={device.name} onPress={() => onConnect(device)} />
+      ))}
+    </View>
+  );
+}
+```
+
+The hooks do not request Android permissions or choose a persistence package for
+you. Ask for permissions in your app before calling scan/connect actions, and
+pass a `defaultDeviceStorage` adapter to `useMentraBluetooth` if you want to
+restore a default device across app restarts.
+
+## Status Shape
+
+React Native exposes `mentra.glasses.connection` as a discriminated union:
+
+```ts
+type GlassesConnectionStatus =
+  | {state: 'disconnected'}
+  | {state: 'scanning'}
+  | {state: 'connecting'}
+  | {state: 'bonding'}
+  | {state: 'connected'; fullyBooted: boolean};
+```
+
+Use `mentra.glasses.connection.state` for link-layer progress. `fullyBooted` only exists when `state === 'connected'`.
+
+Use `useMentraBluetooth()` as the React status API for connection, battery, Wi-Fi, hotspot, scan, and SDK runtime state. `setGalleryModeEnabled(...)` resolves with the ASG `SettingsAckSuccessEvent` and rejects failure statuses, `mentra.sdk.galleryMode.enabled` reflects the acknowledged gallery-mode setting, and `mentra.sdk.galleryMode.applying` is true while that ASG response is in flight.
+
+## Default Device
+
+React Native apps should persist their own default-device record if they want `connectDefault()` to work after restart:
+
+```ts
+const savedDevice = await loadSavedDevice();
+if (savedDevice) {
+  await BluetoothSdk.setDefaultDevice(savedDevice);
+  await BluetoothSdk.connectDefault();
+}
+```
+
+## Local SDK Override
+
+Use this when testing SDK source changes locally:
+
+```bash
+bun add --no-save /path/to/MentraOS/mobile/modules/bluetooth-sdk
+MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/path/to/MentraOS/mobile/modules/bluetooth-sdk bunx expo run:ios
+# or
+MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/path/to/MentraOS/mobile/modules/bluetooth-sdk bunx expo run:android
+```
+
+Keep `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH` in your shell or CI environment, not in committed app config.

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -1,0 +1,77 @@
+---
+title: "Troubleshooting"
+description: "Fix dependency, permission, scan, stream, and React Native build issues."
+icon: "circle-question"
+---
+
+## Android Dependency Resolution Fails
+
+- Confirm your app has `google()` and `mavenCentral()` configured.
+- Confirm `com.mentraglass:bluetooth-sdk:<version>` matches the SDK version you are integrating.
+- Confirm Gradle can resolve the companion `com.mentraglass:lc3Lib` artifact transitively.
+- If a version was just published, Maven Central mirror propagation can lag briefly. Retry after the artifact appears under `https://repo.maven.apache.org/maven2/com/mentraglass/`.
+- If you are testing an unreleased SDK, publish the SDK and companion artifacts to `mavenLocal()` and include `mavenLocal()` in the app repositories.
+
+## Android Build Fails On Native Libraries
+
+- Confirm Android min SDK is at least `28`.
+- Confirm Java 17 is used by Gradle.
+- If your app also includes native media or camera dependencies, add `pickFirsts += "**/libc++_shared.so"` under `android.packaging.jniLibs`.
+- Confirm no app-level packaging rule excludes `libc++_shared.so` or SDK native libraries.
+- Clean only the app build output first. Do not delete SDK source artifacts unless you are intentionally resetting your workspace.
+
+## iOS Swift Package Resolution Fails
+
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.10` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+
+If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
+
+## React Native Native Module Is Missing
+
+- Confirm you are running a development build or production native build. Expo Go cannot load `@mentra/bluetooth-sdk`.
+- Run `bunx expo prebuild` after adding the SDK plugin to `app.json`.
+- Confirm `@mentra/bluetooth-sdk` is installed in the app that is being prebuilt.
+- On iOS, rerun `bunx expo run:ios` after changing native module dependencies.
+- If you are testing a local SDK package, set `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH` to the same package path you installed with Bun.
+
+## Bluetooth Permission Problems
+
+- Android 12+ requires runtime Bluetooth scan/connect permissions.
+- Android scanning may require location permission or Location services depending on OS version and device policy.
+- On some Android 12+ devices, scans can start successfully but return zero callbacks until `ACCESS_FINE_LOCATION` is granted.
+- iOS requires `NSBluetoothAlwaysUsageDescription`.
+- Microphone/audio features require `RECORD_AUDIO` on Android and `NSMicrophoneUsageDescription` on iOS.
+
+## No Devices Found
+
+- Confirm the glasses are charged and in pairing mode.
+- Confirm OS Bluetooth permissions are granted.
+- On Android, confirm location permission is granted and device Location services are enabled.
+- Confirm the selected `DeviceModel` matches the target glasses family.
+- Stop and restart scanning from the UI instead of scanning indefinitely.
+- Try pairing from a clean Bluetooth state after forgetting the device.
+
+## Connected But No Events
+
+- Subscribe before connecting.
+- In React Native, render `useMentraBluetooth()` state for connection, battery, Wi-Fi, hotspot, scan, and SDK state. In native Android/iOS apps, log the SDK status objects.
+- Confirm the hardware feature is available on the connected model.
+- Watch SDK log callbacks for native diagnostics.
+
+## Optional Local Stream Preview Does Not Show Video
+
+- The local demo cloud is only needed when the starter app's Stream screen has **Use cloud server** enabled. If you are using that optional local stream preview, confirm the local demo cloud or MediaMTX helper is running.
+- Use the printed LAN URL, not `localhost`, in the example app's RTMP or WebRTC field.
+- Confirm the glasses, phone, and computer are on a network where local device-to-device traffic is allowed.
+- Confirm Mentra Live is connected to Wi-Fi before starting the stream.
+- For RTMP, the native iOS example embeds the derived HLS preview URL while live. You can also open or refresh the printed HLS preview URL on your computer after tapping **Start stream**.
+- If Docker is running in bridge mode, confirm UDP ports `8890` and `8189` are published.
+- If the helper picked the wrong network interface, restart it with `python3 examples/local-demo-cloud/server.py --host-ip <computer-lan-ip>`.
+
+## React Native Or Expo Apps
+
+React Native and Expo apps use the `@mentra/bluetooth-sdk` package and must run as development builds or production native builds. Expo Go cannot load the native SDK. Start from `examples/react-native` for Expo, `examples/android` for bare Android, or `examples/ios` for bare iOS.
+
+If Android prebuild succeeds but native linking fails, confirm the generated project includes `:lc3Lib` in `android/settings.gradle`. The SDK plugin adds this module automatically during prebuild.
+
+If iOS builds fail with missing Expo adapter symbols, rerun `bunx expo prebuild` so the SDK plugin can configure the Podfile for Expo module registration.


### PR DESCRIPTION
## Summary
- embed the deployed Bluetooth SDK docs under the first-party Mentra Live tab in frozen docs
- add AI IDE Integration to the Mentra Live getting started nav as well as Display Glasses
- update homepage/display overview links to point at the local Mentra Live docs
- restore useful Mentra Live hardware support details into the imported hardware page
- keep the June MentraOS roadmap blogpost link in the Mentra Live overview

## Validation
- python3 -m json.tool docs/docs.json >/dev/null
- git diff --check origin/frozen-docs..HEAD
- bunx --bun mint validate (passes; existing parser warnings remain in LC3-BITRATE-UPGRADE-PLAN.md and issues/docs-overhaul/spec.md)
- bunx --bun mint broken-links (blocked by existing LC3-BITRATE-UPGRADE-PLAN.md parser error before link checking)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation-only changes with no runtime code; main risk is stale external bookmarks to the old camera docs path.
> 
> **Overview**
> Adds a full **Mentra Live** documentation tree under `/mentra-live` and wires it into Mintlify as its own tab (getting started, platform setup, core APIs, release), replacing the single camera README entry.
> 
> **Navigation and entry points** now point Mentra Live builders at `/mentra-live` from the homepage card and Display Glasses overview instead of `/app-devs/core-concepts/camera`.
> 
> **AI IDE / MCP setup** is refreshed for HTTP-first configs (Cursor `url`, VS Code `.vscode/mcp.json` with `servers`, Claude CLI flag order) and duplicated under Mentra Live getting started with links to Bluetooth quickstart/examples. Display Glasses AI IDE troubleshooting drops the `sudo` npx recommendation in favor of permission-manager guidance on the Mentra Live copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd1071da237e4d6de01685dfb5f5b3cdd9124120. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->