### PR TITLE
Fix cloud-v2 Pages deploy: pin Node 22 for Wrangler

### DIFF
--- a/.github/workflows/cloud-v2-pages.yml
+++ b/.github/workflows/cloud-v2-pages.yml
@@ -55,6 +55,15 @@ jobs:
         with:
           bun-version: "1.3.14"
 
+      # `bunx wrangler` runs Wrangler under the runner's system Node, not Bun.
+      # Current Wrangler enforces a runtime minimum of Node 22, while the
+      # Blacksmith image defaults to Node 20 — which failed the deploy with
+      # "Wrangler requires at least Node.js v22.0.0". Pin Node 22 (LTS) here.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Resolve deployment target
         id: target
         shell: bash


### PR DESCRIPTION
## Problem

The **Deploy cloud-v2 websites** workflow (`cloud-v2-pages.yml`) has been failing on every push to `dev` — both the #3272 merge (6/30) and the #3288 merge (7/1):

```
$ bunx wrangler pages secret put CORE_URL --project-name mentra-console2-dev
Wrangler requires at least Node.js v22.0.0. You are using v20.20.0. Please update your version of Node.js.
##[error]Process completed with exit code 1.
```

Run: https://github.com/Mentra-Community/MentraOS/actions/runs/28490524573/job/84445991556

## Root cause

- The job sets up **Bun only** — there is no `setup-node` step. `bunx wrangler` executes Wrangler under the runner's **system Node**, which on the Blacksmith `ubuntu-2404` image is **v20.20.0** (Bun would report ≥24, so it is clearly system Node, not Bun, running Wrangler).
- `deploy-pages.ts` invokes `bunx wrangler` **unpinned**, so each run pulls the latest Wrangler. Current Wrangler enforces a **runtime** minimum of Node 22 (its `engines.node` still says `>=18`, so this is an internal check, not package metadata). Once an unpinned `bunx wrangler` floated into that new minimum, every deploy started failing.

It worked for months on Node 20 and broke the moment a Node-22-requiring Wrangler shipped. **This is not caused by the roles/API-key change in #3288** — that merge was just the push that triggered the (already-broken) deploy.

## Fix

Add `actions/setup-node@v4` with **Node 22 (LTS)** to the deploy job so Wrangler runs on a supported runtime. Minimal, one-step change; no other deploy behavior is altered. Merging this to `dev` re-triggers the workflow (the path filter includes the workflow file), so it self-validates.

## Note / optional follow-up

The deeper smell is that `bunx wrangler` is **unpinned**, so a future Wrangler that bumps its minimum to Node 24 would break this again. Node 22 is Active LTS with plenty of headroom, so this is not urgent, but pinning Wrangler (or Node) to a known-good version in a later change would make deploys fully reproducible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change that pins Node for deploy; no application, auth, or production runtime behavior is modified.
> 
> **Overview**
> Restores the **Deploy cloud-v2 websites** workflow by adding **`actions/setup-node@v4` with Node 22** before deploy steps. **`bunx wrangler`** runs on the runner’s system Node (not Bun); Blacksmith’s default Node 20 no longer satisfies Wrangler’s runtime minimum, which caused deploys to fail with “Wrangler requires at least Node.js v22.0.0”.
> 
> Bun setup and the rest of the job are unchanged—only the Node version on the runner is pinned so existing `deploy-pages.ts` / Wrangler invocations work again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83f0d4e16c26dfcde2de059f019e8bd6ffccd109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing cloud-v2 Pages deploys by pinning Node 22 for `wrangler` in `cloud-v2-pages.yml`. Ensures the deploy job runs `wrangler` on a supported Node version.

- **Bug Fixes**
  - Add `actions/setup-node@v4` with Node 22 before deploy steps.
  - Avoids failures when the runner’s default Node 20 doesn’t meet `wrangler`’s Node 22 requirement.

<sup>Written for commit 83f0d4e16c26dfcde2de059f019e8bd6ffccd109. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

