### PR TITLE
Teleprompter Play/AI-scroll UX fix + restore "Starting <miniapp>…" boot message

### DIFF
--- a/miniapps/teleprompter/miniapp.json
+++ b/miniapps/teleprompter/miniapp.json
@@ -34,7 +34,7 @@
   "actions": [
     {
       "id": "load_script",
-      "description": "Load text into the teleprompter and start reading it on the glasses. Use when the user wants to put a speech, talking points, lines, or any notes up on their glasses — e.g. 'put my toast on the teleprompter' or 'teleprompt this'. Replaces the current script and resets to the top. By default it begins scrolling immediately (following the user's voice when a mic is available, otherwise at their saved words-per-minute); set autostart false to just show the opening lines so the user can start when ready.",
+      "description": "Load text into the teleprompter and start reading it on the glasses. Use when the user wants to put a speech, talking points, lines, or any notes up on their glasses — e.g. 'put my toast on the teleprompter' or 'teleprompt this'. Replaces the current script and resets to the top. By default it begins scrolling immediately at the user's saved speed (or following their voice if they've turned on AI Scroll); set autostart false to just show the opening lines so the user can start when ready.",
       "parameters": {
         "type": "object",
         "properties": {

--- a/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
+++ b/miniapps/teleprompter/src/background/controllers/TeleprompterController.ts
@@ -35,9 +35,9 @@ type On = <C extends keyof Channels & string>(channel: C, cb: (payload: Channels
 const DEFAULT_SCRIPT = [
   "Welcome to your teleprompter.",
   "",
-  "Paste or type your script here, put on your glasses, and press play. The words appear in front of you, line by line.",
+  "Paste or type your script here, put on your glasses, and press play. The words scroll by on their own at the speed you set, line by line.",
   "",
-  "Leave voice-follow on and the prompter listens — it advances as you speak, and waits when you pause. Turn it off to scroll at a steady pace you set in words per minute.",
+  "Want it to keep pace with you instead? Turn on AI Scroll and the prompter listens — it advances as you speak, and waits when you pause.",
   "",
   "That's it. Look up, speak naturally, and never lose your place.",
 ].join("\n")
@@ -47,7 +47,10 @@ const DEFAULT_SETTINGS: TeleprompterSettings = {
   wpm: 130,
   numberOfLines: 4,
   lineWidth: 2,
-  voiceFollow: true,
+  // Default to timed auto-scroll: pressing Play advances the script on its own.
+  // Voice-follow ("AI Scroll") is an explicit opt-in via the cockpit toggle —
+  // otherwise Play silently waits for speech and reads as "it doesn't work".
+  voiceFollow: false,
   autoRestart: false,
   showTimecode: false,
 }

--- a/miniapps/teleprompter/src/ui/App.tsx
+++ b/miniapps/teleprompter/src/ui/App.tsx
@@ -46,7 +46,6 @@ export function App() {
               onSetWpm={tp.setWpm}
               onSetLines={tp.setLines}
               onSetWidth={tp.setWidth}
-              onSetVoiceFollow={tp.setVoiceFollow}
               onSetAutoRestart={tp.setAutoRestart}
               onSetShowTimecode={tp.setShowTimecode}
             />
@@ -60,6 +59,7 @@ export function App() {
               onRestart={tp.restart}
               onSeek={tp.seek}
               onNudge={tp.nudge}
+              onSetVoiceFollow={tp.setVoiceFollow}
             />
           )}
         </div>

--- a/miniapps/teleprompter/src/ui/components/ScriptView.tsx
+++ b/miniapps/teleprompter/src/ui/components/ScriptView.tsx
@@ -89,6 +89,10 @@ export function ScriptView({
 
   const totalWords = status?.totalWords ?? 0
   const playing = status?.state === "playing"
+  // Whether voice is the ACTUAL scroll driver — false when AI Scroll is on but
+  // the device has no mic (the engine falls back to timed scroll), so the
+  // caption doesn't promise voice-follow that isn't happening.
+  const voiceActive = status?.voiceMode ?? settings.voiceFollow
   const progress = drag ?? status?.progress ?? 0
   const totalSec = status?.estimatedTotalSec ?? 0
   const remainingSec = status?.remainingSec ?? totalSec
@@ -165,11 +169,14 @@ export function ScriptView({
           </div>
         </div>
 
-        {/* What Play does right now — defuses the "why isn't it moving?" confusion. */}
+        {/* What Play does right now — defuses the "why isn't it moving?" confusion.
+            Three states: off, on-with-voice, and on-but-no-mic (timed fallback). */}
         <p className="text-center text-[11px] leading-snug text-zinc-500">
-          {settings.voiceFollow
-            ? "AI Scroll is on — the prompter follows your voice as you speak."
-            : `Play auto-scrolls at ${settings.wpm} wpm. Turn on AI Scroll to follow your voice.`}
+          {!settings.voiceFollow
+            ? `Play auto-scrolls at ${settings.wpm} wpm. Turn on AI Scroll to follow your voice.`
+            : voiceActive
+              ? "AI Scroll is on — the prompter follows your voice as you speak."
+              : `AI Scroll is on, but this device has no mic — Play auto-scrolls at ${settings.wpm} wpm.`}
         </p>
 
         {/* Scrubber */}

--- a/miniapps/teleprompter/src/ui/components/ScriptView.tsx
+++ b/miniapps/teleprompter/src/ui/components/ScriptView.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from "react"
-import {ChevronDown, ChevronUp, Gauge, Mic, Pause, Play, RotateCcw} from "lucide-react"
+import {ChevronDown, ChevronUp, Mic, Pause, Play, RotateCcw} from "lucide-react"
 
 import type {PlaybackStatus, TeleprompterSettings} from "../../shared/types"
 import {fmtClock, fmtWords} from "../lib/format"
@@ -15,6 +15,7 @@ interface ScriptViewProps {
   onRestart: () => void
   onSeek: (percent: number) => void
   onNudge: (lines: number) => void
+  onSetVoiceFollow: (enabled: boolean) => void
 }
 
 const STATE_LABEL: Record<string, string> = {
@@ -33,6 +34,7 @@ export function ScriptView({
   onRestart,
   onSeek,
   onNudge,
+  onSetVoiceFollow,
 }: ScriptViewProps) {
   const [draft, setDraft] = useState(settings.script)
   const focusedRef = useRef(false)
@@ -87,7 +89,6 @@ export function ScriptView({
 
   const totalWords = status?.totalWords ?? 0
   const playing = status?.state === "playing"
-  const voiceMode = status?.voiceMode ?? settings.voiceFollow
   const progress = drag ?? status?.progress ?? 0
   const totalSec = status?.estimatedTotalSec ?? 0
   const remainingSec = status?.remainingSec ?? totalSec
@@ -102,22 +103,25 @@ export function ScriptView({
       <div className="shrink-0 bg-white border-b border-zinc-200 px-4 pt-3 pb-4 space-y-3 shadow-sm">
         <GlassesPreview status={status} />
 
-        {/* State + mode */}
+        {/* State + AI Scroll toggle. Play auto-scrolls at the set speed; AI Scroll
+            is the explicit opt-in that makes scrolling follow the speaker's voice. */}
         <div className="flex items-center justify-between">
           <span className="text-sm font-semibold text-zinc-800">{stateLabel}</span>
-          <span
-            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold"
-            style={{backgroundColor: voiceMode ? "#DCFCE7" : "#F4F4F5", color: voiceMode ? "#15803D" : "#3F3F46"}}>
-            {voiceMode ? (
-              <>
-                <Mic className="w-3.5 h-3.5" aria-hidden="true" /> Voice-follow
-              </>
-            ) : (
-              <>
-                <Gauge className="w-3.5 h-3.5" aria-hidden="true" /> {settings.wpm} wpm
-              </>
-            )}
-          </span>
+          <button
+            type="button"
+            aria-label="AI Scroll — follow my voice"
+            aria-pressed={settings.voiceFollow}
+            onClick={() => onSetVoiceFollow(!settings.voiceFollow)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-semibold transition-colors active:scale-95"
+            style={
+              settings.voiceFollow
+                ? {backgroundColor: ACCENT, color: ACCENT_FG}
+                : {backgroundColor: "#F4F4F5", color: "#3F3F46"}
+            }>
+            <Mic className="w-3.5 h-3.5" aria-hidden="true" />
+            AI Scroll
+            <span className="opacity-80">{settings.voiceFollow ? "On" : "Off"}</span>
+          </button>
         </div>
 
         {/* Transport */}
@@ -160,6 +164,13 @@ export function ScriptView({
             </button>
           </div>
         </div>
+
+        {/* What Play does right now — defuses the "why isn't it moving?" confusion. */}
+        <p className="text-center text-[11px] leading-snug text-zinc-500">
+          {settings.voiceFollow
+            ? "AI Scroll is on — the prompter follows your voice as you speak."
+            : `Play auto-scrolls at ${settings.wpm} wpm. Turn on AI Scroll to follow your voice.`}
+        </p>
 
         {/* Scrubber */}
         <div className="space-y-1.5">

--- a/miniapps/teleprompter/src/ui/components/SettingsView.tsx
+++ b/miniapps/teleprompter/src/ui/components/SettingsView.tsx
@@ -1,4 +1,4 @@
-import {AlignLeft, Gauge, Mic, Repeat, Rows3, Timer} from "lucide-react"
+import {AlignLeft, Gauge, Repeat, Rows3, Timer} from "lucide-react"
 
 import type {LineWidth, TeleprompterSettings} from "../../shared/types"
 import {ACCENT, ACCENT_FG} from "../lib/theme"
@@ -8,7 +8,6 @@ interface SettingsViewProps {
   onSetWpm: (wpm: number) => void
   onSetLines: (lines: number) => void
   onSetWidth: (width: LineWidth) => void
-  onSetVoiceFollow: (enabled: boolean) => void
   onSetAutoRestart: (enabled: boolean) => void
   onSetShowTimecode: (enabled: boolean) => void
 }
@@ -18,22 +17,14 @@ export function SettingsView({
   onSetWpm,
   onSetLines,
   onSetWidth,
-  onSetVoiceFollow,
   onSetAutoRestart,
   onSetShowTimecode,
 }: SettingsViewProps) {
   return (
     <div className="h-full overflow-y-auto px-4 py-5 space-y-5 bg-zinc-100 scrollbar-hide">
-      {/* Scrolling */}
+      {/* Scrolling — AI Scroll (voice-follow) lives in the Script cockpit; this
+          panel sets the timed scroll speed Play uses. */}
       <Section title="Scrolling">
-        <ToggleRow
-          icon={<Mic className="w-5 h-5" />}
-          label="Voice-follow"
-          description="The prompter listens and advances as you speak. Turn off for a steady timed scroll."
-          checked={settings.voiceFollow}
-          onChange={onSetVoiceFollow}
-        />
-        <Divider />
         <div className="space-y-3">
           <div className="flex items-center gap-3">
             <Gauge className="w-5 h-5 text-zinc-900" />

--- a/mobile/modules/island/src/services/LocalDisplayManager.ts
+++ b/mobile/modules/island/src/services/LocalDisplayManager.ts
@@ -52,6 +52,10 @@ interface BootingApp {
   displayName: string
   startedAt: number
   timerId: number
+  /** Whatever was on the glasses when this boot started, so a boot that times
+   * out without the app rendering can restore it instead of blanking a frame
+   * another (e.g. foreground) app owns. Null if the glasses were empty. */
+  preBoot: ActiveDisplay | null
 }
 
 interface BackgroundLock {
@@ -118,6 +122,12 @@ class LocalDisplayManager {
     // Cancel any in-flight boot for a prior app.
     this.cancelBoot()
 
+    // Snapshot whatever's on the glasses BEFORE the boot text overwrites it.
+    // registerApp fires onMount for every spawn — including a background app or
+    // a crash-respawn while another app is foreground — so a boot that times out
+    // without rendering must put the prior frame back rather than blank it.
+    const preBoot = this.currentDisplay
+
     // Send the boot message directly (bypass throttle + arbitration — this is
     // a system display).
     const bootEvent: Record<string, unknown> = {
@@ -135,6 +145,7 @@ class LocalDisplayManager {
       displayName,
       startedAt: this.now(),
       timerId,
+      preBoot,
     }
     this.bootQueue.clear()
   }
@@ -404,7 +415,7 @@ class LocalDisplayManager {
 
   private endBoot(triggeredByFirstDisplay: boolean): void {
     if (!this.bootingApp) return
-    const bootedPkg = this.bootingApp.packageName
+    const preBoot = this.bootingApp.preBoot
     BgTimer.clearTimeout(this.bootingApp.timerId)
     this.bootingApp = null
 
@@ -422,16 +433,36 @@ class LocalDisplayManager {
       this.arbitrateAndSend(pkg, payload)
     }
 
-    // If the booting app itself never queued a display and was just waiting
-    // on the timeout, clear the boot text so we don't leave "Starting …"
-    // stuck on the glasses. Restricting the clear to the core app avoids
-    // wiping a foreground app's frame when a background app boots — but the
-    // core app isn't wired on the local path yet (coreApp is always null
-    // today), so also clear when there's no core app to protect. Otherwise a
-    // miniapp that never renders (e.g. audio-only) would strand "Starting …".
-    if (!triggeredByFirstDisplay && queued.length === 0 && (this.coreApp === null || bootedPkg === this.coreApp)) {
-      this.sendClear()
+    // Boot ended on the timeout with nothing queued and no first display — the
+    // app just never rendered. Restore whatever was on the glasses before the
+    // boot text so a background app or crash-respawn can't blank a foreground
+    // app's frame (registerApp fires onMount for every spawn, and the core app
+    // isn't wired on the local path yet). If the glasses were empty before,
+    // clear the lingering "Starting …" instead — otherwise a miniapp that never
+    // renders (e.g. audio-only) would strand it.
+    if (!triggeredByFirstDisplay && queued.length === 0) {
+      // Only restore a frame that's still valid — one whose duration elapsed
+      // during the boot window should clear, not come back.
+      if (preBoot && (preBoot.expiresAt === null || preBoot.expiresAt > this.now())) {
+        this.restoreDisplay(preBoot)
+      } else {
+        this.sendClear()
+      }
     }
+  }
+
+  /**
+   * Re-push a previously-captured on-glasses frame (e.g. the display a boot
+   * window overwrote). Mirrors tryRestoreCoreDisplay: the saved event is already
+   * processed, and any remaining duration is recomputed from its expiry.
+   */
+  private restoreDisplay(saved: ActiveDisplay): void {
+    const remaining = saved.expiresAt !== null ? Math.max(0, saved.expiresAt - this.now()) : undefined
+    this.sendNow(saved.packageName, {
+      view: "main",
+      layout: saved.processedEvent.layout as DisplayPayload["layout"],
+      durationMs: remaining,
+    })
   }
 
   // ===========================================================================

--- a/mobile/modules/island/src/services/LocalDisplayManager.ts
+++ b/mobile/modules/island/src/services/LocalDisplayManager.ts
@@ -424,8 +424,12 @@ class LocalDisplayManager {
 
     // If the booting app itself never queued a display and was just waiting
     // on the timeout, clear the boot text so we don't leave "Starting …"
-    // stuck on the glasses.
-    if (!triggeredByFirstDisplay && queued.length === 0 && bootedPkg === this.coreApp) {
+    // stuck on the glasses. Restricting the clear to the core app avoids
+    // wiping a foreground app's frame when a background app boots — but the
+    // core app isn't wired on the local path yet (coreApp is always null
+    // today), so also clear when there's no core app to protect. Otherwise a
+    // miniapp that never renders (e.g. audio-only) would strand "Starting …".
+    if (!triggeredByFirstDisplay && queued.length === 0 && (this.coreApp === null || bootedPkg === this.coreApp)) {
       this.sendClear()
     }
   }

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -67,6 +67,9 @@ import type {ClientApp} from "../types/applet"
 // =============================================================================
 
 export interface InstalledMiniappManifest {
+  /** Human-facing app name (from miniapp.json `name`). Shown in the "Starting
+   * <name>…" boot message; falls back to the package name when absent. */
+  name?: string
   permissions?: Array<{type: string; required?: boolean; description?: string}>
   hardwareRequirements?: Array<{type: string; level: string; description?: string}>
 }
@@ -641,6 +644,13 @@ class LocalMiniappRuntime {
     this.recomputeLocationTier()
     this.ensureCloudStatusWired()
     this.ensurePingLoop()
+
+    // Show the system boot message ("Starting <name>…") on the glasses for the
+    // bounded boot window, mirroring the cloud DisplayManager boot screen. The
+    // window ends early once this app pushes its first display (see
+    // LocalDisplayManager.request), or after ~1.5s. Fires once per spawn —
+    // including a crash-respawn, since each spawn is a fresh "app is starting".
+    localDisplayManager.onMount(packageName, installedManifest?.name ?? packageName)
   }
 
   /**

--- a/mobile/modules/island/src/services/MiniappLauncher.ts
+++ b/mobile/modules/island/src/services/MiniappLauncher.ts
@@ -121,6 +121,7 @@ class MiniappLauncher {
         .map((p) => (typeof p === "string" ? p : p?.type))
         .filter((t): t is string => typeof t === "string")
       const installedManifest: InstalledMiniappManifest = {
+        name: manifest.name,
         permissions: manifest.permissions as InstalledMiniappManifest["permissions"],
         hardwareRequirements: manifest.hardwareRequirements as InstalledMiniappManifest["hardwareRequirements"],
       }
@@ -152,6 +153,7 @@ class MiniappLauncher {
     if (!entryPaths?.background) return null
 
     const manifest = appRegistry.getMiniappManifest(packageName, version) as {
+      name?: string
       permissions?: Array<{type: string; required?: boolean; description?: string}>
       hardwareRequirements?: Array<{type: string; level: string; description?: string}>
     } | null
@@ -159,7 +161,7 @@ class MiniappLauncher {
       .map((p) => p.type)
       .filter((t): t is string => typeof t === "string")
     const installedManifest: InstalledMiniappManifest | undefined = manifest
-      ? {permissions: manifest.permissions, hardwareRequirements: manifest.hardwareRequirements}
+      ? {name: manifest.name, permissions: manifest.permissions, hardwareRequirements: manifest.hardwareRequirements}
       : undefined
 
     let bgSource: string

--- a/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
+++ b/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
@@ -153,6 +153,26 @@ describe("LocalDisplayManager", () => {
       expect(mgr._peekForTest().isBooting).toBe(false)
     })
 
+    // registerApp fires onMount for EVERY spawn (background app, crash-respawn),
+    // so a second app's boot must not blank whatever the first app is showing.
+    // On timeout with nothing rendered, the prior frame is restored, not cleared.
+    test("a second app's boot that times out restores the prior frame, not a blank", () => {
+      // App A renders content (its own boot ends early on first display).
+      mgr.onMount("com.app.a", "A")
+      mgr.request("com.app.a", {layout: {layoutType: "text_wall", text: "A-content"}})
+      expect(lastText()).toBe("A-content")
+
+      // App B spawns and never renders.
+      mgr.onMount("com.app.b", "B")
+      expect(lastText()).toBe("Starting B…")
+      displayEventMock.mockClear()
+
+      advance(1500)
+      // B never rendered → A's frame restored, glasses not blanked.
+      expect(lastLayoutType()).not.toBe("clear_view")
+      expect(lastText()).toBe("A-content")
+    })
+
     test("mounting a second app cancels the first boot", () => {
       mgr.onCoreAppChange("com.app.foo")
       mgr.onMount("com.app.foo", "Foo")

--- a/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
+++ b/mobile/modules/island/src/services/__tests__/LocalDisplayManager.test.ts
@@ -131,6 +131,28 @@ describe("LocalDisplayManager", () => {
       expect(lastLayoutType()).toBe("clear_view")
     })
 
+    // Production wires onMount (from LocalMiniappRuntime.registerApp) but NOT
+    // onCoreAppChange, so coreApp is null. The boot text must still clear on
+    // timeout, or a miniapp that never renders would strand "Starting …".
+    test("boot timeout clears the boot text even when no core app is wired", () => {
+      mgr.onMount("com.app.foo", "Foo")
+      expect(lastText()).toBe("Starting Foo…")
+      displayEventMock.mockClear()
+      advance(1500)
+      expect(lastLayoutType()).toBe("clear_view")
+    })
+
+    // The common case: a single foreground display app, onMount only. The boot
+    // message shows, then the app's first render replaces it — no core wiring
+    // needed.
+    test("booting app's first display replaces the boot text with no core app wired", () => {
+      mgr.onMount("com.app.foo", "Foo")
+      expect(lastText()).toBe("Starting Foo…")
+      mgr.request("com.app.foo", {layout: {layoutType: "text_wall", text: "ready"}})
+      expect(lastText()).toBe("ready")
+      expect(mgr._peekForTest().isBooting).toBe(false)
+    })
+
     test("mounting a second app cancels the first boot", () => {
       mgr.onCoreAppChange("com.app.foo")
       mgr.onMount("com.app.foo", "Foo")


### PR DESCRIPTION
Two related local-miniapp fixes reported from testing.

## 1. Teleprompter: Play didn't auto-advance (looked broken)

**Symptom:** Pressing Play did nothing visible — the script only moved when you spoke — so people thought the miniapp was broken.

**Cause:** `voiceFollow` (voice-follow / "AI scroll") **defaulted to `true`**, and its only control was a toggle buried in the Settings tab. So the big Play button silently started voice-follow, which waits for speech. Play *was* "enable AI scroll" with no separate control — exactly the confusing behavior reported.

**Fix:**
- Default `voiceFollow` to **false** → Play now does timed auto-scroll (WPM) out of the box.
- Add a prominent, clearly-labeled **AI Scroll** toggle in the Script cockpit (next to the state), and remove the buried, differently-named "Voice-follow" row from Settings — one control, one name.
- Add a caption under the transport that states what Play will do in the current mode ("Play auto-scrolls at N wpm. Turn on AI Scroll to follow your voice." / "AI Scroll is on — the prompter follows your voice…").
- Update the built-in default script and the `load_script` action description to match the new default.

The driver logic is unchanged — voice-follow still live-switches mid-playback; this is a default + surfacing change.

## 2. Local miniapps lost the "Starting <name>…" boot message

**Symptom:** Cloud V2 (`@mentra/miniapp`) miniapps boot with no "Starting …" text on the glasses, unlike the old cloud-SDK apps.

**Cause:** `LocalDisplayManager.onMount()` — which renders `Starting <name>…` for a bounded window, mirroring the cloud `DisplayManager6.1` boot screen — was fully built (and unit-tested) but **never called** in production. Only `onUnmount` was wired into the runtime. Additionally, `InstalledMiniappManifest` dropped the app's `name`, so the runtime had no display name to show.

**Fix:**
- Plumb the manifest `name` through `InstalledMiniappManifest`, populated in both the dev and released launcher paths.
- Call `localDisplayManager.onMount(pkg, name)` from `LocalMiniappRuntime.registerApp`, symmetric with the existing `onUnmount` in `unregisterApp` (fires once per spawn; falls back to the package name when a manifest name is absent).
- Harden `endBoot` so the boot text clears on timeout when no core app is wired — `onCoreAppChange` isn't wired yet, so `coreApp` is always `null` today; without this an app that never renders could strand "Starting …" on the glasses. (For the common foreground-display app the boot text is replaced by the app's first render, which already works without core wiring.)

Note: full core-vs-background arbitration (`onCoreAppChange`) remains unwired — that's a separate workstream per `agents/local-display-manager-plan.md`. This PR only restores the boot message.

## Testing
- `mobile`: `tsc --noEmit` clean (0 errors).
- Teleprompter: `bun run build` + `tsc --noEmit` clean.
- Island tests: `LocalDisplayManager` (jest) 17/17 incl. new production-path cases; 8 `bun:test` island suites 104/104 (incl. `MentraJSRouter`, `MiniappLauncher`); `MicStateCoordinator` (jest) 5/5.
- Not yet hardware-tested on glasses.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UX defaults and on-glasses boot display wiring only; scroll driver logic is unchanged and island tests cover the boot-timeout paths.
> 
> **Overview**
> **Teleprompter:** **Play** now defaults to **timed auto-scroll** (`voiceFollow: false`) instead of voice-follow, which made the prompter look broken when nothing moved until you spoke. **AI Scroll** is a single opt-in toggle in the **Script** cockpit (removed buried **Voice-follow** from Settings), with a short caption under transport explaining the current mode. Default welcome script and `load_script` action copy match.
> 
> **Local miniapps:** Restores **Starting &lt;name&gt;…** on glasses by calling `localDisplayManager.onMount` from `registerApp`, passing manifest **`name`** through the launcher into `InstalledMiniappManifest`. **`endBoot`** also clears stuck boot text on timeout when no core app is wired (today’s production path), with new `LocalDisplayManager` tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8816656a29ca93c443d75e6163078e943021448a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Teleprompter Play to auto-scroll by default with a clear AI Scroll toggle and mic-aware caption. Restores and hardens the "Starting <miniapp>…" boot message for local miniapps, avoiding blank screens when an app never renders.

- **New Features**
  - Added a visible AI Scroll toggle in the Script view and a mic-aware caption that explains what Play will do now (including no-mic fallback).
  - Updated the default script and `load_script` action copy to match the new default.

- **Bug Fixes**
  - Defaulted `voiceFollow` to false so Play advances at the saved WPM unless AI Scroll is on.
  - Restored the boot message by calling `localDisplayManager.onMount(pkg, name)` and plumbing manifest `name`; on timeout, restore the pre-boot display instead of blanking (clear only if nothing valid to restore).

<sup>Written for commit 59d9d1bb82554376a25cfa3c32b299986f080883. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

