### PR TITLE
Retry gallery status query so the sync button appears after a slow glasses boot

### DIFF
--- a/mobile/modules/island/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/island/src/services/asg/gallerySyncService.ts
@@ -13,7 +13,7 @@ import WifiManager from "react-native-wifi-reborn"
 
 import {useGallerySyncStore, HotspotInfo} from "../../stores/gallerySync"
 import {selectGlassesConnected, useGlassesStore} from "../../stores/glasses"
-import {isGlassesConnected} from "../GlassesReadiness"
+import {isGlassesConnected, waitForGlassesReady} from "../GlassesReadiness"
 import {SETTINGS, useSettingsStore} from "../../stores/settings"
 import {PhotoInfo, CaptureGroup} from "../../types/asg"
 import GlobalEventEmitter from "../../utils/GlobalEventEmitter"
@@ -46,6 +46,13 @@ const TIMING = {
   // Cap the native location-services (GPS) check so a hung CrustModule call can't freeze
   // the sync pre-flight (mirrors the host's former PermissionsUtils guard).
   LOCATION_SERVICES_CHECK_TIMEOUT_MS: 5000,
+  // Gallery status query resilience (incident 4127a9ca): the glasses SOC can be
+  // mid-boot right after a (re)connect and miss the query, so wait for it to report
+  // ready and retry a few times instead of silently giving up — otherwise the
+  // "Sync N items" button never appears even though there are photos to sync.
+  GALLERY_STATUS_MAX_ATTEMPTS: 3,
+  GALLERY_STATUS_RETRY_DELAY_MS: 3000,
+  GALLERY_STATUS_READY_TIMEOUT_MS: 15000,
 } as const
 
 type SyncManifestData = {
@@ -76,6 +83,10 @@ class GallerySyncService {
   private wifiSettingsOpenedAt: number | null = null // Timestamp when user was sent to WiFi settings
   private syncStartPromise: Promise<void> | null = null
   private startAborted = false
+  // Coalesces overlapping gallery status queries — the native layer rejects a
+  // second query while one is in flight, and queryGlassesGalleryStatus() already
+  // retries internally, so a concurrent caller would just collide.
+  private galleryStatusQueryInFlight = false
 
   private constructor() {}
 
@@ -149,6 +160,7 @@ class GallerySyncService {
     }
 
     this.syncStartPromise = null
+    this.galleryStatusQueryInFlight = false
     this.isInitialized = false
     console.log("[GallerySyncService] Cleaned up")
   }
@@ -2137,13 +2149,60 @@ class GallerySyncService {
   }
 
   /**
-   * Query glasses for gallery status
+   * Query glasses for gallery status.
+   *
+   * This is a single BLE round-trip: we send `query_gallery_status` and wait for
+   * the glasses to answer with a `gallery_status` event, which populates
+   * `glassesGalleryStatus` — and therefore whether the Gallery screen's
+   * "Sync N items" button appears. If the glasses SOC isn't ready to answer (e.g.
+   * it's still booting right after a (re)connect) the round-trip times out; we
+   * used to swallow that error and never retry, so the sync button silently never
+   * appeared even when there were photos to sync (incident 4127a9ca — the SOC
+   * reported ready ~8s into the query's 15s timeout, and nothing re-queried).
+   *
+   * So: wait (bounded) for the glasses to report ready before each attempt and
+   * retry a few times on failure. The readiness flag can lag reality, so we still
+   * fire the query even if the wait times out — as long as the link is up.
    */
   async queryGlassesGalleryStatus(): Promise<void> {
+    if (this.galleryStatusQueryInFlight) {
+      console.log("[GallerySyncService] Gallery status query already in flight — skipping duplicate")
+      return
+    }
+    this.galleryStatusQueryInFlight = true
     try {
-      await BluetoothSdk.queryGalleryStatus()
-    } catch (error) {
-      console.error("[GallerySyncService] Failed to query gallery status:", error)
+      for (let attempt = 1; attempt <= TIMING.GALLERY_STATUS_MAX_ATTEMPTS; attempt++) {
+        // Give a mid-boot SOC time to come up before firing — resolves immediately
+        // when the glasses already report ready.
+        await waitForGlassesReady({
+          getConnection: () => useGlassesStore.getState().connection,
+          subscribe: (listener) => useGlassesStore.subscribe((state) => state.connection, listener),
+          timeoutMs: TIMING.GALLERY_STATUS_READY_TIMEOUT_MS,
+        })
+
+        // Nothing to query if the glasses are gone.
+        if (!isGlassesConnected(useGlassesStore.getState().connection)) {
+          console.log("[GallerySyncService] Glasses not connected — abandoning gallery status query")
+          return
+        }
+
+        try {
+          await BluetoothSdk.queryGalleryStatus()
+          return // handleGalleryStatus() updated the store from the glasses' reply
+        } catch (error) {
+          console.error(
+            `[GallerySyncService] Failed to query gallery status (attempt ${attempt}/${TIMING.GALLERY_STATUS_MAX_ATTEMPTS}):`,
+            error,
+          )
+          if (attempt < TIMING.GALLERY_STATUS_MAX_ATTEMPTS) {
+            await new Promise<void>((resolve) =>
+              BgTimer.setTimeout(() => resolve(), TIMING.GALLERY_STATUS_RETRY_DELAY_MS),
+            )
+          }
+        }
+      }
+    } finally {
+      this.galleryStatusQueryInFlight = false
     }
   }
 

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -194,6 +194,72 @@ describe("GallerySyncService", () => {
     )
   })
 
