### PR TITLE
[codex] Fix iOS Bluetooth-off disconnect state

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1452,6 +1452,7 @@ struct ViewState {
         DeviceStore.shared.apply("glasses", "deviceModel", "")
         DeviceStore.shared.apply("glasses", "fullyBooted", false)
         DeviceStore.shared.apply("glasses", "connected", false)
+        DeviceStore.shared.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)
         DeviceStore.shared.apply("glasses", "voiceActivityDetectionEnabled", BluetoothSdkDefaults.voiceActivityDetectionEnabled)
         // disconnect the controller as well:
         searchingController = false

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -152,6 +152,8 @@ public final class MentraBluetoothSDK {
     private let configuration: MentraBluetoothSDKConfiguration
     private var discoveredDeviceNames = Set<String>()
     private var bluetoothAvailabilityListenerId: UUID?
+    private var shouldRestoreGlassesOnBluetoothRestore = false
+    private var shouldRestoreControllerOnBluetoothRestore = false
     private var bridgeEventSinkId: String?
     private var storeListenerId: String?
     private let defaultDeviceKeys: Set<String> = ["default_wearable", "device_name", "device_address"]
@@ -315,6 +317,7 @@ public final class MentraBluetoothSDK {
     }
 
     public func connect(to device: Device, options: ConnectOptions = ConnectOptions()) throws {
+        clearBluetoothRestoreIntent()
         if device.model != .simulated {
             try BluetoothAvailability.shared.requirePoweredOn(operation: "connect to glasses")
         }
@@ -334,6 +337,7 @@ public final class MentraBluetoothSDK {
     }
 
     public func connectDefault(options: ConnectOptions = ConnectOptions()) throws {
+        clearBluetoothRestoreIntent()
         guard let device = currentDefaultDevice() else {
             throw BluetoothError(
                 code: "default_device_missing",
@@ -350,18 +354,22 @@ public final class MentraBluetoothSDK {
     }
 
     public func cancelConnectionAttempt() {
+        clearBluetoothRestoreIntent()
         DeviceManager.shared.disconnect()
     }
 
     func connectSimulated() {
+        clearBluetoothRestoreIntent()
         DeviceManager.shared.connectSimulated()
     }
 
     public func disconnect() {
+        clearBluetoothRestoreIntent()
         DeviceManager.shared.disconnect()
     }
 
     public func forget() {
+        clearBluetoothRestoreIntent()
         DeviceManager.shared.forget()
     }
 
@@ -1017,7 +1025,9 @@ public final class MentraBluetoothSDK {
         switch state {
         case .poweredOff, .resetting, .unauthorized, .unsupported:
             handleBluetoothUnavailable()
-        case .poweredOn, .unknown:
+        case .poweredOn:
+            handleBluetoothRestored()
+        case .unknown:
             break
         @unknown default:
             handleBluetoothUnavailable()
@@ -1027,10 +1037,14 @@ public final class MentraBluetoothSDK {
     private func handleBluetoothUnavailable() {
         cancelActiveScanSessions(reason: .cancelled)
         clearBluetoothDiscoveryState()
-        disconnectIfGlassesConnectionActive()
+        disconnectActiveConnections()
     }
 
-    private func disconnectIfGlassesConnectionActive() {
+    private func disconnectActiveConnections() {
+        if glassesStatus.controllerConnected {
+            DeviceManager.shared.disconnectController()
+            shouldRestoreControllerOnBluetoothRestore = true
+        }
         if glassesStatus.deviceModel == DeviceTypes.SIMULATED
             || DeviceManager.shared.sgc?.type.contains(DeviceTypes.SIMULATED) == true
         {
@@ -1038,7 +1052,28 @@ public final class MentraBluetoothSDK {
         }
         if glassesStatus.connected || glassesStatus.connectionState != .disconnected {
             DeviceManager.shared.disconnect()
+            shouldRestoreGlassesOnBluetoothRestore = true
         }
+    }
+
+    /// Reconnect only what `handleBluetoothUnavailable` tore down, never a
+    /// connection the user closed themselves (explicit connect/disconnect
+    /// calls clear the restore intent).
+    private func handleBluetoothRestored() {
+        let restoreGlasses = shouldRestoreGlassesOnBluetoothRestore
+        let restoreController = shouldRestoreControllerOnBluetoothRestore
+        clearBluetoothRestoreIntent()
+
+        if restoreGlasses, !glassesStatus.connected, glassesStatus.connectionState == .disconnected {
+            DeviceManager.shared.connectDefault() // also restores the controller
+        } else if restoreController, !glassesStatus.controllerConnected {
+            DeviceManager.shared.connectDefaultController()
+        }
+    }
+
+    private func clearBluetoothRestoreIntent() {
+        shouldRestoreGlassesOnBluetoothRestore = false
+        shouldRestoreControllerOnBluetoothRestore = false
     }
 
     private func clearBluetoothDiscoveryState() {
@@ -1057,6 +1092,8 @@ public final class MentraBluetoothSDK {
             return
         }
         for (index, id) in ids.enumerated() {
+            // Stop the underlying scan once (first session); the rest only
+            // complete their callbacks.
             finishScanSession(id, reason: reason, shouldStopScan: index == 0)
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -151,6 +151,7 @@ public final class MentraBluetoothSDK {
 
     private let configuration: MentraBluetoothSDKConfiguration
     private var discoveredDeviceNames = Set<String>()
+    private var bluetoothAvailabilityListenerId: UUID?
     private var bridgeEventSinkId: String?
     private var storeListenerId: String?
     private let defaultDeviceKeys: Set<String> = ["default_wearable", "device_name", "device_address"]
@@ -175,7 +176,11 @@ public final class MentraBluetoothSDK {
 
     public init(configuration: MentraBluetoothSDKConfiguration = .default) {
         self.configuration = configuration
-        _ = BluetoothAvailability.shared
+        bluetoothAvailabilityListenerId = BluetoothAvailability.shared.addStateListener { [weak self] state in
+            Task { @MainActor [weak self] in
+                self?.handleBluetoothAvailability(state)
+            }
+        }
         bridgeEventSinkId = Bridge.addEventSink { [weak self] eventName, data in
             Task { @MainActor [weak self] in
                 self?.dispatchBridgeEvent(eventName, data)
@@ -993,6 +998,10 @@ public final class MentraBluetoothSDK {
 
     public func invalidate() {
         stopStreamKeepAliveMonitor()
+        if let bluetoothAvailabilityListenerId {
+            BluetoothAvailability.shared.removeStateListener(bluetoothAvailabilityListenerId)
+            self.bluetoothAvailabilityListenerId = nil
+        }
         if let bridgeEventSinkId {
             Bridge.removeEventSink(bridgeEventSinkId)
             self.bridgeEventSinkId = nil
@@ -1002,6 +1011,40 @@ public final class MentraBluetoothSDK {
             self.storeListenerId = nil
         }
         delegate = nil
+    }
+
+    private func handleBluetoothAvailability(_ state: CBManagerState) {
+        switch state {
+        case .poweredOff, .resetting, .unauthorized, .unsupported:
+            cancelActiveScanSessions(reason: .cancelled)
+            clearBluetoothDiscoveryState()
+            if glassesStatus.connected || glassesStatus.connectionState == .connected {
+                DeviceManager.shared.disconnect()
+            }
+        case .poweredOn, .unknown:
+            break
+        @unknown default:
+            cancelActiveScanSessions(reason: .cancelled)
+            clearBluetoothDiscoveryState()
+            if glassesStatus.connected || glassesStatus.connectionState == .connected {
+                DeviceManager.shared.disconnect()
+            }
+        }
+    }
+
+    private func clearBluetoothDiscoveryState() {
+        discoveredDeviceNames.removeAll()
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searching", false)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searchingController", false)
+        DeviceStore.shared.apply(ObservableStore.bluetoothCategory, "searchResults", [] as [[String: Any]])
+    }
+
+    private func cancelActiveScanSessions(reason: ScanStopReason) {
+        let ids = Array(activeScanSessions.keys)
+        guard !ids.isEmpty else { return }
+        for (index, id) in ids.enumerated() {
+            finishScanSession(id, reason: reason, shouldStopScan: index == 0)
+        }
     }
 
     private func startStreamKeepAliveMonitor(streamId: String, intervalSeconds requestedIntervalSeconds: Int) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1031,6 +1031,11 @@ public final class MentraBluetoothSDK {
     }
 
     private func disconnectIfGlassesConnectionActive() {
+        if glassesStatus.deviceModel == DeviceTypes.SIMULATED
+            || DeviceManager.shared.sgc?.type.contains(DeviceTypes.SIMULATED) == true
+        {
+            return
+        }
         if glassesStatus.connected || glassesStatus.connectionState != .disconnected {
             DeviceManager.shared.disconnect()
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1016,19 +1016,23 @@ public final class MentraBluetoothSDK {
     private func handleBluetoothAvailability(_ state: CBManagerState) {
         switch state {
         case .poweredOff, .resetting, .unauthorized, .unsupported:
-            cancelActiveScanSessions(reason: .cancelled)
-            clearBluetoothDiscoveryState()
-            if glassesStatus.connected || glassesStatus.connectionState == .connected {
-                DeviceManager.shared.disconnect()
-            }
+            handleBluetoothUnavailable()
         case .poweredOn, .unknown:
             break
         @unknown default:
-            cancelActiveScanSessions(reason: .cancelled)
-            clearBluetoothDiscoveryState()
-            if glassesStatus.connected || glassesStatus.connectionState == .connected {
-                DeviceManager.shared.disconnect()
-            }
+            handleBluetoothUnavailable()
+        }
+    }
+
+    private func handleBluetoothUnavailable() {
+        cancelActiveScanSessions(reason: .cancelled)
+        clearBluetoothDiscoveryState()
+        disconnectIfGlassesConnectionActive()
+    }
+
+    private func disconnectIfGlassesConnectionActive() {
+        if glassesStatus.connected || glassesStatus.connectionState != .disconnected {
+            DeviceManager.shared.disconnect()
         }
     }
 
@@ -1041,7 +1045,12 @@ public final class MentraBluetoothSDK {
 
     private func cancelActiveScanSessions(reason: ScanStopReason) {
         let ids = Array(activeScanSessions.keys)
-        guard !ids.isEmpty else { return }
+        guard !ids.isEmpty else {
+            if bluetoothStatus.searching || bluetoothStatus.searchingController {
+                stopScan(reason: reason)
+            }
+            return
+        }
         for (index, id) in ids.enumerated() {
             finishScanSession(id, reason: reason, shouldStopScan: index == 0)
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
@@ -6,6 +6,7 @@ final class BluetoothAvailability: NSObject, CBCentralManagerDelegate {
 
     private var centralManager: CBCentralManager?
     private var state: CBManagerState = .unknown
+    private var listeners: [UUID: (CBManagerState) -> Void] = [:]
 
     override private init() {
         super.init()
@@ -19,6 +20,21 @@ final class BluetoothAvailability: NSObject, CBCentralManagerDelegate {
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         state = central.state
+        for listener in listeners.values {
+            listener(state)
+        }
+    }
+
+    @discardableResult
+    func addStateListener(_ listener: @escaping (CBManagerState) -> Void) -> UUID {
+        let id = UUID()
+        listeners[id] = listener
+        listener(state)
+        return id
+    }
+
+    func removeStateListener(_ id: UUID) {
+        listeners[id] = nil
     }
 
     func requirePoweredOn(operation: String) throws {

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
@@ -20,7 +20,7 @@ final class BluetoothAvailability: NSObject, CBCentralManagerDelegate {
 
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
         state = central.state
-        for listener in listeners.values {
+        for listener in Array(listeners.values) {
             listener(state)
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothAvailability.swift
@@ -27,6 +27,9 @@ final class BluetoothAvailability: NSObject, CBCentralManagerDelegate {
 
     @discardableResult
     func addStateListener(_ listener: @escaping (CBManagerState) -> Void) -> UUID {
+        // `listeners` is unsynchronized; it is only safe because the central
+        // manager queue is `.main` and all callers are main-thread bound.
+        dispatchPrecondition(condition: .onQueue(.main))
         let id = UUID()
         listeners[id] = listener
         listener(state)
@@ -34,6 +37,7 @@ final class BluetoothAvailability: NSObject, CBCentralManagerDelegate {
     }
 
     func removeStateListener(_ id: UUID) {
+        dispatchPrecondition(condition: .onQueue(.main))
         listeners[id] = nil
     }
 


### PR DESCRIPTION
## Summary

Fixes the iOS Bluetooth SDK state path when phone Bluetooth is turned off while glasses are connected or after glasses were scanned.

## Root cause

The SDK checked Bluetooth availability before operations, but it did not globally react to CoreBluetooth state changes. If Bluetooth was disabled, the store could keep stale connected state, including `connectionState == CONNECTED`, and stale scan results even though the radio was unavailable.

## Changes

- Notify SDK listeners when `BluetoothAvailability` state changes.
- On unavailable Bluetooth states, cancel active scan sessions, clear scan/searching state, clear stale scan results, and disconnect connected glasses.
- Ensure `DeviceManager.disconnect()` clears both `connected` and `connectionState`.

## Validation

- Verified on Philippe's iPhone that turning Bluetooth off while connected emits `didUpdateGlasses connected=false connection=DISCONNECTED`.
- `xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core connection and scan lifecycle plus auto-reconnect when Bluetooth is toggled; incorrect restore flags could surprise users, but scope is SDK state rather than security or data handling.
> 
> **Overview**
> Fixes stale iOS Bluetooth SDK state when the phone radio turns off while glasses are connected or a scan is in progress.
> 
> **`BluetoothAvailability`** now exposes **add/remove state listeners** that fire on CoreBluetooth `CBManagerState` updates (and immediately with the current state). **`MentraBluetoothSDK`** subscribes and, on powered-off/resetting/unauthorized/unsupported, **cancels active scan sessions**, **clears searching and scan results**, and **disconnects** connected glasses/controller while recording whether to **auto-reconnect** when Bluetooth comes back. Explicit **connect, disconnect, cancel, and forget** clear that restore intent so user-initiated disconnects are not revived.
> 
> **`DeviceManager.disconnect()`** now sets **`connectionState` to `DISCONNECTED`** alongside `connected = false`, so UI/delegates see a consistent disconnected state after radio loss or teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c754a22fff52a462ec1464eaef53d145019e029c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->