### PR TITLE
Add PR agent orchestrator (Bugbot + Claude 4.6 + Opus 4.8)

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,37 @@
+# Bugbot rules for MentraOS
+
+When reviewing pull requests (including when triggered via `bugbot run` from the PR agent orchestrator):
+
+## Standards
+
+- Follow root `AGENTS.md` and path-specific `AGENTS.md` (`mobile/`, `cloud/`, etc.).
+- Java/Android: Java 17, `mCamelCase` members, PascalCase classes, EventBus for component communication.
+- TypeScript/React Native: functional components, single quotes, strict typing, feature-based `src/` layout.
+- Swift: use swiftformat conventions.
+- Do not suggest adding `Co-Authored-By:` trailers or "Generated with" lines for AI tools in commits or PR descriptions.
+
+## Security
+
+- Cloud/Docker MongoDB must bind to `127.0.0.1:27017`, never `0.0.0.0` or bare `27017:27017`.
+- Do not commit secrets, `.env` values, or device-specific tokens.
+
+## Orchestrator integration
+
+When the PR agent orchestrator triggers this review, end with a top-level PR comment containing:
+
+1. Human-readable summary
+2. HTML marker `<!-- pr-agent-bugbot-verdict -->`
+3. JSON footer (same schema as Claude 4.6 reviewers):
+
+```json
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+```
+
+- Use `blocking` only for issues that must be fixed before merge.
+- Use `nit` for style or optional suggestions.
+- Do not re-raise issues already listed in open `<!-- pr-agent-orchestrator -->` findings unless they regressed.
+
+## Scope
+
+- If changed files are outside your area of concern and look correct, approve.
+- Prefer actionable, minimal findings over exhaustive nitpicks.

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -1,0 +1,47 @@
+# PR Agent Orchestrator configuration
+# See docs/pr-agent-orchestrator-setup.md
+
+dryRun: true
+
+reviewModel: claude-4.6-sonnet-medium-thinking
+fixModel: claude-opus-4-8-thinking-xhigh
+
+authors:
+  mode: label_only # allowlist | all | label_only
+  allowlist: []
+
+limits:
+  maxFixRounds: 5
+  maxOrchestratorCycles: 8
+  maxBugbotWaitMin: 12
+  maxCiWaitMin: 45
+  maxNewBlockingPerCycle: 5
+  maxFixAgentTurns: 20
+  consecutiveNoNewReviewsForHandoff: 2
+  discoveryCycles: 1
+
+# Path-scoped required CI check names (must match workflow `name:` fields)
+ciGates:
+  - paths:
+      - "cloud/**"
+    workflows:
+      - "🧪 Test Cloud build"
+  - paths:
+      - "cloud/packages/**"
+      - "cloud/bun.lock"
+      - "cloud/package.json"
+    workflows:
+      - "Run Cloud Tests ☁️"
+  - paths:
+      - "mobile/**"
+    workflows:
+      - "Mobile App Quality Checks"
+      - "Mobile App Android Build"
+  - paths:
+      - "asg_client/**"
+    workflows:
+      - "MentraOS ASG Client Build"
+  - paths:
+      - "cloud/packages/sdk/**"
+    workflows:
+      - "🧪 Test SDK build"

--- a/.github/pr-agent/prompts/depth-review.md
+++ b/.github/pr-agent/prompts/depth-review.md
@@ -1,0 +1,33 @@
+# Depth review (Claude 4.6)
+
+You are reviewing a pull request for **logic, correctness, and integration risk** in MentraOS.
+
+## Focus
+
+- Bugs, race conditions, null/lifecycle issues, error handling gaps.
+- How changes interact with callers/callees in the same module.
+- Edge cases (BLE disconnect, camera lifecycle, pairing, offline, etc. when relevant).
+- Regressions in behavior implied by the diff.
+
+## Context from orchestrator
+
+The orchestrator may provide:
+
+- Current `openFindings` and `resolvedFindings`
+- PR number, base branch, and changed file list
+
+## Rules
+
+- Do **not** re-raise resolved findings unless they regressed.
+- Only report: (a) new **blocking** issues, (b) regressions, or (c) **nits**.
+- Style-only issues are **nits**, not blocking.
+- If no blocking logic issues, **approve**.
+
+## Output
+
+1. Brief human-readable review (bullet points).
+2. End with a single JSON object on its own line (no markdown fence):
+
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+
+Use `changes_requested` if any **blocking** finding exists. Use `approve` otherwise.

--- a/.github/pr-agent/prompts/pr-fix.md
+++ b/.github/pr-agent/prompts/pr-fix.md
@@ -1,0 +1,40 @@
+# Opus 4.8 fixer
+
+You are fixing a pull request branch for **MentraOS**. Apply **minimal** changes only.
+
+## Inputs
+
+You receive:
+
+- Open blocking findings (full ledger)
+- Failed CI log excerpts (if any)
+- PR diff summary and changed paths
+
+## Process
+
+1. Read finding ledger and CI failures carefully.
+2. **Thoroughly review** affected modules—not only diff hunks:
+   - Read callers/callees of changed files
+   - Check related tests and `AGENTS.md` for the touched package
+   - Look for the same bug class elsewhere in the scoped directory
+3. Apply minimal fixes for all **blocking** findings and CI root causes.
+4. Run targeted verification before finishing:
+   - `cloud/**` → `cd cloud && bun test` (or scoped package test)
+   - `mobile/**` → `cd mobile && bun test` for affected areas
+   - `asg_client/**` → relevant Gradle test task if applicable
+5. Do **not** refactor unrelated code.
+6. Do **not** add AI attribution to commit messages.
+
+## Constraints
+
+- Fix only what is required for blocking items and CI.
+- Prefer surgical edits over broad rewrites.
+- If a finding is a false positive, leave a short note in your final message—do not hack around it in code.
+
+## Output
+
+When done, summarize:
+
+- Files changed and why
+- Tests run and results
+- Any findings you could not fix (with reason)

--- a/.github/pr-agent/prompts/standards-review.md
+++ b/.github/pr-agent/prompts/standards-review.md
@@ -1,0 +1,34 @@
+# Standards review (Claude 4.6)
+
+You are reviewing a pull request for **MentraOS** standards and conventions.
+
+## Focus
+
+- Root `AGENTS.md` and relevant module `AGENTS.md` (e.g. `mobile/`, `cloud/`).
+- Naming conventions (Java `mCamelCase`, TS PascalCase/camelCase, etc.).
+- Commit/PR hygiene (no AI co-author trailers, focused scope).
+- Missing tests when backend/mobile logic changes per AGENTS.md testing guidelines.
+- Security basics (no committed secrets, Mongo localhost binding in cloud Docker).
+
+## Context from orchestrator
+
+The orchestrator may provide:
+
+- Current `openFindings` and `resolvedFindings` from prior cycles
+- PR number, base branch, and changed file list
+
+## Rules
+
+- Do **not** re-raise resolved findings unless they regressed.
+- Only report: (a) new **blocking** issues, (b) regressions, or (c) **nits**.
+- Nits do not block merge.
+- If the diff only touches unrelated files and looks fine, **approve**.
+
+## Output
+
+1. Brief human-readable review (bullet points).
+2. End with a single JSON object on its own line (no markdown fence):
+
+{"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}
+
+Use `changes_requested` if any **blocking** finding exists. Use `approve` otherwise.

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -102,8 +102,17 @@ jobs:
                 head: `${headOwner}:${run.head_branch}`,
                 state: 'open',
               });
