### PR TITLE
Bump Bluetooth SDK to 0.1.15

### DIFF
--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.14")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.15")
 }
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.14`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.15`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.14"
+  from: "0.1.15"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.14")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.15")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.14`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.15`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.14"
+  from: "0.1.15"
 )
 ```
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -213,7 +213,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -477,7 +477,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.14`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.15`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.14`
+Use the same version format as existing SwiftPM tags, for example `0.1.15`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump `@mentra/bluetooth-sdk` from `0.1.14` to `0.1.15`.
- Update the matching workspace lockfile entry.
- Update Mentra Live install docs, package README, and SwiftPM release notes to reference `0.1.15`.

## Validation
- `git diff --check`
- `cd mobile && bun install`
- `cd mobile && bun compile`
- `cd mobile/modules/bluetooth-sdk && npm pack --dry-run`
- `rg -n "0\\.1\\.14"` found no remaining references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and version metadata only; no runtime or Bluetooth logic changes.
> 
> **Overview**
> Bumps **`@mentra/bluetooth-sdk`** from **`0.1.14`** to **`0.1.15`** in `mobile/modules/bluetooth-sdk/package.json` and the **`mobile/bun.lock`** workspace entry.
> 
> Install and release docs now point consumers at **`0.1.15`**: Mentra Live **Android** (`com.mentraglass:bluetooth-sdk`), **iOS** SwiftPM (`from: "0.1.15"` / Xcode package version), **quickstart** tabs, the module **README**, and **`RELEASING_IOS_SPM.md`** tag example. No SDK source or API changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa47c0d595c2eb387921389b7ce3452a5a3e3a63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->