### PR TITLE
Miniapp actions: teleprompter, translation, and Mentra Maps

### DIFF
--- a/miniapps/merge/miniapp/src/ui/App.tsx
+++ b/miniapps/merge/miniapp/src/ui/App.tsx
@@ -32,34 +32,52 @@ const ANSWER_LANGUAGES: AnswerLanguage[] = [
 ]
 
 const MERGE_COLORS = {
-  ink: "#202431",
-  muted: "#747889",
-  pink: "#F45D8B",
+  ink: "#15171C",
+  muted: "#8A8F9C",
+  pink: "#F5497B",
   coral: "#FF6F7D",
   sky: "#39BFE9",
-  violet: "#8D7BF7",
+  violet: "#7C6FF2",
   peach: "#FF9B62",
   offline: "#4B4B5A",
   surface: "#FFFFFF",
-  surfaceTint: "#FFF6F9",
-  border: "#F1DCE5",
+  border: "#ECECF1",
+  chip: "#F3F3F7",
 }
 
 const MERGE_ACTIVE_STYLE: CSSProperties = {
   backgroundColor: MERGE_COLORS.pink,
   color: "#FFFFFF",
-  boxShadow: "0 8px 20px rgba(244, 93, 139, 0.24)",
+  boxShadow: "0 8px 20px rgba(245, 73, 123, 0.28)",
 }
 
-// Flat white so the safe-area insets match the white app bar below them
-// instead of showing a blue→violet→pink gradient behind the status bar.
+// Soft light gradient. Starts near-white so the safe-area top inset (where the
+// phone status bar sits) reads light, then cools toward the bottom — the header
+// and cards float over it instead of sitting on a hard white bar.
 const MERGE_SHELL_STYLE: CSSProperties = {
-  background: MERGE_COLORS.surface,
+  background: "linear-gradient(180deg, #FFFFFF 0%, #FBFAFC 42%, #F1F1F6 100%)",
 }
+
+const CARD_SHADOW = "0 4px 18px rgba(20, 23, 28, 0.06)"
 
 type MergeTab = "insights" | "settings"
 type InsightsMode = "insights" | "activity"
 type ActivityFilter = "all" | "shown" | "quiet"
