### PR TITLE
Release Mentra Live 0.1.12 docs to frozen-docs

### DIFF
--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
 }
 ```
 

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -70,6 +70,105 @@ sdk.invalidate()
 
 Keep one SDK instance per active app session. The SDK owns Bluetooth connection state, native event delivery, and cleanup. Your app owns user identity, UI state, and whether a default device record is persisted across app restarts.
 
+## Mentra SDK Usage Analytics
+
+The SDK reports anonymous usage events to Mentra's PostHog project by default
+so Mentra can understand SDK adoption and successful glasses connections:
+
+| Event | Fires When |
+| --- | --- |
+| `bluetooth_sdk_started` | Once per app runtime after the native SDK starts. |
+| `bluetooth_sdk_glasses_connected` | When SDK status transitions from not connected to connected. Failed scans and failed connection attempts are not counted. |
+
+Analytics delivery is fire-and-forget: events are submitted asynchronously, do
+not block Bluetooth SDK behavior, and are not retried if delivery fails.
+
+Mentra's PostHog project API key is embedded in the SDK as a public analytics
+write token, not a private PostHog personal API key. Apps do not need to
+configure PostHog to send these Mentra SDK usage events.
+
+<Tabs>
+  <Tab title="React Native">
+
+Disable analytics before native SDK startup through the Expo config plugin:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@mentra/bluetooth-sdk",
+        {
+          "analytics": false
+        }
+      ]
+    ]
+  }
+}
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val sdk = MentraBluetoothSdk.create(
+    context = applicationContext,
+    config = MentraBluetoothSdkConfig(
+        analytics = BluetoothSdkAnalyticsConfig.disabled()
+    ),
+    listener = listener,
+)
+```
+
+Android apps can also set application metadata before SDK startup:
+
+```xml
+<meta-data
+    android:name="com.mentra.bluetoothsdk.analytics.disabled"
+    android:value="true" />
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let sdk = MentraBluetoothSDK(
+    configuration: MentraBluetoothSDKConfiguration(
+        analytics: .disabled
+    )
+)
+```
+
+iOS apps can also set `MentraBluetoothSdkAnalyticsDisabled` to `true` in
+`Info.plist` before SDK startup.
+
+  </Tab>
+</Tabs>
+
+Apps do not configure the analytics destination; these SDK usage events are
+always sent to Mentra's PostHog project unless analytics are disabled.
+
+Captured properties are intentionally narrow:
+
+| Property | Meaning |
+| --- | --- |
+| `event_source` | Always `mentra_bluetooth_sdk`. |
+| `sdk_platform` | Native platform that sends the event: `android` or `ios`. |
+| `sdk_surface` | Public SDK surface: `react_native`, `android`, or `ios`. |
+| `sdk_version` | Bluetooth SDK version. |
+| `app_package` / `app_bundle_identifier` | Consuming app identifier. |
+| `os_platform`, `os_version` | Phone OS metadata. |
+| `event_kind` | `sdk_started` or `glasses_connected`. |
+| `fully_booted` | Connection event only; whether the connected status already reports fully booted. |
+| `glasses_model` | Connection event only; included only when the SDK has a non-empty model value. |
+
+The SDK does not upload BLE MAC addresses, CoreBluetooth identifiers, serial
+numbers, Bluetooth device names, user ids, tokens, Wi-Fi credentials,
+microphone data, photos, or transcripts. It stores a locally generated
+anonymous SDK install id and sends it as PostHog `distinct_id`; events include
+`$process_person_profile: false` so PostHog does not create person profiles for
+these SDK usage pings.
+
 ## Connection
 
 <Tabs>
@@ -284,7 +383,7 @@ Important defaults:
 - `requestPhoto({authToken, ...})` omits the `Authorization` header when `authToken` is `null` or empty.
 - `requestPhoto({exposureTimeNs, ...})` uses auto exposure when `exposureTimeNs` is omitted or `null`; pass a positive nanosecond value for one-shot manual exposure.
 - `requestPhoto({exposureTimeNs, iso, ...})` uses `iso` only when `exposureTimeNs` enables one-shot manual exposure. Omit `iso` / pass `null` for auto ISO selection.
