### PR TITLE
ASG: make WakeLockManager extend-only so a short acquire can't cut OTA short

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
@@ -4,6 +4,7 @@ import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.PowerManager;
+import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -31,6 +32,16 @@ public class WakeLockManager {
     // Static wake lock instances for sharing across the app
     private static PowerManager.WakeLock sCpuWakeLock;
     private static PowerManager.WakeLock sScreenWakeLock;
+
+    // Guards acquire/release so the extend-only deadline checks below are race-free when called
+    // from multiple threads (OTA worker, main looper, camera/streaming threads).
+    private static final Object LOCK = new Object();
+
+    // Absolute deadlines (SystemClock.elapsedRealtime() based) for the currently-held locks.
+    // Used to implement extend-only acquisition: a shorter acquire never shortens a longer-lived
+    // lock that is already held. 0 means "no deadline tracked / not held".
+    private static long sCpuWakeLockDeadlineMs = 0;
+    private static long sScreenWakeLockDeadlineMs = 0;
 
     /**
      * Acquire a CPU wake lock to keep the processor running.
@@ -64,27 +75,47 @@ public class WakeLockManager {
      * @return true if the wake lock was successfully acquired
      */
     public static boolean acquireCpuWakeLock(@NonNull Context context, long timeoutMs, String tag) {
-        try {
-            PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            if (powerManager == null) {
-                Log.e(TAG, "PowerManager is null");
+        synchronized (LOCK) {
+            try {
+                PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+                if (powerManager == null) {
+                    Log.e(TAG, "PowerManager is null");
+                    return false;
+                }
+
+                long now = SystemClock.elapsedRealtime();
+                long requestedDeadlineMs = now + timeoutMs;
+
+                // Extend-only: if a CPU wake lock is already held and its deadline is at or beyond
+                // the one being requested, keep the existing (longer-lived) lock and ignore this
+                // shorter acquire. Without this, a short acquire (e.g. a 60s camera/util lock)
+                // stomps a long in-flight operation (e.g. a 10-min OTA) and lets the CPU — and the
+                // MTK SoC — sleep mid-update, which is exactly what stalls OTA. We never shorten;
+                // we only ever push the deadline further out.
+                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()
+                        && requestedDeadlineMs <= sCpuWakeLockDeadlineMs) {
+                    Log.d(TAG, "Keeping existing CPU wake lock (remaining "
+                            + (sCpuWakeLockDeadlineMs - now) + "ms) >= requested " + timeoutMs
+                            + "ms; ignoring shorter acquire");
+                    return true;
+                }
+
+                // Extending to a later deadline: release the shorter-lived lock first.
+                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
+                    sCpuWakeLock.release();
+                    Log.d(TAG, "Released existing CPU wake lock to extend deadline");
+                }
+
+                // Create and acquire a new wake lock
+                sCpuWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag);
+                sCpuWakeLock.acquire(timeoutMs);
+                sCpuWakeLockDeadlineMs = requestedDeadlineMs;
+                Log.d(TAG, "CPU wake lock acquired with timeout: " + timeoutMs + "ms");
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error acquiring CPU wake lock", e);
                 return false;
             }
-
-            // Release existing wake lock if it's held
-            if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
-                sCpuWakeLock.release();
-                Log.d(TAG, "Released existing CPU wake lock");
-            }
-
-            // Create and acquire a new wake lock
-            sCpuWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag);
-            sCpuWakeLock.acquire(timeoutMs);
-            Log.d(TAG, "CPU wake lock acquired with timeout: " + timeoutMs + "ms");
-            return true;
-        } catch (Exception e) {
-            Log.e(TAG, "Error acquiring CPU wake lock", e);
-            return false;
         }
     }
 
