### PR TITLE
Set explicit rootDir in expo module tsconfigs

### DIFF
--- a/mobile/modules/bluetooth-sdk/tsconfig.json
+++ b/mobile/modules/bluetooth-sdk/tsconfig.json
@@ -2,7 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "rootDir": "./src"
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]

--- a/mobile/modules/island/tsconfig.json
+++ b/mobile/modules/island/tsconfig.json
@@ -2,7 +2,8 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build"
+    "outDir": "./build",
+    "rootDir": "./src"
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]


### PR DESCRIPTION
## Scope

The miniapp SDK release workflow's first real (non-dry) run failed during `bun install` in the `sdk/` workspace: `@mentra/bluetooth-sdk`'s expo-module prepare step runs a bare `bunx tsc`, which on a cold runner cache resolves to the latest TypeScript — now 6.0, where an implicit `rootDir` is a hard error:

```
tsconfig.json(5,5): error TS5011: The common source directory of 'tsconfig.json' is './src'.
The 'rootDir' setting must be explicitly set ...
```

The workspace lockfile pins typescript 5.9.3, but `bunx tsc` never consults it. Earlier green runs just had a warm bunx cache with an older tsc.

Fix: set `"rootDir": "./src"` explicitly in the two expo module tsconfigs that were missing it (`bluetooth-sdk`, `island`). This matches what tsc already inferred, so emitted layout is unchanged on TS 5.x, and TS 6 stops erroring.

## Test evidence

- `tsc -p tsconfig.json` with typescript@6.0.3 on bluetooth-sdk: reproduced TS5011 before, exits 0 after.
- Same command with the repo's typescript 5.9.3: clean before and after (no layout change).
- island's compile under TS6 shows only unrelated errors from a stale local `@mentra/miniapp` dist (CAMERA_WARM_UP is present in source on dev); CI builds that dep fresh.

Failed run for reference: https://github.com/Mentra-Community/MentraOS/actions/runs/28627445506

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only TypeScript compiler option aligned with existing include paths; no runtime or API behavior changes.
> 
> **Overview**
> Adds **`"rootDir": "./src"`** to the TypeScript configs for **`bluetooth-sdk`** and **`island`** expo modules so `bunx tsc` during expo-module **prepare** succeeds under **TypeScript 6**, which errors with **TS5011** when `rootDir` is left implicit.
> 
> The value matches what TS 5.x already inferred, so **`outDir` / `build` layout should be unchanged** on the repo’s pinned TypeScript; this mainly unblocks cold CI runners that resolve `bunx tsc` to TS 6 instead of the workspace lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0098eae9ea3c718cbb3159dcb83a703553a8b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set TypeScript `rootDir` to `./src` in the expo modules to stop TS5011 errors with `typescript@6` and unblock the miniapp SDK release workflow. Build output is unchanged on `typescript@5.x`.

- **Bug Fixes**
  - Added `"rootDir": "./src"` to `mobile/modules/bluetooth-sdk/tsconfig.json` and `mobile/modules/island/tsconfig.json`.
  - Fixes TS5011 when `expo-module-scripts` runs `bunx tsc` that can resolve to `typescript@6`.
  - Prevents `bun install` failure in the `sdk/` workspace.

<sup>Written for commit e0098eae9ea3c718cbb3159dcb83a703553a8b2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

