### PR TITLE
[codex] Recognize cached Mentra Live peripherals on iOS

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1506,7 +1506,7 @@ class MentraLive: NSObject, SGCManager {
             Bridge.log("Found already-connected peripheral: \(peripheral.name ?? "Unknown")")
             if let name = peripheral.name,
                name == "Xy_A" || name.hasPrefix("XyBLE_") || name.hasPrefix("MENTRA_LIVE_BLE")
-               || name.hasPrefix("MENTRA_LIVE_BT")
+               || name.hasPrefix("MENTRA_LIVE_BT") || name.lowercased().hasPrefix("mentra_live")
             {
                 Bridge.log("Found already-connected peripheral: \(name)")
                 discoveredPeripherals[name] = peripheral


### PR DESCRIPTION
## Scope

Recognize already-connected Mentra Live peripherals on iOS when CoreBluetooth returns a cached peripheral name using lowercase `mentra_live...` casing.

## Why

After reflashing/re-pairing, the iOS pairing flow could sit on the scanning spinner even though CoreBluetooth had already surfaced the glasses as a connected peripheral. The existing cached-peripheral check only accepted the uppercase Mentra Live prefixes, so the cached lowercase name did not get emitted or selected.

## Validation

- Cherry-picked only the original one-line fix onto `origin/aisraelov/island-namespace-wifi`
- Confirmed the PR diff is limited to `mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift`
- Ran `git diff --check origin/aisraelov/island-namespace-wifi...HEAD`

No full iOS build was run for this one-line Swift predicate change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single predicate addition in the BLE connect path; aligns with existing discovery logic and only broadens name matching for Mentra Live devices.
> 
> **Overview**
> Fixes iOS pairing getting stuck on the scan spinner when CoreBluetooth already has the glasses connected but reports a **lowercase** `mentra_live…` peripheral name.
> 
> **`connectById`** now treats cached already-connected peripherals the same as active scan discovery: it accepts names matching `mentra_live` case-insensitively (via `name.lowercased().hasPrefix("mentra_live")`), so those devices are emitted and auto-connected when they match the saved device name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c19e8e2747d383c8a05e5ea3ebd24c9aed0ed77b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->