### PR TITLE
Preserve iOS button photo size on partial updates

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -501,7 +501,9 @@ public final class MentraBluetoothSDK {
                         DeviceStore.shared.remove(cat, key)
                     }
                 }
-                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_size", settings.size.rawValue)
+                if let size = settings.size {
+                    DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_size", size.rawValue)
+                }
                 if let mfnr = settings.mfnr {
                     DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_photo_mfnr", mfnr)
                 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
@@ -48,7 +48,7 @@ public enum PhotoCompression: String {
 }
 
 public struct ButtonPhotoSettings {
-    public let size: ButtonPhotoSize
+    public let size: ButtonPhotoSize?
     public let mfnr: Bool?
     public let zsl: Bool?
     public let noiseReduction: Bool?
@@ -62,7 +62,7 @@ public struct ButtonPhotoSettings {
     public let resetCaptureTuning: Bool?
 
     public init(
-        size: ButtonPhotoSize,
+        size: ButtonPhotoSize?,
         mfnr: Bool? = nil,
         zsl: Bool? = nil,
         noiseReduction: Bool? = nil,
@@ -90,12 +90,12 @@ public struct ButtonPhotoSettings {
     }
 
     static func from(params: [String: Any]) -> ButtonPhotoSettings {
-        let sizeRaw = params["size"] as? String ?? "medium"
+        let size = (params["size"] as? String).map { ButtonPhotoSize(normalizedRawValue: $0) }
         let aeExposureDivisor =
             optionalIntValue(params, "aeExposureDivisor").flatMap { $0 > 1 ? $0 : nil }
         let isoCap = optionalIntValue(params, "isoCap").flatMap { $0 > 0 ? $0 : nil }
         return ButtonPhotoSettings(
-            size: ButtonPhotoSize(normalizedRawValue: sizeRaw),
+            size: size,
             mfnr: optionalBoolValue(params, "mfnr"),
             zsl: optionalBoolValue(params, "zsl"),
             noiseReduction: optionalBoolValue(params, "noiseReduction"),

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -5210,7 +5210,7 @@ extension MentraLive {
         let sound = DeviceStore.shared.get("bluetooth", "button_photo_sound") as? Bool
 
         let settings = ButtonPhotoSettings(
-            size: ButtonPhotoSize(normalizedRawValue: size ?? "medium") ?? .medium,
+            size: ButtonPhotoSize(normalizedRawValue: size ?? "medium"),
             mfnr: mfnr,
             zsl: zsl,
             noiseReduction: noiseReduction,
@@ -5228,14 +5228,11 @@ extension MentraLive {
     }
 
     func sendButtonPhotoSettings(requestId: String?, size: String) {
-        sendButtonPhotoSettings(
-            requestId: requestId,
-            settings: ButtonPhotoSettings(size: ButtonPhotoSize(normalizedRawValue: size) ?? .medium)
-        )
+        sendButtonPhotoSettings(requestId: requestId, settings: ButtonPhotoSettings(size: ButtonPhotoSize(normalizedRawValue: size)))
     }
 
     func sendButtonPhotoSettings(requestId: String?, settings: ButtonPhotoSettings) {
-        var details = "size=\(settings.size.rawValue)"
+        var details = settings.size.map { "size=\($0.rawValue)" } ?? "size=unchanged"
         if let mfnr = settings.mfnr {
             details += ", mfnr=\(mfnr)"
         }
@@ -5275,8 +5272,10 @@ extension MentraLive {
 
         var json: [String: Any] = [
             "type": "button_photo_setting",
-            "size": settings.size.rawValue,
         ]
+        if let size = settings.size {
+            json["size"] = size.rawValue
+        }
         if let requestId, !requestId.isEmpty {
             json["request_id"] = requestId
         }


### PR DESCRIPTION
## Summary

- Keep `ButtonPhotoSettings.size` optional on iOS so omitted size stays omitted.
- Only update the cached `button_photo_size` when callers explicitly provide a size.
- Only include `size` in the Mentra Live BLE `button_photo_setting` payload when present, while full cached setting replay still supplies the stored/default size.

## Why

This addresses the review comment on #3170. The one-line compile fix made iOS always write `settings.size`, but iOS parsed missing size as `medium`, so reset-only or tuning-only updates could silently change the user's saved button photo size to medium. Android already treats omitted size as "leave stored value unchanged"; this brings iOS in line with that behavior.

## Validation

- `git diff --check`
- `cd mobile && bun run compile`
- `cd mobile/modules/bluetooth-sdk && xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO -quiet build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BLE settings sync and local cache behavior for button photo size; wrong handling could still mis-sync glasses, but scope is narrow and aligns iOS with existing Android semantics.
> 
> **Overview**
> Fixes a regression where iOS treated a missing `size` as **medium** and always wrote it to `DeviceStore` and the BLE `button_photo_setting` payload. **Reset-only** or **capture-tuning-only** updates could silently change the user's saved button photo size.
> 
> `ButtonPhotoSettings.size` is now **optional** end-to-end on iOS: `from(params:)` no longer defaults omitted `size`, `setButtonPhotoSettings` only updates `button_photo_size` when a size is provided, and `MentraLive` omits `size` from the JSON unless present (logs **size=unchanged**). Full reconnect replay still builds settings from the cached store value (with **medium** only when nothing is stored), matching Android's "omit size = leave stored value alone" behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4952ca016c383dd15183083fa589251cc453e5d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->