### PR TITLE
Rename video capture default SDK APIs

### DIFF
--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -366,7 +366,7 @@ These are the supported React Native app developer entrypoints:
 | Default device | `getDefaultDevice`, `setDefaultDevice`, `clearDefaultDevice` |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setButtonVideoRecordingSettings`, `setButtonCameraLed`, `setButtonMaxRecordingTime`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
+| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setVideoRecordingDefaults`, `setCaptureLedEnabled`, `setMaxVideoRecordingDuration`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
 | Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, `setVoiceActivityDetectionEnabled`, `setPreferredMic`, `setOwnAppAudioPlaying`, `getGlassesMediaVolume`, `setGlassesMediaVolume` |
 | LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate` |
@@ -402,7 +402,7 @@ React Native exposes the narrowest return types for clear branching after `await
 | `forgetWifiNetwork(ssid)` | `WifiStatusChangeEvent` once the requested SSID is no longer connected. | Timeout, send failure, or another Wi-Fi status command in flight. |
 | `setHotspotState(enabled)` | `HotspotStatusChangeEvent` matching the requested enabled/disabled state. | `hotspot_error`, timeout, send failure, or another hotspot command in flight. |
 | `requestVersionInfo()` | `VersionInfoResult` from the ASG `version_info` response. | Timeout, send failure, or another version query in flight. |
-| Gallery/button settings | `SettingsAckSuccessEvent` with a non-failure status such as `applied` or `ready`; the SDK local settings store updates only after this ASG ack resolves. | `settings_ack.status` of `error`, `failed`, `failure`, or `rejected`; timeout; or send failure. |
+| Gallery capture settings | `SettingsAckSuccessEvent` with a non-failure status such as `applied` or `ready`; the SDK local settings store updates only after this ASG ack resolves. | `settings_ack.status` of `error`, `failed`, `failure`, or `rejected`; timeout; or send failure. |
 | `setCameraFov(...)` | `CameraFovResult` with `fov`, `roiPosition`, `requestId`, and `timestamp` after the ASG client reports the setting was applied to camera hardware after the restart cooldown; the SDK local FOV setting updates only after this result resolves. | Glasses-side FOV/settings error, persist-only/no hardware-application ack, timeout, or send failure. |
 | `queryGalleryStatus()` | `GalleryStatusEvent`, including `cameraBusy` and optional `cameraBusyReason`. | Timeout, send failure, or another gallery status query in flight. |
 | `requestPhoto(...)` | Terminal response after capture and delivery finish: React Native `PhotoSuccessResponseEvent`; Android/iOS successful `PhotoResponseEvent`. The success includes `uploadUrl`, and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`. Progress follows through `photo_status`. | Raw `photo_response.state === "error"` from glasses/phone, fallback upload failure, terminal response timeout, or send failure. |
@@ -423,10 +423,10 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 | Setting | API |
 | --- | --- |
 | Photo capture defaults | `setPhotoCaptureDefaults(...)` |
-| Video resolution and frame rate | `setButtonVideoRecordingSettings(width, height, fps)` |
-| Maximum video length | `setButtonMaxRecordingTime(minutes)` |
+| Video resolution and frame rate | `setVideoRecordingDefaults({width, height, fps})` |
+| Maximum local video length | `setMaxVideoRecordingDuration(minutes)` |
 | Camera field of view | `setCameraFov(...)` |
-| Camera LED preference | `setButtonCameraLed(...)` |
+| Local capture LED preference | `setCaptureLedEnabled(...)` |
 
 `requestPhoto(...)` accepts `requestId`, `appId`, `size`, `webhookUrl`, `authToken`, `compress`, `save`, `sound`, `exposureTimeNs`, `iso`, `aeExposureDivisor`, `isoCap`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, and `ispAnalogGain`. Native Android and iOS also expose `flash`; React Native always sends the capture light enabled. Manual `iso` is used only when `exposureTimeNs` enables manual exposure.
 
@@ -438,7 +438,7 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 | --- | --- |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `disconnect`, `forget` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera | `requestPhoto`, gallery mode, photo capture defaults, button video settings, camera field of view |
+| Camera | `requestPhoto`, gallery mode, photo capture defaults, video recording defaults, camera field of view |
 | Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, Voice Activity Detection setting and events, audio callbacks, local transcription, media volume |
 | Settings | Gallery mode, camera options, microphone route, Wi-Fi, hotspot, and OTA |

--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -134,7 +134,7 @@ Upload and BLE transfer statuses such as `uploading`, `compressing`, `ble_fallba
 
 ## Video Recording
 
