### PR TITLE
Fix G2 background caption flood (paced direct BLE writes) + restore G1 300ms throttle

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
@@ -1614,7 +1614,10 @@ class G1 : SGCManager() {
 
     override fun clearDisplay() {
         Bridge.log("G1: clearDisplay() - sending space")
-        sendTextWall(" ")
+        // Bypass the throttle (a clear must always land) and drop any pending caption so it can't
+        // overwrite the clear after the fact.
+        cancelPendingThrottledText()
+        displayTextWall(" ")
     }
 
     // G1-specific display throttle (300ms, last-wins) — see G1.swift. G1 firmware can't absorb
@@ -1627,6 +1630,13 @@ class G1 : SGCManager() {
     private var textThrottleLastSent: Long = 0L
     private var textThrottleScheduled = false
     private val TEXT_THROTTLE_WINDOW_MS = 300L
+
+    /** Drop any pending throttled text-wall flush so it can't later overwrite a newer, non-text
+     *  display write (a clear, double-text-wall, or bitmap). The posted flush no-ops when
+     *  `textThrottlePending` is null. Called from every G1 display path that bypasses the throttle. */
+    private fun cancelPendingThrottledText() {
+        textThrottlePending = null
+    }
 
     private fun throttledTextWall(text: String) {
         val now = android.os.SystemClock.uptimeMillis()
@@ -1663,11 +1673,13 @@ class G1 : SGCManager() {
     }
 
     override fun sendDoubleTextWall(top: String, bottom: String) {
+        cancelPendingThrottledText() // a newer layout supersedes any pending caption text
         Bridge.log("G1: sendDoubleTextWall() - top: " + top + ", bottom: " + bottom)
         displayDoubleTextWall(top, bottom)
     }
 
     override fun displayBitmap(base64ImageData: String, x: Int?, y: Int?, width: Int?, height: Int?): Boolean {
+        cancelPendingThrottledText() // a bitmap supersedes any pending caption text
         try {
             // Decode base64 to byte array
             val bmpData = android.util.Base64.decode(base64ImageData, android.util.Base64.DEFAULT)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
@@ -1617,14 +1617,49 @@ class G1 : SGCManager() {
         sendTextWall(" ")
     }
 
+    // G1-specific display throttle (300ms, last-wins) — see G1.swift. G1 firmware can't absorb
+    // rapid text-wall updates; coalesce to the latest within a 300ms window. Belongs in the G1 SGC
+    // (G1 hardware quirk); G2 deliberately does NOT throttle (it must show every caption). The
+    // trailing flush always sends the most recent text, so the final caption is never dropped —
+    // only intermediate frames within a window are coalesced.
+    private val textThrottleHandler = Handler(Looper.getMainLooper())
+    private var textThrottlePending: String? = null
+    private var textThrottleLastSent: Long = 0L
+    private var textThrottleScheduled = false
+    private val TEXT_THROTTLE_WINDOW_MS = 300L
+
+    private fun throttledTextWall(text: String) {
+        val now = android.os.SystemClock.uptimeMillis()
+        val sinceLast = now - textThrottleLastSent
+        if (sinceLast >= TEXT_THROTTLE_WINDOW_MS) {
+            // Past the window — send now.
+            textThrottleLastSent = now
+            textThrottlePending = null
+            displayTextWall(text)
+        } else {
+            // Inside the window — keep only the latest and schedule one trailing flush.
+            textThrottlePending = text
+            if (!textThrottleScheduled) {
+                textThrottleScheduled = true
+                textThrottleHandler.postDelayed({
+                    textThrottleScheduled = false
+                    val pending = textThrottlePending ?: return@postDelayed
+                    textThrottlePending = null
+                    textThrottleLastSent = android.os.SystemClock.uptimeMillis()
+                    displayTextWall(pending)
+                }, TEXT_THROTTLE_WINDOW_MS - sinceLast)
+            }
+        }
+    }
+
     override fun sendText(text: String) {
         Bridge.log("G1: sendText() - text: " + text)
-        displayTextWall(text)
+        throttledTextWall(text)
     }
 
     override fun sendTextWall(text: String) {
         // Bridge.log("G1: sendTextWall() - text: " + text);
-        displayTextWall(text)
+        throttledTextWall(text)
     }
 
     override fun sendDoubleTextWall(top: String, bottom: String) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -1525,13 +1525,36 @@ class G2 : SGCManager() {
         }
 
     @Suppress("deprecation")
+    // BGCAP diagnostic: Android G2's text path is already direct (single packet -> writeOnePacket),
+    // so the iOS root cause (the canSend gate) does NOT exist here. This measures whether
+    // writeCharacteristic is being REJECTED (returns false = Android GATT stack busy/throttled, the
+    // packet is dropped) in the background — the suspected Android accumulation/loss point. The
+    // current code discards the return value. Rate-limited; "BGCAP:" prefix; remove after the
+    // Android repro pins the mechanism.
+    private var bgcapWriteOk = 0
+    private var bgcapWriteFail = 0
+    private var bgcapWriteLogAt = 0L
+
+    private fun bgcapNoteWriteResult(ok: Boolean) {
+        if (ok) bgcapWriteOk++ else bgcapWriteFail++
+        val now = android.os.SystemClock.uptimeMillis()
+        if (now - bgcapWriteLogAt >= 1000) {
+            if (bgcapWriteOk > 0 || bgcapWriteFail > 0) {
+                Bridge.log("BGCAP: g2 writeCharacteristic ok=$bgcapWriteOk fail=$bgcapWriteFail in ${now - bgcapWriteLogAt}ms (fail = stack busy/dropped)")
+            }
+            bgcapWriteOk = 0
+            bgcapWriteFail = 0
+            bgcapWriteLogAt = now
+        }
+    }
+
     private fun writeOnePacket(packet: ByteArray, left: Boolean, right: Boolean) {
         if (right) {
             rightWriteChar?.let { char ->
                 rightGatt?.let { gatt ->
                     char.value = packet
                     char.writeType = BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-                    gatt.writeCharacteristic(char)
+                    bgcapNoteWriteResult(gatt.writeCharacteristic(char)) // BGCAP
                 }
             }
         }
@@ -1540,7 +1563,7 @@ class G2 : SGCManager() {
                 leftGatt?.let { gatt ->
                     char.value = packet
                     char.writeType = BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-                    gatt.writeCharacteristic(char)
+                    bgcapNoteWriteResult(gatt.writeCharacteristic(char)) // BGCAP
                 }
             }
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -785,7 +785,45 @@ class G1: NSObject, SGCManager {
         await sendTextWall(text)
     }
 
+    // G1-specific display throttle (300ms, last-wins). G1 firmware can't absorb rapid text-wall
+    // updates; coalesce to the latest within a 300ms window. This used to live in the cloud
+    // DisplayManager (which fronted G1 before captions moved on-device); it belongs in the G1 SGC
+    // because it's a G1 hardware quirk — G2 deliberately does NOT throttle (it must show every
+    // caption). The trailing flush always sends the most recent text, so the final caption is never
+    // dropped — only intermediate frames within a window are coalesced.
+    private var g1TextThrottlePending: String?
+    private var g1TextThrottleLastSent: Date = .distantPast
+    private var g1TextThrottleScheduled = false
+    private let g1TextThrottleWindow: TimeInterval = 0.3
+
     func sendTextWall(_ text: String) async {
+        let now = Date()
+        let sinceLast = now.timeIntervalSince(g1TextThrottleLastSent)
+        if sinceLast >= g1TextThrottleWindow {
+            // Past the window — send now.
+            g1TextThrottleLastSent = now
+            g1TextThrottlePending = nil
+            await flushTextWall(text)
+        } else {
+            // Inside the window — keep only the latest and schedule one trailing flush.
+            g1TextThrottlePending = text
+            if !g1TextThrottleScheduled {
+                g1TextThrottleScheduled = true
+                let wait = g1TextThrottleWindow - sinceLast
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: UInt64(wait * 1_000_000_000))
+                    guard let self = self else { return }
+                    self.g1TextThrottleScheduled = false
+                    guard let pending = self.g1TextThrottlePending else { return }
+                    self.g1TextThrottlePending = nil
+                    self.g1TextThrottleLastSent = Date()
+                    await self.flushTextWall(pending)
+                }
+            }
+        }
+    }
+
+    private func flushTextWall(_ text: String) async {
         let chunks = textHelper.createTextWallChunks(text)
         queueChunks(chunks, sleepAfterMs: 10)
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -796,6 +796,13 @@ class G1: NSObject, SGCManager {
     private var g1TextThrottleScheduled = false
     private let g1TextThrottleWindow: TimeInterval = 0.3
 
+    /// Drop any pending throttled text-wall flush so it can't later overwrite a newer, non-text
+    /// display write (a clear, double-text-wall, or bitmap). The scheduled flush no-ops when
+    /// `g1TextThrottlePending` is nil. Called from every G1 display path that bypasses the throttle.
+    private func cancelPendingThrottledText() {
+        g1TextThrottlePending = nil
+    }
+
     func sendTextWall(_ text: String) async {
         let now = Date()
         let sinceLast = now.timeIntervalSince(g1TextThrottleLastSent)
@@ -837,6 +844,7 @@ class G1: NSObject, SGCManager {
     }
 
     func sendDoubleTextWall(_ top: String, _ bottom: String) async {
+        cancelPendingThrottledText() // a newer layout supersedes any pending caption text
         let chunks = textHelper.createDoubleTextWallChunks(textTop: top, textBottom: bottom)
         queueChunks(chunks, sleepAfterMs: 10)
 
@@ -1909,6 +1917,7 @@ extension G1 {
     // MARK: - Enhanced BMP Display Methods
 
     func displayBitmap(base64ImageData: String, x _: Int32? = nil, y _: Int32? = nil, width _: Int32? = nil, height _: Int32? = nil) async -> Bool {
+        cancelPendingThrottledText() // a bitmap supersedes any pending caption text
         guard let bmpData = Data(base64Encoded: base64ImageData) else {
             Bridge.log("G1: Failed to decode base64 image data")
             return false
@@ -1923,7 +1932,10 @@ extension G1 {
 
     func clearDisplay() {
         Bridge.log("G1: clearDisplay() - Using space")
-        Task { await sendTextWall(" ") }
+        // Bypass the throttle (a clear must always land) and drop any pending caption so it can't
+        // overwrite the clear after the fact.
+        cancelPendingThrottledText()
+        Task { await flushTextWall(" ") }
     }
 
     /// Create a simple test BMP pattern in hex format

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -1651,101 +1651,84 @@ class G2: NSObject, SGCManager {
 
     // MARK: - BLE Sending
 
-    // Per-side FIFO write queues. We DON'T dump a multi-packet burst into CoreBluetooth in a tight
-    // loop: when its internal buffer is full, `.withoutResponse` writes are silently DROPPED, so the
-    // glasses receive an incomplete fragment, never ACK it, and the send appears to hang. Instead we
-    // enqueue and drain only while `canSendWriteWithoutResponse` is true, resuming from
-    // `peripheralIsReady(toSendWriteWithoutResponse:)`. This also keeps pacing off any timer/looper.
+    // Per-side FIFO write queues, drained by a single paced async writer per side.
+    //
+    // We write `.withoutResponse` directly and pace with a small `Task.sleep` between packets —
+    // exactly like G1 (`G1.swift attemptSend`). We deliberately do NOT gate on
+    // `canSendWriteWithoutResponse` / wait for `peripheralIsReady(toSendWriteWithoutResponse:)`:
+    // iOS suppresses that "ready" callback for a backgrounded bluetooth-central app (G2 has no
+    // active AVAudioSession — glasses-mic audio arrives over BLE), so a gated drain DEADLOCKS in the
+    // background: the queue grows for the whole bg window and floods the glasses on resume — the
+    // captions "freeze in bg, then flood" bug. G1 never gates and never floods; this matches it.
+    // The pace replaces the gate's overflow protection (the original reason for gating). Any packet
+    // CoreBluetooth still drops self-heals: text is re-sent (TextContainer.pendingSends) and image
+    // fragments retry on their ACK (`awaitImageAck`).
     private var leftWriteQueue: [Data] = []
     private var rightWriteQueue: [Data] = []
-
-    // === BGCAP: diagnostic — native BLE write-queue backpressure ============
-    // Host-side BGCAP telemetry proved the JS pipeline (audio uplink, transcript
-    // forward, miniapp render, sendText() entry) stays healthy while
-    // backgrounded — so the captions "freeze in bg, flood on resume" stall is
-    // BELOW sendText(): here, in the EvenHub→BLE drain gated on
-    // `canSendWriteWithoutResponse`. If iOS throttles background writes the queue
-    // backs up (BLOCKED, depth climbs) and flushes on resume (RESUMED) — that's
-    // the flood. If NO BLOCKED lines appear in the background window, bytes left
-    // the phone and the stall is downstream (glasses firmware). Lines prefixed
-    // "BGCAP:"; remove with the host-side block once the fix lands.
-    private let bgcapTelemetry = true
-    // Per-side state: left and right are separate CBPeripherals with independent
-    // `canSendWriteWithoutResponse`, so one arm blocking must not clear or log
-    // the other arm's BLOCKED/RESUMED.
-    private struct BgcapSide {
-        var blockedLogAt: Double = 0
-        var highWater: Int = 0
-        var writesSinceLog: Int = 0
-        var wasBlocked = false
-    }
-    private var bgcapRight = BgcapSide()
-    private var bgcapLeft = BgcapSide()
-
-    private func bgcapNoteWrite(right: Bool) {
-        guard bgcapTelemetry else { return }
-        if right { bgcapRight.writesSinceLog += 1 } else { bgcapLeft.writesSinceLog += 1 }
-    }
-    private func bgcapNoteDrainBlocked(right: Bool, depth: Int) {
-        guard bgcapTelemetry else { return }
-        if right { bgcapBlocked(&bgcapRight, "R", depth) } else { bgcapBlocked(&bgcapLeft, "L", depth) }
-    }
-    private func bgcapBlocked(_ st: inout BgcapSide, _ side: String, _ depth: Int) {
-        st.wasBlocked = true
-        if depth > st.highWater { st.highWater = depth }
-        let now = Date().timeIntervalSince1970
-        if now - st.blockedLogAt >= 1.0 {
-            Bridge.log(
-                "BGCAP: g2 BLE drain BLOCKED side=\(side) queueDepth=\(depth) highWater=\(st.highWater) writesSinceLast=\(st.writesSinceLog) (canSendWriteWithoutResponse=false — bytes NOT reaching glasses)"
-            )
-            st.blockedLogAt = now
-            st.writesSinceLog = 0
-        }
-    }
-    private func bgcapNoteDrainedEmpty(right: Bool) {
-        guard bgcapTelemetry else { return }
-        if right { bgcapDrained(&bgcapRight, "R") } else { bgcapDrained(&bgcapLeft, "L") }
-    }
-    private func bgcapDrained(_ st: inout BgcapSide, _ side: String) {
-        guard st.wasBlocked else { return }
-        st.wasBlocked = false
-        Bridge.log("BGCAP: g2 BLE drain RESUMED side=\(side) — queue emptied, flushed highWater=\(st.highWater)")
-        st.highWater = 0
-    }
-    // =======================================================================
+    private var leftDraining = false
+    private var rightDraining = false
+    // Pace between consecutive packets (~G1's chunk pacing). Off any external callback, so the drain
+    // keeps making progress in the background instead of waiting for a callback iOS won't deliver.
+    private let writePaceNanos: UInt64 = 6_000_000
+    // Diagnostic: warn if a side's queue ever backs up (it shouldn't now — the drainer is always
+    // making progress). Rate-limited. Prefixed "BGCAP:" so it's easy to grep/strip after validation.
+    private var bgcapDepthLogAt: Double = 0
 
     private func sendToGlasses(_ packets: [Data], left: Bool = false, right: Bool = true) {
-        // Bridge.log("G2: sendToGlasses() - sending \(packets.count) packets first byte: \(packets[0][0])")
         if right {
             rightWriteQueue.append(contentsOf: packets)
-            drainWriteQueue(right: true)
+            startDrain(right: true)
         }
         if left {
             leftWriteQueue.append(contentsOf: packets)
-            drainWriteQueue(right: false)
+            startDrain(right: false)
         }
     }
 
-    /// Drain one side's queue while the peripheral can accept write-without-response. Stops as soon
-    /// as the buffer is full; `peripheralIsReady(toSendWriteWithoutResponse:)` resumes the drain.
-    private func drainWriteQueue(right: Bool) {
-        let peripheral = right ? rightPeripheral : leftPeripheral
-        let char = right ? rightWriteChar : leftWriteChar
-        guard let peripheral = peripheral, let char = char else {
-            // No connection for this side; drop its pending packets so they can't replay later.
-            if right { rightWriteQueue.removeAll() } else { leftWriteQueue.removeAll() }
-            return
+    /// Ensure a single paced drainer is running for this side. Idempotent — a second call while one
+    /// is already draining is a no-op (the running loop will pick up the newly-enqueued packets).
+    private func startDrain(right: Bool) {
+        if right {
+            if rightDraining { return }
+            rightDraining = true
+        } else {
+            if leftDraining { return }
+            leftDraining = true
         }
-        while !(right ? rightWriteQueue : leftWriteQueue).isEmpty {
-            guard peripheral.canSendWriteWithoutResponse else {
-                bgcapNoteDrainBlocked(right: right, depth: (right ? rightWriteQueue : leftWriteQueue).count) // BGCAP
+        Task { @MainActor [weak self] in
+            await self?.drainLoop(right: right)
+        }
+    }
+
+    /// Drain one side's queue: write each packet directly (`.withoutResponse`), paced by a small
+    /// sleep. No `canSend` gate (see note above). Runs until the queue is empty, then clears the
+    /// per-side flag so the next enqueue restarts it.
+    private func drainLoop(right: Bool) async {
+        while true {
+            guard let peripheral = right ? rightPeripheral : leftPeripheral,
+                let char = right ? rightWriteChar : leftWriteChar
+            else {
+                // No connection for this side; drop pending packets so they can't replay later.
+                if right { rightWriteQueue.removeAll(); rightDraining = false }
+                else { leftWriteQueue.removeAll(); leftDraining = false }
                 return
+            }
+            let depth = (right ? rightWriteQueue : leftWriteQueue).count
+            if depth == 0 {
+                if right { rightDraining = false } else { leftDraining = false }
+                return
+            }
+            if depth > 20 {
+                let now = Date().timeIntervalSince1970
+                if now - bgcapDepthLogAt >= 1.0 {
+                    Bridge.log("BGCAP: g2 write queue depth=\(depth) side=\(right ? "R" : "L") (draining, not blocked)")
+                    bgcapDepthLogAt = now
+                }
             }
             let packet = right ? rightWriteQueue.removeFirst() : leftWriteQueue.removeFirst()
             peripheral.writeValue(packet, for: char, type: .withoutResponse)
-            bgcapNoteWrite(right: right) // BGCAP
+            try? await Task.sleep(nanoseconds: writePaceNanos)
         }
-        bgcapNoteDrainedEmpty(right: right) // BGCAP: loop exited with empty queue
     }
 
     private func sendEvenHubCommand(_ payload: Data, left: Bool = false, right: Bool = true) {
@@ -4831,15 +4814,16 @@ extension G2: CBPeripheralDelegate {
         }
     }
 
-    /// CoreBluetooth's write-without-response buffer freed up — resume draining that side's queue.
-    /// Called on the BLE queue; hop to the main actor to touch the queue state.
+    /// CoreBluetooth's write-without-response buffer freed up. The paced drainer doesn't depend on
+    /// this (it's suppressed in the background), but in the foreground it's a cheap nudge to make
+    /// sure a drainer is running for that side.
     nonisolated func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
         Task { @MainActor [weak self] in
             guard let self = self else { return }
             if peripheral === self.rightPeripheral {
-                self.drainWriteQueue(right: true)
+                self.startDrain(right: true)
             } else if peripheral === self.leftPeripheral {
-                self.drainWriteQueue(right: false)
+                self.startDrain(right: false)
             }
         }
     }


### PR DESCRIPTION
## Summary

Fixes the **G2 "captions freeze in background then flood on resume"** bug, and (bundled, separate concern) **restores G1's 300ms text throttle** inside the G1 SGC.

## Root cause (G2) — measured

Diagnostic probes (incidents `e8c72f71`, `68a2844f`) showed the JS/cloud/audio pipeline staying **healthy** through a full background window, while the native `rightWriteQueue` grew to **143 packets** with `canSendWriteWithoutResponse` stuck false and **zero bytes out for ~20s**, then flushed on resume.

The `canSend`-gated write queue (added in #3162) **deadlocks in the background**: G2 has no active `AVAudioSession` (glasses-mic audio arrives over BLE), so a backgrounded G2 is a plain `bluetooth-central` app and iOS **suppresses `peripheralIsReady(toSendWriteWithoutResponse:)`**. The drain only resumed on that callback, so it stopped the instant `canSend` went false and never resumed → accumulate → flood.

**G1 (its own SGC) never has this** because it writes `.withoutResponse` **directly, paced ~8ms, no `canSend` gate** — so it always makes progress, even backgrounded. (Confirmed by testing G1: incident `43440fd4`, no flood.)

## Changes

**1. G2 iOS (`G2.swift`) — the fix.** Replace the `canSend`-gated queue + `peripheralIsReady`-driven drain with a **single paced async drainer per side** that writes `.withoutResponse` directly and sleeps ~6ms between packets (matches G1). No `canSend` gate, so it never deadlocks in the background and delivers **every** caption live. The pace replaces the gate's overflow protection; dropped packets self-heal (text re-sends via `pendingSends`, image fragments retry on ACK). Keeps a small rate-limited queue-depth warn to validate the queue stays ~0 in bg.

**2. G1 (`G1.swift` + `G1.kt`) — restore the 300ms throttle.** G1 firmware can't absorb rapid text-wall updates; the 300ms last-wins throttle that used to live in the cloud DisplayManager (before captions moved on-device) is restored **inside the G1 SGC** (G1 hardware quirk). Trailing flush always sends the most recent text → final caption never dropped. **G2 deliberately does NOT throttle — it must show every caption.**

**3. G2 Android (`G2.kt`) — instrumentation, not a blind fix.** Cross-referencing surfaced that **Android G2's text path is already direct** (single packet → `writeOnePacket`, no `canSend` gate), so the iOS root cause doesn't exist on Android. Rather than blind-port the iOS fix, this captures the `writeCharacteristic` return value (false = GATT stack busy → packet dropped) the code currently discards, to pin where Android actually accumulates/drops in the background. **The Android G2 fix is a follow-up once one Android repro shows the mechanism.**

## Validation

- **iOS G2:** build + lock-screen repro (captions running → lock screen, idle ~1–2 min → unlock). Expect captions to stay live in the background, **no flood**, and the `BGCAP: g2 write queue depth` warn to stay quiet (queue ~0).
- **G1 (both):** verify captions display smoothly (no G1 overload), final caption always correct.
- **Android G2:** run the lock-screen repro and send the `BGCAP: g2 writeCharacteristic ok=.. fail=..` lines — they'll tell us the Android accumulation point.

## Cleanup
Diagnostic lines are prefixed `BGCAP:`. After validation, a final commit strips them (here + the host-side telemetry from #3273). Supersedes the diagnostic-only #3277.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> G2 iOS changes core BLE caption delivery in background/foreground; incorrect pacing could drop or delay packets, though retries exist for text/images. G1 throttle is localized to display paths.
> 
> **Overview**
> Fixes **G2 captions freezing in the background and flooding on resume** on iOS, and restores **G1’s 300ms last-wins text coalescing** on iOS and Android.
> 
> **G2 iOS:** Replaces the `canSendWriteWithoutResponse`-gated drain (which stalled when iOS stopped delivering `peripheralIsReady` in the background) with a **paced async `drainLoop`** per side: direct `.withoutResponse` writes and ~6ms sleep between packets, aligned with G1. `peripheralIsReady` only nudges `startDrain` in the foreground. Old BGCAP blocked/resumed telemetry is removed; a rate-limited queue-depth warn remains for validation.
> 
> **G1 iOS + Android:** Adds a **300ms last-wins throttle** on `sendText` / `sendTextWall`; `clearDisplay`, double-text-wall, and bitmap paths **cancel pending throttled text** and bypass the throttle where a clear must win.
> 
> **G2 Android:** Adds **BGCAP** logging of `writeCharacteristic` ok/fail counts (no pacing/throttle change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b08c2b01b3bd1f870b6718e00e485bfde1dde1e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes G2 background caption freeze/flood on iOS by switching to paced direct BLE writes that keep draining in the background. Restores G1’s 300ms last‑wins text throttle, ensures clears/layout changes aren’t overwritten by a pending throttle, and adds Android G2 write diagnostics.

- **Bug Fixes**
  - iOS G2: replace `canSend`-gated queue with a single paced async drainer per side writing `.withoutResponse` and sleeping ~6ms between packets; avoids background deadlock and flood. `peripheralIsReady` is now just a foreground nudge; adds a small rate-limited queue-depth warn.
  - G1 (iOS + Android): restore 300ms last-wins text throttle for captions; trailing flush sends the latest text. `clear` now bypasses the throttle and cancels pending; double-text and bitmap paths also cancel pending so they can’t be overwritten.

- **Refactors**
  - Android G2: add BGCAP diagnostics to log `writeCharacteristic` ok/fail counts (false = GATT busy) to pinpoint background drops. No behavior change.

<sup>Written for commit b08c2b01b3bd1f870b6718e00e485bfde1dde1e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

