### PR TITLE
fix-nav-perm

### DIFF
--- a/sdk/Navigation/miniapp.json
+++ b/sdk/Navigation/miniapp.json
@@ -13,7 +13,8 @@
     "ui": "ui/index.html"
   },
   "permissions": [
-    {"type": "LOCATION", "description": "Used for live position, compass heading, and turn-by-turn directions"}
+    {"type": "LOCATION", "description": "Used for live position, compass heading, and turn-by-turn directions"},
+    {"type": "BACKGROUND_LOCATION", "description": "Used for live position, compass heading, and turn-by-turn directions"}
   ],
   "hardwareRequirements": [
     {"type": "DISPLAY", "level": "REQUIRED", "description": "Shows next maneuver and distance on glasses"}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only permission declaration with no runtime or navigation logic changes; users may see an additional OS background-location prompt when installing or upgrading the app.
> 
> **Overview**
> Updates **Mentra Map** (`sdk/Navigation/miniapp.json`) so the host can request **background location** in addition to foreground **LOCATION**, using the same user-facing description for live position, compass, and turn-by-turn navigation.
> 
> This aligns the manifest with the miniapp’s **background** entry (`background/index.js`), which needs location updates when the UI is not in the foreground. The diff also fixes JSON formatting by adding the missing comma after the existing `LOCATION` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd4d0321ebf1b1de405a113456033e1ddf99b124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->