### PR TITLE
pr-agent: Opus 4.8 for reviewers + fixer, raise turn cap to 80

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -21,7 +21,7 @@ When the PR agent orchestrator triggers this review, end with a top-level PR com
 
 1. Human-readable summary
 2. HTML marker `<!-- pr-agent-bugbot-verdict -->`
-3. JSON footer (same schema as the Opus 4.8 reviewers):
+3. JSON footer (same schema as the other reviewers):
 
 ```json
 {"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -21,7 +21,7 @@ When the PR agent orchestrator triggers this review, end with a top-level PR com
 
 1. Human-readable summary
 2. HTML marker `<!-- pr-agent-bugbot-verdict -->`
-3. JSON footer (same schema as Claude 4.6 reviewers):
+3. JSON footer (same schema as the Opus 4.8 reviewers):
 
 ```json
 {"verdict":"approve|changes_requested","findings":[{"severity":"blocking|nit","file":"path","line":0,"message":"..."}]}

--- a/.github/pr-agent.yml
+++ b/.github/pr-agent.yml
@@ -3,7 +3,7 @@
 
 dryRun: true
 
-reviewModel: claude-sonnet-4-6
+reviewModel: claude-opus-4-8
 fixModel: claude-opus-4-8
 
 authors:
@@ -20,7 +20,7 @@ limits:
   maxBugbotWaitMin: 12
   maxCiWaitMin: 45
   maxNewBlockingPerCycle: 5
-  maxFixAgentTurns: 20
+  maxFixAgentTurns: 80
   consecutiveNoNewReviewsForHandoff: 2
   discoveryCycles: 1
 

--- a/.github/pr-agent/prompts/depth-review.md
+++ b/.github/pr-agent/prompts/depth-review.md
@@ -1,4 +1,4 @@
-# Depth review (Claude 4.6)
+# Depth review (Opus 4.8)
 
 You are reviewing a pull request for **logic, correctness, and integration risk** in MentraOS.
 

--- a/.github/pr-agent/prompts/depth-review.md
+++ b/.github/pr-agent/prompts/depth-review.md
@@ -1,4 +1,4 @@
-# Depth review (Opus 4.8)
+# Depth review
 
 You are reviewing a pull request for **logic, correctness, and integration risk** in MentraOS.
 

--- a/.github/pr-agent/prompts/pr-fix.md
+++ b/.github/pr-agent/prompts/pr-fix.md
@@ -1,4 +1,4 @@
-# Opus 4.8 fixer
+# PR fixer
 
 You are fixing a pull request branch for **MentraOS**. Apply **minimal** changes only.
 

--- a/.github/pr-agent/prompts/standards-review.md
+++ b/.github/pr-agent/prompts/standards-review.md
@@ -1,4 +1,4 @@
-# Standards review (Claude 4.6)
+# Standards review (Opus 4.8)
 
 You are reviewing a pull request for **MentraOS** standards and conventions.
 

--- a/.github/pr-agent/prompts/standards-review.md
+++ b/.github/pr-agent/prompts/standards-review.md
@@ -1,4 +1,4 @@
-# Standards review (Opus 4.8)
+# Standards review
 
 You are reviewing a pull request for **MentraOS** standards and conventions.
 

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -196,7 +196,7 @@ jobs:
             });
 
   review-standards:
-    name: Review (Claude 4.6 standards)
+    name: Review (Opus 4.8 standards)
     needs: [resolve-context, plan]
     if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_standards == 'true'
     runs-on: ubuntu-latest
@@ -231,7 +231,7 @@ jobs:
           if-no-files-found: ignore
 
   review-depth:
-    name: Review (Claude 4.6 depth)
+    name: Review (Opus 4.8 depth)
     needs: [resolve-context, plan]
     if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_depth == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -196,7 +196,7 @@ jobs:
             });
 
   review-standards:
-    name: Review (Opus 4.8 standards)
+    name: Review (standards)
     needs: [resolve-context, plan]
     if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_standards == 'true'
     runs-on: ubuntu-latest
