### PR TITLE
[codex] Warm iPhone tunnel before iOS run

### DIFF
--- a/mobile/scripts/ios.mjs
+++ b/mobile/scripts/ios.mjs
@@ -9,26 +9,52 @@ await $({stdio: "inherit"})`bun expo prebuild --platform ios`
 await $({stdio: "inherit"})`cp .env ios/.xcode.env.local`
 
 // Get connected iOS devices via devicectl
-const tmpFile = `/tmp/devicectl-${Date.now()}.json`
-await $`xcrun devicectl list devices --json-output ${tmpFile} --timeout 5`
-const json = JSON.parse(await fs.readFile(tmpFile, "utf-8"))
-await fs.remove(tmpFile)
+const listDevices = async () => {
+  const tmpFile = `/tmp/devicectl-${Date.now()}.json`
+  await $`xcrun devicectl list devices --json-output ${tmpFile} --timeout 5`
+  const json = JSON.parse(await fs.readFile(tmpFile, "utf-8"))
+  await fs.remove(tmpFile)
+  return json.result?.devices ?? []
+}
 
 const isIphone = (d) =>
   d.hardwareProperties?.deviceType === "iPhone" ||
   d.capabilities?.some((c) => c.name === "iPhone") ||
   d.deviceProperties?.marketingName?.includes("iPhone")
 
-const pairedIphones = json.result?.devices?.filter(
+let pairedIphones = (await listDevices()).filter(
   (d) =>
     isIphone(d) &&
     d.connectionProperties?.pairingState === "paired" &&
     d.connectionProperties?.tunnelState !== "unavailable",
-) ?? []
+)
 
-const connected = pairedIphones.find(
+let connected = pairedIphones.find(
   (d) => d.connectionProperties?.tunnelState === "connected",
 )
+
+// A newly plugged/unlocked iPhone can show as paired+wired but
+// tunnelState=disconnected until a CoreDevice command touches it. Warm the
+// tunnel once before failing, then re-read the list the build path uses.
+if (!connected && pairedIphones.length > 0) {
+  const candidate = pairedIphones.find((d) => d.connectionProperties?.transportType === "wired") ?? pairedIphones[0]
+  const candidateId = candidate.hardwareProperties?.udid ?? candidate.identifier
+  if (candidateId) {
+    console.log(`Warming iPhone tunnel for ${candidate.deviceProperties.name} (${candidateId})...`)
+    try {
+      await $`xcrun devicectl device info details --device ${candidateId} --timeout 15`
+    } catch (error) {
+      console.warn(`Could not warm iPhone tunnel: ${error}`)
+    }
+    pairedIphones = (await listDevices()).filter(
+      (d) =>
+        isIphone(d) &&
+        d.connectionProperties?.pairingState === "paired" &&
+        d.connectionProperties?.tunnelState !== "unavailable",
+    )
+    connected = pairedIphones.find((d) => d.connectionProperties?.tunnelState === "connected")
+  }
+}
 
 if (!connected) {
   if (pairedIphones.length > 0) {


### PR DESCRIPTION
## Summary

- Refactor `mobile/scripts/ios.mjs` device discovery into a reusable `listDevices()` helper.
- When a paired iPhone is visible but no CoreDevice tunnel is connected, run one `devicectl device info details` call against a wired paired device to warm the tunnel.
- Re-read the device list after the warm-up before deciding whether to fail with the existing disconnected-device guidance.

## Why

A newly plugged or recently unlocked iPhone can appear as paired and wired while `tunnelState` is still `disconnected`. In that state the script fails before giving CoreDevice a chance to establish the tunnel, even though a lightweight CoreDevice command can bring it online.

## Validation

- `node --check mobile/scripts/ios.mjs`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the local iOS dev script’s device-detection retry logic; no app runtime, auth, or release pipeline behavior.
> 
> **Overview**
> Fixes a flaky **local iOS dev** flow where `bun ios` (`mobile/scripts/ios.mjs`) could exit early even though a physical iPhone was plugged in, paired, and wired.
> 
> Device discovery is refactored into a reusable **`listDevices()`** helper. When a paired iPhone is visible but **`tunnelState` is not `connected`**, the script now runs one **`xcrun devicectl device info details`** against a wired paired device (or the first candidate) to **warm the CoreDevice tunnel**, then **re-reads** the device list before applying the existing disconnected-device error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21e7a0f1754e76f4803a16839ee7b09a179466a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->