### PR TITLE
[codex] Fix agent guidance doc paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ MentraOS is an open source operating system, app store, and development framewor
 - iOS native module: `mobile/ios`
 - Backend & web portals: `cloud` (includes developer portal & app store)
 - Android-based smart glasses client: `asg_client` (uses `android_core` as a library)
-- MentraOS Store: `cloud/store/` (web app for app discovery)
+- MentraOS Store: `cloud/websites/store/` (web app for app discovery)
 - Developer Console: `cloud/websites/console/` (web app for app management)
 
 ## Monorepo Structure
@@ -28,7 +28,7 @@ Consult module-specific AGENTS.md when working within that module.
 
 ## Project Structure & Module Organization
 
-Core client app lives in `mobile/` (Expo React Native). Backend services, the TypeScript SDK, and the store front end sit in `cloud/packages/`, with integration tests in `cloud/tests/`. Platform SDKs are in `android_core/`, `android_library/`, `sdk_ios/`; hardware tooling lives in `mcu_client/`. Public Mintlify docs live in `mintlify-docs/`; notes and plans live in `agents/` and `notes/`.
+Core client app lives in `mobile/` (Expo React Native). Backend services and the TypeScript SDK sit in `cloud/packages/`, while the Developer Console and Store front ends live in `cloud/websites/`; cloud integration tests are in `cloud/tests/`. Platform SDKs are in `android_core/`, `android_library/`, `sdk_ios/`; hardware tooling lives in `mcu_client/`. Public Mintlify docs live in `mintlify-docs/`; notes and plans live in `agents/` and `notes/`.
 
 ## Build Commands
 

--- a/asg_client/AGENTS.md
+++ b/asg_client/AGENTS.md
@@ -125,7 +125,7 @@ asg_client/
 │   ├── utils/          # Utility classes
 │   ├── di/             # Dependency injection
 │   └── receiver/       # Broadcast receivers
-├── agents/             # Feature documentation
+├── docs/               # ASG documentation, including feature docs and agent scratchpad
 ├── StreamPackLite/     # RTMP streaming library (external)
 ├── credentials/        # Debug keystore (not committed)
 ├── AGENTS.md           # Development guide
@@ -182,13 +182,11 @@ asg_client/
 ## Documentation Reference
 
 - **README.md** - Project overview and quick start
-- **agents/BES_OTA_README.md** - BES OTA update system
-- **agents/CAMERA_WEBSERVER_README.md** - Camera web server documentation
-- **agents/CUSTOM_GATT_AUDIO.md** - Custom GATT audio implementation
-- **agents/DELETE_FILES_ENDPOINT.md** - File deletion endpoint documentation
-- **agents/K900_LED_CONTROL.md** - K900 LED control system
-- **agents/PHOTO_TESTING_GUIDE.md** - Photo capture testing guide
-- **agents/RGB_LED_CONTROL_IMPLEMENTATION.md** - RGB LED control details
+- **docs/features/bes-ota.md** - BES OTA update system
+- **docs/features/camera-web-server.md** - Camera web server documentation, including the `/api/delete-files` endpoint
+- **docs/ASG_CLIENT_API.md** - ASG command surface, including audio and RGB LED commands
+- **docs/agents/PHOTO_TESTING_GUIDE.md** - Photo capture testing guide
+- **docs/features/led-control.md** - K900 local LED and RGB LED control details
 - **app/src/main/java/com/mentra/asg_client/reporting/SENTRY_CONFIGURATION.md** - Sentry error reporting setup
 - **app/src/main/java/com/mentra/asg_client/reporting/README.md** - Comprehensive reporting system guide
 

--- a/cloud/AGENTS.md
+++ b/cloud/AGENTS.md
@@ -63,21 +63,21 @@ The following improvements have been implemented to enhance system reliability:
 - Apps can register their servers with MentraOS Cloud
 - Tracks sessions by App server to enable recovery after restarts
 - Provides automatic reconnection when App servers restart
-- Documentation in `/notes/App-SERVER-REGISTRATION.md`
+- Current reference: `/cloud/packages/cloud/src/services/core/docs/current-websocket-implementation.md` (App Server Registration) and `/cloud/packages/cloud/src/services/layout/docs/websocket-reliability-design.md` (session recovery)
 
 ### Enhanced Error Handling in SDK
 
 - Prevents Apps from crashing when receiving invalid data
 - Adds robust validation and sanitization of all messages
 - Improves error recovery for WebSocket connections