+
+// Per-agent presentation: the tinted icon tile + glyph that fronts each card
+// and the "standing by" chips. Unknown agents fall back to a neutral mark.
+type AgentVisual = {bg: string; fg: string; glyph: ReactNode}
+const AGENT_VISUALS: Record<string, AgentVisual> = {
+  QuestionAnswerer: {bg: "#FFE7F0", fg: MERGE_COLORS.pink, glyph: <SparkGlyph />},
+  FactChecker: {bg: "#ECEAFE", fg: MERGE_COLORS.violet, glyph: <CheckGlyph />},
+  Definer: {bg: "#E2F4FB", fg: MERGE_COLORS.sky, glyph: <BookGlyph />},
+  Initial: {bg: "#FFE7F0", fg: MERGE_COLORS.pink, glyph: <SparkGlyph />},
+}
+const STANDBY_AGENTS = ["QuestionAnswerer", "FactChecker", "Definer"]
+
+function agentVisual(type?: string): AgentVisual {
+  return AGENT_VISUALS[type ?? ""] ?? {bg: MERGE_COLORS.chip, fg: MERGE_COLORS.muted, glyph: <SparkGlyph />}
+}
 
 export function App() {
   const {insets, capsuleMenu} = useSafeArea()
@@ -139,6 +157,9 @@ export function App() {
   const headerPaddingRight = capsuleMenu ? Math.max(20, capsuleMenu.width + 20) : 20
   const latestTranscript = transcripts.slice().reverse().find((entry) => entry.text.trim().length > 0)
   const latestDecision = decisions[decisions.length - 1]
+  const busy = processing || backendStatus === "processing"
+
+  const statusText = busy ? "Thinking…" : insights.length > 0 ? "Listening for useful context" : "Listening"
 
   return (
     <div
@@ -150,20 +171,24 @@ export function App() {
         paddingLeft: insets.left,
         paddingRight: insets.right,
       }}>
-      <div className="min-h-0 flex-1 bg-zinc-100 flex flex-col overflow-hidden">
-        <header
-          className="pt-4 pb-3 pl-5 bg-white border-b border-[#e3e7e6]"
-          style={{paddingRight: headerPaddingRight}}>
-          <div className="flex items-center gap-3 min-w-0">
-            <img src={MergeLogo} alt="" className="h-10 w-10 flex-shrink-0" />
-            <div className="min-w-0">
-              <h1 className="m-0 text-xl font-bold truncate">Merge</h1>
-              <p className="m-0 mt-0.5 text-sm text-[#6b7280] truncate">
-                {processing ? "Thinking..." : insights.length > 0 ? "Listening for useful context" : "Listening"}
-              </p>
+      <div className="relative min-h-0 flex-1 flex flex-col overflow-hidden">
+        {!showDeveloperInfo && (
+          <header className="pt-4 pb-3 pl-5" style={{paddingRight: headerPaddingRight}}>
+            <div className="flex items-center gap-3 min-w-0">
+              <img src={MergeLogo} alt="" className="h-10 w-10 flex-shrink-0" />
+              <div className="min-w-0">
+                <h1 className="m-0 text-xl font-bold text-[#15171c] truncate">Merge</h1>
+                <p className="m-0 mt-0.5 flex items-center gap-1.5 text-sm text-[#8a8f9c] truncate">
+                  <span
+                    className="h-1.5 w-1.5 rounded-full flex-shrink-0"
+                    style={{backgroundColor: busy ? MERGE_COLORS.peach : MERGE_COLORS.pink}}
+                  />
+                  {statusText}
+                </p>
+              </div>
             </div>
-          </div>
-        </header>
+          </header>
+        )}
 
         {showDeveloperInfo ? (
           <DeveloperInfo
@@ -193,6 +218,7 @@ export function App() {
               <InsightsView
                 insights={insights}
                 decisions={decisions}
+                busy={busy}
                 latestTranscript={latestTranscript}
                 latestDecision={latestDecision}
                 cloudPresentation={cloudPresentation}
@@ -205,11 +231,7 @@ export function App() {
         )}
 
         {!showDeveloperInfo && (
-          <BottomNav
-            activeTab={activeTab}
-            onTabChange={setActiveTab}
-            settingsHoldHandlers={holdHandlers}
-          />
+          <BottomNav activeTab={activeTab} onTabChange={setActiveTab} settingsHoldHandlers={holdHandlers} />
         )}
       </div>
     </div>
@@ -219,6 +241,7 @@ export function App() {
 function InsightsView({
   insights,
   decisions,
+  busy,
   latestTranscript,
   latestDecision,
   cloudPresentation,
@@ -228,6 +251,7 @@ function InsightsView({
 }: {
   insights: MergeInsight[]
   decisions: MergeDecision[]
+  busy: boolean
   latestTranscript?: MergeTranscript
   latestDecision?: MergeDecision
   cloudPresentation: Presentation
@@ -239,10 +263,12 @@ function InsightsView({
   const [expandedInsightId, setExpandedInsightId] = useState<string | null>(null)
   const [expandedDecisionId, setExpandedDecisionId] = useState<string | null>(null)
 
+  const newestId = insights.length > 0 ? insights[insights.length - 1].id : null
+
   return (
     <div className="h-full flex flex-col overflow-hidden">
       {developerMode && (
-        <section className="px-4 py-2 bg-white border-b border-[#e3e7e6]">
+        <section className="px-4 py-2">
           <div className="flex items-center justify-between gap-2">
             <div className="flex items-center gap-1.5 min-w-0 flex-1 overflow-hidden">
               <StatusPill label={cloudPresentation.label} detail={cloudPresentation.detail} color={cloudPresentation.accentColor} />
@@ -253,7 +279,7 @@ function InsightsView({
         </section>
       )}
 
-      <main className="flex-1 min-h-0 overflow-y-auto px-5 pb-4">
+      <main className="flex-1 min-h-0 overflow-y-auto px-5">
         {mode === "activity" ? (
           <ActivityTimeline
             decisions={decisions}
@@ -261,15 +287,14 @@ function InsightsView({
             onToggleDecision={(id) => setExpandedDecisionId((current) => (current === id ? null : id))}
           />
         ) : insights.length === 0 ? (
-          <div className="h-full flex flex-col items-center justify-center text-center">
-            <img src={MergeLogo} alt="" className="h-16 w-16 opacity-90" />
-            <h2 className="mt-4 mb-1 text-lg font-bold text-[#202928]">No insights yet</h2>
-            <p className="m-0 max-w-[260px] text-sm leading-5 text-[#6b7280]">
-              Merge stays quiet until it has something useful to add.
-            </p>
-          </div>
+          busy ? (
+            <ThinkingHero quote={latestTranscript?.text} />
+          ) : (
+            <ListeningEmpty />
+          )
         ) : (
-          <div className="flex flex-col gap-3 py-4">
+          <div className="flex flex-col gap-3 pt-3 pb-28">
+            <SectionLabel>Today</SectionLabel>
             {insights
               .slice()
               .reverse()
@@ -280,6 +305,7 @@ function InsightsView({
                     key={insight.id}
                     insight={insight}
                     decision={decision}
+                    isNewest={insight.id === newestId}
                     expanded={expandedInsightId === insight.id}
                     onToggle={() => setExpandedInsightId((current) => (current === insight.id ? null : insight.id))}
                   />
@@ -306,6 +332,89 @@ function InsightsView({
   )
 }
 
+// ── Empty / Thinking hero ────────────────────────────────────────────────
+
+function PulseHero({thinking}: {thinking?: boolean}) {
+  return (
+    <div className="relative flex items-center justify-center" style={{width: 232, height: 232}}>
+      <span className="absolute rounded-full" style={{width: 232, height: 232, border: "1px solid #F2DEE7"}} />
+      <span className="absolute rounded-full" style={{width: 176, height: 176, border: "1px solid #F4D6E2"}} />
+      {thinking ? (
+        <svg
+          className="absolute animate-spin"
+          style={{width: 208, height: 208, animationDuration: "1.4s"}}
+          viewBox="0 0 100 100"
+          fill="none"
+          aria-hidden="true">
+          <circle cx="50" cy="50" r="48" stroke={MERGE_COLORS.pink} strokeWidth="2.5" strokeLinecap="round" strokeDasharray="74 230" />
+        </svg>
+      ) : (
+        <span
+          className="absolute rounded-full animate-pulse"
+          style={{width: 208, height: 208, border: "1px solid #F8CFDE"}}
+        />
+      )}
+      <img src={MergeLogo} alt="" className="relative h-[88px] w-[88px]" />
+    </div>
+  )
+}
+
+function ListeningEmpty() {
+  return (
+    <div className="h-full flex flex-col items-center justify-center text-center px-6 pb-24">
+      <PulseHero />
+      <h2 className="mt-6 mb-0 text-[22px] font-bold text-[#15171c]">No insights yet</h2>
+      <p className="m-0 mt-2 max-w-[280px] text-sm leading-5 text-[#8a8f9c]">
+        Merge stays quiet until it has something useful to add.
+      </p>
+      <p className="m-0 mt-9 text-[11px] font-bold uppercase tracking-[0.16em] text-[#b3b7c2]">Agents standing by</p>
+      <div className="mt-3 flex flex-wrap items-center justify-center gap-2 max-w-[300px]">
+        {STANDBY_AGENTS.map((agent) => (
+          <AgentChip key={agent} type={agent} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ThinkingHero({quote}: {quote?: string}) {
+  return (
+    <div className="h-full flex flex-col items-center justify-center text-center px-6 pb-24">
+      <PulseHero thinking />
+      <h2 className="mt-6 mb-0 text-[22px] font-bold text-[#15171c]">Thinking…</h2>
+      {quote ? (
+        <p className="m-0 mt-2 max-w-[290px] text-base leading-6 text-[#3a3f4c]">“{quote}”</p>
+      ) : (
+        <p className="m-0 mt-2 max-w-[290px] text-base leading-6 text-[#8a8f9c]">Checking what matters…</p>
+      )}
+    </div>
+  )
+}
+
+function AgentChip({type}: {type: string}) {
+  return (
+    <div
+      className="inline-flex items-center gap-2 rounded-full bg-white py-1.5 pl-1.5 pr-3.5 border border-[#F0F0F4]"
+      style={{boxShadow: "0 4px 14px rgba(20, 23, 28, 0.06)"}}>
+      <AgentIconTile type={type} size={24} />
+      <span className="text-sm font-semibold text-[#15171c]">{type}</span>
+    </div>
+  )
+}
+
+function AgentIconTile({type, size = 30}: {type?: string; size?: number}) {
+  const visual = agentVisual(type)
+  return (
+    <span
+      className="inline-flex items-center justify-center rounded-[9px] flex-shrink-0"
+      style={{width: size, height: size, backgroundColor: visual.bg, color: visual.fg}}>
+      {visual.glyph}
+    </span>
+  )
+}
+
+// ── Settings ─────────────────────────────────────────────────────────────
+
 function SettingsView({
   settings,
   developerMode,
@@ -320,73 +429,80 @@ function SettingsView({
   onOpenDeveloperInfo: () => void
 }) {
   return (
-    <div className="h-full overflow-y-auto px-4 py-6 space-y-6 bg-zinc-100">
-      <section className="space-y-3">
-        <h2 className="text-base font-semibold text-gray-900">AI Settings</h2>
-        <div className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100 space-y-5">
-          <div className="space-y-3">
-            <div className="flex items-center gap-3">
-              <LanguageIcon />
-              <div>
-                <div className="text-base font-medium text-gray-900">Answer language</div>
-                <p className="m-0 text-xs leading-4 text-gray-500">
-                  Merge can listen across languages but answers in this language.
-                </p>
-              </div>
-            </div>
-            <div className="relative">
-              <select
-                aria-label="Answer language"
-                value={settings.answerLanguage}
-                onChange={(event) => onAnswerLanguageChange(event.currentTarget.value as AnswerLanguage)}
-                className="h-12 w-full appearance-none rounded-xl border border-[#f1dce5] bg-[#fff7fa] px-4 pr-11 text-base font-semibold text-[#202431] outline-none">
-                {ANSWER_LANGUAGES.map((language) => (
-                  <option key={language} value={language}>
-                    {language}
-                  </option>
-                ))}
-              </select>
-              <div className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-[#747889]">
-                <ChevronDownIcon />
-              </div>
-            </div>
-          </div>
+    <div className="h-full overflow-y-auto px-5 pt-4 pb-28">
+      <h1 className="m-0 text-[26px] font-bold text-[#15171c]">Settings</h1>
+      <p className="m-0 mt-1 text-sm text-[#8a8f9c]">Tune how Merge listens, thinks, and speaks.</p>
 
-          <div className="h-px bg-gray-100 w-full" />
+      <SectionLabel className="mt-7">Intelligence</SectionLabel>
+      <div
+        className="mt-3 rounded-2xl bg-white border border-[#ECECF1] overflow-hidden"
+        style={{boxShadow: CARD_SHADOW}}>
+        {/* Answer language — native picker overlaid on a row that shows the value. */}
+        <div className="relative flex items-center gap-3 px-4 py-3.5">
+          <SettingIconTile>
+            <LanguageIcon />
+          </SettingIconTile>
+          <span className="flex-1 text-[15px] font-semibold text-[#15171c]">Answer language</span>
+          <span className="flex items-center gap-1 text-[15px] text-[#8a8f9c]">
+            {settings.answerLanguage}
+            <ChevronRightIcon />
+          </span>
+          <select
+            aria-label="Answer language"
+            value={settings.answerLanguage}
+            onChange={(event) => onAnswerLanguageChange(event.currentTarget.value as AnswerLanguage)}
+            className="absolute inset-0 h-full w-full cursor-pointer opacity-0">
+            {ANSWER_LANGUAGES.map((language) => (
+              <option key={language} value={language}>
+                {language}
+              </option>
+            ))}
+          </select>
+        </div>
 
-          <div className="space-y-3">
-            <div className="flex items-center gap-3">
+        <div className="h-px bg-[#F1F1F4] mx-4" />
+
+        {/* Insight frequency */}
+        <div className="px-4 py-3.5">
+          <div className="flex items-center gap-3">
+            <SettingIconTile>
               <FrequencyIcon />
-              <div>
-                <div className="text-base font-medium text-gray-900">Insight frequency</div>
-                <p className="m-0 text-xs leading-4 text-gray-500">Controls how eager Merge is to interrupt.</p>
-              </div>
-            </div>
-            <div className="grid grid-cols-3 gap-2">
-              {(["low", "medium", "high"] as const).map((frequency) => (
+            </SettingIconTile>
+            <span className="flex-1 text-[15px] font-semibold text-[#15171c]">Insight frequency</span>
+          </div>
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            {(["low", "medium", "high"] as const).map((frequency) => {
+              const active = settings.frequency === frequency
+              return (
                 <button
                   key={frequency}
                   onClick={() => onFrequencyChange(frequency)}
-                  className={`h-11 rounded-xl text-sm font-semibold capitalize transition-colors ${
-                    settings.frequency === frequency ? "shadow-sm" : "bg-gray-50 text-gray-900 hover:bg-gray-100"
-                  }`}
-                  style={settings.frequency === frequency ? MERGE_ACTIVE_STYLE : {}}>
+                  className="h-11 rounded-xl text-sm font-semibold capitalize transition-colors"
+                  style={active ? MERGE_ACTIVE_STYLE : {backgroundColor: MERGE_COLORS.chip, color: MERGE_COLORS.ink}}>
                   {frequency}
                 </button>
-              ))}
-            </div>
+              )
+            })}
           </div>
         </div>
-      </section>
+      </div>
 
       {developerMode && (
         <button
-          className="w-full py-3 text-xs font-semibold text-zinc-400 hover:text-zinc-600 transition-colors"
+          className="mt-6 w-full py-3 text-xs font-semibold text-zinc-400 hover:text-zinc-600 transition-colors"
           onClick={onOpenDeveloperInfo}>
           Developer info
         </button>
       )}
     </div>
+  )
+}
+
+function SettingIconTile({children}: {children: ReactNode}) {
+  return (
+    <span className="inline-flex h-9 w-9 items-center justify-center rounded-[11px] bg-[#F3F3F7] text-[#5b6070] flex-shrink-0">
+      {children}
+    </span>
   )
 }
 
@@ -405,9 +521,9 @@ function DeveloperInfo({
 }) {
   const publicEnv = publicEnvVars()
   return (
-    <div className="h-full flex flex-col overflow-hidden bg-zinc-100">
-      <div className="bg-white border-b border-zinc-200 px-5 py-3 flex items-center gap-3">
-        <button className="h-9 w-9 rounded-full bg-zinc-100 flex items-center justify-center" onClick={onBack} aria-label="Back">
+    <div className="h-full flex flex-col overflow-hidden">
+      <div className="px-5 py-3 flex items-center gap-3">
+        <button className="h-9 w-9 rounded-full bg-white border border-[#ECECF1] flex items-center justify-center" onClick={onBack} aria-label="Back">
           <BackIcon />
         </button>
         <div>
@@ -415,7 +531,7 @@ function DeveloperInfo({
           <p className="m-0 text-xs text-zinc-500">Public build configuration</p>
         </div>
       </div>
-      <div className="flex-1 overflow-y-auto px-4 py-5 space-y-4">
+      <div className="flex-1 overflow-y-auto px-5 py-3 space-y-4">
         <InfoCard title="Runtime">
           <InfoRow label="Backend URL" value={backendUrl} />
           <InfoRow label="Backend status" value={backendStatus} />
@@ -444,23 +560,29 @@ function BottomNav({
   onTabChange: (tab: MergeTab) => void
   settingsHoldHandlers?: HoldHandlers
 }) {
+  // Floating dock — centered pill that hovers over the scrolling content; the
+  // views reserve bottom padding so nothing hides behind it.
   return (
-    <div className="w-full h-14 bg-white/80 rounded-tl-2xl rounded-tr-2xl backdrop-blur-lg flex justify-center items-stretch">
-      <NavButton active={activeTab === "insights"} label="Insights" onClick={() => onTabChange("insights")}>
-        <InsightsIcon active={activeTab === "insights"} />
-      </NavButton>
-      <NavButton
-        active={activeTab === "settings"}
-        label="Settings"
-        onClick={() => onTabChange("settings")}
-        holdHandlers={settingsHoldHandlers}>
-        <SettingsIcon active={activeTab === "settings"} />
-      </NavButton>
+    <div className="pointer-events-none absolute inset-x-0 bottom-3 flex justify-center">
+      <div
+        className="pointer-events-auto inline-flex items-center gap-1 rounded-full bg-white/90 backdrop-blur-lg p-1.5 border border-[#ECECF1]"
+        style={{boxShadow: "0 12px 30px rgba(20, 23, 28, 0.14)"}}>
+        <DockButton active={activeTab === "insights"} label="Insights" onClick={() => onTabChange("insights")}>
+          <InsightsIcon active={activeTab === "insights"} />
+        </DockButton>
+        <DockButton
+          active={activeTab === "settings"}
+          label="Settings"
+          onClick={() => onTabChange("settings")}
+          holdHandlers={settingsHoldHandlers}>
+          <SettingsIcon active={activeTab === "settings"} />
+        </DockButton>
+      </div>
     </div>
   )
 }
 
-function NavButton({
+function DockButton({
   active,
   label,
   onClick,
@@ -473,8 +595,6 @@ function NavButton({
   holdHandlers?: HoldHandlers
   children: ReactNode
 }) {
-  // The button fills its flex cell so the touch target spans the full nav-bar
-  // height and half its width; the active pill stays icon-sized inside it.
   return (
     <button
       aria-label={label}
@@ -483,11 +603,11 @@ function NavButton({
       onPointerUp={holdHandlers?.onPointerUp}
       onPointerLeave={holdHandlers?.onPointerLeave}
       onPointerCancel={holdHandlers?.onPointerCancel}
-      className="flex-1 inline-flex justify-center items-center">
-      <span
-        className="w-12 h-7 p-2 rounded-3xl inline-flex justify-center items-center transition-colors"
-        style={active ? MERGE_ACTIVE_STYLE : {backgroundColor: "transparent"}}>
-        {children}
+      className="inline-flex h-10 items-center gap-2 rounded-full px-4 transition-colors"
+      style={active ? MERGE_ACTIVE_STYLE : {backgroundColor: "transparent"}}>
+      {children}
+      <span className="text-sm font-semibold" style={{color: active ? "#FFFFFF" : MERGE_COLORS.muted}}>
+        {label}
       </span>
     </button>
   )
@@ -520,39 +640,56 @@ function ModeSwitch({
 function InsightCard({
   insight,
   decision,
+  isNewest,
   expanded,
   onToggle,
 }: {
   insight: MergeInsight
   decision?: MergeDecision
+  isNewest: boolean
   expanded: boolean
   onToggle: () => void
 }) {
+  const quote = decision?.chunkText?.trim()
+  const duration = insight.profiling ? formatDuration(insight.profiling.totalMs) : null
   return (
-    <article className="bg-white border border-[#e0e6e4] rounded-lg p-4 shadow-[0_1px_8px_rgba(16,24,24,0.05)]">
+    <article
+      className={`rounded-[20px] bg-white p-4 ${isNewest ? "border-2 border-[#F8B4CC]" : "border border-[#ECECF1]"}`}
+      style={{boxShadow: CARD_SHADOW}}>
       <button className="w-full text-left" onClick={onToggle}>
-        <div className="flex items-start gap-2 mb-2">
-          <img src={MergeLogo} alt="" className="h-7 w-7 flex-shrink-0" />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center justify-between gap-2">
-              <div className="text-sm font-bold text-[#1e2927] truncate">{insight.agentType || "Merge"}</div>
-              <span className="text-[11px] text-[#9aa4a0] flex-shrink-0">{formatTime(insight.timestamp)}</span>
-            </div>
-            <div className="mt-0.5 flex flex-wrap items-center gap-1.5">
-              {insight.displayAction ? <ActionBadge action={insight.displayAction} /> : null}
-              {typeof insight.confidence === "number" ? (
-                <span className="text-[10px] font-bold uppercase text-zinc-400">
-                  {Math.round(insight.confidence * 100)}%
-                </span>
-              ) : null}
-              {insight.profiling ? <ProfilingBadge totalMs={insight.profiling.totalMs} /> : null}
-              {insight.sources?.length ? <SourceCountBadge count={insight.sources.length} /> : null}
-            </div>
-          </div>
+        <div className="flex items-center gap-2.5">
+          <AgentIconTile type={insight.agentType} />
+          <span className="flex-1 text-[15px] font-bold text-[#15171c] truncate">{insight.agentType || "Merge"}</span>
+          {isNewest ? (
+            <NewBadge />
+          ) : (
+            <span className="text-xs text-[#9aa0ad] flex-shrink-0">{formatClockTime(insight.timestamp)}</span>
+          )}
         </div>
-        <p className="selectable-text m-0 text-base leading-6 text-[#202928] whitespace-pre-wrap break-words">
+
+        {quote ? (
+          <div className="mt-3 flex items-center gap-2 rounded-xl bg-[#F4F4F7] px-3 py-2">
+            <WaveformIcon />
+            <span className="min-w-0 flex-1 truncate text-[13px] italic text-[#8a8f9c]">“{quote}”</span>
+          </div>
+        ) : null}
+
+        <p className="selectable-text m-0 mt-3 text-[15px] font-semibold leading-6 text-[#15171c] whitespace-pre-wrap break-words">
           {insight.text}
         </p>
+
+        <div className="mt-3 flex items-center gap-2">
+          {insight.displayAction ? <ActionBadge action={insight.displayAction} /> : null}
+          {typeof insight.confidence === "number" ? (
+            <span className="text-xs font-semibold text-[#8a8f9c]">{Math.round(insight.confidence * 100)}%</span>
+          ) : null}
+          {duration ? (
+            <>
+              <span className="text-[#c4c8d1]">·</span>
+              <span className="text-xs text-[#8a8f9c]">{duration}</span>
+            </>
+          ) : null}
+        </div>
       </button>
 
       {expanded ? (
@@ -585,10 +722,10 @@ function ActivityTimeline({
 
   if (decisions.length === 0) {
     return (
-      <div className="h-full flex flex-col items-center justify-center text-center">
+      <div className="h-full flex flex-col items-center justify-center text-center pb-24">
         <img src={MergeLogo} alt="" className="h-14 w-14 opacity-80" />
-        <h2 className="mt-4 mb-1 text-base font-bold text-[#202928]">No AI activity yet</h2>
-        <p className="m-0 max-w-[250px] text-sm leading-5 text-[#6b7280]">
+        <h2 className="mt-4 mb-1 text-base font-bold text-[#15171c]">No AI activity yet</h2>
+        <p className="m-0 max-w-[250px] text-sm leading-5 text-[#8a8f9c]">
           Decisions appear after Merge analyzes speech.
         </p>
       </div>
@@ -596,7 +733,7 @@ function ActivityTimeline({
   }
 
   return (
-    <div className="flex flex-col gap-2 py-4">
+    <div className="flex flex-col gap-2 py-4 pb-28">
       <ActivityFilterBar
         filter={filter}
         onFilterChange={setFilter}
@@ -633,8 +770,8 @@ function ActivityFilterBar({
   counts: Record<ActivityFilter, number>
 }) {
   return (
-    <div className="sticky top-0 z-10 -mx-5 px-5 pb-2 bg-zinc-100/95 backdrop-blur">
-      <div className="grid grid-cols-3 gap-1 rounded-full bg-white p-1 border border-[#e0e6e4] shadow-[0_1px_6px_rgba(16,24,24,0.04)]">
+    <div className="sticky top-0 z-10 -mx-5 px-5 pb-2 bg-[#f6f6fa]/95 backdrop-blur">
+      <div className="grid grid-cols-3 gap-1 rounded-full bg-white p-1 border border-[#ECECF1] shadow-[0_1px_6px_rgba(16,24,24,0.04)]">
         {(["all", "shown", "quiet"] as const).map((item) => (
           <button
             key={item}
@@ -661,14 +798,14 @@ function ActivityRow({
   onToggle: () => void
 }) {
   return (
-    <article className="rounded-lg border border-[#e0e6e4] bg-white px-3 py-2 shadow-[0_1px_6px_rgba(16,24,24,0.04)]">
+    <article className="rounded-lg border border-[#ECECF1] bg-white px-3 py-2 shadow-[0_1px_6px_rgba(16,24,24,0.04)]">
       <button className="w-full text-left" onClick={onToggle}>
         <div className="flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
             <span className="h-2.5 w-2.5 rounded-full flex-shrink-0" style={{backgroundColor: actionColor(decision.action)}} />
-            <span className="text-sm font-bold text-[#202928] truncate">{activityTitle(decision)}</span>
+            <span className="text-sm font-bold text-[#15171c] truncate">{activityTitle(decision)}</span>
           </div>
-          <span className="text-[11px] text-[#9aa4a0] flex-shrink-0">{formatTime(decision.timestamp)}</span>
+          <span className="text-[11px] text-[#9aa0ad] flex-shrink-0">{formatTime(decision.timestamp)}</span>
         </div>
         <p className="m-0 mt-1 text-xs leading-4 text-[#66736f] line-clamp-2">
           {decision.reasoning || decision.insightText || decision.chunkText || "No reasoning recorded"}
@@ -728,9 +865,9 @@ function LiveDebugTray({
   const backendText = lastError ? `${backendPresentation.label} · ${lastError}` : backendPresentation.label
 
   return (
-    <footer className="bg-white border-t border-[#e3e7e6] px-5 py-2">
+    <footer className="px-5 pb-20 pt-2">
       <button
-        className="w-full rounded-lg bg-[#f8faf9] border border-[#e0e6e4] px-3 py-2 text-left"
+        className="w-full rounded-lg bg-white border border-[#ECECF1] px-3 py-2 text-left"
         onClick={onOpenActivity}>
         <div className="flex items-center justify-between gap-3">
           <span className="text-[11px] font-bold uppercase text-[#7a8581]">Live</span>
@@ -757,6 +894,24 @@ function LiveDebugTray({
         </div>
       </button>
     </footer>
+  )
+}
+
+function SectionLabel({children, className}: {children: ReactNode; className?: string}) {
+  return (
+    <p className={`m-0 px-1 text-[11px] font-bold uppercase tracking-[0.12em] text-[#b3b7c2] ${className ?? ""}`}>
+      {children}
+    </p>
+  )
+}
+
+function NewBadge() {
+  return (
+    <span
+      className="flex-shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold uppercase text-white"
+      style={{backgroundColor: MERGE_COLORS.pink}}>
+      New
+    </span>
   )
 }
 
@@ -832,18 +987,10 @@ function ProfilingBlock({profiling}: {profiling?: MergeInsight["profiling"]}) {
   )
 }
 
-function ProfilingBadge({totalMs}: {totalMs: number}) {
-  return <span className="text-[10px] font-bold uppercase text-zinc-400">{formatDuration(totalMs)}</span>
-}
-
-function SourceCountBadge({count}: {count: number}) {
-  return <span className="text-[10px] font-bold uppercase text-zinc-400">{count} src</span>
-}
-
 function ActionBadge({action}: {action: MergeDecision["action"]}) {
   return (
     <span
-      className="rounded-full px-2 py-0.5 text-[10px] font-bold uppercase"
+      className="rounded-md px-2 py-0.5 text-[10px] font-bold uppercase"
       style={{backgroundColor: `${actionColor(action)}1A`, color: actionColor(action)}}>
       {action}
     </span>
@@ -852,7 +999,7 @@ function ActionBadge({action}: {action: MergeDecision["action"]}) {
 
 function StatusPill({label, detail, color}: {label: string; detail: string; color: string}) {
   return (
-    <div className="flex items-center gap-1.5 rounded-full border border-[#dbe3e0] bg-[#f8faf9] px-2 py-1 flex-shrink-0">
+    <div className="flex items-center gap-1.5 rounded-full border border-[#e3e4ea] bg-white px-2 py-1 flex-shrink-0">
       <span className="h-2 w-2 rounded-full flex-shrink-0" style={{backgroundColor: color}} />
       <span className="text-[11px] font-bold text-[#24302d] whitespace-nowrap">{compactStatusLabel(label)}</span>
       <span className="text-[10px] font-bold uppercase text-[#7a8581] whitespace-nowrap">
@@ -864,7 +1011,7 @@ function StatusPill({label, detail, color}: {label: string; detail: string; colo
 
 function InfoCard({title, children}: {title: string; children: ReactNode}) {
   return (
-    <section className="bg-white rounded-2xl p-4 shadow-sm border border-gray-100">
+    <section className="bg-white rounded-2xl p-4 border border-[#ECECF1]" style={{boxShadow: CARD_SHADOW}}>
       <h3 className="m-0 mb-3 text-sm font-bold text-zinc-900">{title}</h3>
       <div className="space-y-3">{children}</div>
     </section>
@@ -987,6 +1134,10 @@ function formatTime(timestamp: number): string {
   return new Date(timestamp).toLocaleTimeString([], {hour: "numeric", minute: "2-digit", second: "2-digit"})
 }
 
+function formatClockTime(timestamp: number): string {
+  return new Date(timestamp).toLocaleTimeString([], {hour: "numeric", minute: "2-digit"})
+}
+
 function formatDuration(ms: number): string {
   if (!Number.isFinite(ms)) return "n/a"
   if (ms < 1000) return `${Math.max(0, Math.round(ms))}ms`
@@ -1028,13 +1179,12 @@ function decisionMatchesFilter(decision: MergeDecision, filter: ActivityFilter):
   return true
 }
 
-function iconColor(active: boolean): string {
-  return active ? "#FFFFFF" : MERGE_COLORS.ink
-}
+// ── Icons / glyphs ─────────────────────────────────────────────────────────
 
 function InsightsIcon({active}: {active: boolean}) {
+  const color = active ? "#FFFFFF" : MERGE_COLORS.muted
   return (
-    <svg aria-hidden="true" className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke={iconColor(active)} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M8 15h8" />
       <path d="M9 19h6" />
       <path d="M12 3a6 6 0 0 0-3.5 10.9c.4.3.5.7.5 1.1h6c0-.4.1-.8.5-1.1A6 6 0 0 0 12 3Z" />
@@ -1043,8 +1193,9 @@ function InsightsIcon({active}: {active: boolean}) {
 }
 
 function SettingsIcon({active}: {active: boolean}) {
+  const color = active ? "#FFFFFF" : MERGE_COLORS.muted
   return (
-    <svg aria-hidden="true" className="w-6 h-6" viewBox="0 0 24 24" fill="none" stroke={iconColor(active)} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
       <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.9l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.9-.3 1.7 1.7 0 0 0-1 1.6V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.6 1.7 1.7 0 0 0-1.9.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1A1.7 1.7 0 0 0 4.6 15a1.7 1.7 0 0 0-1.6-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.6-1 1.7 1.7 0 0 0-.3-1.9L4.3 7a2 2 0 1 1 2.8-2.8l.1.1A1.7 1.7 0 0 0 9 4.6a1.7 1.7 0 0 0 1-1.6V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.6 1.7 1.7 0 0 0 1.9-.3l.1-.1A2 2 0 1 1 19.8 7l-.1.1a1.7 1.7 0 0 0-.3 1.9 1.7 1.7 0 0 0 1.6 1h.1a2 2 0 1 1 0 4H21a1.7 1.7 0 0 0-1.6 1Z" />
     </svg>
@@ -1053,7 +1204,7 @@ function SettingsIcon({active}: {active: boolean}) {
 
 function LanguageIcon() {
   return (
-    <svg className="w-6 h-6 text-gray-900 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="m5 8 6 6" />
       <path d="m4 14 6-6 2-3" />
       <path d="M2 5h12" />
@@ -1066,7 +1217,7 @@ function LanguageIcon() {
 
 function FrequencyIcon() {
   return (
-    <svg className="w-6 h-6 text-gray-900 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg className="w-5 h-5 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="M4 18V8" />
       <path d="M10 18V4" />
       <path d="M16 18v-6" />
@@ -1075,10 +1226,10 @@ function FrequencyIcon() {
   )
 }
 
-function ChevronDownIcon() {
+function ChevronRightIcon() {
   return (
-    <svg aria-hidden="true" className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="m6 9 6 6 6-6" />
+    <svg aria-hidden="true" className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m9 6 6 6-6 6" />
     </svg>
   )
 }
@@ -1087,6 +1238,43 @@ function BackIcon() {
   return (
     <svg className="w-5 h-5 text-zinc-800" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
       <path d="m15 18-6-6 6-6" />
+    </svg>
+  )
+}
+
+function WaveformIcon() {
+  return (
+    <svg aria-hidden="true" className="w-4 h-4 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke={MERGE_COLORS.pink} strokeWidth="2" strokeLinecap="round">
+      <path d="M5 10v4" />
+      <path d="M9 7v10" />
+      <path d="M13 4v16" />
+      <path d="M17 8v8" />
+      <path d="M21 11v2" />
+    </svg>
+  )
+}
+
+function SparkGlyph() {
+  return (
+    <svg aria-hidden="true" className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 2c.5 3.6 2.4 5.5 6 6-3.6.5-5.5 2.4-6 6-.5-3.6-2.4-5.5-6-6 3.6-.5 5.5-2.4 6-6Z" />
+    </svg>
+  )
+}
+
+function CheckGlyph() {
+  return (
+    <svg aria-hidden="true" className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
+      <path d="m5 12 4.5 4.5L19 7" />
+    </svg>
+  )
+}
+
+function BookGlyph() {
+  return (
+    <svg aria-hidden="true" className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 5a2 2 0 0 1 2-2h11a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1H6a2 2 0 0 0-2 2Z" />
+      <path d="M4 19a2 2 0 0 1 2-2h12" />
     </svg>
   )
 }

--- a/miniapps/merge/miniapp/src/ui/App.tsx
+++ b/miniapps/merge/miniapp/src/ui/App.tsx
@@ -70,7 +70,7 @@ type AgentVisual = {bg: string; fg: string; glyph: ReactNode}
 const AGENT_VISUALS: Record<string, AgentVisual> = {
   QuestionAnswerer: {bg: "#FFE7F0", fg: MERGE_COLORS.pink, glyph: <SparkGlyph />},
   FactChecker: {bg: "#ECEAFE", fg: MERGE_COLORS.violet, glyph: <CheckGlyph />},
-  Definer: {bg: "#E2F4FB", fg: MERGE_COLORS.sky, glyph: <BookGlyph />},
+  Definer: {bg: "#ECEAFE", fg: MERGE_COLORS.violet, glyph: <CheckGlyph />},
   Initial: {bg: "#FFE7F0", fg: MERGE_COLORS.pink, glyph: <SparkGlyph />},
 }
 const STANDBY_AGENTS = ["QuestionAnswerer", "FactChecker", "Definer"]
@@ -1266,15 +1266,6 @@ function CheckGlyph() {
   return (
     <svg aria-hidden="true" className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.6" strokeLinecap="round" strokeLinejoin="round">
       <path d="m5 12 4.5 4.5L19 7" />
-    </svg>
-  )
-}
-
-function BookGlyph() {
-  return (
-    <svg aria-hidden="true" className="w-[15px] h-[15px]" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-      <path d="M4 5a2 2 0 0 1 2-2h11a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1H6a2 2 0 0 0-2 2Z" />
-      <path d="M4 19a2 2 0 0 1 2-2h12" />
     </svg>
   )
 }

--- a/miniapps/navigation/miniapp.json
+++ b/miniapps/navigation/miniapp.json
@@ -18,5 +18,37 @@
   ],
   "hardwareRequirements": [
     {"type": "DISPLAY", "level": "REQUIRED", "description": "Shows next maneuver and distance on glasses"}
+  ],
+  "actions": [
+    {
+      "id": "start_navigation",
+      "description": "Start turn-by-turn navigation to a destination and show directions on the glasses. Use when the user wants to go somewhere — e.g. 'navigate to Blue Bottle Coffee', 'directions to the airport', 'take me home'. Give the destination as a place name or address in `query` (it gets looked up near the user's current location); only pass latitude/longitude instead if you already have exact coordinates. Defaults to walking directions.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The destination as a place name or address (e.g. 'Blue Bottle Coffee', '369 Hayes St, San Francisco'). Resolved via place search biased to the user's current location. Provide this OR latitude+longitude."
+          },
+          "latitude": {
+            "type": "number",
+            "description": "Destination latitude. Provide latitude+longitude together as an alternative to query, when exact coordinates are known."
+          },
+          "longitude": {
+            "type": "number",
+            "description": "Destination longitude. Provide latitude+longitude together as an alternative to query."
+          },
+          "destination_name": {
+            "type": "string",
+            "description": "Optional friendly label for the destination, shown in the UI (e.g. 'Home', 'Blue Bottle')."
+          },
+          "travel_mode": {
+            "type": "string",
+            "enum": ["walking", "driving", "cycling", "two_wheeler"],
+            "description": "How the user is traveling. Defaults to 'walking'."
+          }
+        }
+      }
+    }
   ]
 }

--- a/miniapps/navigation/src/background/NavigationController.ts
+++ b/miniapps/navigation/src/background/NavigationController.ts
@@ -597,21 +597,37 @@ export class NavigationController {
       const res = await this.navigation.start(withPivotDefaults(startOpts))
       if (!res.ok) {
         this.appendLog(`START failed: ${res.error ?? "unknown"}`)
-        this.trip = {...this.trip, status: "idle", running: false}
-        this.ui.send("nav:trip-state", this.trip)
-        this.refreshHUD()
+        this.rollbackTripToIdle()
       }
       return res
     } catch (err) {
       const error = err instanceof Error ? err.message : String(err)
       this.appendLog(`START error: ${error}`)
-      this.trip = {...this.trip, status: "idle", running: false}
-      this.ui.send("nav:trip-state", this.trip)
-      this.refreshHUD()
+      this.rollbackTripToIdle()
       return {ok: false, error}
     } finally {
       this.starting = false
     }
+  }
+
+  /**
+   * Roll the optimistic "navigating" trip state back to idle after a failed
+   * start. Clears the destination and route fields too — otherwise the phone
+   * map keeps a pin on a destination we never actually started routing to.
+   */
+  private rollbackTripToIdle(): void {
+    this.trip = {
+      ...this.trip,
+      status: "idle",
+      running: false,
+      activeDestination: null,
+      activeDestinationName: null,
+      maneuver: null,
+      routePoints: null,
+      routeSteps: null,
+    }
+    this.ui.send("nav:trip-state", this.trip)
+    this.refreshHUD()
   }
 
   // ── Actions (cross-miniapp / AI) ─────────────────────────────────────
@@ -645,26 +661,33 @@ export class NavigationController {
     const mode = MODES.has(params.travel_mode as TravelMode) ? (params.travel_mode as TravelMode) : "walking"
     const explicitName = typeof params.destination_name === "string" ? params.destination_name.trim() : ""
 
-    // Resolve the destination: explicit coordinates win; otherwise look up the query.
+    // Resolve the destination. A full coordinate pair wins; otherwise fall back
+    // to the place query (so a query still works even when a stray/partial
+    // coordinate is also present); a lone coordinate with no query is an error.
+    const hasLat = typeof params.latitude === "number"
+    const hasLng = typeof params.longitude === "number"
+    const query = typeof params.query === "string" && params.query.trim() ? params.query.trim() : null
+
     let dest: {lat: number; lng: number; name?: string} | null = null
-    if (typeof params.latitude === "number" || typeof params.longitude === "number") {
-      // Validate both as finite, in-range coordinates — `typeof NaN === "number"`,
-      // so a bare typeof check would let NaN/Infinity flow into the native start.
-      const {latitude, longitude} = params
+    if (hasLat && hasLng) {
+      // Validate as finite, in-range coordinates — `typeof NaN === "number"`, so
+      // a bare typeof check would let NaN/Infinity flow into the native start.
+      const latitude = params.latitude as number
+      const longitude = params.longitude as number
       if (
-        typeof latitude !== "number" ||
-        typeof longitude !== "number" ||
         !Number.isFinite(latitude) ||
         !Number.isFinite(longitude) ||
         Math.abs(latitude) > 90 ||
         Math.abs(longitude) > 180
       ) {
-        return {ok: false, error: "latitude and longitude must both be finite coordinates (|lat| ≤ 90, |lng| ≤ 180)."}
+        return {ok: false, error: "latitude and longitude must be finite coordinates (|lat| ≤ 90, |lng| ≤ 180)."}
       }
       dest = {lat: latitude, lng: longitude, name: explicitName || undefined}
-    } else if (typeof params.query === "string" && params.query.trim()) {
-      dest = await this.resolveDestination(params.query.trim())
-      if (!dest) return {ok: false, error: `Couldn't find a place matching "${params.query}".`}
+    } else if (query) {
+      dest = await this.resolveDestination(query)
+      if (!dest) return {ok: false, error: `Couldn't find a place matching "${query}".`}
+    } else if (hasLat || hasLng) {
+      return {ok: false, error: "Provide both latitude and longitude, or a destination query."}
     } else {
       return {ok: false, error: "Provide a destination query, or latitude and longitude."}
     }

--- a/miniapps/navigation/src/background/NavigationController.ts
+++ b/miniapps/navigation/src/background/NavigationController.ts
@@ -14,6 +14,7 @@ import type {
   NavUpdate,
   Pivot,
   StartNavigationOptions,
+  TravelMode,
   UIModule,
 } from "@mentra/miniapp/background"
 
@@ -221,6 +222,7 @@ export class NavigationController {
     this.wireSensorSubscriptions()
     this.wireRpcHandlers()
     this.wireUIBroadcasts()
+    this.registerActions()
     this.wireHUDPump()
     this.wireTouchGestures()
     this.primeNavigationPermission()
@@ -516,94 +518,175 @@ export class NavigationController {
     this.unsubs.push(this.ui.handle("storage:add-recent", (p) => this.storage.addRecentSearch(p)))
   }
 
+  // ── Trip start (shared by the UI's nav:start and the start_navigation action) ──
+
+  /**
+   * Begin a turn-by-turn trip. Drives both the UI's `nav:start` broadcast and
+   * the `start_navigation` action so they share one path: optimistic trip
+   * state, glasses HUD repaint, then `navigation.start()`, rolling back to idle
+   * if the native start fails. Resolves `{ok, error?}` for the action; the UI
+   * listener ignores the return.
+   */
+  private async beginTrip(opts: StartNavigationOptions & {destinationName?: string}): Promise<{ok: boolean; error?: string}> {
+    // Re-entrancy guard: ignore a second start while one is already in flight
+    // (the duplicate's start() would stop() the session the first just created
+    // and freeze the puck).
+    if (this.starting) {
+      this.appendLog("START ignored — already starting")
+      return {ok: false, error: "A navigation start is already in progress"}
+    }
+    this.starting = true
+    const {destinationName, ...startOpts} = opts
+    // Clear the previous trip's route polyline immediately so the
+    // off-route threshold check doesn't run against a stale route
+    // between nav:start and the new onRoute event landing. Without
+    // this, the user can be e.g. 500m from the prior route's
+    // polyline at start, instantly trigger the >30m bucket, flip
+    // status to "rerouting", and fire a redundant auto-rebuild.
+    this.trip = {
+      ...this.trip,
+      status: "navigating",
+      running: true,
+      activeDestination: startOpts.stops?.[startOpts.stops.length - 1] ?? null,
+      activeDestinationName: destinationName ?? null,
+      maneuver: null,
+      routePoints: null,
+      routeSteps: null,
+      offRouteAt: null,
+      arrivalSide: null,
+    }
+    // Snapshot the trip-start context so an auto-rebuild can re-
+    // fire start() with the same shape, and so we can gate
+    // rebuilds on "user has actually moved away from start".
+    this.lastStartOpts = opts
+    this.tripStartCoords = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : null
+    // Reset the movement-vector heading so this trip's "you" arrow measures
+    // direction of travel fresh (anchor re-seeds on the next fix).
+    this.moveBearingAnchor = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : null
+    this.moveBearingDeg = null
+    this.lastAutoRebuildAt = 0
+    this.lastOffRouteBucket = 0
+    this.offRouteAdvisory = false
+    this.offRouteAdvisoryDistanceM = null
+    // Clear any pivots left over from a previous trip. Without this, a new
+    // start with stale activePivot/upcomingPivot would make refreshHUD take
+    // a pivot branch and show the OLD trip's instruction instead of
+    // "Starting…" — the HUD must read "Starting…" until THIS trip's first
+    // real maneuver/pivot lands.
+    this.activePivot = null
+    this.upcomingPivot = null
+    // Cancel any in-flight delayed rebuild — a fresh start
+    // supersedes the old "are we still off-route?" timer.
+    this.cancelPendingRebuild()
+    this.appendLog(`START ${destinationName ?? "(unnamed)"}`)
+    this.ui.send("nav:trip-state", this.trip)
+    // Repaint the glasses HUD immediately so the left text flips from the
+    // idle "Welcome to Mentra Maps!" frame to "Starting…" the instant the
+    // user starts — instead of the welcome frame lingering until the next
+    // GPS tick / HUD pump (~1s). running is already true above, so refreshHUD
+    // takes the "Starting…" branch and showManeuver overwrites the welcome
+    // text in place.
+    this.refreshHUD()
+    try {
+      // start() resolves `{ok:false}` (it never throws) for
+      // permission, GPS, REST, or native failures — on those the
+      // native trip never began and no synthetic onRoute will land,
+      // so we must roll the optimistic "navigating" state set above
+      // back to idle. Inspecting only `catch` left the UI stuck on a
+      // routeless trip with no recovery but a manual stop.
+      const res = await this.navigation.start(withPivotDefaults(startOpts))
+      if (!res.ok) {
+        this.appendLog(`START failed: ${res.error ?? "unknown"}`)
+        this.trip = {...this.trip, status: "idle", running: false}
+        this.ui.send("nav:trip-state", this.trip)
+        this.refreshHUD()
+      }
+      return res
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err)
+      this.appendLog(`START error: ${error}`)
+      this.trip = {...this.trip, status: "idle", running: false}
+      this.ui.send("nav:trip-state", this.trip)
+      this.refreshHUD()
+      return {ok: false, error}
+    } finally {
+      this.starting = false
+    }
+  }
+
+  // ── Actions (cross-miniapp / AI) ─────────────────────────────────────
+
+  /**
+   * Declared in miniapp.json. A system miniapp (e.g. Mentra AI) invokes
+   * start_navigation to "navigate to X" — the host headless-wakes us if we're
+   * stopped, then delivers the call once start() registers the handler. The
+   * destination may be a place query (looked up via Places, biased to the
+   * current location) or explicit coordinates.
+   */
+  private registerActions(): void {
+    try {
+      this.unsubs.push(
+        this.session.actions.handle("start_navigation", (params) => this.startNavigationAction(params)),
+      )
+    } catch (err) {
+      // actions module unavailable on this host, or already registered — the
+      // miniapp still runs, it just can't be started via the action.
+      this.appendLog(`actions register failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  private async startNavigationAction(
+    params: Record<string, unknown>,
+  ): Promise<{ok: boolean; error?: string; destination?: {lat: number; lng: number; name?: string}}> {
+    if (!this.navigation.hasPermission) {
+      return {ok: false, error: "Location permission is required for navigation."}
+    }
+
+    const mode = MODES.has(params.travel_mode as TravelMode) ? (params.travel_mode as TravelMode) : "walking"
+    const explicitName = typeof params.destination_name === "string" ? params.destination_name.trim() : ""
+
+    // Resolve the destination: explicit coordinates win; otherwise look up the query.
+    let dest: {lat: number; lng: number; name?: string} | null = null
+    if (typeof params.latitude === "number" && typeof params.longitude === "number") {
+      dest = {lat: params.latitude, lng: params.longitude, name: explicitName || undefined}
+    } else if (typeof params.query === "string" && params.query.trim()) {
+      dest = await this.resolveDestination(params.query.trim())
+      if (!dest) return {ok: false, error: `Couldn't find a place matching "${params.query}".`}
+    } else {
+      return {ok: false, error: "Provide a destination query, or latitude and longitude."}
+    }
+
+    const res = await this.beginTrip({
+      stops: [{lat: dest.lat, lng: dest.lng}],
+      mode,
+      destinationName: explicitName || dest.name,
+    })
+    if (!res.ok) return {ok: false, error: res.error ?? "Failed to start navigation."}
+    return {ok: true, destination: dest}
+  }
+
+  /**
+   * Geocode a place name/address to coordinates via the Places facade, biased
+   * to the user's current location. Mirrors the UI's autocomplete → details
+   * pick. Returns null when there's no match or the lookup fails.
+   */
+  private async resolveDestination(query: string): Promise<{lat: number; lng: number; name?: string} | null> {
+    try {
+      const near = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : undefined
+      const suggestions = await this.places.autocomplete(query, near)
+      if (!suggestions.length) return null
+      const details = await this.places.details(suggestions[0].placeId)
+      return {lat: details.lat, lng: details.lng, name: details.name}
+    } catch (err) {
+      this.appendLog(`resolveDestination failed: ${err instanceof Error ? err.message : String(err)}`)
+      return null
+    }
+  }
+
   // ── UI broadcast listeners ───────────────────────────────────────────
 
   private wireUIBroadcasts(): void {
-    this.unsubs.push(
-      this.ui.on("nav:start", async (opts) => {
-        // Re-entrancy guard: ignore a second nav:start while one is already
-        // in flight (the duplicate's start() would stop() the session the
-        // first just created and freeze the puck).
-        if (this.starting) {
-          this.appendLog("START ignored — already starting")
-          return
-        }
-        this.starting = true
-        const {destinationName, ...startOpts} = opts
-        // Clear the previous trip's route polyline immediately so the
-        // off-route threshold check doesn't run against a stale route
-        // between nav:start and the new onRoute event landing. Without
-        // this, the user can be e.g. 500m from the prior route's
-        // polyline at start, instantly trigger the >30m bucket, flip
-        // status to "rerouting", and fire a redundant auto-rebuild.
-        this.trip = {
-          ...this.trip,
-          status: "navigating",
-          running: true,
-          activeDestination: startOpts.stops?.[startOpts.stops.length - 1] ?? null,
-          activeDestinationName: destinationName ?? null,
-          maneuver: null,
-          routePoints: null,
-          routeSteps: null,
-          offRouteAt: null,
-          arrivalSide: null,
-        }
-        // Snapshot the trip-start context so an auto-rebuild can re-
-        // fire start() with the same shape, and so we can gate
-        // rebuilds on "user has actually moved away from start".
-        this.lastStartOpts = opts
-        this.tripStartCoords = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : null
-        // Reset the movement-vector heading so this trip's "you" arrow measures
-        // direction of travel fresh (anchor re-seeds on the next fix).
-        this.moveBearingAnchor = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : null
-        this.moveBearingDeg = null
-        this.lastAutoRebuildAt = 0
-        this.lastOffRouteBucket = 0
-        this.offRouteAdvisory = false
-        this.offRouteAdvisoryDistanceM = null
-        // Clear any pivots left over from a previous trip. Without this, a new
-        // start with stale activePivot/upcomingPivot would make refreshHUD take
-        // a pivot branch and show the OLD trip's instruction instead of
-        // "Starting…" — the HUD must read "Starting…" until THIS trip's first
-        // real maneuver/pivot lands.
-        this.activePivot = null
-        this.upcomingPivot = null
-        // Cancel any in-flight delayed rebuild — a fresh start
-        // supersedes the old "are we still off-route?" timer.
-        this.cancelPendingRebuild()
-        this.appendLog(`START ${destinationName ?? "(unnamed)"}`)
-        this.ui.send("nav:trip-state", this.trip)
-        // Repaint the glasses HUD immediately so the left text flips from the
-        // idle "Welcome to Mentra Maps!" frame to "Starting…" the instant the
-        // user starts — instead of the welcome frame lingering until the next
-        // GPS tick / HUD pump (~1s). running is already true above, so refreshHUD
-        // takes the "Starting…" branch and showManeuver overwrites the welcome
-        // text in place.
-        this.refreshHUD()
-        try {
-          // start() resolves `{ok:false}` (it never throws) for
-          // permission, GPS, REST, or native failures — on those the
-          // native trip never began and no synthetic onRoute will land,
-          // so we must roll the optimistic "navigating" state set above
-          // back to idle. Inspecting only `catch` left the UI stuck on a
-          // routeless trip with no recovery but a manual stop.
-          const res = await this.navigation.start(withPivotDefaults(startOpts))
-          if (!res.ok) {
-            this.appendLog(`START failed: ${res.error ?? "unknown"}`)
-            this.trip = {...this.trip, status: "idle", running: false}
-            this.ui.send("nav:trip-state", this.trip)
-            this.refreshHUD()
-          }
-        } catch (err) {
-          this.appendLog(`START error: ${err instanceof Error ? err.message : String(err)}`)
-          this.trip = {...this.trip, status: "idle", running: false}
-          this.ui.send("nav:trip-state", this.trip)
-          this.refreshHUD()
-        } finally {
-          this.starting = false
-        }
-      }),
-    )
+    this.unsubs.push(this.ui.on("nav:start", (opts) => void this.beginTrip(opts)))
     this.unsubs.push(
       this.ui.on("nav:stop", () => {
         this.appendLog("STOP")
@@ -1977,6 +2060,9 @@ function arrowFor(maneuver: string | null | undefined, direction: "left" | "righ
  * (block length ≈ 80m). Set as a single static value because the SDK
  * has no runtime radius setter — same value used for enter and exit.
  */
+/** Valid travel modes for the start_navigation action (mirrors TravelMode). */
+const MODES = new Set<TravelMode>(["walking", "driving", "cycling", "two_wheeler"])
+
 const PIVOT_RADIUS_M_WALKING = 14
 
 // Distance at which the HUD's directional arrow flips from ↑

--- a/miniapps/navigation/src/background/NavigationController.ts
+++ b/miniapps/navigation/src/background/NavigationController.ts
@@ -647,8 +647,21 @@ export class NavigationController {
 
     // Resolve the destination: explicit coordinates win; otherwise look up the query.
     let dest: {lat: number; lng: number; name?: string} | null = null
-    if (typeof params.latitude === "number" && typeof params.longitude === "number") {
-      dest = {lat: params.latitude, lng: params.longitude, name: explicitName || undefined}
+    if (typeof params.latitude === "number" || typeof params.longitude === "number") {
+      // Validate both as finite, in-range coordinates — `typeof NaN === "number"`,
+      // so a bare typeof check would let NaN/Infinity flow into the native start.
+      const {latitude, longitude} = params
+      if (
+        typeof latitude !== "number" ||
+        typeof longitude !== "number" ||
+        !Number.isFinite(latitude) ||
+        !Number.isFinite(longitude) ||
+        Math.abs(latitude) > 90 ||
+        Math.abs(longitude) > 180
+      ) {
+        return {ok: false, error: "latitude and longitude must both be finite coordinates (|lat| ≤ 90, |lng| ≤ 180)."}
+      }
+      dest = {lat: latitude, lng: longitude, name: explicitName || undefined}
     } else if (typeof params.query === "string" && params.query.trim()) {
       dest = await this.resolveDestination(params.query.trim())
       if (!dest) return {ok: false, error: `Couldn't find a place matching "${params.query}".`}

--- a/miniapps/navigation/src/background/NavigationController.ts
+++ b/miniapps/navigation/src/background/NavigationController.ts
@@ -672,7 +672,24 @@ export class NavigationController {
    */
   private async resolveDestination(query: string): Promise<{lat: number; lng: number; name?: string} | null> {
     try {
-      const near = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : undefined
+      let near = this.coords ? {lat: this.coords.lat, lng: this.coords.lng} : undefined
+      // A headless start_navigation invoke can be dispatched before the initial
+      // GPS fix lands (seedInitialFix runs later in start()). Grab a one-shot fix
+      // so place search is biased to the wearer, per the action contract — and
+      // seed this.coords so beginTrip has a start position too.
+      if (!near) {
+        try {
+          const d = await this.location.getOnce()
+          near = {lat: d.lat, lng: d.lng}
+          if (!this.coords) {
+            this.coords = {lat: d.lat, lng: d.lng, accuracy: d.accuracy, ts: d.timestamp ?? Date.now()}
+            this.lastCoordsAt = Date.now()
+            this.ui.send("nav:coords", this.coords)
+          }
+        } catch {
+          /* no fix yet — fall back to an unbiased search */
+        }
+      }
       const suggestions = await this.places.autocomplete(query, near)
       if (!suggestions.length) return null
       const details = await this.places.details(suggestions[0].placeId)

--- a/miniapps/teleprompter/miniapp.json
+++ b/miniapps/teleprompter/miniapp.json
@@ -34,7 +34,7 @@
   "actions": [
     {
       "id": "load_script",
-      "description": "Load text into the teleprompter and show it on the glasses, ready to read. Use when the user wants to put a speech, talking points, lines, or any notes up on their glasses — e.g. 'put my toast on the teleprompter' or 'teleprompt this'. Replaces the current script and resets to the top. Set autostart to begin scrolling immediately (it follows the user's voice when a mic is available, otherwise scrolls at their saved words-per-minute); leave it off to just show the opening lines so the user can start when ready.",
+      "description": "Load text into the teleprompter and start reading it on the glasses. Use when the user wants to put a speech, talking points, lines, or any notes up on their glasses — e.g. 'put my toast on the teleprompter' or 'teleprompt this'. Replaces the current script and resets to the top. By default it begins scrolling immediately (following the user's voice when a mic is available, otherwise at their saved words-per-minute); set autostart false to just show the opening lines so the user can start when ready.",
       "parameters": {
         "type": "object",
         "properties": {
@@ -44,7 +44,7 @@
           },
           "autostart": {
             "type": "boolean",
-            "description": "When true, start scrolling from the top right away. When false or omitted, load the script and show the opening lines without scrolling."
+            "description": "Defaults to true — start scrolling from the top right away. Set false to load the script and show the opening lines without scrolling, so the user can start when ready."
           }
         },
         "required": ["script"]

--- a/miniapps/teleprompter/miniapp.json
+++ b/miniapps/teleprompter/miniapp.json
@@ -30,5 +30,25 @@
       "level": "OPTIONAL",
       "description": "Captures speech so scrolling can follow your voice; timed scrolling works without it"
     }
+  ],
+  "actions": [
+    {
+      "id": "load_script",
+      "description": "Load text into the teleprompter and show it on the glasses, ready to read. Use when the user wants to put a speech, talking points, lines, or any notes up on their glasses — e.g. 'put my toast on the teleprompter' or 'teleprompt this'. Replaces the current script and resets to the top. Set autostart to begin scrolling immediately (it follows the user's voice when a mic is available, otherwise scrolls at their saved words-per-minute); leave it off to just show the opening lines so the user can start when ready.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "script": {
+            "type": "string",
+            "description": "The full script to display. Use blank lines to separate paragraphs; the teleprompter wraps each line to fit the glasses."
+          },
+          "autostart": {
+            "type": "boolean",
+            "description": "When true, start scrolling from the top right away. When false or omitted, load the script and show the opening lines without scrolling."
+          }
+        },
+        "required": ["script"]
+      }
+    }
   ]
 }

--- a/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
+++ b/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
@@ -245,7 +245,8 @@ export class TeleprompterController {
       this.unsubs.push(
         this.session.actions.handle("load_script", (params) => {
           const script = typeof params.script === "string" ? params.script : ""
-          const autostart = params.autostart === true
+          // Default on: opening the teleprompter with text should start reading.
+          const autostart = params.autostart !== false
           return this.loadScript(script, autostart)
         }),
       )

--- a/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
+++ b/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
@@ -244,10 +244,16 @@ export class TeleprompterController {
     try {
       this.unsubs.push(
         this.session.actions.handle("load_script", (params) => {
-          const script = typeof params.script === "string" ? params.script : ""
+          // `script` is required and must be a string. Reject malformed calls
+          // here (the handler is the last line of defense for action params) —
+          // coercing a missing/non-string value to "" would wipe the user's
+          // saved script. The thrown error is returned to the caller.
+          if (typeof params.script !== "string") {
+            throw new Error("load_script: 'script' is required and must be a string")
+          }
           // Default on: opening the teleprompter with text should start reading.
           const autostart = params.autostart !== false
-          return this.loadScript(script, autostart)
+          return this.loadScript(params.script, autostart)
         }),
       )
     } catch (err) {
@@ -269,6 +275,11 @@ export class TeleprompterController {
     this.engine.setScript(next)
     // Reset to the top, stop any in-progress read, then show the opening lines.
     this.toIdle()
+    // Force the push even if the opening window matches what we last sent:
+    // another app may have overwritten the glasses while we were backgrounded,
+    // so an explicit "open with this text" must land on-screen rather than be
+    // deduped away by render()'s lastRenderedText cache.
+    this.lastRenderedText = ""
     this.render()
     this.broadcastSettings()
     this.broadcastStatus()

--- a/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
+++ b/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
@@ -182,6 +182,7 @@ export class TeleprompterController {
     }
 
     this.registerUiHandlers()
+    this.registerActions()
 
     // Show the opening lines as a ready-to-read preview on the glasses.
     this.render()
@@ -226,6 +227,56 @@ export class TeleprompterController {
     this.unsubs.push(this.ui.on("tp:restart", () => this.restart()))
     this.unsubs.push(this.ui.on("tp:seek", ({percent}) => this.seek(percent)))
     this.unsubs.push(this.ui.on("tp:nudge", ({lines}) => this.nudge(lines)))
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Actions (cross-miniapp / AI)
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Declared in miniapp.json. A system miniapp (e.g. Mentra AI) invokes this to
+   * "open the teleprompter with this text" — the host headless-wakes us if we're
+   * stopped, then delivers the call once start() registers the handler. We load
+   * the script and render it to the glasses; the caller gets back a small
+   * summary so the AI can confirm what landed.
+   */
+  private registerActions(): void {
+    try {
+      this.unsubs.push(
+        this.session.actions.handle("load_script", (params) => {
+          const script = typeof params.script === "string" ? params.script : ""
+          const autostart = params.autostart === true
+          return this.loadScript(script, autostart)
+        }),
+      )
+    } catch (err) {
+      // actions module unavailable on this host, or already registered — the
+      // miniapp still runs, it just can't be opened via the action.
+      console.log("Teleprompter: failed to register actions", err)
+    }
+  }
+
+  /**
+   * Replace the script and surface it on the glasses, ready to read. Unlike the
+   * UI's tp:set-script (which no-ops on an unchanged script to avoid disturbing
+   * the editor), this always resets to the top and re-renders — an explicit
+   * "open with this text" should land deterministically. Optionally autostarts.
+   */
+  async loadScript(script: string, autostart: boolean): Promise<{words: number; lines: number; started: boolean}> {
+    const next = script ?? ""
+    this.settings.script = next
+    this.engine.setScript(next)
+    // Reset to the top, stop any in-progress read, then show the opening lines.
+    this.toIdle()
+    this.render()
+    this.broadcastSettings()
+    this.broadcastStatus()
+    await this.persist(STORAGE_KEYS.script, next)
+
+    const started = autostart && this.engine.totalWords > 0
+    if (started) this.play()
+
+    return {words: this.engine.totalWords, lines: this.engine.totalLines, started}
   }
 
   private sendSnapshot(): void {

--- a/miniapps/teleprompter/src/ui/App.tsx
+++ b/miniapps/teleprompter/src/ui/App.tsx
@@ -7,6 +7,7 @@ import {ScriptView} from "./components/ScriptView"
 import {SettingsView} from "./components/SettingsView"
 import {useDeveloperMode} from "./hooks/useDeveloperMode"
 import {useTeleprompter} from "./hooks/useTeleprompter"
+import {HEADER_FROM, HEADER_TO} from "./lib/theme"
 
 /**
  * App — the WebView root for the teleprompter miniapp.
@@ -25,7 +26,7 @@ export function App() {
     <div
       className="w-screen h-screen flex overflow-hidden font-sans"
       style={{
-        backgroundColor: "#15803D",
+        backgroundImage: `linear-gradient(90deg, ${HEADER_FROM}, ${HEADER_TO})`,
         paddingTop: insets.top,
         paddingBottom: insets.bottom,
         paddingLeft: insets.left,

--- a/miniapps/translation/miniapp.json
+++ b/miniapps/translation/miniapp.json
@@ -30,5 +30,24 @@
       "description": "Captures speech for translation"
     }
   ],
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "actions": [
+    {
+      "id": "start_translation",
+      "description": "Start live translation on the glasses. By default it listens to ANY spoken language around the user and translates it into one chosen target language, showing the result on the glasses in real time — so the user understands speech in a language they don't speak. Use when the user wants to translate what they're hearing, understand a foreign-language conversation, or 'translate to <language>'. Pass targetLanguage to set the language they want to read; omit it to keep their saved choice. Only pass sourceLanguage if the user explicitly wants to pin the spoken language to a single one — otherwise leave it off so any language is translated.",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "targetLanguage": {
+            "type": "string",
+            "description": "The language the user wants to read the translation in, as a BCP-47 code (e.g. 'en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh', 'ko', 'ar', 'hi'). Omit to keep the user's saved target language."
+          },
+          "sourceLanguage": {
+            "type": "string",
+            "description": "Optional. Pin the spoken/source language to a single BCP-47 code instead of auto-detecting any language. Leave this out in almost all cases — omitting it translates ANY spoken language, which is the intended default."
+          }
+        }
+      }
+    }
+  ]
 }

--- a/miniapps/translation/miniapp.json
+++ b/miniapps/translation/miniapp.json
@@ -34,17 +34,13 @@
   "actions": [
     {
       "id": "start_translation",
-      "description": "Start live translation on the glasses. By default it listens to ANY spoken language around the user and translates it into one chosen target language, showing the result on the glasses in real time — so the user understands speech in a language they don't speak. Use when the user wants to translate what they're hearing, understand a foreign-language conversation, or 'translate to <language>'. Pass targetLanguage to set the language they want to read; omit it to keep their saved choice. Only pass sourceLanguage if the user explicitly wants to pin the spoken language to a single one — otherwise leave it off so any language is translated.",
+      "description": "Start live translation on the glasses. It listens to ANY spoken language around the user and translates it into one chosen target language, showing the result on the glasses in real time — so the user understands speech in a language they don't speak. Use when the user wants to translate what they're hearing, understand a foreign-language conversation, or 'translate to <language>'. Pass targetLanguage to set the language they want to read; omit it to keep their saved choice.",
       "parameters": {
         "type": "object",
         "properties": {
           "targetLanguage": {
             "type": "string",
             "description": "The language the user wants to read the translation in, as a BCP-47 code (e.g. 'en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh', 'ko', 'ar', 'hi'). Omit to keep the user's saved target language."
-          },
-          "sourceLanguage": {
-            "type": "string",
-            "description": "Optional. Pin the spoken/source language to a single BCP-47 code instead of auto-detecting any language. Leave this out in almost all cases — omitting it translates ANY spoken language, which is the intended default."
           }
         }
       }

--- a/miniapps/translation/src/background/controllers/TranslationController.ts
+++ b/miniapps/translation/src/background/controllers/TranslationController.ts
@@ -297,6 +297,13 @@ export class TranslationController {
       this.subscribeTranslation()
     }
 
+    // subscribeTranslation swallows subscribe failures (it logs and leaves
+    // translationCleanup null). Don't claim "translating" if nothing attached —
+    // surface it as an action error so the caller (e.g. Mentra AI) knows.
+    if (!this.translationCleanup) {
+      throw new Error("Failed to start translation — no active subscription")
+    }
+
     return {targetLanguage: this.settings.targetLanguage, status: "translating"}
   }
 

--- a/miniapps/translation/src/background/controllers/TranslationController.ts
+++ b/miniapps/translation/src/background/controllers/TranslationController.ts
@@ -111,6 +111,12 @@ export class TranslationController {
   private translationCleanup: UnsubscribeFn | null = null
   private inactivityTimer: ReturnType<typeof setTimeout> | null = null
 
+  // Action-scoped source-language pin. Null = translate any spoken language
+  // (the default and the app's normal mode); a code subscribes to that one
+  // source only. Not persisted and not a UI setting — only the start_translation
+  // action sets it, for the rare case a caller wants to pin the spoken language.
+  private pinnedSource: string | null = null
+
   // session.ui, retyped against this miniapp's channel registry. The SDK types
   // `session.ui` as UIModule<default-channels>; cast through unknown to bind it
   // to our Channels (mirrors the example-miniapp's approach).
@@ -178,6 +184,7 @@ export class TranslationController {
     this.subscribeCloudStatus()
 
     this.registerUiHandlers()
+    this.registerActions()
     console.log(`LocalTranslation: started (target=${this.settings.targetLanguage}, profile=${this.currentProfile.id})`)
   }
 
@@ -259,6 +266,48 @@ export class TranslationController {
         this.clearTranscripts()
       }),
     )
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Actions (cross-miniapp / AI)
+  // ───────────────────────────────────────────────────────────────────────
+
+  /**
+   * Declared in miniapp.json. A system miniapp (e.g. Mentra AI) invokes this to
+   * start live translation — the host headless-wakes us if we're stopped, and
+   * by the time this runs start() has already subscribed to any-source → the
+   * saved target. We then apply any caller-requested target/source and confirm.
+   */
+  private registerActions(): void {
+    try {
+      this.unsubs.push(this.session.actions.handle("start_translation", (params) => this.startTranslation(params)))
+    } catch (err) {
+      // actions module unavailable on this host, or already registered — the
+      // miniapp still runs, it just can't be started via the action.
+      console.log("LocalTranslation: failed to register actions", err)
+    }
+  }
+
+  private async startTranslation(
+    params: Record<string, unknown>,
+  ): Promise<{targetLanguage: string; sourceLanguage: string; status: string}> {
+    const target =
+      typeof params.targetLanguage === "string" && params.targetLanguage.trim() ? params.targetLanguage.trim() : null
+    const source =
+      typeof params.sourceLanguage === "string" && params.sourceLanguage.trim() ? params.sourceLanguage.trim() : null
+
+    this.pinnedSource = source
+    if (target && target !== this.settings.targetLanguage) {
+      // setTargetLanguage persists, re-subscribes (reading pinnedSource), and
+      // broadcasts to the UI.
+      await this.setTargetLanguage(target)
+    } else {
+      // Target unchanged — re-subscribe so a new source pin (or a fresh start on
+      // a just-woken session) takes effect.
+      this.subscribeTranslation()
+    }
+
+    return {targetLanguage: this.settings.targetLanguage, sourceLanguage: source ?? "auto", status: "translating"}
   }
 
   private sendSnapshot(): void {
@@ -391,8 +440,12 @@ export class TranslationController {
         void this.handleTranslation(data)
       }
 
-      // Any source language -> selected target language.
-      this.translationCleanup = this.session.translation.to(targetLanguage, handler)
+      // Default: any source language -> selected target language. When a caller
+      // has pinned a source language (via the start_translation action), narrow
+      // to that specific pair instead.
+      this.translationCleanup = this.pinnedSource
+        ? this.session.translation.fromTo(this.pinnedSource, targetLanguage, handler)
+        : this.session.translation.to(targetLanguage, handler)
     } catch (err) {
       console.log(`LocalTranslation: translation subscribe failed for target=${targetLanguage}`, err)
     }

--- a/miniapps/translation/src/background/controllers/TranslationController.ts
+++ b/miniapps/translation/src/background/controllers/TranslationController.ts
@@ -111,12 +111,6 @@ export class TranslationController {
   private translationCleanup: UnsubscribeFn | null = null
   private inactivityTimer: ReturnType<typeof setTimeout> | null = null
 
-  // Action-scoped source-language pin. Null = translate any spoken language
-  // (the default and the app's normal mode); a code subscribes to that one
-  // source only. Not persisted and not a UI setting — only the start_translation
-  // action sets it, for the rare case a caller wants to pin the spoken language.
-  private pinnedSource: string | null = null
-
   // session.ui, retyped against this miniapp's channel registry. The SDK types
   // `session.ui` as UIModule<default-channels>; cast through unknown to bind it
   // to our Channels (mirrors the example-miniapp's approach).
@@ -290,24 +284,20 @@ export class TranslationController {
 
   private async startTranslation(
     params: Record<string, unknown>,
-  ): Promise<{targetLanguage: string; sourceLanguage: string; status: string}> {
+  ): Promise<{targetLanguage: string; status: string}> {
     const target =
       typeof params.targetLanguage === "string" && params.targetLanguage.trim() ? params.targetLanguage.trim() : null
-    const source =
-      typeof params.sourceLanguage === "string" && params.sourceLanguage.trim() ? params.sourceLanguage.trim() : null
 
-    this.pinnedSource = source
     if (target && target !== this.settings.targetLanguage) {
-      // setTargetLanguage persists, re-subscribes (reading pinnedSource), and
-      // broadcasts to the UI.
+      // setTargetLanguage persists, re-subscribes, and broadcasts to the UI.
       await this.setTargetLanguage(target)
     } else {
-      // Target unchanged — re-subscribe so a new source pin (or a fresh start on
-      // a just-woken session) takes effect.
+      // Target unchanged — re-subscribe to ensure translation is live (e.g. a
+      // fresh start on a just-woken session).
       this.subscribeTranslation()
     }
 
-    return {targetLanguage: this.settings.targetLanguage, sourceLanguage: source ?? "auto", status: "translating"}
+    return {targetLanguage: this.settings.targetLanguage, status: "translating"}
   }
 
   private sendSnapshot(): void {
@@ -440,12 +430,10 @@ export class TranslationController {
         void this.handleTranslation(data)
       }
 
-      // Default: any source language -> selected target language. When a caller
-      // has pinned a source language (via the start_translation action), narrow
-      // to that specific pair instead.
-      this.translationCleanup = this.pinnedSource
-        ? this.session.translation.fromTo(this.pinnedSource, targetLanguage, handler)
-        : this.session.translation.to(targetLanguage, handler)
+      // Any source language -> selected target language. Translating whatever
+      // is spoken into one chosen language is the app's whole model; the source
+      // is intentionally not configurable (see the file header).
+      this.translationCleanup = this.session.translation.to(targetLanguage, handler)
     } catch (err) {
       console.log(`LocalTranslation: translation subscribe failed for target=${targetLanguage}`, err)
     }

--- a/mobile/modules/miniapp/src/background/index.ts
+++ b/mobile/modules/miniapp/src/background/index.ts
@@ -48,6 +48,11 @@ export {
   MiniappErrorCode,
 } from "../protocol"
 
+// Action handler types — for typing `session.actions.handle(id, fn)` handlers
+// (the registering side lives in the background JSContext). `InvokeOptions` is
+// for system miniapps that call other apps' actions via `session.actions.invoke`.
+export type {ActionContext, ActionHandler, InvokeOptions} from "../modules/actions"
+
 // Session module types — useful for typing controller classes or
 // utility helpers that take a session-like dependency.
 export type {DisplayManager} from "../modules/display"


### PR DESCRIPTION
Adds AI/cross-miniapp **actions** (declared in `miniapp.json`, registered via `session.actions.handle()`) to three miniapps, so a system app like Mentra AI can drive them:

- **Teleprompter** `load_script` — opens the teleprompter with given text and (now by default) starts reading; `autostart: false` just shows the opening lines.
- **Translation** `start_translation` — starts live translation; its description encodes the default "translate ANY spoken language → one target" behavior so the AI knows what it does. Optional `targetLanguage`, and an optional `sourceLanguage` pin (via the SDK's `translation.fromTo`).
- **Mentra Maps** `start_navigation` — navigates to a destination given as a place `query` (resolved through the existing Places autocomplete→details, biased to current location) or explicit `latitude`/`longitude`; defaults to walking. The existing `nav:start` handler body was extracted into a shared `beginTrip()` so the UI and the action take one path.

Also exports the action handler types (`ActionContext`/`ActionHandler`/`InvokeOptions`) from the `@mentra/miniapp/background` entry, and makes the teleprompter WebView's safe-area frame use the header gradient so the strip above the status bar matches the app bar. These are the first miniapps in the repo to declare actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New AI-invokable entry points affect live navigation, glasses display, and mic/translation subscriptions; Maps changes share critical trip-start logic but add validation and rollback on failure.
> 
> **Overview**
> Introduces **miniapp actions** so system apps (e.g. Mentra AI) can drive other apps via `session.actions.handle()` and declarations in `miniapp.json`, with handler types exported from `@mentra/miniapp/background`.
> 
> **Mentra Maps** adds `start_navigation` (place `query` or lat/lng, optional name and travel mode). Trip start is unified in `beginTrip()` for both UI `nav:start` and the action, with **`rollbackTripToIdle()`** on failed native start and **`resolveDestination()`** (Places search biased to location, including a one-shot GPS fix when headless).
> 
> **Teleprompter** adds `load_script` (required string, `autostart` default true) via `loadScript()` that always resets, re-renders, and can force display past dedupe.
> 
> **Translation** adds `start_translation` with optional `targetLanguage`; re-subscribes and errors if subscription fails.
> 
> **Merge** gets a large **presentation-only** update: new palette/gradient shell, floating dock nav, agent icon tiles, listening/thinking empty heroes, and redesigned insight cards and settings.
> 
> **Teleprompter** WebView safe area uses the header gradient to match the app bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1201d1911dbe40f0d5f75ba1df372b469adecf0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->