### PR TITLE
[codex] Tune ASG photo upload timeouts

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -2545,20 +2545,20 @@ public class MediaCaptureService {
                                 Log.d(TAG, "📊 Photo file size: " + photoFile.length() + " bytes");
                                 Log.d(TAG, "🌐 Sending photo request to: " + webhookUrl);
 
-                                // Large photos over phone-hotspot WiFi can take 15s+ for a 3MB
-                                // transfer. Mirror the video path: generous per-stall timeouts
-                                // plus an end-to-end callTimeout derived from file size.
+                                // Large photos need generous write/call timeouts after a socket
+                                // connects. Keep connect short so unreachable receivers fall back
+                                // to BLE without waiting through a body-transfer-sized timeout.
                                 long minThroughputBytesPerSec = 64L * 1024L; // ~0.5 Mbps floor
                                 long callTimeoutSeconds =
                                         30L + (photoFile.length() / minThroughputBytesPerSec);
                                 OkHttpClient client =
                                         new OkHttpClient.Builder()
                                                 .connectTimeout(
-                                                        15, java.util.concurrent.TimeUnit.SECONDS)
+                                                        5, java.util.concurrent.TimeUnit.SECONDS)
                                                 .writeTimeout(
                                                         60, java.util.concurrent.TimeUnit.SECONDS)
                                                 .readTimeout(
-                                                        30, java.util.concurrent.TimeUnit.SECONDS)
+                                                        10, java.util.concurrent.TimeUnit.SECONDS)
                                                 .callTimeout(
                                                         callTimeoutSeconds,
                                                         java.util.concurrent.TimeUnit.SECONDS)


### PR DESCRIPTION
## Summary

Adjust the ASG photo direct-upload timeouts so unreachable upload endpoints fall back sooner without weakening large-photo transfers.

- reduce photo upload TCP connect timeout from 15s to 5s
- reduce photo upload read timeout from 30s to 10s
- keep the 60s write timeout and file-size-derived call timeout for larger max-size JPEG uploads
- update the inline comment to separate connection establishment from body-transfer timing

## Why

The 15s connect timeout was introduced while improving large photo upload behavior, but the incident logs show the failure path was TCP connection establishment to the phone receiver, not body upload duration. Keeping the write/call deadlines generous preserves large-photo support while avoiding a long wait before BLE fallback when the endpoint cannot be reached.

## Validation

- `scripts/check-android-compile.sh asg`

Note: the ASG compile script requires the ignored `asg_client/StreamPackLite` dependency. It was copied from the existing local `MentraOS-dev` checkout for local validation and is not part of this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path networking tweak in photo upload with no auth or data-model changes; main tradeoff is slightly less tolerance for very slow HTTP responses after connect.
> 
> **Overview**
> Tightens **OkHttp** timeouts on the ASG **direct photo webhook** path in `MediaCaptureService.performDirectUpload` so a dead or unreachable phone receiver fails fast instead of sitting on a long TCP connect wait.
> 
> **Connect** drops from **15s → 5s** and **read** from **30s → 10s**. **Write (60s)** and the **file-size–based call timeout** are unchanged so large JPEG uploads still get time after the socket is up. The inline comment now separates **connection establishment** from **body transfer** timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393b7641ea7d7c545a98b503bf588bbee3a229de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->