### PR TITLE
Hardcode 1/90s manual exposure for video recording and WHIP live streams

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/request/PreviewRequestConfigurator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/request/PreviewRequestConfigurator.java
@@ -39,6 +39,14 @@ public final class PreviewRequestConfigurator {
             Range<Integer> videoFpsRange = Range.create(videoFps, videoFps);
             previewBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, videoFpsRange);
             Log.d(TAG, "Video: Using fixed FPS range " + videoFpsRange + " for consistent frame rate");
+
+            // Manual exposure: 1/90s shutter to reduce motion blur in recorded video.
+            // Overrides the CONTROL_AE_MODE_ON set above; SENSOR_EXPOSURE_TIME is only
+            // honoured by the HAL when AE is disabled.
+            previewBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF);
+            previewBuilder.set(CaptureRequest.SENSOR_EXPOSURE_TIME, 11_111_111L); // 1/90s in nanoseconds
+            previewBuilder.set(CaptureRequest.SENSOR_FRAME_DURATION, 33_333_333L); // 30fps frame duration
+            previewBuilder.set(CaptureRequest.SENSOR_SENSITIVITY, 800); // ISO sensitivity
         } else {
             previewBuilder.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, selectedFpsRange);
             Log.d(TAG, "Photo: Using dynamic FPS range " + selectedFpsRange + " for exposure flexibility");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipCameraCapturer.java
@@ -404,6 +404,14 @@ public class WhipCameraCapturer implements VideoCapturer {
                     new Range<>(mCameraFps, mCameraFps));
             builder.set(CaptureRequest.CONTROL_MODE, CaptureRequest.CONTROL_MODE_AUTO);
 
+            // Manual exposure: 1/90s shutter to reduce motion blur in live streams.
+            // AE must be OFF for SENSOR_EXPOSURE_TIME to take effect; the HAL ignores
+            // it when CONTROL_AE_MODE_ON is active.
+            builder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF);
+            builder.set(CaptureRequest.SENSOR_EXPOSURE_TIME, 11_111_111L); // 1/90s in nanoseconds
+            builder.set(CaptureRequest.SENSOR_FRAME_DURATION, 33_333_333L); // 30fps frame duration
+            builder.set(CaptureRequest.SENSOR_SENSITIVITY, 800); // ISO sensitivity
+
             // Power-saving: disable video stabilization
             builder.set(
                     CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hardcodes a 1/90s manual shutter speed in both the recorded-video and WebRTC/WHIP live-stream capture paths to reduce motion blur.

## Changes

### `WhipCameraCapturer.java` — WHIP live-stream path
Inside `startRepeatingRequest(...)`, immediately after `CONTROL_MODE_AUTO` is set:

```java
// Manual exposure: 1/90s shutter to reduce motion blur in live streams.
builder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF);
builder.set(CaptureRequest.SENSOR_EXPOSURE_TIME, 11_111_111L); // 1/90s in nanoseconds
builder.set(CaptureRequest.SENSOR_FRAME_DURATION, 33_333_333L); // 30fps frame duration
builder.set(CaptureRequest.SENSOR_SENSITIVITY, 800); // ISO sensitivity
```

### `PreviewRequestConfigurator.java` — recorded-video path
Inside `configure(...)`, within the `if (forVideo)` branch, after the FPS range is set:

```java
// Manual exposure: 1/90s shutter to reduce motion blur in recorded video.
previewBuilder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF);
previewBuilder.set(CaptureRequest.SENSOR_EXPOSURE_TIME, 11_111_111L); // 1/90s in nanoseconds
previewBuilder.set(CaptureRequest.SENSOR_FRAME_DURATION, 33_333_333L); // 30fps frame duration
previewBuilder.set(CaptureRequest.SENSOR_SENSITIVITY, 800); // ISO sensitivity
```

## Why AE must be disabled

`SENSOR_EXPOSURE_TIME` is silently ignored by the camera HAL whenever `CONTROL_AE_MODE` is anything other than `CONTROL_AE_MODE_OFF`. Both sites therefore switch AE off before setting the shutter value.

## Tuning notes

| Key | Value | Notes |
|-----|-------|-------|
| `SENSOR_EXPOSURE_TIME` | `11_111_111L` ns | 1/90 s |
| `SENSOR_FRAME_DURATION` | `33_333_333L` ns | 30 fps |
| `SENSOR_SENSITIVITY` | `800` | ISO — adjust as needed |

ISO 800 is a starting point; bump it up if footage is too dark, lower it if there is noise.

## Caveats

- Requires `REQUEST_AVAILABLE_CAPABILITIES_MANUAL_SENSOR` on the camera HAL. If not advertised, the keys are silently ignored and the stream falls back to auto-exposure behaviour.
- Photo capture is **not** affected; changes are gated behind `forVideo` in `PreviewRequestConfigurator`.
- This is an intentional hardcode for custom-app testing, as discussed; a configurable path can follow once the correct exposure value is confirmed on device.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d741b600-5422-40ac-a161-d807582249e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d741b600-5422-40ac-a161-d807582249e0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

