### PR TITLE
Fix mobile tsc resolving @mentra/bluetooth-sdk from stale build types

### DIFF
--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -8,28 +8,28 @@
   "types": "build/index.d.ts",
   "exports": {
     ".": {
-      "types": "./build/index.d.ts",
       "react-native": "./src/index.ts",
+      "types": "./build/index.d.ts",
       "default": "./build/index.js"
     },
     "./internal": {
-      "types": "./build/_internal.d.ts",
       "react-native": "./src/_internal.ts",
+      "types": "./build/_internal.d.ts",
       "default": "./build/_internal.js"
     },
     "./react": {
-      "types": "./build/react/index.d.ts",
       "react-native": "./src/react/index.ts",
+      "types": "./build/react/index.d.ts",
       "default": "./build/react/index.js"
     },
     "./photo-receiver": {
-      "types": "./build/photo-receiver/index.d.ts",
       "react-native": "./src/photo-receiver/index.ts",
+      "types": "./build/photo-receiver/index.d.ts",
       "default": "./build/photo-receiver/index.js"
     },
     "./debug": {
-      "types": "./build/debug.d.ts",
       "react-native": "./src/debug.ts",
+      "types": "./build/debug.d.ts",
       "default": "./build/debug.js"
     },
     "./_private/*": null,

--- a/mobile/src/__tests__/bluetoothSdkModuleResolution.test.ts
+++ b/mobile/src/__tests__/bluetoothSdkModuleResolution.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs"
+import * as path from "path"
+
+// Guards the invariant that `bun run compile` type-checks @mentra/bluetooth-sdk
+// against the same files Metro bundles (src/, via the "react-native" exports
+// condition), never against the gitignored build/ output. build/ is only
+// regenerated when expo-module prepare runs, so once it goes stale tsc would
+// otherwise green-light calls that are undefined at runtime — we shipped
+// exactly that once (a method present in stale build/*.d.ts but absent from
+// the src public surface).
+//
+// Two pieces make the invariant hold:
+//  1. tsc activates the "react-native" condition: customConditions comes from
+//     expo/tsconfig.base, which mobile/tsconfig.json extends.
+//  2. In every bluetooth-sdk exports entry, "react-native" precedes "types".
+//     Exports conditions match in declaration order and "types" is always
+//     active for tsc, so listing "types" first sends tsc back to build/.
+
+const mobileRoot = path.resolve(__dirname, "../..")
+
+const readJson = (filePath: string) => {
+  const raw = fs.readFileSync(filePath, "utf8")
+  try {
+    return JSON.parse(raw)
+  } catch (error) {
+    throw new Error(`Failed to parse ${filePath}: ${error}`)
+  }
+}
+
+describe("bluetooth-sdk type/runtime surface alignment", () => {
+  const packageJson = readJson(path.join(mobileRoot, "modules/bluetooth-sdk/package.json"))
+  const conditionEntries = Object.entries(packageJson.exports as Record<string, unknown>).filter(
+    ([, conditions]) => typeof conditions === "object" && conditions !== null && "react-native" in conditions,
+  ) as Array<[string, Record<string, string>]>
+
+  it("covers the conditional export subpaths", () => {
+    expect(conditionEntries.map(([subpath]) => subpath)).toEqual(
+      expect.arrayContaining([".", "./internal", "./react", "./photo-receiver", "./debug"]),
+    )
+  })
+
+  it.each(conditionEntries)("lists react-native before types for %s", (_subpath, conditions) => {
+    const keys = Object.keys(conditions)
+    expect(keys.indexOf("react-native")).toBeGreaterThanOrEqual(0)
+    expect(keys.indexOf("types")).toBeGreaterThan(keys.indexOf("react-native"))
+    expect(conditions["react-native"]).toMatch(/^\.\/src\//)
+  })
+
+  it("activates the react-native condition for tsc", () => {
+    const tsconfig = readJson(path.join(mobileRoot, "tsconfig.json"))
+    expect(tsconfig.extends).toBe("expo/tsconfig.base")
+
+    const expoBase = readJson(path.join(mobileRoot, "node_modules/expo/tsconfig.base.json"))
+    const effective = (key: string) => tsconfig.compilerOptions?.[key] ?? expoBase.compilerOptions?.[key]
+
+    expect(effective("customConditions")).toContain("react-native")
+    // customConditions only applies under these moduleResolution modes.
+    expect(["bundler", "node16", "nodenext"]).toContain(effective("moduleResolution"))
+  })
+})


### PR DESCRIPTION
## Scope

`cd mobile && bun run compile` could pass while the app crashed at runtime: tsc type-checked `@mentra/bluetooth-sdk` against `build/*.d.ts` (gitignored, regenerated only when `expo-module prepare` runs) while Metro bundles `src/*.ts` via the `react-native` exports condition. With a stale `build/`, we shipped `BluetoothSdk.updateBluetoothSettings(...)` through the public entry with a green compile, and it was `undefined` at runtime (render error).

## Root cause

The `react-native` custom condition is already active for tsc: `expo/tsconfig.base` (which `mobile/tsconfig.json` extends) sets `"customConditions": ["react-native"]` under `moduleResolution: bundler`. But exports conditions match in **declaration order**, and every bluetooth-sdk exports entry listed `"types"` before `"react-native"`. Since `types` is always active for tsc, it won every time and resolution went to `build/`.

## Change

- Reorder `"react-native"` ahead of `"types"` in each `exports` entry of `mobile/modules/bluetooth-sdk/package.json` (`.`, `./internal`, `./react`, `./photo-receiver`, `./debug`). tsc now resolves the same `src/*.ts` files Metro bundles, regardless of `build/` state. No tsconfig change needed — the condition was already inherited.
- Add `mobile/src/__tests__/bluetoothSdkModuleResolution.test.ts` pinning both halves of the invariant (exports key order, and the customConditions inheritance from `expo/tsconfig.base`), since a key-order regression is silent.

## Why other consumers are unaffected

- Resolvers without the `react-native` condition are order-insensitive here: external consumers' tsc still matches `types` → `build/`, node runtime still matches `default` → `build/`.
- The npm release job (`bluetooth-sdk-release.yml`) runs `bun run build` immediately before `npm pack`, so published `build/` types are always fresh; the Maven and SwiftPM jobs don't read the exports map. No version bump included — the next SDK release ships the reordered map as-is.
- Metro and jest already matched `react-native` (never `types`), so runtime and test resolution are unchanged.
- Checked the other local packages for the same trap: `@mentra/island` and `@mentra/cloud-client` resolve to src for both tsc and Metro (tsconfig `paths` + metro aliases + jest moduleNameMapper); `crust`, `miniapp`, and `jspolyfill` resolve types and runtime from the same files (build/dist/src respectively), so they cannot drift apart.

## Test evidence

Acceptance probe: a temp app file calling `BluetoothSdk.updateBluetoothSettings({})` through the public entry (the method exists only on the private module, so a correct compile must reject it).

| `build/` state | probe | before | after |
|---|---|---|---|
| stale `build/*.d.ts` widened with a fake public `updateBluetoothSettings` (incident repro) | present | compile **green** | **fails** `TS2339` on the probe line |
| deleted | present | fails with module-not-found everywhere | fails only on the probe (`TS2339`) |
| deleted | removed | fails with module-not-found everywhere | **green** |

Probe removed after verification. Gates: `cd mobile && bun run compile` passes and `bun run test` passes (40 suites, 319 tests, includes the new guard).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized package.json export ordering plus a unit test; Metro/runtime resolution was already on `react-native`, and external consumers without that condition still use `types`/`default` to `build/`.
> 
> **Overview**
> Fixes a **type-check vs runtime mismatch** for `@mentra/bluetooth-sdk` in the mobile app: `bun run compile` could pass while Metro bundled different sources, so calls could type-check against stale `build/*.d.ts` and be **undefined** at runtime.
> 
> **`mobile/modules/bluetooth-sdk/package.json`** — For each conditional export (`.`, `./internal`, `./react`, `./photo-receiver`, `./debug`), **`"react-native"` is listed before `"types"`**. With Expo’s `customConditions` including `react-native`, tsc now resolves the same `./src/*` entrypoints Metro uses instead of always winning on `types` → `build/`.
> 
> **`mobile/src/__tests__/bluetoothSdkModuleResolution.test.ts`** — Regression guard: export key order per subpath, `react-native` targets under `src/`, and mobile tsconfig still inherits `react-native` from `expo/tsconfig.base`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 941dad1ba7e15f654455b9c81504f10c9e488b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->