### PR TITLE
Fix faint "@" showing in empty home screen grid slots

### DIFF
--- a/mobile/src/components/home/AppsGrid.tsx
+++ b/mobile/src/components/home/AppsGrid.tsx
@@ -784,6 +784,13 @@ export function AppsGrid({
 
   const renderItem = useCallback(
     ({item}: {item: MasonryAppItem}) => {
+      // Synthetic @empty slots exist only to pad the grid / hold drag positions.
+      // Render them as blank spacers: an AppIcon with an empty logoUrl falls back
+      // to the first-letter tile, which paints a faint "@" (from "@emptyN") in
+      // every unoccupied slot.
+      if (item.packageName.startsWith("@empty")) {
+        return <View className="flex-1" />
+      }
       return (
         <TouchableOpacity
           ref={(ref) => {


### PR DESCRIPTION
## Scope

Empty slots on the home screen grid (and the all-apps sheet) started showing a faint "@" glyph in a dim gray tile. Regression from #3272.

## Root cause

#3272 added a letter-fallback to `AppIcon`: when an icon image fails to load, it renders a gray tile with the first character of `app.name || app.packageName`.

The home grid pads itself with synthetic placeholder apps (`DUMMY_APPLET` with `packageName: "@emptyN"`, empty `name`/`logoUrl`) so apps can be dragged into any slot. Their `logoUrl: ""` makes `AppIcon` render `<Image source={{uri: ""}}>`, which now fires the new `onError` handler → letter fallback → first char of `"@emptyN"` = **"@"**, faded to 15% opacity because dummies carry no `compatibility` field. Before #3272 the failed empty image just rendered nothing, so the slots looked empty.

## Fix

`AppsGrid.renderItem` now skips `AppIcon` entirely for `@empty` items and renders a blank spacer — the same guard `BackgroundAppsGrid` already uses for its placeholder cells (`if (!item.name) return <View/>`). Slot geometry is unchanged (the masonry list forces item height from data), and `@empty` items were already inert to press/long-press, so drag/reorder behavior is untouched.

The letter fallback itself is left as-is for real apps with broken/missing icons.

## Testing

- `bun compile` (tsc) passes.
- eslint doesn't run in this workspace (root `eslint.config.mjs` deps not installed); the pre-existing prettier warning on this file is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single render-path guard for dummy grid items; drag geometry and real app icon behavior are unchanged.
> 
> **Overview**
> Fixes a regression where empty home screen and all-apps grid slots showed a faint **"@"** on a dim tile.
> 
> **`AppsGrid.renderItem`** now treats synthetic `@empty*` placeholder items as layout-only spacers and returns a blank `<View className="flex-1" />` instead of mounting **`AppIcon`**. Those dummies still occupy masonry slots for drag/reorder, but their empty `logoUrl` was triggering **`AppIcon`**’s letter fallback (first character of `"@emptyN"`). Real apps with broken icons are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f844c6fb85eb1c51098a1a2a1e1dc97956e3eeb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix faint "@" glyphs showing in empty slots on the home grid and all-apps sheet. Skip AppIcon for `@empty` placeholder items and render a blank spacer instead, preserving layout and drag/reorder behavior.

<sup>Written for commit f844c6fb85eb1c51098a1a2a1e1dc97956e3eeb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

