### PR TITLE
Release Mentra Live docs to frozen-docs

### DIFF
--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
 }
 ```
 

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -366,10 +366,10 @@ These are the supported React Native app developer entrypoints:
 | Default device | `getDefaultDevice`, `setDefaultDevice`, `clearDefaultDevice` |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `cancelConnectionAttempt`, `disconnect`, `forget` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera and gallery | `requestPhoto`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setButtonPhotoSettings`, `setButtonVideoRecordingSettings`, `setButtonCameraLed`, `setButtonMaxRecordingTime`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
+| Camera and gallery | `requestPhoto`, `warmUpCamera`, `queryGalleryStatus`, `setGalleryModeEnabled`, `setPhotoCaptureDefaults`, `setVideoRecordingDefaults`, `setMaxVideoRecordingDuration`, `setCameraFov`, `startVideoRecording`, `stopVideoRecording` |
 | Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, `setVoiceActivityDetectionEnabled`, `setPreferredMic`, `setOwnAppAudioPlaying`, `getGlassesMediaVolume`, `setGlassesMediaVolume` |
-| LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate`, `retryOtaVersionCheck` |
+| LED, version, and OTA | `rgbLedControl`, `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate` |
 
 React Native helper exports include `DeviceModels`, `isConnectedGlassesConnectionStatus`, `isReadyGlassesConnectionStatus`, `isBusyGlassesConnectionStatus`, `isConnectedWifiStatus`, and `isEnabledHotspotStatus`. The React subpath exports `useMentraBluetooth`, `useBluetoothScan`, and `useBluetoothEvent`.
 
@@ -381,11 +381,14 @@ Important defaults:
 - `connect` and `connectDefault` default `saveAsDefault` and `cancelExistingConnectionAttempt` to `true`.
 - `setMicState(enabled)` defaults to glasses microphone on, transcript events off, and LC3 events off. Microphone audio events are continuous while capture is enabled. Use `setVoiceActivityDetectionEnabled(...)` for glasses-side Voice Activity Detection; `voice_activity_detection_status` reports whether it is enabled, and `speaking_status` reports speaking/not-speaking when supported. Microphone audio events include the latest `voiceActivityDetectionEnabled` value.
 - `requestPhoto({authToken, ...})` omits the `Authorization` header when `authToken` is `null` or empty.
+- `requestPhoto(...)` and `warmUpCamera(...)` generate unique request IDs when `requestId` is omitted or blank. Pass an explicit `requestId` only when your app needs to know it before the response, for example to poll a predictable upload-status URL.
 - `requestPhoto({exposureTimeNs, ...})` uses auto exposure when `exposureTimeNs` is omitted or `null`; pass a positive nanosecond value for one-shot manual exposure.
 - `requestPhoto({exposureTimeNs, iso, ...})` uses `iso` only when `exposureTimeNs` enables one-shot manual exposure. Omit `iso` / pass `null` for auto ISO selection.
+- `requestPhoto(...)` capture fields apply to that one request. `setPhotoCaptureDefaults(...)` persists the defaults used by gallery-mode action-button photos.
+- `warmUpCamera({size, exposureTimeNs, durationMs})` opens/configures Mentra Live's camera and holds it warm without capturing or uploading media. Use it while a foreground camera UI is active, refresh before `durationMs` expires, and match the next `requestPhoto(...)` size/exposure settings for reuse. The promise resolves on `camera_status.state === "ready"`; the later `stopped` event marks lease expiry/teardown for listeners and does not settle the already-resolved promise.
 - Request/response commands now resolve from the glasses response rather than only updating local SDK state. React Native returns success-only values for commands whose raw events can also carry errors: `requestPhoto(...)` returns terminal `PhotoSuccessResponseEvent` after capture and delivery finish, `startVideoRecording(...)` returns `VideoRecordingStartedStatusEvent`, `stopVideoRecording(...)` returns `VideoRecordingStoppedStatusEvent`, and `rgbLedControl(...)` returns `RgbLedControlSuccessResponseEvent`. When `stopVideoRecording(...)` includes a webhook URL, the promise resolves after the video upload succeeds. The corresponding raw events still include error variants for listeners.
 - `setCameraFov({fov, roiPosition})` clamps `fov` to 62-118 degrees and accepts `roiPosition` as `"center"`, `"bottom"`, or `"top"`. You can also call `setCameraFov({preset: "narrow" | "standard" | "wide"})`; presets map to 82, 102, and 118 degrees with center ROI. On Mentra Live this persists the setting, restarts the camera, and resolves with `CameraFovResult` only after the ASG client reports the setting was applied to camera hardware after the restart cooldown. The promise rejects if the glasses report an error, persist the setting without hardware application, or time out. Treat FOV as a framing/ROI control; output resolution and effective detail can vary by capture path, firmware, and camera mode.
-- `startStream` optional `video` and `audio` configs are omitted unless supplied, so the connected glasses use their model defaults. The SDK sends stream keep-alives automatically and reports timeout/error state through `stream_status`.
+- `startStream` optional `video` and `audio` configs are omitted unless supplied, so the connected glasses use their model defaults. Stream video input fields are `width`, `height`, `bitrate`, and `fps`; stream status reports the resolved effective frame rate as `resolvedConfig.video.fps`. The SDK sends stream keep-alives automatically and reports timeout/error state through `stream_status`.
 - Photo capture, video recording, and streaming always enable the camera light as a privacy indicator.
 
 ## Promise Results And Errors
@@ -401,16 +404,17 @@ React Native exposes the narrowest return types for clear branching after `await
 | `forgetWifiNetwork(ssid)` | `WifiStatusChangeEvent` once the requested SSID is no longer connected. | Timeout, send failure, or another Wi-Fi status command in flight. |
 | `setHotspotState(enabled)` | `HotspotStatusChangeEvent` matching the requested enabled/disabled state. | `hotspot_error`, timeout, send failure, or another hotspot command in flight. |
 | `requestVersionInfo()` | `VersionInfoResult` from the ASG `version_info` response. | Timeout, send failure, or another version query in flight. |
