### PR TITLE
Clear pre-A6 vendor import leaks from asg-core classes

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/log/BesTracePoller.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/log/BesTracePoller.java
@@ -5,8 +5,9 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
+import com.mentra.asg_client.io.peripheral.IBesTracePoller;
+import com.mentra.asg_client.io.peripheral.IMcuCommander;
 import com.mentra.asg_client.logging.BleTraceLogger;
-import com.mentra.asg_client.service.core.handlers.K900CommandHandler;
 import com.mentra.asg_client.service.system.interfaces.IConfigurationManager;
 
 import org.json.JSONObject;
@@ -15,7 +16,7 @@ import org.json.JSONObject;
  * Debug-only helper that pulls the BES trace ring buffer at a short interval and
  * emits only newly observed lines into the MentraBleTrace log stream.
  */
-public class BesTracePoller {
+public class BesTracePoller implements IBesTracePoller {
   private static final String TAG = "BesTracePoller";
   private static final long DEFAULT_INTERVAL_MS = 5000;
   private static final long MIN_INTERVAL_MS = 3000;
@@ -26,7 +27,7 @@ public class BesTracePoller {
 
   private final Handler mHandler = new Handler(Looper.getMainLooper());
 
-  private K900CommandHandler mK900CommandHandler;
+  private IMcuCommander mK900CommandHandler;
   private Context mContext;
   private IConfigurationManager mConfigurationManager;
   private long mIntervalMs = DEFAULT_INTERVAL_MS;
@@ -37,7 +38,8 @@ public class BesTracePoller {
 
   private final Runnable mPollRunnable = this::pollOnce;
 
-  public synchronized void start(K900CommandHandler k900CommandHandler,
+  @Override
+  public synchronized void start(IMcuCommander k900CommandHandler,
                                  Context context,
                                  IConfigurationManager configurationManager,
                                  long intervalMs) {
@@ -53,6 +55,7 @@ public class BesTracePoller {
     mHandler.post(mPollRunnable);
   }
 
+  @Override
   public synchronized void stop() {
     if (!mRunning) {
       return;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/core/BaseHardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/core/BaseHardwareManager.java
@@ -237,6 +237,15 @@ public class BaseHardwareManager implements IHardwareManager {
     }
 
     @Override
+    public boolean setCameraFov(int fov, int roiPosition) {
+        Log.d(
+                TAG,
+                String.format(
+                        "setCameraFov(%d, %d) called - no-op on base hardware", fov, roiPosition));
+        return false;
+    }
+
+    @Override
     public void shutdown() {
         Log.d(TAG, "Shutting down BaseHardwareManager");
         isInitialized = false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/interfaces/IHardwareManager.java
@@ -230,4 +230,18 @@ public interface IHardwareManager {
      * @param brightness Brightness level (0-255, where 255 is maximum brightness)
      */
     void setRgbLedSolidWhite(int durationMs, int brightness);
+
+    // ============================================
+    // Camera Hardware Control
+    // ============================================
+
+    /**
+     * Apply a camera field-of-view configuration to the hardware ISP.
+     * No-op on devices that do not support hardware FOV adjustment.
+     *
+     * @param fov FOV mode index (device-specific values)
+     * @param roiPosition ROI alignment position (device-specific values)
+     * @return true if FOV was applied to hardware, false if unsupported or unavailable
+     */
+    boolean setCameraFov(int fov, int roiPosition);
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/hardware/managers/K900HardwareManager.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.io.hardware.managers;
 
 import android.content.Context;
 import android.util.Log;
+import com.dev.api.DevApi;
 import com.mentra.asg_client.audio.I2SAudioController;
 import com.mentra.asg_client.hardware.K900LedController;
 import com.mentra.asg_client.hardware.K900RgbLedController;
@@ -499,6 +500,17 @@ public class K900HardwareManager extends BaseHardwareManager {
                             durationMs, brightness));
         } else {
             Log.w(TAG, "RGB LED controller not available");
+        }
+    }
+
+    @Override
+    public boolean setCameraFov(int fov, int roiPosition) {
+        try {
+            DevApi.setCameraFov(fov, roiPosition);
+            return true;
+        } catch (UnsatisfiedLinkError e) {
+            Log.w(TAG, "DevApi.setCameraFov not available on this device: " + e.getMessage());
+            return false;
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/IBesTracePoller.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/IBesTracePoller.java
@@ -1,0 +1,15 @@
+package com.mentra.asg_client.io.peripheral;
+
+import android.content.Context;
+import com.mentra.asg_client.service.system.interfaces.IConfigurationManager;
+
+/** Controls the periodic BES trace-ring-buffer poll loop. */
+public interface IBesTracePoller {
+    void start(
+            IMcuCommander mcuCommander,
+            Context context,
+            IConfigurationManager configManager,
+            long intervalMs);
+
+    void stop();
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/IMcuCommander.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/IMcuCommander.java
@@ -1,0 +1,72 @@
+package com.mentra.asg_client.io.peripheral;
+
+import android.content.Context;
+import com.mentra.asg_client.service.system.interfaces.IConfigurationManager;
+import java.util.function.Consumer;
+import org.json.JSONObject;
+
+/**
+ * Outbound and inbound MCU command surface. Implemented by the vendor-specific MCU handler (e.g.
+ * {@code K900CommandHandler} for Mentra Live). Core classes hold this interface so they stay free
+ * of vendor imports.
+ */
+public interface IMcuCommander {
+
+    /**
+     * Process a raw vendor-protocol command payload received from the companion transport. For
+     * Mentra Live this is a K900/BES frame already decoded from the UART bridge.
+     *
+     * @param json The decoded vendor command JSON
+     */
+    void processVendorProtocolCommand(JSONObject json);
+
+    /** Ask the MCU for its current firmware version. Result arrives as a {@link
+     * com.mentra.asg_client.io.peripheral.events.BesVersionEvent} on the peripheral bus. */
+    void requestSystemVersion();
+
+    /**
+     * Pull the BES trace ring-buffer and optionally upload to the incident backend.
+     *
+     * @param incidentId incident ID to attach; null/empty to only print to logcat
+     * @param context Android context
+     * @param configManager configuration manager for server URL resolution
+     */
+    void requestBesLogs(String incidentId, Context context, IConfigurationManager configManager);
+
+    /**
+     * Like {@link #requestBesLogs(String, Context, IConfigurationManager)} but overrides the
+     * upload base URL.
+     */
+    void requestBesLogs(
+            String incidentId,
+            Context context,
+            IConfigurationManager configManager,
+            String apiBaseUrl);
+
+    /**
+     * BLE-relay variant: assembled BES logs are delivered to {@code relayFirmwareJson} instead of
+     * being uploaded over HTTP.
+     */
+    void requestBesLogs(
+            String incidentId,
+            Context context,
+            IConfigurationManager configManager,
+            Consumer<String> relayFirmwareJson);
+
+    /**
+     * Single-shot BES trace poll for the debug trace poller.
+     *
+     * @param context Android context
+     * @param configManager configuration manager
+     * @param rawLogCallback called with the assembled raw log text when complete
+     * @return true if the request was dispatched, false if a log session is already active
+     */
+    boolean requestBesLogsForTrace(
+            Context context,
+            IConfigurationManager configManager,
+            Consumer<String> rawLogCallback);
+
+    /** Ask the MCU for its BT MAC address. Result arrives as a {@link
+     * com.mentra.asg_client.io.peripheral.events.BtMacEvent} on the peripheral bus. */
+    void requestBtMacAddress();
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -17,7 +17,6 @@ import android.os.IBinder;
 import android.os.Looper;
 import android.util.Log;
 import android.util.Size;
-import com.dev.api.DevApi;
 import com.mentra.asg_client.camera.UvcStreamingState;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.interfaces.TransportListener;
@@ -757,8 +756,7 @@ public class AsgClientService extends Service implements NetworkStateListener, T
             }
             int fov = asgSettings.getCameraFov();
             int roiPosition = asgSettings.getCameraRoiPosition();
-            try {
-                DevApi.setCameraFov(fov, roiPosition);
+            if (hardwareManager.setCameraFov(fov, roiPosition)) {
                 SystemControllerFactory.get(this).restartCameraHal();
                 CameraRestartCooldown.setCooldown();
                 Log.d(
@@ -767,8 +765,8 @@ public class AsgClientService extends Service implements NetworkStateListener, T
                                 + fov
                                 + ", roi_position="
                                 + roiPosition);
-            } catch (UnsatisfiedLinkError e) {
-                Log.d(TAG, "libxydev not available (non-K900?), skipping apply saved FOV");
+            } else {
+                Log.d(TAG, "Camera FOV not applied on start (unsupported or libxydev unavailable)");
             }
         } catch (Exception e) {
             Log.w(TAG, "Could not apply saved camera FOV on start", e);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/ServiceInitializer.java
@@ -3,6 +3,7 @@ package com.mentra.asg_client.service.core;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.bes.log.BesTracePoller;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
@@ -14,6 +15,7 @@ import com.mentra.asg_client.service.communication.interfaces.ICommunicationMana
 import com.mentra.asg_client.service.communication.interfaces.IResponseBuilder;
 import com.mentra.asg_client.service.communication.managers.CommunicationManager;
 import com.mentra.asg_client.service.communication.managers.ResponseBuilder;
+import com.mentra.asg_client.service.core.handlers.K900CommandHandler;
 import com.mentra.asg_client.service.core.handlers.OtaCommandHandler;
 import com.mentra.asg_client.service.core.handlers.RgbLedCommandHandler;
 import com.mentra.asg_client.service.core.handlers.subscribers.BatteryEventSubscriber;
@@ -113,6 +115,12 @@ public final class ServiceInitializer {
         peripheralBus.subscribe(new SwipeVolumeEventSubscriber(serviceManager));
         peripheralBus.subscribe(new VoiceActivityEventSubscriber());
 
+        K900CommandHandler k900CommandHandler =
+                new K900CommandHandler(
+                        serviceManager, stateManager, communicationManager, peripheralBus);
+        BesTracePoller besTracePoller = new BesTracePoller();
+        serviceManager.setBesOtaCommandHandler(k900CommandHandler);
+
         this.commandProcessor =
                 new CommandProcessor(
                         context,
@@ -126,7 +134,10 @@ public final class ServiceInitializer {
                         rgbLedHandler,
                         otaCommandHandler,
                         peripheralBus,
-                        protocolStrategies);
+                        protocolStrategies,
+                        k900CommandHandler,
+                        besTracePoller,
+                        hardwareManager);
 
         this.lifecycleManager =
                 new ServiceLifecycleManager(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/K900CommandHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.io.bes.log.BesLogManager;
+import com.mentra.asg_client.io.peripheral.IMcuCommander;
 import com.mentra.asg_client.io.peripheral.IPeripheralBus;
 import com.mentra.asg_client.io.peripheral.McuEventParser;
 import com.mentra.asg_client.io.peripheral.events.McuEvent;
@@ -23,7 +24,7 @@ import org.json.JSONObject;
  * <p>This class still owns the BES log session and the outgoing (MTK -> BES) command builders, which
  * are request/response flows rather than inbound events.
  */
-public class K900CommandHandler {
+public class K900CommandHandler implements IMcuCommander {
     private static final String TAG = "K900CommandHandler";
 
     private final AsgClientServiceManager serviceManager;
@@ -42,6 +43,11 @@ public class K900CommandHandler {
         this.stateManager = stateManager;
         this.communicationManager = communicationManager;
         this.peripheralBus = peripheralBus;
+    }
+
+    @Override
+    public void processVendorProtocolCommand(JSONObject json) {
+        processK900Command(json);
     }
 
     /**
@@ -123,6 +129,7 @@ public class K900CommandHandler {
      * @param context application context
      * @param configManager provides coreToken for backend auth
      */
+    @Override
     public void requestBesLogs(
             String incidentId, Context context, IConfigurationManager configManager) {
         requestBesLogs(incidentId, context, configManager, "", null);
@@ -136,6 +143,7 @@ public class K900CommandHandler {
      * @param apiBaseUrl backend base URL from the phone (e.g. from sendIncidentId JSON); empty or
      *     null to use glasses' own ServerConfigUtil
      */
+    @Override
     public void requestBesLogs(
             String incidentId,
             Context context,
@@ -148,6 +156,7 @@ public class K900CommandHandler {
      * BLE-relay variant: assembled BES logs are delivered to {@code relayFirmwareJson} instead of
      * being uploaded over HTTP.
      */
+    @Override
     public void requestBesLogs(
             String incidentId,
             Context context,
@@ -226,6 +235,7 @@ public class K900CommandHandler {
         }
     }
 
+    @Override
     public boolean requestBesLogsForTrace(
             Context context,
             IConfigurationManager configManager,
@@ -284,6 +294,7 @@ public class K900CommandHandler {
      * <p>This ensures version info is cached before phone connects, making it available for OTA
      * patch matching and version_info messages to the phone.
      */
+    @Override
     public void requestSystemVersion() {
         Log.i(TAG, "🔧 Requesting BES system version (sh_syvr)");
 
@@ -328,6 +339,7 @@ public class K900CommandHandler {
      * Send request to BES chip to get BT MAC address (cs_btaddr) Call this on startup/UART
      * connection to retrieve the unique device identifier
      */
+    @Override
     public void requestBtMacAddress() {
         Log.i(TAG, "📋 Requesting BT MAC address from BES chip");
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/SettingsCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/SettingsCommandHandler.java
@@ -4,8 +4,8 @@ import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
-import com.dev.api.DevApi;
 import com.mentra.asg_client.camera.policy.PhotoSizeTier;
+import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.interfaces.IResponseBuilder;
 import com.mentra.asg_client.service.core.CameraRestartCooldown;
@@ -30,14 +30,17 @@ public class SettingsCommandHandler implements ICommandHandler {
     private final AsgClientServiceManager serviceManager;
     private final ICommunicationManager communicationManager;
     private final IResponseBuilder responseBuilder;
+    private final IHardwareManager hardwareManager;
 
     public SettingsCommandHandler(
             AsgClientServiceManager serviceManager,
             ICommunicationManager communicationManager,
-            IResponseBuilder responseBuilder) {
+            IResponseBuilder responseBuilder,
+            IHardwareManager hardwareManager) {
         this.serviceManager = serviceManager;
         this.communicationManager = communicationManager;
         this.responseBuilder = responseBuilder;
+        this.hardwareManager = hardwareManager;
     }
 
     @Override
@@ -434,8 +437,7 @@ public class SettingsCommandHandler implements ICommandHandler {
                 sendSettingsAck(requestId, "camera_fov", STATUS_APPLIED, values);
                 return true;
             }
-            try {
-                DevApi.setCameraFov(fov, roiPosition);
+            if (hardwareManager.setCameraFov(fov, roiPosition)) {
                 SystemControllerFactory.get(context).restartCameraHal();
                 CameraRestartCooldown.setCooldown();
                 Log.d(TAG, "Camera FOV applied to hardware and HAL restarted");
@@ -467,8 +469,8 @@ public class SettingsCommandHandler implements ICommandHandler {
                                     }
                                 },
                                 CameraRestartCooldown.DEFAULT_COOLDOWN_DURATION_MS + 500L);
-            } catch (UnsatisfiedLinkError e) {
-                Log.w(TAG, "libxydev not available (non-K900?), FOV persisted but not applied", e);
+            } else {
+                Log.w(TAG, "Camera FOV not applied to hardware (unsupported or libxydev unavailable)");
                 JSONObject values = new JSONObject();
                 values.put("fov", fov);
                 values.put("roi_position", roiPosition);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/UploadIncidentLogsCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/UploadIncidentLogsCommandHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import com.mentra.asg_client.io.bes.log.BesLogManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
+import com.mentra.asg_client.io.peripheral.IMcuCommander;
 import com.mentra.asg_client.reporting.GlassesLogBuffer;
 import com.mentra.asg_client.service.legacy.interfaces.ICommandHandler;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
@@ -51,7 +52,7 @@ public class UploadIncidentLogsCommandHandler implements ICommandHandler {
 
     private final Context mContext;
     private final IConfigurationManager mConfigurationManager;
-    private final K900CommandHandler mK900CommandHandler;
+    private final IMcuCommander mK900CommandHandler;
     private final IStateManager mStateManager;
 
     /**
@@ -65,7 +66,7 @@ public class UploadIncidentLogsCommandHandler implements ICommandHandler {
     public UploadIncidentLogsCommandHandler(
             Context context,
             IConfigurationManager configurationManager,
-            K900CommandHandler k900CommandHandler,
+            IMcuCommander k900CommandHandler,
             IStateManager stateManager,
             AsgClientServiceManager serviceManager) {
         mContext = context;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -2,8 +2,10 @@ package com.mentra.asg_client.service.core.processors;
 
 import android.content.Context;
 import android.util.Log;
-import com.mentra.asg_client.io.bes.log.BesTracePoller;
 import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
+import com.mentra.asg_client.io.peripheral.IBesTracePoller;
+import com.mentra.asg_client.io.peripheral.IMcuCommander;
 import com.mentra.asg_client.io.peripheral.IPeripheralBus;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.reporting.core.ReportManager;
@@ -16,7 +18,6 @@ import com.mentra.asg_client.service.core.handlers.GalleryCommandHandler;
 import com.mentra.asg_client.service.core.handlers.GalleryModeCommandHandler;
 import com.mentra.asg_client.service.core.handlers.I2SAudioCommandHandler;
 import com.mentra.asg_client.service.core.handlers.ImuCommandHandler;
-import com.mentra.asg_client.service.core.handlers.K900CommandHandler;
 import com.mentra.asg_client.service.core.handlers.KeepAwakeCommandHandler;
 import com.mentra.asg_client.service.core.handlers.OtaCommandHandler;
 import com.mentra.asg_client.service.core.handlers.PhoneReadyCommandHandler;
@@ -72,8 +73,9 @@ public class CommandProcessor {
     private final CommandHandlerRegistry commandHandlerRegistry;
     private final CommandParser commandParser;
     private final CommandProtocolDetector protocolDetector;
-    private final K900CommandHandler k900CommandHandler;
-    private final BesTracePoller besTracePoller;
+    private final IMcuCommander mcuCommander;
+    private final IBesTracePoller besTracePoller;
+    private final IHardwareManager hardwareManager;
     private final ResponseSender responseSender;
     private final ChunkReassembler chunkReassembler;
     private final RgbLedCommandHandler rgbLedCommandHandler;
@@ -92,7 +94,10 @@ public class CommandProcessor {
             RgbLedCommandHandler rgbLedCommandHandler,
             OtaCommandHandler otaCommandHandler,
             IPeripheralBus peripheralBus,
-            Set<CommandProtocolDetector.ProtocolDetectionStrategy> extraProtocolStrategies) {
+            Set<CommandProtocolDetector.ProtocolDetectionStrategy> extraProtocolStrategies,
+            IMcuCommander mcuCommander,
+            IBesTracePoller besTracePoller,
+            IHardwareManager hardwareManager) {
         Log.d(TAG, "🔧 Initializing CommandProcessor with dependencies");
         this.context = context;
         this.communicationManager = communicationManager;
@@ -110,10 +115,9 @@ public class CommandProcessor {
         this.commandHandlerRegistry = new CommandHandlerRegistry();
         this.commandParser = new CommandParser();
         this.protocolDetector = new CommandProtocolDetector();
-        this.k900CommandHandler =
-                new K900CommandHandler(
-                        serviceManager, stateManager, communicationManager, peripheralBus);
-        this.besTracePoller = new BesTracePoller();
+        this.mcuCommander = mcuCommander;
+        this.besTracePoller = besTracePoller;
+        this.hardwareManager = hardwareManager;
         this.responseSender = new ResponseSender(serviceManager);
         this.chunkReassembler = new ChunkReassembler();
 
@@ -135,8 +139,8 @@ public class CommandProcessor {
         Log.i(TAG, "✅ CommandProcessor initialization completed successfully");
     }
 
-    public K900CommandHandler getK900CommandHandler() {
-        return k900CommandHandler;
+    public IMcuCommander getMcuCommander() {
+        return mcuCommander;
     }
 
     /**
@@ -260,7 +264,7 @@ public class CommandProcessor {
                 case K900_PROTOCOL:
                     Log.i(TAG, "🎯 Processing K900 protocol command");
                     // Handle K900 format using dedicated handler
-                    k900CommandHandler.processK900Command(json);
+                    mcuCommander.processVendorProtocolCommand(json);
                     // K900 command processed successfully
                     return null; // K900 commands are handled directly
 
@@ -402,7 +406,7 @@ public class CommandProcessor {
 
             commandHandlerRegistry.registerHandler(
                     new SettingsCommandHandler(
-                            serviceManager, communicationManager, responseBuilder));
+                            serviceManager, communicationManager, responseBuilder, hardwareManager));
             Log.d(TAG, "✅ Registered SettingsCommandHandler");
 
             commandHandlerRegistry.registerHandler(otaCommandHandler);
@@ -442,7 +446,7 @@ public class CommandProcessor {
                     new UploadIncidentLogsCommandHandler(
                             context,
                             configurationManager,
-                            k900CommandHandler,
+                            mcuCommander,
                             stateManager,
                             serviceManager));
             Log.d(TAG, "✅ Registered UploadIncidentLogsCommandHandler");
@@ -545,10 +549,10 @@ public class CommandProcessor {
     public void requestSystemVersion() {
         Log.d(TAG, "📤 requestSystemVersion() called");
 
-        if (k900CommandHandler != null) {
-            k900CommandHandler.requestSystemVersion();
+        if (mcuCommander != null) {
+            mcuCommander.requestSystemVersion();
         } else {
-            Log.w(TAG, "⚠️ K900CommandHandler not available - cannot request BES system version");
+            Log.w(TAG, "⚠️ MCU commander not available - cannot request BES system version");
         }
     }
 
@@ -560,16 +564,16 @@ public class CommandProcessor {
             String incidentId,
             android.content.Context context,
             IConfigurationManager configManager) {
-        if (k900CommandHandler != null) {
-            k900CommandHandler.requestBesLogs(incidentId, context, configManager);
+        if (mcuCommander != null) {
+            mcuCommander.requestBesLogs(incidentId, context, configManager);
         } else {
-            Log.w(TAG, "⚠️ K900CommandHandler not available — cannot request BES logs");
+            Log.w(TAG, "⚠️ MCU commander not available — cannot request BES logs");
         }
     }
 
     public void setBesTracePollingEnabled(boolean enabled, long intervalMs) {
         if (enabled) {
-            besTracePoller.start(k900CommandHandler, context, configurationManager, intervalMs);
+            besTracePoller.start(mcuCommander, context, configurationManager, intervalMs);
         } else {
             besTracePoller.stop();
         }
@@ -586,10 +590,10 @@ public class CommandProcessor {
     public void requestBtMacAddress() {
         Log.d(TAG, "📤 requestBtMacAddress() called");
 
-        if (k900CommandHandler != null) {
-            k900CommandHandler.requestBtMacAddress();
+        if (mcuCommander != null) {
+            mcuCommander.requestBtMacAddress();
         } else {
-            Log.w(TAG, "⚠️ K900CommandHandler not available - cannot request BT MAC address");
+            Log.w(TAG, "⚠️ MCU commander not available - cannot request BT MAC address");
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -67,8 +67,12 @@ public class AsgClientServiceManager {
     // StateManager for battery monitoring (set after construction)
     private IStateManager stateManager;
 
-    /** Set before {@link #initialize(K900CommandHandler)} so BES OTA can be constructed with it. */
+    /** Set before {@link #initialize()} so BES OTA can be constructed with it. */
     private K900CommandHandler besOtaK900CommandHandler;
+
+    public void setBesOtaCommandHandler(K900CommandHandler k900CommandHandler) {
+        this.besOtaK900CommandHandler = k900CommandHandler;
+    }
 
     public AsgClientServiceManager(
             Context context,
@@ -103,13 +107,10 @@ public class AsgClientServiceManager {
     }
 
     /**
-     * Initialize all service components.
-     *
-     * @param k900CommandHandler Required on K900 for {@link BesOtaManager}; may be null on generic
-     *     devices
+     * Initialize all service components. Call {@link #setBesOtaCommandHandler(K900CommandHandler)}
+     * first on K900 devices so {@link BesOtaManager} can be constructed.
      */
-    public void initialize(K900CommandHandler k900CommandHandler) {
-        this.besOtaK900CommandHandler = k900CommandHandler;
+    public void initialize() {
         Log.d(
                 TAG,
                 "🚀 initialize() called - Current state: "

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/ServiceLifecycleManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/ServiceLifecycleManager.java
@@ -52,8 +52,8 @@ public class ServiceLifecycleManager implements IServiceLifecycle {
 
         Log.d(TAG, "Initializing service lifecycle");
 
-        // Initialize managers (K900CommandHandler required for BesOtaManager on Mentra Live)
-        serviceManager.initialize(commandProcessor.getK900CommandHandler());
+        // Initialize managers (K900CommandHandler set on serviceManager before initialize())
+        serviceManager.initialize();
 
         // Recovery sidecar is the crash watchdog — start before other delayed init work.
         recoveryWorkerManager.initialize();

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/processors/CommandProcessorRoutingIntegrationTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/processors/CommandProcessorRoutingIntegrationTest.java
@@ -10,14 +10,17 @@ import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.io.bes.log.BesTracePoller;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.K900ProtocolStrategy;
 import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.peripheral.IPeripheralBus;
 import com.mentra.asg_client.io.peripheral.events.FileTransferAckEvent;
 import com.mentra.asg_client.io.peripheral.events.McuEvent;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 import com.mentra.asg_client.service.communication.interfaces.IResponseBuilder;
+import com.mentra.asg_client.service.core.handlers.K900CommandHandler;
 import com.mentra.asg_client.service.core.handlers.OtaCommandHandler;
 import com.mentra.asg_client.service.core.handlers.RgbLedCommandHandler;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
@@ -73,7 +76,14 @@ public class CommandProcessorRoutingIntegrationTest {
                 mock(RgbLedCommandHandler.class),
                 mock(OtaCommandHandler.class),
                 peripheralBus,
-                strategies);
+                strategies,
+                new K900CommandHandler(
+                        serviceManager,
+                        mock(IStateManager.class),
+                        mock(ICommunicationManager.class),
+                        peripheralBus),
+                new BesTracePoller(),
+                mock(IHardwareManager.class));
     }
 
     private static byte[] bytes(JSONObject json) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Clears the last pre-A6 vendor import leaks from core-bound ASG classes ahead of the `:asg-core` / `:vendor-mentra-live` module split (Phase A6).

- **Fix 1 — MCU command surface:** Introduces `IMcuCommander` and `IBesTracePoller` in `io/peripheral/`. `K900CommandHandler` and `BesTracePoller` implement them. `CommandProcessor` and `UploadIncidentLogsCommandHandler` hold interface types and receive implementations via constructor injection from `ServiceInitializer`.
- **Fix 2 — Camera FOV:** Adds `boolean setCameraFov(int, int)` to `IHardwareManager` (with no-op in `BaseHardwareManager`, `DevApi` call in `K900HardwareManager`). `AsgClientService` and `SettingsCommandHandler` route through `hardwareManager` instead of calling `DevApi` directly. Return value preserves existing behavior: HAL restart and `hardware_applied: true` only when FOV is actually applied.
- **Wiring:** `ServiceInitializer` constructs `K900CommandHandler` + `BesTracePoller` and passes them to `CommandProcessor`. `AsgClientServiceManager` gains `setBesOtaCommandHandler()` called before no-arg `initialize()`. `ServiceLifecycleManager` no longer calls `getK900CommandHandler()`.

## Blocker files cleared

| File | Before | After |
|------|--------|-------|
| `CommandProcessor` | `K900CommandHandler`, `BesTracePoller` | `IMcuCommander`, `IBesTracePoller` |
| `UploadIncidentLogsCommandHandler` | `K900CommandHandler` | `IMcuCommander` |
| `SettingsCommandHandler` | `DevApi.setCameraFov` | `IHardwareManager.setCameraFov` |
| `AsgClientService` | `DevApi.setCameraFov` | `IHardwareManager.setCameraFov` |

## Test evidence

```bash
cd asg_client
./gradlew :app:assembleDebug :app:testDebugUnitTest
# BUILD SUCCESSFUL
```

Acceptance grep over core directories: the four blocker files are clean. Remaining hits are expected (`IBesOtaRegistry` regex false positives; `K900CommandHandler` import in `ServiceInitializer` as the designated composition root).

## Out of scope

No file moves, no `OtaHelper` split, no protocol logic changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16f2f9fd-14f2-4012-a018-5a6a1d1c96a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16f2f9fd-14f2-4012-a018-5a6a1d1c96a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

