### PR TITLE
Fix WHIP camera crash on stale Camera2 callback

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -331,10 +331,12 @@ public class WhipCameraCapturer implements VideoCapturer {
                         @Override
                         public void onConfigured(@NonNull CameraCaptureSession session) {
                             synchronized (mCameraStateLock) {
-                                if (mStopRequested || mCameraDevice == null) {
+                                if (mStopRequested
+                                        || mCameraDevice == null
+                                        || session.getDevice() != mCameraDevice) {
                                     Log.w(
                                             TAG,
-                                            "WHIP capture session configured after capture stopped; closing stale session");
+                                            "WHIP capture session configured after capture stopped or camera changed; closing stale session");
                                     session.close();
                                     return;
                                 }
@@ -355,6 +357,12 @@ public class WhipCameraCapturer implements VideoCapturer {
                     cameraHandler);
         } catch (CameraAccessException e) {
             Log.e(TAG, "Failed to create capture session", e);
+            if (!isStopRequested()) {
+                mObserver.onCapturerStarted(false);
+                cleanupAfterStartFailure();
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Failed to create capture session due to stale camera state", e);
             if (!isStopRequested()) {
                 mObserver.onCapturerStarted(false);
                 cleanupAfterStartFailure();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -63,8 +63,10 @@ public class WhipCameraCapturer implements VideoCapturer {
     private HandlerThread mCameraThread;
     private Handler mCameraHandler;
 
+    private final Object mCameraStateLock = new Object();
     private CameraDevice mCameraDevice;
     private CameraCaptureSession mCaptureSession;
+    private boolean mStopRequested;
 
     private int mWidth;
     private int mHeight;
@@ -115,6 +117,11 @@ public class WhipCameraCapturer implements VideoCapturer {
         mNextForwardFrameTimestampNs = 0L;
         mDroppedFrameCount = 0;
         mLoggedFrameSize = false;
+        synchronized (mCameraStateLock) {
+            mStopRequested = false;
+            mCameraDevice = null;
+            mCaptureSession = null;
+        }
 
         // Low-priority camera thread (matches StreamPackLite CameraExecutorManager)
         mCameraThread = new HandlerThread("WhipCameraThread");
@@ -203,7 +210,14 @@ public class WhipCameraCapturer implements VideoCapturer {
                     new CameraDevice.StateCallback() {
                         @Override
                         public void onOpened(@NonNull CameraDevice camera) {
-                            mCameraDevice = camera;
+                            synchronized (mCameraStateLock) {
+                                if (mStopRequested) {
+                                    Log.w(TAG, "Camera opened after WHIP capture stopped; closing stale camera");
+                                    camera.close();
+                                    return;
+                                }
+                                mCameraDevice = camera;
+                            }
                             createCaptureSession();
                         }
 
@@ -211,18 +225,34 @@ public class WhipCameraCapturer implements VideoCapturer {
                         public void onDisconnected(@NonNull CameraDevice camera) {
                             Log.w(TAG, "Camera disconnected");
                             camera.close();
-                            mCameraDevice = null;
-                            mObserver.onCapturerStarted(false);
-                            cleanupAfterStartFailure();
+                            boolean notifyFailure;
+                            synchronized (mCameraStateLock) {
+                                if (mCameraDevice == camera) {
+                                    mCameraDevice = null;
+                                }
+                                notifyFailure = !mStopRequested;
+                            }
+                            if (notifyFailure) {
+                                mObserver.onCapturerStarted(false);
+                                cleanupAfterStartFailure();
+                            }
                         }
 
                         @Override
                         public void onError(@NonNull CameraDevice camera, int error) {
                             Log.e(TAG, "Camera error: " + error);
                             camera.close();
-                            mCameraDevice = null;
-                            mObserver.onCapturerStarted(false);
-                            cleanupAfterStartFailure();
+                            boolean notifyFailure;
+                            synchronized (mCameraStateLock) {
+                                if (mCameraDevice == camera) {
+                                    mCameraDevice = null;
+                                }
+                                notifyFailure = !mStopRequested;
+                            }
+                            if (notifyFailure) {
+                                mObserver.onCapturerStarted(false);
+                                cleanupAfterStartFailure();
+                            }
                         }
                     },
                     mCameraHandler);
@@ -282,30 +312,53 @@ public class WhipCameraCapturer implements VideoCapturer {
     }
 
     private void createCaptureSession() {
+        CameraDevice cameraDevice;
+        Handler cameraHandler;
+        synchronized (mCameraStateLock) {
+            if (mStopRequested || mCameraDevice == null || mCameraHandler == null) {
+                Log.w(TAG, "Skipping WHIP capture session creation after capture stopped");
+                return;
+            }
+            cameraDevice = mCameraDevice;
+            cameraHandler = mCameraHandler;
+        }
         Surface surface = new Surface(mSurfaceTextureHelper.getSurfaceTexture());
 
         try {
-            mCameraDevice.createCaptureSession(
+            cameraDevice.createCaptureSession(
                     Collections.singletonList(surface),
                     new CameraCaptureSession.StateCallback() {
                         @Override
                         public void onConfigured(@NonNull CameraCaptureSession session) {
-                            mCaptureSession = session;
+                            synchronized (mCameraStateLock) {
+                                if (mStopRequested || mCameraDevice == null) {
+                                    Log.w(
+                                            TAG,
+                                            "WHIP capture session configured after capture stopped; closing stale session");
+                                    session.close();
+                                    return;
+                                }
+                                mCaptureSession = session;
+                            }
                             startRepeatingRequest(surface);
                         }
 
                         @Override
                         public void onConfigureFailed(@NonNull CameraCaptureSession session) {
                             Log.e(TAG, "Capture session configuration failed");
-                            mObserver.onCapturerStarted(false);
-                            cleanupAfterStartFailure();
+                            if (!isStopRequested()) {
+                                mObserver.onCapturerStarted(false);
+                                cleanupAfterStartFailure();
+                            }
                         }
                     },
-                    mCameraHandler);
+                    cameraHandler);
         } catch (CameraAccessException e) {
             Log.e(TAG, "Failed to create capture session", e);
-            mObserver.onCapturerStarted(false);
-            cleanupAfterStartFailure();
+            if (!isStopRequested()) {
+                mObserver.onCapturerStarted(false);
+                cleanupAfterStartFailure();
+            }
         }
     }
 
@@ -314,10 +367,26 @@ public class WhipCameraCapturer implements VideoCapturer {
      * applied.
      */
     private void startRepeatingRequest(Surface surface) {
+        CameraDevice cameraDevice;
+        CameraCaptureSession captureSession;
+        Handler cameraHandler;
+        synchronized (mCameraStateLock) {
+            if (mStopRequested
+                    || mCameraDevice == null
+                    || mCaptureSession == null
+                    || mCameraHandler == null) {
+                Log.w(TAG, "Skipping stale WHIP repeating request after capture stopped");
+                return;
+            }
+            cameraDevice = mCameraDevice;
+            captureSession = mCaptureSession;
+            cameraHandler = mCameraHandler;
+        }
+
         try {
             // TEMPLATE_PREVIEW: lighter processing than TEMPLATE_RECORD, reduces thermal load
             CaptureRequest.Builder builder =
-                    mCameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+                    cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
             builder.addTarget(surface);
 
             // Fixed FPS range. On K900, values inside the advertised [5,30] range are honored
@@ -349,7 +418,7 @@ public class WhipCameraCapturer implements VideoCapturer {
             // Avoid per-frame metadata callbacks: SENSOR_FRAME_DURATION is instantaneous and can
             // make
             // resolvedConfig.video.fps jitter even though the requested camera FPS is stable.
-            mCaptureSession.setRepeatingRequest(builder.build(), null, mCameraHandler);
+            captureSession.setRepeatingRequest(builder.build(), null, cameraHandler);
 
             // Match the stock WebRTC Camera2 session semantics:
             // 1. Apply a texture transform for sensor/front-camera correction.
@@ -459,30 +528,46 @@ public class WhipCameraCapturer implements VideoCapturer {
 
         } catch (CameraAccessException e) {
             Log.e(TAG, "Failed to start repeating request", e);
-            mObserver.onCapturerStarted(false);
-            cleanupAfterStartFailure();
+            if (!isStopRequested()) {
+                mObserver.onCapturerStarted(false);
+                cleanupAfterStartFailure();
+            }
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Failed to start repeating request due to stale camera state", e);
+            if (!isStopRequested()) {
+                mObserver.onCapturerStarted(false);
+                cleanupAfterStartFailure();
+            }
         }
     }
 
     @Override
     public void stopCapture() throws InterruptedException {
+        CameraCaptureSession captureSession;
+        CameraDevice cameraDevice;
+        synchronized (mCameraStateLock) {
+            mStopRequested = true;
+            captureSession = mCaptureSession;
+            mCaptureSession = null;
+            cameraDevice = mCameraDevice;
+            mCameraDevice = null;
+        }
+
         if (mSurfaceTextureHelper != null) {
             mSurfaceTextureHelper.stopListening();
         }
 
-        if (mCaptureSession != null) {
+        if (captureSession != null) {
             try {
-                mCaptureSession.stopRepeating();
+                captureSession.stopRepeating();
             } catch (CameraAccessException e) {
                 Log.w(TAG, "Error stopping repeating request", e);
             }
-            mCaptureSession.close();
-            mCaptureSession = null;
+            captureSession.close();
         }
 
-        if (mCameraDevice != null) {
-            mCameraDevice.close();
-            mCameraDevice = null;
+        if (cameraDevice != null) {
+            cameraDevice.close();
         }
 
         if (mCameraThread != null) {
@@ -520,32 +605,47 @@ public class WhipCameraCapturer implements VideoCapturer {
     }
 
     private void cleanupAfterStartFailure() {
+        CameraCaptureSession captureSession;
+        CameraDevice cameraDevice;
+        HandlerThread cameraThread;
+        synchronized (mCameraStateLock) {
+            mStopRequested = true;
+            captureSession = mCaptureSession;
+            mCaptureSession = null;
+            cameraDevice = mCameraDevice;
+            mCameraDevice = null;
+            cameraThread = mCameraThread;
+            mCameraThread = null;
+            mCameraHandler = null;
+        }
+
         if (mSurfaceTextureHelper != null) {
             mSurfaceTextureHelper.stopListening();
         }
 
-        if (mCaptureSession != null) {
-            mCaptureSession.close();
-            mCaptureSession = null;
+        if (captureSession != null) {
+            captureSession.close();
         }
 
-        if (mCameraDevice != null) {
-            mCameraDevice.close();
-            mCameraDevice = null;
+        if (cameraDevice != null) {
+            cameraDevice.close();
         }
 
-        if (mCameraThread != null) {
-            HandlerThread thread = mCameraThread;
-            mCameraThread = null;
-            mCameraHandler = null;
-            thread.quitSafely();
-            if (Thread.currentThread() != thread) {
+        if (cameraThread != null) {
+            cameraThread.quitSafely();
+            if (Thread.currentThread() != cameraThread) {
                 try {
-                    thread.join(2000);
+                    cameraThread.join(2000);
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
                 }
             }
+        }
+    }
+
+    private boolean isStopRequested() {
+        synchronized (mCameraStateLock) {
+            return mStopRequested;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes an ASG-side WHIP streaming crash caused by a stale Camera2 callback continuing after the WHIP capturer has already been stopped by a newer stream start.

The change keeps WHIP camera state behind a small lock, marks capture stop/failure paths as stopped, snapshots the camera/session/handler before use, and ignores or closes late Camera2 callbacks instead of letting them dereference cleared state.

## Raw observed crash logs

Captured from glasses `logcat` during a React Native Bluetooth SDK direct WebRTC stream start on 2026-06-10. Full local capture during debugging was at `/tmp/mentra-direct-stream-broken-20260610-140720/glasses-logcat.txt`.

```text
06-10 21:05:52.140  2757  2810 I MentraBleTrace: BLE_TRACE direction=phone_to_glasses layer=asg_command_router source=asg_client type=start_stream payload={"streamId":"rn-1781125553161","type":"start_stream","keepAliveIntervalSeconds":5,"sound":true,"video":{"frameRate":15},"streamUrl":"http:\/\/192.168.1.125:8190\/whip\/endpoint","keepAlive":true,"flash":true,"mId":7}
06-10 21:05:52.666  2757  2757 I MentraBleTrace: BLE_TRACE direction=glasses_to_phone layer=asg_ble_output source=asg_client type=stream_status bytes=266 payload={"type":"stream_status","status":"initializing","streamId":"rn-1781125553161","resolvedConfig":{"transport":"whip","video":{"width":854,"height":480,"bitrate":1000000,"fps":15},"audio":{"echoCancellation":false,"noiseSuppression":false}},"timestamp":1781125552665}
06-10 21:05:52.715  2757  2810 I WhipCameraCapturer: Resolved WHIP capture fps: requested=15, output=15, camera=15
06-10 21:05:52.808  2757  2810 I MentraBleTrace: BLE_TRACE direction=phone_to_glasses layer=asg_command_router source=asg_client type=start_stream payload={"sound":true,"keepAliveIntervalSeconds":5,"flash":true,"streamId":"rn-1781125553394","streamUrl":"http:\/\/192.168.1.125:8190\/whip\/endpoint","mId":8,"type":"start_stream","video":{"frameRate":15},"keepAlive":true}
06-10 21:05:52.811  2757  2810 I org.webrtc.Logging: SurfaceTextureHelper: stopListening()
06-10 21:05:53.126  2757  3244 E AndroidRuntime: FATAL EXCEPTION: WhipCameraThread
06-10 21:05:53.126  2757  3244 E AndroidRuntime: Process: com.mentra.asg_client, PID: 2757
06-10 21:05:53.126  2757  3244 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'android.hardware.camera2.CaptureRequest$Builder android.hardware.camera2.CameraDevice.createCaptureRequest(int)' on a null object reference
06-10 21:05:53.126  2757  3244 E AndroidRuntime:     at com.mentra.asg_client.io.streaming.services.WhipCameraCapturer.startRepeatingRequest(WhipCameraCapturer.java:320)
06-10 21:05:53.126  2757  3244 E AndroidRuntime:     at com.mentra.asg_client.io.streaming.services.WhipCameraCapturer$2.onConfigured(WhipCameraCapturer.java:294)
```

Post-crash restart noise observed immediately afterward, not the initial cause:

```text
06-10 21:05:53.294   696  3100 W ActivityManager: Scheduling restart of crashed service com.mentra.asg_client/.service.core.AsgClientService in 1000ms for start-requested
06-10 21:05:53.295   696  3100 W ActivityManager: Scheduling restart of crashed service com.mentra.asg_client/.io.streaming.services.WhipStreamingService in 10999ms for start-requested
06-10 21:05:54.561  3295  3354 W RecoveryWorkerManager: Failed to read bundled recovery worker version
06-10 21:05:54.561  3295  3354 W RecoveryWorkerManager: java.io.FileNotFoundException: recovery_worker.apk
06-10 21:05:54.580   488  1708 I CameraProviderManager: Camera provider 'internal/0' has died; removing it
```

## Analysis

The crash is a race in `WhipCameraCapturer` startup/stop handling:

1. The glasses receive a first `start_stream` (`mId=7`) and WHIP camera startup begins.
2. Before the Camera2 session finishes configuring, the glasses receive another `start_stream` (`mId=8`) about 668 ms later.
3. The newer stream start stops the previous WHIP service, including `SurfaceTextureHelper.stopListening()`, and clears the camera/session state.
4. The first Camera2 `onConfigured` callback still runs on `WhipCameraThread` and calls `startRepeatingRequest()`.
5. `startRepeatingRequest()` dereferences `mCameraDevice`, which has already been cleared, causing the `NullPointerException` shown above.

This explains why streaming can sometimes start successfully: the crash only happens when the stop/restart overlaps the asynchronous Camera2 session callback window.

## Fix

- Add a WHIP camera state lock and explicit `mStopRequested` flag.
- Reset guarded camera state during initialize.
- Mark stop/failure cleanup paths as stopped before closing camera/session resources.
- Snapshot `CameraDevice`, `CameraCaptureSession`, and `Handler` under the lock before using them.
- Close or ignore late `onOpened`/`onConfigured` callbacks after capture has stopped.
- Suppress start-failure notifications for callbacks that arrive after an intentional stop.
- Catch stale-state runtime failures in `startRepeatingRequest()` and only report them if capture is still active.

## Validation

On the rebased branch targeting current `origin/dev`:

```text
cd asg_client
./gradlew :app:compileReleaseJavaWithJavac

BUILD SUCCESSFUL in 2s
63 actionable tasks: 4 executed, 59 up-to-date
```

## Notes

This PR does not change the React Native example app or the duplicate `start_stream` behavior. It makes the ASG WHIP capturer robust against that duplicate/restart path so a late Camera2 callback cannot crash the ASG client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live WHIP capture lifecycle and threading on glasses; behavior change is defensive (no new features) but incorrect locking could still affect stream start reliability.
> 
> **Overview**
> Hardens **WHIP** camera capture in `WhipCameraCapturer` against a **start/stop race** when a new `start_stream` tears down capture while Camera2 callbacks are still in flight (the observed crash was an NPE on `mCameraDevice` inside `startRepeatingRequest` after `onConfigured`).
> 
> The change introduces **`mCameraStateLock`** and **`mStopRequested`**, resets guarded device/session state at capture start, and sets the stop flag before clearing resources in **`stopCapture`** and **`cleanupAfterStartFailure`**. Session creation and repeating requests now **snapshot** `CameraDevice`, `CameraCaptureSession`, and `Handler` under the lock and **bail out** if stop was requested or references are null. Late **`onOpened`** / **`onConfigured`** callbacks close stale cameras/sessions instead of continuing startup; disconnect/error/configure-failure paths **skip** `onCapturerStarted(false)` when the stop was intentional. **`RuntimeException`** from stale state during session/repeating setup is caught and only reported if capture is still active.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9daabe67ce20b145ec725b0d4ace9497a9e5e8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->