### PR TITLE
Reify pairing identity: one module, three-state read-model, descriptor-derived sync ownership

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -261,6 +261,10 @@ jest.mock("@mentra/island", () => {
   const realOtaService = jest.requireActual("./modules/island/src/services/OtaService")
   const realAudioCloudUplink = jest.requireActual("./modules/island/src/services/AudioCloudUplink")
   const realDeviceEventRouter = jest.requireActual("./modules/island/src/services/DeviceEventRouter")
+  // Pairing-identity lifecycle (projection + the JS-owned identity writes) — real
+  // implementation (pure: settings store + types only) so host screens/tests
+  // exercise the actual three-state read-model, not a parallel stub.
+  const realPairingIdentity = jest.requireActual("./modules/island/src/services/PairingIdentity")
   // Clock-skew utils moved into island; the host gallery sync + OTA checker import them
   // from @mentra/island, so expose the real (pure) implementations through the mock.
   const realGlassesClockSync = jest.requireActual("./modules/island/src/services/glassesClockSync")
@@ -503,6 +507,11 @@ jest.mock("@mentra/island", () => {
             cb(readiness)
           })
         }),
+        // Identity lifecycle: real projection/writes over the real settings store,
+        // so tests observe the same none/pending/paired snapshots the app does.
+        identity: jest.fn(() => realPairingIdentity.projectPairingIdentity()),
+        onIdentity: jest.fn((cb) => realPairingIdentity.subscribePairingIdentity(cb)),
+        markPendingSelection: jest.fn((model) => realPairingIdentity.markPendingSelection(model)),
         scan: jest.fn(),
         scanning: jest.fn(() => false),
         searchResults: jest.fn(() => []),

--- a/mobile/modules/island/src/facades/glasses.ts
+++ b/mobile/modules/island/src/facades/glasses.ts
@@ -15,6 +15,7 @@ import type {ButtonPressEvent, TouchEvent} from "@mentra/bluetooth-sdk/internal"
 import {useGlassesStore} from "../stores/glasses"
 import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {hasDefaultDevice} from "../services/DeviceStoreHydration"
+import {projectPairingIdentity} from "../services/PairingIdentity"
 import {isGlassesConnected, isGlassesReady} from "../services/GlassesReadiness"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
 import {getModelCapabilities, type DeviceTypes} from "../types"
@@ -114,12 +115,11 @@ export const glasses = {
     }
     return true
   },
-  /** True when no glasses has ever been paired NOR selected (no default wearable and
-   * no pending selection) — e.g. to route a first-run host into the pairing/onboarding
-   * flow. A pending selection is not "first" — the host should offer finish-pairing. */
-  isFirstPairing: (): boolean =>
-    !useSettingsStore.getState().getSetting(SETTINGS.default_wearable.key) &&
-    !useSettingsStore.getState().getSetting(SETTINGS.pending_wearable.key),
+  /** True when no glasses has ever been paired NOR selected (the pairing-identity
+   * lifecycle is in its `none` state) — e.g. to route a first-run host into the
+   * pairing/onboarding flow. A pending selection is not "first" — the host should
+   * offer finish-pairing (see `toolkit.pairing.identity()`). */
+  isFirstPairing: (): boolean => projectPairingIdentity().kind === "none",
   /**
    * True when the SDK has an actual default DEVICE to reconnect to. Distinct from
    * `default_wearable` (a model string that a pending or orphaned selection can

--- a/mobile/modules/island/src/facades/pairing.ts
+++ b/mobile/modules/island/src/facades/pairing.ts
@@ -15,6 +15,12 @@ import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"
 import {hasDefaultDevice} from "../services/DeviceStoreHydration"
 import {
+  markPendingSelection,
+  projectPairingIdentity,
+  subscribePairingIdentity,
+  type IdentitySnapshot,
+} from "../services/PairingIdentity"
+import {
   isGlassesConnected,
   isGlassesLinkLayerBusy,
   isGlassesReady,
@@ -27,6 +33,8 @@ import {
 } from "../services/AutomaticReportResult"
 import {pushAllBluetoothSettings} from "../services/GlassesSettingsSync"
 import {submitAutomaticReport} from "./reports"
+
+export type {IdentitySnapshot} from "../services/PairingIdentity"
 
 export interface PairingReadyWaitOptions {
   deviceModel?: string
@@ -185,6 +193,17 @@ export const pairing = {
       cb(snap)
     })
   },
+
+  // --- pairing-identity lifecycle (the PairingIdentity read-model + the JS-owned
+  // identity writes; promotion to `paired` only ever happens natively) ---
+  /** The identity lifecycle snapshot: none | pending (chosen, never paired) | paired. */
+  identity: (): IdentitySnapshot => projectPairingIdentity(),
+  /** Subscribe to identity changes; fires only when the projected snapshot changes.
+   * Returns an unsubscribe. */
+  onIdentity: (cb: (identity: IdentitySnapshot) => void): (() => void) => subscribePairingIdentity(cb),
+  /** Mark the chosen model as the pending selection (the scan-entry write); the
+   * host renders it as a finish-pairing affordance until pairing succeeds. */
+  markPendingSelection: (model: string) => markPendingSelection(model),
 
   /** Start scanning for nearby glasses. Results land on `searchResults()`/`onFound()`. */
   scan: (...args: Parameters<typeof BluetoothSdk.startScan>) => BluetoothSdk.startScan(...args),

