### PR TITLE
Auto-restart local miniapps on app relaunch

### DIFF
--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -487,6 +487,13 @@ class MantleManager {
     // lets Core move users to newer bundled miniapp releases without shipping a
     // new mobile binary.
     await preinstalledMiniappSync.sync()
+
+    // Re-spawn local miniapps that were running when the app was last killed.
+    // Cloud apps get resurrected by the cloud on reconnect; local (phone-hosted)
+    // miniapps have no server to bring them back, so the host restarts them here
+    // from the persisted running flags. Runs last so newly installed/upgraded
+    // bundles are on disk first. Best-effort — never block miniapp init on it.
+    miniappCatalog.autostartLocalMiniapps().catch((e) => console.warn("MANTLE: autostartLocalMiniapps failed", e))
   }
 
   /**

--- a/mobile/src/services/miniapps/MiniappCatalog.ts
+++ b/mobile/src/services/miniapps/MiniappCatalog.ts
@@ -10,6 +10,9 @@ import {
   HardwareCompatibility,
   HardwareRequirementLevel,
   HardwareType,
+  miniappLauncher,
+  saveLocalAppRunningState,
+  storage,
   sttModelManager as STTModelManager,
   type ClientApp,
   type StartOptions,
@@ -109,6 +112,52 @@ class MiniappCatalog {
       console.error(`MiniappCatalog: retry start failed for ${packageName}: ${startResult.error}`)
       if (!app.isMiniappDev) {
         submitMiniappStartFailedBugReport(app, startResult.error, "retry_start")
+      }
+    }
+  }
+
+  /**
+   * Re-spawn local miniapps that were running when the app was last killed.
+   *
+   * Cloud apps run on a remote server: the cloud persists which ones are
+   * running and resurrects them when the phone reconnects, so a host-app
+   * restart brings them back on its own. Local (phone-hosted) miniapps run in
+   * the phone's own JS engine — a host-process kill tears down their JSContext
+   * and there is no server to resurrect them, so without this they silently
+   * stay stopped on the next launch even though the user left them running.
+   *
+   * Each local miniapp persists its running flag to disk on start/stop
+   * (island's `saveLocalAppRunningState`, via the applet's `onStart`/`onStop`,
+   * keyed `${packageName}_running`). We read those flags back and re-spawn the
+   * background context headlessly (no foreground, no navigation) — the launcher
+   * registers the package so the home tray/switcher project it as running,
+   * exactly as a normal start would. The WebView, if any, re-attaches lazily
+   * when the user opens the app.
+   *
+   * Idempotent and best-effort: skips already-spawned contexts, and clears the
+   * persisted flag for any app whose bundle can no longer be resolved
+   * (uninstalled, or dev server gone) so a dead entry doesn't retry every boot.
+   * Not compatibility-gated: a previously-running background app shouldn't be
+   * dropped just because glasses are momentarily disconnected at boot — it
+   * resumes when they reconnect, same as mid-session.
+   */
+  async autostartLocalMiniapps(): Promise<void> {
+    const apps = await appRegistry.getInstalledMiniapps()
+    for (const app of apps) {
+      // Only phone-hosted miniapps have a JSContext to re-spawn. Offline
+      // built-ins (`local:false, offline:true`) restore their native running
+      // state elsewhere and have no bundle to launch.
+      if (!app.local) continue
+      // Mirror island's getLocalAppRunningState: the running flag is stored at
+      // `${packageName}_running` by saveLocalAppRunningState.
+      const wasRunning = storage.load<boolean>(`${app.packageName}_running`)
+      if (!(wasRunning.is_ok() && wasRunning.value)) continue
+      if (miniappLauncher.isRunning(app.packageName)) continue
+      try {
+        await miniappLauncher.ensureRunning(app.packageName)
+      } catch (e) {
+        console.warn(`MiniappCatalog: autostart failed for ${app.packageName} — clearing stale running flag`, e)
+        saveLocalAppRunningState(app.packageName, false)
       }
     }
   }


### PR DESCRIPTION
## Problem

