### PR TITLE
Speak Merge insights on glasses without a display

### DIFF
--- a/miniapps/merge/miniapp/miniapp.json
+++ b/miniapps/merge/miniapp/miniapp.json
@@ -1,7 +1,7 @@
 {
   "$schema": "./node_modules/@mentra/miniapp-cli/schema/miniapp.schema.json",
   "packageName": "com.mentra.local-merge",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "name": "Local Merge",
   "description": "Local Merge proactive AI assistant. Listens to conversations and surfaces concise contextual insights through a backend that keeps AI secrets off-device.",
   "type": "background",
@@ -23,6 +23,16 @@
       "type": "MICROPHONE",
       "level": "REQUIRED",
       "description": "Captures speech for transcription"
+    },
+    {
+      "type": "DISPLAY",
+      "level": "OPTIONAL",
+      "description": "Shows insights on the glasses display when one is available"
+    },
+    {
+      "type": "SPEAKER",
+      "level": "OPTIONAL",
+      "description": "Speaks insights aloud on glasses without a display (e.g. Mentra Live)"
     }
   ],
   "icon": "icon.png"

--- a/miniapps/merge/miniapp/src/background/index.ts
+++ b/miniapps/merge/miniapp/src/background/index.ts
@@ -532,11 +532,29 @@ class MergeController {
   private showInsight(insight: MergeInsight): void {
     this.clearDisplayTimer()
     this.activeDisplayUntil = Date.now() + DISPLAY_DURATION_MS
-    this.session.display.showTextWall(`// Merge\n${insight.text}`, {
-      durationMs: DISPLAY_DURATION_MS,
-      breakMode: "word",
-    })
+    if (capabilityHasDisplay(this.session.capabilities)) {
+      this.session.display.showTextWall(`// Merge\n${insight.text}`, {
+        durationMs: DISPLAY_DURATION_MS,
+        breakMode: "word",
+      })
+    } else {
+      // No display (e.g. Mentra Live): speak the insight so the app is still
+      // useful on audio-only glasses. Fire-and-forget — speak() only resolves
+      // when playback finishes, but display pacing stays on the
+      // DISPLAY_DURATION_MS window driven by scheduleNextQueuedDisplay().
+      void this.speakInsight(insight)
+    }
     this.scheduleNextQueuedDisplay()
+  }
+
+  private async speakInsight(insight: MergeInsight): Promise<void> {
+    try {
+      // stopOtherAudio mirrors "replace" display semantics for audio: a newer
+      // insight cuts off one that is still being spoken instead of overlapping.
+      await this.session.speaker.speak(insight.text, {stopOtherAudio: true})
+    } catch (err) {
+      console.log("LocalMerge: failed to speak insight", err)
+    }
   }
 
   private clearDisplayTimer(): void {
@@ -661,6 +679,22 @@ function chooseDisplayAction(
   if (Date.now() >= activeDisplayUntil) return insight.displayAction ?? "show"
   if (insight.displayAction === "replace" || insight.urgency === "high") return "replace"
   return "queue"
+}
+
+function capabilityHasDisplay(caps: unknown): boolean {
+  // Capability shapes vary across host versions; accept the common flags.
+  // Default to display output when the shape is unreadable so we never surprise
+  // a display-equipped user with unexpected audio.
+  if (!caps || typeof caps !== "object") return true
+  const record = caps as Record<string, unknown>
+  if (typeof record.hasDisplay === "boolean") return record.hasDisplay
+  const display = record.display
+  if (typeof display === "boolean") return display
+  if (display === null) return false
+  if (display && typeof display === "object") {
+    return (display as {present?: boolean}).present !== false
+  }
+  return true
 }
 
 function userTimezone(): string {

--- a/miniapps/merge/miniapp/src/background/index.ts
+++ b/miniapps/merge/miniapp/src/background/index.ts
@@ -130,6 +130,12 @@ class MergeController {
 
   stop(): void {
     this.clearDisplayTimer()
+    // Leaving/minimizing the app must not leave a spoken insight playing.
+    try {
+      this.session.speaker.stop()
+    } catch {
+      /* transport may already be closing during disconnect */
+    }
     if (this.transcriptionCleanup) {
       this.transcriptionCleanup()
       this.transcriptionCleanup = null
@@ -165,6 +171,7 @@ class MergeController {
         this.lastError = null
         this.backendStatus = "idle"
         this.session.display.clear()
+        this.session.speaker.stop()
         this.sendSnapshot()
       }),
     )


### PR DESCRIPTION
## Problem

The **Local Merge** miniapp (`com.mentra.local-merge`) surfaces its proactive AI insights **only** through `session.display.showTextWall`. Because it requires only a `MICROPHONE`, it lists as **available** when connected to **Mentra Live** — but Mentra Live has no display (`hasDisplay: false`), so the app runs and produces nothing the user can perceive.

## Fix

Add audio output. In `showInsight`, route each insight to `session.speaker.speak(...)` when the connected glasses have no display, and keep the existing display path for glasses that do have one. We deliberately don't speak on display glasses — reading every insight aloud during a live conversation would be intrusive; the display is the right channel there.

- New `capabilityHasDisplay()` helper reads `session.capabilities` defensively (mirrors the shape-tolerant check the teleprompter miniapp uses), defaulting to the display path when capabilities are unreadable so a display user is never surprised by audio.
- `speakInsight()` is fire-and-forget with `stopOtherAudio: true`, which gives audio the same "a newer insight replaces the current one" semantics the display path already has. Display pacing (the `DISPLAY_DURATION_MS` window / queue) is unchanged.
- `miniapp.json`: declare `DISPLAY` and `SPEAKER` as **OPTIONAL** hardware so the dual output is documented, and bump `0.1.24 → 0.1.25`. Both remain optional (mic stays required), so the app keeps running on any mic-equipped glasses — Mentra Live included.

## Testing

- `tsc --noEmit` (miniapp tsconfig): passes
- `bun run build.ts`: builds `dist/background/index.js` + UI + assets successfully

Hardware-untested (no Mentra Live device on hand) — the change uses the same `session.speaker.speak` API the `mentra-ai` miniapp already ships.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped miniapp output routing and lifecycle cleanup using an established speaker API; no auth, backend, or core platform changes.
> 
> **Overview**
> **Local Merge** no longer relies solely on the glasses display for insights. When `session.capabilities` indicate no display (e.g. Mentra Live), insights are spoken via `session.speaker.speak` with `stopOtherAudio: true`; display-capable devices still get the existing `showTextWall` path only—no auto-speak there.
> 
> A new **`capabilityHasDisplay()`** helper tolerates varying capability shapes and defaults to the display path when capabilities are unreadable. **`speakInsight()`** runs fire-and-forget so queue pacing still follows the existing `DISPLAY_DURATION_MS` window. **`stop()`** and the merge clear handler now call **`session.speaker.stop()`** so playback does not continue after leaving or clearing.
> 
> **`miniapp.json`** documents optional **DISPLAY** and **SPEAKER** hardware and bumps version **0.1.24 → 0.1.25**; microphone remains required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78acd594d6118dd642528e7e43b9cfac59d6b3c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speak insights on glasses without a display so Local Merge works on Mentra Live. Stop spoken insights on clear or disconnect; keep showing text on display-capable glasses only.

- **New Features**
  - Speak insights when no display using `session.speaker.speak` with `stopOtherAudio: true`.
  - Add `capabilityHasDisplay()` for safe detection; update `miniapp.json` to declare optional `DISPLAY` and `SPEAKER` (version `0.1.25`).

- **Bug Fixes**
  - Stop any ongoing TTS when clearing or leaving the app by calling `session.speaker.stop()` in `stop()` and the clear/reset handler.

<sup>Written for commit 78acd594d6118dd642528e7e43b9cfac59d6b3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

