### PR TITLE
ci: disk-guard concurrency-safety + scope staging iOS killall (fix mac-runner build kills)

### DIFF
--- a/.github/actions/disk-guard/action.yml
+++ b/.github/actions/disk-guard/action.yml
@@ -1,11 +1,13 @@
 name: "Disk Guard"
 description: >
   Free disk space on self-hosted macOS CI runners, gated on available space so
-  warm builds pay no penalty. Two tiers: a light cache trim when space dips, and
-  an aggressive deep clean (old NDKs, old runner binaries, stale caches) when
-  space is critically low. Replaces the old scheduled cleanup workflow — there is
-  no cron job; this runs inline at the start of every build but only acts when
-  needed.
+  warm builds pay no penalty. Two tiers: a concurrency-safe light trim (only
+  finished-build leftovers) when space dips, and an aggressive emergency deep
+  clean (shared caches, old NDKs, old runner binaries) only when space is
+  critically low. Runs inline at the start of every build but only acts when
+  needed. Note: these hosts run multiple runners, so Tier 1 never deletes a
+  cache a concurrent build might be using; the deep clean is gated behind the
+  critically-low threshold where reclaiming space outweighs that risk.
 inputs:
   light-gb:
     description: "Below this many GiB free, do a light cache trim."
@@ -43,23 +45,28 @@ runs:
           exit 0
         fi
 
