### PR TITLE
Console org roles (owner/admin/member) + default mobile to Cloud V2 Dev

### DIFF
--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -40,6 +40,11 @@ const upsertDeveloperOrgSchema = z.object({
 
 const inviteOrgMemberSchema = z.object({
   email: z.string().email(),
+  role: z.enum(["admin", "member"]).optional(),
+});
+
+const updateOrgMemberRoleSchema = z.object({
+  role: z.enum(["admin", "member"]),
 });
 
 const createMiniAppSchema = z.object({
@@ -88,6 +93,7 @@ app.get("/org/access", getOrgAccess);
 app.post("/org/invitations", postOrgInvitation);
 app.delete("/org/invitations/:invitationId", deleteOrgInvitation);
 app.delete("/org/members/:membershipId", deleteOrgMember);
+app.patch("/org/members/:membershipId", patchOrgMember);
 app.get("/apps", getApps);
 app.post("/apps", postApps);
 app.delete("/apps/:packageName", deleteApp);
@@ -373,6 +379,7 @@ async function getMe(c: AppContext) {
     return c.json({ authenticated: false, reason: authenticatedSession.reason }, 401);
   }
   const developerOrg = await resolveDeveloperOrgForSession(authenticatedSession);
+  const viewerRole = developerOrg ? await resolveOrgRole(authenticatedSession, developerOrg) : null;
 
   return c.json({
     authenticated: true,
@@ -383,6 +390,7 @@ async function getMe(c: AppContext) {
       lastName: authenticatedSession.user.lastName,
     },
     onboardingRequired: developerOrg === null,
+    viewerRole,
     organizationId: developerOrg?.id ?? null,
     packagePrefix: developerOrg?.packagePrefix ?? null,
     packagePrefixStatus: developerOrg?.packagePrefixStatus ?? null,
@@ -441,6 +449,7 @@ async function getOrgAccess(c: AppContext) {
     const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
     return c.json({
       org,
+      viewerRole: await resolveOrgRole(developer.auth, org),
       members: await listWorkosOrgMembers(org),
       invitations: await listWorkosOrgInvitations(org),
     });
@@ -453,21 +462,26 @@ async function getOrgAccess(c: AppContext) {
 async function postOrgInvitation(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!isOrgOwner(developer.auth, developer.org)) {
-    return c.json({ error: "forbidden", error_description: "only the org owner can invite members" }, 403);
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can invite members" }, 403);
   }
 
   const parsed = inviteOrgMemberSchema.safeParse(await readJsonBody(c));
   if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid invitation payload");
 
+  const email = parsed.data.email.trim().toLowerCase();
+  const invitedRole = parsed.data.role ?? "member";
   try {
     const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
     const invitation = await workos().userManagement.sendInvitation({
-      email: parsed.data.email.trim().toLowerCase(),
+      email,
       organizationId: requireWorkosOrgId(org),
       inviterUserId: developer.auth.user.id,
     });
-    return c.json({ invitation: serializeInvitation(invitation) }, 201);
+    // Record the intended role in our DB; it materializes onto the membership
+    // when the invitee first authenticates. WorkOS stores no role.
+    await developerOrgs.setMemberRole(org.id, email, invitedRole);
+    return c.json({ invitation: serializeInvitation(invitation, invitedRole) }, 201);
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
@@ -477,8 +491,8 @@ async function postOrgInvitation(c: AppContext) {
 async function deleteOrgInvitation(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!isOrgOwner(developer.auth, developer.org)) {
-    return c.json({ error: "forbidden", error_description: "only the org owner can revoke invitations" }, 403);
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can revoke invitations" }, 403);
   }
   const invitationId = c.req.param("invitationId");
   if (!invitationId) throw new InvalidRequest("invitationId is required");
@@ -490,6 +504,7 @@ async function deleteOrgInvitation(c: AppContext) {
       return c.json({ error: "not_found", error_description: "invitation was not found" }, 404);
     }
     await workos().userManagement.revokeInvitation(invitationId);
+    await developerOrgs.removeMemberRole(org.id, { email: invitation.email });
     return c.json({ ok: true });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
@@ -500,8 +515,8 @@ async function deleteOrgInvitation(c: AppContext) {
 async function deleteOrgMember(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!isOrgOwner(developer.auth, developer.org)) {
-    return c.json({ error: "forbidden", error_description: "only the org owner can remove members" }, 403);
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can remove members" }, 403);
   }
   const membershipId = c.req.param("membershipId");
   if (!membershipId) throw new InvalidRequest("membershipId is required");
@@ -516,7 +531,47 @@ async function deleteOrgMember(c: AppContext) {
       return c.json({ error: "owner_required", error_description: "the org owner cannot be removed" }, 409);
     }
     await workos().userManagement.deleteOrganizationMembership(membershipId);
+    await developerOrgs.removeMemberRole(org.id, { userId: membership.userId });
     return c.json({ ok: true });
+  } catch (error) {
+    if (isWorkosRequestError(error)) return teamAccessError(error);
+    return serviceError(error);
+  }
+}
+
+async function patchOrgMember(c: AppContext) {
+  const developer = await requireConsoleOrg(c);
+  if (!developer.ok) return developer.response;
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can change member roles" }, 403);
+  }
+  const membershipId = c.req.param("membershipId");
+  if (!membershipId) throw new InvalidRequest("membershipId is required");
+
+  const parsed = updateOrgMemberRoleSchema.safeParse(await readJsonBody(c));
+  if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid role payload");
+
+  try {
+    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
+    const membership = await workos().userManagement.getOrganizationMembership(membershipId);
+    if (membership.organizationId !== org.workosOrgId) {
+      return c.json({ error: "not_found", error_description: "member was not found" }, 404);
+    }
+    if (membership.userId === org.ownerUserId) {
+      return c.json({ error: "owner_required", error_description: "the org owner's role cannot be changed" }, 409);
+    }
+    let email = "";
+    try {
+      const user = await workos().userManagement.getUser(membership.userId);
+      email = user.email ?? "";
+    } catch {
+      // We need an email to key the role row; fall through to the guard below.
+    }
+    if (!email) {
+      return c.json({ error: "member_unresolved", error_description: "could not resolve member email" }, 409);
+    }
+    await developerOrgs.setMemberRole(org.id, email, parsed.data.role, membership.userId);
+    return c.json({ ok: true, role: parsed.data.role });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
@@ -688,8 +743,8 @@ async function getTokens(c: AppContext) {
 async function postToken(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!isOrgOwner(developer.auth, developer.org)) {
-    return c.json({ error: "forbidden", error_description: "only the org owner can create API keys" }, 403);
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can create API keys" }, 403);
   }
 
   const parsed = createApiTokenSchema.safeParse(await readJsonBody(c));
@@ -711,8 +766,8 @@ async function postToken(c: AppContext) {
 async function deleteToken(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!isOrgOwner(developer.auth, developer.org)) {
-    return c.json({ error: "forbidden", error_description: "only the org owner can revoke API keys" }, 403);
+  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+    return c.json({ error: "forbidden", error_description: "only owners and admins can revoke API keys" }, 403);
   }
 
   const tokenId = c.req.param("tokenId");
@@ -816,6 +871,7 @@ async function listWorkosOrgMembers(org: DeveloperOrgRecord): Promise<ConsoleOrg
     statuses: ["active", "inactive"],
     limit: 100,
   });
+  const roleOverlay = await developerOrgs.listMemberRoles(org.id);
 
   const users = new Map<string, ConsoleOrgUser>();
   await Promise.all(
@@ -853,7 +909,12 @@ async function listWorkosOrgMembers(org: DeveloperOrgRecord): Promise<ConsoleOrg
       email: user.email,
       name: user.name,
       avatarUrl: user.avatarUrl,
-      role: membership.userId === org.ownerUserId ? "owner" : "member",
+      role:
+        membership.userId === org.ownerUserId
+          ? "owner"
+          : (user.email ? roleOverlay.get(user.email.toLowerCase()) : undefined) ??
+            roleOverlay.get(`uid:${membership.userId}`) ??
+            "member",
       status: membership.status,
       createdAt: membership.createdAt ?? null,
       updatedAt: membership.updatedAt ?? null,
@@ -866,15 +927,21 @@ async function listWorkosOrgInvitations(org: DeveloperOrgRecord): Promise<Consol
     organizationId: requireWorkosOrgId(org),
     limit: 100,
   });
-  return invitations.data.map(serializeInvitation);
+  const roleOverlay = await developerOrgs.listMemberRoles(org.id);
+  return invitations.data.map(invitation =>
+    serializeInvitation(invitation, roleOverlay.get(invitation.email.toLowerCase())),
+  );
 }
 
-function serializeInvitation(invitation: WorkosInvitationLike): ConsoleOrgInvitation {
+function serializeInvitation(
+  invitation: WorkosInvitationLike,
+  roleOverride?: string,
+): ConsoleOrgInvitation {
   return {
     id: invitation.id,
     email: invitation.email,
     state: invitation.state,
-    role: invitation.roleSlug ?? "member",
+    role: roleOverride ?? invitation.roleSlug ?? "member",
     expiresAt: invitation.expiresAt ?? null,
     createdAt: invitation.createdAt ?? null,
     updatedAt: invitation.updatedAt ?? null,
@@ -916,6 +983,31 @@ function isOrgOwner(
   return authenticatedSession.user.id === org.ownerUserId;
 }
 
+type OrgRole = "owner" | "admin" | "member";
+const ORG_ROLE_RANK: Record<OrgRole, number> = { member: 0, admin: 1, owner: 2 };
+
+/**
+ * The caller's role in an org. `owner` comes from `DeveloperOrg.ownerUserId`
+ * (single source of truth); everyone else is the admin/member overlay stored in
+ * our DB (default `member`). WorkOS is identity/roster only and is not consulted
+ * for roles.
+ */
+async function resolveOrgRole(
+  authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
+  org: DeveloperOrgRecord,
+): Promise<OrgRole> {
+  if (authenticatedSession.user.id === org.ownerUserId) return "owner";
+  const role = await developerOrgs.getMemberRole(org.id, {
+    userId: authenticatedSession.user.id,
+    email: authenticatedSession.user.email,
+  });
+  return role === "admin" ? "admin" : "member";
+}
+
+function roleAtLeast(role: OrgRole, min: OrgRole): boolean {
+  return ORG_ROLE_RANK[role] >= ORG_ROLE_RANK[min];
+}
+
 type ConsoleOrgUser = {
   id: string;
   email: string | null;
@@ -929,7 +1021,7 @@ type ConsoleOrgMember = {
   email: string | null;
   name: string | null;
   avatarUrl: string | null;
-  role: "owner" | "member";
+  role: OrgRole;
   status: string;
   createdAt: string | null;
   updatedAt: string | null;

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -40,7 +40,6 @@ const upsertDeveloperOrgSchema = z.object({
 
 const inviteOrgMemberSchema = z.object({
   email: z.string().email(),
-  role: z.enum(["admin", "member"]).optional(),
 });
 
 const updateOrgMemberRoleSchema = z.object({
@@ -470,7 +469,6 @@ async function postOrgInvitation(c: AppContext) {
   if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid invitation payload");
 
   const email = parsed.data.email.trim().toLowerCase();
-  const invitedRole = parsed.data.role ?? "member";
   try {
     const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
     const invitation = await workos().userManagement.sendInvitation({
@@ -478,11 +476,8 @@ async function postOrgInvitation(c: AppContext) {
       organizationId: requireWorkosOrgId(org),
       inviterUserId: developer.auth.user.id,
     });
-    // Record the intended role in our DB; it materializes onto the membership
-    // when the invitee first authenticates. WorkOS stores no role. This never
-    // overwrites an existing active member's role (see recordInvitedRole).
-    await developerOrgs.recordInvitedRole(org.id, email, invitedRole);
-    return c.json({ invitation: serializeInvitation(invitation, invitedRole) }, 201);
+    // Invitees join as `member`; an owner/admin assigns a higher role afterwards.
+    return c.json({ invitation: serializeInvitation(invitation) }, 201);
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
@@ -532,17 +527,18 @@ async function deleteOrgMember(c: AppContext) {
     if (membership.organizationId !== org.workosOrgId) {
       return c.json({ error: "not_found", error_description: "member was not found" }, 404);
     }
-    // The primary owner (creator) is the org's permanent last owner.
-    if (membership.userId === org.ownerUserId) {
-      return c.json({ error: "owner_required", error_description: "the org owner cannot be removed" }, 409);
-    }
-    // Only an owner may remove a co-owner.
-    const targetRole = await developerOrgs.getMemberRole(org.id, { userId: membership.userId });
-    if (targetRole === "owner" && actorRole !== "owner") {
-      return c.json({ error: "forbidden", error_description: "only an owner can remove another owner" }, 403);
+    // Removing an owner requires being an owner, and never the last one.
+    const targetRole = await developerOrgs.getMemberRole(org.id, membership.userId);
+    if (targetRole === "owner") {
+      if (actorRole !== "owner") {
+        return c.json({ error: "forbidden", error_description: "only an owner can remove another owner" }, 403);
+      }
+      if ((await developerOrgs.countOwners(org.id)) <= 1) {
+        return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
+      }
     }
     await workos().userManagement.deleteOrganizationMembership(membershipId);
-    await developerOrgs.removeMemberRole(org.id, { userId: membership.userId });
+    await developerOrgs.removeMemberRole(org.id, membership.userId);
     return c.json({ ok: true });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
@@ -569,27 +565,19 @@ async function patchOrgMember(c: AppContext) {
     if (membership.organizationId !== org.workosOrgId) {
       return c.json({ error: "not_found", error_description: "member was not found" }, 404);
     }
-    if (membership.userId === org.ownerUserId) {
-      return c.json({ error: "owner_required", error_description: "the org owner's role cannot be changed" }, 409);
-    }
-    let email = "";
-    try {
-      const user = await workos().userManagement.getUser(membership.userId);
-      email = user.email ?? "";
-    } catch {
-      // We need an email to key the role row; fall through to the guard below.
-    }
-    if (!email) {
-      return c.json({ error: "member_unresolved", error_description: "could not resolve member email" }, 409);
-    }
+    const newRole = parsed.data.role;
+    const targetRole = await developerOrgs.getMemberRole(org.id, membership.userId);
     // Granting or changing the owner role is owner-only (no admin can mint an
     // owner or demote one); admins may only move members between admin/member.
-    const targetRole = await developerOrgs.getMemberRole(org.id, { userId: membership.userId, email });
-    if ((parsed.data.role === "owner" || targetRole === "owner") && actorRole !== "owner") {
+    if ((newRole === "owner" || targetRole === "owner") && actorRole !== "owner") {
       return c.json({ error: "forbidden", error_description: "only an owner can grant or change the owner role" }, 403);
     }
-    await developerOrgs.setMemberRole(org.id, email, parsed.data.role, membership.userId);
-    return c.json({ ok: true, role: parsed.data.role });
+    // Never demote the last owner.
+    if (targetRole === "owner" && newRole !== "owner" && (await developerOrgs.countOwners(org.id)) <= 1) {
+      return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
+    }
+    await developerOrgs.setMemberRole(org.id, membership.userId, newRole);
+    return c.json({ ok: true, role: newRole });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
@@ -927,12 +915,7 @@ async function listWorkosOrgMembers(org: DeveloperOrgRecord): Promise<ConsoleOrg
       email: user.email,
       name: user.name,
       avatarUrl: user.avatarUrl,
-      role:
-        membership.userId === org.ownerUserId
-          ? "owner"
-          : (user.email ? roleOverlay.get(user.email.toLowerCase()) : undefined) ??
-            roleOverlay.get(`uid:${membership.userId}`) ??
-            "member",
+      role: roleOverlay.get(membership.userId) ?? "member",
       status: membership.status,
       createdAt: membership.createdAt ?? null,
       updatedAt: membership.updatedAt ?? null,
@@ -945,21 +928,15 @@ async function listWorkosOrgInvitations(org: DeveloperOrgRecord): Promise<Consol
     organizationId: requireWorkosOrgId(org),
     limit: 100,
   });
-  const roleOverlay = await developerOrgs.listMemberRoles(org.id);
-  return invitations.data.map(invitation =>
-    serializeInvitation(invitation, roleOverlay.get(invitation.email.toLowerCase())),
-  );
+  return invitations.data.map(serializeInvitation);
 }
 
-function serializeInvitation(
-  invitation: WorkosInvitationLike,
-  roleOverride?: string,
-): ConsoleOrgInvitation {
+function serializeInvitation(invitation: WorkosInvitationLike): ConsoleOrgInvitation {
   return {
     id: invitation.id,
     email: invitation.email,
     state: invitation.state,
-    role: roleOverride ?? invitation.roleSlug ?? "member",
+    role: invitation.roleSlug ?? "member",
     expiresAt: invitation.expiresAt ?? null,
     createdAt: invitation.createdAt ?? null,
     updatedAt: invitation.updatedAt ?? null,
@@ -1014,13 +991,9 @@ async function resolveOrgRole(
   authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
   org: DeveloperOrgRecord,
 ): Promise<OrgRole> {
-  if (authenticatedSession.user.id === org.ownerUserId) return "owner"; // primary owner
-  const role = await developerOrgs.getMemberRole(org.id, {
-    userId: authenticatedSession.user.id,
-    email: authenticatedSession.user.email,
-  });
-  if (role === "owner") return "owner"; // co-owner
-  return role === "admin" ? "admin" : "member";
+  // Ownership is purely a membership role now; ownerUserId is just created-by.
+  const role = await developerOrgs.getMemberRole(org.id, authenticatedSession.user.id);
+  return role ?? "member";
 }
 
 function roleAtLeast(role: OrgRole, min: OrgRole): boolean {

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -533,7 +533,8 @@ async function deleteOrgMember(c: AppContext) {
       if (actorRole !== "owner") {
         return c.json({ error: "forbidden", error_description: "only an owner can remove another owner" }, 403);
       }
-      if ((await developerOrgs.countOwners(org.id)) <= 1) {
+      // Race-safe: drops the owner row only if another owner remains.
+      if (!(await developerOrgs.removeOwnerIfNotLast(org.id, membership.userId))) {
         return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
       }
     }
@@ -582,11 +583,15 @@ async function patchOrgMember(c: AppContext) {
     if ((newRole === "owner" || targetRole === "owner") && actorRole !== "owner") {
       return c.json({ error: "forbidden", error_description: "only an owner can grant or change the owner role" }, 403);
     }
-    // Never demote the last owner.
-    if (targetRole === "owner" && newRole !== "owner" && (await developerOrgs.countOwners(org.id)) <= 1) {
-      return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
+    // Apply the change. Demoting an owner is race-guarded so two concurrent
+    // requests can't both pass a count check and leave the org with no owner.
+    if (targetRole === "owner" && newRole !== "owner") {
+      if (!(await developerOrgs.demoteOwner(org.id, membership.userId, newRole))) {
+        return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
+      }
+    } else {
+      await developerOrgs.setMemberRole(org.id, membership.userId, newRole);
     }
-    await developerOrgs.setMemberRole(org.id, membership.userId, newRole);
     return c.json({ ok: true, role: newRole });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -44,7 +44,7 @@ const inviteOrgMemberSchema = z.object({
 });
 
 const updateOrgMemberRoleSchema = z.object({
-  role: z.enum(["admin", "member"]),
+  role: z.enum(["owner", "admin", "member"]),
 });
 
 const createMiniAppSchema = z.object({
@@ -519,7 +519,8 @@ async function deleteOrgInvitation(c: AppContext) {
 async function deleteOrgMember(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+  const actorRole = await resolveOrgRole(developer.auth, developer.org);
+  if (!roleAtLeast(actorRole, "admin")) {
     return c.json({ error: "forbidden", error_description: "only owners and admins can remove members" }, 403);
   }
   const membershipId = c.req.param("membershipId");
@@ -531,8 +532,14 @@ async function deleteOrgMember(c: AppContext) {
     if (membership.organizationId !== org.workosOrgId) {
       return c.json({ error: "not_found", error_description: "member was not found" }, 404);
     }
+    // The primary owner (creator) is the org's permanent last owner.
     if (membership.userId === org.ownerUserId) {
       return c.json({ error: "owner_required", error_description: "the org owner cannot be removed" }, 409);
+    }
+    // Only an owner may remove a co-owner.
+    const targetRole = await developerOrgs.getMemberRole(org.id, { userId: membership.userId });
+    if (targetRole === "owner" && actorRole !== "owner") {
+      return c.json({ error: "forbidden", error_description: "only an owner can remove another owner" }, 403);
     }
     await workos().userManagement.deleteOrganizationMembership(membershipId);
     await developerOrgs.removeMemberRole(org.id, { userId: membership.userId });
@@ -546,7 +553,8 @@ async function deleteOrgMember(c: AppContext) {
 async function patchOrgMember(c: AppContext) {
   const developer = await requireConsoleOrg(c);
   if (!developer.ok) return developer.response;
-  if (!roleAtLeast(await resolveOrgRole(developer.auth, developer.org), "admin")) {
+  const actorRole = await resolveOrgRole(developer.auth, developer.org);
+  if (!roleAtLeast(actorRole, "admin")) {
     return c.json({ error: "forbidden", error_description: "only owners and admins can change member roles" }, 403);
   }
   const membershipId = c.req.param("membershipId");
@@ -573,6 +581,12 @@ async function patchOrgMember(c: AppContext) {
     }
     if (!email) {
       return c.json({ error: "member_unresolved", error_description: "could not resolve member email" }, 409);
+    }
+    // Granting or changing the owner role is owner-only (no admin can mint an
+    // owner or demote one); admins may only move members between admin/member.
+    const targetRole = await developerOrgs.getMemberRole(org.id, { userId: membership.userId, email });
+    if ((parsed.data.role === "owner" || targetRole === "owner") && actorRole !== "owner") {
+      return c.json({ error: "forbidden", error_description: "only an owner can grant or change the owner role" }, 403);
     }
     await developerOrgs.setMemberRole(org.id, email, parsed.data.role, membership.userId);
     return c.json({ ok: true, role: parsed.data.role });
@@ -1000,11 +1014,12 @@ async function resolveOrgRole(
   authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
   org: DeveloperOrgRecord,
 ): Promise<OrgRole> {
-  if (authenticatedSession.user.id === org.ownerUserId) return "owner";
+  if (authenticatedSession.user.id === org.ownerUserId) return "owner"; // primary owner
   const role = await developerOrgs.getMemberRole(org.id, {
     userId: authenticatedSession.user.id,
     email: authenticatedSession.user.email,
   });
+  if (role === "owner") return "owner"; // co-owner
   return role === "admin" ? "admin" : "member";
 }
 

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -527,19 +527,30 @@ async function postAcceptInvitation(c: AppContext) {
     if (!invite) {
       return c.json({ error: "invalid_invitation", error_description: "this invitation is invalid or has expired" }, 404);
     }
+    // The invite is addressed to a specific email; the signed-in account must match.
+    if (authenticatedSession.user.email.trim().toLowerCase() !== invite.email) {
+      return c.json(
+        { error: "email_mismatch", error_description: "this invitation was sent to a different email address" },
+        403,
+      );
+    }
     // One org per user: block joining a second org (re-accepting the same one is fine).
     const ownedOrg = await developerOrgs.getPrimaryOrgForUser(authenticatedSession.user);
     const currentOrgId = ownedOrg?.id ?? (await developerOrgs.getMembershipOrgId(authenticatedSession.user.id));
     if (currentOrgId && currentOrgId !== invite.orgId) {
       return c.json({ error: "already_in_org", error_description: "you already belong to an organization" }, 409);
     }
-    // Join with the invited role (their real identity; role kept if already a member).
+    // Single-use: atomically claim the invite before creating the membership so
+    // two concurrent accepts can't both enroll.
+    if (!(await invitations.claim(invite.invitationId))) {
+      return c.json({ error: "invalid_invitation", error_description: "this invitation has already been used" }, 404);
+    }
+    // Join with the invited role (role kept if already a member).
     await developerOrgs.ensureMembership(invite.orgId, authenticatedSession.user.id, {
       email: authenticatedSession.user.email,
       name: sessionDisplayName(authenticatedSession),
       roleIfNew: invite.role,
     });
-    await invitations.markAccepted(invite.invitationId);
     return c.json({ ok: true, org: await developerOrgs.getOrgById(invite.orgId) });
   } catch (error) {
     return serviceError(error);

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -537,6 +537,16 @@ async function deleteOrgMember(c: AppContext) {
         return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
       }
     }
+    // If we're removing the created-by / WorkOS-bootstrap identity, hand the
+    // pointer to another owner so org lookup + bootstrap keep pointing at a real
+    // owner (and a removed user never retains access via the creator fast-path).
+    if (membership.userId === org.ownerUserId) {
+      const nextOwner = await developerOrgs.findAnotherOwner(org.id, membership.userId);
+      if (!nextOwner) {
+        return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
+      }
+      await developerOrgs.reassignCreator(org.id, nextOwner);
+    }
     await workos().userManagement.deleteOrganizationMembership(membershipId);
     await developerOrgs.removeMemberRole(org.id, membership.userId);
     return c.json({ ok: true });
@@ -804,7 +814,8 @@ async function ensureWorkosOrgLinked(
     await ensureOwnerWorkosMembership(org);
     return org;
   }
-  if (!isOrgOwner(authenticatedSession, org)) {
+  // Any owner (by role) may bootstrap the WorkOS org, not only the creator.
+  if ((await resolveOrgRole(authenticatedSession, org)) !== "owner") {
     throw new DeveloperOrgServiceError(
       "team_access_not_ready",
       "team access is not ready for this org yet",
@@ -969,13 +980,6 @@ function requireWorkosOrgId(org: DeveloperOrgRecord): string {
     throw new DeveloperOrgServiceError("team_access_not_ready", "team access is not ready for this org yet", 409);
   }
   return org.workosOrgId;
-}
-
-function isOrgOwner(
-  authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
-  org: DeveloperOrgRecord,
-): boolean {
-  return authenticatedSession.user.id === org.ownerUserId;
 }
 
 type OrgRole = "owner" | "admin" | "member";

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -846,7 +846,7 @@ async function ensureWorkosOrgLinked(
     externalId: org.id,
     metadata: workosOrgMetadata(org),
   });
-  const linkedOrg = await developerOrgs.setWorkosOrgId(authenticatedSession.user, org.id, createdOrg.id);
+  const linkedOrg = await developerOrgs.setWorkosOrgId(org.id, createdOrg.id);
   await ensureOwnerWorkosMembership(linkedOrg);
   return linkedOrg;
 }

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -8,6 +8,7 @@ import {
   DeveloperOrgServiceError,
   type DeveloperOrgRecord,
 } from "../../services/developer-orgs/developer-org.service";
+import { DeveloperApiKeyService } from "../../services/developer-orgs/developer-api-key.service";
 import {
   MiniAppService,
   MiniAppServiceError,
@@ -30,6 +31,7 @@ const PKCE_VERIFIER_COOKIE = "mentra_console_pkce_verifier";
 const RETURN_TO_COOKIE = "mentra_console_return_to";
 const ORG_SELECTION_COOKIE = "mentra_console_org_selection";
 const developerOrgs = new DeveloperOrgService();
+const apiKeys = new DeveloperApiKeyService();
 const miniapps = new MiniAppService();
 const signing = new DeveloperSigningService();
 
@@ -762,14 +764,8 @@ async function getTokens(c: AppContext) {
   if (!developer.ok) return developer.response;
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const tokens = await workos().apiKeys.listOrganizationApiKeys({
-      organizationId: requireWorkosOrgId(org),
-      limit: 100,
-    });
-    return c.json({ tokens: tokens.data.map(serializeApiToken) });
+    return c.json({ tokens: await apiKeys.list(developer.org.id, consoleEnvironmentLabel()) });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -785,12 +781,16 @@ async function postToken(c: AppContext) {
   if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid API key payload");
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const token = await workos().apiKeys.createOrganizationApiKey({
-      organizationId: requireWorkosOrgId(org),
-      name: parsed.data.name.trim(),
-    });
-    return c.json({ token: serializeApiToken(token) }, 201);
+    // Ensure the org is WorkOS-linked so the key authenticates back to it (the
+    // runtime auth path still resolves orgs by workosOrgId for now).
+    await ensureWorkosOrgLinked(developer.auth, developer.org);
+    const token = await apiKeys.create(
+      developer.org.id,
+      parsed.data.name.trim(),
+      developer.auth.user.id,
+      consoleEnvironmentLabel(),
+    );
+    return c.json({ token }, 201);
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
@@ -808,18 +808,11 @@ async function deleteToken(c: AppContext) {
   if (!tokenId) throw new InvalidRequest("tokenId is required");
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const tokens = await workos().apiKeys.listOrganizationApiKeys({
-      organizationId: requireWorkosOrgId(org),
-      limit: 100,
-    });
-    if (!tokens.data.some(token => token.id === tokenId)) {
+    if (!(await apiKeys.revoke(developer.org.id, tokenId))) {
       return c.json({ error: "not_found", error_description: "API key was not found" }, 404);
     }
-    await workos().apiKeys.deleteApiKey(tokenId);
     return c.json({ ok: true });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -972,27 +965,6 @@ function serializeInvitation(invitation: WorkosInvitationLike): ConsoleOrgInvita
   };
 }
 
-function serializeApiToken(apiKey: WorkosApiKeyLike): ConsoleApiToken {
-  return {
-    id: apiKey.id,
-    name: apiKey.name,
-    obfuscatedValue: apiKey.obfuscatedValue ?? null,
-    value: apiKey.value ?? null,
-    permissions: apiKey.permissions ?? [],
-    createdAt: apiKey.createdAt ?? null,
-    updatedAt: apiKey.updatedAt ?? null,
-    lastUsedAt: apiKey.lastUsedAt ?? null,
-  };
-}
-
-function workosApiKeyOrganizationId(apiKey: WorkosApiKeyLike): string | null {
-  const owner = apiKey.owner;
-  if (owner?.type === "organization" && typeof owner.id === "string") return owner.id;
-  if (owner?.type === "user" && typeof owner.organizationId === "string") return owner.organizationId;
-  if (owner?.type === "user" && typeof owner.organization_id === "string") return owner.organization_id;
-  return null;
-}
-
 function requireWorkosOrgId(org: DeveloperOrgRecord): string {
   if (!org.workosOrgId) {
     throw new DeveloperOrgServiceError("team_access_not_ready", "team access is not ready for this org yet", 409);
@@ -1051,17 +1023,6 @@ type ConsoleOrgInvitation = {
   updatedAt: string | null;
 };
 
-type ConsoleApiToken = {
-  id: string;
-  name: string;
-  obfuscatedValue: string | null;
-  value: string | null;
-  permissions: string[];
-  createdAt: string | null;
-  updatedAt: string | null;
-  lastUsedAt: string | null;
-};
-
 type WorkosInvitationLike = {
   id: string;
   email: string;
@@ -1070,23 +1031,6 @@ type WorkosInvitationLike = {
   expiresAt?: string | null;
   createdAt?: string | null;
   updatedAt?: string | null;
-};
-
-type WorkosApiKeyLike = {
-  id: string;
-  owner?: {
-    type?: string;
-    id?: string;
-    organizationId?: string;
-    organization_id?: string;
-  };
-  name: string;
-  obfuscatedValue?: string | null;
-  value?: string | null;
-  permissions?: string[];
-  createdAt?: string | null;
-  updatedAt?: string | null;
-  lastUsedAt?: string | null;
 };
 
 export type ConsoleAuthResult =
@@ -1256,22 +1200,23 @@ async function authenticateBearerToken(token: string): Promise<ConsoleAuthResult
 
 async function authenticateApiKeyToken(token: string): Promise<ConsoleAuthResult> {
   try {
-    const validation = await workos().apiKeys.createValidation({ value: token });
-    const apiKey = validation.apiKey;
-    if (!apiKey) return { authenticated: false, reason: "invalid_bearer_token" };
+    const validated = await apiKeys.validate(token, consoleEnvironmentLabel());
+    if (!validated) return { authenticated: false, reason: "invalid_bearer_token" };
 
-    const organizationId = workosApiKeyOrganizationId(apiKey);
-    if (!organizationId) return { authenticated: false, reason: "api_key_missing_org" };
+    // The runtime auth result still keys orgs by workosOrgId, so map our orgId
+    // to it. (Resolution moves fully to our orgId when membership lands.)
+    const org = await developerOrgs.getOrgById(validated.orgId);
+    if (!org?.workosOrgId) return { authenticated: false, reason: "api_key_missing_org" };
 
     return {
       authenticated: true,
       user: {
-        id: `api_key:${apiKey.id}`,
-        email: `${apiKey.name || "api-token"}@api-token.local`,
-        firstName: apiKey.name || "API key",
+        id: `api_key:${validated.keyId}`,
+        email: `api-key@${validated.keyId}.local`,
+        firstName: "API key",
         lastName: null,
       },
-      organizationId,
+      organizationId: org.workosOrgId,
     };
   } catch {
     return { authenticated: false, reason: "invalid_bearer_token" };

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -430,7 +430,20 @@ async function putOrg(c: AppContext) {
   if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid organization payload");
 
   try {
-    const org = await developerOrgs.upsertPrimaryOrg(authenticatedSession.user, parsed.data);
+    const existingOrg = await resolveDeveloperOrgForSession(authenticatedSession);
+    let org: DeveloperOrgRecord;
+    if (existingOrg) {
+      // Editing an existing org is owner-only, gated on the role rather than the
+      // ownerUserId scalar — and updates the resolved org by id, so a co-owner
+      // edits the same org instead of accidentally creating a second one, and a
+      // demoted creator who still holds ownerUserId can no longer rename it.
+      if ((await resolveOrgRole(authenticatedSession, existingOrg)) !== "owner") {
+        return c.json({ error: "forbidden", error_description: "only owners can update the organization" }, 403);
+      }
+      org = await developerOrgs.updateOrg(existingOrg.id, authenticatedSession.user, parsed.data);
+    } else {
+      org = await developerOrgs.createPrimaryOrg(authenticatedSession.user, parsed.data);
+    }
     const linkedOrg = await ensureWorkosOrgLinked(authenticatedSession, org);
     await syncWorkosOrgName(linkedOrg);
     return c.json({ org: linkedOrg });

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -387,9 +387,12 @@ async function getMe(c: AppContext) {
   // Keep the roster fresh: ensure a membership row for the current human user
   // and backfill their profile fields (skips API-key principals).
   if (developerOrg && !authenticatedSession.user.id.startsWith("api_key:")) {
-    // Self-heal: guarantee the creator has their owner row (a failed ensureOwner
-    // during creation would otherwise leave them a member).
-    if (authenticatedSession.user.id === developerOrg.ownerUserId) {
+    // Self-heal ONLY an ownerless org (a failed create-time ensureOwner): if any
+    // owner already exists we must not re-grant owner to a demoted creator.
+    if (
+      authenticatedSession.user.id === developerOrg.ownerUserId &&
+      (await developerOrgs.countOwners(developerOrg.id)) === 0
+    ) {
       await developerOrgs.ensureOwner(developerOrg.id, authenticatedSession.user.id);
     }
     await developerOrgs.ensureMembership(developerOrg.id, authenticatedSession.user.id, {
@@ -456,7 +459,12 @@ async function putOrg(c: AppContext) {
       // ownerUserId scalar. Self-heal the creator's owner row first: a failed
       // ensureOwner during creation must not permanently brick onboarding.
       let role = await resolveOrgRole(authenticatedSession, existingOrg);
-      if (role !== "owner" && authenticatedSession.user.id === existingOrg.ownerUserId) {
+      // Self-heal only an ownerless org — never re-grant owner to a demoted creator.
+      if (
+        role !== "owner" &&
+        authenticatedSession.user.id === existingOrg.ownerUserId &&
+        (await developerOrgs.countOwners(existingOrg.id)) === 0
+      ) {
         await developerOrgs.ensureOwner(existingOrg.id, authenticatedSession.user.id);
         role = "owner";
       }

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -387,6 +387,11 @@ async function getMe(c: AppContext) {
   // Keep the roster fresh: ensure a membership row for the current human user
   // and backfill their profile fields (skips API-key principals).
   if (developerOrg && !authenticatedSession.user.id.startsWith("api_key:")) {
+    // Self-heal: guarantee the creator has their owner row (a failed ensureOwner
+    // during creation would otherwise leave them a member).
+    if (authenticatedSession.user.id === developerOrg.ownerUserId) {
+      await developerOrgs.ensureOwner(developerOrg.id, authenticatedSession.user.id);
+    }
     await developerOrgs.ensureMembership(developerOrg.id, authenticatedSession.user.id, {
       email: authenticatedSession.user.email,
       name: sessionDisplayName(authenticatedSession),
@@ -447,11 +452,15 @@ async function putOrg(c: AppContext) {
     const existingOrg = await resolveDeveloperOrgForSession(authenticatedSession);
     let org: DeveloperOrgRecord;
     if (existingOrg) {
-      // Editing an existing org is owner-only, gated on the role rather than the
-      // ownerUserId scalar — and updates the resolved org by id, so a co-owner
-      // edits the same org instead of accidentally creating a second one, and a
-      // demoted creator who still holds ownerUserId can no longer rename it.
-      if ((await resolveOrgRole(authenticatedSession, existingOrg)) !== "owner") {
+      // Editing an existing org is owner-only, gated on the role not the
+      // ownerUserId scalar. Self-heal the creator's owner row first: a failed
+      // ensureOwner during creation must not permanently brick onboarding.
+      let role = await resolveOrgRole(authenticatedSession, existingOrg);
+      if (role !== "owner" && authenticatedSession.user.id === existingOrg.ownerUserId) {
+        await developerOrgs.ensureOwner(existingOrg.id, authenticatedSession.user.id);
+        role = "owner";
+      }
+      if (role !== "owner") {
         return c.json({ error: "forbidden", error_description: "only owners can update the organization" }, 403);
       }
       org = await developerOrgs.updateOrg(existingOrg.id, authenticatedSession.user, parsed.data);
@@ -545,12 +554,18 @@ async function postAcceptInvitation(c: AppContext) {
     if (!(await invitations.claim(invite.invitationId))) {
       return c.json({ error: "invalid_invitation", error_description: "this invitation has already been used" }, 404);
     }
-    // Join with the invited role (role kept if already a member).
-    await developerOrgs.ensureMembership(invite.orgId, authenticatedSession.user.id, {
-      email: authenticatedSession.user.email,
-      name: sessionDisplayName(authenticatedSession),
-      roleIfNew: invite.role,
-    });
+    // Join with the invited role (role kept if already a member). If the write
+    // fails, un-claim so the invitee can retry with the same link.
+    try {
+      await developerOrgs.ensureMembership(invite.orgId, authenticatedSession.user.id, {
+        email: authenticatedSession.user.email,
+        name: sessionDisplayName(authenticatedSession),
+        roleIfNew: invite.role,
+      });
+    } catch (err) {
+      await invitations.unclaim(invite.invitationId);
+      throw err;
+    }
     return c.json({ ok: true, org: await developerOrgs.getOrgById(invite.orgId) });
   } catch (error) {
     return serviceError(error);

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -523,17 +523,23 @@ async function postAcceptInvitation(c: AppContext) {
   if (!token) throw new InvalidRequest("token is required");
 
   try {
-    const invite = await invitations.consume(token);
+    const invite = await invitations.peek(token);
     if (!invite) {
       return c.json({ error: "invalid_invitation", error_description: "this invitation is invalid or has expired" }, 404);
     }
-    // The invitee joins the org with the invited role (their real identity, not
-    // necessarily the invited email). If they were already a member, role is kept.
+    // One org per user: block joining a second org (re-accepting the same one is fine).
+    const ownedOrg = await developerOrgs.getPrimaryOrgForUser(authenticatedSession.user);
+    const currentOrgId = ownedOrg?.id ?? (await developerOrgs.getMembershipOrgId(authenticatedSession.user.id));
+    if (currentOrgId && currentOrgId !== invite.orgId) {
+      return c.json({ error: "already_in_org", error_description: "you already belong to an organization" }, 409);
+    }
+    // Join with the invited role (their real identity; role kept if already a member).
     await developerOrgs.ensureMembership(invite.orgId, authenticatedSession.user.id, {
       email: authenticatedSession.user.email,
       name: sessionDisplayName(authenticatedSession),
       roleIfNew: invite.role,
     });
+    await invitations.markAccepted(invite.invitationId);
     return c.json({ ok: true, org: await developerOrgs.getOrgById(invite.orgId) });
   } catch (error) {
     return serviceError(error);
@@ -1027,18 +1033,10 @@ async function resolveDeveloperOrgForSession(
     if (memberOrg) return memberOrg;
   }
 
-  // An org-scoped (SSO) session: WorkOS tells us the org; materialize membership.
-  if (authenticatedSession.organizationId) {
-    const ssoOrg = await developerOrgs.getOrgByWorkosOrgId(authenticatedSession.organizationId);
-    if (ssoOrg) {
-      await developerOrgs.ensureMembership(ssoOrg.id, authenticatedSession.user.id, {
-        email: authenticatedSession.user.email,
-        name: sessionDisplayName(authenticatedSession),
-      });
-      return ssoOrg;
-    }
-  }
-
+  // NOTE: access requires a roster row (or being the creator). We intentionally
+  // do NOT auto-join from a WorkOS org_id here — that would resurrect removed
+  // members (whose vestigial WorkOS membership lingers) and grant access off
+  // stale state. Real SSO provisioning will create a roster row explicitly.
   return null;
 }
 

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -479,8 +479,9 @@ async function postOrgInvitation(c: AppContext) {
       inviterUserId: developer.auth.user.id,
     });
     // Record the intended role in our DB; it materializes onto the membership
-    // when the invitee first authenticates. WorkOS stores no role.
-    await developerOrgs.setMemberRole(org.id, email, invitedRole);
+    // when the invitee first authenticates. WorkOS stores no role. This never
+    // overwrites an existing active member's role (see recordInvitedRole).
+    await developerOrgs.recordInvitedRole(org.id, email, invitedRole);
     return c.json({ invitation: serializeInvitation(invitation, invitedRole) }, 201);
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);
@@ -504,7 +505,10 @@ async function deleteOrgInvitation(c: AppContext) {
       return c.json({ error: "not_found", error_description: "invitation was not found" }, 404);
     }
     await workos().userManagement.revokeInvitation(invitationId);
-    await developerOrgs.removeMemberRole(org.id, { email: invitation.email });
+    // Intentionally do NOT delete the role row here: the same email can key an
+    // active member's overlay (a stale/duplicate invite would otherwise demote
+    // them). A genuinely-pending row is inert until the invitee joins, and a
+    // re-invite updates it via recordInvitedRole.
     return c.json({ ok: true });
   } catch (error) {
     if (isWorkosRequestError(error)) return teamAccessError(error);

--- a/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
+++ b/cloud-v2/packages/core/src/api/console/cli-auth.api.ts
@@ -9,6 +9,8 @@ import {
   type DeveloperOrgRecord,
 } from "../../services/developer-orgs/developer-org.service";
 import { DeveloperApiKeyService } from "../../services/developer-orgs/developer-api-key.service";
+import { DeveloperOrgInvitationService } from "../../services/developer-orgs/developer-org-invitation.service";
+import { sendOrgInviteEmail } from "../../services/email/email.service";
 import {
   MiniAppService,
   MiniAppServiceError,
@@ -32,6 +34,7 @@ const RETURN_TO_COOKIE = "mentra_console_return_to";
 const ORG_SELECTION_COOKIE = "mentra_console_org_selection";
 const developerOrgs = new DeveloperOrgService();
 const apiKeys = new DeveloperApiKeyService();
+const invitations = new DeveloperOrgInvitationService();
 const miniapps = new MiniAppService();
 const signing = new DeveloperSigningService();
 
@@ -92,6 +95,7 @@ app.get("/org", getOrg);
 app.put("/org", putOrg);
 app.get("/org/access", getOrgAccess);
 app.post("/org/invitations", postOrgInvitation);
+app.post("/org/invitations/accept", postAcceptInvitation);
 app.delete("/org/invitations/:invitationId", deleteOrgInvitation);
 app.delete("/org/members/:membershipId", deleteOrgMember);
 app.patch("/org/members/:membershipId", patchOrgMember);
@@ -380,6 +384,14 @@ async function getMe(c: AppContext) {
     return c.json({ authenticated: false, reason: authenticatedSession.reason }, 401);
   }
   const developerOrg = await resolveDeveloperOrgForSession(authenticatedSession);
+  // Keep the roster fresh: ensure a membership row for the current human user
+  // and backfill their profile fields (skips API-key principals).
+  if (developerOrg && !authenticatedSession.user.id.startsWith("api_key:")) {
+    await developerOrgs.ensureMembership(developerOrg.id, authenticatedSession.user.id, {
+      email: authenticatedSession.user.email,
+      name: sessionDisplayName(authenticatedSession),
+    });
+  }
   const viewerRole = developerOrg ? await resolveOrgRole(authenticatedSession, developerOrg) : null;
 
   return c.json({
@@ -460,15 +472,13 @@ async function getOrgAccess(c: AppContext) {
   if (!developer.ok) return developer.response;
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
     return c.json({
-      org,
-      viewerRole: await resolveOrgRole(developer.auth, org),
-      members: await listWorkosOrgMembers(org),
-      invitations: await listWorkosOrgInvitations(org),
+      org: developer.org,
+      viewerRole: await resolveOrgRole(developer.auth, developer.org),
+      members: await listOrgMembers(developer.org),
+      invitations: await invitations.listPending(developer.org.id),
     });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -485,16 +495,47 @@ async function postOrgInvitation(c: AppContext) {
 
   const email = parsed.data.email.trim().toLowerCase();
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const invitation = await workos().userManagement.sendInvitation({
-      email,
-      organizationId: requireWorkosOrgId(org),
-      inviterUserId: developer.auth.user.id,
+    // Invitees join as `member`; an owner/admin promotes them afterwards.
+    const { record, token } = await invitations.create(developer.org.id, email, "member", developer.auth.user.id);
+    const inviteUrl = `${workosConfig().consoleUrl}/invite/${token}`;
+    // Email is best-effort (Resend); inviteUrl is the copy-link fallback.
+    void sendOrgInviteEmail({
+      to: email,
+      orgName: developer.org.name,
+      inviterName: sessionDisplayName(developer.auth),
+      role: record.role,
+      acceptUrl: inviteUrl,
     });
-    // Invitees join as `member`; an owner/admin assigns a higher role afterwards.
-    return c.json({ invitation: serializeInvitation(invitation) }, 201);
+    return c.json({ invitation: record, inviteUrl }, 201);
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
+    return serviceError(error);
+  }
+}
+
+async function postAcceptInvitation(c: AppContext) {
+  const authenticatedSession = await authenticateConsoleSession(c);
+  if (!authenticatedSession.authenticated) {
+    return c.json({ error: "unauthorized", error_description: "console session required" }, 401);
+  }
+
+  const body = await readJsonBody(c);
+  const token = typeof (body as { token?: unknown })?.token === "string" ? (body as { token: string }).token : "";
+  if (!token) throw new InvalidRequest("token is required");
+
+  try {
+    const invite = await invitations.consume(token);
+    if (!invite) {
+      return c.json({ error: "invalid_invitation", error_description: "this invitation is invalid or has expired" }, 404);
+    }
+    // The invitee joins the org with the invited role (their real identity, not
+    // necessarily the invited email). If they were already a member, role is kept.
+    await developerOrgs.ensureMembership(invite.orgId, authenticatedSession.user.id, {
+      email: authenticatedSession.user.email,
+      name: sessionDisplayName(authenticatedSession),
+      roleIfNew: invite.role,
+    });
+    return c.json({ ok: true, org: await developerOrgs.getOrgById(invite.orgId) });
+  } catch (error) {
     return serviceError(error);
   }
 }
@@ -509,19 +550,11 @@ async function deleteOrgInvitation(c: AppContext) {
   if (!invitationId) throw new InvalidRequest("invitationId is required");
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const invitation = await workos().userManagement.getInvitation(invitationId);
-    if (invitation.organizationId !== org.workosOrgId) {
+    if (!(await invitations.revoke(developer.org.id, invitationId))) {
       return c.json({ error: "not_found", error_description: "invitation was not found" }, 404);
     }
-    await workos().userManagement.revokeInvitation(invitationId);
-    // Intentionally do NOT delete the role row here: the same email can key an
-    // active member's overlay (a stale/duplicate invite would otherwise demote
-    // them). A genuinely-pending row is inert until the invitee joins, and a
-    // re-invite updates it via recordInvitedRole.
     return c.json({ ok: true });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -533,41 +566,35 @@ async function deleteOrgMember(c: AppContext) {
   if (!roleAtLeast(actorRole, "admin")) {
     return c.json({ error: "forbidden", error_description: "only owners and admins can remove members" }, 403);
   }
-  const membershipId = c.req.param("membershipId");
-  if (!membershipId) throw new InvalidRequest("membershipId is required");
+  const targetUserId = c.req.param("membershipId"); // the member's userId
+  if (!targetUserId) throw new InvalidRequest("member id is required");
+  const org = developer.org;
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const membership = await workos().userManagement.getOrganizationMembership(membershipId);
-    if (membership.organizationId !== org.workosOrgId) {
+    const targetRole = await developerOrgs.getMemberRole(org.id, targetUserId);
+    if (targetRole === null) {
       return c.json({ error: "not_found", error_description: "member was not found" }, 404);
     }
     // Removing an owner requires being an owner, and never the last one.
-    const targetRole = await developerOrgs.getMemberRole(org.id, membership.userId);
     if (targetRole === "owner") {
       if (actorRole !== "owner") {
         return c.json({ error: "forbidden", error_description: "only an owner can remove another owner" }, 403);
       }
-      // Race-safe: drops the owner row only if another owner remains.
-      if (!(await developerOrgs.removeOwnerIfNotLast(org.id, membership.userId))) {
+      if (!(await developerOrgs.removeOwnerIfNotLast(org.id, targetUserId))) {
         return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
       }
     }
-    // If we're removing the created-by / WorkOS-bootstrap identity, hand the
-    // pointer to another owner so org lookup + bootstrap keep pointing at a real
-    // owner (and a removed user never retains access via the creator fast-path).
-    if (membership.userId === org.ownerUserId) {
-      const nextOwner = await developerOrgs.findAnotherOwner(org.id, membership.userId);
+    // If we're removing the created-by pointer, hand it to another owner.
+    if (targetUserId === org.ownerUserId) {
+      const nextOwner = await developerOrgs.findAnotherOwner(org.id, targetUserId);
       if (!nextOwner) {
         return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
       }
       await developerOrgs.reassignCreator(org.id, nextOwner);
     }
-    await workos().userManagement.deleteOrganizationMembership(membershipId);
-    await developerOrgs.removeMemberRole(org.id, membership.userId);
+    await developerOrgs.removeMemberRole(org.id, targetUserId);
     return c.json({ ok: true });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -579,37 +606,35 @@ async function patchOrgMember(c: AppContext) {
   if (!roleAtLeast(actorRole, "admin")) {
     return c.json({ error: "forbidden", error_description: "only owners and admins can change member roles" }, 403);
   }
-  const membershipId = c.req.param("membershipId");
-  if (!membershipId) throw new InvalidRequest("membershipId is required");
+  const targetUserId = c.req.param("membershipId"); // the member's userId
+  if (!targetUserId) throw new InvalidRequest("member id is required");
 
   const parsed = updateOrgMemberRoleSchema.safeParse(await readJsonBody(c));
   if (!parsed.success) throw new InvalidRequest(parsed.error.issues[0]?.message ?? "invalid role payload");
+  const org = developer.org;
 
   try {
-    const org = await ensureWorkosOrgLinked(developer.auth, developer.org);
-    const membership = await workos().userManagement.getOrganizationMembership(membershipId);
-    if (membership.organizationId !== org.workosOrgId) {
+    const newRole = parsed.data.role;
+    const targetRole = await developerOrgs.getMemberRole(org.id, targetUserId);
+    if (targetRole === null) {
       return c.json({ error: "not_found", error_description: "member was not found" }, 404);
     }
-    const newRole = parsed.data.role;
-    const targetRole = await developerOrgs.getMemberRole(org.id, membership.userId);
     // Granting or changing the owner role is owner-only (no admin can mint an
     // owner or demote one); admins may only move members between admin/member.
     if ((newRole === "owner" || targetRole === "owner") && actorRole !== "owner") {
       return c.json({ error: "forbidden", error_description: "only an owner can grant or change the owner role" }, 403);
     }
-    // Apply the change. Demoting an owner is race-guarded so two concurrent
-    // requests can't both pass a count check and leave the org with no owner.
+    // Demoting an owner is race-guarded so two concurrent requests can't both
+    // pass a count check and leave the org with no owner.
     if (targetRole === "owner" && newRole !== "owner") {
-      if (!(await developerOrgs.demoteOwner(org.id, membership.userId, newRole))) {
+      if (!(await developerOrgs.demoteOwner(org.id, targetUserId, newRole))) {
         return c.json({ error: "last_owner", error_description: "an organization must keep at least one owner" }, 409);
       }
     } else {
-      await developerOrgs.setMemberRole(org.id, membership.userId, newRole);
+      await developerOrgs.setMemberRole(org.id, targetUserId, newRole);
     }
     return c.json({ ok: true, role: newRole });
   } catch (error) {
-    if (isWorkosRequestError(error)) return teamAccessError(error);
     return serviceError(error);
   }
 }
@@ -821,10 +846,7 @@ async function ensureWorkosOrgLinked(
   authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
   org: DeveloperOrgRecord,
 ): Promise<DeveloperOrgRecord> {
-  if (org.workosOrgId) {
-    await ensureOwnerWorkosMembership(org);
-    return org;
-  }
+  if (org.workosOrgId) return org;
   // Any owner (by role) may bootstrap the WorkOS org, not only the creator.
   if ((await resolveOrgRole(authenticatedSession, org)) !== "owner") {
     throw new DeveloperOrgServiceError(
@@ -834,14 +856,14 @@ async function ensureWorkosOrgLinked(
     );
   }
 
+  // The WorkOS org is kept only as the auth/SSO context (membership lives in our
+  // DB now), created lazily and linked back onto our org.
   const createdOrg = await workos().organizations.createOrganization({
     name: org.name,
     externalId: org.id,
     metadata: workosOrgMetadata(org),
   });
-  const linkedOrg = await developerOrgs.setWorkosOrgId(org.id, createdOrg.id);
-  await ensureOwnerWorkosMembership(linkedOrg);
-  return linkedOrg;
+  return developerOrgs.setWorkosOrgId(org.id, createdOrg.id);
 }
 
 async function syncWorkosOrgName(org: DeveloperOrgRecord): Promise<void> {
@@ -879,97 +901,19 @@ function consoleEnvironmentLabel(): string {
   }
 }
 
-async function ensureOwnerWorkosMembership(org: DeveloperOrgRecord): Promise<void> {
-  const organizationId = requireWorkosOrgId(org);
-  try {
-    await workos().userManagement.createOrganizationMembership({
-      organizationId,
-      userId: org.ownerUserId,
-    });
-  } catch (error) {
-    if (isConflictError(error)) return;
-    throw error;
-  }
-}
-
-async function listWorkosOrgMembers(org: DeveloperOrgRecord): Promise<ConsoleOrgMember[]> {
-  const organizationId = requireWorkosOrgId(org);
-  const memberships = await workos().userManagement.listOrganizationMemberships({
-    organizationId,
-    statuses: ["active", "inactive"],
-    limit: 100,
-  });
-  const roleOverlay = await developerOrgs.listMemberRoles(org.id);
-
-  const users = new Map<string, ConsoleOrgUser>();
-  await Promise.all(
-    memberships.data.map(async (membership) => {
-      if (users.has(membership.userId)) return;
-      try {
-        const user = await workos().userManagement.getUser(membership.userId);
-        users.set(membership.userId, {
-          id: user.id,
-          email: user.email,
-          name: user.name || [user.firstName, user.lastName].filter(Boolean).join(" ") || null,
-          avatarUrl: user.profilePictureUrl ?? null,
-        });
-      } catch {
-        users.set(membership.userId, {
-          id: membership.userId,
-          email: null,
-          name: null,
-          avatarUrl: null,
-        });
-      }
-    }),
-  );
-
-  return memberships.data.map((membership) => {
-    const user = users.get(membership.userId) ?? {
-      id: membership.userId,
-      email: null,
-      name: null,
-      avatarUrl: null,
-    };
-    return {
-      id: membership.id,
-      userId: membership.userId,
-      email: user.email,
-      name: user.name,
-      avatarUrl: user.avatarUrl,
-      role: roleOverlay.get(membership.userId) ?? "member",
-      status: membership.status,
-      createdAt: membership.createdAt ?? null,
-      updatedAt: membership.updatedAt ?? null,
-    };
-  });
-}
-
-async function listWorkosOrgInvitations(org: DeveloperOrgRecord): Promise<ConsoleOrgInvitation[]> {
-  const invitations = await workos().userManagement.listInvitations({
-    organizationId: requireWorkosOrgId(org),
-    limit: 100,
-  });
-  return invitations.data.map(serializeInvitation);
-}
-
-function serializeInvitation(invitation: WorkosInvitationLike): ConsoleOrgInvitation {
-  return {
-    id: invitation.id,
-    email: invitation.email,
-    state: invitation.state,
-    role: invitation.roleSlug ?? "member",
-    expiresAt: invitation.expiresAt ?? null,
-    createdAt: invitation.createdAt ?? null,
-    updatedAt: invitation.updatedAt ?? null,
-  };
-}
-
-function requireWorkosOrgId(org: DeveloperOrgRecord): string {
-  if (!org.workosOrgId) {
-    throw new DeveloperOrgServiceError("team_access_not_ready", "team access is not ready for this org yet", 409);
-  }
-  return org.workosOrgId;
+async function listOrgMembers(org: DeveloperOrgRecord): Promise<ConsoleOrgMember[]> {
+  const members = await developerOrgs.listMembers(org.id);
+  return members.map(member => ({
+    id: member.userId,
+    userId: member.userId,
+    email: member.email,
+    name: member.name,
+    avatarUrl: null,
+    role: member.role,
+    status: member.status,
+    createdAt: member.createdAt,
+    updatedAt: member.updatedAt,
+  }));
 }
 
 type OrgRole = "owner" | "admin" | "member";
@@ -994,12 +938,9 @@ function roleAtLeast(role: OrgRole, min: OrgRole): boolean {
   return ORG_ROLE_RANK[role] >= ORG_ROLE_RANK[min];
 }
 
-type ConsoleOrgUser = {
-  id: string;
-  email: string | null;
-  name: string | null;
-  avatarUrl: string | null;
-};
+function sessionDisplayName(auth: Extract<ConsoleAuthResult, { authenticated: true }>): string {
+  return [auth.user.firstName, auth.user.lastName].filter(Boolean).join(" ").trim() || auth.user.email;
+}
 
 type ConsoleOrgMember = {
   id: string;
@@ -1013,26 +954,6 @@ type ConsoleOrgMember = {
   updatedAt: string | null;
 };
 
-type ConsoleOrgInvitation = {
-  id: string;
-  email: string;
-  state: string;
-  role: string;
-  expiresAt: string | null;
-  createdAt: string | null;
-  updatedAt: string | null;
-};
-
-type WorkosInvitationLike = {
-  id: string;
-  email: string;
-  state: string;
-  roleSlug?: string | null;
-  expiresAt?: string | null;
-  createdAt?: string | null;
-  updatedAt?: string | null;
-};
-
 export type ConsoleAuthResult =
   | {
       authenticated: true;
@@ -1043,6 +964,7 @@ export type ConsoleAuthResult =
         lastName?: string | null;
       };
       organizationId?: string | null;
+      developerOrgId?: string | null;
     }
   | { authenticated: false; reason: string };
 
@@ -1088,26 +1010,33 @@ async function requireConsoleOrg(c: AppContext): Promise<
 async function resolveDeveloperOrgForSession(
   authenticatedSession: Extract<ConsoleAuthResult, { authenticated: true }>,
 ): Promise<DeveloperOrgRecord | null> {
+  // API-key principals carry their org directly.
+  if (authenticatedSession.developerOrgId) {
+    const keyOrg = await developerOrgs.getOrgById(authenticatedSession.developerOrgId);
+    if (keyOrg) return keyOrg;
+  }
+
+  // The org this user created.
   const ownedOrg = await developerOrgs.getPrimaryOrgForUser(authenticatedSession.user);
   if (ownedOrg) return ownedOrg;
 
-  if (authenticatedSession.organizationId) {
-    const sessionOrg = await developerOrgs.getOrgByWorkosOrgId(authenticatedSession.organizationId);
-    if (sessionOrg) return sessionOrg;
+  // The org this user is a member of (our roster, no WorkOS lookup).
+  const membershipOrgId = await developerOrgs.getMembershipOrgId(authenticatedSession.user.id);
+  if (membershipOrgId) {
+    const memberOrg = await developerOrgs.getOrgById(membershipOrgId);
+    if (memberOrg) return memberOrg;
   }
 
-  try {
-    const memberships = await workos().userManagement.listOrganizationMemberships({
-      userId: authenticatedSession.user.id,
-      statuses: ["active"],
-      limit: 100,
-    });
-    for (const membership of memberships.data) {
-      const org = await developerOrgs.getOrgByWorkosOrgId(membership.organizationId);
-      if (org) return org;
+  // An org-scoped (SSO) session: WorkOS tells us the org; materialize membership.
+  if (authenticatedSession.organizationId) {
+    const ssoOrg = await developerOrgs.getOrgByWorkosOrgId(authenticatedSession.organizationId);
+    if (ssoOrg) {
+      await developerOrgs.ensureMembership(ssoOrg.id, authenticatedSession.user.id, {
+        email: authenticatedSession.user.email,
+        name: sessionDisplayName(authenticatedSession),
+      });
+      return ssoOrg;
     }
-  } catch {
-    // Fall through to onboardingRequired. Team lookup should not break basic sign-in.
   }
 
   return null;
@@ -1202,12 +1131,6 @@ async function authenticateApiKeyToken(token: string): Promise<ConsoleAuthResult
   try {
     const validated = await apiKeys.validate(token, consoleEnvironmentLabel());
     if (!validated) return { authenticated: false, reason: "invalid_bearer_token" };
-
-    // The runtime auth result still keys orgs by workosOrgId, so map our orgId
-    // to it. (Resolution moves fully to our orgId when membership lands.)
-    const org = await developerOrgs.getOrgById(validated.orgId);
-    if (!org?.workosOrgId) return { authenticated: false, reason: "api_key_missing_org" };
-
     return {
       authenticated: true,
       user: {
@@ -1216,7 +1139,7 @@ async function authenticateApiKeyToken(token: string): Promise<ConsoleAuthResult
         firstName: "API key",
         lastName: null,
       },
-      organizationId: org.workosOrgId,
+      developerOrgId: validated.orgId,
     };
   } catch {
     return { authenticated: false, reason: "invalid_bearer_token" };

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -7,6 +7,7 @@ import mongoose from "mongoose";
 import { createLogger } from "@mentra/cloud-shared";
 import { WorkOS } from "@workos-inc/node";
 import { DeveloperOrgModel } from "../models/developer-org.model";
+import { DeveloperOrgInvitationModel } from "../models/developer-org-invitation.model";
 import { DeveloperOrgMembershipModel } from "../models/developer-org-membership.model";
 import { RefreshTokenModel } from "../models/refresh-token.model";
 import { UserModel } from "../models/user.model";
@@ -18,6 +19,9 @@ const REFRESH_TOKENS_COLLECTION = "refreshTokens";
 const LEGACY_USER_IDENTITY_INDEX = "oemId_1_oemUserId_1";
 const DEVELOPER_ORG_MEMBERSHIPS_COLLECTION = "developer_org_memberships";
 const LEGACY_MEMBERSHIP_EMAIL_INDEX = "orgId_1_email_1";
+const DEVELOPER_ORGS_COLLECTION = "developer_orgs";
+const DEVELOPER_ORG_INVITATIONS_COLLECTION = "developer_org_invitations";
+const LEGACY_INVITATION_EMAIL_INDEX = "orgId_1_email_1";
 
 type DuplicateUserGroup = {
   _id: {
@@ -42,8 +46,36 @@ export async function runStartupMigrations(): Promise<void> {
   // Build the unique index BEFORE any upserts so concurrent Core startups can't
   // race in duplicate (orgId,userId) rows.
   await safeCreateMembershipIndexes();
+  await safeCreateInvitationIndexes();
   await backfillDeveloperOrgOwners();
   await backfillMembersFromWorkos();
+}
+
+// The invitation collection's (orgId,email) index moved to a partial-unique
+// ("one pending invite per email"). Drop any plain legacy index first so the
+// unique one can be built, then create indexes. Non-fatal.
+async function safeCreateInvitationIndexes(): Promise<void> {
+  const collection = mongoose.connection.collection(DEVELOPER_ORG_INVITATIONS_COLLECTION);
+  try {
+    const indexes = await collection.indexes();
+    const legacy = indexes.find(
+      (index) => index.name === LEGACY_INVITATION_EMAIL_INDEX && !index.partialFilterExpression,
+    );
+    if (legacy) {
+      await collection.dropIndex(LEGACY_INVITATION_EMAIL_INDEX);
+      logger.info({ collection: DEVELOPER_ORG_INVITATIONS_COLLECTION }, "dropped legacy invitation email index");
+    }
+  } catch {
+    // collection may not exist yet
+  }
+  try {
+    await DeveloperOrgInvitationModel.createIndexes();
+  } catch (error) {
+    logger.error(
+      { collection: DEVELOPER_ORG_INVITATIONS_COLLECTION, error: (error as Error)?.message },
+      "failed to create invitation indexes",
+    );
+  }
 }
 
 async function backfillLegacyUserIdentityFields(): Promise<void> {
@@ -204,27 +236,30 @@ async function dedupeDeveloperOrgMemberships(): Promise<void> {
 
 // Membership moved from WorkOS into our DB. Seed the roster once from the
 // existing WorkOS memberships (userId + email/name), preserving any roles we
-// already assigned. Idempotent + skips orgs already backfilled (a member row
-// with an email). Best-effort per org; never fails boot.
+// already assigned. A `membersMigratedAt` marker on the org is set ONLY after
+// every page succeeds, so a mid-pagination failure retries on the next boot
+// instead of getting stuck partially migrated. Best-effort per org; never fails boot.
 async function backfillMembersFromWorkos(): Promise<void> {
   const apiKey = process.env.WORKOS_API_KEY;
   if (!apiKey) return;
   const workos = new WorkOS(apiKey);
-  const orgs = await DeveloperOrgModel.find(
-    { workosOrgId: { $type: "string" } },
-    { orgId: 1, workosOrgId: 1 },
-  ).lean<Array<{ orgId: string; workosOrgId: string }>>();
+  const orgsCollection = mongoose.connection.collection(DEVELOPER_ORGS_COLLECTION);
+  const orgs = await orgsCollection
+    .find(
+      { workosOrgId: { $type: "string" }, membersMigratedAt: { $exists: false } },
+      { projection: { orgId: 1, workosOrgId: 1 } },
+    )
+    .toArray();
 
   let seeded = 0;
   for (const org of orgs) {
-    if (await DeveloperOrgMembershipModel.exists({ orgId: org.orgId, email: { $type: "string" } })) {
-      continue; // already migrated
-    }
+    const orgId = org.orgId as string;
+    const workosOrgId = org.workosOrgId as string;
     try {
       let after: string | undefined;
       do {
         const page = await workos.userManagement.listOrganizationMemberships({
-          organizationId: org.workosOrgId,
+          organizationId: workosOrgId,
           statuses: ["active", "inactive"],
           limit: 100,
           after,
@@ -234,7 +269,7 @@ async function backfillMembersFromWorkos(): Promise<void> {
           if (
             await DeveloperOrgMembershipModel.exists({
               userId: membership.userId,
-              orgId: { $ne: org.orgId },
+              orgId: { $ne: orgId },
             })
           ) {
             continue;
@@ -249,10 +284,10 @@ async function backfillMembersFromWorkos(): Promise<void> {
             // profile fetch is best-effort
           }
           await DeveloperOrgMembershipModel.updateOne(
-            { orgId: org.orgId, userId: membership.userId },
+            { orgId, userId: membership.userId },
             {
               $set: { ...(email ? { email } : {}), ...(name ? { name } : {}) },
-              $setOnInsert: { orgId: org.orgId, userId: membership.userId, role: "member" },
+              $setOnInsert: { orgId, userId: membership.userId, role: "member" },
             },
             { upsert: true },
           );
@@ -260,8 +295,10 @@ async function backfillMembersFromWorkos(): Promise<void> {
         }
         after = page.listMetadata?.after ?? undefined;
       } while (after);
+      // All pages succeeded — mark done so we don't re-scan WorkOS every boot.
+      await orgsCollection.updateOne({ orgId }, { $set: { membersMigratedAt: new Date() } });
     } catch (error) {
-      logger.warn({ orgId: org.orgId, error: (error as Error)?.message }, "member backfill failed for org");
+      logger.warn({ orgId, error: (error as Error)?.message }, "member backfill failed for org");
     }
   }
   if (seeded > 0) {

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -137,9 +137,11 @@ async function backfillDeveloperOrgOwners(): Promise<void> {
     if (!org.orgId || !org.ownerUserId) continue;
     const ownerCount = await DeveloperOrgMembershipModel.countDocuments({ orgId: org.orgId, role: "owner" });
     if (ownerCount > 0) continue;
+    // Force the role to owner: if the creator somehow already has a non-owner
+    // row (so ownerCount was 0), upgrade it rather than leaving the org ownerless.
     await DeveloperOrgMembershipModel.updateOne(
       { orgId: org.orgId, userId: org.ownerUserId },
-      { $setOnInsert: { orgId: org.orgId, userId: org.ownerUserId, role: "owner" } },
+      { $set: { role: "owner" }, $setOnInsert: { orgId: org.orgId, userId: org.ownerUserId } },
       { upsert: true },
     );
     seeded += 1;

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -5,6 +5,8 @@
 
 import mongoose from "mongoose";
 import { createLogger } from "@mentra/cloud-shared";
+import { DeveloperOrgModel } from "../models/developer-org.model";
+import { DeveloperOrgMembershipModel } from "../models/developer-org-membership.model";
 import { RefreshTokenModel } from "../models/refresh-token.model";
 import { UserModel } from "../models/user.model";
 
@@ -13,6 +15,8 @@ const logger = createLogger("core").child({ component: "startup-migrations" });
 const USERS_COLLECTION = "users";
 const REFRESH_TOKENS_COLLECTION = "refreshTokens";
 const LEGACY_USER_IDENTITY_INDEX = "oemId_1_oemUserId_1";
+const DEVELOPER_ORG_MEMBERSHIPS_COLLECTION = "developer_org_memberships";
+const LEGACY_MEMBERSHIP_EMAIL_INDEX = "orgId_1_email_1";
 
 type DuplicateUserGroup = {
   _id: {
@@ -32,6 +36,9 @@ export async function runStartupMigrations(): Promise<void> {
   await dropLegacyUserIdentityIndex();
   await dedupeUserIdentityRows();
   await UserModel.createIndexes();
+  await dropLegacyMembershipEmailIndex();
+  await backfillDeveloperOrgOwners();
+  await DeveloperOrgMembershipModel.createIndexes();
 }
 
 async function backfillLegacyUserIdentityFields(): Promise<void> {
@@ -98,6 +105,48 @@ async function dropLegacyUserIdentityIndex(): Promise<void> {
     { collection: USERS_COLLECTION, index: LEGACY_USER_IDENTITY_INDEX },
     "dropped legacy user identity index",
   );
+}
+
+// Developer-org memberships were briefly keyed by (orgId, email) in early Cloud
+// V2 dev; they are now keyed by (orgId, userId). Drop the stale unique index so
+// the new one can take its place.
+async function dropLegacyMembershipEmailIndex(): Promise<void> {
+  const collection = mongoose.connection.collection(DEVELOPER_ORG_MEMBERSHIPS_COLLECTION);
+  let indexes;
+  try {
+    indexes = await collection.indexes();
+  } catch {
+    return; // collection does not exist yet
+  }
+  if (!indexes.some((index) => index.name === LEGACY_MEMBERSHIP_EMAIL_INDEX)) return;
+  await collection.dropIndex(LEGACY_MEMBERSHIP_EMAIL_INDEX);
+  logger.info(
+    { collection: DEVELOPER_ORG_MEMBERSHIPS_COLLECTION, index: LEGACY_MEMBERSHIP_EMAIL_INDEX },
+    "dropped legacy membership email index",
+  );
+}
+
+// Ownership is a membership role now, not the DeveloperOrg.ownerUserId scalar.
+// Seed each org's creator as an owner so existing orgs keep at least one owner
+// once the scalar stops granting the role. Idempotent; skips orgs that already
+// have an owner.
+async function backfillDeveloperOrgOwners(): Promise<void> {
+  const orgs = await DeveloperOrgModel.find({}, { orgId: 1, ownerUserId: 1 }).lean();
+  let seeded = 0;
+  for (const org of orgs) {
+    if (!org.orgId || !org.ownerUserId) continue;
+    const ownerCount = await DeveloperOrgMembershipModel.countDocuments({ orgId: org.orgId, role: "owner" });
+    if (ownerCount > 0) continue;
+    await DeveloperOrgMembershipModel.updateOne(
+      { orgId: org.orgId, userId: org.ownerUserId },
+      { $setOnInsert: { orgId: org.orgId, userId: org.ownerUserId, role: "owner" } },
+      { upsert: true },
+    );
+    seeded += 1;
+  }
+  if (seeded > 0) {
+    logger.info({ seeded }, "seeded developer-org creators as owners");
+  }
 }
 
 async function dedupeUserIdentityRows(): Promise<void> {

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -37,8 +37,9 @@ export async function runStartupMigrations(): Promise<void> {
   await dedupeUserIdentityRows();
   await UserModel.createIndexes();
   await dropLegacyMembershipEmailIndex();
+  await dedupeDeveloperOrgMemberships();
   await backfillDeveloperOrgOwners();
-  await DeveloperOrgMembershipModel.createIndexes();
+  await safeCreateMembershipIndexes();
 }
 
 async function backfillLegacyUserIdentityFields(): Promise<void> {
@@ -148,6 +149,66 @@ async function backfillDeveloperOrgOwners(): Promise<void> {
   }
   if (seeded > 0) {
     logger.info({ seeded }, "seeded developer-org creators as owners");
+  }
+}
+
+// During the email -> userId rekey, a user invited under two emails could end up
+// with two membership rows sharing one userId. Collapse each (orgId, userId) to a
+// single row (highest role wins) BEFORE the new unique index is built, so the
+// index build can't fail and crash boot.
+async function dedupeDeveloperOrgMemberships(): Promise<void> {
+  const collection = mongoose.connection.collection(DEVELOPER_ORG_MEMBERSHIPS_COLLECTION);
+  let groups;
+  try {
+    groups = await collection
+      .aggregate([
+        { $match: { orgId: { $type: "string" }, userId: { $type: "string" } } },
+        {
+          $group: {
+            _id: { orgId: "$orgId", userId: "$userId" },
+            docs: { $push: { id: "$_id", role: "$role" } },
+            count: { $sum: 1 },
+          },
+        },
+        { $match: { count: { $gt: 1 } } },
+      ])
+      .toArray();
+  } catch {
+    return; // collection does not exist yet
+  }
+
+  const rank: Record<string, number> = { owner: 3, admin: 2, member: 1 };
+  let removed = 0;
+  for (const group of groups) {
+    const docs = (group.docs ?? []) as Array<{ id: mongoose.Types.ObjectId; role: string }>;
+    const losers = [...docs]
+      .sort((a, b) => (rank[b.role] ?? 0) - (rank[a.role] ?? 0))
+      .slice(1)
+      .map((doc) => doc.id);
+    if (!losers.length) continue;
+    const result = await collection.deleteMany({ _id: { $in: losers } });
+    removed += result.deletedCount ?? 0;
+  }
+
+  if (removed > 0) {
+    logger.warn(
+      { collection: DEVELOPER_ORG_MEMBERSHIPS_COLLECTION, removed },
+      "deduped duplicate developer-org membership rows",
+    );
+  }
+}
+
+// Build the (orgId, userId) unique index without letting an unexpected failure
+// crash Core boot — log loudly and continue. dedupeDeveloperOrgMemberships above
+// should prevent the only known failure mode (duplicate rows).
+async function safeCreateMembershipIndexes(): Promise<void> {
+  try {
+    await DeveloperOrgMembershipModel.createIndexes();
+  } catch (error) {
+    logger.error(
+      { collection: DEVELOPER_ORG_MEMBERSHIPS_COLLECTION, error: (error as Error)?.message },
+      "failed to create developer-org membership indexes",
+    );
   }
 }
 

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -5,6 +5,7 @@
 
 import mongoose from "mongoose";
 import { createLogger } from "@mentra/cloud-shared";
+import { WorkOS } from "@workos-inc/node";
 import { DeveloperOrgModel } from "../models/developer-org.model";
 import { DeveloperOrgMembershipModel } from "../models/developer-org-membership.model";
 import { RefreshTokenModel } from "../models/refresh-token.model";
@@ -40,6 +41,7 @@ export async function runStartupMigrations(): Promise<void> {
   await dedupeDeveloperOrgMemberships();
   await backfillDeveloperOrgOwners();
   await safeCreateMembershipIndexes();
+  await backfillMembersFromWorkos();
 }
 
 async function backfillLegacyUserIdentityFields(): Promise<void> {
@@ -195,6 +197,59 @@ async function dedupeDeveloperOrgMemberships(): Promise<void> {
       { collection: DEVELOPER_ORG_MEMBERSHIPS_COLLECTION, removed },
       "deduped duplicate developer-org membership rows",
     );
+  }
+}
+
+// Membership moved from WorkOS into our DB. Seed the roster once from the
+// existing WorkOS memberships (userId + email/name), preserving any roles we
+// already assigned. Idempotent + skips orgs already backfilled (a member row
+// with an email). Best-effort per org; never fails boot.
+async function backfillMembersFromWorkos(): Promise<void> {
+  const apiKey = process.env.WORKOS_API_KEY;
+  if (!apiKey) return;
+  const workos = new WorkOS(apiKey);
+  const orgs = await DeveloperOrgModel.find(
+    { workosOrgId: { $type: "string" } },
+    { orgId: 1, workosOrgId: 1 },
+  ).lean<Array<{ orgId: string; workosOrgId: string }>>();
+
+  let seeded = 0;
+  for (const org of orgs) {
+    if (await DeveloperOrgMembershipModel.exists({ orgId: org.orgId, email: { $type: "string" } })) {
+      continue; // already migrated
+    }
+    try {
+      const memberships = await workos.userManagement.listOrganizationMemberships({
+        organizationId: org.workosOrgId,
+        statuses: ["active", "inactive"],
+        limit: 100,
+      });
+      for (const membership of memberships.data) {
+        let email: string | null = null;
+        let name: string | null = null;
+        try {
+          const user = await workos.userManagement.getUser(membership.userId);
+          email = user.email ?? null;
+          name = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email || null;
+        } catch {
+          // profile fetch is best-effort
+        }
+        await DeveloperOrgMembershipModel.updateOne(
+          { orgId: org.orgId, userId: membership.userId },
+          {
+            $set: { ...(email ? { email } : {}), ...(name ? { name } : {}) },
+            $setOnInsert: { orgId: org.orgId, userId: membership.userId, role: "member" },
+          },
+          { upsert: true },
+        );
+        seeded += 1;
+      }
+    } catch (error) {
+      logger.warn({ orgId: org.orgId, error: (error as Error)?.message }, "member backfill failed for org");
+    }
+  }
+  if (seeded > 0) {
+    logger.info({ seeded }, "backfilled developer-org members from WorkOS");
   }
 }
 

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -39,8 +39,10 @@ export async function runStartupMigrations(): Promise<void> {
   await UserModel.createIndexes();
   await dropLegacyMembershipEmailIndex();
   await dedupeDeveloperOrgMemberships();
-  await backfillDeveloperOrgOwners();
+  // Build the unique index BEFORE any upserts so concurrent Core startups can't
+  // race in duplicate (orgId,userId) rows.
   await safeCreateMembershipIndexes();
+  await backfillDeveloperOrgOwners();
   await backfillMembersFromWorkos();
 }
 
@@ -219,31 +221,45 @@ async function backfillMembersFromWorkos(): Promise<void> {
       continue; // already migrated
     }
     try {
-      const memberships = await workos.userManagement.listOrganizationMemberships({
-        organizationId: org.workosOrgId,
-        statuses: ["active", "inactive"],
-        limit: 100,
-      });
-      for (const membership of memberships.data) {
-        let email: string | null = null;
-        let name: string | null = null;
-        try {
-          const user = await workos.userManagement.getUser(membership.userId);
-          email = user.email ?? null;
-          name = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email || null;
-        } catch {
-          // profile fetch is best-effort
+      let after: string | undefined;
+      do {
+        const page = await workos.userManagement.listOrganizationMemberships({
+          organizationId: org.workosOrgId,
+          statuses: ["active", "inactive"],
+          limit: 100,
+          after,
+        });
+        for (const membership of page.data) {
+          // One org per user: skip anyone already on another org's roster.
+          if (
+            await DeveloperOrgMembershipModel.exists({
+              userId: membership.userId,
+              orgId: { $ne: org.orgId },
+            })
+          ) {
+            continue;
+          }
+          let email: string | null = null;
+          let name: string | null = null;
+          try {
+            const user = await workos.userManagement.getUser(membership.userId);
+            email = user.email ?? null;
+            name = [user.firstName, user.lastName].filter(Boolean).join(" ") || user.email || null;
+          } catch {
+            // profile fetch is best-effort
+          }
+          await DeveloperOrgMembershipModel.updateOne(
+            { orgId: org.orgId, userId: membership.userId },
+            {
+              $set: { ...(email ? { email } : {}), ...(name ? { name } : {}) },
+              $setOnInsert: { orgId: org.orgId, userId: membership.userId, role: "member" },
+            },
+            { upsert: true },
+          );
+          seeded += 1;
         }
-        await DeveloperOrgMembershipModel.updateOne(
-          { orgId: org.orgId, userId: membership.userId },
-          {
-            $set: { ...(email ? { email } : {}), ...(name ? { name } : {}) },
-            $setOnInsert: { orgId: org.orgId, userId: membership.userId, role: "member" },
-          },
-          { upsert: true },
-        );
-        seeded += 1;
-      }
+        after = page.listMetadata?.after ?? undefined;
+      } while (after);
     } catch (error) {
       logger.warn({ orgId: org.orgId, error: (error as Error)?.message }, "member backfill failed for org");
     }

--- a/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
@@ -1,0 +1,28 @@
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+/**
+ * Org-scoped developer API key, owned entirely in our DB (no WorkOS). The full
+ * secret is shown once at creation and never stored — we keep only a SHA-256
+ * hash and the last 4 chars for display. The public `keyId` is embedded in the
+ * token string so validation is an indexed lookup + a constant-time hash compare.
+ *
+ * Token shape: `msk_<env>_<keyId>.<secret>` (see developer-api-key.service.ts).
+ */
+const DeveloperOrgApiKeySchema = new Schema(
+  {
+    keyId: { type: String, required: true, unique: true },
+    orgId: { type: String, required: true, index: true },
+    name: { type: String, required: true },
+    hash: { type: String, required: true },
+    last4: { type: String, required: true },
+    createdByUserId: { type: String, required: true },
+    lastUsedAt: { type: Date, default: null },
+    revokedAt: { type: Date, default: null },
+  },
+  { timestamps: true, collection: "developer_org_api_keys" },
+);
+
+DeveloperOrgApiKeySchema.index({ orgId: 1, revokedAt: 1 });
+
+export type DeveloperOrgApiKey = InferSchemaType<typeof DeveloperOrgApiKeySchema>;
+export const DeveloperOrgApiKeyModel = model("DeveloperOrgApiKey", DeveloperOrgApiKeySchema);

--- a/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
@@ -13,6 +13,7 @@ const DeveloperOrgApiKeySchema = new Schema(
     keyId: { type: String, required: true, unique: true },
     orgId: { type: String, required: true, index: true },
     name: { type: String, required: true },
+    env: { type: String, required: true },
     hash: { type: String, required: true },
     last4: { type: String, required: true },
     createdByUserId: { type: String, required: true },

--- a/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
@@ -1,0 +1,31 @@
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+export const DEVELOPER_ORG_INVITATION_ROLES = ["admin", "member"] as const;
+export const DEVELOPER_ORG_INVITATION_STATUSES = ["pending", "accepted", "revoked"] as const;
+
+/**
+ * A pending invite to join a developer org, owned in our DB. The invite link
+ * carries a random token; we store only its sha256 hash (like an API key). On
+ * accept, a membership row is created and the invite is marked accepted.
+ */
+const DeveloperOrgInvitationSchema = new Schema(
+  {
+    invitationId: { type: String, required: true, unique: true },
+    orgId: { type: String, required: true, index: true },
+    email: { type: String, required: true }, // lowercased
+    role: { type: String, enum: DEVELOPER_ORG_INVITATION_ROLES, required: true, default: "member" },
+    tokenHash: { type: String, required: true, index: true },
+    status: { type: String, enum: DEVELOPER_ORG_INVITATION_STATUSES, required: true, default: "pending" },
+    invitedByUserId: { type: String, required: true },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, collection: "developer_org_invitations" },
+);
+
+DeveloperOrgInvitationSchema.index({ orgId: 1, email: 1 });
+
+export type DeveloperOrgInvitation = InferSchemaType<typeof DeveloperOrgInvitationSchema>;
+export const DeveloperOrgInvitationModel = model(
+  "DeveloperOrgInvitation",
+  DeveloperOrgInvitationSchema,
+);

--- a/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
@@ -22,7 +22,11 @@ const DeveloperOrgInvitationSchema = new Schema(
   { timestamps: true, collection: "developer_org_invitations" },
 );
 
-DeveloperOrgInvitationSchema.index({ orgId: 1, email: 1 });
+// At most one pending invite per (org, email) — the DB backs the supersede logic.
+DeveloperOrgInvitationSchema.index(
+  { orgId: 1, email: 1 },
+  { unique: true, partialFilterExpression: { status: "pending" } },
+);
 
 export type DeveloperOrgInvitation = InferSchemaType<typeof DeveloperOrgInvitationSchema>;
 export const DeveloperOrgInvitationModel = model(

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -28,6 +28,9 @@ const DeveloperOrgMembershipSchema = new Schema(
 );
 
 DeveloperOrgMembershipSchema.index({ orgId: 1, userId: 1 }, { unique: true });
+// One org per user: a user has at most one membership row across all orgs. This
+// DB-enforces the invariant that the app's one-org checks rely on.
+DeveloperOrgMembershipSchema.index({ userId: 1 }, { unique: true });
 
 export type DeveloperOrgMembership = InferSchemaType<typeof DeveloperOrgMembershipSchema>;
 export const DeveloperOrgMembershipModel = model(

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -1,14 +1,13 @@
 import { Schema, model, type InferSchemaType } from "mongoose";
 
 /**
- * Roles a developer-org member can hold, stored and owned entirely in our DB.
+ * Per-(org, user) role, stored and owned entirely in our DB. Roles are uniform:
+ * owner | admin | member — there is no special "creator". `DeveloperOrg.ownerUserId`
+ * is only a created-by pointer and does NOT grant the owner role. An org may have
+ * many owners; the console enforces that at least one owner always remains (you
+ * cannot demote or remove the last owner).
  *
- * `DeveloperOrg.ownerUserId` is the org's PRIMARY owner (the creator): always an
- * owner, can never be demoted or removed — that is what guarantees an org always
- * has at least one owner ("can't remove the last owner"). Additional co-owners
- * are stored here as `owner` rows, so an org can have multiple owners. A user
- * with no row resolves to `member` by default.
- *
+ * Keyed by WorkOS userId. A user with no row resolves to `member` by default.
  * WorkOS is not consulted for roles — it remains identity/login + the member
  * roster only. The permission tier is a Mentra console concept.
  */
@@ -17,19 +16,14 @@ export type DeveloperOrgRole = (typeof DEVELOPER_ORG_ROLES)[number];
 
 const DeveloperOrgMembershipSchema = new Schema(
   {
-    // DeveloperOrg.orgId (e.g. `dorg_...`), not the WorkOS org id.
     orgId: { type: String, required: true, index: true },
-    // Lowercased email is the canonical key: it is known at invite time
-    // (before the user exists) and again at login, so it bridges both.
-    email: { type: String, required: true },
-    // WorkOS user id, backfilled the first time the member is resolved by email.
-    userId: { type: String, default: null, index: true },
+    userId: { type: String, required: true },
     role: { type: String, enum: DEVELOPER_ORG_ROLES, required: true, default: "member" },
   },
   { timestamps: true, collection: "developer_org_memberships" },
 );
 
-DeveloperOrgMembershipSchema.index({ orgId: 1, email: 1 }, { unique: true });
+DeveloperOrgMembershipSchema.index({ orgId: 1, userId: 1 }, { unique: true });
 
 export type DeveloperOrgMembership = InferSchemaType<typeof DeveloperOrgMembershipSchema>;
 export const DeveloperOrgMembershipModel = model(

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -3,15 +3,16 @@ import { Schema, model, type InferSchemaType } from "mongoose";
 /**
  * Roles a developer-org member can hold, stored and owned entirely in our DB.
  *
- * `owner` is intentionally NOT in this list: ownership is the single
- * `ownerUserId` field on `DeveloperOrg` and stays the source of truth for the
- * one owner. This collection only records the admin/member overlay for
- * everyone else. A user with no row here resolves to `member` by default.
+ * `DeveloperOrg.ownerUserId` is the org's PRIMARY owner (the creator): always an
+ * owner, can never be demoted or removed — that is what guarantees an org always
+ * has at least one owner ("can't remove the last owner"). Additional co-owners
+ * are stored here as `owner` rows, so an org can have multiple owners. A user
+ * with no row resolves to `member` by default.
  *
  * WorkOS is not consulted for roles — it remains identity/login + the member
  * roster only. The permission tier is a Mentra console concept.
  */
-export const DEVELOPER_ORG_ROLES = ["admin", "member"] as const;
+export const DEVELOPER_ORG_ROLES = ["owner", "admin", "member"] as const;
 export type DeveloperOrgRole = (typeof DEVELOPER_ORG_ROLES)[number];
 
 const DeveloperOrgMembershipSchema = new Schema(

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -29,8 +29,12 @@ const DeveloperOrgMembershipSchema = new Schema(
 
 DeveloperOrgMembershipSchema.index({ orgId: 1, userId: 1 }, { unique: true });
 // One org per user: a user has at most one membership row across all orgs. This
-// DB-enforces the invariant that the app's one-org checks rely on.
-DeveloperOrgMembershipSchema.index({ userId: 1 }, { unique: true });
+// DB-enforces the invariant that the app's one-org checks rely on. Partial so the
+// build can't fail on any legacy row lacking a string userId.
+DeveloperOrgMembershipSchema.index(
+  { userId: 1 },
+  { unique: true, partialFilterExpression: { userId: { $type: "string" } } },
+);
 
 export type DeveloperOrgMembership = InferSchemaType<typeof DeveloperOrgMembershipSchema>;
 export const DeveloperOrgMembershipModel = model(

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -1,0 +1,37 @@
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+/**
+ * Roles a developer-org member can hold, stored and owned entirely in our DB.
+ *
+ * `owner` is intentionally NOT in this list: ownership is the single
+ * `ownerUserId` field on `DeveloperOrg` and stays the source of truth for the
+ * one owner. This collection only records the admin/member overlay for
+ * everyone else. A user with no row here resolves to `member` by default.
+ *
+ * WorkOS is not consulted for roles — it remains identity/login + the member
+ * roster only. The permission tier is a Mentra console concept.
+ */
+export const DEVELOPER_ORG_ROLES = ["admin", "member"] as const;
+export type DeveloperOrgRole = (typeof DEVELOPER_ORG_ROLES)[number];
+
+const DeveloperOrgMembershipSchema = new Schema(
+  {
+    // DeveloperOrg.orgId (e.g. `dorg_...`), not the WorkOS org id.
+    orgId: { type: String, required: true, index: true },
+    // Lowercased email is the canonical key: it is known at invite time
+    // (before the user exists) and again at login, so it bridges both.
+    email: { type: String, required: true },
+    // WorkOS user id, backfilled the first time the member is resolved by email.
+    userId: { type: String, default: null, index: true },
+    role: { type: String, enum: DEVELOPER_ORG_ROLES, required: true, default: "member" },
+  },
+  { timestamps: true, collection: "developer_org_memberships" },
+);
+
+DeveloperOrgMembershipSchema.index({ orgId: 1, email: 1 }, { unique: true });
+
+export type DeveloperOrgMembership = InferSchemaType<typeof DeveloperOrgMembershipSchema>;
+export const DeveloperOrgMembershipModel = model(
+  "DeveloperOrgMembership",
+  DeveloperOrgMembershipSchema,
+);

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -19,6 +19,10 @@ const DeveloperOrgMembershipSchema = new Schema(
     orgId: { type: String, required: true, index: true },
     userId: { type: String, required: true },
     role: { type: String, enum: DEVELOPER_ORG_ROLES, required: true, default: "member" },
+    // Roster display fields, backfilled from the session/invite/WorkOS identity.
+    email: { type: String, default: null },
+    name: { type: String, default: null },
+    status: { type: String, default: "active" },
   },
   { timestamps: true, collection: "developer_org_memberships" },
 );

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
@@ -45,7 +45,8 @@ export class DeveloperApiKeyService {
   }
 
   async list(orgId: string, env: string): Promise<ApiKeyRecord[]> {
-    const rows = await DeveloperOrgApiKeyModel.find({ orgId, revokedAt: null })
+    // Scope to the current environment, matching create/validate which pin env.
+    const rows = await DeveloperOrgApiKeyModel.find({ orgId, env: safeEnv(env), revokedAt: null })
       .sort({ createdAt: -1 })
       .lean();
     return rows.map(row => serializeApiKey(row, env));

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
@@ -1,0 +1,107 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { ulid } from "ulid";
+import { DeveloperOrgApiKeyModel } from "../../models/developer-org-api-key.model";
+
+export interface ApiKeyRecord {
+  id: string; // keyId — what the console uses to revoke
+  name: string;
+  obfuscatedValue: string;
+  value: string | null; // full token, only returned on creation
+  permissions: string[];
+  createdAt: string | null;
+  updatedAt: string | null;
+  lastUsedAt: string | null;
+}
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+// Token env segment must be a single [a-z0-9] word (no `_` / `.` which the token
+// format uses as separators).
+function safeEnv(env: string): string {
+  return env.replace(/[^a-z0-9]/gi, "").toLowerCase() || "local";
+}
+
+/**
+ * Mints and validates org API keys in our DB. Tokens are env-pinned so a key
+ * minted in one environment can never authenticate against another.
+ */
+export class DeveloperApiKeyService {
+  async create(orgId: string, name: string, createdByUserId: string, env: string): Promise<ApiKeyRecord> {
+    const keyId = ulid();
+    const secret = randomBytes(32).toString("base64url");
+    const token = `msk_${safeEnv(env)}_${keyId}.${secret}`;
+    const doc = await DeveloperOrgApiKeyModel.create({
+      keyId,
+      orgId,
+      name,
+      hash: sha256Hex(secret),
+      last4: secret.slice(-4),
+      createdByUserId,
+    });
+    return { ...serializeApiKey(doc.toObject(), env), value: token };
+  }
+
+  async list(orgId: string, env: string): Promise<ApiKeyRecord[]> {
+    const rows = await DeveloperOrgApiKeyModel.find({ orgId, revokedAt: null })
+      .sort({ createdAt: -1 })
+      .lean();
+    return rows.map(row => serializeApiKey(row, env));
+  }
+
+  async revoke(orgId: string, keyId: string): Promise<boolean> {
+    const result = await DeveloperOrgApiKeyModel.updateOne(
+      { orgId, keyId, revokedAt: null },
+      { $set: { revokedAt: new Date() } },
+    );
+    return result.matchedCount > 0;
+  }
+
+  /** Validate a presented bearer token (env-pinned). Returns the owning org or null. */
+  async validate(token: string, env: string): Promise<{ orgId: string; keyId: string } | null> {
+    if (!token.startsWith("msk_")) return null;
+    const dot = token.indexOf(".");
+    if (dot < 0) return null;
+    const parts = token.slice(0, dot).split("_"); // ["msk", "<env>", "<keyId>"]
+    const secret = token.slice(dot + 1);
+    if (parts.length !== 3) return null;
+    const [, tokenEnv, keyId] = parts;
+    if (!keyId || !secret || tokenEnv !== safeEnv(env)) return null;
+
+    const row = await DeveloperOrgApiKeyModel.findOne({ keyId, revokedAt: null }).lean();
+    if (!row) return null;
+    const expected = Buffer.from(row.hash, "hex");
+    const actual = Buffer.from(sha256Hex(secret), "hex");
+    if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null;
+
+    // Throttled last-used update (≤ once/min), fire-and-forget — never block auth.
+    if (!row.lastUsedAt || Date.now() - new Date(row.lastUsedAt).getTime() > 60_000) {
+      void DeveloperOrgApiKeyModel.updateOne({ keyId }, { $set: { lastUsedAt: new Date() } }).catch(() => {});
+    }
+    return { orgId: row.orgId, keyId };
+  }
+}
+
+function serializeApiKey(
+  row: {
+    keyId: string;
+    name: string;
+    last4: string;
+    createdAt?: Date;
+    updatedAt?: Date;
+    lastUsedAt?: Date | null;
+  },
+  env: string,
+): ApiKeyRecord {
+  return {
+    id: row.keyId,
+    name: row.name,
+    obfuscatedValue: `msk_${safeEnv(env)}_…${row.last4}`,
+    value: null,
+    permissions: [],
+    createdAt: row.createdAt?.toISOString() ?? null,
+    updatedAt: row.updatedAt?.toISOString() ?? null,
+    lastUsedAt: row.lastUsedAt ? new Date(row.lastUsedAt).toISOString() : null,
+  };
+}

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-api-key.service.ts
@@ -36,6 +36,7 @@ export class DeveloperApiKeyService {
       keyId,
       orgId,
       name,
+      env: safeEnv(env),
       hash: sha256Hex(secret),
       last4: secret.slice(-4),
       createdByUserId,
@@ -71,6 +72,8 @@ export class DeveloperApiKeyService {
 
     const row = await DeveloperOrgApiKeyModel.findOne({ keyId, revokedAt: null }).lean();
     if (!row) return null;
+    // Env is bound to the stored row, not just the client-supplied prefix.
+    if (row.env !== safeEnv(env)) return null;
     const expected = Buffer.from(row.hash, "hex");
     const actual = Buffer.from(sha256Hex(secret), "hex");
     if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) return null;

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
@@ -1,0 +1,102 @@
+import { createHash, randomBytes } from "node:crypto";
+import { ulid } from "ulid";
+import { DeveloperOrgInvitationModel } from "../../models/developer-org-invitation.model";
+
+export type InvitationRole = "admin" | "member";
+
+export interface InvitationRecord {
+  id: string;
+  email: string;
+  role: string;
+  state: string; // pending | accepted | revoked (the console filters on this)
+  expiresAt: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+const INVITE_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+
+function sha256Hex(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+/** Org invitations owned in our DB (copy-link + emailed). */
+export class DeveloperOrgInvitationService {
+  /** Create a pending invite (superseding any prior pending one for the email). */
+  async create(
+    orgId: string,
+    email: string,
+    role: InvitationRole,
+    invitedByUserId: string,
+  ): Promise<{ record: InvitationRecord; token: string }> {
+    const normalizedEmail = email.trim().toLowerCase();
+    const token = randomBytes(32).toString("base64url");
+    await DeveloperOrgInvitationModel.updateMany(
+      { orgId, email: normalizedEmail, status: "pending" },
+      { $set: { status: "revoked" } },
+    );
+    const doc = await DeveloperOrgInvitationModel.create({
+      invitationId: `dinv_${ulid()}`,
+      orgId,
+      email: normalizedEmail,
+      role,
+      tokenHash: sha256Hex(token),
+      status: "pending",
+      invitedByUserId,
+      expiresAt: new Date(Date.now() + INVITE_TTL_MS),
+    });
+    return { record: serialize(doc.toObject()), token };
+  }
+
+  async listPending(orgId: string): Promise<InvitationRecord[]> {
+    const rows = await DeveloperOrgInvitationModel.find({ orgId, status: "pending" })
+      .sort({ createdAt: -1 })
+      .lean<RawInvitation[]>();
+    return rows.map(serialize);
+  }
+
+  async revoke(orgId: string, invitationId: string): Promise<boolean> {
+    const result = await DeveloperOrgInvitationModel.updateOne(
+      { orgId, invitationId, status: "pending" },
+      { $set: { status: "revoked" } },
+    );
+    return result.matchedCount > 0;
+  }
+
+  /** Validate + consume a pending invite by its raw token. Null if invalid/expired. */
+  async consume(token: string): Promise<{ orgId: string; email: string; role: InvitationRole } | null> {
+    if (!token) return null;
+    const row = await DeveloperOrgInvitationModel.findOne({ tokenHash: sha256Hex(token), status: "pending" });
+    if (!row) return null;
+    if (row.expiresAt.getTime() < Date.now()) {
+      row.status = "revoked";
+      await row.save();
+      return null;
+    }
+    row.status = "accepted";
+    await row.save();
+    return { orgId: row.orgId, email: row.email, role: row.role as InvitationRole };
+  }
+}
+
+type RawInvitation = {
+  invitationId: string;
+  email: string;
+  role: string;
+  status: string;
+  expiresAt?: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
+};
+
+function serialize(row: RawInvitation): InvitationRecord {
+  return {
+    id: row.invitationId,
+    email: row.email,
+    role: row.role,
+    state: row.status,
+    expiresAt: row.expiresAt?.toISOString() ?? null,
+    createdAt: row.createdAt?.toISOString() ?? null,
+    updatedAt: row.updatedAt?.toISOString() ?? null,
+  };
+}

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
@@ -78,11 +78,12 @@ export class DeveloperOrgInvitationService {
     }).lean<{ invitationId: string; orgId: string; email: string; role: string; expiresAt: Date } | null>();
     if (!row) return null;
     if (new Date(row.expiresAt).getTime() < Date.now()) {
-      // Retire the expired invite so it stops showing as pending.
+      // Retire the expired invite so it stops showing as pending. Best-effort —
+      // never let a transient write failure turn a clean expired-null into a 5xx.
       await DeveloperOrgInvitationModel.updateOne(
         { invitationId: row.invitationId, status: "pending" },
         { $set: { status: "revoked" } },
-      );
+      ).catch(() => {});
       return null;
     }
     return { invitationId: row.invitationId, orgId: row.orgId, email: row.email, role: row.role as InvitationRole };

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
@@ -49,7 +49,11 @@ export class DeveloperOrgInvitationService {
   }
 
   async listPending(orgId: string): Promise<InvitationRecord[]> {
-    const rows = await DeveloperOrgInvitationModel.find({ orgId, status: "pending" })
+    const rows = await DeveloperOrgInvitationModel.find({
+      orgId,
+      status: "pending",
+      expiresAt: { $gt: new Date() },
+    })
       .sort({ createdAt: -1 })
       .lean<RawInvitation[]>();
     return rows.map(serialize);
@@ -77,12 +81,17 @@ export class DeveloperOrgInvitationService {
     return { invitationId: row.invitationId, orgId: row.orgId, email: row.email, role: row.role as InvitationRole };
   }
 
-  /** Mark a pending invite accepted (call after the membership is created). */
-  async markAccepted(invitationId: string): Promise<void> {
-    await DeveloperOrgInvitationModel.updateOne(
+  /**
+   * Atomically claim a pending invite (single-use). Returns false if another
+   * request already claimed it — the `{ status: "pending" }` filter + Mongo's
+   * atomic updateOne mean only one concurrent accept wins.
+   */
+  async claim(invitationId: string): Promise<boolean> {
+    const result = await DeveloperOrgInvitationModel.updateOne(
       { invitationId, status: "pending" },
       { $set: { status: "accepted" } },
     );
+    return result.matchedCount === 1;
   }
 }
 

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
@@ -63,19 +63,26 @@ export class DeveloperOrgInvitationService {
     return result.matchedCount > 0;
   }
 
-  /** Validate + consume a pending invite by its raw token. Null if invalid/expired. */
-  async consume(token: string): Promise<{ orgId: string; email: string; role: InvitationRole } | null> {
+  /** Validate a pending invite by its raw token WITHOUT consuming it. */
+  async peek(
+    token: string,
+  ): Promise<{ invitationId: string; orgId: string; email: string; role: InvitationRole } | null> {
     if (!token) return null;
-    const row = await DeveloperOrgInvitationModel.findOne({ tokenHash: sha256Hex(token), status: "pending" });
+    const row = await DeveloperOrgInvitationModel.findOne({
+      tokenHash: sha256Hex(token),
+      status: "pending",
+    }).lean<{ invitationId: string; orgId: string; email: string; role: string; expiresAt: Date } | null>();
     if (!row) return null;
-    if (row.expiresAt.getTime() < Date.now()) {
-      row.status = "revoked";
-      await row.save();
-      return null;
-    }
-    row.status = "accepted";
-    await row.save();
-    return { orgId: row.orgId, email: row.email, role: row.role as InvitationRole };
+    if (new Date(row.expiresAt).getTime() < Date.now()) return null;
+    return { invitationId: row.invitationId, orgId: row.orgId, email: row.email, role: row.role as InvitationRole };
+  }
+
+  /** Mark a pending invite accepted (call after the membership is created). */
+  async markAccepted(invitationId: string): Promise<void> {
+    await DeveloperOrgInvitationModel.updateOne(
+      { invitationId, status: "pending" },
+      { $set: { status: "accepted" } },
+    );
   }
 }
 

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org-invitation.service.ts
@@ -77,7 +77,14 @@ export class DeveloperOrgInvitationService {
       status: "pending",
     }).lean<{ invitationId: string; orgId: string; email: string; role: string; expiresAt: Date } | null>();
     if (!row) return null;
-    if (new Date(row.expiresAt).getTime() < Date.now()) return null;
+    if (new Date(row.expiresAt).getTime() < Date.now()) {
+      // Retire the expired invite so it stops showing as pending.
+      await DeveloperOrgInvitationModel.updateOne(
+        { invitationId: row.invitationId, status: "pending" },
+        { $set: { status: "revoked" } },
+      );
+      return null;
+    }
     return { invitationId: row.invitationId, orgId: row.orgId, email: row.email, role: row.role as InvitationRole };
   }
 
@@ -92,6 +99,14 @@ export class DeveloperOrgInvitationService {
       { $set: { status: "accepted" } },
     );
     return result.matchedCount === 1;
+  }
+
+  /** Revert a claim (back to pending) if the post-claim membership write failed. */
+  async unclaim(invitationId: string): Promise<void> {
+    await DeveloperOrgInvitationModel.updateOne(
+      { invitationId, status: "accepted" },
+      { $set: { status: "pending" } },
+    );
   }
 }
 

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -229,9 +229,25 @@ export class DeveloperOrgService {
    * user is the only owner.
    */
   async removeOwnerIfNotLast(orgId: string, userId: string): Promise<boolean> {
+    const existing = await DeveloperOrgMembershipModel.findOne({ orgId, userId }).lean<
+      { email?: string | null; name?: string | null; status?: string | null } | null
+    >();
     await this.removeMemberRole(orgId, userId);
     if ((await this.countOwners(orgId)) === 0) {
-      await this.setMemberRole(orgId, userId, "owner");
+      // Restore the full row (profile fields included), not just the role.
+      await DeveloperOrgMembershipModel.updateOne(
+        { orgId, userId },
+        {
+          $set: {
+            role: "owner",
+            email: existing?.email ?? null,
+            name: existing?.name ?? null,
+            status: existing?.status ?? "active",
+          },
+          $setOnInsert: { orgId, userId },
+        },
+        { upsert: true },
+      );
       return false;
     }
     return true;

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -169,6 +169,35 @@ export class DeveloperOrgService {
     await DeveloperOrgModel.updateOne({ orgId }, { $set: { ownerUserId: newOwnerUserId } });
   }
 
+  /**
+   * Demote an owner to a lower role, but never the last one. Write-then-verify
+   * so two concurrent demotions can't both pass a count check and leave the org
+   * with zero owners: apply the change, re-count, and roll back if it removed
+   * the last owner. Returns false (no net change) when the user is the only owner.
+   */
+  async demoteOwner(orgId: string, userId: string, newRole: DeveloperOrgRole): Promise<boolean> {
+    await this.setMemberRole(orgId, userId, newRole);
+    if ((await this.countOwners(orgId)) === 0) {
+      await this.setMemberRole(orgId, userId, "owner");
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Remove an owner's role row, but never the last one (same write-then-verify
+   * race guard as demoteOwner). Returns false (and restores the row) when the
+   * user is the only owner.
+   */
+  async removeOwnerIfNotLast(orgId: string, userId: string): Promise<boolean> {
+    await this.removeMemberRole(orgId, userId);
+    if ((await this.countOwners(orgId)) === 0) {
+      await this.setMemberRole(orgId, userId, "owner");
+      return false;
+    }
+    return true;
+  }
+
   /** Roles for every member of an org, keyed by WorkOS userId. */
   async listMemberRoles(orgId: string): Promise<Map<string, DeveloperOrgRole>> {
     const rows = await DeveloperOrgMembershipModel.find({ orgId }).lean();

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -43,30 +43,49 @@ export class DeveloperOrgService {
     return org ? serializeDeveloperOrg(org) : null;
   }
 
-  async upsertPrimaryOrg(user: ConsoleUserIdentity, input: UpsertDeveloperOrgInput): Promise<DeveloperOrgRecord> {
+  /** Create the caller's first org (onboarding) and seed them as its owner. */
+  async createPrimaryOrg(user: ConsoleUserIdentity, input: UpsertDeveloperOrgInput): Promise<DeveloperOrgRecord> {
     const displayName = normalizeDisplayName(input.displayName);
     const packagePrefix = normalizePackagePrefix(input.packagePrefix);
     assertUsablePackagePrefix(packagePrefix, user);
+    await assertPackagePrefixAvailable(packagePrefix);
 
-    const existing = await DeveloperOrgModel.findOne({ ownerUserId: user.id }).sort({ createdAt: 1 });
+    const created = await DeveloperOrgModel.create({
+      orgId: `dorg_${ulid()}`,
+      ownerUserId: user.id,
+      workosOrgId: input.workosOrgId || undefined,
+      displayName,
+      packagePrefix,
+      packagePrefixStatus: packagePrefix === "com.mentra" ? "verified" : "unverified",
+    });
+    // Seed the creator as the org's first owner. From here, ownership is a
+    // membership role (owner|admin|member), not the ownerUserId scalar.
+    await this.ensureOwner(created.orgId, user.id);
+    return serializeDeveloperOrg(created.toObject());
+  }
+
+  /**
+   * Update an existing org by id. The caller's authorization (owner-only) is
+   * enforced at the handler; this keys on orgId, not the ownerUserId scalar, so
+   * any owner can edit the org. The package-prefix usability check only runs
+   * when the prefix actually changes, so editing the name doesn't trip the
+   * reserved-prefix gate for a co-owner.
+   */
+  async updateOrg(
+    orgId: string,
+    user: ConsoleUserIdentity,
+    input: UpsertDeveloperOrgInput,
+  ): Promise<DeveloperOrgRecord> {
+    const displayName = normalizeDisplayName(input.displayName);
+    const packagePrefix = normalizePackagePrefix(input.packagePrefix);
+
+    const existing = await DeveloperOrgModel.findOne({ orgId });
     if (!existing) {
-      await assertPackagePrefixAvailable(packagePrefix);
-      const created = await DeveloperOrgModel.create({
-        orgId: `dorg_${ulid()}`,
-        ownerUserId: user.id,
-        workosOrgId: input.workosOrgId || undefined,
-        displayName,
-        packagePrefix,
-        packagePrefixStatus: packagePrefix === "com.mentra" ? "verified" : "unverified",
-      });
-      // Seed the creator as the org's first owner. From here, ownership is a
-      // membership role (owner|admin|member), not the ownerUserId scalar.
-      await this.ensureOwner(created.orgId, user.id);
-      return serializeDeveloperOrg(created.toObject());
+      throw new DeveloperOrgServiceError("org_not_found", "developer org was not found", 404);
     }
 
-    const nextPrefix = existing.packagePrefix;
-    if (packagePrefix !== nextPrefix) {
+    if (packagePrefix !== existing.packagePrefix) {
+      assertUsablePackagePrefix(packagePrefix, user);
       if (existing.packagePrefixStatus !== "rejected") {
         throw new DeveloperOrgServiceError(
           "package_prefix_locked",

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -59,6 +59,9 @@ export class DeveloperOrgService {
         packagePrefix,
         packagePrefixStatus: packagePrefix === "com.mentra" ? "verified" : "unverified",
       });
+      // Seed the creator as the org's first owner. From here, ownership is a
+      // membership role (owner|admin|member), not the ownerUserId scalar.
+      await this.ensureOwner(created.orgId, user.id);
       return serializeDeveloperOrg(created.toObject());
     }
 
@@ -111,110 +114,50 @@ export class DeveloperOrgService {
   }
 
   /**
-   * Resolve the admin/member overlay role for a member. `owner` is handled by
-   * the caller via `DeveloperOrg.ownerUserId` and never lives here. Matches by
-   * userId first, then by email; when matched by email it backfills userId so
-   * later lookups are by id. Returns null when the user has no row (→ member).
+   * The role a user holds in an org (owner | admin | member), or null when they
+   * have no row (which resolves to `member`). Keyed by WorkOS userId.
    */
-  async getMemberRole(
-    orgId: string,
-    identity: { userId?: string | null; email?: string | null },
-  ): Promise<DeveloperOrgRole | null> {
-    if (identity.userId) {
-      const byId = await DeveloperOrgMembershipModel.findOne({ orgId, userId: identity.userId }).lean();
-      if (byId) return byId.role as DeveloperOrgRole;
-    }
-    const email = identity.email?.trim().toLowerCase();
-    if (email) {
-      const byEmail = await DeveloperOrgMembershipModel.findOne({ orgId, email });
-      if (byEmail) {
-        if (identity.userId && !byEmail.userId) {
-          byEmail.userId = identity.userId;
-          await byEmail.save();
-        }
-        return byEmail.role as DeveloperOrgRole;
-      }
-    }
-    return null;
+  async getMemberRole(orgId: string, userId: string | null | undefined): Promise<DeveloperOrgRole | null> {
+    if (!userId) return null;
+    const row = await DeveloperOrgMembershipModel.findOne({ orgId, userId }).lean();
+    return row ? (row.role as DeveloperOrgRole) : null;
   }
 
-  /**
-   * Set/overwrite a member's role (used when an owner/admin changes a role).
-   * Keyed by lowercased email. When userId is known, first drops any stale rows
-   * for that same user under a different email, so the userId-first lookup in
-   * getMemberRole can never read an outdated role after an email change.
-   */
-  async setMemberRole(
-    orgId: string,
-    email: string,
-    role: DeveloperOrgRole,
-    userId?: string | null,
-  ): Promise<void> {
-    const normalizedEmail = email.trim().toLowerCase();
-    if (!normalizedEmail) return;
-    if (userId) {
-      await DeveloperOrgMembershipModel.deleteMany({
-        orgId,
-        userId,
-        email: { $ne: normalizedEmail },
-      });
-    }
+  /** Set/overwrite a user's role in an org. */
+  async setMemberRole(orgId: string, userId: string, role: DeveloperOrgRole): Promise<void> {
+    if (!userId) return;
     await DeveloperOrgMembershipModel.updateOne(
-      { orgId, email: normalizedEmail },
-      {
-        $set: { role, ...(userId ? { userId } : {}) },
-        $setOnInsert: { orgId, email: normalizedEmail },
-      },
+      { orgId, userId },
+      { $set: { role }, $setOnInsert: { orgId, userId } },
       { upsert: true },
     );
   }
 
-  /**
-   * Record the role an invitee should receive when they join, WITHOUT
-   * overwriting an existing active member's role. An active member's row has a
-   * backfilled `userId`; those are left untouched so an invitation can't be a
-   * backdoor that re-roles a current member (that must go through the
-   * role-change endpoint / setMemberRole). A still-pending row (no userId) is
-   * updated, so a re-invite with a different role takes effect.
-   */
-  async recordInvitedRole(orgId: string, email: string, role: DeveloperOrgRole): Promise<void> {
-    const normalizedEmail = email.trim().toLowerCase();
-    if (!normalizedEmail) return;
-    const existing = await DeveloperOrgMembershipModel.findOne({ orgId, email: normalizedEmail }).lean();
-    if (existing?.userId) return; // active member — never clobber via invite
+  /** Idempotently make a user an owner (used to seed the org creator). */
+  async ensureOwner(orgId: string, userId: string): Promise<void> {
+    if (!userId) return;
     await DeveloperOrgMembershipModel.updateOne(
-      { orgId, email: normalizedEmail },
-      { $set: { role }, $setOnInsert: { orgId, email: normalizedEmail } },
+      { orgId, userId },
+      { $setOnInsert: { orgId, userId, role: "owner" } },
       { upsert: true },
     );
   }
 
-  /** Drop a member's role row(s) on removal / invite revocation. Best-effort. */
-  async removeMemberRole(
-    orgId: string,
-    identity: { userId?: string | null; email?: string | null },
-  ): Promise<void> {
-    const or: Record<string, string>[] = [];
-    if (identity.userId) or.push({ userId: identity.userId });
-    const email = identity.email?.trim().toLowerCase();
-    if (email) or.push({ email });
-    if (!or.length) return;
-    await DeveloperOrgMembershipModel.deleteMany({ orgId, $or: or });
+  /** Remove a user's role row (on removal from the org). */
+  async removeMemberRole(orgId: string, userId: string): Promise<void> {
+    if (!userId) return;
+    await DeveloperOrgMembershipModel.deleteOne({ orgId, userId });
   }
 
-  /**
-   * Roles for every member of an org, keyed by lowercased email AND by
-   * `uid:<userId>` so the member-list join can match on whichever it has.
-   */
+  /** Number of owners in an org. Used to enforce "at least one owner remains". */
+  async countOwners(orgId: string): Promise<number> {
+    return DeveloperOrgMembershipModel.countDocuments({ orgId, role: "owner" });
+  }
+
+  /** Roles for every member of an org, keyed by WorkOS userId. */
   async listMemberRoles(orgId: string): Promise<Map<string, DeveloperOrgRole>> {
     const rows = await DeveloperOrgMembershipModel.find({ orgId }).lean();
-    const byKey = new Map<string, DeveloperOrgRole>();
-    for (const row of rows) {
-      const role = row.role as DeveloperOrgRole;
-      if (row.email) byKey.set(row.email.toLowerCase(), role);
-      if (row.userId) byKey.set(`uid:${row.userId}`, role);
-    }
-    return byKey;
+    return new Map(rows.map(row => [row.userId, row.role as DeveloperOrgRole]));
   }
 }
 

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -139,8 +139,10 @@ export class DeveloperOrgService {
   }
 
   /**
-   * Upsert a member's role, keyed by lowercased email (the identifier we have
-   * both at invite time and at login). Records userId when known.
+   * Set/overwrite a member's role (used when an owner/admin changes a role).
+   * Keyed by lowercased email. When userId is known, first drops any stale rows
+   * for that same user under a different email, so the userId-first lookup in
+   * getMemberRole can never read an outdated role after an email change.
    */
   async setMemberRole(
     orgId: string,
@@ -150,12 +152,39 @@ export class DeveloperOrgService {
   ): Promise<void> {
     const normalizedEmail = email.trim().toLowerCase();
     if (!normalizedEmail) return;
+    if (userId) {
+      await DeveloperOrgMembershipModel.deleteMany({
+        orgId,
+        userId,
+        email: { $ne: normalizedEmail },
+      });
+    }
     await DeveloperOrgMembershipModel.updateOne(
       { orgId, email: normalizedEmail },
       {
         $set: { role, ...(userId ? { userId } : {}) },
         $setOnInsert: { orgId, email: normalizedEmail },
       },
+      { upsert: true },
+    );
+  }
+
+  /**
+   * Record the role an invitee should receive when they join, WITHOUT
+   * overwriting an existing active member's role. An active member's row has a
+   * backfilled `userId`; those are left untouched so an invitation can't be a
+   * backdoor that re-roles a current member (that must go through the
+   * role-change endpoint / setMemberRole). A still-pending row (no userId) is
+   * updated, so a re-invite with a different role takes effect.
+   */
+  async recordInvitedRole(orgId: string, email: string, role: DeveloperOrgRole): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) return;
+    const existing = await DeveloperOrgMembershipModel.findOne({ orgId, email: normalizedEmail }).lean();
+    if (existing?.userId) return; // active member — never clobber via invite
+    await DeveloperOrgMembershipModel.updateOne(
+      { orgId, email: normalizedEmail },
+      { $set: { role }, $setOnInsert: { orgId, email: normalizedEmail } },
       { upsert: true },
     );
   }

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -1,6 +1,12 @@
 import { ulid } from "ulid";
 import { DeveloperOrgModel, type DeveloperOrgPrefixStatus } from "../../models/developer-org.model";
+import {
+  DeveloperOrgMembershipModel,
+  type DeveloperOrgRole,
+} from "../../models/developer-org-membership.model";
 import { MiniAppModel } from "../../models/miniapp.model";
+
+export type { DeveloperOrgRole } from "../../models/developer-org-membership.model";
 
 export interface ConsoleUserIdentity {
   id: string;
@@ -102,6 +108,84 @@ export class DeveloperOrgService {
     org.workosOrgId = workosOrgId;
     await org.save();
     return serializeDeveloperOrg(org.toObject());
+  }
+
+  /**
+   * Resolve the admin/member overlay role for a member. `owner` is handled by
+   * the caller via `DeveloperOrg.ownerUserId` and never lives here. Matches by
+   * userId first, then by email; when matched by email it backfills userId so
+   * later lookups are by id. Returns null when the user has no row (→ member).
+   */
+  async getMemberRole(
+    orgId: string,
+    identity: { userId?: string | null; email?: string | null },
+  ): Promise<DeveloperOrgRole | null> {
+    if (identity.userId) {
+      const byId = await DeveloperOrgMembershipModel.findOne({ orgId, userId: identity.userId }).lean();
+      if (byId) return byId.role as DeveloperOrgRole;
+    }
+    const email = identity.email?.trim().toLowerCase();
+    if (email) {
+      const byEmail = await DeveloperOrgMembershipModel.findOne({ orgId, email });
+      if (byEmail) {
+        if (identity.userId && !byEmail.userId) {
+          byEmail.userId = identity.userId;
+          await byEmail.save();
+        }
+        return byEmail.role as DeveloperOrgRole;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Upsert a member's role, keyed by lowercased email (the identifier we have
+   * both at invite time and at login). Records userId when known.
+   */
+  async setMemberRole(
+    orgId: string,
+    email: string,
+    role: DeveloperOrgRole,
+    userId?: string | null,
+  ): Promise<void> {
+    const normalizedEmail = email.trim().toLowerCase();
+    if (!normalizedEmail) return;
+    await DeveloperOrgMembershipModel.updateOne(
+      { orgId, email: normalizedEmail },
+      {
+        $set: { role, ...(userId ? { userId } : {}) },
+        $setOnInsert: { orgId, email: normalizedEmail },
+      },
+      { upsert: true },
+    );
+  }
+
+  /** Drop a member's role row(s) on removal / invite revocation. Best-effort. */
+  async removeMemberRole(
+    orgId: string,
+    identity: { userId?: string | null; email?: string | null },
+  ): Promise<void> {
+    const or: Record<string, string>[] = [];
+    if (identity.userId) or.push({ userId: identity.userId });
+    const email = identity.email?.trim().toLowerCase();
+    if (email) or.push({ email });
+    if (!or.length) return;
+    await DeveloperOrgMembershipModel.deleteMany({ orgId, $or: or });
+  }
+
+  /**
+   * Roles for every member of an org, keyed by lowercased email AND by
+   * `uid:<userId>` so the member-list join can match on whichever it has.
+   */
+  async listMemberRoles(orgId: string): Promise<Map<string, DeveloperOrgRole>> {
+    const rows = await DeveloperOrgMembershipModel.find({ orgId }).lean();
+    const byKey = new Map<string, DeveloperOrgRole>();
+    for (const row of rows) {
+      const role = row.role as DeveloperOrgRole;
+      if (row.email) byKey.set(row.email.toLowerCase(), role);
+      if (row.userId) byKey.set(`uid:${row.userId}`, role);
+    }
+    return byKey;
   }
 }
 

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -172,9 +172,12 @@ export class DeveloperOrgService {
   /** Idempotently make a user an owner (used to seed the org creator). */
   async ensureOwner(orgId: string, userId: string): Promise<void> {
     if (!userId) return;
+    // Force owner via $set (not $setOnInsert): a concurrent ensureMembership
+    // could insert a `member` row for the creator first, and we must still end
+    // up with them as owner so the org never has zero owners.
     await DeveloperOrgMembershipModel.updateOne(
       { orgId, userId },
-      { $setOnInsert: { orgId, userId, role: "owner" } },
+      { $set: { role: "owner" }, $setOnInsert: { orgId, userId } },
       { upsert: true },
     );
   }

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -154,6 +154,21 @@ export class DeveloperOrgService {
     return DeveloperOrgMembershipModel.countDocuments({ orgId, role: "owner" });
   }
 
+  /** Another owner's userId, for transferring the created-by/bootstrap pointer. */
+  async findAnotherOwner(orgId: string, excludeUserId: string): Promise<string | null> {
+    const row = await DeveloperOrgMembershipModel.findOne({
+      orgId,
+      role: "owner",
+      userId: { $ne: excludeUserId },
+    }).lean();
+    return row?.userId ?? null;
+  }
+
+  /** Repoint DeveloperOrg.ownerUserId (the created-by / WorkOS-bootstrap identity). */
+  async reassignCreator(orgId: string, newOwnerUserId: string): Promise<void> {
+    await DeveloperOrgModel.updateOne({ orgId }, { $set: { ownerUserId: newOwnerUserId } });
+  }
+
   /** Roles for every member of an org, keyed by WorkOS userId. */
   async listMemberRoles(orgId: string): Promise<Map<string, DeveloperOrgRole>> {
     const rows = await DeveloperOrgMembershipModel.find({ orgId }).lean();

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -43,6 +43,11 @@ export class DeveloperOrgService {
     return org ? serializeDeveloperOrg(org) : null;
   }
 
+  async getOrgById(orgId: string): Promise<DeveloperOrgRecord | null> {
+    const org = await DeveloperOrgModel.findOne({ orgId }).lean();
+    return org ? serializeDeveloperOrg(org) : null;
+  }
+
   /** Create the caller's first org (onboarding) and seed them as its owner. */
   async createPrimaryOrg(user: ConsoleUserIdentity, input: UpsertDeveloperOrgInput): Promise<DeveloperOrgRecord> {
     const displayName = normalizeDisplayName(input.displayName);

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -113,7 +113,7 @@ export class DeveloperOrgService {
     return serializeDeveloperOrg(existing.toObject());
   }
 
-  async setWorkosOrgId(user: ConsoleUserIdentity, orgId: string, workosOrgId: string): Promise<DeveloperOrgRecord> {
+  async setWorkosOrgId(orgId: string, workosOrgId: string): Promise<DeveloperOrgRecord> {
     const existingWithWorkosId = await DeveloperOrgModel.findOne({ workosOrgId }).lean();
     if (existingWithWorkosId && existingWithWorkosId.orgId !== orgId) {
       throw new DeveloperOrgServiceError(
@@ -123,7 +123,9 @@ export class DeveloperOrgService {
       );
     }
 
-    const org = await DeveloperOrgModel.findOne({ orgId, ownerUserId: user.id });
+    // Caller authorization (owner role) is enforced by ensureWorkosOrgLinked;
+    // key on orgId only so any owner can link, not just the ownerUserId creator.
+    const org = await DeveloperOrgModel.findOne({ orgId });
     if (!org) {
       throw new DeveloperOrgServiceError("org_not_found", "developer org was not found", 404);
     }

--- a/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
+++ b/cloud-v2/packages/core/src/services/developer-orgs/developer-org.service.ts
@@ -24,6 +24,16 @@ export interface DeveloperOrgRecord {
   updatedAt: string | null;
 }
 
+export interface DeveloperOrgMemberRecord {
+  userId: string;
+  email: string | null;
+  name: string | null;
+  role: DeveloperOrgRole;
+  status: string;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
 export interface UpsertDeveloperOrgInput {
   displayName: string;
   packagePrefix: string;
@@ -228,6 +238,62 @@ export class DeveloperOrgService {
   async listMemberRoles(orgId: string): Promise<Map<string, DeveloperOrgRole>> {
     const rows = await DeveloperOrgMembershipModel.find({ orgId }).lean();
     return new Map(rows.map(row => [row.userId, row.role as DeveloperOrgRole]));
+  }
+
+  /**
+   * Ensure a membership row exists for a user and backfill profile fields.
+   * Role is only set on insert, so this never downgrades an existing owner/admin.
+   */
+  async ensureMembership(
+    orgId: string,
+    userId: string,
+    opts: { email?: string | null; name?: string | null; roleIfNew?: DeveloperOrgRole } = {},
+  ): Promise<void> {
+    if (!userId) return;
+    const set: Record<string, unknown> = {};
+    if (opts.email) set.email = opts.email.trim().toLowerCase();
+    if (opts.name) set.name = opts.name;
+    await DeveloperOrgMembershipModel.updateOne(
+      { orgId, userId },
+      {
+        ...(Object.keys(set).length ? { $set: set } : {}),
+        $setOnInsert: { orgId, userId, role: opts.roleIfNew ?? "member" },
+      },
+      { upsert: true },
+    );
+  }
+
+  /** The orgId a user belongs to via a membership row (one org per user). */
+  async getMembershipOrgId(userId: string): Promise<string | null> {
+    if (!userId) return null;
+    const row = await DeveloperOrgMembershipModel.findOne({ userId }).sort({ createdAt: 1 }).lean();
+    return row?.orgId ?? null;
+  }
+
+  /** Full roster of an org, for the member list. */
+  async listMembers(orgId: string): Promise<DeveloperOrgMemberRecord[]> {
+    const rows = await DeveloperOrgMembershipModel.find({ orgId })
+      .sort({ createdAt: 1 })
+      .lean<
+        Array<{
+          userId: string;
+          email?: string | null;
+          name?: string | null;
+          role: string;
+          status?: string | null;
+          createdAt?: Date;
+          updatedAt?: Date;
+        }>
+      >();
+    return rows.map(row => ({
+      userId: row.userId,
+      email: row.email ?? null,
+      name: row.name ?? null,
+      role: row.role as DeveloperOrgRole,
+      status: row.status ?? "active",
+      createdAt: row.createdAt?.toISOString() ?? null,
+      updatedAt: row.updatedAt?.toISOString() ?? null,
+    }));
   }
 }
 

--- a/cloud-v2/packages/core/src/services/email/email.service.ts
+++ b/cloud-v2/packages/core/src/services/email/email.service.ts
@@ -1,0 +1,78 @@
+import { createLogger } from "@mentra/cloud-shared";
+
+const logger = createLogger("core").child({ component: "email" });
+
+const RESEND_ENDPOINT = "https://api.resend.com/emails";
+
+function sender(): string {
+  return process.env.EMAIL_SENDER || "Mentra <noreply@mentra.glass>";
+}
+
+/**
+ * Send a transactional email via Resend's HTTP API. Best-effort: if
+ * RESEND_API_KEY is unset (e.g. local dev) we log and skip rather than throw,
+ * so the caller (an invite) still succeeds and can fall back to the copy link.
+ */
+export async function sendEmail(opts: {
+  to: string;
+  subject: string;
+  html: string;
+}): Promise<{ ok: boolean; skipped?: boolean }> {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    logger.warn("RESEND_API_KEY not set; skipping email send");
+    return { ok: false, skipped: true };
+  }
+  try {
+    const res = await fetch(RESEND_ENDPOINT, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ from: sender(), to: [opts.to], subject: opts.subject, html: opts.html }),
+    });
+    if (!res.ok) {
+      logger.error({ status: res.status, body: await res.text().catch(() => "") }, "resend email send failed");
+      return { ok: false };
+    }
+    return { ok: true };
+  } catch (error) {
+    logger.error({ error: (error as Error)?.message }, "resend email send error");
+    return { ok: false };
+  }
+}
+
+export async function sendOrgInviteEmail(opts: {
+  to: string;
+  orgName: string;
+  inviterName: string;
+  role: string;
+  acceptUrl: string;
+}): Promise<{ ok: boolean; skipped?: boolean }> {
+  const roleLabel = opts.role === "admin" ? "an admin" : opts.role === "owner" ? "an owner" : "a member";
+  const html = `
+    <div style="font-family:-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;max-width:480px;margin:0 auto;color:#14151b">
+      <h2 style="font-size:20px;margin:0 0 12px">You're invited to ${escapeHtml(opts.orgName)}</h2>
+      <p style="font-size:15px;line-height:1.6;color:#3c3f46;margin:0 0 20px">
+        ${escapeHtml(opts.inviterName)} invited you to join <strong>${escapeHtml(opts.orgName)}</strong>
+        as ${roleLabel} on the Mentra developer console.
+      </p>
+      <p style="margin:0 0 28px">
+        <a href="${opts.acceptUrl}" style="display:inline-block;background:#111217;color:#fff;text-decoration:none;padding:11px 22px;border-radius:999px;font-size:15px;font-weight:600">Accept invitation</a>
+      </p>
+      <p style="font-size:13px;line-height:1.6;color:#8a8d95;margin:0">
+        Or paste this link into your browser:<br/>
+        <span style="word-break:break-all">${opts.acceptUrl}</span>
+      </p>
+    </div>`;
+  return sendEmail({ to: opts.to, subject: `You're invited to ${opts.orgName} on Mentra`, html });
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}

--- a/cloud-v2/packages/core/src/services/email/email.service.ts
+++ b/cloud-v2/packages/core/src/services/email/email.service.ts
@@ -59,11 +59,11 @@ export async function sendOrgInviteEmail(opts: {
         as ${roleLabel} on the Mentra developer console.
       </p>
       <p style="margin:0 0 28px">
-        <a href="${opts.acceptUrl}" style="display:inline-block;background:#111217;color:#fff;text-decoration:none;padding:11px 22px;border-radius:999px;font-size:15px;font-weight:600">Accept invitation</a>
+        <a href="${escapeHtml(opts.acceptUrl)}" style="display:inline-block;background:#111217;color:#fff;text-decoration:none;padding:11px 22px;border-radius:999px;font-size:15px;font-weight:600">Accept invitation</a>
       </p>
       <p style="font-size:13px;line-height:1.6;color:#8a8d95;margin:0">
         Or paste this link into your browser:<br/>
-        <span style="word-break:break-all">${opts.acceptUrl}</span>
+        <span style="word-break:break-all">${escapeHtml(opts.acceptUrl)}</span>
       </p>
     </div>`;
   return sendEmail({ to: opts.to, subject: `You're invited to ${opts.orgName} on Mentra`, html });

--- a/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
@@ -3,8 +3,9 @@ import { useEffect, useState } from "react";
 import { isUnauthorizedError, redirectToConsoleLogin } from "@/api/http";
 import { acceptOrgInvitation } from "./org.api";
 
-// Survives StrictMode's double-mount so a single-use token isn't consumed twice.
-const attemptedTokens = new Set<string>();
+// Cache the in-flight accept per token so StrictMode's double-mount reuses one
+// request (single-use safe) while the live mount still receives the outcome.
+const acceptRequests = new Map<string, ReturnType<typeof acceptOrgInvitation>>();
 
 export function InviteAcceptPage() {
   const { token } = useParams({ from: "/invite/$token" });
@@ -12,14 +13,19 @@ export function InviteAcceptPage() {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (attemptedTokens.has(token)) return;
-    attemptedTokens.add(token);
     let cancelled = false;
-    void (async () => {
-      try {
-        await acceptOrgInvitation(token);
+    let request = acceptRequests.get(token);
+    if (!request) {
+      request = acceptOrgInvitation(token);
+      acceptRequests.set(token, request);
+    }
+    request.then(
+      () => {
         if (!cancelled) navigate({ to: "/organization" });
-      } catch (err) {
+      },
+      (err) => {
+        // Allow a retry (e.g. after signing in) rather than caching the failure.
+        acceptRequests.delete(token);
         // Not signed in yet: bounce through login, then return here to accept.
         if (isUnauthorizedError(err)) {
           redirectToConsoleLogin();
@@ -28,8 +34,8 @@ export function InviteAcceptPage() {
         if (!cancelled) {
           setError(err instanceof Error ? err.message : "This invitation is invalid or has expired.");
         }
-      }
-    })();
+      },
+    );
     return () => {
       cancelled = true;
     };

--- a/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
@@ -3,12 +3,17 @@ import { useEffect, useState } from "react";
 import { isUnauthorizedError, redirectToConsoleLogin } from "@/api/http";
 import { acceptOrgInvitation } from "./org.api";
 
+// Survives StrictMode's double-mount so a single-use token isn't consumed twice.
+const attemptedTokens = new Set<string>();
+
 export function InviteAcceptPage() {
   const { token } = useParams({ from: "/invite/$token" });
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (attemptedTokens.has(token)) return;
+    attemptedTokens.add(token);
     let cancelled = false;
     void (async () => {
       try {

--- a/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
@@ -1,0 +1,56 @@
+import { useNavigate, useParams } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+import { isUnauthorizedError, redirectToConsoleLogin } from "@/api/http";
+import { acceptOrgInvitation } from "./org.api";
+
+export function InviteAcceptPage() {
+  const { token } = useParams({ from: "/invite/$token" });
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        await acceptOrgInvitation(token);
+        if (!cancelled) navigate({ to: "/organization" });
+      } catch (err) {
+        // Not signed in yet: bounce through login, then return here to accept.
+        if (isUnauthorizedError(err)) {
+          redirectToConsoleLogin();
+          return;
+        }
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "This invitation is invalid or has expired.");
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token, navigate]);
+
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-[#f6f7f5] px-4">
+      <div className="w-full max-w-sm rounded-[18px] border border-[#e0e4de] bg-white p-8 text-center shadow-[0_1px_2px_rgba(20,21,27,0.06)]">
+        {error ? (
+          <>
+            <h1 className="font-display text-[18px] font-semibold text-[#14151b]">Invitation problem</h1>
+            <p className="mt-2 text-sm leading-6 text-[#747780]">{error}</p>
+            <a
+              href="/"
+              className="mt-5 inline-block rounded-full bg-[#111217] px-5 py-2.5 text-sm font-semibold text-white hover:bg-[#25262c]"
+            >
+              Go to console
+            </a>
+          </>
+        ) : (
+          <>
+            <h1 className="font-display text-[18px] font-semibold text-[#14151b]">Accepting invitation…</h1>
+            <p className="mt-2 text-sm leading-6 text-[#747780]">One moment while we add you to the organization.</p>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/cloud-v2/websites/console/src/features/org/org.api.ts
+++ b/cloud-v2/websites/console/src/features/org/org.api.ts
@@ -87,7 +87,7 @@ export function inviteOrgMember(input: {
 
 export function updateOrgMemberRole(input: {
   membershipId: string;
-  role: "admin" | "member";
+  role: "owner" | "admin" | "member";
 }): Promise<{ ok: boolean; role: string }> {
   return apiRequest(
     "/console/org/members/" + encodeURIComponent(input.membershipId),

--- a/cloud-v2/websites/console/src/features/org/org.api.ts
+++ b/cloud-v2/websites/console/src/features/org/org.api.ts
@@ -74,12 +74,30 @@ export function getOrgAccess(): Promise<{
   );
 }
 
-export function inviteOrgMember(input: { email: string }): Promise<{ invitation: OrgInvitation }> {
-  return apiRequest("/console/org/invitations", z.object({ invitation: orgInvitationSchema }), {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify(input),
-  });
+export function inviteOrgMember(
+  input: { email: string },
+): Promise<{ invitation: OrgInvitation; inviteUrl: string }> {
+  return apiRequest(
+    "/console/org/invitations",
+    z.object({ invitation: orgInvitationSchema, inviteUrl: z.string() }),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(input),
+    },
+  );
+}
+
+export function acceptOrgInvitation(token: string): Promise<{ ok: boolean; org: DeveloperOrg | null }> {
+  return apiRequest(
+    "/console/org/invitations/accept",
+    z.object({ ok: z.boolean(), org: developerOrgSchema.nullable() }),
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ token }),
+    },
+  );
 }
 
 export function updateOrgMemberRole(input: {

--- a/cloud-v2/websites/console/src/features/org/org.api.ts
+++ b/cloud-v2/websites/console/src/features/org/org.api.ts
@@ -29,13 +29,16 @@ export function saveDeveloperOrg(input: {
   });
 }
 
+export const orgRoleSchema = z.enum(["owner", "admin", "member"]);
+export type OrgRole = z.infer<typeof orgRoleSchema>;
+
 export const orgMemberSchema = z.object({
   id: z.string(),
   userId: z.string(),
   email: z.string().nullable(),
   name: z.string().nullable(),
   avatarUrl: z.string().nullable(),
-  role: z.enum(["owner", "member"]),
+  role: orgRoleSchema,
   status: z.string(),
   createdAt: z.string().nullable(),
   updatedAt: z.string().nullable(),
@@ -56,6 +59,7 @@ export type OrgInvitation = z.infer<typeof orgInvitationSchema>;
 
 export function getOrgAccess(): Promise<{
   org: DeveloperOrg;
+  viewerRole: OrgRole;
   members: OrgMember[];
   invitations: OrgInvitation[];
 }> {
@@ -63,18 +67,37 @@ export function getOrgAccess(): Promise<{
     "/console/org/access",
     z.object({
       org: developerOrgSchema,
+      viewerRole: orgRoleSchema,
       members: z.array(orgMemberSchema),
       invitations: z.array(orgInvitationSchema),
     }),
   );
 }
 
-export function inviteOrgMember(input: { email: string }): Promise<{ invitation: OrgInvitation }> {
+export function inviteOrgMember(input: {
+  email: string;
+  role?: "admin" | "member";
+}): Promise<{ invitation: OrgInvitation }> {
   return apiRequest("/console/org/invitations", z.object({ invitation: orgInvitationSchema }), {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify(input),
   });
+}
+
+export function updateOrgMemberRole(input: {
+  membershipId: string;
+  role: "admin" | "member";
+}): Promise<{ ok: boolean; role: string }> {
+  return apiRequest(
+    "/console/org/members/" + encodeURIComponent(input.membershipId),
+    z.object({ ok: z.boolean(), role: z.string() }),
+    {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ role: input.role }),
+    },
+  );
 }
 
 export function revokeOrgInvitation(invitationId: string): Promise<{ ok: boolean }> {

--- a/cloud-v2/websites/console/src/features/org/org.api.ts
+++ b/cloud-v2/websites/console/src/features/org/org.api.ts
@@ -74,10 +74,7 @@ export function getOrgAccess(): Promise<{
   );
 }
 
-export function inviteOrgMember(input: {
-  email: string;
-  role?: "admin" | "member";
-}): Promise<{ invitation: OrgInvitation }> {
+export function inviteOrgMember(input: { email: string }): Promise<{ invitation: OrgInvitation }> {
   return apiRequest("/console/org/invitations", z.object({ invitation: orgInvitationSchema }), {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -18,9 +18,11 @@ import {
   removeOrgMember,
   revokeOrgInvitation,
   saveDeveloperOrg,
+  updateOrgMemberRole,
   type DeveloperOrg,
   type OrgInvitation,
   type OrgMember,
+  type OrgRole,
 } from "./org.api";
 
 export function OrganizationPage() {
@@ -39,6 +41,7 @@ export function OrganizationPage() {
   const [displayName, setDisplayName] = useState(suggested.displayName);
   const [packagePrefix, setPackagePrefix] = useState(suggested.packagePrefix);
   const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
   const accessQuery = useQuery({
     queryKey: ["developer-org-access"],
     queryFn: getOrgAccess,
@@ -90,6 +93,13 @@ export function OrganizationPage() {
       await queryClient.invalidateQueries({ queryKey: ["developer-org-access"] });
     },
   });
+  const updateMemberRole = useMutation({
+    mutationFn: updateOrgMemberRole,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["developer-org-access"] });
+    },
+  });
+  const viewerRole: OrgRole = accessQuery.data?.viewerRole ?? session.data?.viewerRole ?? "member";
   const canSave =
     displayName.trim().length >= 2 &&
     normalizedPrefix.length > 0 &&
@@ -197,12 +207,15 @@ export function OrganizationPage() {
             error={accessQuery.error}
             isLoading={accessQuery.isLoading}
             currentOrg={org}
-            currentUserId={user?.id ?? null}
+            viewerRole={viewerRole}
             inviteEmail={inviteEmail}
             setInviteEmail={setInviteEmail}
+            inviteRole={inviteRole}
+            setInviteRole={setInviteRole}
             inviteMember={inviteMember}
             revokeInvite={revokeInvite}
             removeMember={removeMember}
+            updateMemberRole={updateMemberRole}
           />
         ) : null}
       </main>
@@ -231,12 +244,25 @@ type TeamAccessSectionProps = {
   error: unknown;
   isLoading: boolean;
   currentOrg: DeveloperOrg;
-  currentUserId: string | null;
+  viewerRole: OrgRole;
   inviteEmail: string;
   setInviteEmail: (value: string) => void;
-  inviteMember: UseMutationResult<{ invitation: OrgInvitation }, Error, { email: string }, unknown>;
+  inviteRole: "admin" | "member";
+  setInviteRole: (value: "admin" | "member") => void;
+  inviteMember: UseMutationResult<
+    { invitation: OrgInvitation },
+    Error,
+    { email: string; role?: "admin" | "member" },
+    unknown
+  >;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
+  updateMemberRole: UseMutationResult<
+    { ok: boolean; role: string },
+    Error,
+    { membershipId: string; role: "admin" | "member" },
+    unknown
+  >;
 };
 
 function TeamAccessSection({
@@ -244,12 +270,15 @@ function TeamAccessSection({
   error,
   isLoading,
   currentOrg,
-  currentUserId,
+  viewerRole,
   inviteEmail,
   setInviteEmail,
+  inviteRole,
+  setInviteRole,
   inviteMember,
   revokeInvite,
   removeMember,
+  updateMemberRole,
 }: TeamAccessSectionProps) {
   const org = access?.org ?? currentOrg;
   const members = access?.members ?? [];
@@ -260,7 +289,7 @@ function TeamAccessSection({
     ...invitations.map(invitation => ({ kind: "invitation" as const, invitation })),
     ...members.map(member => ({ kind: "member" as const, member })),
   ];
-  const canManage = currentUserId === org.ownerUserId;
+  const canManage = viewerRole === "owner" || viewerRole === "admin";
   const canInvite = canManage && inviteEmail.trim().includes("@") && !inviteMember.isPending;
 
   return (
@@ -285,7 +314,7 @@ function TeamAccessSection({
             onSubmit={(event) => {
               event.preventDefault();
               if (!canInvite) return;
-              inviteMember.mutate({ email: inviteEmail.trim().toLowerCase() });
+              inviteMember.mutate({ email: inviteEmail.trim().toLowerCase(), role: inviteRole });
             }}
           >
             <div>
@@ -301,9 +330,24 @@ function TeamAccessSection({
                 onChange={event => setInviteEmail(event.target.value)}
                 disabled={!canManage}
               />
-              {!canManage ? (
-                <p className="mt-2 text-xs leading-5 text-[#8a8d95]">Only the org owner can invite or remove members.</p>
-              ) : null}
+              {canManage ? (
+                <div className="mt-2 flex items-center gap-2">
+                  <Label htmlFor="inviteRole" className="text-xs font-medium text-[#8a8d95]">
+                    Role
+                  </Label>
+                  <select
+                    id="inviteRole"
+                    value={inviteRole}
+                    onChange={event => setInviteRole(event.target.value === "admin" ? "admin" : "member")}
+                    className="h-9 rounded-[10px] border border-[#dfe3dc] bg-white px-2 text-sm text-[#1c1d22] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#9dddc7]/35"
+                  >
+                    <option value="member">Member</option>
+                    <option value="admin">Admin</option>
+                  </select>
+                </div>
+              ) : (
+                <p className="mt-2 text-xs leading-5 text-[#8a8d95]">Only owners and admins can invite or remove members.</p>
+              )}
             </div>
             <Button
               className="h-11 rounded-full bg-[#111217] px-5 text-white hover:bg-[#25262c] sm:self-end"
@@ -342,6 +386,7 @@ function TeamAccessSection({
                     canManage={canManage}
                     removeMember={removeMember}
                     revokeInvite={revokeInvite}
+                    updateMemberRole={updateMemberRole}
                   />
                 ))
               ) : (
@@ -364,11 +409,18 @@ function AccessRow({
   canManage,
   removeMember,
   revokeInvite,
+  updateMemberRole,
 }: {
   row: AccessRow;
   canManage: boolean;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
+  updateMemberRole: UseMutationResult<
+    { ok: boolean; role: string },
+    Error,
+    { membershipId: string; role: "admin" | "member" },
+    unknown
+  >;
 }) {
   if (row.kind === "invitation") {
     return <InvitationRow invitation={row.invitation} canManage={canManage} revokeInvite={revokeInvite} />;
@@ -376,10 +428,11 @@ function AccessRow({
 
   const member = row.member;
   const displayName = member.name || member.email || member.userId;
-  const subtitle = [member.email && member.name ? member.email : null, titleCase(member.status), titleCase(member.role)]
+  const subtitle = [member.email && member.name ? member.email : null, titleCase(member.status)]
     .filter(Boolean)
     .join(" · ");
-  const removable = canManage && member.role !== "owner";
+  const isOwner = member.role === "owner";
+  const canEditRole = canManage && !isOwner;
 
   return (
     <div className="flex min-h-16 items-center gap-3 border-b border-[#eceeeb] px-3 py-3 last:border-b-0 sm:px-4">
@@ -390,7 +443,26 @@ function AccessRow({
         <div className="truncate text-[15px] font-semibold text-[#14151b]">{displayName}</div>
         <div className="truncate text-xs text-[#8a8d95]">{subtitle || member.userId}</div>
       </div>
-      {removable ? (
+      {canEditRole ? (
+        <select
+          value={member.role}
+          disabled={updateMemberRole.isPending}
+          onChange={event =>
+            updateMemberRole.mutate({
+              membershipId: member.id,
+              role: event.target.value === "admin" ? "admin" : "member",
+            })
+          }
+          className="h-9 rounded-[10px] border border-[#dfe3dc] bg-white px-2 text-sm text-[#1c1d22] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#9dddc7]/35"
+          aria-label={`Role for ${displayName}`}
+        >
+          <option value="member">Member</option>
+          <option value="admin">Admin</option>
+        </select>
+      ) : (
+        <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[#8a8d95]">{titleCase(member.role)}</span>
+      )}
+      {canEditRole ? (
         <Button
           type="button"
           variant="ghost"

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -248,7 +248,12 @@ type TeamAccessSectionProps = {
   viewerRole: OrgRole;
   inviteEmail: string;
   setInviteEmail: (value: string) => void;
-  inviteMember: UseMutationResult<{ invitation: OrgInvitation }, Error, { email: string }, unknown>;
+  inviteMember: UseMutationResult<
+    { invitation: OrgInvitation; inviteUrl: string },
+    Error,
+    { email: string },
+    unknown
+  >;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   updateMemberRole: UseMutationResult<
@@ -342,7 +347,12 @@ function TeamAccessSection({
           ) : null}
           {inviteMember.isSuccess ? (
             <div className="rounded-[12px] bg-[#edf8f2] px-4 py-3 text-sm text-[#087d50]">
-              Invitation sent.
+              <div>Invitation sent by email.</div>
+              {inviteMember.data?.inviteUrl ? (
+                <div className="mt-1 break-all text-xs text-[#256953]">
+                  Or share this link: {inviteMember.data.inviteUrl}
+                </div>
+              ) : null}
             </div>
           ) : null}
 

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -41,7 +41,6 @@ export function OrganizationPage() {
   const [displayName, setDisplayName] = useState(suggested.displayName);
   const [packagePrefix, setPackagePrefix] = useState(suggested.packagePrefix);
   const [inviteEmail, setInviteEmail] = useState("");
-  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
   const accessQuery = useQuery({
     queryKey: ["developer-org-access"],
     queryFn: getOrgAccess,
@@ -210,8 +209,6 @@ export function OrganizationPage() {
             viewerRole={viewerRole}
             inviteEmail={inviteEmail}
             setInviteEmail={setInviteEmail}
-            inviteRole={inviteRole}
-            setInviteRole={setInviteRole}
             inviteMember={inviteMember}
             revokeInvite={revokeInvite}
             removeMember={removeMember}
@@ -247,14 +244,7 @@ type TeamAccessSectionProps = {
   viewerRole: OrgRole;
   inviteEmail: string;
   setInviteEmail: (value: string) => void;
-  inviteRole: "admin" | "member";
-  setInviteRole: (value: "admin" | "member") => void;
-  inviteMember: UseMutationResult<
-    { invitation: OrgInvitation },
-    Error,
-    { email: string; role?: "admin" | "member" },
-    unknown
-  >;
+  inviteMember: UseMutationResult<{ invitation: OrgInvitation }, Error, { email: string }, unknown>;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   updateMemberRole: UseMutationResult<
@@ -273,8 +263,6 @@ function TeamAccessSection({
   viewerRole,
   inviteEmail,
   setInviteEmail,
-  inviteRole,
-  setInviteRole,
   inviteMember,
   revokeInvite,
   removeMember,
@@ -314,7 +302,7 @@ function TeamAccessSection({
             onSubmit={(event) => {
               event.preventDefault();
               if (!canInvite) return;
-              inviteMember.mutate({ email: inviteEmail.trim().toLowerCase(), role: inviteRole });
+              inviteMember.mutate({ email: inviteEmail.trim().toLowerCase() });
             }}
           >
             <div>
@@ -330,24 +318,9 @@ function TeamAccessSection({
                 onChange={event => setInviteEmail(event.target.value)}
                 disabled={!canManage}
               />
-              {canManage ? (
-                <div className="mt-2 flex items-center gap-2">
-                  <Label htmlFor="inviteRole" className="text-xs font-medium text-[#8a8d95]">
-                    Role
-                  </Label>
-                  <select
-                    id="inviteRole"
-                    value={inviteRole}
-                    onChange={event => setInviteRole(event.target.value === "admin" ? "admin" : "member")}
-                    className="h-9 rounded-[10px] border border-[#dfe3dc] bg-white px-2 text-sm text-[#1c1d22] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#9dddc7]/35"
-                  >
-                    <option value="member">Member</option>
-                    <option value="admin">Admin</option>
-                  </select>
-                </div>
-              ) : (
+              {!canManage ? (
                 <p className="mt-2 text-xs leading-5 text-[#8a8d95]">Only owners and admins can invite or remove members.</p>
-              )}
+              ) : null}
             </div>
             <Button
               className="h-11 rounded-full bg-[#111217] px-5 text-white hover:bg-[#25262c] sm:self-end"
@@ -385,7 +358,6 @@ function TeamAccessSection({
                     row={row}
                     canManage={canManage}
                     viewerRole={viewerRole}
-                    ownerUserId={org.ownerUserId}
                     removeMember={removeMember}
                     revokeInvite={revokeInvite}
                     updateMemberRole={updateMemberRole}
@@ -410,7 +382,6 @@ function AccessRow({
   row,
   canManage,
   viewerRole,
-  ownerUserId,
   removeMember,
   revokeInvite,
   updateMemberRole,
@@ -418,7 +389,6 @@ function AccessRow({
   row: AccessRow;
   canManage: boolean;
   viewerRole: OrgRole;
-  ownerUserId: string;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   updateMemberRole: UseMutationResult<
@@ -437,12 +407,10 @@ function AccessRow({
   const subtitle = [member.email && member.name ? member.email : null, titleCase(member.status)]
     .filter(Boolean)
     .join(" · ");
-  const isPrimaryOwner = member.userId === ownerUserId; // the creator — never editable
   const targetIsOwner = member.role === "owner";
   const viewerIsOwner = viewerRole === "owner";
-  // Admins manage members/admins; only an owner can edit or remove a co-owner;
-  // the primary owner is fixed.
-  const canEditRole = canManage && !isPrimaryOwner && (!targetIsOwner || viewerIsOwner);
+  // Admins manage members/admins; only an owner can edit or remove another owner.
+  const canEditRole = canManage && (!targetIsOwner || viewerIsOwner);
 
   return (
     <div className="flex min-h-16 items-center gap-3 border-b border-[#eceeeb] px-3 py-3 last:border-b-0 sm:px-4">

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -99,7 +99,11 @@ export function OrganizationPage() {
     },
   });
   const viewerRole: OrgRole = accessQuery.data?.viewerRole ?? session.data?.viewerRole ?? "member";
+  // Editing an existing org is owner-only (server-enforced); onboarding (no org
+  // yet) is always allowed since the creator becomes the owner.
+  const canEditOrg = !org || viewerRole === "owner";
   const canSave =
+    canEditOrg &&
     displayName.trim().length >= 2 &&
     normalizedPrefix.length > 0 &&
     !orgSave.isPending &&

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -260,7 +260,7 @@ type TeamAccessSectionProps = {
   updateMemberRole: UseMutationResult<
     { ok: boolean; role: string },
     Error,
-    { membershipId: string; role: "admin" | "member" },
+    { membershipId: string; role: "owner" | "admin" | "member" },
     unknown
   >;
 };
@@ -384,6 +384,8 @@ function TeamAccessSection({
                     key={row.kind === "invitation" ? `invite:${row.invitation.id}` : `member:${row.member.id}`}
                     row={row}
                     canManage={canManage}
+                    viewerRole={viewerRole}
+                    ownerUserId={org.ownerUserId}
                     removeMember={removeMember}
                     revokeInvite={revokeInvite}
                     updateMemberRole={updateMemberRole}
@@ -407,18 +409,22 @@ type AccessRow =
 function AccessRow({
   row,
   canManage,
+  viewerRole,
+  ownerUserId,
   removeMember,
   revokeInvite,
   updateMemberRole,
 }: {
   row: AccessRow;
   canManage: boolean;
+  viewerRole: OrgRole;
+  ownerUserId: string;
   removeMember: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   revokeInvite: UseMutationResult<{ ok: boolean }, Error, string, unknown>;
   updateMemberRole: UseMutationResult<
     { ok: boolean; role: string },
     Error,
-    { membershipId: string; role: "admin" | "member" },
+    { membershipId: string; role: "owner" | "admin" | "member" },
     unknown
   >;
 }) {
@@ -431,8 +437,12 @@ function AccessRow({
   const subtitle = [member.email && member.name ? member.email : null, titleCase(member.status)]
     .filter(Boolean)
     .join(" · ");
-  const isOwner = member.role === "owner";
-  const canEditRole = canManage && !isOwner;
+  const isPrimaryOwner = member.userId === ownerUserId; // the creator — never editable
+  const targetIsOwner = member.role === "owner";
+  const viewerIsOwner = viewerRole === "owner";
+  // Admins manage members/admins; only an owner can edit or remove a co-owner;
+  // the primary owner is fixed.
+  const canEditRole = canManage && !isPrimaryOwner && (!targetIsOwner || viewerIsOwner);
 
   return (
     <div className="flex min-h-16 items-center gap-3 border-b border-[#eceeeb] px-3 py-3 last:border-b-0 sm:px-4">
@@ -447,17 +457,19 @@ function AccessRow({
         <select
           value={member.role}
           disabled={updateMemberRole.isPending}
-          onChange={event =>
+          onChange={event => {
+            const next = event.target.value;
             updateMemberRole.mutate({
               membershipId: member.id,
-              role: event.target.value === "admin" ? "admin" : "member",
-            })
-          }
+              role: next === "owner" ? "owner" : next === "admin" ? "admin" : "member",
+            });
+          }}
           className="h-9 rounded-[10px] border border-[#dfe3dc] bg-white px-2 text-sm text-[#1c1d22] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#9dddc7]/35"
           aria-label={`Role for ${displayName}`}
         >
           <option value="member">Member</option>
           <option value="admin">Admin</option>
+          {viewerIsOwner ? <option value="owner">Owner</option> : null}
         </select>
       ) : (
         <span className="text-xs font-semibold uppercase tracking-[0.08em] text-[#8a8d95]">{titleCase(member.role)}</span>

--- a/cloud-v2/websites/console/src/features/session/session.api.ts
+++ b/cloud-v2/websites/console/src/features/session/session.api.ts
@@ -10,6 +10,7 @@ export const consoleSessionSchema = z.object({
     lastName: z.string().nullable().optional(),
   }),
   onboardingRequired: z.boolean(),
+  viewerRole: z.enum(["owner", "admin", "member"]).nullable().optional(),
   organizationId: z.string().nullable().optional(),
   packagePrefix: z.string().nullable(),
   packagePrefixStatus: z.enum(["unverified", "verified", "rejected"]).nullable(),

--- a/cloud-v2/websites/console/src/features/session/session.queries.ts
+++ b/cloud-v2/websites/console/src/features/session/session.queries.ts
@@ -6,4 +6,7 @@ export const sessionQuery = () =>
     queryKey: ["console-session"],
     queryFn: getConsoleSession,
     retry: false,
+    // Refresh the viewer's role on tab focus so a just-promoted user's UI
+    // (e.g. the API-keys page gate) reflects their new role without a reload.
+    refetchOnWindowFocus: true,
   });

--- a/cloud-v2/websites/console/src/features/tokens/tokens-page.tsx
+++ b/cloud-v2/websites/console/src/features/tokens/tokens-page.tsx
@@ -15,6 +15,7 @@ export function TokensPage() {
   const session = useQuery(sessionQuery());
   const tokens = useQuery(apiTokensQuery(session.isSuccess && !session.data.onboardingRequired));
   const tokenList = tokens.data?.tokens ?? [];
+  const canManageKeys = session.data?.viewerRole === "owner" || session.data?.viewerRole === "admin";
   const [tokenName, setTokenName] = useState("");
   const [createdToken, setCreatedToken] = useState<ApiToken | null>(null);
   const [copied, setCopied] = useState(false);
@@ -41,7 +42,7 @@ export function TokensPage() {
       await queryClient.invalidateQueries({ queryKey: ["api-tokens"] });
     },
   });
-  const canCreate = tokenName.trim().length > 0 && !createToken.isPending;
+  const canCreate = canManageKeys && tokenName.trim().length > 0 && !createToken.isPending;
 
   async function copyCreatedToken() {
     if (!createdToken?.value) return;
@@ -89,11 +90,17 @@ export function TokensPage() {
                 <CardDescription className="mt-1 text-[13px] leading-5 sm:text-[14px]">
                   Keys are scoped to this org and can be revoked at any time.
                 </CardDescription>
+                {!canManageKeys ? (
+                  <p className="mt-1 text-xs leading-5 text-[#8a8d95]">
+                    Only owners and admins can create or revoke API keys.
+                  </p>
+                ) : null}
               </div>
               <Button
                 type="button"
                 className="h-10 rounded-full bg-[#111217] px-5 text-white hover:bg-[#25262c]"
                 onClick={() => setCreateFormOpen(open => !open)}
+                disabled={!canManageKeys}
               >
                 {createFormOpen ? "Cancel" : "Create API key"}
               </Button>
@@ -155,6 +162,7 @@ export function TokensPage() {
                     <TokenRow
                       key={token.id}
                       token={token}
+                      canRevoke={canManageKeys}
                       isRevoking={revokeToken.isPending}
                       onRevoke={() => revokeToken.mutate(token.id)}
                     />
@@ -244,10 +252,12 @@ function CreateApiKeyForm({
 
 function TokenRow({
   token,
+  canRevoke,
   isRevoking,
   onRevoke,
 }: {
   token: ApiToken;
+  canRevoke: boolean;
   isRevoking: boolean;
   onRevoke: () => void;
 }) {
@@ -263,17 +273,21 @@ function TokenRow({
         <div>{token.createdAt ? `Created ${formatDate(token.createdAt)}` : "Created recently"}</div>
         <div>{token.lastUsedAt ? `Used ${formatDate(token.lastUsedAt)}` : "Never used"}</div>
       </div>
-      <Button
-        type="button"
-        variant="ghost"
-        size="icon-sm"
-        className="justify-self-start rounded-full text-[#8a8d95] hover:bg-[#fff3f1] hover:text-[#a64235] md:justify-self-end"
-        disabled={isRevoking}
-        onClick={onRevoke}
-        aria-label={`Revoke ${token.name}`}
-      >
-        <Trash2 className="size-4" />
-      </Button>
+      {canRevoke ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          className="justify-self-start rounded-full text-[#8a8d95] hover:bg-[#fff3f1] hover:text-[#a64235] md:justify-self-end"
+          disabled={isRevoking}
+          onClick={onRevoke}
+          aria-label={`Revoke ${token.name}`}
+        >
+          <Trash2 className="size-4" />
+        </Button>
+      ) : (
+        <span className="md:justify-self-end" />
+      )}
     </div>
   );
 }

--- a/cloud-v2/websites/console/src/router.tsx
+++ b/cloud-v2/websites/console/src/router.tsx
@@ -4,6 +4,7 @@ import { OrganizationSelectionPage } from "@/components/organization-selection-p
 import { AppsPage } from "@/features/apps/apps-page";
 import { MiniappDetailPage } from "@/features/apps/miniapp-detail-page";
 import { DashboardPage } from "@/features/dashboard/dashboard-page";
+import { InviteAcceptPage } from "@/features/org/invite-accept-page";
 import { OrganizationPage } from "@/features/org/organization-page";
 import { TokensPage } from "@/features/tokens/tokens-page";
 
@@ -57,6 +58,12 @@ const organizationRoute = createRoute({
   component: OrganizationPage,
 });
 
+const inviteAcceptRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/invite/$token",
+  component: InviteAcceptPage,
+});
+
 const routeTree = rootRoute.addChildren([
   loginRoute,
   organizationSelectionRoute,
@@ -65,6 +72,7 @@ const routeTree = rootRoute.addChildren([
   miniappDetailRoute,
   tokensRoute,
   organizationRoute,
+  inviteAcceptRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -68,10 +68,11 @@ MAPBOX_DOWNLOADS_TOKEN=sk-ci-dummy-not-a-real-token
 # EXPO_PUBLIC_STORE_URL_OVERRIDE=https://appsbeta.mentraglass.com
 
 # Cloud V2 (core + runtime) default endpoints, applied at build time. Point
-# every build at the Debug cloud by default. An in-app Dev Settings override
-# still wins over these (see mobile/src/services/cloudClient.ts resolveUrl).
-EXPO_PUBLIC_CLOUD_CORE_URL=https://core.debug.us-west-2.mentraglass.com
-EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.debug.us-west-2.mentraglass.com
+# every build at the Cloud V2 Dev environment by default (it auto-deploys from
+# the dev branch). An in-app Dev Settings override still wins over these (see
+# mobile/src/services/cloudClient.ts resolveUrl).
+EXPO_PUBLIC_CLOUD_CORE_URL=https://core.dev.us-west-2.mentraglass.com
+EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 
 
 # NEEDED FOR RELEASE BUILDING

--- a/mobile/src/services/cloudClient.ts
+++ b/mobile/src/services/cloudClient.ts
@@ -29,14 +29,14 @@ const LOG_TAG = "cloudClient"
 
 type Lc3FrameSizeBytes = 20 | 40 | 60
 
-// Team-friendly defaults for dev builds. Point every build at the Debug cloud
-// by default so a local build with no EXPO_PUBLIC_CLOUD_* env (see
-// .env.example) matches CI instead of silently diverging onto Cloud Dev. Local
-// Cloud V2 is still one tap away via the METRO_AUTO dev-settings preset; it
-// should not be the invisible default because it depends on a local stack plus
-// adb reverse/LAN reachability.
-const DEFAULT_CORE_URL = "https://core.debug.us-west-2.mentraglass.com"
-const DEFAULT_RUNTIME_URL = "https://runtime.debug.us-west-2.mentraglass.com"
+// Team-friendly defaults for dev builds. Point every build at the Cloud V2 Dev
+// environment by default so a local build with no EXPO_PUBLIC_CLOUD_* env (see
+// .env.example) matches the deployed `dev` cloud, which auto-deploys from the
+// dev branch. Local Cloud V2 is still one tap away via the METRO_AUTO
+// dev-settings preset; it should not be the invisible default because it
+// depends on a local stack plus adb reverse/LAN reachability.
+const DEFAULT_CORE_URL = "https://core.dev.us-west-2.mentraglass.com"
+const DEFAULT_RUNTIME_URL = "https://runtime.dev.us-west-2.mentraglass.com"
 
 const CORE_PORT = 3000
 const RUNTIME_PORT = 3001
@@ -54,7 +54,7 @@ function metroUrl(port: number): string | undefined {
  *      resolves to the CURRENT Metro host so "my laptop" survives the laptop
  *      changing networks;
  *   2. env (EXPO_PUBLIC_CLOUD_*) — for CI/staging builds, never personal IPs;
- *   3. Cloud Debug — the default shared backend for team testing.
+ *   3. Cloud Dev — the default shared backend for team testing.
  * Read via the settings store's `getState()` accessor (not a hook) so this
  * service stays React-free.
  */


### PR DESCRIPTION
## Why

Two things from setting up the Mentra org on the new Cloud V2 developer console:

1. **Permissions were owner-only.** Every team and API-key action was gated on a single org owner (`DeveloperOrg.ownerUserId`) via `isOrgOwner()`. A member added to an org hit `only the org owner can create API keys` / `only the org owner can invite or remove members`, with no way to grant anyone else access. There was no role concept at all — the member list even hardcoded `ownerUserId ? "owner" : "member"`.
2. **The mobile app defaulted at the Debug cloud.** Now that Cloud V2 Dev auto-deploys from the `dev` branch, the default should be Dev.

## What this does

### Roles live in our DB (not WorkOS)

WorkOS stays identity/login + the member roster only; the permission tier is a Mentra-console concept owned entirely in our database.

- **New `DeveloperOrgMembership` collection** stores the `admin`/`member` overlay, keyed by lowercased email (the identifier we have at invite time *and* at login), with `userId` backfilled on first resolve. `owner` stays the single `DeveloperOrg.ownerUserId` — it is never written here.
- **`resolveOrgRole()` + `roleAtLeast()`** replace the `isOrgOwner` gates. Invite, remove-member, revoke-invite, and **create/revoke API key** now require **admin-or-owner** instead of owner-only.
- **Invite carries a role** (`admin`/`member`, default member), recorded in our DB so it materializes onto the membership when the invitee first signs in.
- **New `PATCH /org/members/:membershipId`** changes a member's role (admin+); the owner can't be demoted/changed.
- **`viewerRole`** is returned on `/auth/me` and `/org/access`; the console **org page** (invite + per-member role dropdown) and **API-keys page** (create/revoke) gate their controls on it.

Permission matrix:

| Action | member | admin | owner |
|---|:--:|:--:|:--:|
| View org / apps / members / keys | ✅ | ✅ | ✅ |
| Create/edit/delete apps + releases | ✅ | ✅ | ✅ |
| Create / revoke API keys | ❌ | ✅ | ✅ |
| Invite / remove members, revoke invites | ❌ | ✅ | ✅ |
| Change a member's role | ❌ | ✅ | ✅ |
| Rename org / delete org / change owner's role | ❌ | ❌ | ✅ |

### Mobile default → Cloud V2 Dev

`cloudClient.ts` default + `.env.example` (the CI/release source) now point at `core/runtime.dev.us-west-2.mentraglass.com` instead of `debug`. The in-app Dev Settings override still wins.

## Rollout note

Existing org members have **no membership row yet**, so they resolve to `member` after deploy. The **owner promotes them to `admin`** from the org page (or re-invites as admin). This is intentional — we don't auto-grant admin to everyone.

## Verification

- `tsc -b packages/core` → clean (exit 0); console `tsc --noEmit` → clean.
- Manually traced owner / admin / member through every gated path and the email→userId materialization.
- **Follow-up:** add an integration test for the matrix in the `cli-auth` suite — the existing cloud-v2 test harness is live-infra integration (Mongo + WorkOS), so it's a separate, non-trivial add rather than bundled here.

## Out of scope (separate PRs)

- The WorkOS invitation-email redirect bouncing to `localhost` (config + a PKCE-callback fix) — separate.
- Re-homing API keys off WorkOS into Mentra-issued keys — separate design PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication (API key validation, org resolution), authorization across console APIs, and boot-time data migrations that can change who has access after deploy; existing members without rows may need promotion until backfill completes.
> 
> **Overview**
> Moves developer-console **team access off WorkOS** into Mongo: **membership roles** (`owner` / `admin` / `member`), **invitations**, and **API keys** are owned in-app; WorkOS stays login/SSO and optional org linking only.
> 
> **Permissions:** `isOrgOwner` is replaced by **`resolveOrgRole`** / **`roleAtLeast`**. Admins (and owners) can invite, revoke invites, remove members, and create/revoke API keys; **org updates stay owner-only**. Owner changes/removals are **last-owner guarded** (with rollback on races). **`viewerRole`** is exposed on `/auth/me` and `/org/access`; the console gates org edit, team management, and API keys on it (session refetches on window focus).
> 
> **Invites:** `POST /org/invitations` mints DB invites (hashed token), returns **`inviteUrl`**, and sends email via Resend (best-effort). **`POST /org/invitations/accept`** enforces email match, one org per user, and atomic single-use claim (with un-claim on membership failure). New **`/invite/$token`** page accepts after login.
> 
> **API keys:** WorkOS org API keys → **`DeveloperApiKeyService`** tokens `msk_<env>_<keyId>.<secret>` (hashed secret, env-pinned validation). Bearer auth resolves **`developerOrgId`** from the new store.
> 
> **Org resolution:** Session org comes from creator org, membership roster, or API-key principal — **no auto-join from WorkOS `org_id`** (avoids resurrecting removed members).
> 
> **Migrations on boot:** dedupe memberships, seed creators as owners, partial-unique indexes (one org per user, one pending invite per email), one-time WorkOS roster backfill (`membersMigratedAt`).
> 
> **Mobile:** default `EXPO_PUBLIC_CLOUD_*` and `cloudClient.ts` fallbacks switch from **debug** to **dev** Cloud V2 hosts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6de62d29895a2bf03346acdba8b0d26c1bfdce7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved org roles, membership, invitations, and API keys into our DB (WorkOS is now login/SSO only) and set the mobile app’s default Cloud V2 endpoints to Dev. This adds clear permissions, safer keys, simpler onboarding, and better defaults.

- **New Features**
  - Roles and roster live in `DeveloperOrgMembership` (`owner`/`admin`/`member`). `viewerRole` is returned by `/auth/me` and `/org/access`; the console gates actions on it; the session refetches on focus. `/auth/me` ensures a roster row + profile and self‑heals the creator’s owner row only if the org has no owners. Org resolution uses our roster or creator only (no auto‑join from WorkOS); API‑key principals carry `developerOrgId`.
  - Invitations in `developer_org_invitations` with single‑use, atomically claimed tokens (expired invites auto‑revoke on peek). `POST /org/invitations` returns an `inviteUrl` and emails via Resend; `POST /org/invitations/accept` requires the invited email, enforces one org per user, and un‑claims on failure. Console adds `/invite/$token` and caches the in‑flight accept to avoid a StrictMode double‑mount stuck state.
  - Member management: `PATCH /org/members/:membershipId` changes roles (only owners can grant/change/remove owners; last‑owner guard with rollback), `DELETE /org/members/:membershipId` removes members and reassigns the creator pointer if needed. `GET /org/access` returns members and non‑expired invitations from our DB.
  - Org editing and WorkOS link: `PUT /org` creates the first org or owner‑only updates the existing one; any owner can link the WorkOS org. `DeveloperOrg.ownerUserId` is creator‑only and no longer implies a role.
  - Developer API keys live in `developer_org_api_keys`. Tokens are `msk_<env>_<keyId>.<secret>` (hashed secret, last4, soft revoke) with env‑pinned, constant‑time validation. `GET/POST/DELETE /tokens` use the new service; listing is scoped to the current environment; bearer auth validates against it and sets `developerOrgId`.
  - Mobile: default Cloud V2 endpoints switch to Dev (`core.dev` / `runtime.dev`).

- **Migration**
  - Seed creators as owners (force‑set to avoid zero‑owner race) and dedupe duplicate `(orgId,userId)` rows (highest role wins) before building unique indexes; create indexes before any upserts and continue boot on failure. Add a partial‑unique `userId` index (string‑only) to DB‑enforce one org per user.
  - Backfill the roster from WorkOS once with pagination, skipping users already on another org. Mark `membersMigratedAt` only after all pages succeed so a mid‑page failure retries next boot.
  - Drop any legacy `(orgId,email)` invitation index and create a partial‑unique `(orgId,email)` index to enforce one pending invite per email.

<sup>Written for commit 308a9a2510ca10d8542121688fa6cad3c83f82b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3288?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

