### PR TITLE
Fail safe when BES firmware version cache is stale across boots

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -12,6 +12,7 @@ import com.mentra.asg_client.io.bluetooth.utils.DebugNotificationManager;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.reporting.domains.BluetoothReporting;
 import com.mentra.asg_client.service.core.AsgClientService;
+import com.mentra.asg_client.settings.AsgSettings;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -56,6 +57,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final int PACING_DELAY_MS =
             75; // Delay between successful packets - BES2700 needs time to drain BLE TX
     private int consecutiveFailures = 0;
+
+    // BES system-version (syvr) handshake retry: the chip occasionally drops the first request
+    // after a SOC boot, leaving the cached version stale. Re-request until the chip answers (the
+    // cache becomes fresh for this boot) or we exhaust the attempts.
+    private static final int BES_SYVR_MAX_ATTEMPTS = 5;
+    private static final long BES_SYVR_RETRY_DELAY_MS = 2000L;
+    private final android.os.Handler besVersionHandler =
+            new android.os.Handler(android.os.Looper.getMainLooper());
+    private int besSyvrAttempts = 0;
 
     // Inner class to track file transfer state
     private static class FileTransferSession {
@@ -383,29 +393,92 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      * connects, making it available for OTA patch matching.
      */
     public void requestBesSystemVersion() {
-        Log.i(TAG, "🔧 Requesting BES system version (cs_syvr) via UART");
+        // (Re)start the handshake from attempt 0 and clear any retries still pending from a prior
+        // serial-ready event so we don't run two retry chains at once.
+        besVersionHandler.removeCallbacksAndMessages(null);
+        besSyvrAttempts = 0;
+        attemptBesSystemVersionRequest();
+    }
 
+    /**
+     * Send the BES system-version request and, if the chip hasn't answered yet, schedule a retry.
+     * Stops as soon as the version cache is refreshed for this boot, or after {@link
+     * #BES_SYVR_MAX_ATTEMPTS} attempts.
+     */
+    private void attemptBesSystemVersionRequest() {
+        if (besVersionRefreshedThisBoot()) {
+            Log.i(
+                    TAG,
+                    "✅ BES system version already refreshed this boot — stopping syvr retries");
+            return;
+        }
+
+        besSyvrAttempts++;
+        Log.i(
+                TAG,
+                "🔧 Requesting BES system version (attempt "
+                        + besSyvrAttempts
+                        + "/"
+                        + BES_SYVR_MAX_ATTEMPTS
+                        + ") via UART");
+
+        // Send both command variants: some BES builds answer cs_syvr (handled here as sr_syvr),
+        // others answer the sh_syvr variant (handled via McuEventParser -> BesVersionEvent). Sending
+        // both hedges against a firmware that only honors one of them.
+        sendSyvrCommand("cs_syvr");
+        sendSyvrCommand("sh_syvr");
+
+        if (besSyvrAttempts < BES_SYVR_MAX_ATTEMPTS) {
+            besVersionHandler.postDelayed(
+                    this::attemptBesSystemVersionRequest, BES_SYVR_RETRY_DELAY_MS);
+        } else {
+            besVersionHandler.postDelayed(
+                    () -> {
+                        if (!besVersionRefreshedThisBoot()) {
+                            Log.e(
+                                    TAG,
+                                    "❌ BES system version not refreshed after "
+                                            + BES_SYVR_MAX_ATTEMPTS
+                                            + " attempts — cache will read as unknown so OTA fails"
+                                            + " safe toward offering the BES update");
+                        }
+                    },
+                    BES_SYVR_RETRY_DELAY_MS);
+        }
+    }
+
+    /** Build and send one {@code C}/{@code V}/{@code B} syvr request over UART. */
+    private void sendSyvrCommand(String command) {
         try {
-            // Build K900 command format: {"C":"cs_syvr","V":1,"B":""}
             org.json.JSONObject k900Command = new org.json.JSONObject();
-            k900Command.put("C", "cs_syvr");
+            k900Command.put("C", command);
             k900Command.put("V", 1);
             k900Command.put("B", "");
 
             String commandStr = k900Command.toString();
-            Log.d(TAG, "📤 Sending cs_syvr request: " + commandStr);
+            Log.d(TAG, "📤 Sending " + command + " request: " + commandStr);
 
             // Send via sendMessage() which handles protocol formatting and isSerialOpen check
             boolean sent =
                     sendMessage(commandStr.getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
             if (sent) {
-                Log.i(TAG, "✅ BES system version request (cs_syvr) sent successfully via UART");
+                Log.i(TAG, "✅ BES system version request (" + command + ") sent via UART");
             } else {
-                Log.e(TAG, "❌ Failed to send BES system version request via UART");
+                Log.e(TAG, "❌ Failed to send BES system version request (" + command + ")");
             }
         } catch (org.json.JSONException e) {
-            Log.e(TAG, "💥 Failed to build cs_syvr request", e);
+            Log.e(TAG, "💥 Failed to build " + command + " request", e);
+        }
+    }
+
+    /** True once a syvr response has refreshed the cached BES version during the current boot. */
+    private boolean besVersionRefreshedThisBoot() {
+        try {
+            return new AsgSettings(context).hasFreshBesFirmwareVersion();
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to read BES version freshness", e);
+            return false;
         }
     }
 
@@ -475,11 +548,14 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.i(TAG, "📋 Caching BES firmware version: " + version);
 
         try {
-            android.content.SharedPreferences prefs =
-                    context.getSharedPreferences(
-                            "asg_settings", android.content.Context.MODE_PRIVATE);
-            prefs.edit().putString("mcu_firmware_version", version).commit();
+            // Route through AsgSettings so the value is stamped with the current boot; a bare
+            // SharedPreferences write would leave the stamp stale and the value would read as
+            // unknown. setBesFirmwareVersion uses commit() for immediate persistence.
+            new AsgSettings(context).setBesFirmwareVersion(version);
             Log.i(TAG, "✅ BES firmware version cached successfully: " + version);
+
+            // The chip answered — stop any pending syvr retries.
+            besVersionHandler.removeCallbacksAndMessages(null);
 
             // Re-send version chunks so phone/OTA get fresh BES (onCreate may have run before UART
             // was up).

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -29,6 +29,7 @@ import com.mentra.asg_client.io.bes.BesOtaRegistry;
 import com.mentra.asg_client.io.ota.events.DownloadProgressEvent;
 import com.mentra.asg_client.io.ota.events.InstallationProgressEvent;
 import com.mentra.asg_client.io.ota.events.MtkOtaProgressEvent;
+import com.mentra.asg_client.reporting.domains.GeneralReporting;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -553,8 +554,7 @@ public class OtaHelper {
                 if (mtkPatch != null) steps.add("mtk");
             }
             if (rootJson.has("bes_firmware")) {
-                String besVer = "";
-                try { besVer = new AsgSettings(context).getBesFirmwareVersion(); } catch (Exception ignored) {}
+                String besVer = getBesVersionForOtaCheck(context);
                 if (checkBesUpdate(rootJson.getJSONObject("bes_firmware"), besVer)) steps.add("bes");
             }
         } catch (Exception e) {
@@ -944,13 +944,7 @@ public class OtaHelper {
                     }
                 }
                 if (rootJson.has("bes_firmware")) {
-                    String currentBesVersion = "";
-                    try {
-                        AsgSettings asgSettings = new AsgSettings(context);
-                        currentBesVersion = asgSettings.getBesFirmwareVersion();
-                    } catch (Exception e) {
-                        Log.e(TAG, "Error getting BES firmware version from AsgSettings", e);
-                    }
+                    String currentBesVersion = getBesVersionForOtaCheck(context);
                     boolean besNeeded = checkBesUpdate(rootJson.getJSONObject("bes_firmware"), currentBesVersion);
                     if (besNeeded) {
                         Log.i(TAG, "📦 Phase 0: Pre-downloading BES firmware before APK install");
@@ -1077,13 +1071,7 @@ public class OtaHelper {
                 if (rootJson.has("bes_firmware")) {
                     // Get BES version from AsgSettings (cached from hs_syvr response)
                     // AsgSettings uses SharedPreferences, so we can create a new instance to read the cached version
-                    String currentBesVersion = "";
-                    try {
-                        AsgSettings asgSettings = new AsgSettings(context);
-                        currentBesVersion = asgSettings.getBesFirmwareVersion();
-                    } catch (Exception e) {
-                        Log.e(TAG, "Error getting BES firmware version from AsgSettings", e);
-                    }
+                    String currentBesVersion = getBesVersionForOtaCheck(context);
                     besUpdateAvailable = checkBesUpdate(rootJson.getJSONObject("bes_firmware"), currentBesVersion);
                 }
 
@@ -2087,6 +2075,40 @@ public class OtaHelper {
     }
 
     /**
+     * Read the BES firmware version for an OTA decision, failing safe on a stale cache.
+     *
+     * <p>{@link AsgSettings#getBesFirmwareVersion()} returns "" when the cached value predates this
+     * boot and hasn't been refreshed from the chip. That case is genuinely dangerous — the chip may
+     * have been reflashed/downgraded while powered off — so we leave a log + telemetry breadcrumb
+     * before the OTA check treats the version as unknown (and therefore offers the update).
+     *
+     * @return the trusted current BES version, or "" if unknown/unrefreshed (update-needed).
+     */
+    private String getBesVersionForOtaCheck(Context context) {
+        try {
+            AsgSettings asgSettings = new AsgSettings(context);
+            String version = asgSettings.getBesFirmwareVersion();
+            if (version.isEmpty()) {
+                String raw = asgSettings.getCachedBesFirmwareVersionRaw();
+                if (!raw.isEmpty()) {
+                    String msg =
+                            "OTA check running with UNREFRESHED BES version - last cached '"
+                                    + raw
+                                    + "' is from a previous boot and the syvr handshake has not"
+                                    + " confirmed it this boot; treating as unknown (will offer BES"
+                                    + " update)";
+                    Log.w(TAG, "⚠️ " + msg);
+                    GeneralReporting.reportWarning(context, msg, "ota", "bes_version_unrefreshed");
+                }
+            }
+            return version;
+        } catch (Exception e) {
+            Log.e(TAG, "Error getting BES firmware version from AsgSettings", e);
+            return "";
+        }
+    }
+
+    /**
      * Compare two version strings.
      * Supports formats like "17.26.1.14" (BES) or "20241130" (MTK date format).
      * @param version1 First version string
@@ -2147,13 +2169,7 @@ public class OtaHelper {
 
             String manifestVersion = firmwareInfo.optString("version", "");
             if (!manifestVersion.isEmpty()) {
-                String currentBesVersion = "";
-                try {
-                    AsgSettings asgSettings = new AsgSettings(context);
-                    currentBesVersion = asgSettings.getBesFirmwareVersion();
-                } catch (Exception e) {
-                    Log.e(TAG, "Error getting BES firmware version from AsgSettings", e);
-                }
+                String currentBesVersion = getBesVersionForOtaCheck(context);
                 if (!checkBesUpdate(firmwareInfo, currentBesVersion)) {
                     Log.i(TAG, "BES firmware is not newer - skipping update");
                     return false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.settings;
 
 import android.content.Context;
 import android.content.SharedPreferences;
+import android.os.SystemClock;
 import android.util.Log;
 
 import java.util.Arrays;
@@ -24,6 +25,20 @@ public class AsgSettings {
     private static final String KEY_MFNR_ENABLED = "mfnr_enabled";
     private static final String KEY_HDR_BURST_ENABLED = "hdr_burst_enabled";
     private static final String KEY_MCU_FIRMWARE_VERSION = "mcu_firmware_version";
+    /**
+     * Boot stamp (approx. wall-clock time of last device boot) recorded alongside the BES firmware
+     * version. Lets us tell whether the cached version was refreshed from the chip during the
+     * current boot, or carried over from a previous boot (when the chip may have been
+     * reflashed/downgraded while powered off — see the stale-cache OTA bug).
+     */
+    private static final String KEY_BES_FW_BOOT_STAMP = "bes_fw_boot_stamp";
+    /**
+     * Tolerance when comparing the stored boot stamp to the current one. Generous enough to absorb
+     * NTP/clock corrections within a single boot, while a reboot shifts the stamp by the entire
+     * previous uptime (far more than this), so reboots are reliably detected. Biased toward
+     * treating ambiguous cases as stale (fail-safe: re-request + offer update).
+     */
+    private static final long BES_FW_BOOT_STAMP_TOLERANCE_MS = 10_000L;
     private static final String KEY_CAMERA_FOV = "camera_fov";
     private static final String KEY_CAMERA_ROI_POSITION = "camera_roi_position";
 
@@ -287,8 +302,55 @@ public class AsgSettings {
      */
     public String getMcuFirmwareVersion() {
         String version = prefs.getString(KEY_MCU_FIRMWARE_VERSION, "");
+        // A value cached before this boot has not been confirmed against the live chip and may be
+        // stale (e.g. the BES was downgraded while powered off). Report it as unknown so OTA checks
+        // — both here and on the phone — fail safe toward "update needed" instead of trusting it.
+        if (!version.isEmpty() && !isBesVersionFromThisBoot()) {
+            Log.w(
+                    TAG,
+                    "⏳ BES firmware version '"
+                            + version
+                            + "' was cached before this boot and has not been refreshed from the"
+                            + " chip (sh_syvr/sr_syvr) — reporting as unknown until refreshed");
+            return "";
+        }
         Log.d(TAG, "Retrieved MCU firmware version: " + version);
         return version;
+    }
+
+    /** Approximate wall-clock time of the last boot; stable within a boot, jumps across reboots. */
+    private static long currentBootStamp() {
+        return System.currentTimeMillis() - SystemClock.elapsedRealtime();
+    }
+
+    /**
+     * @return true if the cached BES firmware version was written during the current boot (and is
+     *     therefore trustworthy), false if it predates this boot or was never set.
+     */
+    private boolean isBesVersionFromThisBoot() {
+        long storedStamp = prefs.getLong(KEY_BES_FW_BOOT_STAMP, Long.MIN_VALUE);
+        if (storedStamp == Long.MIN_VALUE) {
+            return false;
+        }
+        return Math.abs(storedStamp - currentBootStamp()) <= BES_FW_BOOT_STAMP_TOLERANCE_MS;
+    }
+
+    /**
+     * @return true if a BES firmware version has been refreshed from the chip during the current
+     *     boot. Callers (e.g. the syvr request retry loop) use this to know when the handshake has
+     *     succeeded and the cache can be trusted.
+     */
+    public boolean hasFreshBesFirmwareVersion() {
+        return !prefs.getString(KEY_MCU_FIRMWARE_VERSION, "").isEmpty() && isBesVersionFromThisBoot();
+    }
+
+    /**
+     * @return the last cached BES firmware version regardless of boot age (may be stale). For
+     *     logging/telemetry only — never feed this into an OTA decision; use {@link
+     *     #getBesFirmwareVersion()} which fails safe on stale values.
+     */
+    public String getCachedBesFirmwareVersionRaw() {
+        return prefs.getString(KEY_MCU_FIRMWARE_VERSION, "");
     }
 
     /**
@@ -311,8 +373,13 @@ public class AsgSettings {
             return;
         }
         Log.i(TAG, "📋 Setting MCU firmware version to: " + version);
-        // Using commit() for immediate persistence
-        prefs.edit().putString(KEY_MCU_FIRMWARE_VERSION, version).commit();
+        // Stamp with the current boot so reads this boot are trusted; reads after the next reboot
+        // (until the chip is re-queried) fall back to "unknown". Using commit() for immediate
+        // persistence.
+        prefs.edit()
+                .putString(KEY_MCU_FIRMWARE_VERSION, version)
+                .putLong(KEY_BES_FW_BOOT_STAMP, currentBootStamp())
+                .commit();
     }
 
     /**


### PR DESCRIPTION
## Problem

The ASG client decides whether a BES firmware update is needed using a version cached in `AsgSettings` (`mcu_firmware_version` in SharedPreferences), refreshed from the chip via the `syvr` UART handshake at boot. On real hardware (Mentra Live, 2026-06-12 verification of #3113) this cache went **stale across multiple reboots**: it read `17.26.5.22` while the BES chip actually ran `17.26.1.13`.

Root cause from logcat: the cached (stale) version is sent to the phone *before* the refresh request goes out, and on the affected boot **no `syvr` response ever arrived**, so the cache never refreshed. Result: both the glasses-side check (`OtaHelper.checkBesUpdate`) and the phone-side check (fed by `version_info_3`) reported "BES up to date" and skipped a genuinely needed update — a device in this state silently never receives BES updates.

## Changes

**1. Stale cache fails safe — boot-stamped freshness** (`AsgSettings.java`)
- `setMcuFirmwareVersion` stamps the value with a per-boot token (`currentTimeMillis - elapsedRealtime` — stable within a boot, jumps across reboots).
- `getMcuFirmwareVersion` returns `""` (unknown) when the stored stamp predates the current boot. Both `checkBesUpdate` (glasses) and the phone's `checkBesUpdate` already treat unknown as "update needed", so an unrefreshed value now fails safe (worst case: re-flash the same version) instead of being trusted.
- Adds `hasFreshBesFirmwareVersion()` (retry stop-condition) and `getCachedBesFirmwareVersionRaw()` (telemetry only).

**2. Reliable refresh — retry + both command variants** (`K900BluetoothManager.java`)
- `requestBesSystemVersion()` now retries (5 attempts, 2s apart), stopping once the cache is fresh this boot and logging an error if it never is.
- Each attempt sends **both** `cs_syvr` (→ `sr_syvr`) and `sh_syvr` (→ `hs_syvr`/`BesVersionEvent`), hedging against firmware that only honors one variant.
- `cacheBesFirmwareVersion` routes through `AsgSettings` (so the boot stamp is recorded — a bare prefs write left it stale) and cancels pending retries on success.

**3. Telemetry breadcrumb** (`OtaHelper.java`)
- All four OTA-check read sites go through a new `getBesVersionForOtaCheck(context)`, which logs a warning and emits a Sentry/Console breadcrumb (`ota` / `bes_version_unrefreshed`) when a check runs against a non-empty-but-unrefreshed cache.

`version_info_3` to the phone is handled automatically — it reads through the same getter, so it carries `""` until the chip is confirmed, then `BesVersionEventSubscriber` re-sends the real value once the response lands.

## Tradeoff

On a device where `syvr` *never* succeeds even with retries, every boot reads unknown → offers the BES update → re-flashes the same version each boot. That's the accepted "worst case re-flashes the same version", and strictly better than silently never updating. If the handshake proves permanently broken on some hardware, a phone-side "don't re-offer the version we already flashed this boot" guard would be the follow-up.

## Testing

- `./gradlew :app:compileDebugJavaWithJavac` — BUILD SUCCESSFUL.
- Hardware (to run before merge): downgrade BES via vendor tool, reboot, confirm the cache reflects the chip without manual intervention and the OTA check offers the BES update. If the handshake fails all retries, confirm the `bes_version_unrefreshed` breadcrumb fires and the check still offers the update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BES OTA eligibility and version reporting to phone; wrong boot-stamp logic could spuriously offer updates, but behavior intentionally fails safe when the handshake never succeeds.
> 
> **Overview**
> Fixes a case where **BES firmware version stayed cached across reboots** without a fresh chip read, so OTA and the phone could treat the device as up to date when it was not.
> 
> **`AsgSettings`** now stamps the cached BES version with a per-boot token on write and returns **empty (unknown)** on read when the stamp does not match the current boot. That makes unconfirmed cache values fail safe toward offering a BES update. Adds **`hasFreshBesFirmwareVersion()`** for handshake completion and **`getCachedBesFirmwareVersionRaw()`** for telemetry only.
> 
> **`K900BluetoothManager`** replaces a one-shot `cs_syvr` with a **retry loop** (5 attempts, 2s apart), sends **`cs_syvr` and `sh_syvr`**, stops when the cache is fresh, and caches via **`AsgSettings`** so the boot stamp is set.
> 
> **`OtaHelper`** routes all BES OTA version reads through **`getBesVersionForOtaCheck()`**, which logs and reports **`bes_version_unrefreshed`** when a non-empty but stale raw cache is seen. Phone **`version_info_3`** uses the same getter, so it reports unknown until refresh.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11c61070c0b6cb4e18b823d2c33b7c723d01a6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->