### PR TITLE
Fix asg_client OTA APK cache verification (infinite update loop)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -136,6 +136,12 @@ public class OtaHelper {
     private static final String CACHE_KEY_MTK = "mtk_main";
     private static final String CACHE_KEY_BES = "bes_main";
 
+    // Cached artifacts auto-expire after this age and are re-downloaded on the next check, even
+    // if they still pass integrity verification. Defense-in-depth: a cache entry that somehow
+    // becomes poisoned (e.g. a future bug, or a server-side artifact swap that reuses a path)
+    // cannot persist indefinitely and trap a device in an update loop.
+    private static final long CACHE_MAX_AGE_MS = 7L * 24 * 60 * 60 * 1000; // 7 days
+
     // ⚠️ DEBUG FLAG: Set to true to skip all checks and install MTK firmware from local file
     // This will bypass version checking, downloading, and directly install
     // /storage/emulated/0/asg/mtk_firmware.zip
@@ -418,11 +424,27 @@ public class OtaHelper {
     private void markCachedArtifactReady(
             String cacheKey, String updateType, String localPath, JSONObject metadata) {
         try {
+            // Store the ACTUAL computed hash of the file on disk, not the server's claimed hash
+            // from the manifest. Storing the server's claim made cache validation a tautology
+            // (compare the claim to itself), so a corrupt/partial/stale file would be trusted
+            // forever. Computing the real hash here means isCachedArtifactValid()'s fast path
+            // genuinely verifies the bytes on disk match what the server expects.
+            String computedHash = computeFileSha256(localPath);
+            if (computedHash == null) {
+                Log.e(
+                        TAG,
+                        "Refusing to mark cache ready — could not hash file: "
+                                + localPath
+                                + " ("
+                                + cacheKey
+                                + ")");
+                return;
+            }
+
             SharedPreferences.Editor editor = getCachePrefs().edit();
             editor.putBoolean(cacheField(cacheKey, CACHE_FLAG_READY), true);
             editor.putString(cacheField(cacheKey, CACHE_FIELD_PATH), localPath);
-            editor.putString(
-                    cacheField(cacheKey, CACHE_FIELD_SHA256), metadata.optString("sha256", ""));
+            editor.putString(cacheField(cacheKey, CACHE_FIELD_SHA256), computedHash);
             editor.putString(
                     cacheField(cacheKey, CACHE_FIELD_VERSION),
                     metadata.optString("versionName", ""));
@@ -430,9 +452,33 @@ public class OtaHelper {
             editor.putLong(cacheField(cacheKey, CACHE_FIELD_SIZE), new File(localPath).length());
             editor.putString(cacheField(cacheKey, "type"), updateType);
             editor.apply();
-            Log.i(TAG, "📦 Cache ready: " + cacheKey + " at " + localPath);
+            Log.i(TAG, "📦 Cache ready: " + cacheKey + " at " + localPath + " (sha256=" + computedHash + ")");
         } catch (Exception e) {
             Log.e(TAG, "Failed to mark cached artifact ready: " + cacheKey, e);
+        }
+    }
+
+    /**
+     * Compute the SHA-256 of a file as a lowercase hex string. Returns {@code null} on any I/O or
+     * algorithm error (caller must treat null as "cannot verify").
+     */
+    private String computeFileSha256(String filePath) {
+        try (FileInputStream is = new FileInputStream(filePath)) {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = is.read(buffer)) > 0) {
+                digest.update(buffer, 0, read);
+            }
+            byte[] hashBytes = digest.digest();
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            Log.e(TAG, "Failed to compute SHA-256 for " + filePath, e);
+            return null;
         }
     }
 
@@ -455,16 +501,36 @@ public class OtaHelper {
                 return false;
             }
 
-            // Fast path: if the stored SHA256 matches the expected hash from metadata AND the file
-            // has not been modified since it was verified, skip the expensive full re-hash.
-            // This avoids re-reading large firmware files on every 30-minute periodic check.
-            String storedHash =
-                    getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_SHA256), "");
             long storedTimestamp =
                     getCachePrefs().getLong(cacheField(cacheKey, CACHE_FIELD_TIMESTAMP), 0);