-| Gallery/button settings | `SettingsAckSuccessEvent` with a non-failure status such as `applied` or `ready`; the SDK local settings store updates only after this ASG ack resolves. | `settings_ack.status` of `error`, `failed`, `failure`, or `rejected`; timeout; or send failure. |
+| Gallery capture settings | `SettingsAckSuccessEvent` with a non-failure status such as `applied` or `ready`; the SDK local settings store updates only after this ASG ack resolves. | `settings_ack.status` of `error`, `failed`, `failure`, or `rejected`; timeout; or send failure. |
 | `setCameraFov(...)` | `CameraFovResult` with `fov`, `roiPosition`, `requestId`, and `timestamp` after the ASG client reports the setting was applied to camera hardware after the restart cooldown; the SDK local FOV setting updates only after this result resolves. | Glasses-side FOV/settings error, persist-only/no hardware-application ack, timeout, or send failure. |
 | `queryGalleryStatus()` | `GalleryStatusEvent`, including `cameraBusy` and optional `cameraBusyReason`. | Timeout, send failure, or another gallery status query in flight. |
 | `requestPhoto(...)` | Terminal response after capture and delivery finish: React Native `PhotoSuccessResponseEvent`; Android/iOS successful `PhotoResponseEvent`. The success includes `uploadUrl`, and may include webhook-returned `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`. Progress follows through `photo_status`. | Raw `photo_response.state === "error"` from glasses/phone, fallback upload failure, terminal response timeout, or send failure. |
+| `warmUpCamera(...)` | `CameraStatusEvent` whose `state` is `ready`, meaning the camera is open/configured and held warm for the requested TTL. Progress follows through `camera_status`; `stopped` is a listener-only lifecycle event after `ready`. | `camera_status.state === "error"` such as `camera_busy`, `camera_restart_cooldown`, `photo_capture_in_progress`, `ble_transfer_in_progress`, `media_capture_service_unavailable`, or `camera_warm_up_failed`; timeout; or send failure. |
 | `startVideoRecording(...)` | React Native `VideoRecordingStartedStatusEvent` with `status: "recording_started"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_started"`. | `success: false` statuses such as `already_recording`, timeout, send failure, or duplicate request ID. |
 | `stopVideoRecording(requestId, webhookUrl?, authToken?)` | React Native `VideoRecordingStoppedStatusEvent` with `status: "recording_stopped"`; Android/iOS successful `VideoRecordingStatusEvent` with `status: "recording_stopped"`. When `webhookUrl` is supplied, the promise waits for the video upload to finish successfully. | `success: false` statuses such as `not_recording`, video upload failure, timeout, send failure, or duplicate request ID. |
 | `startStream(...)` | `StreamStatusEvent` for the requested stream once `status` is `streaming`. | `stream_status` error/reconnect failure, timeout, or send failure. |
 | `stopStream()` | `StreamStatusEvent` once `status` is `stopped`; an already-stopped / not-streaming glasses reply resolves as a normalized stopped event. | Real stop error, timeout, send failure, or another stream stop in flight. |
 | `rgbLedControl(...)` | React Native `RgbLedControlSuccessResponseEvent`; Android/iOS successful `RgbLedControlResponseEvent`. | Raw `rgb_led_control_response.state === "error"`, timeout, or send failure. |
-| `checkForOtaUpdate()` / `retryOtaVersionCheck()` | `OtaQueryResult`: either `ota_update_available` or the current `ota_status`. | Command response timeout, send failure, or another OTA query in flight. A returned `ota_status.status === "failed"` is a glasses OTA state to show in UI, not a command transport rejection. |
+| `checkForOtaUpdate()` | `boolean`, true when the configured OTA manifest has an ASG APK, MTK, or BES update for the connected glasses; false only when the manifest was checked successfully and no update is available. | Rejects when the glasses are disconnected, version info is unavailable, the manifest cannot be fetched, or the manifest response is invalid/missing required ASG app version fields. |
 | `startOtaUpdate()` | `OtaStartAckEvent` from `ota_start_ack`. | Start-ack timeout, send failure, or another OTA start in flight. |
 
 ## Gallery Mode
@@ -421,11 +425,16 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 
 | Setting | API |
 | --- | --- |
