### PR TITLE
Default Cloud V2 fallback to Debug instead of Dev

### DIFF
--- a/mobile/src/services/cloudClient.ts
+++ b/mobile/src/services/cloudClient.ts
@@ -29,11 +29,14 @@ const LOG_TAG = "cloudClient"
 
 type Lc3FrameSizeBytes = 20 | 40 | 60
 
-// Team-friendly defaults for dev builds. Local Cloud V2 is still one tap away
-// via the METRO_AUTO dev-settings preset; it should not be the invisible
-// default because it depends on a local stack plus adb reverse/LAN reachability.
-const DEFAULT_CORE_URL = "https://core.dev.us-west-2.mentraglass.com"
-const DEFAULT_RUNTIME_URL = "https://runtime.dev.us-west-2.mentraglass.com"
+// Team-friendly defaults for dev builds. Point every build at the Debug cloud
+// by default so a local build with no EXPO_PUBLIC_CLOUD_* env (see
+// .env.example) matches CI instead of silently diverging onto Cloud Dev. Local
+// Cloud V2 is still one tap away via the METRO_AUTO dev-settings preset; it
+// should not be the invisible default because it depends on a local stack plus
+// adb reverse/LAN reachability.
+const DEFAULT_CORE_URL = "https://core.debug.us-west-2.mentraglass.com"
+const DEFAULT_RUNTIME_URL = "https://runtime.debug.us-west-2.mentraglass.com"
 
 const CORE_PORT = 3000
 const RUNTIME_PORT = 3001
@@ -51,7 +54,7 @@ function metroUrl(port: number): string | undefined {
  *      resolves to the CURRENT Metro host so "my laptop" survives the laptop
  *      changing networks;
  *   2. env (EXPO_PUBLIC_CLOUD_*) — for CI/staging builds, never personal IPs;
- *   3. Cloud Dev — the default shared backend for team testing.
+ *   3. Cloud Debug — the default shared backend for team testing.
  * Read via the settings store's `getState()` accessor (not a hook) so this
  * service stays React-free.
  */


### PR DESCRIPTION
## Scope

When the Mentra app boots with **no** in-app Dev Settings override and **no** `EXPO_PUBLIC_CLOUD_*` env baked in, the Cloud V2 endpoint is resolved from a hardcoded fallback in `mobile/src/services/cloudClient.ts`. That fallback still pointed at **Cloud Dev**, while `.env.example` was later updated (#3247) to point every build at **Cloud Debug** — and CI uses `.env.example` (`cp .env.example .env`).

Net effect: CI/TestFlight builds go to Debug, but a local build whose `.env` predates the env-var change falls through to the stale **Dev** fallback and silently diverges. This is why a fresh local boot landed on Dev Cloud V2 instead of Debug.

## Change

- Flip `DEFAULT_CORE_URL` / `DEFAULT_RUNTIME_URL` from `core.dev…` / `runtime.dev…` to the `…debug…` equivalents, so the code-level fallback matches the stated `.env.example` intent.
- Update the two comments that described the default as "Cloud Dev."

`resolveUrl` precedence is unchanged: in-app Dev Settings override → `EXPO_PUBLIC_CLOUD_*` env → fallback. Only the fallback changed, so anyone who has explicitly picked an environment (or whose build bakes in the env) is unaffected.

## Test evidence

Comment/constant change only; no behavioral code path beyond the fallback constant. Verified the resulting fallback URLs match `.env.example` (`core.debug.us-west-2.mentraglass.com` / `runtime.debug.us-west-2.mentraglass.com`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and default URL constant only; no logic changes beyond which shared backend is used when override and env are absent.
> 
> **Overview**
> When neither in-app Dev Settings nor `EXPO_PUBLIC_CLOUD_*` is set, Cloud V2 now falls back to **Cloud Debug** (`core.debug…` / `runtime.debug…`) instead of **Cloud Dev**.
> 
> That aligns the hardcoded defaults in `cloudClient.ts` with `.env.example` and CI, so older local `.env` files no longer silently hit Dev while TestFlight/CI use Debug. **`resolveUrl` precedence is unchanged** (override → env → fallback); only the third-tier fallback and related comments were updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4573e58356e5756cc639ea4391b83ac126424da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the Cloud V2 fallback to Debug instead of Dev. Local builds without an override or `EXPO_PUBLIC_CLOUD_*` now match CI; precedence stays override → env → fallback.

<sup>Written for commit 4573e58356e5756cc639ea4391b83ac126424da3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

