### PR TITLE
Fix dev miniapp icon not loading after QR scan

### DIFF
--- a/mobile/src/hooks/useCachedRemoteImageSource.test.ts
+++ b/mobile/src/hooks/useCachedRemoteImageSource.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Regression coverage for the dev-miniapp icon load path.
+ *
+ * `mentra dev`'s static server serves the tile icon with `Cache-Control:
+ * no-store`, so expo-image downloads it (prefetch → true) but never persists it
+ * to disk — `getCachePathAsync` stays null. The hook must NOT treat that as a
+ * failure; it should fall back to the original URL (warm in expo-image's memory
+ * cache) so the real logo renders instead of the placeholder.
+ */
+
+const mockPrefetch = jest.fn<Promise<boolean>, [string, unknown?]>()
+const mockGetCachePathAsync = jest.fn<Promise<string | null>, [string]>()
+
+jest.mock("expo-image", () => ({
+  Image: {
+    prefetch: (url: string, opts?: unknown) => mockPrefetch(url, opts),
+    getCachePathAsync: (url: string) => mockGetCachePathAsync(url),
+  },
+}))
+
+import {
+  warmCachedRemoteImageSources,
+  isCachedRemoteImageResolved,
+  isRemoteImageSourceFailed,
+} from "./useCachedRemoteImageSource"
+
+beforeEach(() => {
+  mockPrefetch.mockReset()
+  mockGetCachePathAsync.mockReset()
+})
+
+describe("useCachedRemoteImageSource cache resolution", () => {
+  it("resolves a normal (disk-cacheable) remote icon to its file:// path", async () => {
+    const url = "https://cdn.example.com/store-icon-a.png"
+    mockGetCachePathAsync.mockResolvedValue("/tmp/cache/store-icon-a.png")
+
+    await warmCachedRemoteImageSources([url])
+
+    expect(isCachedRemoteImageResolved(url)).toBe(true)
+    expect(isRemoteImageSourceFailed(url)).toBe(false)
+    // Disk path was available up front — no prefetch needed.
+    expect(mockPrefetch).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the original URL when prefetch succeeds but the icon isn't disk-cached (no-store dev server)", async () => {
+    const url = "http://192.168.1.50:3000/icon.png"
+    // No disk path ever (server sent Cache-Control: no-store), but the bytes
+    // download fine so prefetch reports success.
+    mockGetCachePathAsync.mockResolvedValue(null)
+    mockPrefetch.mockResolvedValue(true)
+
+    await warmCachedRemoteImageSources([url])
+
+    // Resolved (so the grid reveals + the tile shows the real icon), NOT failed.
+    expect(isCachedRemoteImageResolved(url)).toBe(true)
+    expect(isRemoteImageSourceFailed(url)).toBe(false)
+    expect(mockPrefetch).toHaveBeenCalledWith(url, expect.objectContaining({cachePolicy: "memory-disk"}))
+  })
+
+  it("marks the icon failed when the prefetch itself fails (unreachable dev server)", async () => {
+    const url = "http://192.168.1.50:3000/gone.png"
+    mockGetCachePathAsync.mockResolvedValue(null)
+    mockPrefetch.mockResolvedValue(false)
+
+    await warmCachedRemoteImageSources([url])
+
+    expect(isCachedRemoteImageResolved(url)).toBe(false)
+    expect(isRemoteImageSourceFailed(url)).toBe(true)
+  })
+})

--- a/mobile/src/hooks/useCachedRemoteImageSource.ts
+++ b/mobile/src/hooks/useCachedRemoteImageSource.ts
@@ -27,7 +27,18 @@ async function resolveCachedPath(url: string): Promise<string | null> {
         resolvedCache.set(url, fileUri)
         return fileUri
       }
-      return null
+      // Prefetch succeeded but the image isn't on disk. This is the dev-miniapp
+      // case: `mentra dev`'s static server serves the tile icon with
+      // `Cache-Control: no-store`, so expo-image downloads it (prefetch → true)
+      // but never persists it, leaving getCachePathAsync null forever. Returning
+      // null here would (mis)mark the icon as failed and the dev tile would show
+      // its placeholder instead of the real logo. The bytes are valid and already
+      // warm in expo-image's MEMORY cache from the prefetch above, so fall back to
+      // the original URL: <Image> renders it straight from memory. This only
+      // happens after a *successful* prefetch, so it never reintroduces the
+      // failed/slow-remote decode thrash this hook otherwise guards against.
+      resolvedCache.set(url, url)
+      return url
     } finally {
       inflight.delete(url)
     }


### PR DESCRIPTION
## Problem

During the July 1 bug hunt: after scanning a dev miniapp QR code, the home‑screen tile showed a **blank/placeholder icon** instead of the miniapp's real logo (see the "Mini App SDK Fails to Load Icons" report — the dev *Mentra AI* tile renders empty).

## Root cause

A dev miniapp's tile `logoUrl` points at the dev server (`${devUrl}/icon.png`). `mentra dev`'s static server (`sdk/miniapp-cli/src/dev.ts`) serves **every** file with `Cache-Control: no-store`.

`useCachedRemoteImageSource` prefetches remote icons into expo-image's **disk** cache and then hands `<Image>` the resulting `file://` path — this is deliberate, to avoid repeated native decode work on Android for slow/failed remote images. But expo-image won't persist a `no-store` response to disk, so `Image.getCachePathAsync()` stays `null` even though `Image.prefetch()` downloaded the bytes just fine. The hook then returned `null`, which marks the icon **failed**, and the tile falls back to the dev placeholder.

