### PR TITLE
Prefer hardware H264 over software VP8 for WHIP streaming

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/HardwareFirstVideoEncoderFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/HardwareFirstVideoEncoderFactory.java
@@ -1,0 +1,56 @@
+package com.mentra.asg_client.io.streaming.services;
+
+import androidx.annotation.Nullable;
+
+import org.webrtc.EglBase;
+import org.webrtc.HardwareVideoEncoderFactory;
+import org.webrtc.SoftwareVideoEncoderFactory;
+import org.webrtc.VideoCodecInfo;
+import org.webrtc.VideoEncoder;
+import org.webrtc.VideoEncoderFactory;
+import org.webrtc.VideoEncoderFallback;
+
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+
+/**
+ * Combines the WebRTC hardware and software encoder factories like
+ * {@link org.webrtc.DefaultVideoEncoderFactory}, but advertises hardware codecs FIRST.
+ *
+ * DefaultVideoEncoderFactory lists software codecs (VP8/VP9/AV1 — libvpx/libaom on the
+ * CPU) ahead of hardware ones, the SDP offer follows that order, and WHIP servers
+ * generally answer with the first offered codec they support. On Mentra Live (MediaTek
+ * MT6761) the only hardware video encoder is H.264 (OMX.MTK.VIDEO.ENCODER.AVC), so
+ * software-first ordering makes streams negotiate VP8 and encode on the CPU.
+ * Hardware-first ordering lets H.264 lead the offer so encoding runs on the VPU.
+ */
+public class HardwareFirstVideoEncoderFactory implements VideoEncoderFactory {
+
+  private final VideoEncoderFactory mHardwareFactory;
+  private final VideoEncoderFactory mSoftwareFactory = new SoftwareVideoEncoderFactory();
+
+  public HardwareFirstVideoEncoderFactory(EglBase.Context eglContext) {
+    mHardwareFactory = new HardwareVideoEncoderFactory(
+        eglContext, /* enableIntelVp8Encoder= */ true, /* enableH264HighProfile= */ false);
+  }
+
+  @Nullable
+  @Override
+  public VideoEncoder createEncoder(VideoCodecInfo info) {
+    VideoEncoder hardwareEncoder = mHardwareFactory.createEncoder(info);
+    VideoEncoder softwareEncoder = mSoftwareFactory.createEncoder(info);
+    if (hardwareEncoder != null && softwareEncoder != null) {
+      return new VideoEncoderFallback(
+          /* fallback= */ softwareEncoder, /* primary= */ hardwareEncoder);
+    }
+    return hardwareEncoder != null ? hardwareEncoder : softwareEncoder;
+  }
+
+  @Override
+  public VideoCodecInfo[] getSupportedCodecs() {
+    LinkedHashSet<VideoCodecInfo> codecs = new LinkedHashSet<>();
+    codecs.addAll(Arrays.asList(mHardwareFactory.getSupportedCodecs()));
+    codecs.addAll(Arrays.asList(mSoftwareFactory.getSupportedCodecs()));
+    return codecs.toArray(new VideoCodecInfo[0]);
+  }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -34,13 +34,14 @@ import org.webrtc.AudioSource;
 import org.webrtc.AudioTrack;
 import org.webrtc.DataChannel;
 import org.webrtc.DefaultVideoDecoderFactory;
-import org.webrtc.DefaultVideoEncoderFactory;
 import org.webrtc.EglBase;
 import org.webrtc.IceCandidate;
 import org.webrtc.MediaConstraints;
 import org.webrtc.MediaStream;
+import org.webrtc.MediaStreamTrack;
 import org.webrtc.PeerConnection;
 import org.webrtc.PeerConnectionFactory;
+import org.webrtc.RtpCapabilities;
 import org.webrtc.RtpParameters;
 import org.webrtc.RtpReceiver;
 import org.webrtc.RtpSender;
@@ -392,7 +393,7 @@ public class WhipStreamingService extends Service {
     mPeerConnectionFactory = PeerConnectionFactory.builder()
         .setOptions(factoryOptions)
         .setVideoEncoderFactory(
-            new DefaultVideoEncoderFactory(mEglBase.getEglBaseContext(), true, false))
+            new HardwareFirstVideoEncoderFactory(mEglBase.getEglBaseContext()))
         .setVideoDecoderFactory(
             new DefaultVideoDecoderFactory(mEglBase.getEglBaseContext()))
         .createPeerConnectionFactory();
@@ -464,8 +465,10 @@ public class WhipStreamingService extends Service {
       transceiver.setDirection(RtpTransceiver.RtpTransceiverDirection.SEND_ONLY);
     }
 
+    preferHardwareVideoCodec();
+
     // Apply bitrate cap and degradation preference to reduce encoder thermal load.
-    // Without this, the hardware encoder runs uncapped and overheats the SoC.
+    // Without this, the encoder runs uncapped and overheats the SoC.
     applyBitrateConstraints();
 
     MediaConstraints sdpConstraints = new MediaConstraints();
@@ -501,6 +504,44 @@ public class WhipStreamingService extends Service {
   }
 
   /**
+   * Move H.264 to the front of the video codec preference list. The SDP offer follows
+   * this order and WHIP servers generally answer with the first offered codec they
+   * support. H.264 is the only codec with a hardware encoder on Mentra Live; VP8/VP9/AV1
+   * only exist as software encoders (libvpx/libaom) that burn CPU and heat the SoC.
+   * VP8 and friends stay in the list as a fallback for servers without H.264 support.
+   */
+  private void preferHardwareVideoCodec() {
+    RtpCapabilities capabilities = mPeerConnectionFactory.getRtpSenderCapabilities(
+        MediaStreamTrack.MediaType.MEDIA_TYPE_VIDEO);
+
+    List<RtpCapabilities.CodecCapability> h264 = new ArrayList<>();
+    List<RtpCapabilities.CodecCapability> others = new ArrayList<>();
+    for (RtpCapabilities.CodecCapability codec : capabilities.codecs) {
+      if ("H264".equalsIgnoreCase(codec.name)) {
+        h264.add(codec);
+      } else {
+        others.add(codec);
+      }
+    }
+
+    if (h264.isEmpty()) {
+      Log.w(TAG, "No H264 sender capability, keeping default codec order");
+      return;
+    }
+
+    List<RtpCapabilities.CodecCapability> preferred = new ArrayList<>(h264);
+    preferred.addAll(others);
+
+    for (RtpTransceiver transceiver : mPeerConnection.getTransceivers()) {
+      if (transceiver.getMediaType() == MediaStreamTrack.MediaType.MEDIA_TYPE_VIDEO) {
+        transceiver.setCodecPreferences(preferred);
+      }
+    }
+    Log.i(TAG, "Video codec preference: H264 first ("
+        + h264.size() + " H264 entries, " + others.size() + " others)");
+  }
+
+  /**
    * Cap the video encoder bitrate via RTP sender parameters and set degradation
    * preference to MAINTAIN_FRAMERATE so WebRTC drops quality-per-frame instead of
    * frame rate when thermals get tight.
@@ -529,8 +570,52 @@ public class WhipStreamingService extends Service {
   // WHIP HTTP signaling
   // -----------------------------------------------------------------------
 
+  /**
+   * Extracts the codec name of the first payload in the SDP's m=video line — the codec
+   * the far end selected. Diagnostic only: on Mentra Live "H264" means hardware encode,
+   * "VP8"/"VP9"/"AV1" mean software encode on the CPU.
+   */
+  private static String firstVideoCodecFromSdp(String sdp) {
+    String firstPayloadType = null;
+    for (String line : sdp.split("\r?\n")) {
+      if (line.startsWith("m=video")) {
+        // m=video 9 UDP/TLS/RTP/SAVPF 102 103 ... — first payload type is index 3
+        String[] parts = line.trim().split(" ");
+        if (parts.length > 3) {
+          firstPayloadType = parts[3];
+        }
+      } else if (firstPayloadType != null
+          && line.startsWith("a=rtpmap:" + firstPayloadType + " ")) {
+        return line.substring(("a=rtpmap:" + firstPayloadType + " ").length());
+      }
+    }
+    return "unknown";
+  }
+
+  /**
+   * Logs the m=video line plus its rtpmap/fmtp attributes. Codec negotiation problems
+   * (e.g. an H264 profile mismatch making the encoder factory silently return null)
+   * are invisible without seeing what each side actually put on the wire.
+   */
+  private static void logSdpVideoSection(String label, String sdp) {
+    StringBuilder section = new StringBuilder();
+    boolean inVideo = false;
+    for (String line : sdp.split("\r?\n")) {
+      if (line.startsWith("m=")) {
+        inVideo = line.startsWith("m=video");
+        if (inVideo) {
+          section.append(line).append('\n');
+        }
+      } else if (inVideo && (line.startsWith("a=rtpmap:") || line.startsWith("a=fmtp:"))) {
+        section.append(line).append('\n');
+      }
+    }
+    Log.i(TAG, label + " video section:\n" + section);
+  }
+
   private void postOfferToWhip(SessionDescription offer) {
     Log.d(TAG, "POSTing SDP offer to WHIP URL: " + mWhipUrl);
+    logSdpVideoSection("Offer", offer.description);
 
     RequestBody body = RequestBody.create(
         offer.description, MediaType.parse("application/sdp"));
@@ -585,6 +670,7 @@ public class WhipStreamingService extends Service {
           Log.d(TAG, "WHIP resource URL: " + mWhipResourceUrl);
         }
 
+        logSdpVideoSection("Answer", answerSdp);
         SessionDescription answer = new SessionDescription(
             SessionDescription.Type.ANSWER, answerSdp);
 
@@ -605,7 +691,8 @@ public class WhipStreamingService extends Service {
             mMainHandler.postDelayed(mStatsRunnable, STATS_INTERVAL_MS);
             scheduleStreamTimeout(mCurrentStreamId);
             startBatteryMonitoring();
-            Log.d(TAG, "Streaming started via WHIP");
+            Log.i(TAG, "Streaming started via WHIP, negotiated video codec: "
+                + firstVideoCodecFromSdp(answerSdp));
             if (mLedEnabled && mHardwareManager != null && mHardwareManager.supportsRecordingLed()) {
               mHardwareManager.setRecordingLedOn();
             }


### PR DESCRIPTION
## Problem

WHIP streams from Mentra Live encode video in software. `DefaultVideoEncoderFactory` advertises software codecs (VP8/VP9/AV1 — libvpx/libaom) ahead of hardware ones in the SDP offer, and WHIP servers generally answer with the first offered codec they support. On Mentra Live (MT6761) the only hardware video encoder is H.264, so streams negotiate VP8 and encode on the CPU: ~65% of a core at 480p15, plus avoidable SoC heat. Managed streams default to WHIP whenever there are no restream destinations (`ManagedStreamingExtension.ts`), so this is the default managed-stream path.

## Fix

- **`HardwareFirstVideoEncoderFactory`** — same HW+SW combination and software-fallback wrapping as `DefaultVideoEncoderFactory`, but hardware codecs lead `getSupportedCodecs()` so H.264 leads the offer.
- **`preferHardwareVideoCodec()`** in `WhipStreamingService` — explicit `setCodecPreferences` on the video transceiver (H264 entries first), guaranteeing offer order independent of factory merge behavior. VP8/VP9/AV1 stay in the list as fallback for servers without H264.
- **SDP observability** — logs the offer/answer `m=video` sections and the negotiated codec, so codec regressions are visible in incident logs.

## Test evidence (on-device, Mentra Live → mediamtx WHIP sink)

| | Before | After |
|---|---|---|
| Negotiated codec (server log) | VP8 | H264 |
| Encoder | none via MediaCodec — libvpx in-process on CPU | `OMX.MTK.VIDEO.ENCODER.AVC`, surface mode (`HardwareVideoEncoder: initEncode`) |
| App CPU @ 854x480@15 | ~59–68% of a core | ~48–55%, video encoder threads at 0.0% |
| Server-side decode | — | ffprobe via mediamtx HLS: `h264, 854x480, ~15fps` |

Remaining CPU during streaming is audio capture + Opus encode + RTP transport threads (unchanged by this PR).

## Notes

- Follow-up worth doing: confirm on one real managed stream that Cloudflare's WHIP answer also picks H264 (mediamtx did; answerers generally follow offer order). The new `negotiated video codec:` log line makes that a quick check.
- RTMP/SRT paths (StreamPackLite) already use the hardware encoder via platform-default MediaCodec selection; untouched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WHIP SDP codec ordering and negotiation for the default managed-stream path; H.264-first should be safe where servers support it, but mismatches or odd answerers could still fall back to software codecs.
> 
> **Overview**
> WHIP ingest on Mentra Live was often negotiating **VP8** because WebRTC’s default encoder factory lists **software codecs before hardware**, and many WHIP answerers pick the first offered codec. That forces CPU libvpx encoding and extra heat when the device only has a hardware **H.264** path.
> 
> This PR adds **`HardwareFirstVideoEncoderFactory`** (hardware + software encoders with the same fallback wrapping as the default factory, but **hardware codecs listed first**) and wires it into **`WhipStreamingService`** instead of `DefaultVideoEncoderFactory`. Before `createOffer`, **`preferHardwareVideoCodec()`** sets video transceiver **codec preferences** so **H.264 leads** the offer while VP8/VP9/AV1 remain as fallbacks.
> 
> **SDP observability** logs the offer/answer `m=video` sections and the **negotiated video codec** when streaming starts, so codec regressions show up in logs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ec8753bb54e8d87fce2916cc9a84c6d69191fc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer hardware H.264 for WHIP streaming to move video encoding off the CPU and reduce heat/load on Mentra Live (MT6761). VP8/VP9/AV1 remain as fallback for servers without H.264.

- **New Features**
  - Added `HardwareFirstVideoEncoderFactory` so hardware codecs lead `getSupportedCodecs()`; H.264 now leads the SDP offer.
  - Set video transceiver codec preferences to H.264-first in `WhipStreamingService`, independent of factory behavior.
  - Logged offer/answer SDP video sections and the negotiated codec to make codec selection visible in logs.

<sup>Written for commit 0ec8753bb54e8d87fce2916cc9a84c6d69191fc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