+  describe("queryGlassesGalleryStatus", () => {
+    // Regression coverage for incident 4127a9ca: the glasses SOC was still booting
+    // when the Gallery screen fired its one-shot status query, so the BLE round-trip
+    // timed out. The old code swallowed the error and never retried, so the
+    // "Sync N items" button silently never appeared. Now we retry.
+    const READY = {connection: {state: "connected" as const, fullyBooted: true}}
+
+    it("retries and recovers when a later attempt succeeds", async () => {
+      useGlassesStore.getState().setGlassesInfo(READY)
+      const queryMock = BluetoothSdk.queryGalleryStatus as jest.Mock
+      queryMock.mockReset()
+      queryMock.mockRejectedValueOnce({code: "ERR_UNEXPECTED"}).mockResolvedValueOnce(undefined)
+
+      const promise = gallerySyncService.queryGlassesGalleryStatus()
+      // Advance past the inter-attempt retry delay so the second attempt runs.
+      await jest.advanceTimersByTimeAsync(3000)
+      await promise
+
+      expect(queryMock).toHaveBeenCalledTimes(2)
+    })
+
+    it("gives up after the max attempts without throwing", async () => {
+      useGlassesStore.getState().setGlassesInfo(READY)
+      const queryMock = BluetoothSdk.queryGalleryStatus as jest.Mock
+      queryMock.mockReset()
+      queryMock.mockRejectedValue({code: "ERR_UNEXPECTED"})
+
+      const promise = gallerySyncService.queryGlassesGalleryStatus()
+      await jest.advanceTimersByTimeAsync(3000 * 3)
+      await expect(promise).resolves.toBeUndefined()
+
+      expect(queryMock).toHaveBeenCalledTimes(3)
+    })
+
+    it("does not query when the glasses are disconnected", async () => {
+      useGlassesStore.getState().setGlassesInfo({connection: {state: "disconnected"}})
+      const queryMock = BluetoothSdk.queryGalleryStatus as jest.Mock
+      queryMock.mockReset()
+
+      const promise = gallerySyncService.queryGlassesGalleryStatus()
+      // Not ready and never becomes ready — the bounded wait times out, then we bail.
+      await jest.advanceTimersByTimeAsync(15000)
+      await promise
+
+      expect(queryMock).not.toHaveBeenCalled()
+    })
+
+    it("coalesces overlapping queries onto the in-flight one", async () => {
+      useGlassesStore.getState().setGlassesInfo(READY)
+      const queryMock = BluetoothSdk.queryGalleryStatus as jest.Mock
+      queryMock.mockReset()
+      let resolveQuery: () => void = () => {}
+      queryMock.mockImplementation(() => new Promise<void>((resolve) => (resolveQuery = resolve)))
+
+      const first = gallerySyncService.queryGlassesGalleryStatus()
+      // Let the first call get past waitForGlassesReady and invoke the BLE query.
+      await jest.advanceTimersByTimeAsync(0)
+      await gallerySyncService.queryGlassesGalleryStatus() // second call — coalesced, returns immediately
+
+      expect(queryMock).toHaveBeenCalledTimes(1)
+
+      resolveQuery()
+      await first
+    })
+  })
+
   it("cancels an active sync if glasses disconnect", () => {
     gallerySyncService.initialize()
     useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})


