### PR TITLE
Route Connect into pairing when no default device is paired

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -286,6 +286,7 @@ jest.mock("@mentra/island", () => {
     decideReconnect: (input) => {
       if (!input?.reconnectOnForeground) return {kind: "skip", result: true}
       if (!input?.defaultWearable || input?.isSimulated) return {kind: "skip", result: false}
+      if (!input?.hasDefaultDevice) return {kind: "skip", result: false}
       if (input?.connection?.state === "connected" || input?.searching) return {kind: "skip", result: true}
       return {kind: "connect"}
     },

--- a/mobile/modules/island/src/services/ConnectionCoordinator.ts
+++ b/mobile/modules/island/src/services/ConnectionCoordinator.ts
@@ -22,6 +22,8 @@ export interface ReconnectDecisionInput {
   isSimulated: boolean
   /** Current glasses connection snapshot. */
   connection: GlassesConnectionStatus
+  /** True when the SDK holds an actual default device (connectDefault target). */
+  hasDefaultDevice: boolean
   /** True when a scan is already in progress. */
   searching: boolean
 }
@@ -38,6 +40,9 @@ export function decideReconnect(input: ReconnectDecisionInput): ReconnectDecisio
   if (!input.reconnectOnForeground) return {kind: "skip", result: true}
   // No real wearable paired (or the simulated device): nothing to reconnect to.
   if (!input.defaultWearable || input.isSimulated) return {kind: "skip", result: false}
+  // Model chosen but never actually paired (or the native default was cleared):
+  // connectDefault() would throw — skip quietly; pairing is a user-driven flow.
+  if (!input.hasDefaultDevice) return {kind: "skip", result: false}
   // Already connected, or a scan is already running: nothing to do.
   if (isGlassesConnected(input.connection) || input.searching) return {kind: "skip", result: true}
   return {kind: "connect"}

--- a/mobile/src/__tests__/connectionCoordinator.test.ts
+++ b/mobile/src/__tests__/connectionCoordinator.test.ts
@@ -12,6 +12,7 @@ describe("decideReconnect", () => {
     defaultWearable: "Even Realities G1",
     isSimulated: false,
     connection: disconnected,
+    hasDefaultDevice: true,
     searching: false,
   }
 
@@ -33,6 +34,10 @@ describe("decideReconnect", () => {
 
   it("skips when already searching", () => {
     expect(decideReconnect({...base, searching: true})).toEqual({kind: "skip", result: true})
+  })
+
+  it("skips quietly when a model is chosen but no device was ever paired", () => {
+    expect(decideReconnect({...base, hasDefaultDevice: false})).toEqual({kind: "skip", result: false})
   })
 
   it("connects when paired, idle, and disconnected", () => {

--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -36,6 +36,17 @@ export const ConnectDeviceButton = () => {
         return
       }
 
+      // A chosen model (default_wearable) does not imply a paired device: the
+      // setting is written on the selection screen, before pairing succeeds
+      // (or survives states where the native default was cleared). Without a
+      // device, connectDefault() throws — route back into pairing for the
+      // already-selected model instead of surfacing an error alert. Fail open
+      // on a bridge error so connectDefault's own handling still runs.
+      if (!(await BluetoothSdk.getDefaultDevice().catch(() => true))) {
+        push("/pairing/scan", {deviceModel: defaultWearable})
+        return
+      }
+
       await BluetoothSdk.connectDefault()
     } catch (err) {
       console.error("connect to glasses error:", err)

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -130,6 +130,15 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       if (!requirementsCheck) {
         return
       }
+      // A chosen model (default_wearable) does not imply a paired device: the
+      // setting is written on the selection screen, before pairing succeeds.
+      // Without a native default device, connectDefault() throws — route back
+      // into pairing for the already-selected model instead of erroring. Fail
+      // open on a bridge error so connectDefault's own handling still runs.
+      if (!(await BluetoothSdk.getDefaultDevice().catch(() => true))) {
+        push("/pairing/scan", {deviceModel: defaultWearable})
+        return
+      }
       await BluetoothSdk.connectDefault()
     } catch (error) {
       console.error("connect to glasses error:", error)

--- a/mobile/src/effects/Reconnect.test.ts
+++ b/mobile/src/effects/Reconnect.test.ts
@@ -38,4 +38,32 @@ describe("attemptReconnectToDefaultWearable", () => {
       (BluetoothSdk.connectDefault as jest.Mock).mock.invocationCallOrder[0],
     )
   })
+
+  it("skips quietly when a model is chosen but no device was ever paired", async () => {
+    useSettingsStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        [SETTINGS.default_wearable.key]: "Mentra Live",
+      },
+    }))
+    ;(BluetoothSdk.getDefaultDevice as jest.Mock).mockResolvedValueOnce(null)
+
+    await expect(attemptReconnectToDefaultWearable()).resolves.toBe(false)
+
+    expect(BluetoothSdk.connectDefault).not.toHaveBeenCalled()
+  })
+
+  it("fails open to connectDefault when the default-device lookup rejects", async () => {
+    useSettingsStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        [SETTINGS.default_wearable.key]: "Mentra Live",
+      },
+    }))
+    ;(BluetoothSdk.getDefaultDevice as jest.Mock).mockRejectedValueOnce(new Error("bridge unavailable"))
+
+    await expect(attemptReconnectToDefaultWearable()).resolves.toBe(true)
+
+    expect(BluetoothSdk.connectDefault).toHaveBeenCalled()
+  })
 })