When the Mentra app is killed and relaunched, **local miniapps** (built with the new `@mentra/miniapp` SDK — "cloud v2" apps like New Merge) are not automatically restarted, while legacy cloud apps are. Reported by Philippe: *"start New Merge, then kill+restart Mentra app, New Merge will not automatically re-start. The state isn't being persisted for the new miniapp SDK miniapps."*

## Root cause

The two app kinds have different lifecycles:

- **Cloud apps** run on a remote server. The cloud persists which apps are running (`User.runningApps`) and resurrects them via webhook when the phone reconnects (`AppManager.startPreviouslyRunningApps` / `resurrectDormantApps`). So a host-app restart brings them back with no phone-side work.
- **Local miniapps** run in the phone's own JS engine (`@mentra/miniapp` is *"SDK for building MentraOS local miniapps (browser/WebView)"*). A host-process kill tears down their JSContext, and there is no server to resurrect them.

Local miniapps already persist a running flag to disk on start/stop (`saveLocalAppRunningState`, via each applet's `onStart`/`onStop`, keyed `${packageName}_running`). But **nothing read that flag back on boot** — `getLocalAppRunningState` was only used to render the running badge for offline built-ins (`AppRegistry.projectOfflineApps`). The code even anticipated this (`AppRegistry.ts`: *"read on next cold boot so autostart picks the right set of apps"*), but the autostart was never implemented.

## Fix

Add `MiniappCatalog.autostartLocalMiniapps()` and call it once at host bootstrap (end of `MantleManager.initMiniapps`, after the launcher is configured and the miniapp registry is warm / bundles are installed). For every installed **local** miniapp whose persisted running flag is set, it re-spawns the background context **headlessly** via `miniappLauncher.ensureRunning` — no foreground, no navigation. `spawnAndRegister` re-registers the package in `miniappRunningRegistry`, so the home tray/switcher project it as running exactly as a normal start would; the WebView (if any) re-attaches lazily when the user opens the app.

Semantics match a normal start/stop:
- A cleanly **stopped** app writes `running:false` → won't autostart.
- A **killed** app keeps `running:true` on disk → autostarts.
- Compatibility is intentionally **not** gated: a previously-running background app shouldn't be dropped just because glasses are momentarily disconnected at boot; it resumes when glasses reconnect, same as mid-session.

Best-effort and self-healing: skips already-spawned contexts, and clears the persisted flag for any app whose bundle can no longer be resolved (uninstalled / dev server gone) so a dead entry doesn't retry every boot.

Implemented host-side using existing `@mentra/island` exports (`appRegistry`, `miniappLauncher`, `storage`, `saveLocalAppRunningState`). This keeps the host concern in the host and — since mobile Jest resolves `@mentra/island` to its **built output** rather than source — avoids depending on a fresh island export at test time.

## Files
- `mobile/src/services/miniapps/MiniappCatalog.ts` — `autostartLocalMiniapps()`
- `mobile/src/services/MantleManager.ts` — call it at end of `initMiniapps()`

## Testing
- Manual: start a local miniapp (e.g. New Merge) → hard-kill the Mentra app → relaunch → miniapp's JSContext respawns and it shows running / resumes on the glasses.
- Not yet device-tested; `tsc`/lint not run in this workspace (dependencies not installed here). Signatures verified against source. CI runs `bun compile` + Jest for mobile.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches miniapp lifecycle at boot (background spawns for every flagged local app); failures are contained but wrong autostart could affect battery or UX for background apps.
> 
> **Overview**
> Fixes local `@mentra/miniapp` apps staying stopped after the Mentra host is killed, even when the user had left them running.
> 
> **`MiniappCatalog.autostartLocalMiniapps()`** walks installed **local** miniapps, reads the persisted `${packageName}_running` flag (already written on start/stop), and headlessly calls **`miniappLauncher.ensureRunning`** so the JSContext respawns without navigation—matching how cloud apps come back on reconnect. It skips non-local/offline built-ins, skips packages already running, and clears stale flags when launch fails (missing bundle/dev server).
> 
> **`MantleManager.initMiniapps()`** invokes this **after** bundled/preinstall sync so bundles exist first; the call is **fire-and-forget** so boot is never blocked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adf98a77a883001534f402390ab1003cdd8d9fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->