### PR TITLE
Warn before leaving the app on miniapp dev Read the Docs link

### DIFF
--- a/mobile/src/app/miniapps/settings/miniapp-dev.tsx
+++ b/mobile/src/app/miniapps/settings/miniapp-dev.tsx
@@ -1,4 +1,4 @@
-import {Linking, ScrollView, View} from "react-native"
+import {ScrollView, View} from "react-native"
 
 import {Button, Header, Screen, Text} from "@/components/ignite"
 import GlassView from "@/components/ui/GlassView"
@@ -8,6 +8,7 @@ import {Spacer} from "@/components/ui/Spacer"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
+import {showLeaveAppAlert} from "@/utils/AlertUtils"
 
 const DOCS_URL = "https://docs.mentraglass.com"
 
@@ -26,7 +27,7 @@ export default function MiniappDeveloperSettingsScreen() {
             <Text className="text-[13px] leading-[18px] text-textDim" tx="miniappDevSettings:body" />
             <Button
               tx="miniappDevSettings:readDocs"
-              onPress={() => Linking.openURL(DOCS_URL)}
+              onPress={() => showLeaveAppAlert(DOCS_URL)}
               preset="alternate"
               flexContainer={false}
             />

--- a/mobile/src/app/miniapps/settings/privacy.tsx
+++ b/mobile/src/app/miniapps/settings/privacy.tsx
@@ -1,6 +1,6 @@
 import CrustModule from "@mentra/crust"
 import {useEffect, useState} from "react"
-import {AppState, Linking, Platform, ScrollView} from "react-native"
+import {AppState, Platform, ScrollView} from "react-native"
 
 import {Header, Screen} from "@/components/ignite"
 import PermissionButton from "@/components/settings/PermButton"
@@ -9,7 +9,7 @@ import {Spacer} from "@/components/ui/Spacer"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import showAlert from "@/utils/AlertUtils"
+import {showLeaveAppAlert} from "@/utils/AlertUtils"
 import {checkAndRequestNotificationAccessSpecialPermission} from "@/utils/NotificationServiceUtils"
 import {checkFeaturePermissions, PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 
@@ -123,17 +123,7 @@ export default function PrivacySettingsScreen() {
   }, []) // subscribe only once
 
   const handleOpenPrivacyPolicy = () => {
-    showAlert(translate("settings:leaveAppTitle"), translate("settings:leaveAppMessage"), [
-      {text: translate("common:cancel"), style: "cancel"},
-      {
-        text: translate("common:continue"),
-        onPress: () => {
-          Linking.openURL(PRIVACY_POLICY_URL).catch((error) =>
-            console.error("Failed to open privacy policy URL:", error),
-          )
-        },
-      },
-    ])
+    showLeaveAppAlert(PRIVACY_POLICY_URL)
   }
 
   const handleToggleNotifications = async () => {

--- a/mobile/src/utils/AlertUtils.tsx
+++ b/mobile/src/utils/AlertUtils.tsx
@@ -1,12 +1,13 @@
 import * as NavigationBar from "expo-navigation-bar"
 import {StatusBar} from "expo-status-bar"
 import {useState, useEffect, useRef} from "react"
-import {Alert, BackHandler, Platform, Animated} from "react-native"
+import {Alert, BackHandler, Linking, Platform, Animated} from "react-native"
 
 import {Icon, IconTypes} from "@/components/ignite"
 import BasicDialog from "@/components/ui/BasicDialog"
 
 import {useAppTheme} from "@/contexts/ThemeContext"
+import {translate} from "@/i18n"
 
 import {SettingsNavigationUtils} from "./SettingsNavigationUtils"
 
@@ -491,6 +492,23 @@ const showPermissionsAlert = (title: string, message: string, options?: Connecti
 }
 
 /**
+ * Shows a "you are leaving the app" confirmation before opening an external URL
+ * in the system browser. Use this anywhere we hand the user off to an outside
+ * link (privacy policy, docs, etc.) so the copy and behavior stay consistent.
+ */
+const showLeaveAppAlert = (url: string) => {
+  showAlert(translate("settings:leaveAppTitle"), translate("settings:leaveAppMessage"), [
+    {text: translate("common:cancel"), style: "cancel"},
+    {
+      text: translate("common:continue"),
+      onPress: () => {
+        Linking.openURL(url).catch((error) => console.error("Failed to open external URL:", url, error))
+      },
+    },
+  ])
+}
+
+/**
  * Shows a destructive action alert with proper styling
  * Uses the new modal system with BasicDialog for consistent design
  */
@@ -516,6 +534,7 @@ export {
   showLocationServicesAlert,
   showPermissionsAlert,
   showDestructiveAlert,
+  showLeaveAppAlert,
 }
 
 export default showAlert


### PR DESCRIPTION
## What

Pressing **Read the Docs** in the miniapp developer menu now shows a "you are
leaving the Mentra app" confirmation before opening the external docs URL —
matching the existing behavior on the Privacy → Privacy Policy link.

## Why

The docs link opened `Linking.openURL(...)` directly, dropping the user into
their browser with no warning. The privacy menu already warns before handing
off to an external link; the dev menu should be consistent.

## How

- Added a reusable `showLeaveAppAlert(url)` helper to `AlertUtils.tsx`, sitting
  alongside the other `show*Alert` helpers. It reuses the existing
  `settings:leaveAppTitle` / `settings:leaveAppMessage` copy and the
  `common:cancel` / `common:continue` buttons, then opens the URL on confirm.
- Routed the miniapp dev **Read the Docs** button through it.
- Refactored `privacy.tsx` to use the same helper (previously inline), so both
  external-link handoffs share one implementation and copy. No new strings.

No new i18n keys — reuses the strings the privacy flow already ships.

## Test plan

- [ ] Miniapp Developer menu → **Read the Docs** → confirm dialog appears →
  **Continue** opens docs in browser, **Cancel** dismisses.
- [ ] Privacy → **Privacy Policy** still shows the same dialog and opens the
  policy on **Continue** (regression check).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX refactor with shared alert helper; no auth, data, or permission logic changes.
> 
> **Overview**
> External links in **miniapp developer settings** and **privacy settings** now show the same “you are leaving the app” confirmation before opening the system browser.
> 
> A shared **`showLeaveAppAlert(url)`** helper in `AlertUtils` centralizes the existing `settings:leaveAppTitle` / `settings:leaveAppMessage` copy and opens the URL only after **Continue**. **Read the Docs** no longer calls `Linking.openURL` directly; **Privacy Policy** drops its inline alert/`Linking` wiring in favor of the helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998163ad3776a895f1501936934c9ba75edfab44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a “leaving the app” confirmation before opening the miniapp dev “Read the Docs” link, matching the Privacy Policy flow.
Added a reusable showLeaveAppAlert(url) in `AlertUtils` and routed both the docs and privacy-policy links through it; reuses existing i18n copy for consistent messaging.

<sup>Written for commit 998163ad3776a895f1501936934c9ba75edfab44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

