### PR TITLE
Notify Slack when Cloud V2 reports are submitted or complete

### DIFF
--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { notifyReportSlack, type ReportSlackNotification } from "./report-slack.service";
+
+const WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/reports";
+
+const savedEnv = {
+  CLOUD_REPORTS_SLACK_WEBHOOK_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL,
+  CLOUD_CORE_ENVIRONMENT: process.env.CLOUD_CORE_ENVIRONMENT,
+};
+const realFetch = globalThis.fetch;
+
+type FetchCall = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchCall>>;
+
+beforeEach(() => {
+  delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
+  fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  restoreEnv("CLOUD_REPORTS_SLACK_WEBHOOK_URL", savedEnv.CLOUD_REPORTS_SLACK_WEBHOOK_URL);
+  restoreEnv("CLOUD_CORE_ENVIRONMENT", savedEnv.CLOUD_CORE_ENVIRONMENT);
+});
+
+describe("notifyReportSlack", () => {
+  test("is a silent no-op when the webhook env var is unset", async () => {
+    const result = await notifyReportSlack(bugNotification());
+
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(fetchMock.mock.calls).toHaveLength(0);
+  });
+
+  test("posts a bug report summary with trigger, env, and artifact count", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    const result = await notifyReportSlack(bugNotification({ artifactCount: 3 }));
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls).toHaveLength(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(WEBHOOK_URL);
+    expect(init.method).toBe("POST");
+
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    expect(payload.text).toContain("New bug report from user-1 (test-env)");
+    expect(payload.text).toContain("rep_TEST123");
+    expect(payload.text).toContain("Artifacts: 3");
+
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain("rep_TEST123");
+    expect(blocksJson).toContain("ota_update_failed");
+    expect(blocksJson).toContain("glasses stuck on boot screen");
+    expect(blocksJson).toContain("*Artifacts:*\\n3");
+    expect(blocksJson).toContain("*Env:*\\ntest-env");
+  });
+
+  test("truncates long user-authored text", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    const longBehavior = "x".repeat(800);
+
+    await notifyReportSlack(bugNotification({ report: { actualBehavior: longBehavior } }));
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain(`${"x".repeat(500)}...`);
+    expect(blocksJson).not.toContain("x".repeat(501));
+  });
+
+  test("posts feedback text and escapes Slack control characters", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack({
+      reportId: "rep_FEEDBACK1",
+      mentraUserId: "user-2",
+      kind: "feedback",
+      feedback: { type: "feature", message: "more <glasses> & apps", experienceRating: 4 },
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    expect(payload.text).toContain("New feedback report from user-2 (test-env)");
+
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain("more &lt;glasses&gt; &amp; apps");
+    expect(blocksJson).toContain(":star::star::star::star: 4/5");
+  });
+
+  test("resolves without throwing when the webhook request fails", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    fetchMock.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const result = await notifyReportSlack(bugNotification());
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  test("resolves without throwing on a non-2xx webhook response", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    fetchMock.mockImplementation(async () => new Response("no_service", { status: 404 }));
+
+    const result = await notifyReportSlack(bugNotification());
+
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+function bugNotification(overrides: Partial<ReportSlackNotification> = {}): ReportSlackNotification {
+  return {
+    reportId: "rep_TEST123",
+    mentraUserId: "user-1",
+    kind: "bug",
+    trigger: { type: "manual", source: "feedback_screen", reason: "ota_update_failed" },
+    report: { actualBehavior: "glasses stuck on boot screen", userSeverity: 4 },
+    ...overrides,
+  };
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -90,6 +90,40 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain(":star::star::star::star: 4/5");
   });
 
+  test("keeps every block text under Slack's 2000-char section limit", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack({
+      reportId: "rep_LIMITS",
+      mentraUserId: "user-3",
+      kind: "bug",
+      // Worst cases: unbounded trigger strings (the API only requires
+      // non-empty), and behavior text whose escaping expands 4-5x past the
+      // raw truncation budget.
+      trigger: { type: "manual", source: "s".repeat(5000), reason: "r".repeat(5000) },
+      report: { actualBehavior: "<".repeat(5000), expectedBehavior: "&".repeat(5000) },
+      artifactCount: 1,
+    });
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as {
+      blocks: Array<{ text?: { text: string }; fields?: Array<{ text: string }> }>;
+    };
+    const texts = payload.blocks.flatMap((block) => [
+      ...(block.text ? [block.text.text] : []),
+      ...(block.fields ?? []).map((field) => field.text),
+    ]);
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text.length).toBeLessThanOrEqual(2000);
+    }
+
+    // Oversized values are truncated, not dropped.
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain("r".repeat(300));
+    expect(blocksJson).not.toContain("r".repeat(301));
+  });
+
   test("resolves without throwing when the webhook request fails", async () => {
     process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
     fetchMock.mockImplementation(async () => {

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -1,0 +1,286 @@
+/**
+ * @fileoverview Slack notifications for Cloud V2 reports.
+ *
+ * Cloud V2 replacement for the Cloud V1 feedback Slack path
+ * (cloud/packages/cloud/src/services/notifications/slack.service.ts): bug
+ * reports and feedback submitted through /api/client/reports post a summary
+ * to the team channel via a Slack Incoming Webhook.
+ *
+ * Best-effort by design: an unset CLOUD_REPORTS_SLACK_WEBHOOK_URL (local dev,
+ * tests) is a silent skip, and send failures are logged, never thrown, so a
+ * notification can never delay or fail the report API response. Callers
+ * fire-and-forget.
+ */
+
+import { createLogger } from "@mentra/cloud-shared";
+
+const logger = createLogger("core").child({ service: "report-slack.service" });
+
+const SLACK_TIMEOUT_MS = 10_000;
+
+/** How much user-authored text a Slack field keeps, mirroring V1 limits. */
+const BEHAVIOR_TEXT_MAX = 500;
+const FEEDBACK_TEXT_MAX = 1000;
+
+export interface ReportSlackNotification {
+  reportId: string;
+  mentraUserId: string;
+  kind: "bug" | "feedback" | "automatic";
+  /** Trigger/report/feedback are snapshots of the stored (Mixed) report
+   * fields, so every property is read defensively. */
+  trigger?: {
+    type?: string;
+    source?: string;
+    reason?: string;
+    sourceAppletPackageName?: string;
+    sourceAppletName?: string;
+  } | null;
+  report?: {
+    actualBehavior?: string;
+    expectedBehavior?: string;
+    userSeverity?: number;
+    contactEmail?: string;
+  } | null;
+  feedback?: Record<string, unknown> | null;
+  /** Set on ready-time notifications: how many artifacts were attached. */
+  artifactCount?: number;
+}
+
+export interface ReportSlackResult {
+  ok: boolean;
+  skipped?: boolean;
+}
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string; emoji?: boolean };
+  fields?: Array<{ type: string; text: string }>;
+}
+
+/**
+ * Post a report summary to the reports Slack channel. Resolves with
+ * `{ok: false, skipped: true}` when CLOUD_REPORTS_SLACK_WEBHOOK_URL is unset
+ * and `{ok: false}` on send failure; it never rejects.
+ */
+export async function notifyReportSlack(
+  notification: ReportSlackNotification,
+): Promise<ReportSlackResult> {
+  const webhookUrl = process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    logger.debug(
+      { reportId: notification.reportId },
+      "CLOUD_REPORTS_SLACK_WEBHOOK_URL not set; skipping report Slack notification",
+    );
+    return { ok: false, skipped: true };
+  }
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(buildSlackMessage(notification)),
+      signal: AbortSignal.timeout(SLACK_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logger.error(
+        {
+          reportId: notification.reportId,
+          status: res.status,
+          body: await res.text().catch(() => ""),
+        },
+        "report Slack notification failed",
+      );
+      return { ok: false };
+    }
+    logger.info({ reportId: notification.reportId }, "report Slack notification sent");
+    return { ok: true };
+  } catch (error) {
+    logger.error(
+      { reportId: notification.reportId, error: (error as Error)?.message },
+      "report Slack notification error",
+    );
+    return { ok: false };
+  }
+}
+
+function buildSlackMessage(notification: ReportSlackNotification): {
+  text: string;
+  blocks: SlackBlock[];
+} {
+  const { reportId, mentraUserId, kind, trigger, artifactCount } = notification;
+  const env = environmentLabel();
+  const header =
+    kind === "bug"
+      ? ":bug: New Bug Report"
+      : kind === "feedback"
+        ? ":bulb: New Feedback"
+        : ":robot_face: New Automatic Report";
+  const timestamp = new Date().toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Los_Angeles",
+  });
+
+  const identityFields = [
+    { type: "mrkdwn", text: `*User:*\n${escapeSlackText(mentraUserId)}` },
+    { type: "mrkdwn", text: `*Report ID:*\n\`${escapeSlackText(reportId)}\`` },
+    { type: "mrkdwn", text: `*Env:*\n${escapeSlackText(env)}` },
+  ];
+  if (artifactCount !== undefined) {
+    identityFields.push({ type: "mrkdwn", text: `*Artifacts:*\n${artifactCount}` });
+  }
+
+  const blocks: SlackBlock[] = [
+    { type: "header", text: { type: "plain_text", text: header, emoji: true } },
+    { type: "section", fields: identityFields },
+  ];
+
+  const triggerFields: Array<{ type: string; text: string }> = [];
+  if (typeof trigger?.source === "string") {
+    triggerFields.push({
+      type: "mrkdwn",
+      text: `*Trigger source:*\n${escapeSlackText(trigger.source)}`,
+    });
+  }
+  if (typeof trigger?.reason === "string") {
+    triggerFields.push({
+      type: "mrkdwn",
+      text: `*Trigger reason:*\n${escapeSlackText(trigger.reason)}`,
+    });
+  }
+  const sourceApplet = formatSourceApplet(trigger);
+  if (sourceApplet) {
+    triggerFields.push({
+      type: "mrkdwn",
+      text: `*Source applet:*\n${escapeSlackText(sourceApplet)}`,
+    });
+  }
+  if (triggerFields.length > 0) {
+    blocks.push({ type: "section", fields: triggerFields });
+  }
+
+  blocks.push(...buildBodyBlocks(notification));
+  blocks.push({
+    type: "section",
+    text: { type: "mrkdwn", text: `_Submitted: ${timestamp}_` },
+  });
+
+  const fallbackParts = [
+    `New ${kind} report from ${mentraUserId} (${env})`,
+    `Report ID: ${reportId}`,
+    ...(typeof trigger?.reason === "string" ? [`Trigger: ${trigger.reason}`] : []),
+    ...(artifactCount !== undefined ? [`Artifacts: ${artifactCount}`] : []),
+  ];
+
+  return { text: fallbackParts.join("\n"), blocks };
+}
+
+/** Kind-specific body: bug/automatic report details, or the feedback text. */
+function buildBodyBlocks(notification: ReportSlackNotification): SlackBlock[] {
+  const blocks: SlackBlock[] = [];
+
+  const report = notification.report;
+  if (report) {
+    const detailFields: Array<{ type: string; text: string }> = [];
+    if (typeof report.actualBehavior === "string") {
+      detailFields.push({
+        type: "mrkdwn",
+        text: `*Actual:*\n${escapeSlackText(truncate(report.actualBehavior, BEHAVIOR_TEXT_MAX))}`,
+      });
+    }
+    if (typeof report.expectedBehavior === "string") {
+      detailFields.push({
+        type: "mrkdwn",
+        text: `*Expected:*\n${escapeSlackText(truncate(report.expectedBehavior, BEHAVIOR_TEXT_MAX))}`,
+      });
+    }
+    if (detailFields.length > 0) {
+      blocks.push({ type: "section", fields: detailFields });
+    }
+    if (typeof report.userSeverity === "number") {
+      const severityEmoji =
+        report.userSeverity >= 4
+          ? ":red_circle:"
+          : report.userSeverity >= 3
+            ? ":large_orange_circle:"
+            : ":large_green_circle:";
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Severity:* ${severityEmoji} ${report.userSeverity}/5`,
+        },
+      });
+    }
+    if (typeof report.contactEmail === "string") {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: `*Contact:* ${escapeSlackText(report.contactEmail)}` },
+      });
+    }
+  }
+
+  const feedback = notification.feedback;
+  if (feedback) {
+    const message =
+      typeof feedback.message === "string"
+        ? feedback.message
+        : JSON.stringify(feedback);
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Feedback:*\n${escapeSlackText(truncate(message, FEEDBACK_TEXT_MAX))}`,
+      },
+    });
+    if (typeof feedback.type === "string") {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: `*Type:* ${escapeSlackText(feedback.type)}` },
+      });
+    }
+    if (typeof feedback.experienceRating === "number") {
+      const safeRating = Math.max(0, Math.min(5, Math.round(feedback.experienceRating)));
+      blocks.push({
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `*Experience:* ${":star:".repeat(safeRating)} ${feedback.experienceRating}/5`,
+        },
+      });
+    }
+    if (typeof feedback.contactEmail === "string") {
+      blocks.push({
+        type: "section",
+        text: { type: "mrkdwn", text: `*Contact:* ${escapeSlackText(feedback.contactEmail)}` },
+      });
+    }
+  }
+
+  return blocks;
+}
+
+function formatSourceApplet(trigger: ReportSlackNotification["trigger"]): string | null {
+  const name = typeof trigger?.sourceAppletName === "string" ? trigger.sourceAppletName : null;
+  const packageName =
+    typeof trigger?.sourceAppletPackageName === "string" ? trigger.sourceAppletPackageName : null;
+  if (name && packageName) return `${name} (${packageName})`;
+  return name ?? packageName;
+}
+
+/**
+ * Which deployment the report came from (dev/staging/prod), so one channel
+ * can receive several environments without ambiguity.
+ */
+function environmentLabel(): string {
+  return process.env.CLOUD_CORE_ENVIRONMENT || "unknown";
+}
+
+/** Escape &, <, > which have special meaning in Slack mrkdwn. */
+function escapeSlackText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -21,6 +21,14 @@ const SLACK_TIMEOUT_MS = 10_000;
 /** How much user-authored text a Slack field keeps, mirroring V1 limits. */
 const BEHAVIOR_TEXT_MAX = 500;
 const FEEDBACK_TEXT_MAX = 1000;
