### PR TITLE
Local Android build was impossible due to spotless not working in git work trees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,19 @@ Core client app lives in `mobile/` (Expo React Native). Backend services and the
 - iOS setup: `cd ios && pod install && cd ..`
 - Prebuild: `bun expo prebuild` (syncs native projects - NEVER use --clean or --clear flags!)
 
+### Local Android compile checks
+
+- ASG client compile check: `./scripts/check-android-compile.sh asg`
+- Bluetooth SDK Android compile check: `./scripts/check-android-compile.sh bluetooth-sdk`
+- Both checks: `./scripts/check-android-compile.sh`
+
+The Bluetooth SDK Android sources under `mobile/modules/bluetooth-sdk/android`
+are compiled through the generated Expo Android project at `mobile/android`,
+matching CI. Do not rely on a system `gradle` install from the SDK source
+directory; use the repo script so the Gradle wrapper and prebuild setup are
+consistent. The Bluetooth SDK check runs with `-PmentraPublicSdk=true` so it
+validates the public Maven artifact dependency shape.
+
 ### Cloud Backend (cloud)
 
 - Install deps: `bun install`

--- a/asg_client/AGENTS.md
+++ b/asg_client/AGENTS.md
@@ -17,6 +17,7 @@ Android application that runs on Android-based smart glasses like Mentra Live. P
 - **Install on Device**: `./gradlew installDebug`
 - **Clean Build**: `./gradlew clean`
 - **Run Tests**: `./gradlew test`
