### PR TITLE
Bump Bluetooth SDK to 0.1.13

### DIFF
--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.13")
 }
 ```
 

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.12` or newer, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.13` or newer, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.12"
+  from: "0.1.13"
 )
 ```
 

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,7 +21,7 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.13` or newer, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.13`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.13")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.12` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Use version `0.1.13` or newer, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.12"
+  from: "0.1.13"
 )
 ```
 

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -108,7 +108,7 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.13` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.13`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -22,7 +22,7 @@ icon: "circle-question"
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.13` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves the selected SDK version. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -22,7 +22,7 @@ icon: "circle-question"
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.12` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.13` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -206,7 +206,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -459,7 +459,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Add the `MentraBluetoothSDK` product to your app target at version `0.1.13` or newer.
+Select version `0.1.13`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -459,7 +459,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Add the `MentraBluetoothSDK` product to your app target at version `0.1.12` or newer.
+Add the `MentraBluetoothSDK` product to your app target at version `0.1.13` or newer.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.12`
+Use the same version format as existing SwiftPM tags, for example `0.1.13`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",


### PR DESCRIPTION
## Summary

Bumps `@mentra/bluetooth-sdk` from `0.1.12` to `0.1.13` so the release workflow can publish the next public SDK version.

## Changes

- Updates `mobile/modules/bluetooth-sdk/package.json` and the mobile Bun lockfile to `0.1.13`.
- Updates Mentra Live Android, iOS, quickstart, and troubleshooting docs to reference `0.1.13` for the public SDK artifacts.
- Keeps SwiftPM `from: "0.1.13"` snippets while changing nearby Xcode prose to exact-release wording instead of `0.1.13 or newer`.
- Refreshes SDK README guidance and the SwiftPM release doc version example to `0.1.13`.

## Validation

- `cd mobile && bun install --frozen-lockfile`
- `cd mobile/modules/bluetooth-sdk && bun run build`
- `cd mobile/modules/bluetooth-sdk && npm pack --dry-run`
- `git diff --check`
- Confirmed `0.1.13` is not already present on npm, Maven Central, or the SwiftPM mirror tag list.

## Release Notes

After this merges to `dev`, the Bluetooth SDK release workflow should run for `0.1.13`. npm may still require staged package approval, and Maven Central may still require manual Sonatype deployment publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and package metadata only; no runtime or API code changes in the diff.
> 
> **Overview**
> Bumps **`@mentra/bluetooth-sdk`** and published native artifact references from **`0.1.12`** to **`0.1.13`** so the release workflow can ship the next public SDK.
> 
> **`mobile/modules/bluetooth-sdk/package.json`** and **`mobile/bun.lock`** are updated to **`0.1.13`**. Mentra Live docs (**`android.mdx`**, **`ios.mdx`**, **`quickstart.mdx`**) now show **`com.mentraglass:bluetooth-sdk:0.1.13`**, SwiftPM **`from: "0.1.13"`**, and Xcode guidance to pick **`0.1.13`** explicitly instead of “or newer.” **`troubleshooting.mdx`** no longer pins a specific iOS package version in prose. Maintainer docs (**`README.md`**, **`RELEASING_IOS_SPM.md`**) use **`0.1.13`** in examples.
> 
> There are no SDK implementation changes in this diff—only version and documentation alignment ahead of publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 291dd45932eb9f69d77c406da3ed9d1f4118777e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->