### PR TITLE
Use dedicated CLOUDFLARE_PAGES_API_TOKEN for staging OTA Pages deploy

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -880,7 +880,11 @@ jobs:
         if: needs.build-asg.result == 'success' && github.ref_name == 'staging'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          # wrangler reads the CLOUDFLARE_API_TOKEN env var; source it from the
+          # dedicated Pages-scoped token (needs Account > Cloudflare Pages > Edit
+          # and User > User Details > Read) rather than the shared CLOUDFLARE_API_TOKEN,
+          # which lacks those scopes and fails wrangler auth with error 10000.
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           BUILD_SHORT_SHA: ${{ steps.build-info.outputs.sha }}
           VERSION_CODE: ${{ needs.build-asg.outputs.version_code }}
         run: |

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -881,9 +881,9 @@ jobs:
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           # wrangler reads the CLOUDFLARE_API_TOKEN env var; source it from the
-          # dedicated Pages-scoped token (needs Account > Cloudflare Pages > Edit
-          # and User > User Details > Read) rather than the shared CLOUDFLARE_API_TOKEN,
-          # which lacks those scopes and fails wrangler auth with error 10000.
+          # dedicated Account > Cloudflare Pages > Edit token rather than the shared
+          # CLOUDFLARE_API_TOKEN, which lacks Pages access and fails the deploy with
+          # API error 10000 on /accounts/<id>/pages/projects/mentra-live-ota-staging.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           BUILD_SHORT_SHA: ${{ steps.build-info.outputs.sha }}
           VERSION_CODE: ${{ needs.build-asg.outputs.version_code }}

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -880,10 +880,6 @@ jobs:
         if: needs.build-asg.result == 'success' && github.ref_name == 'staging'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          # wrangler reads the CLOUDFLARE_API_TOKEN env var; source it from the
-          # dedicated Account > Cloudflare Pages > Edit token rather than the shared
-          # CLOUDFLARE_API_TOKEN, which lacks Pages access and fails the deploy with
-          # API error 10000 on /accounts/<id>/pages/projects/mentra-live-ota-staging.
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_PAGES_API_TOKEN }}
           BUILD_SHORT_SHA: ${{ steps.build-info.outputs.sha }}
           VERSION_CODE: ${{ needs.build-asg.outputs.version_code }}


### PR DESCRIPTION
## Problem

The staging OTA Cloudflare Pages deploy has been failing on every `staging` build since the OTA PRs merged. `https://mentra-live-ota-staging.pages.dev/staging_live_version.json` returns **522** (no deployment ever landed) and the custom domain `staging.ota.mentraglass.com` fails TLS (never attached, downstream of a working deploy).

Root cause from the [latest run](https://github.com/Mentra-Community/MentraOS/actions/runs/27489978438) — the "Publish ASG OTA staging site to Cloudflare Pages" step:

```
✘ [ERROR] A request to the Cloudflare API (/accounts/***/pages/projects/mentra-live-ota-staging) failed.
   Authentication error [code: 10000]
👋 You are logged in with an User API Token. Unable to retrieve email for this user.
   Are you missing the `User->User Details->Read` permission?
```

The workflow authenticated wrangler with the **shared** `CLOUDFLARE_API_TOKEN` secret (created 2025-10-30), which lacks the Cloudflare Pages Edit and User Details Read scopes. A dedicated `CLOUDFLARE_PAGES_API_TOKEN` secret was added for this purpose (2026-06-05) but the workflow was never wired to it.

## Fix

Source the `CLOUDFLARE_API_TOKEN` env var (which wrangler reads) from `secrets.CLOUDFLARE_PAGES_API_TOKEN`. One line, plus a comment documenting the required scopes.

## Prerequisite for this to work

`CLOUDFLARE_PAGES_API_TOKEN` needs **Account → Cloudflare Pages → Edit** (read/write) — already the case. User → User Details → Read is **not** required (the `missing User->User Details->Read` line in the log is wrangler's cosmetic whoami fallback, not the cause). The `mentra-live-ota-staging` Pages project must exist under the account `CLOUDFLARE_ACCOUNT_ID` references. (Error 10000 is auth/permission; if it persists after this change, the token scopes still need fixing.)

## Not affected

The GitHub-release side of the pipeline is healthy and already publishing: `staging_live_version.json` is live on the `staging-builds` release, valid, and points at present dated APKs. The deploy step runs after artifact + manifest publishing (by design), so this failure never blocked mobile/ASG artifacts. The custom-domain check is non-fatal and will start passing once the domain is attached to the project.

## Verification after merge

A `staging` build should make `https://mentra-live-ota-staging.pages.dev/staging_live_version.json` return 200 with the run's `versionCode`, and the post-deploy verification loop in the same step should pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-secret wiring change in CI only; no application or production OTA path changes.
> 
> **Overview**
> Fixes failing **Publish ASG OTA staging site to Cloudflare Pages** steps on `staging` builds by wiring wrangler’s `CLOUDFLARE_API_TOKEN` to **`secrets.CLOUDFLARE_PAGES_API_TOKEN`** instead of the shared **`CLOUDFLARE_API_TOKEN`**, which lacked Pages deploy permissions and caused Cloudflare API authentication errors.
> 
> No other workflow behavior changes—the same `mentra-live-ota-staging` wrangler deploy and post-deploy manifest verification still run when ASG build succeeds on the `staging` branch. This matches how **`deploy-dev-docs.yml`** already sources Pages deploy credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bc984d917cc85ee2760057150946a890cffaeed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

