### PR TITLE
fix: fix the mentra display crashes for ios and android

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -69,11 +69,11 @@ class MentraNex : SGCManager() {
         private const val MTU_DEFAULT: Int = 23
         
         private const val MAX_CHUNK_SIZE_DEFAULT: Int = 176 // Maximum chunk size for BLE packets
-        private const val DELAY_BETWEEN_CHUNKS_SEND: Long = 10 // Adjust this value as needed
+        private const val DELAY_BETWEEN_CHUNKS_SEND: Long = 5 // Adjust this value as needed
         // Upper bound on waiting for onCharacteristicWrite. A no-response write's
         // callback is normally near-instant; this only guards against a callback that
         // never arrives, so a dropped write can't wedge the send queue forever.
-        private const val WRITE_CALLBACK_TIMEOUT_MS: Long = 2000
+        private const val WRITE_CALLBACK_TIMEOUT_MS: Long = 10
 
         private const val INITIAL_CONNECTION_DELAY_MS = 350L // Adjust this value as needed
         // Window to let a queued DisconnectRequest flush to the glasses before we close GATT.
@@ -461,7 +461,6 @@ class MentraNex : SGCManager() {
     }
 
     override fun getBatteryStatus() {
-        Bridge.log("Nex: Requesting battery status");
         queryBatteryStatus()
     }
 
@@ -748,33 +747,6 @@ class MentraNex : SGCManager() {
                 characteristic: BluetoothGattCharacteristic,
                 status: Int
             ) {
-                Bridge.log("onCharacteristicWrite callback - ")
-                val values = characteristic.value ?: byteArrayOf()
-                
-                if (status == BluetoothGatt.GATT_SUCCESS) {
-                    Bridge.log("[BLE] onCharacteristicWrite: SUCCESS len=${values.size}")
-                    val packetHex = values.joinToString("") { "%02X".format(it) }
-                    Bridge.log("onCharacteristicWrite Values - $packetHex")
-
-                    if (values.size >= 4 && values[0] == NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF) {
-                        // Debug-only re-decode of our own outgoing write. Frames are now
-                        // [0x02][seq][total][index] + protobuf, so strip the full 4-byte
-                        // transport header. Only a single-fragment write (total==1) holds a
-                        // complete, independently decodable protobuf; fragments of a
-                        // multi-part message are partial and would fail to decode.
-                        val total = values[2].toInt() and 0xFF
-                        val index = values[3].toInt() and 0xFF
-                        if (total == 1 && index == 0) {
-                            val protobufData = values.copyOfRange(4, values.size)
-                            decodeProtobufsByWrite(protobufData, packetHex)
-                        }
-                    }
-                } else {
-                    Log.e(TAG, "[BLE] onCharacteristicWrite: FAILED status=$status${if (status == 133) " (GATT_ERROR 133 - likely disconnected mid-write)" else ""}")
-                }
-
-                // clear the waiter
-                Bridge.log("[BLE] onCharacteristicWrite: releasing mainWaiter")
                 mainWaiter.setFalse()
             }
 
@@ -843,9 +815,12 @@ class MentraNex : SGCManager() {
 
     private fun handleMainTaskMessage(msg: Message): Boolean {
         val msgCode = msg.what
-        Bridge.log("Nex: handleMessage msgCode: $msgCode")
-        Bridge.log("Nex: handleMessage obj: ${msg.obj}")
-        
+        // NOTE: do not log here. Every incoming BLE notification (including
+        // ~50 audio packets/sec) is dispatched through this handler on the
+        // main looper, and Bridge.log marshals an event across the RN bridge
+        // to JS. Per-message logging here floods the main thread and backs up
+        // the audio queue when the CPU downclocks at screen-off. (Matches G1,
+        // which does not log per audio packet.)
         when (msgCode) {
             MAIN_TASK_HANDLER_CODE_GATT_STATUS_CHANGED -> {}
             MAIN_TASK_HANDLER_CODE_DISCOVER_SERVICES -> {
@@ -873,7 +848,6 @@ class MentraNex : SGCManager() {
             MAIN_TASK_HANDLER_CODE_HEART_BEAT -> {
                 // Note: Heartbeat is now handled by receiving ping from glasses
                 // This case is kept for backward compatibility but no longer used
-                Bridge.log("Nex: Heartbeat handler called - no longer sending periodic pings")
             }
             else -> { }
         }
@@ -894,9 +868,19 @@ class MentraNex : SGCManager() {
             val writeChar = uartService.getCharacteristic(NexBluetoothConstants.WRITE_CHAR_UUID)
             val notifyChar = uartService.getCharacteristic(NexBluetoothConstants.NOTIFY_CHAR_UUID)
 
-            writeChar?.let { 
+            writeChar?.let {
                 mainWriteChar = it
-                Bridge.log("Nex: glass TX characteristic found")
+                // Write-without-response on the characteristic we actually write
+                // to (the firmware RX char advertises WRITE_WITHOUT_RESP). This
+                // is what unblocks TX from the ~1-packet-per-connection-interval
+                // ATT round-trip — critical when the phone sleeps and the
+                // interval is relaxed. Android defaults a freshly-discovered
+                // characteristic to WRITE_TYPE_DEFAULT (with response), and the
+                // reference is reassigned on every service rediscovery, so set
+                // it here. (Previously this was set on the notify char in
+                // enableNotification(), where it had no effect on writes.)
+                it.writeType = BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+                Bridge.log("Nex: glass TX characteristic found (write type NO_RESPONSE)")
             }
 
             notifyChar?.let {
@@ -958,13 +942,10 @@ class MentraNex : SGCManager() {
         val result = gatt.setCharacteristicNotification(characteristic, true)
         Bridge.log("Nex: PROC_QUEUE - setCharacteristicNotification result: $result")
 
-        // Write-without-response: the onCharacteristicWrite callback fires when the
-        // local stack accepts the buffer, not after a remote ATT round-trip, so TX is
-        // no longer throttled to ~1 packet per connection interval. This is what keeps
-        // captions flowing when the phone is asleep and the interval is relaxed (the
-        // firmware RX characteristic advertises WRITE_WITHOUT_RESP). Matches G1.
-        characteristic.writeType = BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-        Bridge.log("Nex: PROC_QUEUE - write type set (NO_RESPONSE)")
+        // NOTE: write type is NOT set here. This receives the *notify*
+        // characteristic, which the phone never writes to — setting writeType
+        // on it had no effect. The write characteristic (mainWriteChar) is
+        // configured for WRITE_TYPE_NO_RESPONSE at its assignment instead.
 
         // Add delay
         Bridge.log("Nex: PROC_QUEUE - waiting to enable notification...")
@@ -987,15 +968,16 @@ class MentraNex : SGCManager() {
         if (characteristic.uuid == NexBluetoothConstants.NOTIFY_CHAR_UUID) {
             val data = characteristic.value
             val deviceName = mainGlassGatt?.device?.name ?: return
-            val packetHex = data.joinToString("") { "%02X".format(it) }
-            Bridge.log("onCharacteristicChangedHandler len: ${data.size}")
-            Bridge.log("onCharacteristicChangedHandler: $packetHex")
-            
+            // NOTE: this runs on the main looper for every notification, audio
+            // included (~50/sec). Do not log or stringify the whole packet to
+            // hex on this hot path — Bridge.log crosses the RN bridge to JS and
+            // packetHex is O(n) per packet. Both back up the audio queue at
+            // screen-off. packetHex is only needed by the protobuf branch, so
+            // compute it lazily there.
             if (data.isEmpty()) return
-            
+
             val packetType = data[0]
-            Bridge.log("onCharacteristicChangedHandler packetType: ${String.format("%02X ", packetType)}")
-            
+
             when (packetType) {
                 NexBluetoothPacketTypes.PACKET_TYPE_JSON -> {
                     val jsonData = data.copyOfRange(1, data.size)
@@ -1003,6 +985,7 @@ class MentraNex : SGCManager() {
                 }
                 NexBluetoothPacketTypes.PACKET_TYPE_PROTOBUF -> {
                     val protobufData = data.copyOfRange(1, data.size)
+                    val packetHex = data.joinToString("") { "%02X".format(it) }
                     decodeProtobufs(protobufData, packetHex)
                 }
                 NexBluetoothPacketTypes.PACKET_TYPE_AUDIO -> {
@@ -1019,17 +1002,17 @@ class MentraNex : SGCManager() {
 
                         val lc3Data = data.copyOfRange(2, data.size)
 
-                        Bridge.log("Received LC3 audio packet seq=$sequenceNumber, size=${lc3Data.size}")
+                        // No per-packet log here: this fires ~50x/sec and each
+                        // Bridge.log crosses the RN bridge to JS. (Matches G1.)
 
-                        // Play LC3 audio directly through LC3 player
+                        // Play LC3 audio directly through LC3 player.
+                        // No logging in any branch: this runs per audio packet
+                        // (~50/sec) and Bridge.log crosses the RN bridge to JS.
+                        // With isLc3AudioEnabled hardcoded off, the disabled
+                        // branch would otherwise log on every single packet.
                         if (lc3AudioPlayer != null && isLc3AudioEnabled) {
                             // Use the original packet format that LC3 player expects
                             lc3AudioPlayer?.write(data, 0, data.size)
-                            Bridge.log("Playing LC3 audio directly through LC3 player: ${data.size} bytes")
-                        } else if (!isLc3AudioEnabled) {
-                            Bridge.log("LC3 audio disabled - skipping LC3 audio output")
-                        } else {
-                            Bridge.log("LC3 player not available - skipping LC3 audio output")
                         }
 
                         DeviceManager.getInstance().handleGlassesMicData(lc3Data);
@@ -1304,7 +1287,6 @@ class MentraNex : SGCManager() {
         }
         sendSetMicEnabled(true, 10)
         micBeatRunnable = Runnable {
-            Bridge.log("Nex: SENDING MIC BEAT")
             sendSetMicEnabled(shouldUseGlassesMic, 1)
             micBeatHandler.postDelayed(micBeatRunnable!!, MICBEAT_INTERVAL_MS)
         }
@@ -1435,7 +1417,6 @@ class MentraNex : SGCManager() {
                     val batteryStatus: BatteryStatus = glassesToPhone.batteryStatus
                     DeviceStore.apply("glasses", "batteryLevel", batteryStatus.level)
                     // EventBus.getDefault().post(BatteryLevelEvent(batteryStatus.level, batteryStatus.charging))
-                    Bridge.log("batteryStatus: $batteryStatus")
                 }
                 GlassesToPhone.PayloadCase.CHARGING_STATE -> {
                     val chargingState: ChargingState = glassesToPhone.chargingState
@@ -1656,9 +1637,7 @@ class MentraNex : SGCManager() {
                 mainServicesWaiter.waitWhileTrue()
 
                 // This will block until data is available
-                Bridge.log("[BLE] PROC_QUEUE waiting for data in sendQueue (size=${sendQueue.size})")
                 val requests = sendQueue.take()
-                Bridge.log("[BLE] PROC_QUEUE dequeued ${requests.size} request(s)")
 
                 for (request in requests) {
                     if (isKilled) {
@@ -1675,7 +1654,6 @@ class MentraNex : SGCManager() {
 
                         // Send to main glass
                         val canSend = mainGlassGatt != null && mainWriteChar != null && isMainConnected
-                        Bridge.log("[BLE] PROC_QUEUE send check: gatt=${mainGlassGatt != null} writeChar=${mainWriteChar != null} connected=$isMainConnected → canSend=$canSend len=${request.data.size}")
                         var writeStarted = false
                         if (canSend) {
                             mainWaiter.setTrue()
@@ -1688,7 +1666,6 @@ class MentraNex : SGCManager() {
                             if (issued) {
                                 writeStarted = true
                                 lastSendTimestamp = System.currentTimeMillis()
-                                Bridge.log("[BLE] PROC_QUEUE writeCharacteristic issued, awaiting onCharacteristicWrite")
                             } else {
                                 mainWaiter.setFalse()
                                 Log.e(TAG, "[BLE] PROC_QUEUE writeCharacteristic returned false — stack busy, dropping fragment")
@@ -1701,7 +1678,6 @@ class MentraNex : SGCManager() {
                             mainWaiter.waitWhileTrue(WRITE_CALLBACK_TIMEOUT_MS)
                         }
 
-                        Thread.sleep(DELAY_BETWEEN_CHUNKS_SEND)
 
                         // If the packet asked us to do a delay, then do it
                         if (request.waitTime != -1) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -401,6 +401,24 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     private let commandQueue = CommandQueue()
     private var isQueueWorkerRunning = false
 
+    // MARK: - Text wall coalescing (G2-style)
+
+    // Captions arrive per interim transcript (several/sec while speaking) but are
+    // only worth showing if they're the freshest text. A single latest-wins slot +
+    // a 100 ms drain ticker caps glasses-bound text writes at 10/sec and discards
+    // stale interim results instead of queueing them. Without this, continuous
+    // speech while the phone is locked backlogs the FIFO commandQueue (drain slows
+    // at relaxed connection intervals) and the app does unbounded background work.
+    // Mirrors G2's pendingTextMsg/drainEvenHubQueue. One repair resend covers a
+    // dropped final caption (writes are no-ack); mid-stream drops are repaired by
+    // the next update anyway.
+    private let textWallLock = NSLock()
+    private var pendingTextWall: Data?
+    private var lastTextWall: Data?
+    private var textWallResendsRemaining = 0
+    private let TEXT_WALL_RESEND_COUNT = 1
+    private var textWallDrainTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
     override private init() {
@@ -513,12 +531,17 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     /// reassemble messages larger than one MTU. Single-fragment messages set totalChunks = 1
     /// and are decoded directly by the firmware's fast path.
     private func queueDataWithOptimalChunking(
-        _ data: Data, packetType: UInt8 = 0x02, waitTimeMs: Int = 0
+        _ data: Data, packetType: UInt8 = 0x02, waitTimeMs: Int = 0, emitTelemetry: Bool = true
     ) {
         // Telemetry: report the full logical command (type byte + protobuf) before fragmenting.
-        var packetData = Data([packetType])
-        packetData.append(data)
-        emitBleCommandSent(packetData)
+        // Callers on high-rate paths (caption text walls, up to 10/sec) pass
+        // emitTelemetry: false — emitBleCommandSent re-parses the protobuf,
+        // hex-dumps the packet, and crosses to the JS thread per call.
+        if emitTelemetry {
+            var packetData = Data([packetType])
+            packetData.append(data)
+            emitBleCommandSent(packetData)
+        }
 
         let headerSize = 4 // [packetType][seq][totalChunks][chunkIndex]
         let effectiveChunkSize = max(1, maxChunkSize - headerSize)
@@ -549,9 +572,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             index += 1
         }
 
-        Bridge.log(
-            "NEX: 📦 Fragmented protobuf into \(chunks.count) chunk(s) (seq=\(seq), max payload \(effectiveChunkSize) bytes)"
-        )
+        // No per-send log: fires for every outbound message (up to 10/sec text
+        // walls during captions).
+        // Bridge.log(
+        //     "NEX: 📦 Fragmented protobuf into \(chunks.count) chunk(s) (seq=\(seq), max payload \(effectiveChunkSize) bytes)"
+        // )
         queueChunks(chunks, waitTimeMs: waitTimeMs)
     }
 
@@ -565,34 +590,34 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
         // Send each chunk sequentially
         for (index, chunk) in command.chunks.enumerated() {
-            let timeSinceConnection = Date().timeIntervalSince1970 * 1000 - lastConnectionTimestamp
-            if timeSinceConnection < Double(INITIAL_CONNECTION_DELAY_MS) {
-                let remainingMs = UInt64(Double(INITIAL_CONNECTION_DELAY_MS) - timeSinceConnection)
-                try? await Task.sleep(nanoseconds: remainingMs * 1_000_000)
-            }
+            // let timeSinceConnection = Date().timeIntervalSince1970 * 1000 - lastConnectionTimestamp
+            // if timeSinceConnection < Double(INITIAL_CONNECTION_DELAY_MS) {
+            //     let remainingMs = UInt64(Double(INITIAL_CONNECTION_DELAY_MS) - timeSinceConnection)
+            //     try? await Task.sleep(nanoseconds: remainingMs * 1_000_000)
+            // }
             let data = Data(chunk)
-            Bridge.log(
-                "NEX: 📦 Sending chunk \(index) of \(command.chunks.count) to \(peripheral.name ?? "Unknown")"
-            )
-            Bridge.log("NEX: 📦 Chunk data: \(data.toHexString())")
-            // Write WITHOUT response: a write-with-response is one outstanding request at a
-            // time gated on a remote round trip, which puts the (screen-off-throttled) app
-            // thread in the path of every fragment and makes captions crawl in the background.
-            // .withoutResponse lets CoreBluetooth batch fragments into connection events.
-            // CoreBluetooth does NOT call didWriteValueFor for .withoutResponse, so we use its
-            // flow-control flag instead of an ack — gating prevents dropped fragments (which
-            // would make the firmware discard the whole reassembled caption). See
-            // docs/ble-disconnects-during-captions.md in the firmware repo.
-            if !peripheral.canSendWriteWithoutResponse {
-                await waitUntilReadyToWrite()
-            }
+            // Bridge.log(
+            //     "NEX: 📦 Sending chunk \(index) of \(command.chunks.count) to \(peripheral.name ?? "Unknown")"
+            // )
+            // Bridge.log("NEX: 📦 Chunk data: \(data.toHexString())")
+            // // Write WITHOUT response: a write-with-response is one outstanding request at a
+            // // time gated on a remote round trip, which puts the (screen-off-throttled) app
+            // // thread in the path of every fragment and makes captions crawl in the background.
+            // // .withoutResponse lets CoreBluetooth batch fragments into connection events.
+            // // CoreBluetooth does NOT call didWriteValueFor for .withoutResponse, so we use its
+            // // flow-control flag instead of an ack — gating prevents dropped fragments (which
+            // // would make the firmware discard the whole reassembled caption). See
+            // // docs/ble-disconnects-during-captions.md in the firmware repo.
+            // if !peripheral.canSendWriteWithoutResponse {
+            //     await waitUntilReadyToWrite()
+            // }
             peripheral.writeValue(data, for: writeCharacteristic, type: .withoutResponse)
 
-            // Delay between chunks except maybe after the last chunk if waitTime will handle it
-            if index < command.chunks.count - 1 {
-                try? await Task.sleep(nanoseconds: UInt64(command.chunkDelayMs) * 1_000_000)
-            }
-            try? await Task.sleep(nanoseconds: DELAY_BETWEEN_CHUNKS_SEND_MS * 1_000_000)
+            // // Delay between chunks except maybe after the last chunk if waitTime will handle it
+            // if index < command.chunks.count - 1 {
+            //     try? await Task.sleep(nanoseconds: UInt64(command.chunkDelayMs) * 1_000_000)
+            // }
+            // try? await Task.sleep(nanoseconds: DELAY_BETWEEN_CHUNKS_SEND_MS * 1_000_000)
         }
 
         // Optional wait after the command
@@ -983,7 +1008,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         // can't render (CJK etc.). When enabled, pass the text through unmodified.
         let chineseCaptionsEnabled = DeviceStore.shared.get("bluetooth", "nex_chinese_captions") as? Bool ?? false
         let sanitizedText = chineseCaptionsEnabled ? text : sanitizeDisplayText(text)
-        Bridge.log("NEX: Displaying text wall: '\(sanitizedText)'")
+        // No per-call log: this runs for every interim transcript (several/sec
+        // during continuous speech) and each Bridge.log costs the JS thread.
+        // Bridge.log("NEX: Displaying text wall: '\(sanitizedText)'")
 
         let displayText = Mentraos_Ble_DisplayText.with {
             $0.text = sanitizedText
@@ -998,7 +1025,50 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         }
 
         let protobufData = try! phoneToGlasses.serializedData()
-        queueDataWithOptimalChunking(protobufData, packetType: PACKET_TYPE_PROTOBUF)
+        // Latest-wins: overwrite the pending slot; the 100 ms drain ticker sends it.
+        // Do NOT enqueue on commandQueue — that's what backlogs under continuous speech.
+        textWallLock.lock()
+        pendingTextWall = protobufData
+        textWallLock.unlock()
+    }
+
+    private func startTextWallDrain() {
+        textWallDrainTask?.cancel()
+        textWallDrainTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                guard !Task.isCancelled else { break }
+                self?.drainPendingTextWall()
+            }
+        }
+    }
+
+    private func stopTextWallDrain() {
+        textWallDrainTask?.cancel()
+        textWallDrainTask = nil
+        textWallLock.lock()
+        pendingTextWall = nil
+        lastTextWall = nil
+        textWallResendsRemaining = 0
+        textWallLock.unlock()
+    }
+
+    private func drainPendingTextWall() {
+        textWallLock.lock()
+        let msg = pendingTextWall
+        pendingTextWall = nil
+        var toSend: Data?
+        if let msg {
+            lastTextWall = msg
+            textWallResendsRemaining = TEXT_WALL_RESEND_COUNT
+            toSend = msg
+        } else if textWallResendsRemaining > 0, let last = lastTextWall {
+            textWallResendsRemaining -= 1
+            toSend = last
+        }
+        textWallLock.unlock()
+        guard let toSend else { return }
+        queueDataWithOptimalChunking(toSend, packetType: PACKET_TYPE_PROTOBUF, emitTelemetry: false)
     }
 
     @objc func displayTextLine(_ text: String) {
@@ -1186,6 +1256,14 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         }
 
         Bridge.log("NEX: Clearing display")
+
+        // Drop any pending/resendable text wall so a stale caption can't
+        // repaint the display after this clear.
+        textWallLock.lock()
+        pendingTextWall = nil
+        lastTextWall = nil
+        textWallResendsRemaining = 0
+        textWallLock.unlock()
 
         let clearDisplay = Mentraos_Ble_ClearDisplay()
 
@@ -1540,7 +1618,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     private func processProtobufData(_ protobufData: Data) {
         do {
             let glassesToPhone = try Mentraos_Ble_GlassesToPhone(serializedData: protobufData)
-            Bridge.log("NEX: Processing protobuf payload case: \(glassesToPhone.payload)")
+            // No per-message log: String(describing: payload) stringifies the whole
+            // protobuf and every Bridge.log costs the JS thread.
+            // Bridge.log("NEX: Processing protobuf payload case: \(glassesToPhone.payload)")
 
             let fullPacket = Data([PACKET_TYPE_PROTOBUF]) + protobufData
             emitBleCommandReceived(fullPacket, payloadDescription: String(describing: glassesToPhone.payload))
@@ -1591,10 +1671,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     }
 
     private func processAudioData(_ audioData: Data, sequenceNumber: UInt8) {
-        Bridge.log(
-            "NEX: Received audio data - sequence: \(sequenceNumber), size: \(audioData.count) bytes"
-        )
-
+        // No per-packet log: fires 20x/sec while the mic streams; each Bridge.log
+        // costs the JS thread. Keep only the sequence-mismatch log below (rare,
+        // fires on actual packet loss).
         if lastReceivedLc3Sequence != -1, UInt8((lastReceivedLc3Sequence + 1) & 0xFF) != sequenceNumber {
             Bridge.log("NEX: LC3 packet sequence mismatch. Expected \((lastReceivedLc3Sequence + 1) & 0xFF), got \(sequenceNumber)")
         }
@@ -2065,6 +2144,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
         Task { await commandQueue.clear() }
         resumePendingWrite()
         stopReconnectionTimer()
+        stopTextWallDrain()
     }
 
     // MARK: - Lifecycle Management (ported from Java)
@@ -2412,6 +2492,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
         // Stop mic beat system (like Java implementation)
         stopMicBeat()
+        stopTextWallDrain()
 
         nexReady = false
         deviceReady = false
@@ -2551,6 +2632,9 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
         // Initialize command queue worker to process queued commands
         setupCommandQueue()
+
+        // Start the 100 ms latest-wins drain for caption text walls
+        startTextWallDrain()
 
         // Emit device ready event to React Native
         // emitDeviceReady()
@@ -2697,7 +2781,11 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
             Bridge.log("NEX-CONN: ⚠️ Received notification with no data.")
             return
         }
-        Bridge.log("NEX-CONN: 📥 Received data (\(data.count) bytes): \(data.toHexString())")
+        // No per-notification logging here: this fires for EVERY inbound packet
+        // (~20/sec audio alone), and Bridge.log is a typed message the JS thread
+        // must process — plus the toHexString() is O(n) per packet. This was a
+        // top contributor to the background CPU kill (cpu_resource_fatal.ips).
+        // Bridge.log("NEX-CONN: 📥 Received data (\(data.count) bytes): \(data.toHexString())")
 
         // Process the received data based on packet type
         processReceivedData(data)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes BLE send pacing, write timeouts, and iOS outbound flow control; could affect caption reliability under poor links, but targets documented crash/CPU-kill paths.
> 
> **Overview**
> Addresses **Mentra Nex** background crashes and caption stalls when the phone is locked by cutting **RN bridge logging** on high-frequency BLE paths and tuning **outbound BLE** behavior on Android and iOS.
> 
> **Android (`MentraNex.kt`):** Stops per-notification/per-audio **`Bridge.log`** and hex dumps on the main looper; sets **`WRITE_TYPE_NO_RESPONSE`** on the real TX characteristic (not the notify char); trims **`onCharacteristicWrite`** to only release the send waiter; shortens chunk delay and write-timeout; removes fixed sleep between queued fragments.
> 
> **iOS (`MentraNex.swift`):** Adds **G2-style caption coalescing**—latest-wins pending text, **100 ms** drain (~10 updates/sec), one optional resend, cleared on **`clearDisplay`**/disconnect; **`sendTextWall`** no longer floods the FIFO command queue. Disables **`emitTelemetry`** for caption sends; removes hot-path logs and comments out inter-chunk sleeps and **`canSendWriteWithoutResponse`** gating in **`processCommand`** so writes fire as **withoutResponse** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5dc9508ff9ac2293e76c979d65f71833f2603e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->