### PR TITLE
Add session.canvas miniapp display API + compositor/host fixes (no experimental G2)

### DIFF
--- a/miniapps/example-miniapp/src/ui/App.tsx
+++ b/miniapps/example-miniapp/src/ui/App.tsx
@@ -2,6 +2,7 @@ import {HashRouter, Navigate, Route, Routes} from "react-router-dom"
 
 import CaptionsPage from "./pages/CaptionsPage"
 import CameraPage from "./pages/tester/CameraPage"
+import CanvasPage from "./pages/tester/CanvasPage"
 import DisplayPage from "./pages/tester/DisplayPage"
 import StreamingPage from "./pages/tester/StreamingPage"
 import GlassesPage from "./pages/tester/GlassesPage"
@@ -25,6 +26,7 @@ export default function App() {
         <Route path="/" element={<TesterMenu />} />
         <Route path="/captions" element={<CaptionsPage />} />
         <Route path="/tester/display" element={<DisplayPage />} />
+        <Route path="/tester/canvas" element={<CanvasPage />} />
         <Route path="/tester/speaker" element={<SpeakerPage />} />
         <Route path="/tester/mic" element={<MicrophonePage />} />
         <Route path="/tester/transcription" element={<TranscriptionPage />} />

--- a/miniapps/example-miniapp/src/ui/pages/tester/CanvasPage.tsx
+++ b/miniapps/example-miniapp/src/ui/pages/tester/CanvasPage.tsx
@@ -1,0 +1,288 @@
+// Tester page — fire-and-forget actions go through the
+// `tester:invoke` channel; background dispatches to session.canvas.*.
+//
+// Canvas is a distinct command vocabulary from session.display: instead of
+// layouts it exposes show_text / show_bitmap / clear / show_page operations.
+// On the host these currently route through the same native display pipeline
+// (show_page is a recognized no-op until a native page surface exists).
+
+import {useRef, useState} from "react"
+import {useNavigate} from "react-router-dom"
+import {MiniappHeader} from "@mentra/miniapp/ui"
+
+import {useTester} from "../../hooks/useTester"
+import {Shell} from "../Shell"
+import {Button} from "../../components/button"
+import {Input} from "../../components/input"
+import {Label} from "../../components/label"
+import {ErrorRow} from "./_TesterRow"
+
+// Encode an ImageData's pixels as a base64 4-bit grayscale BMP (no data:
+// prefix). The glasses render grayscale, and the phone decodes via iOS
+// UIImage / Android BitmapFactory — an uncompressed 4-bit BMP is decoded
+// reliably by both, whereas some PNG variants are rejected by ImageIO.
+// Each pixel's RGB is reduced to luminance and quantized to one of 16 gray
+// levels via a 16-entry grayscale palette; pixels are packed 2 px/byte.
+function imageDataToBmp4Bit(img: ImageData): string {
+  const {width, height, data} = img
+  const rowSize = Math.ceil(width / 8) * 4 // 4 bits/px, 4-byte aligned rows
+  const pixelOffset = 118 // 14 (file) + 40 (DIB) + 64 (16-color table)
+  const fileSize = pixelOffset + rowSize * height
+  const buf = new Uint8Array(fileSize)
+
+  const u16 = (off: number, v: number) => {
+    buf[off] = v & 0xff
+    buf[off + 1] = (v >>> 8) & 0xff
+  }
+  const u32 = (off: number, v: number) => {
+    buf[off] = v & 0xff
+    buf[off + 1] = (v >>> 8) & 0xff
+    buf[off + 2] = (v >>> 16) & 0xff
+    buf[off + 3] = (v >>> 24) & 0xff
+  }
+
+  // File header
+  buf[0] = 0x42 // 'B'
+  buf[1] = 0x4d // 'M'
+  u32(2, fileSize)
+  u32(10, pixelOffset)
+  // DIB header (BITMAPINFOHEADER)
+  u32(14, 40)
+  u32(18, width)
+  u32(22, height) // positive = bottom-up
+  u16(26, 1) // planes
+  u16(28, 4) // bits per pixel
+  u32(30, 0) // BI_RGB (no compression)
+  u32(34, rowSize * height)
+  u32(38, 2835) // X px/meter
+  u32(42, 2835) // Y px/meter
+  u32(46, 16) // colors used
+  u32(50, 16) // important colors
+  // Color table: 16 grayscale entries (BGRA), level i scaled across 0..255.
+  for (let i = 0; i < 16; i++) {
+    const off = 54 + i * 4
+    const gray = Math.round((i / 15) * 255)
+    buf[off] = gray // B
+    buf[off + 1] = gray // G
+    buf[off + 2] = gray // R
+  }
+
+  for (let y = 0; y < height; y++) {
+    const srcRow = y * width * 4 // RGBA, top-down
+    const destRow = pixelOffset + (height - 1 - y) * rowSize // write bottom-up
+    for (let x = 0; x < width; x++) {
+      const s = srcRow + x * 4
+      // Rec. 601 luma, quantized to 4 bits (0..15).
+      const lum = 0.299 * data[s] + 0.587 * data[s + 1] + 0.114 * data[s + 2]
+      const level = Math.min(15, lum / 16) | 0
+      // Two pixels per byte: even x → high nibble, odd x → low nibble.
+      if ((x & 1) === 0) buf[destRow + (x >> 1)] |= level << 4
+      else buf[destRow + (x >> 1)] |= level
+    }
+  }
+
+  let binary = ""
+  for (let i = 0; i < buf.length; i++) binary += String.fromCharCode(buf[i])
+  return btoa(binary)
+}
+
+// Draw a labeled rectangle to an offscreen canvas and return it as a
+// base64 4-bit grayscale BMP (no data: prefix), the glasses-native bitmap format.
+function makeBitmap(width: number, height: number, label: string): string {
+  const canvas = document.createElement("canvas")
+  canvas.width = width
+  canvas.height = height
+  const ctx = canvas.getContext("2d")!
+  ctx.fillStyle = "#000"
+  ctx.fillRect(0, 0, width, height)
+  ctx.strokeStyle = "#fff"
+  ctx.lineWidth = 4
+  ctx.strokeRect(2, 2, width - 4, height - 4)
+  ctx.fillStyle = "#fff"
+  ctx.font = `bold ${Math.round(height / 4)}px sans-serif`
+  ctx.textAlign = "center"
+  ctx.textBaseline = "middle"
+  ctx.fillText(label, width / 2, height / 2)
+  return imageDataToBmp4Bit(ctx.getImageData(0, 0, width, height))
+}
+
+// The four 100×100 corner containers on the 576×288 display, keyed by rect.
+// First press of a corner sends its code (TL/TR/BR/BL); each later press
+// re-sends to the same rect with an incrementing count, updating in place.
+const CORNERS = [
+  {code: "TL", x: 0, y: 0},
+  {code: "TR", x: 476, y: 0},
+  {code: "BR", x: 476, y: 188},
+  {code: "BL", x: 0, y: 188},
+] as const
+
+type CornerCode = "TL" | "TR" | "BR" | "BL" | "CE" | "full"
+
+// Positioned text containers on the 576×288 canvas — one per corner, each a
+// 180×80 box with a rounded border so the container bounds are visible on
+// glass. Demonstrates `showText`'s x/y/width/height + borderWidth/borderRadius.
+// Codes are prefixed "t" so their press counts don't collide with the bitmap
+// corners above (which reuse TL/TR/BR/BL).
+const TEXT_SLOTS = [
+  {code: "tTL", x: 0, y: 0},
+  {code: "tTR", x: 396, y: 0},
+  {code: "tBR", x: 396, y: 208},
+  {code: "tBL", x: 0, y: 208},
+] as const
+type TextSlotCode = (typeof TEXT_SLOTS)[number]["code"] | "tCE"
+const TEXT_BOX = {width: 180, height: 80, borderWidth: 2, borderRadius: 8} as const
+
+export default function CanvasPage() {
+  const navigate = useNavigate()
+  // useTester opens a (no-op) subscription so `tester:event {kind:"error"}`
+  // from a bad invoke() lands in lastError and surfaces in the UI.
+  const {invoke, lastError} = useTester("canvas")
+  const [text, setText] = useState("Hello from MentraJS!")
+  const [pageId, setPageId] = useState("home")
+  // Per-button press counts. 0 = not yet pressed. Each press bumps the count so
+  // re-pressing a button sends different content (label / text suffix), updating
+  // that container in place. Covers both bitmap corners and text slots.
+  const [counts, setCounts] = useState<Record<CornerCode | TextSlotCode, number>>({
+    TL: 0,
+    TR: 0,
+    BR: 0,
+    BL: 0,
+    CE: 0,
+    full: 0,
+    tTL: 0,
+    tTR: 0,
+    tBR: 0,
+    tBL: 0,
+    tCE: 0,
+  })
+  // Synchronous mirror of `counts` so rapid presses (faster than a React
+  // re-render) read the up-to-date value instead of a stale render closure,
+  // which would otherwise reuse the same count and show a duplicate label.
+  const countsRef = useRef(counts)
+
+  const pressCorner = (code: CornerCode, x: number, y: number) => {
+    const next = incrementCount(code)
+    // First press: just the corner code. Subsequent presses: code + count.
+    const label = `${code} ${next}`
+    invoke("showBitmap", [makeBitmap(100, 100, label), {x, y, width: 100, height: 100}]).catch(() => {})
+  }
+
+  const incrementCount = (code: CornerCode | TextSlotCode) => {
+    const next = countsRef.current[code] + 1
+    countsRef.current = {...countsRef.current, [code]: next}
+    setCounts(countsRef.current)
+    return next
+  }
+
+  return (
+    <Shell>
+      <MiniappHeader title="session.canvas" onBack={() => navigate("/")} />
+      <div className="flex-1 overflow-y-auto px-4 pb-6">
+        <p className="mb-3 text-[13px] text-muted-foreground">
+          Render to the glasses canvas. Tap a button to invoke the corresponding `session.canvas.*` operation in
+          background.
+        </p>
+        <Label htmlFor="canvas-text">text</Label>
+        <Input id="canvas-text" value={text} onChange={(e) => setText(e.target.value)} />
+        <div className="mt-3 flex flex-col gap-2">
+          {/* showText is positioned — fill the whole 576×288 canvas for a text-wall feel. */}
+          <Button onClick={() => invoke("showText", [text, {x: 0, y: 0, width: 576, height: 288}]).catch(() => {})}>
+            showText(text)
+          </Button>
+        </div>
+
+        <p className="mb-2 mt-5 text-[13px] text-muted-foreground">
+          Positioned text. `showText(text, options)` accepts `x`/`y`/`width`/`height` to place the text container
+          anywhere on the 576×288 canvas, plus `borderWidth`/`borderRadius` for a rounded border. Each corner button
+          drops a {`${TEXT_BOX.width}×${TEXT_BOX.height}`} bordered container; Center places one with no border.
+        </p>
+        <div className="flex flex-row gap-2">
+          {TEXT_SLOTS.map(({code, x, y}) => {
+            const label = code.slice(1) // strip the "t" prefix → TL/TR/BR/BL
+            return (
+              <Button
+                key={code}
+                className="w-1/5"
+                onClick={() => {
+                  const next = incrementCount(code)
+                  // Re-pressing updates the same container in place with new content.
+                  invoke("showText", [`${label} ${next}: ${text}`, {x, y, ...TEXT_BOX}]).catch(() => {})
+                }}>
+                {label}
+                {` ${counts[code]}`}
+              </Button>
+            )
+          })}
+        </div>
+        <div className="flex flex-row gap-2 mt-2">
+          <Button
+            onClick={() => {
+              const next = incrementCount("tCE")
+              invoke("showText", [`CE ${next}: ${text}`, {x: 198, y: 104, width: 180, height: 80}]).catch(() => {})
+            }}>
+            Center (no border)
+          </Button>
+        </div>
+
+        <p className="mb-2 mt-5 text-[13px] text-muted-foreground">
+          Bitmaps. `showBitmap(data, options)` accepts optional `x`/`y`/`width`/`height`. On G2 the page tracks up to 4
+          image containers, keyed by rect: a new rect adds a container (evicting the oldest past 4), an existing rect
+          updates in place. Each corner button sends its code on first press, then increments a count in place on later
+          presses.
+        </p>
+        <div className="flex flex-row gap-2">
+          {CORNERS.map(({code, x, y}) => (
+            <Button key={code} onClick={() => pressCorner(code, x, y)} className="w-1/5">
+              {code}
+              {` ${counts[code]}`}
+            </Button>
+          ))}
+        </div>
+
+        <div className="flex flex-row gap-2 mt-5">
+          <Button
+            onClick={() => {
+              let next = incrementCount("CE")
+              invoke("showBitmap", [makeBitmap(100, 100, `CE ${next}`), {x: 288 - 100 / 2, y: 144 - 100 / 2, width: 100, height: 100}]).catch(() => {})
+            }}>
+            Center
+          </Button>
+          <Button
+            onClick={() => {
+              let next = incrementCount("full")
+              invoke("showBitmap", [
+                makeBitmap(288, 144, `full ${next}`),
+                {x: 288 - 288 / 2, y: 144 - 144 / 2, width: 288, height: 144},
+              ]).catch(() => {})
+            }}>
+            Large
+          </Button>
+        </div>
+
+        <p className="mb-2 mt-5 text-[13px] text-muted-foreground">
+          Pages. `showPage(id)` is canvas-only — a forward-looking operation with no native render target yet. The host
+          recognizes and acks it (no-op); this exercises the command path end-to-end.
+        </p>
+        <Label htmlFor="canvas-page-id">page id</Label>
+        <Input id="canvas-page-id" value={pageId} onChange={(e) => setPageId(e.target.value)} />
+        <div className="mt-3 flex flex-col gap-2">
+          <Button onClick={() => invoke("showPage", [pageId]).catch(() => {})}>showPage(id)</Button>
+        </div>
+
+        <div className="mt-5 flex flex-col gap-2">
+          <Button
+            variant="destructive"
+            onClick={() => {
+              const zero = {TL: 0, TR: 0, BR: 0, BL: 0, CE: 0, full: 0, tTL: 0, tTR: 0, tBR: 0, tBL: 0, tCE: 0}
+              countsRef.current = zero
+              setCounts(zero)
+              invoke("clear", []).catch(() => {})
+            }}>
+            clear()
+          </Button>
+        </div>
+        <ErrorRow event={lastError} />
+      </div>
+    </Shell>
+  )
+}

--- a/miniapps/example-miniapp/src/ui/pages/tester/TesterMenu.tsx
+++ b/miniapps/example-miniapp/src/ui/pages/tester/TesterMenu.tsx
@@ -32,6 +32,7 @@ const EXAMPLE_ROWS: Row[] = [
 // then placeholders.
 const API_ROWS: Row[] = [
   {emoji: "🖥️", title: "session.display", subtitle: "text walls, cards, bitmaps", path: "/tester/display"},
+  {emoji: "🎨", title: "session.canvas", subtitle: "show_text / show_bitmap / clear / show_page", path: "/tester/canvas"},
   {emoji: "🔊", title: "session.speaker", subtitle: "play URL, speak text", path: "/tester/speaker"},
   {emoji: "🎙️", title: "session.mic", subtitle: "audio chunks, VAD, stop()", path: "/tester/mic"},
   {emoji: "📝", title: "session.transcription", subtitle: "on / forLanguage / configure / stop", path: "/tester/transcription"},

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -3388,6 +3388,7 @@ class G2: NSObject, SGCManager {
     func sendButtonPhotoSettings() {}
     func sendButtonVideoRecordingSettings() {}
     func sendButtonMaxRecordingTime() {}
+    func sendButtonCameraLedSetting() {}
 
     func sendCameraFovSetting() {}
 

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -18,6 +18,7 @@ import * as Location from "expo-location"
 import BluetoothSdk, {type RgbLedAction, type RgbLedColor} from "@mentra/bluetooth-sdk"
 
 import {
+  CanvasOperation,
   MiniappErrorCode,
   MiniappRequestType,
   MiniappResponseType,
@@ -824,6 +825,9 @@ class LocalMiniappRuntime {
       case MiniappRequestType.DISPLAY:
         this.handleDisplay(packageName, payload, requestId)
         break
+      case MiniappRequestType.CANVAS:
+        this.handleCanvas(packageName, payload, requestId)
+        break
       case MiniappRequestType.PLAY_AUDIO:
         this.handlePlayAudio(packageName, payload, requestId)
         break
@@ -1314,6 +1318,74 @@ class LocalMiniappRuntime {
       this.sendResult(packageName, requestId, false, undefined, {
         code: MiniappErrorCode.INTERNAL,
         message: err instanceof Error ? err.message : "Display error",
+      })
+    }
+  }
+
+  /**
+   * Canvas commands (session.canvas.*). A distinct command vocabulary from
+   * DISPLAY — `{operation, options}` rather than `{view, layout}`. The glasses
+   * have no native canvas surface yet, so each operation is translated into the
+   * equivalent display event and routed through LocalDisplayManager, reusing its
+   * boot/throttle/arbitration/expiry + native BluetoothSdk.displayEvent path.
+   *
+   * `show_page` is the one operation with no native target today (there's no
+   * host-side page concept); it's a recognized no-op so callers don't error.
+   */
+  private handleCanvas(packageName: string, payload: Record<string, unknown>, requestId?: string): void {
+    try {
+      const operation = payload.operation as CanvasOperation | undefined
+      const options = (payload.options as Record<string, unknown> | undefined) ?? {}
+
+      let layout: DisplayPayload["layout"] | null = null
+      switch (operation) {
+        case CanvasOperation.SHOW_TEXT:
+          layout = {
+            layoutType: "positioned_text",
+            text: options.text,
+            x: options.x,
+            y: options.y,
+            width: options.width,
+            height: options.height,
+            borderWidth: options.borderWidth,
+            borderRadius: options.borderRadius,
+          }
+          break
+        case CanvasOperation.SHOW_BITMAP:
+          layout = {
+            layoutType: "bitmap_view",
+            data: options.data,
+            x: options.x,
+            y: options.y,
+            width: options.width,
+            height: options.height,
+          }
+          break
+        case CanvasOperation.CLEAR:
+          layout = {layoutType: "clear_view"}
+          break
+        case CanvasOperation.SHOW_PAGE:
+          // No native page surface yet — recognize the command and ack so the
+          // miniapp's showPage() resolves. Render wiring is future work.
+          console.log(`${LOG_TAG}: canvas show_page (no native target yet):`, options.id)
+          this.sendResult(packageName, requestId, true)
+          return
+        default:
+          this.sendResult(packageName, requestId, false, undefined, {
+            code: MiniappErrorCode.INTERNAL,
+            message: `unknown canvas operation "${String(operation)}"`,
+          })
+          return
+      }
+
+      localDisplayManager.request(packageName, {view: "main", layout})
+
+      this.sendResult(packageName, requestId, true)
+    } catch (err) {
+      console.error(`${LOG_TAG}: canvas error:`, err)
+      this.sendResult(packageName, requestId, false, undefined, {
+        code: MiniappErrorCode.INTERNAL,
+        message: err instanceof Error ? err.message : "Canvas error",
       })
     }
   }

--- a/mobile/modules/island/src/stores/apps.ts
+++ b/mobile/modules/island/src/stores/apps.ts
@@ -65,6 +65,14 @@ export function configureIsland(hooks: IslandHostHooks): void {
 
 interface AppStatusState {
   apps: ClientApp[]
+  /**
+   * Source of truth for which app is foregrounded in the Compositor overlay.
+   * The per-app `foregrounded` boolean is derived from this in `projectApps`
+   * so a refresh can never drop the flag when an app is transiently missing
+   * from one of the two refresh passes (local-only then merged). See
+   * `projectApps` / `setForeground` / `clearForeground`.
+   */
+  foregroundedPackage: string | null
   refresh: () => Promise<void>
   /** Resolves true if the app actually started; false if a host gate aborted it or its JS context failed to spawn. */
   start: (app: ClientApp, opts?: StartOptions) => Promise<boolean>
@@ -197,15 +205,20 @@ function projectApps(previousState: AppStatusState, localApps: ClientApp[], extr
     screenshot: previousByPackage.get(app.packageName)?.screenshot ?? app.screenshot,
     compatibility: HardwareCompatibility.checkCompatibility(app.hardwareRequirements, capabilities),
     hidden: previousState.getHiddenStatus(app.packageName),
-    // Carry over the foreground flag across refreshes (same reasoning as
-    // screenshot): a cloud/local refresh shouldn't drop the WebView the
-    // Compositor is currently rendering. Normalized to a concrete boolean.
-    foregrounded: previousByPackage.get(app.packageName)?.foregrounded ?? false,
+    // Derive the foreground flag from the store's single source of truth
+    // (`foregroundedPackage`), NOT from the previous snapshot. Carrying it over
+    // per-app meant a refresh that momentarily omitted an app (e.g. the
+    // two-pass local-only → merged emit) would reset its flag to false — which
+    // raced OfflineAppHost's interceptor guard and made the hosted miniapp fall
+    // through to the root router (restart). Deriving here keeps the flag stable
+    // across both passes.
+    foregrounded: app.packageName === previousState.foregroundedPackage,
   }))
 }
 
 export const useAppStatusStore = create<AppStatusState>((set, get) => ({
   apps: [],
+  foregroundedPackage: null,
 
   refresh: async () => {
     // Two-pass: local apps first (fast, no network), then merge cloud
@@ -378,6 +391,7 @@ export const useAppStatusStore = create<AppStatusState>((set, get) => ({
     // (the phase machine), so foregrounding needn't wait for it.
     saveLastOpenTime(packageName)
     set((s) => ({
+      foregroundedPackage: packageName,
       apps: s.apps.map((a) => ({...a, foregrounded: a.packageName === packageName})),
     }))
 
@@ -392,6 +406,7 @@ export const useAppStatusStore = create<AppStatusState>((set, get) => ({
 
   clearForeground: () => {
     set((s) => ({
+      foregroundedPackage: null,
       apps: s.apps.some((a) => a.foregrounded)
         ? s.apps.map((a) => (a.foregrounded ? {...a, foregrounded: false} : a))
         : s.apps,

--- a/mobile/modules/miniapp/src/background/index.ts
+++ b/mobile/modules/miniapp/src/background/index.ts
@@ -51,6 +51,7 @@ export {
 // Session module types — useful for typing controller classes or
 // utility helpers that take a session-like dependency.
 export type {DisplayManager} from "../modules/display"
+export type {CanvasManager} from "../modules/canvas"
 export type {
   CameraFovPreset,
   CameraFovRequest,

--- a/mobile/modules/miniapp/src/index.ts
+++ b/mobile/modules/miniapp/src/index.ts
@@ -67,6 +67,14 @@ export type {
   TextWall,
   ViewType,
 } from "./modules/display"
+export {CanvasOperation} from "./modules/canvas"
+export type {
+  BaseOptions as CanvasBaseOptions,
+  Box as CanvasBox,
+  BitmapOptions as CanvasBitmapOptions,
+  ClearOptions as CanvasClearOptions,
+  TextOptions as CanvasTextOptions,
+} from "./modules/canvas"
 export type {
   AccelData,
   AudioChunkData,
@@ -117,6 +125,7 @@ export type {ActionContext, ActionHandler, InvokeOptions} from "./modules/action
 // Domain module types — exported so consumers can type module references
 // (rare; most authors interact via session.<module>.<method> directly).
 export type {DisplayManager} from "./modules/display"
+export type {CanvasManager} from "./modules/canvas"
 export type {MiniappsModule} from "./modules/miniapps"
 export type {ActionsModule} from "./modules/actions"
 export type {GlassesModule} from "./modules/glasses"

--- a/mobile/modules/miniapp/src/modules/canvas.ts
+++ b/mobile/modules/miniapp/src/modules/canvas.ts
@@ -1,0 +1,72 @@
+import {MiniappRequestType} from "../protocol"
+import {MiniappSession} from "../session"
+
+export enum CanvasOperation {
+  SHOW_TEXT = "show_text",
+  SHOW_BITMAP = "show_bitmap",
+  CLEAR = "clear",
+  SHOW_PAGE = "show_page",
+}
+
+/** Fields available on every canvas operation. */
+export interface BaseOptions {
+  page_id?: string
+}
+
+/** Position and size of a view's container on the canvas. */
+export interface Box {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+}
+
+export interface TextOptions extends Box, BaseOptions {
+  borderWidth?: number
+  borderRadius?: number
+}
+
+export type BitmapOptions = Box & BaseOptions
+export type ClearOptions = BaseOptions
+
+// Required + optional fields, keyed by operation. This is the wire shape.
+// page_id rides along on every entry via the shared BaseOptions.
+interface CanvasPayloads {
+  [CanvasOperation.SHOW_TEXT]: TextOptions & {text: string}
+  [CanvasOperation.SHOW_BITMAP]: BitmapOptions & {data: string}
+  [CanvasOperation.SHOW_PAGE]: BaseOptions & {id: string}
+  [CanvasOperation.CLEAR]: ClearOptions
+}
+
+export class CanvasManager {
+  constructor(private readonly session: MiniappSession) {}
+
+  private send<Op extends CanvasOperation>(operation: Op, options: CanvasPayloads[Op]): void {
+    this.session.sendOneShot({
+      type: MiniappRequestType.CANVAS,
+      operation,
+      options,
+    })
+  }
+
+  /** Show a single block of text filling the glasses display. */
+  showText(text: string, options: TextOptions = {}): void {
+    this.send(CanvasOperation.SHOW_TEXT, {text, ...options})
+  }
+
+  /**
+   * Show a bitmap. Phone SGC handles conversion to glasses-native format.
+   * Optional `x`/`y`/`width`/`height` position and size the container; omit for default placement.
+   */
+  showBitmap(data: string, options: BitmapOptions = {}): void {
+    this.send(CanvasOperation.SHOW_BITMAP, {data, ...options})
+  }
+
+  showPage(id: string, options: BaseOptions = {}): void {
+    this.send(CanvasOperation.SHOW_PAGE, {id, ...options})
+  }
+
+  clear(options: ClearOptions = {}): void {
+    this.send(CanvasOperation.CLEAR, options)
+  }
+}

--- a/mobile/modules/miniapp/src/protocol.ts
+++ b/mobile/modules/miniapp/src/protocol.ts
@@ -27,6 +27,9 @@ export enum MiniappRequestType {
   /** Push a layout to the glasses display. */
   DISPLAY = "miniapp_display",
 
+  /** Push a canvas command to the glasses canvas. */
+  CANVAS = "miniapp_canvas",
+
   /** Play an arbitrary audio URL through the phone's audio playback service. */
   PLAY_AUDIO = "miniapp_play_audio",
 

--- a/mobile/modules/miniapp/src/session.ts
+++ b/mobile/modules/miniapp/src/session.ts
@@ -20,6 +20,7 @@ import {MiniappErrorCode, MiniappRequestType, MiniappResponseType} from "./proto
 import {createTransport, CreateTransportOptions} from "./transport/auto"
 import {Transport} from "./transport/types"
 import {CameraModule} from "./modules/camera"
+import {CanvasManager} from "./modules/canvas"
 import {AuthModule} from "./modules/auth"
 import {CloudModule} from "./modules/cloud"
 import {DashboardAPI} from "./modules/dashboard"
@@ -159,6 +160,7 @@ type SessionEmitterEvents = {
 
 export class MiniappSession {
   public readonly auth: AuthModule
+  public readonly canvas: CanvasManager
   public readonly display: DisplayManager
   /**
    * Internal subscription registry + escape hatch.
@@ -261,6 +263,7 @@ export class MiniappSession {
     this.events = new EventManager(this)
     this.speaker = new SpeakerModule(this)
     this.camera = new CameraModule(this)
+    this.canvas = new CanvasManager(this)
     this.cloud = new CloudModule(this)
     this.dashboard = new DashboardAPI(this)
     this.display = new DisplayManager(this)

--- a/mobile/src/components/miniapp/LocalMiniappView.tsx
+++ b/mobile/src/components/miniapp/LocalMiniappView.tsx
@@ -81,7 +81,7 @@ function LocalMiniappView({
   const [webViewCanGoBack, setWebViewCanGoBack] = useState(false)
   const [uiUri, setUiUri] = useState<string | null>(null)
   const [uiBaseDir, setUiBaseDir] = useState<string | null>(null)
-  const [androidGatePassed, setAndroidGatePassed] = useState(false)
+  const [loadGatePassed, setLoadGatePassed] = useState(false)
   const [devMode] = useSetting(SETTINGS.dev_mode.key)
 
   // ----- Load-state tracking -------------------------------------------------
@@ -166,11 +166,10 @@ function LocalMiniappView({
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined)
 
   useEffect(() => {
-    if (Platform.OS !== "android") return
-    // android is slow to start (and doesn't handle opacity properly) so we need to wait for the animation to complete
-    // before attempting to load the webview or we'll get visual jank
+    // if (Platform.OS !== "android") return
+    // delay loading the webview until the animation is complete
     BgTimer.setTimeout(() => {
-      setAndroidGatePassed(true)
+      setLoadGatePassed(true)
     }, 1000)
   }, [])
 
@@ -440,13 +439,13 @@ function LocalMiniappView({
     return <Text text="Missing required parameters" />
   }
 
-  // if (Platform.OS === "android" && !androidGatePassed) {
-  //   return (
-  //     <View className="flex-1">
-  //       <MiniappSplash iconUrl={iconUrl} bgColor={theme.colors.background} isLoaded={false} />
-  //     </View>
-  //   )
-  // }
+  if (!loadGatePassed) {
+    return (
+      <View className="flex-1">
+        <MiniappSplash iconUrl={iconUrl} bgColor={theme.colors.background} isLoaded={false} name={appName} />
+      </View>
+    )
+  }
 
   let isDevApp = packageName == DEV_APP_PACKAGE_NAME
   if (isDevApp) {

--- a/mobile/src/components/miniapp/OfflineAppHost.tsx
+++ b/mobile/src/components/miniapp/OfflineAppHost.tsx
@@ -74,22 +74,37 @@ export default function OfflineAppHost({packageName, appName, iconUrl, onExit, o
   const onShouldCaptureRef = useRef(onShouldCapture)
   onShouldCaptureRef.current = onShouldCapture
 
+  // The host stays mounted through the Compositor's fade-out (renderedApp
+  // lingers after clearForeground). During that window the interceptor must
+  // stand down so real navigation works again.
+  //
+  // This tracks the host's OWN lifecycle rather than reading the apps store's
+  // `foregrounded` flag: that flag can be transiently flipped false by a
+  // background refresh() rebuilding the apps array, which would make the
+  // interceptor decline an internal route and let it fall through to the root
+  // router — remounting the whole hosted miniapp. `activeRef` is true from
+  // mount until the host itself initiates its exit, so a refresh can never
+  // flip it. The host remounts fresh on each foreground, re-initializing it.
+  const activeRef = useRef(true)
+  const isHostForegrounded = useCallback(() => activeRef.current, [])
+
+  // Single exit funnel: stand the interceptor down (so navigation during the
+  // fade-out reaches the real router) THEN run the host's exit. Every exit
+  // path — capsule house/X, compositor back, external-route fall-through —
+  // goes through here so `activeRef` and the exit stay in lockstep.
+  const beginExit = useCallback(() => {
+    activeRef.current = false
+    onExitRef.current()
+  }, [])
+
   const popOrExit = useCallback(() => {
     if (stackRef.current.length > 1) {
       // Removing the top <NativeScreen> plays the native pop transition.
       setStack((s) => s.slice(0, -1))
     } else {
-      onExitRef.current()
+      beginExit()
     }
-  }, [])
-
-  // The host stays mounted through the Compositor's fade-out (renderedApp
-  // lingers after clearForeground). During that window the interceptor must
-  // stand down so real navigation works again.
-  const isHostForegrounded = useCallback(
-    () => useAppStatusStore.getState().apps.some((a) => a.foregrounded && a.packageName === packageName),
-    [packageName],
-  )
+  }, [beginExit])
 
   useEffect(() => {
     if (!def) return
@@ -105,6 +120,7 @@ export default function OfflineAppHost({packageName, appName, iconUrl, onExit, o
           return true
         }
         // External route — close the overlay and let the real push proceed.
+        activeRef.current = false
         onShouldCaptureRef.current?.()
         useAppStatusStore.getState().clearForeground()
         return false
@@ -116,6 +132,7 @@ export default function OfflineAppHost({packageName, appName, iconUrl, onExit, o
           return true
         }
         // e.g. sign-out replace("/") — close the overlay first.
+        activeRef.current = false
         useAppStatusStore.getState().clearForeground()
         return false
       },
@@ -157,10 +174,10 @@ export default function OfflineAppHost({packageName, appName, iconUrl, onExit, o
       // its own <CapsuleMenu forceShow /> below (same trick as LocalMiniappView).
       visibleOnRoutes: ["/intentionally-not-a-real-route"],
       handleLeftPress: () => {
-        onExitRef.current()
+        beginExit()
       },
       handleRightPress: () => {
-        onExitRef.current()
+        beginExit()
         // wait until after the animation is complete to stop the miniapp:
         BgTimer.setTimeout(() => {
           useAppStatusStore.getState().stop(packageName)

--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -342,6 +342,11 @@ export default function Compositor() {
         ref={viewShotRef}>
         {isOfflineHosted(renderedApp.packageName) ? (
           <OfflineAppHost
+            // Key by package for the same reason as LocalMiniappView below:
+            // switching between two offline-hosted apps must mount a fresh host
+            // (the internal stack only seeds from def.initialRoute on mount, so
+            // a reused instance would keep the previous app's stack).
+            key={renderedApp.packageName}
             packageName={renderedApp.packageName}
             appName={renderedApp.name}
             iconUrl={renderedApp.logoUrl}
@@ -352,6 +357,13 @@ export default function Compositor() {
           />
         ) : (
           <LocalMiniappView
+            // Key by package so switching from app A to app B mounts a FRESH
+            // WebView instead of navigating the existing one to B's URL. Reusing
+            // the instance left A's page in WKWebView's back-history, so
+            // `webViewCanGoBack` became true under B — which disabled the
+            // Compositor's minimize-swipe and made the back-swipe pop to A's
+            // page instead of returning home.
+            key={renderedApp.packageName}
             packageName={renderedApp.packageName}
             appName={renderedApp.name}
             version={renderedApp.version}


### PR DESCRIPTION
Same changes as #3199 **without** the experimental G2 display reconcile-loop refactor in `G2.swift`. Branched off `dev`, targets `dev`.

## What's included
- **`session.canvas` end-to-end**: new `CanvasManager` / `miniapp_canvas` protocol, island runtime mapping of `show_text`, `show_bitmap`, and `clear` into display layouts (`show_page` acks as a no-op), plus an example-miniapp tester page with 4-bit BMP helpers and positioned text/bitmap demos.
- **Compositor / miniapp host fixes**: `foregroundedPackage` as the source of truth for foreground state across the two-pass `refresh()`; `OfflineAppHost` uses a mount-scoped `activeRef` instead of the store flag; `key={packageName}` on hosted views so switching apps does not reuse the WebView back-stack; load gate on all platforms before mounting the WebView.
- **G2 iOS**: stub `sendButtonCameraLedSetting()` — the only `G2.swift` change carried over (no-op, keeps the surface consistent).

## What's excluded
- The **experimental G2 display refactor** from #3199 (replacing `DisplayMutex` + text FIFO queue with the single `displayReconcileTask` reconcile loop). `G2.swift` display sending is otherwise unchanged from `dev`.

The 13 canvas/compositor/host files are taken verbatim from #3199 (`fixes-54`); the only `G2.swift` delta vs `dev` is the one-line stub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches miniapp foreground lifecycle, navigation interception, and glasses display routing; regressions could remount hosted apps or mis-route canvas vs display, though canvas reuses the existing display path.
> 
> **Overview**
> Adds **`session.canvas`** as a separate command surface (`showText`, `showBitmap`, `clear`, `showPage`) on `MiniappSession`, with a new `miniapp_canvas` request type and **`CanvasManager`** in the SDK. The island runtime handles canvas by mapping operations to existing display layouts (`positioned_text`, `bitmap_view`, `clear_view`) via **`LocalDisplayManager`**; **`showPage`** is acknowledged as a no-op until a native page target exists.
> 
> The example miniapp gains a **canvas tester** (route + menu entry) with 4-bit BMP generation and positioned text/bitmap demos wired through `tester:invoke`.
> 
> **Compositor / host stability:** `foregroundedPackage` is the single source of truth for which app is foregrounded during two-pass `refresh()`, so transient app list rebuilds no longer clear foreground incorrectly. **`OfflineAppHost`** uses a mount-scoped `activeRef` and a shared **`beginExit`** path so navigation interception does not race store refreshes. **`LocalMiniappView`** and **`OfflineAppHost`** are keyed by `packageName` when switching apps, and WebView load is gated on all platforms until the open animation completes.
> 
> **G2 iOS:** adds a no-op **`sendButtonCameraLedSetting()`** stub only (no display pipeline refactor).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4e95375878a52e08a3082e51b135796dbe816fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `session.canvas` API end to end and a tester page, plus fixes to foregrounding, navigation, and WebView lifecycle in the compositor/host. Excludes the experimental G2 display reconcile loop; `G2.swift` only adds a stubbed `sendButtonCameraLedSetting()`.

- **New Features**
  - Add `CanvasManager` and `miniapp_canvas` protocol.
  - Map `show_text`/`show_bitmap`/`clear` to display layouts; `show_page` acks as a no-op.
  - Example miniapp tester page with positioned text/bitmap demos and 4‑bit BMP helpers.

- **Bug Fixes**
  - `foregroundedPackage` is now the source of truth across the two-pass `refresh()` to keep the foreground flag stable.
  - `OfflineAppHost` uses a mount-scoped `activeRef` and a single exit funnel to avoid fall-through and allow navigation during fade-out.
  - Key hosted views by `packageName` so switching apps mounts a fresh host/WebView (no stale back stack).
  - Add a load gate before mounting the WebView on all platforms; show `MiniappSplash` until ready.

<sup>Written for commit f4e95375878a52e08a3082e51b135796dbe816fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

