### PR TITLE
Route all MTK firmware to 20260626 and bump BES to 17.26.07.03 in V1 manifest (OS-1644)

### DIFF
--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -49,6 +49,36 @@
       "end_firmware": "MentraLive_20260626",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
       "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
+    },
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260626.zip",
+      "sha256": "29f6e576d64af5cbf9b1876b6b4bc4e8dbfe0282d2b55770868835802d588f0c"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260626.zip",
+      "sha256": "b0e03742d7a7f5969a625f9cb96864efb27a4b42c2075e0dff51457724cb5ea2"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260626.zip",
+      "sha256": "7be3fcc0b287a1675d7aee69cd1e8869443041d9eb53dc0f4078406c44720864"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260626.zip",
+      "sha256": "cc58004dc60ddd48a16dae64cb1d1babe2168f04f1ff973f6de3228e0745d554"
+    },
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260626.zip",
+      "sha256": "69430f579c5a2b8d553a1529a7379687a18d71f8ff09239f4cac130f358730d3"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -52,8 +52,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.03",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.03.bin",
+    "sha256": "a652466b5fefab820f76434eee545e52cc481ba1920cb7a00770b9e9360a7133"
   }
 }

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,36 +15,6 @@
   },
   "mtk_patches": [
     {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
-    },
-    {
-      "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
-      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
-    },
-    {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
-      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
-    },
-    {
       "start_firmware": "MentraLive_20260525",
       "end_firmware": "MentraLive_20260626",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds 5 new `mtk_patches` entries to `asg_client/ota_website/prod_live_version.json` pointing devices on older firmware directly to `MentraLive_20260626`.

## New Patch Routes

| Start Firmware | End Firmware | SHA256 |
|---|---|---|
| MentraLive_20260418 | MentraLive_20260626 | `29f6e576...` |
| MentraLive_20260421 | MentraLive_20260626 | `b0e03742...` |
| MentraLive_20260513 | MentraLive_20260626 | `7be3fcc0...` |
| MentraLive_20260204 | MentraLive_20260626 | `cc58004d...` |
| MentraLive_20260113 | MentraLive_20260626 | `69430f57...` |

All SHA256 hashes sourced directly from the [asg-client GitHub Release](https://github.com/Mentra-Community/MentraOS/releases/tag/asg-client). All 5 zip assets are confirmed present in the release.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-875204bc-839c-4e62-9afb-08b98e3460ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-875204bc-839c-4e62-9afb-08b98e3460ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

