### PR TITLE
fix(cloud-v2): sync model indexes on boot to drop obsolete indexes

### DIFF
--- a/cloud-v2/packages/core/src/connections/mongo.connection.ts
+++ b/cloud-v2/packages/core/src/connections/mongo.connection.ts
@@ -24,7 +24,8 @@ const logger = createLogger("core").child({ component: "mongo" });
 /**
  * Connect to MongoDB. Idempotent: calling twice with the same URI is a no-op.
  * Throws on initial connection failure; reconnects automatically thereafter
- * (Mongoose's built-in behavior).
+ * (Mongoose's built-in behavior). Also throws (aborting boot) if a declared
+ * unique index can't be built against existing data — see `syncIndexes`.
  */
 export async function connectMongo(uri: string): Promise<void> {
   if (mongoose.connection.readyState === 1) {
@@ -60,9 +61,21 @@ export async function connectMongo(uri: string): Promise<void> {
  * fields collides on `{null, null}` → E11000. `syncIndexes()` removes the
  * orphaned index so the schema is the single source of truth.
  *
- * Best-effort: a sync failure is logged but does not block boot — a stale index
- * is a latent data issue, not a reason to refuse traffic. Per-model so one
- * model's failure doesn't abort the rest.
+ * Failure handling is split by blast radius. `model.syncIndexes()` drops
+ * obsolete indexes *before* creating missing ones, so if a declared unique
+ * index can't be built — existing rows already violate it (duplicate keys,
+ * E11000) — the old index is gone and the collection is left with **no**
+ * uniqueness guarantee. Application code depends on those guarantees:
+ * `findOrCreateUser()` leans on the `{oemId, oemUserId}` unique index to dedupe
+ * concurrent token exchanges, so silently booting without it lets two races
+ * mint two user records for the same person. Therefore:
+ *
+ * - **Duplicate-key failures (E11000) abort boot.** A declared unique index
+ *   could not be built against current data — a data-integrity hole we must not
+ *   serve traffic on. Migrate the offending rows, then redeploy.
+ * - **Every other failure is best-effort** (logged, boot continues). A stale or
+ *   un-dropped index is a latent issue, not a reason to refuse traffic, and one
+ *   model's transient hiccup shouldn't abort the rest.
  */
 async function syncIndexes(): Promise<void> {
   for (const [name, model] of Object.entries(mongoose.models)) {
@@ -70,9 +83,31 @@ async function syncIndexes(): Promise<void> {
       const dropped = await model.syncIndexes();
       logger.info({ model: name, droppedIndexes: dropped }, "synced indexes");
     } catch (err) {
+      if (isDuplicateKeyError(err)) {
+        logger.error(
+          { err, model: name },
+          "index sync hit a duplicate-key error: a declared unique index could " +
+            "not be built against existing data, leaving uniqueness unenforced. " +
+            "Aborting boot — migrate the duplicate rows and redeploy.",
+        );
+        throw err;
+      }
       logger.error({ err, model: name }, "index sync failed (continuing)");
     }
   }
+}
+
+/**
+ * Mongo duplicate-key error (E11000). During index sync this surfaces when a
+ * unique index can't be created because existing documents already violate it.
+ */
+function isDuplicateKeyError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: number }).code === 11000
+  );
 }
 
 /** Close the Mongo connection. Call from graceful-shutdown handlers. */

--- a/cloud-v2/packages/core/src/connections/mongo.connection.ts
+++ b/cloud-v2/packages/core/src/connections/mongo.connection.ts
@@ -9,6 +9,16 @@
 import mongoose from "mongoose";
 import { createLogger, type ReadinessCheck } from "@mentra/cloud-shared";
 
+// Import every model so it is registered on the connection before we sync
+// indexes. Models otherwise register lazily on first import (from API
+// handlers), which happens after connect — too late for the sync below to see
+// them. Keep this list in step with `models/*.model.ts`.
+import "../models/oem.model";
+import "../models/refresh-token.model";
+import "../models/revoked-jti.model";
+import "../models/seen-jti.model";
+import "../models/user.model";
+
 const logger = createLogger("core").child({ component: "mongo" });
 
 /**
@@ -36,6 +46,33 @@ export async function connectMongo(uri: string): Promise<void> {
     // Fail fast on initial connect; afterwards Mongoose auto-retries.
     serverSelectionTimeoutMS: 10_000,
   });
+
+  await syncIndexes();
+}
+
+/**
+ * Reconcile each model's indexes with its schema: create missing indexes and
+ * **drop indexes that the schema no longer declares**. This is the safeguard
+ * that keeps a renamed/removed index from lingering in the database after a
+ * deploy. `mongoose.connect`'s `autoIndex` only *creates* indexes; it never
+ * drops obsolete ones, so a field rename (e.g. `tenantId` → `oemId`) leaves the
+ * old unique index in place and every insert that doesn't populate the old
+ * fields collides on `{null, null}` → E11000. `syncIndexes()` removes the
+ * orphaned index so the schema is the single source of truth.
+ *
+ * Best-effort: a sync failure is logged but does not block boot — a stale index
+ * is a latent data issue, not a reason to refuse traffic. Per-model so one
+ * model's failure doesn't abort the rest.
+ */
+async function syncIndexes(): Promise<void> {
+  for (const [name, model] of Object.entries(mongoose.models)) {
+    try {
+      const dropped = await model.syncIndexes();
+      logger.info({ model: name, droppedIndexes: dropped }, "synced indexes");
+    } catch (err) {
+      logger.error({ err, model: name }, "index sync failed (continuing)");
+    }
+  }
 }
 
 /** Close the Mongo connection. Call from graceful-shutdown handlers. */


