### PR TITLE
Bump Bluetooth SDK to 0.1.17

### DIFF
--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -70,8 +70,13 @@ jobs:
             echo "BluetoothSdkDefaults.swift must not hardcode the SDK version; iOS OTA defaults must use package metadata." >&2
             exit 1
           fi
-          if ! grep -Fq "normalizedSdkVersion(swiftPackageSdkVersion) ?? packageVersion(from: sdkBundle)" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
-            echo "BluetoothSdkDefaults.swift must prefer the packed SDK version and fall back to iOS package metadata." >&2
+          if grep -Fq "packageVersion(from:" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift \
+            || grep -Fq "Bundle(for: BluetoothSdkBundleToken.self)" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
+            echo "BluetoothSdkDefaults.swift must not derive the SDK version from iOS bundle metadata." >&2
+            exit 1
+          fi
+          if ! grep -Fq "normalizedSdkVersion(swiftPackageSdkVersion)" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
+            echo "BluetoothSdkDefaults.swift must derive the SDK version from the packed SDK version." >&2
             exit 1
           fi
 

--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -63,15 +63,15 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
 
-      - name: Verify iOS SDK version is metadata-derived
+      - name: Verify iOS SDK version is package-derived
         run: |
           set -euo pipefail
           if grep -Fq "compiledSdkVersion" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
             echo "BluetoothSdkDefaults.swift must not hardcode the SDK version; iOS OTA defaults must use package metadata." >&2
             exit 1
           fi
-          if ! grep -Fq "packageVersion(from: sdkBundle)" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
-            echo "BluetoothSdkDefaults.swift must derive the SDK version from iOS package metadata." >&2
+          if ! grep -Fq "normalizedSdkVersion(swiftPackageSdkVersion) ?? packageVersion(from: sdkBundle)" mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift; then
+            echo "BluetoothSdkDefaults.swift must prefer the packed SDK version and fall back to iOS package metadata." >&2
             exit 1
           fi
 
@@ -487,6 +487,40 @@ jobs:
         if: steps.npm-registry.outputs.exists != 'true'
         working-directory: ${{ env.SDK_PACKAGE_DIR }}
         run: npm pack --dry-run
