### PR TITLE
Revert asg client 38 OTA bump in prod_live_version.json

### DIFF
--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 38,
-      "versionName": "38.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38.apk",
-      "sha256": "ccd334a658f1e6aa2d716dc5a2b2ea2751bead5bda25b8cf43be4faffa9e20a8"
+      "versionCode": 37,
+      "versionName": "37.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
+      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -14,24 +14,6 @@
     }
   },
   "mtk_patches": [
-    {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
-    },
     {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",


### PR DESCRIPTION
Reverts the OTA bump from commit acb981c70 ("update ota files"), **for `prod_live_version.json` only**.

## What this reverts
- asg client `versionCode`/`versionName` 38 → 37 (and the matching apkUrl + sha256)
- Removes the three MTK patches added in that commit:
  - `MentraLive_20260418` → `20260525`
  - `MentraLive_20260421` → `20260525`
  - `MentraLive_20260513` → `20260525`

The file is restored to its state at the parent of acb981c70 (asg client 37, original MTK patch set / BES firmware unchanged).

## Scope
Only `asg_client/ota_website/prod_live_version.json` is touched — no other files from acb981c70 are reverted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the live production OTA manifest, so deployed glasses will receive different APK/firmware offers until re-bumped; rollback is intentional but affects all prod OTA consumers.
> 
> **Overview**
> Reverts the production OTA manifest **`prod_live_version.json`** to the pre–v38 state (rollback of commit acb981c70), scoped to this file only.
> 
> **ASG client** live target is rolled back from **38** to **37**: `versionCode`/`versionName`, `apkUrl` (`asg-client-37.apk`), and `sha256` are restored.
> 
> **MTK patches:** three entries added in the v38 bump are removed (`MentraLive_20260418`, `20260421`, and `20260513` → `20260525`). The two older patch rows (`20260204` and `20260113` → `20260525`) and **BES firmware** metadata are unchanged.
> 
> Once deployed to `ota.mentraglass.com`, devices using this manifest will stop being offered client 38 and the removed MTK upgrade paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a54632de02f855020b258196a0f5959245f798. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the OTA bump for `com.mentra.asg_client` in asg_client/ota_website/prod_live_version.json, restoring client 37 and removing the three MTK patches added with 38. Only the app version fields, apkUrl/sha256, and those MTK patches are rolled back; BES firmware and other files remain unchanged.

<sup>Written for commit d6a54632de02f855020b258196a0f5959245f798. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

