### PR TITLE
[codex] Trigger staging builds on all staging pushes

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -27,10 +27,6 @@ on:
   push:
     branches:
       - staging
-    paths:
-      - "mobile/**"
-      - "asg_client/**"
-      - ".github/workflows/staging-builds.yml"
   workflow_dispatch:
     inputs:
       skip_cleanup:


### PR DESCRIPTION
## Summary

Removes the `paths` filter from the `Staging Builds` workflow push trigger.

## Why

`Staging Builds` was configured to run on pushes to `staging`, but only when the push changed one of:

- `mobile/**`
- `asg_client/**`
- `.github/workflows/staging-builds.yml`

That meant an empty retry commit on `staging` did not start the workflow, because it had no changed paths and therefore matched none of the filtered paths.

## Behavior After This Change

Any commit pushed to `staging` will trigger `Staging Builds`, including empty retry commits. The workflow still only listens to the `staging` branch for push events, and the existing manual `workflow_dispatch` trigger remains unchanged.

## Validation

- Confirmed the diff only removes the workflow `paths` filter.
- Ran `git diff --cached --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Staging-only CI change, but every `staging` push now runs heavy self-hosted mobile/ASG builds and OTA publishing—not just mobile/ASG diffs—increasing runner load and release churn risk.
> 
> **Overview**
> Removes the **`paths`** filter under the `push` trigger in **Staging Builds** (`.github/workflows/staging-builds.yml`), so the workflow no longer requires changes under `mobile/**`, `asg_client/**`, or the workflow file itself.
> 
> **Before:** pushes to `staging` only started the workflow when those paths changed, so empty or out-of-scope retry commits did not run builds. **After:** any push to `staging` triggers the full pipeline (mobile Android/iOS, ASG, release upload, OTA, Slack). Manual **`workflow_dispatch`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b0cabc09117b2700bfec658261064499c77cded. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->