### PR TITLE
Fix iOS button photo size compile

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -501,9 +501,7 @@ public final class MentraBluetoothSDK {
                         DeviceStore.shared.remove(cat, key)
                     }
                 }
-                if let size = settings.size {
-                    DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_size", size.rawValue)
-                }
+                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_size", settings.size.rawValue)
                 if let mfnr = settings.mfnr {
                     DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_mfnr", mfnr)
                 }


### PR DESCRIPTION
## Summary

- Fix the iOS Bluetooth SDK compile error in `setButtonPhotoSettings` by writing the required `settings.size` value directly instead of optional-binding it.

## Why

The dev CI fix PR #3169 resolved the mobile install/workspace issue, but its iOS build then failed on:

`MentraBluetoothSDK.swift:504:20: error: initializer for conditional binding must have Optional type, not 'ButtonPhotoSize'`

`ButtonPhotoSettings.size` is a required `ButtonPhotoSize`, so `if let size = settings.size` is invalid Swift. This is a one-line follow-up to unblock the iOS build.

## Validation

- `git diff --check`
- `cd mobile && bun run compile`
- `cd mobile/modules/bluetooth-sdk && xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO -quiet build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line compile fix in device-store caching; behavior unchanged when size was always set.
> 
> **Overview**
> Fixes an iOS **MentraBluetoothSDK** build failure in `setButtonPhotoSettings` where `if let size = settings.size` was invalid because **`ButtonPhotoSettings.size` is a non-optional `ButtonPhotoSize`**.
> 
> The store update now **always** persists `button_photo_size` from `settings.size.rawValue`, matching the required field on the settings model and aligning with how size is already passed through on send.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c718af7af8ea5040db33a979c1e08a75181cdbfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->