### PR TITLE
Notify Slack when a Cloud V2 miniapp release is submitted for review

### DIFF
--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
@@ -73,15 +73,22 @@ describe("notifyMiniAppSubmissionSlack", () => {
     await notifyMiniAppSubmissionSlack(
       submissionNotification({ manifest: { type: "background" } }),
     );
+    // A useless `type` (empty or non-string) must not block the appType fallback.
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({ manifest: { type: "", appType: "standard" } }),
+    );
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({ manifest: { type: 42, appType: "standard" } }),
+    );
 
-    const withoutType = JSON.stringify(
-      JSON.parse(String((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].body)),
-    );
-    const withType = JSON.stringify(
-      JSON.parse(String((fetchMock.mock.calls[1] as unknown as [string, RequestInit])[1].body)),
-    );
-    expect(withoutType).not.toContain("*Type:*");
-    expect(withType).toContain("*Type:*\\nbackground");
+    const bodyAt = (index: number) =>
+      JSON.stringify(
+        JSON.parse(String((fetchMock.mock.calls[index] as unknown as [string, RequestInit])[1].body)),
+      );
+    expect(bodyAt(0)).not.toContain("*Type:*");
+    expect(bodyAt(1)).toContain("*Type:*\\nbackground");
+    expect(bodyAt(2)).toContain("*Type:*\\nstandard");
+    expect(bodyAt(3)).toContain("*Type:*\\nstandard");
   });
 
   test("falls back to placeholders when email and description are missing", async () => {

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+  notifyMiniAppSubmissionSlack,
+  type MiniAppSubmissionSlackNotification,
+} from "./miniapp-slack.service";
+
+const WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/miniapps";
+
+const savedEnv = {
+  CLOUD_MINIAPP_SLACK_WEBHOOK_URL: process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL,
+  CLOUD_CORE_ENVIRONMENT: process.env.CLOUD_CORE_ENVIRONMENT,
+};
+const realFetch = globalThis.fetch;
+
+type FetchCall = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+let fetchMock: ReturnType<typeof mock<FetchCall>>;
+
+beforeEach(() => {
+  delete process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL;
+  process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
+  fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  restoreEnv("CLOUD_MINIAPP_SLACK_WEBHOOK_URL", savedEnv.CLOUD_MINIAPP_SLACK_WEBHOOK_URL);
+  restoreEnv("CLOUD_CORE_ENVIRONMENT", savedEnv.CLOUD_CORE_ENVIRONMENT);
+});
+
+describe("notifyMiniAppSubmissionSlack", () => {
+  test("is a silent no-op when the webhook env var is unset", async () => {
+    const result = await notifyMiniAppSubmissionSlack(submissionNotification());
+
+    expect(result).toEqual({ ok: false, skipped: true });
+    expect(fetchMock.mock.calls).toHaveLength(0);
+  });
+
+  test("posts a submission summary with app, developer, org, and env fields", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    const result = await notifyMiniAppSubmissionSlack(submissionNotification());
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchMock.mock.calls).toHaveLength(1);
+    const [url, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(WEBHOOK_URL);
+    expect(init.method).toBe("POST");
+
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    expect(payload.text).toContain(
+      "New miniapp release submitted: Weather v1.2.0 (com.example.weather)",
+    );
+    expect(payload.text).toContain("dev@example.com (test-env)");
+
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain("New Mini App Release Submitted");
+    expect(blocksJson).toContain("*App Name:*\\nWeather");
+    expect(blocksJson).toContain("*Package:*\\n`com.example.weather`");
+    expect(blocksJson).toContain("*Version:*\\n1.2.0");
+    expect(blocksJson).toContain("*Developer:*\\ndev@example.com");
+    expect(blocksJson).toContain("*Org:*\\n`org_01TEST`");
+    expect(blocksJson).toContain("*Env:*\\ntest-env");
+    expect(blocksJson).toContain("*Description:*\\nHourly forecasts on glasses");
+  });
+
+  test("includes a type field only when the manifest carries one", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyMiniAppSubmissionSlack(submissionNotification());
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({ manifest: { type: "background" } }),
+    );
+
+    const withoutType = JSON.stringify(
+      JSON.parse(String((fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1].body)),
+    );
+    const withType = JSON.stringify(
+      JSON.parse(String((fetchMock.mock.calls[1] as unknown as [string, RequestInit])[1].body)),
+    );
+    expect(withoutType).not.toContain("*Type:*");
+    expect(withType).toContain("*Type:*\\nbackground");
+  });
+
+  test("falls back to placeholders when email and description are missing", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({ developerEmail: null, description: null }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("*Developer:*\\nunknown");
+    expect(blocksJson).not.toContain("*Description:*");
+  });
+
+  test("truncates long descriptions and escapes Slack control characters", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({
+        appName: "Weather <Pro> & Friends",
+        description: "d".repeat(800),
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("Weather &lt;Pro&gt; &amp; Friends");
+    expect(blocksJson).toContain(`${"d".repeat(500)}...`);
+    expect(blocksJson).not.toContain("d".repeat(501));
+  });
+
+  test("keeps every block text under Slack's 2000-char section limit", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyMiniAppSubmissionSlack(
+      submissionNotification({
+        // Worst case: escaping expands the truncated description 4-5x past
+        // its raw budget.
+        appName: "<".repeat(5000),
+        description: "&".repeat(5000),
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as {
+      blocks: Array<{ text?: { text: string }; fields?: Array<{ text: string }> }>;
+    };
+    const texts = payload.blocks.flatMap((block) => [
+      ...(block.text ? [block.text.text] : []),
+      ...(block.fields ?? []).map((field) => field.text),
+    ]);
+    expect(texts.length).toBeGreaterThan(0);
+    for (const text of texts) {
+      expect(text.length).toBeLessThanOrEqual(2000);
+    }
+  });
+
+  test("resolves without throwing when the webhook request fails", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    fetchMock.mockImplementation(async () => {
+      throw new Error("connection refused");
+    });
+
+    const result = await notifyMiniAppSubmissionSlack(submissionNotification());
+
+    expect(result).toEqual({ ok: false });
+  });
+
+  test("resolves without throwing on a non-2xx webhook response", async () => {
+    process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    fetchMock.mockImplementation(async () => new Response("no_service", { status: 404 }));
+
+    const result = await notifyMiniAppSubmissionSlack(submissionNotification());
+
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+function submissionNotification(
+  overrides: Partial<MiniAppSubmissionSlackNotification> = {},
+): MiniAppSubmissionSlackNotification {
+  return {
+    releaseId: "rel_TEST123",
+    packageName: "com.example.weather",
+    version: "1.2.0",
+    appName: "Weather",
+    developerEmail: "dev@example.com",
+    orgId: "org_01TEST",
+    description: "Hourly forecasts on glasses",
+    manifest: { packageName: "com.example.weather", name: "Weather", version: "1.2.0" },
+    ...overrides,
+  };
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.test.ts
@@ -115,10 +115,14 @@ describe("notifyMiniAppSubmissionSlack", () => {
     );
 
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
-    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    const blocksJson = JSON.stringify(payload.blocks);
     expect(blocksJson).toContain("Weather &lt;Pro&gt; &amp; Friends");
     expect(blocksJson).toContain(`${"d".repeat(500)}...`);
     expect(blocksJson).not.toContain("d".repeat(501));
+    // The top-level fallback text is mrkdwn too, so it gets the same escaping.
+    expect(payload.text).toContain("Weather &lt;Pro&gt; &amp; Friends");
+    expect(payload.text).not.toContain("<Pro>");
   });
 
   test("keeps every block text under Slack's 2000-char section limit", async () => {

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
@@ -1,0 +1,200 @@
+/**
+ * @fileoverview Slack notifications for Cloud V2 miniapp release submissions.
+ *
+ * Cloud V2 replacement for the Cloud V1 #mini-app-submissions Slack path
+ * (cloud/packages/cloud/src/services/notifications/slack.service.ts,
+ * notifyMiniAppSubmission): when a developer submits a release for review,
+ * a summary is posted to the team channel via a Slack Incoming Webhook.
+ *
+ * Best-effort by design: an unset CLOUD_MINIAPP_SLACK_WEBHOOK_URL (local dev,
+ * tests) is a silent skip, and send failures are logged, never thrown, so a
+ * notification can never delay or fail the submit API response. Callers
+ * fire-and-forget.
+ */
+
+import { createLogger } from "@mentra/cloud-shared";
+
+const logger = createLogger("core").child({ service: "miniapp-slack.service" });
+
+const SLACK_TIMEOUT_MS = 10_000;
+
+/** How much developer-authored description a Slack field keeps, mirroring V1. */
+const DESCRIPTION_TEXT_MAX = 500;
+const SHORT_TEXT_MAX = 254;
+/** Slack rejects the whole message when one section text exceeds 2000 chars,
+ * which would silently lose the notification. Escaping expands text (up to
+ * 5x), so this cap applies to the escaped result, with headroom for labels. */
+const SLACK_FIELD_TEXT_MAX = 1900;
+
+export interface MiniAppSubmissionSlackNotification {
+  releaseId: string;
+  packageName: string;
+  version: string;
+  appName: string;
+  developerEmail?: string | null;
+  orgId: string;
+  description?: string | null;
+  /** Release manifest snapshot (a Mixed document field), read defensively. */
+  manifest?: Record<string, unknown> | null;
+}
+
+export interface MiniAppSlackResult {
+  ok: boolean;
+  skipped?: boolean;
+}
+
+interface SlackBlock {
+  type: string;
+  text?: { type: string; text: string; emoji?: boolean };
+  fields?: Array<{ type: string; text: string }>;
+}
+
+/**
+ * Post a release-submission summary to the miniapp submissions Slack channel.
+ * Resolves with `{ok: false, skipped: true}` when
+ * CLOUD_MINIAPP_SLACK_WEBHOOK_URL is unset and `{ok: false}` on send failure;
+ * it never rejects.
+ */
+export async function notifyMiniAppSubmissionSlack(
+  notification: MiniAppSubmissionSlackNotification,
+): Promise<MiniAppSlackResult> {
+  const webhookUrl = process.env.CLOUD_MINIAPP_SLACK_WEBHOOK_URL;
+  if (!webhookUrl) {
+    logger.debug(
+      { releaseId: notification.releaseId, packageName: notification.packageName },
+      "CLOUD_MINIAPP_SLACK_WEBHOOK_URL not set; skipping miniapp submission Slack notification",
+    );
+    return { ok: false, skipped: true };
+  }
+
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(buildSlackMessage(notification)),
+      signal: AbortSignal.timeout(SLACK_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      logger.error(
+        {
+          releaseId: notification.releaseId,
+          packageName: notification.packageName,
+          status: res.status,
+          body: await res.text().catch(() => ""),
+        },
+        "miniapp submission Slack notification failed",
+      );
+      return { ok: false };
+    }
+    logger.info(
+      { releaseId: notification.releaseId, packageName: notification.packageName },
+      "miniapp submission Slack notification sent",
+    );
+    return { ok: true };
+  } catch (error) {
+    logger.error(
+      {
+        releaseId: notification.releaseId,
+        packageName: notification.packageName,
+        error: (error as Error)?.message,
+      },
+      "miniapp submission Slack notification error",
+    );
+    return { ok: false };
+  }
+}
+
+function buildSlackMessage(notification: MiniAppSubmissionSlackNotification): {
+  text: string;
+  blocks: SlackBlock[];
+} {
+  const { packageName, version, appName, developerEmail, orgId, description } = notification;
+  const env = environmentLabel();
+  const appType = extractAppType(notification.manifest);
+  const timestamp = new Date().toLocaleString("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+    timeZone: "America/Los_Angeles",
+  });
+
+  const fields = [
+    { type: "mrkdwn", text: `*App Name:*\n${slackText(appName || "Unnamed", SHORT_TEXT_MAX)}` },
+    { type: "mrkdwn", text: `*Package:*\n\`${slackText(packageName, SHORT_TEXT_MAX)}\`` },
+    { type: "mrkdwn", text: `*Version:*\n${slackText(version, SHORT_TEXT_MAX)}` },
+    {
+      type: "mrkdwn",
+      text: `*Developer:*\n${slackText(developerEmail || "unknown", SHORT_TEXT_MAX)}`,
+    },
+    { type: "mrkdwn", text: `*Org:*\n\`${slackText(orgId, SHORT_TEXT_MAX)}\`` },
+    { type: "mrkdwn", text: `*Env:*\n${slackText(env, SHORT_TEXT_MAX)}` },
+  ];
+  if (appType) {
+    fields.push({ type: "mrkdwn", text: `*Type:*\n${slackText(appType, SHORT_TEXT_MAX)}` });
+  }
+
+  const blocks: SlackBlock[] = [
+    {
+      type: "header",
+      text: { type: "plain_text", text: "New Mini App Release Submitted", emoji: true },
+    },
+    { type: "section", fields },
+  ];
+
+  if (typeof description === "string" && description.length > 0) {
+    blocks.push({
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Description:*\n${slackText(description, DESCRIPTION_TEXT_MAX)}`,
+      },
+    });
+  }
+
+  blocks.push({
+    type: "section",
+    text: { type: "mrkdwn", text: `_Submitted: ${timestamp}_` },
+  });
+
+  const fallbackParts = [
+    `New miniapp release submitted: ${truncate(appName || "Unnamed", SHORT_TEXT_MAX)} v${truncate(version, SHORT_TEXT_MAX)} (${truncate(packageName, SHORT_TEXT_MAX)})`,
+    `Developer: ${truncate(developerEmail || "unknown", SHORT_TEXT_MAX)} (${env})`,
+  ];
+
+  return { text: fallbackParts.join("\n"), blocks };
+}
+
+/** V2 manifests have no required type field, so surface one only when the
+ * developer-supplied manifest carries a plausible string. */
+function extractAppType(manifest: Record<string, unknown> | null | undefined): string | null {
+  const type = manifest?.type ?? manifest?.appType;
+  return typeof type === "string" && type.trim().length > 0 ? type : null;
+}
+
+/**
+ * Which deployment the submission came from (dev/staging/prod), so one
+ * channel can receive several environments without ambiguity.
+ */
+function environmentLabel(): string {
+  return process.env.CLOUD_CORE_ENVIRONMENT || "unknown";
+}
+
+/**
+ * Prepare developer-sourced text for a Slack field: cap at the field's own
+ * length budget, escape, then hard-cap the escaped result under Slack's
+ * 2000-char section text limit. A truncated trailing entity is stripped
+ * rather than left dangling.
+ */
+function slackText(text: string, max: number): string {
+  const escaped = escapeSlackText(truncate(text, max));
+  if (escaped.length <= SLACK_FIELD_TEXT_MAX) return escaped;
+  return `${escaped.slice(0, SLACK_FIELD_TEXT_MAX).replace(/&[a-z]*$/i, "")}...`;
+}
+
+/** Escape &, <, > which have special meaning in Slack mrkdwn. */
+function escapeSlackText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max)}...` : text;
+}

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
@@ -166,8 +166,10 @@ function buildSlackMessage(notification: MiniAppSubmissionSlackNotification): {
 /** V2 manifests have no required type field, so surface one only when the
  * developer-supplied manifest carries a plausible string. */
 function extractAppType(manifest: Record<string, unknown> | null | undefined): string | null {
-  const type = manifest?.type ?? manifest?.appType;
-  return typeof type === "string" && type.trim().length > 0 ? type : null;
+  for (const candidate of [manifest?.type, manifest?.appType]) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) return candidate;
+  }
+  return null;
 }
 
 /**

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts
@@ -156,8 +156,8 @@ function buildSlackMessage(notification: MiniAppSubmissionSlackNotification): {
   });
 
   const fallbackParts = [
-    `New miniapp release submitted: ${truncate(appName || "Unnamed", SHORT_TEXT_MAX)} v${truncate(version, SHORT_TEXT_MAX)} (${truncate(packageName, SHORT_TEXT_MAX)})`,
-    `Developer: ${truncate(developerEmail || "unknown", SHORT_TEXT_MAX)} (${env})`,
+    `New miniapp release submitted: ${slackText(appName || "Unnamed", SHORT_TEXT_MAX)} v${slackText(version, SHORT_TEXT_MAX)} (${slackText(packageName, SHORT_TEXT_MAX)})`,
+    `Developer: ${slackText(developerEmail || "unknown", SHORT_TEXT_MAX)} (${slackText(env, SHORT_TEXT_MAX)})`,
   ];
 
   return { text: fallbackParts.join("\n"), blocks };

--- a/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
+++ b/cloud-v2/packages/core/src/services/miniapps/miniapp.service.ts
@@ -5,6 +5,7 @@ import { MiniAppModel } from "../../models/miniapp.model";
 import { MiniAppReleaseModel } from "../../models/miniapp-release.model";
 import { createStorageService, sha256Hex } from "../storage/storage.service";
 import type { SignedBundleMetadata } from "./developer-signing.service";
+import { notifyMiniAppSubmissionSlack } from "./miniapp-slack.service";
 
 const logger = createLogger("core").child({ service: "miniapp.service" });
 
@@ -131,6 +132,20 @@ export class MiniAppService {
     release.submittedAt = new Date();
     release.reviewNotes = null;
     await release.save();
+
+    // Fire-and-forget: a Slack failure can never delay or fail the submit
+    // response, and an unset webhook env var is a silent skip.
+    notifyMiniAppSubmissionSlack({
+      releaseId: release._id.toString(),
+      packageName: release.packageName,
+      version: release.version,
+      appName: app.displayName,
+      description: app.description ?? null,
+      developerEmail: developer.email ?? null,
+      orgId: developer.orgId,
+      manifest: release.manifest as Record<string, unknown> | null,
+    }).catch(() => {});
+
     return serializeRelease(release.toObject());
   }
 


### PR DESCRIPTION
## Problem

Cloud V2's miniapp release lifecycle has no Slack notification when a developer submits a release for review. When console2 replaces the V1 developer console, the team's **#mini-app-submissions** posts (V1: `SLACK_WEBHOOK_MINI_APP_SUBMISSION`, sent from `console.apps.service.ts` via `notifyMiniAppSubmission`) will silently stop — the same failure mode #3377 fixed for feedback/bug reports.

## Change

- **New `cloud-v2/packages/core/src/services/miniapps/miniapp-slack.service.ts`**, mirroring the `report-slack.service.ts` pattern from #3377:
  - webhook URL from new env var `CLOUD_MINIAPP_SLACK_WEBHOOK_URL`
  - unset env var (local dev, tests) is a silent skip; send failures are logged, never thrown
  - 10s fetch timeout; per-field truncation + mrkdwn escaping with a hard cap under Slack's 2000-char section limit
- **Wired into `MiniAppService.submitRelease`** right after the release is saved as `submitted`, fire-and-forget with `.catch(() => {})` so the submit API response is never delayed or failed by Slack.
- **Message content mirrors V1's `notifyMiniAppSubmission`**: app name, `packageName`, developer email, truncated description (500 chars), submitted timestamp — plus the `CLOUD_CORE_ENVIRONMENT` label (as in #3377) and V2-specific fields: release version, org id, and manifest `type`/`appType` when the manifest carries one (V2 manifests have no required type field).

## Deployment note

~~`CLOUD_MINIAPP_SLACK_WEBHOOK_URL` needs to be added to the **doppler cloud-v2 configs (dev_aws / staging / prod)** with the value of V1's `SLACK_WEBHOOK_MINI_APP_SUBMISSION` so posts land in #mini-app-submissions.~~ **Done** — verified present in all three configs (`doppler secrets --only-names`, 2026-07-08). The notifier goes live with the next deploy of each environment.

## Tests

- New `miniapp-slack.service.test.ts` (8 tests, mirrors `report-slack.service.test.ts` from #3377): silent no-op when env unset, payload fields (app/package/version/developer/org/env/description), type field only when the manifest carries one, placeholder fallbacks, truncation + escaping, 2000-char block cap, and failure swallowing for both thrown fetch errors and non-2xx responses.
- `cd cloud-v2 && bun test packages/core/src/services/miniapps/miniapp-slack.service.test.ts` → 8 pass / 0 fail.
- `cd cloud-v2 && bun run typecheck` (tsc -b) → clean.
- Note: `bun test packages/core` has one pre-existing failure on dev (`session.service.test.ts`, mongoose `OverwriteModelError: Cannot overwrite RefreshToken model`) that reproduces without this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Side-effect-only notification on an existing submit path; errors are swallowed and the webhook env var is optional, so submit behavior stays unchanged.
> 
> **Overview**
> Adds **best-effort Slack posts** when a developer submits a miniapp release for review, replacing the Cloud V1 **#mini-app-submissions** path for console2.
> 
> A new **`notifyMiniAppSubmissionSlack`** service reads **`CLOUD_MINIAPP_SLACK_WEBHOOK_URL`** (silent skip if unset), POSTs a block-formatted summary (app, package, version, developer, org, **`CLOUD_CORE_ENVIRONMENT`**, optional manifest type, truncated description), and never throws—failures are logged and return `{ ok: false }`. Developer text is escaped and capped under Slack’s section limits.
> 
> **`MiniAppService.submitRelease`** triggers the notifier **fire-and-forget** immediately after the release is saved as `submitted`, so Slack cannot block or fail the submit API.
> 
> **`miniapp-slack.service.test.ts`** covers no-op, payload shape, type fallbacks, placeholders, truncation/escaping, block size limits, and error swallowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b632f2264db39d431982eccb351ea177cb9b650. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