-- Documentation in `/notes/sdk/ERROR-HANDLING-ENHANCEMENTS.md`
+- Current reference: `/cloud/packages/sdk/src/app/session/index.ts`, `/cloud/packages/sdk/src/logging/errors.ts`, and `/mintlify-docs/app-devs/reference/interfaces/message-types.mdx`
 
 ### Automatic Resource Management
 
 - Automatically tracks and cleans up resources to prevent memory leaks
 - Provides a unified API for managing timers, event handlers, and connections
 - Integrated with AppSession for better connection management
-- Documentation in `/notes/sdk/RESOURCE-TRACKER.md`
+- Current reference: `/mintlify-docs/app-devs/reference/utilities.mdx`, `/cloud/packages/sdk/src/utils/resource-tracker.ts`, and `/cloud/packages/cloud/src/utils/resource-tracker.ts`
 
 ### Connection Health Monitoring
 
@@ -85,7 +85,7 @@ The following improvements have been implemented to enhance system reliability:
 - Tracks connection activity and detects stale connections
 - Automatically closes dead connections to prevent resource wastage
 - Provides system health statistics for monitoring
-- Documentation in `/notes/CONNECTION-HEALTH-MONITORING.md`
+- Current reference: `/cloud/packages/cloud/src/services/core/docs/heartbeat-manager.md` and `/cloud/packages/cloud/src/services/layout/docs/websocket-reliability-design.md`
 
 ## Planned Improvements
 
@@ -97,7 +97,7 @@ The following improvements have been implemented to enhance system reliability:
 - ✅ Implemented robust throttling with proper queue management
 - ◻️ Complete integration and testing
 - ◻️ Optimize performance based on metrics
-- Documentation in `/notes/DISPLAY-MANAGER-IMPROVEMENTS.md`
+- Current reference: `/cloud/docs/cloud-architecture/managers/display-manager.mdx` and `/cloud/packages/cloud/src/services/layout/DisplayManager6.1.ts`
 
 ## Working with Smart Glasses Hardware
 

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -1,7 +1,7 @@
 # MentraOS Manager Guidelines
 
 RULES:
-READ: mentraos-manager-guidelines.mdx
+READ: ../mintlify-docs/os-devs/contributing/mentraos-manager-guidelines.mdx
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Point `mobile/AGENTS.md` at the moved MentraOS Manager guidelines under `mintlify-docs/os-devs/contributing/`.
- Update stale root store path guidance from `cloud/store/` to `cloud/websites/store/` and clarify where cloud packages vs websites live.
- Replace deleted `cloud/AGENTS.md` note references with current docs or source-of-truth files.
- Replace deleted `asg_client/agents/*` references with the current `asg_client/docs/*` docs.

## Validation

- `rg --files | rg '(^|/)AGENTS\.md$'`
- Searched AGENTS guidance for stale `READ:`, `Documentation in`, old `/notes/...`, `cloud/store`, and `asg_client/agents` references.
- Verified every updated referenced path exists.
- `git diff --check -- AGENTS.md mobile/AGENTS.md cloud/AGENTS.md asg_client/AGENTS.md`

Note: Prettier is not installed in this checkout, so no Markdown formatter command was available locally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to AGENTS.md files; no application, API, or build behavior changes.
> 
> **Overview**
> Updates **agent guidance** across the monorepo so `AGENTS.md` files point at current docs and layout instead of removed or moved paths.
> 
> **Root `AGENTS.md`:** MentraOS Store is documented as `cloud/websites/store/` (not `cloud/store/`). Monorepo structure text now separates `cloud/packages/` (backend + SDK) from `cloud/websites/` (Console and Store).
> 
> **`mobile/AGENTS.md`:** The required `READ:` target for Manager guidelines is `../mintlify-docs/os-devs/contributing/mentraos-manager-guidelines.mdx`.
> 
> **`cloud/AGENTS.md`:** “Recent improvements” and Display Manager sections no longer cite deleted `/notes/...` files; they link to current websocket, SDK, resource-tracker, heartbeat, and display-manager docs under `cloud/packages/`, `cloud/docs/`, and `mintlify-docs/`.
> 
> **`asg_client/AGENTS.md`:** Project tree and documentation references use `docs/` (e.g. `docs/features/*`, `docs/ASG_CLIENT_API.md`) instead of the old `agents/` feature markdown paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e0800a455354db31abc214075487712fce3531. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->