### PR TITLE
Tame miniapp runtime liveness warnings

### DIFF
--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/jsc/JSCRuntime.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/jsc/JSCRuntime.kt
@@ -459,15 +459,15 @@ class JSCRuntime private constructor(private val appContext: Context) {
      */
     fun dispatchToJs(packageName: String, envelopeJson: String) {
         val record = contexts[packageName] ?: return
-        // Steady-state NACK — re-arm so a wedged QuickJS context surfaces
-        // an __error/ready_nack frame after 3s instead of silently
-        // swallowing the delivery. Skipped during cold-start (timer still
-        // ticking from spawn).
-        if (record.readyAcked) {
-            armReadyNackTimer(record, STEADY_STATE_NACK_TIMEOUT_MS, cold = false)
-        }
         try {
             record.executor.submit {
+                // Steady-state NACK — re-arm inside the per-context executor so
+                // the timer measures the actual __deliver call, not time spent
+                // waiting behind earlier queued work. Skipped during cold-start
+                // (timer still ticking from spawn).
+                if (record.readyAcked) {
+                    armReadyNackTimer(record, STEADY_STATE_NACK_TIMEOUT_MS, cold = false)
+                }
                 // Soft watchdog around evaluate: warn at 5s, kill at 30s.
                 val warn = timerScheduler.schedule({
                     Log.i(TAG, "watchdog: $packageName __deliver blocked >${WATCHDOG_WARN_MS}ms")

--- a/mobile/modules/island/src/services/MentraJSRouter.ts
+++ b/mobile/modules/island/src/services/MentraJSRouter.ts
@@ -466,7 +466,11 @@ export class MentraJSRouter {
     //    dead and let the host surface a "tap to retry" banner.
     if (iface === "__error") {
       const payload = this.tryParseArgs(msg.argsJson)
-      this.logger.error(`[${packageName}] ${method}`, payload)
+      if (method === "ready_nack") {
+        this.logger.warn(`[${packageName}] ${method}`, payload)
+      } else {
+        this.logger.error(`[${packageName}] ${method}`, payload)
+      }
       if (this.crashController) {
         // Only treat "exception" + "unhandledRejection" + "uncaught" as
         // crash signals. `console.error` calls also flow through the

--- a/mobile/modules/island/src/services/__tests__/MentraJSRouter.test.ts
+++ b/mobile/modules/island/src/services/__tests__/MentraJSRouter.test.ts
@@ -252,6 +252,18 @@ describe("MentraJSRouter", () => {
     expect(logger.error).toHaveBeenCalledTimes(1)
   })
 
+  test("ready_nack logs as warning instead of dev-overlay error", () => {
+    router.start()
+    crust.emit("mentrajs_message", {
+      packageName: "com.foo",
+      iface: "__error",
+      method: "ready_nack",
+      argsJson: '{"phase":"steady-state","timeoutMs":3000}',
+    })
+    expect(logger.warn).toHaveBeenCalledTimes(1)
+    expect(logger.error).not.toHaveBeenCalled()
+  })
+
   test("unknown iface logs a debug line but does NOT crash", () => {
     router.start()
     crust.emit("mentrajs_message", {


### PR DESCRIPTION
## Summary
- measure steady-state miniapp delivery NACKs inside the per-context executor so queued work does not look like a wedged runtime
- log `ready_nack` frames as warnings instead of dev-overlay errors
- add router coverage for the warning behavior

## Test
- `bun test mobile/modules/island/src/services/__tests__/MentraJSRouter.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small timing/logging changes in miniapp delivery and observability; no auth, data, or crash-respawn behavior changes.
> 
> **Overview**
> Reduces noisy “wedged runtime” signals when miniapp JS is merely **backlogged** on its per-context thread, and downgrades how those liveness NACKs appear in dev.
> 
> On Android **`JSCRuntime.dispatchToJs`**, re-arming the steady-state **`ready_nack`** watchdog moved **inside** the per-package executor task so the 3s timer measures time until **`__deliver`** runs, not time spent waiting behind earlier queued work. Cold-start NACK behavior is unchanged.
> 
> In **`MentraJSRouter`**, `__error` frames with method **`ready_nack`** now use **`logger.warn`** instead of **`logger.error`**, so they don’t surface like other miniapp failures in the dev overlay. Crash handling is unchanged (`ready_nack` still isn’t treated as a crash). A unit test covers the warning path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0a3aaeef163cb7438378dbce65728f71db0893c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces false “wedged runtime” alerts by arming the steady-state NACK timer inside the per-context executor, and downgrades `ready_nack` to a warning instead of a dev-overlay error.

- **Bug Fixes**
  - Re-arm steady-state NACK inside the per-context executor so it measures actual `__deliver` time, not queue delay.
  - Log `__error/ready_nack` as a warning in `MentraJSRouter`; added a unit test to cover this behavior.

<sup>Written for commit d0a3aaeef163cb7438378dbce65728f71db0893c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

