### PR TITLE
Pin ASG client CI builds to mac runners with signing keystore

### DIFF
--- a/.github/workflows/mentra-asg-client-build.yml
+++ b/.github/workflows/mentra-asg-client-build.yml
@@ -17,7 +17,9 @@ permissions:
 
 jobs:
   build:
-    runs-on: self-hosted
+    # Pinned to the mac runners: they have the ASG signing keystore provisioned
+    # (~/.mentra/credentials + ~/.gradle/gradle.properties), the Linux Azure VM doesn't.
+    runs-on: [self-hosted, macOS, ARM64]
 
     steps:
       - name: Update PR comment - Build started

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -428,7 +428,9 @@ jobs:
 
   build-asg:
     name: Build ASG Client
-    runs-on: self-hosted
+    # Pinned to the mac runners: they have the ASG signing keystore provisioned
+    # (~/.mentra/credentials + ~/.gradle/gradle.properties), the Linux Azure VM doesn't.
+    runs-on: [self-hosted, macOS, ARM64]
 
     steps:
       - name: Get cache week number


### PR DESCRIPTION
## Scope

ASG client builds were failing whenever they landed on the Linux Azure VM runner (`github-actions-runner-vm-4`): the recovery worker build step hard-fails with `Release keystore not found at credentials/recovery-keystore.jks` because that VM has no keystore in `~/.mentra/credentials` and no `ASG_*` entries in `~/.gradle/gradle.properties`. The big-bob mac runners are provisioned with both, which is why the same commits alternated pass/fail depending on runner assignment.

This pins the two ASG client jobs (`mentra-asg-client-build.yml` build job, `staging-builds.yml` build-asg job) to `[self-hosted, macOS, ARM64]`, matching the iOS builds.

Note: before the recovery worker step existed, main ASG release builds on the Azure VM were silently falling back to **debug signing** (`asg_client/app/build.gradle` falls back with only a console warning), so this also ensures release APKs from CI are production-signed.

## Test evidence

- Failing runs (e.g. 27443832515, 27435186791) all ran on `github-actions-runner-vm-4`; all passing runs ran on `big-bob`/`big-bob-3`.
- This PR touches `mentra-asg-client-build.yml`, which is in its own `paths` filter — the PR build itself exercises the new runner pinning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only runner label changes; no application or signing logic is modified, though CI may queue longer if Mac runner capacity is limited.
> 
> **Overview**
> **Pins ASG client GitHub Actions jobs to `[self-hosted, macOS, ARM64]`** so builds always run on Mac runners that have `~/.mentra/credentials` and `ASG_*` Gradle signing props, instead of any generic self-hosted host (including the Linux Azure VM).
> 
> The change applies to the **`build` job** in `mentra-asg-client-build.yml` and the **`build-asg` job** in `staging-builds.yml`, with inline comments explaining why. This should stop intermittent failures on recovery worker / keystore steps and avoid release APKs being built on hosts that only warn and fall back to debug signing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 524a6e52a9efccd0b2183b2cba668f89faba8b7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin ASG client CI builds to `[self-hosted, macOS, ARM64]` runners that have the ASG signing keystore to stop Linux VM failures and ensure release APKs are production-signed. Applies to `mentra-asg-client-build.yml` and the `build-asg` job in `staging-builds.yml`.

<sup>Written for commit 524a6e52a9efccd0b2183b2cba668f89faba8b7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

