### PR TITLE
Fix Google Play internal upload: stop .env from clobbering CI-injected signing env

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -75,7 +75,11 @@ EXPO_PUBLIC_CLOUD_CORE_URL=https://core.dev.us-west-2.mentraglass.com
 EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 
 
-# NEEDED FOR RELEASE BUILDING
-ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_STORE_PASSWORD=
-ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_PASSWORD=
-ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_ALIAS=
+# Only needed for LOCAL signed release builds — uncomment and fill in your own
+# .env. Must stay commented out here: CI copies .env.example to .env verbatim,
+# and injects the real values as env vars (.github/actions/inject-signing), so
+# uncommented empty keys here would blank them out and silently downgrade the
+# release build to debug signing (this broke Play internal uploads June 2026).
+# ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_STORE_PASSWORD=
+# ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_PASSWORD=
+# ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_ALIAS=

--- a/mobile/scripts/set-build-env.mjs
+++ b/mobile/scripts/set-build-env.mjs
@@ -83,6 +83,15 @@ export async function setBuildEnv() {
   //   process.env[key] = value
   // })
 
+  // Snapshot which variables were already set in the real environment BEFORE
+  // dotenv loads .env. Those keep their values (standard dotenv semantics:
+  // explicit environment beats .env file). CI relies on this — it injects the
+  // release-signing credentials (ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_*) as env
+  // vars while its .env is a verbatim copy of .env.example; letting the file
+  // win clobbered them with empty strings and silently downgraded staging
+  // release builds to debug signing (broken Play internal uploads, June 2026).
+  const inheritedEnv = new Set(Object.keys(process.env))
+
   // Load existing .env
   const existingEnv = config().parsed || {}
 
@@ -121,10 +130,17 @@ export async function setBuildEnv() {
     delete updatedEnv.MAPBOX_DOWNLOADS_TOKEN
   }
 
-  // write env to process.env:
+  // Write env to process.env. buildVars are computed fresh for this build and
+  // always apply; every other key only fills a gap — a variable that was
+  // already set in the environment keeps its value (its actual value is not
+  // echoed either, since env-injected values can be secrets).
   Object.entries(updatedEnv).forEach(([key, value]) => {
-    console.log(`  ${key}: ${value}`)
-    process.env[key] = value
+    if (key in buildVars || !inheritedEnv.has(key)) {
+      process.env[key] = value
+      console.log(`  ${key}: ${value}`)
+    } else {
+      console.log(`  ${key}: (kept from environment)`)
+    }
   })
 
   // Write back to .env


### PR DESCRIPTION
## Problem

Every staging build's Google Play internal upload has failed since **June 11** with:

> Google Api Error: The Android App Bundle was signed with the wrong key. Found: SHA1: `5E:8F:16…` (debug key), expected: `AB:F6:5B…` (upload key)

The workflow stayed green because the Play upload is a soft sub-status, so this ran silently for three weeks. Side effect: the `Mentra_*_Beta_N.apk` files on the staging GitHub release since June 11 are also debug-signed.

## Root cause

1. `553b0094e` (china build, May 26) added empty `ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_*` placeholder lines to `mobile/.env.example` — intended as fill-these-in docs for local signed release builds. They reached `staging` between the June 10 (last good) and June 11 (first failing) runs.
2. The staging workflow copies `.env.example → .env` verbatim.
3. `set-build-env.mjs` force-wrote every `.env` key into `process.env`, overwriting the real signing credentials CI injects (`.github/actions/inject-signing`) with empty strings.
4. Gradle saw an empty store password and **silently fell back to the debug keystore** for the release AAB; fastlane uploaded it; Google rejected it (4 retries, soft-fail).

## Fix

- **`mobile/.env.example`** — comment out the signing placeholder keys, with a warning explaining why they must stay commented (CI copies this file verbatim).
- **`mobile/scripts/set-build-env.mjs`** — variables already set in the environment now keep their values (standard dotenv precedence); `.env` only fills gaps. Computed build vars (`EXPO_PUBLIC_BUILD_*`) still always apply. Env-kept values are logged as `(kept from environment)` instead of echoed, since they can be secrets. This disarms the whole bug class — a future empty placeholder for any CI-injected var can no longer blank it — and also stops the `.env` dummy from clobbering the env-injected `MAPBOX_DOWNLOADS_TOKEN`.

## Test evidence

Ran the real `setBuildEnv()` under a simulated CI environment (secret injected via env + empty key appended to `.env`), all assertions pass:

```
PASS: CI-injected signing password survives empty .env key
PASS: .env value still applies when var not preset in environment
PASS: env-injected Mapbox downloads token no longer clobbered by .env dummy
PASS: .env-only vars (version) still reach process.env
PASS: computed buildVars still applied
PASS: real sk. token not persisted to .env
```

Also verified the secret value never appears in the script's log output.

Real-world confirmation will be the next staging run: the gradle signing block should print `Using RELEASE keystore` instead of `Using DEBUG keystore (no release credentials found)`, and the Slack notify should show `Google Play internal: uploaded`.

## Follow-ups (not in this PR)

- Make debug-signing fallback a hard error for CI release builds so this class of failure turns red instead of soft-failing.
- Re-cut the debug-signed staging Beta APKs uploaded since June 11 (they refuse to install over properly-signed builds).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing and env merge behavior for all mobile builds; fix aligns with dotenv semantics and reduces risk of silent debug signing, but wrong precedence logic could still break CI or local builds.
> 
> **Overview**
> Fixes **staging release AABs being debug-signed** because `set-build-env.mjs` overwrote CI-injected `ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_*` (and similar) with empty values from a verbatim `.env.example` → `.env` copy.
> 
> **`mobile/.env.example`** — Gradle upload-signing placeholders are **commented out** with a note that CI copies this file as-is; uncommented empty keys had been wiping injected secrets.
> 
> **`mobile/scripts/set-build-env.mjs`** — Snapshots env keys **before** loading `.env`, then applies standard precedence: **`EXPO_PUBLIC_BUILD_*` build vars always win**; for everything else, **existing process env keeps its value** and `.env` only fills unset keys. Logs `(kept from environment)` instead of printing secret values. Same pattern protects env-injected Mapbox download tokens from `.env` dummies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3116ec80cb957b2e1138eef803093392361ef59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google Play internal upload failures by stopping `.env` from overriding CI-injected signing variables, so release builds use the correct upload key. Also prevents `.env` dummy values from clobbering other env-injected secrets like `MAPBOX_DOWNLOADS_TOKEN`.

- **Bug Fixes**
  - `mobile/.env.example`: commented `ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_*` placeholders and added a warning since CI copies this file verbatim.
  - `mobile/scripts/set-build-env.mjs`: keep existing environment values and only fill gaps from `.env`; computed `EXPO_PUBLIC_BUILD_*` still always apply; do not echo kept values to logs.

<sup>Written for commit d3116ec80cb957b2e1138eef803093392361ef59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

