### PR TITLE
Bump Bluetooth SDK to 0.1.18

### DIFF
--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.16")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
 }
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.16`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.18`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.16"
+  from: "0.1.18"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.16")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.16`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.16"
+  from: "0.1.18"
 )
 ```
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -230,7 +230,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -475,7 +475,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.16`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.16`
+Use the same version format as existing SwiftPM tags, for example `0.1.18`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -295,7 +295,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.15",
+      "version": "0.1.18",
       "devDependencies": {
         "expo-module-scripts": "^55.0.2",
       },


### PR DESCRIPTION
## Summary

- Bumps `@mentra/bluetooth-sdk` from `0.1.17` to `0.1.18`.
- Updates the matching `mobile/bun.lock` and `sdk/bun.lock` workspace entries.
- Updates Mentra Live install docs, package README, and SwiftPM release notes to reference `0.1.18`.

## Why

This follows the scoped version/docs bump pattern from #3319. The package version, both Bun workspace lockfiles, Maven install snippets, SwiftPM install snippets, package README, and SwiftPM release note example should all move together for the published SDK version.

The iOS baked-version packaging infrastructure from #3321 is already present on `dev`; this PR advances the package/docs version inputs to `0.1.18`.

## iOS npm and SwiftPM checks

The npm `prepack` / `postpack` hook from #3321 was exercised locally. It injected `0.1.18` into the packed iOS source, left no placeholder in the packed tarball, and restored the checkout placeholder afterward.

The SwiftPM export path was also exercised locally into a temporary target. The generated SwiftPM README used `from: "0.1.18"`, and the exported `BluetoothSdkDefaults.swift` contained `swiftPackageSdkVersion = "0.1.18"`.

## Validation

- `rg -n "0\\.1\\.16|0\\.1\\.17" mintlify-docs/mentra-live mobile/modules/bluetooth-sdk mobile/bun.lock sdk/bun.lock` found no remaining references.
- `bun install --frozen-lockfile --ignore-scripts` in `sdk`
- `npm pack --json --pack-destination <tmp>` in `mobile/modules/bluetooth-sdk`
- `scripts/export-bluetooth-sdk-ios-spm.sh --target <tmp>/mentra-bluetooth-sdk-ios`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and documentation-only changes with no application logic or SDK implementation edits in the diff.
> 
> **Overview**
> Bumps **`@mentra/bluetooth-sdk`** to **`0.1.18`** in `mobile/modules/bluetooth-sdk/package.json` and aligns **`mobile/bun.lock`** and **`sdk/bun.lock`** workspace entries with that version.
> 
> **Mentra Live** install docs (`android.mdx`, `ios.mdx`, `quickstart.mdx`) now reference **`com.mentraglass:bluetooth-sdk:0.1.18`** and SwiftPM **`0.1.18`**. The package **README** and **`RELEASING_IOS_SPM.md`** tag example are updated to match. No runtime or SDK source changes in this diff—version and documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86dae179997d87ff586a2f123d5fb94b845f013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->