### PR TITLE
G2: stop clearDisplay from tearing down the EvenHub page

### DIFF
--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -23,11 +23,37 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
 
     steps:
-      - name: Kill stale build processes
+      - name: Kill stale build processes (this runner's prior job only)
         run: |
-          killall xcodebuild 2>/dev/null || true
-          killall Simulator 2>/dev/null || true
-          xcrun simctl shutdown all 2>/dev/null || true
+          # This is a SHARED self-hosted macOS runner. A blanket `killall xcodebuild`
+          # would kill iOS builds for OTHER branches running concurrently here — that was
+          # the cause of the recurring fast, diagnostic-free build failures (xcodebuild
+          # SIGTERM'd mid-compile → exit 65 with no error). The self-hosted runner only
+          # ever executes ONE job at a time per runner process, but multiple runner
+          # processes share this Mac, so we must not touch other runners' xcodebuild.
+          #
+          # Scope the cleanup to xcodebuild processes whose RUNNER_WORKSPACE matches ours.
+          # xcodebuild invocations carry the workspace path in their args, so grep for it
+          # and SIGTERM only those. Anything from another branch lives under a different
+          # runner work dir and is left alone.
+          WS="${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}"
+          echo "Cleaning stale xcodebuild under: $WS"
+          # pgrep -f matches the full arg list; -- guards against paths starting with '-'.
+          pids="$(pgrep -f "xcodebuild.*${WS}" 2>/dev/null || true)"
+          if [ -n "$pids" ]; then
+            echo "Terminating stale xcodebuild pids: $pids"
+            # shellcheck disable=SC2086
+            kill -TERM $pids 2>/dev/null || true
+            sleep 2
+            # shellcheck disable=SC2086
+            kill -KILL $pids 2>/dev/null || true
+          else
+            echo "No stale xcodebuild for this workspace."
+          fi
+          # Simulators are per-job and safe to shut down for THIS runner only; but a
+          # machine-wide `killall Simulator` / `simctl shutdown all` would also disrupt
+          # other runners. Device builds (generic/platform=iOS) don't use a simulator at
+          # all, so we skip simulator teardown entirely here.
 
       - name: Clean previous build outputs only
         run: |
@@ -198,14 +224,30 @@ jobs:
         run: |
           echo "First build failed, nuking caches and retrying from scratch..."
 
-          # Kill any hung Xcode processes from the failed attempt
-          killall xcodebuild 2>/dev/null || true
-          killall Simulator 2>/dev/null || true
-          xcrun simctl shutdown all 2>/dev/null || true
+          # Kill any hung xcodebuild from THIS job's failed attempt only — scoped to our
+          # workspace so we don't SIGTERM other branches' builds on this shared runner
+          # (a machine-wide killall here was part of the recurring cross-build failures).
+          WS="${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}"
+          pids="$(pgrep -f "xcodebuild.*${WS}" 2>/dev/null || true)"
+          if [ -n "$pids" ]; then
+            echo "Terminating stale xcodebuild pids: $pids"
+            # shellcheck disable=SC2086
+            kill -TERM $pids 2>/dev/null || true
+            sleep 2
+            # shellcheck disable=SC2086
+            kill -KILL $pids 2>/dev/null || true
+          fi
 
-          # Wipe all iOS-side caches (Pods, DerivedData, repo-level + global)
+          # DerivedData wipe scoped to THIS workspace's build dir only (the global
+          # ~/Library/.../DerivedData/Mentra-* glob would clobber other branches' builds
+          # mid-flight on the shared runner). build-device is our -derivedDataPath.
+
+          # Wipe iOS caches for THIS workspace only. The build uses
+          # -derivedDataPath build-device, so that dir IS our DerivedData — removing it is
+          # sufficient. We intentionally do NOT `rm -rf ~/Library/.../DerivedData/Mentra-*`:
+          # that global glob would delete other branches' in-flight DerivedData on this
+          # shared runner, which was contributing to the cross-build failures.
           rm -rf Pods Podfile.lock build-device
-          rm -rf ~/Library/Developer/Xcode/DerivedData/Mentra-*
 
           # Reinstall pods from scratch with fresh repo
           pod install --repo-update

--- a/docs/glasses-oems/firmware-spec.md
+++ b/docs/glasses-oems/firmware-spec.md
@@ -6,7 +6,32 @@ Control messages between the phone and the glasses are Protocol Buffers; audio a
 
 We assume one thing of your firmware: a render stack capable of the draw primitives below. If you already ship a chunked image transport, you may reuse it for bitmap pixel data rather than implementing a new one.
 
+## Contents
+
+**Foundations**
+- [Transport](#-transport) — BLE GATT, packet types, MTU
+- [Capability Descriptor](#-capability-descriptor) — what the glasses report about themselves
+- [Fonts](#-fonts) — required glyph coverage, runtime font upload
+- [Acknowledgements & Forward Compatibility](#-acknowledgements--forward-compatibility) — `command_result`, unknown-message handling
+
+**Display**
+- [The Drawing Model](#-the-drawing-model) — queue → atomic `commit`; `clear`, retained elements, `update`
+- [Display Commands](#-display-commands) — text, shapes, bitmaps, commit/clear/update, power, brightness
+- [The Home Screen](#-the-home-screen) — the offline, firmware-rendered screen
+
+**Input, Audio & Notifications**
+- [Input & Sensors](#-input--sensors) — buttons, head gestures, IMU
+- [Audio & Microphone](#-audio--microphone) — LC3 mic stream, VAD
+- [Notifications](#-notifications) — Android (nothing) vs iOS (ANCS relay)
+
+**Device & Implementation**
+- [Device & System](#-device--system) — battery, heartbeat, pairing, reset
+- [Implementation Notes](#-implementation-notes) — protobuf on the MCU, error handling, timing, security
+- [What a Complete Device Implements](#-what-a-complete-device-implements) — the checklist
+
 ---
+
+# Foundations
 
 ## 🔐 Transport
 
@@ -46,11 +71,151 @@ Standard BLE MTU is 23 bytes (20 payload); an extended MTU is negotiated up to 5
 
 ---
 
+## 🧭 Capability Descriptor
+
+The phone needs each device's parameters to lay out frames correctly: screen size, intensity depth, available fonts, and max image size. The glasses report them in response to `request_glasses_info`:
+
+```
+[0x02][PhoneToGlasses { request_glasses_info { msg_id: "info_001" }}]
+```
+
+```protobuf
+message DeviceInfo {
+  string fw_version = 1;
+  string hw_model = 2;
+  Features features = 3;
+
+  DisplayProfile display = 20;
+  FontProfile    fonts = 21;
+}
+
+message Features {
+  bool camera = 1;
+  bool display = 2;
+  bool audio_tx = 3;
+  bool audio_rx = 4;
+  bool imu = 5;
+  bool vad = 6;
+  bool mic_switching = 7;
+  uint32 image_chunk_buffer = 8;   // chunks the firmware buffers per image (e.g. 12)
+}
+
+message DisplayProfile {
+  uint32 width = 1;            // px
+  uint32 height = 2;          // px
+  uint32 intensity_levels = 3;// e.g. 16 (4-bit); 2 = pure 1-bit
+  uint32 max_image_width = 4;
+  uint32 max_image_height = 5;
+  repeated string encodings = 6;   // supported pixel encodings, e.g. ["raw","rle_1bit","rle_4bit"]
+  uint32 max_addressable_elements = 7;  // retained (id'd) elements the firmware can hold at once
+}
+
+message FontProfile {
+  repeated Font fonts = 1;         // fonts resident on the glasses today
+  bool supports_font_upload = 2;   // phone can upload a font at runtime
+  uint32 max_uploaded_fonts = 3;   // slots available for uploaded fonts (0 if none)
+}
+
+message Font {
+  uint32 font_code = 1;            // the id used in display_text.font_code / home-screen text ops
+  uint32 size_px = 2;              // glyph height in px
+  string name = 3;                 // e.g. "IBM Plex Sans"
+  string coverage = 4;             // optional glyph-coverage tag, e.g. "latin+cjk"
+}
+```
+
+---
+
+## 🔠 Fonts
+
+The phone wraps and lays out all text, so it must measure each line against the metrics of the font the glasses will actually render. The glasses report their fonts in the capability descriptor; the phone picks a `font_code` for every text draw and measures against the matching font's metrics, which MentraOS holds. An OEM ships at least one font covering the required languages below; the runtime then wraps text identically to what the glasses render.
+
+**Required glyph coverage:** Latin (incl. extended Latin for European languages such as Spanish, French, German, Italian, Portuguese, Dutch, Polish, Turkish, Vietnamese) and CJK — Chinese (Simplified and Traditional), Japanese, and Korean.
+**Recommended:** other scripts — Cyrillic (Russian, Ukrainian), Arabic, Hebrew, Devanagari (Hindi), Bengali, and Thai.
+
+Use the Mentra-provided IBM Plex Sans build, or share your own font (Mentra loads its metrics into the runtime).
+
+### Runtime font upload (optional)
+
+If `supports_font_upload` is true, the phone can push a font to the glasses at runtime. A font is just another binary asset, so it reuses the **cached-bitmap transfer path** (`preload_image`) rather than a new one: the glyph-table bytes stream over the `0xB0` channel against a `stream_id` and are acked with `image_transfer_complete`, exactly like a preloaded image. The only extra is a control message that says "the blob arriving on this `stream_id` is a font — register it under this `font_code`":
+
+```protobuf
+message UploadFont {
+  string msg_id = 1;
+  string stream_id = 2;    // the glyph-table blob arriving on the 0xB0 channel
+  uint32 total_chunks = 3;
+  uint32 font_code = 4;    // id to register the font under; later draws reference it
+  uint32 size_px = 5;
+  string format = 6;       // agreed glyph-table format
+}
+```
+
+Once the transfer completes, the firmware stores the font in one of the `max_uploaded_fonts` slots and addresses it by `font_code` exactly like a resident font.
+
+---
+
+## ✅ Acknowledgements & Forward Compatibility
+
+Many commands are fire-and-forget. A single generic result message lets the phone confirm that state-changing commands landed and detect features a given firmware doesn't implement. Every `PhoneToGlasses` carries a `msg_id`; the glasses echo it in a result:
+
+```protobuf
+message CommandResult {
+  string msg_id = 1;   // echoes the PhoneToGlasses.msg_id this responds to
+  Status status = 2;
+  string detail = 3;   // optional human-readable note on failure
+}
+
+enum Status {
+  OK = 0;
+  FAIL = 1;
+  UNSUPPORTED = 2;     // glasses do not implement this command/field
+  BAD_PARAM = 3;       // value out of range / malformed
+  BUSY = 4;            // transient; phone may retry
+  NO_MEMORY = 5;       // asset storage full
+}
+```
+
+```
+[0x02][GlassesToPhone { command_result { msg_id: "commit_001", status: OK }}]
+```
+
+The glasses should ack state-changing commands — especially `commit`, `SetHomeScreen`, and asset uploads, where the phone must know the change was persisted — rather than stay silent. High-frequency, fire-and-forget commands (individual `draw_*`) need not be acked.
+
+**Forward compatibility:** unknown fields and message types are ignored, never fatal. When the phone sends a feature the firmware doesn't implement, the firmware ignores the effect **and** returns `UNSUPPORTED`, so the phone can adapt rather than guess.
+
+---
+
+---
+
+# Display
+
 ## 🎞️ The Drawing Model
 
-The screen is driven by a small set of draw commands (`draw_text`, `draw_line`, `draw_rect`, `draw_circle`, `display_image`), a `clear` and an `update`, all flushed atomically by `commit`. This is the model every MentraOS device must implement:
+The phone draws by sending draw commands that **queue** on the glasses, then a `commit` that paints them all at once. Nothing appears until `commit`. Two examples show the whole model.
 
-- **Everything queues; nothing reaches the panel except via `commit`.** `clear_display`, every `draw_*`, and `update` accumulate in a pending batch. `commit` flushes the batch — and that is the only thing the wearer sees change. Commits are atomic: the wearer never sees a half-applied batch.
+**Draw a fresh frame** — lead with `clear`, then the ops, then `commit`:
+
+```
+clear_display          // queued: wipe what was there
+draw_rect   { ... }    // queued
+draw_text   { ... }    // queued, paints over the rectangle
+display_image { ... }  // queued; its pixels stream separately
+commit      { }        // paint it all at once: rect + text + image
+```
+
+**Change one element** — give the element an `id` when you draw it, then `update` that `id` later. No `clear`, so everything else stays:
+
+```
+draw_text { id: 1, text: "12:00", ... }   // retained as element 1
+commit                                     // paints the frame
+
+update { id: 1, op { text { text: "12:01", ... } } }   // queued: new content for element 1
+commit                                                  // repaints only element 1; the rest is untouched
+```
+
+The rules behind those two examples:
+
+- **Everything queues; nothing reaches the panel except via `commit`.** `clear_display`, every `draw_*`, and `update` accumulate in a pending batch. `commit` flushes the batch atomically — the wearer never sees a half-applied batch, and a `commit` is the only thing that changes the screen.
 - **Draw order is layer order.** Commands paint in the order sent; later commands paint over earlier ones. To put text on a filled box, send the rectangle first, the text second.
 - **`clear_display` is the only thing that wipes.** Queue it to start a fresh frame; it drops the standing scene — **including all retained elements, so their `id`s become free** — and the commit begins from blank. A batch with no `clear_display` *amends* the standing scene rather than replacing it.
 - **Retained elements and partial repaint.** A `draw_*` op may carry an optional `id` (1-based; absent = unaddressed), making it a retained element the firmware keeps so the phone can change it later with `update` (see [Updating one element](#updating-one-element)). A `commit` whose batch is **only `update`s** repaints just those elements' regions, leaving the rest of the panel untouched — the flicker-free path for changing one field on a busy screen. Any other batch (a `clear_display`, or any non-`id` `draw_*`) is a full frame and repaints the whole panel.
@@ -58,23 +223,6 @@ The screen is driven by a small set of draw commands (`draw_text`, `draw_line`, 
 - **Bitmaps composite; unset pixels are transparent.** Only lit pixels paint. An unset pixel emits no light, leaves what is beneath untouched, and lets the real world show through — so a bitmap layers cleanly over text and shapes without a hard erase.
 
 > **Pacing is the phone's job, not the firmware's.** The firmware does not implement flow control or backpressure on the display channel. The phone paces its own sends and coalesces redundant frames per device; the glasses simply render what arrives.
-
-**Fresh frame** — lead with `clear`:
-
-```
-clear_display          // queued: drop the standing scene
-draw_rect   { ... }    // queued
-draw_text   { ... }    // queued, paints over the rectangle
-display_image { ... }  // queued; its pixels stream separately
-commit      { }        // full repaint: rect + text + image
-```
-
-**Change one element** — no `clear`, just `update`:
-
-```
-update { id: 1, ... }  // queued: replace element 1's content
-commit      { }        // partial repaint: only element 1's region; everything else stays
-```
 
 ---
 
@@ -340,86 +488,9 @@ message SyncClock {
 
 `format_24h` is a MentraOS user setting; the phone pushes it here and the firmware persists the last value and renders `TIME` accordingly. The firmware does not expose its own 12/24-hour menu.
 
-## 🔔 Notifications
-
-The glasses firmware does very little for notifications. MentraOS owns all notification logic - what to show, how, and when - and renders notifications with the ordinary draw commands described above. The firmware never decides what is notification-worthy and never stores notification UI of its own.
-
-**Android.** The glasses are not involved at all. The phone reads notifications through its own OS-level listener and draws whatever it wants on the glasses. There is nothing to implement on the firmware side.
-
-**iOS.** iOS does not expose notifications to a companion app the way Android does; instead a BLE accessory reads them directly over Apple's **ANCS** (Apple Notification Center Service). So on iOS the glasses do one thing: act as an ANCS consumer and relay each notification to the phone.
-
-- After bonding, the glasses subscribe to ANCS on the iPhone (the iPhone is the Notification Provider; the glasses are the Notification Consumer). This is standard ANCS — most BLE SoC SDKs ship an ANCS client.
-- ANCS delivers **every** notification from the iPhone to the accessory; there is no per-app filter in the protocol itself. Each notification carries the source app's bundle id as an attribute. The glasses do not filter — they relay everything, and MentraOS applies the user's per-app preferences on the phone.
-- For each notification, the glasses forward it to the phone and otherwise do nothing with it:
-
-```protobuf
-message AncsNotification {
-  string app_id = 1;     // ANCS AppIdentifier (bundle id), e.g. "com.apple.MobileSMS"
-  string title = 2;      // ANCS Title attribute
-  string body = 3;       // ANCS Message attribute
-  uint64 timestamp = 4;  // ANCS Date attribute, unix ms
-  uint32 ancs_uid = 5;   // ANCS NotificationUID, valid for the session
-}
-```
-
-```
-[0x02][GlassesToPhone { ancs_notification {
-  app_id: "com.apple.MobileSMS"
-  title: "Alex"
-  body: "dinner at 7?"
-  timestamp: 1718900000000
-}}]
-```
-
-MentraOS takes it from there — it decides whether to show the notification and, if so, draws it with the normal display commands. The firmware's entire responsibility is: subscribe to ANCS, relay, done.
-
 ---
 
-## 🔉 Audio & Microphone
-
-Audio is a binary stream on the `0xA0` channel, controlled by protobuf messages. Frames are LC3, sized to the negotiated MTU; the 1-byte `stream_id` distinguishes streams (e.g. microphone vs TTS).
-
-```
-[0xA0][stream_id (1 byte)][LC3 frame data]
-```
-
-### Microphone
-
-```
-[0x02][PhoneToGlasses { set_mic_state { msg_id: "mic_001", enabled: true }}]
-→ [0x02][GlassesToPhone { mic_state_set { msg_id: "mic_001", success: true }}]
-
-[0x02][PhoneToGlasses { request_mic_status { msg_id: "mic_status_001" }}]
-→ [0x02][GlassesToPhone { mic_status { enabled: true }}]
-```
-
-While the mic is enabled, the glasses stream LC3 frames continuously:
-
-```
-[0xA0][0x01][LC3 frame data...]   // stream_id 0x01 = microphone
-[0xA0][0x01][LC3 frame data...]
-```
-
-### Voice Activity Detection (VAD)
-
-```
-[0x02][PhoneToGlasses { set_vad_enabled { msg_id: "vad_enable_001", enabled: true }}]
-→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_enable_001", success: true }}]   // result echoes msg_id
-
-[0x02][PhoneToGlasses { configure_vad { msg_id: "vad_sens_001", sensitivity: 75 }}]   // 0–100
-→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_sens_001", success: true }}]
-
-[0x02][PhoneToGlasses { request_vad_status { msg_id: "vad_status_001" }}]
-→ [0x02][GlassesToPhone { vad_status { msg_id: "vad_status_001", enabled: true, sensitivity: 75 }}]
-```
-
-When voice activity starts or stops, the glasses emit:
-
-```
-[0x02][GlassesToPhone { vad_event { state: ACTIVE }}]
-```
-
----
+# Input, Audio & Notifications
 
 ## 🎮 Input & Sensors
 
@@ -483,6 +554,91 @@ IMU streaming runs at a configurable 10–100 Hz.
 
 ---
 
+## 🔉 Audio & Microphone
+
+Audio is a binary stream on the `0xA0` channel, controlled by protobuf messages. Frames are LC3, sized to the negotiated MTU; the 1-byte `stream_id` distinguishes streams (e.g. microphone vs TTS).
+
+```
+[0xA0][stream_id (1 byte)][LC3 frame data]
+```
+
+### Microphone
+
+```
+[0x02][PhoneToGlasses { set_mic_state { msg_id: "mic_001", enabled: true }}]
+→ [0x02][GlassesToPhone { mic_state_set { msg_id: "mic_001", success: true }}]
+
+[0x02][PhoneToGlasses { request_mic_status { msg_id: "mic_status_001" }}]
+→ [0x02][GlassesToPhone { mic_status { enabled: true }}]
+```
+
+While the mic is enabled, the glasses stream LC3 frames continuously:
+
+```
+[0xA0][0x01][LC3 frame data...]   // stream_id 0x01 = microphone
+[0xA0][0x01][LC3 frame data...]
+```
+
+### Voice Activity Detection (VAD)
+
+```
+[0x02][PhoneToGlasses { set_vad_enabled { msg_id: "vad_enable_001", enabled: true }}]
+→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_enable_001", success: true }}]   // result echoes msg_id
+
+[0x02][PhoneToGlasses { configure_vad { msg_id: "vad_sens_001", sensitivity: 75 }}]   // 0–100
+→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_sens_001", success: true }}]
+
+[0x02][PhoneToGlasses { request_vad_status { msg_id: "vad_status_001" }}]
+→ [0x02][GlassesToPhone { vad_status { msg_id: "vad_status_001", enabled: true, sensitivity: 75 }}]
+```
+
+When voice activity starts or stops, the glasses emit:
+
+```
+[0x02][GlassesToPhone { vad_event { state: ACTIVE }}]
+```
+
+---
+
+## 🔔 Notifications
+
+The glasses firmware does very little for notifications. MentraOS owns all notification logic - what to show, how, and when - and renders notifications with the ordinary draw commands described above. The firmware never decides what is notification-worthy and never stores notification UI of its own.
+
+**Android.** The glasses are not involved at all. The phone reads notifications through its own OS-level listener and draws whatever it wants on the glasses. There is nothing to implement on the firmware side.
+
+**iOS.** iOS does not expose notifications to a companion app the way Android does; instead a BLE accessory reads them directly over Apple's **ANCS** (Apple Notification Center Service). So on iOS the glasses do one thing: act as an ANCS consumer and relay each notification to the phone.
+
+- After bonding, the glasses subscribe to ANCS on the iPhone (the iPhone is the Notification Provider; the glasses are the Notification Consumer). This is standard ANCS — most BLE SoC SDKs ship an ANCS client.
+- ANCS delivers **every** notification from the iPhone to the accessory; there is no per-app filter in the protocol itself. Each notification carries the source app's bundle id as an attribute. The glasses do not filter — they relay everything, and MentraOS applies the user's per-app preferences on the phone.
+- For each notification, the glasses forward it to the phone and otherwise do nothing with it:
+
+```protobuf
+message AncsNotification {
+  string app_id = 1;     // ANCS AppIdentifier (bundle id), e.g. "com.apple.MobileSMS"
+  string title = 2;      // ANCS Title attribute
+  string body = 3;       // ANCS Message attribute
+  uint64 timestamp = 4;  // ANCS Date attribute, unix ms
+  uint32 ancs_uid = 5;   // ANCS NotificationUID, valid for the session
+}
+```
+
+```
+[0x02][GlassesToPhone { ancs_notification {
+  app_id: "com.apple.MobileSMS"
+  title: "Alex"
+  body: "dinner at 7?"
+  timestamp: 1718900000000
+}}]
+```
+
+MentraOS takes it from there — it decides whether to show the notification and, if so, draws it with the normal display commands. The firmware's entire responsibility is: subscribe to ANCS, relay, done.
+
+---
+
+---
+
+# Device & Implementation
+
 ## 🧰 Device & System
 
 ### Battery and charging
@@ -515,120 +671,6 @@ The glasses send a periodic ping to verify the link is alive; the phone replies:
 [0x02][PhoneToGlasses { restart_device { msg_id: "restart_001" }}]   // reboot
 [0x02][PhoneToGlasses { factory_reset { msg_id: "factory_001" }}]    // clear all settings and cached data
 ```
-
----
-
-## 🧭 Capability Descriptor
-
-The phone needs each device's parameters to lay out frames correctly: screen size, intensity depth, available fonts, and max image size. The glasses report them in response to `request_glasses_info`:
-
-```
-[0x02][PhoneToGlasses { request_glasses_info { msg_id: "info_001" }}]
-```
-
-```protobuf
-message DeviceInfo {
-  string fw_version = 1;
-  string hw_model = 2;
-  Features features = 3;
-
-  DisplayProfile display = 20;
-  FontProfile    fonts = 21;
-}
-
-message Features {
-  bool camera = 1;
-  bool display = 2;
-  bool audio_tx = 3;
-  bool audio_rx = 4;
-  bool imu = 5;
-  bool vad = 6;
-  bool mic_switching = 7;
-  uint32 image_chunk_buffer = 8;   // chunks the firmware buffers per image (e.g. 12)
-}
-
-message DisplayProfile {
-  uint32 width = 1;            // px
-  uint32 height = 2;          // px
-  uint32 intensity_levels = 3;// e.g. 16 (4-bit); 2 = pure 1-bit
-  uint32 max_image_width = 4;
-  uint32 max_image_height = 5;
-  repeated string encodings = 6;   // supported pixel encodings, e.g. ["raw","rle_1bit","rle_4bit"]
-  uint32 max_addressable_elements = 7;  // retained (id'd) elements the firmware can hold at once
-}
-
-message FontProfile {
-  repeated Font fonts = 1;         // fonts resident on the glasses today
-  bool supports_font_upload = 2;   // phone can upload a font at runtime
-  uint32 max_uploaded_fonts = 3;   // slots available for uploaded fonts (0 if none)
-}
-
-message Font {
-  uint32 font_code = 1;            // the id used in display_text.font_code / home-screen text ops
-  uint32 size_px = 2;              // glyph height in px
-  string name = 3;                 // e.g. "IBM Plex Sans"
-  string coverage = 4;             // optional glyph-coverage tag, e.g. "latin+cjk"
-}
-```
-
----
-
-## 🔠 Fonts
-
-The phone wraps and lays out all text, so it must measure each line against the metrics of the font the glasses will actually render. The glasses report their fonts in the capability descriptor; the phone picks a `font_code` for every text draw and measures against the matching font's metrics, which MentraOS holds. An OEM ships at least one font covering the required languages below; the runtime then wraps text identically to what the glasses render.
-
-**Required glyph coverage:** Latin (incl. extended Latin for European languages such as Spanish, French, German, Italian, Portuguese, Dutch, Polish, Turkish, Vietnamese) and CJK — Chinese (Simplified and Traditional), Japanese, and Korean.
-**Recommended:** other scripts — Cyrillic (Russian, Ukrainian), Arabic, Hebrew, Devanagari (Hindi), Bengali, and Thai.
-
-Use the Mentra-provided IBM Plex Sans build, or share your own font (Mentra loads its metrics into the runtime).
-
-### Runtime font upload (optional)
-
-If `supports_font_upload` is true, the phone can push a font to the glasses at runtime. A font is just another binary asset, so it reuses the **cached-bitmap transfer path** (`preload_image`) rather than a new one: the glyph-table bytes stream over the `0xB0` channel against a `stream_id` and are acked with `image_transfer_complete`, exactly like a preloaded image. The only extra is a control message that says "the blob arriving on this `stream_id` is a font — register it under this `font_code`":
-
-```protobuf
-message UploadFont {
-  string msg_id = 1;
-  string stream_id = 2;    // the glyph-table blob arriving on the 0xB0 channel
-  uint32 total_chunks = 3;
-  uint32 font_code = 4;    // id to register the font under; later draws reference it
-  uint32 size_px = 5;
-  string format = 6;       // agreed glyph-table format
-}
-```
-
-Once the transfer completes, the firmware stores the font in one of the `max_uploaded_fonts` slots and addresses it by `font_code` exactly like a resident font.
-
----
-
-## ✅ Acknowledgements & Forward Compatibility
-
-Many commands are fire-and-forget. A single generic result message lets the phone confirm that state-changing commands landed and detect features a given firmware doesn't implement. Every `PhoneToGlasses` carries a `msg_id`; the glasses echo it in a result:
-
-```protobuf
-message CommandResult {
-  string msg_id = 1;   // echoes the PhoneToGlasses.msg_id this responds to
-  Status status = 2;
-  string detail = 3;   // optional human-readable note on failure
-}
-
-enum Status {
-  OK = 0;
-  FAIL = 1;
-  UNSUPPORTED = 2;     // glasses do not implement this command/field
-  BAD_PARAM = 3;       // value out of range / malformed
-  BUSY = 4;            // transient; phone may retry
-  NO_MEMORY = 5;       // asset storage full
-}
-```
-
-```
-[0x02][GlassesToPhone { command_result { msg_id: "commit_001", status: OK }}]
-```
-
-The glasses should ack state-changing commands — especially `commit`, `SetHomeScreen`, and asset uploads, where the phone must know the change was persisted — rather than stay silent. High-frequency, fire-and-forget commands (individual `draw_*`) need not be acked.
-
-**Forward compatibility:** unknown fields and message types are ignored, never fatal. When the phone sends a feature the firmware doesn't implement, the firmware ignores the effect **and** returns `UNSUPPORTED`, so the phone can adapt rather than guess.
 
 ---
 

--- a/docs/glasses-oems/firmware-spec.md
+++ b/docs/glasses-oems/firmware-spec.md
@@ -1,0 +1,690 @@
+# 📦 MentraOS OEM Display Protocol — Firmware Spec
+
+This is the firmware-side contract an OEM implements so that MentraOS — running on the user's phone — can drive your glasses. The phone is the brain: it owns all application logic and screen layout and streams your glasses commands that say what to draw. Your glasses are a thin client for the live display, plus a small firmware-resident home screen they render on their own while disconnected.
+
+Control messages between the phone and the glasses are Protocol Buffers; audio and images stream as raw binary for throughput. Every BLE packet begins with a 1-byte control header that names the payload type.
+
+We assume one thing of your firmware: a render stack capable of the draw primitives below. If you already ship a chunked image transport, you may reuse it for bitmap pixel data rather than implementing a new one.
+
+---
+
+## 🔐 Transport
+
+Communication is standard BLE GATT. The phone is the **central**; the glasses are the **peripheral** and send notifications on the RX characteristic.
+
+| Role    | UUID                                   | Description                          |
+| ------- | -------------------------------------- | ------------------------------------ |
+| Service | `00004860-0000-1000-8000-00805f9b34fb` | MentraOS BLE Service                 |
+| TX Char | `000071FF-0000-1000-8000-00805f9b34fb` | Phone (central) → Glasses (write)    |
+| RX Char | `000070FF-0000-1000-8000-00805f9b34fb` | Glasses → Phone (notify or indicate) |
+| CCCD    | `00002902-0000-1000-8000-00805f9b34fb` | Enable notify on RX Char             |
+
+### Packet types
+
+Every packet's first byte is a control header naming the payload:
+
+| Control Header Byte | Type             | Payload Format                                                |
+| ------------------- | ---------------- | ------------------------------------------------------------- |
+| `0x02`              | Protobuf message | Protobuf-encoded control message                              |
+| `0xA0`              | Audio chunk      | `[A0][stream_id (1 byte)][LC3 frame data]`                    |
+| `0xB0`              | Image chunk      | `[B0][stream_id (2 bytes)][chunk_index (1 byte)][chunk_data]` |
+| `0xD0`–`0xFF`       | Reserved         | —                                                             |
+
+### Protobuf control messages
+
+A protobuf packet is `0x02` followed by the protobuf-encoded bytes:
+
+```
+[0x02][protobuf encoded bytes]
+```
+
+No length header is needed; the BLE characteristic defines packet length. All control messages are `PhoneToGlasses` or `GlassesToPhone` (a `oneof` over every command/event). **If the glasses receive a field or message type they do not recognize, they ignore it rather than fail** — this is what lets the protocol grow without breaking older firmware.
+
+### MTU
+
+Standard BLE MTU is 23 bytes (20 payload); an extended MTU is negotiated up to 512. Image and audio chunks are sized to fit the negotiated MTU minus their headers; an audio frame must fit a single packet.
+
+---
+
+## 🎞️ The Drawing Model
+
+The screen is driven by a small set of draw commands (`draw_text`, `draw_line`, `draw_rect`, `draw_circle`, `display_image`), a `clear` and an `update`, all flushed atomically by `commit`. This is the model every MentraOS device must implement:
+
+- **Everything queues; nothing reaches the panel except via `commit`.** `clear_display`, every `draw_*`, and `update` accumulate in a pending batch. `commit` flushes the batch — and that is the only thing the wearer sees change. Commits are atomic: the wearer never sees a half-applied batch.
+- **Draw order is layer order.** Commands paint in the order sent; later commands paint over earlier ones. To put text on a filled box, send the rectangle first, the text second.
+- **`clear_display` is the only thing that wipes.** Queue it to start a fresh frame; it drops the standing scene — **including all retained elements, so their `id`s become free** — and the commit begins from blank. A batch with no `clear_display` *amends* the standing scene rather than replacing it.
+- **Retained elements and partial repaint.** A `draw_*` op may carry an optional `id` (1-based; absent = unaddressed), making it a retained element the firmware keeps so the phone can change it later with `update` (see [Updating one element](#updating-one-element)). A `commit` whose batch is **only `update`s** repaints just those elements' regions, leaving the rest of the panel untouched — the flicker-free path for changing one field on a busy screen. Any other batch (a `clear_display`, or any non-`id` `draw_*`) is a full frame and repaints the whole panel.
+- **Intensity, not RGB.** The displays are monochrome. Every drawable carries an `intensity` from `0` (off) to `15` (brightest); `0` means "not drawn."
+- **Bitmaps composite; unset pixels are transparent.** Only lit pixels paint. An unset pixel emits no light, leaves what is beneath untouched, and lets the real world show through — so a bitmap layers cleanly over text and shapes without a hard erase.
+
+> **Pacing is the phone's job, not the firmware's.** The firmware does not implement flow control or backpressure on the display channel. The phone paces its own sends and coalesces redundant frames per device; the glasses simply render what arrives.
+
+**Fresh frame** — lead with `clear`:
+
+```
+clear_display          // queued: drop the standing scene
+draw_rect   { ... }    // queued
+draw_text   { ... }    // queued, paints over the rectangle
+display_image { ... }  // queued; its pixels stream separately
+commit      { }        // full repaint: rect + text + image
+```
+
+**Change one element** — no `clear`, just `update`:
+
+```
+update { id: 1, ... }  // queued: replace element 1's content
+commit      { }        // partial repaint: only element 1's region; everything else stays
+```
+
+---
+
+## 🖥️ Display Commands
+
+All display commands are `PhoneToGlasses` protobuf messages, carry a `msg_id`, and queue into the pending batch — they take effect on the next `commit`.
+
+### Text
+
+Text is drawn in UTF-8 with `(x, y)` as the top-left corner of a single line. The phone handles all line breaking and wrapping — it measures against the font metrics (see [Fonts](#-fonts)) and sends each line as its own `display_text`. The glasses never compute multi-line layout.
+
+```
+[0x02][PhoneToGlasses { display_text {
+  msg_id: "txt_hello_001"
+  id: 1             // optional: retain as an addressable element (omit for one-shot)
+  text: "Hello World"
+  intensity: 15     // 0–15
+  font_code: 0x11   // a font_code reported by the glasses (see Fonts)
+  x: 10
+  y: 20
+  size_px: 20       // glyph height in px; must be a size the glasses report
+}}]
+```
+
+### Shapes
+
+```
+[0x02][PhoneToGlasses { draw_line {
+  msg_id: "line_001"
+  intensity: 15    // 0–15
+  stroke: 1
+  x1: 0   y1: 0
+  x2: 100 y2: 50
+}}]
+```
+
+```
+[0x02][PhoneToGlasses { draw_rect {
+  msg_id: "rect_001"
+  intensity: 15
+  stroke: 1        // outline width; filled when stroke == 0
+  x: 10  y: 10
+  width: 60  height: 40
+}}]
+```
+
+```
+[0x02][PhoneToGlasses { draw_circle {
+  msg_id: "circle_001"
+  intensity: 15
+  stroke: 1
+  x: 64  y: 32    // center
+  radius: 20
+}}]
+```
+
+Every `draw_*` op carries an optional `id` (as in `display_text` above) to retain it as an addressable element. These same op messages are also the building blocks of the stored [home screen](#-the-home-screen). The op messages:
+
+```protobuf
+message DrawText   { uint32 id = 1; string text = 2; uint32 intensity = 3; uint32 font_code = 4; uint32 x = 5; uint32 y = 6; uint32 size_px = 7; Align align = 8; Field field = 9; }
+message DrawLine   { uint32 id = 1; uint32 intensity = 2; uint32 stroke = 3; uint32 x1 = 4; uint32 y1 = 5; uint32 x2 = 6; uint32 y2 = 7; }
+message DrawRect   { uint32 id = 1; uint32 intensity = 2; uint32 stroke = 3; uint32 x = 4; uint32 y = 5; uint32 width = 6; uint32 height = 7; }   // stroke 0 = filled
+message DrawCircle { uint32 id = 1; uint32 intensity = 2; uint32 stroke = 3; uint32 x = 4; uint32 y = 5; uint32 radius = 6; }
+message DrawImage  { uint32 id = 1; uint32 intensity = 2; uint32 x = 3; uint32 y = 4; ... see Bitmaps for the image-transfer fields ... }
+
+message DrawOp {    // one op of any type — used by update and the home screen
+  oneof op { DrawText text = 1; DrawLine line = 2; DrawRect rect = 3; DrawCircle circle = 4; DrawImage image = 5; }
+}
+
+enum Field {        // a firmware-filled placeholder; only honored on the stored home screen (see below)
+  NONE = 0;         // use the literal text
+  TIME = 1;         // current local time, firmware RTC (formatted per SyncClock)
+  DATE = 2;         // current date, firmware RTC
+  BATTERY = 3;      // current battery %, firmware gauge
+  LINK_STATUS = 4;  // firmware draws an offline glyph when the link is down
+}
+```
+
+`id` is 1-based; `0` or absent means the op is a one-shot paint, not retained. The firmware can hold up to `max_addressable_elements` retained elements (see [Capability Descriptor](#-capability-descriptor)); creating more returns `NO_MEMORY`. The `field` member is **ignored on the live display** — the phone draws live values itself, and the firmware never repaints the live screen on its own. It is honored only inside a stored home-screen frame, where the firmware renders standalone (see [The Home Screen](#-the-home-screen)).
+
+### Commit and clear
+
+Both queue into the pending batch and take effect on `commit` (see [The Drawing Model](#-the-drawing-model)).
+
+```
+[0x02][PhoneToGlasses { clear_display { msg_id: "clear_001" }}]   // queue: drop the standing scene (start fresh)
+[0x02][PhoneToGlasses { commit { msg_id: "commit_001" }}]         // flush the batch atomically
+```
+
+### Updating one element
+
+`update` replaces the content of a retained element (one whose `draw_*` carried an `id`). It queues like any draw op and takes effect on the next `commit`; a `commit` whose batch is only `update`s repaints just those elements' regions, so changing one field on a busy screen does not flicker the rest of the panel.
+
+`update` carries a full replacement op. It is an **upsert**: if `id` exists, its content is replaced; if it does not (e.g. the scene was wiped by a `clear`), the op is created as a new retained element. The replacement op **must be the same type** as the element it replaces (you cannot turn a `DrawText` element into a `DrawCircle`). Its coordinates may differ from the original, so an `update` can **move** the element — the firmware clears the element's old region and paints it at the new position, all within the partial repaint.
+
+```protobuf
+message Update {
+  string msg_id = 1;
+  uint32 id = 2;     // the element to replace or create
+  DrawOp op = 3;     // the replacement op (same type as the element; its own id field is ignored)
+}
+```
+
+```
+[0x02][PhoneToGlasses { update {
+  msg_id: "upd_cap_017"
+  id: 1
+  op { text { text: "Hello World", intensity: 15, font_code: 0x11, x: 10, y: 20, size_px: 20 } }
+}}]
+```
+
+To change several elements together without tearing, queue several `update`s and a single `commit` — they all repaint in one atomic frame.
+
+For example, to show an image with a label and then change only the label — without re-sending the image:
+
+```
+clear_display
+display_image { id: 10, ... }   // retained
+draw_text     { id: 11, text: "12:00" }
+commit                          // full repaint: image + "12:00"
+
+update { id: 11, op { text { text: "12:01", ... } } }
+commit                          // partial repaint: only the label's region; the image is untouched
+```
+
+### Bitmaps
+
+A bitmap is sent with two messages: a protobuf `display_image` that places it in the draw order and declares its geometry, and the pixel bytes streamed on the binary channel. The bitmap takes its place in the draw order the instant the protobuf message is queued; the pixels are held against its `stream_id` until `commit`, where they render as part of the frame.
+
+```
+[0x02][PhoneToGlasses { display_image {
+  msg_id: "img_clock_001"
+  stream_id: "002A"
+  x: 0   y: 0
+  width: 128  height: 64
+  encoding: "rle_1bit"   // "raw", "rle_1bit", "rle_4bit"
+  total_chunks: 9
+}}]
+```
+
+The pixels follow on the binary channel, one chunk per packet:
+
+```
+[0xB0][0x00][0x2A][0x00][chunk_data...]   // stream_id 0x002A, chunk 0
+[0xB0][0x00][0x2A][0x01][chunk_data...]   // chunk 1
+...
+[0xB0][0x00][0x2A][0x08][chunk_data...]   // chunk 8
+```
+
+- `stream_id`: 2 bytes, matching the `display_image` message.
+- `chunk_index`: 0–255.
+- `chunk_data`: raw pixel bytes, ≤ MTU − 4.
+
+When every chunk of a bitmap has arrived, the glasses confirm the transfer:
+
+```
+[0x02][GlassesToPhone { image_transfer_complete { stream_id: "002A", status: OK }}]
+```
+
+Or, if chunks are missing:
+
+```
+[0x02][GlassesToPhone { image_transfer_complete {
+  stream_id: "002A"
+  status: INCOMPLETE
+  missing_chunks: [3, 4, 6]
+}}]
+```
+
+The phone re-sends only the missing chunks and waits again, repeating until acknowledged or a per-chunk timeout. **The phone waits for `status: OK` before it sends `commit`.** Multiple bitmaps may be in flight in one frame; `stream_id` routes each chunk to the right bitmap.
+
+### Cached bitmaps
+
+A bitmap can be preloaded once and then drawn by id without re-sending the pixels. `preload_image` uses the same binary chunking as `display_image` but stores the image under an `image_id` instead of drawing it. **The image's dimensions and encoding live only here**, at preload time:
+
+```
+[0x02][PhoneToGlasses { preload_image {
+  msg_id: "preload_logo_001"
+  stream_id: "003B"
+  image_id: 42
+  width: 128  height: 64
+  encoding: "rle_1bit"
+  total_chunks: 6
+}}]
+```
+
+The pixel chunks transfer as above; completion is reported with `image_transfer_complete` against `stream_id: "003B"`. Once cached, draw it by id at a position — no dimensions, since the firmware already knows the image's size from preload (this enqueues into the pending frame like any draw op):
+
+```
+[0x02][PhoneToGlasses { display_cached_image {
+  msg_id: "disp_logo_001"
+  image_id: 42
+  x: 10  y: 20
+}}]
+```
+
+Evict a cached bitmap when it is no longer needed:
+
+```
+[0x02][PhoneToGlasses { clear_cached_image { msg_id: "clear_logo_001", image_id: 42 }}]
+```
+
+### Display power and geometry
+
+```
+[0x02][PhoneToGlasses { turn_off_display { msg_id: "disp_off_001" }}]   // panel off
+[0x02][PhoneToGlasses { turn_on_display  { msg_id: "disp_on_001" }}]    // panel on
+[0x02][PhoneToGlasses { set_display_distance { msg_id: "dist_001", distance_cm: 50 }}]  // virtual projection distance
+[0x02][PhoneToGlasses { set_display_height   { msg_id: "height_001", height: 120 }}]    // vertical offset
+```
+
+### Brightness
+
+```
+[0x02][PhoneToGlasses { set_brightness { msg_id: "bright_001", value: 80 }}]                  // 0–100
+[0x02][PhoneToGlasses { set_auto_brightness { msg_id: "auto_bright_001", enabled: true }}]    // ambient control
+[0x02][PhoneToGlasses { set_auto_brightness_multiplier { msg_id: "auto_mult_001", multiplier: 0.8 }}]  // scale auto-brightness
+```
+
+---
+
+## 🏠 The Home Screen
+
+While the phone is connected, MentraOS draws every screen — including any menus or app launchers — with the ordinary draw commands above, reacting to `button_event`s. The firmware has no resident menus or navigation of its own.
+
+The home screen exists for one reason: the glasses must not go dead during a momentary BLE drop. It is a single firmware-resident screen the glasses can render on their own, showing glanceable info, so a disconnect is invisible to the wearer.
+
+### Display states
+
+- **Idle: the display is off.** Nothing is shown until the wearer wakes it (head-up gesture, or a tap — whatever the device supports).
+- **On wake while connected:** the phone is driving — it draws whatever it wants.
+- **On wake while disconnected:** the firmware shows the cached home screen.
+
+### Uploading the home screen
+
+The phone uploads one home-screen frame, built from the **same draw ops as the live display** ([above](#-display-commands)). The firmware persists it in flash and re-renders it whenever it needs to show the home screen offline.
+
+```protobuf
+message SetHomeScreen {
+  string msg_id = 1;
+  repeated DrawOp ops = 2;   // drawn in order; later paints over earlier
+}
+```
+
+Most content is **baked in as literal text** — weather, notification count, calendar, anything phone-sourced. It cannot change on the glasses, so when it changes the phone simply re-uploads the frame; there is nothing for the firmware to track.
+
+The exception is the `field` placeholder, which is honored here (and only here). A few values change on the glasses while disconnected because only the glasses know them — and `field` lets the firmware fill them from its own state as it renders: `TIME`/`DATE` from its RTC, `BATTERY` from its gauge, `LINK_STATUS` as an offline glyph when the link is down. A `DrawText` op with `field` set renders the firmware's live value instead of its literal `text`, and the firmware keeps it current (the clock ticks, the battery updates) for as long as the home screen is shown.
+
+`SetHomeScreen` is acked with `command_result`. `id`s carry no meaning here — the home screen is a stored frame, not a live scene; to change it, re-upload.
+
+### Setting the clock
+
+The firmware ticks `TIME`/`DATE` from its own RTC, so it stays correct while disconnected. The phone syncs the clock on connect and periodically (for drift and timezone):
+
+```protobuf
+message SyncClock {
+  string msg_id = 1;
+  uint64 epoch_ms = 2;            // current time
+  int32  utc_offset_minutes = 3;  // for local display
+  bool   format_24h = 4;          // 12/24-hour preference (a MentraOS user setting)
+}
+```
+
+`format_24h` is a MentraOS user setting; the phone pushes it here and the firmware persists the last value and renders `TIME` accordingly. The firmware does not expose its own 12/24-hour menu.
+
+## 🔔 Notifications
+
+The glasses firmware does very little for notifications. MentraOS owns all notification logic - what to show, how, and when - and renders notifications with the ordinary draw commands described above. The firmware never decides what is notification-worthy and never stores notification UI of its own.
+
+**Android.** The glasses are not involved at all. The phone reads notifications through its own OS-level listener and draws whatever it wants on the glasses. There is nothing to implement on the firmware side.
+
+**iOS.** iOS does not expose notifications to a companion app the way Android does; instead a BLE accessory reads them directly over Apple's **ANCS** (Apple Notification Center Service). So on iOS the glasses do one thing: act as an ANCS consumer and relay each notification to the phone.
+
+- After bonding, the glasses subscribe to ANCS on the iPhone (the iPhone is the Notification Provider; the glasses are the Notification Consumer). This is standard ANCS — most BLE SoC SDKs ship an ANCS client.
+- ANCS delivers **every** notification from the iPhone to the accessory; there is no per-app filter in the protocol itself. Each notification carries the source app's bundle id as an attribute. The glasses do not filter — they relay everything, and MentraOS applies the user's per-app preferences on the phone.
+- For each notification, the glasses forward it to the phone and otherwise do nothing with it:
+
+```protobuf
+message AncsNotification {
+  string app_id = 1;     // ANCS AppIdentifier (bundle id), e.g. "com.apple.MobileSMS"
+  string title = 2;      // ANCS Title attribute
+  string body = 3;       // ANCS Message attribute
+  uint64 timestamp = 4;  // ANCS Date attribute, unix ms
+  uint32 ancs_uid = 5;   // ANCS NotificationUID, valid for the session
+}
+```
+
+```
+[0x02][GlassesToPhone { ancs_notification {
+  app_id: "com.apple.MobileSMS"
+  title: "Alex"
+  body: "dinner at 7?"
+  timestamp: 1718900000000
+}}]
+```
+
+MentraOS takes it from there — it decides whether to show the notification and, if so, draws it with the normal display commands. The firmware's entire responsibility is: subscribe to ANCS, relay, done.
+
+---
+
+## 🔉 Audio & Microphone
+
+Audio is a binary stream on the `0xA0` channel, controlled by protobuf messages. Frames are LC3, sized to the negotiated MTU; the 1-byte `stream_id` distinguishes streams (e.g. microphone vs TTS).
+
+```
+[0xA0][stream_id (1 byte)][LC3 frame data]
+```
+
+### Microphone
+
+```
+[0x02][PhoneToGlasses { set_mic_state { msg_id: "mic_001", enabled: true }}]
+→ [0x02][GlassesToPhone { mic_state_set { msg_id: "mic_001", success: true }}]
+
+[0x02][PhoneToGlasses { request_mic_status { msg_id: "mic_status_001" }}]
+→ [0x02][GlassesToPhone { mic_status { enabled: true }}]
+```
+
+While the mic is enabled, the glasses stream LC3 frames continuously:
+
+```
+[0xA0][0x01][LC3 frame data...]   // stream_id 0x01 = microphone
+[0xA0][0x01][LC3 frame data...]
+```
+
+### Voice Activity Detection (VAD)
+
+```
+[0x02][PhoneToGlasses { set_vad_enabled { msg_id: "vad_enable_001", enabled: true }}]
+→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_enable_001", success: true }}]   // result echoes msg_id
+
+[0x02][PhoneToGlasses { configure_vad { msg_id: "vad_sens_001", sensitivity: 75 }}]   // 0–100
+→ [0x02][GlassesToPhone { vad_configured { msg_id: "vad_sens_001", success: true }}]
+
+[0x02][PhoneToGlasses { request_vad_status { msg_id: "vad_status_001" }}]
+→ [0x02][GlassesToPhone { vad_status { msg_id: "vad_status_001", enabled: true, sensitivity: 75 }}]
+```
+
+When voice activity starts or stops, the glasses emit:
+
+```
+[0x02][GlassesToPhone { vad_event { state: ACTIVE }}]
+```
+
+---
+
+## 🎮 Input & Sensors
+
+### Buttons
+
+Triggered by a hardware button tap or hold:
+
+```
+[0x02][GlassesToPhone { button_event {
+  button: LEFT_BACK   // LEFT_BACK, RIGHT_BACK
+  event: SINGLE_TAP   // SINGLE_TAP, DOUBLE_TAP, TRIPLE_TAP, LONG_HOLD
+}}]
+```
+
+### Head gestures and position
+
+```
+[0x02][PhoneToGlasses { request_head_gesture_event {
+  msg_id: "gesture_001"
+  gesture: HEAD_UP    // NOD, SHAKE, HEAD_UP
+  enabled: true       // start/stop listening
+}}]
+```
+
+When a subscribed gesture fires:
+
+```
+[0x02][GlassesToPhone { head_gesture { gesture: HEAD_UP }}]   // NOD, SHAKE, HEAD_UP
+```
+
+Head tilt angle (degrees), and the head-up detection threshold:
+
+```
+[0x02][PhoneToGlasses { request_head_position { msg_id: "head_001" }}]
+→ [0x02][GlassesToPhone { head_position { angle: 15 }}]
+
+[0x02][PhoneToGlasses { set_head_up_angle { msg_id: "angle_001", angle: 20 }}]
+→ [0x02][GlassesToPhone { head_up_angle_set { success: true }}]
+```
+
+### IMU
+
+```
+[0x02][PhoneToGlasses { request_enable_imu { msg_id: "imu_001", enabled: true }}]   // enable/disable
+
+[0x02][PhoneToGlasses { request_imu_single { msg_id: "imu_001" }}]                  // one sample
+[0x02][PhoneToGlasses { request_imu_stream { msg_id: "imu_stream_001", enabled: true }}]  // start/stop stream
+```
+
+The glasses report:
+
+```
+[0x02][GlassesToPhone { imu_data {
+  accel { x: 0.02, y: -9.81, z: 0.15 }
+  gyro  { x: 0.01, y: 0.02,  z: 0.00 }
+  mag   { x: -10.2, y: 2.1,  z: 41.9 }
+}}]
+```
+
+IMU streaming runs at a configurable 10–100 Hz.
+
+---
+
+## 🧰 Device & System
+
+### Battery and charging
+
+```
+[0x02][PhoneToGlasses { request_battery_state { msg_id: "battery_001" }}]
+→ [0x02][GlassesToPhone { battery_status { level: 82, charging: false }}]
+```
+
+When the glasses detect they are charging, they emit asynchronously:
+
+```
+[0x02][GlassesToPhone { charging_state { state: CHARGING }}]
+```
+
+### Heartbeat
+
+The glasses send a periodic ping to verify the link is alive; the phone replies:
+
+```
+[0x02][GlassesToPhone { ping { msg_id: "ping_001" }}]
+← [0x02][PhoneToGlasses { pong {} }]
+```
+
+### Pairing, disconnect, restart, factory reset
+
+```
+[0x02][PhoneToGlasses { enter_pairing_mode { msg_id: "pair_001" }}]  // also automatic on boot if never paired
+[0x02][PhoneToGlasses { disconnect { msg_id: "disc_001" }}]          // terminate, clean up
+[0x02][PhoneToGlasses { restart_device { msg_id: "restart_001" }}]   // reboot
+[0x02][PhoneToGlasses { factory_reset { msg_id: "factory_001" }}]    // clear all settings and cached data
+```
+
+---
+
+## 🧭 Capability Descriptor
+
+The phone needs each device's parameters to lay out frames correctly: screen size, intensity depth, available fonts, and max image size. The glasses report them in response to `request_glasses_info`:
+
+```
+[0x02][PhoneToGlasses { request_glasses_info { msg_id: "info_001" }}]
+```
+
+```protobuf
+message DeviceInfo {
+  string fw_version = 1;
+  string hw_model = 2;
+  Features features = 3;
+
+  DisplayProfile display = 20;
+  FontProfile    fonts = 21;
+}
+
+message Features {
+  bool camera = 1;
+  bool display = 2;
+  bool audio_tx = 3;
+  bool audio_rx = 4;
+  bool imu = 5;
+  bool vad = 6;
+  bool mic_switching = 7;
+  uint32 image_chunk_buffer = 8;   // chunks the firmware buffers per image (e.g. 12)
+}
+
+message DisplayProfile {
+  uint32 width = 1;            // px
+  uint32 height = 2;          // px
+  uint32 intensity_levels = 3;// e.g. 16 (4-bit); 2 = pure 1-bit
+  uint32 max_image_width = 4;
+  uint32 max_image_height = 5;
+  repeated string encodings = 6;   // supported pixel encodings, e.g. ["raw","rle_1bit","rle_4bit"]
+  uint32 max_addressable_elements = 7;  // retained (id'd) elements the firmware can hold at once
+}
+
+message FontProfile {
+  repeated Font fonts = 1;         // fonts resident on the glasses today
+  bool supports_font_upload = 2;   // phone can upload a font at runtime
+  uint32 max_uploaded_fonts = 3;   // slots available for uploaded fonts (0 if none)
+}
+
+message Font {
+  uint32 font_code = 1;            // the id used in display_text.font_code / home-screen text ops
+  uint32 size_px = 2;              // glyph height in px
+  string name = 3;                 // e.g. "IBM Plex Sans"
+  string coverage = 4;             // optional glyph-coverage tag, e.g. "latin+cjk"
+}
+```
+
+---
+
+## 🔠 Fonts
+
+The phone wraps and lays out all text, so it must measure each line against the metrics of the font the glasses will actually render. The glasses report their fonts in the capability descriptor; the phone picks a `font_code` for every text draw and measures against the matching font's metrics, which MentraOS holds. An OEM ships at least one font covering the required languages below; the runtime then wraps text identically to what the glasses render.
+
+**Required glyph coverage:** Latin (incl. extended Latin for European languages such as Spanish, French, German, Italian, Portuguese, Dutch, Polish, Turkish, Vietnamese) and CJK — Chinese (Simplified and Traditional), Japanese, and Korean.
+**Recommended:** other scripts — Cyrillic (Russian, Ukrainian), Arabic, Hebrew, Devanagari (Hindi), Bengali, and Thai.
+
+Use the Mentra-provided IBM Plex Sans build, or share your own font (Mentra loads its metrics into the runtime).
+
+### Runtime font upload (optional)
+
+If `supports_font_upload` is true, the phone can push a font to the glasses at runtime. A font is just another binary asset, so it reuses the **cached-bitmap transfer path** (`preload_image`) rather than a new one: the glyph-table bytes stream over the `0xB0` channel against a `stream_id` and are acked with `image_transfer_complete`, exactly like a preloaded image. The only extra is a control message that says "the blob arriving on this `stream_id` is a font — register it under this `font_code`":
+
+```protobuf
+message UploadFont {
+  string msg_id = 1;
+  string stream_id = 2;    // the glyph-table blob arriving on the 0xB0 channel
+  uint32 total_chunks = 3;
+  uint32 font_code = 4;    // id to register the font under; later draws reference it
+  uint32 size_px = 5;
+  string format = 6;       // agreed glyph-table format
+}
+```
+
+Once the transfer completes, the firmware stores the font in one of the `max_uploaded_fonts` slots and addresses it by `font_code` exactly like a resident font.
+
+---
+
+## ✅ Acknowledgements & Forward Compatibility
+
+Many commands are fire-and-forget. A single generic result message lets the phone confirm that state-changing commands landed and detect features a given firmware doesn't implement. Every `PhoneToGlasses` carries a `msg_id`; the glasses echo it in a result:
+
+```protobuf
+message CommandResult {
+  string msg_id = 1;   // echoes the PhoneToGlasses.msg_id this responds to
+  Status status = 2;
+  string detail = 3;   // optional human-readable note on failure
+}
+
+enum Status {
+  OK = 0;
+  FAIL = 1;
+  UNSUPPORTED = 2;     // glasses do not implement this command/field
+  BAD_PARAM = 3;       // value out of range / malformed
+  BUSY = 4;            // transient; phone may retry
+  NO_MEMORY = 5;       // asset storage full
+}
+```
+
+```
+[0x02][GlassesToPhone { command_result { msg_id: "commit_001", status: OK }}]
+```
+
+The glasses should ack state-changing commands — especially `commit`, `SetHomeScreen`, and asset uploads, where the phone must know the change was persisted — rather than stay silent. High-frequency, fire-and-forget commands (individual `draw_*`) need not be acked.
+
+**Forward compatibility:** unknown fields and message types are ignored, never fatal. When the phone sends a feature the firmware doesn't implement, the firmware ignores the effect **and** returns `UNSUPPORTED`, so the phone can adapt rather than guess.
+
+---
+
+## 💾 Implementation Notes
+
+### Protobuf on the MCU
+
+**nanopb** (~10 KB footprint, static allocation, no dynamic memory) is the recommended library. A minimal receive path:
+
+```c
+uint8_t buffer[256];
+uint16_t len = ble_read_characteristic(buffer, sizeof(buffer));
+
+if (buffer[0] == 0x02) {  // protobuf control message
+    PhoneToGlasses msg = PhoneToGlasses_init_zero;
+    pb_istream_t stream = pb_istream_from_buffer(buffer + 1, len - 1);
+    if (pb_decode(&stream, PhoneToGlasses_fields, &msg)) {
+        if (msg.has_display_text) {
+            display_text(msg.display_text.text, msg.display_text.x, msg.display_text.y);
+        }
+    }
+}
+```
+
+Schema conventions: field numbers never change; new fields are optional; `oneof` discriminates message type; `repeated` carries arrays (like `missing_chunks`).
+
+### Error handling
+
+- **Invalid message:** if protobuf decode fails, ignore the message.
+- **Unknown fields/messages:** ignore (forward compatibility).
+- **Resource limits:** return a `command_result` error for operations that exceed memory/display limits.
+- **Timeouts:** image transfers ~5 s per chunk; command responses ~1 s.
+- **Connection loss:** clean up pending operations and reset state.
+
+### Timing and buffers
+
+- Audio: 10 ms LC3 frame intervals; buffer 3–5 frames for jitter.
+- Display: aim for < 50 ms latency for responsive UI.
+- IMU streaming: configurable 10–100 Hz.
+- Image chunk buffer: typically 12 chunks (configurable, reported in `Features`).
+- Command queue: support at least 10 pending commands.
+
+### Security
+
+- Implement pairing/bonding and encryption at the BLE level.
+- Validate all input parameters; enforce maximum sizes for strings and arrays.
+- Rate-limit to prevent abuse via excessive commands.
+
+---
+
+## 📌 What a Complete Device Implements
+
+- **Display & input:** the transport, the drawing model (queue → atomic `commit`; `clear` to start fresh; retained `id`'d elements with `update` for flicker-free partial repaint), draw primitives, image transfer and cached bitmaps, brightness, button/IMU/head events.
+- **Capability descriptor & fonts:** report geometry, intensity depth, and the resident fonts so the phone can measure and wrap text.
+- **Acknowledgements:** echo `command_result` for state-changing commands; honor forward-compatibility (ignore unknowns, return `UNSUPPORTED`).
+- **Notifications:** on iOS, subscribe to ANCS and relay each notification to the phone as `ancs_notification`; on Android, nothing. MentraOS draws notifications itself.
+- **Home screen:** accept a phone-uploaded home-screen design (`SetHomeScreen`), render it on wake while disconnected, fill the `TIME`/`DATE`/`BATTERY`/`LINK_STATUS` fields from its own state, and tick the clock from `SyncClock`. Display is off when idle.
+
+**Optional refinements** (none change the contract above): saved-bitmap transforms (scale/rotate a cached image), 4-bit grayscale bitmaps, and curved/arc line support.

--- a/docs/glasses-oems/integration-toolkit.mdx
+++ b/docs/glasses-oems/integration-toolkit.mdx
@@ -1,0 +1,183 @@
+---
+title: "OEM Integration Toolkit"
+description: "Embed the full MentraOS experience (miniapps, the Mentra Miniapp Store, and the developer ecosystem) inside your own phone app, driving your own smart glasses."
+---
+
+## What it is
+
+The **Mentra OEM Integration Toolkit** is all of MentraOS's phone-side logic packaged as a library you embed in your **own** app. Your users stay in your app and on your brand, but they get the full MentraOS experience: the Mentra Miniapp Store, installable miniapps, and the same developer ecosystem that powers the Mentra app.
+
+The toolkit owns everything between your glasses and Mentra's backend services:
+
+- **Mentra Miniapp Store + runtime**: discover, install, and run miniapps on the phone.
+- **Glasses I/O**: display rendering, microphone/audio routing, and the rest of the glasses feature set.
+- **Backend connectivity**: talking to Mentra's backend services for the store, transcription, translation, streaming, and photos.
+
+You bring two things: **your glasses** (and however you talk to them over Bluetooth) and **your app** (its shell, navigation, and branding).
+
+```mermaid
+%%{init: {"flowchart": {"curve": "linear"}}}%%
+flowchart TB
+  subgraph App["Your App: your branding, your user experience, your customer relationship"]
+    direction TB
+    subgraph Toolkit["Mentra OEM Integration Toolkit Library"]
+      direction TB
+      F1["Miniapp Runtime"]
+      F2["Mentra Miniapp Store"]
+      F3["Developer ecosystem"]
+      F1 ~~~ F2
+      F2 ~~~ F3
+    end
+    Adapter["Your Glasses Adapter"]
+    Toolkit --> Adapter
+  end
+
+  Adapter --> Glasses["Your Smart Glasses"]
+
+  classDef app fill:#f8fafc,stroke:#cbd5e1,stroke-width:1px,color:#0f172a
+  classDef toolkit fill:#eef2ff,stroke:#6366f1,stroke-width:1.5px,color:#1e1b4b
+  classDef feature fill:#ffffff,stroke:#a5b4fc,stroke-width:1px,color:#312e81
+  classDef adapter fill:#ecfdf5,stroke:#10b981,stroke-width:1.5px,color:#064e3b
+  classDef external fill:#f1f5f9,stroke:#64748b,stroke-width:1px,color:#0f172a
+
+  class App app
+  class Toolkit toolkit
+  class F1,F2,F3 feature
+  class Adapter adapter
+  class Glasses external
+
+  linkStyle 0 stroke:none
+  linkStyle 1 stroke:none
+  linkStyle default stroke:#94a3b8,stroke-width:1.5px
+```
+
+## Integrating in four moves
+
+### 1. Install the toolkit
+
+Add the toolkit to your app, using the path that matches how your app is built:
+
+- **React Native / Expo**: install the toolkit as a module.
+- **Native (iOS / Android)**: embed the native libraries (iOS framework, Android library) directly.
+- **Flutter**: embed the native libraries and bridge them into Flutter through platform channels.
+
+### 2. Configure the toolkit
+
+You give the toolkit a single configuration when your app boots. The toolkit manages its own settings internally. The only things you hand it are what's yours:
+
+- **Your identity**: how your users are signed in (see [Backend connectivity](#3-connect-to-the-backend-services)).
+- **Optional proxy**: if you route Mentra's backend services through your own infrastructure, you pass your proxy here (see below).
+
+### 3. Connect to the backend services
+
+The toolkit talks to two tiers of Mentra backend services:
+
+- **Mentra Runtime Services.** The capabilities the toolkit relies on: speech-to-text, text-to-speech, translation, live streaming, and photo handling. Self-hostable and/or proxyable (run your own, route through your proxy, or both).
+- **Mentra Cloud Core Services.** The Mentra Miniapp Store, the developer console, and the OEM APIs. Proxyable only (always Mentra-hosted, optionally reached through your proxy).
+
+The toolkit also includes **on-device STT/TTS** as a fallback for offline or degraded-network scenarios. Cloud STT/TTS is the recommended path for production quality; on-device is the safety net.
+
+**Identity.** Your users sign in through *your* identity system. They never create a Mentra account. The toolkit exchanges your app's signed-in identity for a Mentra-scoped session, so your users see only your login.
+
+**Routing through your proxy.** You don't stand up a separate proxy service. When you configure the toolkit, you give it your proxy details and it routes all backend traffic through your infrastructure. Without a proxy, the toolkit talks to the backend services directly.
+
+### 4. Register your glasses
+
+The toolkit talks to glasses through a **Glasses Adapter**: a contract that describes one model of glasses. You implement an adapter for your hardware, in your own app, against your own Bluetooth stack, and register it at startup. The toolkit then treats your glasses as a first-class device, exactly like the glasses Mentra ships.
+
+An adapter declares two things: **capabilities** (what your glasses have) and **behavior** (how to drive each feature over your BLE link). You declare and implement only what your hardware actually has.
+
+**Example: a display + mic device with a touchpad and an IMU (no camera).** This is the common OEM shape today (think Even Realities G2): a monochrome text display, a microphone, a capacitive touchpad, and an IMU, no camera. Here's the whole adapter for one.
+
+**Declare your capabilities.** Same capability shape the toolkit uses for every device it supports. Fill it in for your hardware. This device declares a display, a microphone, an input surface, and an IMU, and leaves the rest out:
+
+```ts
+const capabilities: Capabilities = {
+  modelName: "Acme Vision One",
+
+  display: {
+    ocularity: "binocular",   // "monocular" | "binocular"
+    isColor: false,
+    color: "green",
+    canDisplayBitmap: true,
+    resolution: {width: 640, height: 200},
+    maxTextLines: 5,
+    adjustBrightness: true,
+  },
+
+  microphone: {count: 1, hasVAD: false},
+
+  input: {  
+    surfaces: [{kind: "touchpad"}, {kind: "button"}],
+    events: ["tap", "double_tap", "triple_tap", "long_press", "swipe_up", "swipe_down"],
+  },
+
+  imu: {hasAccelerometer: true, hasGyroscope: true, hasCompass: true},
+
+  power: {hasExternalBattery: false},
+
+  // A capability the device doesn't have is null.
+  camera: null,
+  speaker: null,
+  light: null,
+  wifi: null,
+}
+```
+
+**Implement the behavior.** Each method drives your hardware over your BLE link. The toolkit never calls a method for a capability you didn't declare:
+
+```ts
+const acmeAdapter: GlassesAdapter = {
+  model: "Acme Vision One",
+  capabilities,
+  displayProfile: acmeDisplayProfile,   // how your screen renders text (size, monochrome)
+
+  // Connection lifecycle
+  async scan(onFound)      { /* discover your glasses over BLE; call onFound per device */ return stopScan },
+  async connect(device)    { /* your BLE connect */ },
+  async disconnect()       { /* your BLE disconnect */ },
+  async forget()           { /* unpair / clear the bond */ },
+  onStatusChange(cb)       { /* connected, battery, firmware version, etc. */ return unsubscribe },
+
+  // Display
+  async displayText(text)            { /* push a text wall */ },
+  async displayDoubleText(top, bot)  { /* two-region text layout */ },
+  async displayBitmap(bmp)           { /* push a bitmap */ },
+  async clearDisplay()               { /* clear the screen */ },
+  async setBrightness(n, auto)       { /* set brightness (or auto) */ },
+  async setHeadUpAngle(deg)          { /* angle at which content shows on head-up */ },
+
+  // Dashboard (a built-in overlay the toolkit drives)
+  async showDashboard()              { /* show the dashboard overlay */ },
+  async setDashboardMenu(items)      { /* set dashboard menu entries */ },
+  async setDashboardPosition(h, d)   { /* position the dashboard */ },
+
+  // Microphone
+  async setMicEnabled(on)  { /* turn the mic on/off */ },
+  onAudio(cb)              { /* stream mic audio up to the toolkit */ return unsubscribe },
+
+  // Input (touchpad + buttons)
+  onInputEvent(cb)         { /* report any declared input event: taps, swipes, presses */ return unsubscribe },
+
+  // IMU (sensor feed, not input)
+  async setImuEnabled(on)  { /* start/stop the IMU feed */ },
+  onImuData(cb)            { /* stream orientation / motion when a miniapp subscribes */ return unsubscribe },
+}
+
+registerGlassesAdapter(acmeAdapter)
+```
+
+That's the whole integration. The toolkit handles everything above it: which miniapps run, how their content is laid out for your screen, routing your mic audio to speech-to-text.
+
+Your adapter lives **in your app**: your Bluetooth protocol, your firmware, your transport stay private to you. You never submit glasses code to Mentra, and you never wait on a Mentra release to ship a hardware change.
+
+## Why this works
+
+- **Your hardware, no fork.** The Glasses Adapter is your private extension point. Add or change a model entirely within your app.
+- **Your app, your brand.** Users never leave your app or see a Mentra account. The toolkit is a library inside your experience, not a separate app.
+- **One shared ecosystem.** Every OEM's users and developers live in the same MentraOS ecosystem. That's what makes the Mentra Miniapp Store worth being part of.
+- **You decide what you host.** Use Mentra's backend services as-is or route them all through your own proxy.
+
+## Availability
+
+The Mentra OEM Integration Toolkit releases **July 30, 2026**. To start an integration, reach out to [help@mentra.glass](mailto:help@mentra.glass).

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1316,12 +1316,10 @@ class G2 : SGCManager() {
     private val EVEN_HUB_QUEUE_TICK_MS = 100L
     private var startupPageCreated: Boolean = false
     private var pageCreated: Boolean = false
-    // Live hardware truth: is the firmware mic actually streaming right now. DISTINCT from the
-    // glasses/micEnabled DeviceStore flag, which is *intent* (does the user/cloud want the mic
-    // on). The mic only exists inside a live EvenHub page, so whenever the page dies (systemExit
-    // / abnormalExit / shutdown cmd 9·10 / dashboard takes focus) the firmware kills the mic and
-    // we set this false — WITHOUT touching the intent flag, so recovery can re-arm iff intent says
-    // the mic should be on. See the iOS G2.swift counterpart.
+    // Live hardware truth: is the firmware mic actually streaming. DISTINCT from the
+    // glasses/micEnabled DeviceStore flag, which is *intent* (does the user want the mic on).
+    // Cleared on every page teardown WITHOUT touching intent, so recovery can re-arm iff intent
+    // still says the mic should be on. See the iOS G2.swift counterpart.
     private var evenHubMicActive: Boolean = false
     private var currentTextContent: String = ""
     private var textContainerID: Int = 1
@@ -1354,12 +1352,8 @@ class G2 : SGCManager() {
     private var rightAuthenticated: Boolean = false
     private var currentBitmapBase64: String = ""
     private var dashboardShowing = 0
-    // Recovery throttle — see iOS G2.swift. The firmware spams systemExit + dashboard-close
-    // (08011A00) ~1×/sec on its own; each used to fire a full rebuildState() that the firmware
-    // tore down again → rebuild→exit→rebuild storm that churns the display so captions never
-    // render. We coalesce: at most one recovery rebuild in flight, no more than one every
-    // RECOVERY_DEBOUNCE_MS, and skip entirely when the page is already alive and the mic matches
-    // intent (phantom event).
+    // Recovery throttle (see iOS G2.swift): the firmware spams systemExit + dashboard-close
+    // ~1×/sec. Coalesce so recovery can't storm — one rebuild in flight, one per RECOVERY_DEBOUNCE_MS.
     private var recoveryInFlight = false
     private var lastRecoveryRebuildMs: Long = 0
     private val RECOVERY_DEBOUNCE_MS: Long = 1500
@@ -2091,25 +2085,24 @@ class G2 : SGCManager() {
 
     override fun clearDisplay() {
         Bridge.log("G2: clearDisplay()")
-        displayScope.launch {
-            // reset the content of all text containers to empty:
-            for (i in textContainers.indices) {
-                textContainers[i].content = " "
-                // The rebuild below re-embeds this blank content via createPageWithContainers, so no
-                // separate updateText send is needed — drop any scheduled sends.
-                textContainers[i].pendingSends = 0
-            }
-            for (i in imageContainers.indices) {
-                // Cleared to empty — nothing to (re)send, so mark clean so the reconcile loop skips it.
-                imageContainers[i].bmpData = ByteArray(0)
-                imageContainers[i].dirty = false
-            }
-            // shutdown the page and then recreate the containers without the content.
-            displayScope.launch {
-                rebuildPage()
-                rebuildState()
-            }
+        // Clear the text in place — do NOT shut down + rebuild the EvenHub page. Tearing the page
+        // down (rebuildPage) kills audio streaming AND triggers a firmware systemExit /
+        // dashboard-close → recovery → another rebuild. The cloud sends clearDisplay in bursts
+        // (caption gaps → clear → new caption), and when each clear tore down + rebuilt the page
+        // those bursts became a rebuild storm that churned the display and dropped audio for
+        // several seconds (incident 8164175a). Just blank the text + clear images; the reconcile
+        // loop pushes the blanked text on a live page, and a dead page is only resurrected for
+        // meaningful (non-blank) content, so a clear can't churn it back up.
+        for (i in textContainers.indices) {
+            textContainers[i].content = " "
+            textContainers[i].pendingSends = 1 + EVEN_HUB_RESEND_COUNT
         }
+        for (i in imageContainers.indices) {
+            // Cleared to empty — nothing to (re)send, so mark clean so the reconcile loop skips it.
+            imageContainers[i].bmpData = ByteArray(0)
+            imageContainers[i].dirty = false
+        }
+        signalDisplayDirty()
     }
 
     /**
@@ -2295,17 +2288,16 @@ class G2 : SGCManager() {
     }
 
     /**
-     * Single coalesced recovery: rebuild the page + re-arm the mic from intent, but never stack
-     * rebuilds. The firmware spams systemExit/dashboard-close ~1×/sec; without this guard each one
-     * triggered a rebuild that was torn down again → rebuild→exit→rebuild storm. Skips entirely
-     * when the page is already alive and the mic matches intent (phantom event); otherwise at most
-     * one rebuild in flight and at most one per RECOVERY_DEBOUNCE_MS. See iOS G2.swift.
+     * Single coalesced recovery: rebuild the page + re-arm the mic from intent, never stacking
+     * rebuilds (the firmware spams systemExit/dashboard-close ~1×/sec). Skips when the page is
+     * already alive and the mic matches intent; otherwise one rebuild in flight, one per
+     * RECOVERY_DEBOUNCE_MS. See iOS G2.swift.
      */
     private fun recoverPageAndMic(reason: String) {
         val now = System.currentTimeMillis()
+        // Page alive and mic matches intent → phantom firmware event, nothing to recover.
         val micIntent = DeviceStore.get("glasses", "micEnabled") as? Boolean ?: false
         if (pageCreated && evenHubMicActive == micIntent) {
-            // Bridge.log("G2: recover($reason) skipped — page alive, mic matches intent")
             return
         }
         if (recoveryInFlight) {
@@ -2342,7 +2334,10 @@ class G2 : SGCManager() {
         // dashboard owns the screen.
         if (!pageCreated) {
             val useNativeDashboard = DeviceStore.get("bluetooth", "use_native_dashboard") as? Boolean ?: false
-            val hasPendingText = textContainers.any { it.pendingSends > 0 }
+            // Only resurrect a dead page for MEANINGFUL content. A clearDisplay (blank " ") on an
+            // already-dead page has nothing to show, so don't rebuild just to render blankness —
+            // that would let a clear burst churn the page back up pointlessly.
+            val hasPendingText = textContainers.any { it.pendingSends > 0 && it.content.isNotBlank() }
             val hasPendingImage = imageContainers.any { it.dirty && it.bmpData.isNotEmpty() }
             if ((hasPendingText || hasPendingImage) && !(useNativeDashboard && dashboardShowing > 0)) {
                 Bridge.log("G2: reconcileDisplay() - page down with pending content, rebuilding once")
@@ -4126,23 +4121,12 @@ class G2 : SGCManager() {
                 }
             }
 
-            // System exit: glasses killed our EvenHub page (the firmware's "End this feature?"
-            // screen, or another app — like the native dashboard — taking focus). The page is
-            // gone and the firmware has also killed the mic.
-            //
-            // We ONLY mark state dead here; we do NOT rebuild. systemExit fires together with the
-            // dashboard-close (08011A00) event for the same firmware transition, and a bare
-            // sendText/clearDisplay also follows. If this handler rebuilt the page, the
-            // dashboard-close handler would rebuild it a *second* time, the firmware would tear the
-            // fresh page down (another systemExit), and we'd loop rebuild→exit→rebuild ~1×/sec
-            // forever — the page never settles and captions never render. Recovery is owned by
-            // exactly one place: the dashboard-close handler (08011A00) and the reconcile loop's
-            // "page down with pending content → rebuild once" path. Both run after this and both
-            // re-arm the mic from intent.
-            //
-            // We mark evenHubMicActive=false (live hardware truth) but DELIBERATELY do NOT touch
-            // glasses/micEnabled: that flag is the user/cloud *intent*, and recovery reads it to
-            // decide whether to re-arm. Clobbering it stranded the mic after a dashboard round-trip.
+            // System exit: the firmware killed our page (and the mic). ONLY mark state dead; do
+            // NOT rebuild here. systemExit is fired alongside the dashboard-close (08011A00) event
+            // for the same transition — if both rebuilt, the fresh page gets torn down again →
+            // rebuild→exit→rebuild loop. Recovery is owned by one place: the dashboard-close
+            // handler (and the reconcile page-down path). Don't touch micEnabled (user intent) —
+            // recovery reads it to re-arm; clobbering it strands the mic.
             if (eventType == OsEventType.SYSTEM_EXIT || eventType == OsEventType.ABNORMAL_EXIT) {
                 pageCreated = false
                 evenHubMicActive = false // firmware killed the mic with the page
@@ -4316,17 +4300,9 @@ class G2 : SGCManager() {
         // Dashboard close detection: 08011A00 means dashboard closed
         if (payload.contentEquals(byteArrayOf(0x08, 0x01, 0x1A, 0x00))) {
             Bridge.log("G2: dashboard closed / shutdown - dashboardShowing=$dashboardShowing")
-            // A dashboard-close event unambiguously means the dashboard is gone, so always reset
-            // to 0 and recover. We deliberately do NOT keep a residual depth count (the old
-            // +=2 / -=1 "decrement dance"): that counter drifts when a close frame is dropped by
-            // the 500ms gesture_ctrl dedup or when systemExits interleave with opens, and once it
-            // strands >0 the dashboardShowing>0 guard in restartMic wedges the mic permanently
-            // (cloud keeps calling setMicEnabled(true) but it never arms). Self-heal: clear the
-            // count and recover. recoverPageAndMic() rebuilds the page and re-arms the mic from
-            // intent (rebuildState → restartMicIfAlreadyEnabled), and is debounced so the
-            // firmware's ~1×/sec systemExit+close spam can't storm rebuilds. If the page is
-            // already alive (a phantom close while our page is healthy), the guard makes this a
-            // cheap no-op.
+            // Dashboard is gone — always reset to 0 (a 0/1 flag, not a depth count: the old
+            // +=2/-=1 dance drifted >0 when a close frame was deduped, wedging the mic). Then
+            // recover via the coalesced/debounced path so firmware close-spam can't storm.
             dashboardShowing = 0
             recoverPageAndMic("dashboard-close")
             return

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1352,6 +1352,11 @@ class G2 : SGCManager() {
     private var rightAuthenticated: Boolean = false
     private var currentBitmapBase64: String = ""
     private var dashboardShowing = 0
+    // The 08011A00 gesture_ctrl event is ambiguous: the firmware sends it BOTH when the dashboard
+    // opens (shuts our page down to take the screen) and when it closes. showDashboard() sets this
+    // latch; the next 08011A00 is the OPEN confirm — consume it WITHOUT recovering (else we rebuild
+    // and snatch the screen back). The following 08011A00 is the real CLOSE → recover. See iOS.
+    private var dashboardOpening = false
     // Recovery throttle (see iOS G2.swift): the firmware spams systemExit + dashboard-close
     // ~1×/sec. Coalesce so recovery can't storm — one rebuild in flight, one per RECOVERY_DEBOUNCE_MS.
     private var recoveryInFlight = false
@@ -2485,10 +2490,10 @@ class G2 : SGCManager() {
     /// The glasses fall back to the dashboard automatically when no page is up.
     override fun showDashboard() {
         Bridge.log("G2: showDashboard()")
-        // Dashboard is open: a simple on/off flag, not an accumulating depth. The old `+= 2`
-        // could climb without bound when opens interleaved with dropped close events, stranding
-        // the counter >0 and wedging the mic (the dashboardShowing>0 guard in restartMic).
+        // Dashboard is open: a 0/1 flag (the old +=2/-=1 depth dance drifted >0 and wedged the
+        // mic). dashboardOpening latches so the open-confirm 08011A00 doesn't trigger recovery.
         dashboardShowing = 1
+        dashboardOpening = true
         val msg = EvenHubProto.shutdownMessage()
         sendEvenHubCommand(msg)
         pageCreated = false
@@ -3020,6 +3025,7 @@ class G2 : SGCManager() {
         imageContainers.clear()
         textContainers.clear()
         dashboardShowing = 0
+        dashboardOpening = false
         heartbeatCounter = 0
         currentBitmapBase64 = ""
         menuAppIdToPackageName.clear()
@@ -3572,6 +3578,7 @@ class G2 : SGCManager() {
                         startupPageCreated = false
                         pageCreated = false
                         dashboardShowing = 0
+                        dashboardOpening = false
                         DeviceStore.apply("glasses", "connected", false)
                         DeviceStore.apply("glasses", "fullyBooted", false)
 
@@ -4297,12 +4304,18 @@ class G2 : SGCManager() {
         }
         lastGestureCtrlTimestamp = timestamp
 
-        // Dashboard close detection: 08011A00 means dashboard closed
+        // 08011A00 is the dashboard open/close toggle — it fires on BOTH transitions. Use the
+        // dashboardOpening latch (set by showDashboard) to tell them apart:
+        //   • First event after showDashboard → OPEN confirm. Consume it, keep the dashboard up,
+        //     do NOT recover (recovering rebuilds our page and snatches the screen back — the
+        //     "double-tap flickers captions but never opens the dashboard" bug).
+        //   • Next event → real CLOSE. Reset state and recover our page + mic.
         if (payload.contentEquals(byteArrayOf(0x08, 0x01, 0x1A, 0x00))) {
-            Bridge.log("G2: dashboard closed / shutdown - dashboardShowing=$dashboardShowing")
-            // Dashboard is gone — always reset to 0 (a 0/1 flag, not a depth count: the old
-            // +=2/-=1 dance drifted >0 when a close frame was deduped, wedging the mic). Then
-            // recover via the coalesced/debounced path so firmware close-spam can't storm.
+            Bridge.log("G2: dashboard toggle - dashboardShowing=$dashboardShowing opening=$dashboardOpening")
+            if (dashboardOpening) {
+                dashboardOpening = false // open confirmed; dashboard now owns the screen
+                return
+            }
             dashboardShowing = 0
             recoverPageAndMic("dashboard-close")
             return

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1455,11 +1455,8 @@ class G2: NSObject, SGCManager {
     private var pairingTimeoutTimer: DispatchWorkItem?
     private var useEvenDashboard = true
     private var dashboardShowing = 0
-    // Recovery throttle. The firmware can spam systemExit + dashboard-close (08011A00) ~1×/sec
-    // on its own (not user dashboard toggles). Each one used to fire a full rebuildState(), and
-    // the rebuilt page would be torn down again → rebuild→exit→rebuild storm that churns the
-    // display so captions never render. We coalesce: at most one recovery rebuild in flight, and
-    // no more than one every RECOVERY_DEBOUNCE_MS. A genuine close still recovers within a beat.
+    // Recovery throttle: the firmware spams systemExit + dashboard-close ~1×/sec on its own.
+    // Coalesce so recovery can't storm — one rebuild in flight, one per RECOVERY_DEBOUNCE_MS.
     private var recoveryInFlight = false
     private var lastRecoveryRebuildMs: Int64 = 0
     private let RECOVERY_DEBOUNCE_MS: Int64 = 1500
@@ -1517,12 +1514,10 @@ class G2: NSObject, SGCManager {
     private var foregroundObserver: NSObjectProtocol?
     private var startupPageCreated: Bool = false  // createStartUpPageContainer can only be called once
     private var pageCreated: Bool = false
-    // Live hardware truth: is the firmware mic actually streaming right now. This is DISTINCT
-    // from the `glasses/micEnabled` DeviceStore flag, which is *intent* (does the user/cloud
-    // want the mic on). The mic can only stream inside a live EvenHub page, so whenever the
-    // page dies (systemExit / abnormalExit / shutdown cmd 9·10 / dashboard takes focus) the
-    // firmware kills the mic and we set this false — WITHOUT touching the intent flag, so the
-    // recovery path can re-arm the mic iff intent still says it should be on.
+    // Live hardware truth: is the firmware mic actually streaming. DISTINCT from the
+    // glasses/micEnabled DeviceStore flag, which is *intent* (does the user want the mic on).
+    // Cleared on every page teardown (the firmware kills the mic with the page) WITHOUT touching
+    // intent, so recovery can re-arm iff intent still says the mic should be on.
     private var evenHubMicActive: Bool = false
     private var currentTextContent: String = ""
     private var currentBitmapBase64: String = ""
@@ -2167,33 +2162,19 @@ class G2: NSObject, SGCManager {
 
     func clearDisplay() {
         Bridge.log("G2: clearDisplay()")
-        // Don't shutdown the EvenHub page — that kills audio streaming too.
-        // Instead, just clear the text content by sending a space.
-
-        // if !pageCreated {
-        //     Bridge.log("G2: clearDisplay() - page not created")
-        //     createPageWithContainers()
-        // }
-
-        // reset the content of all text containers to empty:
+        // Blank the text in place — do NOT shut down + rebuild the page. A teardown kills audio
+        // and triggers a firmware systemExit→recovery→rebuild; the cloud sends clearDisplay in
+        // bursts, so that turned into a rebuild storm. The reconcile loop pushes the blanked text.
         for i in textContainers.indices {
             textContainers[i].content = " "
-            // The rebuild below re-embeds this blank content via createPageWithContainers, so no
-            // separate updateText send is needed — drop any scheduled sends.
-            textContainers[i].pendingSends = 0
+            textContainers[i].pendingSends = 1 + EVEN_HUB_RESEND_COUNT
         }
         for i in imageContainers.indices {
             // Cleared to empty — nothing to (re)send, so mark clean so the reconcile loop skips it.
             imageContainers[i].bmpData = Data()
             imageContainers[i].dirty = false
         }
-        // shutdown the page and then recreate the containers without the content:
-        Task {
-            await rebuildPage()
-            await rebuildState()
-            // try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms to settle
-            // createPageWithContainers()
-        }
+        signalDisplayDirty()
     }
 
     /// Send a bitmap to an image container as fragmented updateImageRawData packets.
@@ -2389,7 +2370,11 @@ class G2: NSObject, SGCManager {
         if !pageCreated {
             let useNativeDashboard =
                 DeviceStore.shared.get("bluetooth", "use_native_dashboard") as? Bool ?? false
-            let hasPendingText = textContainers.contains { $0.pendingSends > 0 }
+            // Only resurrect a dead page for non-blank content — don't rebuild just to render a
+            // clearDisplay's blank, or a clear burst churns the page back up pointlessly.
+            let hasPendingText = textContainers.contains {
+                $0.pendingSends > 0 && $0.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            }
             let hasPendingImage = imageContainers.contains { $0.dirty && !$0.bmpData.isEmpty }
             if (hasPendingText || hasPendingImage) && !(useNativeDashboard && dashboardShowing > 0) {
                 Bridge.log("G2: reconcileDisplay() - page down with pending content, rebuilding once")
@@ -4040,24 +4025,12 @@ class G2: NSObject, SGCManager {
             //     Bridge.log("G2: Click detected")
             // }
 
-            // System exit: glasses killed our EvenHub page (the firmware's "End this
-            // feature?" screen, or another app — like the native dashboard — taking focus).
-            // The page is gone and the firmware has also killed the mic.
-            //
-            // We ONLY mark state dead here; we do NOT rebuild. systemExit is fired together
-            // with the dashboard-close (08011A00) event for the same firmware transition, and
-            // a bare sendText/clearDisplay also follows. If this handler rebuilt the page, the
-            // dashboard-close handler would rebuild it a *second* time, the firmware would tear
-            // the fresh page down (another systemExit), and we'd loop rebuild→exit→rebuild
-            // ~1×/sec forever — the page never settles and captions never render. So recovery
-            // is owned by exactly one place: the dashboard-close handler (08011A00) and the
-            // reconcile loop's "page down with pending content → rebuild once" path. Both run
-            // after this, both re-arm the mic from intent.
-            //
-            // We mark evenHubMicActive=false (live hardware truth) but DELIBERATELY do NOT
-            // touch glasses/micEnabled: that flag is the user/cloud *intent*, and recovery
-            // reads it to decide whether to re-arm. Clobbering it stranded the mic after a
-            // dashboard round-trip.
+            // System exit: the firmware killed our page (and the mic). ONLY mark state dead;
+            // do NOT rebuild here. systemExit is fired alongside the dashboard-close (08011A00)
+            // event for the same transition — if both rebuilt, the fresh page gets torn down
+            // again → rebuild→exit→rebuild loop. Recovery is owned by one place: the
+            // dashboard-close handler (and the reconcile page-down path). Don't touch
+            // micEnabled (user intent) — recovery reads it to re-arm; clobbering it strands the mic.
             if eventType == .systemExit || eventType == .abnormalExit {
                 pageCreated = false
                 evenHubMicActive = false  // firmware killed the mic with the page
@@ -4376,17 +4349,9 @@ class G2: NSObject, SGCManager {
         // so we need to revive it:
         if data == Data([0x08, 0x01, 0x1A, 0x00]) {
             Bridge.log("G2: dashboard closed / shutdown - dashboardShowing=\(dashboardShowing)")
-            // A dashboard-close event unambiguously means the dashboard is gone, so always
-            // reset to 0 and recover. We deliberately do NOT keep a residual depth count
-            // (the old +=2 / -=1 "decrement dance"): that counter drifts when a close frame
-            // is dropped by the 500ms gesture_ctrl dedup or when systemExits interleave with
-            // opens, and once it strands >0 the dashboardShowing>0 guard in restartMic wedges
-            // the mic permanently (cloud keeps calling setMicEnabled(true) but it never arms).
-            // Self-heal: clear the count and recover. recoverPageAndMic() rebuilds the page and
-            // re-arms the mic from intent (rebuildState → restartMicIfAlreadyEnabled), and is
-            // debounced so the firmware's ~1×/sec systemExit+close spam can't storm rebuilds.
-            // If the page is already alive (a phantom close while our page is healthy), the
-            // debounce/in-flight guard makes this a cheap no-op.
+            // Dashboard is gone — always reset to 0 (a 0/1 flag, not a depth count: the old
+            // +=2/-=1 dance drifted >0 when a close frame was deduped, wedging the mic). Then
+            // recover via the coalesced/debounced path so firmware close-spam can't storm.
             dashboardShowing = 0
             recoverPageAndMic(reason: "dashboard-close")
             return

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1455,6 +1455,12 @@ class G2: NSObject, SGCManager {
     private var pairingTimeoutTimer: DispatchWorkItem?
     private var useEvenDashboard = true
     private var dashboardShowing = 0
+    // The 08011A00 gesture_ctrl event is ambiguous: the firmware sends it BOTH when the dashboard
+    // opens (it shuts our page down to take the screen) and when it closes (returns to us). When
+    // showDashboard() runs we set this latch; the next 08011A00 is the OPEN confirm — consume it
+    // WITHOUT recovering (else we rebuild our page and snatch the screen back from the dashboard).
+    // The following 08011A00 is the real CLOSE → recover.
+    private var dashboardOpening = false
     // Recovery throttle: the firmware spams systemExit + dashboard-close ~1×/sec on its own.
     // Coalesce so recovery can't storm — one rebuild in flight, one per RECOVERY_DEBOUNCE_MS.
     private var recoveryInFlight = false
@@ -2758,10 +2764,10 @@ class G2: NSObject, SGCManager {
     /// The glasses fall back to the dashboard automatically when no page is up.
     func showDashboard() {
         Bridge.log("G2: showDashboard()")
-        // Dashboard is open: a simple on/off flag, not an accumulating depth. The old
-        // `+= 2` could climb without bound when opens interleaved with dropped close
-        // events, stranding the counter >0 and wedging the mic. Set, don't accumulate.
+        // Dashboard is open: a 0/1 flag (the old +=2/-=1 depth dance drifted >0 and wedged the
+        // mic). dashboardOpening latches so the open-confirm 08011A00 doesn't trigger recovery.
         dashboardShowing = 1
+        dashboardOpening = true
         let msg = EvenHubProto.shutdownMessage()
         sendEvenHubCommand(msg)
         pageCreated = false
@@ -3111,6 +3117,7 @@ class G2: NSObject, SGCManager {
         startupPageCreated = false
         pageCreated = false
         dashboardShowing = 0
+        dashboardOpening = false
         heartbeatCounter = 0
         DeviceStore.shared.apply("glasses", "connected", false)
         DeviceStore.shared.apply("glasses", "fullyBooted", false)
@@ -4345,13 +4352,18 @@ class G2: NSObject, SGCManager {
         }
         lastGestureCtrlTimestamp = timestamp
 
-        // if we got 08011A00 that means we closed the dashboard, which means the mic is probably dead,
-        // so we need to revive it:
+        // 08011A00 is the dashboard open/close toggle. It fires on BOTH transitions, so we use
+        // the dashboardOpening latch (set by showDashboard) to tell them apart:
+        //   • First event after showDashboard → the OPEN confirm. Consume it, keep the dashboard
+        //     up, and do NOT recover (recovering would rebuild our page and snatch the screen back
+        //     — that's the "double-tap makes captions flicker but never opens the dashboard" bug).
+        //   • Next event → the real CLOSE. Reset state and recover our page + mic.
         if data == Data([0x08, 0x01, 0x1A, 0x00]) {
-            Bridge.log("G2: dashboard closed / shutdown - dashboardShowing=\(dashboardShowing)")
-            // Dashboard is gone — always reset to 0 (a 0/1 flag, not a depth count: the old
-            // +=2/-=1 dance drifted >0 when a close frame was deduped, wedging the mic). Then
-            // recover via the coalesced/debounced path so firmware close-spam can't storm.
+            Bridge.log("G2: dashboard toggle - dashboardShowing=\(dashboardShowing) opening=\(dashboardOpening)")
+            if dashboardOpening {
+                dashboardOpening = false  // open confirmed; dashboard now owns the screen
+                return
+            }
             dashboardShowing = 0
             recoverPageAndMic(reason: "dashboard-close")
             return
@@ -4564,6 +4576,7 @@ extension G2: CBCentralManagerDelegate {
             self.startupPageCreated = false
             self.pageCreated = false
             self.dashboardShowing = 0
+            self.dashboardOpening = false
             DeviceStore.shared.apply("glasses", "connected", false)
             DeviceStore.shared.apply("glasses", "fullyBooted", false)
 


### PR DESCRIPTION
## Scope

Fixes the transient EvenHub reconnect loop from incident `8164175a` (iOS, G2): captions/audio dropped for several seconds before recovering.

The prior G2 rebuild-storm fix (`e24320766`, already on `dev`) held — recovery is coalesced (67 rebuilds/514s vs the old 1134/411s). This PR fixes the **residual** churn.

## Root cause

`clearDisplay()` called `rebuildPage()` (page shutdown) + `rebuildState()` on **every** invocation — contradicting its own comment *"Don't shutdown the EvenHub page — that kills audio."* The cloud sends `clearDisplay` in accelerating bursts (1, 2, 3, 5 at a time on caption gaps); each one:

1. Tore down the page → killed audio
2. Triggered a firmware `systemExit`/dashboard-close → recovery rebuild
3. Plus its own rebuild

The `recover()` debounce only guards its own path, so `clearDisplay`'s direct rebuilds bypassed it → the few-second loop. This is also why audio dropped (teardown kills the mic) and why it recovered when the user spoke (a real caption → clean rebuild).

## Changes

- `clearDisplay()` now blanks text **in place** — no teardown, no rebuild. Audio stays up; the reconcile loop pushes the blanked text.
- Reconcile's "page down → rebuild once" path now only resurrects a dead page for **non-blank** content, so a clear can't churn the page back up.
- Ported identically to Android `G2.kt`.
- Trimmed the verbose multi-paragraph comments from the prior G2 fixes down to the load-bearing invariants (net −59 lines).

## Test evidence

- Android `./scripts/check-android-compile.sh bluetooth-sdk` → BUILD SUCCESSFUL
- iOS `swiftc -parse` clean (full type-check needs Pods)
- ⚠️ Still needs a device pass: run captions on G2, confirm no reconnect loop on caption gaps / clearDisplay bursts, audio stays up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> G2 changes affect live captions, audio, and native dashboard on real hardware and still need device validation; CI and docs changes are low risk.
> 
> **Overview**
> Fixes G2 EvenHub churn from incident `8164175a`: **`clearDisplay()`** no longer tears down the page via `rebuildPage()` / `rebuildState()` — it blanks text and images in place and **`signalDisplayDirty()`** so the reconcile loop updates a live page without killing the mic. **Reconcile** only resurrects a dead page when there is **non-blank** pending text or dirty images, so clear bursts cannot spin the page back up.
> 
> **Dashboard:** adds a **`dashboardOpening`** latch so the ambiguous `08011A00` gesture is treated as open-confirm (no recovery) vs close (recover); **`showDashboard()`** sets the latch and uses a 0/1 **`dashboardShowing`** flag. Same logic on **iOS `G2.swift`** and **Android `G2.kt`**.
> 
> **CI:** the shared Mac iOS workflow scopes stale **`xcodebuild`** kills and DerivedData cleanup to **this job’s workspace** (`pgrep` on workspace path, drop global `killall` / `~/Library/.../DerivedData/Mentra-*`).
> 
> **Docs:** new **`firmware-spec.md`** (OEM BLE display protocol) and **`integration-toolkit.mdx`** (Glasses Adapter integration guide).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6354ace8300376accbf2510af69c6fcd03e1f70e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the G2 EvenHub reconnect loop and audio dropouts by handling clearDisplay in-place and stabilizing dashboard transitions on iOS and Android. Adds OEM docs and fixes flaky iOS CI by scoping runner cleanup to this workspace.

- **Bug Fixes**
  - clearDisplay now blanks text in place and signals reconcile; no teardown/rebuild, so audio stays up.
  - Reconcile only resurrects a dead page for non-blank text or pending images; systemExit only marks dead and a single, debounced recovery runs on dashboard-close.
  - Disambiguated the 08011A00 dashboard toggle with a `dashboardOpening` latch; dashboard is a 0/1 state and recovery happens on close (iOS `G2.swift`, Android `G2.kt`).
  - CI (iOS): scoped xcodebuild termination and cache wipes to this runner’s workspace; removed global Simulator/DerivedData teardown to prevent cross-branch build kills.

- **Docs**
  - Added `docs/glasses-oems/firmware-spec.md`: BLE transport, drawing/commit model, bitmaps, home screen, audio, sensors, acks, fonts, capability descriptor.
  - Added `docs/glasses-oems/integration-toolkit.mdx`: how to embed the Mentra OEM Integration Toolkit and implement a Glasses Adapter.

<sup>Written for commit 6354ace8300376accbf2510af69c6fcd03e1f70e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