+/** Trigger metadata and other short client strings (the API only requires
+ * them to be non-empty, so none of them can be trusted to be short). */
+const TRIGGER_TEXT_MAX = 300;
+const SHORT_TEXT_MAX = 254;
+/** Slack rejects the whole message when one section text exceeds 2000 chars,
+ * which would silently lose the notification. Escaping expands text (up to
+ * 5x), so this cap applies to the escaped result, with headroom for labels. */
+const SLACK_FIELD_TEXT_MAX = 1900;
 
 export interface ReportSlackNotification {
   reportId: string;
@@ -122,9 +130,9 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   });
 
   const identityFields = [
-    { type: "mrkdwn", text: `*User:*\n${escapeSlackText(mentraUserId)}` },
-    { type: "mrkdwn", text: `*Report ID:*\n\`${escapeSlackText(reportId)}\`` },
-    { type: "mrkdwn", text: `*Env:*\n${escapeSlackText(env)}` },
+    { type: "mrkdwn", text: `*User:*\n${slackText(mentraUserId, SHORT_TEXT_MAX)}` },
+    { type: "mrkdwn", text: `*Report ID:*\n\`${slackText(reportId, SHORT_TEXT_MAX)}\`` },
+    { type: "mrkdwn", text: `*Env:*\n${slackText(env, SHORT_TEXT_MAX)}` },
   ];
   if (artifactCount !== undefined) {
     identityFields.push({ type: "mrkdwn", text: `*Artifacts:*\n${artifactCount}` });
@@ -139,20 +147,20 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   if (typeof trigger?.source === "string") {
     triggerFields.push({
       type: "mrkdwn",
-      text: `*Trigger source:*\n${escapeSlackText(trigger.source)}`,
+      text: `*Trigger source:*\n${slackText(trigger.source, TRIGGER_TEXT_MAX)}`,
     });
   }
   if (typeof trigger?.reason === "string") {
     triggerFields.push({
       type: "mrkdwn",
-      text: `*Trigger reason:*\n${escapeSlackText(trigger.reason)}`,
+      text: `*Trigger reason:*\n${slackText(trigger.reason, TRIGGER_TEXT_MAX)}`,
     });
   }
   const sourceApplet = formatSourceApplet(trigger);
   if (sourceApplet) {
     triggerFields.push({
       type: "mrkdwn",
-      text: `*Source applet:*\n${escapeSlackText(sourceApplet)}`,
+      text: `*Source applet:*\n${slackText(sourceApplet, TRIGGER_TEXT_MAX)}`,
     });
   }
   if (triggerFields.length > 0) {
@@ -168,7 +176,9 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   const fallbackParts = [
     `New ${kind} report from ${mentraUserId} (${env})`,
     `Report ID: ${reportId}`,
-    ...(typeof trigger?.reason === "string" ? [`Trigger: ${trigger.reason}`] : []),
+    ...(typeof trigger?.reason === "string"
+      ? [`Trigger: ${truncate(trigger.reason, TRIGGER_TEXT_MAX)}`]
+      : []),
     ...(artifactCount !== undefined ? [`Artifacts: ${artifactCount}`] : []),
   ];
 
@@ -185,13 +195,13 @@ function buildBodyBlocks(notification: ReportSlackNotification): SlackBlock[] {
     if (typeof report.actualBehavior === "string") {
       detailFields.push({
         type: "mrkdwn",
-        text: `*Actual:*\n${escapeSlackText(truncate(report.actualBehavior, BEHAVIOR_TEXT_MAX))}`,
+        text: `*Actual:*\n${slackText(report.actualBehavior, BEHAVIOR_TEXT_MAX)}`,
       });
     }
     if (typeof report.expectedBehavior === "string") {
       detailFields.push({
         type: "mrkdwn",
-        text: `*Expected:*\n${escapeSlackText(truncate(report.expectedBehavior, BEHAVIOR_TEXT_MAX))}`,
+        text: `*Expected:*\n${slackText(report.expectedBehavior, BEHAVIOR_TEXT_MAX)}`,
       });
     }
     if (detailFields.length > 0) {
@@ -215,7 +225,7 @@ function buildBodyBlocks(notification: ReportSlackNotification): SlackBlock[] {
     if (typeof report.contactEmail === "string") {
       blocks.push({
         type: "section",
-        text: { type: "mrkdwn", text: `*Contact:* ${escapeSlackText(report.contactEmail)}` },
+        text: { type: "mrkdwn", text: `*Contact:* ${slackText(report.contactEmail, SHORT_TEXT_MAX)}` },
       });
     }
   }
@@ -230,13 +240,13 @@ function buildBodyBlocks(notification: ReportSlackNotification): SlackBlock[] {
       type: "section",
       text: {
         type: "mrkdwn",
-        text: `*Feedback:*\n${escapeSlackText(truncate(message, FEEDBACK_TEXT_MAX))}`,
+        text: `*Feedback:*\n${slackText(message, FEEDBACK_TEXT_MAX)}`,
       },
     });
     if (typeof feedback.type === "string") {
       blocks.push({
         type: "section",
-        text: { type: "mrkdwn", text: `*Type:* ${escapeSlackText(feedback.type)}` },
+        text: { type: "mrkdwn", text: `*Type:* ${slackText(feedback.type, SHORT_TEXT_MAX)}` },
       });
     }
     if (typeof feedback.experienceRating === "number") {
@@ -252,7 +262,7 @@ function buildBodyBlocks(notification: ReportSlackNotification): SlackBlock[] {
     if (typeof feedback.contactEmail === "string") {
       blocks.push({
         type: "section",
-        text: { type: "mrkdwn", text: `*Contact:* ${escapeSlackText(feedback.contactEmail)}` },
+        text: { type: "mrkdwn", text: `*Contact:* ${slackText(feedback.contactEmail, SHORT_TEXT_MAX)}` },
       });
     }
   }
@@ -274,6 +284,18 @@ function formatSourceApplet(trigger: ReportSlackNotification["trigger"]): string
  */
 function environmentLabel(): string {
   return process.env.CLOUD_CORE_ENVIRONMENT || "unknown";
+}
+
+/**
+ * Prepare client-sourced text for a Slack field: cap at the field's own
+ * length budget, escape, then hard-cap the escaped result under Slack's
+ * 2000-char section text limit. A truncated trailing entity is stripped
+ * rather than left dangling.
+ */
+function slackText(text: string, max: number): string {
+  const escaped = escapeSlackText(truncate(text, max));
+  if (escaped.length <= SLACK_FIELD_TEXT_MAX) return escaped;
+  return `${escaped.slice(0, SLACK_FIELD_TEXT_MAX).replace(/&[a-z]*$/i, "")}...`;
 }
 
 /** Escape &, <, > which have special meaning in Slack mrkdwn. */

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -12,6 +12,7 @@ import { ulid } from "ulid";
 import { createLogger } from "@mentra/cloud-shared";
 import { ReportModel } from "../models/report.model";
 import { ReportAssetModel } from "../models/report-asset.model";
+import { notifyReportSlack } from "./report-slack.service";
 import { createStorageService } from "./storage/storage.service";
 
 const logger = createLogger("core").child({ service: "report.service" });
@@ -96,21 +97,34 @@ export interface AddReportArtifactsResult {
 export async function submitReport(input: SubmitReportInput): Promise<SubmitReportResult> {
   const reportId = `rep_${ulid()}`;
   const status: ReportStatus = input.kind === "feedback" ? "ready" : "collecting";
+  const feedback = "feedback" in input
+    ? typeof input.feedback === "string"
+      ? { message: input.feedback }
+      : input.feedback
+    : null;
   await ReportModel.create({
     reportId,
     mentraUserId: input.mentraUserId,
     kind: input.kind,
     trigger: "trigger" in input ? input.trigger : null,
     report: "report" in input ? input.report : null,
-    feedback: "feedback" in input
-      ? typeof input.feedback === "string"
-        ? { message: input.feedback }
-        : input.feedback
-      : null,
+    feedback,
     context: input.context,
     artifacts: [],
     status,
   });
+
+  // Feedback reports are complete as submitted, so they notify here;
+  // bug/automatic reports notify from markReportReady once artifact
+  // collection finishes. Fire-and-forget: the response never waits on Slack.
+  if (status === "ready") {
+    notifyReportSlack({
+      reportId,
+      mentraUserId: input.mentraUserId,
+      kind: input.kind,
+      feedback,
+    }).catch(() => {});
+  }
 
   return { reportId, status };
 }
@@ -158,11 +172,26 @@ export async function markReportReady(input: {
   mentraUserId: string;
   reportId: string;
 }): Promise<ReportStatus | null> {
-  const result = await ReportModel.updateOne(
+  // The pre-update document shows whether this call actually finished
+  // collection (repeated /complete calls find "ready" and stay silent) and
+  // carries the snapshot the Slack notification summarizes.
+  const before = await ReportModel.findOneAndUpdate(
     { reportId: input.reportId, mentraUserId: input.mentraUserId },
     { $set: { status: "ready", updatedAt: new Date() } },
-  );
-  if (result.matchedCount !== 1) return null;
+    { returnDocument: "before" },
+  ).lean();
+  if (!before) return null;
+  if (before.status === "collecting") {
+    notifyReportSlack({
+      reportId: input.reportId,
+      mentraUserId: input.mentraUserId,
+      kind: before.kind,
+      trigger: before.trigger,
+      report: before.report,
+      feedback: before.feedback,
+      artifactCount: before.artifacts?.length ?? 0,
+    }).catch(() => {});
+  }
   return "ready";
 }
 

--- a/cloud-v2/tests/reports.integration.test.ts
+++ b/cloud-v2/tests/reports.integration.test.ts
@@ -20,7 +20,7 @@ import crypto from "node:crypto";
 import { rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from "bun:test";
 
 // Crypto material and the storage root must be set BEFORE core reads them.
 // Signing keys are loaded lazily and the report service creates its storage
@@ -40,6 +40,9 @@ const STORAGE_DIR = join(tmpdir(), `mentra-reports-test-${process.pid}`);
   process.env.SUPABASE_JWT_SECRET = "test-supabase-secret-not-for-production";
   process.env.SUPABASE_URL = "https://testproj.supabase.co";
   process.env.CLOUD_CORE_LOCAL_STORAGE_DIR = STORAGE_DIR;
+  // Only the Slack notification tests opt in to a (mocked) webhook; everything
+  // else must run with the notifier disabled, whatever the shell env says.
+  delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
 }
 
 // eslint-disable-next-line import/first
@@ -271,6 +274,102 @@ describe("reports upload limits", () => {
   });
 });
 
+describe("report Slack notifications", () => {
+  const SLACK_WEBHOOK = "https://hooks.slack.test/services/T0/B0/reports";
+  const realFetch = globalThis.fetch;
+  let slackCalls: Array<{ url: string; payload: { text: string; blocks: unknown[] } }>;
+
+  // The in-process app is invoked via coreApp.fetch (a plain handler call),
+  // so replacing globalThis.fetch intercepts only the notifier's outbound
+  // webhook POST.
+  beforeEach(() => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = SLACK_WEBHOOK;
+    slackCalls = [];
+    globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+      slackCalls.push({
+        url: String(input),
+        payload: JSON.parse(String(init?.body)) as { text: string; blocks: unknown[] },
+      });
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  });
+
+  test("notifies Slack when feedback is submitted", async () => {
+    const res = await coreApp.fetch(
+      new Request(REPORTS_PATH, {
+        method: "POST",
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({
+          kind: "feedback",
+          feedback: { type: "feature", message: "please add a dark mode" },
+          context: {},
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { reportId: string; status: string };
+    expect(body.status).toBe("ready");
+
+    // The notifier fires before the response resolves (fire-and-forget, but
+    // the webhook call starts synchronously), so no waiting is needed.
+    expect(slackCalls).toHaveLength(1);
+    expect(slackCalls[0].url).toBe(SLACK_WEBHOOK);
+    expect(slackCalls[0].payload.text).toContain("feedback");
+    expect(slackCalls[0].payload.text).toContain(body.reportId);
+    expect(slackCalls[0].payload.text).toContain(mentraUserId);
+    expect(JSON.stringify(slackCalls[0].payload.blocks)).toContain("please add a dark mode");
+  });
+
+  test("notifies once with the artifact count when a bug report completes", async () => {
+    const reportId = await submitBugReport();
+    expect(slackCalls).toHaveLength(0);
+
+    const form = new FormData();
+    form.append("type", "screenshot");
+    form.append("source", "phone");
+    form.append("files", new File([crypto.randomBytes(64)], "a.jpg", { type: "image/jpeg" }));
+    form.append("files", new File([crypto.randomBytes(64)], "b.jpg", { type: "image/jpeg" }));
+    expect((await postArtifacts(reportId, form)).status).toBe(200);
+    expect(slackCalls).toHaveLength(0);
+
+    const complete = await completeReport(reportId);
+    expect(complete.status).toBe(200);
+    expect(slackCalls).toHaveLength(1);
+    expect(slackCalls[0].payload.text).toContain("bug");
+    expect(slackCalls[0].payload.text).toContain(reportId);
+    expect(slackCalls[0].payload.text).toContain("Artifacts: 2");
+    const blocksJson = JSON.stringify(slackCalls[0].payload.blocks);
+    expect(blocksJson).toContain("manual_bug_report");
+    expect(blocksJson).toContain("the app crashed");
+
+    // Repeated /complete calls keep the API response but stay silent.
+    const again = await completeReport(reportId);
+    expect(again.status).toBe(200);
+    expect(await again.json()).toEqual({ status: "ready" });
+    expect(slackCalls).toHaveLength(1);
+  });
+
+  test("submits successfully with no Slack call when the webhook env is unset", async () => {
+    delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+
+    const res = await coreApp.fetch(
+      new Request(REPORTS_PATH, {
+        method: "POST",
+        headers: { ...authHeaders(), "content-type": "application/json" },
+        body: JSON.stringify({ kind: "feedback", feedback: "plain text note", context: {} }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { status: string }).status).toBe("ready");
+    expect(slackCalls).toHaveLength(0);
+  });
+});
+
 // === Helpers ===
 
 function authHeaders(): Record<string, string> {
@@ -302,6 +401,16 @@ function postArtifacts(reportId: string, form: FormData): Promise<Response> {
       method: "POST",
       headers: authHeaders(),
       body: form,
+    }),
+  );
+}
+
+function completeReport(reportId: string): Promise<Response> {
+  return coreApp.fetch(
+    new Request(`${REPORTS_PATH}/${reportId}/complete`, {
+      method: "POST",
+      headers: { ...authHeaders(), "content-type": "application/json" },
+      body: "{}",
     }),
   );
 }


### PR DESCRIPTION
## Problem

Bug reports and feedback now flow through the Cloud V2 reports service (`/api/client/reports`), not the old cloud backend. The old path (`cloud/packages/cloud/src/services/client/feedback.service.ts` → `slackService.notifyUserFeedback`) is no longer invoked by the mobile app, so the Slack notifications the team relied on stopped.

## What this does

Adds a fire-and-forget Slack notifier to the Cloud V2 reports service, posting to an Incoming Webhook read from `CLOUD_REPORTS_SLACK_WEBHOOK_URL`:

- **Feedback reports** notify from `submitReport` (they are `ready` as submitted).
- **Bug / automatic reports** notify from `markReportReady`, on the actual `collecting → ready` transition, so the message can say how many artifacts were attached. Repeated `/complete` calls keep returning `{status: "ready"}` but stay silent (`markReportReady` now reads the pre-update document via `findOneAndUpdate` — same single atomic write as before, API surface unchanged).

The message mirrors the V1 `slack.service.ts` conventions (header emoji per kind, mrkdwn fields, `&<>` escaping, truncation, PT timestamp) and includes: kind, trigger source/reason, source applet, actual/expected behavior or feedback text (truncated to 500/1000 chars), severity or experience rating, contact email when given, `mentraUserId`, `reportId`, artifact count, and which environment it came from.

Failure behavior: unset webhook env is a silent skip (dev/test need no config); send errors are logged and swallowed; the webhook call runs fire-and-forget with a 10s timeout, so it can never delay or fail the API response (same `.catch(() => {})` convention as the old feedback service).

## Configuration (action needed before this is live)

- **`CLOUD_REPORTS_SLACK_WEBHOOK_URL`** must be added to the Doppler `cloud-v2` configs (`dev_aws`, `staging`, `prod`), pointing at the reports/feedback channel webhook. Until it is set, the service logs a debug line and skips — nothing breaks.
- The env label in the message comes from **`CLOUD_CORE_ENVIRONMENT`** (falls back to `unknown`), so one channel can receive several environments unambiguously. Worth confirming it is set in those same configs.
- Nothing is hardcoded; no other config changes.

## Tests

- `cloud-v2/packages/core/src/services/report-slack.service.test.ts` (unit, mocked `fetch`): unset webhook env is a no-op (no fetch call); payload carries kind/user/env/reportId/trigger/artifact count; long text truncates; Slack control characters escape; network errors and non-2xx responses resolve without throwing.
- `cloud-v2/tests/reports.integration.test.ts` (in-process app + real Mongo, mocked global `fetch`): feedback submit posts once with the feedback text; a bug report posts nothing at submit/artifact time, posts once on `/complete` with `Artifacts: 2`, and a second `/complete` stays silent; with the env var unset submission succeeds with zero webhook calls. The suite also force-clears `CLOUD_REPORTS_SLACK_WEBHOOK_URL` at startup so other report tests can never hit a real webhook from a developer shell.

Test evidence: `bun test packages/core/src/services/report-slack.service.test.ts` → 6 pass. `bun test tests/reports.integration.test.ts` → all pass (includes the 3 new Slack cases; needs local Mongo via `bun run setup:test`). `bun run typecheck` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Outbound notifications only; failures are swallowed and report APIs are unchanged aside from optional async side effects. Requires setting `CLOUD_REPORTS_SLACK_WEBHOOK_URL` in deploy configs to go live.
> 
> **Overview**
> Restores team Slack alerts for Cloud V2 client reports by adding a **best-effort** `notifyReportSlack` path (Incoming Webhook via `CLOUD_REPORTS_SLACK_WEBHOOK_URL`), replacing the old Cloud V1 feedback notifier.
> 
> **Feedback** posts on `submitReport` when status is already `ready`. **Bug/automatic** posts only on the first `collecting → ready` transition in `markReportReady`, using `findOneAndUpdate` with `returnDocument: "before"` so repeat `/complete` calls stay silent while still including artifact count. Calls are fire-and-forget with a 10s timeout; missing webhook or send failures never block the API.
> 
> The new service builds Block Kit summaries (kind, user, env, trigger, behavior/feedback, severity/rating, truncation, mrkdwn escaping, 2000-char caps). Unit and integration tests cover payloads, idempotency, and disabled webhook behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e9bda53463a4fd10370f6ce83405a89036df2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->