### PR TITLE
Remove capture LED setting path

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -92,7 +92,8 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             PhotoCaptureSettings.logMergeDiagnostics(
                     requestCaptureSettings, captureSettings, asgSettings, requestId);
             String compress = resolvePhotoCompress(data, asgSettings);
-            boolean flash = data.optBoolean("flash", true);
+            // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
+            boolean flash = true;
             boolean sound = resolvePhotoSound(data, asgSettings);
             Long exposureTimeNs = PhotoExposureTimeNs.parse(data);
             Integer requestedIso = PhotoIso.parse(data);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/SettingsCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/SettingsCommandHandler.java
@@ -47,7 +47,6 @@ public class SettingsCommandHandler implements ICommandHandler {
                 "button_video_recording_setting",
                 "button_max_recording_time",
                 "button_photo_setting",
-                "button_camera_led",
                 "button_mode_setting",
                 "camera_fov_setting");
     }
@@ -64,8 +63,6 @@ public class SettingsCommandHandler implements ICommandHandler {
                     return handleButtonMaxRecordingTime(data);
                 case "button_photo_setting":
                     return handleButtonPhotoSetting(data);
-                case "button_camera_led":
-                    return handleButtonCameraLedSetting(data);
                 case "button_mode_setting":
                     return handleButtonModeSetting(data);
                 case "camera_fov_setting":
@@ -359,37 +356,6 @@ public class SettingsCommandHandler implements ICommandHandler {
             }
         } catch (Exception e) {
             Log.e(TAG, "Error handling button photo setting", e);
-            return false;
-        }
-    }
-
-    /** Handle button camera LED setting command */
-    public boolean handleButtonCameraLedSetting(JSONObject data) {
-        try {
-            String requestId = getRequestId(data);
-            boolean enabled = data.optBoolean("enabled", true);
-
-            Log.d(TAG, "📱 Received button camera LED setting: " + enabled);
-
-            AsgSettings asgSettings = serviceManager.getAsgSettings();
-            if (asgSettings != null) {
-                asgSettings.setButtonCameraLedEnabled(enabled);
-                Log.d(TAG, "✅ Button camera LED setting saved: " + enabled);
-                JSONObject values = new JSONObject();
-                values.put("enabled", enabled);
-                sendSettingsAck(requestId, "button_camera_led", STATUS_APPLIED, values);
-                return true;
-            } else {
-                Log.e(TAG, "Settings not available");
-                sendSettingsError(
-                        requestId,
-                        "button_camera_led",
-                        "settings_unavailable",
-                        "Settings are not available.");
-                return false;
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "Error handling button camera LED setting", e);
             return false;
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -167,7 +167,8 @@ public class StreamCommandHandler implements ICommandHandler {
             stopAllServices();
 
             String streamId = data.optString("streamId", "");
-            boolean flash = data.optBoolean("flash", true);
+            // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
+            boolean flash = true;
             boolean sound = data.optBoolean("sound", true);
 
             // Parse video/audio config (supports full and compact keys)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/VideoCommandHandler.java
@@ -191,7 +191,8 @@ public class VideoCommandHandler extends BaseMediaCommandHandler {
 
             // Start recording with settings
             boolean save = data.optBoolean("save", false);
-            boolean flash = data.optBoolean("flash", true);
+            // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
+            boolean flash = true;
             boolean sound = data.optBoolean("sound", true);
             // Optional auto-stop after N minutes; 0 (the default) means record until
             // stopped or interrupted (battery/storage/thermal/error). Validate like the

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -123,8 +123,8 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
             return;
         }
 
-        // Get LED setting
-        boolean ledEnabled = serviceManager.getAsgSettings().getButtonCameraLedEnabled();
+        // Capture light is mandatory for privacy.
+        boolean ledEnabled = true;
 
         // Get current battery level (with null check)
         int batteryLevel = -1;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
@@ -20,7 +20,6 @@ public class AsgSettings {
     private static final String KEY_BUTTON_VIDEO_FPS = "button_video_fps";
     private static final String KEY_BUTTON_MAX_RECORDING_TIME_MINUTES = "button_max_recording_time_minutes";
     private static final String KEY_BUTTON_PHOTO_SIZE = "button_photo_size";
-    private static final String KEY_BUTTON_CAMERA_LED = "button_camera_led";
     private static final String KEY_SAVE_IN_GALLERY_MODE = "save_in_gallery_mode";
     private static final String KEY_ZSL_ENABLED = "zsl_enabled";
     private static final String KEY_MFNR_ENABLED = "mfnr_enabled";
@@ -151,26 +150,6 @@ public class AsgSettings {
         prefs.edit().putString(KEY_BUTTON_PHOTO_SIZE, size).commit();
     }
     
-    /**
-     * Get the camera LED setting for button-initiated recordings
-     * @return true if LED should be enabled, false otherwise
-     */
-    public boolean getButtonCameraLedEnabled() {
-        boolean enabled = prefs.getBoolean(KEY_BUTTON_CAMERA_LED, true); // Default to true
-        Log.d(TAG, "Retrieved button camera LED setting: " + enabled);
-        return enabled;
-    }
-    
-    /**
-     * Set the camera LED setting for button-initiated recordings
-     * @param enabled true to enable LED, false to disable
-     */
-    public void setButtonCameraLedEnabled(boolean enabled) {
-        Log.d(TAG, "Setting button camera LED to: " + enabled);
-        // Using commit() for immediate persistence
-        prefs.edit().putBoolean(KEY_BUTTON_CAMERA_LED, enabled).commit();
-    }
-
     /**
      * Get the camera FOV setting (K900). Supported range: 62-118 inclusive (118 = No ROI).
      * @return FOV in degrees (default 118 = No ROI)

--- a/asg_client/docs/features/button-press-system.md
+++ b/asg_client/docs/features/button-press-system.md
@@ -70,7 +70,7 @@ if (captureService.isRecordingVideo()) {
 Settings consulted:
 
 - `getButtonPhotoSize()` — `small` / `medium` / `large`. Set via [`button_photo_setting`](../ASG_CLIENT_API.md#button_photo_setting).
-- `getButtonCameraLedEnabled()` — privacy LED on/off during capture. Set via [`button_camera_led`](../ASG_CLIENT_API.md#button_camera_led).
+- The privacy LED is always enabled during capture.
 
 ## Long press: video record / stop
 
@@ -113,7 +113,6 @@ The phone app sets button-related settings via the [API commands](../ASG_CLIENT_
 - `button_photo_setting` — short-press photo resolution
 - `button_video_recording_setting` — long-press video resolution + fps
 - `button_max_recording_time` — max long-press recording duration
-- `button_camera_led` — privacy LED enable
 
 ## Logcat tags
 

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -89,7 +89,6 @@ Each command responds with `<command>_response` on success or `rgb_led_control_e
 | Event                     | Local MTK LED               | RGB ring                              |
 | ------------------------- | --------------------------- | ------------------------------------- |
 | Photo capture (flash on)  | brief flash                 | white flash via `rgb_led_photo_flash` |
-| Photo capture (flash off) | nothing                     | nothing                               |
 | Video recording start     | solid on                    | white solid via `rgb_led_video_solid` |
 | Video recording stop      | off                         | off via `rgb_led_control_off`         |
 | Stream start              | solid on                    | (handled by stream service)           |
@@ -98,7 +97,7 @@ Each command responds with `<command>_response` on success or `rgb_led_control_e
 | Buffer recording stopped  | off                         | (BES default)                         |
 | Recording error           | off                         | off                                   |
 
-Whether the local MTK LED actually fires for a given button-triggered capture is gated by the [`button_camera_led` setting](../ASG_CLIENT_API.md#button_camera_led).
+The local MTK capture LED is always enabled for photo, video, and stream capture.
 
 ## Direct manipulation (Java only — not generally needed)
 

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -366,7 +366,7 @@ These are the supported React Native app developer entrypoints:
 | Default device | `getDefaultDevice`, `setDefaultDevice`, `clearDefaultDevice` |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setVideoRecordingDefaults`, `setCaptureLedEnabled`, `setMaxVideoRecordingDuration`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
+| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setVideoRecordingDefaults`, `setMaxVideoRecordingDuration`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
 | Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, `setVoiceActivityDetectionEnabled`, `setPreferredMic`, `setOwnAppAudioPlaying`, `getGlassesMediaVolume`, `setGlassesMediaVolume` |
 | LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate` |
@@ -426,9 +426,8 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 | Video resolution and frame rate | `setVideoRecordingDefaults({width, height, fps})` |
 | Maximum local video length | `setMaxVideoRecordingDuration(minutes)` |
 | Camera field of view | `setCameraFov(...)` |
-| Local capture LED preference | `setCaptureLedEnabled(...)` |
 
-`requestPhoto(...)` accepts `requestId`, `appId`, `size`, `webhookUrl`, `authToken`, `compress`, `save`, `sound`, `exposureTimeNs`, `iso`, `aeExposureDivisor`, `isoCap`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, and `ispAnalogGain`. Native Android and iOS also expose `flash`; React Native always sends the capture light enabled. Manual `iso` is used only when `exposureTimeNs` enables manual exposure.
+`requestPhoto(...)` accepts `requestId`, `appId`, `size`, `webhookUrl`, `authToken`, `compress`, `save`, `sound`, `exposureTimeNs`, `iso`, `aeExposureDivisor`, `isoCap`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, and `ispAnalogGain`. Photo, video, and stream capture always enable the camera light as a privacy indicator. Manual `iso` is used only when `exposureTimeNs` enables manual exposure.
 
 `setPhotoCaptureDefaults(...)` accepts `size`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, `ispAnalogGain`, `aeExposureDivisor`, `isoCap`, `compress`, `sound`, and `resetCaptureTuning`. Omitted fields leave existing action-button photo defaults unchanged. `resetCaptureTuning: true` restores optional tuning fields to standard capture behavior and does not change photo size unless `size` is also provided.
 

--- a/mintlify-docs/mentra-live/camera-streaming.mdx
+++ b/mintlify-docs/mentra-live/camera-streaming.mdx
@@ -73,7 +73,7 @@ print("photo delivered: \(photo.requestId)")
 
 `requestPhoto(...)` resolves when the full photo action reaches terminal success: capture completed and the JPEG was delivered to the webhook, either directly from the glasses over Wi-Fi or through the phone's Bluetooth fallback relay. It rejects or throws when the glasses report a terminal `photo_response` error, when phone-side fallback upload fails, when the SDK cannot send the command, or when no terminal response arrives before the command timeout. Use `photo_status` for intermediate progress such as `accepted`, `configuring`, `capturing`, `captured`, `uploading`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring`; `photo_response` is the final success/error result. The returned success includes `uploadUrl`, and may include webhook-returned metadata such as `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`.
 
-The webhook should accept multipart form data with a `photo` file and `requestId`. If `authToken` is provided, the uploader adds `Authorization: Bearer <token>`. React Native enables the capture light for photo requests; native Android and iOS expose a `flash` request option that defaults to `true`.
+The webhook should accept multipart form data with a `photo` file and `requestId`. If `authToken` is provided, the uploader adds `Authorization: Bearer <token>`. The capture light is always enabled for photo, video, and stream capture as a privacy indicator.
 
 For one-shot manual capture tuning, pass `exposureTimeNs` and `iso` together. `exposureTimeNs` is sensor exposure time in nanoseconds; `iso` is sensor ISO. If `exposureTimeNs` is omitted, `null` / `nil`, invalid, or unsupported by the connected glasses, the camera uses auto exposure and ignores `iso`.
 
@@ -91,7 +91,6 @@ For one-shot manual capture tuning, pass `exposureTimeNs` and `iso` together. `e
 | `compress` | React Native, Android, iOS | Upload compression: `none`, `medium`, or `heavy`. Omitted native values default to `none`. |
 | `save` | React Native, Android, iOS | Keeps the captured photo in the glasses gallery after delivery when `true`. When `false`, the photo is only used for the requested delivery. Defaults to `false`. |
 | `sound` | React Native, Android, iOS | Plays the shutter sound when `true`; defaults to `true`. |
-| `flash` | Android, iOS | Enables the capture flash/privacy light for this request; defaults to `true`. React Native always sends `true`. |
 | `exposureTimeNs` | React Native, Android, iOS | Optional manual sensor exposure time in nanoseconds. Omit or pass `null` / `nil` for auto exposure. |
 | `iso` | React Native, Android, iOS | Optional manual ISO. Used only when `exposureTimeNs` enables manual exposure. |
 | `aeExposureDivisor` | React Native, Android, iOS | Optional scan-style auto-exposure divisor. Values must be greater than `1`. |

--- a/mintlify-docs/os-devs/asg-client/button-system.mdx
+++ b/mintlify-docs/os-devs/asg-client/button-system.mdx
@@ -44,7 +44,7 @@ If a video is currently recording, short press stops the recording. Otherwise, s
 Settings used:
 
 - `button_photo_setting`: photo size, one of `small`, `medium`, or `large`
-- `button_camera_led`: whether to use the privacy LED during capture
+- The privacy LED is always enabled during capture.
 
 ## Long Press
 
@@ -54,7 +54,7 @@ Settings used:
 
 - `button_video_recording_setting`: width, height, and fps
 - `button_max_recording_time`: automatic stop timeout
-- `button_camera_led`: whether to use the privacy LED during recording
+- The privacy LED is always enabled during recording.
 
 ## Other Button Commands
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -449,10 +449,6 @@ class BluetoothSdkModule : Module() {
             requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
         }
 
-        AsyncFunction("setCaptureLedEnabled") { enabled: Boolean ->
-            requireSdk().setCaptureLedEnabled(enabled).values
-        }
-
         AsyncFunction("setMaxVideoRecordingDuration") { minutes: Int ->
             requireSdk().setMaxVideoRecordingDuration(minutes).values
         }
@@ -476,7 +472,7 @@ class BluetoothSdkModule : Module() {
                     }.toMap()
             val req = PhotoRequest.fromMap(sanitized)
             Bridge.log(
-                    "NATIVE: PHOTO PIPELINE [3/6] BluetoothSdk.requestPhoto requestId=${req.requestId} appId=${req.appId} size=${req.size} compress=${req.compress} flash=${req.flash} sound=${req.sound} exposureTimeNs=${req.exposureTimeNs} iso=${req.iso}"
+                    "NATIVE: PHOTO PIPELINE [3/6] BluetoothSdk.requestPhoto requestId=${req.requestId} appId=${req.appId} size=${req.size} compress=${req.compress} sound=${req.sound} exposureTimeNs=${req.exposureTimeNs} iso=${req.iso}"
             )
             requireSdk().requestPhoto(req).values
         }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1365,7 +1365,6 @@ class DeviceManager {
 
     fun startStream(message: MutableMap<String, Any>) {
         Bridge.log("MAN: startStream")
-        message["flash"] = true
         sgc?.startStream(message)
     }
 
@@ -1460,11 +1459,6 @@ class DeviceManager {
     fun sendButtonVideoRecordingSettings(requestId: String, width: Int, height: Int, fps: Int) {
         val live = sgc as? MentraLive ?: throw IllegalStateException("unsupported_device")
         live.sendButtonVideoRecordingSettings(requestId, width, height, fps)
-    }
-
-    fun sendButtonCameraLedSetting(requestId: String, enabled: Boolean) {
-        val live = sgc as? MentraLive ?: throw IllegalStateException("unsupported_device")
-        live.sendButtonCameraLedSetting(requestId, enabled)
     }
 
     fun sendButtonMaxRecordingTime(requestId: String, minutes: Int) {
@@ -1565,11 +1559,11 @@ class DeviceManager {
             maxRecordingTimeMinutes: Int = 0,
     ) {
         Bridge.log(
-                "MAN: onStartVideoRecording: requestId=$requestId, save=$save, flash=true, sound=$sound, " +
+                "MAN: onStartVideoRecording: requestId=$requestId, save=$save, sound=$sound, " +
                         "resolution=${width}x${height}@${fps}fps, maxRecordingTimeMinutes=$maxRecordingTimeMinutes"
         )
         sgc?.startVideoRecording(
-                requestId, save, true, sound, width, height, fps, maxRecordingTimeMinutes)
+                requestId, save, sound, width, height, fps, maxRecordingTimeMinutes)
     }
 
     fun stopVideoRecording(requestId: String, webhookUrl: String?, authToken: String?) {
@@ -1606,11 +1600,11 @@ class DeviceManager {
         val manualIso = if (exposureNs != null) request.iso?.takeIf { it > 0 } else null
         val routed =
                 request.copy(
-                    exposureTimeNs = exposureNs?.toDouble(),
-                    iso = manualIso,
+                        exposureTimeNs = exposureNs?.toDouble(),
+                        iso = manualIso,
                 )
         Bridge.log(
-                "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=${routed.requestId} appId=${routed.appId} size=${routed.size.value} compress=${routed.compress.value} flash=${routed.flash} save=${routed.save} sound=${routed.sound} exposureTimeNs=$exposureNs iso=${manualIso ?: "auto"} aeDivisor=${routed.aeExposureDivisor} isoCap=${routed.isoCap} sgc=${sgc?.javaClass?.simpleName ?: "null"}"
+                "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=${routed.requestId} appId=${routed.appId} size=${routed.size.value} compress=${routed.compress.value} save=${routed.save} sound=${routed.sound} exposureTimeNs=$exposureNs iso=${manualIso ?: "auto"} aeDivisor=${routed.aeExposureDivisor} isoCap=${routed.isoCap} sgc=${sgc?.javaClass?.simpleName ?: "null"}"
         )
         val activeSgc = sgc
         if (activeSgc == null) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -127,7 +127,6 @@ object DeviceStore {
         store.set("bluetooth", "voice_activity_detection_enabled", BluetoothSdkDefaults.VOICE_ACTIVITY_DETECTION_ENABLED)
         store.set("bluetooth", "screen_disabled", false)
         store.set("bluetooth", "button_photo_size", "max")
-        store.set("bluetooth", "button_camera_led", true)
         store.set("bluetooth", "button_max_recording_time", 10)
         store.set("bluetooth", "camera_fov", mapOf("fov" to 118, "roi_position" to 0))
         store.set("bluetooth", "button_video_width", 1280)
@@ -286,9 +285,6 @@ object DeviceStore {
             }
             "bluetooth" to "button_photo_size" -> {
                 DeviceManager.getInstance().sgc?.sendButtonPhotoSettings()
-            }
-            "bluetooth" to "button_camera_led" -> {
-                DeviceManager.getInstance().sgc?.sendButtonCameraLedSetting()
             }
             "bluetooth" to "button_max_recording_time" -> {
                 DeviceManager.getInstance().sgc?.sendButtonMaxRecordingTime()

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -540,13 +540,6 @@ class MentraBluetoothSdk private constructor(
             },
         )
 
-    fun setCaptureLedEnabled(enabled: Boolean): SettingsAckEvent =
-        performSettingsCommand(
-            setting = "button_camera_led",
-            updateStore = { _ -> DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_camera_led", enabled) },
-            send = { requestId -> deviceManager.sendButtonCameraLedSetting(requestId, enabled) },
-        )
-
     fun setMaxVideoRecordingDuration(minutes: Int): SettingsAckEvent =
         performSettingsCommand(
             setting = "button_max_recording_time",

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
@@ -167,7 +167,6 @@ data class PhotoRequest @JvmOverloads constructor(
     val webhookUrl: String,
     val authToken: String? = null,
     val compress: PhotoCompression = PhotoCompression.MEDIUM,
-    val flash: Boolean = true,
     val save: Boolean = false,
     val sound: Boolean = true,
     /** Sensor exposure time for this capture only (ns), or null for auto exposure */
@@ -218,7 +217,6 @@ data class PhotoRequest @JvmOverloads constructor(
                 webhookUrl = stringValue(values, "webhookUrl", "webhook_url").orEmpty(),
                 authToken = stringValue(values, "authToken", "auth_token")?.takeIf { it.isNotBlank() },
                 compress = PhotoCompression.fromValue(stringValue(values, "compress") ?: "none"),
-                flash = boolValue(values, "flash") ?: true,
                 save = boolValue(values, "save", "saveToGallery") ?: false,
                 sound = boolValue(values, "sound") ?: true,
                 exposureTimeNs = exposureTimeNs,

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/ControllerManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/ControllerManager.kt
@@ -20,14 +20,13 @@ abstract class ControllerManager {
     abstract fun startStream(message: Map<String, Any>)
     abstract fun stopStream()
     abstract fun sendStreamKeepAlive(message: Map<String, Any>)
-    abstract fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean)
+    abstract fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean)
     abstract fun stopVideoRecording(requestId: String)
 
     // Button Settings
     abstract fun sendButtonPhotoSettings()
     abstract fun sendButtonVideoRecordingSettings()
     abstract fun sendButtonMaxRecordingTime()
-    abstract fun sendButtonCameraLedSetting()
 
     // Display Control
     abstract fun setBrightness(level: Int, autoMode: Boolean)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/controllers/R1.kt
@@ -863,7 +863,7 @@ class R1 : ControllerManager() {
     override fun sortMicRanking(list: MutableList<String>): MutableList<String> = list
     override fun sendJson(jsonOriginal: Map<String, Any>, wakeUp: Boolean, requireAck: Boolean) {}
     override fun requestPhoto(request: PhotoRequest) {}
-    override fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean) {}
+    override fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean) {}
     override fun stopVideoRecording(requestId: String) {}
     override fun startStream(message: Map<String, Any>) {}
     override fun stopStream() {}
@@ -871,7 +871,6 @@ class R1 : ControllerManager() {
     override fun sendButtonPhotoSettings() {}
     override fun sendButtonVideoRecordingSettings() {}
     override fun sendButtonMaxRecordingTime() {}
-    override fun sendButtonCameraLedSetting() {}
     override fun setBrightness(level: Int, autoMode: Boolean) {}
     override fun clearDisplay() {}
     override fun sendTextWall(text: String) {}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
@@ -1584,7 +1584,7 @@ class G1 : SGCManager() {
 
     }
 
-    override fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean) {
+    override fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean) {
 
     }
 
@@ -1597,10 +1597,6 @@ class G1 : SGCManager() {
     }
 
     override fun sendButtonVideoRecordingSettings() {
-
-    }
-
-    override fun sendButtonCameraLedSetting() {
 
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -2660,7 +2660,6 @@ class G2 : SGCManager() {
     override fun startVideoRecording(
             requestId: String,
             save: Boolean,
-            flash: Boolean,
             sound: Boolean
     ) {
         Bridge.log("G2: startVideoRecording - not supported")
@@ -2681,10 +2680,6 @@ class G2 : SGCManager() {
 
     override fun sendButtonMaxRecordingTime() {
         Bridge.log("G2: sendButtonMaxRecordingTime")
-    }
-
-    override fun sendButtonCameraLedSetting() {
-        Bridge.log("G2: sendButtonCameraLedSetting")
     }
 
     override fun sendCameraFovSetting() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.kt
@@ -183,7 +183,7 @@ class Mach1 : SGCManager() {
 
     }
 
-    override fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean) {
+    override fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean) {
 
     }
 
@@ -200,10 +200,6 @@ class Mach1 : SGCManager() {
     }
 
     override fun sendButtonMaxRecordingTime() {
-
-    }
-
-    override fun sendButtonCameraLedSetting() {
 
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -5207,7 +5207,6 @@ class MentraLive : SGCManager() {
         val webhookUrl = request.webhookUrl
         val authToken = request.authToken
         val compress = request.compress.value
-        val flash = request.flash
         val save = request.save
         val sound = request.sound
         val exposureTimeNs = request.exposureTimeNs
@@ -5226,8 +5225,6 @@ class MentraLive : SGCManager() {
                         (if (hasAuthToken) "***" else "none") +
                         ", compress=" +
                         compress +
-                        ", flash=" +
-                        flash +
                         ", save=" +
                         save +
                         ", sound=" +
@@ -5267,7 +5264,6 @@ class MentraLive : SGCManager() {
             } else {
                 json.put("compress", "none")
             }
-            json.put("flash", flash)
             json.put("save", save)
             json.put("sound", sound)
             if (exposureTimeNs != null && exposureTimeNs > 0L) {
@@ -6141,25 +6137,6 @@ class MentraLive : SGCManager() {
             Bridge.log("LIVE: ✅ [SETTINGS_SYNC] Video settings transmitted via BLE")
         } catch (e: JSONException) {
             Log.e(TAG, "❌ [SETTINGS_SYNC] Error sending button video recording settings", e)
-        }
-    }
-
-    fun sendButtonCameraLedSetting(enabled: Boolean) {
-        sendButtonCameraLedSetting(null, enabled)
-    }
-
-    fun sendButtonCameraLedSetting(requestId: String?, enabled: Boolean) {
-        // Send LED setting to glasses
-        val command = JSONObject()
-        try {
-            command.put("type", "button_camera_led")
-            if (requestId != null && !requestId.isEmpty()) {
-                command.put("request_id", requestId)
-            }
-            command.put("enabled", enabled)
-            sendJson(command, true)
-        } catch (e: Exception) {
-            Log.e(TAG, "Error sending button camera LED setting", e)
         }
     }
 
@@ -8073,9 +8050,6 @@ class MentraLive : SGCManager() {
         // Send button photo settings
         sendButtonPhotoSettings()
 
-        // Send button camera LED setting
-        sendButtonCameraLedSetting()
-
         // Send camera FOV setting (K900 / Mentra Live)
         sendCameraFovSetting()
 
@@ -8142,12 +8116,6 @@ class MentraLive : SGCManager() {
             null, size, mfnr, zsl, noiseReduction, edgeEnhancement,
             ispDigitalGain, ispAnalogGain, aeExposureDivisor, isoCap, compress, sound, false,
         )
-    }
-
-    /** Send button camera LED setting to glasses */
-    override fun sendButtonCameraLedSetting() {
-        val enabled = DeviceStore.get("bluetooth", "button_camera_led") as Boolean
-        sendButtonCameraLedSetting(null, enabled)
     }
 
     /** Send camera FOV setting to glasses (K900 / Mentra Live). */
@@ -8228,17 +8196,15 @@ class MentraLive : SGCManager() {
     override fun startVideoRecording(
             requestId: String,
             save: Boolean,
-            flash: Boolean,
             sound: Boolean
     ) {
-        startVideoRecording(requestId, save, flash, sound, 0, 0, 0, 0) // Use defaults
+        startVideoRecording(requestId, save, sound, 0, 0, 0, 0) // Use defaults
     }
 
     /**
      * Start video recording with optional resolution settings
      * @param requestId Request ID for tracking
      * @param save Whether to save the video
-     * @param flash Whether to enable privacy flash LED
      * @param sound Whether to enable start/stop sounds
      * @param width Video width (0 for default)
      * @param height Video height (0 for default)
@@ -8248,7 +8214,6 @@ class MentraLive : SGCManager() {
     override fun startVideoRecording(
             requestId: String,
             save: Boolean,
-            flash: Boolean,
             sound: Boolean,
             width: Int,
             height: Int,
@@ -8260,8 +8225,6 @@ class MentraLive : SGCManager() {
                         requestId +
                         ", save=" +
                         save +
-                        ", flash=" +
-                        flash +
                         ", sound=" +
                         sound +
                         ", resolution=" +
@@ -8285,7 +8248,6 @@ class MentraLive : SGCManager() {
             json.put("type", "start_video_recording")
             json.put("requestId", requestId)
             json.put("save", save)
-            json.put("flash", flash)
             json.put("sound", sound)
 
             // Auto-stop timer; only sent when set (> 0). 0 = record until stopped.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -343,14 +343,13 @@ class MentraNex : SGCManager() {
     override fun startStream(message: MutableMap<String, Any>) { Bridge.log("Nex: startStream operation not supported") }
     override fun stopStream() { Bridge.log("Nex: stopStream operation not supported") }
     override fun sendStreamKeepAlive(message: MutableMap<String, Any>) { Bridge.log("Nex: sendStreamKeepAlive operation not supported") }
-    override fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean) { Bridge.log("Nex: startVideoRecording operation not supported") }
+    override fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean) { Bridge.log("Nex: startVideoRecording operation not supported") }
     override fun stopVideoRecording(requestId: String) { Bridge.log("Nex: stopVideoRecording operation not supported") }
 
     // Button Settings: Not supported on Nex
     override fun sendButtonPhotoSettings() { Bridge.log("Nex: sendButtonPhotoSettings operation not supported") }
     override fun sendButtonVideoRecordingSettings() { Bridge.log("Nex: sendButtonVideoRecordingSettings operation not supported") }
     override fun sendButtonMaxRecordingTime() { Bridge.log("Nex: sendButtonMaxRecordingTime operation not supported") }
-    override fun sendButtonCameraLedSetting() { Bridge.log("Nex: sendButtonCameraLedSetting operation not supported") }
 
     override fun sendCameraFovSetting() { Bridge.log("Nex: sendCameraFovSetting operation not supported") }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -20,7 +20,7 @@ abstract class SGCManager {
     abstract fun startStream(message: MutableMap<String, Any>)
     abstract fun stopStream()
     abstract fun sendStreamKeepAlive(message: MutableMap<String, Any>)
-    abstract fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean)
+    abstract fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean)
 
     /**
      * Start video recording with optional per-recording resolution/fps. A width,
@@ -32,14 +32,13 @@ abstract class SGCManager {
     open fun startVideoRecording(
         requestId: String,
         save: Boolean,
-        flash: Boolean,
         sound: Boolean,
         width: Int,
         height: Int,
         fps: Int,
         maxRecordingTimeMinutes: Int,
     ) {
-        startVideoRecording(requestId, save, flash, sound)
+        startVideoRecording(requestId, save, sound)
     }
 
     abstract fun stopVideoRecording(requestId: String)
@@ -59,7 +58,6 @@ abstract class SGCManager {
     abstract fun sendButtonPhotoSettings()
     abstract fun sendButtonVideoRecordingSettings()
     abstract fun sendButtonMaxRecordingTime()
-    abstract fun sendButtonCameraLedSetting()
     abstract fun sendCameraFovSetting()
 
     // Display Control

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
@@ -34,7 +34,7 @@ class Simulated : SGCManager() {
 
     // Camera & Media
     override fun requestPhoto(request: PhotoRequest) {
-        Bridge.log("requestPhoto flash=${request.flash}, save=${request.save}, sound=${request.sound}")
+        Bridge.log("requestPhoto save=${request.save}, sound=${request.sound}")
     }
 
     override fun startStream(message: MutableMap<String, Any>) {
@@ -49,8 +49,8 @@ class Simulated : SGCManager() {
         Bridge.log("sendStreamKeepAlive")
     }
 
-    override fun startVideoRecording(requestId: String, save: Boolean, flash: Boolean, sound: Boolean) {
-        Bridge.log("startVideoRecording flash=$flash, sound=$sound")
+    override fun startVideoRecording(requestId: String, save: Boolean, sound: Boolean) {
+        Bridge.log("startVideoRecording sound=$sound")
     }
 
     override fun stopVideoRecording(requestId: String) {
@@ -68,10 +68,6 @@ class Simulated : SGCManager() {
 
     override fun sendButtonMaxRecordingTime() {
         Bridge.log("sendButtonMaxRecordingTime")
-    }
-
-    override fun sendButtonCameraLedSetting() {
-        Bridge.log("sendButtonCameraLedSetting")
     }
 
     override fun sendCameraFovSetting() {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/DeviceStatus.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/DeviceStatus.kt
@@ -248,7 +248,6 @@ internal data class BluetoothStatus(
     val contextualDashboard: Boolean,
     val galleryModeEnabled: Boolean,
     val buttonPhotoSize: ButtonPhotoSize,
-    val buttonCameraLed: Boolean,
     val buttonMaxRecordingTime: Int,
     val buttonVideoWidth: Int,
     val buttonVideoHeight: Int,
@@ -301,7 +300,6 @@ internal data class BluetoothStatus(
             "contextual_dashboard" to contextualDashboard,
             "galleryModeEnabled" to galleryModeEnabled,
             "button_photo_size" to buttonPhotoSize.value,
-            "button_camera_led" to buttonCameraLed,
             "button_max_recording_time" to buttonMaxRecordingTime,
             "button_video_width" to buttonVideoWidth,
             "button_video_height" to buttonVideoHeight,
@@ -349,7 +347,6 @@ internal data class BluetoothStatus(
                 galleryModeEnabled =
                     boolValue(values, "gallery_mode") ?: boolValue(values, "galleryModeEnabled") ?: true,
                 buttonPhotoSize = ButtonPhotoSize.fromValue(stringValue(values, "button_photo_size")),
-                buttonCameraLed = boolValue(values, "button_camera_led") ?: true,
                 buttonMaxRecordingTime = numberValue(values, "button_max_recording_time") ?: 10,
                 buttonVideoWidth = numberValue(values, "button_video_width") ?: 1280,
                 buttonVideoHeight = numberValue(values, "button_video_height") ?: 720,
@@ -554,7 +551,6 @@ internal data class BluetoothStatusUpdate(
     val contextualDashboard: Boolean? = null,
     val galleryModeEnabled: Boolean? = null,
     val buttonPhotoSize: ButtonPhotoSize? = null,
-    val buttonCameraLed: Boolean? = null,
     val buttonMaxRecordingTime: Int? = null,
     val buttonVideoWidth: Int? = null,
     val buttonVideoHeight: Int? = null,
@@ -597,7 +593,6 @@ internal data class BluetoothStatusUpdate(
             putIfNotNull("contextual_dashboard", contextualDashboard)
             putIfNotNull("galleryModeEnabled", galleryModeEnabled)
             buttonPhotoSize?.let { put("button_photo_size", it.value) }
-            putIfNotNull("button_camera_led", buttonCameraLed)
             putIfNotNull("button_max_recording_time", buttonMaxRecordingTime)
             putIfNotNull("button_video_width", buttonVideoWidth)
             putIfNotNull("button_video_height", buttonVideoHeight)
@@ -648,7 +643,6 @@ internal data class BluetoothStatusUpdate(
                     optionalBoolValue(values, "gallery_mode") ?: optionalBoolValue(values, "galleryModeEnabled"),
                 buttonPhotoSize =
                     optionalStringValue(values, "button_photo_size")?.let(ButtonPhotoSize::fromValue),
-                buttonCameraLed = optionalBoolValue(values, "button_camera_led"),
                 buttonMaxRecordingTime = optionalNumberValue(values, "button_max_recording_time"),
                 buttonVideoWidth = optionalNumberValue(values, "button_video_width"),
                 buttonVideoHeight = optionalNumberValue(values, "button_video_height"),

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
@@ -175,23 +175,19 @@ data class StreamRequest @JvmOverloads constructor(
     val sound: Boolean = true,
     val video: StreamVideoConfig? = null,
     val audio: StreamAudioConfig? = null,
-    val extraValues: Map<String, Any> = emptyMap(),
+    val keepAliveMode: String? = null,
 ) {
-    fun toMap(): Map<String, Any> {
-        val values = extraValues.toMutableMap()
-        values.remove("keepAliveMode")
-        values["type"] = "start_stream"
-        values["streamUrl"] = streamUrl
-        values["streamId"] = streamId
-        values["keepAlive"] = keepAlive
-        values["keepAliveIntervalSeconds"] = keepAliveIntervalSeconds
-        // The camera light is a privacy indicator and cannot be disabled by SDK callers.
-        values["flash"] = true
-        values["sound"] = sound
-        video?.toMap()?.takeIf { it.isNotEmpty() }?.let { values["video"] = it }
-        audio?.toMap()?.takeIf { it.isNotEmpty() }?.let { values["audio"] = it }
-        return values
-    }
+    fun toMap(): Map<String, Any> =
+        buildMap {
+            put("type", "start_stream")
+            put("streamUrl", streamUrl)
+            put("streamId", streamId)
+            put("keepAlive", keepAlive)
+            put("keepAliveIntervalSeconds", keepAliveIntervalSeconds)
+            put("sound", sound)
+            video?.toMap()?.takeIf { it.isNotEmpty() }?.let { put("video", it) }
+            audio?.toMap()?.takeIf { it.isNotEmpty() }?.let { put("audio", it) }
+        }
 
     companion object {
         @JvmStatic
@@ -206,26 +202,24 @@ data class StreamRequest @JvmOverloads constructor(
                 sound = values["sound"] as? Boolean ?: true,
                 video = StreamVideoConfig.fromMap(stringMapValue(values["video"])),
                 audio = StreamAudioConfig.fromMap(stringMapValue(values["audio"])),
-                extraValues = values,
+                keepAliveMode = stringValue(values, "keepAliveMode"),
             )
     }
 }
 
 internal fun StreamRequest.isExternallyManagedKeepAlive(): Boolean =
-    stringValue(extraValues, "keepAliveMode") == "external"
+    keepAliveMode == "external"
 
 internal data class StreamKeepAliveRequest @JvmOverloads constructor(
     val streamId: String,
     val ackId: String,
-    val extraValues: Map<String, Any> = emptyMap(),
 ) {
-    fun toMap(): Map<String, Any> {
-        val values = extraValues.toMutableMap()
-        values["type"] = "keep_stream_alive"
-        values["streamId"] = streamId
-        values["ackId"] = ackId
-        return values
-    }
+    fun toMap(): Map<String, Any> =
+        mapOf(
+            "type" to "keep_stream_alive",
+            "streamId" to streamId,
+            "ackId" to ackId,
+        )
 
     companion object {
         @JvmStatic
@@ -233,7 +227,6 @@ internal data class StreamKeepAliveRequest @JvmOverloads constructor(
             StreamKeepAliveRequest(
                 streamId = values["streamId"] as? String ?: "",
                 ackId = values["ackId"] as? String ?: "",
-                extraValues = values,
             )
     }
 }

--- a/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/BluetoothSdkModule.swift
@@ -336,11 +336,6 @@ public class BluetoothSdkModule: Module, MentraBluetoothSDKDelegate {
             return try await sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width: width, height: height, fps: fps)).values
         }
 
-        AsyncFunction("setCaptureLedEnabled") { (enabled: Bool) in
-            let sdk = await MainActor.run { self.bluetoothSdk() }
-            return try await sdk.setCaptureLedEnabled(enabled).values
-        }
-
         AsyncFunction("setMaxVideoRecordingDuration") { (minutes: Int) in
             let sdk = await MainActor.run { self.bluetoothSdk() }
             return try await sdk.setMaxVideoRecordingDuration(minutes: minutes).values

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1115,7 +1115,6 @@ struct ViewState {
 
     func startStream(_ message: [String: Any]) {
         var message = message
-        message["flash"] = true
         Bridge.log("MAN: startStream: \(message)")
         sgc?.startStream(message)
     }
@@ -1205,10 +1204,6 @@ struct ViewState {
         try liveSgc().sendButtonVideoRecordingSettings(requestId: requestId, width: width, height: height, fps: fps)
     }
 
-    func sendButtonCameraLedSetting(requestId: String, enabled: Bool) throws {
-        try liveSgc().sendButtonCameraLedSetting(requestId: requestId, enabled: enabled)
-    }
-
     func sendButtonMaxRecordingTime(requestId: String, minutes: Int) throws {
         try liveSgc().sendButtonMaxRecordingTime(requestId: requestId, minutes: minutes)
     }
@@ -1248,10 +1243,10 @@ struct ViewState {
         _ fps: Int = 0, _ maxRecordingTimeMinutes: Int = 0
     ) {
         Bridge.log(
-            "MAN: onStartVideoRecording: requestId=\(requestId), save=\(save), flash=true, sound=\(sound), resolution=\(width)x\(height)@\(fps)fps, maxRecordingTimeMinutes=\(maxRecordingTimeMinutes)"
+            "MAN: onStartVideoRecording: requestId=\(requestId), save=\(save), sound=\(sound), resolution=\(width)x\(height)@\(fps)fps, maxRecordingTimeMinutes=\(maxRecordingTimeMinutes)"
         )
         sgc?.startVideoRecording(
-            requestId: requestId, save: save, flash: true, sound: sound, width: width, height: height,
+            requestId: requestId, save: save, sound: sound, width: width, height: height,
             fps: fps, maxRecordingTimeMinutes: maxRecordingTimeMinutes
         )
     }
@@ -1334,7 +1329,6 @@ struct ViewState {
             webhookUrl: request.webhookUrl,
             authToken: request.authToken,
             compress: request.compress,
-            flash: request.flash,
             save: request.save,
             sound: request.sound,
             exposureTimeNs: manualExposureNs,
@@ -1349,7 +1343,7 @@ struct ViewState {
             ispAnalogGain: request.ispAnalogGain
         )
         Bridge.log(
-            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) appId=\(routed.appId) webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") flash=\(routed.flash) save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
+            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) appId=\(routed.appId) webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
         )
         guard let sgc else {
             Bridge.log(

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -92,7 +92,6 @@ class DeviceStore {
         store.set("bluetooth", "nex_chinese_captions", false)
         store.set("bluetooth", "screen_disabled", false)
         store.set("bluetooth", "button_photo_size", "max")
-        store.set("bluetooth", "button_camera_led", true)
         store.set("bluetooth", "button_max_recording_time", 10)
         store.set("bluetooth", "camera_fov", ["fov": 118, "roi_position": 0])
         store.set("bluetooth", "button_video_width", 1280)
@@ -257,9 +256,6 @@ class DeviceStore {
 
         case ("bluetooth", "button_photo_size"):
             DeviceManager.shared.sgc?.sendButtonPhotoSettings()
-
-        case ("bluetooth", "button_camera_led"):
-            DeviceManager.shared.sgc?.sendButtonCameraLedSetting()
 
         case ("bluetooth", "button_max_recording_time"):
             DeviceManager.shared.sgc?.sendButtonMaxRecordingTime()

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -560,14 +560,6 @@ public final class MentraBluetoothSDK {
         )
     }
 
-    public func setCaptureLedEnabled(_ enabled: Bool) async throws -> SettingsAckEvent {
-        try await performSettingsCommand(
-            setting: "button_camera_led",
-            updateStore: { _ in DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_camera_led", enabled) },
-            send: { requestId in try DeviceManager.shared.sendButtonCameraLedSetting(requestId: requestId, enabled: enabled) }
-        )
-    }
-
     public func setMaxVideoRecordingDuration(minutes: Int) async throws -> SettingsAckEvent {
         try await performSettingsCommand(
             setting: "button_max_recording_time",

--- a/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
@@ -228,7 +228,6 @@ public struct PhotoRequest {
     public let webhookUrl: String?
     public let authToken: String?
     public let compress: PhotoCompression?
-    public let flash: Bool
     public let save: Bool
     public let sound: Bool
     /// Sensor exposure time for this capture only (ns), or nil for auto exposure
@@ -251,7 +250,6 @@ public struct PhotoRequest {
         webhookUrl: String? = nil,
         authToken: String? = nil,
         compress: PhotoCompression? = nil,
-        flash: Bool = true,
         save: Bool = false,
         sound: Bool,
         exposureTimeNs: Double? = nil,
@@ -271,7 +269,6 @@ public struct PhotoRequest {
         self.webhookUrl = webhookUrl
         self.authToken = authToken
         self.compress = compress
-        self.flash = flash
         self.save = save
         self.sound = sound
         self.exposureTimeNs = exposureTimeNs
@@ -340,7 +337,6 @@ public struct PhotoRequest {
             webhookUrl: params["webhookUrl"] as? String,
             authToken: (params["authToken"] as? String)?.nilIfBlank,
             compress: PhotoCompression(rawValue: compressRaw),
-            flash: params["flash"] as? Bool ?? true,
             save: (params["save"] as? Bool) ?? (params["saveToGallery"] as? Bool) ?? false,
             sound: params["sound"] as? Bool ?? true,
             exposureTimeNs: exposureTimeNs,

--- a/mobile/modules/bluetooth-sdk/ios/Source/controllers/ControllerManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/controllers/ControllerManager.swift
@@ -22,7 +22,7 @@ protocol ControllerManager {
     func startStream(_ message: [String: Any])
     func stopStream()
     func sendStreamKeepAlive(_ message: [String: Any])
-    func startVideoRecording(requestId: String, save: Bool, flash: Bool, sound: Bool)
+    func startVideoRecording(requestId: String, save: Bool, sound: Bool)
     func stopVideoRecording(requestId: String)
 
     // MARK: - Button Settings
@@ -30,7 +30,6 @@ protocol ControllerManager {
     func sendButtonPhotoSettings()
     func sendButtonVideoRecordingSettings()
     func sendButtonMaxRecordingTime()
-    func sendButtonCameraLedSetting()
 
     // MARK: - Display Control
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/controllers/R1.swift
@@ -505,7 +505,7 @@ class R1: NSObject, ControllerManager {
 
     func sendJson(_: [String: Any], wakeUp _: Bool, requireAck _: Bool) {}
     func requestPhoto(_: PhotoRequest) {}
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
     func stopVideoRecording(requestId _: String) {}
     func startStream(_: [String: Any]) {}
     func stopStream() {}
@@ -513,7 +513,6 @@ class R1: NSObject, ControllerManager {
     func sendButtonPhotoSettings() {}
     func sendButtonVideoRecordingSettings() {}
     func sendButtonMaxRecordingTime() {}
-    func sendButtonCameraLedSetting() {}
     func setBrightness(_: Int, autoMode _: Bool) {}
     func clearDisplay() {}
     func sendTextWall(_: String) {}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Frame.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Frame.swift
@@ -75,8 +75,6 @@
 
 //     func sendButtonMaxRecordingTime(_: Int) {}
 
-//     func sendButtonCameraLedSetting() {}
-
 func exit() {}
 
 func sendRgbLedControl(requestId: String, packageName _: String?, action _: String, color _: String?, onDurationMs _: Int, offDurationMs _: Int, count _: Int) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -284,7 +284,7 @@ class G1: NSObject, SGCManager {
 
     func sendStreamKeepAlive(_: [String: Any]) {}
 
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
 
     func stopVideoRecording(requestId _: String) {}
 
@@ -293,8 +293,6 @@ class G1: NSObject, SGCManager {
     func sendButtonVideoRecordingSettings() {}
 
     func sendButtonMaxRecordingTime() {}
-
-    func sendButtonCameraLedSetting() {}
 
     func sendCameraFovSetting() {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -3147,7 +3147,7 @@ class G2: NSObject, SGCManager {
     // MARK: - SGCManager: Camera & Media (not supported on G2)
 
     func requestPhoto(_: PhotoRequest) {}
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
     func startStream(_: [String: Any]) {}
     func stopStream() {}
     func sendStreamKeepAlive(_: [String: Any]) {}
@@ -3155,7 +3155,6 @@ class G2: NSObject, SGCManager {
     func sendButtonPhotoSettings() {}
     func sendButtonVideoRecordingSettings() {}
     func sendButtonMaxRecordingTime() {}
-    func sendButtonCameraLedSetting() {}
 
     func sendCameraFovSetting() {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
@@ -34,8 +34,6 @@ class Mach1: UltraliteBaseViewController, SGCManager {
 
     func sendButtonMaxRecordingTime(_: Int) {}
 
-    func sendButtonCameraLedSetting() {}
-
     func sendCameraFovSetting() {}
 
     func exit() {}
@@ -87,7 +85,7 @@ class Mach1: UltraliteBaseViewController, SGCManager {
 
     func sendStreamKeepAlive(_: [String: Any]) {}
 
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
 
     func stopVideoRecording(requestId _: String) {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1616,7 +1616,7 @@ class MentraLive: NSObject, SGCManager {
 
     func requestPhoto(_ request: PhotoRequest) {
         Bridge.log(
-            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) appId=\(request.appId) flash=\(request.flash) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
+            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) appId=\(request.appId) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
         )
 
         var json: [String: Any] = [
@@ -1656,7 +1656,6 @@ class MentraLive: NSObject, SGCManager {
         json["size"] = allowedSizes.contains(size) ? size : "medium"
 
         json["compress"] = request.compress?.rawValue ?? "none"
-        json["flash"] = request.flash
         json["save"] = request.save
         json["sound"] = request.sound
 
@@ -5085,9 +5084,6 @@ extension MentraLive {
         // Send button photo settings
         sendButtonPhotoSettings()
 
-        // Send button camera LED setting
-        sendButtonCameraLedSetting()
-
         // Send camera FOV setting (K900 / Mentra Live)
         sendCameraFovSetting()
 
@@ -5317,29 +5313,6 @@ extension MentraLive {
         sendJson(json, wakeUp: true)
     }
 
-    func sendButtonCameraLedSetting() {
-        let enabled = DeviceStore.shared.get("bluetooth", "button_camera_led") as! Bool
-        sendButtonCameraLedSetting(requestId: nil, enabled: enabled)
-    }
-
-    func sendButtonCameraLedSetting(requestId: String?, enabled: Bool) {
-        Bridge.log("Sending button camera LED setting: \(enabled)")
-
-        guard connectionState == ConnTypes.CONNECTED else {
-            Bridge.log("Cannot send button camera LED setting - not connected")
-            return
-        }
-
-        var json: [String: Any] = [
-            "type": "button_camera_led",
-            "enabled": enabled,
-        ]
-        if let requestId, !requestId.isEmpty {
-            json["request_id"] = requestId
-        }
-        sendJson(json, wakeUp: true)
-    }
-
     func sendCameraFovSetting() {
         let settings = DeviceStore.shared.get("bluetooth", "camera_fov") as? [String: Any] ?? ["fov": 118, "roi_position": 0]
         let fov = settings["fov"] as? Int ?? 118
@@ -5368,9 +5341,9 @@ extension MentraLive {
         sendJson(json, wakeUp: true)
     }
 
-    func startVideoRecording(requestId: String, save: Bool, flash: Bool, sound: Bool) {
+    func startVideoRecording(requestId: String, save: Bool, sound: Bool) {
         startVideoRecording(
-            requestId: requestId, save: save, flash: flash, sound: sound, width: 0, height: 0, fps: 0,
+            requestId: requestId, save: save, sound: sound, width: 0, height: 0, fps: 0,
             maxRecordingTimeMinutes: 0
         )
     }
@@ -5382,11 +5355,11 @@ extension MentraLive {
     }
 
     func startVideoRecording(
-        requestId: String, save: Bool, flash: Bool, sound: Bool, width: Int, height: Int, fps: Int,
+        requestId: String, save: Bool, sound: Bool, width: Int, height: Int, fps: Int,
         maxRecordingTimeMinutes: Int
     ) {
         Bridge.log(
-            "Starting video recording on glasses: requestId=\(requestId), save=\(save), flash=\(flash), sound=\(sound), resolution=\(width)x\(height)@\(fps)fps, maxRecordingTimeMinutes=\(maxRecordingTimeMinutes)"
+            "Starting video recording on glasses: requestId=\(requestId), save=\(save), sound=\(sound), resolution=\(width)x\(height)@\(fps)fps, maxRecordingTimeMinutes=\(maxRecordingTimeMinutes)"
         )
 
         guard connectionState == ConnTypes.CONNECTED else {
@@ -5398,10 +5371,8 @@ extension MentraLive {
             "type": "start_video_recording",
             "requestId": requestId,
             "save": save,
-            "flash": flash,
             "sound": sound,
         ]
-
         // Auto-stop timer; only sent when set (> 0). 0 = record until stopped.
         if maxRecordingTimeMinutes > 0 {
             json["maxRecordingTimeMinutes"] = maxRecordingTimeMinutes

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -59,7 +59,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
 
     func sendStreamKeepAlive(_: [String: Any]) {}
 
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {}
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {}
 
     func stopVideoRecording(requestId _: String) {}
 
@@ -68,8 +68,6 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     func sendButtonVideoRecordingSettings() {}
 
     func sendButtonMaxRecordingTime() {}
-
-    func sendButtonCameraLedSetting() {}
 
     func sendCameraFovSetting() {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -22,13 +22,13 @@ protocol SGCManager {
     func startStream(_ message: [String: Any])
     func stopStream()
     func sendStreamKeepAlive(_ message: [String: Any])
-    func startVideoRecording(requestId: String, save: Bool, flash: Bool, sound: Bool)
+    func startVideoRecording(requestId: String, save: Bool, sound: Bool)
     /// Start video recording with optional per-recording resolution/fps. A width,
     /// height, or fps of 0 means "use the device's saved button-video default".
     /// Defaulted in an extension to delegate to the basic recording path; devices
     /// that support custom settings (e.g. Mentra Live) override this.
     func startVideoRecording(
-        requestId: String, save: Bool, flash: Bool, sound: Bool, width: Int, height: Int, fps: Int,
+        requestId: String, save: Bool, sound: Bool, width: Int, height: Int, fps: Int,
         maxRecordingTimeMinutes: Int
     )
     func stopVideoRecording(requestId: String)
@@ -44,7 +44,6 @@ protocol SGCManager {
     func sendButtonPhotoSettings()
     func sendButtonVideoRecordingSettings()
     func sendButtonMaxRecordingTime()
-    func sendButtonCameraLedSetting()
     func sendCameraFovSetting()
 
     // MARK: - Display Control
@@ -149,10 +148,10 @@ extension SGCManager {
     // MARK: - Video recording (default: ignore custom settings, use saved defaults)
 
     func startVideoRecording(
-        requestId: String, save: Bool, flash: Bool, sound: Bool, width _: Int, height _: Int,
+        requestId: String, save: Bool, sound: Bool, width _: Int, height _: Int,
         fps _: Int, maxRecordingTimeMinutes _: Int
     ) {
-        startVideoRecording(requestId: requestId, save: save, flash: flash, sound: sound)
+        startVideoRecording(requestId: requestId, save: save, sound: sound)
     }
 
     func stopVideoRecording(requestId: String, webhookUrl _: String?, authToken _: String?) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
@@ -80,7 +80,7 @@ class Simulated: SGCManager {
     // MARK: - Camera & Media
 
     func requestPhoto(_ request: PhotoRequest) {
-        Bridge.log("requestPhoto flash=\(request.flash) save=\(request.save) sound=\(request.sound)")
+        Bridge.log("requestPhoto save=\(request.save) sound=\(request.sound)")
     }
 
     func startStream(_: [String: Any]) {
@@ -95,7 +95,7 @@ class Simulated: SGCManager {
         Bridge.log("sendStreamKeepAlive")
     }
 
-    func startVideoRecording(requestId _: String, save _: Bool, flash _: Bool, sound _: Bool) {
+    func startVideoRecording(requestId _: String, save _: Bool, sound _: Bool) {
         Bridge.log("startVideoRecording")
     }
 
@@ -111,10 +111,6 @@ class Simulated: SGCManager {
 
     func sendButtonVideoRecordingSettings() {
         Bridge.log("sendButtonVideoRecordingSettings")
-    }
-
-    func sendButtonCameraLedSetting() {
-        Bridge.log("sendButtonCameraLedSetting")
     }
 
     func sendCameraFovSetting() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/status/DeviceStatus.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/status/DeviceStatus.swift
@@ -552,10 +552,6 @@ struct BluetoothStatus: CustomStringConvertible {
         ButtonPhotoSize(rawValue: stringValue(values, "button_photo_size") ?? "") ?? .medium
     }
 
-    var buttonCameraLed: Bool {
-        boolValue(values, "button_camera_led") ?? true
-    }
-
     var buttonMaxRecordingTime: Int {
         intValue(values["button_max_recording_time"]) ?? 10
     }
@@ -922,10 +918,6 @@ struct BluetoothStatusUpdate: CustomStringConvertible {
 
     var buttonPhotoSize: ButtonPhotoSize? {
         optionalStringValue(values, "button_photo_size").map { ButtonPhotoSize(normalizedRawValue: $0) }
-    }
-
-    var buttonCameraLed: Bool? {
-        optionalBoolValue(values, "button_camera_led")
     }
 
     var buttonMaxRecordingTime: Int? {

--- a/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
@@ -224,7 +224,7 @@ public struct StreamRequest {
     public let sound: Bool
     public let video: StreamVideoConfig?
     public let audio: StreamAudioConfig?
-    public let extraValues: [String: Any]
+    public let keepAliveMode: String?
 
     public init(
         streamUrl: String,
@@ -234,7 +234,7 @@ public struct StreamRequest {
         sound: Bool = true,
         video: StreamVideoConfig? = nil,
         audio: StreamAudioConfig? = nil,
-        extraValues: [String: Any] = [:]
+        keepAliveMode: String? = nil
     ) {
         self.streamUrl = streamUrl
         self.streamId = streamId
@@ -243,7 +243,7 @@ public struct StreamRequest {
         self.sound = sound
         self.video = video
         self.audio = audio
-        self.extraValues = extraValues
+        self.keepAliveMode = keepAliveMode
     }
 
     init(values: [String: Any]) {
@@ -259,20 +259,17 @@ public struct StreamRequest {
             sound: values["sound"] as? Bool ?? true,
             video: StreamVideoConfig(values: values["video"] as? [String: Any]),
             audio: StreamAudioConfig(values: values["audio"] as? [String: Any]),
-            extraValues: values
+            keepAliveMode: stringValue(values, "keepAliveMode")
         )
     }
 
     public var values: [String: Any] {
-        var values = extraValues
-        values.removeValue(forKey: "keepAliveMode")
+        var values: [String: Any] = [:]
         values["type"] = "start_stream"
         values["streamUrl"] = streamUrl
         values["streamId"] = streamId
         values["keepAlive"] = keepAlive
         values["keepAliveIntervalSeconds"] = keepAliveIntervalSeconds
-        // The camera light is a privacy indicator and cannot be disabled by SDK callers.
-        values["flash"] = true
         values["sound"] = sound
         if let videoValues = video?.dictionary, !videoValues.isEmpty {
             values["video"] = videoValues
@@ -286,31 +283,28 @@ public struct StreamRequest {
 
 extension StreamRequest {
     var isExternallyManagedKeepAlive: Bool {
-        stringValue(extraValues, "keepAliveMode") == "external"
+        keepAliveMode == "external"
     }
 }
 
 struct StreamKeepAliveRequest {
     let streamId: String
     let ackId: String
-    let extraValues: [String: Any]
 
-    init(streamId: String, ackId: String, extraValues: [String: Any] = [:]) {
+    init(streamId: String, ackId: String) {
         self.streamId = streamId
         self.ackId = ackId
-        self.extraValues = extraValues
     }
 
     init(values: [String: Any]) {
         self.init(
             streamId: values["streamId"] as? String ?? "",
-            ackId: values["ackId"] as? String ?? "",
-            extraValues: values
+            ackId: values["ackId"] as? String ?? ""
         )
     }
 
     var values: [String: Any] {
-        var values = extraValues
+        var values: [String: Any] = [:]
         values["type"] = "keep_stream_alive"
         values["streamId"] = streamId
         values["ackId"] = ackId

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -396,7 +396,6 @@ export type SettingsAckSetting =
   | "gallery_mode"
   | "button_photo"
   | "button_video_recording"
-  | "button_camera_led"
   | "button_max_recording_time"
   | "camera_fov"
 
@@ -954,7 +953,6 @@ export interface BluetoothSdkPublicModule {
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
   setPhotoCaptureDefaults(settings: PhotoCaptureDefaults): Promise<SettingsAckSuccessEvent>
   setVideoRecordingDefaults(settings: VideoRecordingDefaults): Promise<SettingsAckSuccessEvent>
-  setCaptureLedEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
   setMaxVideoRecordingDuration(minutes: number): Promise<SettingsAckSuccessEvent>
   setCameraFov(request: CameraFovRequest): Promise<CameraFovResult>
   queryGalleryStatus(): Promise<GalleryStatusEvent>
@@ -1243,7 +1241,6 @@ export type BluetoothSettingsUpdate = Partial<{
   button_video_width: number
   button_video_height: number
   button_video_fps: number
-  button_camera_led: boolean
   button_max_recording_time: number
   camera_fov: NativeCameraFovSetting
   should_send_pcm: boolean

--- a/mobile/modules/bluetooth-sdk/src/__tests__/photoRequestParamsForNative.test.ts
+++ b/mobile/modules/bluetooth-sdk/src/__tests__/photoRequestParamsForNative.test.ts
@@ -14,7 +14,7 @@ describe("photoRequestParamsForNative", () => {
   it("produces only supported native payload keys", () => {
     const payload = photoRequestParamsForNative(baseParams)
     expect(Object.keys(payload).sort()).toEqual(
-      ["appId", "compress", "flash", "requestId", "size", "sound", "webhookUrl"].sort(),
+      ["appId", "compress", "requestId", "size", "sound", "webhookUrl"].sort(),
     )
   })
 

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -123,7 +123,6 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   setVoiceActivityDetectionEnabled(enabled: boolean): Promise<void>
   setPhotoCaptureDefaults(settings: PhotoCaptureDefaults): Promise<SettingsAckSuccessEvent>
   setVideoRecordingDefaults(width: number, height: number, fps: number): Promise<SettingsAckSuccessEvent>
-  setCaptureLedEnabled(enabled: boolean): Promise<SettingsAckSuccessEvent>
   setMaxVideoRecordingDuration(minutes: number): Promise<SettingsAckSuccessEvent>
   setCameraFov(request: CameraFovRequest): Promise<CameraFovResult>
   queryGalleryStatus(): Promise<GalleryStatusEvent>

--- a/mobile/modules/bluetooth-sdk/src/_private/photoRequestPayload.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/photoRequestPayload.ts
@@ -29,7 +29,6 @@ export function photoRequestParamsForNative(
     size: normalizePhotoSizeTier(params.size),
     webhookUrl: params.webhookUrl ?? "",
     compress: params.compress,
-    flash: true,
     sound: params.sound,
   }
   if (params.save != null) {

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -88,7 +88,6 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
   setPhotoCaptureDefaults: PrivateBluetoothSdkModule.setPhotoCaptureDefaults.bind(PrivateBluetoothSdkModule),
   setVideoRecordingDefaults: ({width, height, fps}: VideoRecordingDefaults) =>
     PrivateBluetoothSdkModule.setVideoRecordingDefaults(width, height, fps),
-  setCaptureLedEnabled: PrivateBluetoothSdkModule.setCaptureLedEnabled.bind(PrivateBluetoothSdkModule),
   setMaxVideoRecordingDuration: PrivateBluetoothSdkModule.setMaxVideoRecordingDuration.bind(PrivateBluetoothSdkModule),
   setCameraFov: PrivateBluetoothSdkModule.setCameraFov.bind(PrivateBluetoothSdkModule),
   queryGalleryStatus: PrivateBluetoothSdkModule.queryGalleryStatus.bind(PrivateBluetoothSdkModule),

--- a/mobile/src/app/miniapps/settings/camera.tsx
+++ b/mobile/src/app/miniapps/settings/camera.tsx
@@ -89,7 +89,6 @@ export default function CameraSettingsScreen() {
   const [_devMode, _setDevMode] = useSetting(SETTINGS.debug_mode.key)
   const [storedPhotoSize, setPhotoSize] = useSetting(SETTINGS.button_photo_size.key)
   const photoSize = normalizeButtonPhotoSize(storedPhotoSize)
-  const [_ledEnabled, setLedEnabled] = useSetting(SETTINGS.button_camera_led.key)
   const [videoSettings, setVideoSettings] = useSetting(SETTINGS.button_video_settings.key)
   const [maxRecordingTime, setMaxRecordingTime] = useSetting(SETTINGS.button_max_recording_time.key)
   const [cameraFovSetting, setCameraFovSetting] = useSetting(SETTINGS.camera_fov.key)
@@ -188,14 +187,6 @@ export default function CameraSettingsScreen() {
       button_video_height: height,
       button_video_fps: fps,
     })
-  }
-
-  const _handleLedToggle = (enabled: boolean) => {
-    if (!glassesConnected) {
-      console.log("Cannot toggle LED - glasses not connected")
-      return
-    }
-    setLedEnabled(enabled)
   }
 
   const handleMaxRecordingTimeChange = (time: MaxRecordingTime) => {

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -491,13 +491,6 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: true,
     persist: true,
   },
-  button_camera_led: {
-    key: "button_camera_led",
-    defaultValue: () => true,
-    writable: true,
-    saveOnServer: true,
-    persist: true,
-  },
   button_max_recording_time: {
     key: "button_max_recording_time",
     defaultValue: () => 10,
@@ -683,7 +676,6 @@ const BLUETOOTH_SETTING_KEYS: string[] = [
   SETTINGS.button_photo_size.key,
   // Legacy MentraLive native code reads the object form when syncing video settings.
   SETTINGS.button_video_settings.key,
-  SETTINGS.button_camera_led.key,
   SETTINGS.button_max_recording_time.key,
   SETTINGS.camera_fov.key,
   // device / pairing:


### PR DESCRIPTION
## Summary
- Remove the public/mobile `setCaptureLedEnabled` / `button_camera_led` path from React Native, Android, iOS, DeviceStore sync, status models, and Mentra Live docs.
- Make ASG photo, video, stream, and button-triggered capture ignore caller LED/flash disable values and keep the capture light enabled.
- Stop emitting `flash` from mobile photo/video/stream payloads. The ASG client now owns the privacy/capture-light invariant.
- Prevent raw stream request maps from forwarding arbitrary keys such as `flash` to ASG. The private `keepAliveMode` marker remains only as the mobile SDK keep-alive ownership signal and is not serialized into the ASG `start_stream` command.

## Compatibility notes
- Verified `origin/main` ASG BLE command parsers default omitted `flash` to enabled:
  - `PhotoCommandHandler`: `data.optBoolean("flash", true)`.
  - `VideoCommandHandler`: `data.optBoolean("flash", true)`.
  - `StreamCommandHandler`: `data.optBoolean("flash", true)`.
- Checked older ASG tags around the schema changes:
  - `v2.3`: optional `enable_led`, default `true`.
  - `v2.7`: optional `silent`, default `false`, so the light stayed on when omitted.
  - `v2.8+`: optional `flash`, default `true`.
- `origin/main` local action-button capture read persisted `button_camera_led`; BLE `flash=true` never affected that local button path. This PR removes the ASG setting in new ASG code and removes the mobile public/store path that could write it.

## Validation
- `git diff --check`
- `./scripts/check-android-compile.sh` on `codex/remove-capture-led-setting` after merging current `origin/dev` (runs ASG Java compile and Bluetooth SDK public-mode Android AAR compile through the generated Expo Android project)
- `bun run build` in `mobile/modules/bluetooth-sdk`
- `bun test src/__tests__/photoRequestParamsForNative.test.ts`
- `xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS Simulator' build`

## Known local command notes
- `bun run test` previously failed before running tests because Expo/Jest did not transform the existing TypeScript `import type` in `photoRequestPayload.ts`; the focused Bun test above passes.
- `bun run lint` currently fails before reading source because ESLint cannot resolve the workspace `globals` package from `eslint.config.mjs`.