### PR DESCRIPTION
## What

Run `model.syncIndexes()` for every registered model right after `connectMongo`, so the Mongoose schema is the single source of truth for indexes: missing indexes get created **and obsolete ones get dropped**.

## Why

`connectMongo` relied on Mongoose `autoIndex`, which only ever *creates* indexes — it never drops indexes the schema no longer declares. When the user identity fields were renamed `tenantId/tenantUserId` → `oemId/oemUserId`, the old unique index `tenantId_1_tenantUserId_1` stayed live in the database.

New-schema user docs leave the tenant fields null, so:
1. The first new user took the `{tenantId:null, tenantUserId:null}` slot.
2. **Every subsequent `POST /api/client/auth/exchange` collided on that unique index → `E11000` → 500.**
3. That 500 meant the navigation miniapp could never mint its auth token → every `computeRoute`/`reverseGeocode` threw `AuthExpiredError` → navigation silently failed for any *new* user (worked for already-existing users, hence "works for some, not others").

This was diagnosed from the cloud-debug `core` logs (60× identical `E11000 ... index: tenantId_1_tenantUserId_1` on `/api/client/auth/exchange`). The corrupted debug/dev database was repaired out of band (stale index dropped, old-schema docs migrated `tenant*`→`oem*`, correct `{oemId,oemUserId}` unique index created, verified new-user creation succeeds).

This PR prevents the same drift class from recurring on every future deploy — and on any fresh **prod** database, where the index would otherwise need the same manual cleanup after a field rename.

## Implementation notes

- Models are imported explicitly in `mongo.connection.ts` because they otherwise register lazily (on first import from API handlers), which happens *after* `connect` — too late for the sync to see them via `mongoose.models`.
- `syncIndexes()` is **best-effort and per-model**: a sync failure is logged but does not block boot (a stale index is a latent data issue, not a reason to refuse traffic), and one model's failure doesn't abort the rest.
- No schema/model behavior changes; the `{oemId,oemUserId}` unique index already matches `user.model.ts`.

## Test

- `tsc --noEmit -p packages/core/tsconfig.json` clean (after building `@mentra/cloud-shared` dist).
- Manually verified against the live debug/dev DB that after the correct index is in place, two consecutive brand-new `{oemId,oemUserId}` inserts succeed with no `E11000`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Boot can fail on duplicate data when building unique indexes, and `syncIndexes` drops obsolete indexes before creating new ones—both affect auth/user deduplication paths on startup.
> 
> **Overview**
> **Mongo boot now reconciles indexes with each model schema** so obsolete unique indexes (e.g. after `tenantId` → `oemId` renames) are dropped and declared indexes are created—addressing `E11000` failures on `POST /api/client/auth/exchange` when stale `{null,null}` slots blocked new users.
> 
> `connectMongo` **eager-imports all core models** so they register before sync, then runs **`syncIndexes()`** over `mongoose.models` with **`model.syncIndexes()`** per collection. **E11000 during sync aborts boot** (no traffic without required unique constraints); other per-model sync errors are logged and boot continues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbe3468cd91d5aa0d9e1ec57a08ea2b14dfb080d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync `mongoose` model indexes on boot to drop obsolete indexes and create missing ones, preventing `E11000` collisions after field renames. Keeps the schema as the source of truth so new-user auth works reliably.

- **Bug Fixes**
  - Run `model.syncIndexes()` for each registered model right after `connectMongo`.
  - Eager-import all models in `mongo.connection.ts` so they register before syncing.
  - Abort boot on duplicate-key (`E11000`) when building a declared unique index; log and continue for other sync errors.

<sup>Written for commit fbe3468cd91d5aa0d9e1ec57a08ea2b14dfb080d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

