### PR TITLE
Fallback when glasses mic stops streaming

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -203,6 +203,7 @@ class DeviceManager {
     private var lastReadyHandledAtMs: Long = 0L
     private var lastReadyHandledKey: String = ""
     private var lastSystemTimeSyncConnectionKey: String = ""
+    private var glassesMicDegradedUntilMs: Long = 0L
 
     private var systemMicUnavailable: Boolean
         get() = DeviceStore.store.get("bluetooth", "systemMicUnavailable") as? Boolean ?: false
@@ -354,8 +355,19 @@ class DeviceManager {
         // actually attempt recovery (was 0 before, which made the watchdog a no-op).
         val timeSinceLastLc3Event = System.currentTimeMillis() - (lastLc3Event ?: 0L)
         if (timeSinceLastLc3Event > 5000) {
-            Bridge.log("MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic")
-            sgc?.setMicEnabled(true)
+            if (currentMic == MicTypes.GLASSES_CUSTOM &&
+                            preferredMic != "glasses" &&
+                            micRanking.any { it != MicTypes.GLASSES_CUSTOM }
+            ) {
+                glassesMicDegradedUntilMs = System.currentTimeMillis() + 15_000
+                Bridge.log(
+                        "MAN: No audio activity in the last 5 seconds from glasses, temporarily falling back from glasses mic"
+                )
+                updateMicState()
+            } else {
+                Bridge.log("MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic")
+                sgc?.setMicEnabled(true)
+            }
         }
     }
 
@@ -708,6 +720,7 @@ class DeviceManager {
      */
     fun handleGlassesMicData(rawLC3Data: ByteArray, frameSize: Int = 40) {
         lastLc3Event = System.currentTimeMillis()
+        glassesMicDegradedUntilMs = 0L
         val pcmData: ByteArray?
         synchronized(lc3Lock) {
             if (lc3DecoderPtr == 0L) {
@@ -809,6 +822,20 @@ class DeviceManager {
                 }
 
                 if (micMode == MicTypes.GLASSES_CUSTOM) {
+                    val glassesConnected =
+                            DeviceStore.get("glasses", "connected") as? Boolean ?: false
+                    if (!glassesConnected) {
+                        Bridge.log("MAN: glasses mic skipped because glasses are not connected")
+                        continue
+                    }
+
+                    if (glassesMicDegradedUntilMs > System.currentTimeMillis() &&
+                                    preferredMic != "glasses" &&
+                                    micRanking.any { it != MicTypes.GLASSES_CUSTOM }
+                    ) {
+                        Bridge.log("MAN: glasses mic temporarily skipped due to missing LC3 frames")
+                        continue
+                    }
                     if (sgc?.hasMic == true) {
                         // enable the mic if it's not already on:
                         if (sgc?.micEnabled == false) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -296,6 +296,7 @@ struct ViewState {
     /// Last time we received an LC3 frame from the glasses (used by the mic
     /// inactivity watchdog).
     private var lastLc3Event: Date?
+    private var glassesMicDegradedUntil: Date?
     private var micReinitTimer: Timer?
 
     /// STT:
@@ -394,6 +395,7 @@ struct ViewState {
      */
     func handleGlassesMicData(_ lc3Data: Data, _ frameSize: Int = 20) {
         lastLc3Event = Date()
+        glassesMicDegradedUntil = nil
         guard let lc3Converter = lc3Converter else {
             Bridge.log("MAN: LC3 converter not initialized")
             return
@@ -464,6 +466,20 @@ struct ViewState {
                 }
 
                 if micMode == MicTypes.GLASSES_CUSTOM {
+                    let glassesConnected = DeviceStore.shared.get("glasses", "connected") as? Bool ?? false
+                    if !glassesConnected {
+                        Bridge.log("MAN: glasses mic skipped because glasses are not connected")
+                        continue
+                    }
+
+                    if let degradedUntil = glassesMicDegradedUntil,
+                       degradedUntil > Date(),
+                       preferredMic != "glasses",
+                       micRanking.contains(where: { $0 != MicTypes.GLASSES_CUSTOM })
+                    {
+                        Bridge.log("MAN: glasses mic temporarily skipped due to missing LC3 frames")
+                        continue
+                    }
                     // Bridge.log(
                     //     "MAN: glasses custom mic found - hasMic: \(sgc?.hasMic ?? false), micEnabled: \(sgc?.micEnabled ?? false)"
                     // )
@@ -775,10 +791,21 @@ struct ViewState {
             return
         }
 
-        let timeSinceLastLc3Event = Date().timeIntervalSince(lastLc3Event ?? Date())
+        let timeSinceLastLc3Event = lastLc3Event.map { Date().timeIntervalSince($0) } ?? .greatestFiniteMagnitude
         if timeSinceLastLc3Event > 5 {
-            Bridge.log("MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic")
-            sgc?.setMicEnabled(true)
+            if currentMic == MicTypes.GLASSES_CUSTOM,
+               preferredMic != "glasses",
+               micRanking.contains(where: { $0 != MicTypes.GLASSES_CUSTOM })
+            {
+                glassesMicDegradedUntil = Date().addingTimeInterval(15)
+                Bridge.log(
+                    "MAN: No audio activity in the last 5 seconds from glasses, temporarily falling back from glasses mic"
+                )
+                updateMicState()
+            } else {
+                Bridge.log("MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic")
+                sgc?.setMicEnabled(true)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- skip glasses mic selection when the glasses are disconnected
- temporarily degrade the glasses mic after LC3 inactivity so phone/system mic can recover audio
- clear the degraded state as soon as LC3 frames resume

## Test
- Not run in this split step; native Android/iOS Bluetooth path should be verified on device.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime mic routing and STT/audio capture on the native Bluetooth path; behavior is gated by connection state and mic preference but should be verified on physical devices.
> 
> **Overview**
> When the glasses LC3 stream goes quiet for more than five seconds while the app is on the glasses mic, **Android and iOS `DeviceManager` now temporarily degrades** that source (15s) and calls **`updateMicState()`** so the next mic in `micRanking` can take over—instead of only re-enabling the glasses mic. Users who **force `preferredMic` to glasses** or have no alternate in the ranking still get the **reinit** path.
> 
> **Mic selection** skips `GLASSES_CUSTOM` when **`glasses.connected` is false**, and while the degraded window is active (same preference/ranking exceptions). **Incoming LC3** clears the degraded flag so the glasses mic can be chosen again as soon as frames return.
> 
> On **iOS**, the inactivity watchdog treats **never-seen LC3** as infinite idle (not ~0s vs `Date()`), aligning with Android’s “no frame yet” behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d292e5160086a56be928a36ea30694a37e567202. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an automatic fallback when the glasses mic stops streaming so audio continues via phone/system mic.

- **Bug Fixes**
  - Skip selecting the glasses mic when the glasses are disconnected.
  - After 5s of no LC3 frames, temporarily degrade `MicTypes.GLASSES_CUSTOM` for 15s and switch to a higher-ranked mic when `preferredMic` isn’t `"glasses"`; clear the degraded state as soon as LC3 resumes.
  - Implemented on both Android and iOS DeviceManager.

<sup>Written for commit d292e5160086a56be928a36ea30694a37e567202. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

