### PR TITLE
ci: scope staging iOS killall to this runner (fix cross-runner build kills)

### DIFF
--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -269,11 +269,34 @@ jobs:
       testflight_detail: ${{ steps.release-status.outputs.testflight_detail }}
 
     steps:
-      - name: Kill stale build processes
+      - name: Kill stale build processes (this runner's prior job only)
         run: |
-          killall xcodebuild 2>/dev/null || true
-          killall Simulator 2>/dev/null || true
-          xcrun simctl shutdown all 2>/dev/null || true
+          # This is a SHARED self-hosted macOS runner. A blanket `killall xcodebuild`
+          # would kill iOS builds for OTHER branches running concurrently here — that was
+          # the cause of the recurring fast, diagnostic-free build failures (xcodebuild
+          # SIGTERM'd mid-compile → exit 65 / no error, build halts then ~30min silent
+          # gap until cleanup). The self-hosted runner only ever executes ONE job at a
+          # time per runner process, but multiple runner processes share this Mac
+          # (e.g. bigbob runs big-bob/-2/-3), so we must not touch other runners'
+          # xcodebuild. (The PR iOS workflow was already fixed this way; this staging
+          # job still had the unscoped killall — that's what killed run #3166's iOS build.)
+          #
+          # Scope the cleanup to xcodebuild processes whose RUNNER_WORKSPACE matches ours.
+          WS="${RUNNER_WORKSPACE:-$GITHUB_WORKSPACE}"
+          echo "Cleaning stale xcodebuild under: $WS"
+          pids="$(pgrep -f "xcodebuild.*${WS}" 2>/dev/null || true)"
+          if [ -n "$pids" ]; then
+            echo "Terminating stale xcodebuild pids: $pids"
+            # shellcheck disable=SC2086
+            kill -TERM $pids 2>/dev/null || true
+            sleep 2
+            # shellcheck disable=SC2086
+            kill -KILL $pids 2>/dev/null || true
+          else
+            echo "No stale xcodebuild for this workspace."
+          fi
+          # Do NOT machine-wide `killall Simulator` / `simctl shutdown all` — it would
+          # disrupt other runners. Device builds don't use a simulator anyway.
 
       - name: Clean previous build outputs only
         run: |


### PR DESCRIPTION
## The bug

Staging iOS builds fail intermittently with a distinctive signature: build halts **mid-compile, no `error:` line**, orphaned processes, then a ~30-minute silent gap until cleanup (e.g. staging run #3166's iOS job, 30m35s, ran on `big-bob-2`).

Root cause: the staging iOS job's **first step is a machine-wide `killall xcodebuild`**:
```yaml
- name: Kill stale build processes
  run: |
    killall xcodebuild 2>/dev/null || true   # ← kills EVERY xcodebuild on the host
```
The mac hosts run **multiple runner processes** (`bigbob` = big-bob / big-bob-2 / big-bob-3). When a second iOS build starts on one runner, its `killall` SIGTERMs the **in-flight xcodebuild of another runner's build** → that build dies mid-compile with no diagnostic.

This is **not** OOM (bigbob has 64GB RAM / 742GB free) and not the `bob` double-runner issue (already fixed separately) — it's the known killall cross-runner flake.

## The fix

The **PR iOS workflow** (`mentra-app-ios-build.yml`) was already fixed to scope the kill to `RUNNER_WORKSPACE` — but `staging-builds.yml` still had the old unscoped `killall`. This ports the same scoped logic:
- `pgrep -f "xcodebuild.*$RUNNER_WORKSPACE"` → TERM/KILL **only** this runner's xcodebuild
- Drop the machine-wide `killall Simulator` / `simctl shutdown all` (also cross-runner disruptive; device builds don't use a simulator)

## Test plan
- [ ] Re-run staging iOS build; confirm it no longer dies mid-compile when another iOS build is concurrent on the same host.
- [ ] The scoped kill still cleans this runner's own stale xcodebuild between jobs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the staging iOS build cleanup to this runner’s workspace to stop cross-runner `xcodebuild` kills that halted other builds mid-compile. Removes simulator-wide shutdowns since device builds don’t use the simulator.

- Bug Fixes
  - Replace machine-wide `killall xcodebuild` with a workspace-scoped cleanup using `pgrep -f "xcodebuild.*$RUNNER_WORKSPACE"` and TERM/KILL only those PIDs.
  - Remove `killall Simulator` and `xcrun simctl shutdown all` to avoid disrupting other runners.
  - Result: concurrent iOS builds on the same host no longer interfere; this runner’s stale processes are still cleaned.

<sup>Written for commit 7d636f6b8d047143ecd87d7e98b04432ee3cb84f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to pre-build cleanup on self-hosted runners; no app or release logic touched.
> 
> **Overview**
> Fixes intermittent **staging iOS** failures on shared self-hosted Macs by replacing the job’s first-step **machine-wide** `killall xcodebuild` (and simulator shutdown) with the same **workspace-scoped** cleanup already used in the PR iOS workflow.
> 
> The step now finds `xcodebuild` processes whose args include `RUNNER_WORKSPACE` / `GITHUB_WORKSPACE`, sends TERM then KILL only to those PIDs, and **stops** touching Simulators host-wide. That prevents one staging run from SIGTERM’ing another runner’s in-flight compile on the same host (the suspected cause of mid-build exit 65 / long silent gaps).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d636f6b8d047143ecd87d7e98b04432ee3cb84f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->