### PR TITLE
Fix idle CPU burn on home screen (60fps render loop)

### DIFF
--- a/mobile/src/components/home/AllAppsGridSheet.tsx
+++ b/mobile/src/components/home/AllAppsGridSheet.tsx
@@ -135,6 +135,10 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
             <View className="h-2" />
             <AppsGrid
               showPlaceholders={!isOpen}
+              // The sheet stays mounted while closed (index -1), so its skeleton
+              // does too — freeze the pulse or it animates the app at 60fps from
+              // behind the home screen forever.
+              skeletonPulse={isOpen}
               gateOnIconsReady={true}
               showAllApps={true}
               searchQuery={searchQuery}

--- a/mobile/src/components/home/AppIcon.tsx
+++ b/mobile/src/components/home/AppIcon.tsx
@@ -112,6 +112,10 @@ const AppIcon = ({app, onClick, style, disableLoader, instant, resolveCachedSour
               contentFit="cover"
               transition={instant ? 0 : 200}
               cachePolicy="memory-disk"
+              // Icons can be animated GIFs/WebPs (devs upload anything). A single
+              // looping GIF icon keeps the frame decoder + render pipeline running
+              // forever and measurably heats the phone — render the first frame only.
+              autoplay={false}
               onError={() => {
                 markRemoteImageSourceFailed(app.logoUrl)
                 setIconFailed(true)

--- a/mobile/src/components/home/AppsGrid.tsx
+++ b/mobile/src/components/home/AppsGrid.tsx
@@ -1,6 +1,13 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {Dimensions, FlatList, LayoutChangeEvent, Platform, Pressable, StyleSheet, TouchableOpacity, View} from "react-native"
-import Animated, {Easing, useAnimatedStyle, useSharedValue, withRepeat, withTiming} from "react-native-reanimated"
+import Animated, {
+  cancelAnimation,
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated"
 import {warmCachedRemoteImageSources} from "@/hooks/useCachedRemoteImageSource"
 import {DraggableList} from "@/components/home/DraggableList"
 import {BlurView} from "expo-blur"
@@ -171,15 +178,26 @@ const AppPopover: React.FC<{
 // so its own mt-3 would push it 12px below the grid rows it's covering).
 // `count` is how many skeleton cells to draw — pass the real gridData length so
 // the skeleton matches the grid it's covering cell-for-cell.
-const PlaceholderGrid: React.FC<{asCover?: boolean; count?: number}> = ({
+const PlaceholderGrid: React.FC<{asCover?: boolean; count?: number; pulse?: boolean}> = ({
   asCover = false,
   count = PLACEHOLDER_COUNT,
+  pulse: pulseEnabled = true,
 }) => {
   const pulse = useSharedValue(0.4)
 
   useEffect(() => {
+    if (!pulseEnabled) {
+      // A paused skeleton must not keep an infinite reanimated loop alive: each
+      // loop tick commits new props through Fabric, so an off-screen skeleton
+      // (e.g. inside the closed all-apps sheet) forces the whole app to re-render
+      // at 60fps indefinitely.
+      cancelAnimation(pulse)
+      pulse.value = 0.4
+      return
+    }
     pulse.value = withRepeat(withTiming(1, {duration: 800, easing: Easing.inOut(Easing.ease)}), -1, true)
-  }, [pulse])
+    return () => cancelAnimation(pulse)
+  }, [pulse, pulseEnabled])
 
   const animatedStyle = useAnimatedStyle(() => ({opacity: pulse.value}))
 
@@ -218,6 +236,13 @@ interface AppsGridProps {
    * by the all-apps sheet. The home grid leaves this off to paint immediately.
    */
   gateOnIconsReady?: boolean
+  /**
+   * Animate the placeholder skeleton's pulse. Pass false while the skeleton is
+   * mounted but not visible (the closed all-apps sheet keeps one mounted) — an
+   * infinite reanimated loop commits every frame and pins the render pipeline
+   * at 60fps even though nothing on screen changes.
+   */
+  skeletonPulse?: boolean
 }
 
 export function AppsGrid({
@@ -227,6 +252,7 @@ export function AppsGrid({
   searchQuery,
   showPlaceholders = false,
   gateOnIconsReady = false,
+  skeletonPulse = true,
 }: AppsGridProps) {
   const {themed, theme} = useAppTheme()
 
@@ -836,7 +862,7 @@ export function AppsGrid({
   }
 
   if (showPlaceholders) {
-    return <PlaceholderGrid count={skeletonCount || PLACEHOLDER_COUNT} />
+    return <PlaceholderGrid count={skeletonCount || PLACEHOLDER_COUNT} pulse={skeletonPulse} />
   }
 
   // Gated path (all-apps sheet): the masonry grid renders empty until it measures


### PR DESCRIPTION
## Scope

The Mentra App kept the phone's render pipeline running at a constant 60fps while sitting idle on the home screen — ~60-70% of a CPU core, phone noticeably hot. Reported in both debug and release builds. Diagnosed on a Pixel 6a with perfetto + simpleperf; two independent causes, both on the home screen:

### 1. Invisible skeleton pulse in the closed all-apps sheet (affects every user)

`AllAppsGridSheet` is permanently mounted on home, parked closed at `index={-1}`. While closed it rendered `AppsGrid` with `showPlaceholders`, which mounts the loading skeleton — whose pulse is an infinite reanimated `withRepeat` loop. On Fabric every tick commits new props, so a skeleton nobody can see forced full-app layout + draw + the Android blur re-render on **every frame, forever** (trace: React `UPDATE_PROPS` mount instructions on 463/463 frames over 7.7s).

**Fix:** new `skeletonPulse` prop on `AppsGrid`/`PlaceholderGrid`; the sheet passes `skeletonPulse={isOpen}` and the animation is cancelled while closed. The visible skeleton (open sheet, icons loading) still pulses.

### 2. Animated GIF app icons autoplay (affects anyone with one installed)

Icon URLs are dev-supplied and can be animated — one installed miniapp ships a 6.7MB, 76-frame, 512×288 GIF as its icon. expo-image autoplays it, pinning the GIF frame-decoder thread (~10% of a core) plus per-frame redraws indefinitely. Confirmed by diffing two screenshots 400ms apart: the only changing pixels on the screen were that icon.

**Fix:** `autoplay={false}` on `AppIcon`'s image — animated icons render their first frame only.

## Test evidence

On-device before/after (Pixel 6a, idle on home screen):

| Metric | Before | After |
|---|---|---|
| App CPU (idle) | 57-66% of a core | 7-15% (debug-build baseline) |
| Main thread | ~40% | ~7% |
| `FrameDecoderExe` thread | ~10% | gone |
| `dumpsys gfxinfo` frames drawn / 10s | continuous 60fps | **0** |

Typecheck (`bun compile`) passes with only the 3 pre-existing errors also present on `dev`.

## Notes

- Remaining idle CPU in debug is CheckJNI/Metro overhead plus RN's baseline Fabric frame callback; release should idle near zero.
- Follow-up worth considering: reject or flatten animated icons server-side in the store so a dev upload can't reintroduce this; `CustomBackground` will still autoplay a user-picked animated GIF wallpaper (left as-is — product decision).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted performance fixes on skeleton animation gating and icon display; no auth, data, or API changes.
> 
> **Overview**
> Stops the home screen from driving **~60fps renders and high idle CPU** by fixing two independent causes.
> 
> The **closed all-apps sheet** stays mounted with a placeholder skeleton whose Reanimated pulse never stopped. **`skeletonPulse`** on `AppsGrid` / **`pulse`** on `PlaceholderGrid` cancel that loop when the sheet is closed (`skeletonPulse={isOpen}` in `AllAppsGridSheet`), including cleanup via **`cancelAnimation`**.
> 
> **`AppIcon`** sets **`autoplay={false}`** on `expo-image` so dev-uploaded animated GIF/WebP icons show the first frame only instead of decoding forever.
> 
> Home grid behavior is unchanged (pulse still defaults on).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753682cad9fad0a78560926824913f502683bbfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 60fps render loop on the idle home screen by pausing hidden skeleton animations and stopping animated icon autoplay. This cuts idle CPU from ~60% to near baseline and prevents device heat.

- **Bug Fixes**
  - Paused the placeholder skeleton while the all-apps sheet is closed: added `skeletonPulse` to `AppsGrid`/`PlaceholderGrid` and cancel the reanimated loop when closed to stop off-screen updates.
  - Disabled animated app icon autoplay: set `autoplay={false}` on the `expo-image` in `AppIcon` so GIF/WebP icons render only the first frame, removing the frame decoder and redraws.

<sup>Written for commit 753682cad9fad0a78560926824913f502683bbfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

