### PR TITLE
Route automatic report Slack posts to their own webhook

### DIFF
--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -3,9 +3,11 @@ import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { notifyReportSlack, type ReportSlackNotification } from "./report-slack.service";
 
 const WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/reports";
+const AUTOMATIC_WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/automatic";
 
 const savedEnv = {
   CLOUD_REPORTS_SLACK_WEBHOOK_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL,
+  CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
   CLOUD_CORE_ENVIRONMENT: process.env.CLOUD_CORE_ENVIRONMENT,
 };
 const realFetch = globalThis.fetch;
@@ -16,6 +18,7 @@ let fetchMock: ReturnType<typeof mock<FetchCall>>;
 
 beforeEach(() => {
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL;
   process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
   fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -24,12 +27,56 @@ beforeEach(() => {
 afterEach(() => {
   globalThis.fetch = realFetch;
   restoreEnv("CLOUD_REPORTS_SLACK_WEBHOOK_URL", savedEnv.CLOUD_REPORTS_SLACK_WEBHOOK_URL);
+  restoreEnv(
+    "CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL",
+    savedEnv.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
+  );
   restoreEnv("CLOUD_CORE_ENVIRONMENT", savedEnv.CLOUD_CORE_ENVIRONMENT);
 });
 
 describe("notifyReportSlack", () => {
   test("is a silent no-op when the webhook env var is unset", async () => {
     const result = await notifyReportSlack(bugNotification());
+
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(fetchMock.mock.calls).toHaveLength(0);
+  });
+
+  test("routes automatic reports to the automatic webhook when configured", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL = AUTOMATIC_WEBHOOK_URL;
+
+    const result = await notifyReportSlack(bugNotification({ kind: "automatic" }));
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls).toHaveLength(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(AUTOMATIC_WEBHOOK_URL);
+  });
+
+  test("falls back to the main webhook for automatic reports when the split is unset", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    const result = await notifyReportSlack(bugNotification({ kind: "automatic" }));
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls).toHaveLength(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(WEBHOOK_URL);
+  });
+
+  test("keeps bug and feedback reports on the main webhook when both are configured", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL = AUTOMATIC_WEBHOOK_URL;
+
+    await notifyReportSlack(bugNotification());
+    await notifyReportSlack(bugNotification({ kind: "feedback", feedback: { message: "hi" } }));
+
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    expect(fetchMock.mock.calls[0][0]).toBe(WEBHOOK_URL);
+    expect(fetchMock.mock.calls[1][0]).toBe(WEBHOOK_URL);
+  });
+
+  test("skips automatic reports silently when neither webhook is set", async () => {
+    const result = await notifyReportSlack(bugNotification({ kind: "automatic" }));
 
     expect(result).toEqual({ ok: false, skipped: true });
     expect(fetchMock.mock.calls).toHaveLength(0);

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -4,12 +4,14 @@
  * Cloud V2 replacement for the Cloud V1 feedback Slack path
  * (cloud/packages/cloud/src/services/notifications/slack.service.ts): bug
  * reports and feedback submitted through /api/client/reports post a summary
- * to the team channel via a Slack Incoming Webhook.
+ * to the team channel via a Slack Incoming Webhook. Automatic reports can be
+ * routed to their own channel via CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
+ * falling back to the main webhook when unset — the same routing V1 used for
+ * SLACK_WEBHOOK_AUTOMATIC_INCIDENTS.
  *
- * Best-effort by design: an unset CLOUD_REPORTS_SLACK_WEBHOOK_URL (local dev,
- * tests) is a silent skip, and send failures are logged, never thrown, so a
- * notification can never delay or fail the report API response. Callers
- * fire-and-forget.
+ * Best-effort by design: an unset webhook (local dev, tests) is a silent
+ * skip, and send failures are logged, never thrown, so a notification can
+ * never delay or fail the report API response. Callers fire-and-forget.
  */
 
 import { createLogger } from "@mentra/cloud-shared";
@@ -73,11 +75,11 @@ interface SlackBlock {
 export async function notifyReportSlack(
   notification: ReportSlackNotification,
 ): Promise<ReportSlackResult> {
-  const webhookUrl = process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  const webhookUrl = webhookUrlFor(notification.kind);
   if (!webhookUrl) {
     logger.debug(
-      { reportId: notification.reportId },
-      "CLOUD_REPORTS_SLACK_WEBHOOK_URL not set; skipping report Slack notification",
+      { reportId: notification.reportId, kind: notification.kind },
+      "no Slack webhook configured for this report kind; skipping notification",
     );
     return { ok: false, skipped: true };
   }
@@ -109,6 +111,20 @@ export async function notifyReportSlack(
     );
     return { ok: false };
   }
+}
+
+/**
+ * Automatic reports post to their own channel when
+ * CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL is set, falling back to the main
+ * webhook otherwise, so the feedback channel stays free of watchdog noise
+ * without making the split mandatory.
+ */
+function webhookUrlFor(kind: ReportSlackNotification["kind"]): string | undefined {
+  const main = process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  if (kind === "automatic") {
+    return process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL || main;
+  }
+  return main;
 }
 
 function buildSlackMessage(notification: ReportSlackNotification): {

--- a/cloud-v2/tests/reports.integration.test.ts
+++ b/cloud-v2/tests/reports.integration.test.ts
@@ -43,6 +43,7 @@ const STORAGE_DIR = join(tmpdir(), `mentra-reports-test-${process.pid}`);
   // Only the Slack notification tests opt in to a (mocked) webhook; everything
   // else must run with the notifier disabled, whatever the shell env says.
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
+  delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL;
 }
 
 // eslint-disable-next-line import/first


### PR DESCRIPTION
## What this does

Follow-up to #3377. Automatic reports (`kind: "automatic"` — the crashloop / gallery-integrity / captions-tester / pairing-ready watchdogs) can now post to their own Slack channel instead of sharing the feedback channel:

- New optional env var **`CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL`**: when set, automatic reports post there; when unset, they fall back to `CLOUD_REPORTS_SLACK_WEBHOOK_URL` (today's behavior, unchanged).
- Bug and feedback reports always use the main webhook.
- This is exactly the routing V1 used for `SLACK_WEBHOOK_AUTOMATIC_INCIDENTS` (separate channel when configured, feedback-channel fallback when not).

No API surface changes; skip/failure semantics unchanged (unset webhooks skip silently, send errors are logged and swallowed).

## Configuration (optional, to activate the split)

Add `CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL` to the Doppler `cloud-v2` configs (`dev_aws`, `staging`, `prod`) with the V1 `SLACK_WEBHOOK_AUTOMATIC_INCIDENTS` value. Leaving it unset keeps everything in the single channel — nothing breaks either way.

## Tests

Four new unit cases in `report-slack.service.test.ts`: automatic → automatic webhook when configured; automatic → main webhook fallback; bug/feedback stay on main with both set; automatic with neither set is a silent no-op. Full runs: 11/11 unit, 9/9 reports integration, `tsc -b` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Notification-only routing behind a new optional env var; no API or report persistence changes, with fallback preserving current single-channel behavior.
> 
> **Overview**
> **Automatic** report Slack notifications (`kind: "automatic"`) can post to a separate channel via optional **`CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL`**, mirroring V1’s `SLACK_WEBHOOK_AUTOMATIC_INCIDENTS` split. When that env var is unset, automatic reports still use **`CLOUD_REPORTS_SLACK_WEBHOOK_URL`** so behavior stays the same until ops configure the split.
> 
> `notifyReportSlack` now picks the webhook through **`webhookUrlFor`**: automatic → automatic URL or main fallback; bug and feedback always use the main URL. Skip logging mentions report **kind**; best-effort semantics are unchanged.
> 
> Unit tests cover routing, fallback, and no-op when no webhook is configured; integration setup clears the new env var so Slack stays disabled by default in tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit feab187d76993c928ceac3ea0d64db0545d63da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->