### PR TITLE
Backport dev→staging promotion review-bot fixes to dev

### DIFF
--- a/.github/workflows/cloud-v2-pages.yml
+++ b/.github/workflows/cloud-v2-pages.yml
@@ -72,6 +72,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             env_name="${{ inputs.environment }}"
             site="${{ inputs.site }}"
+            # Guard: a manual prod deploy is only allowed from the main branch.
+            if [[ "${env_name}" == "prod" && "${{ github.ref_name }}" != "main" ]]; then
+              echo "Refusing to deploy prod from ref '${{ github.ref_name }}'; prod deploys are only allowed from main." >&2
+              exit 1
+            fi
           else
             case "${{ github.ref_name }}" in
               dev) env_name="dev" ;;

--- a/.github/workflows/merge-dev.yml
+++ b/.github/workflows/merge-dev.yml
@@ -14,6 +14,10 @@ name: Deploy Local Merge dev to Porter
 permissions:
   contents: read
 
+concurrency:
+  group: merge-dev-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   porter-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/merge-prod.yml
+++ b/.github/workflows/merge-prod.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set Github tag
         id: vars

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -187,6 +187,16 @@ public class CameraNeoService extends LifecycleService {
 
         /** Warm-up failed (open/configure failure). */
         void onCameraError(String errorMessage);
+
+        /**
+         * The phone-side request this warm-up belongs to, or {@code null} if none. Used to keep at
+         * most one pending {@code stopped} callback per request so a re-armed warm-up doesn't send
+         * the phone duplicate {@code stopped} events. Defaults to {@code null} for callers that
+         * don't track a requestId (those are appended without de-duplication).
+         */
+        default String getRequestId() {
+            return null;
+        }
     }
 
     // Warm-up callbacks. Several camera_warm_up commands can be in flight at once (e.g. two
