### PR TITLE
Use Mentra Green for Head-Up Angle slider (fix blue bar)

### DIFF
--- a/mobile/src/components/settings/HeadUpAngleComponent.tsx
+++ b/mobile/src/components/settings/HeadUpAngleComponent.tsx
@@ -126,8 +126,8 @@ const HeadUpAngleArcModal = ({visible, initialAngle, maxAngle = 60, onCancel, on
               <View style={themed($svgWrapper)} {...panResponder.panHandlers}>
                 <Svg width={svgSize} height={svgSize}>
                   <Path d={backgroundArcPath} stroke={theme.colors.border} strokeWidth={7} fill="none" />
-                  <Path d={currentArcPath} stroke={"#007AFF"} strokeWidth={7} fill="none" />
-                  <Circle cx={knobPos.x} cy={knobPos.y} r={15} fill={"#007AFF"} />
+                  <Path d={currentArcPath} stroke={theme.colors.sliderTrackActive} strokeWidth={7} fill="none" />
+                  <Circle cx={knobPos.x} cy={knobPos.y} r={15} fill={theme.colors.sliderTrackActive} />
                 </Svg>
               </View>
 


### PR DESCRIPTION
## Scope

Minor UI fix. In **Dashboard settings → Adjust Head-Up Angle**, the arc slider and its knob were rendered with a hardcoded iOS blue (`#007AFF`) instead of Mentra Green.

## Change

`mobile/src/components/settings/HeadUpAngleComponent.tsx` — swap the two hardcoded `#007AFF` values (arc stroke + knob fill) for the theme token `theme.colors.sliderTrackActive`.

- Resolves to `#00B869` (light) / `#36DD88` (dark) — Mentra Green in both themes.
- Semantically correct: this arc *is* an active slider track, and it's the same token the app's real sliders use (`sliderTrackActive`).
- Chosen over `theme.colors.tint` because `tint` is purple (`#6054D6`) in dark mode; `sliderTrackActive` stays green.

The background arc already used a theme token (`theme.colors.border`), so this brings the active arc in line with it.

## Test evidence

Isolated component (only used by `mobile/src/app/miniapps/settings/dashboard.tsx`); no logic change, color token swap only. Visual: arc + knob now render Mentra Green.

## Before / After

- Before: blue (`#007AFF`) arc + knob
- After: Mentra Green arc + knob (theme-aware)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic token swap only in a single settings modal component; no logic, persistence, or API impact.
> 
> **Overview**
> Fixes the **Adjust Head-Up Angle** modal so the active arc and knob no longer use hardcoded iOS blue (`#007AFF`).
> 
> Both the current-arc stroke and knob fill now use **`theme.colors.sliderTrackActive`**, matching other sliders (e.g. `ThemedSlider`) and keeping Mentra green in light and dark mode. No behavior or layout changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddf49d99443e71cffd5049c864077983ec95ae30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use `theme.colors.sliderTrackActive` for the Head‑Up Angle arc and knob in Dashboard settings, replacing hardcoded `#007AFF`. This switches the blue bar to Mentra Green and keeps it correct in light and dark themes.

<sup>Written for commit ddf49d99443e71cffd5049c864077983ec95ae30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

