### PR TITLE
Stop syncing per-phone pairing identity to the server

### DIFF
--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -294,9 +294,11 @@ class MantleManager {
     const res = await restComms.loadUserSettings() // get settings from server
     if (res.is_ok()) {
       let loadedSettings = res.value
-      // Device-identity keys are per-phone pairing state: never restore them from the
-      // server or stale values clobber the locally paired device and reconnect-on-launch
-      // targets the wrong BLE address.
+      // Device/pairing identity is per-phone state and is now saveOnServer: false, so it
+      // should never come back from the server. These deletes are a migration guard: users
+      // paired before that flag flipped still have stale values persisted server-side, and
+      // restoring them would clobber the locally paired device and point reconnect-on-launch
+      // at the wrong BLE address.
       delete loadedSettings["default_wearable"]
       delete loadedSettings["pending_wearable"]
       delete loadedSettings["device_name"]

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -294,9 +294,13 @@ class MantleManager {
     const res = await restComms.loadUserSettings() // get settings from server
     if (res.is_ok()) {
       let loadedSettings = res.value
-      // exclude default_wearable and pending_wearable from the settings when pulling from the server:
+      // Device-identity keys are per-phone pairing state: never restore them from the
+      // server or stale values clobber the locally paired device and reconnect-on-launch
+      // targets the wrong BLE address.
       delete loadedSettings["default_wearable"]
       delete loadedSettings["pending_wearable"]
+      delete loadedSettings["device_name"]
+      delete loadedSettings["device_address"]
       delete loadedSettings["default_controller"]
       delete loadedSettings["pending_controller"]
       delete loadedSettings["controller_device_name"]

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -172,26 +172,31 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: false,
     persist: false,
   },
+  // Device/pairing identity is per-phone state, not an account setting: a user with
+  // two phones may have each paired to different glasses. These are never synced to the
+  // server (saveOnServer: false) so a stale server copy can't clobber the locally paired
+  // device on relaunch. MantleManager also strips them from any server payload as a guard
+  // against legacy values uploaded before this flag was flipped.
   default_wearable: {
     key: "default_wearable",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
-  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: true, persist: true},
+  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: false, persist: true},
   device_address: {
     key: "device_address",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   default_controller: {
     key: "default_controller",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   pending_controller: {
@@ -205,14 +210,14 @@ export const SETTINGS: Record<string, Setting> = {
     key: "controller_device_name",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   controller_address: {
     key: "controller_address",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   // ui state:


### PR DESCRIPTION
## Problem

Stopping and restarting MentraOS could restore stale glasses `device_name`/`device_address` from the server over the locally-correct values (reported by Yash as "Display store has wrong device id and device name when stopping and restarting MentraOS"). Reconnect-on-launch then targets the wrong BLE address and the home-screen glasses card sits on the connecting spinner forever.

## Root cause

At startup, `MantleManager` loads settings from the server and writes them locally. It already deleted *some* pairing-identity keys from that payload before writing, but the **glasses** identity fields `device_name`/`device_address` were missing from the list (the **controller** counterparts were excluded; the glasses ones weren't).

But the deeper issue is that this state is uploaded to the server at all. **Device/pairing identity is per-phone, not per-account** — a user with two phones may have each paired to different glasses, so syncing these values across devices is meaningless, and it's exactly what lets a stale server copy clobber the locally paired device. The pre-existing "upload but delete-on-restore" arrangement was an asymmetric workaround (tell: `pending_wearable`/`pending_controller` were already `saveOnServer: false` yet still sat in the delete list as no-ops).

## Fix — two layers

1. **Root cause:** flip the whole pairing-identity group to `saveOnServer: false` — `default_wearable`, `device_name`, `device_address`, `default_controller`, `controller_device_name`, `controller_address` (the two `pending_*` keys were already false). These are now never uploaded, so there's no server copy to wrongly restore.
   - Nothing server-side reads these (the cloud stores user settings as an opaque blob and echoes it back), and bug reports snapshot the **live local store** (`bugReportIncident.ts`), not the server copy — so no debugging value is lost by not uploading them.
2. **Migration guard:** keep the delete-on-restore block in `MantleManager`. Users paired *before* this flip still have stale values persisted server-side, and `loadUserSettings` would otherwise hand them back. The block neutralizes that legacy data; its comment is reworded to document this role.

## Origin

This is an **incomplete fix, not a regression**. The delete-on-restore block was introduced in `c760acdbb` ("fixes", 2026-04-27) to stop stale server values from clobbering local pairing — it covered the wearable/controller keys but omitted `device_name`/`device_address`. Before it, the load path wrote every server setting back unconditionally, so these fields have been exposed to stale-restore since they became `saveOnServer: true` (`e6003268f`, 2025-11-21). This PR fixes the symptom *and* the root cause.

## Test evidence

- `bun compile` (tsc) passed on the structural change; the second commit is value-only (`saveOnServer` boolean flips) plus comments, which cannot introduce type errors.
- Manual verification needs real hardware: pair glasses → kill app → relaunch → confirm `device_name`/`device_address` match the paired device and reconnection succeeds. Also worth checking on an account with stale server values to confirm the migration guard holds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup settings merge and stops syncing pairing identity to the server, which directly affects BLE reconnect behavior but is a narrow, intentional fix to a reported pairing bug.
> 
> **Overview**
> Treats **glasses and controller pairing identity** (`default_wearable`, `device_name`, `device_address`, and the matching controller keys) as **per-phone state** by setting **`saveOnServer: false`** on those settings so they are not treated as account-wide prefs.
> 
> On startup, **`MantleManager`** now also strips **`device_name`** and **`device_address`** from the server settings payload before `setManyLocally`, matching the existing exclusions for wearable/controller keys. That guards against **legacy server copies** overwriting the locally paired BLE name/address after restart, which could break **reconnect-on-launch** and leave the home glasses card stuck connecting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4975a22c1f25e84ecd8a9b5fe07ea71752c2291b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->