### PR TITLE
Fix K900 phone frame length encoding

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
@@ -120,49 +120,21 @@ public class K900ProtocolUtils {
     }
 
     /**
-     * Pack raw byte data with K900 BES2700 protocol format for phone-to-device communication
-     * Format: ## + command_type + length(2bytes) + data + $$
-     * Uses little-endian byte order for length field
+     * Pack raw byte data with K900 BES2700 protocol format for phone-to-device communication.
+     * The BES command parser expects the 2-byte length field in big-endian order.
      *
      * @param data The raw data to pack
      * @param cmdType The command type (use CMD_TYPE_STRING for JSON)
      * @return Byte array with packed data according to protocol format
      */
     public static byte[] packDataToK900(byte[] data, byte cmdType) {
-        if (data == null) {
-            return null;
-        }
-
-        int dataLength = data.length;
-
-        // Command structure: ## + type + length(2 bytes) + data + $$
-        byte[] result = new byte[dataLength + 7]; // 2(start) + 1(type) + 2(length) + data + 2(end)
-
-        // Start code ##
-        result[0] = CMD_START_CODE[0]; // #
-        result[1] = CMD_START_CODE[1]; // #
-
-        // Command type
-        result[2] = cmdType;
-
-        // Length (2 bytes, little-endian for phone-to-device)
-        result[3] = (byte) (dataLength & 0xFF);        // LSB first
-        result[4] = (byte) ((dataLength >> 8) & 0xFF); // MSB second
-
-        // Copy the data
-        System.arraycopy(data, 0, result, 5, dataLength);
-
-        // End code $$
-        result[5 + dataLength] = CMD_END_CODE[0]; // $
-        result[6 + dataLength] = CMD_END_CODE[1]; // $
-
-        return result;
+        return packDataCommand(data, cmdType);
     }
 
     /**
      * Pack a JSON string for phone-to-K900 device communication
      * 1. Wrap with C-field: {"C": jsonData}
-     * 2. Then pack with BES2700 protocol using little-endian: ## + type + length + {"C": jsonData} + $$
+     * 2. Then pack with BES2700 protocol: ## + type + length + {"C": jsonData} + $$
      *
      * @param jsonData The JSON string to pack
      * @return Byte array with packed data according to protocol format
@@ -183,7 +155,7 @@ public class K900ProtocolUtils {
             // Convert to string
             String wrappedJson = wrapper.toString();
 
-            // Then pack with BES2700 protocol format using little-endian
+            // Then pack with BES2700 protocol format.
             byte[] jsonBytes = wrappedJson.getBytes(StandardCharsets.UTF_8);
             return packDataToK900(jsonBytes, CMD_TYPE_STRING);
 

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/camera/PhotoRequestTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/camera/PhotoRequestTest.kt
@@ -1,7 +1,8 @@
 package com.mentra.bluetoothsdk.camera
 
-import kotlin.test.Test
-import kotlin.test.assertNull
+import com.mentra.bluetoothsdk.PhotoRequest
+import org.junit.Assert.assertNull
+import org.junit.Test
 
 class PhotoRequestTest {
     @Test

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtilsTest.java
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtilsTest.java
@@ -1,0 +1,24 @@
+package com.mentra.bluetoothsdk.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class K900ProtocolUtilsTest {
+
+    @Test
+    public void packDataToK900_usesBigEndianLengthAt256ByteBoundary() {
+        byte[] payload = new byte[256];
+
+        byte[] packet = K900ProtocolUtils.packDataToK900(payload, K900ProtocolUtils.CMD_TYPE_STRING);
+
+        assertThat(packet).hasSize(263);
+        assertThat(packet[0]).isEqualTo((byte) '#');
+        assertThat(packet[1]).isEqualTo((byte) '#');
+        assertThat(packet[2]).isEqualTo(K900ProtocolUtils.CMD_TYPE_STRING);
+        assertThat(packet[3]).isEqualTo((byte) 0x01);
+        assertThat(packet[4]).isEqualTo((byte) 0x00);
+        assertThat(packet[261]).isEqualTo((byte) '$');
+        assertThat(packet[262]).isEqualTo((byte) '$');
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -4426,39 +4426,16 @@ extension MentraLive {
     /**
      * Pack raw byte data with K900 BES2700 protocol format for phone-to-device communication
      * Format: ## + command_type + length(2bytes) + data + $$
-     * Uses little-endian byte order for length field
+     * The BES command parser expects the 2-byte length field in big-endian order.
      */
     private func packDataToK900(_ data: Data?, cmdType: UInt8) -> Data? {
-        guard let data else { return nil }
-
-        let dataLength = data.count
-
-        // Command structure: ## + type + length(2 bytes) + data + $$
-        var result = Data(capacity: dataLength + 7) // 2(start) + 1(type) + 2(length) + data + 2(end)
-
-        // Start code ##
-        result.append(contentsOf: K900ProtocolUtils.CMD_START_CODE)
-
-        // Command type
-        result.append(cmdType)
-
-        // Length (2 bytes, little-endian for phone-to-device)
-        result.append(UInt8(dataLength & 0xFF)) // LSB first
-        result.append(UInt8((dataLength >> 8) & 0xFF)) // MSB second
-
-        // Copy the data
-        result.append(data)
-
-        // End code $$
-        result.append(contentsOf: K900ProtocolUtils.CMD_END_CODE)
-
-        return result
+        packDataCommand(data, cmdType: cmdType)
     }
 
     /**
      * Pack a JSON string for phone-to-K900 device communication
      * 1. Wrap with C-field: {"C": jsonData}
-     * 2. Then pack with BES2700 protocol using little-endian: ## + type + length + {"C": jsonData} + $$
+     * 2. Then pack with BES2700 protocol: ## + type + length + {"C": jsonData} + $$
      */
     private func packJson(_ jsonData: String?, wakeUp: Bool = false) -> Data? {
         guard let jsonData else { return nil }
@@ -4474,7 +4451,7 @@ extension MentraLive {
             let jsonData = try JSONSerialization.data(withJSONObject: wrapper)
             guard let wrappedJson = String(data: jsonData, encoding: .utf8) else { return nil }
 
-            // Then pack with BES2700 protocol format using little-endian
+            // Then pack with BES2700 protocol format.
             let jsonBytes = wrappedJson.data(using: .utf8)!
             return packDataToK900(jsonBytes, cmdType: K900ProtocolUtils.CMD_TYPE_STRING)
 


### PR DESCRIPTION
## Summary

- Encode phone-to-K900 BES2700 frame lengths as big-endian on both Android and iOS by reusing the canonical protocol packer.
- Update comments that still described phone-to-device K900 frames as little-endian.
- Add Android unit coverage for the 256-byte payload boundary, where the old byte order produced the problematic `00 01` length header.
- Fix stale imports in an existing Bluetooth SDK unit test so the focused unit-test task can compile.

## Why

While investigating K900 transport drops, I used a temporary iOS stress harness that sent 300 K900 frames alternating total packet lengths `262`, `263`, and `264` bytes. Before this fix, every `263`-byte packet had a 256-byte payload and was queued by iOS with this header:

```text
23 23 30 00 01 ...
```

The BES command parser reads the two length bytes as big-endian, so `00 01` is interpreted as a one-byte payload. That makes BES try to parse only the opening `{`, fail JSON parsing, and skip forwarding the command to ASG over UART. The surrounding `262` and `264` byte frames can appear to work, which made the failure look transport-flaky until we hit the exact 256-byte boundary.

With this change, a 256-byte payload is encoded as:

```text
23 23 30 01 00 ...
```

That matches the existing `packDataCommand` implementation and the BES-side parser expectation.

## Reproduction Notes

1. From the old code, send K900 JSON frames whose wrapped payload length is exactly 256 bytes. The temporary stress harness used total packet lengths `262`, `263`, and `264` to make this easy to see.
2. Watch the phone-side BLE queue logs. The broken case emits `23 23 30 00 01` for the 263-byte total packet.
3. Watch ASG UART/raw frame logs. In the failing run, the `263` total-length frames did not appear on ASG even though the iOS BLE writes completed with `status=ok`.
4. Rebuild with this patch and repeat. The 256-byte payload header should be `23 23 30 01 00`.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile/android && ./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.utils.K900ProtocolUtilsTest`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes device command framing on a critical BLE transport path; behavior is narrowly scoped to encoding but wrong frames previously caused silent command loss.
> 
> **Overview**
> **Phone-to-K900 BES2700 frames** no longer use a separate little-endian length encoder. Android `packDataToK900` and iOS `packDataToK900` now delegate to the existing **`packDataCommand`** path so the 2-byte length matches what the BES parser expects (big-endian).
> 
> That fixes a **256-byte payload boundary** bug: little-endian encoding produced `00 01` in the header, which BES read as length 1, broke JSON parsing, and dropped commands on UART while shorter/longer frames could still look fine.
> 
> Adds **`K900ProtocolUtilsTest`** asserting `01 00` for a 256-byte payload. **`PhotoRequestTest`** imports are corrected so unit tests compile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b38f6359315fa88d9a4e53b48affc57cde5a65c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->