### PR TITLE
ASG: replace fixed 475ms AE stabilization delay with adaptive stability detection

### DIFF
--- a/asg_client/app/src/androidTest/java/com/mentra/asg_client/camera/ZslFeasibilityProbeTest.java
+++ b/asg_client/app/src/androidTest/java/com/mentra/asg_client/camera/ZslFeasibilityProbeTest.java
@@ -1,0 +1,302 @@
+package com.mentra.asg_client.camera;
+
+import android.content.Context;
+import android.graphics.ImageFormat;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.hardware.camera2.CameraCaptureSession;
+import android.hardware.camera2.CameraCharacteristics;
+import android.hardware.camera2.CameraDevice;
+import android.hardware.camera2.CameraManager;
+import android.hardware.camera2.CaptureRequest;
+import android.hardware.camera2.CaptureResult;
+import android.hardware.camera2.TotalCaptureResult;
+import android.hardware.camera2.params.StreamConfigurationMap;
+import android.media.Image;
+import android.media.ImageReader;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.util.Log;
+import android.util.Size;
+
+import androidx.annotation.NonNull;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Scratch feasibility probe for a ZSL-style YUV ring buffer on the Mentra Live MTK HAL.
+ * Not part of the shipped suite — run manually, read results from logcat tag ZslProbe:
+ *
+ *   ./gradlew :app:connectedDebugAndroidTest \
+ *     -Pandroid.testInstrumentationRunnerArguments.class=com.mentra.asg_client.camera.ZslFeasibilityProbeTest
+ *
+ * Measures: (1) HAL reprocessing capabilities + YUV/JPEG stream configs and stall durations,
+ * (2) live YUV stream frame cadence at the SDK photo resolution, (3) software JPEG encode
+ * latency from a grabbed YUV frame (the manual-ring fallback path).
+ */
+@RunWith(AndroidJUnit4.class)
+public class ZslFeasibilityProbeTest {
+
+    private static final String TAG = "ZslProbe";
+    private static final Size SDK_SIZE = new Size(1280, 960);
+
+    @Test
+    public void probeCharacteristicsAndYuvRing() throws Exception {
+        Context ctx = ApplicationProvider.getApplicationContext();
+        CameraManager mgr = (CameraManager) ctx.getSystemService(Context.CAMERA_SERVICE);
+
+        // K900 power model: the camera HAL device only registers while the screen/SoC is awake
+        // (CameraNeoService.wakeUpScreen() does this before every open). Mirror it, then poll
+        // for the device to appear.
+        com.mentra.asg_client.utils.WakeLockManager.acquireFullWakeLockAndBringToForeground(
+                ctx, 120000, 30000);
+        String id = null;
+        long tWake = System.nanoTime();
+        for (int i = 0; i < 50; i++) {
+            String[] ids = mgr.getCameraIdList();
+            if (ids.length > 0) {
+                id = ids[0];
+                break;
+            }
+            Thread.sleep(100);
+        }
+        Log.i(TAG, "camera device registered " + ((System.nanoTime() - tWake) / 1_000_000)
+                + "ms after wake (id=" + id + ")");
+        if (id == null) {
+            Log.e(TAG, "RESULT: camera never appeared after 5s awake — probe aborted");
+            return;
+        }
+        CameraCharacteristics ch = mgr.getCameraCharacteristics(id);
+
+        // ---- 1. Static capabilities ----
+        int[] caps = ch.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES);
+        Log.i(TAG, "CAPABILITIES=" + Arrays.toString(caps)
+                + " (4=PRIVATE_REPROCESSING, 7=YUV_REPROCESSING, 12=CONSTRAINED_HIGH_SPEED)");
+        Integer maxInput = ch.get(CameraCharacteristics.REQUEST_MAX_NUM_INPUT_STREAMS);
+        Log.i(TAG, "MAX_NUM_INPUT_STREAMS=" + maxInput);
+        Integer partial = ch.get(CameraCharacteristics.REQUEST_PARTIAL_RESULT_COUNT);
+        Byte pipelineDepth = ch.get(CameraCharacteristics.REQUEST_PIPELINE_MAX_DEPTH);
+        Log.i(TAG, "PARTIAL_RESULT_COUNT=" + partial + " PIPELINE_MAX_DEPTH=" + pipelineDepth);
+
+        StreamConfigurationMap map = ch.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP);
+        int[] inputFormats = map.getInputFormats();
+        Log.i(TAG, "INPUT_FORMATS=" + Arrays.toString(inputFormats));
+        for (int f : inputFormats) {
+            Log.i(TAG, "  input fmt " + f + " sizes=" + Arrays.toString(map.getInputSizes(f)));
+        }
+
+        for (Size s : map.getOutputSizes(ImageFormat.YUV_420_888)) {
+            long minFrame = map.getOutputMinFrameDuration(ImageFormat.YUV_420_888, s);
+            long stall = map.getOutputStallDuration(ImageFormat.YUV_420_888, s);
+            Log.i(TAG, "YUV " + s + " minFrameMs=" + (minFrame / 1e6) + " stallMs=" + (stall / 1e6));
+        }
+        for (Size s : map.getOutputSizes(ImageFormat.JPEG)) {
+            long minFrame = map.getOutputMinFrameDuration(ImageFormat.JPEG, s);
+            long stall = map.getOutputStallDuration(ImageFormat.JPEG, s);
+            Log.i(TAG, "JPEG " + s + " minFrameMs=" + (minFrame / 1e6) + " stallMs=" + (stall / 1e6));
+        }
+
+        // ---- 2. Live YUV stream cadence at SDK photo size ----
+        HandlerThread ht = new HandlerThread("ZslProbe");
+        ht.start();
+        Handler h = new Handler(ht.getLooper());
+
+        ImageReader yuvReader =
+                ImageReader.newInstance(SDK_SIZE.getWidth(), SDK_SIZE.getHeight(),
+                        ImageFormat.YUV_420_888, 4);
+        List<Long> frameTimesNs = new ArrayList<>();
+        AtomicLong lastImageNs = new AtomicLong(0);
+        final Image[] latest = new Image[1];
+        yuvReader.setOnImageAvailableListener(reader -> {
+            Image img = reader.acquireLatestImage();
+            if (img == null) return;
+            synchronized (latest) {
+                if (latest[0] != null) latest[0].close();
+                latest[0] = img;
+            }
+            long now = System.nanoTime();
+            lastImageNs.set(now);
+            synchronized (frameTimesNs) {
+                frameTimesNs.add(now);
+            }
+        }, h);
+
+        CountDownLatch opened = new CountDownLatch(1);
+        final CameraDevice[] devHolder = new CameraDevice[1];
+        long tOpen = System.nanoTime();
+        mgr.openCamera(id, new CameraDevice.StateCallback() {
+            @Override public void onOpened(@NonNull CameraDevice d) { devHolder[0] = d; opened.countDown(); }
+            @Override public void onDisconnected(@NonNull CameraDevice d) { d.close(); opened.countDown(); }
+            @Override public void onError(@NonNull CameraDevice d, int e) {
+                Log.e(TAG, "open error " + e); d.close(); opened.countDown();
+            }
+        }, h);
+        if (!opened.await(5, TimeUnit.SECONDS) || devHolder[0] == null) {
+            Log.e(TAG, "RESULT: camera open failed/busy — is CameraNeoService holding it?");
+            ht.quitSafely();
+            return;
+        }
+        CameraDevice dev = devHolder[0];
+        Log.i(TAG, "camera opened in " + ((System.nanoTime() - tOpen) / 1_000_000) + "ms");
+
+        CountDownLatch configured = new CountDownLatch(1);
+        final CameraCaptureSession[] sesHolder = new CameraCaptureSession[1];
+        long tCfg = System.nanoTime();
+        dev.createCaptureSession(Arrays.asList(yuvReader.getSurface()),
+                new CameraCaptureSession.StateCallback() {
+                    @Override public void onConfigured(@NonNull CameraCaptureSession s) {
+                        sesHolder[0] = s; configured.countDown();
+                    }
+                    @Override public void onConfigureFailed(@NonNull CameraCaptureSession s) {
+                        Log.e(TAG, "session configure FAILED for YUV " + SDK_SIZE);
+                        configured.countDown();
+                    }
+                }, h);
+        configured.await(5, TimeUnit.SECONDS);
+        if (sesHolder[0] == null) {
+            dev.close(); ht.quitSafely();
+            return;
+        }
+        Log.i(TAG, "YUV-only session configured in " + ((System.nanoTime() - tCfg) / 1_000_000) + "ms");
+
+        CaptureRequest.Builder b = dev.createCaptureRequest(CameraDevice.TEMPLATE_PREVIEW);
+        b.addTarget(yuvReader.getSurface());
+        final Integer[] lastAeState = new Integer[1];
+        sesHolder[0].setRepeatingRequest(b.build(), new CameraCaptureSession.CaptureCallback() {
+            @Override public void onCaptureCompleted(@NonNull CameraCaptureSession s,
+                    @NonNull CaptureRequest r, @NonNull TotalCaptureResult res) {
+                lastAeState[0] = res.get(CaptureResult.CONTROL_AE_STATE);
+            }
+        }, h);
+
+        Thread.sleep(3000); // let AE converge and cadence settle
+
+        long[] times;
+        synchronized (frameTimesNs) {
+            times = new long[frameTimesNs.size()];
+            for (int i = 0; i < times.length; i++) times[i] = frameTimesNs.get(i);
+        }
+        if (times.length >= 12) {
+            long spanNs = times[times.length - 1] - times[times.length - 11];
+            Log.i(TAG, "YUV cadence: last 10 intervals avg " + (spanNs / 10 / 1_000_000.0)
+                    + "ms (" + times.length + " frames in 3s), AE_STATE=" + lastAeState[0]);
+        } else {
+            Log.e(TAG, "YUV cadence: only " + times.length + " frames in 3s — stream is NOT viable");
+        }
+
+        // ---- 3. Grab latest frame + software JPEG encode (manual ring path) ----
+        for (int run = 0; run < 3; run++) {
+            Image img;
+            synchronized (latest) {
+                img = latest[0];
+                latest[0] = null;
+            }
+            if (img == null) {
+                Log.e(TAG, "no frame available for encode run " + run);
+                Thread.sleep(200);
+                continue;
+            }
+            long t0 = System.nanoTime();
+            byte[] nv21 = yuv420ToNv21(img);
+            long t1 = System.nanoTime();
+            img.close();
+            YuvImage yuv = new YuvImage(nv21, ImageFormat.NV21,
+                    SDK_SIZE.getWidth(), SDK_SIZE.getHeight(), null);
+            ByteArrayOutputStream bos = new ByteArrayOutputStream(512 * 1024);
+            yuv.compressToJpeg(new Rect(0, 0, SDK_SIZE.getWidth(), SDK_SIZE.getHeight()), 90, bos);
+            long t2 = System.nanoTime();
+            byte[] jpeg = bos.toByteArray();
+            Log.i(TAG, "ENCODE run " + run + ": yuv->nv21 " + ((t1 - t0) / 1_000_000)
+                    + "ms, compressToJpeg " + ((t2 - t1) / 1_000_000) + "ms, jpeg "
+                    + (jpeg.length / 1024) + "KB");
+            if (run == 2) {
+                File out = new File(ctx.getExternalFilesDir(null), "zsl_probe.jpg");
+                try (FileOutputStream fos = new FileOutputStream(out)) {
+                    fos.write(jpeg);
+                }
+                Log.i(TAG, "saved sample to " + out.getAbsolutePath());
+            }
+            Thread.sleep(300); // let a fresh frame land
+        }
+
+        sesHolder[0].close();
+        dev.close();
+        synchronized (latest) {
+            if (latest[0] != null) latest[0].close();
+        }
+        yuvReader.close();
+        ht.quitSafely();
+        Log.i(TAG, "probe complete");
+    }
+
+    /** YUV_420_888 → NV21, handling both pixelStride 1 and 2 chroma layouts. */
+    private static byte[] yuv420ToNv21(Image img) {
+        int w = img.getWidth(), hgt = img.getHeight();
+        byte[] out = new byte[w * hgt * 3 / 2];
+        Image.Plane yP = img.getPlanes()[0];
+        ByteBuffer yBuf = yP.getBuffer();
+        int yRowStride = yP.getRowStride();
+        int pos = 0;
+        if (yRowStride == w) {
+            int n = w * hgt;
+            yBuf.get(out, 0, n);
+            pos = n;
+        } else {
+            byte[] row = new byte[yRowStride];
+            for (int r = 0; r < hgt; r++) {
+                yBuf.position(r * yRowStride);
+                yBuf.get(row, 0, w);
+                System.arraycopy(row, 0, out, pos, w);
+                pos += w;
+            }
+        }
+        Image.Plane uP = img.getPlanes()[1];
+        Image.Plane vP = img.getPlanes()[2];
+        ByteBuffer uBuf = uP.getBuffer();
+        ByteBuffer vBuf = vP.getBuffer();
+        int cRowStride = vP.getRowStride();
+        int cPixStride = vP.getPixelStride();
+        int cH = hgt / 2, cW = w / 2;
+        if (cPixStride == 2 && cRowStride >= w && uBuf.remaining() >= 1) {
+            // Semi-planar (NV12/NV21-style): V plane interleaved; copy VU pairs row by row.
+            byte[] vRow = new byte[cRowStride];
+            byte[] uRow = new byte[cRowStride];
+            for (int r = 0; r < cH; r++) {
+                int vLen = Math.min(cRowStride, vBuf.limit() - r * cRowStride);
+                int uLen = Math.min(cRowStride, uBuf.limit() - r * cRowStride);
+                if (vLen <= 0 || uLen <= 0) break;
+                vBuf.position(r * cRowStride);
+                vBuf.get(vRow, 0, vLen);
+                uBuf.position(r * cRowStride);
+                uBuf.get(uRow, 0, uLen);
+                for (int c = 0; c < cW; c++) {
+                    out[pos++] = vRow[c * 2];
+                    out[pos++] = uRow[c * 2];
+                }
+            }
+        } else {
+            // Planar: interleave V and U samples.
+            for (int r = 0; r < cH; r++) {
+                for (int c = 0; c < cW; c++) {
+                    out[pos++] = vBuf.get(r * cRowStride + c * cPixStride);
+                    out[pos++] = uBuf.get(r * cRowStride + c * cPixStride);
+                }
+            }
+        }
+        return out;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/policy/AeStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/policy/AeStateMachine.java
@@ -17,12 +17,17 @@ public final class AeStateMachine {
     private volatile boolean aeLockRequested;
     private volatile long aeStartTimeNs;
 
-    /** Wall time of the first converged frame in the current wait; 0 = not converged yet. */
+    /**
+     * Wall time of the first converged frame in the current wait; 0 = not converged yet. Once
+     * set it survives AE flicker (converged → searching → converged) so the
+     * {@link #EXPOSURE_STABILIZATION_DELAY_MS} cap is measured from first convergence — matching
+     * the historical fixed-delay worst case. Only {@link #beginWaitingForAe()} resets it.
+     */
     private volatile long firstConvergedNs;
     /** Consecutive converged frames whose exposure×ISO stayed within tolerance. */
     private volatile int stableConvergedFrames;
     /** exposure×ISO of the previous converged frame; 0 = none / HAL not reporting. */
-    private long lastTotalLight;
+    private volatile long lastTotalLight;
 
     public boolean waitingForAeConvergence() {
         return waitingForAeConvergence;
@@ -49,11 +54,17 @@ public final class AeStateMachine {
      * <p>Call from the camera {@link Handler} thread only (same thread as the capture callback).
      */
     public void noteRepeatingFrame(Integer aeState, Long exposureNs, Integer iso) {
-        boolean converged = aeState != null
-                && (aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED
-                        || aeState == CaptureResult.CONTROL_AE_STATE_LOCKED);
+        if (aeState == null) {
+            // Matches AeRepeatCaptureDecision.CONTINUE_WAITING_NULL_AE: a frame with no AE state
+            // is "keep waiting", not evidence that AE left convergence — don't touch the streak.
+            return;
+        }
+        boolean converged = aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED
+                || aeState == CaptureResult.CONTROL_AE_STATE_LOCKED;
         if (!converged) {
-            firstConvergedNs = 0L;
+            // AE regressed (e.g. scene change mid-wait): restart the stability streak, but keep
+            // firstConvergedNs so the stabilization cap still bounds this wait at the historical
+            // fixed delay instead of stretching toward the 2s AE timeout.
             stableConvergedFrames = 0;
             lastTotalLight = 0L;
             return;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/policy/AeStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/policy/AeStateMachine.java
@@ -17,6 +17,13 @@ public final class AeStateMachine {
     private volatile boolean aeLockRequested;
     private volatile long aeStartTimeNs;
 
+    /** Wall time of the first converged frame in the current wait; 0 = not converged yet. */
+    private volatile long firstConvergedNs;
+    /** Consecutive converged frames whose exposure×ISO stayed within tolerance. */
+    private volatile int stableConvergedFrames;
+    /** exposure×ISO of the previous converged frame; 0 = none / HAL not reporting. */
+    private long lastTotalLight;
+
     public boolean waitingForAeConvergence() {
         return waitingForAeConvergence;
     }
@@ -29,6 +36,56 @@ public final class AeStateMachine {
         waitingForAeConvergence = true;
         aeLockRequested = false;
         aeStartTimeNs = System.nanoTime();
+        firstConvergedNs = 0L;
+        stableConvergedFrames = 0;
+        lastTotalLight = 0L;
+    }
+
+    /**
+     * Record one repeating-request frame while waiting for AE. Tracks how long AE has been
+     * converged and how many consecutive converged frames had stable exposure, so the still
+     * capture can fire as soon as exposure has actually settled instead of after a fixed delay.
+     *
+     * <p>Call from the camera {@link Handler} thread only (same thread as the capture callback).
+     */
+    public void noteRepeatingFrame(Integer aeState, Long exposureNs, Integer iso) {
+        boolean converged = aeState != null
+                && (aeState == CaptureResult.CONTROL_AE_STATE_CONVERGED
+                        || aeState == CaptureResult.CONTROL_AE_STATE_LOCKED);
+        if (!converged) {
+            firstConvergedNs = 0L;
+            stableConvergedFrames = 0;
+            lastTotalLight = 0L;
+            return;
+        }
+        if (firstConvergedNs == 0L) {
+            firstConvergedNs = System.nanoTime();
+        }
+        long totalLight = (exposureNs != null && iso != null && exposureNs > 0 && iso > 0)
+                ? exposureNs * iso
+                : 0L;
+        boolean stable;
+        if (totalLight == 0L || lastTotalLight == 0L) {
+            // First converged frame, or HAL doesn't report exposure — nothing to compare against.
+            stable = true;
+        } else {
+            long delta = Math.abs(totalLight - lastTotalLight);
+            stable = delta <= (long) (lastTotalLight * STABILITY_TOLERANCE);
+        }
+        stableConvergedFrames = stable ? stableConvergedFrames + 1 : 1;
+        if (totalLight != 0L) {
+            lastTotalLight = totalLight;
+        }
+    }
+
+    public int stableConvergedFrames() {
+        return stableConvergedFrames;
+    }
+
+    /** Nanoseconds since AE first reported converged in this wait; 0 if not converged yet. */
+    public long nsSinceFirstConverged() {
+        long t = firstConvergedNs;
+        return (t == 0L) ? 0L : System.nanoTime() - t;
     }
 
     public void skipAeForManualCapture() {
@@ -70,14 +127,26 @@ public final class AeStateMachine {
     public static final long AE_WAIT_MAX_NS = 2_000_000_000L;
 
     /**
-     * When {@code true}: after AE converges, clear wait flags and schedule still capture after
-     * {@link #EXPOSURE_STABILIZATION_DELAY_MS}. When {@code false}: request AE lock and wait for
+     * When {@code true}: after AE converges, capture as soon as exposure is stable for
+     * {@link #STABLE_FRAMES_REQUIRED} consecutive frames (capped at
+     * {@link #EXPOSURE_STABILIZATION_DELAY_MS}). When {@code false}: request AE lock and wait for
      * {@link CaptureResult#CONTROL_AE_STATE_LOCKED} / {@link CaptureResult#CONTROL_AE_STATE_FLASH_REQUIRED}.
      */
     public static final boolean USE_IMMEDIATE_CAPTURE_ON_CONVERGENCE = true;
 
-    /** Delay after AE converged before firing still capture (fast path). */
+    /**
+     * Upper bound on the post-convergence stability wait. The capture normally fires as soon as
+     * {@link #STABLE_FRAMES_REQUIRED} consecutive converged frames report stable exposure
+     * (typically ~3 frames ≈ 100ms); if exposure keeps oscillating, the capture is forced after
+     * this many milliseconds — the same worst case as the historical fixed delay.
+     */
     public static final int EXPOSURE_STABILIZATION_DELAY_MS = 475;
+
+    /** Consecutive converged frames with stable exposure required before firing still capture. */
+    public static final int STABLE_FRAMES_REQUIRED = 3;
+
+    /** Max relative change in exposure×ISO between consecutive frames still counted as stable. */
+    public static final double STABILITY_TOLERANCE = 0.05;
 
     /**
      * Outcome of processing one {@code onCaptureCompleted} while waiting for AE (repeating
@@ -94,8 +163,10 @@ public final class AeStateMachine {
         CAPTURE_NOW_LOCK_CONFIRMED,
         /** Lock requested but not yet confirmed — keep waiting (optional periodic logging in caller). */
         CONTINUE_WAITING_FOR_LOCK,
-        /** AE converged (fast path) — clear flags and schedule capture after stabilization delay. */
-        CAPTURE_AFTER_STABILIZATION_DELAY,
+        /** AE converged with stable exposure (or stability wait capped) — capture immediately. */
+        CAPTURE_NOW_STABLE,
+        /** AE converged but exposure still settling — keep waiting for stability. */
+        CONTINUE_WAITING_FOR_STABILITY,
         /** AE converged (legacy path) — caller should call {@code requestAeLock(session)}. */
         REQUEST_AE_LOCK,
         /** AE not yet converged — keep waiting (optional periodic logging in caller). */
@@ -111,7 +182,9 @@ public final class AeStateMachine {
             boolean waitingForAeConvergence,
             boolean aeLockRequested,
             Integer aeState,
-            long elapsedNsSinceAeStart) {
+            long elapsedNsSinceAeStart,
+            int stableConvergedFrames,
+            long nsSinceFirstConverged) {
         if (!waitingForAeConvergence) {
             return AeRepeatCaptureDecision.IGNORE_NOT_WAITING;
         }
@@ -133,7 +206,12 @@ public final class AeStateMachine {
                 || aeState == CaptureResult.CONTROL_AE_STATE_LOCKED);
         if (isAeConverged) {
             if (USE_IMMEDIATE_CAPTURE_ON_CONVERGENCE) {
-                return AeRepeatCaptureDecision.CAPTURE_AFTER_STABILIZATION_DELAY;
+                if (stableConvergedFrames >= STABLE_FRAMES_REQUIRED
+                        || nsSinceFirstConverged
+                                >= EXPOSURE_STABILIZATION_DELAY_MS * 1_000_000L) {
+                    return AeRepeatCaptureDecision.CAPTURE_NOW_STABLE;
+                }
+                return AeRepeatCaptureDecision.CONTINUE_WAITING_FOR_STABILITY;
             }
             return AeRepeatCaptureDecision.REQUEST_AE_LOCK;
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/request/AeCaptureCallback.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/request/AeCaptureCallback.java
@@ -83,13 +83,17 @@ public final class AeCaptureCallback extends CameraCaptureSession.CaptureCallbac
                     + precaptureTrigger + ", AE state: " + AeStateMachine.getAeStateName(aeState));
         }
 
+        aeStateMachine.noteRepeatingFrame(aeState, exposureEarly, sensEarly);
+
         long elapsedNs = aeStateMachine.elapsedNsSinceAeStart();
         AeStateMachine.AeRepeatCaptureDecision decision =
                 AeStateMachine.evaluateRepeatingRequestAeStep(
                         aeStateMachine.waitingForAeConvergence(),
                         aeStateMachine.aeLockRequested(),
                         aeState,
-                        elapsedNs);
+                        elapsedNs,
+                        aeStateMachine.stableConvergedFrames(),
+                        aeStateMachine.nsSinceFirstConverged());
 
         switch (decision) {
             case CONTINUE_WAITING_NULL_AE:
@@ -120,19 +124,24 @@ public final class AeCaptureCallback extends CameraCaptureSession.CaptureCallbac
                             + AeStateMachine.getAeStateName(aeState));
                 }
                 break;
-            case CAPTURE_AFTER_STABILIZATION_DELAY: {
+            case CAPTURE_NOW_STABLE: {
                 long elapsedMs = elapsedNs / 1_000_000;
-                Log.i(TAG, "🔍 ✅ AE CONVERGED in " + elapsedMs + "ms! State: "
-                        + AeStateMachine.getAeStateName(aeState) + ", waiting "
-                        + AeStateMachine.EXPOSURE_STABILIZATION_DELAY_MS
-                        + "ms for exposure stabilization [FAST MODE]");
+                long stabilityMs = aeStateMachine.nsSinceFirstConverged() / 1_000_000;
+                Log.i(TAG, "🔍 ✅ AE CONVERGED+STABLE in " + elapsedMs + "ms! State: "
+                        + AeStateMachine.getAeStateName(aeState) + " (stability wait "
+                        + stabilityMs + "ms, " + aeStateMachine.stableConvergedFrames()
+                        + " stable frames), capturing photo [ADAPTIVE]");
                 aeStateMachine.clearWaitFlags();
-                hooks.postDelayed(() -> {
-                    Log.i(TAG, "🔍 Exposure stabilization complete, capturing photo");
-                    hooks.capturePhoto();
-                }, AeStateMachine.EXPOSURE_STABILIZATION_DELAY_MS);
+                hooks.capturePhoto();
                 break;
             }
+            case CONTINUE_WAITING_FOR_STABILITY:
+                if (callbackCount % 10 == 0) {
+                    Log.d(TAG, "🔍 AE converged, waiting for exposure stability... ("
+                            + aeStateMachine.stableConvergedFrames() + "/"
+                            + AeStateMachine.STABLE_FRAMES_REQUIRED + " stable frames)");
+                }
+                break;
             case REQUEST_AE_LOCK: {
                 long elapsedMs = elapsedNs / 1_000_000;
                 Log.i(TAG, "🔍 ✅ AE CONVERGED in " + elapsedMs + "ms! State: "

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/policy/AeStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/policy/AeStateMachineTest.java
@@ -127,14 +127,32 @@ public class AeStateMachineTest {
     }
 
     @Test
-    public void noteRepeatingFrame_leavingConvergedResetsEverything() {
+    public void noteRepeatingFrame_leavingConvergedResetsStreakButKeepsCapWindow() {
         AeStateMachine sm = new AeStateMachine();
         sm.beginWaitingForAe();
 
         sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
         sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_SEARCHING, 20_000_000L, 500);
         assertThat(sm.stableConvergedFrames()).isZero();
-        assertThat(sm.nsSinceFirstConverged()).isZero();
+        // The stabilization cap keeps counting from FIRST convergence across AE flicker, so the
+        // worst-case wait stays bounded by the historical fixed delay.
+        assertThat(sm.nsSinceFirstConverged()).isGreaterThan(0L);
+    }
+
+    @Test
+    public void noteRepeatingFrame_nullAeStateIsNoOp() {
+        // Null AE state means "keep waiting" (CONTINUE_WAITING_NULL_AE) — it must not erase
+        // streak progress accumulated between valid converged frames.
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        sm.noteRepeatingFrame(null, null, null);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(2);
+        assertThat(sm.nsSinceFirstConverged()).isGreaterThan(0L);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(3);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/policy/AeStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/policy/AeStateMachineTest.java
@@ -20,7 +20,7 @@ public class AeStateMachineTest {
     @Test
     public void evaluate_notWaiting_returnsIgnore() {
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                false, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L))
+                false, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.IGNORE_NOT_WAITING);
     }
 
@@ -28,7 +28,7 @@ public class AeStateMachineTest {
     public void evaluate_waitingNullAe_returnsBeforeTimeout() {
         // Even with huge elapsed, null AE must win (matches historical CameraNeoService order).
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, false, null, Long.MAX_VALUE))
+                true, false, null, Long.MAX_VALUE, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CONTINUE_WAITING_NULL_AE);
     }
 
@@ -36,48 +36,130 @@ public class AeStateMachineTest {
     public void evaluate_timeout_returnsCaptureTimeout() {
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
                 true, false, CaptureResult.CONTROL_AE_STATE_SEARCHING,
-                AeStateMachine.AE_WAIT_MAX_NS + 1))
+                AeStateMachine.AE_WAIT_MAX_NS + 1, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_TIMEOUT);
     }
 
     @Test
     public void evaluate_lockRequestedLocked_returnsCaptureNow() {
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, true, CaptureResult.CONTROL_AE_STATE_LOCKED, 0L))
+                true, true, CaptureResult.CONTROL_AE_STATE_LOCKED, 0L, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_LOCK_CONFIRMED);
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, true, CaptureResult.CONTROL_AE_STATE_FLASH_REQUIRED, 0L))
+                true, true, CaptureResult.CONTROL_AE_STATE_FLASH_REQUIRED, 0L, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_LOCK_CONFIRMED);
     }
 
     @Test
     public void evaluate_lockRequestedNotLocked_returnsContinueLockWait() {
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, true, CaptureResult.CONTROL_AE_STATE_SEARCHING, 0L))
+                true, true, CaptureResult.CONTROL_AE_STATE_SEARCHING, 0L, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CONTINUE_WAITING_FOR_LOCK);
     }
 
     @Test
