### PR TITLE
Add MTK OTA patches (20260418 / 20260421 / 20260513 → 20260525)

### DIFF
--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,6 +15,24 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
+      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
+      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+    },
+    {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",


### PR DESCRIPTION
Adds three MentraLive MTK OTA patch entries to `prod_live_version.json`:

| start_firmware | end_firmware |
|---|---|
| MentraLive_20260418 | MentraLive_20260525 |
| MentraLive_20260421 | MentraLive_20260525 |
| MentraLive_20260513 | MentraLive_20260525 |

These are prepended to the `mtk_patches` array, ahead of the existing `20260204` and `20260113` entries. No other entries (apps, BES firmware, existing patches) are touched.

## Scope
Only `asg_client/ota_website/prod_live_version.json` is modified (18 insertions, 0 deletions). JSON validated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 72189d5529e1406b7ef627633ba4b0ed38d5aeae. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds three MTK OTA patch entries so devices on MentraLive_20260418, MentraLive_20260421, and MentraLive_20260513 can upgrade to MentraLive_20260525.
Updates only asg_client/ota_website/prod_live_version.json (prepends to mtk_patches); no other entries changed.

<sup>Written for commit 72189d5529e1406b7ef627633ba4b0ed38d5aeae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