-Use `startVideoRecording(...)` when your app needs a clip instead of a still image. Pass per-recording settings only when you want to override the saved button-video defaults; `maxRecordingTimeMinutes` is an auto-stop guard, and `0` or an omitted value records until your app stops recording or the glasses interrupt it.
+Use `startVideoRecording(...)` when your app needs a clip instead of a still image. Pass per-recording settings only when you want to override the saved video recording defaults; `maxRecordingTimeMinutes` is an auto-stop guard, and `0` or an omitted value records until your app stops recording or the glasses interrupt it.
 
 <Tabs>
   <Tab title="React Native">
@@ -227,8 +227,8 @@ Mentra Live has gallery mode for the right action button. When gallery mode is e
 ```ts
 await BluetoothSdk.setGalleryModeEnabled(true);
 await BluetoothSdk.setPhotoCaptureDefaults({size: 'medium'});
-await BluetoothSdk.setButtonVideoRecordingSettings(1280, 720, 30);
-await BluetoothSdk.setButtonMaxRecordingTime(3);
+await BluetoothSdk.setVideoRecordingDefaults({width: 1280, height: 720, fps: 30});
+await BluetoothSdk.setMaxVideoRecordingDuration(3);
 const cameraFov = await BluetoothSdk.setCameraFov({fov: 102, roiPosition: 'center'});
 console.log(`Camera ready at ${cameraFov.fov}°`);
 ```
@@ -239,8 +239,8 @@ console.log(`Camera ready at ${cameraFov.fov}°`);
 ```kotlin
 sdk.setGalleryModeEnabled(true)
 sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size = PhotoSize.MEDIUM))
-sdk.setButtonVideoRecordingSettings(width = 1280, height = 720, fps = 30)
-sdk.setButtonMaxRecordingTime(minutes = 3)
+sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width = 1280, height = 720, fps = 30))
+sdk.setMaxVideoRecordingDuration(minutes = 3)
 val cameraFov = sdk.setCameraFov(CameraFov(fov = 102, roiPosition = CameraRoiPosition.CENTER))
 println("Camera ready at ${cameraFov.fov}°")
 ```
@@ -251,8 +251,8 @@ println("Camera ready at ${cameraFov.fov}°")
 ```swift
 try await sdk.setGalleryModeEnabled(true)
 try await sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size: .medium))
-try await sdk.setButtonVideoRecordingSettings(width: 1280, height: 720, fps: 30)
-try await sdk.setButtonMaxRecordingTime(minutes: 3)
+try await sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width: 1280, height: 720, fps: 30))
+try await sdk.setMaxVideoRecordingDuration(minutes: 3)
 let cameraFov = try await sdk.setCameraFov(CameraFov(fov: 102, roiPosition: .center))
 print("Camera ready at \(cameraFov.fov)°")
 ```

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -16,7 +16,7 @@ cd Mentra-Bluetooth-SDK-Starter-Kit
 - Scanning for Mentra Live, connecting, disconnecting, and reconnecting to a saved/default device.
 - Reading typed glasses and Bluetooth status snapshots.
 - Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, video upload, audio, and SDK log events.
-- Controlling Mentra Live features such as gallery mode, button photo/video settings, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
+- Controlling Mentra Live features such as gallery mode, photo capture defaults, video recording defaults, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
 - Running the default glasses-to-phone photo and streaming demos, plus optional cloud-server demos for external media upload and streaming endpoints.
 
 ## Android

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -445,16 +445,16 @@ class BluetoothSdkModule : Module() {
             requireSdk().setPhotoCaptureDefaults(params.toPhotoCaptureDefaults()).values
         }
 