-- Request/response commands now resolve from the glasses response rather than only updating local SDK state. React Native returns success-only values for commands whose raw events can also carry errors: `requestPhoto(...)` returns terminal `PhotoSuccessResponseEvent` after capture and delivery finish, `startVideoRecording(...)` returns `VideoRecordingStartedStatusEvent`, `stopVideoRecording(...)` returns `VideoRecordingStoppedStatusEvent`, and `rgbLedControl(...)` returns `RgbLedControlSuccessResponseEvent`. The corresponding raw events still include error variants for listeners.
+- Request/response commands now resolve from the glasses response rather than only updating local SDK state. React Native returns success-only values for commands whose raw events can also carry errors: `requestPhoto(...)` returns terminal `PhotoSuccessResponseEvent` after capture and delivery finish, `startVideoRecording(...)` returns `VideoRecordingStartedStatusEvent`, `stopVideoRecording(...)` returns `VideoRecordingStoppedStatusEvent`, and `rgbLedControl(...)` returns `RgbLedControlSuccessResponseEvent`. When `stopVideoRecording(...)` includes a webhook URL, the promise resolves after the video upload succeeds. The corresponding raw events still include error variants for listeners.
 - `setCameraFov({fov, roiPosition})` clamps `fov` to 62-118 degrees and accepts `roiPosition` as `"center"`, `"bottom"`, or `"top"`. You can also call `setCameraFov({preset: "narrow" | "standard" | "wide"})`; presets map to 82, 102, and 118 degrees with center ROI. On Mentra Live this persists the setting, restarts the camera, and resolves with `CameraFovResult` only after the ASG client reports the setting was applied to camera hardware after the restart cooldown. The promise rejects if the glasses report an error, persist the setting without hardware application, or time out. Treat FOV as a framing/ROI control; output resolution and effective detail can vary by capture path, firmware, and camera mode.
 - `startStream` optional `video` and `audio` configs are omitted unless supplied, so the connected glasses use their model defaults. The SDK sends stream keep-alives automatically and reports timeout/error state through `stream_status`.
 - Photo capture, video recording, and streaming always enable the camera light as a privacy indicator.
@@ -307,7 +406,7 @@ React Native exposes the narrowest return types for clear branching after `await
 | `queryGalleryStatus()` | `GalleryStatusEvent`, including `cameraBusy` and optional `cameraBusyReason`. | Timeout, send failure, or another gallery status query in flight. |
 | `requestPhoto(...)` | Terminal response after capture and delivery finish: React Native `PhotoSuccessResponseEvent`; Android/iOS successful `PhotoResponseEvent`. The success includes `uploadUrl`, and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`. Progress follows through `photo_status`. | Raw `photo_response.state === "error"` from glasses/phone, fallback upload failure, terminal response timeout, or send failure. |
 | `startVideoRecording(...)` | React Native `VideoRecordingStartedStatusEvent` with `status: "recording_started"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_started"`. | `success: false` statuses such as `already_recording`, timeout, send failure, or duplicate request ID. |
-| `stopVideoRecording(requestId)` | React Native `VideoRecordingStoppedStatusEvent` with `status: "recording_stopped"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_stopped"`. | `success: false` statuses such as `not_recording`, timeout, send failure, or duplicate request ID. |
+| `stopVideoRecording(requestId, webhookUrl?, authToken?)` | React Native `VideoRecordingStoppedStatusEvent` with `status: "recording_stopped"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_stopped"`. When `webhookUrl` is supplied, the promise waits for the video upload to finish successfully. | `success: false` statuses such as `not_recording`, video upload failure, timeout, send failure, or duplicate request ID. |
 | `startStream(...)` | `StreamStatusEvent` for the requested stream once `status` is `streaming`. | `stream_status` error/reconnect failure, timeout, or send failure. |
 | `stopStream()` | `StreamStatusEvent` once `status` is `stopped`; an already-stopped / not-streaming glasses reply resolves as a normalized stopped event. | Real stop error, timeout, send failure, or another stream stop in flight. |
 | `rgbLedControl(...)` | React Native `RgbLedControlSuccessResponseEvent`; Android/iOS successful `RgbLedControlResponseEvent`. | Raw `rgb_led_control_response.state === "error"`, timeout, or send failure. |
