### PR TITLE
Fix Settings app restarting when opening display position

### DIFF
--- a/mobile/src/utils/dev/konami.tsx
+++ b/mobile/src/utils/dev/konami.tsx
@@ -136,10 +136,15 @@ export function KonamiCodeProvider({children}: {children: React.ReactNode}) {
 
   const contextValue = useMemo(() => ({enabled, setEnabled}), [enabled])
 
-  if (!enabled) {
-    return <KonamiContext.Provider value={contextValue}>{children}</KonamiContext.Provider>
-  }
-
+  // Always render the SAME tree shape regardless of `enabled`. This provider
+  // wraps the entire app (AllProviders → AllEffects → Compositor →
+  // OfflineAppHost), so if we returned bare `{children}` when disabled and a
+  // `<GestureDetector>`-wrapped tree when enabled, flipping `enabled` would
+  // change the element type directly under the provider — remounting the whole
+  // app subtree and resetting any hosted offline app (e.g. Settings) back to
+  // its initial route. The display-position screen toggles `enabled` on mount,
+  // which is why opening it "restarted" the Settings app. `enabled` still fully
+  // suppresses code detection via the `enabledRef` guard in `addDirection`.
   return (
     <KonamiContext.Provider value={contextValue}>
       <GestureDetector gesture={composedGesture}>


### PR DESCRIPTION
## The bug

Open the Settings app → tap **Display Position**. The Settings app immediately "restarts" — it snaps back to the Settings main screen. The display-position menu is effectively unreachable through Settings; the only way to land on it is via a path that opens it as a real route (e.g. from the glasses tile flow), not through the offline-hosted Settings app.

## Root cause

`position.tsx` disables the konami-code gesture detector while it's on screen so slider swipes aren't misread as konami directions:

```ts
useEffect(() => {
  setEnabled(false)
  return () => setEnabled(true)
}, [setEnabled])
```

`KonamiCodeProvider` wraps the **entire app** (`AllProviders` → `AllEffects` → `Compositor` → `OfflineAppHost`). It returned a **different JSX tree shape** depending on `enabled`:

```tsx
if (!enabled) {
  return <KonamiContext.Provider value={contextValue}>{children}</KonamiContext.Provider>
}
return (
  <KonamiContext.Provider value={contextValue}>
    <GestureDetector gesture={composedGesture}>
      <View style={{flex: 1}}>{children}</View>
    </GestureDetector>
  </KonamiContext.Provider>
)
```

Flipping `enabled` changes the element type *directly under the provider* (`<GestureDetector>` ↔ the root of `{children}`). React can't reconcile that in place, so it **unmounts and remounts the whole app subtree**. The remounted `OfflineAppHost` re-seeds its internal stack from `def.initialRoute` (`/miniapps/settings/main`) — the "restart."

This is why only Display Position triggers it: `position.tsx` is the sole screen that calls `useKonamiCode()`/`setEnabled`. And it's why entering the screen as a real router route survives — expo-router re-derives that route from the URL after the remount, while the offline host always re-seeds to `main`.

## The fix

Always render the same tree shape from `KonamiCodeProvider`. Detection is still fully suppressed while disabled by the existing `enabledRef` guard at the top of `addDirection` (`if (!enabledRef.current) return`), so konami behavior is unchanged — only the app-wide remount is eliminated.

The gesture detector staying mounted while "disabled" matches how the rest of the app already runs (konami defaults to `enabled=true` everywhere), so there's no new gesture-arbitration risk.

## Testing

- Static reasoning + code trace confirmed the remount chain (`setEnabled` → provider tree-shape change → `AllEffects`/`Compositor`/`OfflineAppHost` remount → host re-seeds to `main`).
- Not yet verified on-device. Repro to confirm: Settings → Display Position should now open and stay, with the sliders working and konami codes not firing while on that screen.

## Scope

One file, 9 insertions / 4 deletions. No behavior change beyond removing the erroneous remount.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file React tree-shape fix with no auth or data changes; konami suppression still uses the existing `enabledRef` guard.
> 
> **Overview**
> **`KonamiCodeProvider` no longer swaps its JSX shape when `enabled` is false.** It always renders `Provider → GestureDetector → View → children`, instead of returning bare `children` without the gesture wrapper.
> 
> Display Position calls `setEnabled(false)` on mount so slider swipes are not treated as konami input. That flip used to change the element type directly under the app-wide provider, which forced React to remount the subtree (including `OfflineAppHost`) and reset hosted Settings to its initial route.
> 
> Konami detection while disabled is unchanged: `addDirection` still bails out via the existing `enabledRef` guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c8943a6d2f999d766fa8f432679cdd49bf976dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings app “restart” when opening Display Position by keeping the `KonamiCodeProvider` JSX tree shape stable. This stops the React remount that sent users back to the Settings main screen.

- **Bug Fixes**
  - Provider always renders a consistent wrapper; detection is gated by `enabledRef` instead of toggling element types.
  - Display Position opens and stays on screen; sliders work and Konami input stays disabled on that view.

<sup>Written for commit 4c8943a6d2f999d766fa8f432679cdd49bf976dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3312?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

