### PR TITLE
Admin console: report triage (list, detail, screenshots, logs)

### DIFF
--- a/cloud-v2/packages/core/src/api/admin/preinstalled.api.ts
+++ b/cloud-v2/packages/core/src/api/admin/preinstalled.api.ts
@@ -1,6 +1,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { adminAuth } from "../middleware/admin-auth.middleware";
+import adminReports from "./reports.api";
 import {
   PREINSTALLED_INSTALL_POLICIES,
 } from "../../models/preinstalled-registry-revision.model";
@@ -66,6 +67,9 @@ app.get("/preinstalled/registries/:registryId/revisions", getRevisions);
 app.post("/preinstalled/registries/:registryId/revisions", postRevision);
 app.post("/preinstalled/registries/:registryId/revisions/:revisionId/promote", postPromoteRevision);
 app.get("/audit-log", getAuditLog);
+// Report triage lives in its own router; mounting it behind the adminAuth
+// gate above keeps auth to a single pass per request.
+app.route("/reports", adminReports);
 
 async function getSubmissions(c: AppContext) {
   return c.json({ submissions: await miniapps.listAdminSubmissions() });

--- a/cloud-v2/packages/core/src/api/admin/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/admin/reports.api.ts
@@ -69,15 +69,31 @@ async function getReportArtifact(c: AppContext) {
   }
   if (!payload) return c.json({ error: "not_found", error_description: "artifact not found" }, 404);
 
+  // Artifact bytes are user-submitted. Only content types a browser cannot
+  // script are served inline (SVG stays out — it can run script); everything
+  // else downloads as an opaque attachment. nosniff plus a deny-all sandbox
+  // CSP keeps even a mislabeled body inert when opened as a document.
+  const contentType = (payload.contentType || "").split(";")[0].trim().toLowerCase();
+  const inline = INLINE_CONTENT_TYPES.has(contentType);
   return new Response(payload.bytes, {
     status: 200,
     headers: {
-      "content-type": payload.contentType || "application/octet-stream",
-      "content-disposition": `inline; filename="${safeFilename(payload.fileName, artifactId)}"`,
+      "content-type": inline ? contentType : "application/octet-stream",
+      "content-disposition": `${inline ? "inline" : "attachment"}; filename="${safeFilename(payload.fileName, artifactId)}"`,
+      "x-content-type-options": "nosniff",
+      "content-security-policy": "default-src 'none'; sandbox",
       "cache-control": "private, max-age=300",
     },
   });
 }
+
+const INLINE_CONTENT_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "application/json",
+]);
 
 function requiredParam(c: AppContext, name: string): string {
   const value = (c.req.param(name) ?? "").trim();

--- a/cloud-v2/packages/core/src/api/admin/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/admin/reports.api.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Admin report triage routes.
+ *
+ * Read-only surface behind the internal admin console's incident system:
+ *   GET /            — newest-first report list (kind/status filters)
+ *   GET /:reportId   — full report document plus its asset rows
+ *   GET /:reportId/artifacts/:artifactId — raw artifact payload bytes
+ *
+ * Mounted at `/reports` inside the admin router (preinstalled.api.ts) AFTER
+ * its `adminAuth` gate, so every route here is admin-only without running the
+ * auth middleware a second time. Do not mount this router anywhere else.
+ */
+
+import { Hono } from "hono";
+import { z } from "zod";
+import {
+  getReport,
+  listReports,
+  readReportArtifactPayload,
+} from "../../services/report.service";
+import type { AppContext, AppEnv } from "../../types/hono.types";
+import { InvalidRequest } from "../../types/oauth.types";
+
+const app = new Hono<AppEnv>();
+
+const listQuerySchema = z.object({
+  kind: z.enum(["bug", "feedback", "automatic"]).optional(),
+  status: z.enum(["collecting", "ready", "closed"]).optional(),
+  limit: z.coerce.number().int().min(1).max(200).optional(),
+  before: z.coerce.date().optional(),
+});
+
+app.get("/", getReportsList);
+app.get("/:reportId", getReportDetail);
+app.get("/:reportId/artifacts/:artifactId", getReportArtifact);
+
+async function getReportsList(c: AppContext) {
+  const parsed = listQuerySchema.safeParse({
+    kind: c.req.query("kind"),
+    status: c.req.query("status"),
+    limit: c.req.query("limit"),
+    before: c.req.query("before"),
+  });
+  if (!parsed.success) {
+    throw new InvalidRequest("invalid report list query");
+  }
+  return c.json({ reports: await listReports(parsed.data) });
+}
+
+async function getReportDetail(c: AppContext) {
+  const detail = await getReport(requiredParam(c, "reportId"));
+  if (!detail) return c.json({ error: "not_found", error_description: "report not found" }, 404);
+  return c.json(detail);
+}
+
+async function getReportArtifact(c: AppContext) {
+  const reportId = requiredParam(c, "reportId");
+  const artifactId = requiredParam(c, "artifactId");
+
+  let payload: Awaited<ReturnType<typeof readReportArtifactPayload>>;
+  try {
+    payload = await readReportArtifactPayload(reportId, artifactId);
+  } catch (error) {
+    // The asset row exists but its blob is unreadable (rolled back or storage
+    // trouble). Surface as missing rather than a bare 500; the log keeps the
+    // distinction diagnosable.
+    c.var.logger.warn({ reportId, artifactId, error: (error as Error)?.message }, "report artifact payload unreadable");
+    return c.json({ error: "not_found", error_description: "artifact payload unavailable" }, 404);
+  }
+  if (!payload) return c.json({ error: "not_found", error_description: "artifact not found" }, 404);
+
+  return new Response(payload.bytes, {
+    status: 200,
+    headers: {
+      "content-type": payload.contentType || "application/octet-stream",
+      "content-disposition": `inline; filename="${safeFilename(payload.fileName, artifactId)}"`,
+      "cache-control": "private, max-age=300",
+    },
+  });
+}
+
+function requiredParam(c: AppContext, name: string): string {
+  const value = (c.req.param(name) ?? "").trim();
+  if (!value) throw new InvalidRequest(`${name} is required`);
+  return value;
+}
+
+/** Client-supplied filenames go through a strict allowlist before reaching a header. */
+function safeFilename(fileName: string | null, fallback: string): string {
+  const cleaned = (fileName ?? "").replace(/[^a-zA-Z0-9._-]/g, "").slice(0, 80);
+  return cleaned || fallback;
+}
+
+export default app;

--- a/cloud-v2/packages/core/src/api/client/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/client/reports.api.ts
@@ -189,6 +189,23 @@ function readReportId(c: AppContext, paramName: string): string {
   return reportId;
 }
 
+// The declared multipart type is attacker-controlled; store it only when it
+// names a plausible screenshot format, otherwise fall back to an opaque type.
+// The admin artifact route additionally allowlists what it will serve inline.
+const SCREENSHOT_CONTENT_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/heic",
+  "image/heif",
+]);
+
+function screenshotContentType(raw: string | undefined): string {
+  const cleaned = (raw ?? "").split(";")[0].trim().toLowerCase();
+  return SCREENSHOT_CONTENT_TYPES.has(cleaned) ? cleaned : "application/octet-stream";
+}
+
 async function readJsonObject(c: AppContext): Promise<Record<string, unknown>> {
   try {
     const parsed = await c.req.json();
@@ -222,7 +239,7 @@ async function readAttachmentFiles(c: AppContext): Promise<ReportAttachmentInput
     }
     files.push({
       filename: value.name || `artifact-${Date.now()}`,
-      contentType: value.type || "application/octet-stream",
+      contentType: screenshotContentType(value.type),
       bytes: new Uint8Array(await value.arrayBuffer()),
     });
   }

