### PR TITLE
speed

### DIFF
--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -62,7 +62,7 @@ const SWITCHER_COMMIT_VELOCITY = -500
 // How far the overlay shrinks while the bottom swipe-up follows the finger.
 const SWIPE_UP_SCALE_TO = 0.5
 const FADE_IN_DELAY_MS = 0
-const FADE_IN_DURATION_MS = Platform.OS === "ios" ? 850 : 1200
+const FADE_IN_DURATION_MS = Platform.OS === "ios" ? 400 : 500
 const FADE_IN_SCALE_FROM = 0.4
 const FADE_OUT_DURATION_MS = 300
 const FADE_OUT_SCALE_TO = 0.4


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single animation timing constant change with no logic or data-path changes; only affects perceived open speed and capsule reveal timing.
> 
> **Overview**
> **Speeds up the miniapp overlay open animation** by shortening `FADE_IN_DURATION_MS` in `Compositor.tsx` from **850ms / 1200ms** (iOS / Android) to **400ms / 500ms**.
> 
> That constant drives the fade-and-scale-in when a local miniapp is foregrounded (including the iOS offline-hosted glass warm-up path) and gates when the capsule control is shown after the animation finishes—both paths now complete roughly twice as fast on iOS and much faster on Android.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d344d50d2c430ba87392650fa9ec8b275d7a12d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->