-    public void evaluate_convergedImmediateMode_returnsStabilizationDelay() {
+    public void evaluate_convergedStableFrames_capturesNow() {
         assertThat(AeStateMachine.USE_IMMEDIATE_CAPTURE_ON_CONVERGENCE).isTrue();
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L))
-                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_AFTER_STABILIZATION_DELAY);
+                true, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L,
+                AeStateMachine.STABLE_FRAMES_REQUIRED, 0L))
+                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_STABLE);
+    }
+
+    @Test
+    public void evaluate_convergedNotYetStable_continuesWaitingForStability() {
+        assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
+                true, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L,
+                AeStateMachine.STABLE_FRAMES_REQUIRED - 1, 0L))
+                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CONTINUE_WAITING_FOR_STABILITY);
+    }
+
+    @Test
+    public void evaluate_convergedUnstableButCapReached_capturesNow() {
+        // Oscillating exposure never yields enough stable frames — the historical fixed delay
+        // acts as the ceiling so worst case matches the old behavior.
+        assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
+                true, false, CaptureResult.CONTROL_AE_STATE_CONVERGED, 0L,
+                1, AeStateMachine.EXPOSURE_STABILIZATION_DELAY_MS * 1_000_000L))
+                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_STABLE);
     }
 
     @Test
     public void evaluate_convergedLockedWithoutLockRequest_usesConvergedBranch() {
-        // LOCKED is also "converged" in the boolean — fast path posts delayed capture.
+        // LOCKED is also "converged" in the boolean — fast path counts stability frames.
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, false, CaptureResult.CONTROL_AE_STATE_LOCKED, 0L))
-                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_AFTER_STABILIZATION_DELAY);
+                true, false, CaptureResult.CONTROL_AE_STATE_LOCKED, 0L,
+                AeStateMachine.STABLE_FRAMES_REQUIRED, 0L))
+                .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CAPTURE_NOW_STABLE);
     }
 
     @Test
     public void evaluate_notConverged_returnsContinueConvergence() {
         assertThat(AeStateMachine.evaluateRepeatingRequestAeStep(
-                true, false, CaptureResult.CONTROL_AE_STATE_SEARCHING, 0L))
+                true, false, CaptureResult.CONTROL_AE_STATE_SEARCHING, 0L, 0, 0L))
                 .isEqualTo(AeStateMachine.AeRepeatCaptureDecision.CONTINUE_WAITING_FOR_CONVERGENCE);