### PR DESCRIPTION
## Incident

[`4127a9ca-1359-4460-b95c-110f8f3babd9`](https://console.mentra.glass/admin/incidents/4127a9ca-1359-4460-b95c-110f8f3babd9) — *"Cannot gallery sync w Mentra Live. Does not show button to sync."* (iOS, Mentra Live, severity 5)

## Root cause

The Gallery screen's **"Sync N items"** button is gated on `glassesGalleryStatus.hasContent`. That flag is only set when the glasses answer a `query_gallery_status` BLE round-trip with a `gallery_status` event. The screen fires that query **exactly once, on mount** (`toolkit.gallery.refreshStatus()`), and `queryGlassesGalleryStatus()` swallowed any error with no retry.

If the glasses SOC isn't ready to answer yet — e.g. it's still booting right after a (re)connect — the round-trip times out (~15s, `ERR_UNEXPECTED`). The result: `hasContent` stays `false`, the sync button silently never appears, and nothing re-queries. No user-visible feedback.

From the incident phone logs:

```
t+0.0s  LIVE: 📸 Querying gallery status from glasses  (characteristic write OK)
t+8.2s  CORE: K900 SOC ready          ← SOC only becomes ready mid-timeout
t+15.0s [GallerySyncService] Failed to query gallery status: {"code":"ERR_UNEXPECTED"}
        (nothing re-queries → button never shows)
```

A retry a few seconds later — after the SOC was ready — would have succeeded.

## Fix

Make `queryGlassesGalleryStatus()` resilient (island `gallerySyncService`):

- **Wait (bounded) for the glasses to report ready** before each attempt, using the existing `waitForGlassesReady` primitive. Resolves immediately when already ready.
- **Retry up to 3× with a 3s delay** on failure. The readiness flag can lag reality (it did in this incident), so we still fire the query even if the ready-wait times out — as long as the BLE link is up.
- **Concurrency guard** coalesces overlapping callers (screen re-mount, post-sync refresh) onto the single in-flight query, since the native layer rejects a second query while one is pending.

## Branch scope

The bug logic exists on **both dev and staging**, but the gallery sync code lives in **different files**:

- **dev** (this PR's base): migrated into the island module — `mobile/modules/island/src/services/asg/gallerySyncService.ts`. This is dev's live path and what this PR fixes.
- **staging** (the incident build's path): still the legacy `mobile/src/services/asg/gallerySyncService.ts` (deleted on dev). Staging picks up this fix via the normal dev→staging merge, which also carries the island migration. No separate staging PR is needed unless we want an immediate staging-only hotfix against the legacy file.

## Testing

- `npx jest gallerySyncService` — 22 passed (4 new: retry-and-recover, give-up-after-max-attempts, skip-when-disconnected, coalescing).
- `npx jest galleryFacade` — passed.
- `tsc --noEmit` — 0 errors.
- Not hardware-tested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to gallery status polling with bounded retries and existing readiness helper; no auth or sync download path changes. Residual risk is slightly longer Gallery load when glasses stay unresponsive.
> 
> **Overview**
> Fixes a case where the Gallery **"Sync N items"** button never appeared after reconnect because the one-shot `query_gallery_status` BLE round-trip timed out while the glasses SOC was still booting, and failures were swallowed with no retry.
> 
> **`queryGlassesGalleryStatus`** now waits (bounded, via `waitForGlassesReady`) before each attempt, retries up to **3×** with a **3s** delay, still queries if the ready wait times out but BLE is connected, skips when disconnected, and **coalesces** overlapping callers so native rejects only one in-flight query. Timing constants and cleanup reset the in-flight guard.
> 
> Adds **four Jest tests** for retry recovery, max attempts, disconnected skip, and coalescing (incident 4127a9ca).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 973932a4f8e383bb0239b6b67f194877b7bdc684. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the gallery status BLE query and waits for glasses readiness so the Gallery "Sync N items" button appears after a slow boot or reconnect. Adds a concurrency guard to prevent duplicate queries.

- **Bug Fixes**
  - Waits (up to 15s) for glasses to report ready before each attempt; still fires if the wait times out and BLE is connected.
  - Retries up to 3 times with a 3s backoff on failure.
  - Coalesces overlapping calls into a single in-flight query and skips when disconnected.

<sup>Written for commit 973932a4f8e383bb0239b6b67f194877b7bdc684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

