### PR TITLE
Add developer OTA manifest URL setting

### DIFF
--- a/mobile/src/app/miniapps/settings/developer.tsx
+++ b/mobile/src/app/miniapps/settings/developer.tsx
@@ -3,6 +3,7 @@ import {useEffect, useRef, useState} from "react"
 import {ScrollView, View} from "react-native"
 
 import BackendUrl from "@/components/dev/BackendUrl"
+import OtaVersionUrl from "@/components/dev/OtaVersionUrl"
 import StoreUrl from "@/components/dev/StoreUrl"
 import {Header, Icon, Screen, Text} from "@/components/ignite"
 import SelectSetting from "@/components/settings/SelectSetting"
@@ -287,6 +288,8 @@ export default function DeveloperSettingsScreen() {
           <BackendUrl />
 
           <StoreUrl />
+
+          <OtaVersionUrl />
 
           {superMode && <RouteButton label="Super Settings" onPress={() => push("/miniapps/settings/super")} />}
 

--- a/mobile/src/app/miniapps/settings/developer.tsx
+++ b/mobile/src/app/miniapps/settings/developer.tsx
@@ -289,7 +289,8 @@ export default function DeveloperSettingsScreen() {
 
           <StoreUrl />
 
-          <OtaVersionUrl />
+          {/* Super mode only: a wrong OTA manifest can brick glasses */}
+          {superMode && <OtaVersionUrl />}
 
           {superMode && <RouteButton label="Super Settings" onPress={() => push("/miniapps/settings/super")} />}
 

--- a/mobile/src/components/dev/OtaVersionUrl.tsx
+++ b/mobile/src/components/dev/OtaVersionUrl.tsx
@@ -149,8 +149,9 @@ export default function OtaVersionUrl() {
       <View style={themed($textContainer)}>
         <Text style={themed($label)}>Custom OTA Manifest URL</Text>
         <Text style={themed($subtitle)}>
-          Override the manifest used for glasses OTA checks and installs. Leave blank to use the default (staging builds
-          use the staging manifest). Legacy glasses firmware ignores the override.
+          Override the manifest used for glasses OTA checks and installs. Leave blank to use the default
+          (glasses-reported or production manifest). Staging testers: use the Staging preset. Legacy glasses firmware
+          ignores the override.
           {otaVersionUrl && `\nCurrently using: ${otaVersionUrl}`}
         </Text>
         <TextInput

--- a/mobile/src/components/dev/OtaVersionUrl.tsx
+++ b/mobile/src/components/dev/OtaVersionUrl.tsx
@@ -149,9 +149,7 @@ export default function OtaVersionUrl() {
       <View style={themed($textContainer)}>
         <Text style={themed($label)}>Custom OTA Manifest URL</Text>
         <Text style={themed($subtitle)}>
-          Override the manifest used for glasses OTA checks and installs. Leave blank to use the default
-          (glasses-reported or production manifest). Staging testers: use the Staging preset. Legacy glasses firmware
-          ignores the override.
+          Override the default glasses OTA manifest URL. Leave blank to use default.
           {otaVersionUrl && `\nCurrently using: ${otaVersionUrl}`}
         </Text>
         <TextInput

--- a/mobile/src/components/dev/OtaVersionUrl.tsx
+++ b/mobile/src/components/dev/OtaVersionUrl.tsx
@@ -1,0 +1,317 @@
+import {useState} from "react"
+import {TextInput, View, ViewStyle, TextStyle, TouchableOpacity} from "react-native"
+
+import {Button, Text} from "@/components/ignite"
+import GlassView from "@/components/ui/GlassView"
+import {OTA_VERSION_URL_PROD, OTA_VERSION_URL_STAGING} from "@/config/ota"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {SETTINGS, useSetting} from "@/stores/settings"
+import {ThemedStyle} from "@/theme"
+import showAlert from "@/utils/AlertUtils"
+
+interface SavedUrl {
+  label: string
+  url: string
+}
+
+export default function OtaVersionUrl() {
+  const {theme, themed} = useAppTheme()
+  const [customUrlInput, setCustomUrlInput] = useState("")
+  const [isSavingUrl, setIsSavingUrl] = useState(false)
+  const [otaVersionUrl, setOtaVersionUrl] = useSetting(SETTINGS.ota_version_url.key)
+  const [savedUrls, setSavedUrls] = useSetting(SETTINGS.saved_ota_version_urls.key)
+
+  // Ensure savedUrls is always an array
+  const bookmarks: SavedUrl[] = Array.isArray(savedUrls) ? savedUrls : []
+
+  const generateLabel = (url: string): string => {
+    try {
+      const parsed = new URL(url)
+      return parsed.host
+    } catch {
+      return url
+    }
+  }
+
+  const validateUrl = (url: string): boolean => {
+    if (!url) {
+      showAlert("Empty URL", "Please enter a URL or reset to default.", [{text: "OK"}])
+      return false
+    }
+
+    if (!url.startsWith("http://") && !url.startsWith("https://")) {
+      showAlert("Invalid URL", "Please enter a valid URL starting with http:// or https://", [{text: "OK"}])
+      return false
+    }
+
+    return true
+  }
+
+  const handleBookmark = () => {
+    const urlToSave = customUrlInput.trim()
+
+    if (!validateUrl(urlToSave)) {
+      return
+    }
+
+    // Check for duplicates
+    if (bookmarks.some((b) => b.url === urlToSave)) {
+      showAlert("Already Bookmarked", "This URL is already in your saved list.", [{text: "OK"}])
+      return
+    }
+
+    const label = generateLabel(urlToSave)
+    setSavedUrls([...bookmarks, {label, url: urlToSave}])
+    showAlert("Bookmarked", `Saved "${label}" to your URLs.`, [{text: "OK"}])
+  }
+
+  const handleDeleteBookmark = (index: number) => {
+    const bookmark = bookmarks[index]
+    showAlert("Remove Bookmark", `Remove "${bookmark.label}" from your saved URLs?`, [
+      {text: "Cancel", style: "cancel"},
+      {
+        text: "Remove",
+        style: "destructive",
+        onPress: () => {
+          setSavedUrls(bookmarks.filter((_, i) => i !== index))
+        },
+      },
+    ])
+  }
+
+  const handleSaveUrl = async () => {
+    const urlToTest = customUrlInput.trim()
+
+    if (!validateUrl(urlToTest)) {
+      return
+    }
+
+    setIsSavingUrl(true)
+
+    try {
+      // Test the URL by fetching the manifest itself
+      const controller = new AbortController()
+      const timeoutId = setTimeout(() => controller.abort(), 5000)
+
+      try {
+        const response = await fetch(urlToTest, {
+          method: "GET",
+          signal: controller.signal,
+        })
+
+        clearTimeout(timeoutId)
+
+        if (!response.ok) {
+          showAlert(
+            "Verification Failed",
+            `The server responded, but with status ${response.status}. Please check the URL and server status.`,
+            [{text: "OK"}],
+          )
+          return
+        }
+
+        const data = await response.json()
+        if (!data || typeof data !== "object") {
+          showAlert("Verification Failed", "The URL did not return a JSON manifest.", [{text: "OK"}])
+          return
+        }
+
+        await setOtaVersionUrl(urlToTest)
+        showAlert("Success", "Custom OTA manifest URL saved. Future OTA checks and installs will use it.", [
+          {text: "OK"},
+        ])
+      } catch (fetchError: unknown) {
+        clearTimeout(timeoutId)
+        throw fetchError
+      }
+    } catch (error: unknown) {
+      console.error("OTA URL test failed:", error instanceof Error ? error.message : "Unknown error")
+
+      let errorMessage = "Could not load the OTA manifest. Please check the URL and your network connection."
+      if (error instanceof Error && error.name === "AbortError") {
+        errorMessage = "Connection timed out. Please check the URL and server status."
+      }
+
+      showAlert("Verification Failed", errorMessage, [{text: "OK"}])
+    } finally {
+      setIsSavingUrl(false)
+    }
+  }
+
+  const handleResetUrl = async () => {
+    await setOtaVersionUrl(null)
+    setCustomUrlInput("")
+    showAlert("Success", "Reset OTA manifest URL to default.", [{text: "OK"}])
+  }
+
+  return (
+    <GlassView className="bg-primary-foreground rounded-2xl" style={themed($container)}>
+      <View style={themed($textContainer)}>
+        <Text style={themed($label)}>Custom OTA Manifest URL</Text>
+        <Text style={themed($subtitle)}>
+          Override the manifest used for glasses OTA checks and installs. Leave blank to use the default (staging builds
+          use the staging manifest). Legacy glasses firmware ignores the override.
+          {otaVersionUrl && `\nCurrently using: ${otaVersionUrl}`}
+        </Text>
+        <TextInput
+          style={themed($urlInput)}
+          placeholder="e.g., http://192.168.1.100:8000/live_version.json"
+          placeholderTextColor={theme.colors.textDim}
+          value={customUrlInput}
+          onChangeText={setCustomUrlInput}
+          autoCapitalize="none"
+          autoCorrect={false}
+          keyboardType="url"
+          editable={!isSavingUrl}
+        />
+        <View style={themed($buttonRow)}>
+          <Button
+            text={isSavingUrl ? "Testing..." : "Save & Test URL"}
+            onPress={handleSaveUrl}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+          <Button
+            tx="common:reset"
+            onPress={handleResetUrl}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+          <Button
+            text="☆ Bookmark"
+            onPress={handleBookmark}
+            disabled={isSavingUrl}
+            preset="alternate"
+            flexContainer={false}
+          />
+        </View>
+
+        {/* Saved URL bookmarks */}
+        {bookmarks.length > 0 && (
+          <View style={themed($savedSection)}>
+            <Text style={themed($sectionLabel)}>My URLs</Text>
+            <View style={themed($chipContainer)}>
+              {bookmarks.map((bookmark, index) => (
+                <TouchableOpacity
+                  key={`${bookmark.url}-${index}`}
+                  style={themed($chip)}
+                  onPress={() => setCustomUrlInput(bookmark.url)}
+                  onLongPress={() => handleDeleteBookmark(index)}
+                  activeOpacity={0.7}>
+                  <Text style={themed($chipText)}>{bookmark.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+            <Text style={themed($chipHint)}>Tap to fill · Long-press to remove</Text>
+          </View>
+        )}
+
+        {/* Environment presets */}
+        <View style={themed($buttonColumn)}>
+          <Button
+            compact
+            text="Production"
+            onPress={() => setCustomUrlInput(OTA_VERSION_URL_PROD)}
+            flexContainer={false}
+            flex
+          />
+          <Button
+            compact
+            tx="developer:staging"
+            onPress={() => setCustomUrlInput(OTA_VERSION_URL_STAGING)}
+            flexContainer={false}
+            flex
+          />
+        </View>
+      </View>
+    </GlassView>
+  )
+}
+
+const $container: ThemedStyle<ViewStyle> = ({spacing}) => ({
+  paddingHorizontal: spacing.s6,
+  paddingVertical: spacing.s4,
+})
+
+const $textContainer: ThemedStyle<ViewStyle> = () => ({
+  flex: 1,
+})
+
+const $label: ThemedStyle<TextStyle> = ({colors}) => ({
+  flexWrap: "wrap",
+  fontSize: 16,
+  color: colors.text,
+})
+
+const $subtitle: ThemedStyle<TextStyle> = ({colors}) => ({
+  flexWrap: "wrap",
+  fontSize: 12,
+  marginTop: 5,
+  color: colors.textDim,
+})
+
+const $urlInput: ThemedStyle<TextStyle> = ({colors, spacing}) => ({
+  backgroundColor: colors.background,
+  borderColor: colors.primary,
+  borderRadius: spacing.s3,
+  paddingHorizontal: 12,
+  paddingVertical: 10,
+  fontSize: 14,
+  marginTop: 10,
+  marginBottom: 10,
+  color: colors.text,
+})
+
+const $buttonRow: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  justifyContent: "space-between",
+  marginTop: 10,
+})
+
+const $buttonColumn: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  gap: 12,
+  justifyContent: "space-between",
+  marginTop: 12,
+})
+
+const $savedSection: ThemedStyle<ViewStyle> = () => ({
+  marginTop: 14,
+  marginBottom: 4,
+})
+
+const $sectionLabel: ThemedStyle<TextStyle> = ({colors}) => ({
+  fontSize: 13,
+  fontWeight: "600",
+  color: colors.textDim,
+  marginBottom: 8,
+})
+
+const $chipContainer: ThemedStyle<ViewStyle> = () => ({
+  flexDirection: "row",
+  flexWrap: "wrap",
+  gap: 8,
+})
+
+const $chip: ThemedStyle<ViewStyle> = ({colors, spacing}) => ({
+  backgroundColor: colors.background,
+  borderWidth: 1,
+  borderColor: colors.primary,
+  borderRadius: spacing.s3,
+  paddingHorizontal: 12,
+  paddingVertical: 6,
+})
+
+const $chipText: ThemedStyle<TextStyle> = ({colors}) => ({
+  fontSize: 12,
+  color: colors.text,
+})
+
+const $chipHint: ThemedStyle<TextStyle> = ({colors}) => ({
+  fontSize: 10,
+  color: colors.textDim,
+  marginTop: 6,
+  fontStyle: "italic",
+})

--- a/mobile/src/config/ota.ts
+++ b/mobile/src/config/ota.ts
@@ -1,6 +1,8 @@
 // ASG OTA manifest URLs.
-// Production is the compiled default for release builds; staging is the
-// manifest the staging-builds workflow deploys to the dedicated Cloudflare
-// Pages project (also baked into staging builds via EXPO_PUBLIC_ASG_OTA_VERSION_URL).
+// Production is the compiled default; staging is the manifest the
+// staging-builds workflow deploys to the dedicated Cloudflare Pages project.
+// Staging is deliberately NOT baked into any distributed build (store
+// binaries are promoted staging builds) — testers opt in via the
+// developer-settings Custom OTA Manifest URL card, where these are presets.
 export const OTA_VERSION_URL_PROD = "https://ota.mentraglass.com/prod_live_version.json"
 export const OTA_VERSION_URL_STAGING = "https://mentra-live-ota-staging.pages.dev/staging_live_version.json"

--- a/mobile/src/config/ota.ts
+++ b/mobile/src/config/ota.ts
@@ -1,0 +1,6 @@
+// ASG OTA manifest URLs.
+// Production is the compiled default for release builds; staging is the
+// manifest the staging-builds workflow deploys to the dedicated Cloudflare
+// Pages project (also baked into staging builds via EXPO_PUBLIC_ASG_OTA_VERSION_URL).
+export const OTA_VERSION_URL_PROD = "https://ota.mentraglass.com/prod_live_version.json"
+export const OTA_VERSION_URL_STAGING = "https://mentra-live-ota-staging.pages.dev/staging_live_version.json"

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -62,6 +62,11 @@ function isLegacyAsgOtaStartBuild(glassesBuildNumber?: string | null): boolean {
 }
 
 function getOtaVersionUrlDevOverride(): string | null {
+  // Super mode only: a wrong OTA manifest can brick glasses, so a saved
+  // override is inert unless super mode is currently enabled.
+  if (!useSettingsStore.getState().getSetting(SETTINGS.super_mode.key)) {
+    return null
+  }
   const value = useSettingsStore.getState().getSetting(SETTINGS.ota_version_url.key)
   const trimmed = typeof value === "string" ? value.trim() : ""
   return trimmed || null

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -12,7 +12,8 @@ import {
   useGlassesStore,
   waitForGlassesState,
 } from "@/stores/glasses"
-import {SETTINGS, useSetting} from "@/stores/settings"
+import {OTA_VERSION_URL_PROD} from "@/config/ota"
+import {SETTINGS, useSetting, useSettingsStore} from "@/stores/settings"
 import showAlert from "@/utils/AlertUtils"
 import {translate} from "@/i18n/translate"
 import {usePathname} from "expo-router"
@@ -54,19 +55,29 @@ interface VersionJson {
   releaseNotes?: string
 }
 
-// OTA version URL constant
-export const OTA_VERSION_URL_PROD = "https://ota.mentraglass.com/prod_live_version.json"
-
 function isLegacyAsgOtaStartBuild(glassesBuildNumber?: string | null): boolean {
   const buildNumber = Number.parseInt(glassesBuildNumber ?? "", 10)
   // Pre-wall-clock ASG builds ignore ota_start.ota_version_url, so compare against the URL they will actually use.
   return Number.isFinite(buildNumber) && buildNumber < 100000
 }
 
+function getOtaVersionUrlDevOverride(): string | null {
+  const value = useSettingsStore.getState().getSetting(SETTINGS.ota_version_url.key)
+  const trimmed = typeof value === "string" ? value.trim() : ""
+  return trimmed || null
+}
+
 export function getAsgOtaVersionUrl(glassesUrl?: string | null, glassesBuildNumber?: string | null): string {
   const deviceUrl = glassesUrl?.trim()
   if (isLegacyAsgOtaStartBuild(glassesBuildNumber)) {
+    // Legacy glasses ignore ota_start.ota_version_url and install from their compiled
+    // default, so the developer override does not apply to them either.
     return deviceUrl || OTA_VERSION_URL_PROD
+  }
+
+  const devOverrideUrl = getOtaVersionUrlDevOverride()
+  if (devOverrideUrl) {
+    return devOverrideUrl
   }
 
   const envUrl = process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL?.trim()

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -154,6 +154,23 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: true,
     persist: true,
   },
+  // Developer override for the ASG OTA manifest URL. null/empty = no override;
+  // the normal selection applies (legacy-glasses gate, EXPO_PUBLIC_ASG_OTA_VERSION_URL,
+  // glasses-reported URL, then production). See getAsgOtaVersionUrl.
+  ota_version_url: {
+    key: "ota_version_url",
+    defaultValue: () => null,
+    writable: true,
+    saveOnServer: false,
+    persist: true,
+  },
+  saved_ota_version_urls: {
+    key: "saved_ota_version_urls",
+    defaultValue: () => [],
+    writable: true,
+    saveOnServer: false,
+    persist: true,
+  },
   reconnect_on_app_foreground: {
     key: "reconnect_on_app_foreground",
     defaultValue: () => true,


### PR DESCRIPTION
## Summary

Stacked on #3113. Ports the developer-settings OTA manifest URL parametrization from #2865 onto the `ota_version_url` plumbing that #3113 introduces, replacing the need for ad-hoc hardcoded URL changes when testing the OTA flow.

- New **Custom OTA Manifest URL** card in Developer Settings (**super mode only** — a wrong manifest can brick glasses), modeled on the Custom Backend URL card: free-text URL with **Save & Test** (fetches the URL and verifies it returns JSON before persisting), **Reset**, **Bookmark** with a tap-to-fill / long-press-to-remove saved list, and **Production** / **Staging** presets.
- The Staging preset is the canonical staging manifest from #3113: `https://mentra-live-ota-staging.pages.dev/staging_live_version.json`.
- New settings: `ota_version_url` (the override; `null` = no override) and `saved_ota_version_urls` (bookmarks). Both persist on-device only (`saveOnServer: false`).
- `getAsgOtaVersionUrl` resolves the override internally, so all five call sites (background check, check-for-updates, both progress screens' `ota_start` sends) pick it up without signature or dependency-array changes.
- OTA manifest URL constants move to `mobile/src/config/ota.ts`.

## This card is the staging opt-in (not just a dev convenience)

The TestFlight / Play internal binaries built by the staging workflow are the exact binaries later promoted to public beta and the app stores, so #3113 no longer bakes `EXPO_PUBLIC_ASG_OTA_VERSION_URL` into them — a compiled-in staging manifest URL would have shipped to customers. The **Staging** preset in this card is how staging testers point their phone's glasses-OTA checks at the staging manifest.

## Precedence

For glasses that honor `ota_start.ota_version_url` (wall-clock builds ≥ 100000):

1. `ota_version_url` developer setting (this PR; only resolved while super mode is enabled — a saved override is inert otherwise)
2. `EXPO_PUBLIC_ASG_OTA_VERSION_URL` (no longer set by CI; available for local dev via `mobile/.env`)
3. Glasses-reported URL, then production default

Legacy glasses ignore the URL in `ota_start` and install from their compiled default, so the override deliberately does not apply to them — same reasoning as the legacy gate in #3113 (a custom-manifest prompt would dead-end). The card's description notes this.

## Differences from #2865

#2865's ASG/BLE plumbing (`version_json_url` key, `startOtaFromPhone(String)`, native `sendOtaStart(url)`) is superseded by #3113's `ota_version_url` implementation, so only the mobile dev-settings layer is ported. The setting also no longer defaults to the production URL: it defaults to `null` ("no override") so that #3113's device-URL/production selection still applies to non-developers, and the override only wins when explicitly set.

## Test plan

- Used for the end-to-end OTA verification of #3113: glasses on old MTK/BES + branch ASG client, phone dev build pointing the override at a locally served manifest (`http://<lan-ip>:8000/...`) whose `apkUrl` references a freshly built wall-clock ASG APK; verifying the sequential APK → MTK → BES flow.
- Settings card verified via Metro hot reload (JS-only change; the native `sendOtaStart(url)` parameter already exists in #3113 dev builds).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> A bad manifest URL can brick glasses firmware; the UI is super-mode gated and requires a successful manifest fetch before save, but the override still changes what every OTA path installs from.
> 
> **Overview**
> Adds a **Custom OTA Manifest URL** card to Developer Settings, shown only when **super mode** is on, so testers can point glasses OTA checks at a custom manifest without hardcoding URLs in the app.
> 
> The new `OtaVersionUrl` UI mirrors the backend URL card: **Save & Test** (GET + JSON validation before persisting), **Reset**, bookmarks, and **Production** / **Staging** presets from `mobile/src/config/ota.ts`. Settings `ota_version_url` (null = no override) and `saved_ota_version_urls` persist on-device only.
> 
> `getAsgOtaVersionUrl` now applies the saved override when super mode is enabled (ahead of `EXPO_PUBLIC_ASG_OTA_VERSION_URL`, glasses-reported URL, and production). The override is ignored for legacy ASG builds that do not honor `ota_start.ota_version_url` (build &lt; 100000), matching existing legacy behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c3a01bb5bb20c91875929aff4203ec6cbbced8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

