### PR TITLE
ci: isolate iOS DerivedData per-workspace + reset watchman (fix staging mobile flakes)

### DIFF
--- a/.github/actions/reset-watchman/action.yml
+++ b/.github/actions/reset-watchman/action.yml
@@ -1,0 +1,28 @@
+name: "Reset watchman"
+description: >
+  Reset the watchman daemon before an Expo/Metro build on a self-hosted macOS
+  runner. watchman is a per-user daemon shared across all runner processes on the
+  host; its state can wedge (stale watch / cookie file the watcher never observes)
+  and then `expo prebuild` / Metro fails with
+  "Watchman error: syncToNow: timed out waiting for cookie file ... within 60000ms".
+  Dropping all watches + shutting the server down forces a clean restart on next
+  use. No-op (and non-fatal) when watchman isn't installed (e.g. ubuntu runners).
+runs:
+  using: "composite"
+  steps:
+    - name: Reset watchman
+      shell: bash
+      run: |
+        if ! command -v watchman >/dev/null 2>&1; then
+          echo "watchman not installed — skipping."
+          exit 0
+        fi
+        echo "Resetting watchman (drop watches + restart daemon)..."
+        # Drop every watch this user's watchman is tracking (clears wedged state).
+        watchman watch-del-all 2>/dev/null || true
+        # Shut the server down; it auto-restarts clean on the next query.
+        watchman shutdown-server 2>/dev/null || true
+        # Clear stale state/cookie files that survive a crash.
+        rm -rf /usr/local/var/run/watchman/"$USER"-state 2>/dev/null || true
+        rm -rf /opt/homebrew/var/run/watchman/"$USER"-state 2>/dev/null || true
+        echo "watchman reset done."

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -97,6 +97,9 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Reset watchman
+        uses: ./.github/actions/reset-watchman
+
       - name: Free disk space if low
         uses: ./.github/actions/disk-guard
 
@@ -306,6 +309,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+
+      - name: Reset watchman
+        uses: ./.github/actions/reset-watchman
 
       - name: Free disk space if low
         uses: ./.github/actions/disk-guard

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -224,7 +224,11 @@ const exportOptionsPlist = isCIForSigning
   ? path.resolve('ci/ios-export/ExportOptions-Match.plist')
   : path.resolve('ci/ios-export/ExportOptions.plist');
 
