### PR TITLE
Fix: offline miniapp lingers in running tray after closing with X

### DIFF
--- a/mobile/src/components/miniapp/OfflineAppHost.tsx
+++ b/mobile/src/components/miniapp/OfflineAppHost.tsx
@@ -36,7 +36,7 @@ import {offlineAppRegistry} from "@/components/miniapp/offlineAppRegistry"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useCapsuleStore} from "@/stores/capsule"
 import {useNavigationStore, type NavInterceptor} from "@/stores/navigation"
-import {BgTimer, useAppStatusStore} from "@mentra/island"
+import {useAppStatusStore} from "@mentra/island"
 
 interface OfflineAppHostProps {
   packageName: string
@@ -177,11 +177,14 @@ export default function OfflineAppHost({packageName, appName, iconUrl, onExit, o
         beginExit()
       },
       handleRightPress: () => {
+        // Stop the app BEFORE playing the exit animation so it clears from the
+        // running-apps tray immediately. The overlay's slide-out is driven by
+        // the Compositor's foreground state (renderedApp is held mounted through
+        // the animation), so stopping now — which only flips the `running` flag
+        // — doesn't interrupt it. Deferring stop() (previously by 1s) left the
+        // app lingering in the tray for the whole animation, then popping out.
+        useAppStatusStore.getState().stop(packageName)
         beginExit()
-        // wait until after the animation is complete to stop the miniapp:
-        BgTimer.setTimeout(() => {
-          useAppStatusStore.getState().stop(packageName)
-        }, 1000)
       },
     }
     useCapsuleStore.getState().setActive(registration)


### PR DESCRIPTION
## Problem

Closing an offline-hosted miniapp (Settings, Store, Mirror, Camera, Feedback) via the capsule **X** button leaves it visible in the running-apps tray for ~1 second after you land back on home, then it pops out.

**Repro:** Start Settings on Android → tap **X** → it animates home → Settings is still shown in the running-apps tray → ~1s later it disappears.

## Root cause

`OfflineAppHost`'s X handler (`handleRightPress`) deferred `stop(packageName)` by a fixed `BgTimer.setTimeout(..., 1000)` "to wait until the animation is complete." But:

- The overlay's slide-out is driven entirely by the **Compositor's foreground state** — `renderedApp` is held mounted through the exit animation (`Compositor.tsx`), independent of the app's `running` flag.
- The running-apps tray (`AppSwitcherButton` → `useActiveApps()`) filters on `running`.

So the 1s gap between `clearForeground()` (returns home immediately) and `stop()` (clears `running`) is exactly the window the closed app lingers in the tray.

## Fix

Call `stop(packageName)` **before** `beginExit()` instead of on a 1s timer. For these offline apps `stop()` only flips `running`/`screenshot` and runs a no-op teardown (`beforeStop`/`onStop` do nothing that touches the phone-screen overlay), so stopping up front doesn't interrupt the slide-out — but the tray now updates on the same frame we return home.

The house/minimize button (`handleLeftPress`) is intentionally unchanged: minimize keeps the app running in the tray.

## Test evidence

- Manual repro/fix verification pending on-device (Android). Change is a 2-line reordering plus an unused-import cleanup; no behavior change to the minimize path or to cloud/local miniapps.

## Scope

- `mobile/src/components/miniapp/OfflineAppHost.tsx` — stop immediately on X; drop now-unused `BgTimer` import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reorder in `OfflineAppHost` capsule X handling for built-in offline apps only; minimize and other miniapp hosts are untouched.
> 
> **Overview**
> Fixes offline-hosted miniapps (Settings, Store, Mirror, etc.) **staying in the running-apps tray for ~1s** after closing with the capsule **X**.
> 
> **`OfflineAppHost`** now calls `useAppStatusStore.stop(packageName)` **before** `beginExit()` on X, instead of delaying `stop` by 1s via `BgTimer`. The tray keys off `running`, while the exit slide-out is driven by the Compositor’s foreground/`renderedApp` state, so early `stop` only updates the tray without cutting the animation. The minimize (house) path is unchanged. Unused `BgTimer` import removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 609b1c41e004fb77e9fd05b9a79437850f80f69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop offline miniapps immediately on close (X) so they disappear from the running tray as soon as you return home. The exit animation still plays because it’s driven by the compositor, not the `running` flag.

- **Bug Fixes**
  - Call `stop(packageName)` before `beginExit()`; remove the 1s `BgTimer` delay.
  - Drop unused `BgTimer` import; minimize (left button) behavior unchanged. Affects offline apps: Settings, Store, Mirror, Camera, Feedback.

<sup>Written for commit 609b1c41e004fb77e9fd05b9a79437850f80f69d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

