### PR TITLE
Retry miniapp auth-token mint so dev miniapps connect without a Cloud V2 reconnect

### DIFF
--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -81,6 +81,18 @@ interface ConnectedMiniapp {
   bgcapLastPingSentAt?: number
   installedManifest?: InstalledMiniappManifest
   authRefreshTimerId: number | null
+  /**
+   * Backoff timer for re-attempting the INITIAL miniapp-token mint after it
+   * failed (distinct from `authRefreshTimerId`, which renews an already-issued
+   * token near expiry). Null when no retry is queued.
+   */
+  authRetryTimerId: number | null
+  /**
+   * True once this app has received a miniapp auth token (in CONNECT_ACK or a
+   * follow-up AUTH_UPDATE). Gates the initial-mint retry loop and the
+   * on-reconnect re-drive so we stop hammering once auth has landed.
+   */
+  authDelivered: boolean
   /** Last speaker state pushed to this app. Used to dedup SPEAKER_STATE pushes. */
   speakerState: SpeakerStateValue
   /**
@@ -132,6 +144,13 @@ const LOG_TAG = "LOCAL_MINIAPP"
 const PING_INTERVAL_MS = 5_000
 const MINIAPP_AUTH_REFRESH_HEADROOM_MS = 5 * 60 * 1000
 const MINIAPP_AUTH_REFRESH_MIN_DELAY_MS = 5_000
+// Backoff bounds for re-minting the INITIAL miniapp token after a failed mint
+// (e.g. the cloud client had not finished its first-boot Core token exchange
+// when the miniapp connected). Exponential from base, capped, so a transient
+// not-yet-connected client self-heals within seconds instead of needing a full
+// manual Cloud V2 reconnect.
+const MINIAPP_AUTH_RETRY_BASE_MS = 1_000
+const MINIAPP_AUTH_RETRY_MAX_MS = 15_000
 const FOREGROUND_LIVENESS_PROBE_TIMEOUT_MS = 2_500
 // Unregister after this many missed pongs. Generous on purpose: a busy
 // context (heavy interim translation traffic) or OS scheduling while idle can
@@ -616,6 +635,10 @@ class LocalMiniappRuntime {
         BgTimer.clearTimeout(existing.authRefreshTimerId)
         existing.authRefreshTimerId = null
       }
+      if (existing.authRetryTimerId !== null) {
+        BgTimer.clearTimeout(existing.authRetryTimerId)
+        existing.authRetryTimerId = null
+      }
       for (const stream of existing.subscriptions) {
         const subs = this.streamSubscribers.get(stream)
         if (subs) {
@@ -632,6 +655,8 @@ class LocalMiniappRuntime {
       lastPongAt: Date.now(),
       installedManifest,
       authRefreshTimerId: null,
+      authRetryTimerId: null,
+      authDelivered: false,
       speakerState: "idle",
       requestedLocationRate: null,
     })
@@ -743,6 +768,7 @@ class LocalMiniappRuntime {
     console.log(`${LOG_TAG}: unregisterApp(${packageName})`)
     this.clearForegroundProbe(packageName)
     this.clearMiniappAuthRefresh(packageName)
+    this.clearMiniappAuthDeliveryRetry(packageName)
     // Drop the handshake flag and fail any in-flight waitForConnect() callers
     // (e.g. a wake that's mid-handshake when the app is torn down). Done before
     // the early-return so it runs even if the connectedApps entry is already gone.
@@ -1166,10 +1192,18 @@ class LocalMiniappRuntime {
     // to false; this is manifest-declaration tracking only — OS-grant state
     // is intentionally not modeled here.
     const declaredPermissions = computeDeclaredPermissionRecord(existing.installedManifest)
+    // Fresh handshake → clear any auth state from a prior context so a stale
+    // retry timer can't fire against this new connection and so the retry loop
+    // below re-arms from scratch.
+    existing.authDelivered = false
+    this.clearMiniappAuthDeliveryRetry(packageName)
     const authPromise = this.requestMiniappAuth(packageName)
     const initialAuth = await withTimeout(authPromise, 1_500)
     const userId = initialAuth?.mentraUserId ?? ""
-    if (initialAuth) this.scheduleMiniappAuthRefresh(packageName, initialAuth)
+    if (initialAuth) {
+      existing.authDelivered = true
+      this.scheduleMiniappAuthRefresh(packageName, initialAuth)
+    }
 
     this.sendToMiniapp(
       packageName,
@@ -1184,18 +1218,14 @@ class LocalMiniappRuntime {
       requestId,
     )
     if (!initialAuth) {
-      authPromise
-        .then((auth) => {
-          if (!auth) return
-          this.scheduleMiniappAuthRefresh(packageName, auth)
-          this.sendToMiniapp(packageName, {
-            type: MiniappResponseType.AUTH_UPDATE,
-            auth,
-          })
-        })
-        .catch((err) => {
-          console.warn(`${LOG_TAG}: miniapp auth unavailable for ${packageName}: ${(err as Error)?.message ?? err}`)
-        })
+      // The mint timed out or (more importantly) REJECTED — the latter happens
+      // when the cloud client hasn't finished its first-boot Core token exchange
+      // yet, which is exactly the case when a dev miniapp is scanned/launched
+      // right after app start. CONNECT_ACK already went out without auth; keep
+      // trying to mint (and re-drive on cloud-connect) so the app authenticates
+      // to its backend on its own, instead of staying dead until a full manual
+      // Cloud V2 reconnect re-runs the whole handshake.
+      this.deliverInitialMiniappAuth(packageName, authPromise, 0)
     }
     this.sendCloudStatusToMiniapp(packageName)
 
@@ -1273,6 +1303,82 @@ class LocalMiniappRuntime {
     const timerId = app.authRefreshTimerId
     BgTimer.clearTimeout(timerId)
     app.authRefreshTimerId = null
+  }
+
+  /**
+   * Deliver the miniapp's FIRST auth token, retrying until it lands. Called from
+   * {@link handleConnect} when the initial mint didn't resolve in the CONNECT_ACK
+   * window. `inFlight` lets attempt 0 reuse the mint the handshake already
+   * started (avoids a redundant duplicate request); later attempts mint fresh.
+   *
+   * A `null` result means auth is fundamentally unavailable (no miniappAuth hook)
+   * — permanent, so we do NOT retry. A REJECTION means a transient failure
+   * (typically the cloud client isn't connection-ready yet) — retry with backoff.
+   * Either way we bail if the app has since disconnected or already got a token
+   * (e.g. via {@link redriveMiniappAuthDelivery} on cloud-connect).
+   */
+  private deliverInitialMiniappAuth(
+    packageName: string,
+    inFlight: Promise<MiniappAuthToken | null> | undefined,
+    attempt: number,
+  ): void {
+    const app = this.connectedApps.get(packageName)
+    if (!app || app.authDelivered) return
+    const mint = inFlight ?? this.requestMiniappAuth(packageName)
+    void mint
+      .then((auth) => {
+        const current = this.connectedApps.get(packageName)
+        if (!current || current.authDelivered) return
+        if (!auth) return // no auth hook — permanent, don't spin
+        current.authDelivered = true
+        this.clearMiniappAuthDeliveryRetry(packageName)
+        this.scheduleMiniappAuthRefresh(packageName, auth)
+        this.sendToMiniapp(packageName, {type: MiniappResponseType.AUTH_UPDATE, auth})
+      })
+      .catch((err) => {
+        console.warn(
+          `${LOG_TAG}: miniapp auth mint failed for ${packageName} (attempt ${attempt}): ${(err as Error)?.message ?? err}`,
+        )
+        this.scheduleInitialMiniappAuthRetry(packageName, attempt)
+      })
+  }
+
+  private scheduleInitialMiniappAuthRetry(packageName: string, attempt: number): void {
+    const app = this.connectedApps.get(packageName)
+    if (!app || app.authDelivered) return
+    this.clearMiniappAuthDeliveryRetry(packageName)
+    const delay = Math.min(MINIAPP_AUTH_RETRY_MAX_MS, MINIAPP_AUTH_RETRY_BASE_MS * 2 ** attempt)
+    app.authRetryTimerId = BgTimer.setTimeout(() => {
+      const current = this.connectedApps.get(packageName)
+      if (!current) return
+      current.authRetryTimerId = null
+      this.deliverInitialMiniappAuth(packageName, undefined, attempt + 1)
+    }, delay)
+  }
+
+  private clearMiniappAuthDeliveryRetry(packageName: string): void {
+    const app = this.connectedApps.get(packageName)
+    if (!app || app.authRetryTimerId === null) return
+    BgTimer.clearTimeout(app.authRetryTimerId)
+    app.authRetryTimerId = null
+  }
+
+  /**
+   * When the cloud client (re)connects, immediately re-attempt the initial mint
+   * for any handshook app still missing its token, instead of waiting out the
+   * backoff. This is what turns "scan a dev app before the cloud is ready" from
+   * "dead until you manually reconnect Cloud V2" into "authenticates on its own
+   * the instant the connection comes up".
+   */
+  private redriveMiniappAuthDelivery(): void {
+    for (const [packageName, app] of this.connectedApps) {
+      if (app.authDelivered) continue
+      // Only apps that finished their CONNECT handshake are in the mint-retry
+      // state; skip anything still mid-handshake (handleConnect owns that).
+      if (!this.handshookApps.has(packageName)) continue
+      this.clearMiniappAuthDeliveryRetry(packageName)
+      this.deliverInitialMiniappAuth(packageName, undefined, 0)
+    }
   }
 
   private handleSubscribe(packageName: string, payload: Record<string, unknown>, requestId?: string): void {
@@ -2934,6 +3040,10 @@ class LocalMiniappRuntime {
     getRuntimeHooks().cloud?.onStatusChanged((status) => {
       if (status.status === "connected") {
         this.updateCloudSubscriptions()
+        // A miniapp that connected before the cloud client was ready never got
+        // its auth token; now that we're connected, mint it without waiting for
+        // the retry backoff (or a full manual reconnect).
+        this.redriveMiniappAuthDelivery()
       }
       this.broadcastCloudStatus()
     })


### PR DESCRIPTION
## Bug

Bug hunt (Jul 1): *"If you scan a dev miniapp it won't connect to its backend until you reconnect to cloud V2."* — sev 5/5, iOS, Cloud V2. (incident `0fc40a7c…`)

Scanning/launching a new developer miniapp registers it on the phone and it appears to start, but it **can't authenticate to its backend** until the user manually disconnects + reconnects Cloud V2.

## Root cause (phone-side)

Cloud V2 is **app-agnostic** — the phone never registers apps with it, so "the cloud doesn't know about the dev app" isn't the mechanism. A dev app is a **local miniapp**; when its JS context sends `CONNECT`, `LocalMiniappRuntime.handleConnect` mints its miniapp auth token but:

1. waits only **1.5s** for the mint, then sends `CONNECT_ACK` with no `auth`;
2. falls back to a **single best-effort `AUTH_UPDATE`** on the same in-flight promise, with only a `console.warn` on failure.

When a dev app is launched right after app start, the cloud client is often still finishing its first-boot Core token exchange, so the mint **rejects**. The `.catch` just logs — **no retry is scheduled, and the auth-refresh timer is never armed** (it only arms once a token exists). So nothing ever re-mints. The token only lands after a **full manual reconnect** re-runs the whole handshake — exactly the reported "reconnect to Cloud V2" workaround.

Both an independent mobile-side and cloud-side trace confirmed this is the only unhandled self-heal gap; transcript subscriptions already re-apply on `onConnected`.

## Fix (`mobile/modules/island/src/services/LocalMiniappRuntime.ts`)

Make the **initial** token delivery self-heal (distinct from the existing near-expiry refresh):

- `deliverInitialMiniappAuth` — retries the mint with capped exponential backoff (1s → 15s) on **rejection** (transient not-yet-connected client); stops on a **null** result (no auth hook — permanent) or once auth is delivered. Attempt 0 reuses the handshake's in-flight mint to avoid a duplicate request.
- `redriveMiniappAuthDelivery` — on cloud `status → connected`, immediately re-attempts the mint for any **handshook** app still missing its token, so it recovers the instant the connection comes up (no backoff wait, no manual reconnect).
- Per-app `authDelivered` + `authRetryTimerId`; retry timer is cleared on re-register/unregister and delivery state is reset on each fresh handshake.

Net effect: a dev miniapp launched before Cloud V2 is connection-ready authenticates to its backend on its own within seconds, instead of staying dead until a manual reconnect.

## Testing

- `bun compile` (tsc `--noEmit`, full mobile project incl. island) — clean.
- `eslint` on the changed file — clean (0 errors; the remaining line-18 `BluetoothSdk` warning is pre-existing).
- Not yet hardware-verified end-to-end — reviewers/QA: scan a dev miniapp immediately after a cold app start (before Cloud V2 finishes connecting) and confirm it authenticates to its backend without a manual reconnect.

## Notes / follow-ups

- The attached incident also shows a separate **Cloud V2 connection-liveness** issue (a half-open runtime socket that took ~3 min to recover after a boot-race token-refresh 400 / 1001 handshake close). That's a deeper cloud-client reconnect-robustness concern and is intentionally **out of scope** here; flagging it for a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches miniapp auth delivery and cloud-connect hooks in a central runtime path; behavior is bounded by backoff and authDelivered gating, but failed-mint edge cases could affect all local miniapps at connect time.
> 
> **Overview**
> Fixes dev miniapps that **cannot reach their backend** when launched right after a cold start, before Cloud V2 finishes its first Core token exchange.
> 
> **`LocalMiniappRuntime`** still sends `CONNECT_ACK` within ~1.5s even when the initial mint fails or times out. Instead of a single fire-and-forget `AUTH_UPDATE` attempt, it now runs a dedicated **initial delivery** path: **`deliverInitialMiniappAuth`** retries rejected mints with capped exponential backoff (1s–15s), sends **`AUTH_UPDATE`** on success, and arms the existing near-expiry refresh only after a token lands. **`authDelivered`** and **`authRetryTimerId`** per connected app gate retries and are cleared on register, unregister, and each new handshake.
> 
> When cloud status becomes **`connected`**, **`redriveMiniappAuthDelivery`** immediately re-mints for handshook apps still missing a token (no backoff wait), so scanning a dev app before the cloud is ready no longer requires a manual Cloud V2 reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec2bae90dc7a4809edb7ff89b3a3850467078df8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the miniapp auth-token mint so dev miniapps launched right after app start authenticate on their own, without a manual Cloud V2 reconnect. Adds self-healing initial auth delivery with backoff and an immediate retry when the cloud connects.

- **Bug Fixes**
  - Implement initial-token retry with capped exponential backoff (1s → 15s); attempt 0 reuses the in-flight mint.
  - On cloud status `connected`, immediately re-attempt the mint for handshook apps still missing a token.
  - Track per-app `authDelivered` and `authRetryTimerId`; clear on re-register/unregister and reset on a fresh handshake.
  - On first successful mint, schedule the standard refresh and send `AUTH_UPDATE`.

<sup>Written for commit ec2bae90dc7a4809edb7ff89b3a3850467078df8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