+
+            // TTL: cached artifacts auto-expire so a poisoned entry can never trap a device
+            // indefinitely. An expired-but-otherwise-valid file is re-downloaded on the next check.
+            long age = System.currentTimeMillis() - storedTimestamp;
+            if (storedTimestamp <= 0 || age > CACHE_MAX_AGE_MS) {
+                Log.i(
+                        TAG,
+                        "Cache expired for "
+                                + cacheKey
+                                + " (age="
+                                + age
+                                + "ms, max="
+                                + CACHE_MAX_AGE_MS
+                                + "ms) — forcing fresh download");
+                return false;
+            }
+
+            // Fast path: the stored hash is the ACTUAL computed hash of the file (see
+            // markCachedArtifactReady). If it matches the server's expected hash AND the file has
+            // not been modified since we verified it, the bytes on disk are genuinely correct and
+            // we can skip the expensive full re-hash. This is a real integrity check, not a
+            // tautology — storedHash now reflects the file content, expectedHash the server claim.
+            String storedHash =
+                    getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_SHA256), "");
             String expectedHash = metadata.optString("sha256", "");
 
             if (!storedHash.isEmpty()
+                    && !expectedHash.isEmpty()
                     && storedHash.equalsIgnoreCase(expectedHash)
                     && file.lastModified() <= storedTimestamp) {
                 Log.d(TAG, "Cache fast-path hit for " + cacheKey + " - skipping re-hash");
@@ -2169,11 +2235,37 @@ public class OtaHelper {
 
         Log.d(TAG, "APK downloaded to: " + apkFile.getAbsolutePath());
 
-        // APK hash check disabled – downloaded APK is accepted without integrity verification.
-        Log.w(
-                TAG,
-                "WARNING: OTA APK SHA256 hash verification is DISABLED. Downloaded APK is not"
-                        + " integrity-checked.");
+        // Completeness check: a dropped connection can make in.read() return -1 early without
+        // throwing, leaving a truncated APK that would otherwise be cached as "valid" and
+        // re-installed forever. Reject any download whose size doesn't match Content-Length.
+        if (fileSize > 0 && total != fileSize) {
+            Log.e(
+                    TAG,
+                    "APK download incomplete: got "
+                            + total
+                            + " of "
+                            + fileSize
+                            + " bytes — deleting partial file and failing");
+            if (apkFile.exists() && !apkFile.delete()) {
+                Log.w(TAG, "Failed deleting partial APK: " + apkFile.getAbsolutePath());
+            }
+            return false;
+        }
+
+        // Integrity check: verify the downloaded bytes match the server's published SHA-256
+        // before declaring the download a success. Without this, a corrupt download poisons the
+        // cache. (MTK/BES firmware already do this; the APK path previously had it disabled.)
+        if (!verifyApkFile(apkFile.getAbsolutePath(), json)) {
+            Log.e(
+                    TAG,
+                    "Downloaded APK failed SHA256 verification — deleting and failing: "
+                            + apkFile.getAbsolutePath());
+            if (apkFile.exists() && !apkFile.delete()) {
+                Log.w(TAG, "Failed deleting corrupt APK: " + apkFile.getAbsolutePath());
+            }
+            return false;
+        }
+
         EventBus.getDefault().post(DownloadProgressEvent.createFinished(fileSize));
         sendProgressToPhone("download", 100, fileSize, fileSize, "FINISHED", null);
         createMetaDataJson(json, context);
@@ -2181,12 +2273,37 @@ public class OtaHelper {
     }
 
     private boolean verifyApkFile(String apkPath, JSONObject jsonObject) {
-        // APK hash check disabled – APK is accepted without integrity verification.
-        Log.w(
-                TAG,
-                "WARNING: OTA APK SHA256 hash verification is DISABLED. APK is not"
-                        + " integrity-checked.");
-        return true;
+        String expectedHash = jsonObject.optString("sha256", "");
+        if (expectedHash.isEmpty()) {
+            // No server-provided hash to check against. Don't hard-fail (older manifests may omit
+            // it), but warn loudly — without a hash we cannot detect a corrupt/partial APK.
+            Log.w(TAG, "No SHA256 hash provided for APK - skipping verification");
+            return true;
+        }
+
+        String calculatedHash = computeFileSha256(apkPath);
+        if (calculatedHash == null) {
+            Log.e(TAG, "APK SHA256 check error - could not hash " + apkPath);
+            return false;
+        }
+
+        Log.d(TAG, "Expected APK SHA256: " + expectedHash);
+        Log.d(TAG, "Calculated APK SHA256: " + calculatedHash);
+
+        boolean match = calculatedHash.equalsIgnoreCase(expectedHash);
+        Log.d(TAG, "APK SHA256 check " + (match ? "passed" : "failed"));
+        if (!match) {
+            Log.e(
+                    TAG,
+                    "APK integrity check FAILED for "
+                            + apkPath
+                            + " (expected "
+                            + expectedHash
+                            + ", got "
+                            + calculatedHash
+                            + ")");
+        }
+        return match;
     }
 
     private void createMetaDataJson(JSONObject json, Context context) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -131,6 +131,12 @@ public class OtaHelper {
     private static final String CACHE_FIELD_VERSION = "version";
     private static final String CACHE_FIELD_TIMESTAMP = "timestamp";
     private static final String CACHE_FIELD_SIZE = "size";
+    // Marks that CACHE_FIELD_SHA256 holds the ACTUAL computed hash of the file on disk (true), vs
+    // a legacy entry written by older code that stored the server's *claimed* hash. The fast path
+    // only trusts entries with this flag; legacy entries (flag absent) are forced through a full
+    // re-hash so a corrupt APK cached by the old buggy code is caught immediately, not after the
+    // TTL. See markCachedArtifactReady()/isCachedArtifactValid().
+    private static final String CACHE_FIELD_HASH_VERIFIED = "hash_verified";
     private static final String CACHE_KEY_APK_ASG = "apk_com.mentra.asg_client";
     private static final String CACHE_KEY_APK_RECOVERY = "apk_com.mentra.recovery";
     private static final String CACHE_KEY_MTK = "mtk_main";
@@ -445,6 +451,10 @@ public class OtaHelper {
             editor.putBoolean(cacheField(cacheKey, CACHE_FLAG_READY), true);
             editor.putString(cacheField(cacheKey, CACHE_FIELD_PATH), localPath);
             editor.putString(cacheField(cacheKey, CACHE_FIELD_SHA256), computedHash);
+            // Mark that the stored hash is a real computed hash of the file (distinguishes this
+            // from legacy entries that stored the server's claimed hash). Only such entries may
+            // take the fast path in isCachedArtifactValid().
+            editor.putBoolean(cacheField(cacheKey, CACHE_FIELD_HASH_VERIFIED), true);
             editor.putString(
                     cacheField(cacheKey, CACHE_FIELD_VERSION),
                     metadata.optString("versionName", ""));
@@ -525,16 +535,33 @@ public class OtaHelper {
             // not been modified since we verified it, the bytes on disk are genuinely correct and
             // we can skip the expensive full re-hash. This is a real integrity check, not a
             // tautology — storedHash now reflects the file content, expectedHash the server claim.
+            //
+            // CACHE_FIELD_HASH_VERIFIED gates this: it is only set when the stored hash was
+            // computed from the file. Legacy entries written by older code stored the server's
+            // *claimed* hash instead, which would make this comparison a claim-vs-claim tautology
+            // (the original bug). Those entries lack the flag and are forced through the slow path
+            // below, which re-hashes the file — so a corrupt APK cached by the old code is caught
+            // on the very next check rather than only after the TTL.
+            boolean hashIsComputed =
+                    getCachePrefs().getBoolean(cacheField(cacheKey, CACHE_FIELD_HASH_VERIFIED), false);
             String storedHash =
                     getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_SHA256), "");
             String expectedHash = metadata.optString("sha256", "");
 
-            if (!storedHash.isEmpty()
+            if (hashIsComputed
+                    && !storedHash.isEmpty()
                     && !expectedHash.isEmpty()
                     && storedHash.equalsIgnoreCase(expectedHash)
                     && file.lastModified() <= storedTimestamp) {
                 Log.d(TAG, "Cache fast-path hit for " + cacheKey + " - skipping re-hash");
                 return true;
+            }
+            if (!hashIsComputed) {
+                Log.i(
+                        TAG,
+                        "Legacy cache entry for "
+                                + cacheKey
+                                + " (no computed hash) — forcing full re-verify");
             }
 
             // Slow path: stored hash absent, mismatched, or file was modified — full verify.
@@ -577,6 +604,7 @@ public class OtaHelper {
             editor.remove(cacheField(cacheKey, CACHE_FLAG_READY));
             editor.remove(cacheField(cacheKey, CACHE_FIELD_PATH));
             editor.remove(cacheField(cacheKey, CACHE_FIELD_SHA256));
+            editor.remove(cacheField(cacheKey, CACHE_FIELD_HASH_VERIFIED));
             editor.remove(cacheField(cacheKey, CACHE_FIELD_VERSION));
             editor.remove(cacheField(cacheKey, CACHE_FIELD_TIMESTAMP));
             editor.remove(cacheField(cacheKey, CACHE_FIELD_SIZE));


### PR DESCRIPTION
## Problem

Some Mentra Live users get stuck in an **infinite OTA update loop** trying to update asg_client (e.g. 37→38). The update reports "complete," but the installed version never changes, so the next check re-detects the update and retries — forever. Symptoms from incident logs: install "FINISHED 100%" in ~3s with `bytesDownloaded:0`, then immediate re-check finding the same version, sometimes interleaved with `ota_start` watchdog timeouts and BLE `status=22` drops.

Notably, `adb install -r -d asg-client-38.apk` on an affected device fixes it **instantly** — proving the device, PackageManager, and the published APK are all fine. The failure is specific to the glasses' own OTA cache/install path.

## Root cause

Three defects, **all in the APK path only** (the MTK and BES firmware paths already verify SHA-256 correctly — which is why firmware OTAs work and only APK OTAs loop):

1. **`downloadApkInternal()` never checked the download completed.** A dropped connection makes `in.read()` return `-1` early without throwing, so the read loop exits cleanly and a **truncated APK is written and returned as a successful download**.

2. **`verifyApkFile()` was stubbed to `return true`** — APK integrity verification was disabled entirely, so the corrupt/partial file was never caught.

3. **`markCachedArtifactReady()` stored the *server's claimed* sha256** (from the manifest) as the cache's "verified" hash, not the file's actual computed hash. `isCachedArtifactValid()`'s fast path then compared `storedHash == expectedHash` — **both pulled from the same server field**, a tautology that always passes regardless of the bytes on disk. A bad file became permanently "valid" and was re-installed on every `ota_start`.

Together: a single flaky download poisons the cache with a corrupt/old APK that is then trusted forever and re-installed in a loop. (The state machine separately reports "complete" on process restart without re-checking the installed version, which is what surfaces as the loop on the phone — see follow-up note below.)

## Fixes (all in `OtaHelper.java`)

- **`downloadApkInternal()`**: reject downloads where `total != Content-Length` (incomplete), and verify the downloaded APK's SHA-256 before reporting success; delete the file and fail otherwise.
- **`verifyApkFile()`**: compute the file's real SHA-256 and compare against the server's expected hash (mirrors `verifyMtkFirmwareChecksum` / `verifyFirmwareFile`). Still no-ops gracefully if the manifest omits `sha256`.
- **`markCachedArtifactReady()`**: store the file's **computed** sha256, so cache validation is a genuine integrity check instead of comparing the server's claim to itself.
- **7-day cache TTL**: cached artifacts auto-expire and are re-downloaded even if otherwise valid, so a poisoned entry can't trap a device indefinitely. **This is also what lets already-poisoned devices self-heal** (see below).
- Add a shared `computeFileSha256()` helper.

## Recovery for already-stuck devices

Devices poisoned by the old code have a stored hash = the server's claim (not the file's real hash). After this lands, their fast-path check still matches (claim == claim), so they don't self-heal immediately on hash alone — **but the new 7-day TTL expires the entry and forces a fresh, now-verified download.** Any fresh download re-stores the computed hash, so from then on the integrity check is real. (For immediate recovery, a clean install over cable / `adb install -r -d` still works.)

## Scope / out of scope

- Did **not** add a post-install version-gate in `resumeFromSession()` (deferred by request). That's the remaining belt-and-suspenders item: the resume path reports "complete" on process restart without confirming `installedVersionCode == target`. Worth a follow-up.
- Flagged separately: a stray `refs/heads/fix` branch on the remote is blocking the entire `fix/*` branch namespace (this PR is branched as `asg-ota-apk-cache-verification-loop` as a workaround).

## Test evidence

- `./gradlew :app:compileDebugJavaWithJavac` — compiles clean (only pre-existing deprecation warnings).
- Verified the published artifacts manually: asg-client-37 and -38 share the same signing cert, monotonic versionCode, and valid zips; the only manifest delta is a harmless new debug receiver — confirming the loop is a cache/verification bug, not a bad artifact.
- Reproduced the loop condition on a device (downgraded to 37 via `adb install -r -d`) and confirmed the working install path goes systemui `cmd=install` → `copySuccess=true` → PackageManager replace; the bug manifests when the cached file handed to that path is corrupt/stale.

Manual on-device verification of the full download→verify→install path on a real Mentra Live is recommended before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core OTA download/install trust for APKs on device; behavior is safer but failed verification or TTL expiry will force re-downloads and could affect users mid-update until a good artifact is cached.
> 
> **Overview**
> Fixes **asg_client APK OTA** so corrupt or partial downloads cannot be cached and re-installed in a loop.
> 
> **Download path:** `downloadApkInternal()` now fails when bytes read do not match `Content-Length`, and runs **SHA-256 verification** (via restored `verifyApkFile()`) before success; bad files are deleted.
> 
> **Cache path:** `markCachedArtifactReady()` persists the **computed** file hash and a `hash_verified` flag instead of the manifest claim. `isCachedArtifactValid()` only uses the fast path when that flag is set and hashes match; legacy entries are **fully re-verified**. Adds a **7-day cache TTL** and clears `hash_verified` when wiping cache entries.
> 
> Shared **`computeFileSha256()`** backs cache marking and APK verification (aligned with MTK/BES behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f65f3591ebadac7cac7ebc98c5e861f685e9c0f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->