### PR TITLE
Guard Merge against mock transcripts

### DIFF
--- a/miniapps/merge/miniapp/src/background/index.ts
+++ b/miniapps/merge/miniapp/src/background/index.ts
@@ -244,6 +244,16 @@ class MergeController {
     this.upsertTranscript(entry)
     this.ui.send("merge:transcript", entry)
 
+    if (isMockTranscript(data, entry.text)) {
+      this.recordDecision({
+        action: "silent",
+        trigger: entry.isFinal ? "final" : "interval",
+        chunkText: entry.text,
+        reasoning: "Skipped deterministic cloud-v2 mock transcript",
+      })
+      return
+    }
+
     if (entry.isFinal) this.enqueueFinalAnalysis(entry)
     else this.enqueueInterimAnalysis(entry)
   }
@@ -626,6 +636,12 @@ function normalizeInsight(text: string): string {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, " ")
     .trim()
+}
+
+function isMockTranscript(data: TranscriptionData, text: string): boolean {
+  const source = (data as {source?: unknown; provider?: unknown}).source ?? (data as {provider?: unknown}).provider
+  if (source === "mock") return true
+  return /^mock [a-z0-9_.:-]+ \d+$/i.test(text.trim())
 }
 
 function completedSentencePrefix(text: string): string {

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -105,7 +105,6 @@ export const BluetoothSdk: BluetoothSdkPublicModule = Object.freeze({
     }
     return PrivateBluetoothSdkModule.setVideoRecordingDefaults(width, height, fps)
   },
-  setCaptureLedEnabled: bindPublicMethod("setCaptureLedEnabled"),
   setMaxVideoRecordingDuration: bindPublicMethod("setMaxVideoRecordingDuration"),
   setCameraFov: bindPublicMethod("setCameraFov"),
   queryGalleryStatus: bindPublicMethod("queryGalleryStatus"),


### PR DESCRIPTION
## Summary

- Skip Local Merge AI analysis for deterministic cloud-v2 mock transcript text while still recording the transcript/activity.
- Remove a stale Bluetooth SDK public export for `setCaptureLedEnabled`, which was intentionally removed from the native SDK path.

## Validation

- `bun run --cwd miniapps/merge build`
- `bun run --cwd mobile/modules/bluetooth-sdk prepare`
- `bun install --frozen-lockfile`
- `git diff --check`

## Notes

PR #3178 was squash-merged while this fix was being made, so this is the small follow-up against current `dev`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavioral guard in Merge miniapp and removal of an unused SDK binding with no auth, security, or data-path changes.
> 
> **Overview**
> **Merge** now detects cloud-v2 **mock** transcripts (via `source`/`provider === "mock"` or deterministic `mock … <n>` text), still upserts and broadcasts them, records a **silent** decision, and **returns before** final/interim insight analysis so the backend is not called for test traffic.
> 
> The mobile **Bluetooth SDK** public surface drops **`setCaptureLedEnabled`**, which no longer exists on the native module after an intentional removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d900c90862b6ac4f8edb7fe98294cf789ec491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Merge analysis for deterministic mock transcripts while still recording the transcript and activity. Remove the stale `setCaptureLedEnabled` export from the `mobile/modules/bluetooth-sdk` public API.

<sup>Written for commit 76d900c90862b6ac4f8edb7fe98294cf789ec491. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

