### PR TITLE
[codex] Bump Bluetooth SDK to 0.1.14

### DIFF
--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.13")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.14")
 }
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.13`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.14`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.13"
+  from: "0.1.14"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.13")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.14")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.13`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.14`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.13"
+  from: "0.1.14"
 )
 ```
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -206,7 +206,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -477,7 +477,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.13`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.14`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.13`
+Use the same version format as existing SwiftPM tags, for example `0.1.14`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",


### PR DESCRIPTION
## Summary
- bump `@mentra/bluetooth-sdk` package metadata and mobile lockfile to `0.1.14`
- update Mentra Live Android/iOS/quickstart install snippets for `0.1.14`
- update the SDK README and SwiftPM release guide version examples

## Validation
- `bun install --frozen-lockfile` (mobile)
- `npm pack --dry-run` (mobile/modules/bluetooth-sdk)
- `scripts/export-bluetooth-sdk-ios-spm.sh --target /tmp/mentra-bluetooth-sdk-ios-0.1.14-export-check --verify`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime, auth, or Bluetooth logic changes in the diff.
> 
> **Overview**
> This PR **bumps the Mentra Bluetooth SDK release to `0.1.14`** across package metadata and consumer-facing install instructions.
> 
> `@mentra/bluetooth-sdk` in `mobile/modules/bluetooth-sdk/package.json` is updated to **`0.1.14`**, and **`mobile/bun.lock`** reflects the new module version. Mentra Live docs (`android.mdx`, `ios.mdx`, `quickstart.mdx`) now show **`com.mentraglass:bluetooth-sdk:0.1.14`** and SwiftPM **`from: "0.1.14"`** / Xcode package version **`0.1.14`**. Maintainer docs (`README.md`, `RELEASING_IOS_SPM.md`) use the same version in examples.
> 
> There are **no application or SDK implementation changes** in this diff—only version strings and lockfile alignment for the published release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80d9abf87f76d3c5d842e3e8e77a078d8566c5f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->