+    }
+
+    @Test
+    public void noteRepeatingFrame_countsStableConvergedFrames() {
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(1);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(2);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_200_000L, 400);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(3);
+        assertThat(sm.nsSinceFirstConverged()).isGreaterThan(0L);
+    }
+
+    @Test
+    public void noteRepeatingFrame_exposureJumpResetsStabilityCount() {
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        // >5% jump in exposure×ISO — restart the stable-frame streak at 1 (current frame).
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 33_000_000L, 400);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(1);
+    }
+
+    @Test
+    public void noteRepeatingFrame_leavingConvergedResetsEverything() {
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_SEARCHING, 20_000_000L, 500);
+        assertThat(sm.stableConvergedFrames()).isZero();
+        assertThat(sm.nsSinceFirstConverged()).isZero();
+    }
+
+    @Test
+    public void noteRepeatingFrame_nullExposureStillCountsConvergedFrames() {
+        // HALs that don't report SENSOR_* keys can't be verified — converged frames still count
+        // so the capture isn't stuck waiting for data that never comes.
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, null, null);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, null, null);
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, null, null);
+        assertThat(sm.stableConvergedFrames()).isEqualTo(3);
+    }
+
+    @Test
+    public void beginWaitingForAe_resetsStabilityTracking() {
+        AeStateMachine sm = new AeStateMachine();
+        sm.beginWaitingForAe();
+        sm.noteRepeatingFrame(CaptureResult.CONTROL_AE_STATE_CONVERGED, 25_000_000L, 400);
+
+        sm.beginWaitingForAe();
+
+        assertThat(sm.stableConvergedFrames()).isZero();
+        assertThat(sm.nsSinceFirstConverged()).isZero();
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/request/AeCaptureCallbackTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/request/AeCaptureCallbackTest.java
@@ -22,7 +22,7 @@ import org.robolectric.annotation.Config;
 public class AeCaptureCallbackTest {
 
     @Test
-    public void onCaptureCompleted_whenAeConverges_postsDelayedCapture() {
+    public void onCaptureCompleted_whenAeConvergesAndExposureStable_capturesAfterStableFrames() {
         AeStateMachine stateMachine = new AeStateMachine();
         FakeHooks hooks = new FakeHooks();
         AeCaptureCallback callback = new AeCaptureCallback(stateMachine, hooks);
@@ -32,12 +32,42 @@ public class AeCaptureCallbackTest {
         stateMachine.beginWaitingForAe();
         when(result.get(CaptureResult.CONTROL_AE_STATE))
                 .thenReturn(CaptureResult.CONTROL_AE_STATE_CONVERGED);
+        when(result.get(CaptureResult.SENSOR_SENSITIVITY)).thenReturn(400);
+        when(result.get(CaptureResult.SENSOR_EXPOSURE_TIME)).thenReturn(25_000_000L);
 
+        for (int i = 0; i < AeStateMachine.STABLE_FRAMES_REQUIRED - 1; i++) {
+            callback.onCaptureCompleted(session, request, result);
+            assertThat(hooks.captureCount).isZero();
+            assertThat(stateMachine.waitingForAeConvergence()).isTrue();
+        }
         callback.onCaptureCompleted(session, request, result);
 
         assertThat(stateMachine.waitingForAeConvergence()).isFalse();
         assertThat(hooks.captureCount).isEqualTo(1);
-        assertThat(hooks.lastDelayMs).isEqualTo(AeStateMachine.EXPOSURE_STABILIZATION_DELAY_MS);
+    }
+
+    @Test
+    public void onCaptureCompleted_whenExposureOscillates_doesNotCaptureBeforeStability() {
+        AeStateMachine stateMachine = new AeStateMachine();
+        FakeHooks hooks = new FakeHooks();
+        AeCaptureCallback callback = new AeCaptureCallback(stateMachine, hooks);
+        CameraCaptureSession session = mock(CameraCaptureSession.class);
+        CaptureRequest request = mock(CaptureRequest.class);
+        TotalCaptureResult result = mock(TotalCaptureResult.class);
+        stateMachine.beginWaitingForAe();
+        when(result.get(CaptureResult.CONTROL_AE_STATE))
+                .thenReturn(CaptureResult.CONTROL_AE_STATE_CONVERGED);
+        when(result.get(CaptureResult.SENSOR_SENSITIVITY)).thenReturn(400);
+        // Exposure swings >5% each frame — the stable streak keeps restarting.
+        when(result.get(CaptureResult.SENSOR_EXPOSURE_TIME))
+                .thenReturn(25_000_000L, 33_000_000L, 25_000_000L, 33_000_000L);
+
+        for (int i = 0; i < 4; i++) {
+            callback.onCaptureCompleted(session, request, result);
+        }
+
+        assertThat(hooks.captureCount).isZero();
+        assertThat(stateMachine.waitingForAeConvergence()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Scope

Every Mentra Live photo (SDK and button, cold and warm) slept a hard-coded 475ms between "AE converged" and firing the still capture (`EXPOSURE_STABILIZATION_DELAY_MS`, added in 66279ff39 as a blind safety margin). On-device profiling shows exposure is already final when that sleep starts — it's pure added latency on every shot.

This PR makes the wait adaptive in `AeStateMachine` + `AeCaptureCallback`:

- Track exposure×ISO across repeating-request frames while waiting for AE.
- Fire the capture once **3 consecutive converged frames** are stable within 5%.
- Keep the old **475ms as the worst-case ceiling** for scenes where AE keeps oscillating — pathological behavior is identical to today.
- Streak resets if AE leaves CONVERGED; HALs that don't report SENSOR_* keys still count converged frames so the wait can't hang.

Camera lifecycle (3s keep-alive, close, service teardown) is untouched — no idle battery impact.

## Test evidence (on Mentra Live hardware)

Profiled via the `ACTION_SEND_COMMAND` take_photo debug intent with logcat timing markers, photos received over a LAN webhook for quality comparison. Same scene, mixed MFNR/non-MFNR shots:

| | stock v39 | this branch |
|---|---|---|
| Stability wait after AE converged | 475ms fixed | **66–78ms** (never hit the cap across all runs) |
| Cold-start photo (request → JPEG saved) | 2.5–2.7s | **1.9–2.3s** |
| Warm photo | ~1.4s | **0.46s** (no MFNR) / ~1.1s (MFNR) |

Quality checks on the received JPEGs: capture exposure converges to the same values as stock (ISO 363–469 @ 33.3ms in the test scene), brightness/sharpness statistics within shot-to-shot noise of baseline, MTK 6-frame MFNR burst still triggers exactly as before (it's HAL-decided at ISO ≥ ~400), visual side-by-side indistinguishable.

`:app:testDebugUnitTest` camera suites pass; AE tests updated for the new logic including oscillating-exposure, streak-reset, and null-SENSOR-key cases.

## Notes

- Log line changes from `AE CONVERGED in Nms! ... waiting 475ms for exposure stabilization [FAST MODE]` to `AE CONVERGED+STABLE in Nms! ... (stability wait Nms, 3 stable frames) [ADAPTIVE]`.
- Related finding, not addressed here: still-capture latency is bimodal (~280ms vs ~930ms) because the MTK HAL runs a 6-frame MFNR fusion when ISO ≥ ~400. That's a genuine low-light quality feature and is left as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when every photo fires relative to AE convergence, which can affect exposure timing; worst-case delay is preserved and behavior is heavily unit-tested.
> 
> **Overview**
> Replaces the **fixed 475ms** post-convergence sleep with **adaptive exposure stability** in `AeStateMachine` and `AeCaptureCallback`, so still captures can fire sooner when AE and exposure have actually settled.
> 
> After AE reports converged, repeating preview frames update a streak via `noteRepeatingFrame` (exposure×ISO within **5%**). Capture runs when **3** consecutive stable converged frames are seen, or immediately at the same **475ms** ceiling if exposure keeps oscillating. AE flicker resets the streak but the cap still counts from **first** convergence; null AE or missing `SENSOR_*` keys avoid hanging the wait. The fast path no longer uses `postDelayed`—it calls `capturePhoto()` as soon as stability (or the cap) is met.
> 
> Unit/integration-style tests cover the new decisions, oscillation, and edge cases. A manual **`ZslFeasibilityProbeTest`** androidTest was added for ZSL/YUV ring feasibility on Mentra Live hardware (not part of the default CI suite).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3584c2a3697ba274242b64adbe58928a63a8e5d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the fixed 475ms AE stabilization with adaptive stability detection to cut photo latency while keeping the worst-case unchanged. Also adds a manual ZSL feasibility probe to evaluate YUV ring-buffer viability on the MTK HAL.

- **New Features**
  - Track exposure_time × ISO on converged frames; within 5% stability counts. Capture on 3 stable frames; fall back to a 475ms cap.
  - Robustness: null AE frames keep progress; leaving CONVERGED resets the streak but the cap is timed from first convergence; missing SENSOR_* keys still progress (no hang).
  - Capture fires immediately when stable (no delayed post).
  - Measured: stability wait ~66–78ms; cold photo ~1.9–2.3s; warm photo ~0.46s (no MFNR) / ~1.1s (MFNR).
  - Add a manual ZSL feasibility probe (instrumentation) that logs HAL reprocessing caps, YUV 1280×960 cadence (~30fps), and SW JPEG encode (~35ms). Run: ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.mentra.asg_client.camera.ZslFeasibilityProbeTest

<sup>Written for commit 3584c2a3697ba274242b64adbe58928a63a8e5d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