@@ -457,7 +556,8 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `hotspot_error` | `HotspotErrorEvent` | Hotspot operation fails. |
 | `photo_response` | `PhotoResponseEvent` | Terminal photo result. Success means capture and webhook delivery completed; error means the glasses or phone rejected/failed the request. `requestPhoto(...)` resolves with the success case and rejects on the error case; progress follows through `photo_status`. |
 | `photo_status` | `PhotoStatusEvent` | Photo capture progress changes. May include `resolvedConfig`, `requestedCaptureConfig`, `meteredPreview`, or `captureMetadata` depending on status. |
-| `video_recording_status` | `VideoRecordingStatusEvent` | Video recording start/stop succeeds or fails, or a status query reports `status: "recording_status"` with `data.recording`. `startVideoRecording(...)` and `stopVideoRecording(...)` resolve only from their matching terminal statuses (`recording_started` / `recording_stopped`); unsuccessful statuses such as `already_recording` reject the promise. |
+| `video_recording_status` | `VideoRecordingStatusEvent` | Video recording start/stop succeeds or fails, or a status query reports `status: "recording_status"` with `data.recording`. `startVideoRecording(...)` resolves from `recording_started`; `stopVideoRecording(...)` resolves from `recording_stopped` unless a webhook upload was requested, in which case it waits for upload success. |
+| `media_success` / `media_error` | `MediaUploadEvent` | Raw glasses media upload completion events. Video webhook stops use these events to resolve or reject the `stopVideoRecording(...)` promise after recording has stopped. |
 | `gallery_status` | `GalleryStatusEvent` | Gallery content/camera-busy status changes. `cameraBusyReason` is included when the glasses report a busy camera reason such as `video` or `stream`. |
 | `settings_ack` | `SettingsAckEvent` | Raw gallery/button/FOV setting acknowledgements from the glasses. Gallery and button setting methods return `SettingsAckSuccessEvent` and reject failure statuses; `setCameraFov(...)` resolves a friendlier `CameraFovResult` after the raw ack reports camera hardware application. |
 | `compatible_glasses_search_stop` | `CompatibleGlassesSearchStopEvent` | Compatible-glasses search stops for a model. |
@@ -475,9 +575,9 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `ota_start_ack` | `OtaStartAckEvent` | Mentra Live acknowledges `startOtaUpdate()`. Also returned by `startOtaUpdate()`. |
 | `ota_status` | `OtaStatusEvent` | OTA step, phase, status, progress, or error changes. |
 