-| Photo size | `setButtonPhotoSettings(...)` |
-| Video resolution and frame rate | `setButtonVideoRecordingSettings(width, height, fps)` |
-| Maximum video length | `setButtonMaxRecordingTime(minutes)` |
+| Photo capture defaults | `setPhotoCaptureDefaults(...)` |
+| Video resolution and frame rate | `setVideoRecordingDefaults({width, height, fps})` |
+| Maximum local video length | `setMaxVideoRecordingDuration(minutes)` |
 | Camera field of view | `setCameraFov(...)` |
-| Camera LED preference | `setButtonCameraLed(...)` |
+
+`requestPhoto(...)` accepts optional `requestId` plus `size`, `webhookUrl`, `authToken`, `compress`, `save`, `sound`, `exposureTimeNs`, `iso`, `aeExposureDivisor`, `isoCap`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, and `ispAnalogGain`. Photo, video, and stream capture always enable the camera light as a privacy indicator. Manual `iso` is used only when `exposureTimeNs` enables manual exposure.
+
+`warmUpCamera(...)` accepts optional `requestId` plus `size`, `exposureTimeNs`, and `durationMs`. Omit or pass a non-positive `durationMs` for the default 15 second warm hold. `camera_status` reports `warming`, `ready`, `stopped`, or `error`; the method resolves on `ready` and rejects on `error`. Every request ID that receives `ready` also receives `stopped` when its warm lease expires or the camera service tears down. A warm-up that is still pending when the camera service tears down rejects with `error` instead.
+
+`setPhotoCaptureDefaults(...)` accepts `size`, `mfnr`, `zsl`, `noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, `ispAnalogGain`, `aeExposureDivisor`, `isoCap`, `compress`, `sound`, and `resetCaptureTuning`. Omitted fields leave existing action-button photo defaults unchanged. `resetCaptureTuning: true` restores optional tuning fields to standard capture behavior and does not change photo size unless `size` is also provided.
 
 ## Common Commands
 
@@ -433,26 +442,25 @@ Use `setGalleryModeEnabled(true)` to enable local button capture, and `setGaller
 | --- | --- |
 | Connection | `scan`, `startScan`, `stopScan`, `connect`, `connectDefault`, `disconnect`, `forget` |
 | Wi-Fi and hotspot | `requestWifiScan`, `sendWifiCredentials`, `forgetWifiNetwork`, `setHotspotState` |
-| Camera | `requestPhoto`, gallery mode, button photo settings, button video settings, camera field of view |
+| Camera | `requestPhoto`, gallery mode, photo capture defaults, video recording defaults, camera field of view |
 | Streaming | `startStream`, `stopStream` |
 | Audio | `setMicState`, Voice Activity Detection setting and events, audio callbacks, local transcription, media volume |
 | Settings | Gallery mode, camera options, microphone route, Wi-Fi, hotspot, and OTA |
 | LEDs | `rgbLedControl` on supported glasses |
-| System | `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate`, `retryOtaVersionCheck` |
+| System | `requestVersionInfo`, `checkForOtaUpdate`, `startOtaUpdate` |
 
 Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. Gate UI by connection readiness, permissions, and the latest SDK status.
 
 ## OTA Updates
 
-Mentra Live OTA is glasses-owned. The SDK exposes the same command and event semantics used by the MentraOS app:
+Mentra Live OTA installation is glasses-owned. The SDK checks the configured manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 
-| API | Glasses command | Purpose |
-| --- | --- | --- |
-| `checkForOtaUpdate()` | `ota_query_status` | Ask the glasses to report update availability or current progress. Resolves with `OtaQueryResult` from the ASG client. |
-| `startOtaUpdate()` | `ota_start` | Start OTA after your app presents the update and the user accepts it. Resolves with `OtaStartAckEvent` from the ASG client. |
-| `retryOtaVersionCheck()` | `ota_retry_version_check` | Re-run the glasses-side version check after a known clock-skew/TLS failure. |
+| API | Purpose |
+| --- | --- |
+| `checkForOtaUpdate()` | Fetch the configured manifest and resolve `true` when an ASG APK, MTK, or BES update is available. |
+| `startOtaUpdate()` | Send `ota_start` with the configured manifest URL after your app presents the update and the user accepts it. Resolves with `OtaStartAckEvent` from the ASG client. |
 
-Use the returned query/start values for one-shot UI. Keep `ota_status` listeners/delegates for install progress and terminal `complete` / `failed` state. React Native still receives `ota_update_available`, `ota_start_ack`, and `ota_status` events for low-level integrations; Android listeners receive `onOtaUpdateAvailable`, `onOtaStartAck`, and `onOtaStatus`; iOS delegates receive `.otaUpdateAvailable`, `.otaStartAck`, and `.otaStatus` through `BluetoothEvent`.
+Use the boolean check result for update prompts and keep `ota_status` listeners/delegates for install progress and terminal `complete` / `failed` state. Availability is exposed through `checkForOtaUpdate()` rather than a public event; React Native receives `ota_start_ack` and `ota_status` events during the install flow. Android listeners receive `onOtaStartAck` and `onOtaStatus`; iOS delegates receive `.otaStartAck` and `.otaStatus` through `BluetoothEvent`.
 
 OTA requires Mentra Live glasses firmware that supports the ASG OTA protocol and network access from the glasses. During install, normal BLE traffic can be interrupted and the glasses may restart; keep the app connected and avoid sending unrelated commands until `ota_status.status` is `complete` or `failed`.
 
