### PR TITLE
Fix Android home screen bottom fade rendering as a solid white block

### DIFF
--- a/mobile/src/components/home/AppSwitcherButtton.tsx
+++ b/mobile/src/components/home/AppSwitcherButtton.tsx
@@ -156,7 +156,7 @@ export default function AppSwitcherButton({swipeProgress, onGridButtonPress, blu
         maskElement={
           <LinearGradient
             colors={["black", "transparent"]}
-            locations={linGradientOnly ? [0.2, 20] : [0.4, 1]}
+            locations={[0.4, 1]}
             start={{x: 0, y: 1}}
             end={{x: 0, y: 0}}
             style={{


### PR DESCRIPTION
## Scope
The Android home screen's bottom fade (behind the running-apps pill) rendered as a solid background-colored slab with a hard cutoff instead of fading out. The no-blur mask gradient used an out-of-range stop — `locations={[0.2, 20]}` — which kept the mask ~96% opaque all the way to its top edge.

## Change
One line in `AppSwitcherButtton.tsx`: use the same valid `[0.4, 1]` gradient stops as iOS for the Android gradient-only path, so the fill genuinely fades from opaque at the bottom to transparent at the top. Positioning (`paddingTop`, container bounds) is intentionally unchanged.

## Test evidence
Verified by code inspection; the invalid stop math (`1 - (1-0.2)/(20-0.2) ≈ 96%` opacity at the top edge) explains the observed white band. Branch is based on `origin/staging` so it can also be merged to staging cleanly if wanted for the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line visual/mask tweak on Android home UI with no auth, data, or API impact.
> 
> **Overview**
> Fixes the Android home screen bottom fade (behind the running-apps pill) rendering as a solid background slab with a hard edge instead of fading out.
> 
> **Change:** In `AppSwitcherButtton.tsx`, the `MaskedView` mask `LinearGradient` no longer uses `locations={[0.2, 20]}` on the Android gradient-only path (`linGradientOnly`). It always uses **`locations={[0.4, 1]}`**, matching iOS, so the mask goes from opaque at the bottom to transparent at the top. Layout (`paddingTop`, bounds) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 980d258ecbc4faf6291205c55b20e7a16e86e114. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Android home screen bottom fade behind the app switcher pill, which rendered as a solid slab. Uses valid gradient stops [0.4, 1] to match iOS so the area fades from opaque to transparent as intended.

<sup>Written for commit 980d258ecbc4faf6291205c55b20e7a16e86e114. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

