### PR TITLE
Move onboarding and OTA debug UI off super mode

### DIFF
--- a/mobile/src/app/miniapps/settings/debug.tsx
+++ b/mobile/src/app/miniapps/settings/debug.tsx
@@ -44,6 +44,8 @@ export default function DebugSettingsScreen() {
   const [appearanceMenuEnabled, setAppearanceMenuEnabled] = useSetting(SETTINGS.appearance_menu_enabled.key)
   const [appBootExtraInfo, setAppBootExtraInfo] = useSetting(SETTINGS.app_boot_extra_info.key)
   const [debugConsole, setDebugConsole] = useSetting(SETTINGS.debug_console.key)
+  const [debugOnboardingUi, setDebugOnboardingUi] = useSetting(SETTINGS.debug_onboarding_ui.key)
+  const [debugOtaUi, setDebugOtaUi] = useSetting(SETTINGS.debug_ota_ui.key)
   const [_onboardingOsCompleted, setOnboardingOsCompleted] = useSetting(SETTINGS.onboarding_os_completed.key)
   const [_onboardingLiveCompleted, setOnboardingLiveCompleted] = useSetting(SETTINGS.onboarding_live_completed.key)
   const [lc3FrameSize, setLc3FrameSize] = useSetting(SETTINGS.lc3_frame_size.key)
@@ -111,6 +113,20 @@ export default function DebugSettingsScreen() {
               subtitle="Show the current boot state under the logo on the loading screen"
               value={appBootExtraInfo}
               onValueChange={(value) => setAppBootExtraInfo(value)}
+            />
+
+            <ToggleSetting
+              label="Onboarding Debug UI"
+              subtitle="Show onboarding debug overlays (back button, step wait indicator, debug videos)"
+              value={debugOnboardingUi}
+              onValueChange={(value) => setDebugOnboardingUi(value)}
+            />
+
+            <ToggleSetting
+              label="OTA Debug UI"
+              subtitle="Show OTA update debug overlay (live progress info + skip button)"
+              value={debugOtaUi}
+              onValueChange={(value) => setDebugOtaUi(value)}
             />
           </Group>
 

--- a/mobile/src/app/ota/progress-legacy.tsx
+++ b/mobile/src/app/ota/progress-legacy.tsx
@@ -64,7 +64,7 @@ const OTA_COVER_VIDEO_URL = "https://mentra-videos-cdn.mentraglass.com/onboardin
 export default function OtaProgressScreen() {
   const {theme} = useAppTheme()
   const {replace, push} = useNavigationStore.getState()
-  const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const [debugOtaUi] = useSetting(SETTINGS.debug_ota_ui.key)
   const otaProgress = useGlassesStore((state) => state.otaProgress)
   const otaUpdateAvailable = useGlassesStore((state) => state.otaUpdateAvailable)
   const glassesConnected = useGlassesStore(selectGlassesConnected)
@@ -189,7 +189,7 @@ export default function OtaProgressScreen() {
         {id: "retry", enabled: true},
         {id: "change_wifi", enabled: true},
       ]
-      if (superMode) {
+      if (debugOtaUi) {
         states.push({id: "skip_super", enabled: true})
       }
       return states
@@ -207,7 +207,7 @@ export default function OtaProgressScreen() {
       ]
     }
     return []
-  }, [continueButtonDisabled, progressState, superMode])
+  }, [continueButtonDisabled, progressState, debugOtaUi])
 
   const trackButtonPress = useCallback(
     (buttonId: OtaButtonId) => {
@@ -1866,7 +1866,7 @@ export default function OtaProgressScreen() {
           <View className="gap-3">
             <Button preset="primary" text="Retry" flexContainer onPress={handleRetryFromFailure} />
             <Button preset="secondary" text="WiFi setup" flexContainer onPress={handleChangeWifi} />
-            {superMode && <Button preset="secondary" text="Skip (super)" onPress={handleSkipSuper} />}
+            {debugOtaUi && <Button preset="secondary" text="Skip (debug)" onPress={handleSkipSuper} />}
           </View>
         </>
       )
@@ -2048,8 +2048,8 @@ completed: [${completedUpdates.join(", ")}]`
     <Screen preset="fixed" safeAreaEdges={["bottom"]}>
       <Header RightActionComponent={<MentraLogoStandalone />} />
 
-      {/* DEBUG OVERLAY - Only shows in super mode */}
-      {superMode && (
+      {/* DEBUG OVERLAY - gated behind the OTA debug UI toggle in Debug Settings */}
+      {debugOtaUi && (
         <View
           style={{
             position: "absolute",

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -94,7 +94,7 @@ export function OnboardingGuide({
 }: OnboardingGuideProps) {
   const {clearHistoryAndGoHome} = useNavigationStore.getState()
   const {theme} = useAppTheme()
-  const [superMode] = useSetting(SETTINGS.super_mode.key)
+  const [debugOnboardingUi] = useSetting(SETTINGS.debug_onboarding_ui.key)
 
   const [currentIndex, setCurrentIndex] = useState(0)
   const [showNextButton, setShowNextButton] = useState(false)
@@ -749,7 +749,7 @@ export function OnboardingGuide({
       )
     }
 
-    if (superMode) {
+    if (debugOnboardingUi) {
       return renderDebugVideos()
     }
 
@@ -933,7 +933,7 @@ export function OnboardingGuide({
   const renderStepCheck = () => {
     const showCheck = step.waitFn && !waitState
 
-    const showDebug = superMode && waitState && step.waitFn
+    const showDebug = debugOnboardingUi && waitState && step.waitFn
     if (!showCheck && !showDebug) {
       // still show a small height if there is a waitFn so the text doesn't move around:
       // if (step.waitFn) {
@@ -941,7 +941,7 @@ export function OnboardingGuide({
       // }
     }
     return (
-      <View id="bottom" className={`flex justify-end h-12 ${superMode ? "bg-chart-4" : ""}`}>
+      <View id="bottom" className={`flex justify-end h-12 ${debugOnboardingUi ? "bg-chart-4" : ""}`}>
         {showCheck && (
           <View className="flex-1 justify-center">
             <View className="flex flex-row justify-center items-center">
@@ -1025,7 +1025,9 @@ export function OnboardingGuide({
 
           {hasStarted && (
             <View className="flex-row gap-4">
-              {superMode && !isFirstStep && <Button flex preset="secondary" tx="common:back" onPress={handleBack} />}
+              {debugOnboardingUi && !isFirstStep && (
+                <Button flex preset="secondary" tx="common:back" onPress={handleBack} />
+              )}
               {renderContinueButton()}
             </View>
           )}

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -48,7 +48,7 @@ jest.mock("@/stores/navigation", () => ({
 }))
 
 jest.mock("@/stores/settings", () => ({
-  SETTINGS: {super_mode: {key: "super_mode"}},
+  SETTINGS: {debug_onboarding_ui: {key: "debug_onboarding_ui"}},
   useSetting: () => [false, jest.fn()],
 }))
 

--- a/mobile/src/stores/settings.ts
+++ b/mobile/src/stores/settings.ts
@@ -96,6 +96,24 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: true,
     persist: true,
   },
+  // Shows the onboarding/prep debug overlays (back button, step wait indicator,
+  // colored bottom bar, debug videos). Formerly gated behind super_mode.
+  debug_onboarding_ui: {
+    key: "debug_onboarding_ui",
+    defaultValue: () => false,
+    writable: true,
+    saveOnServer: true,
+    persist: true,
+  },
+  // Shows the OTA update debug overlay (live progress info + skip button).
+  // Formerly gated behind super_mode.
+  debug_ota_ui: {
+    key: "debug_ota_ui",
+    defaultValue: () => false,
+    writable: true,
+    saveOnServer: true,
+    persist: true,
+  },
   // Mentra Nex feature flags (off by default; toggled from Nex Developer Settings).
   // When on, the Nex display skips ASCII-only text sanitization so CJK/Chinese
   // captions render on glasses. Synced to the Bluetooth SDK via BLUETOOTH_SETTING_KEYS.


### PR DESCRIPTION
## Scope

Super mode currently doubles as a switch for developer test UI on two screens:

- **Onboarding / prep** (`OnboardingGuide.tsx`) — a debug back button, a "waiting for step to complete" indicator, a gold `bg-chart-4` bottom bar, and debug (per-step) videos in place of the composed onboarding video.
- **OTA update flow** (`ota/progress-legacy.tsx`) — a monospace live-progress overlay and a "Skip" button in the disconnected state.

That means anyone who flips super mode (a broader "power user" switch) also gets this test scaffolding on real onboarding and firmware-update screens. This PR decouples them.

## Changes

- Add two dedicated flags in `stores/settings.ts`: `debug_onboarding_ui` and `debug_ota_ui` (both default `false`, same shape as the existing `debug_*` toggles).
- Add two toggles to the **Debug Settings** screen (`miniapps/settings/debug.tsx`), in the existing Settings group:
  - **Onboarding Debug UI**
  - **OTA Debug UI**
- Gate `OnboardingGuide.tsx` on `debug_onboarding_ui` and `ota/progress-legacy.tsx` on `debug_ota_ui`, replacing every `super_mode` check on those screens.
- Relabel the OTA skip button "Skip (super)" → "Skip (debug)" (button id unchanged, so analytics are unaffected).
- Update the `OnboardingGuide.waitFn` test's `SETTINGS` mock to the new key.

Super mode no longer triggers either overlay. The unrelated super-mode gates in Debug Settings (OTA manifest URL, Super Settings route) are left as-is — those are not test overlays.

## Test evidence

- `bun run test -- OnboardingGuide.waitFn` → 1 passed.
- `bun run compile` (tsc `--noEmit`) → exit 0, no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped flag and UI gating changes only; default-off behavior avoids exposing skip/debug overlays to normal users unless toggles are enabled in Debug Settings.
> 
> **Overview**
> **Onboarding and legacy OTA test overlays are no longer tied to super mode.** Two persisted settings—`debug_onboarding_ui` and `debug_ota_ui`—control them independently, each defaulting to off.
> 
> **Debug Settings** gains toggles for **Onboarding Debug UI** and **OTA Debug UI**. **OnboardingGuide** now keys debug back, wait indicators, colored bottom bar, and per-step debug videos on `debug_onboarding_ui`. **`ota/progress-legacy`** uses `debug_ota_ui` for the live progress overlay and the disconnected-state skip control (label **Skip (debug)**; analytics id unchanged). **`OnboardingGuide.waitFn`** test mocks the new onboarding setting key.
> 
> Super mode still gates unrelated developer entries (e.g. OTA manifest URL, Super Settings) in Debug Settings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd05042b377c1c1d993ea56dec22ae57ae27468. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move onboarding and OTA debug overlays off super mode. Add dedicated `debug_onboarding_ui` and `debug_ota_ui` toggles so power users don’t see test scaffolding by accident.

- **Refactors**
  - Add `debug_onboarding_ui` and `debug_ota_ui` in `stores/settings.ts` (default false) and toggles in Debug Settings.
  - Replace `super_mode` checks with these flags in `OnboardingGuide.tsx` and `ota/progress-legacy.tsx`.
  - Rename OTA button text to "Skip (debug)"; analytics event id unchanged.
  - Update `OnboardingGuide.waitFn` test to use the new setting key.

<sup>Written for commit 5cd05042b377c1c1d993ea56dec22ae57ae27468. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