--- a/mobile/modules/island/src/index.ts
+++ b/mobile/modules/island/src/index.ts
@@ -167,6 +167,7 @@ export type {
 } from "./facades/reports"
 export type {IslandNotification, IslandNotificationKind} from "./facades/notifications"
 export type {WifiSearchResult} from "./facades/glassesWifi"
+export type {IdentitySnapshot} from "./services/PairingIdentity"
 export type {DisplayMirrorEvent} from "./facades/displayMirror"
 export type {
   IslandConfigureOptions,

--- a/mobile/modules/island/src/services/DeviceEventRouter.ts
+++ b/mobile/modules/island/src/services/DeviceEventRouter.ts
@@ -25,8 +25,9 @@ import {phonePhotoCoordinator} from "./PhonePhotoCoordinator"
 import {phoneStreamCoordinator} from "./PhoneStreamCoordinator"
 import {isGlassesConnected} from "./GlassesReadiness"
 import {useGlassesStore} from "../stores/glasses"
-import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {useSettingsStore} from "../stores/settings"
 import {useAppStatusStore} from "../stores/apps"
+import {retirePendingSelectionOnPromotion} from "./PairingIdentity"
 import GlobalEventEmitter from "../utils/GlobalEventEmitter"
 import {asgCameraApi} from "./asg/asgCameraApi"
 
@@ -124,14 +125,9 @@ export function startDeviceEventRouter(): void {
       if (settings.getSetting(event.key) !== event.value) {
         await settings.setSetting(event.key, event.value)
       }
-      // Two-phase identity: the native layer promotes the default wearable on
-      // pairing success (handleDeviceReady) and echoes it here — a promoted
-      // default retires the pending selection marker.
-      if (event.key === SETTINGS.default_wearable.key && event.value) {
-        if (settings.getSetting(SETTINGS.pending_wearable.key)) {
-          await settings.setSetting(SETTINGS.pending_wearable.key, "")
-        }
-      }
+      // Two-phase identity: a promoted default retires the pending selection
+      // marker. The rule lives with PairingIdentity (a no-op for other keys).
+      await retirePendingSelectionOnPromotion(event.key, event.value)
     }),
   )
 

--- a/mobile/modules/island/src/services/DeviceStoreHydration.ts
+++ b/mobile/modules/island/src/services/DeviceStoreHydration.ts
@@ -25,6 +25,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {useGlassesStore} from "../stores/glasses"
 import {pushAllBluetoothSettings} from "./GlassesSettingsSync"
+import {demoteDefaultToPending} from "./PairingIdentity"
 import {DeviceTypes} from "../types"
 
 let hydrationPromise: Promise<void> | null = null
@@ -119,15 +120,10 @@ export async function demoteOrphanedDefaultWearable(): Promise<void> {
   if (await BluetoothSdk.getDefaultDevice()) return
 
   console.log(`DeviceStoreHydration: demoting orphaned default_wearable "${model}" to pending_wearable`)
-  // The user's LATEST selection wins: only backfill the pending marker when
-  // none exists — a fresher pending model (a pairing started after the orphan
-  // formed) must not be replaced by the stale orphaned model.
-  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
-    await settings.setSetting(SETTINGS.pending_wearable.key, model)
-  }
-  await settings.setSetting(SETTINGS.default_wearable.key, "")
-  await settings.setSetting(SETTINGS.device_name.key, "")
-  await settings.setSetting(SETTINGS.device_address.key, "")
+  // The identity write set (latest-selection-wins backfill + identity-triplet
+  // clear) lives with PairingIdentity, the single writer of the JS-side
+  // identity keys; this boot repair owns only the guards above.
+  await demoteDefaultToPending(model)
   // The hydration seed already landed the pre-demotion values in the native
   // store; re-push so native mirrors the demoted identity too.
   await pushAllBluetoothSettings()

