### PR TITLE
Fix Android hang on loading screen when reopening app over live foreground service

### DIFF
--- a/mobile/src/app/_layout.tsx
+++ b/mobile/src/app/_layout.tsx
@@ -10,6 +10,7 @@ import {Platform} from "react-native"
 
 import {SentryNavigationIntegration, SentrySetup} from "@/effects/SentrySetup"
 import {initI18n} from "@/i18n"
+import {useNavigationStore} from "@/stores/navigation"
 import {useSettingsStore} from "@/stores/settings"
 import {customFontsToLoad} from "@/theme"
 import {loadDateFnsLocale} from "@/utils/formatDate"
@@ -31,6 +32,16 @@ SplashScreen.setOptions({
   duration: Platform.OS === "android" ? 0 : 1000,
   fade: Platform.OS !== "android",
 })
+
+// The Bluetooth foreground service keeps this JS runtime alive when the user
+// fully closes the app, so reopening remounts a fresh React tree on the same
+// runtime instead of cold-starting. expo-router's module-level router store
+// survives with the runtime, and on Android it then restores the previous
+// session's navigation state instead of booting through "/" — skipping the
+// InitScreen boot flow entirely and stranding the app on the loading screen.
+// Track whether a previous root tree unmounted so the next one can detect the
+// warm relaunch and re-enter the normal boot route.
+let previousRootUnmounted = false
 
 function Root() {
   const [_fontsLoaded, fontError] = useFonts(customFontsToLoad)
@@ -56,6 +67,21 @@ function Root() {
   useEffect(() => {
     if (fontError) throw fontError
   }, [fontError])
+
+  useEffect(() => {
+    return () => {
+      previousRootUnmounted = true
+    }
+  }, [])
+
+  // Runs after the Stack subtree has mounted (child effects run first), so the
+  // navigator is registered and can handle the dispatch.
+  useEffect(() => {
+    if (!loaded || !previousRootUnmounted) return
+    previousRootUnmounted = false
+    console.log("ROOT: warm relaunch on a live JS runtime — rebooting through /")
+    useNavigationStore.getState().replaceAll("/")
+  }, [loaded])
 
   useEffect(() => {
     if (loaded) {


### PR DESCRIPTION
## Problem

On Android, if the foreground service is running and you fully close (swipe away) and reopen the app, it hangs on the loading screen.

## Root cause

The Bluetooth foreground service (`START_STICKY`, no `onTaskRemoved`) keeps the process — and with it the Bridgeless `ReactHost` and JS runtime — alive after the app is swiped away. Reopening attaches a fresh React tree to the **reused** JS runtime (`ReactHost{0}.getOrCreateReactInstanceTask()` in the incident logcat; BGCAP telemetry streams unbroken on the same JS thread across the close/reopen).

expo-router keeps its router state in a module-level singleton that survives the reused runtime, and it has an **Android-only branch** that feeds the previous session's navigation state back in as `initialState` on the next mount (`expo-router/build/global-state/router-store.js:196`, verified on our installed 55.0.16):

```js
if (Platform.OS === 'android' && storeRef.current.state && storeRef.current.context === context) {
    initialState = storeRef.current.state;
}
```

So the new tree never boots through `/` — the incident log shows the providers and `<Stack>` mounting but **zero** `INDEX:` / `MANTLE` / `navigateToDestination` logs afterward. `InitScreen`'s boot flow (version check → token exchange → `mantle.init()` → navigate home) never runs, and the app strands on the loading screen.

## Fix

Detect the warm relaunch in the root layout (`_layout.tsx`) with a module-scoped flag set when a previous root tree unmounts, and force the router back through the normal `/` boot route with `replaceAll("/")` once assets are loaded. Warm relaunches now take the exact same boot path as cold starts.

Why this approach:
- **No JS reload / no native change** — reloading the ReactHost on relaunch would tear down the live glasses session (BLE, mic uplink, captions) that the foreground service exists to keep running.
- **No expo-router patch** — nothing to re-apply or re-verify across SDK upgrades.
- **Single boot path** — the existing, battle-tested InitScreen flow handles both cold and warm launches; `mantle.init()` is already idempotent and `socketComms.setAuthCreds` only stores creds, so re-running boot over a live session is safe.

The dispatch timing is ordering-safe: the effect lives in the root layout and gates on `loaded`, so it runs after the `<Stack>` subtree's effects (child effects run before the parent's), i.e. after the navigator is registered. The incident log confirms `ROOT RENDERED` is reached on warm relaunch, so the hook fires exactly where the hang occurs.

## Testing

- `bun compile` (tsc) passes; prettier clean.
- Not yet verified on hardware — needs a device repro: connect glasses, swipe app away with the foreground service notification present, reopen, and confirm the app boots to home (look for the new `ROOT: warm relaunch on a live JS runtime — rebooting through /` log followed by `INDEX: MOUNTED`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app entry navigation on Android warm relaunch; mis-detection could force an extra boot through `/`, though the flow is intended to be idempotent with an active session.
> 
> **Overview**
> Fixes Android getting stuck on the loading screen when the user swipes the app away while the Bluetooth foreground service keeps the JS runtime alive and then reopens the app.
> 
> **Root layout** now tracks whether a prior root React tree unmounted (`previousRootUnmounted`). After fonts/i18n load on the next mount, if that flag is set it clears the flag and calls `useNavigationStore.getState().replaceAll("/")` so expo-router does not restore the last session’s stack and skip the normal `/` **InitScreen** boot flow.
> 
> The dispatch is gated on `loaded` so it runs after the stack navigator is ready; comments document why this avoids reloading the runtime (preserving the live glasses session).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af06ef3e0ad3055ea4e357a870dcad58f7aedae3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an Android hang on the loading screen when reopening the app while the Bluetooth foreground service is running. Detects warm relaunches and routes back through “/” so the normal boot flow runs without tearing down the live session.

- **Bug Fixes**
  - Added a module-scoped flag in `mobile/src/app/_layout.tsx` to detect warm relaunch on a reused JS runtime.
  - After assets load, calls `useNavigationStore.getState().replaceAll("/")` to re-enter the InitScreen path, avoiding `expo-router`’s Android state restore.
  - No native changes or JS reload; keeps BLE/mic/captions running.

<sup>Written for commit af06ef3e0ad3055ea4e357a870dcad58f7aedae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