+- **Local Compile Check**: from the repo root, `./scripts/check-android-compile.sh asg`
 
 ### Camera module tests
 

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -7,11 +7,26 @@ plugins {
 
 apply plugin: 'com.diffplug.spotless'
 
+def hasSpotlessRatchetGitDir = {
+    def dir = rootProject.projectDir
+    while (dir != null) {
+        if (new File(dir, ".git").isDirectory()) {
+            return true
+        }
+        dir = dir.parentFile
+    }
+    return false
+}
+
 spotless {
     java {
         target 'src/**/*.java'
         googleJavaFormat('1.17.0').aosp()
-        ratchetFrom 'origin/dev'
+        if (hasSpotlessRatchetGitDir()) {
+            ratchetFrom 'origin/dev'
+        } else {
+            logger.lifecycle("Skipping Spotless ratchetFrom because this checkout does not expose a .git directory to Spotless.")
+        }
         toggleOffOn()
         trimTrailingWhitespace()
         endWithNewline()

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -46,6 +46,13 @@ The user-facing app version (`CFBundleShortVersionString` on iOS,
 - Run Maestro E2E tests: `bun test:maestro`
 - Lint code: `bun lint`
 - Type check: `bun compile`
+- Bluetooth SDK Android compile check: `../scripts/check-android-compile.sh bluetooth-sdk`
+
+`modules/bluetooth-sdk/android` contains the SDK Android sources, but local
+Gradle checks should run through the generated `mobile/android` project via the
+repo script above. The script installs mobile dependencies when needed, runs
+`bun expo prebuild --platform android`, uses the generated Gradle wrapper, and
+passes `-PmentraPublicSdk=true` for the SDK module check.
 
 ## Project Setup
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -459,6 +459,18 @@ MENTRA_BLUETOOTH_SDK_PACKAGE_PATH=/path/to/MentraOS/mobile/modules/bluetooth-sdk
 
 Use `bunx expo run:android` for Android. Keep local paths in your shell or CI environment, not in committed app config.
 
+For local Android source compile checks inside this monorepo, run from the
+MentraOS repo root:
+
+```sh
+./scripts/check-android-compile.sh bluetooth-sdk
+```
+
+The `android/` folder in this package is source for the generated Expo Android
+project, not the local Gradle entrypoint. The check script prepares
+`mobile/android` and uses its Gradle wrapper with `-PmentraPublicSdk=true`,
+matching the CI release workflow's public SDK dependency mode.
+
 For bare native iOS apps, use the public SwiftPM repository:
 
 ```text

--- a/mobile/modules/bluetooth-sdk/RELEASING_ANDROID_MAVEN.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_ANDROID_MAVEN.md
@@ -29,6 +29,19 @@ checkout where `mobile/android` is not present yet, run
 `cd mobile && cp .env.example .env && bun expo prebuild --platform android`
 after installing dependencies.
 
+For a local Android compile check without publishing, run this from the
+MentraOS repo root:
+
+```bash
+./scripts/check-android-compile.sh bluetooth-sdk
+```
+
+The script prepares `mobile/android` when needed and uses the generated Gradle
+wrapper with `-PmentraPublicSdk=true`. Do not run `gradle` directly from
+`mobile/modules/bluetooth-sdk/android`; that directory is included as a module
+by the Expo Android project and does not carry its own wrapper or Android Gradle
+plugin classpath.
+
 The public SDK publication uses `-PmentraPublicSdk=true`. Leave this property
 off for normal MentraOS Android app builds so the app keeps the optional local
 STT, VAD, and Vuzix integrations it needs. With the property enabled, those

--- a/scripts/check-android-compile.sh
+++ b/scripts/check-android-compile.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<'USAGE'
+Usage: scripts/check-android-compile.sh [all|asg|bluetooth-sdk] [gradle args...]
+
+Runs focused local Android compile checks using repo-owned Gradle wrappers.
+
+Targets:
+  asg             Run asg_client :app Java debug compile.
+  bluetooth-sdk   Prepare mobile/android and run the public-mode Bluetooth SDK Android AAR compile.
+  all             Run both targets. This is the default.
+
+Set MENTRA_ANDROID_CHECK_SKIP_PREBUILD=1 to reuse an existing mobile/android
+project instead of running Expo prebuild for the bluetooth-sdk target.
+USAGE
+}
+
+require_command() {
+  local name="$1"
+  if ! command -v "$name" >/dev/null 2>&1; then
+    echo "error: '$name' is required for this check." >&2
+    return 1
+  fi
+}
+
+run_asg() {
+  if [[ ! -f "$repo_root/asg_client/StreamPackLite/core/build.gradle" ]]; then
+    cat >&2 <<'MSG'
+error: asg_client/StreamPackLite is missing.
+
+Set up the ASG dependency first:
+  cd asg_client
+  git clone git@github.com:Mentra-Community/StreamPackLite.git
+  cd StreamPackLite
+  git checkout working
+MSG
+    return 1
+  fi
+
+  (
+    cd "$repo_root/asg_client"
+    ./gradlew :app:compileDebugJavaWithJavac --no-daemon "$@"
+  )
+}
+
+ensure_mobile_android_project() {
+  local mobile_dir="$repo_root/mobile"
+
+  if [[ "${MENTRA_ANDROID_CHECK_SKIP_PREBUILD:-}" == "1" ]]; then
+    if [[ ! -x "$mobile_dir/android/gradlew" ]]; then
+      echo "error: mobile/android/gradlew is missing. Unset MENTRA_ANDROID_CHECK_SKIP_PREBUILD or run 'cd mobile && bun expo prebuild --platform android'." >&2
+      return 1
+    fi
+    return 0
+  fi
+
+  require_command bun
+
+  if [[ ! -d "$mobile_dir/node_modules" ]]; then
+    (
+      cd "$mobile_dir"
+      bun install --frozen-lockfile
+    )
+  fi
+
+  if [[ ! -f "$mobile_dir/.env" ]]; then
+    cp "$mobile_dir/.env.example" "$mobile_dir/.env"
+  fi
+
+  (
+    cd "$mobile_dir"
+    bun expo prebuild --platform android
+  )
+
+  if [[ ! -x "$mobile_dir/android/gradlew" ]]; then
+    echo "error: Expo prebuild did not create mobile/android/gradlew." >&2
+    return 1
+  fi
+}
+
+run_bluetooth_sdk() {
+  ensure_mobile_android_project
+  (
+    cd "$repo_root/mobile/android"
+    MENTRA_BLUETOOTH_SDK_PACKAGE_PATH="$repo_root/mobile/modules/bluetooth-sdk" \
+      ./gradlew :mentra-bluetooth-sdk:assembleDebug --no-daemon "$@" -PmentraPublicSdk=true
+  )
+}
+
+target="${1:-all}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+
+case "$target" in
+  -h|--help)
+    usage
+    ;;
+  all)
+    run_asg "$@"
+    run_bluetooth_sdk "$@"
+    ;;
+  asg|asg-client)
+    run_asg "$@"
+    ;;
+  bluetooth-sdk|sdk)
+    run_bluetooth_sdk "$@"
+    ;;
+  *)
+    echo "error: unknown target '$target'" >&2
+    usage >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
## Summary

- Add `scripts/check-android-compile.sh` as a repo-owned entrypoint for focused ASG and Bluetooth SDK Android compile checks.
- Keep ASG Spotless ratcheting on normal checkouts, but skip the ratchet in Git worktrees where Spotless cannot discover a `.git` directory and was failing task configuration.
- Run the Bluetooth SDK compile check with `-PmentraPublicSdk=true` so it validates the public Maven artifact dependency shape.
- Document the local Android compile-check commands in root, ASG, mobile, and Bluetooth SDK docs.

## Why

The ASG Gradle task report failed in worktrees while creating `:app:spotlessJava` because Spotless `ratchetFrom 'origin/dev'` could not resolve a Git repository from a checkout whose monorepo root has a `.git` file. The Bluetooth SDK Android source folder also is not the real local Gradle entrypoint; it is compiled through generated `mobile/android`, so running `gradle` from `mobile/modules/bluetooth-sdk/android` depends on an unavailable system Gradle and still lacks the Android Gradle plugin classpath.

## Validation

- `cd asg_client && ./gradlew tasks --all --no-daemon`
- `./scripts/check-android-compile.sh asg --stacktrace`
- `./scripts/check-android-compile.sh bluetooth-sdk --stacktrace` (runs `:mentra-bluetooth-sdk:assembleDebug` with `-PmentraPublicSdk=true`)
- `git diff --check origin/dev...HEAD`

Note: the ASG compile check still requires the existing local `asg_client/StreamPackLite` dependency. The new script now fails early with the documented clone/checkout commands when that dependency is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to developer tooling, Gradle Spotless configuration guards, and documentation; no runtime app or auth behavior is modified.
> 
> **Overview**
> Fixes **local Android builds failing in git worktrees** where Spotless `ratchetFrom 'origin/dev'` could not resolve a Git repo when the checkout root only has a `.git` file. **`asg_client/app/build.gradle`** now applies `ratchetFrom` only when walking up from the project finds a **`.git` directory**; otherwise it logs and skips ratchet so Gradle configuration succeeds.
> 
> Adds **`scripts/check-android-compile.sh`** as the repo entrypoint for focused compile checks: **ASG** runs `:app:compileDebugJavaWithJavac` via `asg_client/gradlew` (with an early error if `StreamPackLite` is missing); **bluetooth-sdk** ensures `mobile/android` (optional `bun install`, `.env` from example, `bun expo prebuild --platform android`, or reuse with `MENTRA_ANDROID_CHECK_SKIP_PREBUILD=1`) then runs `:mentra-bluetooth-sdk:assembleDebug` with **`-PmentraPublicSdk=true`** and local `MENTRA_BLUETOOTH_SDK_PACKAGE_PATH`, matching CI’s public Maven dependency shape instead of invoking system Gradle from the SDK source folder.
> 
> **AGENTS.md** files (root, `asg_client`, `mobile`) and Bluetooth SDK **README** / **RELEASING_ANDROID_MAVEN.md** document these commands and that SDK Android sources compile through generated **`mobile/android`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69cb0aca13f03e779710c08582e99c66b797122d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->