### PR TITLE
Two-phase pairing identity: hydration contract, non-destructive back-outs, guarded connect paths

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -509,6 +509,7 @@ jest.mock("@mentra/island", () => {
         onFound: jest.fn(() => () => {}),
         pair: jest.fn(() => Promise.resolve()),
         setDefault: jest.fn(() => Promise.resolve()),
+        setBluetoothClassicTarget: jest.fn(() => Promise.resolve()),
         abandonAttempt: jest.fn(() => Promise.resolve()),
         onPairFailure: subscribeVia("pair_failure"),
         onGlassesNotReady: subscribeVia("glasses_not_ready"),

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -376,6 +376,7 @@ jest.mock("@mentra/island", () => {
       }),
       glasses: {
         connectDefault: jest.fn(() => Promise.resolve()),
+        hasDefaultDevice: jest.fn(() => Promise.resolve(true)),
         disconnect: jest.fn(() => Promise.resolve()),
         forget: jest.fn(() => Promise.resolve()),
         connect: jest.fn(() => Promise.resolve()),
@@ -508,6 +509,7 @@ jest.mock("@mentra/island", () => {
         onFound: jest.fn(() => () => {}),
         pair: jest.fn(() => Promise.resolve()),
         setDefault: jest.fn(() => Promise.resolve()),
+        abandonAttempt: jest.fn(() => Promise.resolve()),
         onPairFailure: subscribeVia("pair_failure"),
         onGlassesNotReady: subscribeVia("glasses_not_ready"),
         waitForReady: jest.fn(() => Promise.resolve(false)),

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -261,6 +261,10 @@ jest.mock("@mentra/island", () => {
   const realOtaService = jest.requireActual("./modules/island/src/services/OtaService")
   const realAudioCloudUplink = jest.requireActual("./modules/island/src/services/AudioCloudUplink")
   const realDeviceEventRouter = jest.requireActual("./modules/island/src/services/DeviceEventRouter")
+  // Pairing-identity lifecycle (projection + the JS-owned identity writes) — real
+  // implementation (pure: settings store + types only) so host screens/tests
+  // exercise the actual three-state read-model, not a parallel stub.
+  const realPairingIdentity = jest.requireActual("./modules/island/src/services/PairingIdentity")
   // Clock-skew utils moved into island; the host gallery sync + OTA checker import them
   // from @mentra/island, so expose the real (pure) implementations through the mock.
   const realGlassesClockSync = jest.requireActual("./modules/island/src/services/glassesClockSync")
@@ -503,6 +507,11 @@ jest.mock("@mentra/island", () => {
             cb(readiness)
           })
         }),
+        // Identity lifecycle: real projection/writes over the real settings store,
+        // so tests observe the same none/pending/paired snapshots the app does.
+        identity: jest.fn(() => realPairingIdentity.projectPairingIdentity()),
+        onIdentity: jest.fn((cb) => realPairingIdentity.subscribePairingIdentity(cb)),
+        markPendingSelection: jest.fn((model) => realPairingIdentity.markPendingSelection(model)),
         scan: jest.fn(),
         scanning: jest.fn(() => false),
         searchResults: jest.fn(() => []),

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -930,4 +930,17 @@ global.__reanimatedWorkletInit = jest.fn()
 // after every test (a no-op when not attached) so each test starts clean.
 afterEach(() => {
   jest.requireActual("./modules/island/src/services/OtaInstallCoordinator").otaInstallCoordinator.detach()
+  // The pairing mocks above delegate identity reads/writes to the REAL
+  // PairingIdentity over the shared settings store; scrub the identity keys so
+  // a test that marked a pending selection can't leak a stale identity into
+  // the next test's identity()/onIdentity() reads.
+  const {useSettingsStore: realSettingsStore, PAIRING_IDENTITY_KEYS: realIdentityKeys} = jest.requireActual(
+    "./modules/island/src/stores/settings",
+  )
+  const currentSettings = realSettingsStore.getState().settings
+  if (realIdentityKeys.some((key) => currentSettings[key])) {
+    const cleared = {...currentSettings}
+    for (const key of realIdentityKeys) cleared[key] = ""
+    realSettingsStore.setState({settings: cleared})
+  }
 })

--- a/mobile/modules/island/src/facades/glasses.ts
+++ b/mobile/modules/island/src/facades/glasses.ts
@@ -14,6 +14,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import type {ButtonPressEvent, TouchEvent} from "@mentra/bluetooth-sdk/internal"
 import {useGlassesStore} from "../stores/glasses"
 import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {hasDefaultDevice} from "../services/DeviceStoreHydration"
 import {isGlassesConnected, isGlassesReady} from "../services/GlassesReadiness"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
 import {getModelCapabilities, type DeviceTypes} from "../types"
@@ -113,9 +114,24 @@ export const glasses = {
     }
     return true
   },
-  /** True when no glasses has ever been paired (no saved default wearable) — e.g. to
-   * route a first-run host into the pairing/onboarding flow. */
-  isFirstPairing: (): boolean => !useSettingsStore.getState().getSetting(SETTINGS.default_wearable.key),
+  /** True when no glasses has ever been paired NOR selected (no default wearable and
+   * no pending selection) — e.g. to route a first-run host into the pairing/onboarding
+   * flow. A pending selection is not "first" — the host should offer finish-pairing. */
+  isFirstPairing: (): boolean =>
+    !useSettingsStore.getState().getSetting(SETTINGS.default_wearable.key) &&
+    !useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key),
+  /**
+   * True when the SDK has an actual default DEVICE to reconnect to. Distinct from
+   * `default_wearable` (a model string that a pending or orphaned selection can
+   * hold without any paired device): connectDefault() throws without a device, so
+   * hosts should route to the pairing flow when this is false.
+   *
+   * Hydration-aware: awaits the device-store seed internally, so a cold-start
+   * read can't see a false "absent" for genuinely-paired users. Rejects if
+   * hydration failed — callers guarding destructive or routing decisions must
+   * fail open (treat as "has a device").
+   */
+  hasDefaultDevice: (): Promise<boolean> => hasDefaultDevice(),
 
   // --- read-model (projected from the island-owned glasses store) ---
   status: (): GlassesStatusSnapshot => projectStatus(),

--- a/mobile/modules/island/src/facades/glasses.ts
+++ b/mobile/modules/island/src/facades/glasses.ts
@@ -15,6 +15,7 @@ import type {ButtonPressEvent, TouchEvent} from "@mentra/bluetooth-sdk/internal"
 import {useGlassesStore} from "../stores/glasses"
 import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {hasDefaultDevice} from "../services/DeviceStoreHydration"
+import {projectPairingIdentity} from "../services/PairingIdentity"
 import {isGlassesConnected, isGlassesReady} from "../services/GlassesReadiness"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
 import {getModelCapabilities, type DeviceTypes} from "../types"
@@ -114,12 +115,11 @@ export const glasses = {
     }
     return true
   },
-  /** True when no glasses has ever been paired NOR selected (no default wearable and
-   * no pending selection) — e.g. to route a first-run host into the pairing/onboarding
-   * flow. A pending selection is not "first" — the host should offer finish-pairing. */
-  isFirstPairing: (): boolean =>
-    !useSettingsStore.getState().getSetting(SETTINGS.default_wearable.key) &&
-    !useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key),
+  /** True when no glasses has ever been paired NOR selected (the pairing-identity
+   * lifecycle is in its `none` state) — e.g. to route a first-run host into the
+   * pairing/onboarding flow. A pending selection is not "first" — the host should
+   * offer finish-pairing (see `toolkit.pairing.identity()`). */
+  isFirstPairing: (): boolean => projectPairingIdentity().kind === "none",
   /**
    * True when the SDK has an actual default DEVICE to reconnect to. Distinct from
    * `default_wearable` (a model string that a pending or orphaned selection can

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -245,24 +245,25 @@ export const pairing = {
     BluetoothSdk.updateBluetoothSettings({device_name: device.name}),
   /**
    * Abandon an in-flight pairing attempt (back-out, failure retry, conflict
-   * retry) without destroying an existing pairing:
-   * - Re-pair with the old glasses still connected (nothing tapped yet — an
+   * retry) without destroying an existing pairing. The decision comes from the
+   * LIVE hydrated default-device read — never from flow-entry state, because a
+   * pairing can PROMOTE while the flow is open (the glasses finish pairing
+   * even as the user backs out of the UI), and an entry snapshot would forget
+   * that brand-new pairing:
+   * - Default device exists and glasses are connected (nothing in flight — an
    *   attempt drops the link first): stop the scan, touch nothing else.
-   * - Re-pair with an attempt in flight: cancel it, then re-seed the native
-   *   identity from the phone's persisted settings — the attempt's
+   * - Default device exists with an attempt in flight: cancel it, then re-seed
+   *   the native identity from the phone's persisted settings — the attempt's
    *   connect-by-name overwrote the native device_name, so a later
    *   connectDefault() would otherwise target the abandoned device.
-   * - Fresh pairing (no default device): also forget, clearing the partial
-   *   native pairing state.
-   * The `pending_wearable` marker is deliberately left alone — the host renders
-   * it as a finish-pairing affordance.
-   *
-   * `hadDefaultDevice` lets a screen pass the state it captured at entry (the
-   * scan screen does); when omitted, a live hydrated read is used, failing OPEN
-   * to "preserve" — a transient read failure must never wipe a real pairing.
+   * - No default device (genuinely unpaired attempt): also forget, clearing
+   *   the partial native pairing state.
+   * The read fails OPEN to "preserve" — a transient failure must never wipe a
+   * real pairing. The `pending_wearable` marker is deliberately left alone —
+   * the host renders it as a finish-pairing affordance.
    */
-  abandonAttempt: async (hadDefaultDevice?: boolean): Promise<void> => {
-    const preserve = hadDefaultDevice ?? (await hasDefaultDevice().catch(() => true))
+  abandonAttempt: async (): Promise<void> => {
+    const preserve = await hasDefaultDevice().catch(() => true)
     if (preserve && isGlassesConnected(useGlassesStore.getState().connection)) {
       // Still connected means no connect attempt is in flight (an attempt drops
       // the existing link first): the user browsed the scan and backed out.

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -287,13 +287,16 @@ export const pairing = {
       // Still connected means no connect attempt is in flight (an attempt drops
       // the existing link first): the user browsed the scan and backed out.
       // Stop the scan and leave the live pairing untouched.
+      console.log("PairingIdentity: abandonAttempt — pairing intact and connected; stopping scan only")
       await BluetoothSdk.stopScan()
       return
     }
     await BluetoothSdk.disconnect()
     if (preserve) {
+      console.log("PairingIdentity: abandonAttempt — preserving pairing; attempt cancelled, native identity re-seeded")
       await pushAllBluetoothSettings()
     } else {
+      console.log("PairingIdentity: abandonAttempt — no pairing; forgetting the partial attempt")
       await BluetoothSdk.forget()
     }
   },

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -7,10 +7,16 @@
  * facade is the first-time discovery + pair flow.)
  */
 import BluetoothSdk from "@mentra/bluetooth-sdk"
-import type {PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
+import type {ConnectOptions, Device, PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
 import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"
-import {isGlassesLinkLayerBusy, isGlassesReady, waitForGlassesReady} from "../services/GlassesReadiness"
+import {hasDefaultDevice} from "../services/DeviceStoreHydration"
+import {
+  isGlassesConnected,
+  isGlassesLinkLayerBusy,
+  isGlassesReady,
+  waitForGlassesReady,
+} from "../services/GlassesReadiness"
 import {
   logAutomaticReportSubmissionStatus,
   toAutomaticReportSubmissionStatus,
@@ -182,8 +188,7 @@ export const pairing = {
   /** Whether a scan is currently in progress. */
   scanning: (): boolean => useCoreStore.getState().searching,
   /** Subscribe to scan-in-progress changes; fires only when it changes. Returns an unsubscribe. */
-  onScanning: (cb: (scanning: boolean) => void): (() => void) =>
-    useCoreStore.subscribe((s) => s.searching, cb),
+  onScanning: (cb: (scanning: boolean) => void): (() => void) => useCoreStore.subscribe((s) => s.searching, cb),
   /** Whether a controller scan is currently in progress. */
   scanningController: (): boolean => useCoreStore.getState().searchingController,
   /** Subscribe to controller-scan-in-progress changes; fires only when it changes. Returns an unsubscribe. */
@@ -211,13 +216,53 @@ export const pairing = {
     })
   },
 
-  /** Pair with (connect to) a discovered device. */
-  pair: async (...args: Parameters<typeof BluetoothSdk.connect>): Promise<void> => {
+  /**
+   * Pair with (connect to) a discovered device. Two-phase identity: the connect
+   * attempt only marks the device as pending (`saveAsDefault: false` — no eager
+   * default-device write); the native layer promotes it to the default wearable
+   * when pairing actually succeeds (handleDeviceReady), so an abandoned or
+   * failed attempt can't leave a default identity with no paired device behind.
+   */
+  pair: async (device: Device, options?: ConnectOptions): Promise<void> => {
     await pushAllBluetoothSettings()
-    return BluetoothSdk.connect(...args)
+    return BluetoothSdk.connect(device, {...options, saveAsDefault: false})
   },
   /** Set a device as the default for subsequent `glasses.connectDefault()`. */
   setDefault: (...args: Parameters<typeof BluetoothSdk.setDefaultDevice>) => BluetoothSdk.setDefaultDevice(...args),
+  /**
+   * Abandon an in-flight pairing attempt (back-out, failure retry, conflict
+   * retry) without destroying an existing pairing:
+   * - Re-pair with the old glasses still connected (nothing tapped yet — an
+   *   attempt drops the link first): stop the scan, touch nothing else.
+   * - Re-pair with an attempt in flight: cancel it, then re-seed the native
+   *   identity from the phone's persisted settings — the attempt's
+   *   connect-by-name overwrote the native device_name, so a later
+   *   connectDefault() would otherwise target the abandoned device.
+   * - Fresh pairing (no default device): also forget, clearing the partial
+   *   native pairing state.
+   * The `pending_wearable` marker is deliberately left alone — the host renders
+   * it as a finish-pairing affordance.
+   *
+   * `hadDefaultDevice` lets a screen pass the state it captured at entry (the
+   * scan screen does); when omitted, a live hydrated read is used, failing OPEN
+   * to "preserve" — a transient read failure must never wipe a real pairing.
+   */
+  abandonAttempt: async (hadDefaultDevice?: boolean): Promise<void> => {
+    const preserve = hadDefaultDevice ?? (await hasDefaultDevice().catch(() => true))
+    if (preserve && isGlassesConnected(useGlassesStore.getState().connection)) {
+      // Still connected means no connect attempt is in flight (an attempt drops
+      // the existing link first): the user browsed the scan and backed out.
+      // Stop the scan and leave the live pairing untouched.
+      await BluetoothSdk.stopScan()
+      return
+    }
+    await BluetoothSdk.disconnect()
+    if (preserve) {
+      await pushAllBluetoothSettings()
+    } else {
+      await BluetoothSdk.forget()
+    }
+  },
 
   /** Subscribe to pairing failures; returns an unsubscribe. */
   onPairFailure: (cb: (event: PairFailureEvent) => void): (() => void) => {

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -282,8 +282,8 @@ export const pairing = {
    * the host renders it as a finish-pairing affordance.
    */
   abandonAttempt: async (): Promise<void> => {
-    const preserve = await hasDefaultDevice().catch(() => true)
-    if (preserve && isGlassesConnected(useGlassesStore.getState().connection)) {
+    const nativeHasDefault = await hasDefaultDevice().catch(() => true)
+    if (nativeHasDefault && isGlassesConnected(useGlassesStore.getState().connection)) {
       // Still connected means no connect attempt is in flight (an attempt drops
       // the existing link first): the user browsed the scan and backed out.
       // Stop the scan and leave the live pairing untouched.
@@ -292,20 +292,22 @@ export const pairing = {
       return
     }
     await BluetoothSdk.disconnect()
-    if (preserve) {
-      // Re-seed native ONLY from a COMPLETE paired JS identity. Mid-relay (a
-      // promotion's save_setting echoes still landing), the JS snapshot is
-      // incomplete — pushing it would overwrite the fresher native identity,
-      // the same race the on-connect replay had. Incomplete ⇒ skip; native
-      // already holds the truth and the echoes complete the JS side.
-      if (projectPairingIdentity().kind === "paired") {
-        console.log("PairingIdentity: abandonAttempt — preserving pairing; attempt cancelled, native identity re-seeded")
-        await pushAllBluetoothSettings()
-      } else {
-        console.log("PairingIdentity: abandonAttempt — preserving pairing; JS identity mid-relay, native kept as-is")
-      }
+    if (projectPairingIdentity().kind === "paired") {
+      // The persisted settings describe a COMPLETE pairing: restore it to
+      // native (the attempt's connect-by-name overwrote the native
+      // device_name; and if native somehow lost its default entirely, this
+      // repairs the divergence instead of forgetting a real pairing).
+      console.log("PairingIdentity: abandonAttempt — preserving pairing; attempt cancelled, native identity re-seeded")
+      await pushAllBluetoothSettings()
+    } else if (nativeHasDefault) {
+      // Mid-relay: native promoted and its echoes are still landing — the
+      // incomplete JS snapshot must not be pushed over the fresher native
+      // identity (the on-connect replay's race). Native holds the truth.
+      console.log("PairingIdentity: abandonAttempt — preserving pairing; JS identity mid-relay, native kept as-is")
     } else {
-      console.log("PairingIdentity: abandonAttempt — no pairing; forgetting the partial attempt")
+      // Forgetting requires CONSENSUS: no native default AND no complete
+      // persisted pairing — a genuinely partial attempt.
+      console.log("PairingIdentity: abandonAttempt — no pairing on either layer; forgetting the partial attempt")
       await BluetoothSdk.forget()
     }
   },

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -15,6 +15,12 @@ import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"
 import {hasDefaultDevice} from "../services/DeviceStoreHydration"
 import {
+  markPendingSelection,
+  projectPairingIdentity,
+  subscribePairingIdentity,
+  type IdentitySnapshot,
+} from "../services/PairingIdentity"
+import {
   isGlassesConnected,
   isGlassesLinkLayerBusy,
   isGlassesReady,
@@ -27,6 +33,8 @@ import {
 } from "../services/AutomaticReportResult"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
 import {submitAutomaticReport} from "./reports"
+
+export type {IdentitySnapshot} from "../services/PairingIdentity"
 
 export interface PairingReadyWaitOptions {
   deviceModel?: string
@@ -185,6 +193,17 @@ export const pairing = {
       cb(snap)
     })
   },
+
+  // --- pairing-identity lifecycle (the PairingIdentity read-model + the JS-owned
+  // identity writes; promotion to `paired` only ever happens natively) ---
+  /** The identity lifecycle snapshot: none | pending (chosen, never paired) | paired. */
+  identity: (): IdentitySnapshot => projectPairingIdentity(),
+  /** Subscribe to identity changes; fires only when the projected snapshot changes.
+   * Returns an unsubscribe. */
+  onIdentity: (cb: (identity: IdentitySnapshot) => void): (() => void) => subscribePairingIdentity(cb),
+  /** Mark the chosen model as the pending selection (the scan-entry write); the
+   * host renders it as a finish-pairing affordance until pairing succeeds. */
+  markPendingSelection: (model: string) => markPendingSelection(model),
 
   /** Start scanning for nearby glasses. Results land on `searchResults()`/`onFound()`. */
   scan: (...args: Parameters<typeof BluetoothSdk.startScan>) => BluetoothSdk.startScan(...args),

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -293,8 +293,17 @@ export const pairing = {
     }
     await BluetoothSdk.disconnect()
     if (preserve) {
-      console.log("PairingIdentity: abandonAttempt — preserving pairing; attempt cancelled, native identity re-seeded")
-      await pushAllBluetoothSettings()
+      // Re-seed native ONLY from a COMPLETE paired JS identity. Mid-relay (a
+      // promotion's save_setting echoes still landing), the JS snapshot is
+      // incomplete — pushing it would overwrite the fresher native identity,
+      // the same race the on-connect replay had. Incomplete ⇒ skip; native
+      // already holds the truth and the echoes complete the JS side.
+      if (projectPairingIdentity().kind === "paired") {
+        console.log("PairingIdentity: abandonAttempt — preserving pairing; attempt cancelled, native identity re-seeded")
+        await pushAllBluetoothSettings()
+      } else {
+        console.log("PairingIdentity: abandonAttempt — preserving pairing; JS identity mid-relay, native kept as-is")
+      }
     } else {
       console.log("PairingIdentity: abandonAttempt — no pairing; forgetting the partial attempt")
       await BluetoothSdk.forget()

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -230,6 +230,17 @@ export const pairing = {
   /** Set a device as the default for subsequent `glasses.connectDefault()`. */
   setDefault: (...args: Parameters<typeof BluetoothSdk.setDefaultDevice>) => BluetoothSdk.setDefaultDevice(...args),
   /**
+   * Prime the native Bluetooth Classic audio watcher with the picked device.
+   * The iOS Mentra Live flow pairs Classic audio BEFORE any BLE connect
+   * exists, and native detects the pairing by matching the connected audio
+   * route against its device_name — which two-phase identity no longer sets
+   * at selection time. This is native-only routing state (device_name has no
+   * native→JS echo): the phone's persisted identity is untouched, and
+   * promotion still happens only at pairing success.
+   */
+  setBluetoothClassicTarget: (device: Device): Promise<void> =>
+    BluetoothSdk.updateBluetoothSettings({device_name: device.name}),
+  /**
    * Abandon an in-flight pairing attempt (back-out, failure retry, conflict
    * retry) without destroying an existing pairing:
    * - Re-pair with the old glasses still connected (nothing tapped yet — an

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -6,7 +6,10 @@
  * (Connect-the-already-paired-default is `toolkit.glasses.connectDefault()`; this
  * facade is the first-time discovery + pair flow.)
  */
-import BluetoothSdk from "@mentra/bluetooth-sdk"
+// Internal btsdk surface — updateBluetoothSettings (the Bluetooth Classic
+// target hint) lives on the full surface, not the public entry (same reason
+// the glasses facade imports internal).
+import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import type {ConnectOptions, Device, PairFailureEvent, GlassesNotReadyEvent} from "@mentra/bluetooth-sdk"
 import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"

--- a/mobile/modules/island/src/index.ts
+++ b/mobile/modules/island/src/index.ts
@@ -167,6 +167,7 @@ export type {
 } from "./facades/reports"
 export type {IslandNotification, IslandNotificationKind} from "./facades/notifications"
 export type {WifiSearchResult} from "./facades/glassesWifi"
+export type {IdentitySnapshot} from "./services/PairingIdentity"
 export type {DisplayMirrorEvent} from "./facades/displayMirror"
 export type {
   IslandConfigureOptions,

--- a/mobile/modules/island/src/island.ts
+++ b/mobile/modules/island/src/island.ts
@@ -10,6 +10,7 @@
  */
 import {configure, start as bootstrapStart, stop as bootstrapStop} from "./runtime/bootstrap"
 import {cloudClientService} from "./services/CloudClientService"
+import {hydrateDeviceStore, demoteOrphanedDefaultWearable} from "./services/DeviceStoreHydration"
 import {startGlassesSettingsSync, stopGlassesSettingsSync} from "./services/GlassesSettingsSync"
 import {startGlassesStatusProjection, stopGlassesStatusProjection} from "./services/GlassesStatusProjection"
 import {startOtaService, stopOtaService} from "./services/OtaService"
@@ -17,7 +18,10 @@ import {startAudioCloudUplink, stopAudioCloudUplink} from "./services/AudioCloud
 import {startDeviceEventRouter, stopDeviceEventRouter} from "./services/DeviceEventRouter"
 import {startPhoneNotificationsSync, stopPhoneNotificationsSync} from "./services/PhoneNotificationsSync"
 import {startCaptionsTesterReportService, stopCaptionsTesterReportService} from "./services/CaptionsTesterReportService"
-import {startMentraJSCrashloopReportService, stopMentraJSCrashloopReportService} from "./services/MentraJSCrashloopReportService"
+import {
+  startMentraJSCrashloopReportService,
+  stopMentraJSCrashloopReportService,
+} from "./services/MentraJSCrashloopReportService"
 import {ensureMiniappEngine, stopMiniappEngine} from "./services/MiniappEngine"
 import localMiniappRuntime from "./services/LocalMiniappRuntime"
 import displayProcessor from "./services/DisplayProcessor"
@@ -66,6 +70,24 @@ export const toolkit = {
     // store, miniapp_selected -> launcher) so a bare OEM gets device data, not just the
     // Mentra app's MantleManager.
     startDeviceEventRouter()
+    // Hydration contract: the native DeviceStore is in-memory and starts empty
+    // every launch; seed it from the persisted settings BEFORE start() resolves
+    // so every post-start getDefaultDevice() read is a trustworthy two-state
+    // answer (no false "absent" for genuinely-paired users at cold start).
+    // Ordered before startGlassesSettingsSync so the settings load can't
+    // double-push through the change subscription. A failed hydration must not
+    // brick the runtime: start() continues, and the guards that consume
+    // hasDefaultDevice() see the rejection and fail open.
+    try {
+      await hydrateDeviceStore()
+      // Boot repair: a persisted default_wearable without a native default
+      // device (identity abandoned mid-pairing, or resurrected from the server
+      // before identity stopped syncing) demotes to pending_wearable so hosts
+      // render finish-pairing instead of a connect that would throw.
+      await demoteOrphanedDefaultWearable()
+    } catch (error) {
+      console.warn("toolkit.start: device-store hydration failed:", error instanceof Error ? error.message : error)
+    }
     // Project the glasses' OTA events into the store for the toolkit.ota read surface.
     startOtaService()
     // Forward glasses mic_lc3 frames to the v2 cloud session so cloud transcription
@@ -74,7 +96,10 @@ export const toolkit = {
     try {
       await cloudClientService.syncCoreTokenToBluetooth()
     } catch (error) {
-      console.warn("toolkit.start: initial Cloud V2 core token sync failed:", error instanceof Error ? error.message : error)
+      console.warn(
+        "toolkit.start: initial Cloud V2 core token sync failed:",
+        error instanceof Error ? error.message : error,
+      )
     }
     // Push device-setting changes to the glasses for ANY host, so
     // toolkit.glasses.settings.set() reaches the device (not just the Mentra app).

--- a/mobile/modules/island/src/services/ConnectionCoordinator.ts
+++ b/mobile/modules/island/src/services/ConnectionCoordinator.ts
@@ -20,6 +20,8 @@ export interface ReconnectDecisionInput {
   connected: boolean
   /** True while the native link layer is mid scan / connect / bond. */
   nativeLinkBusy: boolean
+  /** True when the SDK holds an actual default device (connectDefault target). */
+  hasDefaultDevice: boolean
   /** True when a scan is already in progress. */
   searching: boolean
 }
@@ -36,6 +38,11 @@ export function decideReconnect(input: ReconnectDecisionInput): ReconnectDecisio
   if (!input.reconnectOnForeground) return {kind: "skip", result: true}
   // No real wearable paired (or the simulated device): nothing to reconnect to.
   if (!input.defaultWearable || input.isSimulated) return {kind: "skip", result: false}
+  // Model chosen but never actually paired (or the native default was cleared):
+  // connectDefault() would throw — skip quietly; pairing is a user-driven flow.
+  // (Safe to trust at cold start now: hasDefaultDevice reads are gated on the
+  // device-store hydration completing, and callers fail open on rejection.)
+  if (!input.hasDefaultDevice) return {kind: "skip", result: false}
   // Already connected, or a scan/connect/bond is already in flight: starting a
   // second connectDefault() on top of the busy link layer would collide with it
   // (same busy rule as decideConnectButtonAction).

--- a/mobile/modules/island/src/services/DeviceEventRouter.ts
+++ b/mobile/modules/island/src/services/DeviceEventRouter.ts
@@ -25,8 +25,9 @@ import {phonePhotoCoordinator} from "./PhonePhotoCoordinator"
 import {phoneStreamCoordinator} from "./PhoneStreamCoordinator"
 import {isGlassesConnected} from "./GlassesReadiness"
 import {useGlassesStore} from "../stores/glasses"
-import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {useSettingsStore} from "../stores/settings"
 import {useAppStatusStore} from "../stores/apps"
+import {retirePendingSelectionOnPromotion} from "./PairingIdentity"
 import GlobalEventEmitter from "../utils/GlobalEventEmitter"
 import {asgCameraApi} from "./asg/asgCameraApi"
 
@@ -124,14 +125,9 @@ export function startDeviceEventRouter(): void {
       if (settings.getSetting(event.key) !== event.value) {
         await settings.setSetting(event.key, event.value)
       }
-      // Two-phase identity: the native layer promotes the default wearable on
-      // pairing success (handleDeviceReady) and echoes it here — a promoted
-      // default retires the pending selection marker.
-      if (event.key === SETTINGS.default_wearable.key && event.value) {
-        if (settings.getSetting(SETTINGS.pending_wearable.key)) {
-          await settings.setSetting(SETTINGS.pending_wearable.key, "")
-        }
-      }
+      // Two-phase identity: a promoted default retires the pending selection
+      // marker. The rule lives with PairingIdentity (a no-op for other keys).
+      await retirePendingSelectionOnPromotion(event.key, event.value)
     }),
   )
 

--- a/mobile/modules/island/src/services/DeviceEventRouter.ts
+++ b/mobile/modules/island/src/services/DeviceEventRouter.ts
@@ -25,7 +25,7 @@ import {phonePhotoCoordinator} from "./PhonePhotoCoordinator"
 import {phoneStreamCoordinator} from "./PhoneStreamCoordinator"
 import {isGlassesConnected} from "./GlassesReadiness"
 import {useGlassesStore} from "../stores/glasses"
-import {useSettingsStore} from "../stores/settings"
+import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {useAppStatusStore} from "../stores/apps"
 import GlobalEventEmitter from "../utils/GlobalEventEmitter"
 import {asgCameraApi} from "./asg/asgCameraApi"
@@ -118,6 +118,12 @@ export function startDeviceEventRouter(): void {
   subs.push(
     BluetoothSdk.addListener("save_setting", async (event) => {
       await useSettingsStore.getState().setSetting(event.key, event.value)
+      // Two-phase identity: the native layer promotes the default wearable on
+      // pairing success (handleDeviceReady) and echoes it here — a promoted
+      // default retires the pending selection marker.
+      if (event.key === SETTINGS.default_wearable.key && event.value) {
+        await useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, "")
+      }
     }),
   )
 

--- a/mobile/modules/island/src/services/DeviceEventRouter.ts
+++ b/mobile/modules/island/src/services/DeviceEventRouter.ts
@@ -117,12 +117,20 @@ export function startDeviceEventRouter(): void {
   // The inbound complement to GlassesSettingsSync (which only pushes store→device).
   subs.push(
     BluetoothSdk.addListener("save_setting", async (event) => {
-      await useSettingsStore.getState().setSetting(event.key, event.value)
+      const settings = useSettingsStore.getState()
+      // Damp the relay: native re-echoes some settings unconditionally (e.g.
+      // the identity block at every handleDeviceReady) — a same-value echo
+      // must not become a store write (persistence churn + change-push noise).
+      if (settings.getSetting(event.key) !== event.value) {
+        await settings.setSetting(event.key, event.value)
+      }
       // Two-phase identity: the native layer promotes the default wearable on
       // pairing success (handleDeviceReady) and echoes it here — a promoted
       // default retires the pending selection marker.
       if (event.key === SETTINGS.default_wearable.key && event.value) {
-        await useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, "")
+        if (settings.getSetting(SETTINGS.pending_wearable.key)) {
+          await settings.setSetting(SETTINGS.pending_wearable.key, "")
+        }
       }
     }),
   )

--- a/mobile/modules/island/src/services/DeviceStoreHydration.ts
+++ b/mobile/modules/island/src/services/DeviceStoreHydration.ts
@@ -25,6 +25,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {useGlassesStore} from "../stores/glasses"
 import {pushAllBluetoothSettings} from "./GlassesSettingsSync"
+import {demoteDefaultToPending} from "./PairingIdentity"
 import {DeviceTypes} from "../types"
 
 let hydrationPromise: Promise<void> | null = null
@@ -119,15 +120,10 @@ export async function demoteOrphanedDefaultWearable(): Promise<void> {
   if (await BluetoothSdk.getDefaultDevice()) return
 
   console.log(`DeviceStoreHydration: demoting orphaned default_wearable "${model}" to pending_wearable`)
-  // The user's LATEST selection wins: only backfill the pending marker when
-  // none exists — a fresher pending model (a pairing started after the orphan
-  // formed) must not be replaced by the stale orphaned model.
-  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
-    await settings.setSetting(SETTINGS.pending_wearable.key, model)
-  }
-  await settings.setSetting(SETTINGS.default_wearable.key, "")
-  await settings.setSetting(SETTINGS.device_name.key, "")
-  await settings.setSetting(SETTINGS.device_address.key, "")
+  // The identity write set (latest-selection-wins backfill + identity-triplet
+  // clear) lives with PairingIdentity, the single writer of the JS-side
+  // identity keys; this boot repair owns only the guards above.
+  await demoteDefaultToPending(model)
   // The hydration seed already landed the pre-demotion values in the native
   // store; re-push so native mirrors the demoted identity too.
   await pushAllBluetoothSettings()

--- a/mobile/modules/island/src/services/DeviceStoreHydration.ts
+++ b/mobile/modules/island/src/services/DeviceStoreHydration.ts
@@ -63,6 +63,14 @@ export function hydrateDeviceStore(): Promise<void> {
 }
 
 /**
+ * Test-only: clear the hydration memo so each test starts from an unhydrated
+ * store instead of inheriting whichever hydration a previous test ran.
+ */
+export function resetDeviceStoreHydrationForTests(): void {
+  hydrationPromise = null
+}
+
+/**
  * Whether the SDK holds an actual default DEVICE to reconnect to — the
  * hydration-aware two-state read. Distinct from the `default_wearable`
  * setting (a model string that pending/orphaned states can hold without any
@@ -90,6 +98,12 @@ export async function hasDefaultDevice(): Promise<boolean> {
  * connected (an in-flight pairing owns the identity right now).
  */
 export async function demoteOrphanedDefaultWearable(): Promise<void> {
+  // Never judge "native default absent" against an unseeded store: a valid
+  // pairing identity would read as an orphan and be demoted. Awaiting the
+  // (memoized) hydration makes the check safe regardless of call ordering;
+  // a failed hydration rejects here instead of demoting blind.
+  await hydrateDeviceStore()
+
   const settings = useSettingsStore.getState()
   const model = settings.getSetting(SETTINGS.default_wearable.key) as string | undefined
   if (!model) return
@@ -105,7 +119,12 @@ export async function demoteOrphanedDefaultWearable(): Promise<void> {
   if (await BluetoothSdk.getDefaultDevice()) return
 
   console.log(`DeviceStoreHydration: demoting orphaned default_wearable "${model}" to pending_wearable`)
-  await settings.setSetting(SETTINGS.pending_wearable.key, model)
+  // The user's LATEST selection wins: only backfill the pending marker when
+  // none exists — a fresher pending model (a pairing started after the orphan
+  // formed) must not be replaced by the stale orphaned model.
+  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
+    await settings.setSetting(SETTINGS.pending_wearable.key, model)
+  }
   await settings.setSetting(SETTINGS.default_wearable.key, "")
   await settings.setSetting(SETTINGS.device_name.key, "")
   await settings.setSetting(SETTINGS.device_address.key, "")

--- a/mobile/modules/island/src/services/DeviceStoreHydration.ts
+++ b/mobile/modules/island/src/services/DeviceStoreHydration.ts
@@ -1,0 +1,115 @@
+/**
+ * DeviceStoreHydration — the cold-start contract for the native DeviceStore.
+ *
+ * The Bluetooth SDK's DeviceStore is in-memory on BOTH platforms: every key
+ * (including the pairing identity `default_wearable` / `device_name` /
+ * `device_address`) initializes to "" at process start and only becomes real
+ * once JS pushes the persisted settings over `updateBluetoothSettings`. Until
+ * that seed lands, `BluetoothSdk.getDefaultDevice()` returns null for
+ * genuinely-paired users — the false "absent" that made the first
+ * hasDefaultDevice guard misfire at cold start (see the revert of the
+ * hasDefaultDevice pairing-route guards).
+ *
+ * This service makes that seed an explicit, awaited initialization step:
+ *   1. load the persisted settings store (idempotent),
+ *   2. push the full Bluetooth settings set (identity included) to native.
+ * `toolkit.start()` awaits it, so every post-start `getDefaultDevice()` read is
+ * a trustworthy two-state answer. `hasDefaultDevice()` also awaits it
+ * internally (belt-and-suspenders for reads that race start()).
+ *
+ * Failure surfaces as a REJECTION — never a false "absent". Callers guarding
+ * destructive or routing decisions must fail open (treat as "has a device"),
+ * matching the foreground-reconnect pattern.
+ */
+import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
+import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {useGlassesStore} from "../stores/glasses"
+import {pushAllBluetoothSettings} from "./GlassesSettingsSync"
+import {DeviceTypes} from "../types"
+
+let hydrationPromise: Promise<void> | null = null
+
+/**
+ * Seed the native DeviceStore from the persisted settings. Single-flight: the
+ * first caller runs it, everyone else awaits the same promise. On failure the
+ * current awaiters see the rejection (and fail open — the pre-guard behavior,
+ * where the connect calls' own error handling was the last line of defense),
+ * and the memo clears so a LATER read can retry and heal.
+ */
+export function hydrateDeviceStore(): Promise<void> {
+  if (!hydrationPromise) {
+    const startedAt = Date.now()
+    hydrationPromise = (async () => {
+      const loadResult = await useSettingsStore.getState().loadAllSettings()
+      if (loadResult.is_error()) {
+        throw new Error(`DeviceStoreHydration: settings load failed: ${loadResult.error}`)
+      }
+      await pushAllBluetoothSettings()
+      const settings = useSettingsStore.getState()
+      const model = settings.getSetting(SETTINGS.default_wearable.key)
+      const hasName = !!settings.getSetting(SETTINGS.device_name.key)
+      // Cold-start timing evidence: this line must appear BEFORE any
+      // RECONNECT/guard log for the hydration contract to hold on device.
+      console.log(
+        `DeviceStoreHydration: native seed complete in ${Date.now() - startedAt}ms ` +
+          `(default_wearable=${model || "<none>"}, device_name present=${hasName})`,
+      )
+    })().catch((error) => {
+      hydrationPromise = null
+      throw error
+    })
+  }
+  return hydrationPromise
+}
+
+/**
+ * Whether the SDK holds an actual default DEVICE to reconnect to — the
+ * hydration-aware two-state read. Distinct from the `default_wearable`
+ * setting (a model string that pending/orphaned states can hold without any
+ * paired device): `connectDefault()` throws without a device.
+ * Rejects if hydration failed; callers fail open.
+ */
+export async function hasDefaultDevice(): Promise<boolean> {
+  await hydrateDeviceStore()
+  return !!(await BluetoothSdk.getDefaultDevice())
+}
+
+/**
+ * Boot repair for the orphaned-identity population: a persisted
+ * `default_wearable` whose native default device does not exist after a
+ * completed hydration. Two-phase writes stop NEW orphans from forming
+ * (identity is only promoted at pairing success); this demotes the ones
+ * already in the field — selection-time writes abandoned before pairing
+ * succeeded, and identity resurrected from the server before it stopped
+ * syncing — down to `pending_wearable`, which the host renders as a
+ * finish-pairing card instead of a connect button that would throw
+ * "Set a default glasses device before calling connectDefault".
+ *
+ * Runs after hydration on every start; converges because a demoted default
+ * can't re-trip the condition. Skips while the link layer is busy or
+ * connected (an in-flight pairing owns the identity right now).
+ */
+export async function demoteOrphanedDefaultWearable(): Promise<void> {
+  const settings = useSettingsStore.getState()
+  const model = settings.getSetting(SETTINGS.default_wearable.key) as string | undefined
+  if (!model) return
+  // The simulated device is its own identity (name mirrors the model); it
+  // reconstructs a native default from settings alone and never orphans.
+  if (model.includes(DeviceTypes.SIMULATED)) return
+
+  // "disconnected" is the only idle state — anything else (scanning /
+  // connecting / bonding / connected) means a pairing or link owns the
+  // identity right now.
+  if (useGlassesStore.getState().connection.state !== "disconnected") return
+
+  if (await BluetoothSdk.getDefaultDevice()) return
+
+  console.log(`DeviceStoreHydration: demoting orphaned default_wearable "${model}" to pending_wearable`)
+  await settings.setSetting(SETTINGS.pending_wearable.key, model)
+  await settings.setSetting(SETTINGS.default_wearable.key, "")
+  await settings.setSetting(SETTINGS.device_name.key, "")
+  await settings.setSetting(SETTINGS.device_address.key, "")
+  // The hydration seed already landed the pre-demotion values in the native
+  // store; re-push so native mirrors the demoted identity too.
+  await pushAllBluetoothSettings()
+}

--- a/mobile/modules/island/src/services/GlassesSettingsSync.ts
+++ b/mobile/modules/island/src/services/GlassesSettingsSync.ts
@@ -41,20 +41,43 @@ export function diffBluetoothSettingsForPush(
   return changed
 }
 
+/** A copy of the settings record without the pairing-identity keys. */
+export function stripPairingIdentity(settings: Record<string, unknown>): Record<string, unknown> {
+  const stripped: Record<string, unknown> = {}
+  for (const key in settings) {
+    if (PAIRING_IDENTITY_KEYS.includes(key)) continue
+    stripped[key] = settings[key]
+  }
+  return stripped
+}
+
 let unsubChange: (() => void) | null = null
 let unsubConnect: (() => void) | null = null
 
 /**
- * Push the FULL current device-settings set to native over the bluetooth-sdk.
- * Used both by the on-connect transition below and as a pre-connect seed by
- * `toolkit.glasses.connectDefault()`, so native has the phone's settings primed
- * before the connect handshake replays them to the glasses.
+ * Push the FULL current device-settings set — identity included — to native.
+ * This is the explicit identity SEED, for the flows where native genuinely
+ * needs the phone's persisted identity BEFORE it can act: the device-store
+ * hydration at start, the pre-connect seed (connectDefault targets the seeded
+ * identity), the post-demotion re-push, and the abandon re-seed.
  */
 export async function pushAllBluetoothSettings(): Promise<void> {
   // Returns the native write promise so callers can await the seed before the
   // connect handshake replays settings to the glasses (otherwise the handshake
   // can race ahead and replay stale native settings).
   await BluetoothSdk.updateBluetoothSettings(useSettingsStore.getState().getBluetoothSettings())
+}
+
+/**
+ * Push the device-settings set MINUS the pairing identity. The on-connect
+ * replay uses this: while connected, NATIVE owns the identity (it promotes at
+ * device-ready and echoes down), and the JS snapshot can be mid-relay stale —
+ * on Mentra Live "connected" lands together with device-ready, and a full
+ * replay raced the promotion echoes and overwrote the just-promoted identity
+ * with pre-promotion empties (wiping the pairing it had just made).
+ */
+export async function pushDeviceSettingsOnConnect(): Promise<void> {
+  await BluetoothSdk.updateBluetoothSettings(stripPairingIdentity(useSettingsStore.getState().getBluetoothSettings()))
 }
 
 export function startGlassesSettingsSync(): void {
@@ -77,13 +100,15 @@ export function startGlassesSettingsSync(): void {
     {equalityFn: shallow},
   )
 
-  // 2. Push the full set whenever the glasses transition to connected.
+  // 2. Push the device settings whenever the glasses transition to connected —
+  // identity EXCLUDED: native owns the identity it just promoted, and a full
+  // replay here raced the promotion echoes (see pushDeviceSettingsOnConnect).
   let wasConnected = isGlassesConnected(useGlassesStore.getState().connection)
   unsubConnect = useGlassesStore.subscribe(() => {
     const connected = isGlassesConnected(useGlassesStore.getState().connection)
     if (connected && !wasConnected) {
       // Background sync: log-and-continue if the device drops right after connect.
-      void pushAllBluetoothSettings().catch((error) => {
+      void pushDeviceSettingsOnConnect().catch((error) => {
         console.warn("GlassesSettingsSync: on-connect settings push failed:", error)
       })
     }

--- a/mobile/modules/island/src/services/GlassesSettingsSync.ts
+++ b/mobile/modules/island/src/services/GlassesSettingsSync.ts
@@ -15,9 +15,31 @@
 import {shallow} from "zustand/shallow"
 
 import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
-import {useSettingsStore} from "../stores/settings"
+import {useSettingsStore, PAIRING_IDENTITY_KEYS} from "../stores/settings"
 import {useGlassesStore} from "../stores/glasses"
 import {isGlassesConnected} from "./GlassesReadiness"
+
+/**
+ * The changed-keys diff for the change-push, MINUS the pairing-identity keys.
+ * Identity is native-authoritative (promoted on pairing success, cleared on
+ * forget, echoed down via save_setting) and reaches native only through the
+ * explicit full seeds. Pushing identity from the change subscription would
+ * close a feedback loop: native echo → store setSetting → change-push →
+ * native apply → echo…, which self-sustains the moment two different values
+ * are in flight (e.g. a boot demotion crossing a native promotion) and flaps
+ * the pairing UI.
+ */
+export function diffBluetoothSettingsForPush(
+  settings: Record<string, unknown>,
+  previous: Record<string, unknown>,
+): Record<string, unknown> {
+  const changed: Record<string, unknown> = {}
+  for (const key in settings) {
+    if (PAIRING_IDENTITY_KEYS.includes(key)) continue
+    if (settings[key] !== previous[key]) changed[key] = settings[key]
+  }
+  return changed
+}
 
 let unsubChange: (() => void) | null = null
 let unsubConnect: (() => void) | null = null
@@ -39,13 +61,11 @@ export function startGlassesSettingsSync(): void {
   if (unsubChange || unsubConnect) return
 
   // 1. Push only the keys that changed (matching the prior MantleManager sync).
+  // Pairing identity is excluded — see diffBluetoothSettingsForPush.
   unsubChange = useSettingsStore.subscribe(
     (state) => state.getBluetoothSettings(),
     (settings: Record<string, unknown>, previous: Record<string, unknown>) => {
-      const changed: Record<string, unknown> = {}
-      for (const key in settings) {
-        if (settings[key] !== previous[key]) changed[key] = settings[key]
-      }
+      const changed = diffBluetoothSettingsForPush(settings, previous)
       if (Object.keys(changed).length > 0) {
         // Settings can change while the glasses are disconnected — a native
         // rejection must not surface as an unhandled promise rejection.

--- a/mobile/modules/island/src/services/PairingIdentity.ts
+++ b/mobile/modules/island/src/services/PairingIdentity.ts
@@ -34,7 +34,7 @@
  * save_setting persistence is the inbound native→JS echo leg, not a
  * JS-initiated write, and stays with the router.
  */
-import type {AsyncResult} from "typesafe-ts"
+import {result as Res, type AsyncResult} from "typesafe-ts"
 
 import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {DeviceTypes} from "../types"
@@ -93,8 +93,21 @@ export function subscribePairingIdentity(cb: (identity: IdentitySnapshot) => voi
  * finish-pairing card after an app restart.
  */
 export function markPendingSelection(model: string): AsyncResult<void, Error> {
-  console.log(`PairingIdentity: pending selection -> "${model}"`)
-  return useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, model)
+  // Guard the public write-path: an empty/whitespace model would persist a
+  // pending identity that renders a blank finish-pairing card.
+  const trimmed = typeof model === "string" ? model.trim() : ""
+  if (!trimmed) {
+    console.warn(`PairingIdentity: ignoring pending selection with empty model (got ${JSON.stringify(model)})`)
+    return Promise.resolve(Res.ok(undefined)) as AsyncResult<void, Error>
+  }
+  console.log(`PairingIdentity: pending selection -> "${trimmed}"`)
+  const result = useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, trimmed)
+  // setSetting resolves to a Result (never rejects); a persist failure would
+  // silently drop the finish-pairing affordance on restart — surface it.
+  void Promise.resolve(result).then((r) => {
+    if (r.is_error()) console.warn("PairingIdentity: pending selection failed to persist:", r.error)
+  })
+  return result
 }
 
 /**
@@ -123,7 +136,10 @@ export async function retirePendingSelectionOnPromotion(echoedKey: string, echoe
  */
 export async function demoteDefaultToPending(model: string): Promise<void> {
   const settings = useSettingsStore.getState()
-  const fresher = settings.getSetting(SETTINGS.pending_wearable.key)
+  // readIdentityString, not raw getSetting: a truthy non-string legacy value
+  // must read as absent here too, or the orphaned model is never backfilled
+  // while the projection reads the same junk as no pending at all.
+  const fresher = readIdentityString(SETTINGS.pending_wearable.key)
   console.log(
     fresher
       ? `PairingIdentity: demote "${model}" — fresher pending "${fresher}" kept`

--- a/mobile/modules/island/src/services/PairingIdentity.ts
+++ b/mobile/modules/island/src/services/PairingIdentity.ts
@@ -93,6 +93,7 @@ export function subscribePairingIdentity(cb: (identity: IdentitySnapshot) => voi
  * finish-pairing card after an app restart.
  */
 export function markPendingSelection(model: string): AsyncResult<void, Error> {
+  console.log(`PairingIdentity: pending selection -> "${model}"`)
   return useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, model)
 }
 
@@ -105,7 +106,9 @@ export function markPendingSelection(model: string): AsyncResult<void, Error> {
 export async function retirePendingSelectionOnPromotion(echoedKey: string, echoedValue: unknown): Promise<void> {
   if (echoedKey !== SETTINGS.default_wearable.key || !echoedValue) return
   const settings = useSettingsStore.getState()
-  if (settings.getSetting(SETTINGS.pending_wearable.key)) {
+  const pending = settings.getSetting(SETTINGS.pending_wearable.key)
+  if (pending) {
+    console.log(`PairingIdentity: promotion "${String(echoedValue)}" retires pending "${pending}"`)
     await settings.setSetting(SETTINGS.pending_wearable.key, "")
   }
 }
@@ -120,7 +123,13 @@ export async function retirePendingSelectionOnPromotion(echoedKey: string, echoe
  */
 export async function demoteDefaultToPending(model: string): Promise<void> {
   const settings = useSettingsStore.getState()
-  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
+  const fresher = settings.getSetting(SETTINGS.pending_wearable.key)
+  console.log(
+    fresher
+      ? `PairingIdentity: demote "${model}" — fresher pending "${fresher}" kept`
+      : `PairingIdentity: demote "${model}" -> pending`,
+  )
+  if (!fresher) {
     await settings.setSetting(SETTINGS.pending_wearable.key, model)
   }
   await settings.setSetting(SETTINGS.default_wearable.key, "")

--- a/mobile/modules/island/src/services/PairingIdentity.ts
+++ b/mobile/modules/island/src/services/PairingIdentity.ts
@@ -1,0 +1,129 @@
+/**
+ * PairingIdentity — the pairing-identity lifecycle, reified. The two-phase
+ * identity rules (see the pending/default group in stores/settings.ts) exist
+ * as a three-state machine over the identity settings keys:
+ *
+ *   none ──markPendingSelection()──▶ pending ──native promotion──▶ paired
+ *                                       ▲                            │
+ *                                       └───────boot demotion────────┘
+ *
+ * - `none`    — no model ever selected: hosts route to model selection.
+ * - `pending` — a model was CHOSEN (the one JS-owned identity write, made at
+ *               scan entry) but pairing never completed: hosts render
+ *               finish-pairing affordances.
+ * - `paired`  — the native layer promoted the identity at pairing success
+ *               (handleDeviceReady) and echoed it down via save_setting:
+ *               hosts render the device card / connect surfaces.
+ *
+ * Projection law, mirroring native currentDefaultDevice() on both platforms:
+ * `paired` requires default_wearable AND device_name; device_address is
+ * optional. Two read-time alignments with the demotion's own write rules:
+ * - The simulated device is its own identity (its name mirrors the model at
+ *   connectSimulated, and the boot demotion never touches it), so a simulated
+ *   default_wearable projects as `paired` even without a device_name echo.
+ * - A non-simulated default_wearable WITHOUT a device_name is the orphan
+ *   population `demoteOrphanedDefaultWearable` repairs into pending_wearable
+ *   at boot; the projection already reads it as `pending` (a fresher
+ *   pending_wearable wins, matching the demotion's latest-selection-wins
+ *   backfill).
+ *
+ * JS-initiated identity writes live here and only here — the scan screen
+ * (markPendingSelection), the device-event router (promotion retires the
+ * pending marker), and the boot demotion (demoteDefaultToPending) invoke
+ * these methods instead of writing the raw keys. The router's generic
+ * save_setting persistence is the inbound native→JS echo leg, not a
+ * JS-initiated write, and stays with the router.
+ */
+import type {AsyncResult} from "typesafe-ts"
+
+import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {DeviceTypes} from "../types"
+
+export type IdentitySnapshot =
+  | {kind: "none"}
+  | {kind: "pending"; model: string}
+  | {kind: "paired"; model: string; name: string; address?: string}
+
+// Identity keys hold model/name strings; anything else (legacy null, a stray
+// non-string) reads as absent, matching native currentDefaultDevice()'s
+// blank checks.
+function readIdentityString(key: string): string {
+  const value = useSettingsStore.getState().getSetting(key)
+  return typeof value === "string" ? value : ""
+}
+
+/** Project the identity settings keys into the lifecycle snapshot. */
+export function projectPairingIdentity(): IdentitySnapshot {
+  const model = readIdentityString(SETTINGS.default_wearable.key)
+  const name = readIdentityString(SETTINGS.device_name.key)
+
+  if (model && name) {
+    const address = readIdentityString(SETTINGS.device_address.key)
+    return address ? {kind: "paired", model, name, address} : {kind: "paired", model, name}
+  }
+  if (model && model.includes(DeviceTypes.SIMULATED)) {
+    return {kind: "paired", model, name: model}
+  }
+  const pending = readIdentityString(SETTINGS.pending_wearable.key)
+  if (pending) return {kind: "pending", model: pending}
+  if (model) return {kind: "pending", model}
+  return {kind: "none"}
+}
+
+/**
+ * Subscribe to identity changes, deduped on the projected snapshot (same
+ * style as glasses.onStatus): the settings store updates on many keys; the
+ * callback fires only when the identity snapshot actually changes.
+ */
+export function subscribePairingIdentity(cb: (identity: IdentitySnapshot) => void): () => void {
+  let last = JSON.stringify(projectPairingIdentity())
+  return useSettingsStore.subscribe(() => {
+    const snap = projectPairingIdentity()
+    const key = JSON.stringify(snap)
+    if (key === last) return
+    last = key
+    cb(snap)
+  })
+}
+
+/**
+ * Selection: mark the model the user chose as the PENDING wearable (written
+ * at scan entry). Promotion to `paired` only ever happens natively at pairing
+ * success. The marker persists so an abandoned selection still renders its
+ * finish-pairing card after an app restart.
+ */
+export function markPendingSelection(model: string): AsyncResult<void, Error> {
+  return useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, model)
+}
+
+/**
+ * Promotion retires the selection: when the native layer promotes the default
+ * wearable at pairing success and its save_setting echo lands, the pending
+ * marker has served its purpose. Invoked by DeviceEventRouter for every echo;
+ * a no-op for other keys, empty promotions, and an already-clear marker.
+ */
+export async function retirePendingSelectionOnPromotion(echoedKey: string, echoedValue: unknown): Promise<void> {
+  if (echoedKey !== SETTINGS.default_wearable.key || !echoedValue) return
+  const settings = useSettingsStore.getState()
+  if (settings.getSetting(SETTINGS.pending_wearable.key)) {
+    await settings.setSetting(SETTINGS.pending_wearable.key, "")
+  }
+}
+
+/**
+ * Demotion: turn an orphaned default identity back into a pending selection.
+ * The guards (hydration, the native default-device read, link-layer state)
+ * live with the boot repair in demoteOrphanedDefaultWearable — this is only
+ * the identity write set: backfill the pending marker unless a fresher
+ * selection already holds it (the user's LATEST selection wins), then clear
+ * the promoted identity triplet.
+ */
+export async function demoteDefaultToPending(model: string): Promise<void> {
+  const settings = useSettingsStore.getState()
+  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
+    await settings.setSetting(SETTINGS.pending_wearable.key, model)
+  }
+  await settings.setSetting(SETTINGS.default_wearable.key, "")
+  await settings.setSetting(SETTINGS.device_name.key, "")
+  await settings.setSetting(SETTINGS.device_address.key, "")
+}

--- a/mobile/modules/island/src/services/PairingIdentity.ts
+++ b/mobile/modules/island/src/services/PairingIdentity.ts
@@ -98,7 +98,7 @@ export function markPendingSelection(model: string): AsyncResult<void, Error> {
   const trimmed = typeof model === "string" ? model.trim() : ""
   if (!trimmed) {
     console.warn(`PairingIdentity: ignoring pending selection with empty model (got ${JSON.stringify(model)})`)
-    return Promise.resolve(Res.ok(undefined)) as AsyncResult<void, Error>
+    return Res.try_async(async () => {})
   }
   console.log(`PairingIdentity: pending selection -> "${trimmed}"`)
   const result = useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, trimmed)

--- a/mobile/modules/island/src/services/__tests__/DeviceStoreHydration.test.ts
+++ b/mobile/modules/island/src/services/__tests__/DeviceStoreHydration.test.ts
@@ -1,0 +1,152 @@
+/// <reference types="bun-types" />
+
+import {beforeEach, describe, expect, mock, test} from "bun:test"
+
+const mockGetDefaultDevice = mock((): Promise<Record<string, unknown> | null> => Promise.resolve(null))
+mock.module("@mentra/bluetooth-sdk/internal", () => ({
+  __esModule: true,
+  default: {
+    getDefaultDevice: mockGetDefaultDevice,
+  },
+}))
+
+const okResult = {is_error: () => false} as const
+const settingsValues: Record<string, unknown> = {}
+const mockLoadAllSettings = mock(() => Promise.resolve(okResult as {is_error: () => boolean; error?: unknown}))
+const mockSetSetting = mock((key: string, value: unknown) => {
+  settingsValues[key] = value
+  return Promise.resolve(okResult)
+})
+mock.module("../../stores/settings", () => ({
+  SETTINGS: {
+    default_wearable: {key: "default_wearable"},
+    pending_wearable: {key: "pending_wearable"},
+    device_name: {key: "device_name"},
+    device_address: {key: "device_address"},
+  },
+  useSettingsStore: {
+    getState: () => ({
+      loadAllSettings: mockLoadAllSettings,
+      getSetting: (key: string) => settingsValues[key],
+      setSetting: mockSetSetting,
+    }),
+  },
+}))
+
+let connection: {state: string} = {state: "disconnected"}
+mock.module("../../stores/glasses", () => ({
+  useGlassesStore: {
+    getState: () => ({connection}),
+  },
+}))
+
+const mockPushAllBluetoothSettings = mock(() => Promise.resolve())
+mock.module("../GlassesSettingsSync", () => ({
+  pushAllBluetoothSettings: mockPushAllBluetoothSettings,
+}))
+
+// Import AFTER the mocks are registered
+const {hydrateDeviceStore, hasDefaultDevice, demoteOrphanedDefaultWearable} = require("../DeviceStoreHydration")
+
+function resetSettings(values: Record<string, unknown>) {
+  for (const key of Object.keys(settingsValues)) delete settingsValues[key]
+  Object.assign(settingsValues, values)
+}
+
+describe("DeviceStoreHydration", () => {
+  beforeEach(() => {
+    mockGetDefaultDevice.mockClear()
+    mockLoadAllSettings.mockClear()
+    mockSetSetting.mockClear()
+    mockPushAllBluetoothSettings.mockClear()
+    mockLoadAllSettings.mockImplementation(() => Promise.resolve(okResult))
+    mockGetDefaultDevice.mockImplementation(() => Promise.resolve(null))
+    connection = {state: "disconnected"}
+    resetSettings({})
+  })
+
+  test("hydration retries after a failed settings load, then single-flights", async () => {
+    mockLoadAllSettings.mockImplementation(() =>
+      Promise.resolve({is_error: () => true, error: new Error("disk unavailable")}),
+    )
+    // The failure surfaces as a REJECTION (never a false "absent"), and
+    // hasDefaultDevice propagates it so callers can fail open.
+    await expect(hasDefaultDevice()).rejects.toThrow("settings load failed")
+    expect(mockPushAllBluetoothSettings).not.toHaveBeenCalled()
+
+    // The memo cleared on failure: a later call retries and heals.
+    mockLoadAllSettings.mockImplementation(() => Promise.resolve(okResult))
+    await hydrateDeviceStore()
+    expect(mockPushAllBluetoothSettings).toHaveBeenCalledTimes(1)
+
+    // Completed hydration is cached: further calls run nothing again.
+    await hydrateDeviceStore()
+    await hydrateDeviceStore()
+    expect(mockPushAllBluetoothSettings).toHaveBeenCalledTimes(1)
+  })
+
+  test("hasDefaultDevice awaits hydration and reports the native two-state answer", async () => {
+    mockGetDefaultDevice.mockImplementation(() => Promise.resolve(null))
+    expect(await hasDefaultDevice()).toBe(false)
+
+    mockGetDefaultDevice.mockImplementation(() =>
+      Promise.resolve({model: "Even Realities G1", name: "G1_123"}),
+    )
+    expect(await hasDefaultDevice()).toBe(true)
+  })
+
+  test("demotes an orphaned default_wearable to pending and clears the identity", async () => {
+    resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", device_address: "aa:bb"})
+    mockGetDefaultDevice.mockImplementation(() => Promise.resolve(null))
+
+    await demoteOrphanedDefaultWearable()
+
+    expect(settingsValues.pending_wearable).toBe("Mentra Live")
+    expect(settingsValues.default_wearable).toBe("")
+    expect(settingsValues.device_name).toBe("")
+    expect(settingsValues.device_address).toBe("")
+    // Native must mirror the demoted identity (the seed already pushed the
+    // pre-demotion values).
+    expect(mockPushAllBluetoothSettings).toHaveBeenCalled()
+  })
+
+  test("does not demote when the native default device exists", async () => {
+    resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1"})
+    mockGetDefaultDevice.mockImplementation(() =>
+      Promise.resolve({model: "Mentra Live", name: "LIVE_1"}),
+    )
+
+    await demoteOrphanedDefaultWearable()
+
+    expect(mockSetSetting).not.toHaveBeenCalled()
+  })
+
+  test("does not demote the simulated wearable", async () => {
+    resetSettings({default_wearable: "Simulated Glasses"})
+
+    await demoteOrphanedDefaultWearable()
+
+    expect(mockSetSetting).not.toHaveBeenCalled()
+    expect(mockGetDefaultDevice).not.toHaveBeenCalled()
+  })
+
+  test("does not demote while the link layer is busy or connected (a pairing owns the identity)", async () => {
+    resetSettings({default_wearable: "Mentra Live"})
+
+    connection = {state: "connecting"}
+    await demoteOrphanedDefaultWearable()
+    expect(mockSetSetting).not.toHaveBeenCalled()
+
+    connection = {state: "connected"}
+    await demoteOrphanedDefaultWearable()
+    expect(mockSetSetting).not.toHaveBeenCalled()
+  })
+
+  test("does nothing when no default_wearable is set", async () => {
+    resetSettings({pending_wearable: "Mentra Live"})
+
+    await demoteOrphanedDefaultWearable()
+
+    expect(mockSetSetting).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/modules/island/src/services/__tests__/DeviceStoreHydration.test.ts
+++ b/mobile/modules/island/src/services/__tests__/DeviceStoreHydration.test.ts
@@ -46,7 +46,12 @@ mock.module("../GlassesSettingsSync", () => ({
 }))
 
 // Import AFTER the mocks are registered
-const {hydrateDeviceStore, hasDefaultDevice, demoteOrphanedDefaultWearable} = require("../DeviceStoreHydration")
+const {
+  hydrateDeviceStore,
+  hasDefaultDevice,
+  demoteOrphanedDefaultWearable,
+  resetDeviceStoreHydrationForTests,
+} = require("../DeviceStoreHydration")
 
 function resetSettings(values: Record<string, unknown>) {
   for (const key of Object.keys(settingsValues)) delete settingsValues[key]
@@ -55,6 +60,7 @@ function resetSettings(values: Record<string, unknown>) {
 
 describe("DeviceStoreHydration", () => {
   beforeEach(() => {
+    resetDeviceStoreHydrationForTests()
     mockGetDefaultDevice.mockClear()
     mockLoadAllSettings.mockClear()
     mockSetSetting.mockClear()
@@ -105,9 +111,20 @@ describe("DeviceStoreHydration", () => {
     expect(settingsValues.default_wearable).toBe("")
     expect(settingsValues.device_name).toBe("")
     expect(settingsValues.device_address).toBe("")
-    // Native must mirror the demoted identity (the seed already pushed the
-    // pre-demotion values).
-    expect(mockPushAllBluetoothSettings).toHaveBeenCalled()
+    // Two pushes: the hydration seed (pre-demotion values), then the re-push
+    // so native mirrors the demoted identity.
+    expect(mockPushAllBluetoothSettings).toHaveBeenCalledTimes(2)
+  })
+
+  test("demotion backfills pending only when empty — a fresher selection wins", async () => {
+    resetSettings({default_wearable: "Mentra Live", pending_wearable: "Even Realities G1"})
+    mockGetDefaultDevice.mockImplementation(() => Promise.resolve(null))
+
+    await demoteOrphanedDefaultWearable()
+
+    // The user's later selection (G1) survives; the stale orphan is only cleared.
+    expect(settingsValues.pending_wearable).toBe("Even Realities G1")
+    expect(settingsValues.default_wearable).toBe("")
   })
 
   test("does not demote when the native default device exists", async () => {
@@ -127,7 +144,21 @@ describe("DeviceStoreHydration", () => {
     await demoteOrphanedDefaultWearable()
 
     expect(mockSetSetting).not.toHaveBeenCalled()
+    // Hydration runs (the internal await), but the native default is never read.
     expect(mockGetDefaultDevice).not.toHaveBeenCalled()
+  })
+
+  test("demotion refuses to run against an unhydrated store", async () => {
+    resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1"})
+    mockLoadAllSettings.mockImplementation(() =>
+      Promise.resolve({is_error: () => true, error: new Error("disk unavailable")}),
+    )
+
+    await expect(demoteOrphanedDefaultWearable()).rejects.toThrow("settings load failed")
+
+    // Nothing was demoted on the unseeded store.
+    expect(mockSetSetting).not.toHaveBeenCalled()
+    expect(settingsValues.default_wearable).toBe("Mentra Live")
   })
 
   test("does not demote while the link layer is busy or connected (a pairing owns the identity)", async () => {

--- a/mobile/modules/island/src/services/__tests__/PairingIdentity.test.ts
+++ b/mobile/modules/island/src/services/__tests__/PairingIdentity.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="bun-types" />
+
+import {beforeEach, describe, expect, mock, test} from "bun:test"
+
+const settingsValues: Record<string, unknown> = {}
+const listeners = new Set<() => void>()
+const okResult = {is_error: () => false} as const
+const mockSetSetting = mock((key: string, value: unknown) => {
+  settingsValues[key] = value
+  for (const listener of [...listeners]) listener()
+  return Promise.resolve(okResult)
+})
+
+mock.module("../../stores/settings", () => ({
+  SETTINGS: {
+    default_wearable: {key: "default_wearable"},
+    pending_wearable: {key: "pending_wearable"},
+    device_name: {key: "device_name"},
+    device_address: {key: "device_address"},
+  },
+  useSettingsStore: {
+    getState: () => ({
+      getSetting: (key: string) => settingsValues[key],
+      setSetting: mockSetSetting,
+    }),
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  },
+}))
+
+// Import AFTER the mocks are registered
+const {
+  projectPairingIdentity,
+  subscribePairingIdentity,
+  markPendingSelection,
+  retirePendingSelectionOnPromotion,
+  demoteDefaultToPending,
+} = require("../PairingIdentity")
+// Real enum: the simulated special case must track the actual model string.
+const {DeviceTypes} = require("../../types")
+
+function resetSettings(values: Record<string, unknown>) {
+  for (const key of Object.keys(settingsValues)) delete settingsValues[key]
+  Object.assign(settingsValues, values)
+}
+
+describe("PairingIdentity", () => {
+  beforeEach(() => {
+    mockSetSetting.mockClear()
+    listeners.clear()
+    resetSettings({})
+  })
+
+  describe("projectPairingIdentity", () => {
+    test("no identity keys → none", () => {
+      expect(projectPairingIdentity()).toEqual({kind: "none"})
+    })
+
+    test("a pending selection → pending", () => {
+      resetSettings({pending_wearable: "Even Realities G1"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Even Realities G1"})
+    })
+
+    test("paired requires default_wearable AND device_name (native currentDefaultDevice)", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", device_address: "aa:bb"})
+      expect(projectPairingIdentity()).toEqual({
+        kind: "paired",
+        model: "Mentra Live",
+        name: "LIVE_1",
+        address: "aa:bb",
+      })
+    })
+
+    test("address is optional on a paired identity", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1"})
+      expect(projectPairingIdentity()).toEqual({kind: "paired", model: "Mentra Live", name: "LIVE_1"})
+    })
+
+    test("an orphaned default (no device_name) reads as pending — the demotion's target state", () => {
+      resetSettings({default_wearable: "Mentra Live"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Mentra Live"})
+    })
+
+    test("a fresher pending selection wins over an orphaned default", () => {
+      resetSettings({default_wearable: "Mentra Live", pending_wearable: "Even Realities G1"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Even Realities G1"})
+    })
+
+    test("a completed pairing wins over a stale pending marker (retire echo still in flight)", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", pending_wearable: "Mentra Live"})
+      expect(projectPairingIdentity()).toEqual({kind: "paired", model: "Mentra Live", name: "LIVE_1"})
+    })
+
+    test("the simulated device is its own identity: paired from the model alone, name mirrors it", () => {
+      resetSettings({default_wearable: DeviceTypes.SIMULATED})
+      expect(projectPairingIdentity()).toEqual({
+        kind: "paired",
+        model: DeviceTypes.SIMULATED,
+        name: DeviceTypes.SIMULATED,
+      })
+    })
+
+    test("non-string identity values read as absent", () => {
+      resetSettings({default_wearable: null, pending_wearable: undefined, device_name: 42})
+      expect(projectPairingIdentity()).toEqual({kind: "none"})
+    })
+  })
+
+  describe("subscribePairingIdentity", () => {
+    test("fires with the new snapshot when the identity changes, dedupes when it does not", async () => {
+      const seen: unknown[] = []
+      const unsubscribe = subscribePairingIdentity((identity: unknown) => seen.push(identity))
+
+      await markPendingSelection("Even Realities G1")
+      expect(seen).toEqual([{kind: "pending", model: "Even Realities G1"}])
+
+      // A settings-store update that leaves the projection unchanged must not fire.
+      await mockSetSetting("brightness", 80)
+      await markPendingSelection("Even Realities G1")
+      expect(seen).toHaveLength(1)
+
+      unsubscribe()
+      await markPendingSelection("Mentra Live")
+      expect(seen).toHaveLength(1)
+    })
+  })
+
+  describe("identity writes", () => {
+    test("markPendingSelection writes the pending marker", async () => {
+      await markPendingSelection("Even Realities G1")
+      expect(settingsValues.pending_wearable).toBe("Even Realities G1")
+    })
+
+    test("a promoted default retires the pending selection marker", async () => {
+      resetSettings({pending_wearable: "Mentra Live"})
+      await retirePendingSelectionOnPromotion("default_wearable", "Mentra Live")
+      expect(settingsValues.pending_wearable).toBe("")
+    })
+
+    test("retire is a no-op for other keys, empty promotions, and an already-clear marker", async () => {
+      resetSettings({pending_wearable: "Mentra Live"})
+      await retirePendingSelectionOnPromotion("device_name", "LIVE_1")
+      await retirePendingSelectionOnPromotion("default_wearable", "")
+      expect(settingsValues.pending_wearable).toBe("Mentra Live")
+
+      resetSettings({})
+      await retirePendingSelectionOnPromotion("default_wearable", "Mentra Live")
+      expect(mockSetSetting).not.toHaveBeenCalled()
+    })
+
+    test("demoteDefaultToPending backfills the marker and clears the identity triplet", async () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", device_address: "aa:bb"})
+      await demoteDefaultToPending("Mentra Live")
+      expect(settingsValues).toEqual({
+        pending_wearable: "Mentra Live",
+        default_wearable: "",
+        device_name: "",
+        device_address: "",
+      })
+    })
+
+    test("demoteDefaultToPending never overwrites a fresher pending selection", async () => {
+      resetSettings({default_wearable: "Mentra Live", pending_wearable: "Even Realities G1"})
+      await demoteDefaultToPending("Mentra Live")
+      expect(settingsValues.pending_wearable).toBe("Even Realities G1")
+      expect(settingsValues.default_wearable).toBe("")
+    })
+  })
+})

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -721,6 +721,26 @@ export const BLUETOOTH_SETTING_KEYS: string[] = [
   SETTINGS.nex_lc3_audio_playback.key,
 ]
 
+// Pairing identity is NATIVE-authoritative: the native layer writes it on
+// pairing success (handleDeviceReady) / forget and echoes it down via
+// save_setting; JS persists those echoes. JS→native, identity travels ONLY in
+// the explicit full seeds (device-store hydration, pre-connect push,
+// post-demotion re-push) — never in the change-push subscription. Relaying an
+// echoed identity change back up would make the sync bidirectional with loop
+// gain 1: two identity values in flight (e.g. a boot demotion crossing a
+// native promotion) then chase each other through push→apply→echo→push
+// forever, flapping the UI.
+export const PAIRING_IDENTITY_KEYS: string[] = [
+  SETTINGS.pending_wearable.key,
+  SETTINGS.default_wearable.key,
+  SETTINGS.device_name.key,
+  SETTINGS.device_address.key,
+  SETTINGS.default_controller.key,
+  SETTINGS.pending_controller.key,
+  SETTINGS.controller_device_name.key,
+  SETTINGS.controller_address.key,
+]
+
 // const PER_GLASSES_SETTINGS_KEYS: string[] = [SETTINGS.preferred_mic.key]
 
 export interface SettingsState {

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -18,6 +18,12 @@ export interface Setting {
   override?: () => any
   // onWrite?: () => void
   persist: boolean
+  // Pairing-identity keys are NATIVE-authoritative: the native layer writes
+  // them on pairing success (handleDeviceReady) / forget and echoes them down
+  // via save_setting; JS→native they travel only in the explicit full seeds,
+  // never the change-push. PAIRING_IDENTITY_KEYS is derived from this flag so
+  // the sync exclusion can't drift from the descriptors.
+  nativeAuthoritative?: true
 }
 
 export const SETTINGS: Record<string, Setting> = {
@@ -237,6 +243,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   default_wearable: {
     key: "default_wearable",
@@ -244,14 +251,23 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
-  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: false, persist: true},
+  device_name: {
+    key: "device_name",
+    defaultValue: () => "",
+    writable: true,
+    saveOnServer: false,
+    persist: true,
+    nativeAuthoritative: true,
+  },
   device_address: {
     key: "device_address",
     defaultValue: () => "",
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   default_controller: {
     key: "default_controller",
@@ -259,6 +275,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   pending_controller: {
     key: "pending_controller",
@@ -266,6 +283,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   controller_device_name: {
     key: "controller_device_name",
@@ -273,6 +291,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   controller_address: {
     key: "controller_address",
@@ -280,6 +299,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   // ui state:
   home_background: {
@@ -730,16 +750,13 @@ export const BLUETOOTH_SETTING_KEYS: string[] = [
 // gain 1: two identity values in flight (e.g. a boot demotion crossing a
 // native promotion) then chase each other through push→apply→echo→push
 // forever, flapping the UI.
-export const PAIRING_IDENTITY_KEYS: string[] = [
-  SETTINGS.pending_wearable.key,
-  SETTINGS.default_wearable.key,
-  SETTINGS.device_name.key,
-  SETTINGS.device_address.key,
-  SETTINGS.default_controller.key,
-  SETTINGS.pending_controller.key,
-  SETTINGS.controller_device_name.key,
-  SETTINGS.controller_address.key,
-]
+//
+// Derived from the `nativeAuthoritative` descriptor flag (not maintained as a
+// parallel list) so the change-push exclusion in GlassesSettingsSync can't
+// drift from the setting declarations.
+export const PAIRING_IDENTITY_KEYS: string[] = Object.values(SETTINGS)
+  .filter((setting) => setting.nativeAuthoritative)
+  .map((setting) => setting.key)
 
 // const PER_GLASSES_SETTINGS_KEYS: string[] = [SETTINGS.preferred_mic.key]
 

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -20,9 +20,11 @@ export interface Setting {
   persist: boolean
   // Pairing-identity keys are NATIVE-authoritative: the native layer writes
   // them on pairing success (handleDeviceReady) / forget and echoes them down
-  // via save_setting; JS→native they travel only in the explicit full seeds,
-  // never the change-push. PAIRING_IDENTITY_KEYS is derived from this flag so
-  // the sync exclusion can't drift from the descriptors.
+  // via save_setting; JS→native they travel only in the explicit SEEDS
+  // (hydration, pre-connect, post-demotion, abandon re-seed) — never the
+  // change-push and never the on-connect replay, whose mid-relay snapshot can
+  // overwrite a just-promoted identity. PAIRING_IDENTITY_KEYS is derived from
+  // this flag so the sync exclusions can't drift from the descriptors.
   nativeAuthoritative?: true
 }
 

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -22,10 +22,16 @@ export interface Setting {
 
 export const SETTINGS: Record<string, Setting> = {
   // feature flags / mantle settings:
-  dev_mode: {key: "dev_mode", defaultValue: () => __DEV__, writable: true, saveOnServer: true, persist: true},// deprecated
+  dev_mode: {key: "dev_mode", defaultValue: () => __DEV__, writable: true, saveOnServer: true, persist: true}, // deprecated
   debug_mode: {key: "debug_mode", defaultValue: () => __DEV__, writable: true, saveOnServer: true, persist: true},
   super_mode: {key: "super_mode", defaultValue: () => false, writable: true, saveOnServer: true, persist: true},
-  appearance_menu_enabled: {key: "appearance_menu_enabled", defaultValue: () => false, writable: true, saveOnServer: true, persist: true},
+  appearance_menu_enabled: {
+    key: "appearance_menu_enabled",
+    defaultValue: () => false,
+    writable: true,
+    saveOnServer: true,
+    persist: true,
+  },
   app_boot_extra_info: {
     key: "app_boot_extra_info",
     defaultValue: () => false,
@@ -33,7 +39,13 @@ export const SETTINGS: Record<string, Setting> = {
     saveOnServer: true,
     persist: true,
   },
-  miniapp_dev_mode: {key: "miniapp_dev_mode", defaultValue: () => false, writable: true, saveOnServer: true, persist: true},
+  miniapp_dev_mode: {
+    key: "miniapp_dev_mode",
+    defaultValue: () => false,
+    writable: true,
+    saveOnServer: true,
+    persist: true,
+  },
   enable_squircles: {
     key: "enable_squircles",
     defaultValue: () => true,
@@ -208,33 +220,44 @@ export const SETTINGS: Record<string, Setting> = {
   // from or saved to the legacy Cloud V1 settings store.
   core_token: {key: "core_token", defaultValue: () => "", writable: true, saveOnServer: false, persist: false},
   auth_email: {key: "auth_email", defaultValue: () => "", writable: true, saveOnServer: false, persist: true},
+  // Pairing identity is per-phone, not per-account: two phones on one account
+  // can be paired to different glasses, so none of these keys may sync to the
+  // server (saveOnServer: false — a stale server copy resurrecting a local
+  // pairing identity is exactly the desync this group's flags prevent).
+  //
+  // Two-phase identity: pending_wearable is the model the user last STARTED
+  // pairing (written at selection, rendered as a finish-pairing card);
+  // default_wearable + device_name + device_address are only promoted by the
+  // native layer when pairing actually succeeds (handleDeviceReady).
+  // pending_wearable persists so an abandoned selection still shows its
+  // finish-pairing card after an app restart.
   pending_wearable: {
     key: "pending_wearable",
     defaultValue: () => "",
     writable: true,
     saveOnServer: false,
-    persist: false,
+    persist: true,
   },
   default_wearable: {
     key: "default_wearable",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
-  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: true, persist: true},
+  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: false, persist: true},
   device_address: {
     key: "device_address",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   default_controller: {
     key: "default_controller",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   pending_controller: {
@@ -248,14 +271,14 @@ export const SETTINGS: Record<string, Setting> = {
     key: "controller_device_name",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   controller_address: {
     key: "controller_address",
     defaultValue: () => "",
     writable: true,
-    saveOnServer: true,
+    saveOnServer: false,
     persist: true,
   },
   // ui state:
@@ -719,10 +742,19 @@ export interface SettingsState {
 }
 
 const getDefaultSettings = () =>
-  Object.keys(SETTINGS).reduce((acc, key) => {
-    acc[key] = SETTINGS[key].defaultValue()
-    return acc
-  }, {} as Record<string, any>)
+  Object.keys(SETTINGS).reduce(
+    (acc, key) => {
+      acc[key] = SETTINGS[key].defaultValue()
+      return acc
+    },
+    {} as Record<string, any>,
+  )
+
+// Single-flight for loadAllSettings: the host fires it at module load and
+// toolkit.start()'s device-store hydration awaits it — without the memo the
+// second caller runs a duplicate full disk load while the first is still in
+// flight. Cleared on failure so a later call can retry.
+let loadAllSettingsInFlight: AsyncResult<void, Error> | null = null
 
 export const useSettingsStore = create<SettingsState>()(
   subscribeWithSelector((set, get) => ({
@@ -829,7 +861,10 @@ export const useSettingsStore = create<SettingsState>()(
     // loads any preferences that have been changed from the default and saved to DISK!
     loadAllSettings: (): AsyncResult<void, Error> => {
       console.log("SETTINGS: loadAllSettings()")
-      return Res.try_async(async () => {
+      if (loadAllSettingsInFlight) {
+        return loadAllSettingsInFlight
+      }
+      const inFlight = Res.try_async(async () => {
         const state = get()
         let loadedSettings: Record<string, any> = {}
 
@@ -914,6 +949,13 @@ export const useSettingsStore = create<SettingsState>()(
           storage.save(MIGRATION_KEY, true)
         }
       })
+      loadAllSettingsInFlight = inFlight
+      void Promise.resolve(inFlight).then((result) => {
+        if (result.is_error()) {
+          loadAllSettingsInFlight = null
+        }
+      })
+      return inFlight
     },
     getRestUrl: () => {
       const serverUrl = get().getSetting(SETTINGS.backend_url.key)

--- a/mobile/src/__tests__/app/pairing/loading.test.tsx
+++ b/mobile/src/__tests__/app/pairing/loading.test.tsx
@@ -119,7 +119,9 @@ describe("pairing loading screen", () => {
     })
 
     await waitFor(() => {
-      expect(toolkit.glasses.forget).toHaveBeenCalled()
+      // Attempt cleanup preserves a pre-existing pairing (re-pair) instead of
+      // an unconditional forget.
+      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalled()
       expect(replace).toHaveBeenCalledWith("/pairing/failure", {
         error: "pairing:failed",
         deviceModel: "Mentra Live",

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -141,7 +141,7 @@ import {Platform} from "react-native"
 
 import {toolkit} from "@mentra/island"
 import {useLocalSearchParams} from "expo-router"
-import {usePushUnder} from "@/contexts/NavigationHistoryContext"
+import {focusEffectPreventBack, usePushUnder} from "@/contexts/NavigationHistoryContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import SelectGlassesBluetoothScreen from "@/app/pairing/scan"
@@ -176,6 +176,7 @@ describe("pairing scan screen", () => {
     ;(toolkit.pairing.onFound as jest.Mock).mockImplementation((cb: (results: unknown) => void) =>
       useCoreStore.subscribe((s) => s.searchResults, cb),
     )
+    ;(toolkit.glasses.hasDefaultDevice as jest.Mock).mockResolvedValue(true)
     ;(useLocalSearchParams as jest.Mock).mockReturnValue({deviceModel: "Mentra Live"})
     ;(useNavigationStore.getState as jest.Mock).mockReturnValue({replace, push, goBack})
     ;(usePushUnder as jest.Mock).mockReturnValue(pushUnder)
@@ -204,20 +205,61 @@ describe("pairing scan screen", () => {
     fireEvent.press(getByText("001"))
 
     await waitFor(() => {
-      expect(replace).toHaveBeenCalledWith("/pairing/btclassic")
+      expect(replace).toHaveBeenCalledWith("/pairing/btclassic", {
+        device: JSON.stringify({id: "a", model: "Mentra Live", name: "MENTRA_LIVE_BLE_001", address: "a"}),
+      })
       expect(pushUnder).toHaveBeenCalledWith("/pairing/loading", {
         deviceModel: "Mentra Live",
         deviceName: "MENTRA_LIVE_BLE_001",
       })
     })
 
-    expect(toolkit.pairing.setDefault).toHaveBeenCalledWith({
-      id: "a",
-      model: "Mentra Live",
-      name: "MENTRA_LIVE_BLE_001",
-      address: "a",
+    // Two-phase identity: picking a device must NOT write the default identity —
+    // the scan marks the model pending and the native layer promotes on success.
+    expect(toolkit.pairing.setDefault).not.toHaveBeenCalled()
+    expect(useSettingsStore.getState().getSetting(SETTINGS.device_name.key)).toBe("")
+    expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
+  })
+
+  it("marks the chosen model pending on entry", async () => {
+    render(<SelectGlassesBluetoothScreen />)
+
+    await waitFor(() => {
+      expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
     })
-    expect(useSettingsStore.getState().getSetting(SETTINGS.device_name.key)).toBe("MENTRA_LIVE_BLE_001")
+  })
+
+  it("back-out of a FRESH pairing forgets the partial attempt but keeps the pending marker", async () => {
+    ;(toolkit.glasses.hasDefaultDevice as jest.Mock).mockResolvedValue(false)
+    render(<SelectGlassesBluetoothScreen />)
+    await waitFor(() => {
+      expect(toolkit.glasses.hasDefaultDevice).toHaveBeenCalled()
+    })
+
+    const backHandler = (focusEffectPreventBack as jest.Mock).mock.calls[0][0]
+    backHandler({actionType: "GO_BACK"})
+
+    await waitFor(() => {
+      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalledWith(false)
+    })
+    expect(goBack).toHaveBeenCalled()
+    expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
+  })
+
+  it("back-out of a RE-PAIR preserves the existing pairing", async () => {
+    ;(toolkit.glasses.hasDefaultDevice as jest.Mock).mockResolvedValue(true)
+    render(<SelectGlassesBluetoothScreen />)
+    await waitFor(() => {
+      expect(toolkit.glasses.hasDefaultDevice).toHaveBeenCalled()
+    })
+
+    const backHandler = (focusEffectPreventBack as jest.Mock).mock.calls[0][0]
+    backHandler({actionType: "GO_BACK"})
+
+    await waitFor(() => {
+      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalledWith(true)
+    })
+    expect(goBack).toHaveBeenCalled()
   })
 
   it("auto-skips directly into pairing when NOTREQUIREDSKIP is discovered", async () => {

--- a/mobile/src/__tests__/app/pairing/scan.test.tsx
+++ b/mobile/src/__tests__/app/pairing/scan.test.tsx
@@ -229,37 +229,30 @@ describe("pairing scan screen", () => {
     })
   })
 
-  it("back-out of a FRESH pairing forgets the partial attempt but keeps the pending marker", async () => {
-    ;(toolkit.glasses.hasDefaultDevice as jest.Mock).mockResolvedValue(false)
+  it("back-out delegates cleanup to the live abandonAttempt and keeps the pending marker", async () => {
+    // No entry snapshot: the abandon decision must come from the LIVE
+    // default-device read, because a pairing can promote while the flow is
+    // open — an entry snapshot would forget that brand-new pairing.
     render(<SelectGlassesBluetoothScreen />)
-    await waitFor(() => {
-      expect(toolkit.glasses.hasDefaultDevice).toHaveBeenCalled()
-    })
 
     const backHandler = (focusEffectPreventBack as jest.Mock).mock.calls[0][0]
     backHandler({actionType: "GO_BACK"})
 
     await waitFor(() => {
-      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalledWith(false)
+      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalledWith()
     })
     expect(goBack).toHaveBeenCalled()
     expect(useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key)).toBe("Mentra Live")
   })
 
-  it("back-out of a RE-PAIR preserves the existing pairing", async () => {
-    ;(toolkit.glasses.hasDefaultDevice as jest.Mock).mockResolvedValue(true)
+  it("forward navigation (replace to btclassic) skips the back-out cleanup", async () => {
     render(<SelectGlassesBluetoothScreen />)
-    await waitFor(() => {
-      expect(toolkit.glasses.hasDefaultDevice).toHaveBeenCalled()
-    })
 
     const backHandler = (focusEffectPreventBack as jest.Mock).mock.calls[0][0]
-    backHandler({actionType: "GO_BACK"})
+    backHandler({actionType: "REPLACE"})
 
-    await waitFor(() => {
-      expect(toolkit.pairing.abandonAttempt).toHaveBeenCalledWith(true)
-    })
-    expect(goBack).toHaveBeenCalled()
+    expect(toolkit.pairing.abandonAttempt).not.toHaveBeenCalled()
+    expect(goBack).not.toHaveBeenCalled()
   })
 
   it("auto-skips directly into pairing when NOTREQUIREDSKIP is discovered", async () => {

--- a/mobile/src/__tests__/connectionCoordinator.test.ts
+++ b/mobile/src/__tests__/connectionCoordinator.test.ts
@@ -10,6 +10,7 @@ describe("decideReconnect", () => {
     connected: false,
     searching: false,
     nativeLinkBusy: false,
+    hasDefaultDevice: true,
   }
 
   it("skips as a no-op success when reconnect-on-foreground is off", () => {
@@ -34,6 +35,10 @@ describe("decideReconnect", () => {
 
   it("skips when the native link layer is mid connect/bond (no scan running)", () => {
     expect(decideReconnect({...base, nativeLinkBusy: true})).toEqual({kind: "skip", result: true})
+  })
+
+  it("skips quietly when a model is chosen but no device was ever paired", () => {
+    expect(decideReconnect({...base, hasDefaultDevice: false})).toEqual({kind: "skip", result: false})
   })
 
   it("connects when paired, idle, and disconnected", () => {

--- a/mobile/src/__tests__/glassesSettingsSyncDiff.test.ts
+++ b/mobile/src/__tests__/glassesSettingsSyncDiff.test.ts
@@ -1,0 +1,51 @@
+// Imports the real GlassesSettingsSync by path (not via "@mentra/island",
+// which jest mocks) so the actual diff logic runs under the mobile jest CI
+// runner.
+import {diffBluetoothSettingsForPush} from "../../modules/island/src/services/GlassesSettingsSync"
+import {PAIRING_IDENTITY_KEYS, SETTINGS} from "../../modules/island/src/stores/settings"
+
+describe("diffBluetoothSettingsForPush", () => {
+  it("pushes changed non-identity keys only", () => {
+    const previous = {brightness: 50, sensing_enabled: true}
+    const next = {brightness: 80, sensing_enabled: true}
+    expect(diffBluetoothSettingsForPush(next, previous)).toEqual({brightness: 80})
+  })
+
+  it("returns empty when nothing changed", () => {
+    const settings = {brightness: 50}
+    expect(diffBluetoothSettingsForPush(settings, {...settings})).toEqual({})
+  })
+
+  it("never pushes pairing-identity keys, even when they changed", () => {
+    // Identity is native-authoritative and reaches native only via the explicit
+    // seeds. Relaying an echoed identity change back through the change-push
+    // closes a feedback loop: two values in flight (boot demotion crossing a
+    // native promotion) chase each other through push→apply→echo→push forever
+    // and flap the home pairing card.
+    const previous = Object.fromEntries(PAIRING_IDENTITY_KEYS.map((key) => [key, ""]))
+    const next = Object.fromEntries(PAIRING_IDENTITY_KEYS.map((key) => [key, "Even Realities G2"]))
+    expect(diffBluetoothSettingsForPush(next, previous)).toEqual({})
+  })
+
+  it("covers the full identity group", () => {
+    // The oscillation fix only holds if every identity key is in the list.
+    expect(PAIRING_IDENTITY_KEYS.sort()).toEqual(
+      [
+        SETTINGS.pending_wearable.key,
+        SETTINGS.default_wearable.key,
+        SETTINGS.device_name.key,
+        SETTINGS.device_address.key,
+        SETTINGS.default_controller.key,
+        SETTINGS.pending_controller.key,
+        SETTINGS.controller_device_name.key,
+        SETTINGS.controller_address.key,
+      ].sort(),
+    )
+  })
+
+  it("still pushes a mixed diff minus the identity part", () => {
+    const previous = {brightness: 50, default_wearable: ""}
+    const next = {brightness: 80, default_wearable: "Even Realities G2"}
+    expect(diffBluetoothSettingsForPush(next, previous)).toEqual({brightness: 80})
+  })
+})

--- a/mobile/src/__tests__/glassesSettingsSyncDiff.test.ts
+++ b/mobile/src/__tests__/glassesSettingsSyncDiff.test.ts
@@ -1,7 +1,7 @@
 // Imports the real GlassesSettingsSync by path (not via "@mentra/island",
 // which jest mocks) so the actual diff logic runs under the mobile jest CI
 // runner.
-import {diffBluetoothSettingsForPush} from "../../modules/island/src/services/GlassesSettingsSync"
+import {diffBluetoothSettingsForPush, stripPairingIdentity} from "../../modules/island/src/services/GlassesSettingsSync"
 import {PAIRING_IDENTITY_KEYS, SETTINGS} from "../../modules/island/src/stores/settings"
 
 describe("diffBluetoothSettingsForPush", () => {
@@ -47,5 +47,17 @@ describe("diffBluetoothSettingsForPush", () => {
     const previous = {brightness: 50, default_wearable: ""}
     const next = {brightness: 80, default_wearable: "Even Realities G2"}
     expect(diffBluetoothSettingsForPush(next, previous)).toEqual({brightness: 80})
+  })
+})
+
+describe("stripPairingIdentity", () => {
+  it("removes every identity key and keeps the rest — the on-connect replay set", () => {
+    // While connected, NATIVE owns the identity it promoted at device-ready;
+    // the on-connect replay carrying a mid-relay JS snapshot overwrote a
+    // just-promoted identity with pre-promotion empties (Mentra Live pairing
+    // wiped itself right after succeeding).
+    const settings: Record<string, unknown> = {brightness: 80, gallery_mode: true}
+    for (const key of PAIRING_IDENTITY_KEYS) settings[key] = "stale"
+    expect(stripPairingIdentity(settings)).toEqual({brightness: 80, gallery_mode: true})
   })
 })

--- a/mobile/src/app/home.tsx
+++ b/mobile/src/app/home.tsx
@@ -25,6 +25,7 @@ import {BlurTargetView, BlurView} from "expo-blur"
 export default function Homepage() {
   const refreshApps = useRefresh()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
+  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const glassesConnected =
     useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange)).state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -59,7 +60,9 @@ export default function Homepage() {
   }, [glassesConnected, isSearching, defaultWearable])
 
   const renderContent = () => {
-    if (!defaultWearable) {
+    // A pending selection (model chosen, pairing never completed) renders the
+    // glasses card in its finish-pairing state rather than the first-run card.
+    if (!defaultWearable && !pendingWearable) {
       return (
         <>
           <Group>

--- a/mobile/src/app/home.tsx
+++ b/mobile/src/app/home.tsx
@@ -24,8 +24,9 @@ import {BlurTargetView, BlurView} from "expo-blur"
 
 export default function Homepage() {
   const refreshApps = useRefresh()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const glassesConnected =
     useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange)).state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -57,12 +58,12 @@ export default function Homepage() {
     }
 
     attemptInitialConnect()
-  }, [glassesConnected, isSearching, defaultWearable])
+  }, [glassesConnected, isSearching, pairedModel])
 
   const renderContent = () => {
     // A pending selection (model chosen, pairing never completed) renders the
     // glasses card in its finish-pairing state rather than the first-run card.
-    if (!defaultWearable && !pendingWearable) {
+    if (identity.kind === "none") {
       return (
         <>
           <Group>

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -81,11 +81,24 @@ export default function BtClassicPairingScreen() {
   }, [bluetoothClassicConnected])
 
   useEffect(() => {
-    if (!device && !savedDeviceName) {
-      console.log("BTCLASSIC: no device threaded from scan and no saved default, cannot continue")
-      handleBack()
+    if (device) return
+    let cancelled = false
+    // Paired-context entry (no scan device): stay only when a default device
+    // actually exists — the same precondition connectDefault() has, read
+    // hydration-aware. Fail open (stay) on a read error; connectDefault()'s
+    // catch is the fallback for a genuinely missing device.
+    toolkit.glasses
+      .hasDefaultDevice()
+      .catch(() => true)
+      .then((hasDefault) => {
+        if (cancelled || hasDefault) return
+        console.log("BTCLASSIC: no device threaded from scan and no default device, cannot continue")
+        handleBack()
+      })
+    return () => {
+      cancelled = true
     }
-  }, [device, savedDeviceName])
+  }, [device])
 
   let steps: OnboardingStep[] = [
     {

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -74,6 +74,18 @@ export default function BtClassicPairingScreen() {
   }
 
   useEffect(() => {
+    if (!device) return
+    // The Pair Audio step advances when native detects the picked device's
+    // Classic audio route — prime the native watcher with that device (it no
+    // longer learns it from a selection-time identity write). If the audio
+    // device is already paired, the resulting immediate check advances the
+    // screen right away.
+    void toolkit.pairing.setBluetoothClassicTarget(device).catch((error) => {
+      console.warn("BTCLASSIC: failed to set the Bluetooth Classic target:", error)
+    })
+  }, [device])
+
+  useEffect(() => {
     console.log("BTCLASSIC: check bluetoothClassicConnected", bluetoothClassicConnected)
     if (bluetoothClassicConnected) {
       handleSuccess()

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -7,6 +7,7 @@ import {translate} from "@/i18n"
 import {focusEffectPreventBack, usePushPrevious} from "@/contexts/NavigationHistoryContext"
 import {toolkit} from "@mentra/island"
 import type {Device} from "@mentra/bluetooth-sdk"
+import {SETTINGS, useSetting} from "@/stores/settings"
 import {SettingsNavigationUtils} from "@/utils/SettingsNavigationUtils"
 import {View} from "react-native"
 import {useAppTheme} from "@/contexts/ThemeContext"
@@ -20,6 +21,11 @@ export default function BtClassicPairingScreen() {
   // The device the user picked on the scan screen, threaded through the route.
   // Two-phase identity: it is NOT the default device yet — the connect below
   // marks it pending, and the native layer promotes it on pairing success.
+  //
+  // This screen is ALSO entered without a device from paired contexts — the
+  // pairing-success step stack and the home-screen "Bluetooth Classic
+  // disconnected" recovery alert — where the saved default identity is the
+  // device to (re)connect.
   const device = useMemo((): Device | null => {
     const {device: deviceJson} = (route.params ?? {}) as {device?: string}
     if (!deviceJson) return null
@@ -35,16 +41,24 @@ export default function BtClassicPairingScreen() {
   const otherBtConnected = useToolkitSnapshot(toolkit.pairing.otherBtConnected, (onChange) =>
     toolkit.pairing.onOtherBtConnected(onChange),
   )
-  const deviceName = device?.name ?? ""
+  const [savedDeviceName] = useSetting(SETTINGS.device_name.key)
+  const deviceName = device?.name || savedDeviceName || ""
   const {theme} = useAppTheme()
 
   focusEffectPreventBack()
 
   const handleSuccess = () => {
-    if (!device) return
-    toolkit.glasses.connect(device, {saveAsDefault: false}).catch((error) => {
-      console.error("Failed to connect glasses after Bluetooth Classic pairing:", error)
-    })
+    if (device) {
+      toolkit.glasses.connect(device, {saveAsDefault: false}).catch((error) => {
+        console.error("Failed to connect glasses after Bluetooth Classic pairing:", error)
+      })
+    } else {
+      // Paired contexts (success step stack / recovery alert): reconnect the
+      // saved default device.
+      toolkit.glasses.connectDefault().catch((error) => {
+        console.error("Failed to connect default glasses after Bluetooth Classic pairing:", error)
+      })
+    }
     pushPrevious()
   }
 
@@ -67,11 +81,11 @@ export default function BtClassicPairingScreen() {
   }, [bluetoothClassicConnected])
 
   useEffect(() => {
-    if (!device) {
-      console.log("BTCLASSIC: no device threaded from the scan screen, cannot continue")
+    if (!device && !savedDeviceName) {
+      console.log("BTCLASSIC: no device threaded from scan and no saved default, cannot continue")
       handleBack()
     }
-  }, [device])
+  }, [device, savedDeviceName])
 
   let steps: OnboardingStep[] = [
     {

--- a/mobile/src/app/pairing/btclassic.tsx
+++ b/mobile/src/app/pairing/btclassic.tsx
@@ -1,11 +1,12 @@
-import {useEffect} from "react"
+import {useRoute} from "@react-navigation/native"
+import {useEffect, useMemo} from "react"
 import {Button, Screen} from "@/components/ignite"
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
 import {useToolkitSnapshot} from "@/hooks/useToolkitSnapshot"
 import {translate} from "@/i18n"
 import {focusEffectPreventBack, usePushPrevious} from "@/contexts/NavigationHistoryContext"
 import {toolkit} from "@mentra/island"
-import {SETTINGS, useSetting} from "@/stores/settings"
+import type {Device} from "@mentra/bluetooth-sdk"
 import {SettingsNavigationUtils} from "@/utils/SettingsNavigationUtils"
 import {View} from "react-native"
 import {useAppTheme} from "@/contexts/ThemeContext"
@@ -15,20 +16,34 @@ import CrustModule from "@mentra/crust"
 export default function BtClassicPairingScreen() {
   const {goBack} = useNavigationStore.getState()
   const pushPrevious = usePushPrevious()
+  const route = useRoute()
+  // The device the user picked on the scan screen, threaded through the route.
+  // Two-phase identity: it is NOT the default device yet — the connect below
+  // marks it pending, and the native layer promotes it on pairing success.
+  const device = useMemo((): Device | null => {
+    const {device: deviceJson} = (route.params ?? {}) as {device?: string}
+    if (!deviceJson) return null
+    try {
+      return JSON.parse(deviceJson) as Device
+    } catch {
+      return null
+    }
+  }, [route.params])
   const bluetoothClassicConnected = useToolkitSnapshot(toolkit.pairing.readiness, (onChange) =>
     toolkit.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
   const otherBtConnected = useToolkitSnapshot(toolkit.pairing.otherBtConnected, (onChange) =>
     toolkit.pairing.onOtherBtConnected(onChange),
   )
-  const [deviceName] = useSetting(SETTINGS.device_name.key)
+  const deviceName = device?.name ?? ""
   const {theme} = useAppTheme()
 
   focusEffectPreventBack()
 
   const handleSuccess = () => {
-    toolkit.glasses.connectDefault().catch((error) => {
-      console.error("Failed to connect default glasses after Bluetooth Classic pairing:", error)
+    if (!device) return
+    toolkit.glasses.connect(device, {saveAsDefault: false}).catch((error) => {
+      console.error("Failed to connect glasses after Bluetooth Classic pairing:", error)
     })
     pushPrevious()
   }
@@ -52,13 +67,11 @@ export default function BtClassicPairingScreen() {
   }, [bluetoothClassicConnected])
 
   useEffect(() => {
-    console.log("BTCLASSIC: check deviceName", deviceName)
-    if (deviceName == "" || deviceName == null) {
-      console.log("BTCLASSIC: deviceName is empty, cannot continue")
+    if (!device) {
+      console.log("BTCLASSIC: no device threaded from the scan screen, cannot continue")
       handleBack()
-      return
     }
-  }, [deviceName])
+  }, [device])
 
   let steps: OnboardingStep[] = [
     {

--- a/mobile/src/app/pairing/failure.tsx
+++ b/mobile/src/app/pairing/failure.tsx
@@ -30,7 +30,10 @@ export default function PairingFailureScreen() {
   }, [])
 
   const handleRetry = () => {
-    toolkit.glasses.forget()
+    // Clears the failed attempt; a pre-existing pairing (re-pair) is preserved.
+    void toolkit.pairing.abandonAttempt().catch((error) => {
+      console.warn("Pairing retry cleanup failed:", error)
+    })
     clearHistoryAndGoHome()
     push("/pairing/select-glasses-model")
   }

--- a/mobile/src/app/pairing/loading.tsx
+++ b/mobile/src/app/pairing/loading.tsx
@@ -41,7 +41,11 @@ export default function GlassesPairingLoadingScreen() {
 
   const handlePairFailure = useCallback(
     (error: string) => {
-      toolkit.glasses.forget()
+      // Clears the failed attempt; when a real pairing predates this attempt
+      // (re-pair), it is preserved instead of forgotten.
+      void toolkit.pairing.abandonAttempt().catch((cleanupError) => {
+        console.warn("Pairing failure cleanup failed:", cleanupError)
+      })
       if (error === "errors:pairNeedDisconnect") {
         replace("/pairing/unpair-even", {deviceModel: deviceModel})
         return

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -1,7 +1,7 @@
 import {type Device, type DeviceModel} from "@mentra/bluetooth-sdk"
 import {toolkit} from "@mentra/island"
 import {useLocalSearchParams} from "expo-router"
-import {useEffect, useState} from "react"
+import {useEffect, useRef, useState} from "react"
 import {ActivityIndicator, Image, Platform, ScrollView, TouchableOpacity, View} from "react-native"
 
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
@@ -30,11 +30,33 @@ export default function SelectGlassesBluetoothScreen() {
   const bluetoothClassicConnected = useToolkitSnapshot(toolkit.pairing.readiness, (onChange) =>
     toolkit.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
-  const [_deviceName, setDeviceName] = useSetting(SETTINGS.device_name.key)
+  const [, setPendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const searchResults = useToolkitSnapshot(toolkit.pairing.searchResults, (onChange) =>
     toolkit.pairing.onFound(onChange),
   )
   const [rememberedSearchResults, setRememberedSearchResults] = useState<Device[]>(searchResults)
+
+  // Whether a real pairing existed when this screen was ENTERED decides how the
+  // back handler cleans up: fresh pairing → forget the partial attempt; re-pair →
+  // the existing pairing must survive back-out. Defaults to "preserve" until the
+  // hydrated read lands — a race must never wipe a real pairing.
+  const enteredWithDefaultDevice = useRef(true)
+
+  useEffect(() => {
+    // Two-phase identity: reaching the scan screen marks the chosen model as the
+    // PENDING wearable (selection). Promotion to default_wearable only happens
+    // natively when pairing succeeds; until then the home card renders a
+    // finish-pairing affordance from this marker.
+    setPendingWearable(deviceModel)
+    toolkit.glasses
+      .hasDefaultDevice()
+      .then((has) => {
+        enteredWithDefaultDevice.current = has
+      })
+      .catch(() => {
+        enteredWithDefaultDevice.current = true
+      })
+  }, [])
 
   // useFocusEffect(
   //   useCallback(() => {
@@ -48,8 +70,12 @@ export default function SelectGlassesBluetoothScreen() {
     if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
       return
     }
-    toolkit.glasses.disconnect()
-    toolkit.glasses.forget()
+    // Non-destructive back-out: only a FRESH pairing flow forgets on back
+    // (clearing the partial attempt); backing out of a re-pair preserves the
+    // existing pairing. The pending marker survives either way.
+    void toolkit.pairing.abandonAttempt(enteredWithDefaultDevice.current).catch((error) => {
+      console.warn("Pairing scan back-out cleanup failed:", error)
+    })
     goBack()
   }, true)
 
@@ -118,10 +144,9 @@ export default function SelectGlassesBluetoothScreen() {
       return
     }
 
-    await toolkit.pairing.setDefault(device)
-    setDeviceName(device.name)
-    // pair bt classic first:
-    replace("/pairing/btclassic")
+    // pair bt classic first — thread the device through the route; the connect
+    // (and the on-success default promotion) happens after BT Classic links.
+    replace("/pairing/btclassic", {device: JSON.stringify(device)})
     pushUnder("/pairing/loading", {deviceModel: device.model, deviceName: device.name})
   }
 

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -39,7 +39,7 @@ export default function SelectGlassesBluetoothScreen() {
     // PENDING selection. Promotion to `paired` only happens natively when pairing
     // succeeds; until then the home card renders a finish-pairing affordance.
     toolkit.pairing.markPendingSelection(deviceModel)
-  }, [])
+  }, [deviceModel])
 
   // useFocusEffect(
   //   useCallback(() => {
@@ -82,7 +82,7 @@ export default function SelectGlassesBluetoothScreen() {
     }
 
     void initializeAndSearchForDevices()
-  }, [])
+  }, [deviceModel])
 
   const triggerGlassesPairingGuide = async (device: Device) => {
     if (Platform.OS === "android") {

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -1,7 +1,7 @@
 import {type Device, type DeviceModel} from "@mentra/bluetooth-sdk"
 import {toolkit} from "@mentra/island"
 import {useLocalSearchParams} from "expo-router"
-import {useEffect, useState} from "react"
+import {useEffect, useRef, useState} from "react"
 import {ActivityIndicator, Image, Platform, ScrollView, TouchableOpacity, View} from "react-native"
 
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
@@ -47,12 +47,15 @@ export default function SelectGlassesBluetoothScreen() {
   //   }, [setRememberedSearchResults]),
   // )
 
-  focusEffectPreventBack((event) => {
-    // Skip cleanup when navigating forward (e.g. replace() to btclassic) —
-    // only run on actual back navigation.
-    if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
-      return
-    }
+  // One back-out per mount, whichever surface triggers it — the header chevron
+  // and Cancel button (handleBackOut), Android hardware back (the preventBack
+  // handler), or the iOS pop gesture (the beforeRemove listener). The ref
+  // dedupes the overlap: an explicit back-out's goBack() also fires
+  // beforeRemove on iOS, which must not run the cleanup (or pop) again.
+  const backOutRanRef = useRef(false)
+  const runBackOutCleanup = () => {
+    if (backOutRanRef.current) return false
+    backOutRanRef.current = true
     // Non-destructive back-out: abandonAttempt decides from the LIVE hydrated
     // default-device read — a re-pair's existing pairing survives, and so does
     // a pairing that PROMOTED while this flow was open (glasses can finish
@@ -61,8 +64,24 @@ export default function SelectGlassesBluetoothScreen() {
     void toolkit.pairing.abandonAttempt().catch((error) => {
       console.warn("Pairing scan back-out cleanup failed:", error)
     })
-    goBack()
+    return true
+  }
+
+  focusEffectPreventBack((event) => {
+    // Skip cleanup when navigating forward (e.g. replace() to btclassic) —
+    // only run on actual back navigation.
+    if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
+      return
+    }
+    if (runBackOutCleanup()) {
+      goBack()
+    }
   }, true)
+
+  const handleBackOut = () => {
+    runBackOutCleanup()
+    goBack()
+  }
 
   useEffect(() => {
     const skipDevice = searchResults.find((result) => result.name === "NOTREQUIREDSKIP")
@@ -165,7 +184,7 @@ export default function SelectGlassesBluetoothScreen() {
 
   return (
     <Screen preset="fixed" safeAreaEdges={["bottom"]} extraAndroidInsets>
-      <Header leftIcon="chevron-left" onLeftPress={goBack} RightActionComponent={<MentraLogoStandalone />} />
+      <Header leftIcon="chevron-left" onLeftPress={handleBackOut} RightActionComponent={<MentraLogoStandalone />} />
       <View className="flex-1 justify-center">
         <GlassView className="gap-6 rounded-3xl p-6 bg-primary-foreground" transparent={false}>
           <Image
@@ -207,7 +226,7 @@ export default function SelectGlassesBluetoothScreen() {
           )}
           <Divider />
           <View className="flex-row justify-end">
-            <Button preset="primary" compact tx="common:cancel" onPress={() => goBack()} className="min-w-[100px]" />
+            <Button preset="primary" compact tx="common:cancel" onPress={handleBackOut} className="min-w-[100px]" />
           </View>
         </GlassView>
       </View>

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -79,8 +79,11 @@ export default function SelectGlassesBluetoothScreen() {
   }, true)
 
   const handleBackOut = () => {
-    runBackOutCleanup()
-    goBack()
+    // Guard the pop like the preventBack handler does: a rapid double-tap on
+    // Cancel/the chevron must not pop a second route while cleanup ran once.
+    if (runBackOutCleanup()) {
+      goBack()
+    }
   }
 
   useEffect(() => {

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -18,7 +18,6 @@ import {useNavigationStore} from "@/stores/navigation"
 import showAlert from "@/utils/AlertUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {getGlassesOpenImage} from "@/utils/getGlassesImage"
-import {SETTINGS, useSetting} from "@/stores/settings"
 import GlassView from "@/components/ui/GlassView"
 
 export default function SelectGlassesBluetoothScreen() {
@@ -30,7 +29,6 @@ export default function SelectGlassesBluetoothScreen() {
   const bluetoothClassicConnected = useToolkitSnapshot(toolkit.pairing.readiness, (onChange) =>
     toolkit.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
-  const [, setPendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const searchResults = useToolkitSnapshot(toolkit.pairing.searchResults, (onChange) =>
     toolkit.pairing.onFound(onChange),
   )
@@ -38,10 +36,9 @@ export default function SelectGlassesBluetoothScreen() {
 
   useEffect(() => {
     // Two-phase identity: reaching the scan screen marks the chosen model as the
-    // PENDING wearable (selection). Promotion to default_wearable only happens
-    // natively when pairing succeeds; until then the home card renders a
-    // finish-pairing affordance from this marker.
-    setPendingWearable(deviceModel)
+    // PENDING selection. Promotion to `paired` only happens natively when pairing
+    // succeeds; until then the home card renders a finish-pairing affordance.
+    toolkit.pairing.markPendingSelection(deviceModel)
   }, [])
 
   // useFocusEffect(

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -1,7 +1,7 @@
 import {type Device, type DeviceModel} from "@mentra/bluetooth-sdk"
 import {toolkit} from "@mentra/island"
 import {useLocalSearchParams} from "expo-router"
-import {useEffect, useRef, useState} from "react"
+import {useEffect, useState} from "react"
 import {ActivityIndicator, Image, Platform, ScrollView, TouchableOpacity, View} from "react-native"
 
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
@@ -36,26 +36,12 @@ export default function SelectGlassesBluetoothScreen() {
   )
   const [rememberedSearchResults, setRememberedSearchResults] = useState<Device[]>(searchResults)
 
-  // Whether a real pairing existed when this screen was ENTERED decides how the
-  // back handler cleans up: fresh pairing → forget the partial attempt; re-pair →
-  // the existing pairing must survive back-out. Defaults to "preserve" until the
-  // hydrated read lands — a race must never wipe a real pairing.
-  const enteredWithDefaultDevice = useRef(true)
-
   useEffect(() => {
     // Two-phase identity: reaching the scan screen marks the chosen model as the
     // PENDING wearable (selection). Promotion to default_wearable only happens
     // natively when pairing succeeds; until then the home card renders a
     // finish-pairing affordance from this marker.
     setPendingWearable(deviceModel)
-    toolkit.glasses
-      .hasDefaultDevice()
-      .then((has) => {
-        enteredWithDefaultDevice.current = has
-      })
-      .catch(() => {
-        enteredWithDefaultDevice.current = true
-      })
   }, [])
 
   // useFocusEffect(
@@ -70,10 +56,12 @@ export default function SelectGlassesBluetoothScreen() {
     if (event && event.actionType !== "GO_BACK" && event.actionType !== "POP") {
       return
     }
-    // Non-destructive back-out: only a FRESH pairing flow forgets on back
-    // (clearing the partial attempt); backing out of a re-pair preserves the
-    // existing pairing. The pending marker survives either way.
-    void toolkit.pairing.abandonAttempt(enteredWithDefaultDevice.current).catch((error) => {
+    // Non-destructive back-out: abandonAttempt decides from the LIVE hydrated
+    // default-device read — a re-pair's existing pairing survives, and so does
+    // a pairing that PROMOTED while this flow was open (glasses can finish
+    // pairing even when the user backs out of the UI). Only a genuinely
+    // unpaired attempt forgets. The pending marker survives either way.
+    void toolkit.pairing.abandonAttempt().catch((error) => {
       console.warn("Pairing scan back-out cleanup failed:", error)
     })
     goBack()

--- a/mobile/src/app/pairing/select-glasses-model.tsx
+++ b/mobile/src/app/pairing/select-glasses-model.tsx
@@ -1,7 +1,4 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
-import {toolkit} from "@mentra/island"
-import {useFocusEffect} from "expo-router"
-import {useCallback} from "react"
 import {View, TouchableOpacity, Platform, ScrollView, Image} from "react-native"
 
 import {EvenRealitiesLogo} from "@/components/brands/EvenRealitiesLogo"
@@ -25,13 +22,11 @@ export default function SelectGlassesModelScreen() {
   const {push, goBack} = useNavigationStore.getState()
   const [superMode] = useSetting(SETTINGS.super_mode.key)
 
-  // when this screen is focused, forget any glasses that may be paired:
-  useFocusEffect(
-    useCallback(() => {
-      toolkit.glasses.forget()
-      return () => {}
-    }, []),
-  )
+  // (This screen used to forget any paired glasses on focus. With two-phase
+  // identity there is no eager default to clean up before a fresh pairing, and
+  // the forget wiped REAL pairings whenever the screen was entered — or backed
+  // into — while glasses were paired. Attempt cleanup now lives on the specific
+  // abandon paths: scan back-out, pairing failure, and unpair-even retry.)
 
   // Get logo component for manufacturer
   const getManufacturerLogo = (deviceModel: string) => {

--- a/mobile/src/app/pairing/unpair-even.tsx
+++ b/mobile/src/app/pairing/unpair-even.tsx
@@ -24,7 +24,10 @@ export default function UnpairEvenScreen() {
   }
 
   const handleTryAgain = () => {
-    toolkit.glasses.forget()
+    // Clears the failed attempt; a pre-existing pairing (re-pair) is preserved.
+    void toolkit.pairing.abandonAttempt().catch((error) => {
+      console.warn("Pairing retry cleanup failed:", error)
+    })
     clearHistory()
     replace("/pairing/prep", {deviceModel})
   }

--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -14,6 +14,7 @@ export const ConnectDeviceButton = () => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
+  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesConnected = glassesStatus.state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -40,6 +41,16 @@ export const ConnectDeviceButton = () => {
       const requirementsCheck = await checkConnectivityRequirementsUI()
 
       if (!requirementsCheck) {
+        return
+      }
+
+      // A chosen model (default_wearable) does not imply a paired device (an
+      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // device, connectDefault() throws — route back into pairing for the
+      // already-selected model instead of surfacing an error alert. Fail open
+      // on a read error: connectDefault()'s catch is the pre-guard behavior.
+      if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
+        push("/pairing/scan", {deviceModel: defaultWearable})
         return
       }
 
@@ -71,6 +82,13 @@ export const ConnectDeviceButton = () => {
   const defaultWearableEmpty = defaultWearable === ""
 
   if (defaultWearableNull || defaultWearableStringNull || defaultWearableEmpty) {
+    // A pending selection (chosen model, pairing never completed) resumes the
+    // scan for that model instead of restarting from model selection.
+    if (pendingWearable) {
+      return (
+        <Button onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})} tx="home:finishPairingGlasses" />
+      )
+    }
     return <Button onPress={() => push("/pairing/select-glasses-model")} tx="home:pairGlasses" />
   }
 

--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -13,8 +13,9 @@ import {checkConnectivityRequirementsUI} from "@/utils/PermissionsUtils"
 export const ConnectDeviceButton = () => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesConnected = glassesStatus.state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -31,7 +32,7 @@ export const ConnectDeviceButton = () => {
   }
 
   const connectGlasses = async () => {
-    if (!defaultWearable) {
+    if (!pairedModel) {
       push("/pairing/select-glasses-model")
       return
     }
@@ -44,13 +45,13 @@ export const ConnectDeviceButton = () => {
         return
       }
 
-      // A chosen model (default_wearable) does not imply a paired device (an
-      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // A `paired` identity snapshot does not imply a native device to connect
+      // to (the settings echo can outlive the native pairing). Without a
       // device, connectDefault() throws — route back into pairing for the
       // already-selected model instead of surfacing an error alert. Fail open
       // on a read error: connectDefault()'s catch is the pre-guard behavior.
       if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
-        push("/pairing/scan", {deviceModel: defaultWearable})
+        push("/pairing/scan", {deviceModel: pairedModel})
         return
       }
 
@@ -63,7 +64,7 @@ export const ConnectDeviceButton = () => {
 
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
-    const action = decideConnectButtonAction({hasDefaultWearable: !!defaultWearable, busy})
+    const action = decideConnectButtonAction({hasDefaultWearable: !!pairedModel, busy})
     if (action === "cancel") {
       await toolkit.glasses.disconnect()
     } else {
@@ -72,21 +73,16 @@ export const ConnectDeviceButton = () => {
   }
 
   // if we have simulated glasses, show nothing:
-  if (defaultWearable.includes(DeviceTypes.SIMULATED)) {
+  if (pairedModel.includes(DeviceTypes.SIMULATED)) {
     return null
   }
 
-  // Debug the conditional logic
-  const defaultWearableNull = defaultWearable == null
-  const defaultWearableStringNull = defaultWearable == "null"
-  const defaultWearableEmpty = defaultWearable === ""
-
-  if (defaultWearableNull || defaultWearableStringNull || defaultWearableEmpty) {
+  if (identity.kind !== "paired") {
     // A pending selection (chosen model, pairing never completed) resumes the
     // scan for that model instead of restarting from model selection.
-    if (pendingWearable) {
+    if (identity.kind === "pending") {
       return (
-        <Button onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})} tx="home:finishPairingGlasses" />
+        <Button onPress={() => push("/pairing/scan", {deviceModel: identity.model})} tx="home:finishPairingGlasses" />
       )
     }
     return <Button onPress={() => push("/pairing/select-glasses-model")} tx="home:pairGlasses" />

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -128,7 +128,14 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   const connectGlasses = async () => {
     if (!pairedModel) {
-      push("/pairing/select-glasses-model", {transition: "simple_push"})
+      // A pending selection resumes its own scan (including the mid-pairing
+      // window where the link is up but promotion hasn't echoed yet); only a
+      // truly identity-less state starts over at model selection.
+      if (identity.kind === "pending") {
+        push("/pairing/scan", {deviceModel: identity.model})
+      } else {
+        push("/pairing/select-glasses-model", {transition: "simple_push"})
+      }
       return
     }
 

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -61,6 +61,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
+  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const [isCheckingConnectivity, setIsCheckingConnectivity] = useState(false)
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesInfo = useToolkitSnapshot(toolkit.glasses.info, (onChange) => toolkit.glasses.onInfo(onChange))
@@ -136,6 +137,15 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       if (!requirementsCheck) {
         return
       }
+      // A chosen model (default_wearable) does not imply a paired device (an
+      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // native default device, connectDefault() throws — route back into
+      // pairing for the already-selected model instead of erroring. Fail open
+      // on a read error: connectDefault()'s catch is the pre-guard behavior.
+      if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
+        push("/pairing/scan", {deviceModel: defaultWearable})
+        return
+      }
       await toolkit.glasses.connectDefault()
     } catch (error) {
       console.error("connect to glasses error:", error)
@@ -152,6 +162,40 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     } else {
       await connectGlasses()
     }
+  }
+
+  // Pending selection: a model was chosen but pairing never completed (abandoned
+  // mid-flow, or an orphaned identity demoted at boot). Offer to finish pairing
+  // that model — or start over with a different one — instead of a Connect
+  // button that has no device to connect to.
+  if (!defaultWearable && pendingWearable) {
+    return (
+      <View style={style}>
+        <DeviceStatus
+          onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
+          image={getGlassesImage(pendingWearable)}>
+          <View className="flex-row items-center gap-3">
+            <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
+            <Text className="font-semibold text-secondary-foreground text-end self-end" text={pendingWearable} />
+          </View>
+          <Button
+            flex
+            compact
+            className="max-h-10"
+            tx="home:finishPairingGlasses"
+            preset="primary"
+            onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
+          />
+        </DeviceStatus>
+        <Button
+          className="mt-2"
+          compact
+          preset="secondary"
+          tx="home:pairDifferentGlasses"
+          onPress={() => push("/pairing/select-glasses-model", {transition: "simple_push"})}
+        />
+      </View>
+    )
   }
 
   const getCurrentGlassesImage = () => {

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -60,8 +60,9 @@ export const DeviceStatus = ({onPress, image, children, className = "h-28"}: Dev
 export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const [isCheckingConnectivity, setIsCheckingConnectivity] = useState(false)
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesInfo = useToolkitSnapshot(toolkit.glasses.info, (onChange) => toolkit.glasses.onInfo(onChange))
@@ -103,7 +104,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   const {wasSearching, nativeLinkBusy, resetSearching} = useSearchingState(searching, pairingReadiness.nativeLinkBusy)
 
-  if (defaultWearable.includes(DeviceTypes.SIMULATED)) {
+  if (pairedModel.includes(DeviceTypes.SIMULATED)) {
     return (
       <GlassView className="bg-primary-foreground p-5" style={style}>
         <View className="flex-row justify-between items-center mb-4">
@@ -126,7 +127,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const connectGlasses = async () => {
-    if (!defaultWearable) {
+    if (!pairedModel) {
       push("/pairing/select-glasses-model", {transition: "simple_push"})
       return
     }
@@ -137,13 +138,13 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       if (!requirementsCheck) {
         return
       }
-      // A chosen model (default_wearable) does not imply a paired device (an
-      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // A `paired` identity snapshot does not imply a native device to connect
+      // to (the settings echo can outlive the native pairing). Without a
       // native default device, connectDefault() throws — route back into
       // pairing for the already-selected model instead of erroring. Fail open
       // on a read error: connectDefault()'s catch is the pre-guard behavior.
       if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
-        push("/pairing/scan", {deviceModel: defaultWearable})
+        push("/pairing/scan", {deviceModel: pairedModel})
         return
       }
       await toolkit.glasses.connectDefault()
@@ -154,7 +155,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const handleConnectOrDisconnect = async () => {
-    const action = decideConnectButtonAction({hasDefaultWearable: !!defaultWearable, busy: searching || nativeLinkBusy})
+    const action = decideConnectButtonAction({hasDefaultWearable: !!pairedModel, busy: searching || nativeLinkBusy})
     if (action === "cancel") {
       await toolkit.glasses.disconnect()
       setIsCheckingConnectivity(false)
@@ -168,15 +169,15 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   // mid-flow, or an orphaned identity demoted at boot). Offer to finish pairing
   // that model — or start over with a different one — instead of a Connect
   // button that has no device to connect to.
-  if (!defaultWearable && pendingWearable) {
+  if (identity.kind === "pending") {
     return (
       <View style={style}>
         <DeviceStatus
-          onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
-          image={getGlassesImage(pendingWearable)}>
+          onPress={() => push("/pairing/scan", {deviceModel: identity.model})}
+          image={getGlassesImage(identity.model)}>
           <View className="flex-row items-center gap-3">
             <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
-            <Text className="font-semibold text-secondary-foreground text-end self-end" text={pendingWearable} />
+            <Text className="font-semibold text-secondary-foreground text-end self-end" text={identity.model} />
           </View>
           <Button
             flex
@@ -184,7 +185,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
             className="max-h-10"
             tx="home:finishPairingGlasses"
             preset="primary"
-            onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
+            onPress={() => push("/pairing/scan", {deviceModel: identity.model})}
           />
         </DeviceStatus>
         <Button
@@ -199,9 +200,9 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const getCurrentGlassesImage = () => {
-    let image = getGlassesImage(defaultWearable)
+    let image = getGlassesImage(pairedModel)
 
-    if (defaultWearable === DeviceTypes.G1) {
+    if (pairedModel === DeviceTypes.G1) {
       let state = "folded"
       if (!caseRemoved) {
         state = caseOpen ? "case_open" : "case_close"
@@ -210,7 +211,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     }
 
     if (!caseRemoved) {
-      image = caseOpen ? getGlassesOpenImage(defaultWearable) : getGlassesClosedImage(defaultWearable)
+      image = caseOpen ? getGlassesOpenImage(pairedModel) : getGlassesClosedImage(pairedModel)
     }
 
     return image
@@ -225,7 +226,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     _connectingText = translate("glasses:glassesAreReconnecting")
   }
 
-  const features = getModelCapabilities(defaultWearable)
+  const features = getModelCapabilities(pairedModel as DeviceTypes)
   const onPress = () => push("/miniapps/settings/main", {transition: "simple_push"})
 
   if (!glassesConnected || !glassesFullyBooted || isSearching) {
@@ -233,7 +234,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
         <View className="flex-row items-center gap-3">
           <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
-          <Text className="font-semibold text-secondary-foreground text-end self-end" text={defaultWearable} />
+          <Text className="font-semibold text-secondary-foreground text-end self-end" text={pairedModel} />
         </View>
         {!isSearching && (
           <Button
@@ -264,7 +265,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   return (
     <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
-      <Text className="font-semibold text-secondary-foreground text-base" text={defaultWearable} />
+      <Text className="font-semibold text-secondary-foreground text-base" text={pairedModel} />
       <View className="flex-row items-center gap-3">
         {batteryLevel !== -1 && (
           <View className="flex-row items-center gap-1">

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -169,7 +169,13 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   // mid-flow, or an orphaned identity demoted at boot). Offer to finish pairing
   // that model — or start over with a different one — instead of a Connect
   // button that has no device to connect to.
-  if (identity.kind === "pending") {
+  //
+  // NOT when the glasses are already connected: right after a promotion, the
+  // BLE link is up while the save_setting echoes are still landing, so the JS
+  // identity is momentarily still `pending` — render the normal connected card
+  // (with the pending model as its display name) instead of finish-pairing
+  // actions for a device that is already paired and connected.
+  if (identity.kind === "pending" && !glassesConnected) {
     return (
       <View style={style}>
         <DeviceStatus
@@ -199,10 +205,14 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     )
   }
 
-  const getCurrentGlassesImage = () => {
-    let image = getGlassesImage(pairedModel)
+  // The card body's model name/image: the paired model, or — in the mid-relay
+  // window above (connected while the promotion echoes land) — the pending one.
+  const displayModel = pairedModel || (identity.kind === "pending" ? identity.model : "")
 
-    if (pairedModel === DeviceTypes.G1) {
+  const getCurrentGlassesImage = () => {
+    let image = getGlassesImage(displayModel)
+
+    if (displayModel === DeviceTypes.G1) {
       let state = "folded"
       if (!caseRemoved) {
         state = caseOpen ? "case_open" : "case_close"
@@ -211,7 +221,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     }
 
     if (!caseRemoved) {
-      image = caseOpen ? getGlassesOpenImage(pairedModel) : getGlassesClosedImage(pairedModel)
+      image = caseOpen ? getGlassesOpenImage(displayModel) : getGlassesClosedImage(displayModel)
     }
 
     return image
@@ -226,7 +236,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     _connectingText = translate("glasses:glassesAreReconnecting")
   }
 
-  const features = getModelCapabilities(pairedModel as DeviceTypes)
+  const features = getModelCapabilities(displayModel as DeviceTypes)
   const onPress = () => push("/miniapps/settings/main", {transition: "simple_push"})
 
   if (!glassesConnected || !glassesFullyBooted || isSearching) {
@@ -234,7 +244,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
         <View className="flex-row items-center gap-3">
           <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
-          <Text className="font-semibold text-secondary-foreground text-end self-end" text={pairedModel} />
+          <Text className="font-semibold text-secondary-foreground text-end self-end" text={displayModel} />
         </View>
         {!isSearching && (
           <Button
@@ -265,7 +275,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   return (
     <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
-      <Text className="font-semibold text-secondary-foreground text-base" text={pairedModel} />
+      <Text className="font-semibold text-secondary-foreground text-base" text={displayModel} />
       <View className="flex-row items-center gap-3">
         {batteryLevel !== -1 && (
           <View className="flex-row items-center gap-1">

--- a/mobile/src/effects/Reconnect.tsx
+++ b/mobile/src/effects/Reconnect.tsx
@@ -19,6 +19,11 @@ export async function attemptReconnectToDefaultWearable(): Promise<boolean> {
     isSimulated: !!defaultWearable && defaultWearable.includes(DeviceTypes.SIMULATED),
     connected: toolkit.pairing.readiness().connected,
     nativeLinkBusy: toolkit.pairing.readiness().nativeLinkBusy,
+    // Fail open on a bridge/hydration error: pass true so the flow proceeds to
+    // connectDefault(), whose existing catch handles a genuinely missing
+    // device (the pre-guard behavior) — a transient native failure must not
+    // throw out of the app-foreground handler.
+    hasDefaultDevice: await toolkit.glasses.hasDefaultDevice().catch(() => true),
     searching: toolkit.pairing.scanning(),
   })
   if (decision.kind === "skip") {

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -342,6 +342,8 @@ const en = {
   home: {
     title: "MentraOS",
     pairGlasses: "Pair glasses",
+    finishPairingGlasses: "Finish pairing",
+    pairDifferentGlasses: "Pair different glasses",
     pairController: "Pair ring",
     setupWithoutGlasses: "Setup without glasses",
     connectGlasses: "Connect glasses",

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -217,11 +217,11 @@ class MantleManager {
 
     offlineSpeechModelService.startBackgroundDownloads()
 
-    // Give the native Bluetooth SDK some time to boot before auto-connecting.
+    // Spacing only, not a correctness barrier: toolkit.start() already awaited
+    // the device-store hydration (the persisted-settings seed to native), so the
+    // reconnect decision's hasDefaultDevice read is trustworthy whenever this
+    // fires. The delay just keeps auto-connect off the critical boot path.
     BgTimer.setTimeout(() => {
-      // (Device settings are pushed to native by island's GlassesSettingsSync — on
-      // every change AND on the connected transition — so there's no boot push here;
-      // the auto-reconnect below triggers that on-connect push. Single source of truth.)
       attemptReconnectToDefaultWearable()
     }, 1000)
     // (Initial notification-config push now happens in island's


### PR DESCRIPTION
> Stacked on #3331 (`integration/toolkit-boundary`); **retargets to `dev` when #3331 lands**. The revert this builds on (73246b2a9) and all touched code live on that branch.

Design-level fix for the pairing-identity desync behind **"Set a default glasses device before calling connectDefault"** (also reproduced on dev).

## The bug

`default_wearable` (a model string in the phone's persisted settings) could exist without a native default *device*. The card then renders a paired-looking state whose Connect button calls `connectDefault()` — which throws, because the SDK's `currentDefaultDevice()` needs `default_wearable` **and** `device_name` in the native DeviceStore.

How the half-state formed (all three sources confirmed in code):

1. **Select-then-abandon.** Tapping a device in the scan eagerly wrote the default: `pair()` connected with `saveAsDefault: true`, whose `setDefaultDevice()` echoes **only** `default_wearable` back to the phone's persisted settings (the `device_name`/`device_address` echoes happen in `handleDeviceReady`, i.e. only on success). Abandon the attempt → the phone keeps a model with no device behind it, forever.
2. **Legacy server-sync resurrection.** Identity synced to the cloud before #3149; stranded local values persist. **Worse: the island copy of the settings store on this branch regressed #3149's `saveOnServer: false` back to `true`** — identity was being uploaded again. Restored here for the whole identity group.
3. **Asymmetric forget flows.** `scan.tsx`'s back handler ran `disconnect()+forget()` unconditionally, and `select-glasses-model` forgot any paired glasses **on focus** — both wiped real pairings when entered (or backed into) while paired.

## Why the first attempt failed (the revert this replaces)

40845e566/8c35d9172/ee54f78c5 guarded the connect paths with `await BluetoothSdk.getDefaultDevice()`. On-device testing showed the native DeviceStore hydrates **asynchronously** at cold start — it is in-memory on both platforms and only gets the identity keys when JS pushes the persisted settings, and nothing awaited that seed. The first push happened *inside the very reconnect call the guard ran ahead of*, so genuinely-paired users read a false "absent": launch reconnect silently skipped, Connect misrouted into `/pairing/scan`, and scan's destructive back handler wiped the real pairing. Reverted in 73246b2a9.

Per design review: **no tri-state/unknown-exporting API.** The fix makes the two-state read trustworthy instead.

## The fix

**1. Hydration contract (`4d1fac61b`).** `DeviceStoreHydration.hydrateDeviceStore()` = settings load + full native `updateBluetoothSettings` push, single-flight, timing-logged. `toolkit.start()` awaits it before resolving, so every post-start `getDefaultDevice()` read is a trustworthy two-state answer on both platforms (the awaited push is ordered: iOS `AsyncFunction(\"update\")` resolves after the MainActor applies; Android `update` is synchronous). Belt-and-suspenders: `toolkit.glasses.hasDefaultDevice()` awaits hydration internally. Failure surfaces as a **rejection** — never a false absent — and callers fail open (the ee54f78c5 pattern); the memo clears so a later read retries. The old "hydration barrier" was a 1s `setTimeout` in MantleManager.

With the read trustworthy, a **boot repair** demotes the orphaned population: `default_wearable` set + native default absent + link idle → demote to `pending_wearable` (+ clear `device_name`/`device_address`, re-push). Runs post-hydration on every start; converges by construction.

**2. Non-destructive scan back-out (`4b2ef78c1`).** `scan.tsx` captures `hasDefaultDevice()` **at entry** (defaulting to preserve until the hydrated read lands). Back-out of a **fresh** pairing keeps today's disconnect+forget; back-out of a **re-pair** preserves the existing pairing. Cleanup is centralized in `toolkit.pairing.abandonAttempt()`, which also covers the pairing-failure and unpair-even retries, and handles two subtleties: (a) old glasses still connected → only stop the scan; (b) attempt in flight → cancel it **and re-seed the native identity from persisted settings**, because the attempt's connect-by-name overwrote the native `device_name` that `connectDefault()` targets. The `select-glasses-model` focus-forget is removed outright.

**3. Two-phase identity (`4b2ef78c1`).** Selection-time writes go to `pending_wearable`: the scan screen marks the chosen model pending on entry, `pair()` connects with `saveAsDefault: false`, and the Mentra Live BT-Classic path threads the picked `Device` through the route instead of pre-writing it as default. Promotion to `default_wearable` stays where the native layer already does it — `handleDeviceReady` (pairing success) — which echoes the full identity to the phone; the echo retires the pending marker (DeviceEventRouter rule). The home card and connect button render pending state with **Finish pairing** (resume the scan for that model) and **Pair different glasses** affordances. `pending_wearable` becomes persisted (still never server-synced) so an abandoned selection survives restarts. Zero native code changes — the SDK's success-promotion path was already correct; we stop bypassing it.

**Then the guards return (`18bd89f5c`)**, unchanged in spirit from the reverted commits, now safe under 1+2: Connect with a chosen model but no native device routes into `/pairing/scan` for that model; `decideReconnect` skips quietly (restored unit test); the foreground reconnect passes a fail-open read.

## Behavior notes

- Simulated-glasses users now get their SGC initialized deterministically at `toolkit.start()` (the seed push applies `default_wearable=Simulated` → `initSGC`), instead of whenever the first incidental push landed.
- `isFirstPairing()` is now `no default AND no pending` — a pending selection is not \"first\"; OEM hosts should offer finish-pairing.
- After a failed/abandoned re-pair, the old pairing remains the default until a **new pairing succeeds** (promotion overwrites it) — previously the old default was clobbered at tap time.

## Test evidence

- `cd mobile && bun run compile` ✓
- `cd mobile && bun run test` — 52 suites, 408 tests ✓ (scan back-out + pending-marker + abandon-on-failure cases added; coordinator skip test restored)
- `cd mobile/modules/island && bun run test` — 201 tests ✓ (new `DeviceStoreHydration` suite: single-flight, rejection + retry-heal, two-state read, demotion conditions)
- `./scripts/check-mobile-runtime-boundary.sh` ✓ (no new host imports)
- Each commit compiles and tests green independently (bisect-clean).

## REQUIRED before merge: on-device cold-start verification (iOS at minimum)

The hydration log line `DeviceStoreHydration: native seed complete in <N>ms (default_wearable=…, device_name present=…)` must appear **before** any RECONNECT/guard log.

1. **Paired + kill + relaunch** → auto-reconnect works; hydration log precedes the reconnect decision; no `/pairing/scan` misroute.
2. **Fresh select-then-abandon** (pick model → scan → back out; also kill mid-loading) → home shows the finish-pairing card, no connect error, and the card survives another kill+relaunch.
3. **Back-out of a re-pair scan** (paired glasses → pair-different flow → back out at scan) → original pairing preserved and still reconnects (checks the native identity re-seed after an in-flight attempt).
4. **Full fresh Mentra Live pairing on iOS**, including the Pair Audio (Bluetooth Classic) step — verifies the native Classic watcher priming (`setBluetoothClassicTarget`) that replaced the selection-time identity writes, and that the loading screen advances to success.
5. Same on Android when hardware is available.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core Bluetooth pairing, identity persistence, cold-start reconnect, and connect routing; incorrect hydration or abandon logic could skip reconnects or wipe pairings despite fail-open guards.
> 
> **Overview**
> Fixes **"Set a default glasses device before calling connectDefault"** when `default_wearable` existed without a real native default device.
> 
> **Cold-start hydration** — `toolkit.start()` now awaits seeding the in-memory native DeviceStore from persisted settings before sync/reconnect run. `toolkit.glasses.hasDefaultDevice()` is hydration-aware; boot **demotes** orphaned `default_wearable` (no native device, link idle) to persisted `pending_wearable`.
> 
> **Two-phase identity** — Selection writes `pending_wearable` only; `pair()` uses `saveAsDefault: false` so native promotes on success. New `toolkit.pairing.identity()` / `onIdentity()` read-model (`none` | `pending` | `paired`). Identity keys are **native-authoritative** (no server sync, excluded from settings change-push and on-connect replay to stop echo loops).
> 
> **Safer pairing UX** — `abandonAttempt()` replaces unconditional `forget()` on scan back-out, failures, and retries (preserves re-pairs and in-flight promotions). iOS Mentra Live threads the scan device through routes and primes Classic via `setBluetoothClassicTarget`. Home/connect UI uses identity for **Finish pairing** vs connect, and routes to scan when paired in settings but no native device.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90d918f902c94cff5a91cdd314d4fd3088bc7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

