### PR TITLE
Add glasses Wi-Fi to the miniapp SDK (onWifi + requestWifiSetup)

### DIFF
--- a/mobile/modules/island/src/runtime/config.ts
+++ b/mobile/modules/island/src/runtime/config.ts
@@ -58,11 +58,7 @@ export interface CloudRuntimeTtsAdapter {
 export interface CloudRuntimeMapsAdapter {
   directions: (req: DirectionsRequest) => Promise<DirectionsResult>
   reverseGeocode: (coord: LatLng) => Promise<ReverseGeocodeResult>
-  placeAutocomplete: (req: {
-    query: string
-    near?: LatLng
-    sessionToken: string
-  }) => Promise<PlaceAutocompleteResult>
+  placeAutocomplete: (req: {query: string; near?: LatLng; sessionToken: string}) => Promise<PlaceAutocompleteResult>
   placeDetails: (req: {placeId: string; sessionToken: string}) => Promise<PlaceDetailsResult>
 }
 
@@ -458,6 +454,17 @@ export interface InteropAdapter {
   audit?: (event: InteropAuditEvent) => void
 }
 
+/**
+ * Opens the phone's glasses Wi-Fi setup flow on behalf of a miniapp
+ * (session.glasses.requestWifiSetup). The host owns the actual setup UI; the
+ * runtime only forwards the request. Glasses Wi-Fi STATE is delivered
+ * separately via the `glasses_wifi` stream (forwarded by the host).
+ */
+export interface WifiSetupAdapter {
+  /** Open the Wi-Fi setup UI. `reason` is a user-facing line for the prompt. */
+  requestSetup: (reason?: string) => Promise<void> | void
+}
+
 export interface RuntimeHooks {
   socketComms?: SocketCommsAdapter
   /**
@@ -523,6 +530,8 @@ export interface RuntimeHooks {
   cameraSettings?: CameraSettingsAdapter
   /** Phone-orchestrated RTMP/SRT/WHIP publishing. */
   streaming?: StreamingAdapter
+  /** Open the glasses Wi-Fi setup flow on the phone (session.glasses.requestWifiSetup). */
+  wifiSetup?: WifiSetupAdapter
   /** Inter-miniapp interop (session.miniapps + session.actions.invoke). */
   interop?: InteropAdapter
 }

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -1322,22 +1322,23 @@ class LocalMiniappRuntime {
         })
       } else if (stream === "glasses_wifi") {
         // Snapshot the current glasses Wi-Fi state on subscribe (like battery).
-        // The host snapshot carries the canonical nested `wifi: {state, ssid}`
-        // (NOT the legacy flat wifiConnected) — read that.
+        // Read the canonical nested `wifi: {state, ssid}` (NOT the legacy flat
+        // wifiConnected). Effective connectivity requires the glasses connected
+        // AND on Wi-Fi — mirrors the host's store-derived forward, so an
+        // already-disconnected device reports `connected: false` rather than
+        // silently emitting nothing. Always emits so onWifi gets an initial value.
         const wifi = (glassesState as {wifi?: {state?: string; ssid?: string; localIp?: string}}).wifi
-        if (wifi?.state) {
-          const connected = wifi.state === "connected"
-          this.sendToMiniapp(packageName, {
-            type: MiniappResponseType.EVENT,
-            streamType: "glasses_wifi",
-            data: {
-              connected,
-              ssid: connected ? wifi.ssid : undefined,
-              localIp: connected ? wifi.localIp : undefined,
-              timestamp: Date.now(),
-            },
-          })
-        }
+        const connected = glassesState.connected === true && wifi?.state === "connected"
+        this.sendToMiniapp(packageName, {
+          type: MiniappResponseType.EVENT,
+          streamType: "glasses_wifi",
+          data: {
+            connected,
+            ssid: connected ? wifi?.ssid : undefined,
+            localIp: connected ? wifi?.localIp : undefined,
+            timestamp: Date.now(),
+          },
+        })
       } else if (stream === "head_position") {
         const headUp = (glassesState as {headUp?: boolean}).headUp
         if (typeof headUp === "boolean") {

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -1322,14 +1322,18 @@ class LocalMiniappRuntime {
         })
       } else if (stream === "glasses_wifi") {
         // Snapshot the current glasses Wi-Fi state on subscribe (like battery).
-        const wifiConnected = (glassesState as {wifiConnected?: boolean}).wifiConnected
-        if (typeof wifiConnected === "boolean") {
+        // The host snapshot carries the canonical nested `wifi: {state, ssid}`
+        // (NOT the legacy flat wifiConnected) — read that.
+        const wifi = (glassesState as {wifi?: {state?: string; ssid?: string; localIp?: string}}).wifi
+        if (wifi?.state) {
+          const connected = wifi.state === "connected"
           this.sendToMiniapp(packageName, {
             type: MiniappResponseType.EVENT,
             streamType: "glasses_wifi",
             data: {
-              connected: wifiConnected,
-              ssid: (glassesState as {wifiSsid?: string}).wifiSsid || undefined,
+              connected,
+              ssid: connected ? wifi.ssid : undefined,
+              localIp: connected ? wifi.localIp : undefined,
               timestamp: Date.now(),
             },
           })

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -1008,6 +1008,9 @@ class LocalMiniappRuntime {
       case MiniappRequestType.MANAGED_STREAM_STOP:
         void this.handleManagedStreamStop(packageName, payload, requestId)
         break
+      case MiniappRequestType.REQUEST_WIFI_SETUP:
+        void this.handleRequestWifiSetup(packageName, payload, requestId)
+        break
 
       // Inter-miniapp interop (SYSTEM apps only)
       case MiniappRequestType.MINIAPPS_LIST:
@@ -1317,6 +1320,20 @@ class LocalMiniappRuntime {
           streamType: "glasses_connection",
           data: glassesState,
         })
+      } else if (stream === "glasses_wifi") {
+        // Snapshot the current glasses Wi-Fi state on subscribe (like battery).
+        const wifiConnected = (glassesState as {wifiConnected?: boolean}).wifiConnected
+        if (typeof wifiConnected === "boolean") {
+          this.sendToMiniapp(packageName, {
+            type: MiniappResponseType.EVENT,
+            streamType: "glasses_wifi",
+            data: {
+              connected: wifiConnected,
+              ssid: (glassesState as {wifiSsid?: string}).wifiSsid || undefined,
+              timestamp: Date.now(),
+            },
+          })
+        }
       } else if (stream === "head_position") {
         const headUp = (glassesState as {headUp?: boolean}).headUp
         if (typeof headUp === "boolean") {
@@ -2482,6 +2499,35 @@ class LocalMiniappRuntime {
     requestId?: string,
   ): Promise<void> {
     return this.handleStreamStop(packageName, payload, requestId)
+  }
+
+  /**
+   * session.glasses.requestWifiSetup — open the phone's glasses Wi-Fi setup
+   * flow. The host owns the actual UI via the `wifiSetup` runtime hook; this
+   * just forwards the request and reports success/failure.
+   */
+  private async handleRequestWifiSetup(
+    packageName: string,
+    payload: Record<string, unknown>,
+    requestId?: string,
+  ): Promise<void> {
+    const wifiSetup = getRuntimeHooks().wifiSetup
+    if (!wifiSetup) {
+      this.sendResult(packageName, requestId, false, undefined, {
+        code: MiniappErrorCode.NOT_IMPLEMENTED,
+        message: "Wi-Fi setup is not configured on this host",
+      })
+      return
+    }
+    try {
+      await wifiSetup.requestSetup(payload.reason as string | undefined)
+      this.sendResult(packageName, requestId, true)
+    } catch (err) {
+      this.sendResult(packageName, requestId, false, undefined, {
+        code: (err as {code?: string}).code || MiniappErrorCode.INTERNAL,
+        message: err instanceof Error ? err.message : "Wi-Fi setup failed",
+      })
+    }
   }
 
   /**

--- a/mobile/modules/miniapp/src/background/index.ts
+++ b/mobile/modules/miniapp/src/background/index.ts
@@ -28,6 +28,7 @@ export type {
   VadData,
   BatteryData,
   ConnectionData,
+  WifiData,
   HeadPositionData,
   AccelData,
   LocationData,

--- a/mobile/modules/miniapp/src/index.ts
+++ b/mobile/modules/miniapp/src/index.ts
@@ -92,6 +92,7 @@ export type {
   TranslationData,
   UnsubscribeFn,
   VadData,
+  WifiData,
 } from "./modules/events"
 export type {PlayAudioOptions, SpeakOptions, SpeakResult, SpeakerState, SpeakerStateEvent} from "./modules/speaker"
 export type {

--- a/mobile/modules/miniapp/src/modules/events.ts
+++ b/mobile/modules/miniapp/src/modules/events.ts
@@ -103,6 +103,13 @@ export interface ConnectionData {
   modelName?: string
 }
 
+/** Glasses Wi-Fi state. `connected` is false on glasses without Wi-Fi or when offline. */
+export interface WifiData {
+  connected: boolean
+  ssid?: string
+  localIp?: string
+}
+
 export interface PhoneNotificationData {
   /** Stable id from the phone's notification listener. */
   notificationId: string

--- a/mobile/modules/miniapp/src/modules/glasses.ts
+++ b/mobile/modules/miniapp/src/modules/glasses.ts
@@ -6,9 +6,9 @@
  * + connection events on `session.phone`.
  */
 
-import {MiniappStreamType} from "../protocol"
+import {MiniappRequestType, MiniappStreamType} from "../protocol"
 import {MiniappSession} from "../session"
-import type {BatteryData, ConnectionData, UnsubscribeFn} from "./events"
+import type {BatteryData, ConnectionData, UnsubscribeFn, WifiData} from "./events"
 
 export class GlassesModule {
   constructor(private readonly session: MiniappSession) {}
@@ -19,5 +19,26 @@ export class GlassesModule {
 
   onConnection(handler: (data: ConnectionData) => void): UnsubscribeFn {
     return this.session._subscribe(MiniappStreamType.GLASSES_CONNECTION, handler as (data: unknown) => void)
+  }
+
+  /**
+   * Subscribe to glasses Wi-Fi state. Fires the current state on subscribe and
+   * on every change. `connected` is false on glasses without Wi-Fi. Streaming
+   * requires Wi-Fi — pair this with {@link requestWifiSetup} to prompt the user.
+   */
+  onWifi(handler: (data: WifiData) => void): UnsubscribeFn {
+    return this.session._subscribe(MiniappStreamType.GLASSES_WIFI, handler as (data: unknown) => void)
+  }
+
+  /**
+   * Ask the host to open the glasses Wi-Fi setup flow on the phone. Mirrors the
+   * cloud SDK's `session.requestWifiSetup(reason)`. `reason` is a user-facing
+   * line shown in the setup prompt (e.g. "Streaming needs your glasses on Wi-Fi").
+   */
+  async requestWifiSetup(reason?: string): Promise<void> {
+    await this.session.sendRequest<void>({
+      type: MiniappRequestType.REQUEST_WIFI_SETUP,
+      reason,
+    })
   }
 }

--- a/mobile/modules/miniapp/src/protocol.ts
+++ b/mobile/modules/miniapp/src/protocol.ts
@@ -154,6 +154,9 @@ export enum MiniappRequestType {
   MANAGED_STREAM_START = "miniapp_managed_stream_start",
   MANAGED_STREAM_STOP = "miniapp_managed_stream_stop",
 
+  /** Ask the host to open the glasses Wi-Fi setup flow (mirrors the cloud SDK's requestWifiSetup). */
+  REQUEST_WIFI_SETUP = "miniapp_request_wifi_setup",
+
   // ----- Inter-miniapp interop (SYSTEM apps only) -----
   /** List installed miniapps (compatibility-filtered, with declared actions). */
   MINIAPPS_LIST = "miniapp_apps_list",
@@ -253,6 +256,8 @@ export enum MiniappStreamType {
   GLASSES_BATTERY = "glasses_battery",
   PHONE_BATTERY = "phone_battery",
   GLASSES_CONNECTION = "glasses_connection",
+  /** Glasses Wi-Fi state (connected/ssid). Glasses with Wi-Fi only; needed for streaming. */
+  GLASSES_WIFI = "glasses_wifi",
 
   // Speech / audio (cloud or local)
   TRANSCRIPTION = "transcription", // language variant: "transcription:en-US"

--- a/mobile/modules/miniapp/src/transport/mock.ts
+++ b/mobile/modules/miniapp/src/transport/mock.ts
@@ -195,11 +195,11 @@ function syntheticDataFor(requestId: string, requestType: string, requestPayload
         requestPayload.preset === "narrow"
           ? 82
           : requestPayload.preset === "wide"
-          ? 118
-          : requestPayload.preset === "standard"
-          ? 102
-          : undefined
-      const fov = typeof requestPayload.fov === "number" ? requestPayload.fov : presetFov ?? 102
+            ? 118
+            : requestPayload.preset === "standard"
+              ? 102
+              : undefined
+      const fov = typeof requestPayload.fov === "number" ? requestPayload.fov : (presetFov ?? 102)
       const roi = requestPayload.roiPosition
       const roiPosition = roi === "bottom" ? "bottom" : roi === "top" ? "top" : "center"
       return {
@@ -239,6 +239,7 @@ function syntheticDataFor(requestId: string, requestType: string, requestPayload
     case MiniappRequestType.OPEN_URL:
     case MiniappRequestType.COPY_CLIPBOARD:
     case MiniappRequestType.DOWNLOAD:
+    case MiniappRequestType.REQUEST_WIFI_SETUP:
       return {ok: true}
 
     default:

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -607,15 +607,27 @@ class MantleManager {
         BluetoothSdk.addListener("wifi_status_change", (event) => {
           const {type: _type, ...wifi} = event
           useGlassesStore.getState().setGlassesInfo({wifi})
-          // Forward to miniapps (session.glasses.onWifi). Wi-Fi is its own native
-          // event — distinct from glasses connection — so it's forwarded here, not
-          // from onGlassesStatus. Streaming miniapps gate "go live" on this.
-          localMiniappRuntime.forwardEvent("glasses_wifi", {
-            connected: wifi.state === "connected",
-            ssid: wifi.state === "connected" ? wifi.ssid : undefined,
-            localIp: wifi.state === "connected" ? wifi.localIp : undefined,
-          })
         }),
+      )
+
+      // Forward glasses Wi-Fi to miniapps (session.glasses.onWifi) from the
+      // STORE — the single source of truth — so every path converges here:
+      // wifi_status_change, onGlassesStatus, and BLE disconnect. Effective
+      // connectivity requires the glasses to be connected AND on Wi-Fi, so a
+      // disconnect correctly flips `connected` to false (no stale "connected").
+      this.subs.push(
+        useGlassesStore.subscribe(
+          (s) => {
+            const connected = isGlassesConnected(s.connection) && s.wifi.state === "connected"
+            return {
+              connected,
+              ssid: s.wifi.state === "connected" ? s.wifi.ssid : undefined,
+              localIp: s.wifi.state === "connected" ? s.wifi.localIp : undefined,
+            }
+          },
+          (wifi) => localMiniappRuntime.forwardEvent("glasses_wifi", wifi),
+          {equalityFn: shallow},
+        ),
       )
 
       // TODO: remove since we can sub to the zustand store for hotspot info:

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -3,6 +3,7 @@ import CrustModule from "@mentra/crust"
 import {Asset} from "expo-asset"
 import * as Calendar from "expo-calendar"
 import * as Location from "expo-location"
+import {router} from "expo-router"
 import * as TaskManager from "expo-task-manager"
 import {shallow} from "zustand/shallow"
 
@@ -281,6 +282,13 @@ class MantleManager {
         startManaged: (pkg, opts) => phoneStreamCoordinator.startManaged(pkg, opts),
         stop: (pkg, streamId) => phoneStreamCoordinator.stop(pkg, streamId),
         setStatusSubscriber: (cb) => phoneStreamCoordinator.setStatusSubscriber(cb),
+      },
+      wifiSetup: {
+        // session.glasses.requestWifiSetup → open the phone's glasses Wi-Fi
+        // setup flow (same screen pairing/deeplinks use for "wifi-setup").
+        requestSetup: () => {
+          router.push("/wifi/scan")
+        },
       },
     })
     // Wire the runtime's status fanout now that the streaming hook is in.
@@ -575,6 +583,15 @@ class MantleManager {
         // console.log("MANTLE: Glasses status changed", changed)
         useGlassesStore.getState().setGlassesInfo(changed)
         localMiniappRuntime.forwardEvent("glasses_connection_state", changed)
+        // Forward glasses Wi-Fi state to miniapps (session.glasses.onWifi) when it
+        // changes — streaming miniapps gate "go live" on this.
+        const wifi = changed as {wifiConnected?: boolean; wifiSsid?: string}
+        if (wifi.wifiConnected !== undefined || wifi.wifiSsid !== undefined) {
+          localMiniappRuntime.forwardEvent("glasses_wifi", {
+            connected: !!wifi.wifiConnected,
+            ssid: wifi.wifiSsid || undefined,
+          })
+        }
         // TODO: this should be moved to the bluetooth sdk:
         if (changed.connection?.state === "disconnected") {
           useGlassesStore.getState().setOtaUpdateAvailable(null)

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -285,9 +285,13 @@ class MantleManager {
       },
       wifiSetup: {
         // session.glasses.requestWifiSetup → open the phone's glasses Wi-Fi
-        // setup flow (same screen pairing/deeplinks use for "wifi-setup").
-        requestSetup: () => {
-          router.push("/wifi/scan")
+        // setup flow (same screen pairing/deeplinks use for "wifi-setup"). The
+        // miniapp's `reason` is forwarded as a route param so the screen can show
+        // it as the prompt (mirrors the cloud SDK's requestWifiSetup(reason)).
+        // `as any` matches the repo idiom for dynamic params under typedRoutes
+        // (see stores/navigation.ts).
+        requestSetup: (reason?: string) => {
+          router.push({pathname: "/wifi/scan" as any, params: (reason ? {reason} : {}) as any})
         },
       },
     })
@@ -583,15 +587,6 @@ class MantleManager {
         // console.log("MANTLE: Glasses status changed", changed)
         useGlassesStore.getState().setGlassesInfo(changed)
         localMiniappRuntime.forwardEvent("glasses_connection_state", changed)
-        // Forward glasses Wi-Fi state to miniapps (session.glasses.onWifi) when it
-        // changes — streaming miniapps gate "go live" on this.
-        const wifi = changed as {wifiConnected?: boolean; wifiSsid?: string}
-        if (wifi.wifiConnected !== undefined || wifi.wifiSsid !== undefined) {
-          localMiniappRuntime.forwardEvent("glasses_wifi", {
-            connected: !!wifi.wifiConnected,
-            ssid: wifi.wifiSsid || undefined,
-          })
-        }
         // TODO: this should be moved to the bluetooth sdk:
         if (changed.connection?.state === "disconnected") {
           useGlassesStore.getState().setOtaUpdateAvailable(null)
@@ -612,6 +607,14 @@ class MantleManager {
         BluetoothSdk.addListener("wifi_status_change", (event) => {
           const {type: _type, ...wifi} = event
           useGlassesStore.getState().setGlassesInfo({wifi})
+          // Forward to miniapps (session.glasses.onWifi). Wi-Fi is its own native
+          // event — distinct from glasses connection — so it's forwarded here, not
+          // from onGlassesStatus. Streaming miniapps gate "go live" on this.
+          localMiniappRuntime.forwardEvent("glasses_wifi", {
+            connected: wifi.state === "connected",
+            ssid: wifi.state === "connected" ? wifi.ssid : undefined,
+            localIp: wifi.state === "connected" ? wifi.localIp : undefined,
+          })
         }),
       )
 


### PR DESCRIPTION
## What

Adds glasses Wi-Fi support to the **miniapp** SDK so local miniapps can (a) know whether the glasses are on Wi-Fi and (b) prompt the user to connect. The cloud `@mentra/sdk` already has this (`session.requestWifiSetup()`, `session.isWifiConnected()`, `session.device.state.wifiConnected`), but the miniapp SDK never bridged it — so the new Livestreamer miniapp's Wi-Fi check / "connect Wi-Fi" prompt were no-ops.

## Changes (TS only — no native)

**miniapp SDK** (`mobile/modules/miniapp`)
- `protocol.ts`: new `REQUEST_WIFI_SETUP` request + `GLASSES_WIFI` stream
- `modules/glasses.ts`: `session.glasses.onWifi(handler)` (`WifiData {connected, ssid?, localIp?}`) + `session.glasses.requestWifiSetup(reason?)`
- `modules/events.ts` + barrels: export `WifiData`
- `transport/mock.ts`: synthetic `REQUEST_WIFI_SETUP` success

**island host** (`mobile/modules/island`)
- `LocalMiniappRuntime`: dispatch + `handleRequestWifiSetup` (via a new `wifiSetup` runtime hook) + a `glasses_wifi` subscribe-time snapshot (mirrors `glasses_battery`)
- `runtime/config.ts`: `WifiSetupAdapter` + `wifiSetup?` on `RuntimeHooks`

**mobile host** (`mobile/src`)
- `MantleManager`: wire `wifiSetup.requestSetup` → the phone's existing `/wifi/scan` flow, and forward glasses Wi-Fi state changes to miniapps as `glasses_wifi`

Mirrors the cloud SDK shape 1:1 (`requestWifiSetup(reason)` + a wifi-state stream).

## Verification
- `mobile/modules/miniapp` + `mobile/modules/island` typecheck clean
- 201 miniapp module tests pass
- `MantleManager` follows existing `router.push("/wifi/...")` usage; covered by CI (full-mobile tsc not run locally — deps not installed in this env)
- ⚠️ **Needs an on-device check**: that `BluetoothSdk.onGlassesStatus` carries `wifiConnected`/`wifiSsid` and that `/wifi/scan` is the right setup entry from a miniapp request.

## Follow-up (separate repo)
Re-vendor the updated `@mentra/miniapp` into `Livestreamer-Miniapp` and replace the interim `glass-state`/`request-wifi-setup` stubs with `session.glasses.onWifi` + `requestWifiSetup`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive TypeScript bridge and navigation to an existing Wi-Fi screen; no auth or data-model changes, though on-device verification of store/BLE Wi-Fi fields is still recommended.
> 
> **Overview**
> Bridges **glasses Wi-Fi** into the local miniapp SDK so apps can observe connectivity and ask the user to set up Wi-Fi—aligned with the cloud `@mentra/sdk` (`requestWifiSetup` + wifi state).
> 
> **Miniapp SDK** adds wire types `REQUEST_WIFI_SETUP` and `GLASSES_WIFI`, `WifiData`, and on `session.glasses`: **`onWifi`** (subscribe + initial snapshot) and **`requestWifiSetup(reason?)`**. Mock transport acknowledges setup requests in dev.
> 
> **Island runtime** handles the new request via an optional **`wifiSetup`** hook on `RuntimeHooks`, and emits a **`glasses_wifi`** snapshot on subscribe using nested `wifi.state` plus glasses BLE connected (not legacy flat flags).
> 
> **MentleManager** wires `wifiSetup` to **`/wifi/scan`** with optional `reason` route param, and forwards live Wi-Fi from the glasses store to miniapps as **`glasses_wifi`** events (connected requires both BLE and Wi-Fi).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46403b88136f929abc1c13908b8e276d1274ad8e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds glasses Wi‑Fi support to the miniapp SDK so local miniapps can read Wi‑Fi state and prompt users to connect, matching the cloud `@mentra/sdk`. Also switches event sourcing to the store so `onWifi` has a reliable initial value and updates on disconnects.

- **New Features**
  - Protocol: added `REQUEST_WIFI_SETUP` request and `GLASSES_WIFI` stream.
  - SDK: `session.glasses.onWifi(handler)` (`WifiData {connected, ssid?, localIp?}`) and `session.glasses.requestWifiSetup(reason?)`; exports `WifiData`.
  - Island host: `LocalMiniappRuntime` handles `REQUEST_WIFI_SETUP` via a new `wifiSetup` hook and snapshots `glasses_wifi` on subscribe.
  - Mobile host: `MantleManager` opens `/wifi/scan` and forwards glasses Wi‑Fi state to miniapps.

- **Bug Fixes**
  - Forward `glasses_wifi` from the `useGlassesStore` selector, not the `wifi_status_change` event, so updates fire on Wi‑Fi changes and BLE disconnects.
  - Subscribe-time snapshot always emits and derives `connected = glassesConnected && wifi.state === "connected"` (reads nested `wifi` and includes `localIp` when connected).
  - Pass `requestWifiSetup(reason)` through to `/wifi/scan` as a route param.

<sup>Written for commit 46403b88136f929abc1c13908b8e276d1274ad8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