-        AsyncFunction("setButtonVideoRecordingSettings") { width: Int, height: Int, fps: Int ->
-            requireSdk().setButtonVideoRecordingSettings(width, height, fps).values
+        AsyncFunction("setVideoRecordingDefaults") { width: Int, height: Int, fps: Int ->
+            requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
         }
 
-        AsyncFunction("setButtonCameraLed") { enabled: Boolean ->
-            requireSdk().setButtonCameraLed(enabled).values
+        AsyncFunction("setCaptureLedEnabled") { enabled: Boolean ->
+            requireSdk().setCaptureLedEnabled(enabled).values
         }
 
-        AsyncFunction("setButtonMaxRecordingTime") { minutes: Int ->
-            requireSdk().setButtonMaxRecordingTime(minutes).values
+        AsyncFunction("setMaxVideoRecordingDuration") { minutes: Int ->
+            requireSdk().setMaxVideoRecordingDuration(minutes).values
         }
 
         AsyncFunction("setCameraFov") { fov: Map<String, Any> ->

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -527,30 +527,27 @@ class MentraBluetoothSdk private constructor(
             send = { requestId -> deviceManager.sendButtonPhotoSettings(requestId, settings) },
         )
 
-    fun setButtonVideoRecordingSettings(width: Int, height: Int, fps: Int): SettingsAckEvent =
+    fun setVideoRecordingDefaults(defaults: VideoRecordingDefaults): SettingsAckEvent =
         performSettingsCommand(
             setting = "button_video_recording",
             updateStore = { _ ->
-                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_width", width)
-                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_height", height)
-                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_fps", fps)
+                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_width", defaults.width)
+                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_height", defaults.height)
+                DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_fps", defaults.fps)
             },
             send = { requestId ->
-                deviceManager.sendButtonVideoRecordingSettings(requestId, width, height, fps)
+                deviceManager.sendButtonVideoRecordingSettings(requestId, defaults.width, defaults.height, defaults.fps)
             },
         )
 
-    fun setButtonVideoRecordingSettings(settings: ButtonVideoRecordingSettings): SettingsAckEvent =
-        setButtonVideoRecordingSettings(width = settings.width, height = settings.height, fps = settings.fps)
-
-    fun setButtonCameraLed(enabled: Boolean): SettingsAckEvent =
+    fun setCaptureLedEnabled(enabled: Boolean): SettingsAckEvent =
         performSettingsCommand(
             setting = "button_camera_led",
             updateStore = { _ -> DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_camera_led", enabled) },
             send = { requestId -> deviceManager.sendButtonCameraLedSetting(requestId, enabled) },
         )
 
-    fun setButtonMaxRecordingTime(minutes: Int): SettingsAckEvent =
+    fun setMaxVideoRecordingDuration(minutes: Int): SettingsAckEvent =
         performSettingsCommand(
             setting = "button_max_recording_time",
             updateStore = { _ ->

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
@@ -71,7 +71,7 @@ data class PhotoCaptureDefaults(
     val resetCaptureTuning: Boolean = false,
 )
 
-data class ButtonVideoRecordingSettings(
+data class VideoRecordingDefaults(
     val width: Int,
     val height: Int,
     val fps: Int,

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -331,19 +331,19 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
             return try await sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults.from(params: params)).values
         }
 
-        AsyncFunction("setButtonVideoRecordingSettings") { (width: Int, height: Int, fps: Int) in
+        AsyncFunction("setVideoRecordingDefaults") { (width: Int, height: Int, fps: Int) in
             let sdk = await MainActor.run { self.bluetoothSdk() }
-            return try await sdk.setButtonVideoRecordingSettings(width: width, height: height, fps: fps).values
+            return try await sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width: width, height: height, fps: fps)).values
         }
 
-        AsyncFunction("setButtonCameraLed") { (enabled: Bool) in
+        AsyncFunction("setCaptureLedEnabled") { (enabled: Bool) in
             let sdk = await MainActor.run { self.bluetoothSdk() }
-            return try await sdk.setButtonCameraLed(enabled: enabled).values
+            return try await sdk.setCaptureLedEnabled(enabled).values
         }
 
-        AsyncFunction("setButtonMaxRecordingTime") { (minutes: Int) in
+        AsyncFunction("setMaxVideoRecordingDuration") { (minutes: Int) in
             let sdk = await MainActor.run { self.bluetoothSdk() }
-            return try await sdk.setButtonMaxRecordingTime(minutes: minutes).values
+            return try await sdk.setMaxVideoRecordingDuration(minutes: minutes).values
         }
 
         AsyncFunction("setCameraFov") { (fov: [String: Any]) in

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -541,30 +541,26 @@ public final class MentraBluetoothSDK {
         )
     }
 
-    public func setButtonVideoRecordingSettings(width: Int, height: Int, fps: Int) async throws -> SettingsAckEvent {
+    public func setVideoRecordingDefaults(_ defaults: VideoRecordingDefaults) async throws -> SettingsAckEvent {
         try await performSettingsCommand(
             setting: "button_video_recording",
             updateStore: { _ in
-                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_width", width)
-                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_height", height)
-                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_fps", fps)
+                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_width", defaults.width)
+                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_height", defaults.height)
+                DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_fps", defaults.fps)
             },
             send: { requestId in
                 try DeviceManager.shared.sendButtonVideoRecordingSettings(
                     requestId: requestId,
-                    width: width,
-                    height: height,
-                    fps: fps
+                    width: defaults.width,
+                    height: defaults.height,
+                    fps: defaults.fps
                 )
             }
         )
     }
 
-    public func setButtonVideoRecordingSettings(_ settings: ButtonVideoRecordingSettings) async throws -> SettingsAckEvent {
-        try await setButtonVideoRecordingSettings(width: settings.width, height: settings.height, fps: settings.fps)
-    }
-
-    public func setButtonCameraLed(enabled: Bool) async throws -> SettingsAckEvent {
+    public func setCaptureLedEnabled(_ enabled: Bool) async throws -> SettingsAckEvent {
         try await performSettingsCommand(
             setting: "button_camera_led",
             updateStore: { _ in DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_camera_led", enabled) },
@@ -572,7 +568,7 @@ public final class MentraBluetoothSDK {
         )
     }
 
-    public func setButtonMaxRecordingTime(minutes: Int) async throws -> SettingsAckEvent {
+    public func setMaxVideoRecordingDuration(minutes: Int) async throws -> SettingsAckEvent {
         try await performSettingsCommand(
             setting: "button_max_recording_time",
             updateStore: { _ in

--- a/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
@@ -111,7 +111,7 @@ public struct PhotoCaptureDefaults {
     }
 }
 
-public struct ButtonVideoRecordingSettings {
+public struct VideoRecordingDefaults {
     public let width: Int
     public let height: Int
     public let fps: Int

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -448,9 +448,15 @@ export type PhotoCaptureDefaults = {
 }
 export type PhotoCompression = "none" | "medium" | "heavy"
 
+export type VideoRecordingDefaults = {
+  width: number
+  height: number
+  fps: number
+}
+
 /**
  * Optional per-recording video settings for {@link startVideoRecording}. When
- * omitted, the glasses fall back to their saved button-video settings. Any
+ * omitted, the glasses fall back to their saved video recording defaults. Any
  * field left undefined is omitted from the BLE command (glasses default applies).
  */
 export interface VideoRecordingSettings {
@@ -947,9 +953,9 @@ export interface BluetoothSdkPublicModule {
   setGalleryModeEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
   setPhotoCaptureDefaults(settings: PhotoCaptureDefaults): Promise<SettingsAckSuccessEvent>
-  setButtonVideoRecordingSettings(width: number, height: number, fps: number): Promise<SettingsAckSuccessEvent>
-  setButtonCameraLed(enabled: boolean): Promise<SettingsAckSuccessEvent>
-  setButtonMaxRecordingTime(minutes: number): Promise<SettingsAckSuccessEvent>
+  setVideoRecordingDefaults(settings: VideoRecordingDefaults): Promise<SettingsAckSuccessEvent>
+  setCaptureLedEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
+  setMaxVideoRecordingDuration(minutes: number): Promise<SettingsAckSuccessEvent>
   setCameraFov(request: CameraFovRequest): Promise<CameraFovResult>
   queryGalleryStatus(): Promise<GalleryStatusEvent>
   requestPhoto(params: PhotoRequestParams): Promise<PhotoSuccessResponseEvent>

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -122,9 +122,9 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   setGalleryModeEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
   setPhotoCaptureDefaults(settings: PhotoCaptureDefaults): Promise<SettingsAckSuccessEvent>
-  setButtonVideoRecordingSettings(width: number, height: number, fps: number): Promise<SettingsAckSuccessEvent>
-  setButtonCameraLed(enabled: boolean): Promise<SettingsAckSuccessEvent>
-  setButtonMaxRecordingTime(minutes: number): Promise<SettingsAckSuccessEvent>
+  setVideoRecordingDefaults(width: number, height: number, fps: number): Promise<SettingsAckSuccessEvent>
+  setCaptureLedEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
+  setMaxVideoRecordingDuration(minutes: number): Promise<SettingsAckSuccessEvent>
   setCameraFov(request: CameraFovRequest): Promise<CameraFovResult>
   queryGalleryStatus(): Promise<GalleryStatusEvent>
   requestPhoto(params: PhotoRequestParams): Promise<PhotoSuccessResponseEvent>

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -3,6 +3,7 @@ import type {
   BluetoothSdkEventListener,
   BluetoothSdkEventName,
   BluetoothSdkPublicModule,
+  VideoRecordingDefaults,
 } from "./BluetoothSdk.types"
 
 const PUBLIC_EVENT_NAMES = new Set<BluetoothSdkEventName>([
@@ -85,10 +86,10 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
   setVoiceActivityDetectionEnabled:
     PrivateBluetoothSdkModule.setVoiceActivityDetectionEnabled.bind(PrivateBluetoothSdkModule),
   setPhotoCaptureDefaults: PrivateBluetoothSdkModule.setPhotoCaptureDefaults.bind(PrivateBluetoothSdkModule),
-  setButtonVideoRecordingSettings:
-    PrivateBluetoothSdkModule.setButtonVideoRecordingSettings.bind(PrivateBluetoothSdkModule),
-  setButtonCameraLed: PrivateBluetoothSdkModule.setButtonCameraLed.bind(PrivateBluetoothSdkModule),
-  setButtonMaxRecordingTime: PrivateBluetoothSdkModule.setButtonMaxRecordingTime.bind(PrivateBluetoothSdkModule),
+  setVideoRecordingDefaults: ({width, height, fps}: VideoRecordingDefaults) =>
+    PrivateBluetoothSdkModule.setVideoRecordingDefaults(width, height, fps),
+  setCaptureLedEnabled: PrivateBluetoothSdkModule.setCaptureLedEnabled.bind(PrivateBluetoothSdkModule),
+  setMaxVideoRecordingDuration: PrivateBluetoothSdkModule.setMaxVideoRecordingDuration.bind(PrivateBluetoothSdkModule),
   setCameraFov: PrivateBluetoothSdkModule.setCameraFov.bind(PrivateBluetoothSdkModule),
   queryGalleryStatus: PrivateBluetoothSdkModule.queryGalleryStatus.bind(PrivateBluetoothSdkModule),
   requestPhoto: PrivateBluetoothSdkModule.requestPhoto.bind(PrivateBluetoothSdkModule),
@@ -217,6 +218,7 @@ export type {
   SwipeVolumeStatusEvent,
   SwitchStatusEvent,
   TouchEvent,
+  VideoRecordingDefaults,
   VideoRecordingStartedStatusEvent,
   VideoRecordingStatusEvent,
   VideoRecordingStatusState,


### PR DESCRIPTION
## Summary
- Rename the remaining public Bluetooth SDK button-named capture settings APIs to `setVideoRecordingDefaults`, `setCaptureLedEnabled`, and `setMaxVideoRecordingDuration`.
- Expose `VideoRecordingDefaults` as the TS/Android/iOS object shape, matching the existing photo defaults style.
- Update Mentra Live docs/snippets while keeping ASG `button_*` wire/store vocabulary unchanged.

## Logic review
- Action-button long press uses the stored video defaults and max duration.
- Action-button/gallery local captures use the stored LED preference.
- App-driven `startVideoRecording` with partial `settings` also merges missing width/height/fps from the saved video defaults, so the video defaults API is not only a Mentra Live button-trigger setting.
- Max duration and LED are still local-capture defaults, but the public SDK no longer exposes the internal button naming.

## Validation
- `cd mobile/modules/bluetooth-sdk && bun test`
- `cd mobile/modules/bluetooth-sdk && bun run build`
- `git diff --check`
- `cd mobile/modules/bluetooth-sdk && bun run lint` attempted; blocked by existing repo-level ESLint config resolution: `Cannot find package 'globals' imported from /Users/philippe/dev/MentraOS-dev/eslint.config.mjs`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking public API rename across React Native, Android, and iOS; runtime behavior should match the old methods, but any app still calling the removed symbols will fail at compile or runtime until migrated.
> 
> **Overview**
> Renames the public Bluetooth SDK capture-settings surface away from **button-** prefixed names, aligning video defaults with the existing `setPhotoCaptureDefaults` / `PhotoCaptureDefaults` pattern.
> 
> **Public API changes (breaking for integrators):**
> - `setButtonVideoRecordingSettings(width, height, fps)` → **`setVideoRecordingDefaults`** with a **`VideoRecordingDefaults`** `{ width, height, fps }` type on TS, Android, and iOS
> - `setButtonCameraLed` → **`setCaptureLedEnabled`**
> - `setButtonMaxRecordingTime` → **`setMaxVideoRecordingDuration`**
> 
> Wiring is unchanged under the hood: native modules still call the same `sendButton*` device commands and **`button_*`** DeviceStore keys; only the documented developer-facing names and RN export shape change (RN accepts an object and unpacks to the bridge). Mentra Live docs and example snippets are updated to the new names and wording (e.g. “video recording defaults” instead of “button-video defaults”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9448093a9bfc807d42022513a22607dceaa5c6d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->