### PR TITLE
[codex] Fix Mentra Live prod docs review issues

### DIFF
--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -117,11 +117,11 @@ class GlassesController(context: Context) : MentraBluetoothSdkCallback() {
 
 ## Local SDK Override
 
-Use this when testing SDK source changes from a local MentraOS checkout. Run the publish command from the MentraOS source tree, then consume the Maven-local artifact from your app:
+Use this when testing SDK source changes from a local MentraOS checkout. Run the publish command from the SDK Android module with a local Gradle install, then consume the Maven-local artifact from your app:
 
 ```bash
 cd /path/to/MentraOS/mobile/modules/bluetooth-sdk/android
-./gradlew :lc3Lib:publishToMavenLocal :mentra-bluetooth-sdk:publishToMavenLocal -PmentraPublicSdk=true
+gradle :lc3Lib:publishToMavenLocal :publishToMavenLocal -PmentraPublicSdk=true
 ```
 
 Then include `mavenLocal()` before `mavenCentral()` in the app's repositories while testing the local artifact.

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -86,13 +86,22 @@ await BluetoothSdk.connect(device, {saveAsDefault: false});
 
 await BluetoothSdk.setDefaultDevice(device);
 
-const defaultDevice = await BluetoothSdk.getDefaultDevice();
-await BluetoothSdk.connectDefault();
-await BluetoothSdk.clearDefaultDevice();
+async function reconnectSavedDevice() {
+  const defaultDevice = await BluetoothSdk.getDefaultDevice();
+  if (defaultDevice) {
+    await BluetoothSdk.connectDefault();
+  }
+}
 
-await BluetoothSdk.cancelConnectionAttempt();
-await BluetoothSdk.disconnect();
-await BluetoothSdk.forget();
+async function clearSavedDevice() {
+  await BluetoothSdk.clearDefaultDevice();
+}
+
+async function stopConnection() {
+  await BluetoothSdk.cancelConnectionAttempt();
+  await BluetoothSdk.disconnect();
+  await BluetoothSdk.forget();
+}
 ```
 
   </Tab>
@@ -109,13 +118,22 @@ val scanSession = sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDe
     })
 }
 
-val defaultDevice = sdk.getDefaultDevice()
-sdk.connectDefault()
-sdk.clearDefaultDevice()
+fun reconnectSavedDevice() {
+    val defaultDevice = sdk.getDefaultDevice()
+    if (defaultDevice != null) {
+        sdk.connectDefault()
+    }
+}
 
-sdk.cancelConnectionAttempt()
-sdk.disconnect()
-sdk.forget()
+fun clearSavedDevice() {
+    sdk.clearDefaultDevice()
+}
+
+fun stopConnection() {
+    sdk.cancelConnectionAttempt()
+    sdk.disconnect()
+    sdk.forget()
+}
 ```
 
   </Tab>
@@ -135,13 +153,21 @@ let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     }
 }
 
-let defaultDevice = sdk.getDefaultDevice()
-try sdk.connectDefault()
-sdk.clearDefaultDevice()
+func reconnectSavedDevice() throws {
+    if sdk.getDefaultDevice() != nil {
+        try sdk.connectDefault()
+    }
+}
 
-sdk.cancelConnectionAttempt()
-sdk.disconnect()
-sdk.forget()
+func clearSavedDevice() {
+    sdk.clearDefaultDevice()
+}
+
+func stopConnection() {
+    sdk.cancelConnectionAttempt()
+    sdk.disconnect()
+    sdk.forget()
+}
 ```
 
   </Tab>

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -126,8 +126,12 @@ var devices: [Device] = []
 let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     devices = nextDevices
     renderDevicePicker(nextDevices) { device in
-        try? sdk.connect(to: device)
-        sdk.setDefaultDevice(device)
+        do {
+            try sdk.connect(to: device)
+            sdk.setDefaultDevice(device)
+        } catch {
+            handleConnectionError(error)
+        }
     }
 }
 

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -100,16 +100,15 @@ await BluetoothSdk.forget();
 
 ```kotlin
 val devices = mutableListOf<Device>()
-var selectedDevice: Device? = null
 val scanSession = sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
     devices.clear()
     devices.addAll(nextDevices)
-    renderDevicePicker(nextDevices, onSelect = { selectedDevice = it })
+    renderDevicePicker(nextDevices, onSelect = { device ->
+        sdk.connect(device)
+        sdk.setDefaultDevice(device)
+    })
 }
 
-val device = selectedDevice ?: return
-sdk.connect(device)
-sdk.setDefaultDevice(device)
 val defaultDevice = sdk.getDefaultDevice()
 sdk.connectDefault()
 sdk.clearDefaultDevice()
