### PR TITLE
ci-gate: add workflow_dispatch + stop cancel-storm on builder start

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -37,7 +37,15 @@ on:
   pull_request:
     branches: [dev]
     types: [opened, reopened, synchronize]
-  # Re-evaluate every time a gated builder workflow starts or completes.
+  # Manual retrigger. Needed for PRs whose head commit predates ci-gate.yml
+  # landing on dev (no pull_request event ever fired for them) — re-run this
+  # workflow against the PR branch to evaluate and post the status.
+  workflow_dispatch:
+  # Re-evaluate when a gated builder workflow COMPLETES. We intentionally do NOT
+  # listen on `requested` (builder start): combined with cancel-in-progress it
+  # made every builder start cancel the in-flight poll, so the gate could never
+  # post a status. The poll loop already covers "still running", so a single
+  # completion event is enough to drive evaluation.
   workflow_run:
     workflows:
       - "Mobile App iOS Build"
@@ -49,7 +57,7 @@ on:
       - "🧪 Test Console build"
       - "🧪 Test Store build"
       - "Run Cloud Tests ☁️"
-    types: [completed, requested]
+    types: [completed]
 
 concurrency:
   # One evaluation per head SHA at a time; newer evaluations supersede older.


### PR DESCRIPTION
Follow-up to #3208, found once `ci-gate-dev` became required on `dev`.

## Two bugs

**1. PRs older than the gate get stuck.** A PR whose head commit predates `ci-gate.yml` landing on `dev` never had a `pull_request` event fire the gate, and its builders already finished so no `workflow_run` wakeup arrives either → the required `ci-gate-dev` check sits at *"Expected — waiting for status to be reported"* forever. (Exactly what hit #3173.)
→ Add `workflow_dispatch` so such PRs can be evaluated manually. (Updating the branch from `dev` also fixes it, via `synchronize`.)

**2. Cancel storm.** `workflow_run` listened on `requested` (builder *start*) as well as `completed`. With `concurrency: cancel-in-progress: true`, every builder starting cancelled the in-flight gate poll, so it frequently never posted a status. The poll loop already covers "still running", so a single `completed` event is enough.
→ Drop `requested`; listen only on `completed`.

## Fixing in-flight PRs after this merges
PRs created before the gate existed (e.g. #3173) just need their branch updated from `dev`, or a manual `workflow_dispatch` run of **CI Gate (dev)** against the PR branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only GitHub Actions triggers for the dev CI gate; no application, auth, or data-path impact.
> 
> **Overview**
> Fixes two **CI Gate (dev)** behaviors that blocked or prevented the required `ci-gate-dev` status from being posted.
> 
> Adds **`workflow_dispatch`** so the gate can be run manually for PRs whose head commit never saw a `pull_request` event after `ci-gate.yml` landed on `dev` (builders already finished, so no wakeup)—avoiding an eternal *Expected — waiting for status* state.
> 
> Narrows **`workflow_run`** to **`types: [completed]`** only (drops `requested`). Builder starts were re-triggering the gate while **`concurrency` + `cancel-in-progress`** cancelled in-flight polls, so evaluation often never finished; completion events plus the existing poll loop are enough.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bfa36b387b41324d4ab99ba62d80420eaf3901. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `workflow_dispatch` to CI gate and drop `workflow_run: requested` to prevent cancel storms. This unblocks older PRs and makes the gate post statuses reliably.

- **Bug Fixes**
  - Add `workflow_dispatch` so PRs predating `ci-gate.yml` on `dev` can be evaluated manually.
  - Listen only for `workflow_run: completed` (remove `requested`) to avoid cancel-in-progress thrashing; the poll loop already covers running builds.

- **Migration**
  - For older PRs, update from `dev` or manually run "CI Gate (dev)" via `workflow_dispatch` on the PR branch.

<sup>Written for commit b8bfa36b387b41324d4ab99ba62d80420eaf3901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3209?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

