### PR TITLE
Fix dev compile: route the OTA super-skip through a facade discard()

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -591,6 +591,7 @@ const mockIslandEntries = () => {
           detach: jest.fn(() => realOtaInstallCoordinator.otaInstallCoordinator.detach()),
           retry: jest.fn(() => realOtaInstallCoordinator.otaInstallCoordinator.retry()),
           finish: jest.fn(() => realOtaInstallCoordinator.otaInstallCoordinator.finish()),
+          discard: jest.fn(() => realOtaInstallCoordinator.otaInstallCoordinator.discard()),
           snapshot: jest.fn(() => realOtaInstallCoordinator.otaInstallCoordinator.snapshot()),
           onSnapshot: jest.fn((cb) => realOtaInstallCoordinator.otaInstallCoordinator.onSnapshot(cb)),
         },

--- a/mobile/modules/island/src/facades/ota.ts
+++ b/mobile/modules/island/src/facades/ota.ts
@@ -123,6 +123,8 @@ export const ota = {
     retry: () => otaInstallCoordinator.retry(),
     /** Terminal cleanup for Continue/Done (navigation stays in the screen). */
     finish: () => otaInstallCoordinator.finish(),
+    /** Abandon an interrupted session (super-mode skip): finish() + drop the session's status/progress. */
+    discard: () => otaInstallCoordinator.discard(),
     /** Current install read model (displayState/errorMsg/lockout + glasses OTA data). */
     snapshot: (): OtaInstallSnapshot => otaInstallCoordinator.snapshot(),
     /** Subscribe to install snapshot changes (deduped on projected JSON). Returns an unsubscribe. */

--- a/mobile/modules/island/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/island/src/services/OtaInstallCoordinator.ts
@@ -296,6 +296,19 @@ class OtaInstallCoordinator {
     }
   }
 
+  /**
+   * Abandon an interrupted session (the super-mode skip): terminal cleanup
+   * plus dropping the session's status/progress read-state, so
+   * deriveDisplayState doesn't resurrect the stale install when the host
+   * navigates away and back through /ota routes.
+   */
+  discard(): void {
+    this.finish()
+    const store = useGlassesStore.getState()
+    store.setOtaStatus(null)
+    store.setOtaProgress(null)
+  }
+
   snapshot(): OtaInstallSnapshot {
     const state = useGlassesStore.getState()
     const connected = isGlassesConnected(state.connection)

--- a/mobile/src/app/ota/progress.tsx
+++ b/mobile/src/app/ota/progress.tsx
@@ -11,7 +11,6 @@ import {useToolkitSnapshot} from "@/hooks/useToolkitSnapshot"
 import {getOtaErrorMessage, shouldShowChangeWifiForOtaDownloadFailure} from "@/utils/otaErrorMapping"
 import {useNavigationStore} from "@/stores/navigation"
 import {SETTINGS, useSetting} from "@/stores/settings"
-import {useGlassesStore} from "@/stores/glasses"
 
 /**
  * Pure renderer over the island OTA install state machine
@@ -81,10 +80,7 @@ export default function OtaProgressScreen() {
   }, [push])
 
   const handleSkipSuper = useCallback(() => {
-    toolkit.ota.installSession.finish()
-    const store = useGlassesStore.getState()
-    store.setOtaStatus(null)
-    store.setOtaProgress(null)
+    toolkit.ota.installSession.discard()
     replace("/ota/check-for-updates")
   }, [replace])
 


### PR DESCRIPTION
## What broke

Dev's mobile TypeScript check (and the runtime-boundary check) fail at HEAD — which blocks the mobile jobs on **every open PR**. #3355 (super-mode skip on `/ota/progress`) merged on a green CI run that predated #3331 landing, and it imports `@/stores/glasses`, which #3331 deleted:

```
src/app/ota/progress.tsx:14 - error TS2307: Cannot find module '@/stores/glasses'
```

## Fix

The skip handler needed something the OTA facade didn't offer: clearing the interrupted session's `otaStatus`/`otaProgress` so `deriveDisplayState` can't resurrect the stale install after bailing to `/ota/check-for-updates`. That responsibility moves behind the facade:

- `OtaInstallCoordinator.discard()` — `finish()` plus dropping the session's status/progress read-state
- exposed as `toolkit.ota.installSession.discard()`
- `progress.tsx` goes back to being a pure renderer (no store imports); behavior of the Skip button is unchanged
- the jest toolkit mock delegates `discard` to the real coordinator like the other `installSession` commands

## Test evidence

- mobile `tsc --noEmit` clean (was failing on dev HEAD)
- `check-mobile-runtime-boundary.sh` passes, allowlist empty (dev HEAD also violates the failing `useGlassesStore` pattern)
- mobile jest: 54 suites / 424 tests pass, including #3355's 22 progress-screen tests unchanged
- island standalone tsc clean; island `bun test src`: 220 pass

Recommend merging this ahead of other queued PRs so their mobile checks green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small facade addition and a one-line screen change; no auth or new OTA protocol behavior beyond consolidating existing skip cleanup behind island.
> 
> **Overview**
> Fixes mobile TypeScript and the runtime-boundary check after the glasses store moved into island: the super-mode **Skip** handler no longer imports `@/stores/glasses` or mutates `otaStatus`/`otaProgress` directly.
> 
> **`OtaInstallCoordinator.discard()`** runs the same terminal cleanup as `finish()` and also nulls install status/progress so `deriveDisplayState` does not resurrect a stale in-progress UI when leaving `/ota/progress` and returning on other OTA routes.
> 
> The change is wired through **`toolkit.ota.installSession.discard()`** on the OTA facade; **`progress.tsx`** calls it from `handleSkipSuper`. The Jest island mock delegates `discard` to the real coordinator like the other `installSession` commands. Super-mode skip behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594e1e6a1aff08f91875148b1451632b351a4c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->