-await $({ stdio: 'inherit' })`xcodebuild -exportArchive -archivePath ${archivePath} -exportOptionsPlist ${exportOptionsPlist} -exportPath ${exportPath} -derivedDataPath ${derivedDataPath} -allowProvisioningUpdates`;
+// NOTE: -exportArchive does NOT take -derivedDataPath (xcodebuild errors:
+// "The flag -scheme, -testProductsPath, or -xctestrun is required when
+// specifying -derivedDataPath", exit 64). Export works from the archive itself,
+// so it needs no DerivedData isolation. Keep -derivedDataPath on resolve+archive only.
+await $({ stdio: 'inherit' })`xcodebuild -exportArchive -archivePath ${archivePath} -exportOptionsPlist ${exportOptionsPlist} -exportPath ${exportPath} -allowProvisioningUpdates`;
 
 // Find the exported IPA
 const ipaFiles = (await $`ls ${exportPath}/*.ipa`).stdout.trim().split('\n').filter(Boolean);

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -147,11 +147,21 @@ if (isCIForSigning) {
 //      present and succeeds. Previously this error aborted immediately because
 //      the retry predicate only matched Sentry/network errors.
 
+// Per-workspace DerivedData. By DEFAULT xcodebuild uses
+// ~/Library/Developer/Xcode/DerivedData — which is MACHINE-GLOBAL and shared by
+// every runner process on a self-hosted Mac (bigbob runs 3). Concurrent iOS
+// builds then share the same DerivedData + ModuleCache.noindex / SDKStatCaches,
+// which corrupts/locks the module cache and makes a build hang mid-compile then
+// fail ~30min later with no error (the recurring staging iOS failure). Pinning
+// DerivedData inside the runner workspace makes each build fully isolated. The
+// path is absolute under cwd (mobile/), i.e. under RUNNER_WORKSPACE in CI.
+const derivedDataPath = path.resolve('build/DerivedData');
+
 console.log('\n━━━ Step 3.5: Resolving Mapbox SPM packages ━━━');
 
 await withRetry(
   'xcodebuild resolve packages',
-  () => $({ stdio: 'inherit' })`xcodebuild -resolvePackageDependencies -workspace ios/Mentra.xcworkspace -scheme Mentra`,
+  () => $({ stdio: 'inherit' })`xcodebuild -resolvePackageDependencies -workspace ios/Mentra.xcworkspace -scheme Mentra -derivedDataPath ${derivedDataPath}`,
   { shouldRetry: isSPMOrSentryTransientError },
 );
 
@@ -177,7 +187,7 @@ const archivePath = path.resolve('build/Mentra.xcarchive');
 await withRetry(
   'xcodebuild archive',
   () => {
-    const p = $`xcodebuild archive -workspace ios/Mentra.xcworkspace -scheme Mentra -configuration Release -destination generic/platform=iOS -archivePath ${archivePath} -allowProvisioningUpdates DEVELOPMENT_TEAM=${teamId} SWIFT_STRICT_CONCURRENCY=minimal`;
+    const p = $`xcodebuild archive -workspace ios/Mentra.xcworkspace -scheme Mentra -configuration Release -destination generic/platform=iOS -archivePath ${archivePath} -derivedDataPath ${derivedDataPath} -allowProvisioningUpdates DEVELOPMENT_TEAM=${teamId} SWIFT_STRICT_CONCURRENCY=minimal`;
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
     return p;
@@ -202,7 +212,7 @@ const exportOptionsPlist = isCIForSigning
   ? path.resolve('ci/ios-export/ExportOptions-Match.plist')
   : path.resolve('ci/ios-export/ExportOptions.plist');
 
-await $({ stdio: 'inherit' })`xcodebuild -exportArchive -archivePath ${archivePath} -exportOptionsPlist ${exportOptionsPlist} -exportPath ${exportPath} -allowProvisioningUpdates`;
+await $({ stdio: 'inherit' })`xcodebuild -exportArchive -archivePath ${archivePath} -exportOptionsPlist ${exportOptionsPlist} -exportPath ${exportPath} -derivedDataPath ${derivedDataPath} -allowProvisioningUpdates`;
 
 // Find the exported IPA
 const ipaFiles = (await $`ls ${exportPath}/*.ipa`).stdout.trim().split('\n').filter(Boolean);

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -79,6 +79,18 @@ await $({ stdio: 'inherit' })`bun expo prebuild --platform ios`;
 // Copy .env to ios/.xcode.env.local so build env vars are available
 await $({ stdio: 'inherit' })`cp .env ios/.xcode.env.local`;
 
+// Pin NODE_BINARY to THIS node (the one running release:ios, i.e. the Node 20
+// from setup-node). Xcode's "[CP-User] Generate app.config" build phase sources
+// .xcode.env(.local) and otherwise resolves `command -v node` against Xcode's
+// minimal PATH, which on the self-hosted runners hits the SYSTEM node symlink
+// (/usr/local/bin/node → Node 18). Node 18 lacks util.parseEnv, so @expo/env
+// throws "parseEnv is not a function" and the archive fails with exit 65.
+// .xcode.env.local is sourced after .xcode.env, so this overrides it.
+await import('fs').then(fs =>
+  fs.appendFileSync('ios/.xcode.env.local', `\nexport NODE_BINARY=${process.execPath}\n`),
+);
+console.log(`Pinned NODE_BINARY=${process.execPath} (node ${process.version}) for Xcode build phases`);
+
 // In CI, switch the Mentra app target's Release config to MANUAL signing
 // with the fastlane match-installed AppStore profile. Without this,
 // Expo's prebuild leaves the project in Automatic mode which on a CI


### PR DESCRIPTION
**✅ VERIFIED GREEN** — full staging build passes end-to-end (run 28296967462): Android, ASG, and iOS all succeed; iOS IPA exported (`Mentra_iOS_2p12_Beta_4.ipa`, 112MB) + uploaded + TestFlight.

The "staging builds failing" turned out to be a stack of **independent** issues, each masking the next. This PR fixes the iOS/Android build-script + runner-hygiene ones (the host network issue was fixed by rebooting bigbob):

## Fixes in this PR

1. **iOS shared DerivedData → mid-compile hang.** `release-ios.mjs` used the default machine-global `~/Library/.../DerivedData`; concurrent iOS archives on a multi-runner host (bigbob = 3) shared DerivedData/ModuleCache → corruption/lock → hang. Fix: `-derivedDataPath build/DerivedData` (workspace-local) on the resolve + archive calls.

2. **Android (+ iOS prebuild) wedged watchman.** `Watchman error: syncToNow: timed out ... cookie file within 60000ms`. Fix: new `reset-watchman` composite action (`watch-del-all` + `shutdown-server`) before both staging mobile builds.

3. **iOS archive exit 65 — Node 18 in Xcode build phase.** The `[CP-User] Generate app.config` phase resolved `command -v node` against Xcode's minimal PATH → system Node 18 (lacks `util.parseEnv`) → `@expo/env` throws. Fix: pin `NODE_BINARY=<process.execPath>` (setup-node's Node 20) into `ios/.xcode.env.local` after prebuild.

4. **iOS export exit 64.** `-exportArchive` rejects `-derivedDataPath`. Fix: drop it from the export call (kept on resolve/archive).

## Verified
- [x] iOS: `Pinned NODE_BINARY=.../node/20.20.2/...` → `Generate app.config` passes → `Archive created successfully` → IPA exported + TestFlight ✅
- [x] Android: watchman reset runs, build green ✅
- [x] ASG (Ubuntu) green ✅

## Out of scope (handled separately)
- bigbob's Tailscale port-exhaustion network wedge (`EADDRNOTAVAIL`) — fixed by **rebooting bigbob**; all 4 mac runners now online/healthy.

Files: `staging-builds.yml` (watchman steps), `actions/reset-watchman` (new), `release-ios.mjs` (DerivedData + NODE_BINARY + export flag).