-For request/response commands, prefer the returned value from the method, such as the `PhotoSuccessResponseEvent` returned by React Native `requestPhoto(...)` or the operation-specific video result returned by React Native `startVideoRecording(...)` / `stopVideoRecording(...)`. `requestPhoto(...)` waits for the terminal `photo_response`: it resolves after the photo is captured and delivered to the webhook, and rejects if the glasses reject the request, the phone-side fallback upload fails, or the terminal response times out. Capture/upload/Bluetooth fallback progress follows through `photo_status`. Use event listeners for ongoing hardware streams and status updates: for example, `useBluetoothEvent('mic_pcm', ...)` receives a `MicPcmEvent`. `MicPcmEvent` includes `sampleRate`, `bitsPerSample`, `channels`, `encoding`, and `voiceActivityDetectionEnabled`; `MicLc3Event` includes `sampleRate`, `channels`, `encoding`, `frameDurationMs`, `frameSizeBytes`, `bitrate`, `packetizedFromGlasses`, and `voiceActivityDetectionEnabled`. `speaking_status` is separate from microphone audio frames so apps can use continuous audio while still reacting to speech activity.
+For request/response commands, prefer the returned value from the method, such as the `PhotoSuccessResponseEvent` returned by React Native `requestPhoto(...)` or the operation-specific video result returned by React Native `startVideoRecording(...)` / `stopVideoRecording(...)`. `requestPhoto(...)` waits for the terminal `photo_response`: it resolves after the photo is captured and delivered to the webhook, and rejects if the glasses reject the request, the phone-side fallback upload fails, or the terminal response times out. `stopVideoRecording(...)` keeps the same end-to-end shape for video webhook stops: it waits for recording stop plus upload success, and rejects on upload failure. Photo capture/upload/Bluetooth fallback progress follows through `photo_status`; raw video upload completion arrives through `media_success` and `media_error` for listeners that need the glasses event stream directly. Use event listeners for ongoing hardware streams and status updates: for example, `useBluetoothEvent('mic_pcm', ...)` receives a `MicPcmEvent`. `MicPcmEvent` includes `sampleRate`, `bitsPerSample`, `channels`, `encoding`, and `voiceActivityDetectionEnabled`; `MicLc3Event` includes `sampleRate`, `channels`, `encoding`, `frameDurationMs`, `frameSizeBytes`, `bitrate`, `packetizedFromGlasses`, and `voiceActivityDetectionEnabled`. `speaking_status` is separate from microphone audio frames so apps can use continuous audio while still reacting to speech activity.
 
-Public React Native event payload fields usually use camelCase. OTA events intentionally mirror the glasses firmware field names, such as `overall_percent` and `version_name`. For example, touch events expose `deviceModel` and `gestureName`, successful photo responses expose `uploadUrl` and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, and `fileSizeBytes`, hotspot errors expose `errorMessage`, Wi-Fi scan events expose `scanComplete`, and gallery status exposes `hasContent`, `cameraBusy`, and optional `cameraBusyReason`.
+Public React Native event payload fields usually use camelCase. OTA events intentionally mirror the glasses firmware field names, such as `overall_percent` and `version_name`. For example, touch events expose `deviceModel` and `gestureName`, successful photo responses expose `uploadUrl` and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, and `fileSizeBytes`, successful media upload events expose `requestId`, `mediaUrl`, and `mediaType`, hotspot errors expose `errorMessage`, Wi-Fi scan events expose `scanComplete`, and gallery status exposes `hasContent`, `cameraBusy`, and optional `cameraBusyReason`.
 
 ### Photo Status Metadata
 

--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Camera And Streaming"
-description: "Request photos and start RTMP, SRT, or WebRTC streams from supported smart glasses."
+description: "Request photos, record videos, and start RTMP, SRT, or WebRTC streams from supported smart glasses."
 icon: "camera"
 ---
 
