### PR TITLE
chore: enable audio playback for mentra display

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -142,7 +142,7 @@ object DeviceStore {
         store.set("bluetooth", "use_native_dashboard", false)
         // Mentra Nex feature flags (off by default; toggled from Nex Developer Settings):
         store.set("bluetooth", "nex_chinese_captions", false)
-        store.set("bluetooth", "nex_audio_playback", false)
+        store.set("bluetooth", "nex_lc3_audio_playback", false)
     }
 
     fun get(category: String, key: String): Any? {
@@ -268,9 +268,9 @@ object DeviceStore {
             "bluetooth" to "voice_activity_detection_enabled" -> {
                 DeviceManager.getInstance().sgc?.sendVoiceActivityDetectionSetting()
             }
-            "bluetooth" to "nex_audio_playback" -> {
+            "bluetooth" to "nex_lc3_audio_playback" -> {
                 (value as? Boolean)?.let { enabled ->
-                    Bridge.log("DeviceStore: nex_audio_playback changed to $enabled")
+                    Bridge.log("DeviceStore: nex_lc3_audio_playback changed to $enabled")
                     DeviceManager.getInstance().sgc?.applyNexAudioPlaybackSetting()
                 }
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -105,10 +105,9 @@ class MentraNex : SGCManager() {
     private var context: Context? = null
     // private var isDebug: Boolean = true
 
-    // Off by default; toggled from Nex Developer Settings via the nex_audio_playback flag.
+    // Off by default; toggled from Nex Developer Settings via the nex_lc3_audio_playback flag.
     private val isLc3AudioEnabled: Boolean
-        // get() = DeviceStore.get("bluetooth", "nex_audio_playback") as? Boolean ?: false
-        get() = false
+        get() = DeviceStore.get("bluetooth", "nex_lc3_audio_playback") as? Boolean ?: false
     private var lc3AudioPlayer: Lc3Player? = null
 
     private var lc3DecoderPtr: Long = 0
@@ -221,7 +220,7 @@ class MentraNex : SGCManager() {
         }
     }
 
-    /** Start/stop the LC3 player when the nex_audio_playback flag changes. */
+    /** Start/stop the LC3 player when the nex_lc3_audio_playback flag changes. */
     override fun applyNexAudioPlaybackSetting() {
         if (isLc3AudioEnabled) {
             Bridge.log("Nex: LC3 audio playback enabled - starting player")

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -185,7 +185,7 @@ abstract class SGCManager {
     // Voice Activity Detection
     open fun sendVoiceActivityDetectionSetting() {}
 
-    // Start/stop LC3 audio playback from glasses based on the nex_audio_playback flag.
+    // Start/stop LC3 audio playback from glasses based on the nex_lc3_audio_playback flag.
     open fun applyNexAudioPlaybackSetting() {}
 
     // Version info

--- a/mobile/plugins/android.ts
+++ b/mobile/plugins/android.ts
@@ -193,7 +193,7 @@ if (project.hasProperty("sentryUploadEnabled") && project.property("sentryUpload
     // 4a. Enable Core Library Desugaring (required by :crust → Mapbox Nav SDK).
     if (!buildGradle.includes("coreLibraryDesugaringEnabled")) {
       buildGradle = buildGradle.replace(
-        /(namespace\s+['"]com\.mentra\.mentra['"])/,
+        /(namespace\s+['"]com\.mentra\.mentra(?:\.[A-Za-z0-9_.]+)?['"])/,
         `$1
     compileOptions {
         coreLibraryDesugaringEnabled true

--- a/mobile/src/components/glasses/NexDeveloperSettings.tsx
+++ b/mobile/src/components/glasses/NexDeveloperSettings.tsx
@@ -269,8 +269,8 @@ export default function NexDeveloperSettings() {
   const [commandSender, setCommandSender] = useState<BleCommand | null>(null)
   const [commandReceiver, setCommandReceiver] = useState<BleCommand | null>(null)
 
-  // LC3 Audio Control — persisted feature flag synced to the Bluetooth SDK (off by default).
-  const [lc3AudioEnabled, setLc3AudioEnabled] = useSetting(SETTINGS.nex_audio_playback.key)
+  // LC3 Audio Control — local-only dev flag synced to the Bluetooth SDK (off by default, not saved to cloud).
+  const [lc3AudioEnabled, setLc3AudioEnabled] = useSetting(SETTINGS.nex_lc3_audio_playback.key)
 
   // Chinese captions — persisted feature flag synced to the Bluetooth SDK (off by default).
   // When on, the Nex display skips ASCII-only sanitization so CJK text renders.

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -99,11 +99,15 @@ export const SETTINGS: Record<string, Setting> = {
     persist: true,
   },
   // When on, LC3 audio received from Nex glasses is played back (Android only).
-  nex_audio_playback: {
-    key: "nex_audio_playback",
+  // Local-only dev toggle: defaults off and never synced to the cloud account
+  // (saveOnServer: false); persists locally so it survives app restarts.
+  // Key renamed from the legacy `nex_audio_playback` so stale server/local
+  // values (saved back when this was saveOnServer:true) can't re-enable it.
+  nex_lc3_audio_playback: {
+    key: "nex_lc3_audio_playback",
     defaultValue: () => false,
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   china_deployment: {
@@ -712,7 +716,7 @@ const BLUETOOTH_SETTING_KEYS: string[] = [
   SETTINGS.gallery_mode.key,
   // Mentra Nex feature flags:
   SETTINGS.nex_chinese_captions.key,
-  SETTINGS.nex_audio_playback.key,
+  SETTINGS.nex_lc3_audio_playback.key,
 ]
 
 // const PER_GLASSES_SETTINGS_KEYS: string[] = [SETTINGS.preferred_mic.key]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enabling LC3 playback on the hot BLE audio path can affect performance and battery when the dev toggle is on; the setting change is scoped to Nex Android and defaults off.
> 
> **Overview**
> **Nex LC3 audio playback is turned on for real** when developers flip the toggle: Android `MentraNex` no longer hardcodes playback off and instead reads `nex_lc3_audio_playback` from `DeviceStore`, starting/stopping `Lc3Player` on init and when the flag changes.
> 
> The setting is renamed from `nex_audio_playback` to **`nex_lc3_audio_playback`** end-to-end (JS settings, Bluetooth sync list, native store keys). It stays **off by default**, persists **locally only** (`saveOnServer: false`), and the rename avoids legacy cloud-stored `true` values from re-enabling playback after sync.
> 
> Nex Developer Settings binds the LC3 toggle to the new key. Separately, the Android prebuild plugin widens the `namespace` match so **desugaring** injection works for suffixed application IDs (e.g. build variants), not only `com.mentra.mentra`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f31ec50a2008b839524b2111438c83c66ffcf004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->