@@ -556,6 +564,7 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `hotspot_error` | `HotspotErrorEvent` | Hotspot operation fails. |
 | `photo_response` | `PhotoResponseEvent` | Terminal photo result. Success means capture and webhook delivery completed; error means the glasses or phone rejected/failed the request. `requestPhoto(...)` resolves with the success case and rejects on the error case; progress follows through `photo_status`. |
 | `photo_status` | `PhotoStatusEvent` | Photo capture progress changes. May include `resolvedConfig`, `requestedCaptureConfig`, `meteredPreview`, or `captureMetadata` depending on status. |
+| `camera_status` | `CameraStatusEvent` | Camera warm-up lifecycle. `warmUpCamera(...)` resolves on `ready`, rejects on `error`, and listeners can observe `warming` and `stopped` progress. `stopped` is emitted after `ready` when the lease expires or the camera closes; pending warm-ups receive `error` instead if teardown happens before `ready`. |
 | `video_recording_status` | `VideoRecordingStatusEvent` | Video recording start/stop succeeds or fails, or a status query reports `status: "recording_status"` with `data.recording`. `startVideoRecording(...)` resolves from `recording_started`; `stopVideoRecording(...)` resolves from `recording_stopped` unless a webhook upload was requested, in which case it waits for upload success. |
 | `media_success` / `media_error` | `MediaUploadEvent` | Raw glasses media upload completion events. Video webhook stops use these events to resolve or reject the `stopVideoRecording(...)` promise after recording has stopped. |
 | `gallery_status` | `GalleryStatusEvent` | Gallery content/camera-busy status changes. `cameraBusyReason` is included when the glasses report a busy camera reason such as `video` or `stream`. |
@@ -571,7 +580,6 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `mic_pcm` | `MicPcmEvent` | PCM microphone frame arrives. |
 | `mic_lc3` | `MicLc3Event` | LC3 microphone frame arrives. |
 | `stream_status` | `StreamStatusEvent` | Camera stream lifecycle, reconnect, or error state changes. May include `resolvedConfig` with effective stream settings: encoded output size in `video.width` / `video.height`, native camera capture size in `video.captureWidth` / `video.captureHeight`, video bitrate and `fps`, plus audio bitrate, sample rate, echo cancellation, and noise suppression. |
-| `ota_update_available` | `OtaUpdateAvailableEvent` | Mentra Live reports an available OTA package. Also returned by `checkForOtaUpdate()` when an update is available. |
 | `ota_start_ack` | `OtaStartAckEvent` | Mentra Live acknowledges `startOtaUpdate()`. Also returned by `startOtaUpdate()`. |
 | `ota_status` | `OtaStatusEvent` | OTA step, phase, status, progress, or error changes. |
 