@@ -120,31 +151,48 @@ public class WakeLockManager {
      * @return true if the wake lock was successfully acquired
      */
     public static boolean acquireScreenWakeLock(@NonNull Context context, long timeoutMs, String tag) {
-        try {
-            PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-            if (powerManager == null) {
-                Log.e(TAG, "PowerManager is null");
+        synchronized (LOCK) {
+            try {
+                PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+                if (powerManager == null) {
+                    Log.e(TAG, "PowerManager is null");
+                    return false;
+                }
+
+                long now = SystemClock.elapsedRealtime();
+                long requestedDeadlineMs = now + timeoutMs;
+
+                // Extend-only: keep the existing screen lock if it already outlives this request
+                // (see acquireCpuWakeLock for the rationale — a shorter acquire must not cut a
+                // longer-lived one short).
+                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()
+                        && requestedDeadlineMs <= sScreenWakeLockDeadlineMs) {
+                    Log.d(TAG, "Keeping existing screen wake lock (remaining "
+                            + (sScreenWakeLockDeadlineMs - now) + "ms) >= requested " + timeoutMs
+                            + "ms; ignoring shorter acquire");
+                    return true;
+                }
+
+                // Extending to a later deadline: release the shorter-lived lock first.
+                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
+                    sScreenWakeLock.release();
+                    Log.d(TAG, "Released existing screen wake lock to extend deadline");
+                }
+
+                // Create and acquire a new wake lock with flags to turn screen on
+                sScreenWakeLock = powerManager.newWakeLock(
+                        PowerManager.FULL_WAKE_LOCK |
+                        PowerManager.ACQUIRE_CAUSES_WAKEUP |
+                        PowerManager.ON_AFTER_RELEASE,
+                        tag);
+                sScreenWakeLock.acquire(timeoutMs);
+                sScreenWakeLockDeadlineMs = requestedDeadlineMs;
+                Log.d(TAG, "Screen wake lock acquired with timeout: " + timeoutMs + "ms");
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error acquiring screen wake lock", e);
                 return false;
             }
-
-            // Release existing wake lock if it's held
-            if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
-                sScreenWakeLock.release();
-                Log.d(TAG, "Released existing screen wake lock");
-            }
-
-            // Create and acquire a new wake lock with flags to turn screen on
-            sScreenWakeLock = powerManager.newWakeLock(
-                    PowerManager.FULL_WAKE_LOCK |
-                    PowerManager.ACQUIRE_CAUSES_WAKEUP |
-                    PowerManager.ON_AFTER_RELEASE,
-                    tag);
-            sScreenWakeLock.acquire(timeoutMs);
-            Log.d(TAG, "Screen wake lock acquired with timeout: " + timeoutMs + "ms");
-            return true;
-        } catch (Exception e) {
-            Log.e(TAG, "Error acquiring screen wake lock", e);
-            return false;
         }
     }
 