--- a/mobile/modules/island/src/services/PairingIdentity.ts
+++ b/mobile/modules/island/src/services/PairingIdentity.ts
@@ -1,0 +1,129 @@
+/**
+ * PairingIdentity — the pairing-identity lifecycle, reified. The two-phase
+ * identity rules (see the pending/default group in stores/settings.ts) exist
+ * as a three-state machine over the identity settings keys:
+ *
+ *   none ──markPendingSelection()──▶ pending ──native promotion──▶ paired
+ *                                       ▲                            │
+ *                                       └───────boot demotion────────┘
+ *
+ * - `none`    — no model ever selected: hosts route to model selection.
+ * - `pending` — a model was CHOSEN (the one JS-owned identity write, made at
+ *               scan entry) but pairing never completed: hosts render
+ *               finish-pairing affordances.
+ * - `paired`  — the native layer promoted the identity at pairing success
+ *               (handleDeviceReady) and echoed it down via save_setting:
+ *               hosts render the device card / connect surfaces.
+ *
+ * Projection law, mirroring native currentDefaultDevice() on both platforms:
+ * `paired` requires default_wearable AND device_name; device_address is
+ * optional. Two read-time alignments with the demotion's own write rules:
+ * - The simulated device is its own identity (its name mirrors the model at
+ *   connectSimulated, and the boot demotion never touches it), so a simulated
+ *   default_wearable projects as `paired` even without a device_name echo.
+ * - A non-simulated default_wearable WITHOUT a device_name is the orphan
+ *   population `demoteOrphanedDefaultWearable` repairs into pending_wearable
+ *   at boot; the projection already reads it as `pending` (a fresher
+ *   pending_wearable wins, matching the demotion's latest-selection-wins
+ *   backfill).
+ *
+ * JS-initiated identity writes live here and only here — the scan screen
+ * (markPendingSelection), the device-event router (promotion retires the
+ * pending marker), and the boot demotion (demoteDefaultToPending) invoke
+ * these methods instead of writing the raw keys. The router's generic
+ * save_setting persistence is the inbound native→JS echo leg, not a
+ * JS-initiated write, and stays with the router.
+ */
+import type {AsyncResult} from "typesafe-ts"
+
+import {useSettingsStore, SETTINGS} from "../stores/settings"
+import {DeviceTypes} from "../types"
+
+export type IdentitySnapshot =
+  | {kind: "none"}
+  | {kind: "pending"; model: string}
+  | {kind: "paired"; model: string; name: string; address?: string}
+
+// Identity keys hold model/name strings; anything else (legacy null, a stray
+// non-string) reads as absent, matching native currentDefaultDevice()'s
+// blank checks.
+function readIdentityString(key: string): string {
+  const value = useSettingsStore.getState().getSetting(key)
+  return typeof value === "string" ? value : ""
+}
+
+/** Project the identity settings keys into the lifecycle snapshot. */
+export function projectPairingIdentity(): IdentitySnapshot {
+  const model = readIdentityString(SETTINGS.default_wearable.key)
+  const name = readIdentityString(SETTINGS.device_name.key)
+
+  if (model && name) {
+    const address = readIdentityString(SETTINGS.device_address.key)
+    return address ? {kind: "paired", model, name, address} : {kind: "paired", model, name}
+  }
+  if (model && model.includes(DeviceTypes.SIMULATED)) {
+    return {kind: "paired", model, name: model}
+  }
+  const pending = readIdentityString(SETTINGS.pending_wearable.key)
+  if (pending) return {kind: "pending", model: pending}
+  if (model) return {kind: "pending", model}
+  return {kind: "none"}
+}
+
+/**
+ * Subscribe to identity changes, deduped on the projected snapshot (same
+ * style as glasses.onStatus): the settings store updates on many keys; the
+ * callback fires only when the identity snapshot actually changes.
+ */
+export function subscribePairingIdentity(cb: (identity: IdentitySnapshot) => void): () => void {
+  let last = JSON.stringify(projectPairingIdentity())
+  return useSettingsStore.subscribe(() => {
+    const snap = projectPairingIdentity()
+    const key = JSON.stringify(snap)
+    if (key === last) return
+    last = key
+    cb(snap)
+  })
+}
+
+/**
+ * Selection: mark the model the user chose as the PENDING wearable (written
+ * at scan entry). Promotion to `paired` only ever happens natively at pairing
+ * success. The marker persists so an abandoned selection still renders its
+ * finish-pairing card after an app restart.
+ */
+export function markPendingSelection(model: string): AsyncResult<void, Error> {
+  return useSettingsStore.getState().setSetting(SETTINGS.pending_wearable.key, model)
+}
+
+/**
+ * Promotion retires the selection: when the native layer promotes the default
+ * wearable at pairing success and its save_setting echo lands, the pending
+ * marker has served its purpose. Invoked by DeviceEventRouter for every echo;
+ * a no-op for other keys, empty promotions, and an already-clear marker.
+ */
+export async function retirePendingSelectionOnPromotion(echoedKey: string, echoedValue: unknown): Promise<void> {
+  if (echoedKey !== SETTINGS.default_wearable.key || !echoedValue) return
+  const settings = useSettingsStore.getState()
+  if (settings.getSetting(SETTINGS.pending_wearable.key)) {
+    await settings.setSetting(SETTINGS.pending_wearable.key, "")
+  }
+}
+
+/**
+ * Demotion: turn an orphaned default identity back into a pending selection.
+ * The guards (hydration, the native default-device read, link-layer state)
+ * live with the boot repair in demoteOrphanedDefaultWearable — this is only
+ * the identity write set: backfill the pending marker unless a fresher
+ * selection already holds it (the user's LATEST selection wins), then clear
+ * the promoted identity triplet.
+ */
+export async function demoteDefaultToPending(model: string): Promise<void> {
+  const settings = useSettingsStore.getState()
+  if (!settings.getSetting(SETTINGS.pending_wearable.key)) {
+    await settings.setSetting(SETTINGS.pending_wearable.key, model)
+  }
+  await settings.setSetting(SETTINGS.default_wearable.key, "")
+  await settings.setSetting(SETTINGS.device_name.key, "")
+  await settings.setSetting(SETTINGS.device_address.key, "")
+}

