### PR TITLE
Fix G2 clearDisplay leaving bitmaps on screen

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -2126,9 +2126,14 @@ class G2 : SGCManager() {
             textContainers[i].pendingSends = 1 + EVEN_HUB_RESEND_COUNT
         }
         for (i in imageContainers.indices) {
-            // Cleared to empty — nothing to (re)send, so mark clean so the reconcile loop skips it.
-            imageContainers[i].bmpData = ByteArray(0)
-            imageContainers[i].dirty = false
+            // The firmware still shows this container's image; emptying bmpData locally never reaches
+            // it (#3232 dropped the teardown that used to drop empty containers on rebuild). Empty +
+            // dirty tells the reconcile loop to push an all-black frame that overwrites the image
+            // on-glass — the page stays up, so no audio/mic churn. Skip already-empty containers.
+            if (imageContainers[i].bmpData.isNotEmpty()) {
+                imageContainers[i].bmpData = ByteArray(0)
+                imageContainers[i].dirty = true
+            }
         }
         signalDisplayDirty()
     }
@@ -2398,10 +2403,21 @@ class G2 : SGCManager() {
             guardCount += 1
             val container = imageContainers[i]
             val sentBytes = container.bmpData
-            // Empty containers (e.g. cleared) have nothing to send; clear the flag without a send so
-            // the loop doesn't keep re-selecting them (sendImageData would no-op anyway).
+            // Empty + dirty means "just cleared": the firmware still shows the old image, so push an
+            // all-black frame sized to the container to overwrite it on-glass (the page stays up — no
+            // teardown, no mic churn). A container only reaches here when dirty, and clearDisplay is
+            // the sole source of an empty-but-dirty container, so this fires exactly on a clear.
             if (sentBytes.isEmpty()) {
-                imageContainers[i].dirty = false
+                val blank = blankBmp(container.width, container.height)
+                if (blank != null) {
+                    sendImageData(container.id, container.name, blank)
+                }
+                // Only settle the flag if it's still empty — a displayBitmap during the await would
+                // have set new bytes, so leave it dirty for the next pass to send the real image.
+                val jj = imageContainers.indexOfFirst { it.id == container.id }
+                if (jj >= 0 && imageContainers[jj].bmpData.isEmpty()) {
+                    imageContainers[jj].dirty = false
+                }
                 continue
             }
             sendImageData(container.id, container.name, sentBytes)
@@ -2801,6 +2817,17 @@ class G2 : SGCManager() {
         destBitmap.recycle()
 
         return build4BitBmp(grayscalePixels, containerWidth, containerHeight)
+    }
+
+    /**
+     * Build an all-black BMP sized to a container. Sent to overwrite (and thus visually clear) an
+     * image container without tearing the page down — on the green monochrome display, pixel 0 is
+     * unlit, so an all-zero frame reads as blank. Used by the reconcile loop to clear a bitmap.
+     */
+    private fun blankBmp(width: Int, height: Int): ByteArray? {
+        if (width <= 0 || height <= 0) return null
+        val zeros = ByteArray(width * height)  // all-zero 8-bit grayscale = black
+        return build4BitBmp(zeros, width, height)
     }
 
     private fun build4BitBmp(grayscalePixels: ByteArray, width: Int, height: Int): ByteArray? {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -2218,10 +2218,13 @@ class G2: NSObject, SGCManager {
             textContainers[i].content = " "
             textContainers[i].pendingSends = 1 + EVEN_HUB_RESEND_COUNT
         }
-        for i in imageContainers.indices {
-            // Cleared to empty — nothing to (re)send, so mark clean so the reconcile loop skips it.
+        for i in imageContainers.indices where !imageContainers[i].bmpData.isEmpty {
+            // The firmware still shows this container's image; emptying bmpData locally never
+            // reaches it (#3232 dropped the teardown that used to drop empty containers on
+            // rebuild). Empty + dirty tells the reconcile loop to push an all-black frame that
+            // overwrites the image on-glass — the page stays up, so no audio/mic churn.
             imageContainers[i].bmpData = Data()
-            imageContainers[i].dirty = false
+            imageContainers[i].dirty = true
         }
         signalDisplayDirty()
     }
@@ -2454,10 +2457,23 @@ class G2: NSObject, SGCManager {
             guardCount += 1
             let container = imageContainers[i]
             let sentBytes = container.bmpData
-            // Empty containers (e.g. cleared) have nothing to send; clear the flag without a send so
-            // the loop doesn't keep re-selecting them (sendImageData would no-op anyway).
+            // Empty + dirty means "just cleared": the firmware still shows the old image, so push an
+            // all-black frame sized to the container to overwrite it on-glass (the page stays up — no
+            // teardown, no mic churn). A container only reaches here when dirty, and clearDisplay is
+            // the sole source of an empty-but-dirty container, so this fires exactly on a clear.
             if sentBytes.isEmpty {
-                imageContainers[i].dirty = false
+                if let blank = blankBmp(width: Int(container.width), height: Int(container.height)) {
+                    await sendImageData(
+                        containerID: container.id, containerName: container.name, bmpData: blank
+                    )
+                }
+                // Only settle the flag if it's still empty — a displayBitmap during the await would
+                // have set new bytes, so leave it dirty for the next pass to send the real image.
+                if let j = imageContainers.firstIndex(where: { $0.id == container.id }),
+                    imageContainers[j].bmpData.isEmpty
+                {
+                    imageContainers[j].dirty = false
+                }
                 continue
             }
             await sendImageData(
@@ -2726,6 +2742,15 @@ class G2: NSObject, SGCManager {
         }
 
         return bmp
+    }
+
+    /// Build an all-black BMP sized to a container. Sent to overwrite (and thus visually clear) an
+    /// image container without tearing the page down — on the green monochrome display, pixel 0 is
+    /// unlit, so an all-zero frame reads as blank. Used by the reconcile loop to clear a bitmap.
+    private func blankBmp(width: Int, height: Int) -> Data? {
+        guard width > 0, height > 0 else { return nil }
+        let zeros = Data(count: width * height)  // all-zero 8-bit grayscale = black
+        return build4BitBmp(grayscalePixels: zeros, width: width, height: height)
     }
 
     /// Build a 4-bit indexed BMP file from 8-bit grayscale pixel data.


### PR DESCRIPTION
## What

Clearing the G2 display now actually clears any displayed **bitmap**, not just text.

From the July 1 bug hunt — incident `a3515754`, severity 5/5, iOS + G2:

> Bitmaps are not cleared when the G2 display is cleared.

## Root cause

Regression from #3232 ("stop clearDisplay from tearing down the EvenHub page"). That change removed the page teardown + rebuild from `clearDisplay()` to stop an audio-dropping rebuild storm on caption-gap clear bursts.

The teardown had an unintended side effect that was doing the image clearing: `createPageWithContainers()` filters out empty image containers, so the rebuilt page dropped the image and the firmware cleared it. Once the teardown was gone, `clearDisplay()` only emptied `bmpData` locally and marked the container clean — so nothing was ever sent to the glasses to overwrite the image, and it stayed on screen.

## Fix

Clear an image by pushing an **all-black frame** (sized to the container) through the existing reconcile / `sendImageData` path — the page stays up, so no audio/mic churn and no rebuild storm.

- `clearDisplay()` marks an image container **empty + dirty** only when it currently holds an image (already-empty containers are untouched).
- The reconcile loop sees empty + dirty and sends a blank frame (green monochrome: pixel 0 = unlit → reads as blank), then settles the dirty flag — unless a `displayBitmap` raced in new bytes during the send, in which case it stays dirty and the real image goes out next pass.
- Text-only clears (the common caption-burst case) touch **no** image containers, so their cost is unchanged.

New helper `blankBmp(width:height:)` builds the all-black BMP via the existing `build4BitBmp`.

## Platforms

iOS (`G2.swift`) and Android (`G2.kt`) kept in parity (both got #3232).

## Testing

- iOS: `swiftc -parse` clean.
- Android: bluetooth-sdk compile check.
- ⚠️ **Not yet hardware-verified** — needs a G2 device: show a bitmap (e.g. a synced photo / miniapp image), then trigger a display clear, and confirm the image disappears while audio/mic stays up during caption clear bursts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live G2 display reconcile and BLE image traffic on clear; behavior is localized but not yet hardware-verified per the PR.
> 
> **Overview**
> Fixes a regression where **G2 `clearDisplay()`** blanked text but left **bitmaps on the glasses** after #3232 stopped tearing down the EvenHub page.
> 
> **`clearDisplay()`** now marks image containers that still hold pixels as **empty + dirty** (skips already-empty ones). **`reconcileDisplay()`** treats empty+dirty as a clear: it sends an **all-black BMP** sized to the container via the existing `sendImageData` path so firmware overwrites the old image **without** a page rebuild. A new **`blankBmp`** helper builds that frame on iOS and Android.
> 
> Race handling: if **`displayBitmap`** loads new bytes while the blank frame is in flight, the dirty flag stays set so the real image sends on the next pass. Text-only clears still touch no image containers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83c1a1a235ff696592dbda4fff45dda32771e6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes G2 clearDisplay so it also clears images, not just text. Sends a black frame to remove any on-glass bitmap without tearing down the page, avoiding audio/mic churn.

- **Bug Fixes**
  - Clear images by marking containers empty + dirty and pushing an all-black frame via the existing reconcile/`sendImageData` path.
  - Skip already-empty containers; handle races so new images still send on the next pass.
  - Text-only clears are unchanged in cost.
  - iOS (`G2.swift`) and Android (`G2.kt`) updated in parity; builds clean. On-device verification still needed.

<sup>Written for commit 83c1a1a235ff696592dbda4fff45dda32771e6e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

