### PR TITLE
Example OEM app: pair glasses and side-load a miniapp by URL

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -603,6 +603,7 @@ const mockIslandEntries = () => {
         savedUrls: jest.fn(() => []),
         reconnectCloud: jest.fn(),
         getMemoryMB: jest.fn(() => 0),
+        loadDevMiniapp: jest.fn(() => Promise.resolve({ok: false, error: "not available in tests"})),
         bluetoothStatus: jest.fn(() => {
           const {setCoreInfo: _s, reset: _r, ...state} = realCore.useCoreStore.getState()
           return {...state}

--- a/mobile/modules/island/src/facades/dev.ts
+++ b/mobile/modules/island/src/facades/dev.ts
@@ -18,6 +18,9 @@ import {useSettingsStore, SETTINGS} from "../stores/settings"
 import {cloudClientService} from "../services/CloudClientService"
 import restComms from "../services/RestComms"
 import {getConfigValues} from "../runtime/bootstrap"
+import {decideDevLaunchRoute} from "../utils/devMiniappLaunch"
+import {registerDevApp, DEV_APP_PACKAGE_NAME, type DevAppRecord} from "../services/AppRegistry"
+import {useAppStatusStore} from "../stores/apps"
 
 type CloudUrlOverrides = {core?: string; runtime?: string}
 
@@ -130,6 +133,48 @@ export const dev = {
   bluetoothStatus: (): Record<string, unknown> => {
     const {setCoreInfo: _setCoreInfo, reset: _reset, ...state} = useCoreStore.getState()
     return {...state}
+  },
+
+  /**
+   * Side-load a miniapp being served from a dev machine (the `mentra dev` / CLI
+   * flow) by its URL: probes `<url>/miniapp.json`, and on a reachable manifest
+   * registers it into the single dev slot so it appears in `toolkit.miniapps`
+   * and can be started. This is the OEM-host equivalent of the first-party
+   * developer-URL screen — the registration itself is island-internal, so a
+   * host reaches it here rather than the internal registry. Rendering still
+   * flows through the normal display path once the miniapp is started.
+   */
+  loadDevMiniapp: async (
+    url: string,
+    name?: string,
+  ): Promise<{ok: true; packageName: string; name: string} | {ok: false; error: string}> => {
+    const devUrl = url.trim().replace(/\/+$/, "")
+    if (!devUrl) return {ok: false, error: "empty url"}
+    const result = await decideDevLaunchRoute("", devUrl)
+    if (result.decision !== "live") {
+      return {ok: false, error: "dev server unreachable, or no miniapp.json served there"}
+    }
+    const manifest = result.manifest
+    let devPort: number | undefined
+    try {
+      const parsed = new URL(devUrl).port
+      devPort = parsed ? Number(parsed) : undefined
+    } catch {
+      devPort = undefined
+    }
+    const appName = name ?? manifest.name ?? "Dev Miniapp"
+    registerDevApp({
+      packageName: DEV_APP_PACKAGE_NAME,
+      name: appName,
+      iconUrl: manifest.icon ? new URL(manifest.icon, `${devUrl}/`).toString() : `${devUrl}/icon.png`,
+      devUrl,
+      devPort,
+      type: manifest.type as DevAppRecord["type"],
+      permissions: manifest.permissions as DevAppRecord["permissions"],
+      hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
+    })
+    await useAppStatusStore.getState().refresh()
+    return {ok: true, packageName: DEV_APP_PACKAGE_NAME, name: appName}
   },
 
   /** Current island runtime status for toolkit-owned debug surfaces. */

--- a/mobile/modules/island/src/facades/dev.ts
+++ b/mobile/modules/island/src/facades/dev.ts
@@ -155,16 +155,22 @@ export const dev = {
       return {ok: false, error: "dev server unreachable, or no miniapp.json served there"}
     }
     const manifest = result.manifest
+    // The `mentra-miniapp dev` server puts the hot-reload/log sidecar on the
+    // user port PLUS ONE — same convention as the first-party developer-URL
+    // screen's deriveDevPort.
     let devPort: number | undefined
     try {
-      const parsed = new URL(devUrl).port
-      devPort = parsed ? Number(parsed) : undefined
+      const parsed = Number(new URL(devUrl).port)
+      devPort = Number.isFinite(parsed) && parsed > 0 ? parsed + 1 : undefined
     } catch {
       devPort = undefined
     }
     const appName = name ?? manifest.name ?? "Dev Miniapp"
     registerDevApp({
-      packageName: DEV_APP_PACKAGE_NAME,
+      // The REAL manifest package: registerDevApp preserves it as
+      // sourcePackageName (miniapp auth + dev-slot cleanup key off it) before
+      // forcing packageName to the single dev slot.
+      packageName: (manifest.packageName as string | undefined) ?? DEV_APP_PACKAGE_NAME,
       name: appName,
       iconUrl: manifest.icon ? new URL(manifest.icon, `${devUrl}/`).toString() : `${devUrl}/icon.png`,
       devUrl,
@@ -172,6 +178,7 @@ export const dev = {
       type: manifest.type as DevAppRecord["type"],
       permissions: manifest.permissions as DevAppRecord["permissions"],
       hardwareRequirements: manifest.hardwareRequirements as DevAppRecord["hardwareRequirements"],
+      actions: manifest.actions as DevAppRecord["actions"],
     })
     await useAppStatusStore.getState().refresh()
     return {ok: true, packageName: DEV_APP_PACKAGE_NAME, name: appName}

--- a/sdk/example-oem-app/App.tsx
+++ b/sdk/example-oem-app/App.tsx
@@ -1,12 +1,19 @@
-import {useApps, useStart, useStop} from "@mentra/island"
+import {toolkit, useApps, useStart, useStop} from "@mentra/island"
 import {miniappRunningRegistry} from "@mentra/island/devtools"
 import {StatusBar} from "expo-status-bar"
 import {useCallback, useEffect, useState} from "react"
-import {SafeAreaView, ScrollView, StyleSheet, Text, View} from "react-native"
+import {SafeAreaView, ScrollView, StyleSheet, Text, TextInput, View} from "react-native"
 
 import {startIslandRuntime} from "./src/islandRuntime"
 import {ActionButton, Section, StatusRow} from "./src/ui"
 import {useLog} from "./src/useLog"
+
+// This example host targets Even Realities G2. A real OEM host would let the
+// user pick from the models it supports; DeviceModel is a plain string union,
+// so the literal is all the toolkit needs.
+const GLASSES_MODEL = "Even Realities G2"
+
+type ScanResult = ReturnType<typeof toolkit.pairing.searchResults>[number]
 
 export default function App() {
   const logger = useLog()
@@ -16,6 +23,11 @@ export default function App() {
   const start = useStart()
   const stop = useStop()
   const [running, setRunning] = useState<string[]>(() => miniappRunningRegistry.getAll())
+
+  const [glassesState, setGlassesState] = useState<string>(() => toolkit.glasses.status().state)
+  const [scanning, setScanning] = useState(false)
+  const [devices, setDevices] = useState<ScanResult[]>([])
+  const [devUrl, setDevUrl] = useState("")
 
   // Configure + start the island runtime once (the OEM bootstrap contract);
   // demo listeners feed the console below.
@@ -35,20 +47,70 @@ export default function App() {
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot bootstrap
   }, [])
 
+  // Live read-models: glasses connection, scan progress, scan results, running set.
+  useEffect(() => toolkit.glasses.onStatus((s) => setGlassesState(s.state)), [])
+  useEffect(() => toolkit.pairing.onScanning(setScanning), [])
+  useEffect(() => toolkit.pairing.onFound(setDevices), [])
   useEffect(() => {
     setRunning(miniappRunningRegistry.getAll())
     return miniappRunningRegistry.subscribe(() => setRunning(miniappRunningRegistry.getAll()))
   }, [])
 
+  const connected = glassesState === "connected"
   const firstApp = apps[0]
+
+  // --- Pairing ---
+  const scanForGlasses = useCallback(async () => {
+    // Mark the model as the pending selection (the scan-entry write of the
+    // two-phase identity contract), then start scanning. Results stream into
+    // `devices` via onFound.
+    toolkit.pairing.markPendingSelection(GLASSES_MODEL)
+    await run(`scan(${GLASSES_MODEL})`, () => toolkit.pairing.scan(GLASSES_MODEL))
+  }, [run])
+
+  const pairDevice = useCallback(
+    async (device: ScanResult) => {
+      // pair() marks pending only; native promotes to default on pairing
+      // success. Watch the glasses status row flip to "connected".
+      await run(`pair(${device.name})`, () => toolkit.pairing.pair(device))
+    },
+    [run],
+  )
+
+  const reconnect = useCallback(async () => {
+    await run("glasses.connectDefault()", () => toolkit.glasses.connectDefault())
+  }, [run])
+
+  const disconnect = useCallback(async () => {
+    await run("glasses.disconnect()", () => toolkit.glasses.disconnect())
+  }, [run])
+
+  // --- Miniapps ---
+  const loadMiniapp = useCallback(async () => {
+    const trimmed = devUrl.trim()
+    if (!trimmed) {
+      logger.logError("Enter the dev URL your miniapp is served from (e.g. http://192.168.x.x:8080).")
+      return
+    }
+    // Called directly (not via run) to read the typed {ok} result.
+    log(`▶ dev.loadDevMiniapp(${trimmed})`)
+    try {
+      const result = await toolkit.dev.loadDevMiniapp(trimmed)
+      if (result.ok) log(`✓ loaded ${result.name} (${result.packageName})`)
+      else logger.logError(`✗ load failed: ${result.error}`)
+    } catch (err) {
+      logger.logError(`✗ load failed: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }, [devUrl, log, logger])
 
   const startMiniapp = useCallback(async () => {
     if (!firstApp) {
-      logger.logError("No miniapps registered — install one via the island host first.")
+      logger.logError("No miniapp registered — load one by URL above first.")
       return
     }
+    if (!connected) log("Note: no glasses connected, so the miniapp has nowhere to render.")
     await run(`start(${firstApp.packageName})`, () => start(firstApp))
-  }, [firstApp, run, start, logger])
+  }, [firstApp, connected, run, start, log, logger])
 
   const stopMiniapp = useCallback(async () => {
     const target = running[0] ?? firstApp?.packageName
@@ -59,28 +121,51 @@ export default function App() {
     await run(`stop(${target})`, () => stop(target))
   }, [running, firstApp, run, stop, logger])
 
-  const listRunning = useCallback(() => {
-    const list = miniappRunningRegistry.getAll()
-    log(`Running miniapps (${list.length}): ${list.length ? list.join(", ") : "none"}`)
-    log(`Registered miniapps (${apps.length}): ${apps.length ? apps.map((a) => a.packageName).join(", ") : "none"}`)
-  }, [apps, log])
-
   return (
     <SafeAreaView style={styles.screen}>
       <StatusBar style="dark" />
       <ScrollView contentContainerStyle={styles.scroll}>
         <Text style={styles.title}>Example OEM App</Text>
-        <Text style={styles.subtitle}>Mentra Island SDK — miniapp control</Text>
+        <Text style={styles.subtitle}>Mentra Island SDK — pair glasses & run a miniapp</Text>
 
         <Section title="State" subtitle="From @mentra/island">
-          <StatusRow label="Registered" value={String(apps.length)} />
-          <StatusRow label="Running" value={String(running.length)} />
+          <StatusRow label="Glasses" value={glassesState} busy={scanning} />
+          <StatusRow label="Registered miniapps" value={String(apps.length)} />
+          <StatusRow label="Running miniapps" value={String(running.length)} />
         </Section>
 
-        <Section title="Miniapps" subtitle="start / stop / list">
+        <Section title="Pair glasses" subtitle={`toolkit.pairing / toolkit.glasses — ${GLASSES_MODEL}`}>
+          {connected ? (
+            <ActionButton label="Disconnect" onPress={disconnect} variant="danger" />
+          ) : (
+            <>
+              <ActionButton
+                label={scanning ? "Scanning…" : "Scan for glasses"}
+                onPress={scanForGlasses}
+                disabled={scanning}
+              />
+              {devices.map((device) => (
+                <ActionButton key={device.id} label={`Pair: ${device.name}`} onPress={() => pairDevice(device)} />
+              ))}
+              <ActionButton label="Reconnect last paired" onPress={reconnect} />
+            </>
+          )}
+        </Section>
+
+        <Section title="Miniapps" subtitle="Load a dev miniapp by URL, then start / stop">
+          <TextInput
+            style={styles.input}
+            value={devUrl}
+            onChangeText={setDevUrl}
+            placeholder="http://192.168.x.x:8080"
+            placeholderTextColor="#9ca3af"
+            autoCapitalize="none"
+            autoCorrect={false}
+            keyboardType="url"
+          />
+          <ActionButton label="Load miniapp from URL" onPress={loadMiniapp} />
           <ActionButton label="Start miniapp" onPress={startMiniapp} />
           <ActionButton label="Stop miniapp" onPress={stopMiniapp} />
-          <ActionButton label="List running miniapps" onPress={listRunning} />
         </Section>
 
         <Section title="Console" subtitle="Most recent calls and results">
@@ -123,6 +208,17 @@ const styles = StyleSheet.create({
     color: "#6b7280",
     marginHorizontal: 16,
     marginBottom: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    fontSize: 14,
+    color: "#111827",
+    backgroundColor: "#f9fafb",
+    marginBottom: 8,
   },
   console: {
     backgroundColor: "#0f172a",


### PR DESCRIPTION
## Why

The first on-device run of the example OEM host (after the #3375 crash fix) proved island boots via the public API — and exposed that the app was a control panel with no data source: no pairing UI, and **no public way to register a miniapp at all** (`registerDevApp` is `/internal`-only). This PR turns it into a complete second-host demo: pair real glasses, side-load a dev miniapp, run it — public entry only.

## What

**New public facade method — `toolkit.dev.loadDevMiniapp(url, name?)`**: probes `<url>/miniapp.json` (via the already-public `decideDevLaunchRoute`), registers the manifest into the single dev slot, refreshes the apps list, returns a typed `{ok}` result. This is the OEM-host equivalent of the first-party developer-URL screen, filling the gap the exercise found.

**Example app UI:**
- **Pair glasses** (targets Even Realities G2): `markPendingSelection` → `pairing.scan` → found devices render as tap-to-pair buttons → `pairing.pair()` (two-phase identity respected — no eager default save; native promotes on success). Plus reconnect-last-paired and disconnect. Live status row driven by `glasses.onStatus` / `pairing.onScanning` / `pairing.onFound`.
- **Miniapps**: URL field → `loadDevMiniapp` → start/stop through the existing public hooks. Serve any of the repo's `miniapps/*` with `miniapp-cli` and load it by LAN URL.
- jest island mock gains the `loadDevMiniapp` stub (mock parity).

## Stacked

On #3375 (the expo SDK-pin crash fix) — merge that first and this diff collapses to the demo changes.

## Test evidence

- island standalone tsc clean; island `bun test src`: 220 pass
- example OEM app tsc clean against rebuilt public types; `expo export` bundles clean (exit 0)
- mobile tsc clean; full jest 55 suites / 429 tests
- **On-device pass wanted**: scan→pair G2s from the example host, then load+start a served miniapp and confirm it renders to the glasses (the display path from a second host has never been exercised on hardware)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API touches dev miniapp registration and app registry refresh; behavior depends on network manifest probing but stays on the existing dev-slot path rather than production install flows.
> 
> **Overview**
> Adds **`toolkit.dev.loadDevMiniapp(url, name?)`** on the public dev facade so OEM hosts can side-load a LAN-served miniapp without calling internal `registerDevApp`: it fetches `miniapp.json` via `decideDevLaunchRoute`, registers the single dev slot (including dev port +1), refreshes the apps list, and returns a typed `{ok}` result.
> 
> The **example OEM app** is expanded from start/stop-only into an end-to-end demo: **Even Realities G2** pairing (scan, pair, reconnect, disconnect) wired to `toolkit.pairing` / `toolkit.glasses` subscriptions, plus a URL field that calls `loadDevMiniapp` before start/stop. **Mobile Jest** mocks gain a `loadDevMiniapp` stub for parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bdd619bd0d849f080da4b7f4e88d206368fa040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->