+
+      - name: Verify packed npm iOS SDK version
+        if: steps.npm-registry.outputs.exists != 'true'
+        working-directory: ${{ env.SDK_PACKAGE_DIR }}
+        env:
+          SDK_VERSION: ${{ needs.detect.outputs.version }}
+        run: |
+          set -euo pipefail
+          pack_dir="$(mktemp -d)"
+          trap 'rm -rf "$pack_dir"' EXIT
+
+          npm pack --json --pack-destination "$pack_dir" > "$pack_dir/pack.json"
+          tarball="$(find "$pack_dir" -maxdepth 1 -name '*.tgz' -print -quit)"
+          if [ -z "$tarball" ]; then
+            echo "npm pack did not produce a tarball." >&2
+            exit 1
+          fi
+
+          mkdir "$pack_dir/unpacked"
+          tar -xzf "$tarball" -C "$pack_dir/unpacked"
+
+          packed_defaults="$pack_dir/unpacked/package/ios/Source/BluetoothSdkDefaults.swift"
+          if ! grep -Fq "swiftPackageSdkVersion = \"${SDK_VERSION}\"" "$packed_defaults"; then
+            echo "Packed npm iOS SDK did not contain SDK version ${SDK_VERSION}." >&2
+            exit 1
+          fi
+          if grep -Fq "__MENTRA_BLUETOOTH_SDK_VERSION__" "$packed_defaults"; then
+            echo "Packed npm iOS SDK still contains the SDK version placeholder." >&2
+            exit 1
+          fi
+          if ! grep -Fq 'swiftPackageSdkVersion = "__MENTRA_BLUETOOTH_SDK_VERSION__"' ios/Source/BluetoothSdkDefaults.swift; then
+            echo "npm pack did not restore the source SDK version placeholder." >&2
+            exit 1
+          fi
 
       - name: Stage npm package
         if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.exists != 'true'

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -230,7 +230,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
@@ -3,33 +3,12 @@ import Foundation
 /// Defaults for the public Bluetooth SDK surface.
 enum BluetoothSdkDefaults {
     static var sdkVersion: String? {
-        normalizedSdkVersion(swiftPackageSdkVersion) ?? packageVersion(from: sdkBundle)
+        normalizedSdkVersion(swiftPackageSdkVersion)
     }
 
     static let voiceActivityDetectionEnabled = false
     private static let swiftPackageSdkVersion = "__MENTRA_BLUETOOTH_SDK_VERSION__"
     private static let swiftPackageSdkVersionPlaceholder = "__MENTRA" + "_BLUETOOTH_SDK_VERSION__"
-
-    private static var sdkBundle: Bundle {
-        #if SWIFT_PACKAGE
-            Bundle.module
-        #else
-            Bundle(for: BluetoothSdkBundleToken.self)
-        #endif
-    }
-
-    private static func packageVersion(from bundle: Bundle) -> String? {
-        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
-        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
-
-        for candidate in [version, build] {
-            if let sdkVersion = normalizedSdkVersion(candidate) {
-                return sdkVersion
-            }
-        }
-
-        return nil
-    }
 
     private static func normalizedSdkVersion(_ value: String?) -> String? {
         guard let value else {
@@ -37,7 +16,6 @@ enum BluetoothSdkDefaults {
         }
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty,
-              trimmed != "1.0",
               trimmed != swiftPackageSdkVersionPlaceholder
         else {
             return nil
@@ -45,5 +23,3 @@ enum BluetoothSdkDefaults {
         return trimmed
     }
 }
-
-private final class BluetoothSdkBundleToken {}

--- a/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/BluetoothSdkDefaults.swift
@@ -3,11 +3,7 @@ import Foundation
 /// Defaults for the public Bluetooth SDK surface.
 enum BluetoothSdkDefaults {
     static var sdkVersion: String? {
-        #if SWIFT_PACKAGE
-            normalizedSdkVersion(swiftPackageSdkVersion)
-        #else
-            packageVersion(from: sdkBundle)
-        #endif
+        normalizedSdkVersion(swiftPackageSdkVersion) ?? packageVersion(from: sdkBundle)
     }
 
     static let voiceActivityDetectionEnabled = false

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",
@@ -59,6 +59,7 @@
     "!ios/Pods/**",
     "plugin/build",
     "README.md",
+    "scripts",
     "src",
     "!src/__tests__"
   ],
@@ -68,6 +69,8 @@
     "clean": "expo-module clean",
     "test": "expo-module test",
     "prepare": "expo-module prepare",
+    "prepack": "node scripts/inject-ios-sdk-version.mjs",
+    "postpack": "node scripts/inject-ios-sdk-version.mjs --restore",
     "prepublishOnly": "expo-module prepublishOnly",
     "lint": "expo-module lint",
     "expo-module": "expo-module",

--- a/mobile/modules/bluetooth-sdk/scripts/inject-ios-sdk-version.mjs
+++ b/mobile/modules/bluetooth-sdk/scripts/inject-ios-sdk-version.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import fs from "node:fs/promises"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const packageJsonPath = path.join(packageRoot, "package.json")
+const sourcePath = path.join(packageRoot, "ios/Source/BluetoothSdkDefaults.swift")
+const backupPath = path.join(packageRoot, ".bluetooth-sdk-version-prepack-backup")
+const restore = process.argv.includes("--restore")
+
+const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf8"))
+const version = packageJson.version
+
+if (typeof version !== "string" || version.trim() === "") {
+  throw new Error("mobile/modules/bluetooth-sdk/package.json is missing a version")
+}
+
+const placeholder = 'private static let swiftPackageSdkVersion = "__MENTRA_BLUETOOTH_SDK_VERSION__"'
+const injectedVersion = `private static let swiftPackageSdkVersion = "${version}"`
+
+async function pathExists(filePath) {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+if (restore) {
+  if (!(await pathExists(backupPath))) {
+    console.log("No iOS SDK version prepack backup found; nothing to restore.")
+    process.exit(0)
+  }
+
+  await fs.writeFile(sourcePath, await fs.readFile(backupPath, "utf8"))
+  await fs.rm(backupPath)
+  console.log("Restored placeholder iOS SDK version after packing.")
+  process.exit(0)
+}
+
+if (await pathExists(backupPath)) {
+  throw new Error("Found an existing iOS SDK version prepack backup. Run `npm run postpack` before packing again.")
+}
+
+const originalSource = await fs.readFile(sourcePath, "utf8")
+let packedSource
+
+if (originalSource.includes(placeholder)) {
+  packedSource = originalSource.replace(placeholder, injectedVersion)
+} else if (originalSource.includes(injectedVersion)) {
+  packedSource = originalSource
+} else {
+  throw new Error("BluetoothSdkDefaults.swift does not contain the expected SDK version placeholder.")
+}
+
+await fs.writeFile(backupPath, originalSource)
+
+if (packedSource !== originalSource) {
+  await fs.writeFile(sourcePath, packedSource)
+}
+
+console.log(`Injected iOS SDK version ${version} for npm packaging.`)


### PR DESCRIPTION
## Summary

- Bumps `@mentra/bluetooth-sdk` from `0.1.16` to `0.1.17` and updates the mobile Bun lockfile entry to match.
- Makes iOS SDK version resolution depend only on the baked `swiftPackageSdkVersion` constant.
- Adds an npm `prepack` / `postpack` hook that temporarily replaces `__MENTRA_BLUETOOTH_SDK_VERSION__` in `BluetoothSdkDefaults.swift` with the package version from `package.json`, then restores the source placeholder after packing.
- Adds release CI verification that unpacks the npm tarball and asserts the shipped iOS source contains the release version and no placeholder, and that the source checkout was restored afterward.
- Adds a release CI guard that rejects iOS bundle metadata fallback code for SDK version resolution.

## Why

The React Native iOS package is consumed through the npm package and Expo/CocoaPods wiring, not through the public SwiftPM artifact. In that path `SWIFT_PACKAGE` is not defined, and `Bundle(for:)` can resolve to the host app bundle rather than an SDK-owned bundle. That produced an SDK version like `1.0.0`, which is the app version, and therefore an OTA manifest URL like `bluetooth-sdk-1.0.0-version.json`.

That is worse than failing. If the SDK package version was not baked into the shipped iOS source, the default OTA manifest URL should throw `missing_sdk_version` instead of guessing from bundle metadata.

Android already derives its SDK version from Gradle/package metadata. The public SwiftPM export already replaces `__MENTRA_BLUETOOTH_SDK_VERSION__` with the package version. This PR gives the npm/RN iOS artifact the same baked package-version behavior and removes the iOS bundle metadata fallback entirely.

## SwiftPM artifact check

The SwiftPM exporter still copies `ios/Source` into the mirror and replaces `__MENTRA_BLUETOOTH_SDK_VERSION__` with the SDK package version. With this change, the exported SwiftPM source resolves `sdkVersion` from that baked constant only.

I verified the SwiftPM export locally with `scripts/export-bluetooth-sdk-ios-spm.sh --verify` into a temp target. The generated `BluetoothSdkDefaults.swift` contained `swiftPackageSdkVersion = "0.1.17"`, no placeholder remained, no bundle metadata fallback symbols were present, and the generic iOS SwiftPM build completed.

## Validation

- `node scripts/inject-ios-sdk-version.mjs` injected `0.1.17`, then `node scripts/inject-ios-sdk-version.mjs --restore` restored the placeholder.
- `npm pack --json --pack-destination <tmp>` produced a tarball whose unpacked `ios/Source/BluetoothSdkDefaults.swift` contained `swiftPackageSdkVersion = "0.1.17"`, with no placeholder and no bundle metadata fallback symbols; the source checkout was restored afterward.
- `npm pack --dry-run`
- `bun run build` in `mobile/modules/bluetooth-sdk`
- `scripts/export-bluetooth-sdk-ios-spm.sh --target <tmp>/mentra-bluetooth-sdk-ios --verify`
- `bun install --frozen-lockfile --ignore-scripts` at repo root
- `bun install --frozen-lockfile --ignore-scripts` in `mobile`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how iOS OTA default manifest URLs resolve SDK version; wrong or missing injection could break OTA or analytics, but release CI verifies packed artifacts and guards against regressions.
> 
> **Overview**
> Bumps `@mentra/bluetooth-sdk` to **0.1.17** (including `mobile/bun.lock`).
> 
> **iOS SDK version** no longer falls back to bundle `CFBundle*` metadata (which could resolve the host app version on the npm/RN path). `BluetoothSdkDefaults.sdkVersion` now comes only from the baked `swiftPackageSdkVersion` constant, with `__MENTRA_BLUETOOTH_SDK_VERSION__` left in source until pack time.
> 
> Adds **`prepack` / `postpack`** hooks via `scripts/inject-ios-sdk-version.mjs` to substitute the placeholder with `package.json`’s version for the tarball, then restore the checkout. Release CI now **rejects** bundle-metadata resolution code, and **unpacks** the npm artifact to assert the shipped Swift contains the release version (no placeholder) and that the repo was restored after `npm pack`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0efb7a8bce449dd17b234e2021534c13e07afc5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->