### PR TITLE
ci-gate: one clean run per PR (kill cancel-storm), branch-keyed concurrency

### DIFF
--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -41,27 +41,21 @@ on:
   # landing on dev (no pull_request event ever fired for them) — re-run this
   # workflow against the PR branch to evaluate and post the status.
   workflow_dispatch:
-  # Re-evaluate when a gated builder workflow COMPLETES. We intentionally do NOT
-  # listen on `requested` (builder start): combined with cancel-in-progress it
-  # made every builder start cancel the in-flight poll, so the gate could never
-  # post a status. The poll loop already covers "still running", so a single
-  # completion event is enough to drive evaluation.
-  workflow_run:
-    workflows:
-      - "Mobile App iOS Build"
-      - "Mobile App Android Build"
-      - "MentraOS ASG Client Build"
-      - "Mobile App Quality Checks"
-      - "🧪 Test Cloud build"
-      - "🧪 Test SDK build"
-      - "🧪 Test Console build"
-      - "🧪 Test Store build"
-      - "Run Cloud Tests ☁️"
-    types: [completed]
+
+# NOTE: we deliberately do NOT use a `workflow_run` trigger anymore. Each gated
+# builder completing fired a fresh ci-gate run that cancelled the in-flight poll
+# (cancel-in-progress), littering every PR with a pile of "cancelled" CI Gate
+# runs. The single poll loop below already watches every builder to completion,
+# so one run per commit (from pull_request / workflow_dispatch) is sufficient.
+# To avoid declaring success before a slow-to-register builder has appeared, the
+# loop enforces a settling grace window (see GRACE_MS).
 
 concurrency:
