### PR TITLE
Skip dashboard settings for glasses with a native firmware dashboard (G2)

### DIFF
--- a/cloud/packages/cloud/src/config/capabilities/even-realities-g2.ts
+++ b/cloud/packages/cloud/src/config/capabilities/even-realities-g2.ts
@@ -70,4 +70,8 @@ export const evenRealitiesG2: Capabilities = {
 
   // OTA capabilities - G2 firmware updates are not driven by the ASG OTA flow
   hasOta: false,
+
+  // Dashboard - G2 renders Even Realities' native dashboard in firmware, so
+  // MentraOS does not manage the dashboard or expose dashboard settings for it
+  hasNativeDashboard: true,
 };

--- a/cloud/packages/types/src/capabilities/even-realities-g2.ts
+++ b/cloud/packages/types/src/capabilities/even-realities-g2.ts
@@ -70,4 +70,8 @@ export const evenRealitiesG2: Capabilities = {
 
   // OTA capabilities - G2 firmware updates are not driven by the ASG OTA flow
   hasOta: false,
+
+  // Dashboard - G2 renders Even Realities' native dashboard in firmware, so
+  // MentraOS does not manage the dashboard or expose dashboard settings for it
+  hasNativeDashboard: true,
 };

--- a/cloud/packages/types/src/hardware.ts
+++ b/cloud/packages/types/src/hardware.ts
@@ -153,6 +153,13 @@ export interface Capabilities {
 
   // OTA capability
   hasOta: boolean;
+
+  // Native dashboard capability
+  // True when the device renders its own dashboard in firmware (e.g. Even
+  // Realities' built-in dashboard on G2). MentraOS does not manage or expose
+  // dashboard settings for these devices. Absent/false means MentraOS owns the
+  // dashboard.
+  hasNativeDashboard?: boolean;
 }
 
 /**

--- a/mobile/modules/island/src/types/capabilities/even-realities-g2.ts
+++ b/mobile/modules/island/src/types/capabilities/even-realities-g2.ts
@@ -67,4 +67,8 @@ export const evenRealitiesG2: Capabilities = {
 
   // WiFi capabilities - G2 does not support WiFi
   hasWifi: false,
+
+  // Dashboard - G2 renders Even Realities' native dashboard in firmware, so
+  // MentraOS does not manage the dashboard or expose dashboard settings for it
+  hasNativeDashboard: true,
 };

--- a/mobile/modules/island/src/types/hardware.ts
+++ b/mobile/modules/island/src/types/hardware.ts
@@ -149,6 +149,13 @@ export interface Capabilities {
 
   // WiFi capability
   hasWifi: boolean;
+
+  // Native dashboard capability
+  // True when the device renders its own dashboard in firmware (e.g. Even
+  // Realities' built-in dashboard on G2). MentraOS does not manage or expose
+  // dashboard settings for these devices. Absent/false means MentraOS owns the
+  // dashboard.
+  hasNativeDashboard?: boolean;
 }
 
 /**

--- a/mobile/src/components/settings/DeviceSettingsSection.tsx
+++ b/mobile/src/components/settings/DeviceSettingsSection.tsx
@@ -118,8 +118,10 @@ export function DeviceSettingsSection() {
         />
       )}
 
-      {/* Dashboard — glasses with a display only */}
-      {defaultWearable && features?.hasDisplay && (
+      {/* Dashboard — glasses with a MentraOS-managed display dashboard only.
+          Devices with a native firmware dashboard (e.g. G2) manage it on-device,
+          so our dashboard settings don't apply. */}
+      {defaultWearable && features?.hasDisplay && !features?.hasNativeDashboard && (
         <RouteButton
           icon={<Icon name="layout-dashboard" size={24} color={theme.colors.secondary_foreground} />}
           label={translate("settings:dashboardSettings")}


### PR DESCRIPTION
## Summary

G2 uses **Even Realities' native dashboard, baked into its firmware**. MentraOS's own contextual-dashboard settings therefore don't apply to it, but today the **Dashboard** settings row still shows for G2 (it's gated only on `hasDisplay`, which G2 has).

This adds a `hasNativeDashboard` flag to the glasses config object and hides the entire Dashboard Settings entry point for devices that have it.

## Changes

- **New capability flag** `hasNativeDashboard?: boolean` on the `Capabilities` interface — *"device renders its own dashboard in firmware; MentraOS does not manage or expose dashboard settings for it."* Added to all copies of the interface:
  - `cloud/packages/types/src/hardware.ts` (source of truth; re-exported through `@mentra/sdk` and imported directly by the mobile app)
  - `mobile/modules/island/src/types/hardware.ts` (separate island copy)
- **Set `hasNativeDashboard: true` on the G2 profile** in all three capability copies (`@mentra/types`, `cloud` config, mobile `island`).
- **Mobile UI:** `DeviceSettingsSection.tsx` now gates the Dashboard row on `features?.hasDisplay && !features?.hasNativeDashboard`, so it is hidden for G2 and unchanged for G1 / every other display device.

The flag is **optional** (absent/false = MentraOS owns the dashboard), so no other device profile needs to change.

## Scope / notes

- Scoped to the **Dashboard** settings entry per the request ("the entire route for Dashboard Settings should not apply to G2"). The adjacent **Display position** row (`dashboard_depth`/`dashboard_height`) is left as-is since it arguably governs general content placement, not just the dashboard — easy to also gate on `hasNativeDashboard` if we decide it should follow.
- Entry-point hiding is the real user-facing path; the deep-linkable `/miniapps/settings/dashboard` route is left reachable (harmless, and those toggles are cloud-synced prefs that still matter for a user's other glasses).
- The new flag is defined but not yet consumed cloud-side; it's positioned so the backend can later skip sending dashboard layouts to native-dashboard devices.

## Testing

- `@mentra/types` typechecks clean (TS 5.6).
- Mobile deps aren't installed in this worktree, so the full RN typecheck runs in CI (the change is a one-line optional-field access on an already-`Capabilities`-typed object). Will babysit CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small capability flag plus a single UI gate; no auth, data, or dashboard runtime behavior changes in this diff.
> 
> **Overview**
> Adds an optional **`hasNativeDashboard`** capability on glasses profiles and sets it on **Even Realities G2**, where the dashboard is rendered in firmware rather than by MentraOS.
> 
> The **Dashboard** row in device settings is now shown only when the device has a display **and** MentraOS manages the dashboard (`!hasNativeDashboard`), so G2 users no longer see settings that do not apply. The flag is wired through the shared **`Capabilities`** type and the parallel G2 capability copies in cloud and island; other models are unchanged (absent/false still means MentraOS-owned dashboard).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 276cfad6d731d33e33e2059f933afac9b6509892. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Dashboard settings for G2 by adding a `hasNativeDashboard` capability and gating the UI, since G2 uses a native firmware dashboard. Other devices with displays are unchanged.

- **New Features**
  - Added optional `hasNativeDashboard` to `Capabilities` in `@mentra/types` and the mobile island types.
  - Set `hasNativeDashboard: true` for the Even Realities G2 capability profiles (cloud and mobile).
  - Gated the mobile Dashboard settings row on `hasDisplay && !hasNativeDashboard` in `DeviceSettingsSection`.

<sup>Written for commit 276cfad6d731d33e33e2059f933afac9b6509892. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

