### PR TITLE
Re-run readiness handshake when glasses SOC reboots under intact BLE link

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -3332,6 +3332,16 @@ public class MentraLive extends SGCManager {
                         int ready = bodyObj.optInt("ready", 0);
                         if (ready == 0) {
                             Bridge.log("LIVE: K900 SOC not ready (ready=0)");
+                            if (glassesReady) {
+                                // The MTK SOC rebooted underneath an intact BLE link (e.g. after an
+                                // MTK firmware OTA apply) — the BES chip keeps the GATT connection
+                                // alive, so no disconnect edge ever resets the handshake flags. Left
+                                // stale, they block phone_ready from being re-sent and fullyBooted
+                                // never recovers. Reset and poll until the SOC is ready again.
+                                Bridge.log("LIVE: 🔄 SOC not ready after handshake completed - glasses rebooted, restarting readiness handshake");
+                                glassesReadyReceived = false;
+                                startReadinessCheckLoop();
+                            }
                             DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
                             Bridge.sendTypedMessage("glasses_not_ready", new HashMap<String, Object>() {});
                             if (batteryPercentage > 0 && batteryPercentage <= 20) {
@@ -3345,7 +3355,9 @@ public class MentraLive extends SGCManager {
                             Bridge.log("LIVE: K900 SOC ready");
                             // Only send phone_ready if we haven't already established connection
                             // This prevents re-initialization on every heartbeat after initial connection
-                            // The glassesReady flag is reset on disconnect/reconnect, so this won't prevent proper reconnection
+                            // The glassesReady flag is reset on disconnect/reconnect and on a
+                            // ready=0 heartbeat (SOC reboot under an intact BLE link), so this
+                            // won't prevent proper reconnection
                             if (!glassesReady) {
                                 Bridge.log("LIVE: 📱 Sending phone_ready to glasses - waiting for glasses_ready response");
                                 JSONObject readyMsg = new JSONObject();

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.java
@@ -2854,6 +2854,10 @@ public class MentraLive extends SGCManager {
                     Log.e(TAG, "Failed to parse build number as integer: " + buildNumberLegacy);
                 }
 
+                // version_info is unsolicited ASG-boot/connect traffic — use it to recover the
+                // handshake if the SOC came up under an intact link without re-handshaking.
+                recoverReadinessHandshakeIfStalled("version_info");
+
                 break;
 
             case "ota_download_progress":
@@ -3045,6 +3049,10 @@ public class MentraLive extends SGCManager {
 
                     Bridge.log("LIVE: Processed version_info fields and sent to RN");
                     Bridge.sendVersionInfo(fields);
+
+                    // version_info* is unsolicited ASG-boot/connect traffic — use it to recover the
+                    // handshake if the SOC came up under an intact link without re-handshaking.
+                    recoverReadinessHandshakeIfStalled(type);
                 } else {
                     Log.d(TAG, "📦 Unknown message type: " + type);
                 }
@@ -3332,16 +3340,6 @@ public class MentraLive extends SGCManager {
                         int ready = bodyObj.optInt("ready", 0);
                         if (ready == 0) {
                             Bridge.log("LIVE: K900 SOC not ready (ready=0)");
-                            if (glassesReady) {
-                                // The MTK SOC rebooted underneath an intact BLE link (e.g. after an
-                                // MTK firmware OTA apply) — the BES chip keeps the GATT connection
-                                // alive, so no disconnect edge ever resets the handshake flags. Left
-                                // stale, they block phone_ready from being re-sent and fullyBooted
-                                // never recovers. Reset and poll until the SOC is ready again.
-                                Bridge.log("LIVE: 🔄 SOC not ready after handshake completed - glasses rebooted, restarting readiness handshake");
-                                glassesReadyReceived = false;
-                                startReadinessCheckLoop();
-                            }
                             DeviceStore.INSTANCE.apply("glasses", "fullyBooted", false);
                             Bridge.sendTypedMessage("glasses_not_ready", new HashMap<String, Object>() {});
                             if (batteryPercentage > 0 && batteryPercentage <= 20) {
@@ -3355,9 +3353,7 @@ public class MentraLive extends SGCManager {
                             Bridge.log("LIVE: K900 SOC ready");
                             // Only send phone_ready if we haven't already established connection
                             // This prevents re-initialization on every heartbeat after initial connection
-                            // The glassesReady flag is reset on disconnect/reconnect and on a
-                            // ready=0 heartbeat (SOC reboot under an intact BLE link), so this
-                            // won't prevent proper reconnection
+                            // The glassesReady flag is reset on disconnect/reconnect, so this won't prevent proper reconnection
                             if (!glassesReady) {
                                 Bridge.log("LIVE: 📱 Sending phone_ready to glasses - waiting for glasses_ready response");
                                 JSONObject readyMsg = new JSONObject();
@@ -4569,6 +4565,38 @@ public class MentraLive extends SGCManager {
 
         // Start the loop
         handler.post(readinessCheckRunnable);
+    }
+
+    /**
+     * Recover the phone_ready/glasses_ready handshake when glasses-originated app traffic arrives
+     * while the BLE link is up but the handshake never completed (or silently fell apart).
+     *
+     * The trigger is the ASG client's version_info, which it emits unsolicited both on its own
+     * boot (AsgClientService.onCreate) and on every BT connect. Receiving it while we are linked
+     * but not yet fully booted — and with no readiness loop already driving the handshake — means
+     * the glasses SOC came up under us without the phone re-running the handshake.
+     *
+     * The motivating case: the MTK SOC reboots (e.g. after an MTK firmware OTA apply) while the BES
+     * chip holds the BLE/GATT link open, so the phone never sees a disconnect edge and never
+     * restarts the readiness loop. The same gap exists for an Android GATT auto-reconnect that
+     * restores the link without re-running service discovery (the normal startReadinessCheckLoop
+     * trigger at writeNextDescriptor). In both cases fullyBooted stays false and the home-screen
+     * card is stuck on the connecting spinner even though data flows.
+     *
+     * Restarting the readiness loop re-sends phone_ready; the ASG's stateless phone_ready handler
+     * always answers glasses_ready, which re-establishes fullyBooted via the existing handler.
+     */
+    private void recoverReadinessHandshakeIfStalled(String reason) {
+        if (isKilled || !isConnected || glassesReady) {
+            return;
+        }
+        // A non-null runnable means a readiness loop is already driving the handshake (normal
+        // connect) — don't disturb it. We only step in when nobody is re-sending phone_ready.
+        if (readinessCheckRunnable != null) {
+            return;
+        }
+        Bridge.log("LIVE: 🔄 Glasses traffic (" + reason + ") while link up but handshake incomplete and idle - restarting readiness handshake");
+        startReadinessCheckLoop();
     }
 
     /**

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2443,6 +2443,10 @@ class MentraLive: NSObject, SGCManager {
                 }
 
                 Bridge.sendVersionInfo(fields)
+
+                // version_info* is unsolicited ASG-boot/connect traffic — use it to recover the
+                // handshake if the SOC came up under an intact link without re-handshaking.
+                recoverReadinessHandshakeIfStalled(type)
             } else {
                 Bridge.log("Unhandled message type: \(type)")
             }
@@ -4263,6 +4267,33 @@ class MentraLive: NSObject, SGCManager {
         readinessCheckDispatchTimer?.cancel()
         readinessCheckDispatchTimer = nil
         Bridge.log("LIVE: 🔄 Stopped glasses SOC readiness check loop")
+    }
+
+    /// Recover the phone_ready/glasses_ready handshake when glasses-originated app traffic arrives
+    /// while the BLE link is up but the handshake never completed (or silently fell apart).
+    ///
+    /// The trigger is the ASG client's version_info, which it emits unsolicited both on its own
+    /// boot (AsgClientService.onCreate) and on every BT connect. Receiving it while we are linked
+    /// but not fully booted — and with no readiness loop already driving the handshake — means the
+    /// glasses SOC came up under us (e.g. an Android GATT auto-reconnect that restored the link
+    /// without re-discovering characteristics, the normal startReadinessCheckLoop trigger) without
+    /// the phone re-running the handshake, leaving the connecting card stuck even though data flows.
+    ///
+    /// Restarting the readiness loop re-sends phone_ready; the ASG's stateless phone_ready handler
+    /// always answers glasses_ready, which re-establishes fullyBooted via handleGlassesReady().
+    ///
+    /// NOTE: the pure MTK-SOC-reboot-under-intact-BES-link case leaves fullyBooted stale-true here
+    /// (no disconnect edge, BES holds ready=1), so this guard does not cover it — that needs the
+    /// ASG-side change to re-announce glasses_ready on boot. This covers the silent-reconnect case
+    /// where fullyBooted was already cleared.
+    private func recoverReadinessHandshakeIfStalled(_ reason: String) {
+        guard !isKilled, connectedPeripheral != nil, !fullyBooted,
+              readinessCheckDispatchTimer == nil
+        else {
+            return
+        }
+        Bridge.log("LIVE: 🔄 Glasses traffic (\(reason)) while link up but handshake incomplete and idle - restarting readiness handshake")
+        startReadinessCheckLoop()
     }
 
     private func startConnectionTimeout() {


### PR DESCRIPTION
## Scope

Stacked on #3147 (`codex/dev-ota-url-setting`). Mobile Bluetooth SDK fix (Android + iOS).

After a Mentra Live full reboot while the app is running (observed after an MTK firmware OTA apply, but any `adb reboot` reproduces), the home-screen glasses card sticks on the connecting spinner indefinitely even though BLE traffic flows both ways (heartbeats, version_info, wifi_status).

## Root cause

The readiness handshake (`phone_ready` → `glasses_ready`) that sets `fullyBooted` only runs when the readiness loop is started — at service discovery on first connect. When the **MTK SOC reboots while the BES chip holds the BLE/GATT link open**, the phone never sees a disconnect edge, so the loop is never restarted and `phone_ready` is never re-sent. The same gap exists for an Android GATT auto-reconnect that restores the link without re-running service discovery.

### Why not a `ready=0` heartbeat (first commit, superseded by second)

The first commit keyed recovery off a `ready=0` `sr_hrt` heartbeat. Verified against the BES firmware (`mentra-live-bes-main`): **the BES never reports `ready=0` for an MTK-only reboot.** `g_android_system_ready` is reset only at BES boot (`lxy_uart_init`), so an MTK reboot under an intact BES link keeps `ready=1` the whole time — the trigger never fires. The second commit replaces that approach.

## Fix

Recover off the ASG client's `version_info`, which it emits **unsolicited on its own boot** (`AsgClientService.onCreate`) and on every BT connect. When it arrives while we are linked but the handshake is incomplete and no readiness loop is running, restart the loop. The ASG's `phone_ready` handler is stateless and always answers `glasses_ready`, which re-establishes `fullyBooted` and re-runs the SOC-dependent init (MTU, coreToken, user settings, mic restore).

**iOS:** symmetric guard added. Note the pure MTK-reboot leaves `fullyBooted` stale-true on iOS (no disconnect edge, BES holds `ready=1`), so the guard covers the silent-reconnect-that-cleared-`fullyBooted` case; fully closing the iOS stale-true case needs an ASG-side re-announce of `glasses_ready` on boot (follow-up, requires a glasses OTA).

## Test plan

- [ ] Connect Mentra Live glasses, then `adb -s <glasses> reboot`
- [ ] Logcat shows `Glasses traffic (version_info...) while link up but handshake incomplete and idle - restarting readiness handshake` followed by `Sending phone_ready` / `Received glasses_ready`
- [ ] Glasses card returns to connected on its own after boot (previously: stuck on spinner + Cancel until manual reconnect)
- [ ] Normal first-time connect and regular disconnect/reconnect unchanged (guard is a no-op when a readiness loop is already running)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BLE connect/boot state on both platforms; wrong guards could re-run init or fight an in-progress handshake, though the idle-loop checks limit that.
> 
> **Overview**
> Adds **`recoverReadinessHandshakeIfStalled`** on Android and iOS **MentraLive** and invokes it when unsolicited **`version_info`** (and chunked **`version_info*`** on Android) arrives from the glasses.
> 
> If BLE is up but the **`phone_ready` / `glasses_ready`** handshake never finished and no readiness loop is already running, the SDK **restarts `startReadinessCheckLoop()`** so **`phone_ready`** is sent again and the UI can leave the connecting state after SOC boot or silent GATT reconnect without a disconnect edge.
> 
> Guards skip recovery when already ready (`glassesReady` on Android, `!fullyBooted` on iOS) or when a readiness timer/runnable is active. iOS documents that MTK reboot under an intact link with stale **`fullyBooted`** may still need an ASG-side **`glasses_ready`** re-announce.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e652ea9b95a1cf9dd23d618b739763ac670b27ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->