--- a/cloud-v2/packages/core/src/models/report.model.ts
+++ b/cloud-v2/packages/core/src/models/report.model.ts
@@ -59,6 +59,8 @@ const ReportSchema = new Schema(
 );
 
 ReportSchema.index({ mentraUserId: 1, createdAt: -1 });
+// Admin triage lists reports newest-first across all users.
+ReportSchema.index({ createdAt: -1 });
 
 export type Report = InferSchemaType<typeof ReportSchema>;
 export const ReportModel = model("Report", ReportSchema);

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -275,6 +275,152 @@ async function addArtifacts(input: {
   }
 }
 
+// === Admin read surface ===
+// Consumed by the adminAuth-gated routes behind the internal admin console.
+
+export interface AdminReportArtifact {
+  artifactId: string;
+  type: "logs" | "screenshot" | "state_snapshot";
+  source: string;
+  filename: string | null;
+  contentType: string | null;
+  sizeBytes: number | null;
+  createdAt: string | null;
+}
+
+export interface AdminReportSummary {
+  reportId: string;
+  kind: ReportKind;
+  status: ReportStatus;
+  mentraUserId: string;
+  trigger: ReportTrigger | null;
+  report: (ReportDetails & Record<string, unknown>) | null;
+  feedback: Record<string, unknown> | null;
+  artifacts: AdminReportArtifact[];
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface AdminReportDetail extends AdminReportSummary {
+  context: Record<string, unknown>;
+}
+
+export interface AdminReportAsset {
+  artifactId: string;
+  storageKey: string;
+  fileName: string | null;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+  createdAt: string | null;
+}
+
+export interface ListReportsFilter {
+  kind?: ReportKind;
+  status?: ReportStatus;
+  limit?: number;
+  before?: Date;
+}
+
+export async function listReports(filter: ListReportsFilter = {}): Promise<AdminReportSummary[]> {
+  const query: Record<string, unknown> = {};
+  if (filter.kind) query.kind = filter.kind;
+  if (filter.status) query.status = filter.status;
+  if (filter.before) query.createdAt = { $lt: filter.before };
+  const limit = Math.min(Math.max(Math.trunc(filter.limit ?? 50), 1), 200);
+  // Context is the one potentially chunky field and the list view never shows
+  // it; everything else on a report is metadata-sized.
+  const rows = await ReportModel.find(query, { context: 0 })
+    .sort({ createdAt: -1 })
+    .limit(limit)
+    .lean();
+  return rows.map(serializeReportSummary);
+}
+
+export async function getReport(
+  reportId: string,
+): Promise<{ report: AdminReportDetail; assets: AdminReportAsset[] } | null> {
+  const row = await ReportModel.findOne({ reportId }).lean();
+  if (!row) return null;
+  const assets = await ReportAssetModel.find({ reportId }).sort({ createdAt: 1 }).lean();
+  return {
+    report: {
+      ...serializeReportSummary(row),
+      context: (row.context ?? {}) as Record<string, unknown>,
+    },
+    assets: assets.map((asset) => ({
+      artifactId: asset.artifactId,
+      storageKey: asset.storageKey,
+      fileName: asset.fileName ?? null,
+      contentType: asset.contentType,
+      sizeBytes: asset.sizeBytes,
+      sha256: asset.sha256,
+      createdAt: toIso(asset.createdAt),
+    })),
+  };
+}
+
+/**
+ * Payload bytes for one artifact, or null when no such asset row exists.
+ * Throws when the row exists but the blob cannot be read (deleted or storage
+ * outage) — the API layer decides how to present that.
+ */
+export async function readReportArtifactPayload(
+  reportId: string,
+  artifactId: string,
+): Promise<{ bytes: Uint8Array; contentType: string; fileName: string | null } | null> {
+  const asset = await ReportAssetModel.findOne({ reportId, artifactId }).lean();
+  if (!asset) return null;
+  const bytes = await getStorage().getObject(asset.storageKey);
+  return { bytes, contentType: asset.contentType, fileName: asset.fileName ?? null };
+}
+
+function serializeReportSummary(row: {
+  reportId: string;
+  kind: string;
+  status: string;
+  mentraUserId: string;
+  trigger?: unknown;
+  report?: unknown;
+  feedback?: unknown;
+  artifacts?: Array<{
+    artifactId: string;
+    type: string;
+    source: string;
+    filename?: string | null;
+    contentType?: string | null;
+    sizeBytes?: number | null;
+    createdAt?: Date | null;
+  }> | null;
+  createdAt?: Date | null;
+  updatedAt?: Date | null;
+}): AdminReportSummary {
+  return {
+    reportId: row.reportId,
+    kind: row.kind as ReportKind,
+    status: row.status as ReportStatus,
+    mentraUserId: row.mentraUserId,
+    trigger: (row.trigger ?? null) as AdminReportSummary["trigger"],
+    report: (row.report ?? null) as AdminReportSummary["report"],
+    feedback: (row.feedback ?? null) as AdminReportSummary["feedback"],
+    artifacts: (row.artifacts ?? []).map((artifact) => ({
+      artifactId: artifact.artifactId,
+      type: artifact.type as AdminReportArtifact["type"],
+      source: artifact.source,
+      filename: artifact.filename ?? null,
+      contentType: artifact.contentType ?? null,
+      sizeBytes: artifact.sizeBytes ?? null,
+      createdAt: toIso(artifact.createdAt),
+    })),
+    createdAt: toIso(row.createdAt),
+    updatedAt: toIso(row.updatedAt),
+  };
+}
+
+function toIso(value: Date | null | undefined): string | null {
+  return value ? new Date(value).toISOString() : null;
+}
+
 /**
  * Best-effort rollback of stored blobs and asset rows; failures are logged,
  * never thrown. The blob goes first, and its asset row is only removed once

--- a/cloud-v2/tests/admin-reports.integration.test.ts
+++ b/cloud-v2/tests/admin-reports.integration.test.ts
@@ -192,6 +192,54 @@ describe("admin reports read surface", () => {
     const missing = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/art_nope`);
     expect(missing.status).toBe(404);
   });
+
+  test("serves genuine images inline with hardening headers", async () => {
+    const reportId = await seedReport("inline headers");
+    const detail = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}`);
+    const { report } = (await detail.json()) as {
+      report: { artifacts: Array<{ artifactId: string; type: string }> };
+    };
+    const shot = report.artifacts.find(a => a.type === "screenshot")!;
+
+    const res = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/${shot.artifactId}`);
+    expect(res.headers.get("content-type")).toBe("image/jpeg");
+    expect(res.headers.get("content-disposition")).toStartWith("inline;");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(res.headers.get("content-security-policy")).toContain("default-src 'none'");
+  });
+
+  test("never renders a spoofed screenshot content type inline", async () => {
+    const reportId = await seedReport("hostile upload");
+
+    // A reporter attaches HTML bytes claiming to be a screenshot. The upload
+    // path must not store the scriptable type, and the admin artifact route
+    // must serve it as an opaque download rather than same-origin HTML.
+    const form = new FormData();
+    form.append(
+      "files",
+      new File(["<script>document.title='pwned'</script>"], "evil.html", { type: "text/html" }),
+    );
+    const upload = await coreApp.fetch(
+      new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+        method: "POST",
+        headers: { authorization: `Bearer ${userAccessToken}` },
+        body: form,
+      }),
+    );
+    expect(upload.status).toBe(200);
+
+    const detail = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}`);
+    const { report } = (await detail.json()) as {
+      report: { artifacts: Array<{ artifactId: string; filename: string | null }> };
+    };
+    const hostile = report.artifacts.find(a => a.filename === "evil.html")!;
+
+    const res = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/${hostile.artifactId}`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/octet-stream");
+    expect(res.headers.get("content-disposition")).toStartWith("attachment;");
+    expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+  });
 });
 
 // === Helpers ===

--- a/cloud-v2/tests/admin-reports.integration.test.ts
+++ b/cloud-v2/tests/admin-reports.integration.test.ts
@@ -1,0 +1,293 @@
+/**
+ * @fileoverview Admin report triage API integration tests.
+ *
+ * Covers the adminAuth-gated read surface behind the internal admin console:
+ * list (filters, context excluded), detail (context + asset rows), artifact
+ * payload bytes, and the auth gate itself (401 without credentials, 403 for a
+ * non-allowlisted principal).
+ *
+ * Admin auth uses the org API-key bearer path: an `msk_…` token is not a JWT,
+ * so authenticateBearerToken falls through to the local DB validation without
+ * touching WorkOS, and the resulting synthetic `api-key@{keyId}.local` email
+ * is allowlisted via CLOUD_CORE_ADMIN_EMAILS. Fully local — no WorkOS needed.
+ *
+ * Prereq: a running Mongo. Defaults to
+ * `mongodb://127.0.0.1:27017/mentra-cloud-v2-test`; override via `MONGO_URL`.
+ * The test wipes its own collections between cases — do NOT point at a real DB.
+ *
+ * Run: `bun test tests/admin-reports.integration.test.ts`
+ */
+
+import crypto from "node:crypto";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+const STORAGE_DIR = join(tmpdir(), `mentra-admin-reports-test-${process.pid}`);
+const savedAdminEmails = process.env.CLOUD_CORE_ADMIN_EMAILS;
+{
+  const { privateKey: nodePriv, publicKey: nodePub } =
+    crypto.generateKeyPairSync("ed25519");
+  process.env.MENTRA_JWT_PRIVATE_KEY = stripPemWrap(
+    nodePriv.export({ type: "pkcs8", format: "pem" }).toString(),
+  );
+  process.env.MENTRA_JWT_PUBLIC_KEY = stripPemWrap(
+    nodePub.export({ type: "spki", format: "pem" }).toString(),
+  );
+  process.env.REFRESH_TOKEN_PEPPER ??= "test-pepper-not-for-production";
+  process.env.MONGO_URL ??= "mongodb://127.0.0.1:27017/mentra-cloud-v2-test";
+  process.env.SUPABASE_JWT_SECRET = "test-supabase-secret-not-for-production";
+  process.env.SUPABASE_URL = "https://testproj.supabase.co";
+  process.env.CLOUD_CORE_LOCAL_STORAGE_DIR = STORAGE_DIR;
+  // Pin the API-key environment label so minted keys validate deterministically.
+  process.env.CLOUD_CORE_ENVIRONMENT = "local";
+}
+
+// eslint-disable-next-line import/first
+import {
+  connectMongo,
+  disconnectMongo,
+  mongoReadinessCheck,
+} from "../packages/core/src/connections/mongo.connection";
+import { createApp } from "../packages/core/src/api/app";
+import { ReportModel } from "../packages/core/src/models/report.model";
+import { ReportAssetModel } from "../packages/core/src/models/report-asset.model";
+import { UserModel } from "../packages/core/src/models/user.model";
+import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
+import { SeenJtiModel } from "../packages/core/src/models/seen-jti.model";
+import { RevokedJtiModel } from "../packages/core/src/models/revoked-jti.model";
+import { DeveloperOrgApiKeyModel } from "../packages/core/src/models/developer-org-api-key.model";
+import { DeveloperApiKeyService } from "../packages/core/src/services/developer-orgs/developer-api-key.service";
+
+const REPORTS_PATH = "http://localhost/api/client/reports";
+const ADMIN_REPORTS_PATH = "http://localhost/api/admin/reports";
+
+let coreApp: ReturnType<typeof createApp>;
+let userAccessToken: string;
+let adminBearer: string;
+let nonAdminBearer: string;
+
+beforeAll(async () => {
+  await connectMongo(process.env.MONGO_URL!);
+  await Promise.all([
+    ReportModel.syncIndexes(),
+    ReportAssetModel.syncIndexes(),
+    UserModel.syncIndexes(),
+    RefreshTokenModel.syncIndexes(),
+    SeenJtiModel.syncIndexes(),
+    RevokedJtiModel.syncIndexes(),
+    DeveloperOrgApiKeyModel.syncIndexes(),
+  ]);
+  coreApp = createApp({ readinessChecks: [mongoReadinessCheck] });
+
+  const exchanged = await exchange(mintSupabaseJwt("admin-reports-user-1"));
+  expect(exchanged.status).toBe(200);
+  userAccessToken = ((await exchanged.json()) as { access_token: string }).access_token;
+
+  const apiKeys = new DeveloperApiKeyService();
+  const adminKey = await apiKeys.create("org_admin_reports_test", "admin", "user_admin", "local");
+  const nonAdminKey = await apiKeys.create("org_admin_reports_test", "plain", "user_plain", "local");
+  adminBearer = adminKey.value!;
+  nonAdminBearer = nonAdminKey.value!;
+  process.env.CLOUD_CORE_ADMIN_EMAILS = `api-key@${adminKey.id}.local`;
+});
+
+afterAll(async () => {
+  if (savedAdminEmails === undefined) delete process.env.CLOUD_CORE_ADMIN_EMAILS;
+  else process.env.CLOUD_CORE_ADMIN_EMAILS = savedAdminEmails;
+  await DeveloperOrgApiKeyModel.deleteMany({ orgId: "org_admin_reports_test" });
+  await disconnectMongo();
+  await rm(STORAGE_DIR, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await Promise.all([
+    ReportModel.deleteMany({}),
+    ReportAssetModel.deleteMany({}),
+  ]);
+});
+
+describe("admin reports auth gate", () => {
+  test("rejects requests without credentials and non-admin principals", async () => {
+    const anonymous = await coreApp.fetch(new Request(ADMIN_REPORTS_PATH));
+    expect(anonymous.status).toBe(401);
+
+    const forbidden = await coreApp.fetch(
+      new Request(ADMIN_REPORTS_PATH, { headers: { authorization: `Bearer ${nonAdminBearer}` } }),
+    );
+    expect(forbidden.status).toBe(403);
+  });
+});
+
+describe("admin reports read surface", () => {
+  test("lists reports newest-first with artifact metadata and no context", async () => {
+    const first = await seedReport("first crash");
+    const second = await seedReport("second crash");
+
+    const res = await adminGet(ADMIN_REPORTS_PATH);
+    expect(res.status).toBe(200);
+    const { reports } = (await res.json()) as { reports: Array<Record<string, unknown>> };
+    const ids = reports.map(r => r.reportId);
+    expect(ids.indexOf(second)).toBeLessThan(ids.indexOf(first));
+
+    const row = reports.find(r => r.reportId === first)!;
+    expect(row.kind).toBe("bug");
+    expect(row.mentraUserId).toMatch(/^mu_/);
+    expect("context" in row).toBe(false);
+    const artifacts = row.artifacts as Array<Record<string, unknown>>;
+    expect(artifacts).toHaveLength(2);
+    expect(artifacts.map(a => a.type).sort()).toEqual(["logs", "screenshot"]);
+
+    const filtered = await adminGet(`${ADMIN_REPORTS_PATH}?kind=feedback`);
+    expect(((await filtered.json()) as { reports: unknown[] }).reports).toHaveLength(0);
+
+    const badQuery = await adminGet(`${ADMIN_REPORTS_PATH}?kind=nonsense`);
+    expect(badQuery.status).toBe(400);
+  });
+
+  test("returns full detail with context and asset rows", async () => {
+    const reportId = await seedReport("detail crash");
+
+    const res = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      report: Record<string, unknown>;
+      assets: Array<Record<string, unknown>>;
+    };
+    expect(body.report.reportId).toBe(reportId);
+    expect(body.report.context).toEqual({ app: { appVersion: "test" } });
+    expect(body.assets).toHaveLength(2);
+    for (const asset of body.assets) {
+      expect(typeof asset.storageKey).toBe("string");
+      expect(typeof asset.sha256).toBe("string");
+    }
+
+    const missing = await adminGet(`${ADMIN_REPORTS_PATH}/rep_nope`);
+    expect(missing.status).toBe(404);
+  });
+
+  test("serves artifact payload bytes with the stored content type", async () => {
+    const screenshot = crypto.randomBytes(1536);
+    const reportId = await seedReport("artifact crash", screenshot);
+
+    const detail = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}`);
+    const { report } = (await detail.json()) as {
+      report: { artifacts: Array<{ artifactId: string; type: string }> };
+    };
+    const shot = report.artifacts.find(a => a.type === "screenshot")!;
+    const logs = report.artifacts.find(a => a.type === "logs")!;
+
+    const shotRes = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/${shot.artifactId}`);
+    expect(shotRes.status).toBe(200);
+    expect(shotRes.headers.get("content-type")).toBe("image/jpeg");
+    expect(Buffer.from(await shotRes.arrayBuffer()).equals(screenshot)).toBe(true);
+
+    const logsRes = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/${logs.artifactId}`);
+    expect(logsRes.status).toBe(200);
+    expect(logsRes.headers.get("content-type")).toBe("application/json");
+    const parsed = (await logsRes.json()) as { entries: Array<{ message: string }> };
+    expect(parsed.entries[0].message).toBe("glasses connected");
+
+    const missing = await adminGet(`${ADMIN_REPORTS_PATH}/${reportId}/artifacts/art_nope`);
+    expect(missing.status).toBe(404);
+  });
+});
+
+// === Helpers ===
+
+function adminGet(url: string): Promise<Response> {
+  return coreApp.fetch(new Request(url, { headers: { authorization: `Bearer ${adminBearer}` } }));
+}
+
+/** Submit a bug report with one log bundle and one screenshot; returns the reportId. */
+async function seedReport(actualBehavior: string, screenshot?: Buffer): Promise<string> {
+  const submit = await coreApp.fetch(
+    new Request(REPORTS_PATH, {
+      method: "POST",
+      headers: { authorization: `Bearer ${userAccessToken}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        kind: "bug",
+        trigger: { type: "manual", source: "feedback_screen", reason: "manual_bug_report" },
+        report: { actualBehavior },
+        context: { app: { appVersion: "test" } },
+      }),
+    }),
+  );
+  expect(submit.status).toBe(200);
+  const { reportId } = (await submit.json()) as { reportId: string };
+
+  const logs = await coreApp.fetch(
+    new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${userAccessToken}`, "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "logs",
+        source: "glasses",
+        entries: [{ timestamp: 1700000000001, level: "info", message: "glasses connected" }],
+      }),
+    }),
+  );
+  expect(logs.status).toBe(200);
+
+  const form = new FormData();
+  form.append("files", new File([screenshot ?? crypto.randomBytes(512)], "shot.jpg", { type: "image/jpeg" }));
+  const shots = await coreApp.fetch(
+    new Request(`${REPORTS_PATH}/${reportId}/artifacts`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${userAccessToken}` },
+      body: form,
+    }),
+  );
+  expect(shots.status).toBe(200);
+
+  return reportId;
+}
+
+async function exchange(jwt: string): Promise<Response> {
+  const body = new URLSearchParams({
+    grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+    subject_token: jwt,
+    subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+  });
+  return coreApp.fetch(
+    new Request("http://localhost/api/client/auth/exchange", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    }),
+  );
+}
+
+/** Mint an HS256 JWT shaped like a Supabase session token. */
+function mintSupabaseJwt(sub: string): string {
+  const now = Math.floor(Date.now() / 1000);
+  const header = b64url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const payload = b64url(
+    JSON.stringify({
+      sub,
+      iss: `${process.env.SUPABASE_URL}/auth/v1`,
+      aud: "authenticated",
+      role: "authenticated",
+      iat: now,
+      exp: now + 3600,
+    }),
+  );
+  const signingInput = `${header}.${payload}`;
+  const sig = crypto
+    .createHmac("sha256", process.env.SUPABASE_JWT_SECRET!)
+    .update(signingInput)
+    .digest("base64url");
+  return `${signingInput}.${sig}`;
+}
+
+function b64url(value: string): string {
+  return Buffer.from(value).toString("base64url");
+}
+
+function stripPemWrap(pem: string): string {
+  return pem
+    .replace(/-----BEGIN [A-Z ]+-----/, "")
+    .replace(/-----END [A-Z ]+-----/, "")
+    .replace(/\s+/g, "");
+}

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -1029,7 +1029,7 @@ function ReportArtifactView({ reportId, artifact }: { reportId: string; artifact
     </div>
   );
 
-  if (artifact.type === "screenshot") {
+  if (artifact.type === "screenshot" && artifact.contentType?.startsWith("image/")) {
     return (
       <div className="rounded-[14px] bg-[#f5f7f4] p-3">
         {header}

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -1022,6 +1022,17 @@ function ReportDetailDrawer(props: { reportId: string; onClose: () => void }) {
   );
 }
 
+// Mirrors the admin API's INLINE_CONTENT_TYPES: anything outside this set is
+// served as an opaque attachment, so an <img> preview would render broken —
+// HEIC/HEIF iOS screenshots being the common case. Those fall through to the
+// download link instead.
+const PREVIEWABLE_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
+
+function isPreviewableImage(contentType: string | null | undefined): boolean {
+  if (!contentType) return false;
+  return PREVIEWABLE_IMAGE_TYPES.has(contentType.split(";")[0].trim().toLowerCase());
+}
+
 function ReportArtifactView({ reportId, artifact }: { reportId: string; artifact: ReportArtifact }) {
   const url = `/api/admin/reports/${reportId}/artifacts/${artifact.artifactId}`;
   const header = (
@@ -1033,7 +1044,7 @@ function ReportArtifactView({ reportId, artifact }: { reportId: string; artifact
     </div>
   );
 
-  if (artifact.type === "screenshot" && artifact.contentType?.startsWith("image/")) {
+  if (artifact.type === "screenshot" && isPreviewableImage(artifact.contentType)) {
     return (
       <div className="rounded-[14px] bg-[#f5f7f4] p-3">
         {header}

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertCircle, Bug, Check, ClipboardList, CloudUpload, History, Home, Loader2, MessageSquareWarning, PackageCheck, RotateCcw, ShieldCheck, X } from "lucide-react";
+import { AlertCircle, Bug, Check, ClipboardList, CloudUpload, FileText, History, Home, Loader2, MessageSquareWarning, PackageCheck, RefreshCcw, RotateCcw, ShieldCheck, X } from "lucide-react";
 import { useMemo, useState } from "react";
 import { AppShell, type NavItem } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
@@ -56,6 +56,56 @@ interface AuditEvent {
   targetId: string;
   reason: string | null;
   createdAt: string | null;
+}
+
+type ReportKind = "bug" | "feedback" | "automatic";
+type ReportStatus = "collecting" | "ready" | "closed";
+
+interface ReportArtifact {
+  artifactId: string;
+  type: "logs" | "screenshot" | "state_snapshot";
+  source: string;
+  filename: string | null;
+  contentType: string | null;
+  sizeBytes: number | null;
+  createdAt: string | null;
+}
+
+interface ReportSummary {
+  reportId: string;
+  kind: ReportKind;
+  status: ReportStatus;
+  mentraUserId: string;
+  trigger: {
+    type: string;
+    source: string;
+    reason: string;
+    sourceAppletPackageName?: string;
+    sourceAppletName?: string;
+  } | null;
+  report: ({ actualBehavior?: string; expectedBehavior?: string; userSeverity?: number; contactEmail?: string } & Record<string, unknown>) | null;
+  feedback: Record<string, unknown> | null;
+  artifacts: ReportArtifact[];
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+interface ReportDetailResponse {
+  report: ReportSummary & { context: Record<string, unknown> };
+  assets: Array<{
+    artifactId: string;
+    fileName: string | null;
+    contentType: string;
+    sizeBytes: number;
+    sha256: string;
+  }>;
+}
+
+interface ReportLogEntry {
+  timestamp: number;
+  level: string;
+  message: string;
+  source?: string;
 }
 
 const queryClient = new QueryClient({
@@ -234,7 +284,7 @@ function AdminPage() {
     review: { title: "Miniapp review", body: "Review developer-submitted releases before they are published to the store." },
     preinstalled: { title: "Preinstalled miniapps", body: "The managed default set MentraOS installs and keeps updated without a mobile app release." },
     audit: { title: "Audit log", body: "Every admin mutation: who approved, rejected, published, or promoted something." },
-    incidents: { title: "Incident system", body: "User reports, logs, triage, and release incidents — coming to this console." },
+    incidents: { title: "Incident system", body: "Bug reports and feedback filed from the Mentra App, with their screenshots and log bundles." },
   };
 
   if (me.isLoading) return <Splash label="Checking admin session" />;
@@ -303,7 +353,7 @@ function AdminPage() {
 
       {page === "audit" ? <AuditPage events={auditEvents} loading={audit.isLoading} /> : null}
 
-      {page === "incidents" ? <IncidentsPlaceholder /> : null}
+      {page === "incidents" ? <ReportsPage /> : null}
 
       {detailRelease ? (
         <SubmissionDetail
@@ -765,37 +815,318 @@ function AuditRow({ event, compact = false }: { event: AuditEvent; compact?: boo
   );
 }
 
-function IncidentsPlaceholder() {
+function ReportsPage() {
+  const [kind, setKind] = useState<"all" | ReportKind>("all");
+  const [status, setStatus] = useState<"all" | ReportStatus>("all");
+  const [detailId, setDetailId] = useState<string | null>(null);
+
+  const reports = useQuery({
+    queryKey: ["admin-reports", kind, status],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      if (kind !== "all") params.set("kind", kind);
+      if (status !== "all") params.set("status", status);
+      const qs = params.toString();
+      return api<{ reports: ReportSummary[] }>(`/api/admin/reports${qs ? `?${qs}` : ""}`);
+    },
+  });
+  const rows = reports.data?.reports ?? [];
+
   return (
-    <section className="rounded-[24px] border border-[#e0e4de] bg-white shadow-[0_1px_2px_rgba(20,21,27,0.06)]">
-      <div className="border-b border-[#eceeeb] p-5">
-        <div className="flex items-center gap-3">
-          <div className="flex size-12 items-center justify-center rounded-[16px] bg-[#eef2ff] text-[#3a55c8]">
-            <Bug className="size-6" />
-          </div>
+    <div className="space-y-6">
+      <section className="rounded-[24px] border border-[#e0e4de] bg-white shadow-[0_1px_2px_rgba(20,21,27,0.06)]">
+        <div className="flex flex-wrap items-center justify-between gap-4 border-b border-[#eceeeb] p-5">
           <div>
-            <h2 className="text-xl font-bold">Incident system</h2>
-            <p className="mt-1 text-sm text-[#68746d]">Not active yet. User reports, logs, and release-incident triage will move into this console here.</p>
+            <h2 className="text-xl font-bold">User reports</h2>
+            <p className="mt-1 text-sm text-[#68746d]">
+              Everything filed through the Mentra App reporting flow — open a report for its context, screenshots, and logs.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <FilterPills
+              value={kind}
+              onChange={setKind}
+              options={[["all", "All kinds"], ["bug", "Bug"], ["feedback", "Feedback"], ["automatic", "Automatic"]]}
+            />
+            <FilterPills
+              value={status}
+              onChange={setStatus}
+              options={[["all", "Any status"], ["collecting", "Collecting"], ["ready", "Ready"], ["closed", "Closed"]]}
+            />
+            <Button
+              variant="ghost"
+              size="icon"
+              className="rounded-full"
+              onClick={() => reports.refetch()}
+              aria-label="Refresh reports"
+              disabled={reports.isFetching}
+            >
+              <RefreshCcw className={`size-4 ${reports.isFetching ? "animate-spin" : ""}`} />
+            </Button>
           </div>
         </div>
-      </div>
-      <div className="grid gap-4 p-5 md:grid-cols-3">
-        {[
-          ["Reports", "Browse submitted user feedback and linked logs."],
-          ["Triage", "Assign status, owner, severity, and release impact."],
-          ["Review", "Connect incidents back to miniapp releases and app versions."],
-        ].map(([title, body]) => (
-          <div key={title} className="rounded-[18px] bg-[#f5f7f4] p-5">
-            <div className="text-lg font-bold">{title}</div>
-            <p className="mt-2 text-sm leading-6 text-[#68746d]">{body}</p>
-            <span className="mt-4 inline-flex rounded-full border border-[#dfe3dc] bg-white px-3 py-1 text-xs font-bold uppercase tracking-[0.12em] text-[#a0a3aa]">
-              Planned
-            </span>
+        {reports.isLoading ? (
+          <div className="p-5"><InlineLoading label="Loading reports" /></div>
+        ) : reports.isError ? (
+          <div className="p-5"><ErrorText error={reports.error} /></div>
+        ) : rows.length === 0 ? (
+          <EmptyState title="No reports" body="Bug reports and feedback submitted from the Mentra App will appear here." />
+        ) : (
+          <div className="divide-y divide-[#eceeeb]">
+            {rows.map(report => (
+              <button
+                key={report.reportId}
+                className="flex w-full items-start gap-4 p-5 text-left hover:bg-[#fafbfa]"
+                onClick={() => setDetailId(report.reportId)}
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <ReportKindTag kind={report.kind} />
+                    <ReportStatusTag status={report.status} />
+                    {report.artifacts.length > 0 ? (
+                      <span className="rounded-full bg-[#f0f2ef] px-2.5 py-0.5 text-xs font-semibold text-[#4f5d54]">
+                        {report.artifacts.length} artifact{report.artifacts.length === 1 ? "" : "s"}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-2 line-clamp-2 text-sm font-semibold leading-5">{reportSummaryText(report)}</div>
+                  <div className="mt-1 truncate font-mono text-xs text-[#a0a3aa]">
+                    {report.mentraUserId} · {report.trigger?.source ?? "—"}
+                  </div>
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-sm text-[#747780]">{formatDate(report.createdAt)}</div>
+                  <div className="mt-1 text-sm font-semibold text-[#087d50]">Open →</div>
+                </div>
+              </button>
+            ))}
           </div>
-        ))}
-      </div>
-    </section>
+        )}
+      </section>
+
+      <p className="px-1 text-xs text-[#a0a3aa]">
+        Triage (owner, severity, release impact) and release review are planned follow-ups for this page.
+      </p>
+
+      {detailId ? <ReportDetailDrawer reportId={detailId} onClose={() => setDetailId(null)} /> : null}
+    </div>
   );
+}
+
+function FilterPills<T extends string>(props: {
+  value: T;
+  onChange: (value: T) => void;
+  options: ReadonlyArray<readonly [T, string]>;
+}) {
+  return (
+    <div className="flex h-9 items-center gap-1 rounded-full border border-[#e0e4de] bg-[#f7f8f6] p-1">
+      {props.options.map(([value, label]) => (
+        <button
+          key={value}
+          onClick={() => props.onChange(value)}
+          className={`h-7 rounded-full px-3 text-xs font-semibold ${
+            props.value === value ? "bg-white text-[#14151b] shadow-sm" : "text-[#68746d] hover:text-[#14151b]"
+          }`}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function ReportDetailDrawer(props: { reportId: string; onClose: () => void }) {
+  const detail = useQuery({
+    queryKey: ["admin-report", props.reportId],
+    queryFn: () => api<ReportDetailResponse>(`/api/admin/reports/${props.reportId}`),
+  });
+  const report = detail.data?.report;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-[#111217]/30" onClick={props.onClose}>
+      <div
+        className="h-full w-full max-w-[640px] overflow-y-auto bg-[#f7f8f6] shadow-2xl"
+        onClick={event => event.stopPropagation()}
+      >
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-[#e4e6e2] bg-white/90 px-6 py-4 backdrop-blur">
+          <h2 className="font-display text-lg font-bold">Report</h2>
+          <Button variant="ghost" size="icon" className="rounded-full" onClick={props.onClose} aria-label="Close">
+            <X className="size-5" />
+          </Button>
+        </div>
+
+        <div className="space-y-5 p-6">
+          {detail.isLoading ? <InlineLoading label="Loading report" /> : null}
+          {detail.isError ? <ErrorText error={detail.error} /> : null}
+          {report ? (
+            <>
+              <div className="rounded-[18px] border border-[#e0e4de] bg-white p-5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <ReportKindTag kind={report.kind} />
+                  <ReportStatusTag status={report.status} />
+                </div>
+                <div className="mt-3 font-mono text-xs text-[#68746d]">{report.reportId}</div>
+                <p className="mt-3 whitespace-pre-wrap text-sm leading-6 text-[#14151b]">{reportSummaryText(report)}</p>
+                {report.report?.expectedBehavior ? (
+                  <p className="mt-2 text-sm leading-6 text-[#68746d]">
+                    <span className="font-semibold text-[#4f5d54]">Expected:</span> {report.report.expectedBehavior}
+                  </p>
+                ) : null}
+              </div>
+
+              <DetailGrid
+                rows={[
+                  ["User", report.mentraUserId],
+                  ["Filed", formatDate(report.createdAt)],
+                  ["Source", report.trigger?.source ?? "—"],
+                  ["Reason", report.trigger?.reason ?? "—"],
+                  ["Severity", report.report?.userSeverity != null ? `${report.report.userSeverity}/5` : "—"],
+                  ["Contact", report.report?.contactEmail ?? "—"],
+                  ["Applet", report.trigger?.sourceAppletName ?? report.trigger?.sourceAppletPackageName ?? "—"],
+                  ["Updated", formatDate(report.updatedAt)],
+                ]}
+              />
+
+              <div className="rounded-[18px] border border-[#e0e4de] bg-white p-5">
+                <div className="text-xs font-medium uppercase tracking-[0.1em] text-[#a0a3aa]">
+                  Artifacts ({report.artifacts.length})
+                </div>
+                {report.artifacts.length === 0 ? (
+                  <p className="mt-2 text-sm text-[#68746d]">No screenshots or logs were attached.</p>
+                ) : (
+                  <div className="mt-3 space-y-4">
+                    {report.artifacts.map(artifact => (
+                      <ReportArtifactView key={artifact.artifactId} reportId={report.reportId} artifact={artifact} />
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              <details className="rounded-[18px] border border-[#e0e4de] bg-white p-5">
+                <summary className="cursor-pointer text-xs font-medium uppercase tracking-[0.1em] text-[#a0a3aa]">
+                  Device context
+                </summary>
+                <pre className="mt-3 max-h-96 overflow-auto rounded-[12px] bg-[#f5f7f4] p-4 font-mono text-xs leading-5 text-[#4f5d54]">
+                  {JSON.stringify(report.context, null, 2)}
+                </pre>
+              </details>
+            </>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ReportArtifactView({ reportId, artifact }: { reportId: string; artifact: ReportArtifact }) {
+  const url = `/api/admin/reports/${reportId}/artifacts/${artifact.artifactId}`;
+  const header = (
+    <div className="flex flex-wrap items-center gap-2 text-xs text-[#68746d]">
+      <span className="font-semibold uppercase tracking-[0.08em]">{artifact.type.replace("_", " ")}</span>
+      <span>· {artifact.source}</span>
+      {artifact.sizeBytes != null ? <span>· {formatBytes(artifact.sizeBytes)}</span> : null}
+      {artifact.filename ? <span className="truncate font-mono">· {artifact.filename}</span> : null}
+    </div>
+  );
+
+  if (artifact.type === "screenshot") {
+    return (
+      <div className="rounded-[14px] bg-[#f5f7f4] p-3">
+        {header}
+        <a href={url} target="_blank" rel="noreferrer">
+          <img
+            src={url}
+            alt={artifact.filename ?? "screenshot"}
+            loading="lazy"
+            className="mt-2 max-h-72 rounded-[10px] border border-[#e0e4de] bg-white"
+          />
+        </a>
+      </div>
+    );
+  }
+  if (artifact.type === "logs") {
+    return (
+      <div className="rounded-[14px] bg-[#f5f7f4] p-3">
+        {header}
+        <LogArtifactViewer url={url} />
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-[14px] bg-[#f5f7f4] p-3">
+      {header}
+      <a className="mt-2 inline-flex items-center gap-2 text-sm font-semibold text-[#087d50]" href={url} download>
+        <FileText className="size-4" /> Download payload
+      </a>
+    </div>
+  );
+}
+
+function LogArtifactViewer({ url }: { url: string }) {
+  const [open, setOpen] = useState(false);
+  const logs = useQuery({
+    queryKey: ["admin-report-log", url],
+    queryFn: () => api<{ entries: ReportLogEntry[] }>(url),
+    enabled: open,
+  });
+
+  if (!open) {
+    return (
+      <Button variant="ghost" className="mt-2 h-8 rounded-full px-3 text-xs text-[#087d50] hover:bg-white" onClick={() => setOpen(true)}>
+        <FileText className="size-3.5" /> View log entries
+      </Button>
+    );
+  }
+  if (logs.isLoading) return <div className="mt-2"><InlineLoading label="Loading log entries" /></div>;
+  if (logs.isError) return <ErrorText error={logs.error} />;
+  const entries = logs.data?.entries ?? [];
+  return (
+    <div className="mt-2 max-h-72 overflow-auto rounded-[10px] border border-[#e0e4de] bg-white p-3 font-mono text-xs leading-5">
+      {entries.length === 0 ? (
+        <span className="text-[#68746d]">Log bundle is empty.</span>
+      ) : entries.map((entry, index) => (
+        <div key={index} className="whitespace-pre-wrap">
+          <span className="text-[#a0a3aa]">{new Date(entry.timestamp).toISOString()}</span>{" "}
+          <span className={entry.level === "error" ? "font-semibold text-[#a64235]" : "text-[#087d50]"}>{entry.level}</span>{" "}
+          {entry.source ? <span className="text-[#68746d]">[{entry.source}]</span> : null} {entry.message}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ReportKindTag({ kind }: { kind: ReportKind }) {
+  const tone: Record<ReportKind, string> = {
+    bug: "bg-[#fff3f1] text-[#a64235]",
+    feedback: "bg-[#eef2ff] text-[#3a55c8]",
+    automatic: "bg-[#f0f2ef] text-[#68746d]",
+  };
+  return <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.08em] ${tone[kind]}`}>{kind}</span>;
+}
+
+function ReportStatusTag({ status }: { status: ReportStatus }) {
+  const tone: Record<ReportStatus, string> = {
+    collecting: "bg-[#fff7df] text-[#a66a00]",
+    ready: "bg-[#e9f8f1] text-[#087d50]",
+    closed: "bg-[#111217] text-white",
+  };
+  return <span className={`rounded-full px-2.5 py-0.5 text-xs font-semibold uppercase tracking-[0.08em] ${tone[status]}`}>{status}</span>;
+}
+
+function reportSummaryText(report: ReportSummary): string {
+  if (report.report?.actualBehavior) return String(report.report.actualBehavior);
+  if (report.feedback) {
+    if (typeof report.feedback.message === "string" && report.feedback.message) return report.feedback.message;
+    const text = JSON.stringify(report.feedback);
+    if (text && text !== "{}") return text;
+  }
+  return report.trigger?.reason ?? "—";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function ReleaseIdentity({ release, compact = false }: { release: ReleaseSummary; compact?: boolean }) {

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -288,7 +288,11 @@ function AdminPage() {
   };
 
   if (me.isLoading) return <Splash label="Checking admin session" />;
-  if (me.isError) return <LoginGate />;
+  if (me.isError) {
+    // A 403 means the Mentra login itself worked but the account isn't on the
+    // admin allowlist; offering the login button again would be misleading.
+    return <LoginGate denied={me.error instanceof ApiError && me.error.status === 403} />;
+  }
 
   return (
     <AppShell
@@ -1197,8 +1201,17 @@ function formatDate(value: string | null | undefined): string {
   return date.toLocaleString(undefined, { dateStyle: "medium", timeStyle: "short" });
 }
 
-function LoginGate() {
+function LoginGate({ denied = false }: { denied?: boolean }) {
   const loginUrl = `/api/console/auth/login?return_to=${encodeURIComponent(`${window.location.origin}/`)}`;
+
+  async function signOutAndReload() {
+    try {
+      await fetch("/api/console/auth/logout", { method: "POST", headers: { accept: "application/json" } });
+    } catch {
+      // best-effort; the reload lands back on this gate either way
+    }
+    window.location.reload();
+  }
 
   return (
     <main className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[linear-gradient(180deg,#ffffff_0%,#f4f8f6_100%)] px-5 py-10 text-[#14141a]">
@@ -1219,21 +1232,33 @@ function LoginGate() {
 
             <div className="h-[18px]" />
             <h1 className="font-display text-[26px] font-bold leading-[30px] tracking-[-0.52px] text-[#14141a]">
-              Sign into Mentra Admin
+              {denied ? "No admin access" : "Sign into Mentra Admin"}
             </h1>
 
             <div className="h-2.5" />
             <p className="mx-auto max-w-[300px] font-body text-[13.5px] leading-[20px] text-[#7a7a82]">
-              Review miniapp releases, publish preinstalled registries, and manage internal operations.
+              {denied
+                ? "You're signed in, but this account isn't on the admin allowlist. Switch accounts, or ask for your email to be added to the Core admin allowlist."
+                : "Review miniapp releases, publish preinstalled registries, and manage internal operations."}
             </p>
 
             <div className="h-8" />
-            <a
-              className="flex h-[48px] w-full items-center justify-center rounded-full bg-[#14141a] px-[18px] font-display text-sm font-semibold text-white shadow-[0_18px_44px_-10px_rgba(20,20,26,0.25),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-[#24242b] focus:outline-none focus:ring-4 focus:ring-[#14141a]/10"
-              href={loginUrl}
-            >
-              Continue with Mentra login
-            </a>
+            {denied ? (
+              <button
+                type="button"
+                className="flex h-[48px] w-full items-center justify-center rounded-full bg-[#14141a] px-[18px] font-display text-sm font-semibold text-white shadow-[0_18px_44px_-10px_rgba(20,20,26,0.25),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-[#24242b] focus:outline-none focus:ring-4 focus:ring-[#14141a]/10"
+                onClick={signOutAndReload}
+              >
+                Sign out and switch account
+              </button>
+            ) : (
+              <a
+                className="flex h-[48px] w-full items-center justify-center rounded-full bg-[#14141a] px-[18px] font-display text-sm font-semibold text-white shadow-[0_18px_44px_-10px_rgba(20,20,26,0.25),inset_0_1px_0_rgba(255,255,255,0.14)] transition hover:bg-[#24242b] focus:outline-none focus:ring-4 focus:ring-[#14141a]/10"
+                href={loginUrl}
+              >
+                Continue with Mentra login
+              </a>
+            )}
 
             <div className="h-5" />
             <p className="font-body text-[11.5px] leading-4 text-[#a6a6ac]">
@@ -1274,6 +1299,12 @@ function ErrorText({ error }: { error: unknown }) {
   );
 }
 
+class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
 async function api<T>(path: string, opts?: { method?: string; body?: unknown }): Promise<T> {
   const res = await fetch(path, {
     method: opts?.method ?? "GET",
@@ -1291,7 +1322,7 @@ async function api<T>(path: string, opts?: { method?: string; body?: unknown }):
     } catch {
       // keep status detail
     }
-    throw new Error(detail);
+    throw new ApiError(detail, res.status);
   }
   return res.json() as Promise<T>;
 }


### PR DESCRIPTION
Since the Mentra App reporting flow moved to Cloud V2 (#3331, #3344), submitted bug reports and feedback only existed in Mongo — the old Slack notifications and the v1 incidents page no longer see them, and the admin console's incident-system tile was a placeholder. This makes the reports readable where they're meant to live: the internal admin console.

## Core: read-only admin surface

New `admin/reports.api.ts`, sub-mounted at `/api/admin/reports` **inside** the existing admin router behind its single `adminAuth` gate (a second mount at `/api/admin` would run the sealed-session authenticate twice per request, and the double refresh can burn the single-use WorkOS refresh token):

- `GET /api/admin/reports` — newest-first list with `kind`/`status`/`limit`/`before` filters; `context` (the one potentially chunky field) is excluded from list responses. Backed by a new `createdAt` index.
- `GET /api/admin/reports/:reportId` — full document (including context) plus its `report_assets` rows.
- `GET /api/admin/reports/:reportId/artifacts/:artifactId` — artifact payload bytes from blob storage with the stored content type. Client-supplied filenames are allowlist-sanitized before reaching the `content-disposition` header; a readable row with an unreadable blob 404s with a distinct description and a warn log.

Serialization lives in `report.service.ts` next to the write path (`AdminReportSummary`/`AdminReportDetail`/`AdminReportAsset`).

## Admin website: live Reports page

The incidents placeholder becomes a working page: kind/status filter pills, newest-first report list (summary text, user, source, artifact count), and a detail drawer with the report details grid, collapsible device-context JSON, inline screenshot previews, and an expandable log-bundle viewer — all via the existing same-origin `/api` proxy, so it works identically under `bun run dev:admin` and the Pages deployments (`admin.dev./staging./mentraglass.com`). Triage/ownership remains a planned follow-up and is noted on the page.

## Tests

`cloud-v2/tests/admin-reports.integration.test.ts` drives the routes end-to-end against local Mongo + storage with **no WorkOS dependency**: an org API key (`msk_…`) is not a JWT, so `authenticateBearerToken` falls through to local DB validation, and the key's synthetic `api-key@{keyId}.local` email is allowlisted via `CLOUD_CORE_ADMIN_EMAILS`. Covers the auth gate (401 anonymous, 403 non-allowlisted), list shape/order/filters/invalid-query 400, detail with context + asset rows, artifact byte round-trips (image + JSON logs), and 404s.

`bun run typecheck`, `bun run typecheck:admin`, and the admin-site build are clean; 20 tests pass across the reports/admin-reports/auth/miniapp-release suites.

UI screenshots to follow from the dev deployment once this lands (the page needs an authenticated admin session plus seeded reports to show meaningful content).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a cross-user admin read API and serves user-uploaded artifact bytes; mitigations (adminAuth, content-type allowlists, download-only for scriptable types) are in place but the surface is security-sensitive.
> 
> **Overview**
> Adds **read-only admin report triage** so Cloud V2 user bug/feedback reports are visible in the internal console instead of only in Mongo.
> 
> **Core:** New `admin/reports.api.ts` is mounted at `/api/admin/reports` **inside** the existing admin router (after `adminAuth`, so auth runs once). Endpoints list reports (newest-first, `kind`/`status`/`limit`/`before`, list omits `context`), fetch detail + asset rows, and stream artifact bytes with inline allowlisting (safe images/JSON only), sanitized filenames, `nosniff`/sandbox CSP, and attachment fallback for hostile types. `report.service.ts` gains admin serializers and storage reads; reports get a `createdAt` index for triage. **Client upload** now stores screenshot multipart `content-type` only when it matches an image allowlist (otherwise `application/octet-stream`).
> 
> **Admin site:** The incidents placeholder becomes a **User reports** page—filters, list, detail drawer (metadata, device context, inline screenshots, expandable logs, downloads for non-preview types). **403** on `/api/admin/me` shows a dedicated “no admin access” gate with sign-out; `ApiError` preserves HTTP status for that check.
> 
> **Tests:** `admin-reports.integration.test.ts` covers auth (401/403), list/detail/artifacts, response hardening, and spoofed HTML-as-screenshot behavior end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dee1063ea13e0100b2432a1e86b2604d22da6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->