### PR TITLE
Remove the debug-mode tap-countdown toast

### DIFF
--- a/mobile/src/components/dev/VersionInfo.tsx
+++ b/mobile/src/components/dev/VersionInfo.tsx
@@ -48,7 +48,6 @@ export const VersionInfo = () => {
     const timeDiff = currentTime - lastPressTime.current
     const maxTimeDiff = 2000
     const maxPressCount = 10
-    const showAlertAtPressCount = 5
 
     // Reset counter if too much time has passed
     if (timeDiff > maxTimeDiff) {
@@ -66,23 +65,13 @@ export const VersionInfo = () => {
       clearTimeout(pressTimeout.current)
     }
 
-    // Handle different press counts
+    // Enable debug mode once the version number has been tapped enough times.
     if (pressCount.current === maxPressCount) {
       showAlert(translate("debug:debugModeEnabled"), translate("debug:debugModeEnabled"), [
         {text: translate("common:ok")},
       ])
       setDebugMode(true)
       pressCount.current = 0
-    } else if (pressCount.current >= showAlertAtPressCount) {
-      const remaining = maxPressCount - pressCount.current
-      Toast.show({
-        type: "info",
-        text1: translate("debug:debugMode"),
-        text2: translate("debug:debugModeMoreTaps", {number: remaining}),
-        position: "bottom",
-        topOffset: 80,
-        visibilityTime: 1000,
-      })
     }
 
     // Reset counter after 2 seconds of no activity


### PR DESCRIPTION
Tapping the version number on the settings page to enable debug mode popped an info toast on every tap from 5 through 9 ("N more taps to enable debug mode"). This removes that toast.

The flow is otherwise unchanged: debug mode still enables on the 10th tap and shows the "Debug mode enabled" confirmation alert. The other version-info toasts (version copied, super mode activated) are untouched.

Single file: `mobile/src/components/dev/VersionInfo.tsx`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only settings easter-egg UX tweak with no auth, data, or production feature impact.
> 
> **Overview**
> Removes the **info toast on taps 5–9** when repeatedly tapping the settings version label to unlock debug mode. Users no longer see “N more taps to enable debug mode” on each tap in that range.
> 
> **Unchanged:** debug mode still turns on on the **10th** tap with the existing confirmation alert; version copy and super-mode toasts are untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab1063b01e3e1c7f0587948c9c3cefb4fd216203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->