--- a/mobile/src/effects/Reconnect.tsx
+++ b/mobile/src/effects/Reconnect.tsx
@@ -19,6 +19,11 @@ export async function attemptReconnectToDefaultWearable(): Promise<boolean> {
     defaultWearable,
     isSimulated: !!defaultWearable && defaultWearable.includes(DeviceTypes.SIMULATED),
     connection: useGlassesStore.getState().connection,
+    // Fail open on a bridge error: pass true so the flow proceeds to
+    // connectDefault(), whose existing catch handles a genuinely missing
+    // device (the pre-guard behavior) — a transient native failure must not
+    // throw out of the app-foreground handler.
+    hasDefaultDevice: !!(await BluetoothSdk.getDefaultDevice().catch(() => true)),
     searching: useCoreStore.getState().searching,
   })
   if (decision.kind === "skip") {

--- a/mobile/src/test-utils/mockBluetoothSdk.ts
+++ b/mobile/src/test-utils/mockBluetoothSdk.ts
@@ -75,7 +75,9 @@ export const bluetoothSdkMock = {
   displayText: jest.fn(() => Promise.resolve()),
   clearDisplay: jest.fn(() => Promise.resolve()),
   requestStatus: jest.fn(() => Promise.resolve()),
-  getDefaultDevice: jest.fn(() => null),
+  // Default: a device is paired (the common case for connect-path tests);
+  // override with mockResolvedValueOnce(null) to exercise the unpaired state.
+  getDefaultDevice: jest.fn(() => Promise.resolve({id: "mock-default-device", model: "Mock Glasses", name: "Mock Glasses"})),
   setDefaultDevice: jest.fn(() => Promise.resolve()),
   clearDefaultDevice: jest.fn(() => Promise.resolve()),
   startScan: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
## Problem

Tapping **Connect** on the glasses card throws:

> connect to glasses error: Error: Set a default glasses device before calling connectDefault.

Reproduced by Philippe and CTO.

**Root cause:** the `default_wearable` setting stores the MODEL string and is written on the model-selection screen **before any pairing succeeds** — it does not imply a native default device. The SDK's `connectDefault()` (`MentraBluetoothSDK.swift:358` / `MentraBluetoothSdk.kt:361`) throws when `getDefaultDevice()` is empty. Any user who picks a model and backs out of pairing (or loses the native default) hits the error from every connect affordance, and the foreground reconnect warn-logs the same throw on every app foreground.

## Fix

Gate on `BluetoothSdk.getDefaultDevice()` before calling `connectDefault()`:

- **Glasses card button** (`ConnectDeviceButton.tsx`) and **home card** (`DeviceStatus.tsx`, the reported stack trace): when there is genuinely no device, route into the pairing flow for the already-selected model — `push("/pairing/scan", {deviceModel: defaultWearable})` — instead of surfacing the error alert. UX change: **error alert → straight into scan for the selected model.**
- **Foreground reconnect** (`Reconnect.tsx` / `decideReconnect` in the island ConnectionCoordinator): new `hasDefaultDevice` input; skips quietly (returns false) instead of calling `connectDefault()` and warn-logging the throw.
- All three paths **fail open** when `getDefaultDevice()` rejects: the unknown state proceeds to `connectDefault()`, whose existing catch handles it (alert on buttons, warn+false in reconnect) — a transient bridge error must not misroute into pairing or throw out of the app-foreground handler.

Other `connectDefault()` call site reviewed and left as is: `pairing/btclassic.tsx` runs it only after Bluetooth Classic pairing succeeded (a default device exists by then) and already catches locally.

## Tests

- `decideReconnect` rule covered in `src/__tests__/connectionCoordinator.test.ts` (skip-quietly case).
- Wiring covered in `src/effects/Reconnect.test.ts`: no-device → skip without `connectDefault`; lookup rejection → fail open into `connectDefault`.
- Gates: `cd mobile && bun run compile && bun run test` — 39 suites, 315 tests passing.

## ⚠️ Merge-conflict note for #3331

PR #3331 (`integration/toolkit-boundary`) carries this same fix in facade-based form (`toolkit.glasses.hasDefaultDevice()`, commits 40845e5, 8c35d91, ee54f78). When #3331 merges after this hotfix, the merge **will conflict** in `ConnectDeviceButton.tsx`, `DeviceStatus.tsx`, `Reconnect.tsx`, `ConnectionCoordinator.ts`, `jest.setup.js`, and the tests. **Resolution rule: keep #3331's facade-based shape** — it is the same logic behind the toolkit facade.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core glasses connect and app-foreground reconnect behavior; logic is guarded and tested but mis-handling `getDefaultDevice` could misroute users or skip reconnect incorrectly.
> 
> **Overview**
> Fixes **Connect** and **foreground reconnect** when `default_wearable` is set but the SDK has no native default device (model is chosen before pairing, or the default was cleared). **`connectDefault()`** would throw; the app now treats that as “needs pairing,” not a hard failure.
> 
> **Connect affordances** (`ConnectDeviceButton`, home `GlassesStatus` in `DeviceStatus`): after connectivity checks, **`BluetoothSdk.getDefaultDevice()`** runs first. If there is no device, navigation goes to **`/pairing/scan`** with the already-selected `deviceModel` instead of showing a connection error. If the lookup **rejects** (bridge glitch), the flow **fails open** and still calls `connectDefault()` so existing error handling applies.
> 
> **Foreground reconnect** (`Reconnect.tsx` + island **`decideReconnect`**): adds **`hasDefaultDevice`** to the decision input. When a real model is configured but no default device exists, reconnect **skips** (returns `false`) without calling `connectDefault()` or warn-logging. The same fail-open rule applies when `getDefaultDevice()` rejects.
> 
> **Tests/mocks**: new `decideReconnect` and `attemptReconnectToDefaultWearable` cases; Jest island stub and **`mockBluetoothSdk.getDefaultDevice`** default to a paired device so connect-path tests stay realistic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1dc39ad764c6e8a3b355bbbd133145b3e939fe5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->