@@ -231,7 +231,7 @@ jobs:
           if-no-files-found: ignore
 
   review-depth:
-    name: Review (Opus 4.8 depth)
+    name: Review (depth)
     needs: [resolve-context, plan]
     if: needs.plan.outputs.should_skip != 'true' && needs.plan.outputs.recheck_only != 'true' && needs.plan.outputs.run_depth == 'true'
     runs-on: ubuntu-latest
@@ -343,7 +343,7 @@ jobs:
         run: bun run cli aggregate
 
   fix:
-    name: Fix (Opus 4.8)
+    name: Fix
     needs: [resolve-context, plan, aggregate]
     if: |
       needs.aggregate.outputs.should_handoff != 'true' &&
@@ -363,7 +363,7 @@ jobs:
       - working-directory: scripts/pr-agent
         run: bun install --frozen-lockfile || bun install
 
-      - name: Run Opus fixer
+      - name: Run fixer
         working-directory: scripts/pr-agent
         env:
           PR_NUMBER: ${{ needs.resolve-context.outputs.pr_number }}

--- a/docs/pr-agent-orchestrator-setup.md
+++ b/docs/pr-agent-orchestrator-setup.md
@@ -1,6 +1,6 @@
 # PR Agent Orchestrator — Setup
 
-Automated PR review (Bugbot + Claude 4.6) and fix (Opus 4.8) via [`.github/workflows/pr-agent-orchestrator.yml`](../.github/workflows/pr-agent-orchestrator.yml).
+Automated PR review (Bugbot + Opus 4.8) and fix (Opus 4.8) via [`.github/workflows/pr-agent-orchestrator.yml`](../.github/workflows/pr-agent-orchestrator.yml).
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ Install the [Cursor GitHub app](https://cursor.com/docs/integrations/github) on 
 
 | Secret | Required | Purpose |
 |--------|----------|---------|
-| `CURSOR_API_KEY` | Yes | Claude 4.6 reviews + Opus 4.8 fixer ([Cursor SDK](https://cursor.com/docs/sdk/typescript)) |
+| `CURSOR_API_KEY` | Yes | Opus 4.8 reviews + fixer ([Cursor SDK](https://cursor.com/docs/sdk/typescript)) |
 | `PR_AGENT_GITHUB_TOKEN` | Optional | Fine-grained PAT with `contents:write` + `pull-requests:write` if `GITHUB_TOKEN` cannot push fixes |
 
 Create a team service account key at [Cursor Dashboard → Integrations](https://cursor.com/dashboard/integrations).
@@ -29,7 +29,7 @@ Edit [`.github/pr-agent.yml`](../.github/pr-agent.yml):
 
 - `authors.mode` — start with `label_only` or `allowlist` for rollout
 - `dryRun` — set `false` after Phase A testing
-- `reviewModel` / `fixModel` — defaults: Claude 4.6 / Opus 4.8
+- `reviewModel` / `fixModel` — defaults: Opus 4.8 / Opus 4.8
 
 ## Rollout phases
 

--- a/scripts/pr-agent/src/config.ts
+++ b/scripts/pr-agent/src/config.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 
 const ConfigSchema = z.object({
   dryRun: z.boolean().default(true),
-  reviewModel: z.string().default('claude-sonnet-4-6'),
+  reviewModel: z.string().default('claude-opus-4-8'),
   fixModel: z.string().default('claude-opus-4-8'),
   authors: z
     .object({
@@ -20,7 +20,7 @@ const ConfigSchema = z.object({
       maxBugbotWaitMin: z.number().default(12),
       maxCiWaitMin: z.number().default(45),
       maxNewBlockingPerCycle: z.number().default(5),
-      maxFixAgentTurns: z.number().default(20),
+      maxFixAgentTurns: z.number().default(80),
       consecutiveNoNewReviewsForHandoff: z.number().default(2),
       discoveryCycles: z.number().default(1),
     })


### PR DESCRIPTION
## Summary

Tunes the PR agent orchestrator (added in #3174) on two axes:

- **Opus 4.8 for all model-driven agents.** Switches `reviewModel` from `claude-sonnet-4-6` to `claude-opus-4-8`, so the standards review, depth review, and the fixer all run on Opus 4.8. (Bugbot is Cursor's hosted reviewer with no model knob — unchanged. It stays the third reviewer in the 2-of-3 rotation.)
- **Raises the fixer turn cap from 20 to 80** (`maxFixAgentTurns`). One fix round is a multi-turn Cursor Agent session; 80 gives it real headroom to read callers/callees, edit, and run tests without getting force-cancelled mid-edit. With `maxFixRounds: 5` unchanged, the effective per-PR fix budget is now up to ~400 turns across rounds, with reviewer/CI feedback injected between rounds.

## Changes

- `.github/pr-agent.yml` — `reviewModel` → `claude-opus-4-8`; `maxFixAgentTurns` 20 → 80
- `scripts/pr-agent/src/config.ts` — matching schema defaults
- Prompt titles, workflow job names, setup docs, `.cursor/BUGBOT.md` — relabel "Claude 4.6" → "Opus 4.8" for consistency (no behavior change)

## Tradeoffs

- **Cost/latency up.** Review runs 2 reviewers/cycle for up to 8 cycles; moving those off Sonnet onto Opus raises per-PR spend and wall-clock. The original split put Sonnet on high-volume reviewing and reserved Opus for the (less frequent) fix work — this collapses that. Worth watching credit usage during Phase B/C rollout before widening `authors.mode`.
- Still gated by `dryRun: true` and `authors.mode: label_only`, so no behavior change until those are flipped / the `agent-review` label is applied.

## Out of scope (noted, not addressed)

The fixer still does an unconditional commit/push after a forced turn-cap cancel (`fix.ts`), so a session guillotined mid-edit can push a partial fix. Bumping the cap makes that rarer but doesn't remove it — happy to do a follow-up that distinguishes a natural finish from a cap-cancel before committing.

## Test plan

- [ ] CI green on this PR (pr-agent has no dedicated suite; config parses via zod at runtime)
- [ ] On a test PR with `agent-review`, confirm review jobs show "Opus 4.8" job names and the fixer respects the 80-turn cap

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch all PR-agent reviewers to `claude-opus-4-8` and raise the fixer’s per-round turn cap to 80. No behavior change until `dryRun`/`authors.mode` are updated.

- **Refactors**
  - Set `reviewModel` to `claude-opus-4-8` (standards + depth); fixer already on Opus 4.8.
  - Raise `limits.maxFixAgentTurns` from 20 to 80.
  - Drop model names from prompt titles and workflow job labels; keep the model in `.github/pr-agent.yml` and setup docs. Update `.cursor/BUGBOT.md` wording; Bugbot unchanged.

<sup>Written for commit 1056d6214a7f61df5fca74137056b0f1f74cf1f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> When enabled, every review cycle will use a heavier model (higher cost/latency) and longer fix sessions can still commit after a turn-cap cancel; no product runtime or auth paths change.
> 
> **Overview**
> Moves the PR agent orchestrator onto **Opus 4.8 for standards and depth reviews** by changing `reviewModel` from `claude-sonnet-4-6` to `claude-opus-4-8` in `.github/pr-agent.yml` and matching Zod defaults in `scripts/pr-agent/src/config.ts` (the fixer was already on Opus via `fixModel`).
> 
> **Raises `limits.maxFixAgentTurns` from 20 to 80**, giving each fix-round Cursor Agent session more steps before the turn-cap cancel in `fix.ts`; `maxFixRounds` stays at 5.
> 
> Prompt titles, workflow job display names, setup docs, and `.cursor/BUGBOT.md` are updated to drop “Claude 4.6” branding—**no orchestration logic changes**. Behavior is still gated by `dryRun: true` and `authors.mode: label_only` until rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1056d6214a7f61df5fca74137056b0f1f74cf1f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->