@@ -180,16 +228,19 @@ public class WakeLockManager {
      * @return true if the wake lock was released or wasn't held
      */
     public static boolean releaseCpuWakeLock() {
-        try {
-            if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
-                sCpuWakeLock.release();
+        synchronized (LOCK) {
+            try {
+                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
+                    sCpuWakeLock.release();
+                    Log.d(TAG, "CPU wake lock released");
+                }
                 sCpuWakeLock = null;
-                Log.d(TAG, "CPU wake lock released");
+                sCpuWakeLockDeadlineMs = 0;
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error releasing CPU wake lock", e);
+                return false;
             }
-            return true;
-        } catch (Exception e) {
-            Log.e(TAG, "Error releasing CPU wake lock", e);
-            return false;
         }
     }
 
@@ -199,16 +250,19 @@ public class WakeLockManager {
      * @return true if the wake lock was released or wasn't held
      */
     public static boolean releaseScreenWakeLock() {
-        try {
-            if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
-                sScreenWakeLock.release();
+        synchronized (LOCK) {
+            try {
+                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
+                    sScreenWakeLock.release();
+                    Log.d(TAG, "Screen wake lock released");
+                }
                 sScreenWakeLock = null;
-                Log.d(TAG, "Screen wake lock released");
+                sScreenWakeLockDeadlineMs = 0;
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error releasing screen wake lock", e);
+                return false;
             }
-            return true;
-        } catch (Exception e) {
-            Log.e(TAG, "Error releasing screen wake lock", e);
-            return false;
         }
     }
 

--- a/asg_client/app/src/test/java/com/mentra/asg_client/utils/WakeLockManagerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/utils/WakeLockManagerTest.java
@@ -1,0 +1,101 @@
+package com.mentra.asg_client.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.app.Application;
+import android.os.PowerManager;
+import androidx.test.core.app.ApplicationProvider;
+import java.time.Duration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowPowerManager;
+import org.robolectric.shadows.ShadowSystemClock;
+
+/**
+ * Verifies the extend-only ("longest deadline wins") behavior of {@link WakeLockManager}.
+ *
+ * <p>The shared static CPU wake lock used to be replaced on every acquire, so a short acquire
+ * (e.g. a 60s camera/util lock) could cut an in-flight long operation (e.g. a 10-min OTA) short
+ * and let the CPU — and the MTK SoC — sleep mid-update. These tests pin the new contract: a
+ * shorter acquire never shortens a longer lock that is already held; only a later deadline
+ * swaps the lock.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class WakeLockManagerTest {
+
+    private Application app;
+
+    @Before
+    public void setUp() {
+        app = ApplicationProvider.getApplicationContext();
+        // WakeLockManager keeps process-static state that Robolectric does not reset between
+        // tests; clear it so each test starts with no held lock and no tracked deadline.
+        WakeLockManager.releaseAllWakeLocks();
+    }
+
+    @After
+    public void tearDown() {
+        WakeLockManager.releaseAllWakeLocks();
+    }
+
+    @Test
+    public void shorterAcquire_doesNotReplaceLongerHeldCpuLock() {
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue(); // 10 min
+        PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
+        assertThat(first.isHeld()).isTrue();
+
+        // 1 minute later, a 2-minute acquire must be ignored — the original lock still outlives it.
+        ShadowSystemClock.advanceBy(Duration.ofMinutes(1));
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 120_000)).isTrue(); // 2 min
+
+        // No new lock was created; the original 10-min lock is still the active one.
+        assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(first);
+        assertThat(first.isHeld()).isTrue();
+    }
+
+    @Test
+    public void longerAcquire_extendsCpuLock() {
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 120_000)).isTrue(); // 2 min
+        PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
+
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue(); // 10 min
+        PowerManager.WakeLock second = ShadowPowerManager.getLatestWakeLock();
+
+        // Extending to a later deadline swaps in a fresh, longer lock and releases the old one.
+        assertThat(second).isNotSameAs(first);
+        assertThat(second.isHeld()).isTrue();
+        assertThat(first.isHeld()).isFalse();
+    }
+
+    @Test
+    public void release_thenShorterAcquire_startsFreshLock() {
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue();
+        PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
+
+        WakeLockManager.releaseCpuWakeLock();
+        assertThat(first.isHeld()).isFalse();
+
+        // An explicit release clears the tracked deadline, so a short acquire is honored again.
+        assertThat(WakeLockManager.acquireCpuWakeLock(app, 60_000)).isTrue();
+        PowerManager.WakeLock second = ShadowPowerManager.getLatestWakeLock();
+        assertThat(second).isNotSameAs(first);
+        assertThat(second.isHeld()).isTrue();
+    }
+
+    @Test
+    public void screenLock_isExtendOnlyToo() {
+        assertThat(WakeLockManager.acquireScreenWakeLock(app, 60_000)).isTrue();
+        PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(1));
+        assertThat(WakeLockManager.acquireScreenWakeLock(app, 5_000)).isTrue(); // shorter
+
+        assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(first);
+        assertThat(first.isHeld()).isTrue();
+    }
+}


### PR DESCRIPTION
## Problem

During OTA, the MTK SoC sleeps and the update stalls. Root cause is **the wake lock dying too soon**, not staying too long.

`WakeLockManager` holds **one** shared static CPU lock (and one screen lock). Every `acquireCpuWakeLock()` *released whatever was held and installed a fresh lock with the new timeout*. So any **shorter** acquire that lands during a long operation shortens the in-flight deadline:

- OTA acquires the CPU lock for 10 min (`OtaHelper.startOtaFromPhone`).
- A 60s camera/util acquire — or the 5-min BES acquire — lands mid-OTA and **replaces** the 10-min lock with a shorter one.
- The shortened lock expires → CPU + MTK sleep → BES/MTK transfer fails.

## Fix — "longest deadline wins" (extend-only)

Instead of re-plumbing every call site into a ref-counted/owner-keyed system, make acquisition **extend-only**:

- Track an absolute deadline (`SystemClock.elapsedRealtime`-based) per lock.
- On acquire: if a lock is already held **and its deadline is at or beyond** the requested one, keep it and **ignore the shorter acquire**. Only a *later* deadline swaps the lock.
- The Android timeout still auto-releases as a backstop; an explicit `release()` clears the tracked deadline so a later short acquire is honored again.
- `acquire`/`release` are now `synchronized` so the deadline check is race-free across the OTA worker, main looper, and camera/streaming threads.

Applied symmetrically to the CPU and screen locks. **No call sites changed** — the behavior change is entirely inside `WakeLockManager`.

Concretely: `acquire(10min)` then, 1 min later, `acquire(2min)` → the 2-min request is ignored and the original 10-min lock rides to its deadline.

## Scope

- **ASG client only.** This is the wake lock function fix. The mobile-side `keep_awake` spam during OTA (belt-and-suspenders that keeps MTK awake at the firmware level via BES) is being handled separately by Philippe.

## Known follow-ups (not in this PR)

- The OTA resume path after the ASG APK self-install (`OtaService.resumeFromSession` → `startVersionCheckWithUrl`) never re-acquires the OTA wake lock, so the post-restart MTK step still runs unprotected. Philippe's firmware-level `keep_awake` covers this window; a dedicated ASG re-acquire there would be a cheap complementary fix.
- Release is still immediate/owner-blind, so an unrelated `releaseAllWakeLocks()` (camera/stream teardown) during OTA can still drop the OTA lock. Not addressed here by design (would require ownership); flagging for visibility.

## Test

`WakeLockManagerTest` (Robolectric) — 4 cases, all green locally (`:app:testDebugUnitTest`):
- `shorterAcquire_doesNotReplaceLongerHeldCpuLock` — advance 1 min, request 2 min → original 10-min lock kept, no new lock created.
- `longerAcquire_extendsCpuLock` — 2 min then 10 min → fresh longer lock, old one released.
- `release_thenShorterAcquire_startsFreshLock` — explicit release clears the deadline; a short acquire is honored again.
- `screenLock_isExtendOnlyToo` — same contract on the screen lock path.

Main sources compile clean (`:app:compileDebugJavaWithJavac`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global wake-lock semantics for all ASG features (OTA, camera, BES); fixes OTA stalls but owner-blind release can still drop long locks, which the PR explicitly leaves unaddressed.
> 
> **Overview**
> **`WakeLockManager` no longer replaces the shared CPU/screen wake locks on every acquire.** It now tracks absolute deadlines (`SystemClock.elapsedRealtime`) and uses **extend-only** rules: if a lock is already held with a deadline at or beyond the new request, the shorter acquire is ignored; only a later deadline releases and re-acquires with a longer timeout. Acquire/release paths are **`synchronized`** so OTA, main, and camera threads cannot race the deadline logic.
> 
> **Explicit `release*` clears tracked deadlines** so a subsequent short acquire works again after teardown. Call sites are unchanged; behavior is entirely inside the manager.
> 
> Adds **`WakeLockManagerTest`** (Robolectric) covering shorter-acquire ignored, longer-acquire extends, release-then-short acquire, and the same contract for screen locks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6364006c9daa0e4b0f6cb21be3c1219122c657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `WakeLockManager` extend-only for CPU and screen locks so shorter acquires can’t cut longer ones (like OTA) short. This prevents MTK sleep during updates and improves OTA reliability.

- **Bug Fixes**
  - Track absolute deadlines (`SystemClock.elapsedRealtime`) and ignore shorter acquires; only later deadlines replace/extend the lock.
  - Synchronize acquire/release to avoid races; applied to both CPU and screen locks. Explicit release clears the tracked deadline. No call sites changed.
  - Added `WakeLockManagerTest` (Robolectric) covering shorter-ignored, longer-extends, release-then-reacquire, and screen-lock paths.

<sup>Written for commit c6364006c9daa0e4b0f6cb21be3c1219122c657b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