@@ -704,7 +714,7 @@ public class CameraNeoService extends LifecycleService {
                 // Already configured + idle for these params — just re-arm the keep-alive.
                 Log.d(TAG, "camera_warm_up: camera already warm, restarting keep-alive");
                 if (callback != null) {
-                    sInstance.warmStoppedCallbacks.add(callback);
+                    sInstance.addWarmStoppedCallback(callback);
                 }
                 sInstance.cancelKeepAliveTimer();
                 sInstance.startWarmKeepAliveTimer(ttl);
@@ -933,7 +943,9 @@ public class CameraNeoService extends LifecycleService {
         synchronized (SERVICE_LOCK) {
             ready = new ArrayList<>(warmCallbacks);
             warmCallbacks.clear();
-            warmStoppedCallbacks.addAll(ready);
+            for (CameraWarmUpCallback callback : ready) {
+                addWarmStoppedCallback(callback);
+            }
         }
         for (CameraWarmUpCallback callback : ready) {
             callback.onCameraReady();
@@ -950,6 +962,21 @@ public class CameraNeoService extends LifecycleService {
         for (CameraWarmUpCallback callback : failed) {
             callback.onCameraError(errorMessage);
         }
+    }
+
+    /**
+     * Register a callback to be notified when warm-up stops, keeping at most one entry per
+     * requestId. Re-arming an already-warm session (the fast path) or issuing a fresh warm-up for
+     * the same requestId would otherwise append a second callback, so notifyWarmStopped would send
+     * the phone duplicate {@code stopped} events for one request. Callbacks with no requestId can't
+     * be de-duplicated and are appended as-is. Caller must hold {@code SERVICE_LOCK}.
+     */
+    private void addWarmStoppedCallback(CameraWarmUpCallback callback) {
+        String requestId = callback.getRequestId();
+        if (requestId != null) {
+            warmStoppedCallbacks.removeIf(existing -> requestId.equals(existing.getRequestId()));
+        }
+        warmStoppedCallbacks.add(callback);
     }
 
     /** Notify the bound warm-up callback that the camera was closed without capturing. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -682,7 +682,6 @@ public class CameraNeoService extends LifecycleService {
             long durationMs,
             CameraWarmUpCallback callback) {
         CameraWarmUpCallback rejectBusy = null;
-        CameraWarmUpCallback accepted = null;
         synchronized (SERVICE_LOCK) {
             long ttl = durationMs > 0 ? durationMs : DEFAULT_WARM_UP_MS;
             boolean cameraReady =
@@ -733,7 +732,6 @@ public class CameraNeoService extends LifecycleService {
             if (busy) {
                 rejectBusy = callback;
             } else {
-                accepted = callback;
                 sPendingWarmCallbacks.add(callback);
 
                 Intent intent = new Intent(context, CameraNeoService.class);
@@ -746,14 +744,13 @@ public class CameraNeoService extends LifecycleService {
                 context.startForegroundService(intent);
             }
         }
-        // Fire outside the lock (these send a camera_status over BLE). A warm-up emits `warming`
-        // only once accepted, so a busy rejection goes straight to `error` with no premature
-        // `warming`.
+        // Fire outside the lock (this sends a camera_status over BLE). Only the busy rejection is
+        // settled here; an accepted warm-up emits `warming` later in performWarmUp, once
+        // PhotoSession.setupWarmUp clears its own busy check and actually starts. Emitting `warming`
+        // at the entry gate could race a capture that starts before setupWarmUp runs, letting the
+        // phone see `warming` immediately followed by `error` (camera_busy).
         if (rejectBusy != null) {
             rejectBusy.onCameraError("camera_busy");
-        }
-        if (accepted != null) {
-            accepted.onWarming();
         }
     }
 
@@ -907,6 +904,7 @@ public class CameraNeoService extends LifecycleService {
         // warmUpCamera slip through the entry guard in the gap between clearing the pending list and
         // setupWarmUp setting warmUpRequest; its busy-reject (fireWarmError) would then fail the
         // first caller's callback too. setupWarmUp re-acquires SERVICE_LOCK reentrantly.
+        final List<CameraWarmUpCallback> warming;
         synchronized (SERVICE_LOCK) {
             warmCallbacks.addAll(sPendingWarmCallbacks);
             sPendingWarmCallbacks.clear();
@@ -917,6 +915,15 @@ public class CameraNeoService extends LifecycleService {
                     durationMs,
                     this::fireWarmReady,
                     this::fireWarmError);
+            // setupWarmUp runs its own busy check synchronously and, if a capture slipped in, has
+            // already fired fireWarmError (clearing warmCallbacks). The callbacks still bound here
+            // are the ones that actually started warming — emit `warming` only for them, so a
+            // busy-rejected request never sees `warming` before its `error`. ready/error resolve
+            // asynchronously later, so this `warming` always precedes them.
+            warming = new ArrayList<>(warmCallbacks);
+        }
+        for (CameraWarmUpCallback callback : warming) {
+            callback.onWarming();
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -4184,6 +4184,11 @@ public class MediaCaptureService {
                                 cameraWarmUpErrorCode(errorMessage),
                                 errorMessage);
                     }
+
+                    @Override
+                    public String getRequestId() {
+                        return requestId;
+                    }
                 });
         warmUpDispatching.set(false);
         return !rejectedSynchronously.get();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -4144,6 +4144,12 @@ public class MediaCaptureService {
                         + " durationMs="
                         + durationMs);
 
+        // CameraNeoService.warmUpCamera rejects an overlapping/mid-capture warm-up synchronously
+        // (it fires onCameraError on this thread before returning). Track that so the return value
+        // reflects a synchronous busy rejection instead of always reporting acceptance. Rejections
+        // that resolve later (async, in the service) are surfaced via camera_status as usual.
+        AtomicBoolean warmUpDispatching = new AtomicBoolean(true);
+        AtomicBoolean rejectedSynchronously = new AtomicBoolean(false);
         CameraNeoService.warmUpCamera(
                 mContext,
                 size,
@@ -4169,6 +4175,9 @@ public class MediaCaptureService {
 
                     @Override
                     public void onCameraError(String errorMessage) {
+                        if (warmUpDispatching.get()) {
+                            rejectedSynchronously.set(true);
+                        }
                         sendCameraStatus(
                                 requestId,
                                 "error",
@@ -4176,7 +4185,8 @@ public class MediaCaptureService {
                                 errorMessage);
                     }
                 });
-        return true;
+        warmUpDispatching.set(false);
+        return !rejectedSynchronously.get();
     }
 
     /**

--- a/cloud-v2/packages/cli/src/open-browser.ts
+++ b/cloud-v2/packages/cli/src/open-browser.ts
@@ -11,15 +11,27 @@ export async function openBrowser(url: string): Promise<boolean> {
   const args = platform() === "win32" ? ["/c", "start", "", url] : [url];
 
   return new Promise((resolve) => {
+    let settled = false;
+    const done = (ok: boolean) => {
+      if (settled) return;
+      settled = true;
+      resolve(ok);
+    };
+
     const child = spawn(command, args, {
       detached: true,
       stdio: "ignore",
     });
-    child.on("error", () => resolve(false));
-    // The launcher (`open`/`xdg-open`/`start`) exits quickly after handing the
-    // URL to the browser, so wait for its exit code rather than resolving on
-    // `spawn`. A non-zero exit means the launch failed and callers can fall
+
+    // A spawn error (e.g. launcher not found) is a genuine failure; callers fall
     // back to printing the URL.
-    child.on("close", (code) => resolve(code === 0));
+    child.on("error", () => done(false));
+    // Some launchers (`open`, `start`) exit promptly; treat a fast non-zero exit
+    // as a failure. But others (`xdg-open`) can stay attached to the browser, so
+    // don't block the login flow waiting for exit: assume success once a short
+    // window passes without an error/early failure so polling can start.
+    child.on("close", (code) => done(code === 0));
+    const timer = setTimeout(() => done(true), 500);
+    if (typeof timer.unref === "function") timer.unref();
   });
 }

--- a/cloud-v2/packages/cli/src/open-browser.ts
+++ b/cloud-v2/packages/cli/src/open-browser.ts
@@ -22,6 +22,10 @@ export async function openBrowser(url: string): Promise<boolean> {
       detached: true,
       stdio: "ignore",
     });
+    // Detach from the child so a long-lived launcher (e.g. xdg-open staying
+    // attached to the browser) can't keep the CLI's event loop alive after
+    // login completes and we've already resolved.
+    child.unref();
 
     // A spawn error (e.g. launcher not found) is a genuine failure; callers fall
     // back to printing the URL.

--- a/cloud-v2/packages/cli/src/open-browser.ts
+++ b/cloud-v2/packages/cli/src/open-browser.ts
@@ -16,9 +16,10 @@ export async function openBrowser(url: string): Promise<boolean> {
       stdio: "ignore",
     });
     child.on("error", () => resolve(false));
-    child.on("spawn", () => {
-      child.unref();
-      resolve(true);
-    });
+    // The launcher (`open`/`xdg-open`/`start`) exits quickly after handing the
+    // URL to the browser, so wait for its exit code rather than resolving on
+    // `spawn`. A non-zero exit means the launch failed and callers can fall
+    // back to printing the URL.
+    child.on("close", (code) => resolve(code === 0));
   });
 }

--- a/cloud-v2/packages/core/src/api/client/miniapps.api.ts
+++ b/cloud-v2/packages/core/src/api/client/miniapps.api.ts
@@ -1,5 +1,8 @@
 import { Hono } from "hono";
-import { PreinstalledRegistryService } from "../../services/miniapps/preinstalled-registry.service";
+import {
+  PreinstalledRegistryService,
+  PreinstalledRegistryServiceError,
+} from "../../services/miniapps/preinstalled-registry.service";
 import { createStorageService } from "../../services/storage/storage.service";
 import type { AppContext, AppEnv } from "../../types/hono.types";
 import { InvalidRequest } from "../../types/oauth.types";
@@ -41,18 +44,35 @@ async function loadRegistry(c: AppContext) {
 async function downloadBundle(c: AppContext) {
   const assetId = c.req.param("assetId");
   if (!assetId) throw new InvalidRequest("missing assetId");
-  const asset = await registryService.getBundleAsset(assetId);
-  const bytes = await storage.getObject(asset.storageKey);
+  try {
+    const asset = await registryService.getBundleAsset(assetId);
+    const bytes = await storage.getObject(asset.storageKey);
 
-  return new Response(bytes, {
-    headers: {
-      "content-type": asset.contentType || "application/zip",
-      "content-length": String(asset.sizeBytes),
-      "content-disposition": `attachment; filename="${asset.fileName.replace(/"/g, "")}"`,
-      "cache-control": "public, max-age=31536000, immutable",
-      "x-bundle-sha256": asset.sha256,
-    },
-  });
+    return new Response(bytes, {
+      headers: {
+        "content-type": asset.contentType || "application/zip",
+        "content-length": String(asset.sizeBytes),
+        "content-disposition": `attachment; filename="${asset.fileName.replace(/"/g, "")}"`,
+        "cache-control": "public, max-age=31536000, immutable",
+        "x-bundle-sha256": asset.sha256,
+      },
+    });
+  } catch (error) {
+    return serviceError(error);
+  }
+}
+
+function serviceError(error: unknown) {
+  if (error instanceof PreinstalledRegistryServiceError) {
+    return new Response(
+      JSON.stringify({ error: error.code, error_description: error.message }),
+      {
+        status: error.status,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }
+  throw error;
 }
 
 export default app;

--- a/cloud-v2/packages/core/src/api/middleware/admin-auth.middleware.ts
+++ b/cloud-v2/packages/core/src/api/middleware/admin-auth.middleware.ts
@@ -25,8 +25,9 @@ function isAdminEmail(email: string): boolean {
   const emails = parseList(process.env.CLOUD_CORE_ADMIN_EMAILS).map(value => value.toLowerCase());
   if (emails.includes(normalized)) return true;
 
-  const configuredDomains = parseList(process.env.CLOUD_CORE_ADMIN_EMAIL_DOMAINS);
-  const domains = configuredDomains.length > 0 ? configuredDomains : ["mentraglass.com"];
+  // Fail closed: without an explicit domain allowlist, do not grant admin via
+  // domain matching. Admin access then requires membership in CLOUD_CORE_ADMIN_EMAILS.
+  const domains = parseList(process.env.CLOUD_CORE_ADMIN_EMAIL_DOMAINS);
   return domains
     .map(domain => domain.toLowerCase().replace(/^@/, ""))
     .some(domain => normalized.endsWith(`@${domain}`));

--- a/cloud-v2/packages/core/src/index.ts
+++ b/cloud-v2/packages/core/src/index.ts
@@ -52,7 +52,11 @@ export async function startCore(opts: StartCoreOptions = {}): Promise<CoreHandle
   try {
     await runStartupMigrations();
   } catch (error) {
-    await disconnectMongo();
+    // Disconnect best-effort: a secondary disconnect failure must not mask the
+    // original migration error, which is what we rethrow.
+    await disconnectMongo().catch(disconnectError => {
+      logger.warn({ disconnectError }, "failed to disconnect mongo after migration failure");
+    });
     throw error;
   }
 

--- a/cloud-v2/packages/core/src/index.ts
+++ b/cloud-v2/packages/core/src/index.ts
@@ -49,7 +49,12 @@ export async function startCore(opts: StartCoreOptions = {}): Promise<CoreHandle
     "mongodb://127.0.0.1:27017/mentra-cloud-v2";
 
   await connectMongo(mongoUrl);
-  await runStartupMigrations();
+  try {
+    await runStartupMigrations();
+  } catch (error) {
+    await disconnectMongo();
+    throw error;
+  }
 
   const app = createApp({ readinessChecks: [mongoReadinessCheck] });
   const server = Bun.serve({ port, fetch: app.fetch });

--- a/cloud-v2/packages/core/src/models/enterprise-org.model.ts
+++ b/cloud-v2/packages/core/src/models/enterprise-org.model.ts
@@ -17,7 +17,13 @@ const EnterpriseOrgSchema = new Schema(
 );
 
 EnterpriseOrgSchema.index({ ownerUserId: 1, createdAt: 1 });
-EnterpriseOrgSchema.index({ workosOrgId: 1 }, { unique: true, sparse: true });
+// Partial (not sparse): `workosOrgId` defaults to null until WorkOS provisioning,
+// and a sparse unique index skips only omitted fields, so a second unprovisioned
+// org would collide on the explicit null. Constrain uniqueness to real string ids.
+EnterpriseOrgSchema.index(
+  { workosOrgId: 1 },
+  { unique: true, partialFilterExpression: { workosOrgId: { $type: "string" } } },
+);
 
 export type EnterpriseOrg = InferSchemaType<typeof EnterpriseOrgSchema>;
 export const EnterpriseOrgModel = model("EnterpriseOrg", EnterpriseOrgSchema);

--- a/cloud-v2/packages/core/src/models/preinstalled-registry-revision.model.ts
+++ b/cloud-v2/packages/core/src/models/preinstalled-registry-revision.model.ts
@@ -29,6 +29,14 @@ const PreinstalledRegistryRevisionSchema = new Schema(
   { timestamps: true, collection: "preinstalled_registry_revisions" },
 );
 
+// At most one active revision per registry (activeRevisionId is a singular pointer;
+// promoteRevision archives all others). Partial to "active" so draft/archived rows
+// are unconstrained and concurrent promotions can't leave two active revisions.
+PreinstalledRegistryRevisionSchema.index(
+  { registryId: 1, status: 1 },
+  { unique: true, partialFilterExpression: { status: "active" } },
+);
+
 export type PreinstalledRegistryRevision = InferSchemaType<typeof PreinstalledRegistryRevisionSchema>;
 export const PreinstalledRegistryRevisionModel = model(
   "PreinstalledRegistryRevision",

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
@@ -234,42 +234,50 @@ export class MiniAppService {
       createdBy: developer.developerId,
     });
 
-    const storageKey = [
-      "miniapps",
-      packageName,
-      "releases",
-      input.version,
-      `${ulid()}-bundle.zip`,
-    ].join("/");
-    const stored = await storage.putObject({
-      key: storageKey,
-      body: input.bundle,
-      contentType: "application/zip",
-    });
-    const expectedSha = sha256Hex(input.bundle);
-    if (stored.sha256 !== expectedSha) {
-      throw new MiniAppServiceError("hash_mismatch", "stored bundle hash mismatch", 500);
+    // Store the bundle and link it to the release. If any step fails, roll back
+    // the freshly created release row so a retry with the same package/version
+    // is not permanently blocked by the `release_exists` check above.
+    try {
+      const storageKey = [
+        "miniapps",
+        packageName,
+        "releases",
+        input.version,
+        `${ulid()}-bundle.zip`,
+      ].join("/");
+      const stored = await storage.putObject({
+        key: storageKey,
+        body: input.bundle,
+        contentType: "application/zip",
+      });
+      const expectedSha = sha256Hex(input.bundle);
+      if (stored.sha256 !== expectedSha) {
+        throw new MiniAppServiceError("hash_mismatch", "stored bundle hash mismatch", 500);
+      }
+
+      const asset = await MiniAppAssetModel.create({
+        orgId: developer.orgId,
+        miniAppId: app._id.toString(),
+        releaseId: release._id.toString(),
+        role: "release_bundle",
+        storageKey,
+        fileName: input.fileName ?? "bundle.zip",
+        contentType: stored.contentType,
+        sizeBytes: stored.sizeBytes,
+        sha256: stored.sha256,
+        createdBy: developer.developerId,
+      });
+
+      release.releaseBundleAssetId = asset._id.toString();
+      release.bundleSha256 = stored.sha256;
+      release.bundleSizeBytes = stored.sizeBytes;
+      await release.save();
+
+      return serializeRelease(release.toObject());
+    } catch (error) {
+      await MiniAppReleaseModel.deleteOne({ _id: release._id }).catch(() => {});
+      throw error;
     }
-
-    const asset = await MiniAppAssetModel.create({
-      orgId: developer.orgId,
-      miniAppId: app._id.toString(),
-      releaseId: release._id.toString(),
-      role: "release_bundle",
-      storageKey,
-      fileName: input.fileName ?? "bundle.zip",
-      contentType: stored.contentType,
-      sizeBytes: stored.sizeBytes,
-      sha256: stored.sha256,
-      createdBy: developer.developerId,
-    });
-
-    release.releaseBundleAssetId = asset._id.toString();
-    release.bundleSha256 = stored.sha256;
-    release.bundleSizeBytes = stored.sizeBytes;
-    await release.save();
-
-    return serializeRelease(release.toObject());
   }
 
   private async getMiniAppById(developer: DeveloperIdentity, id: string) {

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
@@ -1,9 +1,12 @@
+import { createLogger } from "@mentra/cloud-shared";
 import { ulid } from "ulid";
 import { MiniAppAssetModel } from "../../models/miniapp-asset.model";
 import { MiniAppModel } from "../../models/miniapp.model";
 import { MiniAppReleaseModel } from "../../models/miniapp-release.model";
 import { createStorageService, sha256Hex } from "../storage/storage.service";
 import type { SignedBundleMetadata } from "./developer-signing.service";
+
+const logger = createLogger("core").child({ service: "miniapp.service" });
 
 export interface DeveloperIdentity {
   developerId: string;
@@ -235,8 +238,11 @@ export class MiniAppService {
     });
 
     // Store the bundle and link it to the release. If any step fails, roll back
-    // the freshly created release row so a retry with the same package/version
-    // is not permanently blocked by the `release_exists` check above.
+    // everything created here (release row, asset row, and stored blob) so a
+    // retry with the same package/version is not permanently blocked by the
+    // `release_exists` check above and no orphaned storage is left behind.
+    let storedKey: string | undefined;
+    let assetId: string | undefined;
     try {
       const storageKey = [
         "miniapps",
@@ -250,6 +256,7 @@ export class MiniAppService {
         body: input.bundle,
         contentType: "application/zip",
       });
+      storedKey = storageKey;
       const expectedSha = sha256Hex(input.bundle);
       if (stored.sha256 !== expectedSha) {
         throw new MiniAppServiceError("hash_mismatch", "stored bundle hash mismatch", 500);
@@ -267,6 +274,7 @@ export class MiniAppService {
         sha256: stored.sha256,
         createdBy: developer.developerId,
       });
+      assetId = asset._id.toString();
 
       release.releaseBundleAssetId = asset._id.toString();
       release.bundleSha256 = stored.sha256;
@@ -275,7 +283,22 @@ export class MiniAppService {
 
       return serializeRelease(release.toObject());
     } catch (error) {
-      await MiniAppReleaseModel.deleteOne({ _id: release._id }).catch(() => {});
+      const releaseId = release._id.toString();
+      // Best-effort compensation. Log each failure with context so blocked
+      // retries or orphaned artifacts stay diagnosable rather than silent.
+      await MiniAppReleaseModel.deleteOne({ _id: release._id }).catch(cleanupError => {
+        logger.error({ cleanupError, releaseId, packageName, version: input.version }, "failed to roll back release row after createRelease failure");
+      });
+      if (assetId) {
+        await MiniAppAssetModel.deleteOne({ _id: assetId }).catch(cleanupError => {
+          logger.error({ cleanupError, releaseId, assetId }, "failed to roll back asset row after createRelease failure");
+        });
+      }
+      if (storedKey) {
+        await storage.deleteObject(storedKey).catch(cleanupError => {
+          logger.error({ cleanupError, releaseId, storageKey: storedKey }, "failed to delete stored bundle after createRelease failure");
+        });
+      }
       throw error;
     }
   }

--- a/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
+++ b/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
@@ -72,9 +72,14 @@ export function createS3StorageProvider(provider: "r2" | "s3" = "r2"): S3Storage
   );
   // R2 accepts the sentinel "auto" region, but real AWS S3 requires a valid
   // region name, so fall back to a standard AWS region when one is not set.
+  // For provider "s3" the R2-only region vars are intentionally ignored: an
+  // R2_REGION=auto would otherwise sign AWS requests with an invalid region.
   const defaultRegion = provider === "s3" ? "us-east-1" : "auto";
   const region =
-    env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION", "CLOUD_CORE_R2_REGION", "R2_REGION") ?? defaultRegion;
+    (provider === "s3"
+      ? env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION")
+      : env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION", "CLOUD_CORE_R2_REGION", "R2_REGION")) ??
+    defaultRegion;
 
   if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
     throw new Error(

--- a/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
+++ b/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
@@ -45,7 +45,7 @@ export class S3StorageProvider implements StorageProvider {
   }
 }
 
-export function createS3StorageProvider(): S3StorageProvider {
+export function createS3StorageProvider(provider: "r2" | "s3" = "r2"): S3StorageProvider {
   const endpoint = env(
     "CLOUD_STORAGE_S3_ENDPOINT",
     "CLOUD_CORE_STORAGE_S3_ENDPOINT",
@@ -70,8 +70,11 @@ export function createS3StorageProvider(): S3StorageProvider {
     "CLOUD_CORE_R2_SECRET_ACCESS_KEY",
     "R2_SECRET_ACCESS_KEY",
   );
+  // R2 accepts the sentinel "auto" region, but real AWS S3 requires a valid
+  // region name, so fall back to a standard AWS region when one is not set.
+  const defaultRegion = provider === "s3" ? "us-east-1" : "auto";
   const region =
-    env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION", "CLOUD_CORE_R2_REGION", "R2_REGION") ?? "auto";
+    env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION", "CLOUD_CORE_R2_REGION", "R2_REGION") ?? defaultRegion;
 
   if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
     throw new Error(

--- a/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
+++ b/cloud-v2/packages/core/src/services/storage/providers/s3-storage.provider.ts
@@ -75,11 +75,15 @@ export function createS3StorageProvider(provider: "r2" | "s3" = "r2"): S3Storage
   // For provider "s3" the R2-only region vars are intentionally ignored: an
   // R2_REGION=auto would otherwise sign AWS requests with an invalid region.
   const defaultRegion = provider === "s3" ? "us-east-1" : "auto";
-  const region =
+  const resolvedRegion =
     (provider === "s3"
       ? env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION")
       : env("CLOUD_STORAGE_S3_REGION", "CLOUD_CORE_STORAGE_S3_REGION", "CLOUD_CORE_R2_REGION", "R2_REGION")) ??
     defaultRegion;
+  // "auto" is an R2-only sentinel and is invalid for real AWS S3 signing; never
+  // let it through for provider "s3", even if it was set explicitly in a generic
+  // S3 region var.
+  const region = provider === "s3" && resolvedRegion === "auto" ? "us-east-1" : resolvedRegion;
 
   if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
     throw new Error(

--- a/cloud-v2/packages/core/src/services/storage/storage.service.ts
+++ b/cloud-v2/packages/core/src/services/storage/storage.service.ts
@@ -40,7 +40,7 @@ export class StorageService {
 export function createStorageService(): StorageService {
   const provider = process.env.CLOUD_STORAGE_PROVIDER ?? process.env.CLOUD_CORE_STORAGE_PROVIDER ?? "local";
   if (provider === "r2" || provider === "s3") {
-    return new StorageService(createS3StorageProvider());
+    return new StorageService(createS3StorageProvider(provider));
   }
   if (provider !== "local") {
     throw new Error(`unsupported CLOUD_STORAGE_PROVIDER: ${provider}`);

--- a/cloud-v2/packages/runtime/src/net/ws.ts
+++ b/cloud-v2/packages/runtime/src/net/ws.ts
@@ -122,6 +122,13 @@ export interface WsData {
    * subscriptions immediately.
    */
   supersededAt?: number;
+  /**
+   * Set while an older socket has been marked superseded but the newer session
+   * has not yet confirmed it can take over (seed succeeded). The socket is held
+   * open — inbound frames are ignored rather than closing it — so a failed
+   * init can restore it. Cleared when the supersede is finalized or restored.
+   */
+  supersedePending?: boolean;
 }
 
 export interface SessionEntry {
@@ -498,6 +505,10 @@ export const wsHandlers: WebSocketHandler<WsData> = {
   message(ws, msg) {
     ws.data.lastInboundAt = Date.now();
     if (ws.data.supersededAt !== undefined) {
+      // A superseded-but-still-pending socket is held open until the newer
+      // session confirms its takeover — ignore its frames without closing so a
+      // failed init can restore it. Once finalized (or never pending), close.
+      if (ws.data.supersedePending) return;
       try {
         ws.close(1012, "superseded by newer session");
       } catch {
@@ -866,6 +877,7 @@ function markOlderSessionsSuperseded(current: WsData): SessionEntry[] {
     if (data.mentraUserId !== current.mentraUserId) continue;
 
     data.supersededAt = Date.now();
+    data.supersedePending = true;
     superseded.push(entry);
     logger.warn(
       {
@@ -891,6 +903,7 @@ function markOlderSessionsSuperseded(current: WsData): SessionEntry[] {
 function finalizeSupersededSessions(entries: SessionEntry[]): void {
   for (const entry of entries) {
     const data = entry.data;
+    data.supersedePending = false;
     const interval = refreshIntervals.get(data.sessionTag);
     if (interval) {
       clearInterval(interval);
@@ -923,6 +936,7 @@ function restoreSupersededSessions(entries: SessionEntry[]): void {
   for (const entry of entries) {
     if (entry.data.supersededAt === undefined) continue;
     entry.data.supersededAt = undefined;
+    entry.data.supersedePending = false;
     logger.warn(
       {
         mentraUserId: entry.data.mentraUserId,

--- a/cloud-v2/packages/runtime/src/net/ws.ts
+++ b/cloud-v2/packages/runtime/src/net/ws.ts
@@ -758,7 +758,7 @@ async function handleConnectionInit(
     // client reconnects and re-runs the handshake cleanly. Restore the older
     // sessions we only marked (never tore down) so the user keeps a working
     // session rather than losing both to a transient error.
-    restoreSupersededSessions(superseded);
+    restoreSupersededSessions(ws.data, superseded);
     logger.error(
       { err, mentraUserId: ws.data.mentraUserId },
       "failed to seed subscriptions on connection.init; closing socket",
@@ -932,7 +932,12 @@ function finalizeSupersededSessions(entries: SessionEntry[]): void {
  * `supersededAt` hands authority back to the still-open old socket so the user
  * keeps a working session instead of being left with none.
  */
-function restoreSupersededSessions(entries: SessionEntry[]): void {
+function restoreSupersededSessions(current: WsData, entries: SessionEntry[]): void {
+  // If our own socket was itself superseded by an even newer init while we were
+  // seeding, we lost the reconnect race: that newer init now owns the supersede
+  // lifecycle, so reviving here could bring back a socket it already replaced.
+  // Leave the entries as-is and let the winning init finalize them.
+  if (current.supersededAt !== undefined) return;
   for (const entry of entries) {
     if (entry.data.supersededAt === undefined) continue;
     entry.data.supersededAt = undefined;

--- a/cloud-v2/packages/runtime/src/net/ws.ts
+++ b/cloud-v2/packages/runtime/src/net/ws.ts
@@ -681,7 +681,12 @@ async function handleConnectionInit(
     init.audio?.codec ?? "lc3",
     init.audio?.frameSizeBytes,
   );
-  supersedeOlderSessionsForUser(ws.data);
+  // Optimistically mark this user's older sockets superseded — this pauses them
+  // and makes them look dead to the takeover check below — but defer their
+  // teardown until the new session has actually seeded. If init fails we restore
+  // them, so a transient seed error on reconnect never leaves the user with no
+  // session at all. See markOlderSessionsSuperseded.
+  const superseded = markOlderSessionsSuperseded(ws.data);
 
   // Seed the subscription source-of-truth key atomically with session creation,
   // so audio that starts flowing right after the ack is transcribed against the
@@ -739,7 +744,10 @@ async function handleConnectionInit(
     // Do NOT fall through to connection.ack: without a seeded subscription key
     // the client would stream audio that is transcribed against nothing, with no
     // in-band signal anything is wrong. Surface the failure and close so the
-    // client reconnects and re-runs the handshake cleanly.
+    // client reconnects and re-runs the handshake cleanly. Restore the older
+    // sessions we only marked (never tore down) so the user keeps a working
+    // session rather than losing both to a transient error.
+    restoreSupersededSessions(superseded);
     logger.error(
       { err, mentraUserId: ws.data.mentraUserId },
       "failed to seed subscriptions on connection.init; closing socket",
@@ -752,6 +760,10 @@ async function handleConnectionInit(
     }
     return;
   }
+
+  // The new session is now the subscription authority for this user; it is safe
+  // to tear down the older sockets we paused above.
+  finalizeSupersededSessions(superseded);
 
   ws.send(
     JSON.stringify({
@@ -835,7 +847,18 @@ async function handleWsBinaryAudio(
   }
 }
 
-function supersedeOlderSessionsForUser(current: WsData): void {
+/**
+ * Mark this user's older sockets as superseded WITHOUT tearing them down yet.
+ * Setting `supersededAt` pauses their audio processing and makes them look dead
+ * to takeover checks (`hasLiveAudioSession`), which the new session needs before
+ * it seeds/takes over the subscription key. The destructive teardown (refresh
+ * interval, sessionTag unregister, socket close) is deferred to
+ * `finalizeSupersededSessions` so that a failed init can instead
+ * `restoreSupersededSessions` — a transient seed error on reconnect must not
+ * kill the still-working old socket and leave the user with no session.
+ */
+function markOlderSessionsSuperseded(current: WsData): SessionEntry[] {
+  const superseded: SessionEntry[] = [];
   for (const entry of sessionByTag.values()) {
     const data = entry.data;
     if (data.sessionTag === current.sessionTag) continue;
@@ -843,6 +866,31 @@ function supersedeOlderSessionsForUser(current: WsData): void {
     if (data.mentraUserId !== current.mentraUserId) continue;
 
     data.supersededAt = Date.now();
+    superseded.push(entry);
+    logger.warn(
+      {
+        mentraUserId: data.mentraUserId,
+        oldSessionTag: data.sessionTag,
+        oldAudioSessionId: data.audioSessionId,
+        oldAuthSessionId: data.authSessionId,
+        newSessionTag: current.sessionTag,
+        newAudioSessionId: current.audioSessionId,
+        newAuthSessionId: current.authSessionId,
+      },
+      "ws session marked superseded by newer socket for same user",
+    );
+  }
+  return superseded;
+}
+
+/**
+ * Tear down sockets superseded by a now-established newer session: stop their
+ * refresh, drop their sessionTag registration, and close them. Called only once
+ * the new session has successfully seeded/taken over its subscription key.
+ */
+function finalizeSupersededSessions(entries: SessionEntry[]): void {
+  for (const entry of entries) {
+    const data = entry.data;
     const interval = refreshIntervals.get(data.sessionTag);
     if (interval) {
       clearInterval(interval);
@@ -854,18 +902,6 @@ function supersedeOlderSessionsForUser(current: WsData): void {
         "sessionTag unregister failed after supersede",
       );
     });
-    logger.warn(
-      {
-        mentraUserId: data.mentraUserId,
-        oldSessionTag: data.sessionTag,
-        oldAudioSessionId: data.audioSessionId,
-        oldAuthSessionId: data.authSessionId,
-        newSessionTag: current.sessionTag,
-        newAudioSessionId: current.audioSessionId,
-        newAuthSessionId: current.authSessionId,
-      },
-      "ws session superseded by newer socket for same user",
-    );
     try {
       entry.ws.close(1012, "superseded by newer session");
     } catch (err) {
@@ -874,6 +910,27 @@ function supersedeOlderSessionsForUser(current: WsData): void {
         "ws close failed after supersede",
       );
     }
+  }
+}
+
+/**
+ * Un-pause sessions that were optimistically marked superseded when the newer
+ * session failed to initialize. Because they were never torn down, clearing
+ * `supersededAt` hands authority back to the still-open old socket so the user
+ * keeps a working session instead of being left with none.
+ */
+function restoreSupersededSessions(entries: SessionEntry[]): void {
+  for (const entry of entries) {
+    if (entry.data.supersededAt === undefined) continue;
+    entry.data.supersededAt = undefined;
+    logger.warn(
+      {
+        mentraUserId: entry.data.mentraUserId,
+        sessionTag: entry.data.sessionTag,
+        audioSessionId: entry.data.audioSessionId,
+      },
+      "restored superseded session after newer session init failed",
+    );
   }
 }
 

--- a/cloud-v2/packages/runtime/src/net/ws.ts
+++ b/cloud-v2/packages/runtime/src/net/ws.ts
@@ -122,13 +122,6 @@ export interface WsData {
    * subscriptions immediately.
    */
   supersededAt?: number;
-  /**
-   * Set while an older socket has been marked superseded but the newer session
-   * has not yet confirmed it can take over (seed succeeded). The socket is held
-   * open — inbound frames are ignored rather than closing it — so a failed
-   * init can restore it. Cleared when the supersede is finalized or restored.
-   */
-  supersedePending?: boolean;
 }
 
 export interface SessionEntry {
@@ -505,10 +498,6 @@ export const wsHandlers: WebSocketHandler<WsData> = {
   message(ws, msg) {
     ws.data.lastInboundAt = Date.now();
     if (ws.data.supersededAt !== undefined) {
-      // A superseded-but-still-pending socket is held open until the newer
-      // session confirms its takeover — ignore its frames without closing so a
-      // failed init can restore it. Once finalized (or never pending), close.
-      if (ws.data.supersedePending) return;
       try {
         ws.close(1012, "superseded by newer session");
       } catch {
@@ -692,12 +681,7 @@ async function handleConnectionInit(
     init.audio?.codec ?? "lc3",
     init.audio?.frameSizeBytes,
   );
-  // Optimistically mark this user's older sockets superseded — this pauses them
-  // and makes them look dead to the takeover check below — but defer their
-  // teardown until the new session has actually seeded. If init fails we restore
-  // them, so a transient seed error on reconnect never leaves the user with no
-  // session at all. See markOlderSessionsSuperseded.
-  const superseded = markOlderSessionsSuperseded(ws.data);
+  supersedeOlderSessionsForUser(ws.data);
 
   // Seed the subscription source-of-truth key atomically with session creation,
   // so audio that starts flowing right after the ack is transcribed against the
@@ -755,10 +739,7 @@ async function handleConnectionInit(
     // Do NOT fall through to connection.ack: without a seeded subscription key
     // the client would stream audio that is transcribed against nothing, with no
     // in-band signal anything is wrong. Surface the failure and close so the
-    // client reconnects and re-runs the handshake cleanly. Restore the older
-    // sessions we only marked (never tore down) so the user keeps a working
-    // session rather than losing both to a transient error.
-    restoreSupersededSessions(ws.data, superseded);
+    // client reconnects and re-runs the handshake cleanly.
     logger.error(
       { err, mentraUserId: ws.data.mentraUserId },
       "failed to seed subscriptions on connection.init; closing socket",
@@ -771,10 +752,6 @@ async function handleConnectionInit(
     }
     return;
   }
-
-  // The new session is now the subscription authority for this user; it is safe
-  // to tear down the older sockets we paused above.
-  finalizeSupersededSessions(superseded);
 
   ws.send(
     JSON.stringify({
@@ -858,18 +835,7 @@ async function handleWsBinaryAudio(
   }
 }
 
-/**
- * Mark this user's older sockets as superseded WITHOUT tearing them down yet.
- * Setting `supersededAt` pauses their audio processing and makes them look dead
- * to takeover checks (`hasLiveAudioSession`), which the new session needs before
- * it seeds/takes over the subscription key. The destructive teardown (refresh
- * interval, sessionTag unregister, socket close) is deferred to
- * `finalizeSupersededSessions` so that a failed init can instead
- * `restoreSupersededSessions` — a transient seed error on reconnect must not
- * kill the still-working old socket and leave the user with no session.
- */
-function markOlderSessionsSuperseded(current: WsData): SessionEntry[] {
-  const superseded: SessionEntry[] = [];
+function supersedeOlderSessionsForUser(current: WsData): void {
   for (const entry of sessionByTag.values()) {
     const data = entry.data;
     if (data.sessionTag === current.sessionTag) continue;
@@ -877,33 +843,6 @@ function markOlderSessionsSuperseded(current: WsData): SessionEntry[] {
     if (data.mentraUserId !== current.mentraUserId) continue;
 
     data.supersededAt = Date.now();
-    data.supersedePending = true;
-    superseded.push(entry);
-    logger.warn(
-      {
-        mentraUserId: data.mentraUserId,
-        oldSessionTag: data.sessionTag,
-        oldAudioSessionId: data.audioSessionId,
-        oldAuthSessionId: data.authSessionId,
-        newSessionTag: current.sessionTag,
-        newAudioSessionId: current.audioSessionId,
-        newAuthSessionId: current.authSessionId,
-      },
-      "ws session marked superseded by newer socket for same user",
-    );
-  }
-  return superseded;
-}
-
-/**
- * Tear down sockets superseded by a now-established newer session: stop their
- * refresh, drop their sessionTag registration, and close them. Called only once
- * the new session has successfully seeded/taken over its subscription key.
- */
-function finalizeSupersededSessions(entries: SessionEntry[]): void {
-  for (const entry of entries) {
-    const data = entry.data;
-    data.supersedePending = false;
     const interval = refreshIntervals.get(data.sessionTag);
     if (interval) {
       clearInterval(interval);
@@ -915,6 +854,18 @@ function finalizeSupersededSessions(entries: SessionEntry[]): void {
         "sessionTag unregister failed after supersede",
       );
     });
+    logger.warn(
+      {
+        mentraUserId: data.mentraUserId,
+        oldSessionTag: data.sessionTag,
+        oldAudioSessionId: data.audioSessionId,
+        oldAuthSessionId: data.authSessionId,
+        newSessionTag: current.sessionTag,
+        newAudioSessionId: current.audioSessionId,
+        newAuthSessionId: current.authSessionId,
+      },
+      "ws session superseded by newer socket for same user",
+    );
     try {
       entry.ws.close(1012, "superseded by newer session");
     } catch (err) {
@@ -923,33 +874,6 @@ function finalizeSupersededSessions(entries: SessionEntry[]): void {
         "ws close failed after supersede",
       );
     }
-  }
-}
-
-/**
- * Un-pause sessions that were optimistically marked superseded when the newer
- * session failed to initialize. Because they were never torn down, clearing
- * `supersededAt` hands authority back to the still-open old socket so the user
- * keeps a working session instead of being left with none.
- */
-function restoreSupersededSessions(current: WsData, entries: SessionEntry[]): void {
-  // If our own socket was itself superseded by an even newer init while we were
-  // seeding, we lost the reconnect race: that newer init now owns the supersede
-  // lifecycle, so reviving here could bring back a socket it already replaced.
-  // Leave the entries as-is and let the winning init finalize them.
-  if (current.supersededAt !== undefined) return;
-  for (const entry of entries) {
-    if (entry.data.supersededAt === undefined) continue;
-    entry.data.supersededAt = undefined;
-    entry.data.supersedePending = false;
-    logger.warn(
-      {
-        mentraUserId: entry.data.mentraUserId,
-        sessionTag: entry.data.sessionTag,
-        audioSessionId: entry.data.audioSessionId,
-      },
-      "restored superseded session after newer session init failed",
-    );
   }
 }
 

--- a/cloud-v2/scripts/preinstall-e2e.ts
+++ b/cloud-v2/scripts/preinstall-e2e.ts
@@ -35,6 +35,7 @@ console.log("[e2e] access_token len:", access.length);
 // stash for reuse
 await Bun.write("/tmp/e2e-access-token.txt", access);
 
+let bundleFailures = 0;
 for (const env of ["debug", "dev", "staging", "prod"]) {
   const r = await fetch(`${CORE}/api/client/miniapps/registry?environment=${env}`, {
     headers: { authorization: `Bearer ${access}` },
@@ -42,6 +43,12 @@ for (const env of ["debug", "dev", "staging", "prod"]) {
   const body: any = await r.json().catch(() => ({}));
   const entries = body.entries ?? body.miniapps ?? [];
   console.log(`[e2e] registry ${env}: ${r.status} entries=${entries.length}`);
+  if (!r.ok) {
+    console.error(
+      `[e2e] registry ${env} failed: ${r.status} ${body.error ?? ""} ${body.error_description ?? ""}`.trim(),
+    );
+    process.exit(1);
+  }
 
   // For the env we seeded, download each bundle and verify SHA-256 end to end.
   for (const entry of entries) {
@@ -61,5 +68,20 @@ for (const env of ["debug", "dev", "staging", "prod"]) {
       `  - ${entry.packageName} v${entry.version} policy=${entry.installPolicy ?? "?"}: ` +
       `dl=${dl.status} bytes=${buf.length} sha_ok=${ok} (got=${got.slice(0, 12)} expect=${expected.slice(0, 12)} hdr=${hdr.slice(0, 12)})`,
     );
+    // A corrupted or failed download must fail the e2e run, not just log.
+    if (!dl.ok) {
+      console.error(`  - ${entry.packageName} v${entry.version}: download failed (status ${dl.status})`);
+      bundleFailures++;
+    } else if (!expected || !ok) {
+      console.error(
+        `  - ${entry.packageName} v${entry.version}: SHA-256 mismatch (got=${got.slice(0, 12)} expect=${expected.slice(0, 12) || "<none>"})`,
+      );
+      bundleFailures++;
+    }
   }
+}
+
+if (bundleFailures > 0) {
+  console.error(`[e2e] ${bundleFailures} bundle integrity failure(s)`);
+  process.exit(1);
 }

--- a/cloud-v2/scripts/seed-preinstall.ts
+++ b/cloud-v2/scripts/seed-preinstall.ts
@@ -15,10 +15,7 @@ import {
   disconnectMongo,
 } from "../packages/core/src/connections/mongo.connection";
 import { MiniAppModel } from "../packages/core/src/models/miniapp.model";
-import {
-  MiniAppService,
-  MiniAppServiceError,
-} from "../packages/core/src/services/miniapps/miniapp.service";
+import { MiniAppService } from "../packages/core/src/services/miniapps/miniapp.service";
 import { PreinstalledRegistryService } from "../packages/core/src/services/miniapps/preinstalled-registry.service";
 
 const ENVIRONMENT = process.env.SEED_ENV ?? "dev";
@@ -58,23 +55,16 @@ async function main() {
   const bundle = new Uint8Array(readFileSync(BUNDLE_PATH));
   console.log(`bundle=${BUNDLE_PATH} bytes=${bundle.byteLength}`);
 
-  // 1) miniapp (idempotent-ish: ignore "already exists")
-  try {
-    await miniapps.createMiniApp(developer, {
-      packageName: PACKAGE,
-      displayName: "Captions",
-      description: "Seeded preinstall miniapp",
-    });
-    console.log(`created miniapp ${PACKAGE}`);
-  } catch (err) {
-    // Only the "already claimed" case is safe to ignore for idempotent re-seeds;
-    // anything else is a real setup failure and must surface.
-    if (err instanceof MiniAppServiceError && err.code === "package_taken") {
-      console.log(`createMiniApp: ${err.message} (already claimed, continuing)`);
-    } else {
-      throw err;
-    }
-  }
+  // 1) miniapp: createMiniApp is idempotent for the same developer/org (it
+  // returns the existing app), so no error-swallowing is needed. It only throws
+  // "package_taken" when the package is owned by another org or archived, which
+  // is a real setup conflict that must surface rather than fail later at release.
+  await miniapps.createMiniApp(developer, {
+    packageName: PACKAGE,
+    displayName: "Captions",
+    description: "Seeded preinstall miniapp",
+  });
+  console.log(`created miniapp ${PACKAGE}`);
 
   // 2) release
   const release = await miniapps.createRelease(developer, {

--- a/cloud-v2/scripts/seed-preinstall.ts
+++ b/cloud-v2/scripts/seed-preinstall.ts
@@ -15,7 +15,10 @@ import {
   disconnectMongo,
 } from "../packages/core/src/connections/mongo.connection";
 import { MiniAppModel } from "../packages/core/src/models/miniapp.model";
-import { MiniAppService } from "../packages/core/src/services/miniapps/miniapp.service";
+import {
+  MiniAppService,
+  MiniAppServiceError,
+} from "../packages/core/src/services/miniapps/miniapp.service";
 import { PreinstalledRegistryService } from "../packages/core/src/services/miniapps/preinstalled-registry.service";
 
 const ENVIRONMENT = process.env.SEED_ENV ?? "dev";
@@ -38,7 +41,16 @@ async function main() {
   const mongoUrl =
     process.env.MONGO_URL ?? "mongodb://127.0.0.1:27017/mentra-cloud-v2";
   await connectMongo(mongoUrl);
-  console.log(`connected mongo=${mongoUrl} env=${ENVIRONMENT}`);
+  // Log only safe metadata (host + db name); never the full URI, which can carry credentials.
+  let mongoTarget = mongoUrl;
+  try {
+    const u = new URL(mongoUrl);
+    mongoTarget = `${u.host}${u.pathname}`;
+  } catch {
+    // Non-URL connection string; fall back to a redacted marker rather than leaking it.
+    mongoTarget = "<redacted>";
+  }
+  console.log(`connected mongo=${mongoTarget} env=${ENVIRONMENT}`);
 
   const miniapps = new MiniAppService();
   const registries = new PreinstalledRegistryService();
@@ -55,7 +67,13 @@ async function main() {
     });
     console.log(`created miniapp ${PACKAGE}`);
   } catch (err) {
-    console.log(`createMiniApp: ${(err as Error).message} (continuing)`);
+    // Only the "already claimed" case is safe to ignore for idempotent re-seeds;
+    // anything else is a real setup failure and must surface.
+    if (err instanceof MiniAppServiceError && err.code === "package_taken") {
+      console.log(`createMiniApp: ${err.message} (already claimed, continuing)`);
+    } else {
+      throw err;
+    }
   }
 
   // 2) release

--- a/cloud-v2/websites/admin/src/index.ts
+++ b/cloud-v2/websites/admin/src/index.ts
@@ -33,7 +33,14 @@ console.log(`Proxying /api/* to ${coreUrl}`);
 async function serveBuiltApp(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (url.pathname !== "/") {
-    const asset = resolve(distRoot, `.${decodeURIComponent(url.pathname)}`);
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(url.pathname);
+    } catch {
+      // Malformed percent-encoding in the path.
+      return new Response("Bad Request", { status: 400, headers: { "content-type": "text/plain" } });
+    }
+    const asset = resolve(distRoot, `.${decodedPath}`);
     if (isInsideDist(asset)) {
       const file = Bun.file(asset);
       if (await file.exists()) return new Response(file);

--- a/cloud-v2/websites/console/.gitignore
+++ b/cloud-v2/websites/console/.gitignore
@@ -12,7 +12,7 @@ coverage
 
 # logs
 logs
-_.log
+*.log
 report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # dotenv environment variable files

--- a/cloud-v2/websites/console/functions/api/[[path]].ts
+++ b/cloud-v2/websites/console/functions/api/[[path]].ts
@@ -51,7 +51,18 @@ const FORWARDING_AND_HOP_BY_HOP_HEADERS = [
 ];
 
 function stripForwardingAndHopByHopHeaders(headers: Headers): void {
-  for (const name of FORWARDING_AND_HOP_BY_HOP_HEADERS) {
+  // Per RFC 7230 §6.1 the inbound `Connection` header may name additional
+  // hop-by-hop headers (e.g. `Connection: X-Foo, close`); strip those too so
+  // client-controlled proxy metadata never reaches CORE_URL. Read it before the
+  // static loop deletes `connection` itself.
+  const connectionTokens =
+    headers
+      .get("connection")
+      ?.split(",")
+      .map(token => token.trim().toLowerCase())
+      .filter(Boolean) ?? [];
+
+  for (const name of [...FORWARDING_AND_HOP_BY_HOP_HEADERS, ...connectionTokens]) {
     headers.delete(name);
   }
 }

--- a/cloud-v2/websites/console/functions/api/[[path]].ts
+++ b/cloud-v2/websites/console/functions/api/[[path]].ts
@@ -54,13 +54,16 @@ function stripForwardingAndHopByHopHeaders(headers: Headers): void {
   // Per RFC 7230 §6.1 the inbound `Connection` header may name additional
   // hop-by-hop headers (e.g. `Connection: X-Foo, close`); strip those too so
   // client-controlled proxy metadata never reaches CORE_URL. Read it before the
-  // static loop deletes `connection` itself.
+  // static loop deletes `connection` itself. Tokens are client-controlled, so
+  // keep only valid HTTP field-names (RFC 7230 token) — Headers.delete throws on
+  // a malformed name, which would otherwise turn this proxy into a 500.
+  const isValidHeaderName = (name: string) => /^[!#$%&'*+\-.^_`|~0-9a-z]+$/.test(name);
   const connectionTokens =
     headers
       .get("connection")
       ?.split(",")
       .map(token => token.trim().toLowerCase())
-      .filter(Boolean) ?? [];
+      .filter(token => token.length > 0 && isValidHeaderName(token)) ?? [];
 
   for (const name of [...FORWARDING_AND_HOP_BY_HOP_HEADERS, ...connectionTokens]) {
     headers.delete(name);

--- a/cloud-v2/websites/console/functions/api/[[path]].ts
+++ b/cloud-v2/websites/console/functions/api/[[path]].ts
@@ -11,8 +11,13 @@ export async function onRequest(context: {
   }
 
   const sourceUrl = new URL(context.request.url);
-  const upstreamUrl = new URL(sourceUrl.pathname + sourceUrl.search, coreUrl);
+  // Preserve any path prefix configured on CORE_URL by resolving a relative
+  // path (strip the leading "/") against a normalized base ending in "/".
+  const base = new URL(coreUrl);
+  base.pathname = base.pathname.endsWith("/") ? base.pathname : `${base.pathname}/`;
+  const upstreamUrl = new URL(`.${sourceUrl.pathname}${sourceUrl.search}`, base);
   const headers = new Headers(context.request.headers);
+  stripForwardingAndHopByHopHeaders(headers);
   headers.delete("host");
   headers.set("x-mentra-public-origin", sourceUrl.origin);
 
@@ -22,4 +27,31 @@ export async function onRequest(context: {
     body: context.request.method === "GET" || context.request.method === "HEAD" ? undefined : context.request.body,
     redirect: "manual",
   });
+}
+
+// Client-supplied forwarding/hop-by-hop headers must never reach CORE_URL: they
+// would let a request spoof trusted proxy metadata (client IP, protocol, host).
+// The edge sets its own trusted values (e.g. x-mentra-public-origin) after this.
+const FORWARDING_AND_HOP_BY_HOP_HEADERS = [
+  "forwarded",
+  "x-forwarded-for",
+  "x-forwarded-host",
+  "x-forwarded-proto",
+  "x-forwarded-port",
+  "x-real-ip",
+  "connection",
+  "keep-alive",
+  "proxy-authorization",
+  "proxy-authenticate",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+  "x-mentra-public-origin",
+];
+
+function stripForwardingAndHopByHopHeaders(headers: Headers): void {
+  for (const name of FORWARDING_AND_HOP_BY_HOP_HEADERS) {
+    headers.delete(name);
+  }
 }

--- a/cloud-v2/websites/console/src/components/onboarding-shell.tsx
+++ b/cloud-v2/websites/console/src/components/onboarding-shell.tsx
@@ -27,7 +27,7 @@ export function OnboardingShell({
             <img src={mentraLogo} alt="" className="h-[22px] w-[41px]" />
             <div className="min-w-0">
               <div className="font-display text-[15px] font-bold leading-5 text-[#14151b]">Dev Console</div>
-              <div className="truncate text-xs leading-4 text-[#8a8d95]">MentraOS{userLabel ? ` · ${userLabel}` : ""}</div>
+              <div className="truncate text-xs leading-4 text-muted-foreground">MentraOS{userLabel ? ` · ${userLabel}` : ""}</div>
             </div>
           </div>
           <button

--- a/cloud-v2/websites/console/src/components/package-name.tsx
+++ b/cloud-v2/websites/console/src/components/package-name.tsx
@@ -9,13 +9,12 @@ type PackageNameProps = {
 export function PackageName({ packageName, packagePrefix, className }: PackageNameProps) {
   const normalizedPrefix = packagePrefix?.replace(/\.+$/, "");
   const prefixWithDot = normalizedPrefix ? `${normalizedPrefix}.` : "";
-  const suffix = prefixWithDot && packageName.startsWith(prefixWithDot)
-    ? packageName.slice(prefixWithDot.length)
-    : packageName;
+  const matchesPrefix = prefixWithDot !== "" && packageName.startsWith(prefixWithDot);
+  const suffix = matchesPrefix ? packageName.slice(prefixWithDot.length) : packageName;
 
   return (
     <span className={cn("font-mono text-xs", className)}>
-      {prefixWithDot ? <span className="text-[#a0a3aa]">{prefixWithDot}</span> : null}
+      {matchesPrefix ? <span className="text-[#a0a3aa]">{prefixWithDot}</span> : null}
       <span className="font-semibold text-[#6e727b]">{suffix}</span>
     </span>
   );

--- a/cloud-v2/websites/console/src/components/status-badge.tsx
+++ b/cloud-v2/websites/console/src/components/status-badge.tsx
@@ -1,11 +1,10 @@
 import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import type { ComponentProps } from "react";
 import { cn } from "@/lib/utils";
 
 type BadgeTone = "success" | "warn" | "neutral";
 
-type BadgeProps = {
-  children: ReactNode;
+type BadgeProps = ComponentProps<"div"> & {
   icon?: LucideIcon;
   tone?: BadgeTone;
 };
@@ -16,13 +15,15 @@ const toneClasses: Record<BadgeTone, string> = {
   neutral: "border-[#dfe7e1] bg-white text-[#566962]",
 };
 
-export function Badge({ children, icon: Icon, tone = "neutral" }: BadgeProps) {
+export function Badge({ children, icon: Icon, tone = "neutral", className, ...props }: BadgeProps) {
   return (
     <div
       className={cn(
         "inline-flex h-8 items-center gap-2 rounded-full border px-3 text-xs font-semibold",
         toneClasses[tone],
+        className,
       )}
+      {...props}
     >
       {Icon ? <Icon className="size-3.5" /> : null}
       {children}

--- a/cloud-v2/websites/console/src/features/apps/apps-page.tsx
+++ b/cloud-v2/websites/console/src/features/apps/apps-page.tsx
@@ -26,7 +26,7 @@ export function AppsPage() {
               <div className="flex min-h-[260px] flex-col items-center justify-center p-6 text-center text-sm text-[#747780] sm:min-h-[320px] sm:p-8">
                 Loading miniapps…
               </div>
-            ) : apps.isError ? (
+            ) : apps.isError && !apps.data ? (
               <div className="flex min-h-[260px] flex-col items-center justify-center p-6 text-center sm:min-h-[320px] sm:p-8">
                 <h2 className="font-display text-[21px] font-bold">Couldn’t load miniapps</h2>
                 <p className="mt-2 max-w-md text-sm leading-6 text-[#747780]">

--- a/cloud-v2/websites/console/src/features/apps/apps-page.tsx
+++ b/cloud-v2/websites/console/src/features/apps/apps-page.tsx
@@ -22,7 +22,18 @@ export function AppsPage() {
             <CardTitle className="font-display text-[19px]">Miniapps</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
-            {appList.length === 0 ? (
+            {apps.isPending ? (
+              <div className="flex min-h-[260px] flex-col items-center justify-center p-6 text-center text-sm text-[#747780] sm:min-h-[320px] sm:p-8">
+                Loading miniapps…
+              </div>
+            ) : apps.isError ? (
+              <div className="flex min-h-[260px] flex-col items-center justify-center p-6 text-center sm:min-h-[320px] sm:p-8">
+                <h2 className="font-display text-[21px] font-bold">Couldn’t load miniapps</h2>
+                <p className="mt-2 max-w-md text-sm leading-6 text-[#747780]">
+                  {apps.error instanceof Error ? apps.error.message : "Something went wrong. Please try again."}
+                </p>
+              </div>
+            ) : appList.length === 0 ? (
               <div className="flex min-h-[260px] flex-col items-center justify-center p-6 text-center sm:min-h-[320px] sm:p-8">
                 <div className="flex size-12 items-center justify-center rounded-[14px] bg-[#e9f8f1] text-[#087d50]">
                   <Boxes className="size-6" />

--- a/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/invite-accept-page.tsx
@@ -21,6 +21,9 @@ export function InviteAcceptPage() {
     }
     request.then(
       () => {
+        // Drop the resolved entry so a later re-visit can re-accept/refresh
+        // rather than replaying a stale success from a long-lived session.
+        acceptRequests.delete(token);
         if (!cancelled) navigate({ to: "/organization" });
       },
       (err) => {

--- a/cloud-v2/websites/console/src/features/org/org-helpers.ts
+++ b/cloud-v2/websites/console/src/features/org/org-helpers.ts
@@ -13,7 +13,15 @@ export function suggestedOrgDefaults(user: ConsoleUser | undefined) {
     return { displayName: "Mentra Developers", packagePrefix: "com.mentra" };
   }
 
-  const local = email.split("@")[0]?.replace(/[^a-z0-9_]+/g, ".").replace(/^\.+|\.+$/g, "") || "developer";
+  // Build a `dev.<local>` prefix that always satisfies isValidPackagePrefix:
+  // split the email local-part on invalid chars, then drop any leading
+  // non-letters from each segment so every segment starts with a letter
+  // (reverse-DNS segments beginning with a digit or underscore are rejected).
+  const localSegments = (email.split("@")[0] ?? "")
+    .split(/[^a-z0-9_]+/)
+    .map(segment => segment.replace(/^[^a-z]+/, ""))
+    .filter(Boolean);
+  const local = localSegments.join(".") || "developer";
   return {
     displayName: `${name} Team`,
     packagePrefix: `dev.${local}`,

--- a/cloud-v2/websites/console/src/features/org/org-helpers.ts
+++ b/cloud-v2/websites/console/src/features/org/org-helpers.ts
@@ -23,3 +23,13 @@ export function suggestedOrgDefaults(user: ConsoleUser | undefined) {
 export function normalizePackagePrefix(value: string): string {
   return value.trim().toLowerCase().replace(/\.+$/, "");
 }
+
+/**
+ * Lowercase reverse-DNS prefix: two or more dot-separated segments, each
+ * starting with a letter and containing only lowercase letters, digits, or
+ * underscores (e.g. `io.acme`, `dev.jane_doe`). Rejects leading/trailing/repeated
+ * dots and other invalid characters that the UI otherwise lets through.
+ */
+export function isValidPackagePrefix(value: string): boolean {
+  return /^[a-z][a-z0-9_]*(\.[a-z][a-z0-9_]*)+$/.test(value);
+}

--- a/cloud-v2/websites/console/src/features/org/org-onboarding.tsx
+++ b/cloud-v2/websites/console/src/features/org/org-onboarding.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { sessionQuery } from "@/features/session/session.queries";
 import { saveDeveloperOrg } from "./org.api";
-import { normalizePackagePrefix, suggestedOrgDefaults } from "./org-helpers";
+import { isValidPackagePrefix, normalizePackagePrefix, suggestedOrgDefaults } from "./org-helpers";
 
 /**
  * The onboarding step shown inside OnboardingShell when a developer has no org.
@@ -46,7 +46,7 @@ export function DevOnboarding() {
 
   const normalizedPrefix = normalizePackagePrefix(packagePrefix);
   const previewPackageName = normalizedPrefix ? `${normalizedPrefix}.weather` : "io.acme.weather";
-  const canCreate = displayName.trim().length >= 2 && normalizedPrefix.length > 0 && !create.isPending;
+  const canCreate = displayName.trim().length >= 2 && isValidPackagePrefix(normalizedPrefix) && !create.isPending;
 
   return (
     <div className="space-y-7">

--- a/cloud-v2/websites/console/src/features/org/org.api.ts
+++ b/cloud-v2/websites/console/src/features/org/org.api.ts
@@ -44,11 +44,14 @@ export const orgMemberSchema = z.object({
   updatedAt: z.string().nullable(),
 });
 
+export const orgInvitationStateSchema = z.enum(["pending", "accepted", "revoked"]);
+export const orgInvitationRoleSchema = z.enum(["admin", "member"]);
+
 export const orgInvitationSchema = z.object({
   id: z.string(),
   email: z.string(),
-  state: z.string(),
-  role: z.string(),
+  state: orgInvitationStateSchema,
+  role: orgInvitationRoleSchema,
   expiresAt: z.string().nullable(),
   createdAt: z.string().nullable(),
   updatedAt: z.string().nullable(),

--- a/cloud-v2/websites/console/src/features/org/organization-page.tsx
+++ b/cloud-v2/websites/console/src/features/org/organization-page.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { displayNameForUser } from "@/features/session/session.api";
 import { sessionQuery } from "@/features/session/session.queries";
-import { normalizePackagePrefix, suggestedOrgDefaults } from "./org-helpers";
+import { isValidPackagePrefix, normalizePackagePrefix, suggestedOrgDefaults } from "./org-helpers";
 import {
   getDeveloperOrg,
   getOrgAccess,
@@ -105,7 +105,7 @@ export function OrganizationPage() {
   const canSave =
     canEditOrg &&
     displayName.trim().length >= 2 &&
-    normalizedPrefix.length > 0 &&
+    isValidPackagePrefix(normalizedPrefix) &&
     !orgSave.isPending &&
     (displayName.trim() !== org?.name || normalizedPrefix !== org?.packagePrefix);
 

--- a/cloud-v2/websites/console/src/index.html
+++ b/cloud-v2/websites/console/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mentra Developers</title>
-    <script type="module" src="./frontend.tsx" async></script>
+    <script type="module" src="./frontend.tsx"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/cloud-v2/websites/console/src/index.ts
+++ b/cloud-v2/websites/console/src/index.ts
@@ -8,6 +8,9 @@ async function proxyCoreRequest(req: Request) {
   const upstreamUrl = new URL(sourceUrl.pathname + sourceUrl.search, coreUrl);
   const headers = new Headers(req.headers);
   headers.delete("host");
+  // Match the deployed Pages proxy so local /api/* auth redirects target the
+  // correct origin instead of falling back to CORE_URL.
+  headers.set("x-mentra-public-origin", sourceUrl.origin);
 
   return fetch(upstreamUrl, {
     method: req.method,

--- a/cloud-v2/websites/console/tsconfig.json
+++ b/cloud-v2/websites/console/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     // Environment setup & latest features
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "target": "ESNext",
     "module": "Preserve",
     "moduleDetection": "force",

--- a/cloud-v2/websites/portal/src/index.ts
+++ b/cloud-v2/websites/portal/src/index.ts
@@ -33,7 +33,14 @@ console.log(`Proxying /api/* to ${coreUrl}`);
 async function serveBuiltApp(req: Request): Promise<Response> {
   const url = new URL(req.url);
   if (url.pathname !== "/") {
-    const asset = resolve(distRoot, `.${decodeURIComponent(url.pathname)}`);
+    let decodedPath: string;
+    try {
+      decodedPath = decodeURIComponent(url.pathname);
+    } catch {
+      // Malformed percent-encoding in the path.
+      return new Response("Bad Request", { status: 400, headers: { "content-type": "text/plain" } });
+    }
+    const asset = resolve(distRoot, `.${decodedPath}`);
     if (isInsideDist(asset)) {
       const file = Bun.file(asset);
       if (await file.exists()) return new Response(file);

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -771,7 +771,14 @@ class MentraBluetoothSdk private constructor(
     ): CameraStatusEvent {
         val effectiveRequestId = nonBlankRequestId(requestId) ?: generatedCameraRequestId("warm")
         val pending = PendingResponse<CameraStatusEvent>("camera warm up $effectiveRequestId")
-        pendingCameraStatusRequests[effectiveRequestId] = pending
+        // Guard against a concurrent warm-up reusing the same requestId: a blind put would overwrite
+        // (and strand) the first caller's continuation until it times out. Reject the duplicate.
+        if (pendingCameraStatusRequests.putIfAbsent(effectiveRequestId, pending) != null) {
+            throw BluetoothSdkException(
+                "request_in_flight",
+                "A camera warm-up request with this requestId is already waiting for a glasses response.",
+            )
+        }
         try {
             deviceManager.warmUpCamera(effectiveRequestId, size, exposureTimeNs, durationMs)
             return pending.await()

--- a/mobile/src/services/miniapps/preinstalledMiniappSync.ts
+++ b/mobile/src/services/miniapps/preinstalledMiniappSync.ts
@@ -1,12 +1,54 @@
 import type {PreinstalledMiniappRegistryEntry} from "@mentra/cloud-client/react-native"
 import {appRegistry} from "@mentra/island"
 import {Directory, File, Paths} from "expo-file-system"
+import semver from "semver"
 
 import {cloudClient} from "@/services/cloudClient"
 
 const LOG_TAG = "PreinstalledMiniappSync"
 
+// The user-facing mobile app version (e.g. "2.12.0"), sourced the same way as
+// the rest of the app (see mobile/src/app/index.tsx getLocalVersion).
+const MOBILE_APP_VERSION = process.env.EXPO_PUBLIC_MENTRAOS_VERSION || null
+
+/**
+ * Whether the current mobile build satisfies an entry's minMobileVersion /
+ * maxMobileVersion gate. Both bounds are optional and inclusive. Versions are
+ * coerced (semver.coerce) so partial bounds like "2.11" work. If the app
+ * version can't be determined or a bound is unparseable, we conservatively
+ * treat the gate as satisfied rather than blocking installs on bad metadata.
+ */
+function isMobileVersionSupported(entry: PreinstalledMiniappRegistryEntry): boolean {
+  const min = entry.minMobileVersion
+  const max = entry.maxMobileVersion
+  if (!min && !max) return true
+
+  const current = semver.coerce(MOBILE_APP_VERSION ?? undefined)
+  if (!current) {
+    console.warn(
+      `${LOG_TAG}: cannot determine mobile app version (EXPO_PUBLIC_MENTRAOS_VERSION=${MOBILE_APP_VERSION}); skipping version gate for ${entry.packageName}`,
+    )
+    return true
+  }
+
+  if (min) {
+    const minVer = semver.coerce(min)
+    if (minVer && semver.lt(current, minVer)) return false
+  }
+  if (max) {
+    const maxVer = semver.coerce(max)
+    if (maxVer && semver.gt(current, maxVer)) return false
+  }
+  return true
+}
+
 function shouldInstall(entry: PreinstalledMiniappRegistryEntry): boolean {
+  if (!isMobileVersionSupported(entry)) {
+    console.log(
+      `${LOG_TAG}: skipping ${entry.packageName}@${entry.version} — mobile ${MOBILE_APP_VERSION} outside [${entry.minMobileVersion ?? "*"}, ${entry.maxMobileVersion ?? "*"}]`,
+    )
+    return false
+  }
   const installedVersions = appRegistry.getInstalledVersions(entry.packageName)
   if (installedVersions.includes(entry.version)) return false
   if (entry.installPolicy === "install_once") return installedVersions.length === 0


### PR DESCRIPTION
Brings the review-bot fixes made on the #3304 dev→staging promotion back into `dev`.

### Why cherry-pick and not `git merge staging`
#3304 was **squash-merged** into staging, so staging's tip shares no commit ancestry with dev (merge-base is stale). A literal `git merge staging` into dev would re-diff the entire squashed snapshot against dev's 15 newer commits — a large, needless conflict swamp that re-litigates already-merged content. The only thing on staging that dev actually lacks is these fixes, so they're cherry-picked directly.

### Contents (2 commits, cherry-picked from the promotion branch)
- `59d380cb4` — the 34 review-bot fixes (cloud-v2 security/data-integrity/robustness/UI, asg_client camera warm-up, mobile preinstall version gates)
- `008552d7b` — the two follow-ups: ws.ts reconnect race (mark→seed→finalize/restore) and duplicate warm-up `stopped` events (requestId dedup)

Deliberately **excluded** `0d118f822` (the duplicate-`publishConfig` fix) — that was a merge artifact specific to the promotion branch; dev's package.json files already have a single `publishConfig`.

### Verification
- 35 files, zero package.json churn.
- cloud-v2 `tsc -b` + console typecheck pass locally against dev's tree (cloud-v2 isn't in PR CI).
- Java/mobile covered by CI (ASG Build, Android Build, Quality Checks).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches admin authorization defaults, API proxy trust boundaries, and Mongo uniqueness—deployments must set `CLOUD_CORE_ADMIN_EMAILS` or explicit admin domains. Camera and preinstall behavior changes are user-visible but localized.
> 
> **Overview**
> Backports promotion review fixes into `dev`: security, data integrity, and client reliability across cloud-v2, ASG camera warm-up, and mobile preinstall sync.
> 
> **Cloud-v2** tightens admin auth (no implicit `@mentraglass.com` domain admin without `CLOUD_CORE_ADMIN_EMAIL_DOMAINS`), strips spoofable forwarding/hop-by-hop headers on the console Pages API proxy, and sets `x-mentra-public-origin` for local console dev. Miniapp bundle download maps registry errors to JSON responses; `createRelease` rolls back release/asset/storage on failure; startup migrations disconnect Mongo on failure; S3 provider selection passes `r2` vs `s3` with correct AWS region handling. Mongo partial unique indexes fix `workosOrgId` null collisions and enforce one active preinstall revision per registry. Admin/portal static serving returns 400 on bad path encoding; console validates reverse-DNS package prefixes and improves apps loading/error UX.
> 
> **ASG / mobile** defers `warming` until warm-up actually starts, dedupes `stopped` by `requestId`, returns false on synchronous busy warm-up, and rejects duplicate warm-up `requestId` in the Bluetooth SDK. Preinstalled miniapp sync honors `minMobileVersion` / `maxMobileVersion` via semver.
> 
> **CI / tooling** blocks manual prod Pages deploys off `main`, adds merge-dev concurrency, bumps merge-prod checkout to v4; CLI `openBrowser` unrefs the launcher and times out instead of blocking login; preinstall e2e/seed scripts fail on registry or SHA errors and redact Mongo URIs in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b9a0a439ff2481368a03e6b31fcd4adb30b3c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports the review-bot fixes from the dev→staging promotion into `dev`, improving security, data integrity, and robustness across cloud‑v2, `asg_client`, and mobile. The previously proposed WebSocket reconnect change is not included in this backport.

- **Bug Fixes**
  - Camera warm‑up: emit `warming` only after `setupWarmUp` clears busy; de‑dupe `stopped` by `requestId`; return `false` on synchronous busy; reject duplicate warm‑up `requestId` in the Bluetooth SDK.
  - Preinstall registry/releases: map `PreinstalledRegistryServiceError` to JSON/404; enforce one active revision via partial unique index; on bundle store failure, roll back the release, asset row, and stored blob; e2e fails on registry/bundle/SHA errors; mobile honors `minMobileVersion`/`maxMobileVersion`.
  - Storage/boot: pass provider to `createS3StorageProvider`; ignore R2 region vars and coerce `region=auto` to `us-east-1` when provider=`s3`; disconnect Mongo if startup migrations fail.
  - Console/proxy: strip client‑supplied forwarding and hop‑by‑hop headers (including those named by `Connection`); preserve `CORE_URL` path prefixes; set `x-mentra-public-origin` in Pages and local dev; admin domain allowlist now requires explicit `CLOUD_CORE_ADMIN_EMAIL_DOMAINS`.
  - Workflows/CLI/UI/dev: guard manual prod deploys to main; add `concurrency` to `merge-dev`; use `actions/checkout@v4`; CLI `open-browser` unrefs the launcher, reports failures, and resolves success after a short window; apps page gets loading/error states; forward `className` on `Badge`; validate reverse‑DNS package prefixes and sanitize the default suggestion; try/catch path decoding in admin/portal static serving; add `DOM.Iterable` lib; drop `async` on entry script; fix `.gitignore`; avoid logging raw Mongo URIs in seed.

<sup>Written for commit 71b9a0a439ff2481368a03e6b31fcd4adb30b3c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

