### PR TITLE
Fix leftover rounded corners on opened miniapps (Android)

### DIFF
--- a/mobile/src/components/miniapp/LocalMiniappView.tsx
+++ b/mobile/src/components/miniapp/LocalMiniappView.tsx
@@ -491,7 +491,7 @@ function LocalMiniappView({
   }
 
   return (
-    <View className="flex-1 bg-black" style={{borderRadius: theme.spacing.s12}}>
+    <View className="flex-1 bg-black">
       <WebView
         ref={handleRef}
         source={{uri: uiUri}}
@@ -528,7 +528,7 @@ function LocalMiniappView({
         // react-native-webview#1649, manuelstofer/pinchzoom#115.
         nestedScrollEnabled={true}
         webviewDebuggingEnabled={__DEV__}
-        style={{flex: 1, borderRadius: theme.spacing.s12}}
+        style={{flex: 1}}
       />
       <MiniappSplash
         name={appName}

--- a/mobile/src/components/miniapp/MiniappSplash.tsx
+++ b/mobile/src/components/miniapp/MiniappSplash.tsx
@@ -3,10 +3,9 @@
  * icon centered on the host's background color. Styled to match AppIcon on
  * the home screen: 128px squircle with memory-disk image caching.
  *
- * Fades + scales in on mount so foregrounding feels like a soft zoom rather
- * than a hard cut. Fades out (opacity 1 → 0) when `isLoaded` flips true so
- * the WebView's first paint isn't preceded by a hard splash unmount + white
- * flash.
+ * Fades in on mount so foregrounding feels soft rather than a hard cut. Fades
+ * out (opacity 1 → 0) when `isLoaded` flips true so the WebView's first paint
+ * isn't preceded by a hard splash unmount + white flash.
  */
 
 import {Image} from "expo-image"
@@ -79,7 +78,7 @@ export default function MiniappSplash({
       pointerEvents="none"
       style={[
         StyleSheet.absoluteFill,
-        {backgroundColor: bgColor, borderRadius: theme.spacing.s12, justifyContent: "center", alignItems: "center"},
+        {backgroundColor: bgColor, justifyContent: "center", alignItems: "center"},
         animatedStyle,
       ]}>
       {(iconUrl || devApp) && (


### PR DESCRIPTION
## Problem

When you start a Mentra Miniapp SDK miniapp on **Android**, the opened app has **rounded corners**. It's leftover from the launch animation.

## Root cause

`LocalMiniappView`'s container `View` + the `WebView`, and the `MiniappSplash` overlay, all carried a static `borderRadius: theme.spacing.s12` (**48px**). That was a holdover from the old **fade + zoom** open animation, where the app-icon squircle grew into the screen and the big radius made the growing surface look like a rounded icon.

That zoom was since replaced by a plain **horizontal slide-in** (the `Compositor`'s OS-style stack push — see `Compositor.tsx`, which only animates `translateX`). With the zoom gone, the radius does nothing but round the corners of the fully-open miniapp.

- On **iOS** the WKWebView content isn't clipped by the RN style radius, so it went unnoticed.
- On **Android** the WebView clips to the radius, so the opened miniapp is left with permanently rounded corners.

The commit that dropped the zoom (`d97a375936`) removed the `scale` animation but left the 48px radius behind on every surface.

## Fix

Remove the leftover `borderRadius` from:
- `LocalMiniappView` — the root container `View` and the `WebView` style
- `MiniappSplash` — the full-screen overlay

A foregrounded miniapp now fills the screen with square corners, matching the slide-in transition. Also fixed the stale `MiniappSplash` doc comment that still described the removed scale/zoom.

`OfflineAppHost` (native offline apps like Settings) is intentionally left alone — it uses `overflow: hidden` + `borderCurve: continuous` for a deliberate rounded-card look that renders identically on both platforms.

## Test plan

- [ ] Android: launch an SDK miniapp from the home screen → opened miniapp has **square** corners (previously rounded).
- [ ] Android: launch splash (icon over background) has square corners during load.
- [ ] iOS: no visual regression — miniapps still open with the slide-in and fill the screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling on miniapp shell views; no logic, auth, or data changes.
> 
> **Overview**
> Removes stale **`borderRadius: theme.spacing.s12`** from **`LocalMiniappView`** (root container and **WebView**) and from the full-screen **`MiniappSplash`** overlay. That radius was left over after the open animation switched from icon zoom to a horizontal slide-in; on **Android** the WebView clips to the radius, so opened SDK miniapps looked permanently rounded.
> 
> Splash and load states now use square corners to match a full-screen slide-in. **`MiniappSplash`** docs no longer mention the removed scale/zoom fade-in. **`OfflineAppHost`** is unchanged and still uses intentional rounded-card styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9ae7a024a759a539092cbde76f5e3cde0616cd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes rounded corners on Android miniapps by removing the leftover 48px borderRadius from the container, WebView, and splash overlay. Miniapps now fill the screen with square corners to match the slide-in transition, with no change on iOS.

- **Bug Fixes**
  - Dropped `borderRadius` from `LocalMiniappView` container and `WebView` styles.
  - Removed radius and updated comment in `MiniappSplash` overlay.

<sup>Written for commit d9ae7a024a759a539092cbde76f5e3cde0616cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3306?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

