### PR TITLE
Drive G2 display queue off events, not a background-stalled timer

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1302,12 +1302,21 @@ class G2 : SGCManager() {
     private val mainHandler = Handler(Looper.getMainLooper())
     private var heartbeatRunnable: Runnable? = null
     private var devSettingsHeartbeatRunnable: Runnable? = null
-    private var evenHubQueueRunnable: Runnable? = null
-    private var pendingTextMsg: ByteArray? = null
+    // Event-driven text-container update queue.
+    //
+    // History: a 100ms postDelayed polling loop drained the latest pending update.
+    // A polling loop does not run on schedule while the app is suspended in the
+    // background, so under streaming captions updates piled up and flushed in a burst
+    // on the next wake. Now we drain on enqueue (post to the handler immediately) and
+    // keep the LATEST update PER containerID, so distinct containers all survive while
+    // repeated updates to the same container coalesce to newest — a backlog cannot form.
+    private var pendingTextByContainer = LinkedHashMap<Int, ByteArray>()
     private var lastEvenHubMsg: ByteArray? = null
-    private var lastEvenHubResendsRemaining: Int = 0
-    private val EVEN_HUB_RESEND_COUNT: Int = 1
-    private val EVEN_HUB_QUEUE_TICK_MS = 100L
+    // One-shot resend (write-without-response reliability): the only piece that needs a
+    // timer, since it is a deferred action with no triggering event. Superseded if a
+    // newer update is sent first.
+    private var evenHubResendRunnable: Runnable? = null
+    private val EVEN_HUB_RESEND_DELAY_MS = 100L
     private var startupPageCreated: Boolean = false
     private var pageCreated: Boolean = false
     private var currentTextContent: String = ""
@@ -1806,16 +1815,8 @@ class G2 : SGCManager() {
         devSettingsHeartbeatRunnable = dsRunnable
         mainHandler.postDelayed(dsRunnable, 5000)
 
-        // EvenHub text command queue: drain the most recent pending updateText every 100ms
-        val queueRunnable =
-                object : Runnable {
-                    override fun run() {
-                        drainEvenHubQueue()
-                        mainHandler.postDelayed(this, EVEN_HUB_QUEUE_TICK_MS)
-                    }
-                }
-        evenHubQueueRunnable = queueRunnable
-        mainHandler.postDelayed(queueRunnable, EVEN_HUB_QUEUE_TICK_MS)
+        // EvenHub text command queue is drained event-driven (see queueEvenHubCommand);
+        // no standing poll here.
     }
 
     private fun stopHeartbeats() {
@@ -1823,11 +1824,12 @@ class G2 : SGCManager() {
         heartbeatRunnable = null
         devSettingsHeartbeatRunnable?.let { mainHandler.removeCallbacks(it) }
         devSettingsHeartbeatRunnable = null
-        evenHubQueueRunnable?.let { mainHandler.removeCallbacks(it) }
-        evenHubQueueRunnable = null
-        pendingTextMsg = null
-        lastEvenHubMsg = null
-        lastEvenHubResendsRemaining = 0
+        evenHubResendRunnable?.let { mainHandler.removeCallbacks(it) }
+        evenHubResendRunnable = null
+        synchronized(this) {
+            pendingTextByContainer.clear()
+            lastEvenHubMsg = null
+        }
     }
 
     private fun sendEvenHubHeartbeat() {
@@ -1990,7 +1992,7 @@ class G2 : SGCManager() {
                     contentLength = container.content.toByteArray(Charsets.UTF_8).size,
                     content = container.content
             )
-            queueEvenHubCommand(msg)
+            queueEvenHubCommand(msg, container.id)
             return
         }
         container =
@@ -2546,25 +2548,54 @@ class G2 : SGCManager() {
     }
 
     @Synchronized
-    private fun queueEvenHubCommand(payload: ByteArray) {
-        pendingTextMsg = payload
+    private fun queueEvenHubCommand(payload: ByteArray, containerID: Int) {
+        synchronized(this) {
+            // Keep only the LATEST update per container (LinkedHashMap preserves
+            // insertion order for fair draining across containers). Distinct containers
+            // all survive; repeated updates to the same container coalesce to newest, so
+            // no backlog can form even if many frames arrive between BLE wakes. Text
+            // updates are idempotent, so dropping superseded frames is correct.
+            pendingTextByContainer.remove(containerID) // move to most-recent insertion order
+            pendingTextByContainer[containerID] = payload
+        }
+        // Drain on the handler immediately — the enqueue (typically a transcription
+        // event) is itself what woke the process, so the update goes out in that wake
+        // rather than waiting on a timer that may have stalled in the background.
+        mainHandler.post { drainEvenHubQueue() }
     }
 
     @Synchronized
     private fun drainEvenHubQueue() {
-        val msg = pendingTextMsg
-        pendingTextMsg = null
-        val toSend: ByteArray? = if (msg != null) {
-            lastEvenHubMsg = msg
-            lastEvenHubResendsRemaining = EVEN_HUB_RESEND_COUNT
-            msg
-        } else if (lastEvenHubResendsRemaining > 0 && lastEvenHubMsg != null) {
-            lastEvenHubResendsRemaining -= 1
-            lastEvenHubMsg
-        } else {
-            null
+        val entry = pendingTextByContainer.entries.firstOrNull()
+        if (entry == null) return
+        pendingTextByContainer.remove(entry.key)
+        val toSend = entry.value
+        lastEvenHubMsg = toSend
+        sendEvenHubCommand(toSend)
+
+        // Arm the one-shot resend for reliability. Superseded by any newer send, and
+        // skipped entirely if the app suspends before it fires — the next real frame
+        // re-pushes current content, so correctness doesn't depend on it.
+        scheduleEvenHubResend(toSend)
+
+        // Keep draining if other containers are still pending.
+        if (pendingTextByContainer.isNotEmpty()) {
+            mainHandler.post { drainEvenHubQueue() }
         }
-        toSend?.let { sendEvenHubCommand(it) }
+    }
+
+    private fun scheduleEvenHubResend(expected: ByteArray) {
+        evenHubResendRunnable?.let { mainHandler.removeCallbacks(it) }
+        val runnable = Runnable {
+            synchronized(this) {
+                // Only resend if nothing newer was sent in the meantime.
+                if (lastEvenHubMsg === expected) {
+                    sendEvenHubCommand(expected)
+                }
+            }
+        }
+        evenHubResendRunnable = runnable
+        mainHandler.postDelayed(runnable, EVEN_HUB_RESEND_DELAY_MS)
     }
 
     // ---------- Bitmap Conversion ----------

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1563,16 +1563,36 @@ class G2: NSObject, SGCManager {
     private var heartbeatTask: Task<Void, Never>?
     private var heartbeatCounter: Int = 0
     private var evenHubQueueTask: Task<Void, Never>?
-    // FIFO of pending text-container updates. A single-slot var here used to let
-    // a later update (e.g. the constantly-refreshing maneuver text) overwrite an
-    // earlier one for a DIFFERENT container (e.g. the bottom-left trip stats),
-    // so the second container's content never reached the glasses. A queue lets
-    // updates to distinct containers each get drained.
-    private var pendingTextMsgs: [Data] = []
+    // Event-driven text-container update queue.
+    //
+    // History: a single-slot var let a later update (e.g. the constantly-refreshing
+    // maneuver text) overwrite an earlier one for a DIFFERENT container (e.g. the
+    // bottom-left trip stats), so the second container never reached the glasses.
+    // That was fixed with a FIFO array drained by a 100ms polling Task.sleep loop —
+    // but a polling loop does not run on schedule while the app is suspended in the
+    // background (iOS only wakes the process briefly per BLE event, and Mach time
+    // stops while suspended). Under streaming captions that meant updates piled up
+    // and then flushed in a burst on the next wake.
+    //
+    // Now: keep the LATEST pending update PER containerID (distinct containers all
+    // survive; repeated updates to the same container coalesce to newest), and drain
+    // event-driven — `queueEvenHubCommand` signals `evenHubQueueSignal`, which wakes
+    // the drain coroutine immediately in whatever wake delivered the update. No
+    // standing timer gates throughput, so no backlog can accumulate behind a frozen
+    // tick.
+    private var pendingTextByContainer: [Int32: Data] = [:]
+    private var pendingTextOrder: [Int32] = []
+    // One-shot resend: after a real send we re-transmit it ONCE after a short delay
+    // (write-without-response reliability). This is the only piece that needs a
+    // timer — it is a deferred action with no triggering event. It rides a one-shot
+    // Task (see AckManager pattern) and is superseded if a newer update arrives.
     private var lastEvenHubMsg: Data?
-    private var lastEvenHubResendsRemaining: Int = 0
-    private let EVEN_HUB_RESEND_COUNT: Int = 1
+    private var evenHubResendTask: Task<Void, Never>?
+    private let EVEN_HUB_RESEND_DELAY_NS: UInt64 = 100_000_000  // 100ms, matches old tick spacing
     private let evenHubQueueLock = NSLock()
+    // Continuation parked by the drain coroutine while the queue is empty; resumed by
+    // `queueEvenHubCommand` on enqueue. Guarded by `evenHubQueueLock`.
+    private var evenHubQueueSignal: CheckedContinuation<Void, Never>?
     private var authStarted: Bool = false
 
     /// Dashboard menu: appId → packageName mapping for selection reverse lookup
@@ -1986,11 +2006,14 @@ class G2: NSObject, SGCManager {
             }
         }
 
-        // EvenHub text command queue: drain the most recent pending updateText every 100ms
+        // EvenHub text command queue: drain event-driven. The coroutine parks on a
+        // continuation while the queue is empty and is woken the instant an update is
+        // enqueued — so a pending caption frame goes out in whatever BLE wake delivered
+        // it, never waiting on a timer that has stalled in the background.
         evenHubQueueTask?.cancel()
         evenHubQueueTask = Task { [weak self] in
             while !Task.isCancelled {
-                try? await Task.sleep(nanoseconds: 100_000_000)
+                await self?.waitForEvenHubWork()
                 guard !Task.isCancelled else { break }
                 await MainActor.run {
                     self?.drainEvenHubQueue()
@@ -1999,15 +2022,40 @@ class G2: NSObject, SGCManager {
         }
     }
 
+    /// Suspends until there is at least one pending text update. Returns immediately
+    /// if work is already queued; otherwise parks on a continuation that
+    /// `queueEvenHubCommand` resumes.
+    private func waitForEvenHubWork() async {
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            evenHubQueueLock.lock()
+            if !pendingTextOrder.isEmpty {
+                evenHubQueueLock.unlock()
+                cont.resume()
+                return
+            }
+            // Park. A prior continuation should never exist (single consumer), but if
+            // it somehow does, resume it so it isn't leaked.
+            evenHubQueueSignal?.resume()
+            evenHubQueueSignal = cont
+            evenHubQueueLock.unlock()
+        }
+    }
+
     private func stopHeartbeats() {
         heartbeatTask?.cancel()
         heartbeatTask = nil
         evenHubQueueTask?.cancel()
         evenHubQueueTask = nil
+        evenHubResendTask?.cancel()
+        evenHubResendTask = nil
         evenHubQueueLock.lock()
-        pendingTextMsgs.removeAll()
+        pendingTextByContainer.removeAll()
+        pendingTextOrder.removeAll()
         lastEvenHubMsg = nil
-        lastEvenHubResendsRemaining = 0
+        // Wake the drain coroutine so it observes cancellation and exits instead of
+        // staying parked on a continuation forever.
+        evenHubQueueSignal?.resume()
+        evenHubQueueSignal = nil
         evenHubQueueLock.unlock()
     }
 
@@ -2128,7 +2176,7 @@ class G2: NSObject, SGCManager {
                 contentLength: Int32(container.content.utf8.count),
                 content: container.content
             )
-            queueEvenHubCommand(msg)
+            queueEvenHubCommand(msg, containerID: container.id)
             return
         }
 
@@ -2887,36 +2935,71 @@ class G2: NSObject, SGCManager {
         pageCreated = true
     }
 
-    private func queueEvenHubCommand(_ payload: Data) {
+    private func queueEvenHubCommand(_ payload: Data, containerID: Int32) {
         evenHubQueueLock.lock()
-        // Append rather than overwrite so updates to different text containers
-        // (maneuver text + bottom-left trip stats) all survive. Cap the backlog
-        // so a stall can't grow it unbounded; dropping the oldest is fine since
-        // text updates are idempotent (the next frame re-pushes current content).
-        pendingTextMsgs.append(payload)
-        if pendingTextMsgs.count > 8 {
-            pendingTextMsgs.removeFirst(pendingTextMsgs.count - 8)
+        // Keep only the LATEST update per container: distinct containers (maneuver
+        // text + bottom-left trip stats) all survive, while repeated updates to the
+        // same container coalesce to newest. This is what makes a backlog impossible —
+        // even if many caption frames arrive between wakes, only the current one for
+        // each container is ever pending. Text updates are idempotent, so dropping
+        // superseded frames is correct, not lossy.
+        if pendingTextByContainer[containerID] == nil {
+            pendingTextOrder.append(containerID)
         }
+        pendingTextByContainer[containerID] = payload
+        // Wake the drain coroutine if it's parked.
+        let signal = evenHubQueueSignal
+        evenHubQueueSignal = nil
         evenHubQueueLock.unlock()
+        signal?.resume()
     }
 
     private func drainEvenHubQueue() {
         evenHubQueueLock.lock()
-        let toSend: Data?
-        if !pendingTextMsgs.isEmpty {
-            let msg = pendingTextMsgs.removeFirst()
-            lastEvenHubMsg = msg
-            lastEvenHubResendsRemaining = EVEN_HUB_RESEND_COUNT
-            toSend = msg
-        } else if lastEvenHubResendsRemaining > 0, let last = lastEvenHubMsg {
-            lastEvenHubResendsRemaining -= 1
-            toSend = last
-        } else {
-            toSend = nil
+        guard !pendingTextOrder.isEmpty else {
+            evenHubQueueLock.unlock()
+            return
         }
+        let containerID = pendingTextOrder.removeFirst()
+        let toSend = pendingTextByContainer.removeValue(forKey: containerID)
+        let moreQueued = !pendingTextOrder.isEmpty
+        lastEvenHubMsg = toSend
         evenHubQueueLock.unlock()
+
         guard let toSend = toSend else { return }
         sendEvenHubCommand(toSend)
+        // Arm the one-shot resend for reliability (write-without-response). A newer
+        // enqueue supersedes lastEvenHubMsg and re-arms this, so a stale duplicate is
+        // never sent. If the app is suspended before it fires, the resend is simply
+        // skipped — the next real frame re-pushes current content, so correctness does
+        // not depend on this timer firing.
+        scheduleEvenHubResend()
+
+        // If other containers are still pending, keep draining without parking — the
+        // drain coroutine loops and waitForEvenHubWork() returns immediately.
+        if moreQueued {
+            evenHubQueueLock.lock()
+            let signal = evenHubQueueSignal
+            evenHubQueueSignal = nil
+            evenHubQueueLock.unlock()
+            signal?.resume()
+        }
+    }
+
+    /// One-shot resend of the last sent EvenHub message, after a short delay. Cancels
+    /// any prior pending resend. Skipped if a newer message has since been sent.
+    private func scheduleEvenHubResend() {
+        evenHubResendTask?.cancel()
+        let expected = lastEvenHubMsg
+        evenHubResendTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: self?.EVEN_HUB_RESEND_DELAY_NS ?? 100_000_000)
+            guard let self, !Task.isCancelled else { return }
+            await MainActor.run {
+                // Only resend if nothing newer was sent in the meantime.
+                guard let expected, self.lastEvenHubMsg == expected else { return }
+                self.sendEvenHubCommand(expected)
+            }
+        }
     }
 
     private func restartMicIfAlreadyEnabled() {

--- a/mobile/modules/island/src/services/LocalDisplayManager.ts
+++ b/mobile/modules/island/src/services/LocalDisplayManager.ts
@@ -7,7 +7,6 @@
  * for the features that matter on the phone:
  *
  *   - boot message ("Starting <AppName>…") with a bounded window
- *   - per-request throttle (leading + trailing, ~300 ms, last-write-wins)
  *   - durationMs auto-clear
  *   - core-app vs background-app arbitration with a background lock
  *
@@ -15,8 +14,17 @@
  * and may race with local displays during dev; that's acceptable per plan
  * (agents/local-display-manager-plan.md).
  *
- * All timers use BgTimer so they keep firing when the phone screen
- * is off.
+ * Display pacing is NOT done here. A JS-side ~300ms throttle used to live in
+ * this class, but JS timers (and therefore the throttle's trailing flush) do
+ * not fire on schedule while the iOS app is suspended in the background — so
+ * under streaming captions, updates accumulated and then flushed in a burst on
+ * the next wake. Pacing + last-wins coalescing now live in the native per-device
+ * queue (e.g. G2's event-driven EvenHub queue), which drains off the same BLE
+ * events that wake the process. This class forwards every request straight
+ * through; the native layer collapses redundant frames per display target.
+ *
+ * The remaining BgTimer use (boot window, durationMs expiry) is timing that
+ * does not need sub-second background fidelity.
  */
 
 import displayProcessor from "./DisplayProcessor"
@@ -59,7 +67,6 @@ interface BackgroundLock {
 
 const LOG_TAG = "LOCAL_DISPLAY"
 const BOOT_DURATION_MS = 1500
-const THROTTLE_MS = 300
 // Mirrors cloud lease for a bg app holding the display. The bg app has to
 // keep driving the display to hold the lock; if it goes quiet and the core
 // app wants the screen, we release.
@@ -81,10 +88,6 @@ class LocalDisplayManager {
 
   private bootingApp: BootingApp | null = null
   private bootQueue: Map<string, DisplayPayload> = new Map()
-
-  private pendingThrottledByApp: Map<string, DisplayPayload> = new Map()
-  private throttleTimerId: number | null = null
-  private lastSendAt = 0
 
   private expiryTimerId: number | null = null
 
@@ -138,20 +141,13 @@ class LocalDisplayManager {
 
   /**
    * Mark which miniapp is the "core" (foreground) app. Pass null when no local
-   * miniapp is foreground. When the core app flips, any pending throttled
-   * request from the previous core is dropped.
+   * miniapp is foreground.
    */
   public onCoreAppChange(packageName: string | null): void {
     if (this.coreApp === packageName) return
     console.log(`${LOG_TAG}: onCoreAppChange(${packageName ?? "null"})`)
 
-    const prevCore = this.coreApp
     this.coreApp = packageName
-
-    // Drop stale throttle pending for the old core — new core starts clean.
-    if (prevCore) {
-      this.pendingThrottledByApp.delete(prevCore)
-    }
 
     // No core app means no saved frame to restore on the next unmount.
     // Without this, the previous core's last frame can flicker back onto
@@ -173,7 +169,6 @@ class LocalDisplayManager {
       this.cancelBoot()
     }
     this.bootQueue.delete(packageName)
-    this.pendingThrottledByApp.delete(packageName)
 
     // Release bg lock if this app held it.
     if (this.backgroundLock?.packageName === packageName) {
@@ -268,7 +263,7 @@ class LocalDisplayManager {
         this.backgroundLock = null
       }
 
-      this.throttledSend(packageName, payload)
+      this.sendNow(packageName, payload)
       return
     }
 
@@ -291,58 +286,7 @@ class LocalDisplayManager {
       this.backgroundLock.expiresAt = now + BACKGROUND_LOCK_TIMEOUT_MS
     }
 
-    this.throttledSend(packageName, payload)
-  }
-
-  // ===========================================================================
-  // Internals — throttle
-  // ===========================================================================
-
-  private throttledSend(packageName: string, payload: DisplayPayload): void {
-    const now = this.now()
-    const elapsed = now - this.lastSendAt
-
-    if (elapsed >= THROTTLE_MS) {
-      this.sendNow(packageName, payload)
-      return
-    }
-
-    // Queue (replace any pending request from the same app — last wins).
-    this.pendingThrottledByApp.set(packageName, payload)
-    if (this.throttleTimerId === null) {
-      const delay = THROTTLE_MS - elapsed
-      this.throttleTimerId = BgTimer.setTimeout(() => {
-        this.throttleTimerId = null
-        this.flushThrottled()
-      }, delay)
-    }
-  }
-
-  private flushThrottled(): void {
-    // Prefer the core app if it has something pending. Otherwise, the current
-    // bg lock holder. Otherwise, skip.
-    let candidate: {pkg: string; payload: DisplayPayload} | null = null
-
-    if (this.coreApp) {
-      const p = this.pendingThrottledByApp.get(this.coreApp)
-      if (p) candidate = {pkg: this.coreApp, payload: p}
-    }
-    if (!candidate && this.backgroundLock) {
-      const p = this.pendingThrottledByApp.get(this.backgroundLock.packageName)
-      if (p) candidate = {pkg: this.backgroundLock.packageName, payload: p}
-    }
-    if (!candidate) {
-      this.pendingThrottledByApp.clear()
-      return
-    }
-
-    this.pendingThrottledByApp.delete(candidate.pkg)
-    this.sendNow(candidate.pkg, candidate.payload)
-
-    // If more requests accumulated from other apps during the window, they've
-    // been overwritten by later ones anyway; anything left behind (e.g. a
-    // stale bg request while core is live) we drop.
-    this.pendingThrottledByApp.clear()
+    this.sendNow(packageName, payload)
   }
 
   // ===========================================================================
@@ -392,12 +336,6 @@ class LocalDisplayManager {
       console.error(`${LOG_TAG}: native display failed:`, err)
     }
 
-    // System-originated displays (boot message, clear) don't count toward the
-    // user-throttle budget — they're forced, not requested by a miniapp.
-    const isSystem = packageName === SYSTEM_BOOT_PKG || packageName === "system.clear"
-    if (!isSystem) {
-      this.lastSendAt = this.now()
-    }
     this.currentDisplay = {packageName, processedEvent, expiresAt}
 
     this.clearExpiryTimer()
@@ -516,17 +454,11 @@ class LocalDisplayManager {
   public _resetForTest(): void {
     this.cancelBoot()
     this.clearExpiryTimer()
-    if (this.throttleTimerId !== null) {
-      BgTimer.clearTimeout(this.throttleTimerId)
-      this.throttleTimerId = null
-    }
     this.coreApp = null
     this.coreAppDisplay = null
     this.currentDisplay = null
     this.backgroundLock = null
     this.bootQueue.clear()
-    this.pendingThrottledByApp.clear()
-    this.lastSendAt = 0
     this.now = () => Date.now()
   }
 

--- a/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
+++ b/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
@@ -1,8 +1,9 @@
 /**
  * Unit tests for LocalDisplayManager.
  *
- * Covers boot window, throttle, durationMs expiry, and core-vs-background
- * arbitration. Uses jest fake timers + an injected clock.
+ * Covers boot window, pass-through (pacing now lives in the native per-device
+ * queue, not here), durationMs expiry, and core-vs-background arbitration.
+ * Uses jest fake timers + an injected clock.
  */
 
 const displayEventMock = jest.fn()
@@ -141,63 +142,55 @@ describe("LocalDisplayManager", () => {
   })
 
   // ==========================================================================
-  // Throttle
+  // Pass-through (no JS-side throttle)
   // ==========================================================================
+  //
+  // Display pacing + last-wins coalescing now live in the native per-device
+  // queue (e.g. G2's event-driven EvenHub queue), not here — a JS throttle could
+  // not flush on schedule while the iOS app was suspended, so updates bursted on
+  // the next wake. This class forwards every request straight through.
 
-  describe("throttle", () => {
+  describe("pass-through", () => {
     beforeEach(() => {
       mgr.onCoreAppChange("com.app.foo")
       mgr.onMount("com.app.foo", "Foo")
-      // Consume the boot message so timing is clean.
+      // Consume the boot message so counts are clean.
       mgr.request("com.app.foo", {
         layout: {layoutType: "text_wall", text: "boot-flush"},
       })
       displayEventMock.mockClear()
     })
 
-    test("5 rapid-fire requests → 2 sends (leading + trailing, last wins)", () => {
-      // Leading send fires immediately at t=0 (lastSendAt from boot-flush above
-      // was set; advance past the throttle window first so this is truly a
-      // fresh burst).
-      advance(THROTTLE_MS)
-      displayEventMock.mockClear()
-
+    test("5 rapid-fire requests → 5 sends, no time advance, in order", () => {
       for (let i = 0; i < 5; i++) {
         mgr.request("com.app.foo", {
           layout: {layoutType: "text_wall", text: `msg${i}`},
         })
-        advance(30)
       }
 
-      // After the burst: leading send of "msg0" happened; msg1..msg4 are pending.
-      expect(displayEventMock.mock.calls.length).toBe(1)
-      expect(lastText()).toBe("msg0")
-
-      // Flush the trailing timer.
-      advance(THROTTLE_MS)
-      expect(displayEventMock.mock.calls.length).toBe(2)
+      // Every request forwarded immediately — no throttle, no coalescing here.
+      expect(displayEventMock.mock.calls.length).toBe(5)
       expect(lastText()).toBe("msg4")
+
+      // Nothing deferred to a trailing timer.
+      advance(THROTTLE_MS)
+      expect(displayEventMock.mock.calls.length).toBe(5)
     })
 
-    test("later request from same app replaces pending one", () => {
-      advance(THROTTLE_MS)
-      displayEventMock.mockClear()
-
+    test("each request renders immediately without waiting for a window", () => {
       mgr.request("com.app.foo", {
         layout: {layoutType: "text_wall", text: "a"},
       })
-      advance(50)
+      expect(lastText()).toBe("a")
       mgr.request("com.app.foo", {
         layout: {layoutType: "text_wall", text: "b"},
       })
+      expect(lastText()).toBe("b")
       mgr.request("com.app.foo", {
         layout: {layoutType: "text_wall", text: "c"},
       })
-      // Leading send: "a"
-      expect(lastText()).toBe("a")
-      // Trailing flush: "c" wins.
-      advance(THROTTLE_MS)
       expect(lastText()).toBe("c")
+      expect(displayEventMock.mock.calls.length).toBe(3)
     })
   })
 
@@ -336,29 +329,36 @@ describe("LocalDisplayManager", () => {
   // ==========================================================================
 
   describe("onCoreAppChange", () => {
-    test("flipping core drops pending throttled request from previous core", () => {
+    test("flipping core to null drops the saved core display", () => {
       mgr.onCoreAppChange("com.app.a")
       mgr.onMount("com.app.a", "A")
       advance(1500)
-      advance(THROTTLE_MS)
       displayEventMock.mockClear()
 
-      // Start a burst to create a pending trailing send for com.app.a
-      mgr.request("com.app.a", {layout: {layoutType: "text_wall", text: "a1"}})
-      mgr.request("com.app.a", {layout: {layoutType: "text_wall", text: "a2"}})
-      // Leading "a1" has fired; "a2" is pending.
+      mgr.request("com.app.a", {
+        layout: {layoutType: "text_wall", text: "a1"},
+        durationMs: 10_000,
+      })
       expect(lastText()).toBe("a1")
 
-      // Core flips to a different app.
-      mgr.onCoreAppChange("com.app.b")
+      // Core goes away → saved frame is dropped so it can't flicker back later.
+      mgr.onCoreAppChange(null)
+      expect(mgr._peekForTest().coreApp).toBeNull()
 
-      // Trailing timer fires — should NOT send "a2" because a is no longer core.
+      // A bg app can now take the screen; the old core frame is not restored
+      // when that bg app later unmounts.
+      mgr.request("com.app.bg", {layout: {layoutType: "text_wall", text: "bg"}})
+      expect(lastText()).toBe("bg")
       displayEventMock.mockClear()
-      advance(THROTTLE_MS)
-      expect(displayEventMock).not.toHaveBeenCalled()
+      mgr.onUnmount("com.app.bg")
+      const restoredOldCore = displayEventMock.mock.calls.some(
+        ([e]: any[]) => e.layout?.text === "a1",
+      )
+      expect(restoredOldCore).toBe(false)
     })
   })
 })
 
-// Keep in sync with THROTTLE_MS in LocalDisplayManager.ts.
+// Generic "let some time pass" amount for arbitration/expiry tests. The JS
+// throttle this once mirrored is gone; pacing now lives in the native queue.
 const THROTTLE_MS = 300


### PR DESCRIPTION
## Problem

Local-miniapp **captions on G2 streamed late and then flooded the glasses in a burst** after the iOS app had been backgrounded (classic repro: screen off ~60s, then wake). Confirmed from incident `f6a1c129-94c5-47f6-bf36-f9fb1935cf77`: a 176s log gap (true suspension), then clustered `sendText` calls (30 pairs landing 1–47ms apart) on top of the normal ~3/sec stream.

## Root cause

Display pacing lived on **timers that don't run on schedule while an iOS app is suspended**. With `bluetooth-central` background mode, iOS only wakes the app *briefly per BLE event*, and Mach time stops while suspended — so a polling timer can't pace anything in the background. Three timers were implicated:

- `LocalDisplayManager`'s ~300ms **JS throttle** (`BgTimer` → plain `setTimeout` on iOS), whose trailing flush fired late and bunched on the next wake.
- G2's **EvenHub queue**, drained by a 100ms `Task.sleep` poll (iOS) / 100ms `postDelayed` poll (Android).

The native queues only *appeared* to keep up because streaming glasses-mic audio over BLE re-woke the process many times a second. The moment that traffic paused, both stalled and the backlog bursted on resume. (Same underlying suspension behavior as the known G2 background-disconnect issue.)

Verified against Apple's Core Bluetooth background docs: a backgrounded BLE app is *suspended and woken per event for ~10s*, not continuously alive — so **neither a Swift `Task.sleep` loop nor a JS `setTimeout` is a reliable background clock.** The fix is to stop using a scheduled timer for pacing and instead react to the BLE/transcription events that already wake the process.

## Fix

Make the native G2 queue **event-driven**, and structurally prevent a backlog:

- **iOS G2:** replace the 100ms poll with a **continuation-driven drain** — the consumer parks until `queueEvenHubCommand` signals it (mirrors G1's existing `CommandQueue`).
- **Android G2:** drop the standing `postDelayed` loop; **post a drain on enqueue**.
- **Both:** keep the **latest pending update per `containerID`** — distinct containers (e.g. maneuver text + trip stats) all survive, while repeated updates to one container **coalesce to newest**. Even a pile-up between wakes collapses to current content, so a flood is impossible.
- The write-without-response **resend** (the one genuinely deferred action) becomes a **one-shot delayed task armed at send-time**, superseded by any newer send, instead of riding the poll loop. If suspension swallows it, the next real frame re-pushes current content — correctness doesn't depend on it firing.
- **Remove the JS 300ms throttle** from `LocalDisplayManager` entirely; it now forwards every request straight through. Boot window, `durationMs` expiry, and core/background arbitration are unchanged.

### Out of scope: Mentra Live
Intentionally untouched. It has no text HUD (iOS `sendTextWall` is a stub) and its Android send queue **already** drains off the BLE write-complete callback rather than a standing poll.

## Testing

- ✅ Android `bluetooth-sdk` compile check (`./scripts/check-android-compile.sh bluetooth-sdk`) — BUILD SUCCESSFUL.
- ✅ `LocalDisplayManager` jest suite updated (throttle tests → pass-through tests) and green (15/15).
- ✅ `swiftformat --lint` parses G2.swift; no findings in changed regions.
- ⏳ Device verification on iOS G2 (background captions, screen-off 60s+) recommended before merge — the suspension path can't be exercised in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for glasses HUD text under background BLE; behavior change is intentional but needs device verification for caption pacing and multi-container updates.
> 
> **Overview**
> Fixes **background caption bursts on G2** by replacing timer-based display pacing with **event-driven native queues** that drain when updates arrive (same BLE wake that delivers transcription), instead of 100ms polls or JS throttles that stall while iOS is suspended.
> 
> **Native G2 (iOS + Android):** The EvenHub text update path no longer uses a standing 100ms timer loop. Enqueue **posts/wakes the drain immediately**, keeps the **latest update per `containerID`** (multiple HUD regions preserved; duplicate frames coalesce), and uses a **one-shot ~100ms resend** for write-without-response reliability, superseded by newer sends.
> 
> **`LocalDisplayManager`:** Removes the **~300ms JS throttle** and forwards every display request straight to native; boot window, `durationMs`, and core/background arbitration are unchanged. Tests now assert pass-through instead of leading/trailing throttle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 653b9e6c37c651627d013f1f4e75c5f9ce2a4df5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make G2 display updates event-driven to fix delayed-then-bursty captions when the iOS app is backgrounded. Removes the JS throttle and replaces polling with per-event draining and per-container coalescing so only the latest frame is sent.

- Bug Fixes
  - Fix late and bursty captions on G2 by removing timer-based pacing that stalls when the app is suspended.
  - Updates now send during BLE/transcription events; any backlog collapses to the latest per container.

- Refactors
  - iOS (`G2.swift`): replace the 100ms poll with a continuation-driven drain; keep the latest pending update per `containerID`; add a one-shot resend for write-without-response.
  - Android (`G2.kt`): drop the 100ms `postDelayed` loop; drain on enqueue; keep the latest pending update per `containerID`; add a one-shot resend.
  - JS (`LocalDisplayManager.ts`): remove the ~300ms throttle; forward every request; keep boot window, `durationMs` expiry, and core/background arbitration. Tests updated for pass-through behavior.

<sup>Written for commit 653b9e6c37c651627d013f1f4e75c5f9ce2a4df5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3207?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