Store / CDN icons ship cacheable headers, so they disk-cache normally — which is why this only ever bit **dev** miniapps.

## Fix

When a prefetch succeeds but no disk path is available, fall back to the **original URL**. The bytes are already warm in expo-image's memory cache from the prefetch, so `<Image>` renders them straight from memory. This branch only runs *after a successful prefetch*, so it never reintroduces the failed/slow-remote decode thrash the hook guards against. One-line change in `resolveCachedPath`; both consumers (`AppIcon`, `AppsGrid` warm/gate) flow through unchanged.

## Test

Added `useCachedRemoteImageSource.test.ts` covering all three resolve outcomes:
- disk-cacheable icon → resolves to `file://` path (no prefetch needed)
- **no-store dev server** → prefetch ok + no disk path → resolves to original URL, **not** marked failed *(regression guard)*
- unreachable dev server → prefetch fails → marked failed

```
PASS src/hooks/useCachedRemoteImageSource.test.ts  (3 passed)
```

`bun compile` (tsc) and `prettier --check` on the changed files both pass.

## Notes / scope
- Client-only fix, so it works for **every** dev host (LAN `mentra dev`, ngrok, Porter) — not just callers on the newest CLI. The `no-store` header in the CLI is left as-is (intentional for live reload); the client now handles it correctly.
- No device build was run locally; verification is via the unit tests + typecheck. Worth a quick on-glasses sanity check during the next bug-hunt pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-only change in remote icon resolution with unit tests; fallback runs only after successful prefetch, preserving existing protection against failed/slow remote decodes.
> 
> **Overview**
> Fixes **blank dev miniapp tile icons** after QR scan when `logoUrl` is served with **`Cache-Control: no-store`**: expo-image prefetches successfully but never writes disk, so `getCachePathAsync` stayed null and the hook treated the icon as **failed**.
> 
> **`resolveCachedPath`** now, after a successful prefetch with no disk path, **caches and returns the original HTTP(S) URL** so `AppIcon` / the apps grid still count the icon as resolved and render from expo-image’s memory cache—without weakening the guard that only avoids handing remote URLs to `<Image>` when prefetch actually fails.
> 
> Adds **`useCachedRemoteImageSource.test.ts`** with three cases: disk `file://` resolution, no-store fallback (regression), and unreachable server → failed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3d8596ceb2054d5b8cfc2b66f217873a36275aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev miniapp tiles showing blank icons after QR scan. If a prefetch succeeds but `expo-image` can’t write a disk cache path (dev server sends `no-store`), we now render from the original URL using memory cache.

- **Bug Fixes**
  - In `useCachedRemoteImageSource`, when prefetch is true and no `file://` path exists, resolve to the original URL instead of marking the icon failed.
  - Added unit tests for disk-cached, `no-store` memory fallback, and prefetch failure cases.

<sup>Written for commit b3d8596ceb2054d5b8cfc2b66f217873a36275aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