-              pr =
-                pulls.data.find((p) => p.head.sha === run.head_sha) ?? pulls.data[0];
+              if (pulls.data.length === 1) {
+                // Unambiguous branch: use it even if the head advanced past the CI sha.
+                pr = pulls.data[0];
+              } else {
+                // Multiple open PRs share this branch: require an exact head_sha
+                // match. Never guess — bail if it is ambiguous or absent.
+                const shaMatches = pulls.data.filter(
+                  (p) => p.head.sha === run.head_sha,
+                );
+                pr = shaMatches.length === 1 ? shaMatches[0] : undefined;
+              }
             } else {
               core.setOutput('ci_recheck_only', 'false');
             }

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -1,0 +1,382 @@
+name: PR Agent Orchestrator
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+  workflow_run:
+    workflows:
+      - "🧪 Test Cloud build"
+      - "Mobile App Quality Checks"
+      - "MentraOS ASG Client Build"
+      - "Mobile App Android Build"
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number (required for manual run)
+        required: true
+        type: string
+      force_rotation:
+        description: Force reviewer rotation
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: pr-agent-${{ github.event.pull_request.number || github.event.inputs.pr_number || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  checks: read
+
+env:
+  FORCE_ROTATION: ${{ github.event.inputs.force_rotation || 'false' }}
+
+jobs:
+  resolve-context:
+    name: Resolve PR context
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.ctx.outputs.pr_number }}
+      head_sha: ${{ steps.ctx.outputs.head_sha }}
+      base_ref: ${{ steps.ctx.outputs.base_ref }}
+      pr_author: ${{ steps.ctx.outputs.pr_author }}
+      pr_draft: ${{ steps.ctx.outputs.pr_draft }}
+      pr_is_fork: ${{ steps.ctx.outputs.pr_is_fork }}
+      ci_trigger_failed: ${{ steps.ctx.outputs.ci_trigger_failed }}
+    steps:
+      - name: Resolve from event
+        id: ctx
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let pr = context.payload.pull_request;
+            let ciFailed = 'false';
+
+            if (!pr && context.eventName === 'workflow_run') {
+              const run = context.payload.workflow_run;
+              if (run.conclusion !== 'failure' && run.conclusion !== 'cancelled') {
+                core.setOutput('pr_number', '');
+                return;
+              }
+              ciFailed = 'true';
+              const pulls = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head: `${context.repo.owner}:${run.head_branch}`,
+                state: 'open',
+              });
+              pr = pulls.data[0];
+            }
+
+            if (!pr && context.eventName === 'workflow_dispatch') {
+              const n = parseInt('${{ github.event.inputs.pr_number }}', 10);
+              const { data } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: n,
+              });
+              pr = data;
+            }
+
+            if (!pr) {
+              core.setOutput('pr_number', '');
+              return;
+            }
+
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_ref', pr.base.ref);
+            core.setOutput('pr_author', pr.user.login);
+            core.setOutput('pr_draft', String(pr.draft));
+            core.setOutput(
+              'pr_is_fork',
+              String(pr.head.repo.full_name !== pr.base.repo.full_name),
+            );
+            core.setOutput('ci_trigger_failed', ciFailed);
+
+  plan:
+    name: Plan agent cycle
+    needs: resolve-context
+    if: needs.resolve-context.outputs.pr_number != ''
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.plan.outputs.should_skip }}
+      skip_reason: ${{ steps.plan.outputs.skip_reason }}
+      run_bugbot: ${{ steps.plan.outputs.run_bugbot }}
+      run_standards: ${{ steps.plan.outputs.run_standards }}
+      run_depth: ${{ steps.plan.outputs.run_depth }}
+      active_pair: ${{ steps.plan.outputs.active_pair }}
+      is_dry_run: ${{ steps.plan.outputs.is_dry_run }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v1
+
+      - name: Install pr-agent deps
+        working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Plan
+        id: plan
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          PR_AUTHOR: ${{ needs.resolve-context.outputs.pr_author }}
+          PR_DRAFT: ${{ needs.resolve-context.outputs.pr_draft }}
+          PR_IS_FORK: ${{ needs.resolve-context.outputs.pr_is_fork }}
+          GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: bun run cli plan
+        working-directory: scripts/pr-agent
+
+      - name: Mark in progress
+        if: steps.plan.outputs.should_skip != 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.PR_NUMBER, 10),
+              labels: ['agent-in-progress'],
+            });
+
+  review-standards:
+    name: Review (Claude 4.6 standards)
+    needs: [resolve-context, plan]
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_standards == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-context.outputs.head_sha }}
+          fetch-depth: 0
+
+      - run: git fetch origin ${{ needs.resolve-context.outputs.base_ref }}
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Run standards review
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          BASE_REF: ${{ needs.resolve-context.outputs.base_ref }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: bun run cli review standards
+
+      - name: Upload review output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-agent-review-standards
+          path: .pr-agent/review-standards.txt
+          if-no-files-found: ignore
+
+  review-depth:
+    name: Review (Claude 4.6 depth)
+    needs: [resolve-context, plan]
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_depth == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-context.outputs.head_sha }}
+          fetch-depth: 0
+
+      - run: git fetch origin ${{ needs.resolve-context.outputs.base_ref }}
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Run depth review
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          BASE_REF: ${{ needs.resolve-context.outputs.base_ref }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+        run: bun run cli review depth
+
+      - name: Upload review output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-agent-review-depth
+          path: .pr-agent/review-depth.txt
+          if-no-files-found: ignore
+
+  review-bugbot:
+    name: Review (Bugbot)
+    needs: [resolve-context, plan]
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_bugbot == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      bugbot_success: ${{ steps.poll.outputs.bugbot_success }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Trigger Bugbot
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli bugbot-trigger
+
+      - name: Poll Bugbot check
+        id: poll
+        working-directory: scripts/pr-agent
+        env:
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli bugbot-poll
+
+  aggregate:
+    name: Aggregate findings
+    needs:
+      - resolve-context
+      - plan
+      - review-standards
+      - review-depth
+      - review-bugbot
+    if: always() && needs.plan.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      should_fix: ${{ steps.agg.outputs.should_fix }}
+      should_handoff: ${{ steps.agg.outputs.should_handoff }}
+      handoff_reason: ${{ steps.agg.outputs.handoff_reason }}
+      ci_failed: ${{ steps.agg.outputs.ci_failed }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-context.outputs.head_sha }}
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Download review artifacts
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: pr-agent-review-*
+          merge-multiple: true
+          path: .pr-agent
+
+      - name: Aggregate
+        id: agg
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
+          ACTIVE_PAIR: ${{ needs.plan.outputs.active_pair }}
+          BUGBOT_SUCCESS: ${{ needs.review-bugbot.outputs.bugbot_success || 'false' }}
+          CI_TRIGGER_FAILED: ${{ needs.resolve-context.outputs.ci_trigger_failed }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli aggregate
+
+  fix:
+    name: Fix (Opus 4.8)
+    needs: [resolve-context, plan, aggregate]
+    if: |
+      needs.aggregate.outputs.should_handoff != 'true' &&
+      needs.aggregate.outputs.should_fix == 'true' &&
+      needs.resolve-context.outputs.pr_is_fork != 'true' &&
+      needs.plan.outputs.is_dry_run != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-context.outputs.head_sha }}
+          fetch-depth: 0
+          token: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Run Opus fixer
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          CI_LOG_EXCERPT: ${{ github.event.workflow_run && format('Failed workflow: {0}', github.event.workflow_run.html_url) || '' }}
+          GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: bun run cli fix
+
+  wait-ci:
+    name: Wait for CI
+    needs: [resolve-context, plan, aggregate, fix]
+    if: |
+      always() && needs.plan.outputs.should_skip != 'true' &&
+      (needs.fix.result == 'success' || needs.fix.result == 'skipped') &&
+      needs.aggregate.outputs.should_handoff != 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      ci_green: ${{ steps.wait.outputs.ci_green }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Poll CI checks
+        id: wait
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli wait-ci
+
+  finalize:
+    name: Finalize handoff
+    needs: [resolve-context, plan, aggregate]
+    if: |
+      always() && needs.plan.outputs.should_skip != 'true' &&
+      needs.aggregate.outputs.should_handoff == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Post handoff
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
+          HANDOFF_REASON: ${{ needs.aggregate.outputs.handoff_reason || 'human_handoff' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli finalize
+
+  notify-failure:
+    name: Notify on failure
+    needs: [plan, aggregate, fix, finalize]
+    if: failure() && needs.plan.outputs.should_skip != 'true'
+    uses: ./.github/workflows/reusable-pr-comment.yml
+    with:
+      message: |
+        PR Agent Orchestrator failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -60,6 +60,11 @@ jobs:
           script: |
             let pr = context.payload.pull_request;
             let ciFailed = 'false';
+            let workflowRunSha = null;
+
+            if (context.eventName === 'workflow_run') {
+              workflowRunSha = context.payload.workflow_run.head_sha;
+            }
 
             if (!pr && context.eventName === 'workflow_run') {
               const run = context.payload.workflow_run;
@@ -99,7 +104,7 @@ jobs:
             }
 
             core.setOutput('pr_number', String(pr.number));
-            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_sha', workflowRunSha ?? pr.head.sha);
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('pr_author', pr.user.login);

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -33,6 +33,7 @@ permissions:
   pull-requests: write
   issues: write
   checks: read
+  actions: read
 
 env:
   FORCE_ROTATION: ${{ github.event.inputs.force_rotation || 'false' }}
@@ -44,11 +45,13 @@ jobs:
     outputs:
       pr_number: ${{ steps.ctx.outputs.pr_number }}
       head_sha: ${{ steps.ctx.outputs.head_sha }}
+      head_ref: ${{ steps.ctx.outputs.head_ref }}
       base_ref: ${{ steps.ctx.outputs.base_ref }}
       pr_author: ${{ steps.ctx.outputs.pr_author }}
       pr_draft: ${{ steps.ctx.outputs.pr_draft }}
       pr_is_fork: ${{ steps.ctx.outputs.pr_is_fork }}
       ci_trigger_failed: ${{ steps.ctx.outputs.ci_trigger_failed }}
+      ci_recheck_only: ${{ steps.ctx.outputs.ci_recheck_only }}
     steps:
       - name: Resolve from event
         id: ctx
@@ -60,11 +63,15 @@ jobs:
 
             if (!pr && context.eventName === 'workflow_run') {
               const run = context.payload.workflow_run;
-              if (run.conclusion !== 'failure' && run.conclusion !== 'cancelled') {
+              const isFailure =
+                run.conclusion === 'failure' || run.conclusion === 'cancelled';
+              const isSuccess = run.conclusion === 'success';
+              if (!isFailure && !isSuccess) {
                 core.setOutput('pr_number', '');
                 return;
               }
-              ciFailed = 'true';
+              ciFailed = String(isFailure);
+              core.setOutput('ci_recheck_only', String(isSuccess));
               const pulls = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -72,6 +79,8 @@ jobs:
                 state: 'open',
               });
               pr = pulls.data[0];
+            } else {
+              core.setOutput('ci_recheck_only', 'false');
             }
 
             if (!pr && context.eventName === 'workflow_dispatch') {
@@ -91,6 +100,7 @@ jobs:
 
             core.setOutput('pr_number', String(pr.number));
             core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('head_ref', pr.head.ref);
             core.setOutput('base_ref', pr.base.ref);
             core.setOutput('pr_author', pr.user.login);
             core.setOutput('pr_draft', String(pr.draft));
@@ -115,6 +125,7 @@ jobs:
       is_dry_run: ${{ steps.plan.outputs.is_dry_run }}
       should_handoff: ${{ steps.plan.outputs.should_handoff }}
       handoff_reason: ${{ steps.plan.outputs.handoff_reason }}
+      recheck_only: ${{ steps.plan.outputs.recheck_only }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -133,6 +144,7 @@ jobs:
           PR_AUTHOR: ${{ needs.resolve-context.outputs.pr_author }}
           PR_DRAFT: ${{ needs.resolve-context.outputs.pr_draft }}
           PR_IS_FORK: ${{ needs.resolve-context.outputs.pr_is_fork }}
+          CI_RECHECK_ONLY: ${{ needs.resolve-context.outputs.ci_recheck_only }}
           GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
         run: bun run cli plan
         working-directory: scripts/pr-agent
@@ -155,7 +167,7 @@ jobs:
   review-standards:
     name: Review (Claude 4.6 standards)
     needs: [resolve-context, plan]
-    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_standards == 'true'
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_standards == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +201,7 @@ jobs:
   review-depth:
     name: Review (Claude 4.6 depth)
     needs: [resolve-context, plan]
-    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_depth == 'true'
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_depth == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -223,7 +235,7 @@ jobs:
   review-bugbot:
     name: Review (Bugbot)
     needs: [resolve-context, plan]
-    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.run_bugbot == 'true'
+    if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_bugbot == 'true'
     runs-on: ubuntu-latest
     outputs:
       bugbot_success: ${{ steps.poll.outputs.bugbot_success }}
@@ -258,7 +270,7 @@ jobs:
       - review-standards
       - review-depth
       - review-bugbot
-    if: always() && needs.plan.outputs.should_skip != 'true'
+    if: always() && needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true'
     runs-on: ubuntu-latest
     outputs:
       should_fix: ${{ steps.agg.outputs.should_fix }}
@@ -307,7 +319,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.resolve-context.outputs.head_sha }}
+          ref: ${{ needs.resolve-context.outputs.head_ref }}
           fetch-depth: 0
           token: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
 
@@ -320,6 +332,7 @@ jobs:
         working-directory: scripts/pr-agent
         env:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          PR_HEAD_REF: ${{ needs.resolve-context.outputs.head_ref }}
           CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
           CI_LOG_EXCERPT: ${{ github.event.workflow_run && format('Failed workflow: {0}', github.event.workflow_run.html_url) || '' }}
           GITHUB_TOKEN: ${{ secrets.PR_AGENT_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
@@ -352,13 +365,45 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run cli wait-ci
 
+  recheck-handoff:
+    name: Recheck handoff after CI
+    needs: [resolve-context, plan, aggregate, fix, wait-ci]
+    if: |
+      always() && needs.plan.outputs.should_skip != 'true' &&
+      (needs.plan.outputs.recheck_only == 'true' ||
+        (needs.aggregate.result == 'success' &&
+          needs.aggregate.outputs.should_handoff != 'true' &&
+          (needs.wait-ci.result == 'success' || needs.wait-ci.result == 'skipped') &&
+          needs.wait-ci.outputs.ci_green == 'true'))
+    runs-on: ubuntu-latest
+    outputs:
+      should_handoff: ${{ steps.recheck.outputs.should_handoff }}
+      handoff_reason: ${{ steps.recheck.outputs.handoff_reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v1
+
+      - working-directory: scripts/pr-agent
+        run: bun install --frozen-lockfile || bun install
+
+      - name: Recheck clean handoff
+        id: recheck
+        working-directory: scripts/pr-agent
+        env:
+          PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
+          HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: bun run cli recheck-handoff
+
   finalize:
     name: Finalize handoff
-    needs: [resolve-context, plan, aggregate]
+    needs: [resolve-context, plan, aggregate, recheck-handoff]
     if: |
       always() && (
         needs.plan.outputs.should_handoff == 'true' ||
-        (needs.aggregate.result == 'success' && needs.aggregate.outputs.should_handoff == 'true')
+        (needs.aggregate.result == 'success' && needs.aggregate.outputs.should_handoff == 'true') ||
+        (needs.recheck-handoff.result == 'success' && needs.recheck-handoff.outputs.should_handoff == 'true')
       )
     runs-on: ubuntu-latest
     steps:
@@ -374,13 +419,13 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
-          HANDOFF_REASON: ${{ needs.plan.outputs.should_handoff == 'true' && needs.plan.outputs.handoff_reason || needs.aggregate.outputs.handoff_reason || 'human_handoff' }}
+          HANDOFF_REASON: ${{ needs.plan.outputs.should_handoff == 'true' && needs.plan.outputs.handoff_reason || needs.aggregate.outputs.handoff_reason || needs.recheck-handoff.outputs.handoff_reason || 'human_handoff' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run cli finalize
 
   notify-failure:
     name: Notify on failure
-    needs: [plan, aggregate, fix, finalize]
+    needs: [plan, aggregate, fix, recheck-handoff, finalize]
     if: failure() && needs.plan.outputs.should_skip != 'true'
     uses: ./.github/workflows/reusable-pr-comment.yml
     with:

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -6,6 +6,8 @@ on:
   workflow_run:
     workflows:
       - "🧪 Test Cloud build"
+      - "Run Cloud Tests ☁️"
+      - "🧪 Test SDK build"
       - "Mobile App Quality Checks"
       - "MentraOS ASG Client Build"
       - "Mobile App Android Build"
@@ -111,6 +113,8 @@ jobs:
       run_depth: ${{ steps.plan.outputs.run_depth }}
       active_pair: ${{ steps.plan.outputs.active_pair }}
       is_dry_run: ${{ steps.plan.outputs.is_dry_run }}
+      should_handoff: ${{ steps.plan.outputs.should_handoff }}
+      handoff_reason: ${{ steps.plan.outputs.handoff_reason }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -352,8 +356,10 @@ jobs:
     name: Finalize handoff
     needs: [resolve-context, plan, aggregate]
     if: |
-      always() && needs.plan.outputs.should_skip != 'true' &&
-      needs.aggregate.outputs.should_handoff == 'true'
+      always() && (
+        needs.plan.outputs.should_handoff == 'true' ||
+        (needs.aggregate.result == 'success' && needs.aggregate.outputs.should_handoff == 'true')
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -368,7 +374,7 @@ jobs:
         env:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
-          HANDOFF_REASON: ${{ needs.aggregate.outputs.handoff_reason || 'human_handoff' }}
+          HANDOFF_REASON: ${{ needs.plan.outputs.should_handoff == 'true' && needs.plan.outputs.handoff_reason || needs.aggregate.outputs.handoff_reason || 'human_handoff' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run cli finalize
 

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -62,6 +62,23 @@ jobs:
             let ciFailed = 'false';
             let workflowRunSha = null;
 
+            if (
+              pr &&
+              context.eventName === 'pull_request' &&
+              context.payload.action === 'labeled'
+            ) {
+              const label = context.payload.label?.name;
+              const internalLabels = [
+                'agent-in-progress',
+                'ready-for-human-review',
+                'agent-needs-human',
+              ];
+              if (internalLabels.includes(label)) {
+                core.setOutput('pr_number', '');
+                return;
+              }
+            }
+
             if (context.eventName === 'workflow_run') {
               workflowRunSha = context.payload.workflow_run.head_sha;
             }
@@ -77,13 +94,16 @@ jobs:
               }
               ciFailed = String(isFailure);
               core.setOutput('ci_recheck_only', String(isSuccess));
+              const headOwner =
+                run.head_repository?.owner?.login ?? context.repo.owner;
               const pulls = await github.rest.pulls.list({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                head: `${context.repo.owner}:${run.head_branch}`,
+                head: `${headOwner}:${run.head_branch}`,
                 state: 'open',
               });
-              pr = pulls.data[0];
+              pr =
+                pulls.data.find((p) => p.head.sha === run.head_sha) ?? pulls.data[0];
             } else {
               core.setOutput('ci_recheck_only', 'false');
             }
@@ -243,6 +263,7 @@ jobs:
     if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_bugbot == 'true'
     runs-on: ubuntu-latest
     outputs:
+      bugbot_completed: ${{ steps.poll.outputs.bugbot_completed }}
       bugbot_success: ${{ steps.poll.outputs.bugbot_success }}
     steps:
       - uses: actions/checkout@v4
@@ -307,6 +328,7 @@ jobs:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}
           HEAD_SHA: ${{ needs.resolve-context.outputs.head_sha }}
           ACTIVE_PAIR: ${{ needs.plan.outputs.active_pair }}
+          BUGBOT_COMPLETED: ${{ needs.review-bugbot.outputs.bugbot_completed || 'false' }}
           BUGBOT_SUCCESS: ${{ needs.review-bugbot.outputs.bugbot_success || 'false' }}
           CI_TRIGGER_FAILED: ${{ needs.resolve-context.outputs.ci_trigger_failed }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -428,11 +450,50 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: bun run cli finalize
 
+  cleanup-progress-label:
+    name: Clear progress label on stop
+    needs: [resolve-context, plan, finalize]
+    if: |
+      always() && needs.resolve-context.outputs.pr_number != '' && (
+        failure() ||
+        needs.plan.outputs.should_skip == 'true' ||
+        needs.finalize.result == 'success'
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove agent-in-progress
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = parseInt('${{ needs.resolve-context.outputs.pr_number }}', 10);
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr,
+                name: 'agent-in-progress',
+              });
+            } catch (e) {
+              if (e.status !== 404) throw e;
+            }
+
   notify-failure:
     name: Notify on failure
-    needs: [plan, aggregate, fix, recheck-handoff, finalize]
-    if: failure() && needs.plan.outputs.should_skip != 'true'
-    uses: ./.github/workflows/reusable-pr-comment.yml
-    with:
-      message: |
-        PR Agent Orchestrator failed. See run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    needs: [resolve-context, plan, aggregate, fix, recheck-handoff, finalize]
+    if: failure() && needs.resolve-context.outputs.pr_number != '' && needs.plan.outputs.should_skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const pr = parseInt('${{ needs.resolve-context.outputs.pr_number }}', 10);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body: `PR Agent Orchestrator failed. See run: ${runUrl}`,
+            });

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -451,14 +451,19 @@ jobs:
         run: bun run cli finalize
 
   cleanup-progress-label:
-    name: Clear progress label on stop
-    needs: [resolve-context, plan, finalize]
-    if: |
-      always() && needs.resolve-context.outputs.pr_number != '' && (
-        failure() ||
-        needs.plan.outputs.should_skip == 'true' ||
-        needs.finalize.result == 'success'
-      )
+    name: Clear progress label
+    needs:
+      - resolve-context
+      - plan
+      - review-standards
+      - review-depth
+      - review-bugbot
+      - aggregate
+      - fix
+      - wait-ci
+      - recheck-handoff
+      - finalize
+    if: always() && needs.resolve-context.outputs.pr_number != ''
     runs-on: ubuntu-latest
     steps:
       - name: Remove agent-in-progress

--- a/.gitignore
+++ b/.gitignore
@@ -382,7 +382,11 @@ issues
 # Local session notes
 MEMORY.md
 # Cursor IDE local config (MCP, etc.)
-.cursor/
+.cursor/*
+!.cursor/BUGBOT.md
+
+# PR agent orchestrator local outputs
+.pr-agent/
 
 # Nested starter-kit repo (separate git history)
 Mentra-Bluetooth-SDK-Starter-Kit/

--- a/docs/pr-agent-orchestrator-setup.md
+++ b/docs/pr-agent-orchestrator-setup.md
@@ -1,0 +1,59 @@
+# PR Agent Orchestrator — Setup
+
+Automated PR review (Bugbot + Claude 4.6) and fix (Opus 4.8) via [`.github/workflows/pr-agent-orchestrator.yml`](../.github/workflows/pr-agent-orchestrator.yml).
+
+## Prerequisites
+
+### 1. Cursor GitHub app
+
+Install the [Cursor GitHub app](https://cursor.com/docs/integrations/github) on the org/repo with access to pull requests and checks.
+
+### 2. Bugbot (manual trigger only)
+
+1. Enable Bugbot for this repo in the [Bugbot dashboard](https://cursor.com/bugbot).
+2. Set **Run only when mentioned** (`bugbot run` / `cursor review`) so the orchestrator controls when Bugbot runs (required for 2-of-3 rotation).
+3. Do **not** enable Bugbot Autofix — the Opus 4.8 SDK fixer is the only auto-commit agent.
+
+### 3. GitHub secrets
+
+| Secret | Required | Purpose |
+|--------|----------|---------|
+| `CURSOR_API_KEY` | Yes | Claude 4.6 reviews + Opus 4.8 fixer ([Cursor SDK](https://cursor.com/docs/sdk/typescript)) |
+| `PR_AGENT_GITHUB_TOKEN` | Optional | Fine-grained PAT with `contents:write` + `pull-requests:write` if `GITHUB_TOKEN` cannot push fixes |
+
+Create a team service account key at [Cursor Dashboard → Integrations](https://cursor.com/dashboard/integrations).
+
+### 4. Repo config
+
+Edit [`.github/pr-agent.yml`](../.github/pr-agent.yml):
+
+- `authors.mode` — start with `label_only` or `allowlist` for rollout
+- `dryRun` — set `false` after Phase A testing
+- `reviewModel` / `fixModel` — defaults: Claude 4.6 / Opus 4.8
+
+## Rollout phases
+
+1. **Phase A:** `dryRun: true` — logs which reviewers would run; no fixer push
+2. **Phase B:** `dryRun: false`, reviews enabled; verify Bugbot polling
+3. **Phase C:** fixer enabled; tune `maxFixRounds` after observing credit usage
+4. **Phase D:** widen `authors.mode` to `all` when ready
+
+## Human controls
+
+| Control | Effect |
+|---------|--------|
+| Label `agent-review` | Opt-in when `authors.mode: label_only` |
+| Label `agent-stop` | Disable orchestrator on PR |
+| Label `agent-resume` | Re-enable after handoff |
+| Comment `agent-resolve <id>` | Mark finding false positive |
+
+Handoff applies label `ready-for-human-review`. **Humans always merge** — agents never auto-merge.
+
+## Local development
+
+```bash
+cd scripts/pr-agent
+bun install
+export CURSOR_API_KEY=cursor_...
+bun run cli -- help
+```

--- a/scripts/pr-agent/bun.lock
+++ b/scripts/pr-agent/bun.lock
@@ -1,0 +1,156 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@mentra/pr-agent",
+      "dependencies": {
+        "@cursor/sdk": "^1.0.0",
+        "@octokit/rest": "^21.1.1",
+        "minimatch": "^10.0.1",
+        "yaml": "^2.7.0",
+        "zod": "^3.24.2",
+      },
+      "devDependencies": {
+        "@types/node": "^22.13.10",
+        "tsx": "^4.19.3",
+        "typescript": "^5.8.2",
+      },
+    },
+  },
+  "packages": {
+    "@bufbuild/protobuf": ["@bufbuild/protobuf@1.10.0", "", {}, "sha512-QDdVFLoN93Zjg36NoQPZfsVH9tZew7wKDKyV5qRdj8ntT4wQCOradQjRaTdwMhWUYsgKsvCINKKm87FdEk96Ag=="],
+
+    "@connectrpc/connect": ["@connectrpc/connect@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0" } }, "sha512-iNKdJRi69YP3mq6AePRT8F/HrxWCewrhxnLMNm0vpqXAR8biwzRtO6Hjx80C6UvtKJ5sFmffQT7I4Baecz389w=="],
+
+    "@connectrpc/connect-web": ["@connectrpc/connect-web@1.7.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.10.0", "@connectrpc/connect": "1.7.0" } }, "sha512-qyP0YOnUPRWwCc/VfsoydMJvkb7EyUPr2q9sHgBuJzbADjiqck1gKH5V5ZPzPhTLBvmz5UvG+wiZ5sMRQHU1MQ=="],
+
+    "@cursor/sdk": ["@cursor/sdk@1.0.19", "", { "dependencies": { "@bufbuild/protobuf": "1.10.0", "@connectrpc/connect": "^1.6.1", "@connectrpc/connect-web": "^1.6.1", "@statsig/js-client": "3.31.0", "zod": "^3.25.0" }, "optionalDependencies": { "@cursor/sdk-darwin-arm64": "1.0.19", "@cursor/sdk-darwin-x64": "1.0.19", "@cursor/sdk-linux-arm64": "1.0.19", "@cursor/sdk-linux-x64": "1.0.19", "@cursor/sdk-win32-x64": "1.0.19" } }, "sha512-DJbVnGeRJq7iwt9mz1cMACqVfAYP15IB+Q8Iz2eDtEN4A8Dp83yB0Y31YREj1jeA9EPUEdRZJRIYch/s+Wi9Ow=="],
+
+    "@cursor/sdk-darwin-arm64": ["@cursor/sdk-darwin-arm64@1.0.19", "", { "os": "darwin", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-CPhqcpDaqjjqkkVGMLsdfXv7PGznL5L6U5CJXps/oaGW5mtHoxDpsRNj1rszCRQXNAvmMU+EFxLWnBwlE8mUNg=="],
+
+    "@cursor/sdk-darwin-x64": ["@cursor/sdk-darwin-x64@1.0.19", "", { "os": "darwin", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-6/Jj0hxrxEs9V9wtYEApSkMcJwYAaT4Vwna9xBzgN6CK1K4Ws0E1/PfiddahAAFZpkp9pgjb8wQXwG7qJ2g77A=="],
+
+    "@cursor/sdk-linux-arm64": ["@cursor/sdk-linux-arm64@1.0.19", "", { "os": "linux", "cpu": "arm64", "bin": { "rg": "bin/rg" } }, "sha512-Dq/BhGT1jAZ6eHJwy1Vugi/Upc+yoL0X/LN6ppd9cVPM9OAB1xX5KIbvIwsGlNiZccPLVXFv/1KOp5SBK+y+jQ=="],
+
+    "@cursor/sdk-linux-x64": ["@cursor/sdk-linux-x64@1.0.19", "", { "os": "linux", "cpu": "x64", "bin": { "rg": "bin/rg" } }, "sha512-ZHgHH+SdEwYwfPg/uVKqZRVOIMCV3/3vghxc/usOMYMrhbY9TYXZxYqwWTduVLzCXH7Dz0aT19mSJHmhwkQ1CA=="],
+
+    "@cursor/sdk-win32-x64": ["@cursor/sdk-win32-x64@1.0.19", "", { "os": "win32", "cpu": "x64", "bin": { "rg": "bin/rg.exe" } }, "sha512-XGIQmx3J0K8uKkA00qnoy1FJHFdFdwNdcmUqtRF1PXLcYup91YYetAHk9afXM7S/v1t0L4EatydsirL8uz7SIw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@5.1.2", "", {}, "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="],
+
+    "@octokit/core": ["@octokit/core@6.1.6", "", { "dependencies": { "@octokit/auth-token": "^5.0.0", "@octokit/graphql": "^8.2.2", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "before-after-hook": "^3.0.2", "universal-user-agent": "^7.0.0" } }, "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@10.1.4", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@8.2.2", "", { "dependencies": { "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@25.1.0", "", {}, "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@11.6.0", "", { "dependencies": { "@octokit/types": "^13.10.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw=="],
+
+    "@octokit/plugin-request-log": ["@octokit/plugin-request-log@5.3.1", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@13.5.0", "", { "dependencies": { "@octokit/types": "^13.10.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw=="],
+
+    "@octokit/request": ["@octokit/request@9.2.4", "", { "dependencies": { "@octokit/endpoint": "^10.1.4", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^2.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@6.1.8", "", { "dependencies": { "@octokit/types": "^14.0.0" } }, "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ=="],
+
+    "@octokit/rest": ["@octokit/rest@21.1.1", "", { "dependencies": { "@octokit/core": "^6.1.4", "@octokit/plugin-paginate-rest": "^11.4.2", "@octokit/plugin-request-log": "^5.3.1", "@octokit/plugin-rest-endpoint-methods": "^13.3.0" } }, "sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg=="],
+
+    "@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
+
+    "@statsig/client-core": ["@statsig/client-core@3.31.0", "", {}, "sha512-SuxQD6TmVszPG7FoMKwTk/uyBuVFk7XnxI3T/E0uyb7PL7GNjONtfsoh+NqBBVUJVse0CUeSFfgJPoZy1ZOslQ=="],
+
+    "@statsig/js-client": ["@statsig/js-client@3.31.0", "", { "dependencies": { "@statsig/client-core": "3.31.0" } }, "sha512-LFa5E0LjT6sTfZv3sNGoyRLSZ1078+agdgOA+Vm1ecjG+KbSOfBLTW7hMwimrJ29slRwbYDzbtKaPJo/R37N2g=="],
+
+    "@types/node": ["@types/node@22.19.21", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "before-after-hook": ["before-after-hook@3.0.2", "", {}, "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="],
+
+    "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@2.0.1", "", {}, "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "tsx": ["tsx@4.22.4", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
+
+    "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+
+    "@octokit/plugin-rest-endpoint-methods/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
+  }
+}

--- a/scripts/pr-agent/package.json
+++ b/scripts/pr-agent/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@mentra/pr-agent",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "cli": "tsx src/cli.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@cursor/sdk": "^1.0.0",
+    "@octokit/rest": "^21.1.1",
+    "minimatch": "^10.0.1",
+    "yaml": "^2.7.0",
+    "zod": "^3.24.2"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.10",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.2"
+  }
+}

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -10,6 +10,7 @@ import {
   verdictToFindings,
 } from './findings.js';
 import { frozenPairFromFindings } from './rotate.js';
+import { listAllIssueComments } from './state.js';
 import { MARKER_BUGBOT_VERDICT, type AggregateOutput, type PrAgentState, type ReviewSlot } from './types.js';
 import { isCiFailed, isCiGreen, type CiCheckStatus } from './ci-gates.js';
 
@@ -19,6 +20,15 @@ export type ReviewOutputs = {
   bugbot?: string;
   bugbotCheckSuccess?: boolean;
 };
+
+function slotReviewSucceeded(slot: ReviewSlot, reviews: ReviewOutputs): boolean {
+  if (slot === 'standards' || slot === 'depth') {
+    const text = slot === 'standards' ? reviews.standards : reviews.depth;
+    return !!text && !!parseVerdictFromText(text);
+  }
+  if (reviews.bugbot && parseVerdictFromText(reviews.bugbot)) return true;
+  return reviews.bugbotCheckSuccess === true;
+}
 
 export function aggregateCycle(
   repoRoot: string,
@@ -58,13 +68,15 @@ export function aggregateCycle(
     }
   }
 
+  const allSlotsSucceeded = activePair.every((slot) => slotReviewSucceeded(slot, reviews));
+
   const newBlockingCount = newBlockingFingerprints.length;
   const ciFailed =
     isCiFailed(ciChecks) || process.env.CI_TRIGGER_FAILED === 'true';
   const ciGreen = isCiGreen(ciChecks);
 
   let consecutiveNoNewReviews = state.consecutiveNoNewReviews;
-  if (newBlockingCount === 0 && allApproved) {
+  if (newBlockingCount === 0 && allApproved && allSlotsSucceeded) {
     consecutiveNoNewReviews += 1;
   } else {
     consecutiveNoNewReviews = 0;
@@ -163,12 +175,7 @@ export async function loadBugbotVerdict(
   repo: string,
   issueNumber: number,
 ): Promise<string | undefined> {
-  const { data: comments } = await octokit.issues.listComments({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    per_page: 100,
-  });
+  const comments = await listAllIssueComments(octokit, owner, repo, issueNumber);
   const verdictComment = [...comments]
     .reverse()
     .find((c) => c.body?.includes(MARKER_BUGBOT_VERDICT));

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -1,0 +1,176 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Octokit } from '@octokit/rest';
+import { loadConfig } from './config.js';
+import {
+  mergeFindings,
+  openBlocking,
+  parseVerdictFromText,
+  sourceCounts,
+  verdictToFindings,
+} from './findings.js';
+import { frozenPairFromFindings } from './rotate.js';
+import { MARKER_BUGBOT_VERDICT, type AggregateOutput, type PrAgentState, type ReviewSlot } from './types.js';
+import { isCiFailed, isCiGreen, type CiCheckStatus } from './ci-gates.js';
+
+export type ReviewOutputs = {
+  standards?: string;
+  depth?: string;
+  bugbot?: string;
+  bugbotCheckSuccess?: boolean;
+};
+
+export function aggregateCycle(
+  repoRoot: string,
+  state: PrAgentState,
+  reviews: ReviewOutputs,
+  ciChecks: CiCheckStatus[],
+  activePair: ReviewSlot[],
+): AggregateOutput {
+  const config = loadConfig(repoRoot);
+  let cycle = state.cycle;
+  let openFindings = [...state.openFindings];
+  let nitFindings = [...state.nitFindings];
+  let newBlockingFingerprints: string[] = [];
+  let allApproved = true;
+
+  const ingest = (text: string | undefined, source: ReviewSlot) => {
+    if (!text) return;
+    const verdict = parseVerdictFromText(text);
+    if (!verdict) return;
+    if (verdict.verdict !== 'approve') allApproved = false;
+    const { blocking, nits } = verdictToFindings(verdict, source, cycle);
+    const mergedOpen = mergeFindings(openFindings, blocking, cycle);
+    openFindings = mergedOpen.merged;
+    newBlockingFingerprints.push(...mergedOpen.newFingerprints);
+    const mergedNits = mergeFindings(nitFindings, nits, cycle);
+    nitFindings = mergedNits.merged;
+  };
+
+  if (activePair.includes('standards')) ingest(reviews.standards, 'standards');
+  if (activePair.includes('depth')) ingest(reviews.depth, 'depth');
+  if (activePair.includes('bugbot')) {
+    if (reviews.bugbot) {
+      ingest(reviews.bugbot, 'bugbot');
+    }
+    if (reviews.bugbotCheckSuccess === false) {
+      allApproved = false;
+    }
+  }
+
+  const newBlockingCount = newBlockingFingerprints.length;
+  const ciFailed =
+    isCiFailed(ciChecks) || process.env.CI_TRIGGER_FAILED === 'true';
+  const ciGreen = isCiGreen(ciChecks);
+
+  let consecutiveNoNewReviews = state.consecutiveNoNewReviews;
+  if (newBlockingCount === 0 && allApproved) {
+    consecutiveNoNewReviews += 1;
+  } else {
+    consecutiveNoNewReviews = 0;
+  }
+
+  let phase = state.phase;
+  let frozenPair = state.frozenPair;
+  if (state.fixRound > 0 || openFindings.length > 0) {
+    phase = 'convergence';
+    if (!frozenPair || frozenPair.length < 2) {
+      frozenPair = frozenPairFromFindings(sourceCounts(openFindings));
+    }
+  }
+
+  let status = state.status;
+  let handoffReason: AggregateOutput['handoffReason'];
+
+  const openCount = openBlocking(openFindings).length;
+  let stagnationFixRounds = state.stagnationFixRounds;
+  if (state.lastOpenCount !== undefined && openCount === state.lastOpenCount && openCount > 0) {
+    stagnationFixRounds += 1;
+  } else if (openCount < (state.lastOpenCount ?? openCount)) {
+    stagnationFixRounds = 0;
+  }
+
+  if (state.fixRound >= config.limits.maxFixRounds) {
+    status = 'budget_exhausted';
+    handoffReason = 'budget_exhausted';
+  } else if (state.cycle >= config.limits.maxOrchestratorCycles) {
+    status = 'budget_exhausted';
+    handoffReason = 'budget_exhausted';
+  } else if (newBlockingCount >= config.limits.maxNewBlockingPerCycle) {
+    status = 'diverging';
+    handoffReason = 'diverging';
+  } else if (stagnationFixRounds >= 2 && openCount > 0) {
+    status = 'diverging';
+    handoffReason = 'diverging';
+  } else if (newBlockingCount >= 3 && state.fixRound >= 2) {
+    status = 'diverging';
+    handoffReason = 'diverging';
+  }
+
+  const cleanHandoff =
+    ciGreen &&
+    openCount === 0 &&
+    consecutiveNoNewReviews >= config.limits.consecutiveNoNewReviewsForHandoff;
+
+  if (cleanHandoff && status === 'in_progress') {
+    status = 'human_handoff';
+    handoffReason = 'human_handoff';
+  }
+
+  const shouldHandoff =
+    status === 'human_handoff' || status === 'budget_exhausted' || status === 'diverging';
+
+  const shouldFix =
+    !shouldHandoff &&
+    status === 'in_progress' &&
+    (openCount > 0 || ciFailed) &&
+    state.fixRound < config.limits.maxFixRounds;
+
+  const nextState: PrAgentState = {
+    ...state,
+    cycle: cycle + 1,
+    totalReviewerRuns: state.totalReviewerRuns + 1,
+    openFindings,
+    nitFindings,
+    consecutiveNoNewReviews,
+    phase,
+    frozenPair,
+    lastPair: activePair,
+    status,
+    stagnationFixRounds,
+    lastOpenCount: openCount,
+  };
+
+  return {
+    state: nextState,
+    shouldFix,
+    shouldHandoff,
+    handoffReason,
+    ciFailed,
+    newBlockingCount,
+  };
+}
+
+export function loadReviewOutput(repoRoot: string, slot: ReviewSlot): string | undefined {
+  const path = join(repoRoot, `.pr-agent/review-${slot}.txt`);
+  if (!existsSync(path)) return undefined;
+  return readFileSync(path, 'utf8');
+}
+
+export async function loadBugbotVerdict(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<string | undefined> {
+  const { data: comments } = await octokit.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+  const verdictComment = [...comments]
+    .reverse()
+    .find((c) => c.body?.includes(MARKER_BUGBOT_VERDICT));
+  return verdictComment?.body ?? undefined;
+}

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -27,8 +27,8 @@ function slotReviewSucceeded(slot: ReviewSlot, reviews: ReviewOutputs): boolean 
     const text = slot === 'standards' ? reviews.standards : reviews.depth;
     return !!text && !!parseVerdictFromText(text);
   }
-  if (reviews.bugbot && parseVerdictFromText(reviews.bugbot)) return true;
-  return reviews.bugbotCheckSuccess === true;
+  if (reviews.bugbotCheckSuccess !== true) return false;
+  return !!reviews.bugbot && !!parseVerdictFromText(reviews.bugbot);
 }
 
 export function aggregateCycle(
@@ -72,7 +72,7 @@ export function aggregateCycle(
   if (activePair.includes('standards')) ingest(reviews.standards, 'standards');
   if (activePair.includes('depth')) ingest(reviews.depth, 'depth');
   if (activePair.includes('bugbot')) {
-    if (reviews.bugbot) {
+    if (reviews.bugbotCheckSuccess === true && reviews.bugbot) {
       ingest(reviews.bugbot, 'bugbot');
     }
     if (reviews.bugbotCheckSuccess === false) {
@@ -189,8 +189,27 @@ export async function loadBugbotVerdict(
   issueNumber: number,
 ): Promise<string | undefined> {
   const comments = await listAllIssueComments(octokit, owner, repo, issueNumber);
+
+  const triggerComments = comments.filter(
+    (c) => c.body?.trim() === 'bugbot run' || c.body?.includes('bugbot run'),
+  );
+  const latestTrigger = [...triggerComments].sort(
+    (a, b) =>
+      new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+  )[0];
+  if (!latestTrigger?.created_at) return undefined;
+
+  const triggerTime = new Date(latestTrigger.created_at).getTime();
   const verdictComment = [...comments]
-    .reverse()
-    .find((c) => c.body?.includes(MARKER_BUGBOT_VERDICT));
+    .filter(
+      (c) =>
+        c.body?.includes(MARKER_BUGBOT_VERDICT) &&
+        new Date(c.created_at ?? 0).getTime() >= triggerTime,
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+    )[0];
+
   return verdictComment?.body ?? undefined;
 }

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -6,6 +6,7 @@ import {
   mergeFindings,
   openBlocking,
   parseVerdictFromText,
+  resolveOpenFindingsFromSource,
   sourceCounts,
   verdictToFindings,
 } from './findings.js';
@@ -40,6 +41,7 @@ export function aggregateCycle(
   const config = loadConfig(repoRoot);
   let cycle = state.cycle;
   let openFindings = [...state.openFindings];
+  let resolvedFindings = [...state.resolvedFindings];
   let nitFindings = [...state.nitFindings];
   let newBlockingFingerprints: string[] = [];
   let allApproved = true;
@@ -55,6 +57,16 @@ export function aggregateCycle(
     newBlockingFingerprints.push(...mergedOpen.newFingerprints);
     const mergedNits = mergeFindings(nitFindings, nits, cycle);
     nitFindings = mergedNits.merged;
+    if (verdict.verdict === 'approve' && blocking.length === 0) {
+      const resolved = resolveOpenFindingsFromSource(
+        openFindings,
+        resolvedFindings,
+        source,
+        cycle,
+      );
+      openFindings = resolved.open;
+      resolvedFindings = resolved.resolved;
+    }
   };
 
   if (activePair.includes('standards')) ingest(reviews.standards, 'standards');
@@ -65,6 +77,18 @@ export function aggregateCycle(
     }
     if (reviews.bugbotCheckSuccess === false) {
       allApproved = false;
+    } else if (
+      reviews.bugbotCheckSuccess === true &&
+      (!reviews.bugbot || !parseVerdictFromText(reviews.bugbot))
+    ) {
+      const resolved = resolveOpenFindingsFromSource(
+        openFindings,
+        resolvedFindings,
+        'bugbot',
+        cycle,
+      );
+      openFindings = resolved.open;
+      resolvedFindings = resolved.resolved;
     }
   }
 
@@ -143,6 +167,7 @@ export function aggregateCycle(
     cycle: cycle + 1,
     totalReviewerRuns: state.totalReviewerRuns + 1,
     openFindings,
+    resolvedFindings,
     nitFindings,
     consecutiveNoNewReviews,
     phase,

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -47,6 +47,8 @@ export function aggregateCycle(
   const newBlockingFingerprints: string[] = [];
   let allApproved = true;
 
+  const muted = new Set(state.mutedFingerprints);
+
   const ingest = (
     text: string | undefined,
     source: ReviewSlot,
@@ -56,7 +58,9 @@ export function aggregateCycle(
     const verdict = parseVerdictFromText(text);
     if (!verdict) return;
     if (verdict.verdict !== 'approve') allApproved = false;
-    const { blocking, nits } = verdictToFindings(verdict, source, cycle);
+    const { blocking: rawBlocking, nits } = verdictToFindings(verdict, source, cycle);
+    // Drop findings a human marked as false positive via `agent-resolve`.
+    const blocking = rawBlocking.filter((b) => !muted.has(b.fingerprint));
     const mergedOpen = mergeFindings(openFindings, blocking, cycle);
     openFindings = mergedOpen.merged;
     newBlockingFingerprints.push(...mergedOpen.newFingerprints);

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -19,6 +19,7 @@ export type ReviewOutputs = {
   standards?: string;
   depth?: string;
   bugbot?: string;
+  bugbotCheckCompleted?: boolean;
   bugbotCheckSuccess?: boolean;
 };
 
@@ -27,7 +28,7 @@ function slotReviewSucceeded(slot: ReviewSlot, reviews: ReviewOutputs): boolean 
     const text = slot === 'standards' ? reviews.standards : reviews.depth;
     return !!text && !!parseVerdictFromText(text);
   }
-  if (reviews.bugbotCheckSuccess !== true) return false;
+  if (reviews.bugbotCheckCompleted !== true) return false;
   return !!reviews.bugbot && !!parseVerdictFromText(reviews.bugbot);
 }
 
@@ -46,7 +47,11 @@ export function aggregateCycle(
   let newBlockingFingerprints: string[] = [];
   let allApproved = true;
 
-  const ingest = (text: string | undefined, source: ReviewSlot) => {
+  const ingest = (
+    text: string | undefined,
+    source: ReviewSlot,
+    options?: { resolveOnApprove?: boolean },
+  ) => {
     if (!text) return;
     const verdict = parseVerdictFromText(text);
     if (!verdict) return;
@@ -57,7 +62,8 @@ export function aggregateCycle(
     newBlockingFingerprints.push(...mergedOpen.newFingerprints);
     const mergedNits = mergeFindings(nitFindings, nits, cycle);
     nitFindings = mergedNits.merged;
-    if (verdict.verdict === 'approve' && blocking.length === 0) {
+    const resolveOnApprove = options?.resolveOnApprove ?? true;
+    if (verdict.verdict === 'approve' && blocking.length === 0 && resolveOnApprove) {
       const resolved = resolveOpenFindingsFromSource(
         openFindings,
         resolvedFindings,
@@ -72,10 +78,12 @@ export function aggregateCycle(
   if (activePair.includes('standards')) ingest(reviews.standards, 'standards');
   if (activePair.includes('depth')) ingest(reviews.depth, 'depth');
   if (activePair.includes('bugbot')) {
-    if (reviews.bugbotCheckSuccess === true && reviews.bugbot) {
-      ingest(reviews.bugbot, 'bugbot');
+    if (reviews.bugbotCheckCompleted === true && reviews.bugbot) {
+      ingest(reviews.bugbot, 'bugbot', {
+        resolveOnApprove: reviews.bugbotCheckSuccess === true,
+      });
     }
-    if (reviews.bugbotCheckSuccess === false) {
+    if (reviews.bugbotCheckCompleted === false) {
       allApproved = false;
     }
   }

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -77,18 +77,6 @@ export function aggregateCycle(
     }
     if (reviews.bugbotCheckSuccess === false) {
       allApproved = false;
-    } else if (
-      reviews.bugbotCheckSuccess === true &&
-      (!reviews.bugbot || !parseVerdictFromText(reviews.bugbot))
-    ) {
-      const resolved = resolveOpenFindingsFromSource(
-        openFindings,
-        resolvedFindings,
-        'bugbot',
-        cycle,
-      );
-      openFindings = resolved.open;
-      resolvedFindings = resolved.resolved;
     }
   }
 

--- a/scripts/pr-agent/src/aggregate.ts
+++ b/scripts/pr-agent/src/aggregate.ts
@@ -40,11 +40,11 @@ export function aggregateCycle(
   activePair: ReviewSlot[],
 ): AggregateOutput {
   const config = loadConfig(repoRoot);
-  let cycle = state.cycle;
+  const cycle = state.cycle;
   let openFindings = [...state.openFindings];
   let resolvedFindings = [...state.resolvedFindings];
   let nitFindings = [...state.nitFindings];
-  let newBlockingFingerprints: string[] = [];
+  const newBlockingFingerprints: string[] = [];
   let allApproved = true;
 
   const ingest = (

--- a/scripts/pr-agent/src/bugbot.ts
+++ b/scripts/pr-agent/src/bugbot.ts
@@ -1,0 +1,40 @@
+import type { Octokit } from '@octokit/rest';
+
+const BUGBOT_CHECK_NAME = 'Cursor Bugbot';
+
+export async function triggerBugbot(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<void> {
+  await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body: 'bugbot run',
+  });
+}
+
+export async function pollBugbotCheck(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  maxWaitMin: number,
+): Promise<{ completed: boolean; success: boolean }> {
+  const deadline = Date.now() + maxWaitMin * 60_000;
+  while (Date.now() < deadline) {
+    const { data } = await octokit.checks.listForRef({ owner, repo, ref, per_page: 100 });
+    const run = data.check_runs.find((r) => r.name === BUGBOT_CHECK_NAME);
+    if (run?.status === 'completed') {
+      return { completed: true, success: run.conclusion === 'success' };
+    }
+    await sleep(20_000);
+  }
+  return { completed: false, success: false };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/scripts/pr-agent/src/bugbot.ts
+++ b/scripts/pr-agent/src/bugbot.ts
@@ -26,9 +26,15 @@ export async function pollBugbotCheck(
   const deadline = Date.now() + maxWaitMin * 60_000;
   while (Date.now() < deadline) {
     const { data } = await octokit.checks.listForRef({ owner, repo, ref, per_page: 100 });
-    const run = data.check_runs.find((r) => r.name === BUGBOT_CHECK_NAME);
-    if (run?.status === 'completed') {
-      return { completed: true, success: run.conclusion === 'success' };
+    const matching = data.check_runs.filter((r) => r.name === BUGBOT_CHECK_NAME);
+    if (matching.length > 0) {
+      const latest = [...matching].sort(
+        (a, b) =>
+          new Date(b.started_at ?? 0).getTime() - new Date(a.started_at ?? 0).getTime() || b.id - a.id,
+      )[0]!;
+      if (latest.status === 'completed') {
+        return { completed: true, success: latest.conclusion === 'success' };
+      }
     }
     await sleep(20_000);
   }

--- a/scripts/pr-agent/src/ci-gates.ts
+++ b/scripts/pr-agent/src/ci-gates.ts
@@ -61,9 +61,6 @@ export async function fetchWorkflowStatuses(
   });
 }
 
-/** @deprecated Use fetchWorkflowStatuses */
-export const fetchCheckStatuses = fetchWorkflowStatuses;
-
 function requiredChecks(checks: CiCheckStatus[]): CiCheckStatus[] {
   return checks.filter((c) => c.required);
 }
@@ -123,16 +120,6 @@ export async function getPrHeadSha(
 ): Promise<string> {
   const { data } = await octokit.pulls.get({ owner, repo, pull_number: pullNumber });
   return data.head.sha;
-}
-
-export async function getPrHeadRef(
-  octokit: Octokit,
-  owner: string,
-  repo: string,
-  pullNumber: number,
-): Promise<string> {
-  const { data } = await octokit.pulls.get({ owner, repo, pull_number: pullNumber });
-  return data.head.ref;
 }
 
 export async function getChangedFiles(

--- a/scripts/pr-agent/src/ci-gates.ts
+++ b/scripts/pr-agent/src/ci-gates.ts
@@ -1,0 +1,117 @@
+import { minimatch } from 'minimatch';
+import type { Octokit } from '@octokit/rest';
+import { loadConfig } from './config.js';
+
+export type CiCheckStatus = {
+  name: string;
+  status: string;
+  conclusion: string | null;
+  required: boolean;
+};
+
+export function requiredWorkflowsForPaths(changedFiles: string[], repoRoot: string): string[] {
+  const config = loadConfig(repoRoot);
+  const required = new Set<string>();
+  for (const gate of config.ciGates) {
+    const matches = changedFiles.some((f) =>
+      gate.paths.some((p) => minimatch(f, p, { dot: true })),
+    );
+    if (matches) {
+      for (const w of gate.workflows) required.add(w);
+    }
+  }
+  return [...required];
+}
+
+export async function fetchCheckStatuses(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  requiredNames: string[],
+): Promise<CiCheckStatus[]> {
+  const { data } = await octokit.checks.listForRef({ owner, repo, ref, per_page: 100 });
+  const runs = data.check_runs;
+
+  return requiredNames.map((name) => {
+    const run = runs.find((r) => r.name === name);
+    return {
+      name,
+      status: run?.status ?? 'missing',
+      conclusion: run?.conclusion ?? null,
+      required: true,
+    };
+  });
+}
+
+export function isCiGreen(checks: CiCheckStatus[]): boolean {
+  if (checks.length === 0) return true;
+  return checks.every(
+    (c) => c.status === 'completed' && (c.conclusion === 'success' || c.conclusion === 'skipped'),
+  );
+}
+
+export function isCiFailed(checks: CiCheckStatus[]): boolean {
+  return checks.some(
+    (c) =>
+      c.status === 'completed' &&
+      c.conclusion != null &&
+      !['success', 'skipped', 'neutral'].includes(c.conclusion),
+  );
+}
+
+export async function pollCiUntilSettled(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  ref: string,
+  requiredNames: string[],
+  maxWaitMin: number,
+): Promise<CiCheckStatus[]> {
+  const deadline = Date.now() + maxWaitMin * 60_000;
+  while (Date.now() < deadline) {
+    const checks = await fetchCheckStatuses(octokit, owner, repo, ref, requiredNames);
+    const allCompleted = checks.every(
+      (c) => c.status === 'completed' || c.status === 'missing',
+    );
+    if (allCompleted) return checks;
+    await sleep(30_000);
+  }
+  return fetchCheckStatuses(octokit, owner, repo, ref, requiredNames);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export async function getPrHeadSha(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<string> {
+  const { data } = await octokit.pulls.get({ owner, repo, pull_number: pullNumber });
+  return data.head.sha;
+}
+export async function getChangedFiles(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<string[]> {
+  const files: string[] = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.pulls.listFiles({
+      owner,
+      repo,
+      pull_number: pullNumber,
+      per_page: 100,
+      page,
+    });
+    if (data.length === 0) break;
+    files.push(...data.map((f) => f.filename));
+    page++;
+  }
+  return files;
+}

--- a/scripts/pr-agent/src/ci-gates.ts
+++ b/scripts/pr-agent/src/ci-gates.ts
@@ -23,40 +23,71 @@ export function requiredWorkflowsForPaths(changedFiles: string[], repoRoot: stri
   return [...required];
 }
 
-export async function fetchCheckStatuses(
+/** Match configured workflow `name:` values via Actions workflow runs for the commit. */
+export async function fetchWorkflowStatuses(
   octokit: Octokit,
   owner: string,
   repo: string,
   ref: string,
-  requiredNames: string[],
+  requiredWorkflowNames: string[],
 ): Promise<CiCheckStatus[]> {
-  const { data } = await octokit.checks.listForRef({ owner, repo, ref, per_page: 100 });
-  const runs = data.check_runs;
+  const { data } = await octokit.actions.listWorkflowRunsForRepo({
+    owner,
+    repo,
+    head_sha: ref,
+    per_page: 100,
+  });
 
-  return requiredNames.map((name) => {
-    const run = runs.find((r) => r.name === name);
+  return requiredWorkflowNames.map((workflowName) => {
+    const runs = data.workflow_runs.filter((r) => r.name === workflowName);
+    if (runs.length === 0) {
+      return {
+        name: workflowName,
+        status: 'not_required',
+        conclusion: null,
+        required: false,
+      };
+    }
+    const latest = [...runs].sort(
+      (a, b) =>
+        new Date(b.created_at ?? 0).getTime() - new Date(a.created_at ?? 0).getTime(),
+    )[0]!;
     return {
-      name,
-      status: run?.status ?? 'missing',
-      conclusion: run?.conclusion ?? null,
+      name: workflowName,
+      status: latest.status ?? 'missing',
+      conclusion: latest.conclusion ?? null,
       required: true,
     };
   });
 }
 
+/** @deprecated Use fetchWorkflowStatuses */
+export const fetchCheckStatuses = fetchWorkflowStatuses;
+
+function requiredChecks(checks: CiCheckStatus[]): CiCheckStatus[] {
+  return checks.filter((c) => c.required);
+}
+
 export function isCiGreen(checks: CiCheckStatus[]): boolean {
-  if (checks.length === 0) return true;
-  return checks.every(
-    (c) => c.status === 'completed' && (c.conclusion === 'success' || c.conclusion === 'skipped'),
-  );
+  const required = requiredChecks(checks);
+  if (required.length === 0) return true;
+  return required.every((c) => {
+    if (['in_progress', 'queued', 'waiting', 'pending'].includes(c.status)) {
+      return false;
+    }
+    if (c.status === 'completed') {
+      return c.conclusion === 'success' || c.conclusion === 'skipped';
+    }
+    return false;
+  });
 }
 
 export function isCiFailed(checks: CiCheckStatus[]): boolean {
-  return checks.some(
+  return requiredChecks(checks).some(
     (c) =>
       c.status === 'completed' &&
       c.conclusion != null &&
-      !['success', 'skipped', 'neutral'].includes(c.conclusion),
+      !['success', 'skipped'].includes(c.conclusion),
   );
 }
 
@@ -70,14 +101,14 @@ export async function pollCiUntilSettled(
 ): Promise<CiCheckStatus[]> {
   const deadline = Date.now() + maxWaitMin * 60_000;
   while (Date.now() < deadline) {
-    const checks = await fetchCheckStatuses(octokit, owner, repo, ref, requiredNames);
-    const allCompleted = checks.every(
-      (c) => c.status === 'completed' || c.status === 'missing',
-    );
-    if (allCompleted) return checks;
+    const checks = await fetchWorkflowStatuses(octokit, owner, repo, ref, requiredNames);
+    const required = requiredChecks(checks);
+    if (required.length === 0) return checks;
+    const allSettled = required.every((c) => c.status === 'completed');
+    if (allSettled) return checks;
     await sleep(30_000);
   }
-  return fetchCheckStatuses(octokit, owner, repo, ref, requiredNames);
+  return fetchWorkflowStatuses(octokit, owner, repo, ref, requiredNames);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -93,6 +124,17 @@ export async function getPrHeadSha(
   const { data } = await octokit.pulls.get({ owner, repo, pull_number: pullNumber });
   return data.head.sha;
 }
+
+export async function getPrHeadRef(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  pullNumber: number,
+): Promise<string> {
+  const { data } = await octokit.pulls.get({ owner, repo, pull_number: pullNumber });
+  return data.head.ref;
+}
+
 export async function getChangedFiles(
   octokit: Octokit,
   owner: string,

--- a/scripts/pr-agent/src/ci-gates.ts
+++ b/scripts/pr-agent/src/ci-gates.ts
@@ -43,9 +43,9 @@ export async function fetchWorkflowStatuses(
     if (runs.length === 0) {
       return {
         name: workflowName,
-        status: 'not_required',
+        status: 'pending',
         conclusion: null,
-        required: false,
+        required: true,
       };
     }
     const latest = [...runs].sort(

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -4,9 +4,10 @@ import { join } from 'node:path';
 import { aggregateCycle, loadBugbotVerdict, loadReviewOutput } from './aggregate.js';
 import { pollBugbotCheck, triggerBugbot } from './bugbot.js';
 import {
-  fetchCheckStatuses,
+  fetchWorkflowStatuses,
   getChangedFiles,
   getPrHeadSha,
+  isCiGreen,
   pollCiUntilSettled,
   requiredWorkflowsForPaths,
 } from './ci-gates.js';
@@ -14,6 +15,7 @@ import { loadConfig } from './config.js';
 import { runFix } from './fix.js';
 import { buildHandoffComment } from './handoff.js';
 import { runPlan, writePlanOutputs } from './plan.js';
+import { recheckHandoff } from './recheck-handoff.js';
 import { runReview } from './review.js';
 import {
   createOctokit,
@@ -81,7 +83,7 @@ async function cmdAggregate() {
 
   const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
   const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
-  const ciChecks = await fetchCheckStatuses(octokit, owner, repo, headSha, required);
+  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, headSha, required);
 
   const reviews = {
     standards: loadReviewOutput(repoRoot, 'standards'),
@@ -138,16 +140,23 @@ async function cmdWaitCi() {
   );
   const out = process.env.GITHUB_OUTPUT;
   if (out) {
-    const green = checks.every((c) => {
-      if (c.status === 'missing') return true;
-      return (
-        c.status === 'completed' &&
-        (c.conclusion === 'success' || c.conclusion === 'skipped')
-      );
-    });
-    appendFileSync(out, `ci_green=${green}\n`);
+    appendFileSync(out, `ci_green=${isCiGreen(checks)}\n`);
   }
   console.log(JSON.stringify(checks, null, 2));
+}
+
+async function cmdRecheckHandoff() {
+  const octokit = createOctokit();
+  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const result = await recheckHandoff(repoRoot, octokit, owner, repo, prNumber, state);
+  await saveState(octokit, owner, repo, prNumber, result.state, commentId);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    appendFileSync(out, `should_handoff=${result.shouldHandoff}\n`);
+    appendFileSync(out, `handoff_reason=${result.handoffReason ?? ''}\n`);
+  }
+  console.log(JSON.stringify(result, null, 2));
 }
 
 async function cmdFinalize() {
@@ -159,7 +168,7 @@ async function cmdFinalize() {
   const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
   const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
   const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
-  const ciChecks = await fetchCheckStatuses(octokit, owner, repo, headSha, required);
+  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, headSha, required);
 
   const finalState = { ...state, status: reason };
   await saveState(octokit, owner, repo, prNumber, finalState, commentId);
@@ -203,6 +212,9 @@ async function main() {
     case 'wait-ci':
       await cmdWaitCi();
       break;
+    case 'recheck-handoff':
+      await cmdRecheckHandoff();
+      break;
     case 'finalize':
       await cmdFinalize();
       break;
@@ -210,7 +222,7 @@ async function main() {
     default:
       console.log(`Usage: cli.ts <command>
   plan | review <standards|depth> | bugbot-trigger | bugbot-poll
-  aggregate | fix | wait-ci | finalize`);
+  aggregate | fix | wait-ci | recheck-handoff | finalize`);
   }
 }
 

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -90,6 +90,7 @@ async function cmdAggregate() {
     standards: loadReviewOutput(repoRoot, 'standards'),
     depth: loadReviewOutput(repoRoot, 'depth'),
     bugbot: await loadBugbotVerdict(octokit, owner, repo, prNumber),
+    bugbotCheckCompleted: process.env.BUGBOT_COMPLETED === 'true',
     bugbotCheckSuccess: process.env.BUGBOT_SUCCESS === 'true',
   };
 

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+import { appendFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { aggregateCycle, loadBugbotVerdict, loadReviewOutput } from './aggregate.js';
+import { pollBugbotCheck, triggerBugbot } from './bugbot.js';
+import {
+  fetchCheckStatuses,
+  getChangedFiles,
+  getPrHeadSha,
+  pollCiUntilSettled,
+  requiredWorkflowsForPaths,
+} from './ci-gates.js';
+import { loadConfig } from './config.js';
+import { runFix } from './fix.js';
+import { buildHandoffComment } from './handoff.js';
+import { runPlan, writePlanOutputs } from './plan.js';
+import { runReview } from './review.js';
+import {
+  createOctokit,
+  ensureLabel,
+  loadOrCreateState,
+  removeLabel,
+  saveState,
+} from './state.js';
+import type { ReviewSlot } from './types.js';
+import { MARKER_HANDOFF } from './types.js';
+
+const repoRoot = process.env.GITHUB_WORKSPACE ?? process.cwd();
+const owner = process.env.GITHUB_REPOSITORY_OWNER!;
+const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]!;
+const prNumber = Number(process.env.PR_NUMBER);
+const headSha = process.env.HEAD_SHA ?? '';
+const baseRef = process.env.BASE_REF ?? 'main';
+
+function env() {
+  return { owner, repo, prNumber, headSha, baseRef, repoRoot };
+}
+
+async function cmdPlan() {
+  const plan = await runPlan(repoRoot);
+  console.log(JSON.stringify(plan, null, 2));
+  await writePlanOutputs(plan);
+}
+
+async function cmdReview(slot: string) {
+  const { state } = await loadOrCreateState(createOctokit(), owner, repo, prNumber);
+  if (slot !== 'standards' && slot !== 'depth') {
+    throw new Error('slot must be standards or depth');
+  }
+  await runReview(repoRoot, slot, prNumber, baseRef, state);
+}
+
+async function cmdBugbotTrigger() {
+  await triggerBugbot(createOctokit(), owner, repo, prNumber);
+}
+
+async function cmdBugbotPoll() {
+  const config = loadConfig(repoRoot);
+  const result = await pollBugbotCheck(
+    createOctokit(),
+    owner,
+    repo,
+    headSha,
+    config.limits.maxBugbotWaitMin,
+  );
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    appendFileSync(out, `bugbot_completed=${result.completed}\n`);
+    appendFileSync(out, `bugbot_success=${result.success}\n`);
+  }
+  console.log(JSON.stringify(result));
+}
+
+async function cmdAggregate() {
+  const octokit = createOctokit();
+  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+
+  const activePair = (process.env.ACTIVE_PAIR ?? 'bugbot,standards')
+    .split(',')
+    .filter(Boolean) as ReviewSlot[];
+
+  const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+  const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+  const ciChecks = await fetchCheckStatuses(octokit, owner, repo, headSha, required);
+
+  const reviews = {
+    standards: loadReviewOutput(repoRoot, 'standards'),
+    depth: loadReviewOutput(repoRoot, 'depth'),
+    bugbot: await loadBugbotVerdict(octokit, owner, repo, prNumber),
+    bugbotCheckSuccess: process.env.BUGBOT_SUCCESS === 'true',
+  };
+
+  const result = aggregateCycle(repoRoot, state, reviews, ciChecks, activePair);
+
+  if (result.shouldFix) {
+    result.state.fixRound = state.fixRound;
+  }
+
+  await saveState(octokit, owner, repo, prNumber, result.state, commentId);
+
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    appendFileSync(out, `should_fix=${result.shouldFix}\n`);
+    appendFileSync(out, `should_handoff=${result.shouldHandoff}\n`);
+    appendFileSync(out, `handoff_reason=${result.handoffReason ?? ''}\n`);
+    appendFileSync(out, `ci_failed=${result.ciFailed}\n`);
+    appendFileSync(out, `fix_round=${result.state.fixRound}\n`);
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+async function cmdFix() {
+  const octokit = createOctokit();
+  const { state } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const ciLog = process.env.CI_LOG_EXCERPT ?? '';
+  await runFix(repoRoot, state, ciLog);
+  const next = { ...state, fixRound: state.fixRound + 1 };
+  const { commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  await saveState(octokit, owner, repo, prNumber, next, commentId);
+}
+
+async function cmdWaitCi() {
+  const config = loadConfig(repoRoot);
+  const octokit = createOctokit();
+  const ref =
+    (await getPrHeadSha(octokit, owner, repo, prNumber)) || headSha;
+  const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+  const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+  const checks = await pollCiUntilSettled(
+    octokit,
+    owner,
+    repo,
+    ref,
+    required,
+    config.limits.maxCiWaitMin,
+  );
+  const out = process.env.GITHUB_OUTPUT;
+  if (out) {
+    const green = checks.every((c) => {
+      if (c.status === 'missing') return true;
+      return (
+        c.status === 'completed' &&
+        (c.conclusion === 'success' || c.conclusion === 'skipped')
+      );
+    });
+    appendFileSync(out, `ci_green=${green}\n`);
+  }
+  console.log(JSON.stringify(checks, null, 2));
+}
+
+async function cmdFinalize() {
+  const reason = (process.env.HANDOFF_REASON ?? 'human_handoff') as
+    | 'human_handoff'
+    | 'budget_exhausted'
+    | 'diverging';
+  const octokit = createOctokit();
+  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+  const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+  const ciChecks = await fetchCheckStatuses(octokit, owner, repo, headSha, required);
+
+  const finalState = { ...state, status: reason };
+  await saveState(octokit, owner, repo, prNumber, finalState, commentId);
+
+  const body = buildHandoffComment(reason, finalState, ciChecks);
+  await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: prNumber,
+    body,
+  });
+
+  await ensureLabel(octokit, owner, repo, prNumber, 'ready-for-human-review');
+  if (reason !== 'human_handoff') {
+    await ensureLabel(octokit, owner, repo, prNumber, 'agent-needs-human');
+  }
+  await removeLabel(octokit, owner, repo, prNumber, 'agent-in-progress');
+}
+
+async function main() {
+  const [command, arg] = process.argv.slice(2);
+  switch (command) {
+    case 'plan':
+      await cmdPlan();
+      break;
+    case 'review':
+      await cmdReview(arg!);
+      break;
+    case 'bugbot-trigger':
+      await cmdBugbotTrigger();
+      break;
+    case 'bugbot-poll':
+      await cmdBugbotPoll();
+      break;
+    case 'aggregate':
+      await cmdAggregate();
+      break;
+    case 'fix':
+      await cmdFix();
+      break;
+    case 'wait-ci':
+      await cmdWaitCi();
+      break;
+    case 'finalize':
+      await cmdFinalize();
+      break;
+    case 'help':
+    default:
+      console.log(`Usage: cli.ts <command>
+  plan | review <standards|depth> | bugbot-trigger | bugbot-poll
+  aggregate | fix | wait-ci | finalize`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -25,7 +25,6 @@ import {
   saveState,
 } from './state.js';
 import type { ReviewSlot } from './types.js';
-import { MARKER_HANDOFF } from './types.js';
 
 const repoRoot = process.env.GITHUB_WORKSPACE ?? process.cwd();
 const owner = process.env.GITHUB_REPOSITORY_OWNER!;
@@ -33,10 +32,6 @@ const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]!;
 const prNumber = Number(process.env.PR_NUMBER);
 const headSha = process.env.HEAD_SHA ?? '';
 const baseRef = process.env.BASE_REF ?? 'main';
-
-function env() {
-  return { owner, repo, prNumber, headSha, baseRef, repoRoot };
-}
 
 async function cmdPlan() {
   const plan = await runPlan(repoRoot);
@@ -95,10 +90,6 @@ async function cmdAggregate() {
   };
 
   const result = aggregateCycle(repoRoot, state, reviews, ciChecks, activePair);
-
-  if (result.shouldFix) {
-    result.state.fixRound = state.fixRound;
-  }
 
   await saveState(octokit, owner, repo, prNumber, result.state, commentId);
 

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -83,7 +83,8 @@ async function cmdAggregate() {
 
   const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
   const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
-  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, headSha, required);
+  const ref = (await getPrHeadSha(octokit, owner, repo, prNumber)) || headSha;
+  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
 
   const reviews = {
     standards: loadReviewOutput(repoRoot, 'standards'),

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -118,8 +118,8 @@ async function cmdFix() {
   const octokit = createOctokit();
   const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
   const ciLog = process.env.CI_LOG_EXCERPT ?? '';
-  const committed = await runFix(repoRoot, state, ciLog);
-  if (committed) {
+  const { ran } = await runFix(repoRoot, state, ciLog);
+  if (ran) {
     const next = { ...state, fixRound: state.fixRound + 1 };
     await saveState(octokit, owner, repo, prNumber, next, commentId);
   }

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -41,7 +41,7 @@ function env() {
 async function cmdPlan() {
   const plan = await runPlan(repoRoot);
   console.log(JSON.stringify(plan, null, 2));
-  await writePlanOutputs(plan);
+  await writePlanOutputs(repoRoot, plan);
 }
 
 async function cmdReview(slot: string) {
@@ -166,9 +166,10 @@ async function cmdFinalize() {
     | 'diverging';
   const octokit = createOctokit();
   const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const ref = (await getPrHeadSha(octokit, owner, repo, prNumber)) || headSha;
   const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
   const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
-  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, headSha, required);
+  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
 
   const finalState = { ...state, status: reason };
   await saveState(octokit, owner, repo, prNumber, finalState, commentId);

--- a/scripts/pr-agent/src/cli.ts
+++ b/scripts/pr-agent/src/cli.ts
@@ -112,12 +112,13 @@ async function cmdAggregate() {
 
 async function cmdFix() {
   const octokit = createOctokit();
-  const { state } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
   const ciLog = process.env.CI_LOG_EXCERPT ?? '';
-  await runFix(repoRoot, state, ciLog);
-  const next = { ...state, fixRound: state.fixRound + 1 };
-  const { commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
-  await saveState(octokit, owner, repo, prNumber, next, commentId);
+  const committed = await runFix(repoRoot, state, ciLog);
+  if (committed) {
+    const next = { ...state, fixRound: state.fixRound + 1 };
+    await saveState(octokit, owner, repo, prNumber, next, commentId);
+  }
 }
 
 async function cmdWaitCi() {

--- a/scripts/pr-agent/src/config.ts
+++ b/scripts/pr-agent/src/config.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+import { z } from 'zod';
+
+const ConfigSchema = z.object({
+  dryRun: z.boolean().default(true),
+  reviewModel: z.string().default('claude-4.6-sonnet-medium-thinking'),
+  fixModel: z.string().default('claude-opus-4-8-thinking-xhigh'),
+  authors: z
+    .object({
+      mode: z.enum(['allowlist', 'all', 'label_only']).default('label_only'),
+      allowlist: z.array(z.string()).default([]),
+    })
+    .default({ mode: 'label_only', allowlist: [] }),
+  limits: z
+    .object({
+      maxFixRounds: z.number().default(5),
+      maxOrchestratorCycles: z.number().default(8),
+      maxBugbotWaitMin: z.number().default(12),
+      maxCiWaitMin: z.number().default(45),
+      maxNewBlockingPerCycle: z.number().default(5),
+      maxFixAgentTurns: z.number().default(20),
+      consecutiveNoNewReviewsForHandoff: z.number().default(2),
+      discoveryCycles: z.number().default(1),
+    })
+    .default({}),
+  ciGates: z
+    .array(
+      z.object({
+        paths: z.array(z.string()),
+        workflows: z.array(z.string()),
+      }),
+    )
+    .default([]),
+});
+
+export type PrAgentConfig = z.infer<typeof ConfigSchema>;
+
+let cached: PrAgentConfig | null = null;
+
+export function loadConfig(repoRoot: string): PrAgentConfig {
+  if (cached) return cached;
+  const path = join(repoRoot, '.github/pr-agent.yml');
+  const raw = parse(readFileSync(path, 'utf8'));
+  cached = ConfigSchema.parse(raw);
+  return cached;
+}
+
+export function resetConfigCache(): void {
+  cached = null;
+}

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -59,9 +59,12 @@ export function mergeFindings(
   for (const f of incoming) {
     const prev = byFp.get(f.fingerprint);
     if (prev) {
-      prev.lastSeenCycle = cycle;
-      prev.message = f.message;
-      if (f.line) prev.line = f.line;
+      byFp.set(f.fingerprint, {
+        ...prev,
+        lastSeenCycle: cycle,
+        message: f.message,
+        line: f.line ?? prev.line,
+      });
     } else {
       byFp.set(f.fingerprint, {
         ...f,
@@ -114,21 +117,47 @@ export function sourceCounts(findings: Finding[]): Record<ReviewSlot, number> {
 }
 
 export function parseVerdictFromText(text: string): Verdict | null {
-  const lines = text.trim().split('\n');
-  for (let i = lines.length - 1; i >= 0; i--) {
-    const line = lines[i]!.trim();
-    if (!line.startsWith('{')) continue;
+  // Extract every balanced top-level JSON object (string-aware), then return the
+  // last one that validates as a verdict. Handles compact, pretty-printed, and
+  // fenced (```json) payloads regardless of surrounding prose.
+  const candidates = extractJsonObjects(text);
+  for (let i = candidates.length - 1; i >= 0; i--) {
     try {
-      return VerdictSchema.parse(JSON.parse(line));
+      return VerdictSchema.parse(JSON.parse(candidates[i]!));
     } catch {
       continue;
     }
   }
-  const match = text.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
-  if (!match) return null;
-  try {
-    return VerdictSchema.parse(JSON.parse(match[0]));
-  } catch {
-    return null;
+  return null;
+}
+
+function extractJsonObjects(text: string): string[] {
+  const objects: string[] = [];
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i]!;
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (ch === '\\') escaped = true;
+      else if (ch === '"') inString = false;
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (ch === '}' && depth > 0) {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        objects.push(text.slice(start, i + 1));
+        start = -1;
+      }
+    }
   }
+  return objects;
 }

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -77,6 +77,27 @@ export function mergeFindings(
   return { merged: [...byFp.values()], newFingerprints };
 }
 
+export function resolveOpenFindingsFromSource(
+  openFindings: Finding[],
+  resolvedFindings: Finding[],
+  source: string,
+  cycle: number,
+): { open: Finding[]; resolved: Finding[] } {
+  const toResolve = openFindings.filter(
+    (f) => f.source === source && f.severity === 'blocking' && f.status === 'open',
+  );
+  if (toResolve.length === 0) {
+    return { open: openFindings, resolved: resolvedFindings };
+  }
+  const resolvedIds = new Set(toResolve.map((f) => f.fingerprint));
+  const open = openFindings.filter((f) => !resolvedIds.has(f.fingerprint));
+  const resolved = [
+    ...resolvedFindings,
+    ...toResolve.map((f) => ({ ...f, status: 'resolved' as const, lastSeenCycle: cycle })),
+  ];
+  return { open, resolved };
+}
+
 export function openBlocking(findings: Finding[]): Finding[] {
   return findings.filter((f) => f.severity === 'blocking' && f.status === 'open');
 }

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -1,0 +1,115 @@
+import { createHash } from 'node:crypto';
+import { VerdictSchema, type Finding, type ReviewSlot, type Verdict } from './types.js';
+
+export function fingerprintFinding(file: string, message: string): string {
+  const category = categorize(message);
+  const normalizedFile = file.replace(/\\/g, '/').toLowerCase();
+  return `${normalizedFile}:${category}`;
+}
+
+function categorize(message: string): string {
+  const m = message.toLowerCase();
+  if (m.includes('thread') || m.includes('main thread')) return 'thread-safety';
+  if (m.includes('null') || m.includes('npe')) return 'null-safety';
+  if (m.includes('test')) return 'tests';
+  if (m.includes('security') || m.includes('secret')) return 'security';
+  if (m.includes('memory') || m.includes('leak')) return 'memory';
+  if (m.includes('race')) return 'race';
+  return createHash('sha1').update(m.slice(0, 80)).digest('hex').slice(0, 8);
+}
+
+export function shortId(fingerprint: string): string {
+  return createHash('sha1').update(fingerprint).digest('hex').slice(0, 6);
+}
+
+export function verdictToFindings(
+  verdict: Verdict,
+  source: ReviewSlot | string,
+  cycle: number,
+): { blocking: Finding[]; nits: Finding[] } {
+  const blocking: Finding[] = [];
+  const nits: Finding[] = [];
+
+  for (const f of verdict.findings) {
+    const fp = fingerprintFinding(f.file || 'unknown', f.message);
+    const item: Finding = {
+      id: shortId(fp),
+      fingerprint: fp,
+      source,
+      severity: f.severity,
+      file: f.file,
+      line: f.line,
+      message: f.message,
+      status: 'open',
+      introducedCycle: cycle,
+      lastSeenCycle: cycle,
+    };
+    if (f.severity === 'blocking') blocking.push(item);
+    else nits.push(item);
+  }
+  return { blocking, nits };
+}
+
+export function mergeFindings(
+  existing: Finding[],
+  incoming: Finding[],
+  cycle: number,
+): { merged: Finding[]; newFingerprints: string[] } {
+  const byFp = new Map(existing.map((f) => [f.fingerprint, f]));
+  const newFingerprints: string[] = [];
+
+  for (const f of incoming) {
+    const prev = byFp.get(f.fingerprint);
+    if (prev) {
+      prev.lastSeenCycle = cycle;
+      prev.message = f.message;
+      if (f.line) prev.line = f.line;
+    } else {
+      byFp.set(f.fingerprint, {
+        ...f,
+        introducedCycle: cycle,
+        lastSeenCycle: cycle,
+      });
+      newFingerprints.push(f.fingerprint);
+    }
+  }
+
+  return { merged: [...byFp.values()], newFingerprints };
+}
+
+export function openBlocking(findings: Finding[]): Finding[] {
+  return findings.filter((f) => f.severity === 'blocking' && f.status === 'open');
+}
+
+export function sourceCounts(findings: Finding[]): Record<ReviewSlot, number> {
+  const counts: Record<ReviewSlot, number> = {
+    bugbot: 0,
+    standards: 0,
+    depth: 0,
+  };
+  for (const f of openBlocking(findings)) {
+    const s = f.source as ReviewSlot;
+    if (s in counts) counts[s]++;
+  }
+  return counts;
+}
+
+export function parseVerdictFromText(text: string): Verdict | null {
+  const lines = text.trim().split('\n');
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i]!.trim();
+    if (!line.startsWith('{')) continue;
+    try {
+      return VerdictSchema.parse(JSON.parse(line));
+    } catch {
+      continue;
+    }
+  }
+  const match = text.match(/\{[\s\S]*"verdict"[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return VerdictSchema.parse(JSON.parse(match[0]));
+  } catch {
+    return null;
+  }
+}

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -1,5 +1,11 @@
 import { createHash } from 'node:crypto';
-import { VerdictSchema, type Finding, type ReviewSlot, type Verdict } from './types.js';
+import {
+  VerdictSchema,
+  type Finding,
+  type PrAgentState,
+  type ReviewSlot,
+  type Verdict,
+} from './types.js';
 
 export function fingerprintFinding(file: string, message: string): string {
   const normalizedFile = file.replace(/\\/g, '/').toLowerCase();
@@ -101,6 +107,53 @@ export function resolveOpenFindingsFromSource(
 
 export function openBlocking(findings: Finding[]): Finding[] {
   return findings.filter((f) => f.severity === 'blocking' && f.status === 'open');
+}
+
+/** Extract finding ids from `agent-resolve <id>` human comments. */
+export function parseResolveIds(commentBodies: Array<string | null | undefined>): string[] {
+  const ids = new Set<string>();
+  const re = /agent-resolve\s+([a-zA-Z0-9]{4,16})/gi;
+  for (const body of commentBodies) {
+    if (!body) continue;
+    for (const m of body.matchAll(re)) {
+      ids.add(m[1]!.toLowerCase());
+    }
+  }
+  return [...ids];
+}
+
+/**
+ * Apply human `agent-resolve <id>` commands: move matching open findings to
+ * resolved and mute their fingerprints so later re-reports stay suppressed.
+ */
+export function applyResolvedIds(
+  state: PrAgentState,
+  ids: string[],
+  cycle: number,
+): {
+  openFindings: Finding[];
+  resolvedFindings: Finding[];
+  mutedFingerprints: string[];
+  changed: boolean;
+} {
+  const idSet = new Set(ids.map((i) => i.toLowerCase()));
+  const toResolve = state.openFindings.filter((f) => idSet.has(f.id.toLowerCase()));
+  if (toResolve.length === 0) {
+    return {
+      openFindings: state.openFindings,
+      resolvedFindings: state.resolvedFindings,
+      mutedFingerprints: state.mutedFingerprints,
+      changed: false,
+    };
+  }
+  const resolveFps = new Set(toResolve.map((f) => f.fingerprint));
+  const openFindings = state.openFindings.filter((f) => !resolveFps.has(f.fingerprint));
+  const resolvedFindings = [
+    ...state.resolvedFindings,
+    ...toResolve.map((f) => ({ ...f, status: 'resolved' as const, lastSeenCycle: cycle })),
+  ];
+  const mutedFingerprints = [...new Set([...state.mutedFingerprints, ...resolveFps])];
+  return { openFindings, resolvedFindings, mutedFingerprints, changed: true };
 }
 
 export function sourceCounts(findings: Finding[]): Record<ReviewSlot, number> {

--- a/scripts/pr-agent/src/findings.ts
+++ b/scripts/pr-agent/src/findings.ts
@@ -2,20 +2,18 @@ import { createHash } from 'node:crypto';
 import { VerdictSchema, type Finding, type ReviewSlot, type Verdict } from './types.js';
 
 export function fingerprintFinding(file: string, message: string): string {
-  const category = categorize(message);
   const normalizedFile = file.replace(/\\/g, '/').toLowerCase();
-  return `${normalizedFile}:${category}`;
-}
-
-function categorize(message: string): string {
-  const m = message.toLowerCase();
-  if (m.includes('thread') || m.includes('main thread')) return 'thread-safety';
-  if (m.includes('null') || m.includes('npe')) return 'null-safety';
-  if (m.includes('test')) return 'tests';
-  if (m.includes('security') || m.includes('secret')) return 'security';
-  if (m.includes('memory') || m.includes('leak')) return 'memory';
-  if (m.includes('race')) return 'race';
-  return createHash('sha1').update(m.slice(0, 80)).digest('hex').slice(0, 8);
+  const normalizedMessage = message
+    .toLowerCase()
+    .replace(/[`'"]/g, '')
+    .replace(/\b\d+\b/g, '#')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const messageHash = createHash('sha1')
+    .update(normalizedMessage)
+    .digest('hex')
+    .slice(0, 12);
+  return `${normalizedFile}:${messageHash}`;
 }
 
 export function shortId(fingerprint: string): string {

--- a/scripts/pr-agent/src/fix.ts
+++ b/scripts/pr-agent/src/fix.ts
@@ -6,18 +6,25 @@ import { loadConfig } from './config.js';
 import type { Finding, PrAgentState } from './types.js';
 import { openBlocking } from './findings.js';
 
+export type FixResult = {
+  /** Whether the fixer agent actually executed a turn (counts toward fix rounds). */
+  ran: boolean;
+  /** Whether the fixer produced and pushed a commit. */
+  committed: boolean;
+};
+
 export async function runFix(
   repoRoot: string,
   state: PrAgentState,
   ciLogExcerpt: string,
-): Promise<boolean> {
+): Promise<FixResult> {
   const config = loadConfig(repoRoot);
   const apiKey = process.env.CURSOR_API_KEY;
   if (!apiKey) throw new Error('CURSOR_API_KEY is required');
 
   if (config.dryRun) {
     console.log('[DRY_RUN] Skipping fixer commit/push');
-    return false;
+    return { ran: false, committed: false };
   }
 
   const promptPath = join(repoRoot, '.github/pr-agent/prompts/pr-fix.md');
@@ -61,7 +68,7 @@ Apply fixes in the working tree. Run relevant tests before finishing.
     const status = execSync('git status --porcelain', { cwd: repoRoot, encoding: 'utf8' });
     if (!status.trim()) {
       console.log('No file changes from fixer');
-      return false;
+      return { ran: true, committed: false };
     }
 
     execSync('git config user.name "github-actions[bot]"', { cwd: repoRoot });
@@ -79,7 +86,7 @@ Apply fixes in the working tree. Run relevant tests before finishing.
     }
     execSync(`git push origin HEAD:refs/heads/${headRef}`, { cwd: repoRoot });
     console.log('Pushed fix commit');
-    return true;
+    return { ran: true, committed: true };
   } catch (err) {
     if (err instanceof CursorAgentError) {
       console.error('Fix startup failed:', err.message);

--- a/scripts/pr-agent/src/fix.ts
+++ b/scripts/pr-agent/src/fix.ts
@@ -73,7 +73,11 @@ Apply fixes in the working tree. Run relevant tests before finishing.
       `git commit -m "fix(pr-agent): round ${state.fixRound + 1} [pr-agent-fix]"`,
       { cwd: repoRoot },
     );
-    execSync('git push', { cwd: repoRoot });
+    const headRef = process.env.PR_HEAD_REF;
+    if (!headRef) {
+      throw new Error('PR_HEAD_REF is required to push fix commits to the PR branch');
+    }
+    execSync(`git push origin HEAD:refs/heads/${headRef}`, { cwd: repoRoot });
     console.log('Pushed fix commit');
     return true;
   } catch (err) {

--- a/scripts/pr-agent/src/fix.ts
+++ b/scripts/pr-agent/src/fix.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { execSync } from 'node:child_process';
-import { Agent, CursorAgentError } from '@cursor/sdk';
+import { Agent, CursorAgentError, type Run } from '@cursor/sdk';
 import { loadConfig } from './config.js';
 import type { Finding, PrAgentState } from './types.js';
 import { openBlocking } from './findings.js';
@@ -46,6 +46,7 @@ Apply fixes in the working tree. Run relevant tests before finishing.
 `;
 
   const fixModel = process.env.PR_AGENT_FIX_MODEL ?? config.fixModel;
+  const maxTurns = config.limits.maxFixAgentTurns;
 
   try {
     await using agent = await Agent.create({
@@ -54,13 +55,37 @@ Apply fixes in the working tree. Run relevant tests before finishing.
       local: { cwd: repoRoot, settingSources: [] },
     });
 
-    const run = await agent.send(`${basePrompt}\n\n---\n\n${context}`);
+    let assistantTurns = 0;
+    let cancelledForTurns = false;
+    let activeRun: Run | undefined;
+
+    const run = await agent.send(`${basePrompt}\n\n---\n\n${context}`, {
+      onStep: async ({ step }) => {
+        if (step.type !== 'assistantMessage') return;
+        assistantTurns += 1;
+        if (assistantTurns >= maxTurns && !cancelledForTurns && activeRun) {
+          cancelledForTurns = true;
+          console.warn(
+            `Fixer hit maxFixAgentTurns (${maxTurns}); cancelling run to commit progress.`,
+          );
+          try {
+            await activeRun?.cancel();
+          } catch (e) {
+            console.warn('Run cancel failed:', (e as Error).message);
+          }
+        }
+      },
+    });
+    activeRun = run;
     console.log('Fix agent run id:', run.id);
 
     const result = await run.wait();
     if (result.status === 'error') {
       console.error('Fix run failed:', result.id);
       process.exit(2);
+    }
+    if (cancelledForTurns) {
+      console.warn(`Fixer stopped after ${assistantTurns} turns (cap ${maxTurns}).`);
     }
 
     console.log(result.result?.slice(0, 2000) ?? '(no text)');

--- a/scripts/pr-agent/src/fix.ts
+++ b/scripts/pr-agent/src/fix.ts
@@ -10,14 +10,14 @@ export async function runFix(
   repoRoot: string,
   state: PrAgentState,
   ciLogExcerpt: string,
-): Promise<void> {
+): Promise<boolean> {
   const config = loadConfig(repoRoot);
   const apiKey = process.env.CURSOR_API_KEY;
   if (!apiKey) throw new Error('CURSOR_API_KEY is required');
 
   if (config.dryRun) {
     console.log('[DRY_RUN] Skipping fixer commit/push');
-    return;
+    return false;
   }
 
   const promptPath = join(repoRoot, '.github/pr-agent/prompts/pr-fix.md');
@@ -61,7 +61,7 @@ Apply fixes in the working tree. Run relevant tests before finishing.
     const status = execSync('git status --porcelain', { cwd: repoRoot, encoding: 'utf8' });
     if (!status.trim()) {
       console.log('No file changes from fixer');
-      return;
+      return false;
     }
 
     execSync('git config user.name "github-actions[bot]"', { cwd: repoRoot });
@@ -75,6 +75,7 @@ Apply fixes in the working tree. Run relevant tests before finishing.
     );
     execSync('git push', { cwd: repoRoot });
     console.log('Pushed fix commit');
+    return true;
   } catch (err) {
     if (err instanceof CursorAgentError) {
       console.error('Fix startup failed:', err.message);

--- a/scripts/pr-agent/src/fix.ts
+++ b/scripts/pr-agent/src/fix.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { Agent, CursorAgentError } from '@cursor/sdk';
+import { loadConfig } from './config.js';
+import type { Finding, PrAgentState } from './types.js';
+import { openBlocking } from './findings.js';
+
+export async function runFix(
+  repoRoot: string,
+  state: PrAgentState,
+  ciLogExcerpt: string,
+): Promise<void> {
+  const config = loadConfig(repoRoot);
+  const apiKey = process.env.CURSOR_API_KEY;
+  if (!apiKey) throw new Error('CURSOR_API_KEY is required');
+
+  if (config.dryRun) {
+    console.log('[DRY_RUN] Skipping fixer commit/push');
+    return;
+  }
+
+  const promptPath = join(repoRoot, '.github/pr-agent/prompts/pr-fix.md');
+  const basePrompt = readFileSync(promptPath, 'utf8');
+
+  const blocking = openBlocking(state.openFindings);
+  const context = `
+## Fix round ${state.fixRound + 1}
+
+## Open blocking findings
+\`\`\`json
+${JSON.stringify(blocking, null, 2)}
+\`\`\`
+
+## CI logs (excerpt)
+${ciLogExcerpt || '(none)'}
+
+Apply fixes in the working tree. Run relevant tests before finishing.
+`;
+
+  const fixModel = process.env.PR_AGENT_FIX_MODEL ?? config.fixModel;
+
+  try {
+    await using agent = await Agent.create({
+      apiKey,
+      model: { id: fixModel },
+      local: { cwd: repoRoot, settingSources: [] },
+    });
+
+    const run = await agent.send(`${basePrompt}\n\n---\n\n${context}`);
+    console.log('Fix agent run id:', run.id);
+
+    const result = await run.wait();
+    if (result.status === 'error') {
+      console.error('Fix run failed:', result.id);
+      process.exit(2);
+    }
+
+    console.log(result.result?.slice(0, 2000) ?? '(no text)');
+
+    const status = execSync('git status --porcelain', { cwd: repoRoot, encoding: 'utf8' });
+    if (!status.trim()) {
+      console.log('No file changes from fixer');
+      return;
+    }
+
+    execSync('git config user.name "github-actions[bot]"', { cwd: repoRoot });
+    execSync('git config user.email "github-actions[bot]@users.noreply.github.com"', {
+      cwd: repoRoot,
+    });
+    execSync('git add -A', { cwd: repoRoot });
+    execSync(
+      `git commit -m "fix(pr-agent): round ${state.fixRound + 1} [pr-agent-fix]"`,
+      { cwd: repoRoot },
+    );
+    execSync('git push', { cwd: repoRoot });
+    console.log('Pushed fix commit');
+  } catch (err) {
+    if (err instanceof CursorAgentError) {
+      console.error('Fix startup failed:', err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/pr-agent/src/handoff.ts
+++ b/scripts/pr-agent/src/handoff.ts
@@ -1,0 +1,73 @@
+import type { CiCheckStatus } from './ci-gates.js';
+import { openBlocking } from './findings.js';
+import type { Finding, PrAgentState } from './types.js';
+import { MARKER_HANDOFF } from './types.js';
+
+export function buildHandoffComment(
+  reason: 'human_handoff' | 'budget_exhausted' | 'diverging',
+  state: PrAgentState,
+  ciChecks: CiCheckStatus[],
+): string {
+  const open = openBlocking(state.openFindings);
+  const reasonText =
+    reason === 'human_handoff'
+      ? 'Clean handoff — CI green, no blocking findings, models have no further reviews.'
+      : reason === 'budget_exhausted'
+        ? 'Budget exhausted — fix or review cycle cap reached.'
+        : 'Diverging — stagnation or review churn detected.';
+
+  const ciTable =
+    ciChecks.length === 0
+      ? '_No path-scoped CI workflows required for this PR._'
+      : ciChecks
+          .map(
+            (c) =>
+              `| ${c.name} | ${c.status} | ${c.conclusion ?? '—'} |`,
+          )
+          .join('\n');
+
+  const blockingList =
+    open.length === 0
+      ? '_None_'
+      : open
+          .map((f: Finding) => `- **${f.id}** (\`${f.file}\`) [${f.source}]: ${f.message}`)
+          .join('\n');
+
+  const nits =
+    state.nitFindings.length === 0
+      ? '_None_'
+      : state.nitFindings
+          .slice(0, 20)
+          .map((f) => `- (\`${f.file}\`) ${f.message}`)
+          .join('\n');
+
+  return `${MARKER_HANDOFF}
+## PR Agent Handoff
+
+**Exit reason:** ${reasonText}
+
+| Metric | Value |
+|--------|-------|
+| Fix rounds | ${state.fixRound} |
+| Review cycles | ${state.cycle} |
+| Consecutive no-new-review cycles | ${state.consecutiveNoNewReviews} |
+
+### CI status
+
+| Check | Status | Conclusion |
+|-------|--------|------------|
+${ciTable}
+
+### Remaining blocking findings
+
+${blockingList}
+
+### Nits (informational)
+
+${nits}
+
+---
+
+**Humans merge when ready.** Agents do not auto-merge. Label \`agent-resume\` to re-run the loop after new commits.
+`;
+}

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -4,6 +4,7 @@ import {
   createOctokit,
   loadOrCreateState,
   prHasLabel,
+  removeLabel,
   saveState,
 } from './state.js';
 import { getChangedFiles } from './ci-gates.js';
@@ -65,9 +66,27 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
     return skipPlan(octokit, owner, repo, prNumber, 'draft PR');
   }
 
-  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  const { state: loadedState, commentId } = await loadOrCreateState(
+    octokit,
+    owner,
+    repo,
+    prNumber,
+  );
+  let state = loadedState;
 
-  if (state.status !== 'in_progress' && !labelNames.includes('agent-resume')) {
+  if (labelNames.includes('agent-resume')) {
+    state = {
+      ...state,
+      status: 'in_progress',
+      consecutiveNoNewReviews: 0,
+    };
+    await removeLabel(octokit, owner, repo, prNumber, 'agent-resume');
+    await removeLabel(octokit, owner, repo, prNumber, 'ready-for-human-review');
+    await removeLabel(octokit, owner, repo, prNumber, 'agent-needs-human');
+    await saveState(octokit, owner, repo, prNumber, state, commentId);
+  }
+
+  if (state.status !== 'in_progress') {
     return {
       runBugbot: false,
       runStandards: false,
@@ -80,14 +99,18 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
   }
 
   if (state.cycle >= config.limits.maxOrchestratorCycles) {
+    const exhausted = { ...state, status: 'budget_exhausted' as const };
+    await saveState(octokit, owner, repo, prNumber, exhausted, commentId);
     return {
       runBugbot: false,
       runStandards: false,
       runDepth: false,
       activePair: [],
-      state: { ...state, status: 'budget_exhausted' },
+      state: exhausted,
       shouldSkip: true,
       skipReason: 'max cycles',
+      shouldHandoff: true,
+      handoffReason: 'budget_exhausted',
     };
   }
 
@@ -144,6 +167,8 @@ export async function writePlanOutputs(plan: PlanOutput): Promise<void> {
   set('run_depth', String(plan.runDepth));
   set('active_pair', plan.activePair.join(','));
   set('is_dry_run', String(loadConfig(process.cwd()).dryRun));
+  set('should_handoff', String(plan.shouldHandoff ?? false));
+  set('handoff_reason', plan.handoffReason ?? '');
 }
 
 export { getChangedFiles };

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -86,6 +86,29 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
     await saveState(octokit, owner, repo, prNumber, state, commentId);
   }
 
+  if (process.env.CI_RECHECK_ONLY === 'true') {
+    if (state.status !== 'in_progress') {
+      return {
+        runBugbot: false,
+        runStandards: false,
+        runDepth: false,
+        activePair: [],
+        state,
+        shouldSkip: true,
+        skipReason: `ci recheck skipped: status ${state.status}`,
+      };
+    }
+    return {
+      runBugbot: false,
+      runStandards: false,
+      runDepth: false,
+      activePair: [],
+      state,
+      shouldSkip: false,
+      recheckOnly: true,
+    };
+  }
+
   if (state.status !== 'in_progress') {
     return {
       runBugbot: false,
@@ -169,6 +192,7 @@ export async function writePlanOutputs(plan: PlanOutput): Promise<void> {
   set('is_dry_run', String(loadConfig(process.cwd()).dryRun));
   set('should_handoff', String(plan.shouldHandoff ?? false));
   set('handoff_reason', plan.handoffReason ?? '');
+  set('recheck_only', String(plan.recheckOnly ?? false));
 }
 
 export { getChangedFiles };

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -1,0 +1,149 @@
+import { loadConfig } from './config.js';
+import { resolveActivePair } from './rotate.js';
+import {
+  createOctokit,
+  loadOrCreateState,
+  prHasLabel,
+  saveState,
+} from './state.js';
+import { getChangedFiles } from './ci-gates.js';
+import type { PlanOutput } from './types.js';
+
+export async function runPlan(repoRoot: string): Promise<PlanOutput> {
+  const config = loadConfig(repoRoot);
+  const owner = process.env.GITHUB_REPOSITORY_OWNER!;
+  const repo = process.env.GITHUB_REPOSITORY?.split('/')[1]!;
+  const prNumber = Number(process.env.PR_NUMBER);
+  const author = process.env.PR_AUTHOR ?? '';
+  const isDraft = process.env.PR_DRAFT === 'true';
+  const isFork = process.env.PR_IS_FORK === 'true';
+  const forceRotation = process.env.FORCE_ROTATION === 'true';
+
+  const octokit = createOctokit();
+
+  if (await prHasLabel(octokit, owner, repo, prNumber, 'agent-stop')) {
+    return {
+      runBugbot: false,
+      runStandards: false,
+      runDepth: false,
+      activePair: [],
+      state: (await loadOrCreateState(octokit, owner, repo, prNumber)).state,
+      shouldSkip: true,
+      skipReason: 'agent-stop label',
+    };
+  }
+
+  if (await prHasLabel(octokit, owner, repo, prNumber, 'ready-for-human-review')) {
+    const hasResume = await prHasLabel(octokit, owner, repo, prNumber, 'agent-resume');
+    if (!hasResume) {
+      const { state } = await loadOrCreateState(octokit, owner, repo, prNumber);
+      return {
+        runBugbot: false,
+        runStandards: false,
+        runDepth: false,
+        activePair: [],
+        state,
+        shouldSkip: true,
+        skipReason: 'awaiting human handoff',
+      };
+    }
+  }
+
+  const labels = await octokit.issues.get({ owner, repo, issue_number: prNumber });
+  const labelNames = (labels.data.labels ?? []).map((l) =>
+    typeof l === 'string' ? l : l.name!,
+  );
+
+  if (config.authors.mode === 'allowlist' && !config.authors.allowlist.includes(author)) {
+    return skipPlan(octokit, owner, repo, prNumber, 'author not in allowlist');
+  }
+  if (config.authors.mode === 'label_only' && !labelNames.includes('agent-review')) {
+    return skipPlan(octokit, owner, repo, prNumber, 'missing agent-review label');
+  }
+
+  if (isDraft && !labelNames.includes('agent-review')) {
+    return skipPlan(octokit, owner, repo, prNumber, 'draft PR');
+  }
+
+  const { state, commentId } = await loadOrCreateState(octokit, owner, repo, prNumber);
+
+  if (state.status !== 'in_progress' && !labelNames.includes('agent-resume')) {
+    return {
+      runBugbot: false,
+      runStandards: false,
+      runDepth: false,
+      activePair: [],
+      state,
+      shouldSkip: true,
+      skipReason: `status ${state.status}`,
+    };
+  }
+
+  if (state.cycle >= config.limits.maxOrchestratorCycles) {
+    return {
+      runBugbot: false,
+      runStandards: false,
+      runDepth: false,
+      activePair: [],
+      state: { ...state, status: 'budget_exhausted' },
+      shouldSkip: true,
+      skipReason: 'max cycles',
+    };
+  }
+
+  const activePair = resolveActivePair(state, forceRotation);
+
+  const output: PlanOutput = {
+    runBugbot: activePair.includes('bugbot'),
+    runStandards: activePair.includes('standards'),
+    runDepth: activePair.includes('depth'),
+    activePair,
+    state,
+    shouldSkip: false,
+  };
+
+  if (isFork) {
+    console.log('Fork PR: reviews only, fixer will be skipped');
+  }
+
+  await saveState(octokit, owner, repo, prNumber, state, commentId);
+  return output;
+}
+
+async function skipPlan(
+  octokit: ReturnType<typeof createOctokit>,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  reason: string,
+): Promise<PlanOutput> {
+  const { state } = await loadOrCreateState(octokit, owner, repo, prNumber);
+  return {
+    runBugbot: false,
+    runStandards: false,
+    runDepth: false,
+    activePair: [],
+    state,
+    shouldSkip: true,
+    skipReason: reason,
+  };
+}
+
+export async function writePlanOutputs(plan: PlanOutput): Promise<void> {
+  const { appendFileSync, mkdirSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const out = process.env.GITHUB_OUTPUT;
+  if (!out) return;
+
+  const set = (k: string, v: string) => appendFileSync(out, `${k}=${v}\n`);
+
+  set('should_skip', String(plan.shouldSkip));
+  set('skip_reason', plan.skipReason ?? '');
+  set('run_bugbot', String(plan.runBugbot));
+  set('run_standards', String(plan.runStandards));
+  set('run_depth', String(plan.runDepth));
+  set('active_pair', plan.activePair.join(','));
+  set('is_dry_run', String(loadConfig(process.cwd()).dryRun));
+}
+
+export { getChangedFiles };

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -175,9 +175,8 @@ async function skipPlan(
   };
 }
 
-export async function writePlanOutputs(plan: PlanOutput): Promise<void> {
-  const { appendFileSync, mkdirSync } = await import('node:fs');
-  const { join } = await import('node:path');
+export async function writePlanOutputs(repoRoot: string, plan: PlanOutput): Promise<void> {
+  const { appendFileSync } = await import('node:fs');
   const out = process.env.GITHUB_OUTPUT;
   if (!out) return;
 
@@ -189,7 +188,7 @@ export async function writePlanOutputs(plan: PlanOutput): Promise<void> {
   set('run_standards', String(plan.runStandards));
   set('run_depth', String(plan.runDepth));
   set('active_pair', plan.activePair.join(','));
-  set('is_dry_run', String(loadConfig(process.cwd()).dryRun));
+  set('is_dry_run', String(loadConfig(repoRoot).dryRun));
   set('should_handoff', String(plan.shouldHandoff ?? false));
   set('handoff_reason', plan.handoffReason ?? '');
   set('recheck_only', String(plan.recheckOnly ?? false));

--- a/scripts/pr-agent/src/plan.ts
+++ b/scripts/pr-agent/src/plan.ts
@@ -1,7 +1,9 @@
 import { loadConfig } from './config.js';
 import { resolveActivePair } from './rotate.js';
+import { applyResolvedIds, parseResolveIds } from './findings.js';
 import {
   createOctokit,
+  listAllIssueComments,
   loadOrCreateState,
   prHasLabel,
   removeLabel,
@@ -84,6 +86,23 @@ export async function runPlan(repoRoot: string): Promise<PlanOutput> {
     await removeLabel(octokit, owner, repo, prNumber, 'ready-for-human-review');
     await removeLabel(octokit, owner, repo, prNumber, 'agent-needs-human');
     await saveState(octokit, owner, repo, prNumber, state, commentId);
+  }
+
+  const resolveIds = parseResolveIds(
+    (await listAllIssueComments(octokit, owner, repo, prNumber)).map((c) => c.body),
+  );
+  if (resolveIds.length > 0) {
+    const applied = applyResolvedIds(state, resolveIds, state.cycle);
+    if (applied.changed) {
+      state = {
+        ...state,
+        openFindings: applied.openFindings,
+        resolvedFindings: applied.resolvedFindings,
+        mutedFingerprints: applied.mutedFingerprints,
+      };
+      await saveState(octokit, owner, repo, prNumber, state, commentId);
+      console.log(`Resolved findings via agent-resolve: ${resolveIds.join(', ')}`);
+    }
   }
 
   if (process.env.CI_RECHECK_ONLY === 'true') {

--- a/scripts/pr-agent/src/recheck-handoff.ts
+++ b/scripts/pr-agent/src/recheck-handoff.ts
@@ -1,0 +1,56 @@
+import { loadConfig } from './config.js';
+import {
+  fetchWorkflowStatuses,
+  getChangedFiles,
+  getPrHeadSha,
+  isCiGreen,
+  requiredWorkflowsForPaths,
+} from './ci-gates.js';
+import { openBlocking } from './findings.js';
+import type { Octokit } from '@octokit/rest';
+import type { PrAgentState } from './types.js';
+
+export type RecheckHandoffResult = {
+  state: PrAgentState;
+  shouldHandoff: boolean;
+  handoffReason?: 'human_handoff';
+};
+
+/** Re-evaluate clean handoff after CI settles (no new review ingest, no cycle bump). */
+export async function recheckHandoff(
+  repoRoot: string,
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  prNumber: number,
+  state: PrAgentState,
+): Promise<RecheckHandoffResult> {
+  const config = loadConfig(repoRoot);
+  const ref = await getPrHeadSha(octokit, owner, repo, prNumber);
+  const changedFiles = await getChangedFiles(octokit, owner, repo, prNumber);
+  const required = requiredWorkflowsForPaths(changedFiles, repoRoot);
+  const ciChecks = await fetchWorkflowStatuses(octokit, owner, repo, ref, required);
+  const ciGreen = isCiGreen(ciChecks);
+  const openCount = openBlocking(state.openFindings).length;
+
+  const cleanHandoff =
+    state.status === 'in_progress' &&
+    ciGreen &&
+    openCount === 0 &&
+    state.consecutiveNoNewReviews >= config.limits.consecutiveNoNewReviewsForHandoff;
+
+  if (!cleanHandoff) {
+    return { state, shouldHandoff: false };
+  }
+
+  const nextState: PrAgentState = {
+    ...state,
+    status: 'human_handoff',
+  };
+
+  return {
+    state: nextState,
+    shouldHandoff: true,
+    handoffReason: 'human_handoff',
+  };
+}

--- a/scripts/pr-agent/src/review.ts
+++ b/scripts/pr-agent/src/review.ts
@@ -1,0 +1,93 @@
+import { mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { Agent, CursorAgentError } from '@cursor/sdk';
+import { loadConfig } from './config.js';
+import type { PrAgentState, ReviewSlot } from './types.js';
+import { execSync } from 'node:child_process';
+
+const SLOT_PROMPT: Record<Exclude<ReviewSlot, 'bugbot'>, string> = {
+  standards: 'standards-review.md',
+  depth: 'depth-review.md',
+};
+
+export async function runReview(
+  repoRoot: string,
+  slot: Exclude<ReviewSlot, 'bugbot'>,
+  prNumber: number,
+  baseRef: string,
+  state: PrAgentState,
+): Promise<void> {
+  const config = loadConfig(repoRoot);
+  const apiKey = process.env.CURSOR_API_KEY;
+  if (!apiKey) throw new Error('CURSOR_API_KEY is required');
+
+  const promptPath = join(repoRoot, '.github/pr-agent/prompts', SLOT_PROMPT[slot]);
+  const basePrompt = readFileSync(promptPath, 'utf8');
+
+  const diff = execSync(`git diff origin/${baseRef}...HEAD --stat`, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  }).trim();
+
+  const changedFiles = execSync(`git diff --name-only origin/${baseRef}...HEAD`, {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean);
+
+  const context = `
+PR #${prNumber}
+Base: ${baseRef}
+
+## Orchestrator state
+\`\`\`json
+${JSON.stringify(
+  {
+    openFindings: state.openFindings,
+    resolvedFindings: state.resolvedFindings,
+    phase: state.phase,
+    cycle: state.cycle,
+  },
+  null,
+  2,
+)}
+\`\`\`
+
+## Changed files
+${changedFiles.map((f) => `- ${f}`).join('\n')}
+
+## Diff stat
+${diff || '(no diff)'}
+`;
+
+  const fullPrompt = `${basePrompt}\n\n---\n\n${context}`;
+
+  const reviewModel =
+    process.env.PR_AGENT_REVIEW_MODEL ?? config.reviewModel;
+
+  try {
+    const result = await Agent.prompt(fullPrompt, {
+      apiKey,
+      model: { id: reviewModel },
+      local: { cwd: repoRoot, settingSources: [] },
+    });
+
+    if (result.status === 'error') {
+      console.error('Review run failed:', result.id);
+      process.exit(2);
+    }
+
+    const outDir = join(repoRoot, '.pr-agent');
+    mkdirSync(outDir, { recursive: true });
+    writeFileSync(join(outDir, `review-${slot}.txt`), result.result ?? '', 'utf8');
+    console.log(`Review ${slot} complete. agent run: ${result.id}`);
+  } catch (err) {
+    if (err instanceof CursorAgentError) {
+      console.error('Review startup failed:', err.message, 'retryable=', err.isRetryable);
+      process.exit(1);
+    }
+    throw err;
+  }
+}

--- a/scripts/pr-agent/src/rotate.ts
+++ b/scripts/pr-agent/src/rotate.ts
@@ -1,0 +1,56 @@
+import type { ReviewSlot } from './types.js';
+
+const ROTATION_PAIRS: ReviewSlot[][] = [
+  ['bugbot', 'standards'],
+  ['bugbot', 'depth'],
+  ['standards', 'depth'],
+];
+
+export function pairForCycle(cycle: number): ReviewSlot[] {
+  return ROTATION_PAIRS[((cycle % 3) + 3) % 3]!;
+}
+
+export function pairIncludes(pair: ReviewSlot[], slot: ReviewSlot): boolean {
+  return pair.includes(slot);
+}
+
+export function frozenPairFromFindings(
+  counts: Record<ReviewSlot, number>,
+): ReviewSlot[] {
+  const entries = (Object.entries(counts) as [ReviewSlot, number][]).filter(
+    ([, n]) => n > 0,
+  );
+  entries.sort((a, b) => b[1] - a[1]);
+  if (entries.length >= 2) {
+    return [entries[0]![0], entries[1]![0]];
+  }
+  if (entries.length === 1) {
+    const other = ROTATION_PAIRS.flat().find((s) => s !== entries[0]![0]);
+    return other ? [entries[0]![0], other] : pairForCycle(0);
+  }
+  return pairForCycle(0);
+}
+
+export function resolveActivePair(
+  state: {
+    cycle: number;
+    fixRound: number;
+    phase: 'discovery' | 'convergence';
+    frozenPair?: ReviewSlot[];
+    openFindings: { source: string }[];
+  },
+  forceRotation: boolean,
+): ReviewSlot[] {
+  if (forceRotation) {
+    return pairForCycle(state.cycle);
+  }
+  const inConvergence =
+    state.phase === 'convergence' ||
+    state.fixRound > 0 ||
+    state.openFindings.length > 0;
+
+  if (inConvergence && state.frozenPair?.length === 2) {
+    return state.frozenPair;
+  }
+  return pairForCycle(state.cycle);
+}

--- a/scripts/pr-agent/src/rotate.ts
+++ b/scripts/pr-agent/src/rotate.ts
@@ -10,10 +10,6 @@ export function pairForCycle(cycle: number): ReviewSlot[] {
   return ROTATION_PAIRS[((cycle % 3) + 3) % 3]!;
 }
 
-export function pairIncludes(pair: ReviewSlot[], slot: ReviewSlot): boolean {
-  return pair.includes(slot);
-}
-
 export function frozenPairFromFindings(
   counts: Record<ReviewSlot, number>,
 ): ReviewSlot[] {

--- a/scripts/pr-agent/src/state.ts
+++ b/scripts/pr-agent/src/state.ts
@@ -1,0 +1,126 @@
+import { Octokit } from '@octokit/rest';
+import {
+  MARKER_ORCHESTRATOR,
+  PrAgentStateSchema,
+  type PrAgentState,
+} from './types.js';
+
+export function createOctokit(token?: string): Octokit {
+  const auth = token ?? process.env.GITHUB_TOKEN ?? process.env.PR_AGENT_GITHUB_TOKEN;
+  if (!auth) {
+    throw new Error('GITHUB_TOKEN or PR_AGENT_GITHUB_TOKEN required');
+  }
+  return new Octokit({ auth });
+}
+
+export function parseStateFromComment(body: string): PrAgentState | null {
+  if (!body.includes(MARKER_ORCHESTRATOR)) return null;
+  const jsonMatch = body.match(/```json\s*([\s\S]*?)\s*```/);
+  if (!jsonMatch) return null;
+  try {
+    return PrAgentStateSchema.parse(JSON.parse(jsonMatch[1]!));
+  } catch {
+    return null;
+  }
+}
+
+export function formatStateComment(state: PrAgentState): string {
+  return `${MARKER_ORCHESTRATOR}
+## PR Agent Orchestrator State
+
+\`\`\`json
+${JSON.stringify(state, null, 2)}
+\`\`\`
+`;
+}
+
+export function defaultState(): PrAgentState {
+  return PrAgentStateSchema.parse({});
+}
+
+export async function loadOrCreateState(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<{ state: PrAgentState; commentId?: number }> {
+  const { data: comments } = await octokit.issues.listComments({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    per_page: 100,
+  });
+
+  const markerComment = comments.find((c) => c.body?.includes(MARKER_ORCHESTRATOR));
+  if (markerComment?.body) {
+    const parsed = parseStateFromComment(markerComment.body);
+    if (parsed) {
+      return { state: parsed, commentId: markerComment.id };
+    }
+  }
+  return { state: defaultState() };
+}
+
+export async function saveState(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  state: PrAgentState,
+  commentId?: number,
+): Promise<void> {
+  const body = formatStateComment(state);
+  if (commentId) {
+    await octokit.issues.updateComment({
+      owner,
+      repo,
+      comment_id: commentId,
+      body,
+    });
+    return;
+  }
+  await octokit.issues.createComment({
+    owner,
+    repo,
+    issue_number: issueNumber,
+    body,
+  });
+}
+
+export async function prHasLabel(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<boolean> {
+  const { data } = await octokit.issues.get({ owner, repo, issue_number: issueNumber });
+  return (data.labels ?? []).some((l) => (typeof l === 'string' ? l : l.name) === label);
+}
+
+export async function ensureLabel(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  const has = await prHasLabel(octokit, owner, repo, issueNumber, label);
+  if (!has) {
+    await octokit.issues.addLabels({ owner, repo, issue_number: issueNumber, labels: [label] });
+  }
+}
+
+export async function removeLabel(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+  label: string,
+): Promise<void> {
+  try {
+    await octokit.issues.removeLabel({ owner, repo, issue_number: issueNumber, name: label });
+  } catch {
+    // label may not exist
+  }
+}

--- a/scripts/pr-agent/src/state.ts
+++ b/scripts/pr-agent/src/state.ts
@@ -18,8 +18,8 @@ export async function listAllIssueComments(
   owner: string,
   repo: string,
   issueNumber: number,
-): Promise<Array<{ id: number; body?: string | null }>> {
-  const all: Array<{ id: number; body?: string | null }> = [];
+): Promise<Array<{ id: number; body?: string | null; created_at?: string | null }>> {
+  const all: Array<{ id: number; body?: string | null; created_at?: string | null }> = [];
   let page = 1;
   for (;;) {
     const { data } = await octokit.issues.listComments({

--- a/scripts/pr-agent/src/state.ts
+++ b/scripts/pr-agent/src/state.ts
@@ -13,6 +13,30 @@ export function createOctokit(token?: string): Octokit {
   return new Octokit({ auth });
 }
 
+export async function listAllIssueComments(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  issueNumber: number,
+): Promise<Array<{ id: number; body?: string | null }>> {
+  const all: Array<{ id: number; body?: string | null }> = [];
+  let page = 1;
+  for (;;) {
+    const { data } = await octokit.issues.listComments({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: 100,
+      page,
+    });
+    if (data.length === 0) break;
+    all.push(...data);
+    if (data.length < 100) break;
+    page++;
+  }
+  return all;
+}
+
 export function parseStateFromComment(body: string): PrAgentState | null {
   if (!body.includes(MARKER_ORCHESTRATOR)) return null;
   const jsonMatch = body.match(/```json\s*([\s\S]*?)\s*```/);
@@ -44,12 +68,7 @@ export async function loadOrCreateState(
   repo: string,
   issueNumber: number,
 ): Promise<{ state: PrAgentState; commentId?: number }> {
-  const { data: comments } = await octokit.issues.listComments({
-    owner,
-    repo,
-    issue_number: issueNumber,
-    per_page: 100,
-  });
+  const comments = await listAllIssueComments(octokit, owner, repo, issueNumber);
 
   const markerComment = comments.find((c) => c.body?.includes(MARKER_ORCHESTRATOR));
   if (markerComment?.body) {

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -67,6 +67,8 @@ export type PlanOutput = {
   state: PrAgentState;
   shouldSkip: boolean;
   skipReason?: string;
+  shouldHandoff?: boolean;
+  handoffReason?: 'human_handoff' | 'budget_exhausted' | 'diverging';
 };
 
 export type AggregateOutput = {

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -35,6 +35,8 @@ export const PrAgentStateSchema = z.object({
   stagnationFixRounds: z.number().default(0),
   lastOpenCount: z.number().optional(),
   fingerprintReopenCounts: z.record(z.number()).default({}),
+  /** Fingerprints a human marked as false positive via `agent-resolve <id>`. */
+  mutedFingerprints: z.array(z.string()).default([]),
 });
 
 export type PrAgentState = z.infer<typeof PrAgentStateSchema>;

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod';
+
+export const ReviewSlotSchema = z.enum(['bugbot', 'standards', 'depth']);
+export type ReviewSlot = z.infer<typeof ReviewSlotSchema>;
+
+export const FindingSchema = z.object({
+  id: z.string(),
+  fingerprint: z.string(),
+  source: z.string(),
+  severity: z.enum(['blocking', 'nit']),
+  file: z.string(),
+  line: z.number().optional(),
+  message: z.string(),
+  status: z.enum(['open', 'resolved']),
+  introducedCycle: z.number(),
+  lastSeenCycle: z.number(),
+});
+
+export type Finding = z.infer<typeof FindingSchema>;
+
+export const PrAgentStateSchema = z.object({
+  cycle: z.number().default(0),
+  fixRound: z.number().default(0),
+  totalReviewerRuns: z.number().default(0),
+  consecutiveNoNewReviews: z.number().default(0),
+  openFindings: z.array(FindingSchema).default([]),
+  resolvedFindings: z.array(FindingSchema).default([]),
+  nitFindings: z.array(FindingSchema).default([]),
+  frozenPair: z.array(ReviewSlotSchema).optional(),
+  phase: z.enum(['discovery', 'convergence']).default('discovery'),
+  status: z
+    .enum(['in_progress', 'human_handoff', 'budget_exhausted', 'diverging'])
+    .default('in_progress'),
+  lastPair: z.array(ReviewSlotSchema).optional(),
+  stagnationFixRounds: z.number().default(0),
+  lastOpenCount: z.number().optional(),
+  fingerprintReopenCounts: z.record(z.number()).default({}),
+});
+
+export type PrAgentState = z.infer<typeof PrAgentStateSchema>;
+
+export const VerdictSchema = z.object({
+  verdict: z.enum(['approve', 'changes_requested']),
+  findings: z
+    .array(
+      z.object({
+        severity: z.enum(['blocking', 'nit']),
+        file: z.string(),
+        line: z.number().optional(),
+        message: z.string(),
+      }),
+    )
+    .default([]),
+});
+
+export type Verdict = z.infer<typeof VerdictSchema>;
+
+export const MARKER_ORCHESTRATOR = '<!-- pr-agent-orchestrator -->';
+export const MARKER_HANDOFF = '<!-- pr-agent-handoff -->';
+export const MARKER_BUGBOT_VERDICT = '<!-- pr-agent-bugbot-verdict -->';
+
+export type PlanOutput = {
+  runBugbot: boolean;
+  runStandards: boolean;
+  runDepth: boolean;
+  activePair: ReviewSlot[];
+  state: PrAgentState;
+  shouldSkip: boolean;
+  skipReason?: string;
+};
+
+export type AggregateOutput = {
+  state: PrAgentState;
+  shouldFix: boolean;
+  shouldHandoff: boolean;
+  handoffReason?: 'human_handoff' | 'budget_exhausted' | 'diverging';
+  ciFailed: boolean;
+  newBlockingCount: number;
+};

--- a/scripts/pr-agent/src/types.ts
+++ b/scripts/pr-agent/src/types.ts
@@ -69,6 +69,7 @@ export type PlanOutput = {
   skipReason?: string;
   shouldHandoff?: boolean;
   handoffReason?: 'human_handoff' | 'budget_exhausted' | 'diverging';
+  recheckOnly?: boolean;
 };
 
 export type AggregateOutput = {

--- a/scripts/pr-agent/tsconfig.json
+++ b/scripts/pr-agent/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary

- Adds GitHub Actions orchestrator that rotates 2 of 3 reviewers per PR (Bugbot, Claude 4.6 standards, Claude 4.6 depth)
- Opus 4.8 fixer addresses blocking findings and CI failures; loops until CI green and models have no new reviews
- Human handoff via `ready-for-human-review` label — agents never auto-merge
- Ships with `dryRun: true` and `authors.mode: label_only` — add `agent-review` label to opt in

## Setup required before use

- GitHub secret: `CURSOR_API_KEY`
- Cursor GitHub app + Bugbot enabled (**run only when mentioned**)
- See [docs/pr-agent-orchestrator-setup.md](docs/pr-agent-orchestrator-setup.md)

## Test plan

- [ ] Add `CURSOR_API_KEY` to repo secrets
- [ ] Open test PR, add `agent-review` label
- [ ] Verify orchestrator runs plan + review jobs (dry run skips fix push)
- [ ] Set `dryRun: false` when ready for Opus fixer commits


Made with [Cursor](https://cursor.com)