### PR TITLE
Fix Bluetooth SDK 0.1.15 release recovery

### DIFF
--- a/.github/CI_GATE.md
+++ b/.github/CI_GATE.md
@@ -28,11 +28,13 @@ posts a single `ci-gate-dev` commit status:
 
 Two kinds of gated workflow, with different "runs when" behavior:
 
-- **Path-filtered builders** — iOS/Android/ASG/jest and `Run Cloud Tests ☁️`
-  only run when their area changes (`mobile/**`, `asg_client/**`, `cloud/**`). On
-  a PR that doesn't touch their area they **don't run at all**, so the gate never
-  waits on them. This is the heavy work (Mac builds, device tests) we want
-  scoped — a cloud-only PR never runs iOS/Android, and vice-versa.
+- **Path-filtered builders** — iOS/Android/ASG/jest, `Bun Lockfile Checks`, and
+  `Run Cloud Tests ☁️` only run when their area changes (`mobile/**`,
+  `asg_client/**`, lockfile/workspace package manifests, `cloud/**`). On a PR
+  that doesn't touch their area they **don't run at all**, so the gate never
+  waits on them. This is the heavy work (Mac builds, device tests) plus the
+  targeted dependency-integrity work we want scoped — a cloud-only PR never runs
+  iOS/Android, and vice-versa.
 - **Always-on cloud builds** — the four `🧪 Test * build` workflows have an
   **unfiltered** `pull_request` trigger, so they run on **every** `dev` PR. They
   self-skip internally (via `dorny/paths-filter`) when their package didn't
@@ -62,6 +64,7 @@ below. `Recovery Worker Build` is deliberately excluded.
 | Android | `Mobile App Android Build` | `mobile/**` |
 | ASG | `MentraOS ASG Client Build` | `asg_client/**` |
 | Mobile jest | `Mobile App Quality Checks` | `mobile/**` |
+| Lockfiles | `Bun Lockfile Checks` | root/mobile/sdk lockfiles and workspace package manifests |
 | Cloud | `🧪 Test Cloud build` | all dev PRs (self-skips internally) |
 | SDK | `🧪 Test SDK build` | all dev PRs (self-skips internally) |
 | Console | `🧪 Test Console build` | all dev PRs (self-skips internally) |

--- a/.github/workflows/augmentos-manager-jest.yml
+++ b/.github/workflows/augmentos-manager-jest.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: ./mobile
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run TypeScript type check
         working-directory: ./mobile

--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -46,6 +46,7 @@ jobs:
       previous_version: ${{ steps.release-info.outputs.previous_version }}
       compare_sha: ${{ steps.release-info.outputs.compare_sha }}
       version_changed: ${{ steps.release-info.outputs.version_changed }}
+      force_release: ${{ steps.release-info.outputs.force_release }}
       run_release: ${{ steps.release-info.outputs.run_release }}
       dry_run: ${{ steps.release-info.outputs.dry_run }}
       swiftpm_tag: ${{ steps.release-info.outputs.swiftpm_tag }}
@@ -96,8 +97,8 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64]
     outputs:
       manifest_url: ${{ steps.sdk-ota-info.outputs.manifest_url }}
-      version_code: ${{ steps.asg-build-info.outputs.version_code }}
-      version_name: ${{ steps.asg-build-info.outputs.version_name }}
+      version_code: ${{ steps.existing-sdk-ota.outputs.version_code || steps.asg-build-info.outputs.version_code }}
+      version_name: ${{ steps.existing-sdk-ota.outputs.version_name || steps.asg-build-info.outputs.version_name }}
     steps:
       - name: Refuse non-dev publish
         if: needs.detect.outputs.dry_run != 'true' && github.ref_name != 'dev'
@@ -163,20 +164,62 @@ jobs:
           echo "manifest_asset=${MANIFEST_ASSET}" >> "$GITHUB_OUTPUT"
           echo "manifest_url=${MANIFEST_URL}" >> "$GITHUB_OUTPUT"
 
