### PR TITLE
Reports service: blob-backed artifact storage, upload caps, retry-core dedup

### DIFF
--- a/cloud-v2/packages/cloud-client/src/http.test.ts
+++ b/cloud-v2/packages/cloud-client/src/http.test.ts
@@ -41,6 +41,98 @@ describe("createHttpClient", () => {
     }
   });
 
+  test("postForm goes through the shared retry core: no Content-Type, POST not retried by default", async () => {
+    const originalFetch = globalThis.fetch;
+    const seen: Array<{ headers: Record<string, string>; body: unknown }> = [];
+    globalThis.fetch = (async (_url: string, init: RequestInit) => {
+      seen.push({
+        headers: (init.headers ?? {}) as Record<string, string>,
+        body: init.body,
+      });
+      throw new TypeError("network down");
+    }) as unknown as typeof fetch;
+
+    try {
+      const http = createHttpClient({
+        baseUrl: "https://core.test",
+        getToken: async () => "token-123",
+        logger,
+      });
+      const form = new FormData();
+      form.append("files", new Blob(["x"]), "s.jpg");
+
+      try {
+        await http.postForm("/api/client/reports/rep_1/artifacts", form);
+        throw new Error("expected request to fail");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        expect((err as HttpError).code).toBe("NETWORK_ERROR");
+      }
+
+      // POST is not idempotent, so the transient failure is not retried.
+      expect(seen).toHaveLength(1);
+      // fetch/FormData must generate the multipart boundary itself.
+      expect(seen[0].headers["Content-Type"]).toBeUndefined();
+      expect(seen[0].headers["Authorization"]).toBe("Bearer token-123");
+      expect(seen[0].body).toBe(form);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("postForm retries transient network failures when marked idempotent", async () => {
+    const originalFetch = globalThis.fetch;
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls === 1) throw new TypeError("connection reset");
+      return new Response(JSON.stringify({ stored: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    try {
+      const http = createHttpClient({ baseUrl: "https://core.test", logger });
+      const result = await http.postForm(
+        "/api/client/reports/rep_1/artifacts",
+        new FormData(),
+        { idempotent: true },
+      );
+      expect(result).toEqual({ stored: 1 });
+      expect(calls).toBe(2);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("postForm maps non-2xx responses to HttpError like JSON requests", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response(
+        JSON.stringify({
+          error: "invalid_request",
+          error_description: "request body exceeds 53477376 bytes",
+        }),
+        { status: 413, headers: { "Content-Type": "application/json" } },
+      )) as unknown as typeof fetch;
+
+    try {
+      const http = createHttpClient({ baseUrl: "https://core.test", logger });
+      try {
+        await http.postForm("/api/client/reports/rep_1/artifacts", new FormData());
+        throw new Error("expected request to fail");
+      } catch (err) {
+        expect(err).toBeInstanceOf(HttpError);
+        const httpError = err as HttpError;
+        expect(httpError.status).toBe(413);
+        expect(httpError.code).toBe("invalid_request");
+      }
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("keeps the older code/message error body mapping", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = (async () =>

--- a/cloud-v2/packages/cloud-client/src/http.ts
+++ b/cloud-v2/packages/cloud-client/src/http.ts
@@ -95,35 +95,26 @@ export function createHttpClient(deps: CreateHttpClientDeps): HttpClient {
   }
 
   /**
+   * The one retry loop behind every request shape (JSON, form, bodyless).
+   *
    * A network-level failure (DNS, reset, timeout) is transient and worth a
    * retry on an idempotent call. A non-2xx response is NOT transient here: it is
    * a definite answer from the server, mapped to an `HttpError` for the caller
    * to branch on (auth handles its own 401 refresh-and-retry a layer up).
+   * The thrown exhaustion error keeps the network-error detail out of its
+   * message to avoid leaking anything host-specific into a string a host might
+   * surface to a user.
    */
-  async function requestRaw(
-    method: "GET" | "POST" | "PUT" | "DELETE" | "HEAD",
-    path: string,
-    body: unknown,
-    opts?: ReqOpts,
-  ): Promise<Response> {
+  async function fetchWithRetry(args: {
+    method: "GET" | "POST" | "PUT" | "DELETE" | "HEAD";
+    path: string;
+    headers: Record<string, string>;
+    body: string | FormData | undefined;
+    idempotent: boolean;
+  }): Promise<Response> {
+    const { method, path, headers, body, idempotent } = args;
     const url = joinUrl(baseUrl, path);
-    const bearer = await resolveBearer(opts);
 
-    const headers: Record<string, string> = {};
-    if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
-
-    let payload: string | undefined;
-    if (body !== undefined) {
-      headers["Content-Type"] = "application/json";
-      payload = JSON.stringify(body);
-    }
-
-    // GET and DELETE are idempotent by HTTP semantics, so safe to retry; other
-    // verbs opt in via the flag.
-    const idempotent =
-      opts?.idempotent ?? (method === "GET" || method === "DELETE" || method === "HEAD");
-
-    let lastNetworkError: unknown;
     for (let attempt = 0; attempt <= (idempotent ? MAX_RETRIES : 0); attempt++) {
       if (attempt > 0) {
         const backoff = RETRY_BASE_MS * 2 ** (attempt - 1);
@@ -133,10 +124,9 @@ export function createHttpClient(deps: CreateHttpClientDeps): HttpClient {
 
       let res: Response;
       try {
-        res = await fetch(url, { method, headers, body: payload });
-      } catch (err) {
-        // Transient network failure: remember it and let the loop retry.
-        lastNetworkError = err;
+        res = await fetch(url, { method, headers, body });
+      } catch {
+        // Transient network failure: let the loop retry.
         logger.warn("http network error", { method, path, attempt });
         continue;
       }
@@ -155,10 +145,31 @@ export function createHttpClient(deps: CreateHttpClientDeps): HttpClient {
       0,
       "NETWORK_ERROR",
     );
-    // `lastNetworkError` is intentionally referenced for the logger above; the
-    // thrown error keeps the original detail out of the message to avoid leaking
-    // anything host-specific into a string a host might surface to a user.
-    void lastNetworkError;
+  }
+
+  async function requestRaw(
+    method: "GET" | "POST" | "PUT" | "DELETE" | "HEAD",
+    path: string,
+    body: unknown,
+    opts?: ReqOpts,
+  ): Promise<Response> {
+    const bearer = await resolveBearer(opts);
+
+    const headers: Record<string, string> = {};
+    if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
+
+    let payload: string | undefined;
+    if (body !== undefined) {
+      headers["Content-Type"] = "application/json";
+      payload = JSON.stringify(body);
+    }
+
+    // GET and DELETE are idempotent by HTTP semantics, so safe to retry; other
+    // verbs opt in via the flag.
+    const idempotent =
+      opts?.idempotent ?? (method === "GET" || method === "DELETE" || method === "HEAD");
+
+    return await fetchWithRetry({ method, path, headers, body: payload, idempotent });
   }
 
   async function request<T>(
@@ -176,43 +187,21 @@ export function createHttpClient(deps: CreateHttpClientDeps): HttpClient {
     form: FormData,
     opts?: ReqOpts,
   ): Promise<T> {
-    const url = joinUrl(baseUrl, path);
     const bearer = await resolveBearer(opts);
+
+    // No Content-Type here: fetch/FormData must generate the multipart
+    // boundary. POST is not idempotent, so retries stay opt-in.
     const headers: Record<string, string> = {};
     if (bearer) headers["Authorization"] = `Bearer ${bearer}`;
 
-    let lastNetworkError: unknown;
-    for (let attempt = 0; attempt <= (opts?.idempotent ? MAX_RETRIES : 0); attempt++) {
-      if (attempt > 0) {
-        const backoff = RETRY_BASE_MS * 2 ** (attempt - 1);
-        logger.debug("http retrying form request", { method: "POST", path, attempt });
-        await delay(backoff);
-      }
-
-      let res: Response;
-      try {
-        // Do not set Content-Type here: fetch/FormData must generate the
-        // multipart boundary.
-        res = await fetch(url, { method: "POST", headers, body: form });
-      } catch (err) {
-        lastNetworkError = err;
-        logger.warn("http form network error", { method: "POST", path, attempt });
-        continue;
-      }
-
-      if (!res.ok) {
-        throw await toHttpError(res, "POST", path);
-      }
-
-      return await parseJson<T>(res);
-    }
-
-    throw new HttpError(
-      `Network request failed: POST ${path}`,
-      0,
-      "NETWORK_ERROR",
-    );
-    void lastNetworkError;
+    const res = await fetchWithRetry({
+      method: "POST",
+      path,
+      headers,
+      body: form,
+      idempotent: opts?.idempotent ?? false,
+    });
+    return await parseJson<T>(res);
   }
 
   /**

--- a/cloud-v2/packages/core/src/api/client/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/client/reports.api.ts
@@ -6,6 +6,7 @@
  */
 
 import { Hono } from "hono";
+import { bodyLimit } from "hono/body-limit";
 import { z } from "zod";
 import { userAuth } from "../middleware/user-auth.middleware";
 import { InvalidRequest } from "../../types/oauth.types";
@@ -29,29 +30,24 @@ const logEntrySchema = z.object({
   message: z.string(),
   source: z.string().optional(),
 });
-const reportTriggerSchema = z.discriminatedUnion("type", [
-  z.object({
-    type: z.literal("manual"),
-    source: nonEmptyStringSchema,
-    reason: nonEmptyStringSchema,
-    sourceAppletPackageName: optionalNonEmptyStringSchema,
-    sourceAppletName: optionalNonEmptyStringSchema,
-  }),
-  z.object({
-    type: z.literal("automatic"),
-    source: nonEmptyStringSchema,
-    reason: nonEmptyStringSchema,
-    sourceAppletPackageName: optionalNonEmptyStringSchema,
-    sourceAppletName: optionalNonEmptyStringSchema,
-  }),
-]);
-const automaticReportTriggerSchema = z.object({
-  type: z.literal("automatic"),
+const reportTriggerFields = {
   source: nonEmptyStringSchema,
   reason: nonEmptyStringSchema,
   sourceAppletPackageName: optionalNonEmptyStringSchema,
   sourceAppletName: optionalNonEmptyStringSchema,
+};
+const manualReportTriggerSchema = z.object({
+  type: z.literal("manual"),
+  ...reportTriggerFields,
 });
+const automaticReportTriggerSchema = z.object({
+  type: z.literal("automatic"),
+  ...reportTriggerFields,
+});
+const reportTriggerSchema = z.discriminatedUnion("type", [
+  manualReportTriggerSchema,
+  automaticReportTriggerSchema,
+]);
 const reportDetailsSchema = z.object({
   actualBehavior: nonEmptyStringSchema,
   expectedBehavior: optionalNonEmptyStringSchema,
@@ -91,6 +87,32 @@ const logsArtifactSchema = z.object({
 });
 
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+// The feedback UI attaches at most 5 screenshots, and the cloud-client sends
+// them in a single multipart call.
+const MAX_ATTACHMENT_FILES = 5;
+// Router-wide request-body ceiling: the full attachment budget plus slack for
+// multipart framing. Also bounds the JSON routes (submit, logs).
+const MAX_REQUEST_BODY_BYTES =
+  MAX_ATTACHMENT_BYTES * MAX_ATTACHMENT_FILES + 1024 * 1024;
+
+// Reject oversized request bodies before the handlers buffer them: bodyLimit
+// fails fast on Content-Length and otherwise caps the stream as it is read.
+// The custom onError keeps the RFC error shape instead of bodyLimit's default
+// HTTPException, which the app-level error handler would report as a 500.
+reportsApp.use(
+  "*",
+  bodyLimit({
+    maxSize: MAX_REQUEST_BODY_BYTES,
+    onError: (c) =>
+      c.json(
+        {
+          error: "invalid_request",
+          error_description: `request body exceeds ${MAX_REQUEST_BODY_BYTES} bytes`,
+        },
+        413,
+      ),
+  }),
+);
 
 reportsApp.post("/", userAuth, postSubmitReport);
 reportsApp.post("/:reportId/artifacts", userAuth, postReportArtifacts);
@@ -173,8 +195,10 @@ async function readJsonObject(c: AppContext): Promise<Record<string, unknown>> {
     if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
       return parsed as Record<string, unknown>;
     }
-  } catch {
-    // fall through to InvalidRequest
+  } catch (error) {
+    // Only malformed JSON falls through to InvalidRequest; anything else
+    // (e.g. the bodyLimit cap tripping mid-read) must keep its own status.
+    if (!(error instanceof SyntaxError)) throw error;
   }
   throw new InvalidRequest("request body must be a JSON object");
 }
@@ -188,14 +212,18 @@ async function readAttachmentFiles(c: AppContext): Promise<ReportAttachmentInput
   const files: ReportAttachmentInput[] = [];
   for (const value of values) {
     if (typeof value === "string") continue;
-    const bytes = new Uint8Array(await value.arrayBuffer());
-    if (bytes.byteLength > MAX_ATTACHMENT_BYTES) {
+    if (files.length >= MAX_ATTACHMENT_FILES) {
+      throw new InvalidRequest(`too many artifact files (max ${MAX_ATTACHMENT_FILES})`);
+    }
+    // Enforce the per-file limit on the parsed size BEFORE buffering the file
+    // into its own array, so an oversized upload is rejected without copies.
+    if (value.size > MAX_ATTACHMENT_BYTES) {
       throw new InvalidRequest(`artifact ${value.name || "file"} exceeds ${MAX_ATTACHMENT_BYTES} bytes`);
     }
     files.push({
       filename: value.name || `artifact-${Date.now()}`,
       contentType: value.type || "application/octet-stream",
-      bytes,
+      bytes: new Uint8Array(await value.arrayBuffer()),
     });
   }
 

--- a/cloud-v2/packages/core/src/models/report-asset.model.ts
+++ b/cloud-v2/packages/core/src/models/report-asset.model.ts
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview `report_assets` collection.
+ *
+ * One row per stored report artifact payload (screenshot bytes, serialized log
+ * bundles). Follows the MiniAppAsset pattern: the payload itself lives in blob
+ * storage under `storageKey` (see services/storage) and Mongo keeps only the
+ * metadata row, so `reports` documents stay small no matter how many artifacts
+ * a report collects. `artifactId` joins the row to the artifact entry embedded
+ * in the owning report document.
+ */
+
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+const ReportAssetSchema = new Schema(
+  {
+    artifactId: { type: String, required: true, unique: true },
+    reportId: { type: String, required: true, index: true },
+    mentraUserId: { type: String, required: true, index: true },
+    storageKey: { type: String, required: true, unique: true },
+    fileName: { type: String, default: null },
+    contentType: { type: String, required: true },
+    sizeBytes: { type: Number, required: true },
+    sha256: { type: String, required: true },
+  },
+  { timestamps: { createdAt: true, updatedAt: false }, collection: "report_assets" },
+);
+
+export type ReportAsset = InferSchemaType<typeof ReportAssetSchema>;
+export const ReportAssetModel = model("ReportAsset", ReportAssetSchema);

--- a/cloud-v2/packages/core/src/models/report.model.ts
+++ b/cloud-v2/packages/core/src/models/report.model.ts
@@ -5,6 +5,13 @@
  * automatic runtime reports, and feature/general feedback. The root record
  * captures the report kind, user/system-authored payload, toolkit-collected
  * runtime context, and typed evidence artifacts.
+ *
+ * Artifact entries hold metadata only. Payloads (screenshot bytes, serialized
+ * log bundles) live in blob storage, described by a `report_assets` row keyed
+ * by the same `artifactId` (see report-asset.model.ts). Keeping payloads out of
+ * this document caps its size well below Mongo's 16MB document limit and keeps
+ * report queries cheap. This layout shipped before the collection ever reached
+ * a deployed environment, so no inline-payload documents exist to migrate.
  */
 
 import { Schema, model, type InferSchemaType } from "mongoose";
@@ -18,11 +25,9 @@ const ReportArtifactSchema = new Schema(
       required: true,
     },
     source: { type: String, required: true },
-    data: { type: Schema.Types.Mixed, default: null },
     filename: { type: String, default: null },
     contentType: { type: String, default: null },
     sizeBytes: { type: Number, default: null },
-    dataBase64: { type: String, default: null },
     createdAt: { type: Date, required: true },
   },
   { _id: false },

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -1,9 +1,28 @@
 /**
  * @fileoverview Report service for Cloud V2 core.
+ *
+ * Artifact payloads (screenshot bytes, serialized log bundles) never live in
+ * the report document: each one is written to blob storage and described by a
+ * `report_assets` row (same pattern as miniapp assets), while the report
+ * embeds only artifact metadata. A report therefore stays a few KB no matter
+ * how many attachments it collects.
  */
 
 import { ulid } from "ulid";
+import { createLogger } from "@mentra/cloud-shared";
 import { ReportModel } from "../models/report.model";
+import { ReportAssetModel } from "../models/report-asset.model";
+import { createStorageService } from "./storage/storage.service";
+
+const logger = createLogger("core").child({ service: "report.service" });
+
+// Same provider selection as miniapp assets: local disk in dev, S3/R2 when
+// CLOUD_STORAGE_PROVIDER says so. Created on first use, not at import, so the
+// provider env vars are read after test setup has pointed them somewhere safe.
+let storageInstance: ReturnType<typeof createStorageService> | undefined;
+function getStorage() {
+  return (storageInstance ??= createStorageService());
+}
 
 export type ReportKind = "bug" | "feedback" | "automatic";
 export type ReportStatus = "collecting" | "ready" | "closed";
@@ -102,24 +121,19 @@ export async function addLogArtifact(input: {
   source: string;
   entries: ReportLogEntry[];
 }): Promise<AddReportArtifactsResult | null> {
-  const artifact = {
-    artifactId: `art_${ulid()}`,
-    type: "logs",
-    source: input.source,
-    data: { entries: input.entries },
-    createdAt: new Date(),
-  };
-
-  const result = await ReportModel.updateOne(
-    { reportId: input.reportId, mentraUserId: input.mentraUserId },
-    {
-      $push: { artifacts: artifact },
-      $set: { updatedAt: new Date() },
-    },
-  );
-
-  if (result.matchedCount !== 1) return null;
-  return { stored: 1 };
+  return await addArtifacts({
+    reportId: input.reportId,
+    mentraUserId: input.mentraUserId,
+    payloads: [
+      {
+        type: "logs",
+        source: input.source,
+        filename: null,
+        contentType: "application/json",
+        bytes: Buffer.from(JSON.stringify({ entries: input.entries }), "utf8"),
+      },
+    ],
+  });
 }
 
 export async function addScreenshotArtifacts(input: {
@@ -127,28 +141,17 @@ export async function addScreenshotArtifacts(input: {
   reportId: string;
   files: ReportAttachmentInput[];
 }): Promise<AddReportArtifactsResult | null> {
-  const now = new Date();
-  const artifacts = input.files.map((file) => ({
-    artifactId: `art_${ulid()}`,
-    type: "screenshot",
-    source: "phone",
-    filename: file.filename,
-    contentType: file.contentType,
-    sizeBytes: file.bytes.byteLength,
-    dataBase64: Buffer.from(file.bytes).toString("base64"),
-    createdAt: now,
-  }));
-
-  const result = await ReportModel.updateOne(
-    { reportId: input.reportId, mentraUserId: input.mentraUserId },
-    {
-      $push: { artifacts: { $each: artifacts } },
-      $set: { updatedAt: now },
-    },
-  );
-
-  if (result.matchedCount !== 1) return null;
-  return { stored: artifacts.length };
+  return await addArtifacts({
+    reportId: input.reportId,
+    mentraUserId: input.mentraUserId,
+    payloads: input.files.map((file) => ({
+      type: "screenshot" as const,
+      source: "phone",
+      filename: file.filename,
+      contentType: file.contentType,
+      bytes: file.bytes,
+    })),
+  });
 }
 
 export async function markReportReady(input: {
@@ -161,4 +164,116 @@ export async function markReportReady(input: {
   );
   if (result.matchedCount !== 1) return null;
   return "ready";
+}
+
+interface ReportArtifactPayload {
+  type: "logs" | "screenshot" | "state_snapshot";
+  source: string;
+  filename: string | null;
+  contentType: string;
+  bytes: Uint8Array;
+}
+
+interface StoredReportAsset {
+  artifactId: string;
+  storageKey: string;
+}
+
+/**
+ * Store artifact payloads and attach their metadata to the owning report.
+ *
+ * Order: ownership check (so an unknown reportId 404s without touching
+ * storage), then blob + asset row per payload, then one metadata push onto the
+ * report. Any failure after the first blob write rolls back everything stored
+ * so far, so a failed call leaves no orphaned blobs or asset rows behind.
+ */
+async function addArtifacts(input: {
+  reportId: string;
+  mentraUserId: string;
+  payloads: ReportArtifactPayload[];
+}): Promise<AddReportArtifactsResult | null> {
+  const { reportId, mentraUserId } = input;
+  const owned = await ReportModel.exists({ reportId, mentraUserId });
+  if (!owned) return null;
+
+  const now = new Date();
+  const stored: StoredReportAsset[] = [];
+  const artifacts: Array<{
+    artifactId: string;
+    type: ReportArtifactPayload["type"];
+    source: string;
+    filename: string | null;
+    contentType: string;
+    sizeBytes: number;
+    createdAt: Date;
+  }> = [];
+  try {
+    for (const payload of input.payloads) {
+      const artifactId = `art_${ulid()}`;
+      // Only server-generated ids appear in the key; the client-supplied
+      // filename stays metadata so it can never shape a storage path.
+      const storageKey = `reports/${reportId}/${artifactId}`;
+      const object = await getStorage().putObject({
+        key: storageKey,
+        body: payload.bytes,
+        contentType: payload.contentType,
+      });
+      stored.push({ artifactId, storageKey });
+      await ReportAssetModel.create({
+        artifactId,
+        reportId,
+        mentraUserId,
+        storageKey,
+        fileName: payload.filename,
+        contentType: object.contentType,
+        sizeBytes: object.sizeBytes,
+        sha256: object.sha256,
+      });
+      artifacts.push({
+        artifactId,
+        type: payload.type,
+        source: payload.source,
+        filename: payload.filename,
+        contentType: payload.contentType,
+        sizeBytes: object.sizeBytes,
+        createdAt: now,
+      });
+    }
+
+    const result = await ReportModel.updateOne(
+      { reportId, mentraUserId },
+      {
+        $push: { artifacts: { $each: artifacts } },
+        $set: { updatedAt: now },
+      },
+    );
+    if (result.matchedCount !== 1) {
+      // The report vanished between the ownership check and the metadata
+      // write; treat it as not-found and leave nothing orphaned.
+      await discardReportAssets(reportId, stored);
+      return null;
+    }
+    return { stored: artifacts.length };
+  } catch (error) {
+    await discardReportAssets(reportId, stored);
+    throw error;
+  }
+}
+
+/** Best-effort rollback of stored blobs and asset rows; failures are logged, never thrown. */
+async function discardReportAssets(reportId: string, assets: StoredReportAsset[]): Promise<void> {
+  for (const asset of assets) {
+    await ReportAssetModel.deleteOne({ artifactId: asset.artifactId }).catch((cleanupError) => {
+      logger.error(
+        { cleanupError, reportId, artifactId: asset.artifactId },
+        "failed to roll back report asset row",
+      );
+    });
+    await getStorage().deleteObject(asset.storageKey).catch((cleanupError) => {
+      logger.error(
+        { cleanupError, reportId, storageKey: asset.storageKey },
+        "failed to delete stored report artifact",
+      );
+    });
+  }
 }

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -255,24 +255,48 @@ async function addArtifacts(input: {
     }
     return { stored: artifacts.length };
   } catch (error) {
-    await discardReportAssets(reportId, stored);
+    if (stored.length > 0) {
+      // The metadata push may have failed AMBIGUOUSLY (e.g. a network error
+      // after the server applied it), which would leave the report pointing at
+      // payloads the rollback below removes. Sweep the pushed artifactIds
+      // first so both ambiguous outcomes converge on "nothing stored".
+      await ReportModel.updateOne(
+        { reportId, mentraUserId },
+        { $pull: { artifacts: { artifactId: { $in: stored.map((asset) => asset.artifactId) } } } },
+      ).catch((cleanupError) => {
+        logger.error(
+          { cleanupError, reportId },
+          "failed to sweep report artifact metadata during rollback",
+        );
+      });
+      await discardReportAssets(reportId, stored);
+    }
     throw error;
   }
 }
 
-/** Best-effort rollback of stored blobs and asset rows; failures are logged, never thrown. */
+/**
+ * Best-effort rollback of stored blobs and asset rows; failures are logged,
+ * never thrown. The blob goes first, and its asset row is only removed once
+ * the blob delete succeeded: a surviving row keeps a failed blob delete
+ * discoverable (and retryable), whereas removing the row first would leave an
+ * unreferenced blob nothing can find again.
+ */
 async function discardReportAssets(reportId: string, assets: StoredReportAsset[]): Promise<void> {
   for (const asset of assets) {
+    try {
+      await getStorage().deleteObject(asset.storageKey);
+    } catch (cleanupError) {
+      logger.error(
+        { cleanupError, reportId, storageKey: asset.storageKey },
+        "failed to delete stored report artifact; keeping its asset row so the blob stays discoverable",
+      );
+      continue;
+    }
     await ReportAssetModel.deleteOne({ artifactId: asset.artifactId }).catch((cleanupError) => {
       logger.error(
         { cleanupError, reportId, artifactId: asset.artifactId },
         "failed to roll back report asset row",
-      );
-    });
-    await getStorage().deleteObject(asset.storageKey).catch((cleanupError) => {
-      logger.error(
-        { cleanupError, reportId, storageKey: asset.storageKey },
-        "failed to delete stored report artifact",
       );
     });
   }

--- a/cloud-v2/tests/reports.integration.test.ts
+++ b/cloud-v2/tests/reports.integration.test.ts
@@ -1,0 +1,360 @@
+/**
+ * @fileoverview Reports API integration tests.
+ *
+ * Covers the artifact asset store (screenshot and log payloads land in blob
+ * storage described by `report_assets` rows, while the `reports` document
+ * keeps metadata only) and the upload size limits (per-file, file count, and
+ * the router-wide body cap).
+ *
+ * Wires the core in-process via app.fetch and authenticates through the real
+ * Supabase-subject token exchange, mirroring auth.mentra-user-exchange tests.
+ *
+ * Prereq: a running Mongo. Defaults to
+ * `mongodb://127.0.0.1:27017/mentra-cloud-v2-test`; override via `MONGO_URL`.
+ * The test wipes its own collections between cases — do NOT point at a real DB.
+ *
+ * Run: `bun test tests/reports.integration.test.ts`
+ */
+
+import crypto from "node:crypto";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// Crypto material and the storage root must be set BEFORE core reads them.
+// Signing keys are loaded lazily and the report service creates its storage
+// provider on first use, so setting env at module evaluation is early enough.
+const STORAGE_DIR = join(tmpdir(), `mentra-reports-test-${process.pid}`);
+{
+  const { privateKey: nodePriv, publicKey: nodePub } =
+    crypto.generateKeyPairSync("ed25519");
+  process.env.MENTRA_JWT_PRIVATE_KEY = stripPemWrap(
+    nodePriv.export({ type: "pkcs8", format: "pem" }).toString(),
+  );
+  process.env.MENTRA_JWT_PUBLIC_KEY = stripPemWrap(
+    nodePub.export({ type: "spki", format: "pem" }).toString(),
+  );
+  process.env.REFRESH_TOKEN_PEPPER ??= "test-pepper-not-for-production";
+  process.env.MONGO_URL ??= "mongodb://127.0.0.1:27017/mentra-cloud-v2-test";
+  process.env.SUPABASE_JWT_SECRET = "test-supabase-secret-not-for-production";
+  process.env.SUPABASE_URL = "https://testproj.supabase.co";
+  process.env.CLOUD_CORE_LOCAL_STORAGE_DIR = STORAGE_DIR;
+}
+
+// eslint-disable-next-line import/first
+import {
+  connectMongo,
+  disconnectMongo,
+  mongoReadinessCheck,
+} from "../packages/core/src/connections/mongo.connection";
+import { createApp } from "../packages/core/src/api/app";
+import { ReportModel } from "../packages/core/src/models/report.model";
+import { ReportAssetModel } from "../packages/core/src/models/report-asset.model";
+import { UserModel } from "../packages/core/src/models/user.model";
+import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
+import { SeenJtiModel } from "../packages/core/src/models/seen-jti.model";
+import { RevokedJtiModel } from "../packages/core/src/models/revoked-jti.model";
+import {
+  createStorageService,
+  sha256Hex,
+} from "../packages/core/src/services/storage/storage.service";
+
+// Mirrors the limits in api/client/reports.api.ts.
+const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+const MAX_ATTACHMENT_FILES = 5;
+const MAX_REQUEST_BODY_BYTES =
+  MAX_ATTACHMENT_BYTES * MAX_ATTACHMENT_FILES + 1024 * 1024;
+
+const REPORTS_PATH = "http://localhost/api/client/reports";
+
+let coreApp: ReturnType<typeof createApp>;
+let accessToken: string;
+let mentraUserId: string;
+
+beforeAll(async () => {
+  await connectMongo(process.env.MONGO_URL!);
+  await Promise.all([
+    ReportModel.syncIndexes(),
+    ReportAssetModel.syncIndexes(),
+    UserModel.syncIndexes(),
+    RefreshTokenModel.syncIndexes(),
+    SeenJtiModel.syncIndexes(),
+    RevokedJtiModel.syncIndexes(),
+  ]);
+  coreApp = createApp({ readinessChecks: [mongoReadinessCheck] });
+
+  const res = await exchange(mintSupabaseJwt("reports-user-1"));
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { access_token: string };
+  accessToken = body.access_token;
+  mentraUserId = decodeJwtPayload(accessToken).sub as string;
+});
+
+afterAll(async () => {
+  await disconnectMongo();
+  await rm(STORAGE_DIR, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await Promise.all([
+    ReportModel.deleteMany({}),
+    ReportAssetModel.deleteMany({}),
+  ]);
+});
+
+describe("reports artifact asset store", () => {
+  test("stores screenshot payloads in blob storage, keeping the report metadata-only", async () => {
+    const reportId = await submitBugReport();
+    const imageA = crypto.randomBytes(2048);
+    const imageB = crypto.randomBytes(4096);
+
+    const form = new FormData();
+    form.append("type", "screenshot");
+    form.append("source", "phone");
+    form.append("files", new File([imageA], "one.jpg", { type: "image/jpeg" }));
+    form.append("files", new File([imageB], "two.png", { type: "image/png" }));
+
+    const res = await postArtifacts(reportId, form);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ stored: 2 });
+
+    // The stored document embeds metadata only — no payload fields at all.
+    const doc = await ReportModel.collection.findOne({ reportId });
+    const artifacts = (doc?.artifacts ?? []) as Array<Record<string, unknown>>;
+    expect(artifacts).toHaveLength(2);
+    for (const artifact of artifacts) {
+      expect(artifact.type).toBe("screenshot");
+      expect(artifact.source).toBe("phone");
+      expect(typeof artifact.artifactId).toBe("string");
+      expect("dataBase64" in artifact).toBe(false);
+      expect("data" in artifact).toBe(false);
+    }
+
+    // Each artifact has an asset row and the blob round-trips byte-for-byte.
+    const storage = createStorageService();
+    for (const [bytes, name, contentType] of [
+      [imageA, "one.jpg", "image/jpeg"],
+      [imageB, "two.png", "image/png"],
+    ] as const) {
+      const artifact = artifacts.find((a) => a.filename === name);
+      expect(artifact?.contentType).toBe(contentType);
+      expect(artifact?.sizeBytes).toBe(bytes.byteLength);
+
+      const asset = await ReportAssetModel.findOne({
+        artifactId: artifact?.artifactId,
+      }).lean();
+      expect(asset?.reportId).toBe(reportId);
+      expect(asset?.mentraUserId).toBe(mentraUserId);
+      expect(asset?.fileName).toBe(name);
+      expect(asset?.contentType).toBe(contentType);
+      expect(asset?.sizeBytes).toBe(bytes.byteLength);
+      expect(asset?.sha256).toBe(sha256Hex(bytes));
+      expect(asset?.storageKey).toStartWith(`reports/${reportId}/`);
+
+      const stored = await storage.getObject(asset!.storageKey);
+      expect(Buffer.from(stored).equals(bytes)).toBe(true);
+    }
+  });
+
+  test("stores log bundles in blob storage and round-trips the entries", async () => {
+    const reportId = await submitBugReport();
+    const entries = [
+      { timestamp: 1700000000001, level: "info", message: "glasses connected" },
+      { timestamp: 1700000000002, level: "error", message: "ota failed", source: "asg" },
+    ];
+
+    const res = await coreApp.fetch(
+      new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+        method: "POST",
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ type: "logs", source: "glasses", entries }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ stored: 1 });
+
+    const doc = await ReportModel.collection.findOne({ reportId });
+    const artifacts = (doc?.artifacts ?? []) as Array<Record<string, unknown>>;
+    expect(artifacts).toHaveLength(1);
+    expect(artifacts[0].type).toBe("logs");
+    expect(artifacts[0].source).toBe("glasses");
+    expect(artifacts[0].contentType).toBe("application/json");
+    expect("data" in artifacts[0]).toBe(false);
+    expect("dataBase64" in artifacts[0]).toBe(false);
+
+    const asset = await ReportAssetModel.findOne({
+      artifactId: artifacts[0].artifactId,
+    }).lean();
+    expect(asset?.contentType).toBe("application/json");
+
+    const stored = await createStorageService().getObject(asset!.storageKey);
+    expect(JSON.parse(Buffer.from(stored).toString("utf8"))).toEqual({ entries });
+
+    const complete = await coreApp.fetch(
+      new Request(`${REPORTS_PATH}/${reportId}/complete`, {
+        method: "POST",
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: "{}",
+      }),
+    );
+    expect(complete.status).toBe(200);
+    expect(await complete.json()).toEqual({ status: "ready" });
+  });
+
+  test("returns 404 for an unknown report without storing anything", async () => {
+    const form = new FormData();
+    form.append("files", new File([crypto.randomBytes(16)], "s.jpg", { type: "image/jpeg" }));
+
+    const res = await postArtifacts("rep_does_not_exist", form);
+    expect(res.status).toBe(404);
+    expect(await ReportAssetModel.countDocuments({})).toBe(0);
+  });
+});
+
+describe("reports upload limits", () => {
+  test("rejects an artifact over the per-file limit before storing anything", async () => {
+    const reportId = await submitBugReport();
+    const oversized = new Uint8Array(MAX_ATTACHMENT_BYTES + 1);
+
+    const form = new FormData();
+    form.append("files", new File([oversized], "huge.jpg", { type: "image/jpeg" }));
+
+    const res = await postArtifacts(reportId, form);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_request");
+    expect(body.error_description).toContain("exceeds");
+
+    const doc = await ReportModel.collection.findOne({ reportId });
+    expect(doc?.artifacts ?? []).toHaveLength(0);
+    expect(await ReportAssetModel.countDocuments({})).toBe(0);
+  });
+
+  test("rejects more artifact files than the per-request cap", async () => {
+    const reportId = await submitBugReport();
+
+    const form = new FormData();
+    for (let i = 0; i < MAX_ATTACHMENT_FILES + 1; i++) {
+      form.append("files", new File([crypto.randomBytes(8)], `s${i}.jpg`, { type: "image/jpeg" }));
+    }
+
+    const res = await postArtifacts(reportId, form);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_request");
+    expect(body.error_description).toContain("too many artifact files");
+    expect(await ReportAssetModel.countDocuments({})).toBe(0);
+  });
+
+  test("caps the raw request body at the router-wide limit", async () => {
+    const reportId = await submitBugReport();
+    // One byte over the router cap, sent as an opaque multipart body so the
+    // limit has to trip while the stream is being read.
+    const body = new Uint8Array(MAX_REQUEST_BODY_BYTES + 1);
+
+    const res = await coreApp.fetch(
+      new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+        method: "POST",
+        headers: {
+          ...authHeaders(),
+          "content-type": "multipart/form-data; boundary=deadbeef",
+        },
+        body,
+      }),
+    );
+    expect(res.status).toBe(413);
+    const parsed = (await res.json()) as { error: string; error_description: string };
+    expect(parsed.error).toBe("invalid_request");
+    expect(parsed.error_description).toContain("exceeds");
+    expect(await ReportAssetModel.countDocuments({})).toBe(0);
+  });
+});
+
+// === Helpers ===
+
+function authHeaders(): Record<string, string> {
+  return { authorization: `Bearer ${accessToken}` };
+}
+
+async function submitBugReport(): Promise<string> {
+  const res = await coreApp.fetch(
+    new Request(REPORTS_PATH, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "bug",
+        trigger: { type: "manual", source: "feedback_screen", reason: "manual_bug_report" },
+        report: { actualBehavior: "the app crashed" },
+        context: { app: { appVersion: "test" } },
+      }),
+    }),
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { reportId: string; status: string };
+  expect(body.status).toBe("collecting");
+  return body.reportId;
+}
+
+function postArtifacts(reportId: string, form: FormData): Promise<Response> {
+  return coreApp.fetch(
+    new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+      method: "POST",
+      headers: authHeaders(),
+      body: form,
+    }),
+  );
+}
+
+async function exchange(jwt: string): Promise<Response> {
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    subject_token: jwt,
+    subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+  });
+  return coreApp.fetch(
+    new Request("http://localhost/api/client/auth/exchange", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    }),
+  );
+}
+
+/** Mint an HS256 JWT shaped like a Supabase session token. */
+function mintSupabaseJwt(sub: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({
+      sub,
+      iss: `${process.env.SUPABASE_URL}/auth/v1`,
+      aud: "authenticated",
+      role: "authenticated",
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const sig = crypto
+    .createHmac("sha256", process.env.SUPABASE_JWT_SECRET!)
+    .update(signingInput)
+    .digest("base64url");
+  return `${signingInput}.${sig}`;
+}
+
+function b64url(value: string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const part = token.split(".")[1] ?? "";
+  return JSON.parse(Buffer.from(part, "base64url").toString("utf8"));
+}
+
+function stripPemWrap(pem: string): string {
+  return pem
+    .replace(/-----BEGIN [A-Z ]+-----/, "")
+    .replace(/-----END [A-Z ]+-----/, "")
+    .replace(/\s+/g, "");
+}


### PR DESCRIPTION
Follow-up to the reports-service architecture findings the review bots raised on #3331, which were deliberately deferred out of that PR as design-review-worthy. Stacked on `integration/toolkit-boundary`; once #3331 merges this retargets to `dev` and the diff reduces to the two commits here.

## What changed

**1. Artifact payloads move out of the `reports` document** (cubic P1 on `report.model.ts`, codex P2 on `report.service.ts`)
Screenshot bytes and log bundles were base64/JSON-encoded inline in the report document — five near-limit screenshots (10 MB each, ~13 MB base64) could blow the 16 MB Mongo document cap, and every report query dragged the payloads along. Payloads now go through the shared `StorageService` (local disk in dev, S3/R2 in prod) under `reports/{reportId}/{artifactId}` keys, each described by a `report_assets` metadata row (`storageKey`, `fileName`, `contentType`, `sizeBytes`, `sha256`) — the same pattern as `MiniAppAsset`. The report document keeps artifact metadata only (`data`/`dataBase64` fields are gone), so it stays a few KB regardless of attachments. A failed artifact call rolls back any blobs and asset rows it already stored, so nothing is orphaned. Storage keys contain only server-generated ids; client filenames stay metadata and can never shape a storage path.

**Migration story:** none needed. cloud-v2 deploys only run from `dev`/`staging`/`main` (plus the named debug branches), and no deploy has ever run from `integration/toolkit-boundary` — verified against the workflow run history. The `reports` collection therefore does not exist in any deployed database; the inline-payload layout never shipped.

**2. Upload memory safety** (cubic P1 on `reports.api.ts:191`)
The per-file limit is now enforced against the parsed `File.size` *before* the bytes are copied out with `arrayBuffer()`, requests are capped at 5 artifact files (the feedback UI maximum, sent as one multipart call by the cloud-client), and a router-wide `bodyLimit` (5×10 MB + 1 MB framing slack) rejects oversized bodies with 413 — fail-fast on `Content-Length`, streamed cap otherwise — before handlers buffer them. The bodyLimit `onError` keeps the RFC error shape instead of the default `HTTPException` the app-level handler would report as a 500, and `readJsonObject` now only maps `SyntaxError` to `invalid_request` so the cap's status isn't masked on the JSON routes.

**3. Shared retry core in cloud-client http** (cubic P2 on `http.ts:174`)
`requestForm` duplicated `requestRaw`'s entire retry/backoff/logging/error-mapping loop. Both now call one `fetchWithRetry` helper; only body-specific setup (JSON stringify + Content-Type vs FormData passthrough) remains per path. Also removes the unreachable `lastNetworkError` bookkeeping.

**4. Trigger schema dedup** (cubic P2 on `reports.api.ts:48`)
The automatic trigger variant is defined once (`automaticReportTriggerSchema` built from shared `reportTriggerFields`) and referenced by both the discriminated union and the `kind: "automatic"` submit branch.

## Contract
The mobile island reports facade and the cloud-client API surface are unchanged (`toolkit.reports.submit` contract stays); this is a server-side storage refactor. For legitimate clients (≤5 screenshots ≤10 MB each) request/response behavior is identical.

## Tests
- New `cloud-v2/tests/reports.integration.test.ts` (in-process app + real Mongo + local storage provider, authenticated via the real token exchange): asset-store round-trip for screenshots and log bundles (blob bytes match byte-for-byte, asset rows carry correct hashes/sizes, stored documents verified payload-free at the raw-driver level), per-file size rejection, file-count rejection, router-wide 413 body cap, and 404 on unknown report without touching storage.
- Extended `cloud-v2/packages/cloud-client/src/http.test.ts`: form path through the shared retry core — no Content-Type header, POST not retried by default, opt-in idempotent retry, non-2xx error mapping.
- `bun run typecheck` clean; 96 tests pass across the cloud-client package and the core integration suites (auth, oem-auth, trusted-issuer, startup-migrations, miniapp release lifecycle, enterprise portal, reports).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the report attachment write path (blob + Mongo + rollback) and request body handling; API contract for normal clients is unchanged and coverage is strong.
> 
> **Overview**
> Report **screenshot and log payloads** no longer live inline on Mongo `reports` documents (`data` / `dataBase64` removed). They are written through **`StorageService`** under `reports/{reportId}/{artifactId}`, tracked in a new **`report_assets`** collection, with **metadata-only** entries on the report. **`addArtifacts`** verifies ownership first, then stores blobs with rollback (metadata sweep + blob delete) on failure.
> 
> The **reports API** adds router-wide **`bodyLimit`** (413 with OAuth-style errors), a **5-file** cap, **per-file size checks before `arrayBuffer()`**, and **`readJsonObject`** only maps **`SyntaxError`** so body-limit errors are not turned into 400s. Trigger Zod schemas share **`reportTriggerFields`**.
> 
> **`cloud-client`** JSON and **`postForm`** paths now share **`fetchWithRetry`**; form uploads still omit **`Content-Type`** and only retry when **`idempotent: true`**.
> 
> New **`reports.integration.test.ts`** and extended **`http.test.ts`** cover storage round-trips, limits, and form retry/error behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 079fdc18fc061c934b898881d0aaeb120de9ffbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->