--- a/mobile/modules/island/src/services/__tests__/PairingIdentity.test.ts
+++ b/mobile/modules/island/src/services/__tests__/PairingIdentity.test.ts
@@ -1,0 +1,171 @@
+/// <reference types="bun-types" />
+
+import {beforeEach, describe, expect, mock, test} from "bun:test"
+
+const settingsValues: Record<string, unknown> = {}
+const listeners = new Set<() => void>()
+const okResult = {is_error: () => false} as const
+const mockSetSetting = mock((key: string, value: unknown) => {
+  settingsValues[key] = value
+  for (const listener of [...listeners]) listener()
+  return Promise.resolve(okResult)
+})
+
+mock.module("../../stores/settings", () => ({
+  SETTINGS: {
+    default_wearable: {key: "default_wearable"},
+    pending_wearable: {key: "pending_wearable"},
+    device_name: {key: "device_name"},
+    device_address: {key: "device_address"},
+  },
+  useSettingsStore: {
+    getState: () => ({
+      getSetting: (key: string) => settingsValues[key],
+      setSetting: mockSetSetting,
+    }),
+    subscribe: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  },
+}))
+
+// Import AFTER the mocks are registered
+const {
+  projectPairingIdentity,
+  subscribePairingIdentity,
+  markPendingSelection,
+  retirePendingSelectionOnPromotion,
+  demoteDefaultToPending,
+} = require("../PairingIdentity")
+// Real enum: the simulated special case must track the actual model string.
+const {DeviceTypes} = require("../../types")
+
+function resetSettings(values: Record<string, unknown>) {
+  for (const key of Object.keys(settingsValues)) delete settingsValues[key]
+  Object.assign(settingsValues, values)
+}
+
+describe("PairingIdentity", () => {
+  beforeEach(() => {
+    mockSetSetting.mockClear()
+    listeners.clear()
+    resetSettings({})
+  })
+
+  describe("projectPairingIdentity", () => {
+    test("no identity keys → none", () => {
+      expect(projectPairingIdentity()).toEqual({kind: "none"})
+    })
+
+    test("a pending selection → pending", () => {
+      resetSettings({pending_wearable: "Even Realities G1"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Even Realities G1"})
+    })
+
+    test("paired requires default_wearable AND device_name (native currentDefaultDevice)", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", device_address: "aa:bb"})
+      expect(projectPairingIdentity()).toEqual({
+        kind: "paired",
+        model: "Mentra Live",
+        name: "LIVE_1",
+        address: "aa:bb",
+      })
+    })
+
+    test("address is optional on a paired identity", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1"})
+      expect(projectPairingIdentity()).toEqual({kind: "paired", model: "Mentra Live", name: "LIVE_1"})
+    })
+
+    test("an orphaned default (no device_name) reads as pending — the demotion's target state", () => {
+      resetSettings({default_wearable: "Mentra Live"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Mentra Live"})
+    })
+
+    test("a fresher pending selection wins over an orphaned default", () => {
+      resetSettings({default_wearable: "Mentra Live", pending_wearable: "Even Realities G1"})
+      expect(projectPairingIdentity()).toEqual({kind: "pending", model: "Even Realities G1"})
+    })
+
+    test("a completed pairing wins over a stale pending marker (retire echo still in flight)", () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", pending_wearable: "Mentra Live"})
+      expect(projectPairingIdentity()).toEqual({kind: "paired", model: "Mentra Live", name: "LIVE_1"})
+    })
+
+    test("the simulated device is its own identity: paired from the model alone, name mirrors it", () => {
+      resetSettings({default_wearable: DeviceTypes.SIMULATED})
+      expect(projectPairingIdentity()).toEqual({
+        kind: "paired",
+        model: DeviceTypes.SIMULATED,
+        name: DeviceTypes.SIMULATED,
+      })
+    })
+
+    test("non-string identity values read as absent", () => {
+      resetSettings({default_wearable: null, pending_wearable: undefined, device_name: 42})
+      expect(projectPairingIdentity()).toEqual({kind: "none"})
+    })
+  })
+
+  describe("subscribePairingIdentity", () => {
+    test("fires with the new snapshot when the identity changes, dedupes when it does not", async () => {
+      const seen: unknown[] = []
+      const unsubscribe = subscribePairingIdentity((identity: unknown) => seen.push(identity))
+
+      await markPendingSelection("Even Realities G1")
+      expect(seen).toEqual([{kind: "pending", model: "Even Realities G1"}])
+
+      // A settings-store update that leaves the projection unchanged must not fire.
+      await mockSetSetting("brightness", 80)
+      await markPendingSelection("Even Realities G1")
+      expect(seen).toHaveLength(1)
+
+      unsubscribe()
+      await markPendingSelection("Mentra Live")
+      expect(seen).toHaveLength(1)
+    })
+  })
+
+  describe("identity writes", () => {
+    test("markPendingSelection writes the pending marker", async () => {
+      await markPendingSelection("Even Realities G1")
+      expect(settingsValues.pending_wearable).toBe("Even Realities G1")
+    })
+
+    test("a promoted default retires the pending selection marker", async () => {
+      resetSettings({pending_wearable: "Mentra Live"})
+      await retirePendingSelectionOnPromotion("default_wearable", "Mentra Live")
+      expect(settingsValues.pending_wearable).toBe("")
+    })
+
+    test("retire is a no-op for other keys, empty promotions, and an already-clear marker", async () => {
+      resetSettings({pending_wearable: "Mentra Live"})
+      await retirePendingSelectionOnPromotion("device_name", "LIVE_1")
+      await retirePendingSelectionOnPromotion("default_wearable", "")
+      expect(settingsValues.pending_wearable).toBe("Mentra Live")
+
+      resetSettings({})
+      await retirePendingSelectionOnPromotion("default_wearable", "Mentra Live")
+      expect(mockSetSetting).not.toHaveBeenCalled()
+    })
+
+    test("demoteDefaultToPending backfills the marker and clears the identity triplet", async () => {
+      resetSettings({default_wearable: "Mentra Live", device_name: "LIVE_1", device_address: "aa:bb"})
+      await demoteDefaultToPending("Mentra Live")
+      expect(settingsValues).toEqual({
+        pending_wearable: "Mentra Live",
+        default_wearable: "",
+        device_name: "",
+        device_address: "",
+      })
+    })
+
+    test("demoteDefaultToPending never overwrites a fresher pending selection", async () => {
+      resetSettings({default_wearable: "Mentra Live", pending_wearable: "Even Realities G1"})
+      await demoteDefaultToPending("Mentra Live")
+      expect(settingsValues.pending_wearable).toBe("Even Realities G1")
+      expect(settingsValues.default_wearable).toBe("")
+    })
+  })
+})

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -18,6 +18,12 @@ export interface Setting {
   override?: () => any
   // onWrite?: () => void
   persist: boolean
+  // Pairing-identity keys are NATIVE-authoritative: the native layer writes
+  // them on pairing success (handleDeviceReady) / forget and echoes them down
+  // via save_setting; JS→native they travel only in the explicit full seeds,
+  // never the change-push. PAIRING_IDENTITY_KEYS is derived from this flag so
+  // the sync exclusion can't drift from the descriptors.
+  nativeAuthoritative?: true
 }
 
 export const SETTINGS: Record<string, Setting> = {
@@ -237,6 +243,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   default_wearable: {
     key: "default_wearable",
@@ -244,14 +251,23 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
-  device_name: {key: "device_name", defaultValue: () => "", writable: true, saveOnServer: false, persist: true},
+  device_name: {
+    key: "device_name",
+    defaultValue: () => "",
+    writable: true,
+    saveOnServer: false,
+    persist: true,
+    nativeAuthoritative: true,
+  },
   device_address: {
     key: "device_address",
     defaultValue: () => "",
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   default_controller: {
     key: "default_controller",
@@ -259,6 +275,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   pending_controller: {
     key: "pending_controller",
@@ -266,6 +283,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   controller_device_name: {
     key: "controller_device_name",
@@ -273,6 +291,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   controller_address: {
     key: "controller_address",
@@ -280,6 +299,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    nativeAuthoritative: true,
   },
   // ui state:
   home_background: {
@@ -730,16 +750,13 @@ export const BLUETOOTH_SETTING_KEYS: string[] = [
 // gain 1: two identity values in flight (e.g. a boot demotion crossing a
 // native promotion) then chase each other through push→apply→echo→push
 // forever, flapping the UI.
-export const PAIRING_IDENTITY_KEYS: string[] = [
-  SETTINGS.pending_wearable.key,
-  SETTINGS.default_wearable.key,
-  SETTINGS.device_name.key,
-  SETTINGS.device_address.key,
-  SETTINGS.default_controller.key,
-  SETTINGS.pending_controller.key,
-  SETTINGS.controller_device_name.key,
-  SETTINGS.controller_address.key,
-]
+//
+// Derived from the `nativeAuthoritative` descriptor flag (not maintained as a
+// parallel list) so the change-push exclusion in GlassesSettingsSync can't
+// drift from the setting declarations.
+export const PAIRING_IDENTITY_KEYS: string[] = Object.values(SETTINGS)
+  .filter((setting) => setting.nativeAuthoritative)
+  .map((setting) => setting.key)
 
 // const PER_GLASSES_SETTINGS_KEYS: string[] = [SETTINGS.preferred_mic.key]
 

--- a/mobile/src/app/home.tsx
+++ b/mobile/src/app/home.tsx
@@ -24,8 +24,9 @@ import {BlurTargetView, BlurView} from "expo-blur"
 
 export default function Homepage() {
   const refreshApps = useRefresh()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const glassesConnected =
     useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange)).state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -57,12 +58,12 @@ export default function Homepage() {
     }
 
     attemptInitialConnect()
-  }, [glassesConnected, isSearching, defaultWearable])
+  }, [glassesConnected, isSearching, pairedModel])
 
   const renderContent = () => {
     // A pending selection (model chosen, pairing never completed) renders the
     // glasses card in its finish-pairing state rather than the first-run card.
-    if (!defaultWearable && !pendingWearable) {
+    if (identity.kind === "none") {
       return (
         <>
           <Group>

--- a/mobile/src/app/pairing/scan.tsx
+++ b/mobile/src/app/pairing/scan.tsx
@@ -18,7 +18,6 @@ import {useNavigationStore} from "@/stores/navigation"
 import showAlert from "@/utils/AlertUtils"
 import {PermissionFeatures, requestFeaturePermissions} from "@/utils/PermissionsUtils"
 import {getGlassesOpenImage} from "@/utils/getGlassesImage"
-import {SETTINGS, useSetting} from "@/stores/settings"
 import GlassView from "@/components/ui/GlassView"
 
 export default function SelectGlassesBluetoothScreen() {
@@ -30,7 +29,6 @@ export default function SelectGlassesBluetoothScreen() {
   const bluetoothClassicConnected = useToolkitSnapshot(toolkit.pairing.readiness, (onChange) =>
     toolkit.pairing.onReadiness(onChange),
   ).bluetoothClassicConnected
-  const [, setPendingWearable] = useSetting(SETTINGS.pending_wearable.key)
   const searchResults = useToolkitSnapshot(toolkit.pairing.searchResults, (onChange) =>
     toolkit.pairing.onFound(onChange),
   )
@@ -38,10 +36,9 @@ export default function SelectGlassesBluetoothScreen() {
 
   useEffect(() => {
     // Two-phase identity: reaching the scan screen marks the chosen model as the
-    // PENDING wearable (selection). Promotion to default_wearable only happens
-    // natively when pairing succeeds; until then the home card renders a
-    // finish-pairing affordance from this marker.
-    setPendingWearable(deviceModel)
+    // PENDING selection. Promotion to `paired` only happens natively when pairing
+    // succeeds; until then the home card renders a finish-pairing affordance.
+    toolkit.pairing.markPendingSelection(deviceModel)
   }, [])
 
   // useFocusEffect(

--- a/mobile/src/components/glasses/ConnectDeviceButton.tsx
+++ b/mobile/src/components/glasses/ConnectDeviceButton.tsx
@@ -13,8 +13,9 @@ import {checkConnectivityRequirementsUI} from "@/utils/PermissionsUtils"
 export const ConnectDeviceButton = () => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesConnected = glassesStatus.state === "connected"
   const isSearching = useToolkitSnapshot(toolkit.pairing.scanning, (onChange) => toolkit.pairing.onScanning(onChange))
@@ -31,7 +32,7 @@ export const ConnectDeviceButton = () => {
   }
 
   const connectGlasses = async () => {
-    if (!defaultWearable) {
+    if (!pairedModel) {
       push("/pairing/select-glasses-model")
       return
     }
@@ -44,13 +45,13 @@ export const ConnectDeviceButton = () => {
         return
       }
 
-      // A chosen model (default_wearable) does not imply a paired device (an
-      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // A `paired` identity snapshot does not imply a native device to connect
+      // to (the settings echo can outlive the native pairing). Without a
       // device, connectDefault() throws — route back into pairing for the
       // already-selected model instead of surfacing an error alert. Fail open
       // on a read error: connectDefault()'s catch is the pre-guard behavior.
       if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
-        push("/pairing/scan", {deviceModel: defaultWearable})
+        push("/pairing/scan", {deviceModel: pairedModel})
         return
       }
 
@@ -63,7 +64,7 @@ export const ConnectDeviceButton = () => {
 
   // New handler: if already connecting, pressing the button calls disconnect.
   const handleConnectOrDisconnect = async () => {
-    const action = decideConnectButtonAction({hasDefaultWearable: !!defaultWearable, busy})
+    const action = decideConnectButtonAction({hasDefaultWearable: !!pairedModel, busy})
     if (action === "cancel") {
       await toolkit.glasses.disconnect()
     } else {
@@ -72,21 +73,16 @@ export const ConnectDeviceButton = () => {
   }
 
   // if we have simulated glasses, show nothing:
-  if (defaultWearable.includes(DeviceTypes.SIMULATED)) {
+  if (pairedModel.includes(DeviceTypes.SIMULATED)) {
     return null
   }
 
-  // Debug the conditional logic
-  const defaultWearableNull = defaultWearable == null
-  const defaultWearableStringNull = defaultWearable == "null"
-  const defaultWearableEmpty = defaultWearable === ""
-
-  if (defaultWearableNull || defaultWearableStringNull || defaultWearableEmpty) {
+  if (identity.kind !== "paired") {
     // A pending selection (chosen model, pairing never completed) resumes the
     // scan for that model instead of restarting from model selection.
-    if (pendingWearable) {
+    if (identity.kind === "pending") {
       return (
-        <Button onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})} tx="home:finishPairingGlasses" />
+        <Button onPress={() => push("/pairing/scan", {deviceModel: identity.model})} tx="home:finishPairingGlasses" />
       )
     }
     return <Button onPress={() => push("/pairing/select-glasses-model")} tx="home:pairGlasses" />

--- a/mobile/src/components/home/DeviceStatus.tsx
+++ b/mobile/src/components/home/DeviceStatus.tsx
@@ -60,8 +60,9 @@ export const DeviceStatus = ({onPress, image, children, className = "h-28"}: Dev
 export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
-  const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
-  const [pendingWearable] = useSetting(SETTINGS.pending_wearable.key)
+  // Pairing-identity read-model: none | pending (chosen, never paired) | paired.
+  const identity = useToolkitSnapshot(toolkit.pairing.identity, (onChange) => toolkit.pairing.onIdentity(onChange))
+  const pairedModel = identity.kind === "paired" ? identity.model : ""
   const [isCheckingConnectivity, setIsCheckingConnectivity] = useState(false)
   const glassesStatus = useToolkitSnapshot(toolkit.glasses.status, (onChange) => toolkit.glasses.onStatus(onChange))
   const glassesInfo = useToolkitSnapshot(toolkit.glasses.info, (onChange) => toolkit.glasses.onInfo(onChange))
@@ -103,7 +104,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   const {wasSearching, nativeLinkBusy, resetSearching} = useSearchingState(searching, pairingReadiness.nativeLinkBusy)
 
-  if (defaultWearable.includes(DeviceTypes.SIMULATED)) {
+  if (pairedModel.includes(DeviceTypes.SIMULATED)) {
     return (
       <GlassView className="bg-primary-foreground p-5" style={style}>
         <View className="flex-row justify-between items-center mb-4">
@@ -126,7 +127,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const connectGlasses = async () => {
-    if (!defaultWearable) {
+    if (!pairedModel) {
       push("/pairing/select-glasses-model", {transition: "simple_push"})
       return
     }
@@ -137,13 +138,13 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       if (!requirementsCheck) {
         return
       }
-      // A chosen model (default_wearable) does not imply a paired device (an
-      // orphaned identity the boot demotion hasn't repaired yet). Without a
+      // A `paired` identity snapshot does not imply a native device to connect
+      // to (the settings echo can outlive the native pairing). Without a
       // native default device, connectDefault() throws — route back into
       // pairing for the already-selected model instead of erroring. Fail open
       // on a read error: connectDefault()'s catch is the pre-guard behavior.
       if (!(await toolkit.glasses.hasDefaultDevice().catch(() => true))) {
-        push("/pairing/scan", {deviceModel: defaultWearable})
+        push("/pairing/scan", {deviceModel: pairedModel})
         return
       }
       await toolkit.glasses.connectDefault()
@@ -154,7 +155,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const handleConnectOrDisconnect = async () => {
-    const action = decideConnectButtonAction({hasDefaultWearable: !!defaultWearable, busy: searching || nativeLinkBusy})
+    const action = decideConnectButtonAction({hasDefaultWearable: !!pairedModel, busy: searching || nativeLinkBusy})
     if (action === "cancel") {
       await toolkit.glasses.disconnect()
       setIsCheckingConnectivity(false)
@@ -168,15 +169,15 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   // mid-flow, or an orphaned identity demoted at boot). Offer to finish pairing
   // that model — or start over with a different one — instead of a Connect
   // button that has no device to connect to.
-  if (!defaultWearable && pendingWearable) {
+  if (identity.kind === "pending") {
     return (
       <View style={style}>
         <DeviceStatus
-          onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
-          image={getGlassesImage(pendingWearable)}>
+          onPress={() => push("/pairing/scan", {deviceModel: identity.model})}
+          image={getGlassesImage(identity.model)}>
           <View className="flex-row items-center gap-3">
             <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
-            <Text className="font-semibold text-secondary-foreground text-end self-end" text={pendingWearable} />
+            <Text className="font-semibold text-secondary-foreground text-end self-end" text={identity.model} />
           </View>
           <Button
             flex
@@ -184,7 +185,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
             className="max-h-10"
             tx="home:finishPairingGlasses"
             preset="primary"
-            onPress={() => push("/pairing/scan", {deviceModel: pendingWearable})}
+            onPress={() => push("/pairing/scan", {deviceModel: identity.model})}
           />
         </DeviceStatus>
         <Button
@@ -199,9 +200,9 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
   }
 
   const getCurrentGlassesImage = () => {
-    let image = getGlassesImage(defaultWearable)
+    let image = getGlassesImage(pairedModel)
 
-    if (defaultWearable === DeviceTypes.G1) {
+    if (pairedModel === DeviceTypes.G1) {
       let state = "folded"
       if (!caseRemoved) {
         state = caseOpen ? "case_open" : "case_close"
@@ -210,7 +211,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     }
 
     if (!caseRemoved) {
-      image = caseOpen ? getGlassesOpenImage(defaultWearable) : getGlassesClosedImage(defaultWearable)
+      image = caseOpen ? getGlassesOpenImage(pairedModel) : getGlassesClosedImage(pairedModel)
     }
 
     return image
@@ -225,7 +226,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
     _connectingText = translate("glasses:glassesAreReconnecting")
   }
 
-  const features = getModelCapabilities(defaultWearable)
+  const features = getModelCapabilities(pairedModel as DeviceTypes)
   const onPress = () => push("/miniapps/settings/main", {transition: "simple_push"})
 
   if (!glassesConnected || !glassesFullyBooted || isSearching) {
@@ -233,7 +234,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
       <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
         <View className="flex-row items-center gap-3">
           <Icon name="bluetooth-off" size={18} color={theme.colors.foreground} />
-          <Text className="font-semibold text-secondary-foreground text-end self-end" text={defaultWearable} />
+          <Text className="font-semibold text-secondary-foreground text-end self-end" text={pairedModel} />
         </View>
         {!isSearching && (
           <Button
@@ -264,7 +265,7 @@ export const GlassesStatus = ({style}: {style?: ViewStyle}) => {
 
   return (
     <DeviceStatus onPress={onPress} image={getCurrentGlassesImage()}>
-      <Text className="font-semibold text-secondary-foreground text-base" text={defaultWearable} />
+      <Text className="font-semibold text-secondary-foreground text-base" text={pairedModel} />
       <View className="flex-row items-center gap-3">
         {batteryLevel !== -1 && (
           <View className="flex-row items-center gap-1">


### PR DESCRIPTION
Stacked on #3346 (retarget to `dev` when it merges). **Expression-only refactor**: the laws #3346 established — the three-state identity lifecycle, native-authoritative identity, seed-only JS→native travel — were enforced by convention across five files. This PR restates them as structure; behavior does not change, and the diff is shaped to prove that.

## What moved where

**New: `island/src/services/PairingIdentity.ts`** owns the lifecycle as a sum type

```
{kind:"none"} | {kind:"pending", model} | {kind:"paired", model, name, address?}
```

projected from the settings keys, `paired` requiring `default_wearable` AND `device_name` — exactly native `currentDefaultDevice()` on both platforms. Exposed as `toolkit.pairing.identity()` / `onIdentity(cb)` (deduped on the projected snapshot, same style as `glasses.onStatus`).

**Single writer.** The three JS-initiated identity writes are now module methods invoked from the existing call sites:
- scan entry: `setPendingWearable(model)` → `toolkit.pairing.markPendingSelection(model)`
- DeviceEventRouter: the promotion-retires-pending rule → `retirePendingSelectionOnPromotion(key, value)`
- DeviceStoreHydration: the demotion write set (latest-selection-wins backfill + triplet clear) → `demoteDefaultToPending(model)`; the boot repair keeps only its guards. The router's generic `save_setting` persistence is the inbound echo leg and stays put.

**Host readers → read-model.** `home.tsx` (first-run gate), `DeviceStatus.tsx` (simulated check, pending card, connect gating, display reads), `ConnectDeviceButton.tsx`. `glasses.isFirstPairing()` restates itself as `identity().kind === "none"`.

**Sync ownership on the descriptor.** `Setting` gains `nativeAuthoritative?: true`, set on the eight identity keys; `PAIRING_IDENTITY_KEYS` is derived from the flag, so `diffBluetoothSettingsForPush` and the `glassesSettingsSyncDiff` test (unmodified, still green) can't drift from the declarations.

## Why behavior is unchanged

- The projection encodes two read-time alignments with rules the module already owns: a simulated `default_wearable` is `paired` from the model alone (name mirrors the model at `connectSimulated`; the demotion deliberately never touches it), and a non-simulated default without a name — the orphan population — reads as `pending`, i.e. the state the boot demotion persists it into. Since `toolkit.start()` awaits `demoteOrphanedDefaultWearable()` and the host awaits `mantle.init()` before navigating to home, storage matches the projection before these screens ever mount.
- Deliberately **not** converted: the `index.tsx` onboarding gate ("if straightforward" — it is not: it keys on raw `default_wearable` truthiness, which the sum type deliberately collapses for the orphan state; converting would move users mid-pairing past onboarding).
- `ConnectDeviceButton`'s legacy `defaultWearable == "null"` string check is subsumed by `kind !== "paired"`; the literal-"null" storage state was already rendered inconsistently across the two home cards, and the projection now gives all readers one answer.

## Test evidence

- `mobile bun run compile` ✓
- `mobile bun run test` ✓ — 53 suites / 413 tests, all pre-existing suites green **unmodified** (the island jest mock gained the new facade methods, delegating to the real projection so `scan.test.tsx` observes real store writes)
- `island bun run test` ✓ — 218 pass, including 15 new `PairingIdentity.test.ts` cases (projection truth table, dedupe, writer rules); `DeviceStoreHydration.test.ts` green unmodified
- `./scripts/check-mobile-runtime-boundary.sh` ✓ — host raw glasses-identity-key reads drop **29 → 22 sites (24 → 20 files)**; remaining are display-only readers (settings screens, OTA, mirror) outside this PR's scope

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pairing routing and identity persistence across island and home UI; behavior is intended unchanged but mistakes could mis-route first-run, finish-pairing, or connect flows.
> 
> **Overview**
> **Expression-only refactor:** pairing lifecycle rules stay the same; they live in one island module and one read-model instead of scattered settings reads/writes.
> 
> Introduces **`PairingIdentity`** with `IdentitySnapshot` (`none` | `pending` | `paired`), projection from identity settings (aligned with native `currentDefaultDevice()`, including simulated and orphan edge cases), deduped `subscribePairingIdentity`, and the only JS-initiated identity writes: `markPendingSelection`, `retirePendingSelectionOnPromotion`, and `demoteDefaultToPending`. **`toolkit.pairing`** exposes `identity()`, `onIdentity()`, and `markPendingSelection()`; **`glasses.isFirstPairing()`** is `identity().kind === "none"`.
> 
> **Call sites** now delegate: scan uses `markPendingSelection`; `DeviceEventRouter` calls `retirePendingSelectionOnPromotion`; boot demotion calls `demoteDefaultToPending`. **Home, scan, `DeviceStatus`, and `ConnectDeviceButton`** subscribe to the identity snapshot instead of `default_wearable` / `pending_wearable`.
> 
> Settings gain **`nativeAuthoritative`** on eight identity keys; **`PAIRING_IDENTITY_KEYS`** is derived from that flag so BLE change-push exclusion cannot drift. Jest’s island mock uses the real `PairingIdentity`; new **`PairingIdentity.test.ts`** covers projection, subscription dedupe, and writers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5c250c2e533fa01bda11cdfa6e68a43ee5165d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->