### PR TITLE
Fix WiFi scan showing no results and timing out on Mentra Live

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -67,6 +67,7 @@ class MentraBluetoothSdk private constructor(
         private val SCAN_STATE_KEYS = setOf("searching", "searchingController", "searchResults")
         private const val DEFAULT_SCAN_TIMEOUT_MS = 15_000L
         private const val DEFAULT_REQUEST_TIMEOUT_MS = 15_000L
+        private const val WIFI_SCAN_TIMEOUT_MS = 20_000L
         private const val VIDEO_UPLOAD_STOP_TIMEOUT_MS = 10 * 60 * 1000L
         private const val STREAM_START_TIMEOUT_MS = 30_000L
         private const val STREAM_STOP_TIMEOUT_MS = 15_000L
@@ -633,35 +634,35 @@ class MentraBluetoothSdk private constructor(
     fun requestWifiScan(): List<WifiScanResult> {
         val pending = PendingResponse<List<WifiScanResult>>("WiFi scan request")
         val request = PendingWifiScan(pending)
-        synchronized(oneShotLock) {
-            if (pendingWifiScan != null) {
-                throw BluetoothSdkException(
-                    "request_in_flight",
-                    "A WiFi scan is already waiting for a glasses response.",
-                )
+        val existing =
+            synchronized(oneShotLock) {
+                pendingWifiScan ?: run {
+                    pendingWifiScan = request
+                    null
+                }
             }
-            pendingWifiScan = request
+        if (existing != null) {
+            // Join the in-flight scan instead of failing with request_in_flight;
+            // the scan screen auto-starts a scan on mount and can be pushed twice.
+            return existing.pending.await(WIFI_SCAN_TIMEOUT_MS)
         }
         try {
             deviceManager.requestWifiScan()
-            return pending.await()
-        } catch (error: BluetoothSdkException) {
-            if (error.code == "request_timeout") {
-                val fallbackResults =
-                    synchronized(oneShotLock) {
-                        if (request.latestResults.isNotEmpty()) {
-                            if (pendingWifiScan === request) {
-                                pendingWifiScan = null
-                            }
-                            request.latestResults
-                        } else {
-                            emptyList()
-                        }
-                    }
+            // The glasses wait up to 15s for scan-results broadcasts before sending
+            // scan_complete, so give them longer than that before falling back.
+            return pending.await(WIFI_SCAN_TIMEOUT_MS)
+        } catch (error: Throwable) {
+            if (error is BluetoothSdkException && error.code == "request_timeout") {
+                val fallbackResults = synchronized(oneShotLock) { request.latestResults }
                 if (fallbackResults.isNotEmpty()) {
+                    // Resolve so callers joined on the same scan get the fallback too.
+                    pending.resolve(fallbackResults)
                     return fallbackResults
                 }
             }
+            // Fail joined callers immediately instead of letting them run out their
+            // own timeout.
+            pending.reject(error)
             throw error
         } finally {
             synchronized(oneShotLock) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -148,6 +148,7 @@ private final class PendingResponse<T> {
 
 @MainActor
 public final class MentraBluetoothSDK {
+    private static let wifiScanTimeoutMs = 20_000
     private static let otaBesVersionWaitMs = 5_000
     private static let otaMtkVersionWaitMs = 2_000
     private static let otaVersionPollMs = 100
@@ -180,6 +181,7 @@ public final class MentraBluetoothSDK {
     private var pendingOtaQuery: PendingResponse<OtaQueryResult>?
     private var pendingOtaStart: PendingResponse<OtaStartAckEvent>?
     private var pendingWifiScan: PendingWifiScan?
+    private var wifiScanTask: Task<[WifiScanResult], Error>?
     private var pendingWifiStatus: PendingWifiStatusRequest?
     private var pendingHotspotStatus: PendingHotspotStatusRequest?
     private var pendingVersionInfo: PendingResponse<VersionInfoResult>?
@@ -664,37 +666,38 @@ public final class MentraBluetoothSDK {
     }
 
     public func requestWifiScan() async throws -> [WifiScanResult] {
-        guard pendingWifiScan == nil else {
-            throw BluetoothSdkError(
-                code: "request_in_flight",
-                message: "A WiFi scan is already waiting for a glasses response."
-            )
+        if let existing = wifiScanTask {
+            // Join the in-flight scan instead of failing with request_in_flight;
+            // the scan screen auto-starts a scan on mount and can be pushed twice.
+            return try await existing.value
         }
         let pending = PendingResponse<[WifiScanResult]>(operation: "WiFi scan request")
         let request = PendingWifiScan(pending: pending)
         pendingWifiScan = request
         DeviceManager.shared.requestWifiScan()
-        do {
-            let results = try await pending.wait()
-            if pendingWifiScan?.pending === pending {
-                pendingWifiScan = nil
+        let task = Task { @MainActor [weak self] () async throws -> [WifiScanResult] in
+            defer {
+                if let self {
+                    if self.pendingWifiScan === request {
+                        self.pendingWifiScan = nil
+                    }
+                    self.wifiScanTask = nil
+                }
             }
-            return results
-        } catch {
-            let fallbackResults: [WifiScanResult]
-            if (error as? BluetoothSdkError)?.code == "request_timeout" {
-                fallbackResults = request.latestResults
-            } else {
-                fallbackResults = []
+            do {
+                // The glasses wait up to 15s for scan-results broadcasts before sending
+                // scan_complete, so give them longer than that before falling back.
+                return try await pending.wait(timeoutMs: MentraBluetoothSDK.wifiScanTimeoutMs)
+            } catch {
+                if (error as? BluetoothSdkError)?.code == "request_timeout",
+                   !request.latestResults.isEmpty {
+                    return request.latestResults
+                }
+                throw error
             }
-            if pendingWifiScan?.pending === pending {
-                pendingWifiScan = nil
-            }
-            if !fallbackResults.isEmpty {
-                return fallbackResults
-            }
-            throw error
         }
+        wifiScanTask = task
+        return try await task.value
     }
 
     public func sendWifiCredentials(ssid: String, password: String) async throws -> WifiStatusEvent {

--- a/mobile/src/app/wifi/scan.tsx
+++ b/mobile/src/app/wifi/scan.tsx
@@ -1,6 +1,6 @@
 import BluetoothSdk, {WifiSearchResult} from "@mentra/bluetooth-sdk"
 import {useFocusEffect} from "expo-router"
-import {useCallback, useEffect, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 import {ActivityIndicator, ScrollView, TouchableOpacity, View} from "react-native"
 import Toast from "react-native-toast-message"
 
@@ -22,6 +22,8 @@ export default function WifiScanScreen() {
   const {theme} = useAppTheme()
 
   const [networks, setNetworks] = useState<WifiSearchResult[]>([])
+  const networksRef = useRef(networks)
+  networksRef.current = networks
   const [savedNetworks, setSavedNetworks] = useState<string[]>([])
   const [isScanning, setIsScanning] = useState(true)
   const connectedWifi = useGlassesStore((state) => (state.wifi.state === "connected" ? state.wifi : null))
@@ -73,7 +75,24 @@ export default function WifiScanScreen() {
   useEffect(() => {
     refreshSavedNetworks()
     startScan()
+
+    // The glasses stream networks one by one while the scan runs; show them as
+    // they arrive instead of waiting for the final requestWifiScan() result.
+    const sub = BluetoothSdk.addListener("wifi_scan_result", (event) => {
+      if (event.networks.length > 0) {
+        setNetworks(mapNetworks(event.networks))
+      }
+    })
+    return () => sub.remove()
   }, [refreshSavedNetworks])
+
+  const mapNetworks = (scanResults: WifiSearchResult[]): WifiSearchResult[] =>
+    scanResults.map((network) => ({
+      ssid: network.ssid || "",
+      requiresPassword: network.requiresPassword !== false,
+      signalStrength: network.signalStrength || -100,
+      frequency: network.frequency,
+    }))
 
   const startScan = async () => {
     console.log("WIFI_SCAN: ========= STARTING NEW WIFI SCAN =========")
@@ -83,22 +102,19 @@ export default function WifiScanScreen() {
     try {
       const scanResults = await BluetoothSdk.requestWifiScan()
       console.log(`WIFI_SCAN: Received ${scanResults.length} WiFi scan results`)
-      setNetworks(
-        scanResults.map((network) => ({
-          ssid: network.ssid || "",
-          requiresPassword: network.requiresPassword !== false,
-          signalStrength: network.signalStrength || -100,
-          frequency: network.frequency,
-        })),
-      )
+      setNetworks(mapNetworks(scanResults))
       setIsScanning(false)
     } catch (error) {
       console.error("WIFI_SCAN: Error scanning for WiFi networks:", error)
       setIsScanning(false)
-      Toast.show({
-        type: "error",
-        text1: "Failed to scan for WiFi networks",
-      })
+      // Networks that streamed in before the failure are still shown; only
+      // surface the error when the user would otherwise see an empty list.
+      if (networksRef.current.length === 0) {
+        Toast.show({
+          type: "error",
+          text1: "Failed to scan for WiFi networks",
+        })
+      }
     }
   }
 
@@ -241,18 +257,23 @@ export default function WifiScanScreen() {
 
         {/* Content - flex-1 makes it take remaining space, flex-shrink allows it to shrink */}
         <View className="flex-1 flex-shrink min-h-0 pb-4">
-          {isScanning ? (
-            <View className="flex-1 justify-center items-center py-12">
-              <ActivityIndicator size="large" color={theme.colors.foreground} />
-              <Text className="mt-4 text-base text-text-dim" tx="wifi:scanningForNetworks" />
-            </View>
-          ) : networks.length > 0 ? (
+          {networks.length > 0 ? (
             <>
               {/* <Text className="text-sm font-semibold text-text mb-2" tx="wifi:networks" /> */}
               <ScrollView className="flex-1 px-5 -mx-5" contentContainerClassName="pb-4">
                 <Group>{sortedNetworks.map(renderNetworkItem)}</Group>
+                {isScanning && (
+                  <View className="flex-row justify-center items-center py-4">
+                    <ActivityIndicator size="small" color={theme.colors.foreground} />
+                  </View>
+                )}
               </ScrollView>
             </>
+          ) : isScanning ? (
+            <View className="flex-1 justify-center items-center py-12">
+              <ActivityIndicator size="large" color={theme.colors.foreground} />
+              <Text className="mt-4 text-base text-text-dim" tx="wifi:scanningForNetworks" />
+            </View>
           ) : (
             <View className="flex-1 justify-center items-center py-12">
               <Text className="text-base text-text-dim mb-6 text-center" tx="wifi:noNetworksFound" />


### PR DESCRIPTION
## Scope

Fixes incident `def7238d-e20d-42a1-bb62-17eab5a2ed2b` (severity 5): "Scanning for WiFi networks not showing any results. Times out" — iOS 2.12.0 + Mentra Live build 39.

## What the logs showed

- Every real scan resolved at **exactly ~15,000ms** via the `request_timeout` fallback (5 then 2 partial results) — the glasses' `scan_complete: true` never arrived in time. Glasses-side `BaseNetworkManager` waits up to 15s for the scan-results broadcast before sending `scan_complete`, so the phone's 15s deadline always lost the race. In this incident the glasses also flagged "Heartbeat timeout - marking as disconnected" mid-scan, which makes `sendWifiScanResultsOverBleEnhanced` silently drop the completion message.
- The onboarding flow pushed `/wifi/scan` twice; the screen auto-scans on mount, so the second instance's `requestWifiScan()` instantly rejected with `request_in_flight` (surfaced to JS as `ERR_UNEXPECTED`). The visible screen rendered **"No networks found"** while the real results resolved into the buried first instance. Rapid user retries all failed the same way.
- The glasses stream networks one message at a time and the native bridge already emits accumulated `wifi_scan_result` events to JS — but the screen never subscribed, so the user watched a spinner for 15s even though networks were on the phone within ~2s.

## Fix (phone-side only, robust to all firmware)

- **BluetoothSdk iOS/Android**: `requestWifiScan()` now joins an in-flight scan and returns its results instead of throwing `request_in_flight`.
- **BluetoothSdk iOS/Android**: wifi scan wait bumped 15s → 20s so a full glasses-side scan (15s worst case + BLE transit) completes normally instead of always hitting the timeout fallback.
- **Android**: the timeout fallback resolves the shared pending so joined callers get the partial results too; errors reject it so joiners fail fast instead of running out their own timeout.
- **wifi/scan screen**: networks render live as they stream in (`wifi_scan_result` listener), with a small scanning indicator under the list while the scan continues; on error the streamed networks stay visible and the failure toast only shows when the list would be empty.

Net effect: results appear within a couple of seconds of opening the screen, re-entering the screen mid-scan shows the same live results instead of an instant empty state, and slow scans complete with full results instead of partial timeout fallbacks.

## Test evidence

- `bun compile` (tsc) in `mobile/`: clean
- `./scripts/check-android-compile.sh bluetooth-sdk`: BUILD SUCCESSFUL
- `prettier --check` on the edited screen: clean; `swiftc -parse` on the edited Swift file: clean
- Not yet verified on hardware — needs a device pass on the Mentra Live pairing flow (scan, re-enter screen mid-scan, rescan)

Follow-up (not in this PR): glasses-side `sendWifiScanResultsOverBleEnhanced` drops the `scan_complete` message when the transport is transiently marked disconnected; worth queueing/retrying in asg_client.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes concurrent WiFi scan semantics in the native Bluetooth SDK and pairing UI; low security impact but affects a critical onboarding path and shared pending-state behavior on both platforms.
> 
> **Overview**
> Fixes **WiFi scan timeouts and empty results** during Mentra Live pairing when the scan screen mounts twice or the phone’s 15s deadline beat the glasses’ `scan_complete`.
> 
> **`@mentra/bluetooth-sdk` (iOS & Android):** `requestWifiScan()` now **joins an in-flight scan** and returns the same result instead of throwing `request_in_flight`. The wait is **15s → 20s** so a full glasses-side scan can finish before the timeout fallback. On Android, timeout with partial results **resolves the shared pending** (so joined callers get them); failures **reject** joined waiters instead of hanging.
> 
> **`wifi/scan` screen:** Subscribes to **`wifi_scan_result`** and updates the list as networks stream in; shows the list with a small spinner while scanning instead of a full-screen loader until `requestWifiScan()` completes. On scan error, **keeps streamed networks** and only shows the error toast when the list would still be empty.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e5d335020e4fdf8c15d9f25abd2f63025702c19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WiFi scans showing no results and timing out on Mentra Live by joining concurrent scan requests, extending the scan wait to 20s, and streaming results to the UI so networks appear within a few seconds.

- **Bug Fixes**
  - `@mentra/bluetooth-sdk` (iOS/Android): `requestWifiScan()` now joins an in-flight scan; wait increased to 20s; on timeout, return partial results when available; on other errors, joined callers fail fast.
  - Wifi scan screen: subscribes to `wifi_scan_result` and renders networks as they arrive; shows a small spinner while scanning; keeps streamed networks on error and only shows a toast if the list is empty.

<sup>Written for commit 9e5d335020e4fdf8c15d9f25abd2f63025702c19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

