### PR TITLE
Store blobs with mime-derived file extensions

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/blob.mdx
+++ b/mintlify-docs/app-devs/core-concepts/blob.mdx
@@ -62,9 +62,9 @@ const cover = await session.blob.setFromUrl(
 );
 
 // OS file picker. Resolves to BlobMeta, or null if the user cancels.
-const picked = await session.blob.importFile({ mimeType: "application/pdf" });
+const picked = await session.blob.importFile({ mimeType: "audio/wav" });
 if (picked) {
-  await session.speaker.play(picked.uri);
+  await session.speaker.play({ audioUrl: picked.uri });
 }
 ```
 

--- a/mobile/modules/bluetooth-sdk/tsconfig.json
+++ b/mobile/modules/bluetooth-sdk/tsconfig.json
@@ -2,8 +2,7 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build",
-    "rootDir": "./src"
+    "outDir": "./build"
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]

--- a/mobile/modules/island/src/services/BlobStore.ts
+++ b/mobile/modules/island/src/services/BlobStore.ts
@@ -18,8 +18,10 @@
  *   bytes:    Paths.document/mentra_blobs/{userId}/{packageName}/{fileName}
  *   metadata: MMKV key  mentraos_blobmeta_{userId}_{packageName}_{key}  → StoredBlobMeta JSON
  *
- * The on-disk file name is a generated id; the logical `key` (caller-chosen) is
- * the MMKV key. This decouples the filesystem from arbitrary caller keys.
+ * The on-disk file name is a generated id plus a mime-derived extension (iOS
+ * AVPlayer keys a local file's format off the path extension, so blobs played
+ * via `session.speaker.play` must carry one); the logical `key` (caller-chosen)
+ * is the MMKV key. This decouples the filesystem from arbitrary caller keys.
  *
  * expo-file-system's new API is synchronous (create/writeBytes/md5/size), so
  * streaming chunk writes do no async work.
@@ -31,7 +33,7 @@ import {Directory, File, Paths, type FileHandle} from "expo-file-system"
 
 import {MiniappErrorCode} from "@mentra/miniapp"
 import {storage as mmkvStorage} from "../utils/storage/storage"
-import {sanitizeSegment, shareFileName} from "./blobPaths"
+import {sanitizeSegment, shareFileName, withDiskExt} from "./blobPaths"
 
 const LOG_TAG = "LocalMiniappRuntime"
 
@@ -204,6 +206,18 @@ export class BlobStore {
     name: string | undefined,
     extraMeta: Record<string, string | number | boolean> | undefined,
   ) {
+    // Attach a mime-derived extension to the on-disk name. Consumers that key
+    // format off the path — iOS AVPlayer under `session.speaker.play` — cannot
+    // open an extension-less file, even though the bytes are valid.
+    const named = withDiskExt(fileName, mimeType)
+    if (named !== fileName) {
+      try {
+        this.fileFor(packageName, fileName).rename(named)
+        fileName = named
+      } catch {
+        /* keep the extension-less name — the blob still stores and shares fine */
+      }
+    }
     const prior = this.readMeta(packageName, key)
     if (prior && prior.fileName !== fileName) {
       this.deleteFileQuiet(packageName, prior.fileName)
@@ -582,12 +596,13 @@ export class BlobStore {
       })
       return
     }
-    // The on-disk blob name is a generated, extension-less id. react-native-share
-    // derives the shared file's name + extension from the URL's path (its
-    // `filename` option only applies to base64/data payloads, not file:// URLs),
-    // so sharing `file.uri` directly hands the recipient an extension-less file.
-    // Copy to a temp file that carries the real display name + extension, share
-    // that, then clean it up.
+    // The on-disk blob name is a generated id (mime extension attached at
+    // commit; legacy blobs may lack it). react-native-share derives the shared
+    // file's name + extension from the URL's path (its `filename` option only
+    // applies to base64/data payloads, not file:// URLs), so sharing `file.uri`
+    // directly would hand the recipient a machine-named file. Copy to a temp
+    // file that carries the real display name + extension, share that, then
+    // clean it up.
     const shareName = shareFileName(meta)
     // Copy into a per-share unique subdir so two concurrent shares that resolve
     // to the same display name can't clobber each other's temp file while

--- a/mobile/modules/island/src/services/blobPaths.test.ts
+++ b/mobile/modules/island/src/services/blobPaths.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "bun:test"
 
-import {extForMime, sanitizeSegment, shareFileName} from "./blobPaths"
+import {extForMime, sanitizeSegment, shareFileName, withDiskExt} from "./blobPaths"
 
 describe("sanitizeSegment", () => {
   it("keeps safe chars, replaces the rest", () => {
@@ -56,6 +56,20 @@ describe("shareFileName", () => {
     const out = shareFileName({name: "b".repeat(500), fileName: "x", mimeType: "audio/wav"})
     expect(out.length).toBeLessThanOrEqual(120)
     expect(out.endsWith(".wav")).toBe(true)
+  })
+})
+
+describe("withDiskExt", () => {
+  it("attaches the mime-derived extension to a generated id (the Recorder playback case)", () => {
+    // iOS AVPlayer can't open a local file without a path extension, so the
+    // stored WAV must land on disk as *.wav for session.speaker.play to work.
+    expect(withDiskExt("mr46hl98-huglgjvzmt8e", "audio/wav")).toBe("mr46hl98-huglgjvzmt8e.wav")
+  })
+  it("leaves a name that already has an extension untouched", () => {
+    expect(withDiskExt("mr46hl98.wav", "audio/wav")).toBe("mr46hl98.wav")
+  })
+  it("leaves the name untouched when the mime is unknown", () => {
+    expect(withDiskExt("mr46hl98-huglgjvzmt8e", "application/octet-stream")).toBe("mr46hl98-huglgjvzmt8e")
   })
 })
 

--- a/mobile/modules/island/src/services/blobPaths.ts
+++ b/mobile/modules/island/src/services/blobPaths.ts
@@ -12,10 +12,12 @@ export function sanitizeSegment(s: string): string {
 
 /**
  * Filesystem-safe display name for a shared blob, guaranteed to carry an
- * extension. The on-disk blob name is a generated, extension-less id, so the OS
- * share sheet (which keys off the file path, not any metadata) would otherwise
- * emit an extension-less file — breaking "open with"/preview on the receiving
- * side. Derives the extension from the mimeType when the stored name lacks one.
+ * extension. The on-disk blob name is a generated machine id (with a
+ * mime-derived extension since withDiskExt; legacy blobs may lack it), so the
+ * OS share sheet (which keys off the file path, not any metadata) would
+ * otherwise emit a machine-named file — breaking "open with"/preview on the
+ * receiving side. Derives the extension from the mimeType when the stored name
+ * lacks one.
  */
 export function shareFileName(meta: {name?: string; fileName: string; mimeType: string}): string {
   const raw = (meta.name || meta.fileName).trim()
@@ -39,6 +41,19 @@ export function shareFileName(meta: {name?: string; fileName: string; mimeType: 
     base = base.slice(0, Math.max(1, MAX_LEN - suffix.length))
   }
   return base + suffix
+}
+
+/**
+ * On-disk name for a stored blob: the generated id plus a mime-derived
+ * extension when one is known. iOS AVPlayer resolves a local file's format
+ * from its path extension (not content sniffing), so an extension-less WAV is
+ * unplayable through `session.speaker.play` even though the bytes are valid.
+ * Leaves a name that already has an extension untouched.
+ */
+export function withDiskExt(fileName: string, mimeType: string): string {
+  if (fileName.includes(".")) return fileName
+  const ext = extForMime(mimeType)
+  return ext ? `${fileName}.${ext}` : fileName
 }
 
 /** Best-effort file extension (no dot) for a MIME type. Inverse of inferMime in BlobStore. */

--- a/mobile/modules/island/tsconfig.json
+++ b/mobile/modules/island/tsconfig.json
@@ -2,8 +2,7 @@
 {
   "extends": "expo-module-scripts/tsconfig.base",
   "compilerOptions": {
-    "outDir": "./build",
-    "rootDir": "./src"
+    "outDir": "./build"
   },
   "include": ["./src"],
   "exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]


### PR DESCRIPTION
## Scope

Fixes silent Recorder miniapp playback on iOS (incident `2a974c5e-c217-4e9c-a413-3ea4cec66dc7`): the progress bar ran but no audio played.

## Root cause

`BlobStore` names on-disk files with a bare generated id (`mr46hl98-huglgjvzmt8e`). iOS AVPlayer resolves a local file's format from its path extension — no content sniffing — so the recorder's stored WAV handed to `session.speaker.play` never loaded. expo-audio surfaces no load error to JS, so playback "started" and then nothing: no finish event, no failure, for the full 28s captured in the incident logs. The share path had already hit the same wall and works around it by copying to a renamed temp file (`handleShare`); playback had no such workaround.

This is host responsibility, not the miniapp's: the docs promise a blob's `uri` can be handed to `session.speaker.play`, and the miniapp has no lever over the on-disk name.

## Change

- `commitFile` now attaches an extension derived from the declared `mimeType` (via new pure helper `withDiskExt` in `blobPaths.ts`), covering all three write paths: streamed writes, `setFromUrl`, `importFile`.
- Legacy extension-less blobs are left as-is (dev-only state, never shipped). Rename fails soft — the blob still stores/shares.
- Docs: `blob.mdx` example passed a bare uri to `speaker.play` instead of `{audioUrl}` (and "played" a PDF); fixed.

## Test evidence

- `bun test blobPaths.test.ts`: 16 pass (3 new `withDiskExt` cases).
- `tsc --noEmit` over mobile (island module included): clean.
- Not yet verified on iOS hardware — needs a record → play check on device; existing recordings made before this fix stay extension-less and will still be silent (delete + re-record).

## Follow-ups (not in this PR)

- `handlePlayAudio` accepts any `file://` path unvalidated — should be scoped to the caller's own blob dir.
- BlobStore's `getUserId` is wired to the raw coreToken JWT (`LocalMiniappRuntime.ts:2017`), putting a decodeable token prefix (sub + email) into blob paths and logs; should be a stable non-secret id.
- `AudioPlaybackService` has no load timeout, so iOS load failures strand the miniapp's `play()` promise forever.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the on-disk naming path for all new blob commits; behavior is narrow and tested, but existing iOS recordings without extensions still won’t play until re-recorded.
> 
> **Overview**
> Fixes **silent local audio playback on iOS** when miniapps pass a blob `uri` to `session.speaker.play`: AVPlayer picks format from the **path extension**, so extension-less generated ids never loaded.
> 
> **`BlobStore.commitFile`** now renames the on-disk file via new **`withDiskExt`** (mime → extension through existing `extForMime`), covering streamed commits, `setFromUrl`, and `importFile`. Rename failures are ignored so storage/share still work; **legacy extension-less blobs are not migrated**.
> 
> Docs **`blob.mdx`** example corrected to import WAV and call **`speaker.play({ audioUrl })`** instead of a bare uri / PDF. **`blobPaths.test.ts`** adds `withDiskExt` cases. Unrelated **`tsconfig.json`** tweaks drop `rootDir` in two mobile modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab06ecdd3e11d303ee22033ff9d05cd17b9e3783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent Recorder playback on iOS by storing blobs with mime-derived file extensions so the OS detects audio format. Updates docs and tests; existing iOS recordings without extensions won’t play and should be re-recorded.

- **Bug Fixes**
  - Attach a mime-derived extension to on-disk blob names at commit across streamed writes, `setFromUrl`, and `importFile` via `withDiskExt`.
  - Keep legacy extension-less blobs as-is; share still works via temp rename.
  - Docs: use `{ audioUrl: picked.uri }` with `session.speaker.play` and correct example mime.

- **Dependencies**
  - Accept regenerated `expo-module-scripts` tsconfig output by removing explicit `rootDir` in module tsconfigs to avoid persistent dirty diffs.

<sup>Written for commit ab06ecdd3e11d303ee22033ff9d05cd17b9e3783. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

