### PR TITLE
ci: move Android + ASG Gradle builds to Blacksmith runners

### DIFF
--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -24,11 +24,12 @@ permissions:
 
 jobs:
   build:
-    # GitHub-hosted Ubuntu: a compile/test check that release-signs with the
+    # Blacksmith 4 vCPU Ubuntu: a compile/test check that release-signs with the
     # upload key injected from secrets (no Play upload). It does not need the mac
-    # runners, so moving it here frees self-hosted macOS capacity for iOS +
-    # staging/release builds.
-    runs-on: ubuntu-latest
+    # runners, so keeping it off them frees self-hosted macOS capacity for iOS +
+    # staging/release builds. Blacksmith (more vCPU + NVMe) is faster than the
+    # free ubuntu-latest tier; same provider we already use for cloud builds.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Update PR comment - Build started

--- a/.github/workflows/mentra-asg-client-build.yml
+++ b/.github/workflows/mentra-asg-client-build.yml
@@ -24,10 +24,11 @@ permissions:
 
 jobs:
   build:
-    # GitHub-hosted Ubuntu. Signing creds come from secrets via inject-signing
-    # (no longer needs the mac runners' ~/.mentra/credentials), freeing mac
-    # capacity for iOS + staging/release builds.
-    runs-on: ubuntu-latest
+    # Blacksmith 4 vCPU Ubuntu. Signing creds come from secrets via inject-signing
+    # (no longer needs the mac runners' ~/.mentra/credentials), keeping mac
+    # capacity free for iOS + staging/release builds. Faster than the free
+    # ubuntu-latest tier (more vCPU + NVMe); same provider as our cloud builds.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     steps:
       - name: Update PR comment - Build started

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -559,10 +559,11 @@ jobs:
 
   build-asg:
     name: Build ASG Client
-    # GitHub-hosted Ubuntu. Signing creds come from secrets via inject-signing;
+    # Blacksmith 4 vCPU Ubuntu. Signing creds come from secrets via inject-signing;
     # it's a clean gradle build (no fastlane/upload), so it doesn't need the mac
-    # runners. The GH-release upload happens later in the ubuntu upload-releases job.
-    runs-on: ubuntu-latest
+    # runners. Faster than the free ubuntu-latest tier; the GH-release upload
+    # still happens later in the ubuntu-latest upload-releases job.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
 
     outputs:
       version_code: ${{ steps.asg-build-info.outputs.version_code }}


### PR DESCRIPTION
## What

Swaps the three slow **`ubuntu-latest` Android/Gradle build jobs** from the free GitHub tier (2 vCPU / 7 GB) to **`blacksmith-4vcpu-ubuntu-2404`** — the same Blacksmith provider ~26 of our cloud/porter jobs already run on:

| Workflow | Job |
|---|---|
| `mentra-app-android-build.yml` | `build` |
| `mentra-asg-client-build.yml` | `build` |
| `staging-builds.yml` | `build-asg` |

## Why

These are the CPU/IO-bound Gradle builds that were slow on the free 2-vCPU tier. Blacksmith gives more vCPU + NVMe + sticky-disk caching, which is exactly where the wall-clock win is. No GitHub plan change or org-settings provisioning needed — the label already resolves for this org (used across all cloud/porter builds), whereas GitHub's own larger runners aren't available to `Mentra-Community`.

## Scope / notes

- **Label swap only.** The existing `actions/cache@v4` keys are scoped by `runner.environment` (intentionally, per the in-file comments), so on Blacksmith they re-warm once on the first run rather than colliding with the github-hosted caches — a one-time cold build, not a breakage.
- The free-disk-space (`sudo rm`) and `docker prune` steps are standard Ubuntu and unaffected.
- Comments updated from "GitHub-hosted Ubuntu" → "Blacksmith 4 vCPU Ubuntu" to stay truthful.

## Intentionally left on `ubuntu-latest`

~30 other `ubuntu-latest` jobs — `pr-agent-orchestrator` (12 AI-orchestration jobs), `reusable-pr-comment`, `pr-checkout-helper`, `merge-dev`/`merge-prod` Porter deploys, `ci-gate`, Slack-notify, `upload-releases`, China/docs deploys — are **API/IO-latency-bound**, not CPU-bound. Paying for Blacksmith minutes there would add cost with no meaningful speedup, so they stay on the free tier.

Follow-ups if we want more speed (not in this PR): switch the Gradle cache to Blacksmith-native `useblacksmith/cache` (sticky disk), and consider `8vcpu` variants if 4 isn't enough. Happy to broaden to the SDK-release / cloud-CI bun jobs if wanted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Runner-label-only change with no application or signing logic touched; main operational note is one-time Gradle cache re-warm and Blacksmith minute cost.
> 
> **Overview**
> Moves the **CPU-heavy Gradle build jobs** off GitHub’s free `ubuntu-latest` tier onto **`blacksmith-4vcpu-ubuntu-2404`**, matching the runner label already used for cloud/Porter CI.
> 
> **Jobs updated:** `mentra-app-android-build.yml` (`build`), `mentra-asg-client-build.yml` (`build`), and `staging-builds.yml` (`build-asg`). Build steps, signing, and artifacts are unchanged; only `runs-on` and inline comments (“GitHub-hosted Ubuntu” → Blacksmith) differ.
> 
> **Cache behavior:** Existing `actions/cache` keys still include `runner.environment`, so Gradle/Bun caches from `ubuntu-latest` won’t restore on Blacksmith—the **first run on each job may be colder**, then caches warm under the new environment. Release upload in staging still runs on `ubuntu-latest` in `upload-releases`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49efc9dde3508b8cc7f5345059162f0bcedce154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move Android/ASG Gradle builds from `ubuntu-latest` to `blacksmith-4vcpu-ubuntu-2404` to speed up CPU/IO-bound jobs. Expect faster builds with more vCPU and NVMe; no workflow logic changes.

- **Refactors**
  - Swapped `runs-on` for three jobs: `mentra-app-android-build.yml/build`, `mentra-asg-client-build.yml/build`, `staging-builds.yml/build-asg`.
  - `actions/cache@v4` keys use `runner.environment`, so caches re-warm once; other IO-bound workflows remain on `ubuntu-latest`.

<sup>Written for commit 49efc9dde3508b8cc7f5345059162f0bcedce154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

