### PR TITLE
Bump Bluetooth SDK to 0.1.16

### DIFF
--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.15")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.16")
 }
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.15`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.16`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.15"
+  from: "0.1.16"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.15")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.16")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.15`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.16`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.15"
+  from: "0.1.16"
 )
 ```
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -228,7 +228,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -475,7 +475,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.15`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.16`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.15`
+Use the same version format as existing SwiftPM tags, for example `0.1.16`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump `@mentra/bluetooth-sdk` from `0.1.15` to `0.1.16`.
- Update the matching `mobile/bun.lock` workspace entry.
- Update Mentra Live install docs, package README, and SwiftPM release notes to reference `0.1.16`.

## Notes
- This mirrors the scoped version/docs bump pattern from #3253.
- The diff intentionally excludes unrelated stale lockfile metadata refreshes from current `dev`.

## Validation
- `git diff --check`
- `cd mobile && bun install`
- `cd mobile && bun compile`
- `cd mobile/modules/bluetooth-sdk && npm pack --dry-run`
- `rg -n "0\\.1\\.15"` found no remaining references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no runtime or SDK source modifications in the diff.
> 
> **Overview**
> Bumps **`@mentra/bluetooth-sdk`** from **0.1.15** to **0.1.16** in `mobile/modules/bluetooth-sdk/package.json` and the matching **`mobile/bun.lock`** workspace entry.
> 
> Install and release docs now point consumers at **0.1.16**: Mentra Live **Android** (`com.mentraglass:bluetooth-sdk`), **iOS** SwiftPM (`from: "0.1.16"` / Xcode package version), **quickstart** tabs, the module **README**, and **RELEASING_IOS_SPM** tag example. No SDK implementation changes in this diff—version and documentation alignment only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09ebeb6d74e9e254c7bb1df069171a83e081aba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->