### PR TITLE
Remove the offline captions built-in; migrate its stale mic-gate flag

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -146,10 +146,6 @@ class DeviceManager {
         get() = DeviceStore.store.get("bluetooth", "bypass_vad") as? Boolean ?: false
         set(value) = DeviceStore.apply("bluetooth", "bypass_vad", value)
 
-    private var offlineCaptionsRunning: Boolean
-        get() = DeviceStore.store.get("bluetooth", "offline_captions_running") as? Boolean ?: false
-        set(value) = DeviceStore.apply("bluetooth", "offline_captions_running", value)
-
     private var localSttFallbackActive: Boolean
         get() = DeviceStore.store.get("bluetooth", "local_stt_fallback_active") as? Boolean ?: false
         set(value) = DeviceStore.apply("bluetooth", "local_stt_fallback_active", value)
@@ -749,7 +745,7 @@ class DeviceManager {
         // class to fire `vad_status` (a separate signal the cloud SDK
         // surfaces as `session.audio.isSpeaking`).
         handleSendingPcm(pcmData)
-        if (shouldSendTranscript || offlineCaptionsRunning || localSttFallbackActive) {
+        if (shouldSendTranscript || localSttFallbackActive) {
             if (ensureTranscriberInitialized()) {
                 transcriber?.acceptAudio(pcmData)
             }
@@ -1776,7 +1772,7 @@ class DeviceManager {
 
     fun setMicState() {
         val willSendPcm = shouldSendPcm || shouldSendLc3
-        val willSendTranscript = shouldSendTranscript || offlineCaptionsRunning || localSttFallbackActive
+        val willSendTranscript = shouldSendTranscript || localSttFallbackActive
         val nextEnabled = willSendPcm || willSendTranscript
         // Tell VAD when the mic is shutting down so it doesn't get stuck in
         // a stale "speaking" state and keep emitting vad_status=true after

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -303,12 +303,6 @@ object DeviceStore {
                     DeviceManager.getInstance().setMicState()
                 }
             }
-            "bluetooth" to "offline_captions_running" -> {
-                (value as? Boolean)?.let { running ->
-                    Bridge.log("DeviceStore: offline_captions_running changed to $running")
-                    DeviceManager.getInstance().setMicState()
-                }
-            }
             "bluetooth" to "local_stt_fallback_active" -> {
                 (value as? Boolean)?.let { active ->
                     Bridge.log("DeviceStore: local_stt_fallback_active changed to $active")

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/DeviceStatus.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/DeviceStatus.kt
@@ -255,7 +255,6 @@ internal data class BluetoothStatus(
     val shouldSendPcm: Boolean,
     val shouldSendLc3: Boolean,
     val shouldSendTranscript: Boolean,
-    val offlineCaptionsRunning: Boolean,
     val localSttFallbackActive: Boolean,
     val shouldSendBootingMessage: Boolean,
 ) {
@@ -307,7 +306,6 @@ internal data class BluetoothStatus(
             "should_send_pcm" to shouldSendPcm,
             "should_send_lc3" to shouldSendLc3,
             "should_send_transcript" to shouldSendTranscript,
-            "offline_captions_running" to offlineCaptionsRunning,
             "local_stt_fallback_active" to localSttFallbackActive,
             "shouldSendBootingMessage" to shouldSendBootingMessage,
         )
@@ -354,7 +352,6 @@ internal data class BluetoothStatus(
                 shouldSendPcm = boolValue(values, "should_send_pcm") ?: false,
                 shouldSendLc3 = boolValue(values, "should_send_lc3") ?: false,
                 shouldSendTranscript = boolValue(values, "should_send_transcript") ?: false,
-                offlineCaptionsRunning = boolValue(values, "offline_captions_running") ?: false,
                 localSttFallbackActive = boolValue(values, "local_stt_fallback_active") ?: false,
                 shouldSendBootingMessage = boolValue(values, "shouldSendBootingMessage") ?: true,
             )
@@ -558,7 +555,6 @@ internal data class BluetoothStatusUpdate(
     val shouldSendPcm: Boolean? = null,
     val shouldSendLc3: Boolean? = null,
     val shouldSendTranscript: Boolean? = null,
-    val offlineCaptionsRunning: Boolean? = null,
     val localSttFallbackActive: Boolean? = null,
     val shouldSendBootingMessage: Boolean? = null,
 ) {
@@ -600,7 +596,6 @@ internal data class BluetoothStatusUpdate(
             putIfNotNull("should_send_pcm", shouldSendPcm)
             putIfNotNull("should_send_lc3", shouldSendLc3)
             putIfNotNull("should_send_transcript", shouldSendTranscript)
-            putIfNotNull("offline_captions_running", offlineCaptionsRunning)
             putIfNotNull("local_stt_fallback_active", localSttFallbackActive)
             putIfNotNull("shouldSendBootingMessage", shouldSendBootingMessage)
         }
@@ -650,7 +645,6 @@ internal data class BluetoothStatusUpdate(
                 shouldSendPcm = optionalBoolValue(values, "should_send_pcm"),
                 shouldSendLc3 = optionalBoolValue(values, "should_send_lc3"),
                 shouldSendTranscript = optionalBoolValue(values, "should_send_transcript"),
-                offlineCaptionsRunning = optionalBoolValue(values, "offline_captions_running"),
                 localSttFallbackActive = optionalBoolValue(values, "local_stt_fallback_active"),
                 shouldSendBootingMessage = optionalBoolValue(values, "shouldSendBootingMessage"),
             )

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -186,11 +186,6 @@ struct ViewState {
         set { DeviceStore.shared.apply("bluetooth", "bypass_vad", newValue) }
     }
 
-    private var offlineCaptionsRunning: Bool {
-        get { DeviceStore.shared.get("bluetooth", "offline_captions_running") as? Bool ?? false }
-        set { DeviceStore.shared.apply("bluetooth", "offline_captions_running", newValue) }
-    }
-
     private var localSttFallbackActive: Bool {
         get { DeviceStore.shared.get("bluetooth", "local_stt_fallback_active") as? Bool ?? false }
         set { DeviceStore.shared.apply("bluetooth", "local_stt_fallback_active", newValue) }
@@ -427,7 +422,7 @@ struct ViewState {
 
         // Send PCM to local transcriber.
 #if !SWIFT_PACKAGE || MENTRA_FEATURE_LOCAL_STT
-        if shouldSendTranscript || offlineCaptionsRunning || localSttFallbackActive {
+        if shouldSendTranscript || localSttFallbackActive {
             transcriber?.acceptAudio(pcm16le: pcmData)
         }
 #endif
@@ -1431,7 +1426,7 @@ struct ViewState {
 
     func setMicState() {
         let willSendPcm = shouldSendPcm || shouldSendLc3
-        let willSendTranscript = shouldSendTranscript || offlineCaptionsRunning || localSttFallbackActive
+        let willSendTranscript = shouldSendTranscript || localSttFallbackActive
         micEnabled = willSendPcm || willSendTranscript
         updateMicState()
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -273,11 +273,6 @@ class DeviceStore {
                 DeviceManager.shared.setMicState()
             }
 
-        case ("bluetooth", "offline_captions_running"):
-            if let running = value as? Bool {
-                DeviceManager.shared.setMicState()
-            }
-
         case ("bluetooth", "local_stt_fallback_active"):
             if let active = value as? Bool {
                 DeviceManager.shared.setMicState()

--- a/mobile/modules/bluetooth-sdk/ios/Source/status/DeviceStatus.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/status/DeviceStatus.swift
@@ -580,10 +580,6 @@ struct BluetoothStatus: CustomStringConvertible {
         boolValue(values, "should_send_transcript") ?? false
     }
 
-    var offlineCaptionsRunning: Bool {
-        boolValue(values, "offline_captions_running") ?? false
-    }
-
     var localSttFallbackActive: Bool {
         boolValue(values, "local_stt_fallback_active") ?? false
     }
@@ -946,10 +942,6 @@ struct BluetoothStatusUpdate: CustomStringConvertible {
 
     var shouldSendTranscript: Bool? {
         optionalBoolValue(values, "should_send_transcript")
-    }
-
-    var offlineCaptionsRunning: Bool? {
-        optionalBoolValue(values, "offline_captions_running")
     }
 
     var localSttFallbackActive: Bool? {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -1283,7 +1283,6 @@ export type BluetoothSettingsUpdate = Partial<{
   should_send_lc3: boolean
   should_send_transcript: boolean
   offline_mode: boolean
-  offline_captions_running: boolean
   local_stt_fallback_active: boolean
   pending_wearable: DeviceModel | ""
   default_wearable: DeviceModel | ""

--- a/mobile/modules/island/src/facades/glassesSettings.ts
+++ b/mobile/modules/island/src/facades/glassesSettings.ts
@@ -28,7 +28,6 @@ const INTERNAL_KEYS = new Set<string>([
   SETTINGS.controller_address.key,
   // internal runtime flags
   SETTINGS.local_stt_fallback_active.key,
-  SETTINGS.offline_captions_running.key,
 ])
 const DEVICE_KEYS = BLUETOOTH_SETTING_KEYS.filter((k) => !INTERNAL_KEYS.has(k))
 

--- a/mobile/modules/island/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/island/src/services/LocalMiniappRuntime.ts
@@ -158,7 +158,6 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | nul
 const LOG_TAG = "LOCAL_MINIAPP"
 const SYSTEM_MINIAPP_PACKAGES = new Set([
   "com.mentra.camera",
-  "com.mentra.offline_captions",
   "com.mentra.gallery",
   "com.mentra.settings",
   "com.mentra.simulated",

--- a/mobile/modules/island/src/stores/bluetoothSettingKeys.ts
+++ b/mobile/modules/island/src/stores/bluetoothSettingKeys.ts
@@ -12,7 +12,6 @@ export const MENTRA_LIVE_SETTING_KEYS: string[] = [
   "button_max_recording_time",
   "camera_fov",
   "offline_mode",
-  "offline_captions_running",
   "local_stt_fallback_active",
   "gallery_mode",
   "default_wearable",

--- a/mobile/modules/island/src/stores/settings.ts
+++ b/mobile/modules/island/src/stores/settings.ts
@@ -584,13 +584,6 @@ export const SETTINGS: Record<string, Setting> = {
   },
   // offline applets
   offline_mode: {key: "offline_mode", defaultValue: () => false, writable: true, saveOnServer: true, persist: true},
-  offline_captions_running: {
-    key: "offline_captions_running",
-    defaultValue: () => false,
-    writable: true,
-    saveOnServer: true,
-    persist: true,
-  },
   // Runtime flag: coordinator flips this on when cloud STT has failed and fallback is active.
   // Native GlassesStore watches it to gate PCM → Sherpa feeding. Not user-facing.
   local_stt_fallback_active: {
@@ -736,7 +729,6 @@ export const BLUETOOTH_SETTING_KEYS: string[] = [
   SETTINGS.controller_address.key,
   // offline applets:
   SETTINGS.offline_mode.key,
-  SETTINGS.offline_captions_running.key,
   // Runtime flag flipped by LocalSttFallbackCoordinator. Native reads it from
   // GlassesStore to gate PCM → Sherpa feeding in handlePcm and to keep the
   // mic on while local STT is the active engine.

--- a/mobile/src/app/miniapps/settings/speech.tsx
+++ b/mobile/src/app/miniapps/settings/speech.tsx
@@ -39,7 +39,6 @@ export default function SpeechSettingsScreen() {
   const [autoStatus, setAutoStatus] = useState<DownloadStatus | null>(offlineSpeechModelService.getStatus())
 
   const [isLoading, setIsLoading] = useState(true)
-  const [_offlineCaptionsAppRunning, setOfflineCaptionsAppRunning] = useSetting(SETTINGS.offline_captions_running.key)
   const [_enforceLocalTranscription, setEnforceLocalTranscription] = useSetting(
     SETTINGS.enforce_local_transcription.key,
   )
@@ -73,8 +72,6 @@ export default function SpeechSettingsScreen() {
           onPress: async () => {
             if (!offlineMode) {
               await stopAllApps()
-            } else {
-              setOfflineCaptionsAppRunning(false)
             }
             setOfflineMode(!offlineMode)
           },

--- a/mobile/src/components/glasses/OtaProgressSection.tsx
+++ b/mobile/src/components/glasses/OtaProgressSection.tsx
@@ -4,6 +4,7 @@ import {View, ViewStyle, TextStyle} from "react-native"
 import {Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {ThemedStyle, type Theme} from "@/theme"
+import GlassView from "../ui/GlassView"
 
 interface OtaProgressSectionProps {
   otaProgress: OtaProgress | null
@@ -21,7 +22,7 @@ export default function OtaProgressSection({otaProgress}: OtaProgressSectionProp
   const showByteCount = otaProgress.stage === "download" && otaProgress.totalBytes > 0
 
   return (
-    <View style={themed($container)}>
+    <GlassView style={themed($container)}>
       <Text style={[themed($subtitle), {marginBottom: theme.spacing.s2}]}>Mentra Live Software Update</Text>
 
       <View style={themed($progressItem)}>
@@ -49,7 +50,7 @@ export default function OtaProgressSection({otaProgress}: OtaProgressSectionProp
           </>
         )}
       </View>
-    </View>
+    </GlassView>
   )
 }
 

--- a/mobile/src/components/settings/DeviceSettingsSection.tsx
+++ b/mobile/src/components/settings/DeviceSettingsSection.tsx
@@ -192,7 +192,7 @@ export function DeviceSettingsSection() {
       )}
 
       {/* OTA Progress — OTA-capable glasses in super mode */}
-      {superMode && glassesConnected && features?.hasOta && <OtaProgressSection otaProgress={otaProgress} />}
+      {superMode && glassesConnected && features?.hasOta && otaProgress?.progress && otaProgress?.progress < 100 && <OtaProgressSection otaProgress={otaProgress} />}
 
       {/* Nex Developer Settings — Mentra Display only */}
       {defaultWearable && defaultWearable.includes(DeviceTypes.NEX) && (

--- a/mobile/src/constants/miniapps.ts
+++ b/mobile/src/constants/miniapps.ts
@@ -1,5 +1,4 @@
 export const cameraPackageName = "com.mentra.camera"
-export const captionsPackageName = "com.mentra.offline_captions"
 export const galleryPackageName = "com.mentra.gallery"
 export const settingsPackageName = "com.mentra.settings"
 export const simulatedPackageName = "com.mentra.simulated"
@@ -14,16 +13,15 @@ export const isChinaBuild = (): boolean => process.env.EXPO_PUBLIC_DEPLOYMENT_RE
 
 /**
  * Apps that are not shipped in the China build: Mentra Map (navigation),
- * Offline Captions, Notify, and Feedback. Enforced at every registration
- * surface — bundled-miniapp install, the offline-app catalog, and the
- * post-process filter that the cloud/local merge flows through.
+ * Notify, and Feedback. Enforced at every registration surface —
+ * bundled-miniapp install, the offline-app catalog, and the post-process
+ * filter that the cloud/local merge flows through.
  */
-export const CHINA_HIDDEN_APPS = [navigationPackageName, captionsPackageName, notifyPackageName, feedbackPackageName]
+export const CHINA_HIDDEN_APPS = [navigationPackageName, notifyPackageName, feedbackPackageName]
 
 // these apps cannot be uninstalled:
 export const SYSTEM_APPS = [
   cameraPackageName,
-  captionsPackageName,
   galleryPackageName,
   settingsPackageName,
   simulatedPackageName,

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -648,9 +648,6 @@ const en = {
   },
   transcription: {
     downloadModelToEnableLocalTranscription: "Download a model to enable local transcription",
-    noModelInstalled: "No Speech Model Installed",
-    noModelInstalledMessage: "To use offline Live Captions, you need to download a speech recognition model first.",
-    goToSettings: "Go to Settings",
   },
   profileSettings: {
     title: "Profile Settings",
@@ -1026,13 +1023,12 @@ const en = {
     camera: "Camera",
     settings: "Settings",
     liveCaptions: "Live Captions",
-    offlineCaptions: "Offline Captions",
     mirror: "Glasses Mirror",
     simulated: "Simulated Glasses",
     store: "MiniApp Store",
     notify: "Notifications",
     feedback: "Give Feedback",
-    lmaLoader: "Side Loader",
+    lmaLoader: "Miniapp Developer",
   },
   appInfo: {
     notInstalled: "App not installed",

--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -206,8 +206,8 @@ describe("MantleManager", () => {
     // (covered by deviceEventRouter.test.ts); MantleManager no longer handles them.
 
     // Local transcripts no longer roundtrip through the cloud (SocketComms has
-    // no transcription send anymore). With no local-miniapp subscription and
-    // the offline-captions flag off, the transcript is simply dropped.
+    // no transcription send anymore). With no local-miniapp subscription,
+    // the transcript is simply dropped.
     emitBluetoothSdkEvent("local_transcription", {
       text: "hello world",
       isFinal: true,

--- a/mobile/src/services/Migrations.ts
+++ b/mobile/src/services/Migrations.ts
@@ -34,12 +34,20 @@ const migrations: Migration[] = [
       }
     },
   },
-  // {
-  //   version: 3,
-  //   run: async () => {
-  //     // migrates from 2 → 3
-  //   },
-  // },
+  {
+    version: 3,
+    run: async () => {
+      // migrates from 2 → 3: the hardcoded Offline Captions built-in
+      // (com.mentra.offline_captions) was removed — the SDK Captions miniapp
+      // auto-switches between online and offline transcription now. Clear its
+      // persisted state: the offline_captions_running setting (BLE-synced into
+      // the native mic gate on older builds) and the app-tray running flag
+      // that would otherwise resurrect a now-nonexistent app on boot.
+      storage.remove("offline_captions_running")
+      storage.remove("com.mentra.offline_captions_running")
+      storage.remove("com.mentra.offline_captions_screenshot")
+    },
+  },
 ]
 
 const migration_version_key = "migration_version"

--- a/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
+++ b/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
@@ -22,7 +22,6 @@ import {markMiniappDevMode} from "@/utils/miniappDevMode"
 
 import {
   cameraPackageName,
-  captionsPackageName,
   CHINA_HIDDEN_APPS,
   feedbackPackageName,
   isChinaBuild,
@@ -57,14 +56,11 @@ class BuiltInMiniappCatalog {
     this.initialized = true
 
     for (const app of this.buildOfflineApps()) {
-      // Captions cannot start without the on-device STT model; island gates
-      // start() on this flag and calls onMissingSpeechModel when it blocks.
-      appRegistry.installOfflineApp(app, {requiresLocalSttModel: app.packageName === captionsPackageName})
+      appRegistry.installOfflineApp(app)
     }
 
     installAppStoreHooks({
       onIncompatibleBlocked: (app) => this.showIncompatibleAlert(app),
-      onMissingSpeechModel: (app) => void this.showMissingSpeechModelAlert(app),
       onOpenRequested: (app, opts) => {
         const nav = useNavigationStore.getState()
         if (!opts?.skipNavigation && nav.getCurrentRoute() === "/home") {
@@ -102,21 +98,6 @@ class BuiltInMiniappCatalog {
       buttons: [{text: translate("common:ok")}],
       message: translate("home:hardwareIncompatibleMessage", {app: app.name, missing: missingHardware}),
     })
-  }
-
-  /** Missing on-device STT model alert + optional settings navigation (island already blocked). */
-  private async showMissingSpeechModelAlert(_app: ClientApp): Promise<void> {
-    const result = await showAlert({
-      title: translate("transcription:noModelInstalled"),
-      message: translate("transcription:noModelInstalledMessage"),
-      buttons: [
-        {text: translate("common:cancel"), style: "cancel"},
-        {text: translate("transcription:goToSettings"), style: "default"},
-      ],
-    })
-    if (result === 1) {
-      useNavigationStore.getState().push("/miniapps/settings/speech")
-    }
   }
 
   private navigateForApp(app: ClientApp): void {
@@ -217,32 +198,6 @@ class BuiltInMiniappCatalog {
         ],
       },
       {
-        packageName: captionsPackageName,
-        name: translate("miniApps:offlineCaptions"),
-        type: "standard",
-        offline: true,
-        logoUrl: require("@assets/applet-icons/captions.png"),
-        webviewUrl: "",
-        healthy: true,
-        hidden: false,
-        permissions: [],
-        offlineRoute: "",
-        running: false,
-        loading: false,
-        local: false,
-        onStart: () => {
-          void toolkit.speech.restartTranscriber()
-          toolkit.settings.set(SETTINGS.offline_captions_running.key, true)
-        },
-        onStop: () => {
-          toolkit.settings.set(SETTINGS.offline_captions_running.key, false)
-        },
-        hardwareRequirements: [
-          {type: HardwareType.DISPLAY, level: HardwareRequirementLevel.REQUIRED},
-          {type: HardwareType.EXIST, level: HardwareRequirementLevel.REQUIRED},
-        ],
-      },
-      {
         packageName: settingsPackageName,
         name: translate("miniApps:settings"),
         type: "background",
@@ -318,14 +273,14 @@ class BuiltInMiniappCatalog {
     }
 
     if (
-      toolkit.settings.get(SETTINGS.miniapp_dev_mode.key) && false
+      toolkit.settings.get(SETTINGS.miniapp_dev_mode.key)
     ) {
       apps.push({
         packageName: "com.mentra.miniappdev",
         name: translate("miniApps:lmaLoader"),
         type: "standard",
         offline: true,
-        offlineRoute: "/miniapps/miniappdev/main",
+        offlineRoute: "/miniapps/settings/miniapp-dev",
         local: false,
         webviewUrl: "",
         permissions: [],


### PR DESCRIPTION
## Scope

The SDK Captions miniapp (`com.mentra.captions`) now auto-switches between online and offline transcription, so the hardcoded `com.mentra.offline_captions` built-in is obsolete. This removes it end to end and migrates away its persisted state.

### Why the migration matters

`offline_captions_running` was never force-set at boot — it *persisted* (`persist:true`, `saveOnServer:true`) and was restored on every cold boot via two tracks:

1. The setting itself, BLE-synced into native where **both platforms OR it into the mic-enable gate** (`shouldSendTranscript || offlineCaptionsRunning || localSttFallbackActive`). Stuck `true` = mic hot and local transcriber fed forever.
2. A separate MMKV key (`com.mentra.offline_captions_running`) that resurrected the app's running tile in the tray.

Any user who ever launched offline captions has stale `true` in both, so removal alone isn't enough.

### Changes

- **Miniapp deleted**: BuiltInMiniappCatalog entry, `constants/miniapps.ts` (`SYSTEM_APPS`, `CHINA_HIDDEN_APPS`), island `SYSTEM_MINIAPP_PACKAGES`, i18n strings, and the now-dead `onMissingSpeechModel` alert wiring (nothing registers `requiresLocalSttModel` anymore; the island API stays).
- **Setting removed everywhere**: settings store definition, `BLUETOOTH_SETTING_KEYS`, Mentra Live key list, glassesSettings `INTERNAL_KEYS`, `BluetoothSdk.types.ts`, dead speech.tsx refs.
- **Native plumbing removed (iOS + Android)**: DeviceManager property + both mic/transcriber gates, DeviceStore change handlers, DeviceStatus wire fields.
- **Migration v3**: one-shot, clears the persisted setting, the app-tray running flag, and the screenshot key. Server residue is inert (`setManyLocally` skips unknown keys); the glasses menu never allowed system apps so no scrub needed. The flag never reached the glasses (change handlers only ran phone-side `setMicState`; zero asg_client/android_core refs) and native DeviceStore is in-memory re-fed from JS each boot, so this fully cleans existing installs.
- **Rider (separate commit)**: OTA progress section wrapped in GlassView and gated to only show mid-update; miniapp-dev loader entry enabled and pointed at its settings route.

## Test evidence

- `bun compile` — clean (only the 3 pre-existing `LocalMiniappRuntime` errors, confirmed identical on the clean tree)
- Island suite — **220 pass, 0 fail**
- `./scripts/check-android-compile.sh bluetooth-sdk` — **BUILD SUCCESSFUL**
- iOS Swift edits are mechanical mirrors of the Kotlin ones but not compile-verified locally — rely on the CI iOS build
- Mobile jest is broken in this workspace on the clean tree too (`typesafe-ts` ESM transform error) — pre-existing, unrelated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches native mic/STT gating and persisted flags; stale `offline_captions_running` could have left the mic on until migration runs, but v3 and gate removal address that.
> 
> **Overview**
> Removes the obsolete **`com.mentra.offline_captions`** built-in now that SDK Captions handles online/offline STT. The app entry, constants, island settings/keys, i18n, and **`requiresLocalSttModel`** / missing-model alert wiring are deleted.
> 
> **`offline_captions_running`** is dropped from JS settings, BLE types, and **iOS/Android** `DeviceManager` mic/transcriber gates (only **`shouldSendTranscript`** and **`local_stt_fallback_active`** remain). **Migration v3** clears persisted setting and tray keys so upgrades don’t keep the mic hot or show a ghost running app.
> 
> **Riders:** OTA progress uses **`GlassView`** and only shows while progress &lt; 100%; miniapp-dev loader is enabled and routed to **`/miniapps/settings/miniapp-dev`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c5c82feafd0035ba77913bcd2025472dd828187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the obsolete `com.mentra.offline_captions` built‑in and its `offline_captions_running` mic gate in favor of the SDK Captions miniapp (`com.mentra.captions`) that auto‑handles online/offline transcription. Also cleaned native gates on iOS/Android and minor UI/dev tools updates.

- **New Features**
  - OTA progress shows only during updates and is styled with `GlassView`.
  - Enabled miniapp developer loader; routed to `/miniapps/settings/miniapp-dev`.

- **Migration**
  - v3 clears stale keys to avoid hot mic and ghost tiles: `offline_captions_running`, `com.mentra.offline_captions_running`, `com.mentra.offline_captions_screenshot`.

<sup>Written for commit 6c5c82feafd0035ba77913bcd2025472dd828187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