@@ -105,6 +105,91 @@ useBluetoothEvent('photo_status', (event) => {
 | `captured` | `captureMetadata` | Read the actual HAL-applied still capture values, including exposure time, ISO, frame duration, AE state/name, noise reduction mode, edge mode, sensor timestamp, and MFNR hint when available. |
 
 Upload and BLE transfer statuses such as `uploading`, `compressing`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring` are transport progress only. They do not carry capture metadata, so use the `captured` event when you need the actual exposure/ISO/frame data for debugging or UI. `ble_fallback_compression` means the direct Wi-Fi/webhook upload failed and the glasses are compressing the already-captured photo for Bluetooth fallback delivery.
+
+## Video Recording
+
+Use `startVideoRecording(...)` when your app needs a clip instead of a still image. Pass per-recording settings only when you want to override the saved button-video defaults; `maxRecordingTimeMinutes` is an auto-stop guard, and `0` or an omitted value records until your app stops recording or the glasses interrupt it.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+const requestId = `video-${Date.now()}`;
+
+const started = await BluetoothSdk.startVideoRecording(requestId, true, true, {
+  width: 1280,
+  height: 720,
+  fps: 30,
+  maxRecordingTimeMinutes: 1,
+});
+console.log('video started', started.status);
+
+const stopped = await BluetoothSdk.stopVideoRecording(
+  requestId,
+  'https://api.example.com/mentra/video',
+  'optional-token',
+);
+console.log('video uploaded', stopped.status);
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+val requestId = "video-${System.currentTimeMillis()}"
+
+val started = sdk.startVideoRecording(
+    VideoRecordingRequest(
+        requestId = requestId,
+        save = true,
+        sound = true,
+        width = 1280,
+        height = 720,
+        fps = 30,
+        maxRecordingTimeMinutes = 1,
+    )
+)
+println("video started: ${started.status}")
+
+val stopped = sdk.stopVideoRecording(
+    requestId = requestId,
+    webhookUrl = "https://api.example.com/mentra/video",
+    authToken = "optional-token",
+)
+println("video uploaded: ${stopped.status}")
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+let requestId = "video-\(Date().timeIntervalSince1970)"
+
+let started = try await sdk.startVideoRecording(
+    VideoRecordingRequest(
+        requestId: requestId,
+        save: true,
+        sound: true,
+        width: 1280,
+        height: 720,
+        fps: 30,
+        maxRecordingTimeMinutes: 1
+    )
+)
+print("video started: \(started.status)")
+
+let stopped = try await sdk.stopVideoRecording(
+    requestId: requestId,
+    webhookUrl: "https://api.example.com/mentra/video",
+    authToken: "optional-token"
+)
+print("video uploaded: \(stopped.status)")
+```
+
+  </Tab>
+</Tabs>
+
+`startVideoRecording(...)` resolves from `recording_started`. `stopVideoRecording(...)` without a webhook resolves from `recording_stopped`; when you pass a webhook URL, it waits for `recording_stopped` plus video `media_success`, and rejects on video `media_error`. Raw `video_recording_status`, `media_success`, and `media_error` events remain available for listeners that need the glasses event stream directly. The video upload webhook should accept multipart form data with a `video` field and `requestId`. Pass the webhook URL and auth token at stop time so upload credentials can be fresh when the recording ends.
 
 ## Gallery Mode
 

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -15,9 +15,9 @@ cd Mentra-Bluetooth-SDK-Starter-Kit
 
 - Scanning for Mentra Live, connecting, disconnecting, and reconnecting to a saved/default device.
 - Reading typed glasses and Bluetooth status snapshots.
-- Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, audio, and SDK log events.
+- Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, video upload, audio, and SDK log events.
 - Controlling Mentra Live features such as gallery mode, button photo/video settings, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
-- Running the default glasses-to-phone photo and streaming demos, plus optional cloud-server demos for external upload and streaming endpoints.
+- Running the default glasses-to-phone photo and streaming demos, plus optional cloud-server demos for external media upload and streaming endpoints.
 
 ## Android
 
@@ -50,11 +50,11 @@ bun run android:dev
 
 The React Native example installs the SDK as `@mentra/bluetooth-sdk` and demonstrates the same Device, Camera, Stream, System, and Console flows as the native examples.
 
-## Optional Local Photo And Streaming Helper
+## Optional Local Media And Streaming Helper
 
 The Camera and Stream screens default to a glasses-to-phone flow where the example app starts a receiver on the phone and sends the glasses output there. You do not need this helper for that default path.
 
-Use this helper only when you turn on **Use cloud server** in the example app and want to test an external endpoint without deploying your own photo webhook or streaming server. Production apps can use any reachable HTTPS upload endpoint and any reachable RTMP, SRT, or WHIP ingest URL.
+Use this helper only when you turn on **Use cloud server** in the example app and want to test an external endpoint without deploying your own media upload webhook or streaming server. Production apps can use any reachable HTTPS upload endpoint and any reachable RTMP, SRT, or WHIP ingest URL.
 
 From the repo root:
 
@@ -62,7 +62,7 @@ From the repo root:
 python3 examples/local-demo-cloud/server.py
 ```
 
-After enabling **Use cloud server**, paste the printed LAN `/upload` URL into the Camera screen, or paste the printed RTMP, SRT, or WHIP publish URL into the Stream screen. If Docker is not installed or not running, the helper starts the photo webhook and skips streaming with a warning.
+After enabling **Use cloud server**, paste the printed LAN `/upload` URL into the Camera screen, or paste the printed RTMP, SRT, or WHIP publish URL into the Stream screen. If Docker is not installed or not running, the helper starts the media upload webhook and skips streaming with a warning.
 
 <Warning>
 Do not use `localhost` in the app. The glasses, phone, and computer must be on a network where the glasses can reach the printed LAN address.

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.10` or newer, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.12` or newer, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.10"
+  from: "0.1.12"
 )
 ```
 

--- a/docs/mentra-live/production-checklist.mdx
+++ b/docs/mentra-live/production-checklist.mdx
@@ -6,6 +6,13 @@ icon: "clipboard-check"
 
 Use this checklist before shipping an app with the Mentra Bluetooth SDK.
 
+## Analytics
+
+- Mentra Bluetooth SDK usage analytics are enabled by default and use Mentra's embedded PostHog project write key.
+- If your app disables SDK analytics, do it before SDK startup with the Expo config plugin, Android manifest metadata, iOS `Info.plist`, or native SDK configuration.
+- Verify `bluetooth_sdk_started` appears after SDK startup and `bluetooth_sdk_glasses_connected` appears only after a successful glasses connection.
+- Confirm your privacy copy reflects anonymous SDK usage analytics if needed for your app's distribution channel.
+
 ## App Setup
 
 - Android, iOS, and/or React Native native builds are configured for the app stack you ship.

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.10")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.10` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Use version `0.1.12` or newer, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.10"
+  from: "0.1.12"
 )
 ```
 

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -22,7 +22,7 @@ icon: "circle-question"
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.10` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.12` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 


### PR DESCRIPTION
## Summary

- Release the latest Mentra Live / Bluetooth SDK docs from `dev` onto `frozen-docs`.
- Update install snippets from `0.1.10` to `0.1.12` for Android and SwiftPM.
- Add the dev docs updates for SDK usage analytics and video recording webhook upload behavior.

## Scope

Only the public Mentra Live docs pages under `docs/mentra-live/` were updated. The broader `docs/` nav and unrelated dev docs churn were intentionally left out because `frozen-docs` already has the Mentra Live tab wired.

## Validation

- `git diff --check`
- `cd docs && bunx --bun mint export --output /tmp/mentra-frozen-docs-mentra-live-0.1.12-export.zip`

Note: Mintlify export completed successfully, but the existing frozen-docs tree still emits parsing warnings in old non-nav markdown files: `LC3-BITRATE-UPGRADE-PLAN.md` and `issues/docs-overhaul/spec.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes under `docs/mentra-live/` with no runtime or SDK code modified.
> 
> **Overview**
> Updates **Mentra Live** public docs on `frozen-docs` for Bluetooth SDK **0.1.12**: Android Maven and iOS SwiftPM install snippets move from `0.1.10` to `0.1.12` (quickstart, android, ios, troubleshooting).
> 
> **API reference** adds a **Mentra SDK Usage Analytics** section: default PostHog events (`bluetooth_sdk_started`, `bluetooth_sdk_glasses_connected`), opt-out on RN/Android/iOS, and a narrow property/privacy list. **Video recording** docs now state that `stopVideoRecording(...)` with a webhook waits for upload success via `media_success` / `media_error`, not only `recording_stopped`.
> 
> **Camera And Streaming** gains a **Video Recording** section with cross-platform start/stop + webhook examples. **Production checklist** adds an **Analytics** section; **examples** wording shifts from photo-only to broader media upload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d815fe58b9164dbd27801bb2f08e6040567556. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->