### PR TITLE
Fix Android back exiting offline miniapp instead of going back one page

### DIFF
--- a/mobile/src/effects/NavigationHost.tsx
+++ b/mobile/src/effects/NavigationHost.tsx
@@ -16,7 +16,18 @@ export default function NavigationHost() {
 
   useEffect(() => {
     const sub = BackHandler.addEventListener("hardwareBackPress", () => {
-      const {preventBack, androidBackFn, goBack} = useNavigationStore.getState()
+      const {preventBack, androidBackFn, goBack, interceptor} = useNavigationStore.getState()
+      // An offline-hosted miniapp (Settings, Store, …) registers a NavInterceptor
+      // and owns its own internal stack. Route hardware back straight through
+      // goBack() so it reaches interceptor.goBack() → the host's popOrExit: pop one
+      // sub-screen, and minimize to home only at the host's root. This bypasses
+      // the global androidBackFn slot, which the still-mounted root screen can
+      // clobber with its "minimize-to-home" handler on any re-render — the cause
+      // of Android back exiting the whole miniapp instead of going back one page.
+      if (interceptor) {
+        goBack()
+        return true
+      }
       if (!preventBack) {
         goBack()
         return true


### PR DESCRIPTION
## Problem

In an offline-hosted native miniapp (e.g. the Settings miniapp), navigating into a sub-page and then pressing the Android back button/gesture exits the whole miniapp back to the Mentra home screen instead of going back one page. The behavior is intermittent ("weird") because it depends on render timing.

## Root cause

The Settings miniapp is rendered by `OfflineAppHost` inside the Compositor overlay, with its sub-pages in an internal `react-native-screens` `<ScreenStack>`. The host registers a `NavInterceptor` that owns back navigation (`interceptor.goBack()` → `popOrExit`: pop one sub-screen, minimize only at the root).

Android hardware back, though, was dispatched by `NavigationHost` to the **global `androidBackFn` slot** whenever `preventBack` was true (`NavigationHost.tsx`). That slot is racy:

- The host's `handleHostBack` is memoized on stack `depth`, so it only re-asserts itself when the depth changes.
- The still-mounted root screen `main.tsx` (`useRegisterCapsule` → `focusEffectPreventBack`) re-registers its **"minimize-to-home"** handler on **every render** (it passes a fresh closure each render, so the underlying `useFocusEffect` re-subscribes).

So any re-render of the root screen while you're on a sub-page flips `androidBackFn` back to the minimize handler. The next hardware back runs `handleLeftPress(true)` → `goBack()` **and** `clearForeground()` — popping one page **and** closing the entire overlay — landing on the home screen.

## Fix

Route hardware back through the store's `goBack()` whenever a `NavInterceptor` is registered, so it reaches `interceptor.goBack()` → the host's `popOrExit`, which reads the live internal stack and **cannot be clobbered** by the render race. The fragile `androidBackFn` slot is bypassed entirely for offline-hosted apps.

```ts
if (interceptor) { goBack(); return true }   // → interceptor.goBack() → host.popOrExit()
if (!preventBack) { goBack(); return true }
androidBackFn?.()
```

## Scope / not affected

- **iOS** — unaffected. No hardware back; in-overlay back uses the native back-swipe → `onDismissed` → single JS pop. `main.tsx`'s iOS path is a `beforeRemove` listener on the root navigation that never fires for in-overlay nav (`iosDontPreventBack`).
- **Local webview miniapps** — unaffected. No nested native stack and no competing host re-assertion; `LocalMiniappView` registers a single `onBackPress` that pops the WebView's internal history and only `clearForeground()`s at the root. (These don't register a `NavInterceptor`, so this branch is a no-op for them.)
- Non-host navigation (no interceptor) is unchanged.

## Testing

- node_modules isn't installed in this workspace, so lint/typecheck/tests weren't run locally. The change is a 12-line, type-safe addition (`interceptor` is an existing field on the nav store).
- Manual verification recommended on Android: Settings miniapp → open a sub-page (e.g. Profile) → press the system back button/gesture → should return to the Settings list, not the home screen. Repeat from the root → should minimize to home.

## Optional follow-up (not in this PR)

Defensive hardening: memoize the back closure in `useRegisterCapsule` so `focusEffectPreventBack` stops re-subscribing every render. Not required once back routes through the interceptor, but it removes the latent `androidBackFn` clobber/`preventBack`-count churn.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to Android back dispatch order; non-interceptor navigation paths are unchanged.
> 
> **Overview**
> **Fixes Android hardware back** in offline-hosted miniapps (Settings, Store, etc.) exiting to Mentra home instead of popping one internal sub-page.
> 
> When a `NavInterceptor` is registered on the navigation store, `NavigationHost` now calls **`goBack()` first** on hardware back, so back reaches the host’s `interceptor.goBack()` → `popOrExit` (pop internal stack, minimize only at root). That **bypasses the global `androidBackFn` slot**, which the still-mounted root screen could overwrite on re-render with a “minimize-to-home” handler and cause a race.
> 
> Behavior when **no** interceptor is registered is unchanged (`preventBack` / `androidBackFn` path as before). iOS and local webview miniapps are unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8a91fedfdc3225a6e17a761fa3c2732a49f2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android hardware back in offline-hosted miniapps (e.g. Settings) so it goes back one page instead of exiting to home. Routes back events through the nav interceptor when present to avoid the racy global `androidBackFn`.

- **Bug Fixes**
  - In `mobile/src/effects/NavigationHost.tsx`, if a `NavInterceptor` is registered, send hardware back to `goBack()` and consume the event.
  - This reaches the host’s `popOrExit`, popping the internal `react-native-screens` stack and only minimizing at the root.
  - iOS and local webview miniapps are unchanged.

<sup>Written for commit 4b8a91fedfdc3225a6e17a761fa3c2732a49f2f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

