### PR TITLE
Add npm CI/CD and cut first dev release for the miniapp SDK + Cloud V2 packages

### DIFF
--- a/.github/scripts/miniapp-sdk-release-info.mjs
+++ b/.github/scripts/miniapp-sdk-release-info.mjs
@@ -18,8 +18,12 @@
 import {execFileSync} from 'node:child_process';
 import {readFileSync} from 'node:fs';
 
-// Ordered: the scaffolder's template pins @mentra/miniapp + @mentra/miniapp-cli,
-// so publish those first.
+// Ordered by dependency so a max-parallel:1 matrix publishes in an order where
+// downstream pins resolve once their base lands:
+//   - the scaffolder's template pins @mentra/miniapp + @mentra/miniapp-cli
+//   - the Cloud V2 CLI (@mentra/cli) has a workspace `file:` dep on
+//     @mentra/miniapp-cli that the publish job rewrites to an exact version
+//     (see .github/scripts/rewrite-file-deps.mjs), so miniapp-cli publishes first.
 const PACKAGES = [
   {
     key: 'miniapp',
@@ -29,7 +33,7 @@ const PACKAGES = [
     buildCmd: 'bun run build',
   },
   {
-    key: 'cli',
+    key: 'miniapp-cli',
     path: 'sdk/miniapp-cli/package.json',
     dir: 'sdk/miniapp-cli',
     installDir: 'sdk',
@@ -40,6 +44,27 @@ const PACKAGES = [
     path: 'sdk/create-mentra-miniapp/package.json',
     dir: 'sdk/create-mentra-miniapp',
     installDir: 'sdk',
+    buildCmd: '',
+  },
+  {
+    // Cloud V2 auth helper for miniapp backends (JWKS token verification).
+    // Leaf package, compiled to dist/ via `tsc -b`, Node-compatible.
+    key: 'auth',
+    path: 'cloud-v2/packages/auth/package.json',
+    dir: 'cloud-v2/packages/auth',
+    installDir: 'cloud-v2',
+    buildCmd: 'bun run build',
+  },
+  {
+    // Cloud V2 developer CLI (`mentra`). Wraps @mentra/miniapp-cli (dev/build/pack)
+    // and adds login / org / miniapps / releases / publish. Bun-only, no build
+    // step (ships raw .ts under a `#!/usr/bin/env bun` shebang). Its `file:` dep
+    // on @mentra/miniapp-cli is rewritten to an exact version before packing, so
+    // it must come after miniapp-cli in this list.
+    key: 'cli',
+    path: 'cloud-v2/packages/cli/package.json',
+    dir: 'cloud-v2/packages/cli',
+    installDir: 'cloud-v2',
     buildCmd: '',
   },
 ];

--- a/.github/scripts/rewrite-file-deps.mjs
+++ b/.github/scripts/rewrite-file-deps.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Rewrites workspace `file:` dependencies in a package's package.json to the
+// referenced package's exact version, so the tarball npm publishes is installable
+// by end users. npm does not resolve `file:` specifiers for consumers — it ships
+// the literal `file:../..` string, which breaks `npm install` of the tarball — so
+// the wrapper must point at a real published version instead.
+//
+// Runs on every package in the release matrix and is a no-op for packages with no
+// `file:` deps (miniapp, miniapp-cli, create, auth). Today only @mentra/cli hits
+// it, for its `@mentra/miniapp-cli` link.
+//
+// The pin is the referenced package's *exact* version. A wrapper and its base
+// publish together in the same run, and an exact pin is dist-tag-agnostic: it
+// resolves regardless of which tag (latest/beta/dev/alpha) the base was shipped
+// under. The tradeoff is that a base bump requires republishing the wrapper to
+// pick it up — acceptable while these are pre-1.0/alpha.
+//
+// Usage: node rewrite-file-deps.mjs <packageDir>
+import {readFileSync, writeFileSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+const pkgDir = process.argv[2];
+if (!pkgDir) {
+  console.error('usage: rewrite-file-deps.mjs <packageDir>');
+  process.exit(1);
+}
+
+const pkgPath = resolve(pkgDir, 'package.json');
+const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+const label = pkg.name || pkgDir;
+
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+let changed = 0;
+
+for (const field of DEP_FIELDS) {
+  const deps = pkg[field];
+  if (!deps) continue;
+  for (const [name, spec] of Object.entries(deps)) {
+    if (typeof spec !== 'string' || !spec.startsWith('file:')) continue;
+    const targetPath = resolve(pkgDir, spec.slice('file:'.length), 'package.json');
+    let target;
+    try {
+      target = JSON.parse(readFileSync(targetPath, 'utf8'));
+    } catch (err) {
+      throw new Error(`${label}: cannot resolve file: dep ${name} -> ${spec} (${targetPath}): ${err.message}`);
+    }
+    if (!target.version) throw new Error(`${label}: referenced package ${targetPath} has no version`);
+    const pinned = target.version;
+    console.log(`${label}: ${field}.${name}  ${spec} -> ${pinned}`);
+    deps[name] = pinned;
+    changed++;
+  }
+}
+
+if (changed === 0) {
+  console.log(`${label}: no file: deps to rewrite`);
+} else {
+  writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(`${label}: rewrote ${changed} file: dep(s)`);
+}

--- a/.github/scripts/stamp-template-versions.mjs
+++ b/.github/scripts/stamp-template-versions.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// Stamps a scaffolder's template/package.json dependency pins to the exact
+// versions of the monorepo packages being published in this run, so a project
+// scaffolded from the *published* tarball installs cleanly on any channel.
+//
+// Why: create-mentra-miniapp's template pins @mentra/miniapp + @mentra/miniapp-cli
+// with caret ranges (^0.3.0) for source readability, but a caret excludes
+// prereleases — so a project scaffolded off a dev-channel build (only 0.3.0-dev.0
+// on npm, no stable 0.3.0) can't `bun install`. Stamping the concrete published
+// version fixes it for every channel at once.
+//
+// Runs at publish time on the packed checkout only and is NEVER committed — same
+// contract as rewrite-file-deps.mjs. The repo keeps the caret pins. No-op for any
+// package without a template/package.json.
+//
+// Pin style: a prerelease is pinned *exact* (0.3.0-dev.0) — a caret over a
+// prerelease is surprising, and an exact prerelease installs regardless of which
+// dist-tag it sits on. A stable version keeps a caret (^0.3.2) so patches float.
+//
+// Usage: node stamp-template-versions.mjs <packageDir>
+import {readFileSync, writeFileSync, existsSync} from 'node:fs';
+import {resolve} from 'node:path';
+
+// Template dependency name -> source package.json (repo-root-relative) whose
+// `version` is the source of truth for the stamp.
+const SOURCES = {
+  '@mentra/miniapp': 'mobile/modules/miniapp/package.json',
+  '@mentra/miniapp-cli': 'sdk/miniapp-cli/package.json',
+};
+
+const pkgDir = process.argv[2];
+if (!pkgDir) {
+  console.error('usage: stamp-template-versions.mjs <packageDir>');
+  process.exit(1);
+}
+
+const templatePath = resolve(pkgDir, 'template/package.json');
+if (!existsSync(templatePath)) {
+  console.log(`${pkgDir}: no template/package.json — nothing to stamp`);
+  process.exit(0);
+}
+
+function pinFor(name) {
+  const src = SOURCES[name];
+  if (!src) return null;
+  const version = JSON.parse(readFileSync(resolve(src), 'utf8')).version;
+  if (!version) throw new Error(`${src} has no version`);
+  return version.includes('-') ? version : `^${version}`;
+}
+
+const tpl = JSON.parse(readFileSync(templatePath, 'utf8'));
+const FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
+let changed = 0;
+
+for (const field of FIELDS) {
+  const deps = tpl[field];
+  if (!deps) continue;
+  for (const name of Object.keys(deps)) {
+    const pin = pinFor(name);
+    if (!pin || deps[name] === pin) continue;
+    console.log(`template ${field}.${name}  ${deps[name]} -> ${pin}`);
+    deps[name] = pin;
+    changed++;
+  }
+}
+
+if (changed === 0) {
+  console.log(`${templatePath}: no @mentra pins to stamp`);
+} else {
+  writeFileSync(templatePath, JSON.stringify(tpl, null, 2) + '\n');
+  console.log(`stamped ${changed} template pin(s)`);
+}

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -1,16 +1,22 @@
 name: Release Miniapp SDK
 
-# Publishes the @mentra/miniapp SDK family to npm.
+# Publishes the @mentra/miniapp SDK family + the Cloud V2 developer packages to
+# npm: @mentra/miniapp, @mentra/miniapp-cli, create-mentra-miniapp, @mentra/auth,
+# and @mentra/cli.
 #
 # Channel = branch -> dist-tag (derived from the package version's prerelease label):
 #   main     -> latest   (X.Y.Z)
 #   staging  -> beta     (X.Y.Z-beta.N)
 #   dev      -> dev      (X.Y.Z-dev.N)
+#   (any other -<label>.N -> <label>, e.g. -alpha.N -> alpha)
 #
 # A package publishes only when the `version` field in its package.json changes
 # on the push (same gate as bluetooth-sdk-release.yml). Bump the version, merge
 # to the channel branch, and CI ships it. Existing versions are skipped, so
 # re-runs are safe.
+#
+# Before packing, workspace `file:` deps are rewritten to exact published versions
+# (rewrite-file-deps.mjs) so wrappers like @mentra/cli install cleanly for users.
 #
 # Requires repo secret NPM_TOKEN: an npm *automation* token (bypasses 2FA) for
 # an account with publish rights on the @mentra org. See sdk/PUBLISHING.md.
@@ -22,7 +28,10 @@ on:
       - "mobile/modules/miniapp/**"
       - "sdk/miniapp-cli/**"
       - "sdk/create-mentra-miniapp/**"
+      - "cloud-v2/packages/auth/**"
+      - "cloud-v2/packages/cli/**"
       - ".github/scripts/miniapp-sdk-release-info.mjs"
+      - ".github/scripts/rewrite-file-deps.mjs"
       - ".github/workflows/miniapp-sdk-release.yml"
   workflow_dispatch:
     inputs:
@@ -108,6 +117,12 @@ jobs:
         if: matrix.pkg.buildCmd != ''
         working-directory: ${{ matrix.pkg.dir }}
         run: ${{ matrix.pkg.buildCmd }}
+
+      # Rewrite workspace `file:` deps to exact published versions so the tarball
+      # installs for end users (no-op for packages without them). This only
+      # mutates the checkout that gets packed/published — it is never committed.
+      - name: "Rewrite workspace file: deps"
+        run: node .github/scripts/rewrite-file-deps.mjs "${{ matrix.pkg.dir }}"
 
       - name: Check npm registry
         id: registry

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -32,6 +32,7 @@ on:
       - "cloud-v2/packages/cli/**"
       - ".github/scripts/miniapp-sdk-release-info.mjs"
       - ".github/scripts/rewrite-file-deps.mjs"
+      - ".github/scripts/stamp-template-versions.mjs"
       - ".github/workflows/miniapp-sdk-release.yml"
   workflow_dispatch:
     inputs:
@@ -123,6 +124,13 @@ jobs:
       # mutates the checkout that gets packed/published — it is never committed.
       - name: "Rewrite workspace file: deps"
         run: node .github/scripts/rewrite-file-deps.mjs "${{ matrix.pkg.dir }}"
+
+      # Stamp the scaffolder's template pins to the exact versions being published
+      # this run, so a scaffolded project installs on any channel (the caret pins
+      # in the repo can't reach -dev prereleases). No-op for packages without a
+      # template/package.json. Packed checkout only — never committed.
+      - name: Stamp scaffolder template versions
+        run: node .github/scripts/stamp-template-versions.mjs "${{ matrix.pkg.dir }}"
 
       - name: Check npm registry
         id: registry

--- a/cloud-v2/packages/auth/package.json
+++ b/cloud-v2/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/auth",
-  "version": "0.0.0",
+  "version": "0.1.0-dev.0",
   "description": "Verify Mentra Local Runtime auth tokens (JWKS) in miniapp backends.",
   "type": "module",
   "main": "./dist/index.js",
@@ -14,7 +14,7 @@
   "files": ["dist", "README.md"],
   "publishConfig": {
     "access": "public",
-    "tag": "alpha"
+    "tag": "dev"
   },
   "scripts": {
     "build": "tsc -b",

--- a/cloud-v2/packages/auth/package.json
+++ b/cloud-v2/packages/auth/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mentra/auth",
   "version": "0.0.0",
+  "description": "Verify Mentra Local Runtime auth tokens (JWKS) in miniapp backends.",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,6 +11,7 @@
       "default": "./dist/index.js"
     }
   },
+  "files": ["dist", "README.md"],
   "publishConfig": {
     "access": "public",
     "tag": "alpha"

--- a/cloud-v2/packages/cli/README.md
+++ b/cloud-v2/packages/cli/README.md
@@ -1,0 +1,38 @@
+# @mentra/cli
+
+The Mentra developer CLI — the `mentra` command. Build, publish, and manage
+Mentra miniapps against the Cloud V2 developer console.
+
+It wraps [`@mentra/miniapp-cli`](https://www.npmjs.com/package/@mentra/miniapp-cli)
+(the `dev` / `build` / `pack` author flow) and adds account and store operations:
+`login`, `whoami`, `org`, `miniapps`, `releases`, and `publish`.
+
+> **Bun-only.** This CLI ships as TypeScript and runs under [Bun](https://bun.sh)
+> (`#!/usr/bin/env bun`). Use `bun` / `bunx`, not `npx`/Node.
+
+## Install
+
+```bash
+bun add -g @mentra/cli@alpha
+mentra --help
+```
+
+Or run without installing:
+
+```bash
+bunx @mentra/cli@alpha --help
+```
+
+## Common commands
+
+```bash
+mentra login              # sign in to the Mentra Developer Console
+mentra dev                # local dev server with a signed Cloud V2 identity
+mentra build              # build the current miniapp
+mentra pack               # zip dist/ into a submittable release
+mentra publish            # upload + publish a release
+mentra miniapps list      # miniapps owned by your org
+mentra releases submit    # submit an uploaded release for review
+```
+
+Run `mentra <command> --help` for the full option set.

--- a/cloud-v2/packages/cli/package.json
+++ b/cloud-v2/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/cli",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0-dev.0",
   "description": "Mentra developer CLI — build, publish, and manage Mentra miniapps (Cloud V2). Bun-only.",
   "type": "module",
   "bin": {
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "alpha"
+    "tag": "dev"
   },
   "scripts": {
     "dev": "bun src/index.ts",

--- a/cloud-v2/packages/cli/package.json
+++ b/cloud-v2/packages/cli/package.json
@@ -1,10 +1,14 @@
 {
   "name": "@mentra/cli",
   "version": "2.0.0-alpha.0",
-  "private": true,
+  "description": "Mentra developer CLI — build, publish, and manage Mentra miniapps (Cloud V2). Bun-only.",
   "type": "module",
   "bin": {
     "mentra": "./src/index.ts"
+  },
+  "files": ["src"],
+  "engines": {
+    "bun": ">=1.0.0"
   },
   "publishConfig": {
     "access": "public",

--- a/mobile/modules/miniapp/package.json
+++ b/mobile/modules/miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/miniapp",
-  "version": "0.3.0",
+  "version": "0.3.0-dev.0",
   "description": "SDK for building MentraOS local miniapps (browser/WebView)",
   "author": "Mentra Labs",
   "license": "MIT",
@@ -33,7 +33,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "alpha"
+    "tag": "dev"
   },
   "sideEffects": false,
   "scripts": {

--- a/sdk/PUBLISHING.md
+++ b/sdk/PUBLISHING.md
@@ -1,14 +1,21 @@
 # Publishing the Miniapp SDK to npm
 
-The miniapp SDK ships as three npm packages:
+The miniapp SDK + Cloud V2 developer packages ship as five npm packages, all from
+one workflow ([`miniapp-sdk-release.yml`](../.github/workflows/miniapp-sdk-release.yml)):
 
 | Package | Source | What it is |
 | --- | --- | --- |
 | [`@mentra/miniapp`](https://www.npmjs.com/package/@mentra/miniapp) | `mobile/modules/miniapp` | The SDK runtime (`MiniappSession`, modules, `/background`, `/ui`, `/react`). Ships compiled JS + types. |
-| [`@mentra/miniapp-cli`](https://www.npmjs.com/package/@mentra/miniapp-cli) | `sdk/miniapp-cli` | The `mentra-miniapp` author CLI (`dev` / `release` / `pack` / `manifest`). |
-| [`create-mentra-miniapp`](https://www.npmjs.com/package/create-mentra-miniapp) | `sdk/create-mentra-miniapp` | The `bunx create-mentra-miniapp` scaffolder + template. |
+| [`@mentra/miniapp-cli`](https://www.npmjs.com/package/@mentra/miniapp-cli) | `sdk/miniapp-cli` | The `mentra-miniapp` author CLI (`dev` / `release` / `pack` / `manifest`). Bun-only. |
+| [`create-mentra-miniapp`](https://www.npmjs.com/package/create-mentra-miniapp) | `sdk/create-mentra-miniapp` | The `bunx create-mentra-miniapp` scaffolder + template. Bun-only. |
+| [`@mentra/auth`](https://www.npmjs.com/package/@mentra/auth) | `cloud-v2/packages/auth` | Cloud V2 auth helper for miniapp backends — verify Local Runtime JWKS tokens. Compiled JS + types (Node-compatible). |
+| [`@mentra/cli`](https://www.npmjs.com/package/@mentra/cli) | `cloud-v2/packages/cli` | The `mentra` developer CLI — build + **publish** to the Cloud V2 console. Wraps `@mentra/miniapp-cli` and adds login/org/miniapps/releases/publish. Bun-only. This is the CLI most developers want. |
 
-None of the three are on npm yet — this doc is how they get there and stay there.
+`@mentra/miniapp`, `@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/auth`
+are not on npm yet. `@mentra/cli` has a legacy `1.0.3` on the `latest` tag (the
+v1 CLI); the Cloud V2 rewrite here is `2.0.0-alpha.*` and publishes to the `alpha`
+tag, so it does **not** disturb `latest` — see the collision note below. This doc
+is how they get to npm and stay there.
 
 ## Channels (branch → dist-tag)
 
@@ -54,8 +61,16 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
 - **Idempotent:** before publishing it runs `npm view <pkg>@<version>` and skips
   if that exact version already exists. Re-running a workflow is safe.
 - **Ordered:** packages publish sequentially in dependency order
-  (`@mentra/miniapp` → `@mentra/miniapp-cli` → `create-mentra-miniapp`) so the
-  scaffolder's template pins resolve once it lands.
+  (`@mentra/miniapp` → `@mentra/miniapp-cli` → `create-mentra-miniapp` →
+  `@mentra/auth` → `@mentra/cli`) so downstream pins resolve once their base lands
+  (the scaffolder's template pins, and `@mentra/cli`'s dep on `@mentra/miniapp-cli`).
+- **`file:` rewrite:** before packing, [`rewrite-file-deps.mjs`](../.github/scripts/rewrite-file-deps.mjs)
+  rewrites any workspace `file:` dependency to the referenced package's **exact**
+  version. Today only `@mentra/cli` has one (`@mentra/miniapp-cli`), which is a
+  `file:` link in-repo but must be a real version in the published tarball. The
+  rewrite touches only the checkout that gets packed — it is never committed, so
+  local dev keeps the `file:` link. An exact pin is dist-tag-agnostic; the
+  tradeoff is that a base bump needs the wrapper republished to pick it up.
 - **Guardrail:** a plain (non-prerelease) version resolves to the `latest`
   dist-tag — the workflow refuses to publish that from any branch other than
   `main`, so a `-dev` build can never accidentally become what `npm install`
@@ -84,22 +99,42 @@ The workflow's ordering handles this within a run; when you bump the SDK to a
 version the template's caret range can't reach (e.g. a major), update
 `sdk/create-mentra-miniapp/template/package.json` in the same change.
 
-## ⚠️ Decision flag: the two CLIs are Bun-only
+## The CLIs are Bun-only (settled)
 
-`@mentra/miniapp-cli` and `create-mentra-miniapp` ship **raw `.ts` bins with
-`#!/usr/bin/env bun` shebangs** — there is no compile-to-JS step. They run under
-`bunx`, **not** `npx`/Node:
+`@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/cli` ship **raw
+`.ts` bins with `#!/usr/bin/env bun` shebangs** — there is no compile-to-JS step.
+They run under `bun` / `bunx`, **not** `npx`/Node:
 
 ```bash
 bunx create-mentra-miniapp my-app    # works
 npx create-mentra-miniapp my-app     # fails — no Bun
+
+bun add -g @mentra/cli@alpha         # works
+npm i -g @mentra/cli                  # installs, but `mentra` needs Bun to run
 ```
 
-`@mentra/miniapp` (the runtime) is normal compiled JS and works under Node/any
-bundler — only the two CLIs are Bun-only. This is consistent with the SDK being
-Bun-only today, but it means we should **document `bunx` everywhere** and decide
-whether to add a Node-compatible build (`bun build --compile` or tsc + a `node`
-shebang) before a wide launch. Until then, the published docs must say `bunx`.
+This is a deliberate decision — the SDK/CLI stack is Bun-first, so the CLIs stay
+Bun-only rather than adding a Node-compatible build. `@mentra/cli` declares
+`"engines": { "bun": ">=1.0.0" }` to make the requirement explicit. Only the two
+runtime/library packages are Node-compatible: `@mentra/miniapp` (compiled JS +
+types) and `@mentra/auth` (compiled `dist/`). **Published docs must say `bunx` /
+`bun` for anything that invokes a CLI.**
+
+## ⚠️ `@mentra/cli` version collision (1.x latest vs 2.x alpha)
+
+`@mentra/cli@1.0.3` already sits on the `latest` tag on npm — that's the v1 CLI
+(same maintainers, so we own the name). The Cloud V2 rewrite in
+`cloud-v2/packages/cli` is `2.0.0-alpha.*` and, because of its prerelease label,
+publishes to the **`alpha`** tag. So:
+
+- `npm i @mentra/cli` (or `bun add`) still resolves the old `1.0.3`.
+- `bun add @mentra/cli@alpha` gets the Cloud V2 CLI.
+
+This is intentional during the alpha. **Do not** ship a bare `2.0.0` (no
+prerelease) until the team decides to promote v2 to `latest` — that would replace
+what every plain install resolves. When ready, that promotion is just a version
+bump to `2.0.0` merged to `main` (the workflow's `latest`-only-on-`main` guardrail
+still applies).
 
 ## Manual publishing (fallback)
 
@@ -116,10 +151,22 @@ cd ../../../sdk && bun install
 cd miniapp-cli
 npm publish --tag <latest|beta|dev> --access public
 
-# 3. create-mentra-miniapp  (LAST — after the two above are live)
+# 3. create-mentra-miniapp  (after the two above are live)
 cd ../create-mentra-miniapp
 npm publish --tag <latest|beta|dev> --access public
+
+# 4. @mentra/auth  (independent; compiled dist/)
+cd ../../cloud-v2 && bun install
+cd packages/auth && bun run build
+npm publish --tag <alpha|dev|beta|latest> --access public
+
+# 5. @mentra/cli  (LAST — after @mentra/miniapp-cli is live)
+#    Rewrite its file: dep to the published miniapp-cli version first.
+cd ../cli
+node ../../../.github/scripts/rewrite-file-deps.mjs .
+npm publish --tag alpha --access public   # keep on alpha; do NOT publish a bare 2.0.0
+git checkout -- package.json               # undo the rewrite locally
 ```
 
 You need `npm login` (or `NPM_TOKEN` in `~/.npmrc`) with `@mentra` publish
-rights, and `bun` on PATH (the CLI's `prepare` script runs under Bun).
+rights, and `bun` on PATH (the CLIs' bins run under Bun).

--- a/sdk/PUBLISHING.md
+++ b/sdk/PUBLISHING.md
@@ -71,6 +71,11 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
   rewrite touches only the checkout that gets packed — it is never committed, so
   local dev keeps the `file:` link. An exact pin is dist-tag-agnostic; the
   tradeoff is that a base bump needs the wrapper republished to pick it up.
+- **Template stamp:** also before packing, [`stamp-template-versions.mjs`](../.github/scripts/stamp-template-versions.mjs)
+  rewrites `create-mentra-miniapp`'s `template/package.json` `@mentra/*` pins to
+  the **exact versions being published this run** (prerelease → exact, stable →
+  caret). This is why a project scaffolded from *any* channel installs — see
+  below. No-op for packages without a `template/`; never committed.
 - **Guardrail:** a plain (non-prerelease) version resolves to the `latest`
   dist-tag — the workflow refuses to publish that from any branch other than
   `main`, so a `-dev` build can never accidentally become what `npm install`
@@ -89,15 +94,25 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
 3. Promotion is a version bump, not a re-tag: land `0.4.0-beta.1` on `staging`,
    then land `0.4.0` on `main`.
 
-## Publish order & the template pin
+## Publish order & the template stamp
 
 `create-mentra-miniapp` bundles `template/package.json`, which pins
-`@mentra/miniapp` and `@mentra/miniapp-cli`. The scaffolder itself publishes
-fine regardless (npm doesn't validate template contents), but a **scaffolded
-project's `bun install` only works once those pinned versions exist on npm**.
-The workflow's ordering handles this within a run; when you bump the SDK to a
-version the template's caret range can't reach (e.g. a major), update
-`sdk/create-mentra-miniapp/template/package.json` in the same change.
+`@mentra/miniapp` and `@mentra/miniapp-cli`. In the repo these stay as friendly
+caret ranges (`^0.3.0`) for readability — but a caret **excludes prereleases**,
+so a project scaffolded from a dev/beta build (where only `0.3.0-dev.0` exists on
+npm, no stable `0.3.0`) could never `bun install`.
+
+The publish job fixes this automatically: `stamp-template-versions.mjs` rewrites
+those pins to the **exact versions being published in the same run** before
+packing. So `create-mentra-miniapp@dev` ships a template pinned to
+`@mentra/miniapp@0.3.0-dev.0` (exact — installs regardless of dist-tag), and the
+`latest` scaffolder ships `^<stable>`. Each channel's scaffolder is
+self-consistent, and you never hand-edit the template for a release. The matrix
+still publishes in dependency order so the pinned versions exist by the time a
+scaffolded project installs them.
+
+This is the publish-time-stamp pattern (à la `create-vite`): deterministic,
+offline-safe, and no runtime registry call during scaffolding.
 
 ## The CLIs are Bun-only (settled)
 

--- a/sdk/create-mentra-miniapp/package.json
+++ b/sdk/create-mentra-miniapp/package.json
@@ -1,10 +1,11 @@
 {
   "name": "create-mentra-miniapp",
-  "version": "0.1.0",
+  "version": "0.1.0-dev.0",
   "description": "Scaffold a new MentraOS miniapp project",
   "type": "module",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "tag": "dev"
   },
   "bin": {
     "create-mentra-miniapp": "./bin/index.ts"

--- a/sdk/miniapp-cli/package.json
+++ b/sdk/miniapp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/miniapp-cli",
-  "version": "0.1.0",
+  "version": "0.1.0-dev.0",
   "description": "Dev tools for MentraOS miniapps",
   "type": "module",
   "bin": {
@@ -8,7 +8,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "alpha"
+    "tag": "dev"
   },
   "exports": {
     ".": "./src/api.ts",


### PR DESCRIPTION
## What

Two things in one:
1. **Wires npm publish CI/CD** for the two Cloud V2 developer packages into the existing miniapp SDK release pipeline (`miniapp-sdk-release.yml`) — same version-change gate + `prerelease-label → dist-tag` convention.
2. **Cuts the first `dev`-channel release** of the whole family (all five → `-dev.0`), so merging to `dev` publishes them to npm on the `dev` tag.

## Packages & first versions

| Package | Source | this PR | tag | runtime |
|---|---|---|---|---|
| `@mentra/miniapp` | `mobile/modules/miniapp` | `0.3.0-dev.0` | `dev` | Node-compatible |
| `@mentra/miniapp-cli` | `sdk/miniapp-cli` | `0.1.0-dev.0` | `dev` | Bun-only |
| `create-mentra-miniapp` | `sdk/create-mentra-miniapp` | `0.1.0-dev.0` | `dev` | Bun-only |
| `@mentra/auth` | `cloud-v2/packages/auth` | `0.1.0-dev.0` | `dev` | Node-compatible |
| `@mentra/cli` (the `mentra` CLI — build + **publish**) | `cloud-v2/packages/cli` | `2.0.0-dev.0` | `dev` | Bun-only |

Developers use **`mentra`** (`@mentra/cli`); it wraps `@mentra/miniapp-cli` and adds login/org/miniapps/releases/publish.

## Pipeline changes

- **release-info matrix** — added `@mentra/auth` + `@mentra/cli` in dependency order (`@mentra/miniapp-cli` before `@mentra/cli`, which depends on it).
- **`rewrite-file-deps.mjs`** (new) — at pack time, rewrites `@mentra/cli`'s `file:` link to `@mentra/miniapp-cli`'s exact version so the tarball installs for end users. Packed checkout only; never committed.
- **`stamp-template-versions.mjs`** (new) — at pack time, stamps `create-mentra-miniapp`'s `template/package.json` `@mentra/*` pins to the exact versions published this run (prerelease → exact, stable → caret), so a scaffolded project installs on any channel. Packed checkout only; the repo keeps its caret pins.
- **`@mentra/cli`** — dropped `private: true`, added `description`/`files`/`engines.bun`, README. Bun-only.
- **`@mentra/auth`** — added `description` + `files: [dist, README.md]`.
- **`publishConfig.tag`** aligned to `dev` on all five so a manual publish matches CI.

## Tags — no disruption

`@mentra/cli@1.0.3` (the old v1 CLI) stays on `latest`. Everything here ships to `dev` by its `-dev.*` suffix. `bun add @mentra/cli` still gets v1; `bun add @mentra/cli@dev` gets the Cloud V2 CLI. A bare (non-prerelease) version → `latest` remains blocked off `main` by the existing guardrail.

## Ops status — both prerequisites cleared

- ✅ **`NPM_TOKEN`** repo secret is set (automation token, `@mentra` publish rights).
- ✅ **Version bumps** are in this PR — so **merging to `dev` publishes all five** to the `dev` tag via the release workflow.

## Scaffolder works on every channel (was the one gap — now fixed)

`create-mentra-miniapp`'s template pins the SDK with caret ranges (`^0.3.0` / `^0.1.0`), and a caret **excludes prereleases** — so a project scaffolded from a dev build (only `0.3.0-dev.0` on npm) could not `bun install`. The publish job now stamps those pins to the exact versions published in the same run (`stamp-template-versions.mjs`): `create-mentra-miniapp@dev` ships a `@dev`-pinned template, the `latest` scaffolder ships a stable one — no per-release hand-editing. Publish-time-stamp pattern (create-vite style): deterministic, offline-safe, no runtime registry call. The repo keeps the friendly caret pins.

## Validation (local)

- Matrix emits all 5 with `tag=dev`.
- `rewrite-file-deps.mjs` pins `@mentra/miniapp-cli` `file:` → exact; no-op elsewhere.
- `stamp-template-versions.mjs` rewrites template `^0.3.0 → 0.3.0-dev.0`, `^0.1.0 → 0.1.0-dev.0`; leaves react/typescript; no-op without a template.
- `npm pack --dry-run`: `@mentra/cli` ships `src/` + README + Bun shebang; `@mentra/auth` builds to `dist/` and packs `dist/` + README.
- Workflow YAML + scripts + all package.json parse clean.

## Docs

`PUBLISHING.md` updated for all five packages, the `file:` rewrite, the template stamp, the Bun-only decision, and the `@mentra/cli` version collision. Public mintlify miniapp-SDK docs describe the base author CLI and stay accurate; `@mentra/cli`'s public command docs are deferred until it leaves the `dev` stage.