+      - name: Check existing SDK OTA manifest
+        id: existing-sdk-ota
+        if: needs.detect.outputs.dry_run != 'true'
+        env:
+          MANIFEST_URL: ${{ steps.sdk-ota-info.outputs.manifest_url }}
+        run: |
+          set -euo pipefail
+
+          http_status=$(curl --silent --show-error --location \
+            --output /tmp/sdk_ota_version.json \
+            --write-out "%{http_code}" \
+            "$MANIFEST_URL" || true)
+
+          if [[ "$http_status" == "404" ]]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$http_status" != "200" ]]; then
+            echo "Unexpected HTTP ${http_status} while checking ${MANIFEST_URL}" >&2
+            exit 1
+          fi
+
+          jq -e \
+            '.apps["com.mentra.asg_client"].versionCode
+              and .apps["com.mentra.asg_client"].versionName
+              and (.mtk_patches | type == "array" and length > 0)
+              and (.bes_firmware | type == "object")' \
+            /tmp/sdk_ota_version.json >/dev/null
+
+          version_code=$(jq -er '.apps["com.mentra.asg_client"].versionCode' /tmp/sdk_ota_version.json)
+          version_name=$(jq -er '.apps["com.mentra.asg_client"].versionName' /tmp/sdk_ota_version.json)
+
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          echo "version_code=${version_code}" >> "$GITHUB_OUTPUT"
+          echo "version_name=${version_name}" >> "$GITHUB_OUTPUT"
+          echo "Reusing existing SDK OTA manifest at ${MANIFEST_URL}."
+
       - name: Setup Java
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Setup Android SDK
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         uses: android-actions/setup-android@v2
 
       - name: Setup ASG environment
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         working-directory: ./asg_client
         run: cp .env.example .env
 
       - name: Clone StreamPackLite dependency
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         working-directory: ./asg_client
         run: |
           git clone https://github.com/Mentra-Community/StreamPackLite.git
@@ -184,6 +227,7 @@ jobs:
           git checkout working
 
       - name: Cache Gradle dependencies
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         uses: actions/cache@v4
         with:
           path: |
@@ -195,6 +239,7 @@ jobs:
             asg-gradle-${{ runner.os }}-
 
       - name: Build recovery worker asset
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         working-directory: ./asg_client/recovery_worker
         run: |
           chmod +x ./build_and_deploy.sh
@@ -203,12 +248,13 @@ jobs:
 
       - name: Build ASG release APK
         id: gradle-build
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         working-directory: ./asg_client
         run: ./gradlew -PASG_VERSION_CODE="${{ steps.asg-build-info.outputs.version_code }}" -PASG_VERSION_NAME="${{ steps.asg-build-info.outputs.version_name }}" assembleRelease --build-cache --parallel
         continue-on-error: true
 
       - name: Retry ASG build with clean cache
-        if: steps.gradle-build.outcome == 'failure'
+        if: steps.existing-sdk-ota.outputs.exists != 'true' && steps.gradle-build.outcome == 'failure'
         working-directory: ./asg_client
         run: |
           echo "First ASG build failed, cleaning Gradle cache and retrying..."
@@ -218,6 +264,7 @@ jobs:
 
       - name: Collect ASG APK info
         id: asg-apk-info
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         run: |
           set -euo pipefail
           APK="asg_client/app/build/outputs/apk/release/app-release.apk"
@@ -230,6 +277,7 @@ jobs:
           echo "size=$(wc -c < "$APK" | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Generate SDK OTA manifest
+        if: steps.existing-sdk-ota.outputs.exists != 'true'
         env:
           ASG_APK_SHA256: ${{ steps.asg-apk-info.outputs.sha256 }}
           ASG_APK_SIZE: ${{ steps.asg-apk-info.outputs.size }}
@@ -242,7 +290,7 @@ jobs:
         run: node .github/scripts/build-bluetooth-sdk-ota-manifest.mjs
 
       - name: Upload ASG APK and manifest to SDK OTA release
-        if: needs.detect.outputs.dry_run != 'true'
+        if: needs.detect.outputs.dry_run != 'true' && steps.existing-sdk-ota.outputs.exists != 'true'
         uses: actions/github-script@v7
         with:
           script: |
@@ -336,7 +384,7 @@ jobs:
       - name: Verify SDK OTA manifest release asset
         if: needs.detect.outputs.dry_run != 'true'
         env:
-          VERSION_CODE: ${{ steps.asg-build-info.outputs.version_code }}
+          VERSION_CODE: ${{ steps.existing-sdk-ota.outputs.version_code || steps.asg-build-info.outputs.version_code }}
         run: |
           set -euo pipefail
 
@@ -363,10 +411,11 @@ jobs:
             echo "## Bluetooth SDK OTA artifact"
             echo ""
             echo "- SDK version: \`${{ needs.detect.outputs.version }}\`"
