### PR TITLE
Block incompatible miniapps from foregrounding their webview

### DIFF
--- a/mobile/src/components/home/AppsGrid.tsx
+++ b/mobile/src/components/home/AppsGrid.tsx
@@ -671,6 +671,15 @@ export function AppsGrid({
   const handlePress = async (app: ClientApp) => {
     if (app.packageName.includes("@empty")) return // ignore dummy apps
 
+    // Hardware-incompatible apps must not foreground the overlay or prompt for
+    // permissions — startApplet's beforeStart gate shows the incompatible alert
+    // and rejects the launch. Foregrounding first would open the miniapp
+    // WebView underneath that alert (same predicate as the beforeStart gate).
+    if (!app.compatibility?.isCompatible) {
+      startApplet(app)
+      return
+    }
+
     // Overlay-hosted app types (local miniapps + offline-hosted built-ins) get
     // their splash painted by foregrounding the Compositor overlay. Other types
     // navigate via routes inside startApplet, so we leave their flow untouched.


### PR DESCRIPTION
## Scope

Tapping a hardware-incompatible miniapp (e.g. Teleprompter while Mentra Live is the connected wearable) showed the "Hardware Incompatible" alert — but the miniapp WebView opened behind it and stayed open after dismissing the alert.

**Root cause:** `AppsGrid.handlePress` foregrounds overlay-hosted apps (local miniapps + offline-hosted built-ins) via `setForeground()` *before* `startApplet()` runs the `beforeStart` compatibility gate in `MiniappCatalog`. The gate correctly rejects the launch and shows the alert, but by then the Compositor overlay has already mounted the WebView, and nothing tears it down.

**Fix:** `handlePress` now bails out early — before the permission check and before `setForeground` — when the app fails the same `!app.compatibility?.isCompatible` predicate the `beforeStart` gate uses. `startApplet` still runs, so the existing gate shows the right alert (hardware incompatible / glasses required) and rejects the launch with nothing painted behind it. The all-apps sheet also stays open now (previously `onOpenApp` closed it despite nothing launching).

Side benefit: incompatible apps no longer trigger a permission prompt ahead of an alert saying they can't run.

**Not touched:**
- `beforeStart` gate itself — unchanged, still the source of truth.
- Popover "Start" action — already goes through the gate before any navigation.
- AppSwitcher — only lists active apps, which can't have passed the gate while incompatible.
- Apps with no hardware requirements (Settings, Store, …) always report compatible, so offline built-ins still open when no glasses are paired.

## Test evidence

- `bun compile` (tsc) clean.
- Prettier clean on the added lines (the one pre-existing unformatted import line in the file was left untouched).
- No existing Jest coverage of AppsGrid press flow; the change is a guard using the exact predicate the launch gate already enforces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single guard on home grid press flow; launch gate unchanged and compatible apps follow the same path as before.
> 
> **Overview**
> Fixes a tap on a **hardware-incompatible** miniapp (e.g. Teleprompter with the wrong wearable) showing the correct alert while the **Compositor overlay still mounted the miniapp WebView** underneath and left it open after dismiss.
> 
> **`AppsGrid.handlePress`** now returns early when `!app.compatibility?.isCompatible` — the same check the **`beforeStart`** launch gate uses. It only calls **`startApplet(app)`**, so the gate still shows the incompatible / glasses-required alert and rejects the launch **without** calling **`setForeground`**, **`checkPermissionsUI`**, or **`onOpenApp`** first.
> 
> Compatible apps keep the existing order: permissions, then overlay foreground for local/offline-hosted apps, then start and sheet close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43087db604f4b3b6c48d3a6cec48de2cc2bdebda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent hardware-incompatible miniapps from foregrounding their WebView. The grid now checks compatibility before foregrounding and lets the existing launch gate show the alert and cancel the start.

- **Bug Fixes**
  - In `AppsGrid.handlePress`, bail out on `!app.compatibility?.isCompatible`; still call `startApplet(app)` so `beforeStart` shows the correct alert without painting the overlay.
  - No permission prompt and the all‑apps sheet stays open when incompatible; other flows (popover Start, AppSwitcher, apps with no hardware needs) are unchanged.

<sup>Written for commit 43087db604f4b3b6c48d3a6cec48de2cc2bdebda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