@@ -124,17 +123,14 @@ sdk.forget()
 
 ```swift
 var devices: [Device] = []
-var selectedDevice: Device? = nil
 let scanSession = try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     devices = nextDevices
     renderDevicePicker(nextDevices) { device in
-        selectedDevice = device
+        try? sdk.connect(to: device)
+        sdk.setDefaultDevice(device)
     }
 }
 
-guard let device = selectedDevice else { return }
-try sdk.connect(to: device)
-sdk.setDefaultDevice(device)
 let defaultDevice = sdk.getDefaultDevice()
 try sdk.connectDefault()
 sdk.clearDefaultDevice()

--- a/docs/mentra-live/audio.mdx
+++ b/docs/mentra-live/audio.mdx
@@ -195,7 +195,20 @@ let session = AVAudioSession.sharedInstance()
 try session.setCategory(.playback, mode: .default, options: [.duckOthers])
 try session.setActive(true)
 
-let player = AVPlayer(url: audioUrl)
+let item = AVPlayerItem(url: audioUrl)
+let player = AVPlayer(playerItem: item)
+var playbackEndObserver: NSObjectProtocol?
+playbackEndObserver = NotificationCenter.default.addObserver(
+    forName: .AVPlayerItemDidPlayToEndTime,
+    object: item,
+    queue: .main
+) { _ in
+    sdk.setOwnAppAudioPlaying(false)
+    if let observer = playbackEndObserver {
+        NotificationCenter.default.removeObserver(observer)
+    }
+}
+
 sdk.setOwnAppAudioPlaying(true)
 player.play()
 ```

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -33,27 +33,21 @@ await BluetoothSdk.connect(await chooseDevice(devices));
   <Tab title="Android">
 
 ```kotlin
-var selectedDevice: Device? = null
 sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
-    renderDevicePicker(nextDevices, onSelect = { selectedDevice = it })
+    renderDevicePicker(nextDevices, onSelect = { device ->
+        sdk.connect(device)
+    })
 }
-
-selectedDevice?.let { sdk.connect(it) }
 ```
 
   </Tab>
   <Tab title="iOS">
 
 ```swift
-var selectedDevice: Device? = nil
 try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     renderDevicePicker(nextDevices) { device in
-        selectedDevice = device
+        try? sdk.connect(to: device)
     }
-}
-
-if let selectedDevice {
-    try sdk.connect(to: selectedDevice)
 }
 ```
 

--- a/docs/mentra-live/hardware.mdx
+++ b/docs/mentra-live/hardware.mdx
@@ -46,7 +46,11 @@ sdk.scan(DeviceModel.MENTRA_LIVE, timeoutMs = 10_000) { nextDevices ->
 ```swift
 try sdk.scan(model: .mentraLive, timeout: 10) { nextDevices in
     renderDevicePicker(nextDevices) { device in
-        try? sdk.connect(to: device)
+        do {
+            try sdk.connect(to: device)
+        } catch {
+            handleConnectionError(error)
+        }
     }
 }
 ```


### PR DESCRIPTION
## Summary
- fix the Mentra Live Android local SDK override command to match the SDK module layout
- update Mentra Live Android/iOS scan examples so connect runs from device selection callbacks instead of immediately after scan starts

## Validation
- git diff --check origin/frozen-docs..HEAD
- python3 -m json.tool docs/docs.json >/dev/null
- searched commented files for stale ./gradlew / :mentra-bluetooth-sdk publish commands and immediate selectedDevice scan/connect examples

This targets frozen production docs only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to frozen production MDX; no runtime or API behavior changes.
> 
> **Overview**
> Updates **frozen Mentra Live production docs** so copy-paste examples match current SDK layout and safer connection patterns.
> 
> **Android local SDK override** (`android.mdx`): Clarifies publishing from the SDK Android module with a local Gradle install and replaces `./gradlew :lc3Lib:publishToMavenLocal :mentra-bluetooth-sdk:publishToMavenLocal` with `gradle :lc3Lib:publishToMavenLocal :publishToMavenLocal -PmentraPublicSdk=true`.
> 
> **Scan / connect examples** (`api-reference.mdx`, `hardware.mdx`): Android and iOS samples no longer defer connect until after scan via a `selectedDevice` variable (which could race). **Connect runs inside the device-picker callback**; iOS wraps connect in `do/catch`. **api-reference** also groups default-device reconnect, clear, and disconnect/forget into named helper snippets across RN, Android, and iOS.
> 
> **iOS speaker playback** (`audio.mdx`): Documents resetting `setOwnAppAudioPlaying(false)` when playback ends using `AVPlayerItem` + `AVPlayerItemDidPlayToEndTime` observer cleanup, aligned with the RN/Android completion patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9b71cd223144ddf29940b20ee8ffe4ea88dff6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->