### PR TITLE
[codex] Queue ASG BLE sends to unblock photo upload

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -586,9 +586,12 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         try {
             return future.get(timeoutMs, TimeUnit.MILLISECONDS);
         } catch (TimeoutException e) {
-            future.cancel(true);
-            Log.e(TAG, "Timed out waiting for outbound BLE file transfer start result", e);
-            return false;
+            Log.w(
+                    TAG,
+                    "Timed out waiting for already-running outbound BLE file transfer start; "
+                            + "leaving the worker uninterrupted",
+                    e);
+            return true;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             Log.e(TAG, "Interrupted waiting for outbound BLE file transfer start result", e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -511,17 +511,38 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
             Log.e(TAG, "Rejected outbound BLE file transfer start", e);
             return false;
         } catch (TimeoutException e) {
-            if (future != null) {
-                future.cancel(false);
+            if (future != null && future.cancel(false)) {
+                Log.e(TAG, "Timed out waiting for queued outbound BLE file transfer start", e);
+                return false;
             }
-            Log.e(TAG, "Timed out waiting for outbound BLE file transfer start", e);
-            return false;
+            Log.w(
+                    TAG,
+                    "Timed out waiting for outbound BLE file transfer start after it began; "
+                            + "waiting for the actual start result",
+                    e);
+            return awaitFileTransferStartResult(future);
         } catch (InterruptedException e) {
             if (future != null) {
                 future.cancel(false);
             }
             Thread.currentThread().interrupt();
             Log.e(TAG, "Interrupted waiting for outbound BLE file transfer start", e);
+            return false;
+        } catch (ExecutionException e) {
+            Log.e(TAG, "Outbound BLE file transfer start failed", e);
+            return false;
+        }
+    }
+
+    private boolean awaitFileTransferStartResult(Future<Boolean> future) {
+        if (future == null) {
+            return false;
+        }
+        try {
+            return future.get();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            Log.e(TAG, "Interrupted waiting for outbound BLE file transfer start result", e);
             return false;
         } catch (ExecutionException e) {
             Log.e(TAG, "Outbound BLE file transfer start failed", e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -129,16 +129,26 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     /** Queue an outbound message and notify once the queued send attempt finishes. */
     @Override
     public final boolean sendMessage(byte[] data, SendMessageCallback callback) {
-        return queueOutboundMessage(data, callback, true);
+        return sendMessage(data, callback, null);
+    }
+
+    /** Queue an outbound message with a final worker-side send gate. */
+    @Override
+    public final boolean sendMessage(
+            byte[] data, SendMessageCallback callback, SendMessageGate gate) {
+        return queueOutboundMessage(data, callback, true, gate);
     }
 
     /** Queue an outbound command that should not be broadcast back to phone-facing listeners. */
     protected final boolean sendInternalCommand(byte[] data) {
-        return queueOutboundMessage(data, null, false);
+        return queueOutboundMessage(data, null, false, null);
     }
 
     private boolean queueOutboundMessage(
-            byte[] data, SendMessageCallback callback, boolean broadcastJsonResponses) {
+            byte[] data,
+            SendMessageCallback callback,
+            boolean broadcastJsonResponses,
+            SendMessageGate gate) {
         if (data == null || data.length == 0) {
             return false;
         }
@@ -159,7 +169,8 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
                                                     queuedAtMs,
                                                     traceInfo,
                                                     callback,
-                                                    broadcastJsonResponses)));
+                                                    broadcastJsonResponses,
+                                                    gate)));
             logOutboundQueueEvent(
                     "queued",
                     sequence,
@@ -194,7 +205,8 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
             long queuedAtMs,
             OutboundTraceInfo traceInfo,
             SendMessageCallback callback,
-            boolean broadcastJsonResponses) {
+            boolean broadcastJsonResponses,
+            SendMessageGate gate) {
         long dequeuedAtMs = System.currentTimeMillis();
         logOutboundQueueEvent(
                 "dequeued",
@@ -210,25 +222,44 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
 
         long sendStartedAtMs = System.currentTimeMillis();
         boolean success = false;
+        boolean skipped = false;
         Exception error = null;
         try {
+            if (!shouldSendQueuedMessage(gate)) {
+                skipped = true;
+                return;
+            }
             success = sendMessageNow(data, broadcastJsonResponses);
         } catch (Exception e) {
             error = e;
             Log.e(TAG, "Error sending queued outbound BLE message", e);
         } finally {
-            logOutboundQueueEvent(
-                    "send_result",
-                    sequence,
-                    traceInfo,
-                    queuedAtMs,
-                    sendStartedAtMs - queuedAtMs,
-                    System.currentTimeMillis() - sendStartedAtMs,
-                    success,
-                    data.length,
-                    outboundBleExecutor.getQueue().size(),
-                    error);
+            if (!skipped) {
+                logOutboundQueueEvent(
+                        "send_result",
+                        sequence,
+                        traceInfo,
+                        queuedAtMs,
+                        sendStartedAtMs - queuedAtMs,
+                        System.currentTimeMillis() - sendStartedAtMs,
+                        success,
+                        data.length,
+                        outboundBleExecutor.getQueue().size(),
+                        error);
+            }
             notifySendMessageCallback(callback, success);
+        }
+    }
+
+    private boolean shouldSendQueuedMessage(SendMessageGate gate) {
+        if (gate == null) {
+            return true;
+        }
+        try {
+            return gate.shouldSend();
+        } catch (Exception e) {
+            Log.w(TAG, "Queued send gate failed", e);
+            return false;
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -2,13 +2,23 @@ package com.mentra.asg_client.io.bluetooth.core;
 
 import android.content.Context;
 import android.util.Log;
+
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.interfaces.TransportListener;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.receiver.IntentResponseBroadcaster;
-import java.util.ArrayList;
-import java.util.List;
+
 import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Base implementation of the IBluetoothManager interface. Provides common functionality for all
@@ -16,10 +26,15 @@ import org.json.JSONObject;
  */
 public abstract class BaseBluetoothManager implements ICompanionTransport {
     private static final String TAG = "BaseBluetoothManager";
+    private static final long SIGNIFICANT_QUEUE_DELAY_MS = 250;
+    private static final long SIGNIFICANT_SEND_DURATION_MS = 250;
+    private static final int SIGNIFICANT_QUEUE_SIZE = 5;
 
     protected final Context context;
     protected final List<TransportListener> listeners = new ArrayList<>();
     protected boolean isConnected = false;
+    private final ThreadPoolExecutor outboundBleExecutor;
+    private final AtomicLong outboundBleSequence = new AtomicLong(1);
 
     /**
      * Create a new BaseBluetoothManager
@@ -28,6 +43,20 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
      */
     public BaseBluetoothManager(Context context) {
         this.context = context.getApplicationContext();
+        this.outboundBleExecutor =
+                new ThreadPoolExecutor(
+                        1,
+                        1,
+                        0L,
+                        TimeUnit.MILLISECONDS,
+                        new LinkedBlockingQueue<>(),
+                        runnable -> {
+                            Thread thread =
+                                    new Thread(
+                                            runnable, getClass().getSimpleName() + "-outbound-ble");
+                            thread.setDaemon(true);
+                            return thread;
+                        });
     }
 
     @Override
@@ -84,30 +113,278 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         }
     }
 
-    /**
-     * Template method: broadcasts JSON responses to registered intent listeners, then delegates to
-     * the subclass-specific send implementation.
-     */
+    /** Queue an outbound message so BLE chunk pacing never blocks app/camera handler threads. */
     @Override
     public final boolean sendMessage(byte[] data) {
         if (data == null || data.length == 0) {
             return false;
         }
 
+        byte[] payload = Arrays.copyOf(data, data.length);
+        long sequence = outboundBleSequence.getAndIncrement();
+        long queuedAtMs = System.currentTimeMillis();
+        OutboundTraceInfo traceInfo = OutboundTraceInfo.from(payload);
+
+        try {
+            outboundBleExecutor.execute(
+                    () -> sendQueuedMessage(payload, sequence, queuedAtMs, traceInfo));
+            logOutboundQueueEvent(
+                    "queued",
+                    sequence,
+                    traceInfo,
+                    queuedAtMs,
+                    null,
+                    null,
+                    null,
+                    payload.length,
+                    outboundBleExecutor.getQueue().size(),
+                    null);
+            return true;
+        } catch (RejectedExecutionException e) {
+            logOutboundQueueEvent(
+                    "rejected",
+                    sequence,
+                    traceInfo,
+                    queuedAtMs,
+                    null,
+                    null,
+                    false,
+                    payload.length,
+                    outboundBleExecutor.getQueue().size(),
+                    e);
+            return false;
+        }
+    }
+
+    private void sendQueuedMessage(
+            byte[] data, long sequence, long queuedAtMs, OutboundTraceInfo traceInfo) {
+        long dequeuedAtMs = System.currentTimeMillis();
+        logOutboundQueueEvent(
+                "dequeued",
+                sequence,
+                traceInfo,
+                queuedAtMs,
+                dequeuedAtMs - queuedAtMs,
+                null,
+                null,
+                data.length,
+                outboundBleExecutor.getQueue().size(),
+                null);
+
+        long sendStartedAtMs = System.currentTimeMillis();
+        boolean success = false;
+        Exception error = null;
+        try {
+            success = sendMessageNow(data);
+        } catch (Exception e) {
+            error = e;
+            Log.e(TAG, "Error sending queued outbound BLE message", e);
+        } finally {
+            logOutboundQueueEvent(
+                    "send_result",
+                    sequence,
+                    traceInfo,
+                    queuedAtMs,
+                    sendStartedAtMs - queuedAtMs,
+                    System.currentTimeMillis() - sendStartedAtMs,
+                    success,
+                    data.length,
+                    outboundBleExecutor.getQueue().size(),
+                    error);
+        }
+    }
+
+    /**
+     * Template method: broadcasts JSON responses to registered intent listeners, then delegates to
+     * the subclass-specific send implementation.
+     */
+    private boolean sendMessageNow(byte[] data) {
         BleTraceLogger.logBytes("glasses_to_phone", "asg_ble_output", data);
 
         // Try to broadcast JSON responses to intent listeners
         try {
-            String str = new String(data, "UTF-8");
+            String str = new String(data, StandardCharsets.UTF_8);
             if (str.startsWith("{")) {
                 JSONObject json = new JSONObject(str);
                 IntentResponseBroadcaster.getInstance().broadcastResponse(context, json);
             }
         } catch (Exception e) {
-            // Not valid JSON — skip broadcast, still send over BLE
+            // Not valid JSON; skip broadcast, still send over BLE.
         }
 
         return sendMessageInternal(data);
+    }
+
+    private void logOutboundQueueEvent(
+            String stage,
+            long sequence,
+            OutboundTraceInfo traceInfo,
+            long queuedAtMs,
+            Long queueDelayMs,
+            Long sendDurationMs,
+            Boolean success,
+            int payloadBytes,
+            int queueSize,
+            Exception error) {
+        String warningReason =
+                outboundQueueWarningReason(
+                        stage, queueDelayMs, sendDurationMs, success, queueSize, error);
+        if (warningReason == null) {
+            return;
+        }
+
+        JSONObject payload = new JSONObject();
+        try {
+            payload.put("level", "warning");
+            payload.put("warningReason", warningReason);
+            payload.put("stage", stage);
+            payload.put("sequence", sequence);
+            payload.put("commandType", traceInfo.commandType);
+            putIfPresent(payload, "requestId", traceInfo.requestId);
+            putIfPresent(payload, "appId", traceInfo.appId);
+            if (traceInfo.messageId != -1) {
+                payload.put("messageId", traceInfo.messageId);
+            }
+            payload.put("queuedAtMs", queuedAtMs);
+            payload.put("payloadBytes", payloadBytes);
+            payload.put("queueSize", queueSize);
+            if (queueDelayMs != null) {
+                payload.put("queueDelayMs", queueDelayMs.longValue());
+            }
+            if (sendDurationMs != null) {
+                payload.put("sendDurationMs", sendDurationMs.longValue());
+            }
+            if (success != null) {
+                payload.put("success", success.booleanValue());
+            }
+            if (error != null) {
+                payload.put("errorClass", error.getClass().getSimpleName());
+                payload.put("errorMessage", error.getMessage());
+            }
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+
+        BleTraceLogger.logEvent(
+                "glasses_to_phone", "asg_ble_outbound_queue", traceInfo.commandType, payload);
+    }
+
+    private static String outboundQueueWarningReason(
+            String stage,
+            Long queueDelayMs,
+            Long sendDurationMs,
+            Boolean success,
+            int queueSize,
+            Exception error) {
+        if (error != null) {
+            return "send_error";
+        }
+        if (Boolean.FALSE.equals(success)) {
+            return "send_failed";
+        }
+        if ("rejected".equals(stage)) {
+            return "queue_rejected";
+        }
+        if (queueDelayMs != null && queueDelayMs >= SIGNIFICANT_QUEUE_DELAY_MS) {
+            return "queue_delay";
+        }
+        if (sendDurationMs != null && sendDurationMs >= SIGNIFICANT_SEND_DURATION_MS) {
+            return "send_duration";
+        }
+        if ("queued".equals(stage) && queueSize >= SIGNIFICANT_QUEUE_SIZE) {
+            return "queue_depth";
+        }
+        return null;
+    }
+
+    private static void putIfPresent(JSONObject payload, String key, String value) {
+        try {
+            if (value != null && !value.isEmpty()) {
+                payload.put(key, value);
+            }
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+    }
+
+    private static final class OutboundTraceInfo {
+        final String commandType;
+        final String requestId;
+        final String appId;
+        final long messageId;
+
+        OutboundTraceInfo(String commandType, String requestId, String appId, long messageId) {
+            this.commandType = commandType;
+            this.requestId = requestId;
+            this.appId = appId;
+            this.messageId = messageId;
+        }
+
+        static OutboundTraceInfo from(byte[] data) {
+            String commandType = "unknown";
+            String requestId = null;
+            String appId = null;
+            long messageId = -1;
+
+            try {
+                String str = new String(data, StandardCharsets.UTF_8).trim();
+                if (!str.startsWith("{")) {
+                    return new OutboundTraceInfo("raw", null, null, -1);
+                }
+
+                JSONObject json = new JSONObject(str);
+                commandType = nonEmptyString(json, "type");
+                requestId = nonEmptyString(json, "requestId");
+                appId = nonEmptyString(json, "appId");
+                messageId = optMessageId(json);
+
+                String cValue = json.optString("C", "");
+                if ((commandType == null || commandType.isEmpty()) && !cValue.isEmpty()) {
+                    try {
+                        JSONObject inner = new JSONObject(cValue);
+                        commandType = firstNonEmpty(inner, "type", "t");
+                        requestId = firstNonEmpty(inner, "requestId", "r");
+                        appId = firstNonEmpty(inner, "appId", "a");
+                        messageId = optMessageId(inner);
+                    } catch (Exception ignored) {
+                        // C is often a compact K900 command, not JSON.
+                    }
+
+                    if (commandType == null || commandType.isEmpty()) {
+                        commandType = "k900";
+                    }
+                }
+            } catch (Exception ignored) {
+                // Best-effort trace metadata only.
+            }
+
+            if (commandType == null || commandType.isEmpty()) {
+                commandType = "unknown";
+            }
+            return new OutboundTraceInfo(commandType, requestId, appId, messageId);
+        }
+
+        private static String firstNonEmpty(JSONObject json, String... keys) {
+            for (String key : keys) {
+                String value = nonEmptyString(json, key);
+                if (value != null) {
+                    return value;
+                }
+            }
+            return null;
+        }
+
+        private static String nonEmptyString(JSONObject json, String key) {
+            String value = json.optString(key, "");
+            return value.isEmpty() ? null : value;
+        }
+
+        private static long optMessageId(JSONObject json) {
+            if (json.has("messageId")) {
+                return json.optLong("messageId", -1);
+            }
+            return json.optLong("mId", -1);
+        }
     }
 
     /**
@@ -133,6 +410,7 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     @Override
     public void shutdown() {
         Log.d(TAG, "Shutting down bluetooth manager");
+        outboundBleExecutor.shutdownNow();
         listeners.clear();
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -225,11 +225,26 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         boolean skipped = false;
         Exception error = null;
         try {
-            if (!shouldSendQueuedMessage(gate)) {
-                skipped = true;
-                return;
+            if (gate == null) {
+                success = sendMessageNow(data, broadcastJsonResponses);
+            } else {
+                Object gateLock = gate.lock();
+                if (gateLock == null) {
+                    if (!shouldSendQueuedMessage(gate)) {
+                        skipped = true;
+                        return;
+                    }
+                    success = sendMessageNow(data, broadcastJsonResponses);
+                } else {
+                    synchronized (gateLock) {
+                        if (!shouldSendQueuedMessage(gate)) {
+                            skipped = true;
+                            return;
+                        }
+                        success = sendMessageNow(data, broadcastJsonResponses);
+                    }
+                }
             }
-            success = sendMessageNow(data, broadcastJsonResponses);
         } catch (Exception e) {
             error = e;
             Log.e(TAG, "Error sending queued outbound BLE message", e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -14,8 +14,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
@@ -29,12 +33,15 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     private static final long SIGNIFICANT_QUEUE_DELAY_MS = 250;
     private static final long SIGNIFICANT_SEND_DURATION_MS = 250;
     private static final int SIGNIFICANT_QUEUE_SIZE = 5;
+    private static final long OUTBOUND_FILE_START_TIMEOUT_MS = 30000;
 
     protected final Context context;
     protected final List<TransportListener> listeners = new ArrayList<>();
     protected boolean isConnected = false;
     private final ThreadPoolExecutor outboundBleExecutor;
     private final AtomicLong outboundBleSequence = new AtomicLong(1);
+    private final ThreadLocal<Boolean> outboundBleWorkerThread =
+            ThreadLocal.withInitial(() -> false);
 
     /**
      * Create a new BaseBluetoothManager
@@ -116,6 +123,12 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     /** Queue an outbound message so BLE chunk pacing never blocks app/camera handler threads. */
     @Override
     public final boolean sendMessage(byte[] data) {
+        return sendMessage(data, null);
+    }
+
+    /** Queue an outbound message and notify once the queued send attempt finishes. */
+    @Override
+    public final boolean sendMessage(byte[] data, SendMessageCallback callback) {
         if (data == null || data.length == 0) {
             return false;
         }
@@ -127,7 +140,15 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
 
         try {
             outboundBleExecutor.execute(
-                    () -> sendQueuedMessage(payload, sequence, queuedAtMs, traceInfo));
+                    () ->
+                            runOnOutboundBleWorker(
+                                    () ->
+                                            sendQueuedMessage(
+                                                    payload,
+                                                    sequence,
+                                                    queuedAtMs,
+                                                    traceInfo,
+                                                    callback)));
             logOutboundQueueEvent(
                     "queued",
                     sequence,
@@ -157,7 +178,11 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     }
 
     private void sendQueuedMessage(
-            byte[] data, long sequence, long queuedAtMs, OutboundTraceInfo traceInfo) {
+            byte[] data,
+            long sequence,
+            long queuedAtMs,
+            OutboundTraceInfo traceInfo,
+            SendMessageCallback callback) {
         long dequeuedAtMs = System.currentTimeMillis();
         logOutboundQueueEvent(
                 "dequeued",
@@ -191,6 +216,47 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
                     data.length,
                     outboundBleExecutor.getQueue().size(),
                     error);
+            notifySendMessageCallback(callback, success);
+        }
+    }
+
+    private void runOnOutboundBleWorker(Runnable runnable) {
+        boolean wasWorker = Boolean.TRUE.equals(outboundBleWorkerThread.get());
+        outboundBleWorkerThread.set(true);
+        try {
+            runnable.run();
+        } finally {
+            if (wasWorker) {
+                outboundBleWorkerThread.set(true);
+            } else {
+                outboundBleWorkerThread.remove();
+            }
+        }
+    }
+
+    private <T> T callOnOutboundBleWorker(Callable<T> callable) throws Exception {
+        boolean wasWorker = Boolean.TRUE.equals(outboundBleWorkerThread.get());
+        outboundBleWorkerThread.set(true);
+        try {
+            return callable.call();
+        } finally {
+            if (wasWorker) {
+                outboundBleWorkerThread.set(true);
+            } else {
+                outboundBleWorkerThread.remove();
+            }
+        }
+    }
+
+    private static void notifySendMessageCallback(
+            SendMessageCallback callback, boolean success) {
+        if (callback == null) {
+            return;
+        }
+        try {
+            callback.onSendComplete(success);
+        } catch (Exception e) {
+            Log.w(TAG, "Queued send callback failed", e);
         }
     }
 
@@ -426,7 +492,44 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         return false;
     }
 
-    public boolean sendFile(String path) {
+    public final boolean sendFile(String path) {
+        if (path == null || path.isEmpty()) {
+            return false;
+        }
+
+        if (Boolean.TRUE.equals(outboundBleWorkerThread.get())) {
+            return sendFileInternal(path);
+        }
+
+        Future<Boolean> future = null;
+        try {
+            future =
+                    outboundBleExecutor.submit(
+                            () -> callOnOutboundBleWorker(() -> sendFileInternal(path)));
+            return future.get(OUTBOUND_FILE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        } catch (RejectedExecutionException e) {
+            Log.e(TAG, "Rejected outbound BLE file transfer start", e);
+            return false;
+        } catch (TimeoutException e) {
+            if (future != null) {
+                future.cancel(false);
+            }
+            Log.e(TAG, "Timed out waiting for outbound BLE file transfer start", e);
+            return false;
+        } catch (InterruptedException e) {
+            if (future != null) {
+                future.cancel(false);
+            }
+            Thread.currentThread().interrupt();
+            Log.e(TAG, "Interrupted waiting for outbound BLE file transfer start", e);
+            return false;
+        } catch (ExecutionException e) {
+            Log.e(TAG, "Outbound BLE file transfer start failed", e);
+            return false;
+        }
+    }
+
+    protected boolean sendFileInternal(String path) {
         Log.w(TAG, "sendFile not implemented in " + getClass().getSimpleName());
         return false;
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -129,6 +129,16 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
     /** Queue an outbound message and notify once the queued send attempt finishes. */
     @Override
     public final boolean sendMessage(byte[] data, SendMessageCallback callback) {
+        return queueOutboundMessage(data, callback, true);
+    }
+
+    /** Queue an outbound command that should not be broadcast back to phone-facing listeners. */
+    protected final boolean sendInternalCommand(byte[] data) {
+        return queueOutboundMessage(data, null, false);
+    }
+
+    private boolean queueOutboundMessage(
+            byte[] data, SendMessageCallback callback, boolean broadcastJsonResponses) {
         if (data == null || data.length == 0) {
             return false;
         }
@@ -148,7 +158,8 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
                                                     sequence,
                                                     queuedAtMs,
                                                     traceInfo,
-                                                    callback)));
+                                                    callback,
+                                                    broadcastJsonResponses)));
             logOutboundQueueEvent(
                     "queued",
                     sequence,
@@ -182,7 +193,8 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
             long sequence,
             long queuedAtMs,
             OutboundTraceInfo traceInfo,
-            SendMessageCallback callback) {
+            SendMessageCallback callback,
+            boolean broadcastJsonResponses) {
         long dequeuedAtMs = System.currentTimeMillis();
         logOutboundQueueEvent(
                 "dequeued",
@@ -200,7 +212,7 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         boolean success = false;
         Exception error = null;
         try {
-            success = sendMessageNow(data);
+            success = sendMessageNow(data, broadcastJsonResponses);
         } catch (Exception e) {
             error = e;
             Log.e(TAG, "Error sending queued outbound BLE message", e);
@@ -264,18 +276,20 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
      * Template method: broadcasts JSON responses to registered intent listeners, then delegates to
      * the subclass-specific send implementation.
      */
-    private boolean sendMessageNow(byte[] data) {
+    private boolean sendMessageNow(byte[] data, boolean broadcastJsonResponses) {
         BleTraceLogger.logBytes("glasses_to_phone", "asg_ble_output", data);
 
         // Try to broadcast JSON responses to intent listeners
-        try {
-            String str = new String(data, StandardCharsets.UTF_8);
-            if (str.startsWith("{")) {
-                JSONObject json = new JSONObject(str);
-                IntentResponseBroadcaster.getInstance().broadcastResponse(context, json);
+        if (broadcastJsonResponses) {
+            try {
+                String str = new String(data, StandardCharsets.UTF_8);
+                if (str.startsWith("{")) {
+                    JSONObject json = new JSONObject(str);
+                    IntentResponseBroadcaster.getInstance().broadcastResponse(context, json);
+                }
+            } catch (Exception e) {
+                // Not valid JSON; skip broadcast, still send over BLE.
             }
-        } catch (Exception e) {
-            // Not valid JSON; skip broadcast, still send over BLE.
         }
 
         return sendMessageInternal(data);
@@ -520,7 +534,7 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
                     "Timed out waiting for outbound BLE file transfer start after it began; "
                             + "waiting for the actual start result",
                     e);
-            return awaitFileTransferStartResult(future);
+            return awaitFileTransferStartResult(future, OUTBOUND_FILE_START_TIMEOUT_MS);
         } catch (InterruptedException e) {
             if (future != null) {
                 future.cancel(false);
@@ -534,12 +548,16 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         }
     }
 
-    private boolean awaitFileTransferStartResult(Future<Boolean> future) {
+    private boolean awaitFileTransferStartResult(Future<Boolean> future, long timeoutMs) {
         if (future == null) {
             return false;
         }
         try {
-            return future.get();
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            future.cancel(true);
+            Log.e(TAG, "Timed out waiting for outbound BLE file transfer start result", e);
+            return false;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             Log.e(TAG, "Interrupted waiting for outbound BLE file transfer start result", e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
@@ -24,10 +24,10 @@ public interface IBluetoothManager {
     void disconnect();
 
     /**
-     * Send a message to the connected device.
+     * Queue a message to send to the connected device.
      *
      * @param data The data to send
-     * @return true if the data was sent successfully, false otherwise
+     * @return true if the data was accepted for outbound delivery, false otherwise
      */
     boolean sendMessage(byte[] data);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
@@ -27,6 +27,10 @@ public interface IBluetoothManager {
         void onSendComplete(boolean success);
     }
 
+    interface SendMessageGate {
+        boolean shouldSend();
+    }
+
     /**
      * Queue a message to send to the connected device.
      *
@@ -44,6 +48,16 @@ public interface IBluetoothManager {
      * @return true if the data was accepted for outbound delivery, false otherwise
      */
     boolean sendMessage(byte[] data, SendMessageCallback callback);
+
+    /**
+     * Queue a message and check whether it is still valid immediately before the queued send.
+     *
+     * @param data The data to send
+     * @param callback Optional callback invoked after the queued send attempt completes
+     * @param gate Optional gate checked on the outbound worker before writing
+     * @return true if the data was accepted for outbound delivery, false otherwise
+     */
+    boolean sendMessage(byte[] data, SendMessageCallback callback, SendMessageGate gate);
 
     /**
      * Send a file to the connected device.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
@@ -29,6 +29,8 @@ public interface IBluetoothManager {
 
     interface SendMessageGate {
         boolean shouldSend();
+
+        Object lock();
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
@@ -23,6 +23,10 @@ public interface IBluetoothManager {
     /** Disconnect from the currently connected device */
     void disconnect();
 
+    interface SendMessageCallback {
+        void onSendComplete(boolean success);
+    }
+
     /**
      * Queue a message to send to the connected device.
      *
@@ -32,10 +36,20 @@ public interface IBluetoothManager {
     boolean sendMessage(byte[] data);
 
     /**
+     * Queue a message to send to the connected device and notify when the queued send attempt
+     * completes.
+     *
+     * @param data The data to send
+     * @param callback Optional callback invoked after the queued send attempt completes
+     * @return true if the data was accepted for outbound delivery, false otherwise
+     */
+    boolean sendMessage(byte[] data, SendMessageCallback callback);
+
+    /**
      * Send a file to the connected device.
      *
      * @param filePath path to the file
-     * @return true if transfer started or completed successfully
+     * @return true if transfer start was accepted after earlier outbound messages drained
      */
     boolean sendFile(String filePath);
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -242,12 +242,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         return sent;
     }
 
-    /**
-     * Sends an internal command directly to the glasses transport without broadcasting it as a
-     * phone-facing command response.
-     */
+    /** Queues an internal command without broadcasting it as a phone-facing command response. */
     public boolean sendCommandToGlasses(byte[] data) {
-        return sendMessageInternal(data);
+        return sendInternalCommand(data);
     }
 
     private boolean sendChunkedJson(String originalJson) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
+
 import com.mentra.asg_client.io.bluetooth.core.BaseBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesMessageParser;
@@ -12,6 +13,9 @@ import com.mentra.asg_client.io.bluetooth.utils.DebugNotificationManager;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.reporting.domains.BluetoothReporting;
 import com.mentra.asg_client.service.core.AsgClientService;
+
+import org.json.JSONObject;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -22,7 +26,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
-import org.json.JSONObject;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -53,7 +57,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final int MAX_BACKOFF_MS = 1000; // Cap exponential backoff at 1 second
     private static final int PACING_DELAY_MS =
             75; // Delay between successful packets - BES2700 needs time to drain BLE TX
+    private static final long SIGNIFICANT_CHUNK_TRACE_DURATION_MS = 250;
+    private static final long SIGNIFICANT_CHUNK_SEND_DURATION_MS = 250;
+    private static final long SIGNIFICANT_CHUNK_SPACING_MS = PACING_DELAY_MS + 150;
     private int consecutiveFailures = 0;
+    private final AtomicLong bleChunkTraceSequence = new AtomicLong(1);
 
     // Inner class to track file transfer state
     private static class FileTransferSession {
@@ -178,7 +186,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 if (originalData.startsWith("{") && !BesWireFormat.isCWrappedJson(originalData)) {
                     Log.d(
                             TAG,
-                            "📡 🔧 JSON data detected, applying C-wrapping and protocol formatting...");
+                            "📡 🔧 JSON data detected, applying C-wrapping and protocol"
+                                    + " formatting...");
                     Log.d(TAG, "📡 📦 JSON DATA BEFORE C-WRAPPING: " + originalData);
                     String wrappedJson = BesWireFormat.createTransmissionWrapperJson(originalData);
                     if (MessageChunker.needsChunking(wrappedJson)) {
@@ -243,21 +252,25 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     private boolean sendChunkedJson(String originalJson) {
         try {
-            long messageId = -1;
-            try {
-                JSONObject original = new JSONObject(originalJson);
-                messageId = original.optLong("mId", -1);
-            } catch (Exception ignored) {
-                // Chunking also supports non-ACK messages.
-            }
+            OutgoingJsonTraceInfo traceInfo = parseOutgoingJsonTraceInfo(originalJson);
 
-            List<JSONObject> chunks = MessageChunker.createChunks(originalJson, messageId);
+            List<JSONObject> chunks =
+                    MessageChunker.createChunks(originalJson, traceInfo.messageId);
             Log.d(TAG, "📡 🧩 Sending chunked JSON as " + chunks.size() + " chunks");
 
             boolean allSent = true;
+            long previousSendAtMs = -1;
+            long chunkedSendStartedAtMs = System.currentTimeMillis();
+            long maxChunkSendDurationMs = 0;
+            long maxChunkSpacingMs = 0;
             for (int i = 0; i < chunks.size(); i++) {
-                byte[] chunkData =
-                        BesWireFormat.formatMessageForTransmission(chunks.get(i).toString());
+                JSONObject chunk = chunks.get(i);
+                String chunkJson = chunk.toString();
+                byte[] chunkData = BesWireFormat.formatMessageForTransmission(chunkJson);
+                long sequence = bleChunkTraceSequence.getAndIncrement();
+                logOutgoingBleChunk(
+                        "created", traceInfo, chunk, sequence, chunkData, chunkJson, null, null,
+                        null, null);
                 Log.d(
                         TAG,
                         "📡 🧩 Sending chunk "
@@ -267,7 +280,29 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                                 + " ("
                                 + chunkData.length
                                 + " bytes packed)");
+                long sendStartedAtMs = System.currentTimeMillis();
                 boolean sent = comManager.send(chunkData);
+                long sendFinishedAtMs = System.currentTimeMillis();
+                long sendDurationMs = sendFinishedAtMs - sendStartedAtMs;
+                maxChunkSendDurationMs = Math.max(maxChunkSendDurationMs, sendDurationMs);
+                Long timeSincePreviousChunkSendMs =
+                        previousSendAtMs >= 0 ? sendStartedAtMs - previousSendAtMs : null;
+                if (timeSincePreviousChunkSendMs != null) {
+                    maxChunkSpacingMs =
+                            Math.max(maxChunkSpacingMs, timeSincePreviousChunkSendMs.longValue());
+                }
+                previousSendAtMs = sendStartedAtMs;
+                logOutgoingBleChunk(
+                        "send_result",
+                        traceInfo,
+                        chunk,
+                        sequence,
+                        chunkData,
+                        chunkJson,
+                        sent,
+                        sendDurationMs,
+                        timeSincePreviousChunkSendMs,
+                        i < chunks.size() - 1 ? PACING_DELAY_MS : null);
                 allSent = allSent && sent;
                 if (!sent) {
                     Log.w(
@@ -290,10 +325,246 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 }
             }
 
+            logOutgoingBleChunkSummary(
+                    traceInfo,
+                    chunks.size(),
+                    System.currentTimeMillis() - chunkedSendStartedAtMs,
+                    maxChunkSendDurationMs,
+                    maxChunkSpacingMs,
+                    allSent);
             return allSent;
         } catch (Exception e) {
             Log.e(TAG, "Error chunking JSON for K900 transmission", e);
             return false;
+        }
+    }
+
+    private OutgoingJsonTraceInfo parseOutgoingJsonTraceInfo(String originalJson) {
+        int messageBytes = utf8ByteCount(originalJson);
+        try {
+            JSONObject original = new JSONObject(originalJson);
+            return new OutgoingJsonTraceInfo(
+                    nonEmptyString(original, "type"),
+                    nonEmptyString(original, "requestId"),
+                    nonEmptyString(original, "appId"),
+                    original.optLong("mId", -1),
+                    messageBytes);
+        } catch (Exception ignored) {
+            // Chunking also supports non-JSON/ACK-less messages; keep trace logging best-effort.
+            return new OutgoingJsonTraceInfo(null, null, null, -1, messageBytes);
+        }
+    }
+
+    private void logOutgoingBleChunk(
+            String stage,
+            OutgoingJsonTraceInfo traceInfo,
+            JSONObject chunk,
+            long sequence,
+            byte[] packedData,
+            String chunkJson,
+            Boolean success,
+            Long sendDurationMs,
+            Long timeSincePreviousChunkSendMs,
+            Integer pacingDelayMs) {
+        String warningReason =
+                outgoingChunkWarningReason(success, sendDurationMs, timeSincePreviousChunkSendMs);
+        if (warningReason == null) {
+            return;
+        }
+
+        JSONObject payload = new JSONObject();
+        try {
+            int chunkIndex = optIntFallback(chunk, "chunk", "c", -1);
+            int totalChunks = optIntFallback(chunk, "total", "n", -1);
+            String chunkData = optStringFallback(chunk, "data", "d");
+            String chunkId = optStringFallback(chunk, "chunkId", "id");
+
+            payload.put("level", "warning");
+            payload.put("warningReason", warningReason);
+            payload.put("stage", stage);
+            payload.put("sequence", sequence);
+            payload.put("chunked", true);
+            putIfPresent(payload, "commandType", traceInfo.commandType);
+            putIfPresent(payload, "requestId", traceInfo.requestId);
+            putIfPresent(payload, "appId", traceInfo.appId);
+            if (traceInfo.messageId != -1) {
+                payload.put("messageId", traceInfo.messageId);
+            }
+            putIfPresent(payload, "chunkId", chunkId);
+            if (chunkIndex >= 0) {
+                payload.put("chunkIndex", chunkIndex);
+                payload.put("chunkNumber", chunkIndex + 1);
+            }
+            if (totalChunks > 0) {
+                payload.put("totalChunks", totalChunks);
+            }
+            payload.put("packedBytes", packedData != null ? packedData.length : 0);
+            payload.put("payloadBytes", utf8ByteCount(chunkData));
+            payload.put("chunkJsonBytes", utf8ByteCount(chunkJson));
+            payload.put("messageBytes", traceInfo.messageBytes);
+            if (success != null) {
+                payload.put("success", success.booleanValue());
+            }
+            if (sendDurationMs != null) {
+                payload.put("sendDurationMs", sendDurationMs.longValue());
+            }
+            if (timeSincePreviousChunkSendMs != null) {
+                payload.put(
+                        "timeSincePreviousChunkSendMs", timeSincePreviousChunkSendMs.longValue());
+            }
+            if (pacingDelayMs != null) {
+                payload.put("pacingDelayMs", pacingDelayMs.intValue());
+            }
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+
+        BleTraceLogger.logEvent(
+                "glasses_to_phone",
+                "sdk_ble_chunk",
+                traceInfo.commandType != null ? traceInfo.commandType : "chunked",
+                payload);
+    }
+
+    private void logOutgoingBleChunkSummary(
+            OutgoingJsonTraceInfo traceInfo,
+            int totalChunks,
+            long durationMs,
+            long maxChunkSendDurationMs,
+            long maxChunkSpacingMs,
+            boolean success) {
+        String warningReason =
+                outgoingChunkSummaryWarningReason(
+                        success, durationMs, maxChunkSendDurationMs, maxChunkSpacingMs);
+        if (warningReason == null) {
+            return;
+        }
+
+        JSONObject payload = new JSONObject();
+        try {
+            payload.put("level", "warning");
+            payload.put("warningReason", warningReason);
+            payload.put("stage", "summary");
+            payload.put("sequence", bleChunkTraceSequence.getAndIncrement());
+            payload.put("chunked", true);
+            putIfPresent(payload, "commandType", traceInfo.commandType);
+            putIfPresent(payload, "requestId", traceInfo.requestId);
+            putIfPresent(payload, "appId", traceInfo.appId);
+            if (traceInfo.messageId != -1) {
+                payload.put("messageId", traceInfo.messageId);
+            }
+            payload.put("totalChunks", totalChunks);
+            payload.put("messageBytes", traceInfo.messageBytes);
+            payload.put("durationMs", durationMs);
+            payload.put("maxChunkSendDurationMs", maxChunkSendDurationMs);
+            payload.put("maxChunkSpacingMs", maxChunkSpacingMs);
+            payload.put("pacingDelayMs", PACING_DELAY_MS);
+            payload.put("success", success);
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+
+        BleTraceLogger.logEvent(
+                "glasses_to_phone",
+                "sdk_ble_chunk",
+                traceInfo.commandType != null ? traceInfo.commandType : "chunked",
+                payload);
+    }
+
+    private static String outgoingChunkWarningReason(
+            Boolean success, Long sendDurationMs, Long timeSincePreviousChunkSendMs) {
+        if (Boolean.FALSE.equals(success)) {
+            return "chunk_send_failed";
+        }
+        if (sendDurationMs != null && sendDurationMs >= SIGNIFICANT_CHUNK_SEND_DURATION_MS) {
+            return "chunk_send_duration";
+        }
+        if (timeSincePreviousChunkSendMs != null
+                && timeSincePreviousChunkSendMs >= SIGNIFICANT_CHUNK_SPACING_MS) {
+            return "chunk_spacing";
+        }
+        return null;
+    }
+
+    private static String outgoingChunkSummaryWarningReason(
+            boolean success, long durationMs, long maxChunkSendDurationMs, long maxChunkSpacingMs) {
+        if (!success) {
+            return "chunked_message_failed";
+        }
+        if (durationMs >= SIGNIFICANT_CHUNK_TRACE_DURATION_MS) {
+            return "chunked_message_duration";
+        }
+        if (maxChunkSendDurationMs >= SIGNIFICANT_CHUNK_SEND_DURATION_MS) {
+            return "chunk_send_duration";
+        }
+        if (maxChunkSpacingMs >= SIGNIFICANT_CHUNK_SPACING_MS) {
+            return "chunk_spacing";
+        }
+        return null;
+    }
+
+    private static String optStringFallback(JSONObject json, String fullKey, String compactKey) {
+        if (json == null) {
+            return null;
+        }
+        if (json.has(fullKey)) {
+            return json.optString(fullKey, null);
+        }
+        if (json.has(compactKey)) {
+            return json.optString(compactKey, null);
+        }
+        return null;
+    }
+
+    private static int optIntFallback(
+            JSONObject json, String fullKey, String compactKey, int defaultValue) {
+        if (json == null) {
+            return defaultValue;
+        }
+        if (json.has(fullKey)) {
+            return json.optInt(fullKey, defaultValue);
+        }
+        return json.optInt(compactKey, defaultValue);
+    }
+
+    private static String nonEmptyString(JSONObject json, String key) {
+        String value = json.optString(key, "");
+        return value.isEmpty() ? null : value;
+    }
+
+    private static void putIfPresent(JSONObject payload, String key, String value) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        try {
+            payload.put(key, value);
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+    }
+
+    private static int utf8ByteCount(String value) {
+        return value != null ? value.getBytes(StandardCharsets.UTF_8).length : 0;
+    }
+
+    private static class OutgoingJsonTraceInfo {
+        final String commandType;
+        final String requestId;
+        final String appId;
+        final long messageId;
+        final int messageBytes;
+
+        OutgoingJsonTraceInfo(
+                String commandType,
+                String requestId,
+                String appId,
+                long messageId,
+                int messageBytes) {
+            this.commandType = commandType;
+            this.requestId = requestId;
+            this.appId = appId;
+            this.messageId = messageId;
+            this.messageBytes = messageBytes;
         }
     }
 
@@ -466,7 +737,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         if (svc != null) {
                             Log.i(
                                     TAG,
-                                    "📋 BES version updated from UART — re-sending version info to phone");
+                                    "📋 BES version updated from UART — re-sending version info to"
+                                            + " phone");
                             svc.sendVersionInfo();
                         }
                     });

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -930,7 +930,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      * @return true if transfer started successfully
      */
     @Override
-    public boolean sendFile(String filePath) {
+    protected boolean sendFileInternal(String filePath) {
         if (!isSerialOpen) {
             Log.e(TAG, "Cannot send file - serial port not open");
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -34,9 +34,10 @@ public class CommunicationManager
 
         this.reliableManager =
                 new ReliableMessageManager(
-                        data -> {
+                        (data, callback) -> {
                             if (this.transport != null) {
-                                return this.transport.sendMessage(data);
+                                return this.transport.sendMessage(
+                                        data, callback != null ? callback::onComplete : null);
                             }
                             return false;
                         });

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -1,6 +1,7 @@
 package com.mentra.asg_client.service.communication.managers;
 
 import android.util.Log;
+import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.models.NetworkInfo;
@@ -39,13 +40,31 @@ public class CommunicationManager
                                 return this.transport.sendMessage(
                                         data,
                                         callback != null ? callback::onComplete : null,
-                                        gate != null ? gate::shouldSend : null);
+                                        adaptSendGate(gate));
                             }
                             return false;
                         });
 
         // Enable by default - worst case with old phones is just some extra retries
         this.reliableManager.setEnabled(true, 1);
+    }
+
+    private static IBluetoothManager.SendMessageGate adaptSendGate(
+            ReliableMessageManager.SendGate gate) {
+        if (gate == null) {
+            return null;
+        }
+        return new IBluetoothManager.SendMessageGate() {
+            @Override
+            public boolean shouldSend() {
+                return gate.shouldSend();
+            }
+
+            @Override
+            public Object lock() {
+                return gate.lock();
+            }
+        };
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -34,10 +34,12 @@ public class CommunicationManager
 
         this.reliableManager =
                 new ReliableMessageManager(
-                        (data, callback) -> {
+                        (data, callback, gate) -> {
                             if (this.transport != null) {
                                 return this.transport.sendMessage(
-                                        data, callback != null ? callback::onComplete : null);
+                                        data,
+                                        callback != null ? callback::onComplete : null,
+                                        gate != null ? gate::shouldSend : null);
                             }
                             return false;
                         });

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.security.SecureRandom;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -23,6 +24,7 @@ public class ReliableMessageManager {
     private static final int MAX_RETRIES = 2;             // 2 retries (3 total attempts)
     private static final long MAX_PENDING_MESSAGES = 10;  // Resource constraint
     private static final long CLEANUP_INTERVAL_MS = 30000; // 30 seconds
+    private static final long QUEUED_SEND_CLEANUP_MS = CLEANUP_INTERVAL_MS * 10; // 5 minutes
 
     // State
     private final ConcurrentHashMap<Long, PendingMessage> pendingMessages;
@@ -53,6 +55,8 @@ public class ReliableMessageManager {
 
     public interface SendGate {
         boolean shouldSend();
+
+        Object lock();
     }
 
     /**
@@ -126,7 +130,7 @@ public class ReliableMessageManager {
                                     totalFailures++;
                                 }
                             },
-                            () -> pendingMessages.get(messageId) == pending);
+                            pendingGate(messageId, pending));
             if (!accepted && pendingMessages.remove(messageId, pending)) {
                 totalFailures++;
             }
@@ -143,17 +147,23 @@ public class ReliableMessageManager {
      * @param messageId The message ID being acknowledged
      */
     public void handleAck(long messageId) {
-        PendingMessage pending = pendingMessages.remove(messageId);
+        PendingMessage pending = pendingMessages.get(messageId);
         if (pending != null) {
-            // Cancel timeout
-            if (pending.timeoutRunnable != null) {
-                retryHandler.removeCallbacks(pending.timeoutRunnable);
-            }
-            totalAcksReceived++;
+            synchronized (pending) {
+                if (!pendingMessages.remove(messageId, pending)) {
+                    return;
+                }
 
-            Log.d(TAG, String.format("ACK received for message %d (attempts: %d, time: %dms)",
-                messageId, pending.retryCount + 1,
-                System.currentTimeMillis() - pending.timestamp));
+                // Cancel timeout
+                if (pending.timeoutRunnable != null) {
+                    retryHandler.removeCallbacks(pending.timeoutRunnable);
+                }
+                totalAcksReceived++;
+
+                Log.d(TAG, String.format("ACK received for message %d (attempts: %d, time: %dms)",
+                    messageId, pending.retryCount + 1,
+                    System.currentTimeMillis() - pending.timestamp));
+            }
         }
     }
 
@@ -249,7 +259,7 @@ public class ReliableMessageManager {
                                 totalFailures++;
                             }
                         },
-                        () -> pendingMessages.get(messageId) == retryPending);
+                        pendingGate(messageId, retryPending));
         if (!accepted && pendingMessages.remove(messageId, retryPending)) {
             totalFailures++;
         }
@@ -275,6 +285,20 @@ public class ReliableMessageManager {
         }
     }
 
+    private SendGate pendingGate(long messageId, PendingMessage pending) {
+        return new SendGate() {
+            @Override
+            public boolean shouldSend() {
+                return pendingMessages.get(messageId) == pending;
+            }
+
+            @Override
+            public Object lock() {
+                return pending;
+            }
+        };
+    }
+
     /**
      * Schedule periodic cleanup of old messages.
      */
@@ -291,22 +315,31 @@ public class ReliableMessageManager {
     private void cleanupOldMessages() {
         long now = System.currentTimeMillis();
         long cutoff = now - (CLEANUP_INTERVAL_MS * 2);
+        long queuedCutoff = now - QUEUED_SEND_CLEANUP_MS;
 
-        pendingMessages.entrySet().removeIf(entry -> {
+        for (Map.Entry<Long, PendingMessage> entry : pendingMessages.entrySet()) {
+            long messageId = entry.getKey();
             PendingMessage pending = entry.getValue();
-            // The ACK timer is armed only after the queued transport send completes.
-            if (pending.timeoutRunnable == null) {
-                return false;
-            }
-            if (pending.timestamp < cutoff) {
-                Log.w(TAG, "Removing stale message: " + entry.getKey());
-                if (pending.timeoutRunnable != null) {
-                    retryHandler.removeCallbacks(pending.timeoutRunnable);
+
+            synchronized (pending) {
+                // The ACK timer is armed only after the queued transport send completes.
+                if (pending.timeoutRunnable == null) {
+                    if (pending.timestamp < queuedCutoff
+                            && pendingMessages.remove(messageId, pending)) {
+                        Log.w(TAG, "Removing stale queued message: " + messageId);
+                        totalFailures++;
+                    }
+                    continue;
                 }
-                return true;
+
+                if (pending.timestamp < cutoff
+                        && pendingMessages.remove(messageId, pending)) {
+                    Log.w(TAG, "Removing stale message: " + messageId);
+                    retryHandler.removeCallbacks(pending.timeoutRunnable);
+                    totalFailures++;
+                }
             }
-            return false;
-        });
+        }
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
@@ -294,6 +294,10 @@ public class ReliableMessageManager {
 
         pendingMessages.entrySet().removeIf(entry -> {
             PendingMessage pending = entry.getValue();
+            // The ACK timer is armed only after the queued transport send completes.
+            if (pending.timeoutRunnable == null) {
+                return false;
+            }
             if (pending.timestamp < cutoff) {
                 Log.w(TAG, "Removing stale message: " + entry.getKey());
                 if (pending.timeoutRunnable != null) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
@@ -44,11 +44,15 @@ public class ReliableMessageManager {
      * Implemented by the class that has access to Bluetooth.
      */
     public interface IMessageSender {
-        boolean sendData(byte[] data, SendCompletionCallback callback);
+        boolean sendData(byte[] data, SendCompletionCallback callback, SendGate gate);
     }
 
     public interface SendCompletionCallback {
         void onComplete(boolean success);
+    }
+
+    public interface SendGate {
+        boolean shouldSend();
     }
 
     /**
@@ -121,7 +125,8 @@ public class ReliableMessageManager {
                                 } else if (pendingMessages.remove(messageId, pending)) {
                                     totalFailures++;
                                 }
-                            });
+                            },
+                            () -> pendingMessages.get(messageId) == pending);
             if (!accepted && pendingMessages.remove(messageId, pending)) {
                 totalFailures++;
             }
@@ -243,7 +248,8 @@ public class ReliableMessageManager {
                             } else if (pendingMessages.remove(messageId, retryPending)) {
                                 totalFailures++;
                             }
-                        });
+                        },
+                        () -> pendingMessages.get(messageId) == retryPending);
         if (!accepted && pendingMessages.remove(messageId, retryPending)) {
             totalFailures++;
         }
@@ -255,13 +261,14 @@ public class ReliableMessageManager {
      * @return true if sent successfully, false otherwise
      */
     private boolean sendDirectly(JSONObject message) {
-        return sendDirectly(message, null);
+        return sendDirectly(message, null, null);
     }
 
-    private boolean sendDirectly(JSONObject message, SendCompletionCallback callback) {
+    private boolean sendDirectly(
+            JSONObject message, SendCompletionCallback callback, SendGate gate) {
         try {
             String jsonString = message.toString();
-            return messageSender.sendData(jsonString.getBytes(), callback);
+            return messageSender.sendData(jsonString.getBytes(), callback, gate);
         } catch (Exception e) {
             Log.e(TAG, "Error sending message", e);
             return false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
@@ -44,7 +44,11 @@ public class ReliableMessageManager {
      * Implemented by the class that has access to Bluetooth.
      */
     public interface IMessageSender {
-        boolean sendData(byte[] data);
+        boolean sendData(byte[] data, SendCompletionCallback callback);
+    }
+
+    public interface SendCompletionCallback {
+        void onComplete(boolean success);
     }
 
     /**
@@ -103,15 +107,23 @@ public class ReliableMessageManager {
             long messageId = generateMessageId();
             message.put("mId", messageId);
 
-            // Track the message
-            trackMessage(messageId, message);
-
-            // Send immediately
-            boolean sent = sendDirectly(message);
-            if (sent) {
-                totalMessagesSent++;
+            // Send immediately, then start ACK tracking only after the queued transport send
+            // actually completes.
+            boolean accepted =
+                    sendDirectly(
+                            message,
+                            success -> {
+                                if (success) {
+                                    trackMessage(messageId, message, 0, ACK_TIMEOUT_MS);
+                                    totalMessagesSent++;
+                                } else {
+                                    totalFailures++;
+                                }
+                            });
+            if (!accepted) {
+                totalFailures++;
             }
-            return sent;
+            return accepted;
 
         } catch (JSONException e) {
             Log.e(TAG, "Error adding message ID", e);
@@ -167,15 +179,16 @@ public class ReliableMessageManager {
      * @param messageId The message ID to track
      * @param message The message content
      */
-    private void trackMessage(long messageId, JSONObject message) {
+    private void trackMessage(
+            long messageId, JSONObject message, int retryCount, long timeoutMs) {
         Runnable timeoutRunnable = () -> handleTimeout(messageId);
 
-        PendingMessage pending = new PendingMessage(message, 0, timeoutRunnable);
+        PendingMessage pending = new PendingMessage(message, retryCount, timeoutRunnable);
 
         pendingMessages.put(messageId, pending);
 
         // Schedule timeout check
-        retryHandler.postDelayed(timeoutRunnable, ACK_TIMEOUT_MS);
+        retryHandler.postDelayed(timeoutRunnable, timeoutMs);
     }
 
     /**
@@ -209,21 +222,29 @@ public class ReliableMessageManager {
      * @param pending The pending message information
      */
     private void retryMessage(long messageId, PendingMessage pending) {
-        // Create updated pending message with incremented retry count
-        PendingMessage updated = new PendingMessage(
-            pending.message,
-            pending.retryCount + 1,
-            pending.timeoutRunnable
-        );
-
-        pendingMessages.put(messageId, updated);
-
-        // Send again
-        sendDirectly(pending.message);
-
-        // Reschedule timeout with exponential backoff
+        int nextRetryCount = pending.retryCount + 1;
         long backoffDelay = ACK_TIMEOUT_MS * (1L << pending.retryCount);
-        retryHandler.postDelayed(pending.timeoutRunnable, backoffDelay);
+
+        // Send again, then restart the ACK timeout only after the queued retry actually completes.
+        boolean accepted =
+                sendDirectly(
+                        pending.message,
+                        success -> {
+                            if (success && pendingMessages.containsKey(messageId)) {
+                                trackMessage(
+                                        messageId,
+                                        pending.message,
+                                        nextRetryCount,
+                                        backoffDelay);
+                            } else if (!success) {
+                                pendingMessages.remove(messageId);
+                                totalFailures++;
+                            }
+                        });
+        if (!accepted) {
+            pendingMessages.remove(messageId);
+            totalFailures++;
+        }
     }
 
     /**
@@ -232,9 +253,13 @@ public class ReliableMessageManager {
      * @return true if sent successfully, false otherwise
      */
     private boolean sendDirectly(JSONObject message) {
+        return sendDirectly(message, null);
+    }
+
+    private boolean sendDirectly(JSONObject message, SendCompletionCallback callback) {
         try {
             String jsonString = message.toString();
-            return messageSender.sendData(jsonString.getBytes());
+            return messageSender.sendData(jsonString.getBytes(), callback);
         } catch (Exception e) {
             Log.e(TAG, "Error sending message", e);
             return false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/reliability/ReliableMessageManager.java
@@ -58,13 +58,12 @@ public class ReliableMessageManager {
         final JSONObject message;
         final long timestamp;
         final int retryCount;
-        final Runnable timeoutRunnable;
+        volatile Runnable timeoutRunnable;
 
-        PendingMessage(JSONObject message, int retryCount, Runnable timeoutRunnable) {
+        PendingMessage(JSONObject message, int retryCount) {
             this.message = message;
             this.timestamp = System.currentTimeMillis();
             this.retryCount = retryCount;
-            this.timeoutRunnable = timeoutRunnable;
         }
     }
 
@@ -107,20 +106,23 @@ public class ReliableMessageManager {
             long messageId = generateMessageId();
             message.put("mId", messageId);
 
-            // Send immediately, then start ACK tracking only after the queued transport send
-            // actually completes.
+            PendingMessage pending = new PendingMessage(message, 0);
+            pendingMessages.put(messageId, pending);
+
+            // Accept ACKs immediately, but start the timeout only after the queued transport send
+            // actually completes so outbound queue delay does not consume the ACK window.
             boolean accepted =
                     sendDirectly(
                             message,
                             success -> {
                                 if (success) {
-                                    trackMessage(messageId, message, 0, ACK_TIMEOUT_MS);
+                                    startAckTimeoutIfPending(messageId, pending, ACK_TIMEOUT_MS);
                                     totalMessagesSent++;
-                                } else {
+                                } else if (pendingMessages.remove(messageId, pending)) {
                                     totalFailures++;
                                 }
                             });
-            if (!accepted) {
+            if (!accepted && pendingMessages.remove(messageId, pending)) {
                 totalFailures++;
             }
             return accepted;
@@ -139,7 +141,9 @@ public class ReliableMessageManager {
         PendingMessage pending = pendingMessages.remove(messageId);
         if (pending != null) {
             // Cancel timeout
-            retryHandler.removeCallbacks(pending.timeoutRunnable);
+            if (pending.timeoutRunnable != null) {
+                retryHandler.removeCallbacks(pending.timeoutRunnable);
+            }
             totalAcksReceived++;
 
             Log.d(TAG, String.format("ACK received for message %d (attempts: %d, time: %dms)",
@@ -175,20 +179,18 @@ public class ReliableMessageManager {
     }
 
     /**
-     * Track a message for retry if ACK not received.
+     * Arm the ACK timeout if the message is still pending.
      * @param messageId The message ID to track
-     * @param message The message content
+     * @param pending The pending message to arm
      */
-    private void trackMessage(
-            long messageId, JSONObject message, int retryCount, long timeoutMs) {
+    private void startAckTimeoutIfPending(long messageId, PendingMessage pending, long timeoutMs) {
         Runnable timeoutRunnable = () -> handleTimeout(messageId);
+        pending.timeoutRunnable = timeoutRunnable;
 
-        PendingMessage pending = new PendingMessage(message, retryCount, timeoutRunnable);
-
-        pendingMessages.put(messageId, pending);
-
-        // Schedule timeout check
         retryHandler.postDelayed(timeoutRunnable, timeoutMs);
+        if (pendingMessages.get(messageId) != pending) {
+            retryHandler.removeCallbacks(timeoutRunnable);
+        }
     }
 
     /**
@@ -224,25 +226,25 @@ public class ReliableMessageManager {
     private void retryMessage(long messageId, PendingMessage pending) {
         int nextRetryCount = pending.retryCount + 1;
         long backoffDelay = ACK_TIMEOUT_MS * (1L << pending.retryCount);
+        PendingMessage retryPending = new PendingMessage(pending.message, nextRetryCount);
 
-        // Send again, then restart the ACK timeout only after the queued retry actually completes.
+        if (!pendingMessages.replace(messageId, pending, retryPending)) {
+            return;
+        }
+
+        // Keep accepting ACKs while the retry is queued, but restart the ACK timeout only after
+        // the queued retry actually completes.
         boolean accepted =
                 sendDirectly(
                         pending.message,
                         success -> {
-                            if (success && pendingMessages.containsKey(messageId)) {
-                                trackMessage(
-                                        messageId,
-                                        pending.message,
-                                        nextRetryCount,
-                                        backoffDelay);
-                            } else if (!success) {
-                                pendingMessages.remove(messageId);
+                            if (success) {
+                                startAckTimeoutIfPending(messageId, retryPending, backoffDelay);
+                            } else if (pendingMessages.remove(messageId, retryPending)) {
                                 totalFailures++;
                             }
                         });
-        if (!accepted) {
-            pendingMessages.remove(messageId);
+        if (!accepted && pendingMessages.remove(messageId, retryPending)) {
             totalFailures++;
         }
     }
@@ -287,7 +289,9 @@ public class ReliableMessageManager {
             PendingMessage pending = entry.getValue();
             if (pending.timestamp < cutoff) {
                 Log.w(TAG, "Removing stale message: " + entry.getKey());
-                retryHandler.removeCallbacks(pending.timeoutRunnable);
+                if (pending.timeoutRunnable != null) {
+                    retryHandler.removeCallbacks(pending.timeoutRunnable);
+                }
                 return true;
             }
             return false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ChunkedMessageProtocolStrategy.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ChunkedMessageProtocolStrategy.java
@@ -8,6 +8,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -20,6 +21,8 @@ public class ChunkedMessageProtocolStrategy
     private static final String TAG = "ChunkedMessageStrategy";
     private static final AtomicLong CHUNK_TRACE_SEQUENCE = new AtomicLong(1);
     private static final long SIGNIFICANT_CHUNK_REASSEMBLY_MS = 250;
+    private static final long CHUNK_TRACE_SESSION_TIMEOUT_MS = 30000;
+    private static final int MAX_CHUNK_TRACE_SESSIONS = 10;
 
     private final ChunkReassembler chunkReassembler;
     private final ConcurrentHashMap<String, InboundChunkTraceSession> chunkTraceSessions =
@@ -235,6 +238,7 @@ public class ChunkedMessageProtocolStrategy
 
     private InboundChunkTraceSession noteInboundChunk(
             String chunkId, int chunkIndex, int totalChunks) {
+        pruneInboundChunkTraceSessions(chunkId);
         return chunkTraceSessions.compute(
                 chunkId,
                 (id, existing) -> {
@@ -246,6 +250,34 @@ public class ChunkedMessageProtocolStrategy
                     session.lastChunkAtMs = System.currentTimeMillis();
                     return session;
                 });
+    }
+
+    private void pruneInboundChunkTraceSessions(String incomingChunkId) {
+        long now = System.currentTimeMillis();
+        chunkTraceSessions
+                .entrySet()
+                .removeIf(
+                        entry ->
+                                now - entry.getValue().lastChunkAtMs
+                                        > CHUNK_TRACE_SESSION_TIMEOUT_MS);
+
+        if (chunkTraceSessions.size() < MAX_CHUNK_TRACE_SESSIONS
+                || chunkTraceSessions.containsKey(incomingChunkId)) {
+            return;
+        }
+
+        String oldestChunkId = null;
+        long oldestChunkAtMs = Long.MAX_VALUE;
+        for (Map.Entry<String, InboundChunkTraceSession> entry : chunkTraceSessions.entrySet()) {
+            long lastChunkAtMs = entry.getValue().lastChunkAtMs;
+            if (lastChunkAtMs < oldestChunkAtMs) {
+                oldestChunkAtMs = lastChunkAtMs;
+                oldestChunkId = entry.getKey();
+            }
+        }
+        if (oldestChunkId != null) {
+            chunkTraceSessions.remove(oldestChunkId);
+        }
     }
 
     private static void logInboundBleChunk(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ChunkedMessageProtocolStrategy.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ChunkedMessageProtocolStrategy.java
@@ -2,22 +2,33 @@ package com.mentra.asg_client.service.core.processors;
 
 import android.util.Log;
 
+import com.mentra.asg_client.logging.BleTraceLogger;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
 /**
- * Protocol detection strategy for chunked messages.
- * Detects and handles reassembly of messages split across multiple chunks.
+ * Protocol detection strategy for chunked messages. Detects and handles reassembly of messages
+ * split across multiple chunks.
  */
-public class ChunkedMessageProtocolStrategy implements CommandProtocolDetector.ProtocolDetectionStrategy {
+public class ChunkedMessageProtocolStrategy
+        implements CommandProtocolDetector.ProtocolDetectionStrategy {
     private static final String TAG = "ChunkedMessageStrategy";
-    
+    private static final AtomicLong CHUNK_TRACE_SEQUENCE = new AtomicLong(1);
+    private static final long SIGNIFICANT_CHUNK_REASSEMBLY_MS = 250;
+
     private final ChunkReassembler chunkReassembler;
-    
+    private final ConcurrentHashMap<String, InboundChunkTraceSession> chunkTraceSessions =
+            new ConcurrentHashMap<>();
+
     public ChunkedMessageProtocolStrategy(ChunkReassembler chunkReassembler) {
         this.chunkReassembler = chunkReassembler;
     }
-    
+
     @Override
     public boolean canHandle(JSONObject json) {
         // Can handle if it has a "C" field containing chunked message
@@ -41,14 +52,15 @@ public class ChunkedMessageProtocolStrategy implements CommandProtocolDetector.P
         String type = json.optString("type", json.optString("t", ""));
         return "chunked_msg".equals(type) || "ck".equals(type);
     }
-    
+
     @Override
     public CommandProtocolDetector.ProtocolDetectionResult detect(JSONObject json) {
         try {
             JSONObject chunkMessage;
-            
+            boolean cWrapped = json.has("C");
+
             // Extract chunk message from C field if present
-            if (json.has("C")) {
+            if (cWrapped) {
                 String dataPayload = json.optString("C", "");
                 chunkMessage = new JSONObject(dataPayload);
                 Log.d(TAG, "Detected chunked message in C field format");
@@ -57,89 +69,285 @@ public class ChunkedMessageProtocolStrategy implements CommandProtocolDetector.P
                 chunkMessage = json;
                 Log.d(TAG, "Detected chunked message in direct format");
             }
-            
+
             // Extract chunk information (supports both verbose and compact keys)
             String chunkId = optStringFallback(chunkMessage, "chunkId", "id");
             int chunkIndex = optIntFallback(chunkMessage, "chunk", "c", -1);
             int totalChunks = optIntFallback(chunkMessage, "total", "n", -1);
             String data = optStringFallback(chunkMessage, "data", "d");
             long messageId = chunkMessage.optLong("mId", -1);
+            long traceSequence = CHUNK_TRACE_SEQUENCE.getAndIncrement();
 
-            if (chunkId == null || chunkId.isEmpty() || chunkIndex < 0
-                    || totalChunks <= 0 || chunkIndex >= totalChunks || data == null) {
+            if (chunkId == null
+                    || chunkId.isEmpty()
+                    || chunkIndex < 0
+                    || totalChunks <= 0
+                    || chunkIndex >= totalChunks
+                    || data == null) {
                 Log.e(TAG, "Missing required chunk fields");
+                logInboundBleChunk(
+                        "invalid",
+                        "chunked",
+                        traceSequence,
+                        chunkId,
+                        chunkIndex,
+                        totalChunks,
+                        data,
+                        messageId,
+                        cWrapped,
+                        json,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "missing_required_chunk_fields");
                 return new CommandProtocolDetector.ProtocolDetectionResult(
-                    CommandProtocolDetector.ProtocolType.UNKNOWN, json, "", -1, false);
+                        CommandProtocolDetector.ProtocolType.UNKNOWN, json, "", -1, false);
             }
-            
-            Log.d(TAG, "Processing chunk " + chunkIndex + "/" + (totalChunks - 1) + 
-                      " for session " + chunkId + 
-                      (messageId != -1 ? " (mId: " + messageId + ")" : ""));
-            
+
+            InboundChunkTraceSession traceSession =
+                    noteInboundChunk(chunkId, chunkIndex, totalChunks);
+
+            Log.d(
+                    TAG,
+                    "Processing chunk "
+                            + chunkIndex
+                            + "/"
+                            + (totalChunks - 1)
+                            + " for session "
+                            + chunkId
+                            + (messageId != -1 ? " (mId: " + messageId + ")" : ""));
+            logInboundBleChunk(
+                    "received",
+                    "chunked",
+                    traceSequence,
+                    chunkId,
+                    chunkIndex,
+                    totalChunks,
+                    data,
+                    messageId,
+                    cWrapped,
+                    json,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null);
+
             // Add chunk to reassembler
             String reassembled = chunkReassembler.addChunk(chunkId, chunkIndex, totalChunks, data);
-            
+
             if (reassembled != null) {
                 // Message complete - parse and return the reassembled message
-                Log.d(TAG, "Chunk session " + chunkId + " complete, processing reassembled message");
-                
+                Log.d(
+                        TAG,
+                        "Chunk session " + chunkId + " complete, processing reassembled message");
+
                 try {
                     JSONObject reassembledJson = new JSONObject(reassembled);
-                    
+
                     // Extract command type and message ID from reassembled message
                     String commandType = reassembledJson.optString("type", "");
                     long reassembledMessageId = reassembledJson.optLong("mId", messageId);
-                    
-                    Log.d(TAG, "Reassembled message type: " + commandType + 
-                              ", messageId: " + reassembledMessageId);
-                    
+                    long reassemblyDurationMs = traceSession.durationMs();
+                    int receivedChunks = traceSession.receivedChunks;
+                    chunkTraceSessions.remove(chunkId);
+                    logInboundBleChunk(
+                            "reassembled",
+                            commandType,
+                            traceSequence,
+                            chunkId,
+                            chunkIndex,
+                            totalChunks,
+                            data,
+                            reassembledMessageId,
+                            cWrapped,
+                            json,
+                            reassembled,
+                            reassembledJson,
+                            reassemblyDurationMs,
+                            receivedChunks,
+                            null);
+
+                    Log.d(
+                            TAG,
+                            "Reassembled message type: "
+                                    + commandType
+                                    + ", messageId: "
+                                    + reassembledMessageId);
+
                     return new CommandProtocolDetector.ProtocolDetectionResult(
-                        CommandProtocolDetector.ProtocolType.JSON_COMMAND,
-                        reassembledJson,
-                        commandType,
-                        reassembledMessageId,
-                        true
-                    );
-                    
+                            CommandProtocolDetector.ProtocolType.JSON_COMMAND,
+                            reassembledJson,
+                            commandType,
+                            reassembledMessageId,
+                            true);
+
                 } catch (JSONException e) {
                     Log.e(TAG, "Failed to parse reassembled message as JSON: " + reassembled, e);
-                    
+                    chunkTraceSessions.remove(chunkId);
+                    logInboundBleChunk(
+                            "reassemble_parse_error",
+                            "chunked",
+                            traceSequence,
+                            chunkId,
+                            chunkIndex,
+                            totalChunks,
+                            data,
+                            messageId,
+                            cWrapped,
+                            json,
+                            reassembled,
+                            null,
+                            traceSession.durationMs(),
+                            traceSession.receivedChunks,
+                            e.getClass().getSimpleName());
+
                     // Return as unknown protocol if not valid JSON
                     return new CommandProtocolDetector.ProtocolDetectionResult(
-                        CommandProtocolDetector.ProtocolType.UNKNOWN,
-                        json,
-                        "",
-                        messageId,
-                        false
-                    );
+                            CommandProtocolDetector.ProtocolType.UNKNOWN,
+                            json,
+                            "",
+                            messageId,
+                            false);
                 }
             } else {
                 // Chunk added but message not complete yet
                 Log.d(TAG, "Chunk added, waiting for more chunks");
-                
+
                 // Return a special result indicating chunk processing in progress
                 // This should not trigger further processing
                 return new CommandProtocolDetector.ProtocolDetectionResult(
-                    CommandProtocolDetector.ProtocolType.JSON_COMMAND,
-                    null,  // No data to process yet
-                    "chunk_in_progress",
-                    -1,    // No ACK needed for individual chunks
-                    false  // Not valid for processing
-                );
+                        CommandProtocolDetector.ProtocolType.JSON_COMMAND,
+                        null, // No data to process yet
+                        "chunk_in_progress",
+                        -1, // No ACK needed for individual chunks
+                        false // Not valid for processing
+                        );
             }
-            
+
         } catch (Exception e) {
             Log.e(TAG, "Error processing chunked message", e);
             return new CommandProtocolDetector.ProtocolDetectionResult(
-                CommandProtocolDetector.ProtocolType.UNKNOWN,
-                json,
-                "",
-                -1,
-                false
-            );
+                    CommandProtocolDetector.ProtocolType.UNKNOWN, json, "", -1, false);
         }
     }
-    
+
+    private InboundChunkTraceSession noteInboundChunk(
+            String chunkId, int chunkIndex, int totalChunks) {
+        return chunkTraceSessions.compute(
+                chunkId,
+                (id, existing) -> {
+                    InboundChunkTraceSession session =
+                            existing != null ? existing : new InboundChunkTraceSession();
+                    session.receivedChunks++;
+                    session.totalChunks = totalChunks;
+                    session.maxChunkIndex = Math.max(session.maxChunkIndex, chunkIndex);
+                    session.lastChunkAtMs = System.currentTimeMillis();
+                    return session;
+                });
+    }
+
+    private static void logInboundBleChunk(
+            String stage,
+            String eventType,
+            long sequence,
+            String chunkId,
+            int chunkIndex,
+            int totalChunks,
+            String data,
+            long messageId,
+            boolean cWrapped,
+            JSONObject sourceJson,
+            String reassembled,
+            JSONObject reassembledJson,
+            Long reassemblyDurationMs,
+            Integer receivedChunks,
+            String errorMessage) {
+        String warningReason = inboundChunkWarningReason(stage, reassemblyDurationMs, errorMessage);
+        if (warningReason == null) {
+            return;
+        }
+
+        JSONObject payload = new JSONObject();
+        try {
+            payload.put("level", "warning");
+            payload.put("warningReason", warningReason);
+            payload.put("stage", stage);
+            payload.put("sequence", sequence);
+            payload.put("chunked", true);
+            payload.put("cWrapped", cWrapped);
+            if (chunkId != null && !chunkId.isEmpty()) {
+                payload.put("chunkId", chunkId);
+            }
+            if (chunkIndex >= 0) {
+                payload.put("chunkIndex", chunkIndex);
+                payload.put("chunkNumber", chunkIndex + 1);
+            }
+            if (totalChunks > 0) {
+                payload.put("totalChunks", totalChunks);
+            }
+            payload.put("payloadBytes", utf8ByteCount(data));
+            if (sourceJson != null) {
+                payload.put("wireJsonBytes", utf8ByteCount(sourceJson.toString()));
+            }
+            if (messageId != -1) {
+                payload.put("messageId", messageId);
+            }
+            if (receivedChunks != null) {
+                payload.put("receivedChunks", receivedChunks.intValue());
+            }
+            if (reassemblyDurationMs != null) {
+                payload.put("durationMs", reassemblyDurationMs.longValue());
+            }
+            if (reassembled != null) {
+                payload.put("reassembledBytes", utf8ByteCount(reassembled));
+                payload.put("complete", true);
+            }
+            if (reassembledJson != null) {
+                putIfPresent(payload, "commandType", reassembledJson.optString("type", ""));
+                putIfPresent(payload, "requestId", reassembledJson.optString("requestId", ""));
+                putIfPresent(payload, "appId", reassembledJson.optString("appId", ""));
+            }
+            putIfPresent(payload, "errorMessage", errorMessage);
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+
+        BleTraceLogger.logEvent(
+                "phone_to_glasses",
+                "sdk_ble_chunk",
+                eventType != null && !eventType.isEmpty() ? eventType : "chunked",
+                payload);
+    }
+
+    private static String inboundChunkWarningReason(
+            String stage, Long reassemblyDurationMs, String errorMessage) {
+        if (errorMessage != null && !errorMessage.isEmpty()) {
+            return "chunk_reassembly_error";
+        }
+        if ("invalid".equals(stage) || "reassemble_parse_error".equals(stage)) {
+            return "chunk_reassembly_error";
+        }
+        if (reassemblyDurationMs != null
+                && reassemblyDurationMs >= SIGNIFICANT_CHUNK_REASSEMBLY_MS) {
+            return "chunk_reassembly_duration";
+        }
+        return null;
+    }
+
+    private static class InboundChunkTraceSession {
+        final long firstChunkAtMs = System.currentTimeMillis();
+        long lastChunkAtMs = firstChunkAtMs;
+        int receivedChunks = 0;
+        int totalChunks = 0;
+        int maxChunkIndex = -1;
+
+        long durationMs() {
+            return lastChunkAtMs - firstChunkAtMs;
+        }
+    }
+
     @Override
     public CommandProtocolDetector.ProtocolType getProtocolType() {
         return CommandProtocolDetector.ProtocolType.JSON_COMMAND;
@@ -157,10 +365,26 @@ public class ChunkedMessageProtocolStrategy implements CommandProtocolDetector.P
     }
 
     /** Try full key first, then compact key, then default */
-    private static int optIntFallback(JSONObject json, String fullKey, String compactKey, int defaultValue) {
+    private static int optIntFallback(
+            JSONObject json, String fullKey, String compactKey, int defaultValue) {
         if (json.has(fullKey)) {
             return json.optInt(fullKey, defaultValue);
         }
         return json.optInt(compactKey, defaultValue);
+    }
+
+    private static void putIfPresent(JSONObject payload, String key, String value) {
+        if (value == null || value.isEmpty()) {
+            return;
+        }
+        try {
+            payload.put(key, value);
+        } catch (Exception ignored) {
+            // Keep trace logging non-fatal.
+        }
+    }
+
+    private static int utf8ByteCount(String value) {
+        return value != null ? value.getBytes(StandardCharsets.UTF_8).length : 0;
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
@@ -30,10 +30,14 @@ public class ResponseSender {
         // reference
         this.reliableManager =
                 new ReliableMessageManager(
-                        data -> {
+                        (data, callback) -> {
                             if (this.serviceManager != null
                                     && this.serviceManager.getBluetoothManager() != null) {
-                                return this.serviceManager.getBluetoothManager().sendMessage(data);
+                                return this.serviceManager
+                                        .getBluetoothManager()
+                                        .sendMessage(
+                                                data,
+                                                callback != null ? callback::onComplete : null);
                             }
                             return false;
                         });

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
@@ -1,6 +1,7 @@
 package com.mentra.asg_client.service.core.processors;
 
 import android.util.Log;
+import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.service.communication.reliability.ReliableMessageManager;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import org.json.JSONException;
@@ -38,7 +39,7 @@ public class ResponseSender {
                                         .sendMessage(
                                                 data,
                                                 callback != null ? callback::onComplete : null,
-                                                gate != null ? gate::shouldSend : null);
+                                                adaptSendGate(gate));
                             }
                             return false;
                         });
@@ -47,6 +48,24 @@ public class ResponseSender {
         this.reliableManager.setEnabled(true, 1);
 
         Log.d(TAG, "✅ Response sender initialized with reliability support");
+    }
+
+    private static IBluetoothManager.SendMessageGate adaptSendGate(
+            ReliableMessageManager.SendGate gate) {
+        if (gate == null) {
+            return null;
+        }
+        return new IBluetoothManager.SendMessageGate() {
+            @Override
+            public boolean shouldSend() {
+                return gate.shouldSend();
+            }
+
+            @Override
+            public Object lock() {
+                return gate.lock();
+            }
+        };
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/ResponseSender.java
@@ -30,14 +30,15 @@ public class ResponseSender {
         // reference
         this.reliableManager =
                 new ReliableMessageManager(
-                        (data, callback) -> {
+                        (data, callback, gate) -> {
                             if (this.serviceManager != null
                                     && this.serviceManager.getBluetoothManager() != null) {
                                 return this.serviceManager
                                         .getBluetoothManager()
                                         .sendMessage(
                                                 data,
-                                                callback != null ? callback::onComplete : null);
+                                                callback != null ? callback::onComplete : null,
+                                                gate != null ? gate::shouldSend : null);
                             }
                             return false;
                         });

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -157,6 +157,8 @@ class MentraLive : SGCManager() {
 
         // Rate limiting - minimum delay between BLE characteristic writes
         private const val MIN_SEND_DELAY_MS = 160L // 160ms minimum delay (increased from 100ms)
+        private const val SIGNIFICANT_BLE_TRACE_DELAY_MS = 250L
+        private const val SIGNIFICANT_BLE_TRACE_QUEUE_SIZE = 5
 
         // File transfer management
         private const val FILE_SAVE_DIR = "MentraLive_Images"
@@ -237,7 +239,35 @@ class MentraLive : SGCManager() {
     private var a2dpProfile: BluetoothA2dp? = null
     private var isA2dpProxyRegistered = false
 
-    private var sendQueue = ConcurrentLinkedQueue<ByteArray>()
+    private data class OutgoingBleCommandTraceInfo(
+            val commandType: String,
+            val requestId: String?,
+            val appId: String?,
+            val messageId: Long?
+    )
+
+    private data class BleWriteTrace(
+            val sequence: Long,
+            val commandType: String,
+            val requestId: String?,
+            val appId: String?,
+            val messageId: Long?,
+            val chunkId: String?,
+            val chunkIndex: Int?,
+            val totalChunks: Int?,
+            val payloadBytes: Int?,
+            val packedBytes: Int,
+            val wakeup: Boolean,
+            val chunked: Boolean,
+            val queuedAtMs: Long
+    )
+
+    private data class QueuedBleWrite(val data: ByteArray, val trace: BleWriteTrace?)
+
+    private var sendQueue = ConcurrentLinkedQueue<QueuedBleWrite>()
+    private val bleWriteTraceSequence = AtomicLong(1)
+    private var inFlightBleWriteTrace: BleWriteTrace? = null
+    private var inFlightBleWriteStartedAtMs = 0L
     // Queue for serializing BLE descriptor writes (only one GATT operation at a time)
     private val pendingDescriptorWrites = ConcurrentLinkedQueue<BluetoothGattDescriptor>()
     private var isDescriptorWriteInProgress = false
@@ -1671,11 +1701,20 @@ class MentraLive : SGCManager() {
                         characteristic: BluetoothGattCharacteristic,
                         status: Int
                 ) {
+                    val trace = inFlightBleWriteTrace
+                    val callbackAtMs = System.currentTimeMillis()
+                    val callbackDelayMs =
+                            if (inFlightBleWriteStartedAtMs > 0L)
+                                    callbackAtMs - inFlightBleWriteStartedAtMs
+                            else null
+                    inFlightBleWriteTrace = null
+                    inFlightBleWriteStartedAtMs = 0L
+
                     if (status == BluetoothGatt.GATT_SUCCESS) {
                         // Bridge.log("LIVE: Characteristic write successful");
 
                         // Calculate time since last send to enforce rate limiting
-                        val currentTimeMs = System.currentTimeMillis()
+                        val currentTimeMs = callbackAtMs
                         val timeSinceLastSendMs = currentTimeMs - lastSendTimeMs
                         val nextProcessDelayMs: Long
 
@@ -1690,9 +1729,34 @@ class MentraLive : SGCManager() {
                         }
 
                         // Schedule the next queue processing with appropriate delay
+                        logBleWriteTrace(
+                                "write_callback",
+                                trace,
+                                mapOf(
+                                        "status" to status,
+                                        "success" to true,
+                                        "callbackDelayMs" to callbackDelayMs,
+                                        "timeSinceLastSendMs" to timeSinceLastSendMs,
+                                        "nextProcessDelayMs" to nextProcessDelayMs,
+                                        "queueSize" to sendQueue.size,
+                                        "characteristicUuid" to characteristic.uuid.toString()
+                                )
+                        )
                         handler.postDelayed(processSendQueueRunnable!!, nextProcessDelayMs)
                     } else {
                         Log.e(TAG, "Characteristic write failed with status: " + status)
+                        logBleWriteTrace(
+                                "write_callback",
+                                trace,
+                                mapOf(
+                                        "status" to status,
+                                        "success" to false,
+                                        "callbackDelayMs" to callbackDelayMs,
+                                        "retryDelayMs" to 500L,
+                                        "queueSize" to sendQueue.size,
+                                        "characteristicUuid" to characteristic.uuid.toString()
+                                )
+                        )
                         // If write fails, try again with a longer delay
                         handler.postDelayed(processSendQueueRunnable!!, 500L)
                     }
@@ -2100,13 +2164,22 @@ class MentraLive : SGCManager() {
             Bridge.log(
                     "LIVE: Rate limiting: Waiting " + remainingDelayMs + "ms before next BLE send"
             )
+            logBleWriteTrace(
+                    "rate_limited",
+                    sendQueue.peek()?.trace,
+                    mapOf(
+                            "remainingDelayMs" to remainingDelayMs,
+                            "timeSinceLastSendMs" to timeSinceLastSendMs,
+                            "queueSize" to sendQueue.size
+                    )
+            )
             handler.postDelayed(processSendQueueRunnable!!, remainingDelayMs)
             return
         }
 
         // Send the next item from the queue
-        val data = sendQueue.poll()
-        if (data != null) {
+        val queuedWrite = sendQueue.poll()
+        if (queuedWrite != null) {
             // Update last send time before sending
             lastSendTimeMs = currentTimeMs
             Bridge.log(
@@ -2116,28 +2189,78 @@ class MentraLive : SGCManager() {
                             timeSinceLastSendMs +
                             "ms"
             )
-            sendDataInternal(data)
+            logBleWriteTrace(
+                    "dequeued",
+                    queuedWrite.trace,
+                    mapOf(
+                            "queueDelayMs" to
+                                    (queuedWrite.trace?.let { currentTimeMs - it.queuedAtMs }),
+                            "timeSinceLastSendMs" to timeSinceLastSendMs,
+                            "queueSizeAfterPoll" to sendQueue.size
+                    )
+            )
+            sendDataInternal(queuedWrite)
         }
     }
 
     /** Send data through BLE */
-    private fun sendDataInternal(data: ByteArray?) {
-        if (!isConnected || bluetoothGatt == null || txCharacteristic == null || data == null) {
+    private fun sendDataInternal(write: QueuedBleWrite?) {
+        if (!isConnected || bluetoothGatt == null || txCharacteristic == null || write == null) {
             return
         }
 
         try {
-            txCharacteristic!!.value = data
-            bluetoothGatt!!.writeCharacteristic(txCharacteristic)
+            val writeStartedAtMs = System.currentTimeMillis()
+            txCharacteristic!!.value = write.data
+            inFlightBleWriteTrace = write.trace
+            inFlightBleWriteStartedAtMs = writeStartedAtMs
+            val writeAccepted = bluetoothGatt!!.writeCharacteristic(txCharacteristic)
+            logBleWriteTrace(
+                    "write_call",
+                    write.trace,
+                    mapOf(
+                            "writeAccepted" to writeAccepted,
+                            "currentMtu" to currentMtu,
+                            "writeType" to txCharacteristic!!.writeType,
+                            "queueSize" to sendQueue.size,
+                            "characteristicUuid" to txCharacteristic!!.uuid.toString()
+                    )
+            )
+            if (!writeAccepted) {
+                inFlightBleWriteTrace = null
+                inFlightBleWriteStartedAtMs = 0L
+            }
         } catch (e: Exception) {
             Log.e(TAG, "Error sending data via BLE", e)
+            logBleWriteTrace(
+                    "write_exception",
+                    write.trace,
+                    mapOf(
+                            "errorClass" to e.javaClass.simpleName,
+                            "errorMessage" to (e.message ?: "unknown")
+                    )
+            )
+            inFlightBleWriteTrace = null
+            inFlightBleWriteStartedAtMs = 0L
         }
     }
 
     /** Queue data to be sent */
-    private fun queueData(data: ByteArray?) {
+    private fun queueData(data: ByteArray?, trace: BleWriteTrace? = null) {
         if (data != null) {
-            sendQueue.add(data)
+            val queuedTrace =
+                    trace?.copy(
+                            queuedAtMs =
+                                    if (trace.queuedAtMs > 0L)
+                                            trace.queuedAtMs
+                                    else System.currentTimeMillis()
+                    )
+            sendQueue.add(QueuedBleWrite(data, queuedTrace))
+            logBleChunkTrace(
+                    "queued",
+                    queuedTrace,
+                    mapOf("queueSizeAfterAdd" to sendQueue.size)
+            )
             // Bridge.log("LIVE: 📋 Added " + data.length + " to send queue - New queue size: " +
             // sendQueue.size());
 
@@ -6899,6 +7022,7 @@ class MentraLive : SGCManager() {
 
         try {
             val outgoingSummary = summarizeOutgoingMessage(data)
+            val commandTraceInfo = parseOutgoingBleCommandTraceInfo(data)
             val isPhotoRequest = outgoingSummary.contains("type=take_photo")
             if (isPhotoRequest) {
                 Bridge.log(
@@ -6956,11 +7080,34 @@ class MentraLive : SGCManager() {
                     val packedData =
                             K900ProtocolUtils.packJsonToK900(
                                     chunkStr,
-                                    wakeup && i == 0
-                            ) // Only wakeup on first chunk
+                                            wakeup && i == 0
+                                    ) // Only wakeup on first chunk
+
+                    val trace =
+                            createBleWriteTrace(
+                                    commandTraceInfo,
+                                    chunk.optString("id", "").takeIf { it.isNotBlank() },
+                                    chunk.optInt("c", i),
+                                    chunk.optInt("n", chunks.size),
+                                    chunk.optString("d", "")
+                                            .toByteArray(StandardCharsets.UTF_8)
+                                            .size,
+                                    packedData.size,
+                                    wakeup && i == 0,
+                                    true
+                            )
+                    logBleChunkTrace(
+                            "created",
+                            trace,
+                            mapOf(
+                                    "chunkJsonBytes" to
+                                            chunkStr.toByteArray(StandardCharsets.UTF_8).size,
+                                    "messageBytes" to data.toByteArray(StandardCharsets.UTF_8).size
+                            )
+                    )
 
                     // Queue the chunk for sending
-                    queueData(packedData)
+                    queueData(packedData, trace)
 
                     // Add small delay between chunks to avoid overwhelming the connection
                     if (i < chunks.size - 1) {
@@ -6982,9 +7129,25 @@ class MentraLive : SGCManager() {
 
                 // Pack the data using the centralized utility
                 val packedData = K900ProtocolUtils.packJsonToK900(data, wakeup)
+                val trace =
+                        createBleWriteTrace(
+                                commandTraceInfo,
+                                null,
+                                null,
+                                null,
+                                data.toByteArray(StandardCharsets.UTF_8).size,
+                                packedData.size,
+                                wakeup,
+                                false
+                        )
+                logBleChunkTrace(
+                        "created",
+                        trace,
+                        mapOf("messageBytes" to data.toByteArray(StandardCharsets.UTF_8).size)
+                )
 
                 // Queue the data for sending
-                queueData(packedData)
+                queueData(packedData, trace)
                 if (isPhotoRequest) {
                     Bridge.log(
                             "LIVE: PHOTO PIPELINE BLE handoff — packedLen=" +
@@ -6995,6 +7158,179 @@ class MentraLive : SGCManager() {
             }
         } catch (e: Exception) {
             Log.e(TAG, "Error creating data JSON", e)
+        }
+    }
+
+    private fun parseOutgoingBleCommandTraceInfo(payload: String): OutgoingBleCommandTraceInfo {
+        return try {
+            val obj = JSONObject(payload)
+            OutgoingBleCommandTraceInfo(
+                    commandType = obj.optString("type", "unknown"),
+                    requestId = optNonBlankString(obj, "requestId"),
+                    appId = optNonBlankString(obj, "appId"),
+                    messageId = if (obj.has("mId")) obj.optLong("mId") else null
+            )
+        } catch (_: Exception) {
+            OutgoingBleCommandTraceInfo(
+                    commandType = "unknown",
+                    requestId = null,
+                    appId = null,
+                    messageId = null
+            )
+        }
+    }
+
+    private fun createBleWriteTrace(
+            commandInfo: OutgoingBleCommandTraceInfo,
+            chunkId: String?,
+            chunkIndex: Int?,
+            totalChunks: Int?,
+            payloadBytes: Int?,
+            packedBytes: Int,
+            wakeup: Boolean,
+            chunked: Boolean
+    ): BleWriteTrace {
+        return BleWriteTrace(
+                sequence = bleWriteTraceSequence.getAndIncrement(),
+                commandType = commandInfo.commandType,
+                requestId = commandInfo.requestId,
+                appId = commandInfo.appId,
+                messageId = commandInfo.messageId,
+                chunkId = chunkId,
+                chunkIndex = chunkIndex,
+                totalChunks = totalChunks,
+                payloadBytes = payloadBytes,
+                packedBytes = packedBytes,
+                wakeup = wakeup,
+                chunked = chunked,
+                queuedAtMs = System.currentTimeMillis()
+        )
+    }
+
+    private fun optNonBlankString(obj: JSONObject, key: String): String? {
+        return obj.optString(key, "").takeIf { it.isNotBlank() }
+    }
+
+    private fun logBleChunkTrace(
+            stage: String,
+            trace: BleWriteTrace?,
+            extra: Map<String, Any?> = emptyMap()
+    ) {
+        logBleTrace("sdk_ble_chunk", stage, trace, extra)
+    }
+
+    private fun logBleWriteTrace(
+            stage: String,
+            trace: BleWriteTrace?,
+            extra: Map<String, Any?> = emptyMap()
+    ) {
+        logBleTrace("sdk_ble_write", stage, trace, extra)
+    }
+
+    private fun logBleTrace(
+            layer: String,
+            stage: String,
+            trace: BleWriteTrace?,
+            extra: Map<String, Any?> = emptyMap()
+    ) {
+        if (trace == null) {
+            return
+        }
+
+        val warningReason = bleTraceWarningReason(stage, extra)
+        if (warningReason == null) {
+            return
+        }
+
+        try {
+            val payload = mutableMapOf<String, Any>(
+                    "level" to "warning",
+                    "warningReason" to warningReason,
+                    "stage" to stage,
+                    "sequence" to trace.sequence,
+                    "commandType" to trace.commandType,
+                    "packedBytes" to trace.packedBytes,
+                    "wakeup" to trace.wakeup,
+                    "chunked" to trace.chunked,
+                    "queuedAtMs" to trace.queuedAtMs
+            )
+            trace.requestId?.let { payload["requestId"] = it }
+            trace.appId?.let { payload["appId"] = it }
+            trace.messageId?.let { payload["messageId"] = it }
+            trace.chunkId?.let { payload["chunkId"] = it }
+            trace.chunkIndex?.let {
+                payload["chunkIndex"] = it
+                payload["chunkNumber"] = it + 1
+            }
+            trace.totalChunks?.let { payload["totalChunks"] = it }
+            trace.payloadBytes?.let { payload["payloadBytes"] = it }
+            extra.forEach { (key, value) ->
+                if (value != null) {
+                    payload[key] = value
+                }
+            }
+
+            BleTraceLogger.logMap("phone_to_glasses", layer, trace.commandType, payload)
+        } catch (e: Exception) {
+            Log.d(TAG, "BLE trace logging failed for $layer/$stage", e)
+        }
+    }
+
+    private fun bleTraceWarningReason(stage: String, extra: Map<String, Any?>): String? {
+        if (extra["errorClass"] != null || extra["errorMessage"] != null) {
+            return "ble_write_error"
+        }
+        if (extra["success"] == false) {
+            return "ble_write_failed"
+        }
+        if (extra["writeAccepted"] == false) {
+            return "ble_write_rejected"
+        }
+
+        if (traceLongAtLeast(extra["queueDelayMs"], SIGNIFICANT_BLE_TRACE_DELAY_MS)) {
+            return "queue_delay"
+        }
+        if (traceLongAtLeast(extra["callbackDelayMs"], SIGNIFICANT_BLE_TRACE_DELAY_MS)) {
+            return "write_callback_delay"
+        }
+        if (traceLongAtLeast(extra["remainingDelayMs"], SIGNIFICANT_BLE_TRACE_DELAY_MS)) {
+            return "rate_limit_delay"
+        }
+        if (traceLongAtLeast(extra["nextProcessDelayMs"], SIGNIFICANT_BLE_TRACE_DELAY_MS)) {
+            return "next_process_delay"
+        }
+        if (extra["retryDelayMs"].asTraceLong() != null) {
+            return "write_retry"
+        }
+        if (stage == "queued" &&
+                        traceIntAtLeast(extra["queueSizeAfterAdd"], SIGNIFICANT_BLE_TRACE_QUEUE_SIZE)
+        ) {
+            return "queue_depth"
+        }
+        return null
+    }
+
+    private fun traceLongAtLeast(value: Any?, threshold: Long): Boolean {
+        return (value.asTraceLong() ?: Long.MIN_VALUE) >= threshold
+    }
+
+    private fun traceIntAtLeast(value: Any?, threshold: Int): Boolean {
+        return (value.asTraceInt() ?: Int.MIN_VALUE) >= threshold
+    }
+
+    private fun Any?.asTraceLong(): Long? {
+        return when (this) {
+            is Number -> this.toLong()
+            is String -> this.toLongOrNull()
+            else -> null
+        }
+    }
+
+    private fun Any?.asTraceInt(): Int? {
+        return when (this) {
+            is Number -> this.toInt()
+            is String -> this.toIntOrNull()
+            else -> null
         }
     }
 

--- a/scripts/ble-trace-pretty.mjs
+++ b/scripts/ble-trace-pretty.mjs
@@ -257,6 +257,69 @@ function summarize(trace) {
     return parts.slice(0, 10).join(' ');
   }
 
+  if (
+    trace.layer === 'sdk_ble_chunk' ||
+    trace.layer === 'sdk_ble_write' ||
+    trace.layer === 'asg_ble_outbound_queue'
+  ) {
+    const priorityKeys = [
+      'level',
+      'warningReason',
+      'stage',
+      'requestId',
+      'commandType',
+      'appId',
+      'chunkNumber',
+      'totalChunks',
+      'chunkIndex',
+      'sequence',
+      'messageId',
+      'durationMs',
+      'queueDelayMs',
+      'sendDurationMs',
+      'maxChunkSendDurationMs',
+      'maxChunkSpacingMs',
+      'callbackDelayMs',
+      'timeSinceLastSendMs',
+      'timeSincePreviousChunkSendMs',
+      'nextProcessDelayMs',
+      'remainingDelayMs',
+      'retryDelayMs',
+      'pacingDelayMs',
+      'writeAccepted',
+      'success',
+      'complete',
+      'status',
+      'queueSize',
+      'queueSizeAfterAdd',
+      'queueSizeAfterPoll',
+      'packedBytes',
+      'payloadBytes',
+      'chunkJsonBytes',
+      'messageBytes',
+      'wireJsonBytes',
+      'reassembledBytes',
+      'receivedChunks',
+      'currentMtu',
+      'writeType',
+      'queuedAtMs',
+      'wakeup',
+      'chunked',
+      'cWrapped',
+      'chunkId',
+      'characteristicUuid',
+      'errorClass',
+      'errorMessage',
+    ];
+    const parts = [];
+    for (const key of priorityKeys) {
+      if (trace.payload[key] != null) {
+        parts.push(`${key}=${singleLine(trace.payload[key])}`);
+      }
+    }
+    return parts.slice(0, 16).join(' ');
+  }
+
   if (trace.type === 'k900:sr_log' && trace.payload.B) {
     const body = trace.payload.B.body ?? '';
     return [
@@ -285,20 +348,23 @@ function singleLine(value) {
 }
 
 function formatTrace(trace) {
+  const warning =
+    trace.payload && typeof trace.payload === 'object' && trace.payload.level === 'warning';
   const left = [
     trace.time.padEnd(12),
     compactLabel(trace.direction, trace.layer).padEnd(noColor ? 18 : 27),
     trace.layer.padEnd(20),
-    color(trace.type.padEnd(18), 'dim'),
+    color(trace.type.padEnd(18), warning ? 'yellow' : 'dim'),
   ].join('  ');
 
   const summary = summarize(trace);
+  const styledSummary = warning ? color(summary, 'yellow') : summary;
   const details =
     verbose && (trace.source || trace.bytes)
       ? color(` source=${trace.source}${trace.bytes ? ` bytes=${trace.bytes}` : ''}`, 'dim')
       : '';
 
-  return `${left}${summary ? `  ${summary}` : ''}${details}`;
+  return `${left}${summary ? `  ${styledSummary}` : ''}${details}`;
 }
 
 const rl = readline.createInterface({


### PR DESCRIPTION

<img width="2270" height="1158" alt="image" src="https://github.com/user-attachments/assets/e24cb4f7-276d-4e2e-93e1-227d3105bedb" />

Asg client log trace left, Bluetooth SDK log trace right.
New asg client log trace has warnings for queuing delays

## Summary

This fixes the latency problem found in the photo capture path: ASG-to-phone BLE sends were chunked synchronously, and the caller was forced to sit inside the BLE chunk/pacing loop before any later work could continue.

For photo capture, that meant `MediaCaptureService` could finish capture, call `sendPhotoStatus("captured", captureMetadata)`, and then remain blocked while K900 BLE chunking sent the large metadata payload chunk-by-chunk with pacing sleeps. Only after that synchronous send returned would the code proceed to start the Wi-Fi upload. In practice, the upload path was waiting below BLE status delivery.

This PR moves that synchronous work out of caller threads by making `BaseBluetoothManager.sendMessage(...)` enqueue outbound BLE payloads onto one ordered background sender. The queue preserves ASG-to-phone message ordering, but app/camera/service handlers no longer wait for BLE chunk pacing to finish.

## Why This Matters

The expensive operation was not the photo upload. A measurable portion of pre-upload latency came from the ASG client synchronously serializing and pacing BLE status chunks before upload was allowed to start.

The worst offender in the measured flow was the `captured` photo status because it carries capture metadata and becomes an 8-chunk BLE message. Before this change, the code path effectively did:

1. capture photo
2. synchronously send `captured` over BLE, including chunk pacing
3. only then start webhook upload

After this change, the path becomes:

1. capture photo
2. enqueue `captured` for ordered BLE delivery
3. immediately continue to upload while the BLE worker drains chunks in order

The phone still receives `captured` before `uploading`, because both messages go through the same ordered outbound queue. The important change is that ASG logic is no longer blocked by the BLE transport timing.

## Implementation

- `BaseBluetoothManager.sendMessage(...)` now copies the payload, records trace metadata, enqueues the payload on a single-thread outbound executor, and returns once accepted for delivery.
- The existing subclass send implementation still performs the actual BLE/K900 send, but now from the ordered worker thread.
- The queue is global at the ASG Bluetooth transport edge, so this applies to all ASG-to-phone events from all handlers, not just photo-specific messages.
- `IBluetoothManager.sendMessage(...)` docs now reflect the actual contract: accepted for outbound delivery rather than synchronously sent to completion.

## Measured Behavior

Using the React Native example app with a local media server and these photo options:

- `size=max`
- `compress=none`
- `save=false`
- `sound=true`
- `aeExposureDivisor=3`

Before this PR, the ASG-side timeline showed upload waiting until the `captured` BLE message finished chunking:

- `captured` BLE output started at `16:12:37.542`
- final `captured` chunk finished at `16:12:38.113`
- Wi-Fi upload started at `16:12:38.135`

So upload started only after the 8-chunk `captured` status drained.

After this PR, the ASG-side timeline showed upload starting while the `captured` BLE chunks were still draining:

- `captured` status was queued at `16:40:42.975`
- Wi-Fi upload started at `16:40:42.996`
- final `captured` chunk finished later at `16:40:43.616`

This confirms the blocking wait was removed. In that run, ASG command-to-upload-start improved from `2788ms` to `2253ms`, about `535ms` faster before upload. The phone-observed command-to-`photo_response` improved from `5573ms` to `4396ms`, about `1.18s`, but about `0.59s` of that end-to-end difference was due to the Wi-Fi upload itself being faster in the second run (`1457ms` vs `869ms`). The pre-upload improvement attributable to this change is about `0.5-0.6s` in the measured run.

## Conditional Warning Diagnostics

The trace work is supporting instrumentation, not the main fix. It is intentionally quiet during normal flow.

The low-level diagnostic layers now gather timing and queue metadata first, then emit only when something looks backed up or failed. Emitted diagnostics are marked with `level=warning` and a `warningReason`, and `scripts/ble-trace-pretty.mjs` colors those warning summaries yellow.

Current warning conditions include:

- outbound ASG queue delay >= `250ms`
- outbound ASG send duration >= `250ms`
- outbound ASG queue depth >= `5`
- ASG outgoing chunked-message duration >= `250ms`
- ASG outgoing chunk send/spacing delays above threshold
- ASG incoming chunk reassembly duration >= `250ms`
- phone-side SDK BLE write queue/callback/rate-limit delays >= `250ms`
- send failures, rejected writes, malformed chunks, and parse errors

This keeps PLA usable: high-level photo/status/upload trace lines still appear normally, while noisy chunk/write/queue internals only appear as yellow warnings when they explain real latency or failures.

## Notes / Caveats

- Reliable-message ACK timers now begin after the queued transport send attempt completes, so outbound queue delay no longer eats into the ACK timeout window.
- Because delivery is globally ordered through one worker, this avoids handler-level blocking without allowing ASG-to-phone events to reorder.
- If a BLE file-start wait times out after the worker task has already begun, `sendFile(...)` now waits for the actual start result instead of returning `false` while the transfer may continue in the background.

## Validation

Ran after rebasing onto current `origin/dev`:

- `git diff --check`
- `node --check scripts/ble-trace-pretty.mjs`
- Google Java Format dry-run on touched ASG Java files
- `scripts/check-android-compile.sh`

Device/log validation:

- Rebuilt and reflashed the ASG client.
- Confirmed the new queued outbound sender was running by observing `asg_ble_outbound_queue` traces in `logap2.txt`.
- Confirmed upload starts before the `captured` BLE chunk sequence finishes.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes ordering and timing across all ASG-to-phone BLE traffic and reliable-message ACK/retry behavior, not only photo paths; regressions could affect message delivery or duplicate sends if the gate/queue semantics are wrong.
> 
> **Overview**
> **Outbound BLE on ASG no longer blocks camera/service threads.** `BaseBluetoothManager.sendMessage` now enqueues copies on a single-thread executor and returns when accepted; K900 chunk pacing and UART writes run on that worker. `sendFile` is routed through the same queue with timeout handling if start already began on the worker.
> 
> **Reliable delivery is aligned with the queue.** `IBluetoothManager` adds optional send-completion callbacks and a worker-side `SendMessageGate`. `ReliableMessageManager` starts ACK timeouts only after the queued send finishes and can skip stale retries via the gate; `CommunicationManager` and `ResponseSender` wire this through.
> 
> **Diagnostics only surface problems.** Conditional `level=warning` traces were added for outbound queue depth/delay, K900 chunk timing, inbound chunk reassembly, and phone SDK BLE write/queue delays; `ble-trace-pretty.mjs` highlights those lines in yellow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1937549936258c84cb1175ae0484217862394c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