@@ -594,13 +602,13 @@ Transport statuses such as `uploading`, `compressing`, `ble_fallback_compression
 
 Local action-button photos emitted by the glasses use the same `photo_status` shape when the phone SDK is connected. Those local captures set `resolvedConfig.source` to `button` and `resolvedConfig.transferMethod` to `local`.
 
-Android and iOS expose typed callbacks/delegate methods instead of the React Native string event API. Android uses `MentraBluetoothSdkListener` methods such as `onStateChanged`, `onGlassesChanged`, `onSdkStateChanged`, `onScanChanged`, `onDeviceDiscovered`, `onButtonPress`, `onSpeakingStatus`, `onPhotoResponse`, `onPhotoStatus`, `onMicPcm`, `onStreamStatus`, and `onOtaStatus`. iOS uses `MentraBluetoothSDKDelegate` methods such as `mentraBluetoothSDK(_:didUpdate:)`, `mentraBluetoothSDK(_:didUpdateGlasses:)`, `mentraBluetoothSDK(_:didUpdateSdkState:)`, `mentraBluetoothSDK(_:didUpdateScan:)`, `mentraBluetoothSDK(_:didDiscover:)`, `mentraBluetoothSDK(_:didReceive:)`, `mentraBluetoothSDK(_:didReceiveMicPcm:)`, and `mentraBluetoothSDK(_:didReceiveMicLc3:)`; OTA arrives through `didReceive` as `.otaUpdateAvailable`, `.otaStartAck`, or `.otaStatus`. Microphone audio callbacks use `MicPcmEvent` and `MicLc3Event` objects with the same metadata as React Native.
+Android and iOS expose typed callbacks/delegate methods instead of the React Native string event API. Android uses `MentraBluetoothSdkListener` methods such as `onStateChanged`, `onGlassesChanged`, `onSdkStateChanged`, `onScanChanged`, `onDeviceDiscovered`, `onButtonPress`, `onSpeakingStatus`, `onPhotoResponse`, `onPhotoStatus`, `onMicPcm`, `onStreamStatus`, and `onOtaStatus`. iOS uses `MentraBluetoothSDKDelegate` methods such as `mentraBluetoothSDK(_:didUpdate:)`, `mentraBluetoothSDK(_:didUpdateGlasses:)`, `mentraBluetoothSDK(_:didUpdateSdkState:)`, `mentraBluetoothSDK(_:didUpdateScan:)`, `mentraBluetoothSDK(_:didDiscover:)`, `mentraBluetoothSDK(_:didReceive:)`, `mentraBluetoothSDK(_:didReceiveMicPcm:)`, and `mentraBluetoothSDK(_:didReceiveMicLc3:)`; OTA install progress arrives through `didReceive` as `.otaStartAck` or `.otaStatus`. Microphone audio callbacks use `MicPcmEvent` and `MicLc3Event` objects with the same metadata as React Native.
 
 | Event area | Examples |
 | --- | --- |
 | Input | Button press, touch, swipe, head-up |
 | Device state | Battery, case, Wi-Fi, hotspot, connection, RSSI |
-| Camera | Photo request result, gallery state, camera settings |
+| Camera | Photo request result, camera warm-up state, gallery state, camera settings |
 | Streaming | Stream initializing, active, stopped, error |
 | OTA | Update available, start acknowledged, step/progress status |
 | Audio | Microphone PCM, LC3, local transcription, audio route state |

--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -15,8 +15,6 @@ Photo upload sends a JPEG from supported glasses to a webhook URL. In the starte
 
 ```ts
 const photo = await BluetoothSdk.requestPhoto({
-  requestId: `photo-${Date.now()}`,
-  appId: 'com.example.app',
   size: 'medium',
   webhookUrl: 'https://api.example.com/mentra/photo',
   authToken: 'optional-token',
@@ -34,8 +32,6 @@ console.log('photo delivered', photo.photoUrl ?? photo.uploadUrl);
 ```kotlin
 val photo = sdk.requestPhoto(
     PhotoRequest(
-        requestId = "photo-${System.currentTimeMillis()}",
-        appId = "com.example.app",
         size = PhotoSize.MEDIUM,
         webhookUrl = "https://api.example.com/mentra/photo",
         authToken = "optional-token",
@@ -54,8 +50,6 @@ println("photo delivered: ${photo.requestId}")
 ```swift
 let photo = try await sdk.requestPhoto(
     PhotoRequest(
-        requestId: "photo-\(Date().timeIntervalSince1970)",
-        appId: "com.example.app",
         size: .medium,
         webhookUrl: "https://api.example.com/mentra/photo",
         authToken: "optional-token",
@@ -73,9 +67,33 @@ print("photo delivered: \(photo.requestId)")
 
 `requestPhoto(...)` resolves when the full photo action reaches terminal success: capture completed and the JPEG was delivered to the webhook, either directly from the glasses over Wi-Fi or through the phone's Bluetooth fallback relay. It rejects or throws when the glasses report a terminal `photo_response` error, when phone-side fallback upload fails, when the SDK cannot send the command, or when no terminal response arrives before the command timeout. Use `photo_status` for intermediate progress such as `accepted`, `configuring`, `capturing`, `captured`, `uploading`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring`; `photo_response` is the final success/error result. The returned success includes `uploadUrl`, and may include webhook-returned metadata such as `photoUrl`, `statusUrl`, `contentType`, or `fileSizeBytes`.
 
-The webhook should accept multipart form data with a `photo` file and `requestId`. If `authToken` is provided, the uploader adds `Authorization: Bearer <token>`. The camera light is always enabled for photo capture.
+The webhook should accept multipart form data with a `photo` file and `requestId`. The SDK generates a unique photo `requestId` when you omit one; pass your own only when your app needs to know it before the terminal response, such as when polling a predictable `/uploads/<requestId>.json` endpoint. If `authToken` is provided, the uploader adds `Authorization: Bearer <token>`. The capture light is always enabled for photo, video, and stream capture as a privacy indicator.
 
 For one-shot manual capture tuning, pass `exposureTimeNs` and `iso` together. `exposureTimeNs` is sensor exposure time in nanoseconds; `iso` is sensor ISO. If `exposureTimeNs` is omitted, `null` / `nil`, invalid, or unsupported by the connected glasses, the camera uses auto exposure and ignores `iso`.
+
+### Photo Parameters
+
+`requestPhoto(...)` is a one-shot request. Its capture fields apply only to that request and do not change the action-button photo defaults used by gallery mode.
+
+| Parameter | Applies to | Behavior |
+| --- | --- | --- |
+| `requestId` | React Native, Android, iOS | Optional ID used to correlate status and final response events. The SDK generates one when omitted or blank. |
+| `size` | React Native, Android, iOS | JPEG size tier: `low`, `medium`, `high`, or `max`. |
+| `webhookUrl` | React Native, Android, iOS | Upload URL that receives the multipart `photo` file and `requestId`. |
+| `authToken` | React Native, Android, iOS | Optional bearer token for the upload request. Omit it or pass `null` / `nil` to send no `Authorization` header. |
+| `compress` | React Native, Android, iOS | Upload compression: `none`, `medium`, or `heavy`. Omitted native values default to `none`. |
+| `save` | React Native, Android, iOS | Keeps the captured photo in the glasses gallery after delivery when `true`. When `false`, the photo is only used for the requested delivery. Defaults to `false`. |
+| `sound` | React Native, Android, iOS | Plays the shutter sound when `true`; defaults to `true`. |
+| `exposureTimeNs` | React Native, Android, iOS | Optional manual sensor exposure time in nanoseconds. Omit or pass `null` / `nil` for auto exposure. |
+| `iso` | React Native, Android, iOS | Optional manual ISO. Used only when `exposureTimeNs` enables manual exposure. |
+| `aeExposureDivisor` | React Native, Android, iOS | Optional scan-style auto-exposure divisor. Values must be greater than `1`. |
+| `isoCap` | React Native, Android, iOS | Optional scan-style ISO cap. Values must be greater than `0`. |
+| `mfnr` | React Native, Android, iOS | Optional per-request multi-frame noise reduction preference. |
+| `zsl` | React Native, Android, iOS | Optional per-request zero-shutter-lag preference. |
+| `noiseReduction` | React Native, Android, iOS | Optional per-request noise-reduction preference. Some firmware may report that this tuning is not implemented. |
+| `edgeEnhancement` | React Native, Android, iOS | Optional per-request edge-enhancement preference. Some firmware may report that this tuning is not implemented. |
+| `ispDigitalGain` | React Native, Android, iOS | Optional per-request ISP digital gain hint. Some firmware may report that this tuning is not implemented. |
+| `ispAnalogGain` | React Native, Android, iOS | Optional per-request ISP analog gain hint. Some firmware may report that this tuning is not implemented. |
 
 Listen for `photo_status` to render progress and inspect the effective settings the glasses used:
 
@@ -106,9 +124,57 @@ useBluetoothEvent('photo_status', (event) => {
 
 Upload and BLE transfer statuses such as `uploading`, `compressing`, `ble_fallback_compression`, `ready_for_transfer`, and `transferring` are transport progress only. They do not carry capture metadata, so use the `captured` event when you need the actual exposure/ISO/frame data for debugging or UI. `ble_fallback_compression` means the direct Wi-Fi/webhook upload failed and the glasses are compressing the already-captured photo for Bluetooth fallback delivery.
 
+## Camera Warm-Up
+
+Use `warmUpCamera(...)` when your UI is about to offer photo capture and you want the next same-configuration `requestPhoto(...)` to skip most of the camera open/configure latency. A warm-up opens and configures the Mentra Live camera with the same size and optional manual exposure path as a photo request, starts preview/AE settling, and holds that session warm for a short TTL without taking a photo or uploading media. Because warm-up does not capture or transmit media, it does not pulse the capture light; photo, video, and stream capture still enable the light as the privacy indicator.
+
+In foreground camera UI, call warm-up when the screen or tab becomes active, then refresh it before the TTL expires. The starter apps use a `30_000ms` warm-up and refresh about every `20_000ms` while the Camera tab is foreground.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+await BluetoothSdk.warmUpCamera({
+  size: 'medium',
+  exposureTimeNs: null,
+  durationMs: 30_000,
+});
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+sdk.warmUpCamera(
+    size = PhotoSize.MEDIUM,
+    exposureTimeNs = null,
+    durationMs = 30_000,
+)
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+try await sdk.warmUpCamera(
+    size: .medium,
+    exposureTimeNs: nil,
+    durationMs: 30_000
+)
+```
+
+  </Tab>
+</Tabs>
+
+`warmUpCamera(...)` returns the matching `camera_status` `ready` event. It throws or rejects when the glasses send `camera_status` `error`, when the command cannot be sent, or when the response times out. Listen for `camera_status` if you want progress events: `warming` means the warm-up was accepted, `ready` means the camera is open/configured for reuse, `stopped` means the warm lease expired or the camera closed, and `error` includes `errorCode` / `errorMessage` when available.
+
+The `stopped` event is not a promise settlement; it is the lifecycle end for a warm lease that already reached `ready`. If multiple callers warmed or refreshed the same camera session and received `ready`, each request ID receives its own `stopped` event when that lease expires or the camera service tears down. If the camera service tears down before a warm-up reaches `ready`, the pending warm-up rejects with `error` instead.
+
+Warm-up reuse is configuration-sensitive: the next photo should use the same `size` and `exposureTimeNs` value. A different size or manual-exposure setting may force the camera to reconfigure. If video recording or streaming already owns the camera, warm-up reports `ready` immediately because the camera is already active. If a photo capture, Bluetooth transfer, camera restart, or another warm-up is in flight, the glasses may report a retryable `camera_busy`, `photo_capture_in_progress`, `ble_transfer_in_progress`, or `camera_restart_cooldown` error; retry on the next foreground refresh rather than blocking capture UI. If a `requestPhoto(...)` arrives while warm-up is opening the session, the glasses finish parking the warm session first, then dispatch the queued photo on that same warm camera configuration.
+
 ## Video Recording
 
-Use `startVideoRecording(...)` when your app needs a clip instead of a still image. Pass per-recording settings only when you want to override the saved button-video defaults; `maxRecordingTimeMinutes` is an auto-stop guard, and `0` or an omitted value records until your app stops recording or the glasses interrupt it.
+Use `startVideoRecording(...)` when your app needs a clip instead of a still image. Pass per-recording settings only when you want to override the saved video recording defaults; `maxRecordingTimeMinutes` is an auto-stop guard, and `0` or an omitted value records until your app stops recording or the glasses interrupt it.
 
 <Tabs>
   <Tab title="React Native">
@@ -200,9 +266,9 @@ Mentra Live has gallery mode for the right action button. When gallery mode is e
 
 ```ts
 await BluetoothSdk.setGalleryModeEnabled(true);
-await BluetoothSdk.setButtonPhotoSettings('medium');
-await BluetoothSdk.setButtonVideoRecordingSettings(1280, 720, 30);
-await BluetoothSdk.setButtonMaxRecordingTime(3);
+await BluetoothSdk.setPhotoCaptureDefaults({size: 'medium'});
+await BluetoothSdk.setVideoRecordingDefaults({width: 1280, height: 720, fps: 30});
+await BluetoothSdk.setMaxVideoRecordingDuration(3);
 const cameraFov = await BluetoothSdk.setCameraFov({fov: 102, roiPosition: 'center'});
 console.log(`Camera ready at ${cameraFov.fov}°`);
 ```
@@ -212,9 +278,9 @@ console.log(`Camera ready at ${cameraFov.fov}°`);
 
 ```kotlin
 sdk.setGalleryModeEnabled(true)
-sdk.setButtonPhotoSettings(size = ButtonPhotoSize.MEDIUM)
-sdk.setButtonVideoRecordingSettings(width = 1280, height = 720, fps = 30)
-sdk.setButtonMaxRecordingTime(minutes = 3)
+sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size = PhotoSize.MEDIUM))
+sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width = 1280, height = 720, fps = 30))
+sdk.setMaxVideoRecordingDuration(minutes = 3)
 val cameraFov = sdk.setCameraFov(CameraFov(fov = 102, roiPosition = CameraRoiPosition.CENTER))
 println("Camera ready at ${cameraFov.fov}°")
 ```
@@ -224,9 +290,9 @@ println("Camera ready at ${cameraFov.fov}°")
 
 ```swift
 try await sdk.setGalleryModeEnabled(true)
-try await sdk.setButtonPhotoSettings(size: .medium)
-try await sdk.setButtonVideoRecordingSettings(width: 1280, height: 720, fps: 30)
-try await sdk.setButtonMaxRecordingTime(minutes: 3)
+try await sdk.setPhotoCaptureDefaults(PhotoCaptureDefaults(size: .medium))
+try await sdk.setVideoRecordingDefaults(VideoRecordingDefaults(width: 1280, height: 720, fps: 30))
+try await sdk.setMaxVideoRecordingDuration(minutes: 3)
 let cameraFov = try await sdk.setCameraFov(CameraFov(fov: 102, roiPosition: .center))
 print("Camera ready at \(cameraFov.fov)°")
 ```
@@ -237,6 +303,23 @@ print("Camera ready at \(cameraFov.fov)°")
 Use `setGalleryModeEnabled(false)` when you want the action button to report events without triggering local gallery capture while the glasses are connected.
 
 Action-button photos emitted by the glasses use the same `photo_status` metadata shape when the phone SDK is connected. These local captures report `resolvedConfig.source: "button"` and `resolvedConfig.transferMethod: "local"`, then expose `requestedCaptureConfig` / `meteredPreview` on `capturing` and `captureMetadata` on `captured`.
+
+`setPhotoCaptureDefaults(...)` controls action-button photo defaults. Omitted fields leave the existing defaults unchanged. Pass `resetCaptureTuning: true` to restore the optional tuning fields to standard capture behavior; this does not change photo size unless you also pass `size`. If you include other fields in the same call, those fields become the new defaults after the reset.
+
+| Default field | Behavior |
+| --- | --- |
+| `size` | Action-button photo size tier: `low`, `medium`, `high`, or `max`. |
+| `mfnr` | Multi-frame noise reduction preference for action-button photos. |
+| `zsl` | Zero-shutter-lag preference for action-button photos. |
+| `noiseReduction` | Noise-reduction preference for action-button photos. |
+| `edgeEnhancement` | Edge-enhancement preference for action-button photos. |
+| `ispDigitalGain` | ISP digital gain hint for action-button photos. |
+| `ispAnalogGain` | ISP analog gain hint for action-button photos. |
+| `aeExposureDivisor` | Scan-style auto-exposure divisor for action-button photos. Values must be greater than `1`. |
+| `isoCap` | Scan-style ISO cap for action-button photos. Values must be greater than `0`. |
+| `compress` | Upload compression for action-button photos: `none`, `medium`, or `heavy`. |
+| `sound` | Shutter sound preference for action-button photos. |
+| `resetCaptureTuning` | Restores optional tuning fields to standard capture behavior before applying any fields included in the same call. |
 
 `setCameraFov` accepts FOV degrees from 62 to 118 and ROI position `"center"`, `"bottom"`, or `"top"` on React Native, `CameraRoiPosition` on Android, and `CameraRoiPosition` on iOS. React Native also accepts `{preset: "narrow" | "standard" | "wide"}`; presets map to 82, 102, and 118 degrees with center ROI. On Mentra Live, applying FOV/ROI restarts the camera; the returned `CameraFovResult` resolves from the ASG client only when the setting has been applied to camera hardware after the restart cooldown, and the promise rejects on glasses-side error, persist-only/no hardware-application ack, or timeout. Treat FOV as a framing/ROI control; output resolution and effective detail can vary by capture path, firmware, and camera mode.
 
@@ -254,6 +337,7 @@ await BluetoothSdk.startStream({
   type: 'start_stream',
   streamUrl: 'http://192.168.1.42:8889/mentra-live/whip',
   streamId,
+  video: {fps: 15},
 });
 
 await BluetoothSdk.stopStream();
@@ -269,6 +353,7 @@ sdk.startStream(
     StreamRequest(
         streamUrl = "http://192.168.1.42:8889/mentra-live/whip",
         streamId = streamId,
+        video = StreamVideoConfig(fps = 15),
     )
 )
 
@@ -284,7 +369,8 @@ let streamId = "stream-\(Date().timeIntervalSince1970)"
 try await sdk.startStream(
     StreamRequest(
         streamUrl: "http://192.168.1.42:8889/mentra-live/whip",
-        streamId: streamId
+        streamId: streamId,
+        video: StreamVideoConfig(fps: 15)
     )
 )
 
@@ -336,8 +422,6 @@ const uploadSubscription = MentraPhotoReceiver.addListener('photoUpload', (event
 
 try {
   const photo = await BluetoothSdk.requestPhoto({
-    requestId: `photo-${Date.now()}`,
-    appId: 'com.example.app',
     size: 'medium',
     webhookUrl: receiver.uploadUrl,
     authToken: null,

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -16,7 +16,7 @@ cd Mentra-Bluetooth-SDK-Starter-Kit
 - Scanning for Mentra Live, connecting, disconnecting, and reconnecting to a saved/default device.
 - Reading typed glasses and Bluetooth status snapshots.
 - Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, video upload, audio, and SDK log events.
-- Controlling Mentra Live features such as gallery mode, button photo/video settings, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
+- Controlling Mentra Live features such as gallery mode, photo capture defaults, video recording defaults, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.
 - Running the default glasses-to-phone photo and streaming demos, plus optional cloud-server demos for external media upload and streaming endpoints.
 
 ## Android

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.12` or newer, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.18`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.12"
+  from: "0.1.18"
 )
 ```
 

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.12")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Use version `0.1.12` or newer, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.12"
+  from: "0.1.18"
 )
 ```
 

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -22,7 +22,7 @@ icon: "circle-question"
 
 ## iOS Swift Package Resolution Fails
 
-Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves version `0.1.12` or newer. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
+Check that your iOS deployment target is at least `15.1`, that the package URL is `https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git`, and that Xcode resolves the selected SDK version. If Xcode has stale package state, reset package caches and resolve packages again from Xcode.
 
 If your app also uses Firebase with static frameworks, Firebase modular header configuration belongs in your app, not in the Bluetooth SDK.
 


### PR DESCRIPTION
## Summary
- Sync `docs/mentra-live/` on `frozen-docs` from `origin/dev:mintlify-docs/mentra-live/`.
- Release the Mentra Live docs updates for SDK `0.1.18`.
- Keep the existing frozen-docs navigation and `mentra-live/overview` route shape unchanged.

## Notable content updates
- Updates Android and iOS install snippets to SDK `0.1.18`.
- Documents camera warm-up, photo capture defaults, and gallery-mode default setting APIs.
- Adds stream video `fps` examples and clarifies resolved stream status fields.
- Refreshes OTA wording around `checkForOtaUpdate()` / `startOtaUpdate()` behavior.

## Validation
- `diff -ru /tmp/mentra-live-dev-tree/mintlify-docs/mentra-live docs/mentra-live`
- `git diff --check`
- `git diff --cached --check`
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8')); console.log('docs/docs.json ok')"`
- `bunx --bun mint export --output /tmp/mentraos-frozen-mentra-live-release.zip`
- Inspected exported nav: `Mentra Live => /mentra-live/overview`
- Inspected exported page: `mentra-live/overview/index.html` title is `Mentra Live - MentraOS`

Note: the frozen-docs export still reports the pre-existing parser warnings in `docs/LC3-BITRATE-UPGRADE-PLAN.md` and `docs/issues/docs-overhaul/spec.md`; export exits successfully.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Mintlify MDX under `docs/mentra-live/` with no application or SDK code; risk is doc accuracy for integrators migrating from older API names.
> 
> **Overview**
> Syncs **`docs/mentra-live/`** on frozen-docs to the dev Mentra Live docs set and pins install snippets to Bluetooth SDK **`0.1.18`** (Android Maven, iOS SwiftPM, quickstart).
> 
> The API reference and camera/streaming guides are expanded for **0.1.18** behavior: **`warmUpCamera`** and **`camera_status`** lifecycle, renamed gallery defaults (**`setPhotoCaptureDefaults`**, **`setVideoRecordingDefaults`**, **`setMaxVideoRecordingDuration`**), optional auto-generated photo **`requestId`**, richer **`requestPhoto`** tuning docs, and stream **`video.fps`** examples plus **`resolvedConfig.video.fps`** in status.
> 
> **OTA** docs now describe phone-side manifest checks via **`checkForOtaUpdate()`** returning a **boolean** (no public **`ota_update_available`** event / **`retryOtaVersionCheck`**). Examples and troubleshooting wording are updated to match; site nav is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f5a8aee28beb3734138589baa1131663d2559c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->