-            echo "- ASG versionCode: \`${{ steps.asg-build-info.outputs.version_code }}\`"
-            echo "- ASG versionName: \`${{ steps.asg-build-info.outputs.version_name }}\`"
-            echo "- APK asset: \`${{ steps.sdk-ota-info.outputs.apk_asset }}\`"
+            echo "- ASG versionCode: \`${{ steps.existing-sdk-ota.outputs.version_code || steps.asg-build-info.outputs.version_code }}\`"
+            echo "- ASG versionName: \`${{ steps.existing-sdk-ota.outputs.version_name || steps.asg-build-info.outputs.version_name }}\`"
+            echo "- APK asset: \`${{ steps.existing-sdk-ota.outputs.exists == 'true' && 'reused from existing manifest' || steps.sdk-ota-info.outputs.apk_asset }}\`"
             echo "- Manifest URL: \`${{ steps.sdk-ota-info.outputs.manifest_url }}\`"
+            echo "- Existing manifest reused: \`${{ steps.existing-sdk-ota.outputs.exists == 'true' }}\`"
             echo "- Dry run: \`${{ needs.detect.outputs.dry_run }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -75,6 +75,21 @@ jobs:
             exit 1
           fi
 
+      - name: Setup Bun for release preflight
+        if: steps.release-info.outputs.run_release == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Validate root Bun lockfile
+        if: steps.release-info.outputs.run_release == 'true'
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate mobile Bun lockfile
+        if: steps.release-info.outputs.run_release == 'true'
+        working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
       - name: Summarize release decision
         run: |
           {

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -63,6 +63,9 @@ jobs:
         working-directory: mobile
         run: bun install --frozen-lockfile --ignore-scripts
 
+      - name: Clean workspace installs before SDK validation
+        run: git clean -ffdX
+
       - name: Validate SDK Bun lockfile
         working-directory: sdk
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -63,19 +63,16 @@ jobs:
         working-directory: mobile
         run: bun install --frozen-lockfile --ignore-scripts
 
-      - name: Clean workspace installs before SDK validation
-        run: git clean -ffdX
-
-      # Bun 1.3.14 on Ubuntu currently hits ELOOP while resolving this workspace.
-      - name: Setup Bun for SDK lockfile validation
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.11"
-
       - name: Validate SDK Bun lockfile
-        working-directory: sdk
-        env:
-          BUN_INSTALL_CACHE_DIR: /tmp/bun-sdk-lockfile-cache
         run: |
-          rm -rf "$BUN_INSTALL_CACHE_DIR"
-          bun install --frozen-lockfile --ignore-scripts
+          set -euo pipefail
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+          git archive HEAD | tar -x -C "$tmp_dir"
+          docker run --rm \
+            --user "$(id -u):$(id -g)" \
+            -e BUN_INSTALL_CACHE_DIR=/tmp/bun-cache \
+            -v "$tmp_dir:/work" \
+            -w /work/sdk \
+            oven/bun:1.3.11 \
+            bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -74,4 +74,8 @@ jobs:
 
       - name: Validate SDK Bun lockfile
         working-directory: sdk
-        run: bun install --frozen-lockfile --ignore-scripts
+        env:
+          BUN_INSTALL_CACHE_DIR: /tmp/bun-sdk-lockfile-cache
+        run: |
+          rm -rf "$BUN_INSTALL_CACHE_DIR"
+          bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Clean workspace installs before SDK validation
         run: git clean -ffdX
 
+      # Bun 1.3.14 on Ubuntu currently hits ELOOP while resolving this workspace.
+      - name: Setup Bun for SDK lockfile validation
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.11"
+
       - name: Validate SDK Bun lockfile
         working-directory: sdk
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -1,0 +1,62 @@
+name: Bun Lockfile Checks
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - "package.json"
+      - "bun.lock"
+      - "mobile/package.json"
+      - "mobile/bun.lock"
+      - "mobile/modules/**/package.json"
+      - "cloud-v2/packages/**/package.json"
+      - "miniapps/**/package.json"
+      - "sdk/miniapp-cli/package.json"
+      - ".github/workflows/bun-lockfile-checks.yml"
+      - ".github/workflows/ci-gate.yml"
+  push:
+    branches: [dev]
+    paths:
+      - "package.json"
+      - "bun.lock"
+      - "mobile/package.json"
+      - "mobile/bun.lock"
+      - "mobile/modules/**/package.json"
+      - "cloud-v2/packages/**/package.json"
+      - "miniapps/**/package.json"
+      - "sdk/miniapp-cli/package.json"
+      - ".github/workflows/bun-lockfile-checks.yml"
+      - ".github/workflows/ci-gate.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: bun-lockfile-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-lockfiles-${{ hashFiles('bun.lock', 'mobile/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-lockfiles-
+
+      - name: Validate root Bun lockfile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate mobile Bun lockfile
+        working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/bun-lockfile-checks.yml
+++ b/.github/workflows/bun-lockfile-checks.yml
@@ -11,7 +11,8 @@ on:
       - "mobile/modules/**/package.json"
       - "cloud-v2/packages/**/package.json"
       - "miniapps/**/package.json"
-      - "sdk/miniapp-cli/package.json"
+      - "sdk/bun.lock"
+      - "sdk/**/package.json"
       - ".github/workflows/bun-lockfile-checks.yml"
       - ".github/workflows/ci-gate.yml"
   push:
@@ -24,7 +25,8 @@ on:
       - "mobile/modules/**/package.json"
       - "cloud-v2/packages/**/package.json"
       - "miniapps/**/package.json"
-      - "sdk/miniapp-cli/package.json"
+      - "sdk/bun.lock"
+      - "sdk/**/package.json"
       - ".github/workflows/bun-lockfile-checks.yml"
       - ".github/workflows/ci-gate.yml"
   workflow_dispatch:
@@ -50,7 +52,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-lockfiles-${{ hashFiles('bun.lock', 'mobile/bun.lock') }}
+          key: ${{ runner.os }}-bun-lockfiles-${{ hashFiles('bun.lock', 'mobile/bun.lock', 'sdk/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-lockfiles-
 
@@ -59,4 +61,8 @@ jobs:
 
       - name: Validate mobile Bun lockfile
         working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate SDK Bun lockfile
+        working-directory: sdk
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/ci-gate.yml
+++ b/.github/workflows/ci-gate.yml
@@ -55,6 +55,7 @@ on:
       - "Mobile App Android Build"
       - "MentraOS ASG Client Build"
       - "Mobile App Quality Checks"
+      - "Bun Lockfile Checks"
       - "🧪 Test Cloud build"
       - "🧪 Test SDK build"
       - "🧪 Test Console build"
@@ -107,6 +108,7 @@ jobs:
               "Mobile App Android Build",
               "MentraOS ASG Client Build",
               "Mobile App Quality Checks",
+              "Bun Lockfile Checks",
               "🧪 Test Cloud build",
               "🧪 Test SDK build",
               "🧪 Test Console build",

--- a/.github/workflows/pr-agent-orchestrator.yml
+++ b/.github/workflows/pr-agent-orchestrator.yml
@@ -9,6 +9,7 @@ on:
       - "Run Cloud Tests ☁️"
       - "🧪 Test SDK build"
       - "Mobile App Quality Checks"
+      - "Bun Lockfile Checks"
       - "MentraOS ASG Client Build"
       - "Mobile App Android Build"
     types: [completed]

--- a/bun.lock
+++ b/bun.lock
@@ -29,23 +29,25 @@
     },
     "cloud-v2/packages/auth": {
       "name": "@mentra/auth",
-      "version": "0.0.0",
+      "version": "0.1.0-dev.0",
       "dependencies": {
         "jose": "^5.9.6",
       },
     },
     "cloud-v2/packages/cli": {
       "name": "@mentra/cli",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-dev.0",
       "bin": {
         "mentra": "./src/index.ts",
       },
       "dependencies": {
         "@mentra/miniapp-cli": "file:../../../sdk/miniapp-cli",
         "commander": "^14.0.2",
+        "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/qrcode": "^1.5.5",
       },
     },
     "cloud-v2/packages/cloud-client": {
@@ -317,7 +319,7 @@
     },
     "mobile/modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0",
+      "version": "0.3.0-dev.0",
       "dependencies": {
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
@@ -336,7 +338,7 @@
     },
     "sdk/miniapp-cli": {
       "name": "@mentra/miniapp-cli",
-      "version": "0.1.0",
+      "version": "0.1.0-dev.0",
       "bin": {
         "mentra-miniapp": "./src/index.ts",
       },

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -150,23 +150,25 @@
     },
     "../cloud-v2/packages/auth": {
       "name": "@mentra/auth",
-      "version": "0.0.0",
+      "version": "0.1.0-dev.0",
       "dependencies": {
         "jose": "^5.9.6",
       },
     },
     "../cloud-v2/packages/cli": {
       "name": "@mentra/cli",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0-dev.0",
       "bin": {
         "mentra": "./src/index.ts",
       },
       "dependencies": {
         "@mentra/miniapp-cli": "file:../../../sdk/miniapp-cli",
         "commander": "^14.0.2",
+        "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@types/bun": "latest",
+        "@types/qrcode": "^1.5.5",
       },
     },
     "../cloud-v2/packages/cloud-client": {
@@ -305,7 +307,7 @@
     },
     "modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0",
+      "version": "0.3.0-dev.0",
       "dependencies": {
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -5,9 +5,25 @@
     "": {},
     "../cloud-v2/packages/auth": {
       "name": "@mentra/auth",
-      "version": "0.0.0",
+      "version": "0.1.0-dev.0",
       "dependencies": {
         "jose": "^5.9.6",
+      },
+    },
+    "../cloud-v2/packages/cli": {
+      "name": "@mentra/cli",
+      "version": "2.0.0-dev.0",
+      "bin": {
+        "mentra": "./src/index.ts",
+      },
+      "dependencies": {
+        "@mentra/miniapp-cli": "file:../../../sdk/miniapp-cli",
+        "commander": "^14.0.2",
+        "qrcode": "^1.5.4",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/qrcode": "^1.5.5",
       },
     },
     "../cloud-v2/packages/cloud-client": {
@@ -27,6 +43,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@mentra/cloud-shared": "workspace:*",
+        "@workos-inc/node": "^10.3.0",
         "hono": "^4.11.1",
         "jose": "^5.9.6",
         "mongoose": "^8.8.4",
@@ -84,6 +101,16 @@
         "bun-plugin-tailwind": "^0.1.2",
       },
     },
+    "../miniapps/codex-kawaii-e2e": {
+      "name": "codex-kawaii-e2e-miniapp",
+      "dependencies": {
+        "@mentra/miniapp": "workspace:*",
+      },
+      "devDependencies": {
+        "@mentra/miniapp-cli": "workspace:*",
+        "bun-types": "^1.3.14",
+      },
+    },
     "../miniapps/everything": {
       "name": "local-everything",
       "dependencies": {
@@ -130,6 +157,16 @@
         "@types/react": "^19.1.6",
         "@types/react-dom": "^19.1.6",
         "bun-plugin-tailwind": "^0.1.2",
+      },
+    },
+    "../miniapps/kawaii": {
+      "name": "kawaii-miniapp",
+      "dependencies": {
+        "@mentra/miniapp": "workspace:*",
+      },
+      "devDependencies": {
+        "@mentra/miniapp-cli": "workspace:*",
+        "bun-types": "^1.3.14",
       },
     },
     "../miniapps/mentra-ai": {
@@ -258,7 +295,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },
@@ -313,7 +350,7 @@
     },
     "../mobile/modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0",
+      "version": "0.3.0-dev.0",
       "dependencies": {
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
@@ -332,7 +369,7 @@
     },
     "create-mentra-miniapp": {
       "name": "create-mentra-miniapp",
-      "version": "0.1.0",
+      "version": "0.1.0-dev.0",
       "bin": {
         "create-mentra-miniapp": "./bin/index.ts",
       },
@@ -376,7 +413,7 @@
     },
     "miniapp-cli": {
       "name": "@mentra/miniapp-cli",
-      "version": "0.1.0",
+      "version": "0.1.0-dev.0",
       "bin": {
         "mentra-miniapp": "./src/index.ts",
       },
@@ -805,6 +842,8 @@
 
     "@mentra/bluetooth-sdk": ["@mentra/bluetooth-sdk@workspace:../mobile/modules/bluetooth-sdk"],
 
+    "@mentra/cli": ["@mentra/cli@workspace:../cloud-v2/packages/cli"],
+
     "@mentra/cloud-client": ["@mentra/cloud-client@workspace:../cloud-v2/packages/cloud-client"],
 
     "@mentra/cloud-core": ["@mentra/cloud-core@workspace:../cloud-v2/packages/core"],
@@ -1213,6 +1252,8 @@
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/d3-voronoi": ["@types/d3-voronoi@1.1.12", "", {}, "sha512-DauBl25PKZZ0WVJr42a6CNvI6efsdzofl9sajqZr2Gf5Gu733WkDdUGiPkUHXiUvYGzNNlFQde2wdZdfQPG+yw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
@@ -1284,6 +1325,8 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.62.0", "", { "dependencies": { "@typescript-eslint/types": "8.62.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.2", "", {}, "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA=="],
+
+    "@workos-inc/node": ["@workos-inc/node@10.7.0", "", {}, "sha512-rffa9znZuIv4yo+9JRxGOLTTSxh0XhOT6jlsktgqEi9MuB9V0VFHRzLd3bTpkq+J9sgrPZNGpvX4aWNfMqt5cQ=="],
 
     "@xmldom/xmldom": ["@xmldom/xmldom@0.8.13", "", {}, "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw=="],
 
@@ -1461,6 +1504,8 @@
 
     "co": ["co@4.6.0", "", {}, "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ=="],
 
+    "codex-kawaii-e2e-miniapp": ["codex-kawaii-e2e-miniapp@workspace:../miniapps/codex-kawaii-e2e"],
+
     "collect-v8-coverage": ["collect-v8-coverage@1.0.3", "", {}, "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
@@ -1471,7 +1516,7 @@
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "compressible": ["compressible@2.0.18", "", { "dependencies": { "mime-db": ">= 1.43.0 < 2" } }, "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg=="],
 
@@ -2060,6 +2105,8 @@
     "jszip": ["jszip@3.10.1", "", { "dependencies": { "lie": "~3.3.0", "pako": "~1.0.2", "readable-stream": "~2.3.6", "setimmediate": "^1.0.5" } }, "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g=="],
 
     "kareem": ["kareem@2.6.3", "", {}, "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q=="],
+
+    "kawaii-miniapp": ["kawaii-miniapp@workspace:../miniapps/kawaii"],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -2945,6 +2992,8 @@
 
     "expect/jest-matcher-utils": ["jest-matcher-utils@29.7.0", "", { "dependencies": { "chalk": "^4.0.0", "jest-diff": "^29.7.0", "jest-get-type": "^29.6.3", "pretty-format": "^29.7.0" } }, "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g=="],
 
+    "expo-module-scripts/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
     "finalhandler/debug": ["debug@2.6.9", "", { "dependencies": { "ms": "2.0.0" } }, "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="],
@@ -3060,6 +3109,8 @@
     "qrcode/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
     "react-devtools-core/ws": ["ws@7.5.11", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA=="],
+
+    "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "workspaces": [
-    "*",
+    "create-mentra-miniapp",
+    "example-oem-app",
+    "miniapp-cli",
     "../cloud-v2/packages/*",
     "../mobile/modules/miniapp",
     "../mobile/modules/island",


### PR DESCRIPTION
## Summary

This fixes the recovery path for the failed Bluetooth SDK `0.1.15` release.

The release run for #3253 did trigger correctly on `dev`:

- Workflow: `Release Bluetooth SDK`
- Run: https://github.com/Mentra-Community/MentraOS/actions/runs/28542293439
- Merge commit: `5540fdf6a49c2a9979913e87e8d849dd8d376fe4`

That run partially succeeded:

- `Detect SDK version change` succeeded.
- `Publish SDK-pinned ASG OTA manifest` succeeded.
- The `0.1.15` SDK OTA assets were uploaded and verified:
  - `asg-client-sdk-0.1.15-vc47344348-5540fdf6.apk`
  - `bluetooth-sdk-0.1.15-version.json`
- `Release iOS SwiftPM mirror` succeeded and pushed tag `0.1.15`.

The run failed before npm and Maven publication:

- `Stage npm package` failed at `Install mobile dependencies`.
- `Publish Maven Central artifacts` failed at `Install mobile dependencies`.
- Both failures were the same error: `bun install --frozen-lockfile` detected stale lockfile content.

## Changes

- Refreshes the stale Bun lock metadata in both lockfiles:
  - `bun.lock`
  - `mobile/bun.lock`
- Adds an explicit SDK OTA recovery path to `.github/workflows/bluetooth-sdk-release.yml`:
  - checks whether the immutable SDK OTA manifest for the SDK version already exists;
  - validates the existing manifest shape;
  - extracts the existing ASG `versionCode` / `versionName`;
  - skips the ASG build/upload path when that manifest already exists;
  - still verifies the release manifest URL before allowing downstream jobs to continue.
- Adds a release preflight before any side-effecting release jobs:
  - validates the root Bun lockfile with `bun install --frozen-lockfile --ignore-scripts`;
  - validates the mobile Bun lockfile with `bun install --frozen-lockfile --ignore-scripts`;
  - validates the SDK Bun lockfile with `bun install --frozen-lockfile --ignore-scripts`;
  - runs inside `Detect SDK version change`, so stale lockfiles fail before SDK OTA, SwiftPM, npm, or Maven can publish anything.
- Adds a normal PR CI guard for this class of failure:
  - new `Bun Lockfile Checks` workflow validates root, mobile, and SDK lockfiles when workspace package manifests or lockfiles change;
  - wires that workflow into `ci-gate-dev`;
  - makes `Mobile App Quality Checks` install with `bun install --frozen-lockfile` instead of a mutable install.

This matters because a manual forced recovery run for `0.1.15` will run from a newer `dev` commit than the original #3253 merge. Without this change, the workflow would try to generate a new `bluetooth-sdk-0.1.15-version.json` with a different ASG build identity and then refuse to overwrite the existing immutable manifest. The existing manifest is already the correct artifact for SDK `0.1.15`, so recovery should reuse it and continue to npm/Maven.

## Validation

Locally validated in a clean worktree:

- `bun install --frozen-lockfile` from repo root passes.
- `bun install --frozen-lockfile` from `mobile/` passes.
- `bun install --frozen-lockfile --ignore-scripts` from repo root passes.
- `bun install --frozen-lockfile --ignore-scripts` from `mobile/` passes.
- `bun install --frozen-lockfile --ignore-scripts` from `sdk/` passes.
- `Mobile App Quality Checks` dependency install command, `bun install --frozen-lockfile` from `mobile/`, passes locally.
- The SDK OTA manifest probe succeeds against the real `0.1.15` manifest URL and extracts:
  - `versionCode=47344348`
  - `versionName=sdk.0.1.15.20260701.192548.5540fdf6`
- YAML parses successfully.
- `git diff --check` passes.

## Recovery after merge

After this lands on `dev`, manually dispatch `Release Bluetooth SDK` with:

- `dry_run=false`
- `force_release=true`

Expected behavior for the recovery run:

- SDK OTA job reuses and verifies the existing `0.1.15` manifest.
- iOS SwiftPM sees tag `0.1.15` already exists and skips safely.
- npm and Maven proceed past the fixed frozen-lockfile install and publish `0.1.15`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release publishing and dependency install paths for mobile/SDK; incorrect OTA reuse logic could skip needed builds, but manifest validation and immutable-asset checks limit blast radius.
> 
> **Overview**
> Unblocks **Bluetooth SDK `0.1.15` recovery** after npm/Maven failed on stale lockfiles, and adds CI/release guards so the same failure is caught earlier.
> 
> **Release workflow (`bluetooth-sdk-release.yml`):** Before publishing, **detect** runs **frozen-lockfile** installs for root and mobile. **SDK OTA** probes the immutable manifest URL; if a valid `bluetooth-sdk-<version>-version.json` already exists, it **reuses** ASG `versionCode`/`versionName`, **skips** the ASG build/upload path, and still **verifies** the manifest before downstream jobs. Summaries and verify steps use existing vs freshly built metadata.
> 
> **CI:** New **`Bun Lockfile Checks`** workflow (path-filtered) validates root, mobile, and SDK lockfiles via `bun install --frozen-lockfile --ignore-scripts` (SDK in Docker). Wired into **`ci-gate-dev`** and **PR agent orchestrator**. **Mobile App Quality Checks** now uses **`--frozen-lockfile`**. **`CI_GATE.md`** documents the lockfile gate.
> 
> **Lockfiles / SDK workspace:** Refreshes **`bun.lock`**, **`mobile/bun.lock`**, and **`sdk/bun.lock`** (workspace metadata, dev version suffixes, CLI/qrcode, **`@mentra/bluetooth-sdk` `0.1.15`**). **`sdk/package.json`** workspaces list is narrowed to explicit SDK packages plus linked monorepo paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84269fd647a256228957d1bf04a7c4d6b66ee0ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