-  # One evaluation per head SHA at a time; newer evaluations supersede older.
-  group: ci-gate-dev-${{ github.event.workflow_run.head_sha || github.event.pull_request.head.sha || github.sha }}
+  # Key by PR BRANCH (like the builder workflows), not by SHA. A new commit on
+  # the same PR then cancels the previous commit's in-flight poll, freeing the
+  # runner and stopping a now-stale evaluation — instead of leaving it to time
+  # out. One live evaluation per PR branch at a time.
+  group: ci-gate-dev-${{ github.event.pull_request.head.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -128,7 +122,7 @@ jobs:
             // reduce it to a verdict. We match by unique WORKFLOW NAME (not the
             // ambiguous job name "build"), and for reruns keep the NEWEST run per
             // workflow (listWorkflowRunsForRepo returns newest first).
-            async function snapshot() {
+            async function snapshot(elapsedMs) {
               const allRuns = await github.paginate(
                 github.rest.actions.listWorkflowRunsForRepo,
                 { owner, repo, head_sha: sha, per_page: 100 },
@@ -149,14 +143,24 @@ jobs:
 
               let state, description, settled;
               if (failed.length > 0) {
+                // A real failure settles immediately — no grace needed.
                 state = "failure"; settled = true;
                 description = `Failed: ${failed.map(r => r.name).join(", ")}`;
               } else if (incomplete.length > 0 || unknown.length > 0) {
                 state = "pending"; settled = false;
                 description = `Waiting on: ${[...incomplete, ...unknown].map(r => r.name).join(", ")}`;
-              } else if (passed.length > 0) {
+              } else if (passed.length > 0 && elapsedMs >= GRACE_MS) {
+                // Every gated workflow PRESENT so far has passed AND we've waited
+                // out the grace window, so a slow-to-register builder has had time
+                // to appear. Safe to declare success.
                 state = "success"; settled = true;
                 description = `All required area builds passed (${passed.length})`;
+              } else if (passed.length > 0) {
+                // Present builders all passed, but we're still inside the grace
+                // window — a path-matched builder may not have registered its run
+                // yet. Hold pending until the window elapses.
+                state = "pending"; settled = false;
+                description = "Confirming all area builds have registered…";
               } else {
                 // No gated workflow has appeared for this commit yet — builders are
                 // still spinning up. Not settled; keep polling.
@@ -175,16 +179,21 @@ jobs:
             // pending statuses so the required check reflects live progress.
             const MAX_MS = 30 * 60 * 1000;   // 30 min ceiling
             const INTERVAL_MS = 20 * 1000;   // poll every 20s
+            // Minimum time before we'll declare success, so a path-matched builder
+            // that is slow to register a run (e.g. queued behind Mac runners) is
+            // not missed. A real failure still settles immediately regardless.
+            const GRACE_MS = 90 * 1000;      // 90s settle window
             const sleep = (ms) => new Promise(r => setTimeout(r, ms));
-            const deadline = Date.now() + MAX_MS;
+            const start = Date.now();
+            const deadline = start + MAX_MS;
 
-            let result = await snapshot();
+            let result = await snapshot(Date.now() - start);
             await postStatus(result.state, result.description);
             core.info(`${STATUS_CONTEXT} -> ${result.state}: ${result.description}`);
 
             while (!result.settled && Date.now() < deadline) {
               await sleep(INTERVAL_MS);
-              result = await snapshot();
+              result = await snapshot(Date.now() - start);
               await postStatus(result.state, result.description);
               core.info(`${STATUS_CONTEXT} -> ${result.state}: ${result.description}`);
             }

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -63,12 +63,13 @@ on:
     types: [completed]
 
 concurrency:
-  # Key per-PR. For pull_request events github.ref is refs/pull/<n>/merge, which
-  # is unique per PR (so unrelated fork PRs sharing a branch name like "fix" or
-  # "main" do NOT collide). For workflow_run events github.ref is the base branch
-  # (dev), so we fall back to the triggering run's head_sha to keep re-evaluations
-  # grouped with the right PR.
-  group: ci-gate-dev-${{ github.event.workflow_run.head_sha || github.ref }}
+  # Key by the COMMIT (head SHA), consistently across every event type, so all
+  # evaluations of the same commit land in one group and never run in parallel
+  # (which would race on createCommitStatus for that SHA). Both the pull_request
+  # head SHA and the workflow_run head SHA refer to the same commit, so unrelated
+  # fork PRs sharing a branch name do NOT collide (different commits -> different
+  # groups). github.sha is the final fallback (e.g. workflow_dispatch).
+  group: ci-gate-dev-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.sha }}
   # Do NOT cancel in progress: re-evaluations from builder completions should
   # queue and replace, not cancel each other. Cancelling was what littered every
   # PR with "cancelled" CI Gate runs. The poll loop exits quickly once settled,
@@ -121,6 +122,25 @@ jobs:
             const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
             const OK = new Set(["success", "skipped", "neutral"]);
 
+            // Was this commit ALREADY marked green by an earlier ci-gate run? If
+            // so, a re-evaluation (e.g. a workflow_run wakeup after a builder
+            // rerun) must not regress the required check back to pending during
+            // its own grace window. We only need this snapshot once, at startup.
+            let alreadyGreen = false;
+            try {
+              const existing = await github.paginate(
+                github.rest.repos.listCommitStatusesForRef,
+                { owner, repo, ref: sha, per_page: 100 },
+              );
+              // listCommitStatusesForRef returns newest first; find the latest
+              // status for our context.
+              const latest = existing.find(s => s.context === STATUS_CONTEXT);
+              alreadyGreen = latest?.state === "success";
+            } catch (e) {
+              core.info(`could not read existing ci-gate-dev status: ${e.message}`);
+            }
+            core.info(`alreadyGreen=${alreadyGreen}`);
+
             // The commit-status `description` field rejects 4-byte Unicode
             // (422 "Description doesn't accept 4-byte Unicode"). Some gated
             // workflow names contain emoji (e.g. "🧪 Test Cloud build"), so strip
@@ -166,16 +186,20 @@ jobs:
               } else if (incomplete.length > 0 || unknown.length > 0) {
                 state = "pending"; settled = false;
                 description = `Waiting on: ${[...incomplete, ...unknown].map(r => r.name).join(", ")}`;
-              } else if (passed.length > 0 && elapsedMs >= GRACE_MS) {
-                // Every gated workflow PRESENT so far has passed AND we've waited
-                // out the grace window, so a slow-to-register builder has had time
-                // to appear. Safe to declare success.
+              } else if (passed.length > 0 && (elapsedMs >= GRACE_MS || alreadyGreen)) {
+                // Every gated workflow PRESENT has passed, and EITHER we've waited
+                // out the grace window (so a slow-to-register builder has had time
+                // to appear) OR this commit was already marked green by a prior
+                // run. The `alreadyGreen` case is important for workflow_run
+                // re-evaluations: without it, a re-eval would start at elapsedMs=0
+                // and regress the required check success -> pending for up to 90s
+                // even though the commit was already green.
                 state = "success"; settled = true;
                 description = `All required area builds passed (${passed.length})`;
               } else if (passed.length > 0) {
-                // Present builders all passed, but we're still inside the grace
-                // window — a path-matched builder may not have registered its run
-                // yet. Hold pending until the window elapses.
+                // Present builders all passed, but this is a first evaluation still
+                // inside the grace window — a path-matched builder may not have
+                // registered its run yet. Hold pending until the window elapses.
                 state = "pending"; settled = false;
                 description = "Confirming all area builds have registered…";
               } else {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -117,24 +117,26 @@ jobs:
               context.payload.pull_request?.head?.sha ||
               context.sha;
 
-            // If a builder COMPLETION triggered this run (workflow_run), then by
-            // definition every builder has already registered its run, so the
-            // grace window — which only guards against a not-yet-registered
-            // builder on a fresh commit — is unnecessary. Skipping it here means a
-            // recovery after a failed builder rerun posts success immediately
-            // rather than waiting the full grace window.
-            const triggeredByBuilderCompletion = context.eventName === "workflow_run";
-
             const { owner, repo } = context.repo;
 
             const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
             const OK = new Set(["success", "skipped", "neutral"]);
 
-            // Was this commit ALREADY marked green by an earlier ci-gate run? If
-            // so, a re-evaluation (e.g. a workflow_run wakeup after a builder
-            // rerun) must not regress the required check back to pending during
-            // its own grace window. We only need this snapshot once, at startup.
-            let alreadyGreen = false;
+            // Did an earlier ci-gate run already SETTLE this commit (post success
+            // or failure)? If so, every builder the PR triggers had already
+            // registered by then, so the grace window — whose only job is to wait
+            // for path-filtered builders to first appear — is no longer needed.
+            // Skipping grace when already settled does two things:
+            //   - a workflow_run re-eval of an already-green commit re-affirms
+            //     success immediately instead of regressing to pending for 90s;
+            //   - recovery after a failed builder rerun (prior status = failure)
+            //     posts success immediately instead of waiting the full window.
+            // Crucially we do NOT skip grace merely because a builder completion
+            // triggered the run: the builder that completed may be a fast cloud
+            // check while a path-filtered mobile build has not registered yet —
+            // skipping grace there could declare success without the heavy
+            // builders. "Already settled" is the correct signal, not the trigger.
+            let alreadySettled = false;
             try {
               const existing = await github.paginate(
                 github.rest.repos.listCommitStatusesForRef,
@@ -143,11 +145,11 @@ jobs:
               // listCommitStatusesForRef returns newest first; find the latest
               // status for our context.
               const latest = existing.find(s => s.context === STATUS_CONTEXT);
-              alreadyGreen = latest?.state === "success";
+              alreadySettled = latest?.state === "success" || latest?.state === "failure";
             } catch (e) {
               core.info(`could not read existing ci-gate-dev status: ${e.message}`);
             }
-            core.info(`alreadyGreen=${alreadyGreen}`);
+            core.info(`alreadySettled=${alreadySettled}`);
 
             // The commit-status `description` field rejects 4-byte Unicode
             // (422 "Description doesn't accept 4-byte Unicode"). Some gated
@@ -194,16 +196,15 @@ jobs:
               } else if (incomplete.length > 0 || unknown.length > 0) {
                 state = "pending"; settled = false;
                 description = `Waiting on: ${[...incomplete, ...unknown].map(r => r.name).join(", ")}`;
-              } else if (passed.length > 0 && (elapsedMs >= GRACE_MS || alreadyGreen || triggeredByBuilderCompletion)) {
-                // Every gated workflow PRESENT has passed. Declare success when any
-                // of these hold:
+              } else if (passed.length > 0 && (elapsedMs >= GRACE_MS || alreadySettled)) {
+                // Every gated workflow PRESENT has passed. Declare success when
+                // either:
                 //   - the grace window has elapsed (a slow-to-register builder has
                 //     had time to appear), OR
-                //   - this commit was already marked green by a prior run (don't
-                //     regress success -> pending on a re-evaluation), OR
-                //   - a builder completion triggered this run, so every builder has
-                //     already registered and grace is moot (this also makes
-                //     recovery after a failed builder rerun post success at once).
+                //   - a prior run already settled this commit (success or failure),
+                //     so all expected builders had already registered by then —
+                //     no need to re-wait grace. This re-affirms green without a
+                //     pending dip, and makes failure->rerun->green post at once.
                 state = "success"; settled = true;
                 description = `All required area builds passed (${passed.length})`;
               } else if (passed.length > 0) {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -117,6 +117,14 @@ jobs:
               context.payload.pull_request?.head?.sha ||
               context.sha;
 
+            // If a builder COMPLETION triggered this run (workflow_run), then by
+            // definition every builder has already registered its run, so the
+            // grace window — which only guards against a not-yet-registered
+            // builder on a fresh commit — is unnecessary. Skipping it here means a
+            // recovery after a failed builder rerun posts success immediately
+            // rather than waiting the full grace window.
+            const triggeredByBuilderCompletion = context.eventName === "workflow_run";
+
             const { owner, repo } = context.repo;
 
             const BAD = new Set(["failure", "cancelled", "timed_out", "action_required", "startup_failure", "stale"]);
@@ -186,14 +194,16 @@ jobs:
               } else if (incomplete.length > 0 || unknown.length > 0) {
                 state = "pending"; settled = false;
                 description = `Waiting on: ${[...incomplete, ...unknown].map(r => r.name).join(", ")}`;
-              } else if (passed.length > 0 && (elapsedMs >= GRACE_MS || alreadyGreen)) {
-                // Every gated workflow PRESENT has passed, and EITHER we've waited
-                // out the grace window (so a slow-to-register builder has had time
-                // to appear) OR this commit was already marked green by a prior
-                // run. The `alreadyGreen` case is important for workflow_run
-                // re-evaluations: without it, a re-eval would start at elapsedMs=0
-                // and regress the required check success -> pending for up to 90s
-                // even though the commit was already green.
+              } else if (passed.length > 0 && (elapsedMs >= GRACE_MS || alreadyGreen || triggeredByBuilderCompletion)) {
+                // Every gated workflow PRESENT has passed. Declare success when any
+                // of these hold:
+                //   - the grace window has elapsed (a slow-to-register builder has
+                //     had time to appear), OR
+                //   - this commit was already marked green by a prior run (don't
+                //     regress success -> pending on a re-evaluation), OR
+                //   - a builder completion triggered this run, so every builder has
+                //     already registered and grace is moot (this also makes
+                //     recovery after a failed builder rerun post success at once).
                 state = "success"; settled = true;
                 description = `All required area builds passed (${passed.length})`;
               } else if (passed.length > 0) {

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -41,22 +41,39 @@ on:
   # landing on dev (no pull_request event ever fired for them) — re-run this
   # workflow against the PR branch to evaluate and post the status.
   workflow_dispatch:
-
-# NOTE: we deliberately do NOT use a `workflow_run` trigger anymore. Each gated
-# builder completing fired a fresh ci-gate run that cancelled the in-flight poll
-# (cancel-in-progress), littering every PR with a pile of "cancelled" CI Gate
-# runs. The single poll loop below already watches every builder to completion,
-# so one run per commit (from pull_request / workflow_dispatch) is sufficient.
-# To avoid declaring success before a slow-to-register builder has appeared, the
-# loop enforces a settling grace window (see GRACE_MS).
+  # Re-evaluate when a gated builder COMPLETES. This is what makes the gate
+  # self-correct after a builder is RE-RUN (e.g. a flaky failure that an
+  # engineer reruns to green) or after a builder registers/finishes later than
+  # the initial poll's settle — without it, the status would be frozen at
+  # whatever the one poll concluded. We listen only on `completed` (never
+  # `requested`), and concurrency below uses cancel-in-progress: false, so these
+  # re-evaluations queue-and-replace instead of producing a litter of cancelled
+  # runs (the original storm).
+  workflow_run:
+    workflows:
+      - "Mobile App iOS Build"
+      - "Mobile App Android Build"
+      - "MentraOS ASG Client Build"
+      - "Mobile App Quality Checks"
+      - "🧪 Test Cloud build"
+      - "🧪 Test SDK build"
+      - "🧪 Test Console build"
+      - "🧪 Test Store build"
+      - "Run Cloud Tests ☁️"
+    types: [completed]
 
 concurrency:
-  # Key by PR BRANCH (like the builder workflows), not by SHA. A new commit on
-  # the same PR then cancels the previous commit's in-flight poll, freeing the
-  # runner and stopping a now-stale evaluation — instead of leaving it to time
-  # out. One live evaluation per PR branch at a time.
-  group: ci-gate-dev-${{ github.event.pull_request.head.ref || github.ref }}
-  cancel-in-progress: true
+  # Key per-PR. For pull_request events github.ref is refs/pull/<n>/merge, which
+  # is unique per PR (so unrelated fork PRs sharing a branch name like "fix" or
+  # "main" do NOT collide). For workflow_run events github.ref is the base branch
+  # (dev), so we fall back to the triggering run's head_sha to keep re-evaluations
+  # grouped with the right PR.
+  group: ci-gate-dev-${{ github.event.workflow_run.head_sha || github.ref }}
+  # Do NOT cancel in progress: re-evaluations from builder completions should
+  # queue and replace, not cancel each other. Cancelling was what littered every
+  # PR with "cancelled" CI Gate runs. The poll loop exits quickly once settled,
+  # so the queue drains fast.
+  cancel-in-progress: false
 
 permissions:
   actions: read


### PR DESCRIPTION
Follow-up to #3208/#3209. Fixes the pile of **`cancelled` "CI Gate (dev)" runs** that show up on every PR.

## What was happening
The `workflow_run` trigger fired a fresh ci-gate run on **every** gated builder completion. With `concurrency: cancel-in-progress: true`, each new run cancelled the in-flight poll → 7+ builders → 7+ cancelled runs per PR. Purely cosmetic (the final run still posted the right status), but it reads as failures in the Actions tab.

## Fix
- **Remove the `workflow_run` trigger.** The single poll loop already watches every builder to completion, so **one run per commit** (from `pull_request` / `workflow_dispatch`) is enough.
- **Add a 90s settle grace window.** The only thing `workflow_run` re-fires bought us was catching a builder that registers its run *late* (e.g. queued behind Mac runners). The loop now won't declare `success` until ≥90s elapsed, so a slow-to-register path-matched builder isn't missed. A real **failure still settles immediately** — no grace.
- **Re-key concurrency from SHA → PR branch** (`github.event.pull_request.head.ref`), matching the builder workflows. A new commit now cancels the previous commit's stale poll, **freeing the runner** instead of letting it time out.

## Re: does this hurt runner-freeing on new commits?
No — and it slightly helps. The cancel-on-new-commit that frees the **Mac** runners lives inside each builder workflow (`ios-build-…-${{ github.ref }}`, `cancel-in-progress: true`), which this PR does **not** touch. This PR only changes the ci-gate workflow (cheap `ubuntu-latest`, no building). Branch-keying ci-gate's own concurrency means a new commit also cancels the old commit's ubuntu poll — net positive.

Result: one tidy `CI Gate (dev)` run per commit, no cancelled-run litter, same correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes logic for the required `ci-gate-dev` check on every PR to `dev`; incorrect grace or settle detection could briefly block merges or miss a late builder until the next poll.
> 
> **Overview**
> Fixes **cancelled CI Gate runs** and stale or flickering `ci-gate-dev` statuses by changing how the dev gate workflow is triggered and how it decides success.
> 
> **Concurrency** is keyed by **head commit SHA** (same SHA for `pull_request` and `workflow_run`) so parallel evaluations do not race on `createCommitStatus`, and **`cancel-in-progress` is disabled** so builder-completion re-runs queue instead of cancelling each other.
> 
> The evaluate script adds a **90s grace window** before declaring success when all *present* gated builders have passed, so path-filtered jobs that register late are not skipped. **Failures still settle immediately.** Success can also post right away when a prior run already left **`success` or `failure`** on that commit (`alreadySettled`), avoiding a green→pending dip on re-eval and fast recovery after a flaky builder rerun—without skipping grace on first-time evaluations where only fast builders have shown up yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eaa63405b99d0caf3eb7e3449f619b52dce0c563. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the CI Gate cancel storm and keeps statuses accurate after builder reruns or late registrations. Restores `workflow_run: [completed]` with queued per-commit concurrency and safer grace handling to avoid flicker and premature success.

- **Bug Fixes**
  - Queue re-evaluations on builder `completed` with `cancel-in-progress: false`, and key concurrency by head SHA across all events to prevent fork branch collisions and cancelled-run litter.
  - Add a 90s settle window on first evaluations to catch late-registering builders; failures still settle immediately.
  - Skip the grace window only when the prior ci-gate status is already settled (success or failure), avoiding green→pending flicker while allowing immediate failure→rerun→green recovery without risking premature success.

<sup>Written for commit eaa63405b99d0caf3eb7e3449f619b52dce0c563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

