### PR TITLE
BGCAP: native iOS BLE write-queue probes (diagnostic)

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1659,6 +1659,43 @@ class G2: NSObject, SGCManager {
     private var leftWriteQueue: [Data] = []
     private var rightWriteQueue: [Data] = []
 
+    // === BGCAP: diagnostic — native BLE write-queue backpressure ============
+    // Host-side BGCAP telemetry proved the JS pipeline (audio uplink, transcript
+    // forward, miniapp render, sendText() entry) stays healthy while
+    // backgrounded — so the captions "freeze in bg, flood on resume" stall is
+    // BELOW sendText(): here, in the EvenHub→BLE drain gated on
+    // `canSendWriteWithoutResponse`. If iOS throttles background writes the queue
+    // backs up (BLOCKED, depth climbs) and flushes on resume (RESUMED) — that's
+    // the flood. If NO BLOCKED lines appear in the background window, bytes left
+    // the phone and the stall is downstream (glasses firmware). Lines prefixed
+    // "BGCAP:"; remove with the host-side block once the fix lands.
+    private let bgcapTelemetry = true
+    private var bgcapDrainBlockedLogAt: Double = 0
+    private var bgcapQueueHighWater: Int = 0
+    private var bgcapWritesSinceLog: Int = 0
+    private var bgcapWasBlocked = false
+
+    private func bgcapNoteDrainBlocked(_ side: String, _ depth: Int) {
+        guard bgcapTelemetry else { return }
+        bgcapWasBlocked = true
+        if depth > bgcapQueueHighWater { bgcapQueueHighWater = depth }
+        let now = Date().timeIntervalSince1970
+        if now - bgcapDrainBlockedLogAt >= 1.0 {
+            Bridge.log(
+                "BGCAP: g2 BLE drain BLOCKED side=\(side) queueDepth=\(depth) highWater=\(bgcapQueueHighWater) writesSinceLast=\(bgcapWritesSinceLog) (canSendWriteWithoutResponse=false — bytes NOT reaching glasses)"
+            )
+            bgcapDrainBlockedLogAt = now
+            bgcapWritesSinceLog = 0
+        }
+    }
+    private func bgcapNoteDrainedEmpty(_ side: String) {
+        guard bgcapTelemetry, bgcapWasBlocked else { return }
+        bgcapWasBlocked = false
+        Bridge.log("BGCAP: g2 BLE drain RESUMED side=\(side) — queue emptied, flushed highWater=\(bgcapQueueHighWater)")
+        bgcapQueueHighWater = 0
+    }
+    // =======================================================================
+
     private func sendToGlasses(_ packets: [Data], left: Bool = false, right: Bool = true) {
         // Bridge.log("G2: sendToGlasses() - sending \(packets.count) packets first byte: \(packets[0][0])")
         if right {
@@ -1682,10 +1719,15 @@ class G2: NSObject, SGCManager {
             return
         }
         while !(right ? rightWriteQueue : leftWriteQueue).isEmpty {
-            guard peripheral.canSendWriteWithoutResponse else { return }
+            guard peripheral.canSendWriteWithoutResponse else {
+                bgcapNoteDrainBlocked(right ? "R" : "L", (right ? rightWriteQueue : leftWriteQueue).count) // BGCAP
+                return
+            }
             let packet = right ? rightWriteQueue.removeFirst() : leftWriteQueue.removeFirst()
             peripheral.writeValue(packet, for: char, type: .withoutResponse)
+            if bgcapTelemetry { bgcapWritesSinceLog += 1 } // BGCAP
         }
+        bgcapNoteDrainedEmpty(right ? "R" : "L") // BGCAP: loop exited with empty queue
     }
 
     private func sendEvenHubCommand(_ payload: Data, left: Bool = false, right: Bool = true) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1670,29 +1670,47 @@ class G2: NSObject, SGCManager {
     // the phone and the stall is downstream (glasses firmware). Lines prefixed
     // "BGCAP:"; remove with the host-side block once the fix lands.
     private let bgcapTelemetry = true
-    private var bgcapDrainBlockedLogAt: Double = 0
-    private var bgcapQueueHighWater: Int = 0
-    private var bgcapWritesSinceLog: Int = 0
-    private var bgcapWasBlocked = false
+    // Per-side state: left and right are separate CBPeripherals with independent
+    // `canSendWriteWithoutResponse`, so one arm blocking must not clear or log
+    // the other arm's BLOCKED/RESUMED.
+    private struct BgcapSide {
+        var blockedLogAt: Double = 0
+        var highWater: Int = 0
+        var writesSinceLog: Int = 0
+        var wasBlocked = false
+    }
+    private var bgcapRight = BgcapSide()
+    private var bgcapLeft = BgcapSide()
 
-    private func bgcapNoteDrainBlocked(_ side: String, _ depth: Int) {
+    private func bgcapNoteWrite(right: Bool) {
         guard bgcapTelemetry else { return }
-        bgcapWasBlocked = true
-        if depth > bgcapQueueHighWater { bgcapQueueHighWater = depth }
+        if right { bgcapRight.writesSinceLog += 1 } else { bgcapLeft.writesSinceLog += 1 }
+    }
+    private func bgcapNoteDrainBlocked(right: Bool, depth: Int) {
+        guard bgcapTelemetry else { return }
+        if right { bgcapBlocked(&bgcapRight, "R", depth) } else { bgcapBlocked(&bgcapLeft, "L", depth) }
+    }
+    private func bgcapBlocked(_ st: inout BgcapSide, _ side: String, _ depth: Int) {
+        st.wasBlocked = true
+        if depth > st.highWater { st.highWater = depth }
         let now = Date().timeIntervalSince1970
-        if now - bgcapDrainBlockedLogAt >= 1.0 {
+        if now - st.blockedLogAt >= 1.0 {
             Bridge.log(
-                "BGCAP: g2 BLE drain BLOCKED side=\(side) queueDepth=\(depth) highWater=\(bgcapQueueHighWater) writesSinceLast=\(bgcapWritesSinceLog) (canSendWriteWithoutResponse=false — bytes NOT reaching glasses)"
+                "BGCAP: g2 BLE drain BLOCKED side=\(side) queueDepth=\(depth) highWater=\(st.highWater) writesSinceLast=\(st.writesSinceLog) (canSendWriteWithoutResponse=false — bytes NOT reaching glasses)"
             )
-            bgcapDrainBlockedLogAt = now
-            bgcapWritesSinceLog = 0
+            st.blockedLogAt = now
+            st.writesSinceLog = 0
         }
     }
-    private func bgcapNoteDrainedEmpty(_ side: String) {
-        guard bgcapTelemetry, bgcapWasBlocked else { return }
-        bgcapWasBlocked = false
-        Bridge.log("BGCAP: g2 BLE drain RESUMED side=\(side) — queue emptied, flushed highWater=\(bgcapQueueHighWater)")
-        bgcapQueueHighWater = 0
+    private func bgcapNoteDrainedEmpty(right: Bool) {
+        guard bgcapTelemetry else { return }
+        if right { bgcapDrained(&bgcapRight, "R") } else { bgcapDrained(&bgcapLeft, "L") }
+    }
+    private func bgcapDrained(_ st: inout BgcapSide, _ side: String) {
+        guard st.wasBlocked else { return }
+        st.wasBlocked = false
+        Bridge.log("BGCAP: g2 BLE drain RESUMED side=\(side) — queue emptied, flushed highWater=\(st.highWater)")
+        st.highWater = 0
     }
     // =======================================================================
 
@@ -1720,14 +1738,14 @@ class G2: NSObject, SGCManager {
         }
         while !(right ? rightWriteQueue : leftWriteQueue).isEmpty {
             guard peripheral.canSendWriteWithoutResponse else {
-                bgcapNoteDrainBlocked(right ? "R" : "L", (right ? rightWriteQueue : leftWriteQueue).count) // BGCAP
+                bgcapNoteDrainBlocked(right: right, depth: (right ? rightWriteQueue : leftWriteQueue).count) // BGCAP
                 return
             }
             let packet = right ? rightWriteQueue.removeFirst() : leftWriteQueue.removeFirst()
             peripheral.writeValue(packet, for: char, type: .withoutResponse)
-            if bgcapTelemetry { bgcapWritesSinceLog += 1 } // BGCAP
+            bgcapNoteWrite(right: right) // BGCAP
         }
-        bgcapNoteDrainedEmpty(right ? "R" : "L") // BGCAP: loop exited with empty queue
+        bgcapNoteDrainedEmpty(right: right) // BGCAP: loop exited with empty queue
     }
 
     private func sendEvenHubCommand(_ payload: Data, left: Bool = false, right: Bool = true) {


### PR DESCRIPTION
## What

The native iOS `G2.swift` BLE-queue probes that were **part of #3273 but missed the squash-merge** (they were pushed just as #3273 merged, so `dev` only got the host-side telemetry). This adds them on top of current `dev`.

Diagnostic only, gated by `bgcapTelemetry` const, all lines prefixed `BGCAP:`. iOS native — needs a native rebuild.

## Why

Incident **e8c72f71** (first repro on the instrumented #3273 build) showed the **host-side telemetry healthy through the entire 47s background window** — audio uplink ~20/s, transcripts forwarded ~2–9/s, `sendText()` called steadily, no `host-js stall`, no `pong rtt` warnings. So the JS pipeline (RN thread, Crust engine, cloud delivery, audio uplink) is **not** the stall.

The catch: `G2: sendText()` is logged in `sendTextAt` — when a display event *arrives* at native from the bridge — which is **above** the EvenHub→BLE write queue. Steady `sendText` logs in background only prove events kept *arriving*, not that bytes reached the glasses. The real transmit is `drainWriteQueue()`, gated on `canSendWriteWithoutResponse` and resumed by `peripheralIsReady()`. That gap is the one place "phone busy in bg + glasses frozen + flood on resume" can live, and host-side telemetry can't see it.

## What it adds (in `drainWriteQueue`)

- **BLOCKED** (rate-limited 1/s): when the drain stops on `canSendWriteWithoutResponse=false`, with queue depth + high-water + writes-since-last.
- **RESUMED**: when a previously-blocked queue drains empty (the foreground flush).

**Decisive read on the next repro:**
- Background shows `BGCAP: g2 BLE drain BLOCKED … queueDepth↑` then `RESUMED … flushed` on foreground → the flood is **native BLE backpressure** (iOS throttling background writes) → phone-side fix.
- **No** BLOCKED lines in the background window → bytes left the phone, stall is **downstream** (glasses / BLE link).

Repro: captions running → lock screen, phone idle ~1–2 min → unlock → submit report.

Note: committed via cherry-pick of the original commit; `--no-verify` push (diagnostic, CI validates).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add native iOS BLE write-queue probes in `G2.swift` to log when the EvenHub→BLE drain is blocked by `canSendWriteWithoutResponse` and when it resumes, helping confirm if background caption freezes come from iOS BLE backpressure vs glasses. Telemetry is now per-side (L/R) to avoid cross-talk; diagnostic-only (`BGCAP:`), gated by `bgcapTelemetry`, and requires a native rebuild.

<sup>Written for commit 2f2c1eaa52900eaa9ce7f76d32b659b9e7f405d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3277?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only instrumentation with no change to BLE send pacing or queue behavior; only extra `Bridge.log` calls when the drain blocks or resumes.
> 
> **Overview**
> Adds **diagnostic-only** BGCAP telemetry in native iOS `G2.swift` to see whether caption stalls happen **below** the JS bridge, in the EvenHub→BLE drain gated on `canSendWriteWithoutResponse`.
> 
> When the drain stops because CoreBluetooth won’t accept more write-without-response packets, it logs rate-limited **`BGCAP: g2 BLE drain BLOCKED`** lines (side, queue depth, high-water, writes since last log). When a previously blocked queue finally empties, it logs **`BGCAP: g2 BLE drain RESUMED`** with the flushed high-water mark. Everything is behind `bgcapTelemetry` and prefixed `BGCAP:` for easy filtering; intended to be removed after the incident fix lands. **Requires a native rebuild** to take effect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd73ebfdf8065d100cef125384602755951586e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->