### PR TITLE
Default Cloud V2 mobile endpoints to Dev instead of Debug

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -68,10 +68,10 @@ MAPBOX_DOWNLOADS_TOKEN=sk-ci-dummy-not-a-real-token
 # EXPO_PUBLIC_STORE_URL_OVERRIDE=https://appsbeta.mentraglass.com
 
 # Cloud V2 (core + runtime) default endpoints, applied at build time. Point
-# every build at the Debug cloud by default. An in-app Dev Settings override
+# every build at the Dev cloud by default. An in-app Dev Settings override
 # still wins over these (see mobile/src/services/cloudClient.ts resolveUrl).
-EXPO_PUBLIC_CLOUD_CORE_URL=https://core.debug.us-west-2.mentraglass.com
-EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.debug.us-west-2.mentraglass.com
+EXPO_PUBLIC_CLOUD_CORE_URL=https://core.dev.us-west-2.mentraglass.com
+EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 
 
 # NEEDED FOR RELEASE BUILDING

--- a/mobile/src/services/cloudClient.ts
+++ b/mobile/src/services/cloudClient.ts
@@ -29,14 +29,14 @@ const LOG_TAG = "cloudClient"
 
 type Lc3FrameSizeBytes = 20 | 40 | 60
 
-// Team-friendly defaults for dev builds. Point every build at the Debug cloud
+// Team-friendly defaults for dev builds. Point every build at the Dev cloud
 // by default so a local build with no EXPO_PUBLIC_CLOUD_* env (see
-// .env.example) matches CI instead of silently diverging onto Cloud Dev. Local
-// Cloud V2 is still one tap away via the METRO_AUTO dev-settings preset; it
-// should not be the invisible default because it depends on a local stack plus
-// adb reverse/LAN reachability.
-const DEFAULT_CORE_URL = "https://core.debug.us-west-2.mentraglass.com"
-const DEFAULT_RUNTIME_URL = "https://runtime.debug.us-west-2.mentraglass.com"
+// .env.example) matches CI instead of silently diverging. Local Cloud V2 is
+// still one tap away via the METRO_AUTO dev-settings preset; it should not be
+// the invisible default because it depends on a local stack plus adb
+// reverse/LAN reachability.
+const DEFAULT_CORE_URL = "https://core.dev.us-west-2.mentraglass.com"
+const DEFAULT_RUNTIME_URL = "https://runtime.dev.us-west-2.mentraglass.com"
 
 const CORE_PORT = 3000
 const RUNTIME_PORT = 3001


### PR DESCRIPTION
## What

Change the mobile client's default Cloud V2 endpoints from **Debug** to **Dev** — both the compiled fallback and the `.env.example` used by CI staging builds.

## Why

Dev is the intended default backend for the mobile client; Debug was the prior default.

## Changes

- `mobile/src/services/cloudClient.ts` — `DEFAULT_CORE_URL` / `DEFAULT_RUNTIME_URL` now point at `core.dev` / `runtime.dev` (was `.debug`). Comment updated to match.
- `mobile/.env.example` — `EXPO_PUBLIC_CLOUD_CORE_URL` / `EXPO_PUBLIC_CLOUD_RUNTIME_URL` now point at Dev. This is what CI staging builds `cp` into `.env`.

The in-app Dev Settings override (and the `METRO_AUTO` local preset) still take precedence — this only changes the invisible default when no env or override is set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Environment default URL swap only; no changes to auth, connection logic, or override precedence.
> 
> **Overview**
> **Default Cloud V2 backend** for the mobile app is now **Dev** (`core.dev` / `runtime.dev`) instead of **Debug**, when neither in-app Dev Settings nor `EXPO_PUBLIC_CLOUD_*` env vars are set.
> 
> `DEFAULT_CORE_URL` and `DEFAULT_RUNTIME_URL` in `cloudClient.ts` and the matching entries in `.env.example` (used when CI copies env for staging builds) are updated so local builds without cloud env align with the intended shared backend. **In-app overrides** and the **METRO_AUTO** local preset are unchanged and still take precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e5a3634c2998d2a3491b21607656298dc47c8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the mobile app’s Cloud V2 endpoints to Dev instead of Debug. Updates the code fallback in `mobile/src/services/cloudClient.ts` and the build-time defaults in `mobile/.env.example`, so local and CI staging builds hit Dev unless an env var or in-app override (`METRO_AUTO`) is set.

<sup>Written for commit d7e5a3634c2998d2a3491b21607656298dc47c8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

