### PR TITLE
Update CODEOWNERS reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,5 @@ mobile/ @aisraelov @AryanFP
 cloud-v2/ @aisraelov @AryanFP @isaiahb
 cloud/ @aisraelov @isaiahb
 mintlify-docs/ @aisraelov @isaiahb
+mintlify-docs/mentra-live/ @aisraelov @isaiahb @PhilippeFerreiraDeSousa
 mobile/modules/bluetooth-sdk/ @aisraelov @AryanFP @PhilippeFerreiraDeSousa

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,9 @@
-* @Mentra-Community/core
+# The last matching CODEOWNERS pattern wins, so keep @aisraelov on each narrower rule.
+* @aisraelov
+
+miniapps/ @aisraelov @AryanFP @isaiahb
+mobile/ @aisraelov @AryanFP
+cloud-v2/ @aisraelov @AryanFP @isaiahb
+cloud/ @aisraelov @isaiahb
+mintlify-docs/ @aisraelov @isaiahb
+mobile/modules/bluetooth-sdk/ @aisraelov @AryanFP @PhilippeFerreiraDeSousa


### PR DESCRIPTION
## Summary
- Replace the catch-all `@Mentra-Community/core` CODEOWNERS rule with explicit user ownership.
- Keep `@aisraelov` on all paths via the catch-all and repeated narrower rules because CODEOWNERS uses the last matching pattern.
- Add path-specific owners for `miniapps/`, `mobile/`, `cloud-v2/`, `cloud/`, `mintlify-docs/`, and `mobile/modules/bluetooth-sdk/`.

## Validation
- `git diff --check`
- `gh api 'repos/Mentra-Community/MentraOS/codeowners/errors?ref=codex/update-codeowners-reviewers' --jq '.errors'` returned `[]`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only GitHub review routing in `.github/CODEOWNERS` changes; no application or infrastructure code is affected.
> 
> **Overview**
> **CODEOWNERS** no longer routes every path through `@Mentra-Community/core`. The catch-all is now `@aisraelov`, with narrower rules for major areas so the right people are requested on review.
> 
> Path-specific owners were added for `miniapps/`, `mobile/`, `cloud-v2/`, `cloud/`, `mintlify-docs/`, `mintlify-docs/mentra-live/`, and `mobile/modules/bluetooth-sdk/`. A comment documents that the **last matching pattern wins**, so `@aisraelov` is repeated on each narrower line to keep baseline coverage where intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95d6d6a180d49c61fc64630be3b2be6819064a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->