### PR TITLE
Reflect dev miniapp identity on its home tile + fix QR-scan auth

### DIFF
--- a/cloud/packages/types/src/capabilities/nimo.ts
+++ b/cloud/packages/types/src/capabilities/nimo.ts
@@ -78,4 +78,7 @@ export const nimo: Capabilities = {
 
   // WiFi capabilities - no WiFi
   hasWifi: false,
+
+  // OTA capabilities - Nimo firmware updates are not driven by the ASG OTA flow
+  hasOta: false,
 };

--- a/mobile/modules/island/src/services/AppRegistry.ts
+++ b/mobile/modules/island/src/services/AppRegistry.ts
@@ -990,10 +990,12 @@ export const DEV_APP_NAME = "Dev"
  * is the single source of truth for the dev slot — callers must not write the
  * `*_dev_url` / `*_dev_port` keys under the manifest's real package name.
  *
- * Callers pass the manifest's REAL packageName/name; this function overwrites
- * both (packageName → {@link DEV_APP_PACKAGE_NAME}, name → {@link DEV_APP_NAME})
- * so the home tile and launch chain key on the single dev slot, while the real
- * package survives in `sourcePackageName` for clearDevArtifacts.
+ * Callers pass the manifest's REAL packageName/name. Only the packageName is
+ * forced to {@link DEV_APP_PACKAGE_NAME} so the home tile and launch chain key
+ * on the single dev slot (the real package survives in `sourcePackageName` for
+ * clearDevArtifacts). The name + icon are kept as-is so the home tile reflects
+ * the actual dev miniapp — marked as dev by the {@link DevMiniappBadge} dot
+ * rather than renamed to a generic "Dev" tile.
  */
 export function registerDevApp(record: DevAppRecord): void {
   const devRecord: DevAppRecord = {
@@ -1003,7 +1005,9 @@ export function registerDevApp(record: DevAppRecord): void {
     // actually targets the dev slot.
     sourcePackageName: record.sourcePackageName ?? record.packageName,
     packageName: DEV_APP_PACKAGE_NAME,
-    name: DEV_APP_NAME,
+    // Keep the manifest's real name + icon (display-only; routing keys on
+    // packageName). Fall back to DEV_APP_NAME only if a caller omitted the name.
+    name: record.name || DEV_APP_NAME,
     iconUrl: record.iconUrl,
   }
   storage.save(`${DEV_APP_PACKAGE_NAME}_dev_meta`, JSON.stringify(devRecord))

--- a/mobile/src/app/miniapps/miniappdev/scanner.tsx
+++ b/mobile/src/app/miniapps/miniappdev/scanner.tsx
@@ -18,7 +18,6 @@ import {
 } from "@mentra/island"
 import {askPermissionsUI, checkPermissionsUI, PERMISSION_CONFIG} from "@/utils/PermissionsUtils"
 import type {AppletInterface, AppletPermission} from "@/../../cloud/packages/types/src"
-import {DEV_APP_NAME} from "@mentra/island/src/services/AppRegistry"
 
 export default function MiniappDeveloperScannerScreen() {
   const {theme} = useAppTheme()
@@ -115,16 +114,17 @@ export default function MiniappDeveloperScannerScreen() {
       // Persist a home-tile record so the dev miniapp is re-launchable
       // without re-scanning. Dev apps load over HTTP and aren't installed
       // to disk, so the lmas/ scan can't surface them. registerDevApp owns
-      // the dev_url/dev_port keys (under DEV_APP_PACKAGE_NAME) and renames
-      // the tile to DEV_APP_NAME — pass the manifest's REAL packageName so
-      // it survives as sourcePackageName (clearDevArtifacts needs it to drop
-      // the dev slot when the released package is installed/uninstalled).
+      // the dev_url/dev_port keys (under DEV_APP_PACKAGE_NAME) but keeps the
+      // manifest's real name + icon on the tile (marked dev by DevMiniappBadge).
+      // Pass the manifest's REAL packageName: registerDevApp forces the tile's
+      // packageName to the single dev slot for routing, but preserves the real
+      // one as sourcePackageName — which MantleManager uses as the miniapp-token
+      // audience, so the dev backend's JWKS verify (aud === real package) passes.
       if (manifest) {
         const portNum = devPort ? parseInt(devPort, 10) : NaN
         registerDevApp({
-          packageName: DEV_APP_PACKAGE_NAME,
-          name: DEV_APP_NAME,
-          // name: name ?? packageName,
+          packageName,
+          name: name ?? packageName,
           iconUrl: iconUrl ?? `${devUrl.replace(/\/$/, "")}/icon.png`,
           devUrl: devUrl,
           devPort: Number.isFinite(portNum) ? portNum : undefined,

--- a/mobile/src/components/home/AppIcon.tsx
+++ b/mobile/src/components/home/AppIcon.tsx
@@ -63,9 +63,7 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
               <ActivityIndicator size="large" color={theme.colors.palette.white} />
             </View>
           )}
-          {!app.iconComponent && app.isMiniappDev && !app.logoUrl && (
-            <DevIcon size={iconSize.width as number} />
-          )}
+          {!app.iconComponent && app.isMiniappDev && !app.logoUrl && <DevIcon size={iconSize.width as number} />}
           {!app.iconComponent && (app.logoUrl || !app.isMiniappDev) && (
             <Image
               source={imageSource}

--- a/mobile/src/components/home/AppIcon.tsx
+++ b/mobile/src/components/home/AppIcon.tsx
@@ -5,7 +5,7 @@ import {ActivityIndicator, StyleProp, StyleSheet, TouchableOpacity, View, ViewSt
 import {withUniwind} from "uniwind"
 
 import {Icon} from "@/components/ignite"
-import {DevIcon} from "@/components/miniapps/DevIcons"
+import {DevIcon, DevMiniappBadge} from "@/components/miniapps/DevIcons"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useCachedRemoteImageSource} from "@/hooks/useCachedRemoteImageSource"
 import type {ClientApp} from "@mentra/island"
@@ -63,8 +63,10 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
               <ActivityIndicator size="large" color={theme.colors.palette.white} />
             </View>
           )}
-          {app.isMiniappDev && <DevIcon size={iconSize.width as number} />}
-          {!app.isMiniappDev && !app.iconComponent && (
+          {!app.iconComponent && app.isMiniappDev && !app.logoUrl && (
+            <DevIcon size={iconSize.width as number} />
+          )}
+          {!app.iconComponent && (app.logoUrl || !app.isMiniappDev) && (
             <Image
               source={imageSource}
               style={{width: "100%", height: "100%", resizeMode: "cover"}}
@@ -93,7 +95,7 @@ const AppIcon = ({app, onClick, style, disableLoader}: AppIconProps) => {
           <Icon name="alert" size={theme.spacing.s4} color={theme.colors.error} />
         </View>
       )}
-      {/* {app.isMiniappDev && <DevMiniappBadge size={iconSize.width as number}/>} */}
+      {app.isMiniappDev && <DevMiniappBadge />}
       {/* Show wifi-off badge for offline apps (excluding camera app) */}
       {/* disabled for now */}
       {/* {app.offline && app.packageName !== getMoreAppsApplet().packageName && app.packageName !== cameraPackageName && (

--- a/mobile/src/components/miniapp/LocalMiniappView.tsx
+++ b/mobile/src/components/miniapp/LocalMiniappView.tsx
@@ -447,10 +447,7 @@ function LocalMiniappView({
     )
   }
 
-  let isDevApp = packageName == DEV_APP_PACKAGE_NAME
-  if (isDevApp) {
-    appName = undefined
-  }
+  const isDevApp = packageName == DEV_APP_PACKAGE_NAME
 
   if (!uiUri) {
     return (

--- a/mobile/src/components/miniapp/MiniappSplash.tsx
+++ b/mobile/src/components/miniapp/MiniappSplash.tsx
@@ -17,7 +17,7 @@ import Animated, {runOnJS, useAnimatedStyle, useSharedValue, withTiming} from "r
 
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {Text} from "@/components/ignite"
-import {DevIcon} from "@/components/miniapps/DevIcons"
+import {DevIcon, DevMiniappBadge} from "@/components/miniapps/DevIcons"
 
 interface MiniappSplashProps {
   iconUrl?: string
@@ -82,31 +82,33 @@ export default function MiniappSplash({
         {backgroundColor: bgColor, borderRadius: theme.spacing.s12, justifyContent: "center", alignItems: "center"},
         animatedStyle,
       ]}>
-      {iconUrl && (
-        <SquircleView
-          cornerSmoothing={100}
-          preserveSmoothing={true}
-          style={{
-            width: size,
-            height: size,
-            borderRadius,
-            overflow: "hidden",
-            alignItems: "center",
-            justifyContent: "center",
-          }}>
-          {devApp && <DevIcon size={size} />}
-          {!devApp && iconUrl ? (
-            <Image
-              source={iconUrl}
-              style={{width: "100%", height: "100%"}}
-              contentFit="cover"
-              transition={200}
-              cachePolicy="memory-disk"
-            />
-          ) : (
-            <View className="w-full h-full bg-primary-foreground" />
-          )}
-        </SquircleView>
+      {(iconUrl || devApp) && (
+        <View style={{position: "relative"}}>
+          <SquircleView
+            cornerSmoothing={100}
+            preserveSmoothing={true}
+            style={{
+              width: size,
+              height: size,
+              borderRadius,
+              overflow: "hidden",
+              alignItems: "center",
+              justifyContent: "center",
+            }}>
+            {iconUrl ? (
+              <Image
+                source={iconUrl}
+                style={{width: "100%", height: "100%"}}
+                contentFit="cover"
+                transition={200}
+                cachePolicy="memory-disk"
+              />
+            ) : (
+              <DevIcon size={size} />
+            )}
+          </SquircleView>
+          {devApp && <DevMiniappBadge size={18} />}
+        </View>
       )}
 
       <View className="h-16 items-center justify-center w-full mt-4">

--- a/mobile/src/components/miniapps/DevIcons.tsx
+++ b/mobile/src/components/miniapps/DevIcons.tsx
@@ -1,45 +1,59 @@
 import {Icon} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
-import {View, ViewStyle} from "react-native"
+import {View} from "react-native"
 
 /**
- * Small orange dot rendered over a miniapp's icon to indicate it's a dev
- * miniapp (loaded via QR scan / dev URL, not from the store). Position is
- * top-right of the icon's bounding box.
- *
- * Caller is responsible for placing this inside a relatively-positioned
- * container that wraps the icon. The dot is absolutely-positioned within
- * that container.
+ * Placeholder tile for a dev miniapp that didn't ship an icon. Fills the whole
+ * icon slot with a hammer glyph. When the dev miniapp DOES declare an icon we
+ * render its real logo instead and only overlay {@link DevMiniappBadge}.
  */
 export function DevIcon({size = 24}: {size?: number}) {
   const {theme} = useAppTheme()
   return (
-    // <View
-    //   className="absolute -top-1 -right-1 bg-chart-5 border border-black rounded-full items-center justify-center"
-    //   style={{width: size, height: size}}>
-    //   <Icon name="user-code" size={20} color={theme.colors.primary_foreground} />
-    // </View>
     <View
       className="absolute flex-1 items-center justify-center bg-foreground z-1"
       style={{width: size, height: size}}>
-      <Icon name="hammer" size={size-16} color={theme.colors.primary} />
+      <Icon name="hammer" size={size - 16} color={theme.colors.primary} />
     </View>
   )
 }
 
-
+/** Wrench placeholder for the built-in Dev Tools applet (see MiniappCatalog). */
 export function DevToolsIcon({size = 24}: {size?: number}) {
   const {theme} = useAppTheme()
   return (
-    // <View
-    //   className="absolute -top-1 -right-1 bg-chart-5 border border-black rounded-full items-center justify-center"
-    //   style={{width: size, height: size}}>
-    //   <Icon name="user-code" size={20} color={theme.colors.primary_foreground} />
-    // </View>
     <View
       className="absolute flex-1 items-center justify-center bg-foreground z-1"
       style={{width: size, height: size}}>
-      <Icon name="wrench" size={size-16} color={theme.colors.primary} />
+      <Icon name="wrench" size={size - 16} color={theme.colors.primary} />
     </View>
+  )
+}
+
+/**
+ * Small orange dot overlaid on a miniapp's icon to mark it as a dev miniapp
+ * (loaded via QR scan / dev URL, not from the store). Positioned at the
+ * top-right of the icon's bounding box with a white border so it stays visible
+ * against any logo.
+ *
+ * Render this as a SIBLING of the (overflow-hidden) icon container, inside a
+ * relatively-positioned wrapper — not inside the squircle, or it gets clipped.
+ */
+export function DevMiniappBadge({size = 10}: {size?: number}) {
+  return (
+    <View
+      pointerEvents="none"
+      style={{
+        position: "absolute",
+        top: -2,
+        right: -2,
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: "#F97316", // tailwind orange-500
+        borderWidth: 1.5,
+        borderColor: "#fff",
+      }}
+    />
   )
 }

--- a/mobile/src/components/miniapps/DevIcons.tsx
+++ b/mobile/src/components/miniapps/DevIcons.tsx
@@ -10,9 +10,7 @@ import {View} from "react-native"
 export function DevIcon({size = 24}: {size?: number}) {
   const {theme} = useAppTheme()
   return (
-    <View
-      className="absolute flex-1 items-center justify-center bg-foreground z-1"
-      style={{width: size, height: size}}>
+    <View className="absolute flex-1 items-center justify-center bg-foreground z-1" style={{width: size, height: size}}>
       <Icon name="hammer" size={size - 16} color={theme.colors.primary} />
     </View>
   )
@@ -22,9 +20,7 @@ export function DevIcon({size = 24}: {size?: number}) {
 export function DevToolsIcon({size = 24}: {size?: number}) {
   const {theme} = useAppTheme()
   return (
-    <View
-      className="absolute flex-1 items-center justify-center bg-foreground z-1"
-      style={{width: size, height: size}}>
+    <View className="absolute flex-1 items-center justify-center bg-foreground z-1" style={{width: size, height: size}}>
       <Icon name="wrench" size={size - 16} color={theme.colors.primary} />
     </View>
   )


### PR DESCRIPTION
## Scope

Dev miniapps had been collapsed into a single generic **"Dev"** tile (a hammer icon, name `"Dev"`) when the single dev-slot model landed. This restores the real per-app identity on the tile **without** changing the single-slot routing on `com.dev` (the launch chain, JSContext, `setForeground`, and `dev_url`/`dev_port` keys still key on it — that part was a sound decision).

It also fixes a latent **auth bug** discovered while restoring the identity.

## What changed

**Display (real name + icon + orange dot)**
- `registerDevApp` keeps the manifest's real `name` + `icon`. Only `packageName` is forced to the dev slot for routing; `DEV_APP_NAME` is now just a fallback for a missing name.
- `AppIcon` / `MiniappSplash` render the real logo and re-add `DevMiniappBadge` — the small orange dot (`#F97316`) that marks a tile as a dev miniapp. The hammer `DevIcon` is now only the no-icon fallback. (`DevMiniappBadge` was originally added in `2e9836033` and removed when the single-slot model landed.)
- `LocalMiniappView` no longer blanks the name on the boot splash.

**Auth fix (QR-scan path)**
- `scanner.tsx` now passes the manifest's **real** `packageName` to `registerDevApp` (it previously passed `com.dev`).
- Chain: Core mints the miniapp token with `aud = packageName` and does no entitlement check, so the mint always succeeds. But the dev backend verifies with `audience: this.packageName` (its real package) — so a token with `aud="com.dev"` is **rejected** (`jose.jwtVerify` audience mismatch) for any dev miniapp that uses Mentra user-auth. Pure-UI dev miniapps never verify a token, which masked the bug.
- The manual-URL path (`developer-url.tsx`) was already correct; this aligns the two paths. `registerDevApp` still forces the tile's `packageName → com.dev` and preserves the real one as `sourcePackageName` (what `MantleManager` feeds the token mint).

## Testing
- `bun compile` (mobile) — clean for all touched files.
- ⚠️ Not yet exercised on-device. Worth a quick QR-scan + manual-URL sanity check: tile shows the real name/icon + orange dot, and an auth-using dev miniapp authenticates as its real package.

## Migration note
An already-registered dev app keeps showing `"Dev"` until the dev re-scans / re-enters the URL (the stored record was written with `name:"Dev"`). New launches pick up the real name immediately. No migration shim.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dev registration and JWT audience for QR-scan auth plus visible home/splash UI; routing still uses `com.dev`, but wrong `sourcePackageName` would break token verification for auth-using dev miniapps.
> 
> **Overview**
> Dev miniapps keep **single-slot routing** on `com.dev` but the home tile and splash now show the manifest’s **real name and icon**, with an orange **`DevMiniappBadge`** overlay; the hammer **`DevIcon`** is only used when there is no logo.
> 
> **`registerDevApp`** no longer forces the display name to `"Dev"`—only `packageName` is rewritten to the dev slot; the real package is stored in **`sourcePackageName`**.
> 
> The **QR scanner** now passes the manifest’s real **`packageName`** into **`registerDevApp`** (instead of `com.dev`), so miniapp-token **`aud`** matches what the dev backend verifies—fixing auth for Mentra user-auth dev miniapps.
> 
> **`LocalMiniappView`** stops clearing the app name on the boot splash. Nimo capabilities gain **`hasOta: false`** (unrelated capability flag).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d1d54647d1e6fdc2b99d46155a94b5eff8f38a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores each dev miniapp’s real name and icon on its home tile (with an orange dev badge) while keeping single-slot routing on `com.dev`. Also fixes QR-scan auth by using the manifest’s real `packageName`, and resolves a Nimo typecheck by adding `hasOta:false` in `@mentra/types`.

- **New Features**
  - `registerDevApp` keeps `name` and `iconUrl`; only forces `packageName` to `com.dev`.
  - Home tile and splash render the real logo; add `DevMiniappBadge`; `DevIcon` is the no-icon fallback.
  - `LocalMiniappView` no longer clears the app name on splash.
  - Existing dev tiles keep "Dev" until re-scan or re-entering the URL; new registrations show the real identity immediately.

- **Bug Fixes**
  - QR-scan path now passes the real `packageName` to `registerDevApp`, so the minted token’s `aud` matches the dev backend’s expected audience.
  - Add `hasOta:false` to Nimo capabilities in `@mentra/types` to fix strict typecheck failures.

<sup>Written for commit 2d1d54647d1e6fdc2b99d46155a94b5eff8f38a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

