### PR TITLE
Add ci-gate-dev: single required check for dev PRs (per-area, only-what-ran)

### DIFF
--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -26,10 +26,24 @@ posts a single `ci-gate-dev` commit status:
 | A gated workflow that ran is still in progress / queued | ⏳ pending |
 | A gated workflow **did not run** (path filter didn't match this PR) | not gated — ignored |
 
-So a **cloud-only PR** is gated on the cloud builds + cloud tests and is **not**
-gated on iOS/Android/ASG (those never ran). A **mobile-only PR** is gated on
-iOS/Android/jest and not on cloud. Each PR is gated **only on the areas it
-touches** — which is the requirement.
+Two kinds of gated workflow, with different "runs when" behavior:
+
+- **Path-filtered builders** — iOS/Android/ASG/jest and `Run Cloud Tests ☁️`
+  only run when their area changes (`mobile/**`, `asg_client/**`, `cloud/**`). On
+  a PR that doesn't touch their area they **don't run at all**, so the gate never
+  waits on them. This is the heavy work (Mac builds, device tests) we want
+  scoped — a cloud-only PR never runs iOS/Android, and vice-versa.
+- **Always-on cloud builds** — the four `🧪 Test * build` workflows have an
+  **unfiltered** `pull_request` trigger, so they run on **every** `dev` PR. They
+  self-skip internally (via `dorny/paths-filter`) when their package didn't
+  change, reporting `success` quickly. So the gate technically always includes
+  them, but on an unrelated PR they finish near-instantly and don't meaningfully
+  block.
+
+Net effect: each PR is gated on the **heavy** builders only for the areas it
+touches (the requirement — your cloud engineer never runs iOS/Android), plus the
+four lightweight cloud build checks that run-and-pass on everything. Nothing that
+doesn't run is ever waited on.
 
 ### Why match by workflow name, not job/check-run name
 

--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -1,0 +1,74 @@
+# CI Gate — single required check for `dev` PRs
+
+## Problem this solves
+
+Branch protection requires a **fixed list of check names**. Our area builders are
+**path-filtered** (iOS/Android only run when `mobile/**` changes, cloud only when
+`cloud/**` changes, etc.). A path-filtered workflow that doesn't match **never
+reports a status**, so requiring it directly leaves the PR stuck forever in
+*"Expected — waiting for status to be reported."* That is exactly what blocked
+every `dev` PR (#3204, #3205, #3206, …): the required contexts
+`Build Mobile App (iOS/Android)`, `Build ASG Client`, `Upload to staging-builds release`
+come from `staging-builds.yml`, which only runs on **push to `staging`** — never
+on a PR — so they could never report.
+
+## How `ci-gate` works
+
+`.github/workflows/ci-gate.yml` runs on every PR into `dev` and again each time a
+builder workflow finishes. It reads the check-runs that **actually exist** for the
+PR head commit and posts a single `ci-gate` commit status:
+
+| Situation | `ci-gate` |
+|---|---|
+| Every builder that ran finished success / skipped / neutral | ✅ success |
+| Any builder that ran finished failure / cancelled / timed_out | ❌ failure |
+| A builder that ran is still in progress | ⏳ pending |
+| A builder **did not run** (path filter didn't match this PR) | not gated — ignored |
+
+So a **cloud-only PR** is gated on the cloud builds + cloud tests and is **not**
+gated on iOS/Android/ASG (those never ran). A **mobile-only PR** is gated on
+iOS/Android/jest and not on cloud. Each PR is gated **only on the areas it
+touches** — which is the requirement.
+
+### Builders aggregated
+
+| Area | Workflow | Check name(s) | Runs when |
+|---|---|---|---|
+| iOS | Mobile App iOS Build | `build` | `mobile/**` |
+| Android | Mobile App Android Build | `build` | `mobile/**` |
+| ASG | MentraOS ASG Client Build | `build` | `asg_client/**` |
+| Mobile jest | Mobile App Quality Checks | `test` | `mobile/**` |
+| Cloud | 🧪 Test Cloud build | `Build cloud/packages/cloud` | all dev PRs (self-skips internally) |
+| SDK | 🧪 Test SDK build | `Build cloud/packages/sdk` | all dev PRs (self-skips internally) |
+| Console | 🧪 Test Console build | `Build cloud/websites/console` | all dev PRs (self-skips internally) |
+| Store | 🧪 Test Store build | `Build cloud/websites/store` | all dev PRs (self-skips internally) |
+| Cloud tests | Run Cloud Tests ☁️ | `Build & Test` | `cloud/**` (PR trigger added in this PR) |
+
+## Rollout (manual step — do AFTER this PR merges to `dev`)
+
+`workflow_run` triggers only fire for a workflow that exists **on the default/base
+branch**. So `ci-gate` becomes active only once this PR is merged to `dev`. Then:
+
+1. Open a throwaway PR to `dev` touching `mobile/**`; confirm `ci-gate` goes
+   pending → success and that iOS/Android/jest are the builders it waited on.
+2. Open one touching only `cloud/**`; confirm `ci-gate` waits on the cloud builds
+   + `Build & Test` and **not** on mobile.
+3. Set branch protection on `dev` to require the single context **`ci-gate`**
+   (Settings → Branches → `dev`, or the API call below). Remove the old
+   `Build Mobile App (*)`, `Build ASG Client`, `Upload to staging-builds release`,
+   and the individual `Build cloud/*` contexts — `ci-gate` subsumes them.
+
+```bash
+gh api -X PATCH repos/Mentra-Community/MentraOS/branches/dev/protection/required_status_checks \
+  -f strict=false \
+  -f 'contexts[]=ci-gate'
+```
+
+> ⚠️ Never rename the `ci-gate` context. Branch protection pins to that exact
+> string; renaming it re-introduces the "waiting forever" block.
+
+## Note on `staging-builds.yml`
+
+`Upload to staging-builds release` and the staging mobile/iOS/ASG builds are
+**deliberately not** part of `ci-gate` — they publish OTA manifests and release
+assets and must stay `staging`-push-only. They should not be required on `dev`.

--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -12,63 +12,84 @@ every `dev` PR (#3204, #3205, #3206, …): the required contexts
 come from `staging-builds.yml`, which only runs on **push to `staging`** — never
 on a PR — so they could never report.
 
-## How `ci-gate` works
+## How `ci-gate-dev` works
 
 `.github/workflows/ci-gate.yml` runs on every PR into `dev` and again each time a
-builder workflow finishes. It reads the check-runs that **actually exist** for the
-PR head commit and posts a single `ci-gate` commit status:
+gated builder workflow starts/finishes. It gates on the **workflow runs** for the
+PR head commit — matched by **workflow name** against an explicit allowlist — and
+posts a single `ci-gate-dev` commit status:
 
-| Situation | `ci-gate` |
+| Situation | `ci-gate-dev` |
 |---|---|
-| Every builder that ran finished success / skipped / neutral | ✅ success |
-| Any builder that ran finished failure / cancelled / timed_out | ❌ failure |
-| A builder that ran is still in progress | ⏳ pending |
-| A builder **did not run** (path filter didn't match this PR) | not gated — ignored |
+| Every gated workflow that ran finished success / skipped / neutral | ✅ success |
+| Any gated workflow that ran finished failure / cancelled / timed_out / … | ❌ failure |
+| A gated workflow that ran is still in progress / queued | ⏳ pending |
+| A gated workflow **did not run** (path filter didn't match this PR) | not gated — ignored |
 
 So a **cloud-only PR** is gated on the cloud builds + cloud tests and is **not**
 gated on iOS/Android/ASG (those never ran). A **mobile-only PR** is gated on
 iOS/Android/jest and not on cloud. Each PR is gated **only on the areas it
 touches** — which is the requirement.
 
-### Builders aggregated
+### Why match by workflow name, not job/check-run name
 
-| Area | Workflow | Check name(s) | Runs when |
-|---|---|---|---|
-| iOS | Mobile App iOS Build | `build` | `mobile/**` |
-| Android | Mobile App Android Build | `build` | `mobile/**` |
-| ASG | MentraOS ASG Client Build | `build` | `asg_client/**` |
-| Mobile jest | Mobile App Quality Checks | `test` | `mobile/**` |
-| Cloud | 🧪 Test Cloud build | `Build cloud/packages/cloud` | all dev PRs (self-skips internally) |
-| SDK | 🧪 Test SDK build | `Build cloud/packages/sdk` | all dev PRs (self-skips internally) |
-| Console | 🧪 Test Console build | `Build cloud/websites/console` | all dev PRs (self-skips internally) |
-| Store | 🧪 Test Store build | `Build cloud/websites/store` | all dev PRs (self-skips internally) |
-| Cloud tests | Run Cloud Tests ☁️ | `Build & Test` | `cloud/**` (PR trigger added in this PR) |
+Several workflows name their job `build` (iOS, Android, ASG — **and the unrelated
+`Recovery Worker Build`**), so matching gated checks by the job name `build` is
+ambiguous and would pull in workflows we never meant to gate on. The gate instead
+reads `GET /actions/runs?head_sha=…`, which exposes each run's **unique workflow
+name** plus its overall status/conclusion, and matches against the allowlist
+below. `Recovery Worker Build` is deliberately excluded.
+
+### Workflows aggregated (the allowlist)
+
+| Area | Workflow name | Runs when |
+|---|---|---|
+| iOS | `Mobile App iOS Build` | `mobile/**` |
+| Android | `Mobile App Android Build` | `mobile/**` |
+| ASG | `MentraOS ASG Client Build` | `asg_client/**` |
+| Mobile jest | `Mobile App Quality Checks` | `mobile/**` |
+| Cloud | `🧪 Test Cloud build` | all dev PRs (self-skips internally) |
+| SDK | `🧪 Test SDK build` | all dev PRs (self-skips internally) |
+| Console | `🧪 Test Console build` | all dev PRs (self-skips internally) |
+| Store | `🧪 Test Store build` | all dev PRs (self-skips internally) |
+| Cloud tests | `Run Cloud Tests ☁️` | `cloud/**` (PR trigger added in this PR) |
+
+If you add or remove a builder, update the `GATED` set **and** the `workflow_run`
+`workflows:` list in `ci-gate.yml` — both must list the same workflow names.
+
+## Naming: `ci-gate-dev`
+
+The status context is `ci-gate-dev` (not just `ci-gate`) so a future
+`ci-gate-staging` can mirror this file for the `staging` branch without a name
+clash. Each branch gets its own gate context.
 
 ## Rollout (manual step — do AFTER this PR merges to `dev`)
 
 `workflow_run` triggers only fire for a workflow that exists **on the default/base
-branch**. So `ci-gate` becomes active only once this PR is merged to `dev`. Then:
+branch**. So `ci-gate-dev` becomes active only once this PR is merged to `dev`.
+Then:
 
-1. Open a throwaway PR to `dev` touching `mobile/**`; confirm `ci-gate` goes
+1. Open a throwaway PR to `dev` touching `mobile/**`; confirm `ci-gate-dev` goes
    pending → success and that iOS/Android/jest are the builders it waited on.
-2. Open one touching only `cloud/**`; confirm `ci-gate` waits on the cloud builds
-   + `Build & Test` and **not** on mobile.
-3. Set branch protection on `dev` to require the single context **`ci-gate`**
+2. Open one touching only `cloud/**`; confirm `ci-gate-dev` waits on the cloud
+   builds + `Run Cloud Tests ☁️` and **not** on mobile.
+3. Set branch protection on `dev` to require the single context **`ci-gate-dev`**
    (Settings → Branches → `dev`, or the API call below). Remove the old
    `Build Mobile App (*)`, `Build ASG Client`, `Upload to staging-builds release`,
-   and the individual `Build cloud/*` contexts — `ci-gate` subsumes them.
+   and the individual `Build cloud/*` contexts — `ci-gate-dev` subsumes them.
 
 ```bash
 gh api -X PATCH repos/Mentra-Community/MentraOS/branches/dev/protection/required_status_checks \
   -f strict=false \
-  -f 'contexts[]=ci-gate'
+  -f 'contexts[]=ci-gate-dev'
 ```
 
-> ⚠️ Never rename the `ci-gate` context. Branch protection pins to that exact
+> ⚠️ Never rename the `ci-gate-dev` context. Branch protection pins to that exact
 > string; renaming it re-introduces the "waiting forever" block.
 
 ## Note on `staging-builds.yml`
 
 `Upload to staging-builds release` and the staging mobile/iOS/ASG builds are
-**deliberately not** part of `ci-gate` — they publish OTA manifests and release
-assets and must stay `staging`-push-only. They should not be required on `dev`.
+**deliberately not** part of `ci-gate-dev` — they publish OTA manifests and
+release assets and must stay `staging`-push-only. They should not be required on
+`dev`. A future `ci-gate-staging` would gate the `staging` branch separately.

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -64,6 +64,9 @@ permissions:
 jobs:
   evaluate:
     runs-on: ubuntu-latest
+    # Slightly above the 30-min poll ceiling in the script so the loop, not the
+    # runner, decides when to give up.
+    timeout-minutes: 32
     steps:
       - name: Evaluate gated workflows and post ci-gate-dev status
         uses: actions/github-script@v7
@@ -96,73 +99,91 @@ jobs:
 
             const { owner, repo } = context.repo;
 
-            // All workflow runs for this commit (paginated). Each run exposes its
-            // workflow `name`, `status`, and `conclusion` directly — no need to
-            // disambiguate job/check-run names.
-            const allRuns = await github.paginate(
-              github.rest.actions.listWorkflowRunsForRepo,
-              { owner, repo, head_sha: sha, per_page: 100 },
-            );
-
-            // Keep only gated workflows, and for reruns keep the NEWEST run per
-            // workflow name (listWorkflowRunsForRepo returns newest first).
-            const latestByName = new Map();
-            for (const run of allRuns) {
-              if (!GATED.has(run.name)) continue;
-              if (!latestByName.has(run.name)) latestByName.set(run.name, run);
-            }
-            const gated = [...latestByName.values()];
-
             const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
             const OK = new Set(["success", "skipped", "neutral"]);
-
-            const incomplete = gated.filter(r => r.status !== "completed");
-            const failed = gated.filter(r => r.status === "completed" && BAD.has(r.conclusion));
-            const passed = gated.filter(r => r.status === "completed" && OK.has(r.conclusion));
-            // Any completed run whose conclusion is neither OK nor BAD is treated
-            // conservatively as not-yet-passing (keeps the gate from passing on an
-            // unknown conclusion).
-            const unknown = gated.filter(r => r.status === "completed" && !OK.has(r.conclusion) && !BAD.has(r.conclusion));
-
-            let state, description;
-            if (failed.length > 0) {
-              state = "failure";
-              description = `Failed: ${failed.map(r => r.name).join(", ")}`.slice(0, 140);
-            } else if (incomplete.length > 0 || unknown.length > 0) {
-              state = "pending";
-              const waiting = [...incomplete, ...unknown].map(r => r.name);
-              description = `Waiting on: ${waiting.join(", ")}`.slice(0, 140);
-            } else if (passed.length > 0) {
-              // Every gated workflow that ran is complete and OK.
-              state = "success";
-              description = `All required area builds passed (${passed.length})`;
-            } else {
-              // No gated workflow has appeared for this commit yet. Stay pending
-              // — builders are likely still spinning up. The cloud builds run on
-              // every dev PR, so for any real PR a gated run appears shortly.
-              state = "pending";
-              description = "Waiting for area builds to report";
-            }
-
-            core.info(`${STATUS_CONTEXT} -> ${state}: ${description}`);
-            core.info(`gated runs: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
 
             // The commit-status `description` field rejects 4-byte Unicode
             // (422 "Description doesn't accept 4-byte Unicode"). Some gated
             // workflow names contain emoji (e.g. "🧪 Test Cloud build"), so strip
             // any astral-plane code points and clamp to the 140-char limit.
-            const safeDescription = description
-              .replace(/[\u{10000}-\u{10FFFF}]/gu, "")
-              .replace(/\s+/g, " ")
-              .trim()
-              .slice(0, 140);
+            const sanitize = (s) =>
+              s.replace(/[\u{10000}-\u{10FFFF}]/gu, "").replace(/\s+/g, " ").trim().slice(0, 140);
 
-            await github.rest.repos.createCommitStatus({
-              owner,
-              repo,
-              sha,
-              state,
-              context: STATUS_CONTEXT,
-              description: safeDescription,
-              target_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
-            });
+            const postStatus = (state, description) =>
+              github.rest.repos.createCommitStatus({
+                owner, repo, sha, state, context: STATUS_CONTEXT,
+                description: sanitize(description),
+                target_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+              });
+
+            // Take one snapshot of the gated workflow runs for this commit and
+            // reduce it to a verdict. We match by unique WORKFLOW NAME (not the
+            // ambiguous job name "build"), and for reruns keep the NEWEST run per
+            // workflow (listWorkflowRunsForRepo returns newest first).
+            async function snapshot() {
+              const allRuns = await github.paginate(
+                github.rest.actions.listWorkflowRunsForRepo,
+                { owner, repo, head_sha: sha, per_page: 100 },
+              );
+              const latestByName = new Map();
+              for (const run of allRuns) {
+                if (!GATED.has(run.name)) continue;
+                if (!latestByName.has(run.name)) latestByName.set(run.name, run);
+              }
+              const gated = [...latestByName.values()];
+
+              const incomplete = gated.filter(r => r.status !== "completed");
+              const failed = gated.filter(r => r.status === "completed" && BAD.has(r.conclusion));
+              const passed = gated.filter(r => r.status === "completed" && OK.has(r.conclusion));
+              // Completed but neither OK nor BAD -> treat conservatively as pending,
+              // never as a pass.
+              const unknown = gated.filter(r => r.status === "completed" && !OK.has(r.conclusion) && !BAD.has(r.conclusion));
+
+              let state, description, settled;
+              if (failed.length > 0) {
+                state = "failure"; settled = true;
+                description = `Failed: ${failed.map(r => r.name).join(", ")}`;
+              } else if (incomplete.length > 0 || unknown.length > 0) {
+                state = "pending"; settled = false;
+                description = `Waiting on: ${[...incomplete, ...unknown].map(r => r.name).join(", ")}`;
+              } else if (passed.length > 0) {
+                state = "success"; settled = true;
+                description = `All required area builds passed (${passed.length})`;
+              } else {
+                // No gated workflow has appeared for this commit yet — builders are
+                // still spinning up. Not settled; keep polling.
+                state = "pending"; settled = false;
+                description = "Waiting for area builds to report";
+              }
+              core.info(`gated runs: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
+              return { state, description, settled };
+            }
+
+            // Poll until the gated runs settle (all OK -> success, any BAD ->
+            // failure) or we hit the time budget. Polling makes the gate
+            // self-healing: it does not depend on a workflow_run wakeup arriving
+            // for every builder completion (those only fire once ci-gate.yml is on
+            // the base branch, and can race even then). We post intermediate
+            // pending statuses so the required check reflects live progress.
+            const MAX_MS = 30 * 60 * 1000;   // 30 min ceiling
+            const INTERVAL_MS = 20 * 1000;   // poll every 20s
+            const sleep = (ms) => new Promise(r => setTimeout(r, ms));
+            const deadline = Date.now() + MAX_MS;
+
+            let result = await snapshot();
+            await postStatus(result.state, result.description);
+            core.info(`${STATUS_CONTEXT} -> ${result.state}: ${result.description}`);
+
+            while (!result.settled && Date.now() < deadline) {
+              await sleep(INTERVAL_MS);
+              result = await snapshot();
+              await postStatus(result.state, result.description);
+              core.info(`${STATUS_CONTEXT} -> ${result.state}: ${result.description}`);
+            }
+
+            if (!result.settled) {
+              // Timed out still pending — leave the pending status in place and
+              // fail this job so it is visible/rerunnable, rather than silently
+              // leaving the gate stuck.
+              core.setFailed(`ci-gate-dev did not settle within ${MAX_MS / 60000} min: ${result.description}`);
+            }

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -147,12 +147,22 @@ jobs:
             core.info(`${STATUS_CONTEXT} -> ${state}: ${description}`);
             core.info(`gated runs: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
 
+            // The commit-status `description` field rejects 4-byte Unicode
+            // (422 "Description doesn't accept 4-byte Unicode"). Some gated
+            // workflow names contain emoji (e.g. "🧪 Test Cloud build"), so strip
+            // any astral-plane code points and clamp to the 140-char limit.
+            const safeDescription = description
+              .replace(/[\u{10000}-\u{10FFFF}]/gu, "")
+              .replace(/\s+/g, " ")
+              .trim()
+              .slice(0, 140);
+
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
               sha,
               state,
               context: STATUS_CONTEXT,
-              description,
+              description: safeDescription,
               target_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
             });

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,6 +1,6 @@
-name: CI Gate
+name: CI Gate (dev)
 
-# Single required status check for PRs into dev.
+# Single required status check for PRs into dev: `ci-gate-dev`.
 #
 # Why this exists:
 #   Branch protection requires a FIXED list of check names. Our area builders
@@ -11,19 +11,25 @@ name: CI Gate
 #   path filtering.
 #
 # How it works:
-#   This workflow runs on every PR into dev and AGAIN each time one of the
-#   builder workflows finishes (via workflow_run). It looks at the check-runs
-#   that ACTUALLY EXIST for the PR head commit and posts a single `ci-gate`
-#   commit status:
-#     - PASS  if every builder that ran finished success/skipped/neutral
-#     - FAIL  if any builder that ran finished failure/cancelled/timed_out
-#     - PENDING while a builder that ran is still in progress / queued
-#   A builder that DID NOT run (its path filter didn't match) is simply absent
-#   and is not gated on — exactly the "only require what this PR touches"
+#   This workflow runs on every PR into dev and again each time one of the
+#   builder workflows finishes (via workflow_run). It gates on WORKFLOW RUNS
+#   for the PR head commit — matched by WORKFLOW NAME against an explicit
+#   allowlist — and posts a single `ci-gate-dev` commit status:
+#     - PASS    if every gated workflow that ran finished success/skipped/neutral
+#     - FAIL    if any gated workflow that ran finished failure/cancelled/etc.
+#     - PENDING while a gated workflow that ran is still in progress / queued
+#   A gated workflow that DID NOT run (its path filter didn't match) is simply
+#   absent and is not gated on — exactly the "only require what this PR touches"
 #   behavior we want.
 #
-# Branch protection: require ONLY the `ci-gate` context on dev. Never rename it
-#   — that name is the API branch protection pins to.
+#   We match by WORKFLOW NAME, not by job/check-run name, on purpose: several
+#   workflows name their job "build" (iOS, Android, ASG, and the unrelated
+#   Recovery Worker Build), so a job-name match would be ambiguous and could
+#   pull in workflows we never intended to gate on. Workflow names are unique.
+#
+# Branch protection: require ONLY the `ci-gate-dev` context on dev. Never rename
+#   it — that name is the API branch protection pins to. A future
+#   `ci-gate-staging` can mirror this file for the staging branch.
 
 on:
   # Post an initial pending status the moment a PR opens / updates, so the
@@ -31,7 +37,7 @@ on:
   pull_request:
     branches: [dev]
     types: [opened, reopened, synchronize]
-  # Re-evaluate every time a builder workflow completes.
+  # Re-evaluate every time a gated builder workflow starts or completes.
   workflow_run:
     workflows:
       - "Mobile App iOS Build"
@@ -47,35 +53,39 @@ on:
 
 concurrency:
   # One evaluation per head SHA at a time; newer evaluations supersede older.
-  group: ci-gate-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+  group: ci-gate-dev-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
   cancel-in-progress: true
 
 permissions:
-  checks: read
+  actions: read
   statuses: write
   pull-requests: read
-  actions: read
 
 jobs:
   evaluate:
     runs-on: ubuntu-latest
     steps:
-      - name: Evaluate area builders and post ci-gate status
+      - name: Evaluate gated workflows and post ci-gate-dev status
         uses: actions/github-script@v7
         with:
           script: |
-            // The set of builder check-run names this gate aggregates. These are
-            // the JOB names (check contexts) produced by the builder workflows.
-            // If a builder is absent for a given commit, it didn't run for this
-            // PR (path filter didn't match) and is intentionally not gated on.
+            const STATUS_CONTEXT = "ci-gate-dev";
+
+            // Workflows this gate aggregates, matched by exact workflow name.
+            // A workflow absent from a commit's runs didn't run for this PR
+            // (its path filter didn't match) and is intentionally not gated on.
+            // NOTE: "Recovery Worker Build" is deliberately NOT here — it also
+            // names its job "build" but is not a required area builder.
             const GATED = new Set([
-              "build",                            // iOS / Android / ASG builders all name their job "build"
-              "test",                             // Mobile App Quality Checks (jest)
-              "Build cloud/packages/cloud",
-              "Build cloud/packages/sdk",
-              "Build cloud/websites/console",
-              "Build cloud/websites/store",
-              "Build & Test",                     // cloud-tests.yml
+              "Mobile App iOS Build",
+              "Mobile App Android Build",
+              "MentraOS ASG Client Build",
+              "Mobile App Quality Checks",
+              "🧪 Test Cloud build",
+              "🧪 Test SDK build",
+              "🧪 Test Console build",
+              "🧪 Test Store build",
+              "Run Cloud Tests ☁️",
             ]);
 
             // Resolve the head SHA for whichever event triggered us.
@@ -84,59 +94,65 @@ jobs:
               context.payload.pull_request?.head?.sha ||
               context.sha;
 
-            // Never gate ci-gate on itself.
-            const SELF = "ci-gate";
-
             const { owner, repo } = context.repo;
 
-            // Pull every check-run on the head commit (paginated).
-            const runs = await github.paginate(
-              github.rest.checks.listForRef,
-              { owner, repo, ref: sha, per_page: 100 },
+            // All workflow runs for this commit (paginated). Each run exposes its
+            // workflow `name`, `status`, and `conclusion` directly — no need to
+            // disambiguate job/check-run names.
+            const allRuns = await github.paginate(
+              github.rest.actions.listWorkflowRunsForRepo,
+              { owner, repo, head_sha: sha, per_page: 100 },
             );
 
-            const gated = runs.filter(r => GATED.has(r.name) && r.name !== SELF);
+            // Keep only gated workflows, and for reruns keep the NEWEST run per
+            // workflow name (listWorkflowRunsForRepo returns newest first).
+            const latestByName = new Map();
+            for (const run of allRuns) {
+              if (!GATED.has(run.name)) continue;
+              if (!latestByName.has(run.name)) latestByName.set(run.name, run);
+            }
+            const gated = [...latestByName.values()];
 
-            // Terminal-bad conclusions that should fail the gate.
-            const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "stale"]);
-            // Conclusions that are acceptable (success, or skipped-as-pass).
+            const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
             const OK = new Set(["success", "skipped", "neutral"]);
 
-            const stillRunning = gated.filter(r => r.status !== "completed");
+            const incomplete = gated.filter(r => r.status !== "completed");
             const failed = gated.filter(r => r.status === "completed" && BAD.has(r.conclusion));
             const passed = gated.filter(r => r.status === "completed" && OK.has(r.conclusion));
+            // Any completed run whose conclusion is neither OK nor BAD is treated
+            // conservatively as not-yet-passing (keeps the gate from passing on an
+            // unknown conclusion).
+            const unknown = gated.filter(r => r.status === "completed" && !OK.has(r.conclusion) && !BAD.has(r.conclusion));
 
             let state, description;
             if (failed.length > 0) {
               state = "failure";
               description = `Failed: ${failed.map(r => r.name).join(", ")}`.slice(0, 140);
-            } else if (stillRunning.length > 0) {
+            } else if (incomplete.length > 0 || unknown.length > 0) {
               state = "pending";
-              description = `Waiting on: ${stillRunning.map(r => r.name).join(", ")}`.slice(0, 140);
+              const waiting = [...incomplete, ...unknown].map(r => r.name);
+              description = `Waiting on: ${waiting.join(", ")}`.slice(0, 140);
             } else if (passed.length > 0) {
+              // Every gated workflow that ran is complete and OK.
               state = "success";
               description = `All required area builds passed (${passed.length})`;
             } else {
-              // No gated builder ran for this commit yet. Stay pending on the
-              // pull_request 'opened' event (builders may still be spinning up);
-              // for a settled commit with genuinely no gated areas, this would
-              // remain pending — acceptable, since such a PR touches none of the
-              // gated paths and a human can merge via admin. In practice every
-              // PR touches at least one gated area or the cloud builds (which run
-              // on all dev PRs) will be present.
+              // No gated workflow has appeared for this commit yet. Stay pending
+              // — builders are likely still spinning up. The cloud builds run on
+              // every dev PR, so for any real PR a gated run appears shortly.
               state = "pending";
               description = "Waiting for area builds to report";
             }
 
-            core.info(`ci-gate -> ${state}: ${description}`);
-            core.info(`gated check-runs seen: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
+            core.info(`${STATUS_CONTEXT} -> ${state}: ${description}`);
+            core.info(`gated runs: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
 
             await github.rest.repos.createCommitStatus({
               owner,
               repo,
               sha,
               state,
-              context: SELF,
+              context: STATUS_CONTEXT,
               description,
               target_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
             });

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -1,0 +1,142 @@
+name: CI Gate
+
+# Single required status check for PRs into dev.
+#
+# Why this exists:
+#   Branch protection requires a FIXED list of check names. Our area builders
+#   (iOS / Android / ASG / cloud) are PATH-FILTERED — a cloud-only PR never runs
+#   the iOS workflow, so an "iOS build" required check would sit forever in
+#   "Expected — waiting for status to be reported" and block the PR. Requiring
+#   the individual builders directly is therefore incompatible with per-area
+#   path filtering.
+#
+# How it works:
+#   This workflow runs on every PR into dev and AGAIN each time one of the
+#   builder workflows finishes (via workflow_run). It looks at the check-runs
+#   that ACTUALLY EXIST for the PR head commit and posts a single `ci-gate`
+#   commit status:
+#     - PASS  if every builder that ran finished success/skipped/neutral
+#     - FAIL  if any builder that ran finished failure/cancelled/timed_out
+#     - PENDING while a builder that ran is still in progress / queued
+#   A builder that DID NOT run (its path filter didn't match) is simply absent
+#   and is not gated on — exactly the "only require what this PR touches"
+#   behavior we want.
+#
+# Branch protection: require ONLY the `ci-gate` context on dev. Never rename it
+#   — that name is the API branch protection pins to.
+
+on:
+  # Post an initial pending status the moment a PR opens / updates, so the
+  # required check appears immediately rather than only after a builder starts.
+  pull_request:
+    branches: [dev]
+    types: [opened, reopened, synchronize]
+  # Re-evaluate every time a builder workflow completes.
+  workflow_run:
+    workflows:
+      - "Mobile App iOS Build"
+      - "Mobile App Android Build"
+      - "MentraOS ASG Client Build"
+      - "Mobile App Quality Checks"
+      - "🧪 Test Cloud build"
+      - "🧪 Test SDK build"
+      - "🧪 Test Console build"
+      - "🧪 Test Store build"
+      - "Run Cloud Tests ☁️"
+    types: [completed, requested]
+
+concurrency:
+  # One evaluation per head SHA at a time; newer evaluations supersede older.
+  group: ci-gate-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+  cancel-in-progress: true
+
+permissions:
+  checks: read
+  statuses: write
+  pull-requests: read
+  actions: read
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate area builders and post ci-gate status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // The set of builder check-run names this gate aggregates. These are
+            // the JOB names (check contexts) produced by the builder workflows.
+            // If a builder is absent for a given commit, it didn't run for this
+            // PR (path filter didn't match) and is intentionally not gated on.
+            const GATED = new Set([
+              "build",                            // iOS / Android / ASG builders all name their job "build"
+              "test",                             // Mobile App Quality Checks (jest)
+              "Build cloud/packages/cloud",
+              "Build cloud/packages/sdk",
+              "Build cloud/websites/console",
+              "Build cloud/websites/store",
+              "Build & Test",                     // cloud-tests.yml
+            ]);
+
+            // Resolve the head SHA for whichever event triggered us.
+            const sha =
+              context.payload.workflow_run?.head_sha ||
+              context.payload.pull_request?.head?.sha ||
+              context.sha;
+
+            // Never gate ci-gate on itself.
+            const SELF = "ci-gate";
+
+            const { owner, repo } = context.repo;
+
+            // Pull every check-run on the head commit (paginated).
+            const runs = await github.paginate(
+              github.rest.checks.listForRef,
+              { owner, repo, ref: sha, per_page: 100 },
+            );
+
+            const gated = runs.filter(r => GATED.has(r.name) && r.name !== SELF);
+
+            // Terminal-bad conclusions that should fail the gate.
+            const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "stale"]);
+            // Conclusions that are acceptable (success, or skipped-as-pass).
+            const OK = new Set(["success", "skipped", "neutral"]);
+
+            const stillRunning = gated.filter(r => r.status !== "completed");
+            const failed = gated.filter(r => r.status === "completed" && BAD.has(r.conclusion));
+            const passed = gated.filter(r => r.status === "completed" && OK.has(r.conclusion));
+
+            let state, description;
+            if (failed.length > 0) {
+              state = "failure";
+              description = `Failed: ${failed.map(r => r.name).join(", ")}`.slice(0, 140);
+            } else if (stillRunning.length > 0) {
+              state = "pending";
+              description = `Waiting on: ${stillRunning.map(r => r.name).join(", ")}`.slice(0, 140);
+            } else if (passed.length > 0) {
+              state = "success";
+              description = `All required area builds passed (${passed.length})`;
+            } else {
+              // No gated builder ran for this commit yet. Stay pending on the
+              // pull_request 'opened' event (builders may still be spinning up);
+              // for a settled commit with genuinely no gated areas, this would
+              // remain pending — acceptable, since such a PR touches none of the
+              // gated paths and a human can merge via admin. In practice every
+              // PR touches at least one gated area or the cloud builds (which run
+              // on all dev PRs) will be present.
+              state = "pending";
+              description = "Waiting for area builds to report";
+            }
+
+            core.info(`ci-gate -> ${state}: ${description}`);
+            core.info(`gated check-runs seen: ${gated.map(r => `${r.name}=${r.status}/${r.conclusion}`).join("; ") || "(none yet)"}`);
+
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state,
+              context: SELF,
+              description,
+              target_url: `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`,
+            });

--- a/.github/workflows/cloud-tests.yml
+++ b/.github/workflows/cloud-tests.yml
@@ -3,6 +3,19 @@ name: Run Cloud Tests ☁️
 
 # trigger
 on:
+  # Run on PRs into dev/staging/main so cloud tests gate PRs (via ci-gate).
+  # Path-filtered so non-cloud PRs don't run it — matching the rest of the
+  # cloud builders and keeping the ci-gate per-area.
+  pull_request:
+    branches:
+      - main
+      - dev
+      - staging
+    paths:
+      - "cloud/packages/**"
+      - "cloud/bun.lock"
+      - "cloud/package.json"
+      - ".github/workflows/cloud-tests.yml"
   push:
     paths:
       - "cloud/packages/**"


### PR DESCRIPTION
## Why

Branch protection requires a **fixed list of check names**, but our area builders are **path-filtered** — iOS/Android only run on `mobile/**`, ASG on `asg_client/**`, cloud on `cloud/**`. A path-filtered workflow that doesn't match **never reports a status**, so requiring it directly leaves a PR stuck forever in *"Expected — waiting for status to be reported."*

That is exactly what blocked every open `dev` PR (#3204, #3205, #3206, …): the required contexts `Build Mobile App (iOS/Android)`, `Build ASG Client`, and `Upload to staging-builds release` come from `staging-builds.yml`, which **only runs on push to `staging`** and never on a PR — so they could never report. (Branch protection's required-checks list was since cleared as a stopgap, leaving `dev` PRs ungated. This PR re-establishes gating, correctly.)

## What this does

Adds `.github/workflows/ci-gate.yml` — one workflow that runs on every PR into `dev` and again whenever a builder workflow finishes (`workflow_run`). It reads the check-runs that **actually exist** for the PR head commit and posts a single `ci-gate` commit status:

- ✅ **pass** if every builder that *ran* finished success / skipped / neutral
- ❌ **fail** if any builder that *ran* finished failure / cancelled / timed_out
- ⏳ **pending** while a builder that ran is still in flight
- a builder that **did not run** (path filter didn't match) is **ignored**

So each PR is gated **only on the areas it touches**:
- cloud-only PR → gated on the cloud builds + `Build & Test`, **not** iOS/Android/ASG
- mobile-only PR → gated on iOS/Android/jest, **not** cloud

Your cloud engineer never runs iOS/Android builds, and vice-versa.

Also adds a **path-filtered `pull_request` trigger to `cloud-tests.yml`** so cloud tests (`Build & Test`) actually gate PRs (they were `push`-only before, so never ran on PRs).

## Builders aggregated

| Area | Check | Runs when |
|---|---|---|
| iOS / Android / ASG | `build` | `mobile/**` / `asg_client/**` |
| Mobile jest | `test` | `mobile/**` |
| Cloud / SDK / Console / Store | `Build cloud/*` | all dev PRs (self-skip internally) |
| Cloud tests | `Build & Test` | `cloud/**` (trigger added here) |

`staging-builds.yml` (OTA/release publishing) is **deliberately excluded** — it stays `staging`-push-only and should not gate `dev`.

## ⚠️ Rollout — manual step after merge

`workflow_run` triggers only fire for a workflow that exists on the **base branch**, so `ci-gate` activates only once this merges to `dev`. Then:

1. Smoke-test with a mobile-only PR and a cloud-only PR; confirm `ci-gate` waits only on the touched areas.
2. Set branch protection on `dev` to require the single context **`ci-gate`** and drop the old per-builder contexts:

```bash
gh api -X PATCH repos/Mentra-Community/MentraOS/branches/dev/protection/required_status_checks \
  -f strict=false -f 'contexts[]=ci-gate'
```

Never rename the `ci-gate` context — branch protection pins to that exact string.

Full write-up in `.github/CI_GATE.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge gating for `dev` and depends on correct workflow-name allowlisting; misconfiguration could block or under-gate PRs until branch protection is updated post-merge.
> 
> **Overview**
> Introduces a **`ci-gate-dev`** commit status so `dev` PRs can use one branch-protection check instead of per-builder names that never report when path filters skip workflows.
> 
> **`ci-gate.yml`** runs on PRs to `dev` and on `workflow_run` for an allowlisted set of workflow **names** (mobile iOS/Android/quality, ASG, four cloud package test builds, cloud tests). It polls Actions runs for the PR head SHA, ignores builders that did not run, and posts success / failure / pending; descriptions strip emoji to satisfy the status API.
> 
> **`cloud-tests.yml`** gains a path-filtered **`pull_request`** trigger so `Run Cloud Tests ☁️` can run on relevant PRs and participate in the gate (previously push-only).
> 
> **`.github/CI_GATE.md`** documents behavior, the allowlist, rollout (require only `ci-gate-dev` after merge), and that staging release workflows stay excluded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05736a495d4156978ef824e65808823e10faaf55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ci-gate-dev`, a single required status check for PRs into `dev` that gates only on workflows that actually ran, so path‑filtered areas don’t block merges. Adds a self‑healing poll loop so the gate settles automatically; cloud build checks run on all PRs but self‑skip quickly, and cloud tests now run on PRs and count in the gate.

- New Features
  - `ci-gate-dev` posts one commit status: success when all ran gated workflows finished success/skipped/neutral; failure on any failure/cancelled/timed_out; pending while any are in progress; workflows that didn’t run are ignored. It polls every 20s (up to 30 min) and posts intermediate updates until runs settle, deduping to the newest rerun per workflow.
  - Triggers on `pull_request` into `dev` and on `workflow_run` for an allowlisted set (iOS/Android/ASG, mobile jest, cloud builds, cloud tests). Matches by workflow name, excludes the unrelated `Recovery Worker Build`. Adds a path‑filtered PR trigger to `cloud-tests.yml` so `Run Cloud Tests ☁️` gates relevant PRs; the four cloud build checks run on all PRs but self‑skip. Staging workflows remain excluded.
  - Sanitizes the status description (drops 4‑byte Unicode, collapses whitespace, 140‑char cap) to avoid GitHub API errors when workflow names include emoji.

- Migration
  - After merging to `dev`, update branch protection to require only the `ci-gate-dev` check.
  - Smoke-test with a mobile‑only PR and a cloud‑only PR to confirm the gate waits only on the touched heavy builders.

<sup>Written for commit 05736a495d4156978ef824e65808823e10faaf55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

