### PR TITLE
Serialize K900 outbound message sends

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -34,6 +34,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private final SerialPortBridge comManager;
     private boolean isSerialOpen = false;
     private final DebugNotificationManager notificationManager;
+    // Keep normal K900 messages contiguous on the shared ASG-to-BES UART stream.
+    private final Object outboundSendLock = new Object();
     private BesMessageParser messageParser;
 
     // File transfer state management
@@ -143,6 +145,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     @Override
     protected boolean sendMessageInternal(byte[] data) {
+        synchronized (outboundSendLock) {
+            return sendMessageInternalLocked(data);
+        }
+    }
+
+    private boolean sendMessageInternalLocked(byte[] data) {
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 K900 BLUETOOTH SEND DATA");
         Log.d(TAG, "📡 =========================================");


### PR DESCRIPTION
## Summary

- Serialize normal K900 outbound sends in `K900BluetoothManager`.
- Keep an entire chunked JSON message contiguous on the shared ASG-to-BES UART stream.
- Leave BES OTA/file-transfer paths untouched; this only wraps the normal `sendMessageInternal(...)` path.

## Evidence

We investigated the iPhone/Mentra Live Wi-Fi scan timeout path with ASG/BES K900 tracing and a temporary stress command. The original suspicious payload shape was:

```text
{"C":"{\"type\":\"request_wifi_scan\",\"mId\":3##09��{"C":
```

After fixing the iOS K900 length-endian issue separately, a clean stress run without concurrent BES trace pulling no longer reproduced inbound parser corruption:

```text
K900_RAW_TRACE stage=ASG_UART_RX: 208
K900_FRAME_ANOMALY: 0
Failed to parse JSON: 0
Failed to extract payload: 0
No handler found: 0
raw_no_valid_candidate: 0
nested_start_before_first_end_raw: 0
Command handled successfully by modern handler: request_wifi_scan: 10
Command handled successfully by modern handler: k900_transport_stress: 196
```

The remaining concrete failure was outbound send overlap inside ASG while sending chunked phone-facing responses. The clean run captured six failed chunk sends, all lining up with simultaneous chunked sends on different Android threads:

```text
06-23 00:53:09.247 thread=5194 activeId=-1_1782175989161_174 failedChunk=2/3
06-23 00:53:09.327 thread=5379 activeId=-1_1782175989161_175 failedChunk=3/3
06-23 00:53:11.483 thread=5194 activeId=-1_1782175991394_187 failedChunk=2/3
06-23 00:53:11.708 thread=5194 activeId=-1_1782175991615_189 failedChunk=2/3
06-23 00:53:11.859 thread=5380 activeId=-1_1782175991842_191 failedChunk=1/3
06-23 00:53:12.019 thread=5194 activeId=-1_1782175991842_192 failedChunk=3/3
```

Representative overlap windows from the same run:

- IDs 174 and 175 both started chunked sends around `00:53:09` on different threads; one failed chunk `2/3`, the other failed chunk `3/3`.
- IDs 187 and 188 both started around `00:53:11`; ID 187 failed chunk `2/3`.
- IDs 191 and 192 both started around `00:53:12`; one failed chunk `1/3`, the other failed chunk `3/3`.

The code path had no serialization at the logical message level: `sendChunkedJson(...)` sent `chunk 1`, slept, then `chunk 2`, etc. A second caller could enter `sendMessageInternal(...)` during that sleep or during another chunk group and race on the same `SerialPortBridge` output path. Locking only `SerialPortBridge.send(...)` would not be enough because the chunk group itself would still be interleavable.

This PR adds the lock at `K900BluetoothManager.sendMessageInternal(...)`, so the full logical message, including every chunk in a chunked JSON response, is sent contiguously.

## Validation

Validated the staged-only patch in a temporary clean worktree based on `origin/aisraelov/island-namespace-wifi` with only this commit applied. The main checkout still had local debug/probe changes, so this avoided contaminating the compile result.

```bash
./scripts/check-android-compile.sh asg
```

Result:

```text
BUILD SUCCESSFUL in 10s
63 actionable tasks: 19 executed, 44 from cache
```

Notes:

- The temporary worktree needed the existing local `asg_client/StreamPackLite` dependency linked in, since it is an untracked nested checkout in the main workspace.
- The compile emitted only existing deprecation warnings in ASG settings/hardware code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the hot path for all normal K900 phone-facing UART output and can add brief blocking when many responses queue; scope is narrow and file-transfer/OTA paths are not locked.
> 
> **Overview**
> Fixes **outbound send races** on K900 by serializing the normal `sendMessageInternal(...)` path with `outboundSendLock`, so a full logical send—including every chunk in `sendChunkedJson(...)` and pacing sleeps—runs contiguously on the shared ASG-to-BES UART.
> 
> The previous implementation could let multiple Android threads enter sends at once and **interleave** chunked JSON (e.g. corrupted payloads like `...mId":3##09...{"C":`), which showed up as failed chunk sends under concurrent Wi‑Fi scan / stress traffic. **BES OTA and file-transfer** traffic that bypasses this path (e.g. `comManager.sendFile`) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65ca2da41867cc0a036e4aacabd7409da808e558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->