-        # ---- Tier 1: light cache trim (rebuildable, regenerates next build) ----
-        echo "Below light threshold — trimming rebuildable caches..."
-        (command -v gradle >/dev/null 2>&1 && gradle --stop) >/dev/null 2>&1 || true
-        pkill -f 'GradleDaemon' >/dev/null 2>&1 || true
-        rm -rf ~/Library/Caches/CocoaPods/* 2>/dev/null || true
-        rm -rf ~/Library/Caches/org.swift.swiftpm/* 2>/dev/null || true
-        rm -rf ~/Library/Caches/Homebrew/* 2>/dev/null || true
-        rm -rf ~/.gradle/caches/build-cache-* ~/.gradle/caches/transforms-* ~/.gradle/caches/journal-* 2>/dev/null || true
-        rm -rf ~/.gradle/daemon 2>/dev/null || true
-        rm -rf ~/.bun/install/cache/* 2>/dev/null || true
+        # ---- Tier 1: light trim (concurrency-SAFE only) ----
+        # These hosts run more than one runner, so a second build may be reading
+        # the shared caches (~/.bun, SwiftPM, CocoaPods, ~/.gradle/caches, NDK)
+        # while this runs. Deleting those here can corrupt a concurrent build and
+        # also throws away the warm caches that keep builds fast — so Tier 1 only
+        # reclaims things scoped to *finished* builds, never a live one. Shared
+        # caches are touched only in the Tier 2 emergency below.
+        echo "Below light threshold — trimming finished-build leftovers (concurrency-safe)..."
+        # Old DerivedData only (>3 days): a concurrent build's DerivedData is
+        # fresh, so it never matches the age filter.
         find ~/Library/Developer/Xcode/DerivedData -mindepth 1 -maxdepth 1 -mtime +3 -exec rm -rf {} \; 2>/dev/null || true
-        rm -rf ~/.android/avd/* ~/.android/cache/* 2>/dev/null || true
 
-        # ---- Tier 2: aggressive deep clean when critically low ----
+        # ---- Tier 2: aggressive emergency deep clean when critically low ----
+        # Last resort. This DOES delete shared caches (and so can race a
+        # concurrent build), but at <DEEP_GB free the build is about to die with
+        # "No space left on device" anyway — reclaiming space beats a guaranteed
+        # failure. It should fire rarely; if it fires often, the host is over-
+        # provisioned with runners or something is hoarding disk (investigate the
+        # host, don't lower the threshold).
         now=$(free_gb)
         if [ "${now}" -lt "${DEEP_GB}" ]; then
-          echo "Still below deep threshold (${now} GiB) — deep cleaning..."
+          echo "Still below deep threshold (${now} GiB) — emergency deep clean (may race a concurrent build)..."
 
           # Old NDK versions — keep only the build-pinned one, but ONLY prune if
           # that version is actually installed. Otherwise the runner may have a

--- a/.github/actions/disk-guard/action.yml
+++ b/.github/actions/disk-guard/action.yml
@@ -84,6 +84,20 @@ runs:
             echo "  keep-NDK ${KEEP_NDK} not installed — skipping NDK prune (won't delete the only NDK)"
           fi
 
+          # Shared rebuildable caches — the big reclaimable items. These are the
+          # ones Tier 1 deliberately skips (a concurrent build may be reading
+          # them); here at <DEEP_GB the build is about to fail anyway, so deleting
+          # them is the lesser evil. Also stop the Gradle daemon so its cache
+          # files are unlocked before deletion.
+          (command -v gradle >/dev/null 2>&1 && gradle --stop) >/dev/null 2>&1 || true
+          pkill -f 'GradleDaemon' >/dev/null 2>&1 || true
+          rm -rf ~/.bun/install/cache/* 2>/dev/null || true
+          rm -rf ~/Library/Caches/CocoaPods/* 2>/dev/null || true
+          rm -rf ~/Library/Caches/org.swift.swiftpm/* 2>/dev/null || true
+          rm -rf ~/Library/Caches/Homebrew/* 2>/dev/null || true
+          rm -rf ~/.gradle/caches/build-cache-* ~/.gradle/caches/transforms-* ~/.gradle/caches/journal-* ~/.gradle/daemon 2>/dev/null || true
+          rm -rf ~/.android/avd/* ~/.android/cache/* 2>/dev/null || true
+
           # Emulator + SDK sources — not needed for assembleRelease CI.
           rm -rf ~/Library/Android/sdk/emulator/* 2>/dev/null || true
           rm -rf ~/Library/Android/sdk/sources/* 2>/dev/null || true

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -269,11 +269,34 @@ jobs:
       testflight_detail: ${{ steps.release-status.outputs.testflight_detail }}
 
     steps:
-      - name: Kill stale build processes
+      - name: Kill stale build processes (this runner's prior job only)
         run: |
-          killall xcodebuild 2>/dev/null || true
-          killall Simulator 2>/dev/null || true
-          xcrun simctl shutdown all 2>/dev/null || true
+          # This is a SHARED self-hosted macOS runner. A blanket `killall xcodebuild`
+          # would kill iOS builds for OTHER branches running concurrently here — that was
+          # the cause of the recurring fast, diagnostic-free build failures (xcodebuild
+          # SIGTERM'd mid-compile → exit 65 / no error, build halts then ~30min silent
+          # gap until cleanup). The self-hosted runner only ever executes ONE job at a
+          # time per runner process, but multiple runner processes share this Mac
+          # (e.g. bigbob runs big-bob/-2/-3), so we must not touch other runners'
+          # xcodebuild. (The PR iOS workflow was already fixed this way; this staging
+          # job still had the unscoped killall — that's what killed run #3166's iOS build.)
+          #
+          # Scope the cleanup to xcodebuild processes whose RUNNER_WORKSPACE matches ours.
+          WS="${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}"
+          echo "Cleaning stale xcodebuild under: $WS"
+          pids="$(pgrep -f "xcodebuild.*${WS}" 2>/dev/null || true)"
+          if [ -n "$pids" ]; then
+            echo "Terminating stale xcodebuild pids: $pids"
+            # shellcheck disable=SC2086
+            kill -TERM $pids 2>/dev/null || true
+            sleep 2
+            # shellcheck disable=SC2086
+            kill -KILL $pids 2>/dev/null || true
+          else
+            echo "No stale xcodebuild for this workspace."
+          fi
+          # Do NOT machine-wide `killall Simulator` / `simctl shutdown all` — it would
+          # disrupt other runners. Device builds don't use a simulator anyway.
 
       - name: Clean previous build outputs only
         run: |


### PR DESCRIPTION
Two related self-hosted-mac-runner CI fixes, both about **multiple runners sharing one host stepping on each other's builds**. Targets `staging`.

## 1. Scope the staging iOS `killall` to this runner (`staging-builds.yml`)

The staging iOS job's first step ran a **machine-wide `killall xcodebuild`**. The mac hosts run multiple runner processes (`bigbob` = big-bob / big-bob-2 / big-bob-3), so when a second iOS build starts on one runner, its `killall` SIGTERMs the **in-flight xcodebuild of another runner's build** → that build dies mid-compile with **no `error:`**, orphaned processes, ~30-min silent hang. That's what killed staging run #3166's iOS build (30m35s, ran on `big-bob-2`).

Not OOM (bigbob = 64GB RAM / 742GB free), not the `bob` double-runner issue. It's the known killall cross-runner flake — already fixed in the PR iOS workflow (`mentra-app-ios-build.yml`) but never ported here. Fix: `pgrep -f "xcodebuild.*$RUNNER_WORKSPACE"` + TERM/KILL only this runner's processes; drop machine-wide `killall Simulator` / `simctl shutdown all`.

## 2. disk-guard Tier 1 concurrency-safety (`disk-guard/action.yml`)

The disk-guard's **Tier 1** (fires near the 40GB light threshold — the common path) was `rm -rf`-ing **shared caches** (`~/.bun`, SwiftPM, CocoaPods, `~/.gradle/caches`) + killing the Gradle daemon. On a multi-runner host a concurrent build may be reading those → corrupts a sibling build (same no-error mid-build death) and throws away warm caches.

- **Tier 1** now only reclaims finished-build leftovers (old DerivedData `>3 days`, which a live build never matches). Concurrency-safe.
- **Tier 2** (emergency, `<20GB` free) keeps the aggressive shared-cache deletion as a last resort — at that point the build is about to die with `No space left on device` anyway, so a possible race beats a guaranteed failure. (Review bots caught that the first revision dropped these deletes entirely; they're restored in Tier 2.)

## Context (host-side, done out-of-band)
- `bob` (16GB mini) was running 2 runners → OOM on its own builds; dropped to 1 runner + reclaimed ~40GB. Separate from the bigbob killall issue this PR fixes.

## Test plan
- [ ] Re-run staging iOS build; no mid-compile death when another iOS build is concurrent on the same host.
- [ ] disk-guard Tier 1 no longer touches shared caches; Tier 2 still reclaims them when critically low.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI cleanup behavior on shared hosts; Tier 2 disk-guard can still race concurrent builds, and mis-scoped `pgrep` could leave stale or kill wrong processes—low app/runtime risk but affects build reliability.
> 
> **Overview**
> Fixes **shared self-hosted Mac runners** stepping on concurrent jobs: staging iOS cleanup and disk-guard no longer touch resources other runner processes may be using.
> 
> **Staging iOS** (`staging-builds.yml`) replaces machine-wide `killall xcodebuild` and simulator shutdown with **`pgrep` + TERM/KILL only for `xcodebuild` tied to this job’s `RUNNER_WORKSPACE`**, matching the PR iOS workflow. That avoids SIGTERM’ing another runner’s in-flight compile (e.g. staging run #3166).
> 
> **disk-guard** (`action.yml`) makes **Tier 1** concurrency-safe: it only removes **DerivedData older than 3 days** instead of wiping shared caches (`~/.bun`, SwiftPM, CocoaPods, Gradle, Android AVD/cache) or stopping Gradle. **Tier 2** (&lt;20 GiB free) still does the aggressive shared-cache reclaim, Gradle daemon stop, NDK prune, etc., documented as an emergency that may race a sibling build when disk would otherwise fail the job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b21fb7a58970497e5c98fce1c6557666445f323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->