### PR TITLE
Restrict legacy OTA manifest fallback to ASG builds below 39

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1119,7 +1119,7 @@ class MentraBluetoothSdk private constructor(
 
     private fun isLegacyAsgOtaStartBuild(buildNumber: String): Boolean {
         val parsed = buildNumber.toIntOrNull()
-        return parsed != null && parsed < 100_000
+        return parsed != null && parsed < 39
     }
 
     internal fun sendShutdown() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1178,7 +1178,7 @@ public final class MentraBluetoothSDK {
 
     private func isLegacyAsgOtaStartBuild(_ buildNumber: String) -> Bool {
         guard let parsed = Int(buildNumber) else { return false }
-        return parsed < 100_000
+        return parsed < 39
     }
 
     func sendShutdown() {

--- a/mobile/src/services/asg/asgOtaVersionUrl.ts
+++ b/mobile/src/services/asg/asgOtaVersionUrl.ts
@@ -3,8 +3,8 @@ import {SETTINGS, useSettingsStore} from "@/stores/settings"
 
 function isLegacyAsgOtaStartBuild(glassesBuildNumber?: string | null): boolean {
   const buildNumber = Number.parseInt(glassesBuildNumber ?? "", 10)
-  // Pre-wall-clock ASG builds ignore ota_start.ota_version_url, so compare against the URL they will actually use.
-  return Number.isFinite(buildNumber) && buildNumber < 100000
+  // ASG builds before 39 ignore ota_start.ota_version_url, so compare against the URL they will actually use.
+  return Number.isFinite(buildNumber) && buildNumber < 39
 }
 
 function getOtaVersionUrlDevOverride(): string | null {


### PR DESCRIPTION
## Summary
- Change the legacy ASG OTA manifest fallback cutoff from pre-wall-clock builds (`< 100000`) to ASG builds strictly below 39.
- Apply the same cutoff in MentraOS, Android Bluetooth SDK, and iOS Bluetooth SDK OTA checks.

## Why
ASG client 39 is the production hotfix build that accepts `ota_start.ota_version_url`. Only ASG clients before 39 need the OTA check to compare against the hard-coded legacy production manifest URL, because those clients ignore the supplied OTA URL when `ota_start` is sent.

## Validation
- `git diff --check`
- `cd mobile && bun install`
- `cd mobile && bun compile`
- `cd mobile && ../scripts/check-android-compile.sh bluetooth-sdk`

SwiftPM validation remains blocked locally by the existing toolchain/platform issue:
- `cd mobile/modules/bluetooth-sdk && swift build` fails with `DeviceManager.swift:12:8: error: no such module 'UIKit'`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which OTA manifest URL is used for ASG builds 39–99999, which affects update availability and what gets sent on `ota_start`; incorrect pairing could mislead users or push the wrong manifest, though scope is a small constant change aligned with known client behavior.
> 
> **Overview**
> **Legacy ASG OTA handling** no longer treats every pre–wall-clock build (`< 100000`) as ignoring `ota_start.ota_version_url`. The cutoff is now **ASG build &lt; 39** everywhere OTA manifest URLs are resolved.
> 
> The same `isLegacyAsgOtaStartBuild` threshold is updated in **MentraOS** (`asgOtaVersionUrl.ts`), the **Android** Bluetooth SDK, and the **iOS** Bluetooth SDK. Builds **39 and newer** follow the non-legacy path (SDK/app-configured manifest URL for update checks and `ota_start`), since client 39+ honors the supplied OTA URL. Only builds **below 39** still compare against the hard-coded legacy production manifest when the glasses ignore the URL on start.
> 
> The TypeScript comment is updated to describe “before 39” instead of “pre-wall-clock.”
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d04aabbb015fca0127642294f52305a939caeab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->