### PR TITLE
feat(019): mobile login on Cloud V2 account auth (drop legacy Cloud V1 + Supabase)

### DIFF
--- a/.github/workflows/cloud-v2-isaiah.yml
+++ b/.github/workflows/cloud-v2-isaiah.yml
@@ -1,0 +1,70 @@
+name: Deploy cloud-v2 isaiah
+
+# Personal sandbox env (cloud-isaiah) — issue 019 account-auth testing while
+# cloud-debug is frozen for enterprise customers. Same shape as cloud-debug.
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - mentra-account-auth
+      - cloud-v2/isaiah
+      - cloud-v2/isaiah/**
+    paths:
+      - "cloud-v2/**"
+      - ".github/workflows/cloud-v2-isaiah.yml"
+
+concurrency:
+  group: cloud-v2-isaiah-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy cloud-isaiah to AWS us-west-2
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      PORTER_CLUSTER: "5692"
+      PORTER_PROJECT: "15081"
+      PORTER_DEPLOYMENT_TARGET_ID: 87f939d6-b019-4955-9f4b-1050e8ff57bd
+      PORTER_HOST: https://dashboard.porter.run
+      PORTER_APP_NAME: cloud-isaiah
+      PORTER_REPO_NAME: ${{ github.event.repository.name }}
+      PORTER_TOKEN: ${{ secrets.PORTER_TOKEN }}
+      CORE_HOSTNAME: core.isaiah.us-west-2.mentraglass.com
+      RUNTIME_HOSTNAME: runtime.isaiah.us-west-2.mentraglass.com
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set Git SHA tag
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Setup Porter CLI
+        uses: porter-dev/setup-porter@v0.1.0
+
+      - name: Deploy cloud-isaiah app
+        timeout-minutes: 45
+        working-directory: cloud-v2
+        env:
+          PORTER_TAG: ${{ steps.vars.outputs.sha_short }}
+        run: porter apply -w -f porter.isaiah.yaml
+
+      - name: Verify isaiah health
+        run: |
+          set -euo pipefail
+          if ! getent hosts "${CORE_HOSTNAME}" >/dev/null || ! getent hosts "${RUNTIME_HOSTNAME}" >/dev/null; then
+            echo "::warning::Isaiah DNS is not configured yet; skipping public health checks."
+            exit 0
+          fi
+          curl --retry 12 --retry-delay 10 --retry-all-errors -fsS "https://${CORE_HOSTNAME}/healthz"
+          echo
+          curl --retry 12 --retry-delay 10 --retry-all-errors -fsS "https://${RUNTIME_HOSTNAME}/healthz"
+          echo

--- a/cloud-v2/deploy/audio-udp-nlb-debug.yaml
+++ b/cloud-v2/deploy/audio-udp-nlb-debug.yaml
@@ -1,7 +1,17 @@
 # Debug UDP Network Load Balancer for cloud-v2 runtime audio.
 #
-# Apply after the Porter app exists:
-#   porter kubectl apply -f deploy/audio-udp-nlb-debug.yaml
+# This is also the TEMPLATE for other environments: clone it and replace
+# cloud-debug with cloud-<env> in metadata.name, metadata.labels, and
+# spec.selector. Full steps: docs/runbooks/deploy/udp-nlb-aws.md.
+#
+# Apply after the Porter app exists, with DIRECT kubectl (aws eks
+# update-kubeconfig first; `porter kubectl` is read-only and cannot create
+# Services):
+#   kubectl apply -f deploy/audio-udp-nlb-debug.yaml
+#
+# Then put the provisioned NLB hostname into the env's own Doppler config
+# (AUDIO_UDP_ADVERTISED_HOST) and redeploy, or clients keep advertising a
+# dead host and silently fall back to WS audio.
 #
 # This service is intentionally separate from Porter's generated services:
 # Porter exposes HTTP/WS through nginx/ALB, while UDP audio needs a direct NLB.

--- a/cloud-v2/deploy/audio-udp-nlb-isaiah.yaml
+++ b/cloud-v2/deploy/audio-udp-nlb-isaiah.yaml
@@ -1,0 +1,35 @@
+# UDP Network Load Balancer for the cloud-isaiah personal env's runtime audio.
+# Cloned from audio-udp-nlb-debug.yaml (the per-env template).
+#
+# Apply with DIRECT kubectl (aws sso login + the EKS kubeconfig;
+# `porter kubectl` is read-only and cannot create Services):
+#   kubectl apply -f deploy/audio-udp-nlb-isaiah.yaml
+#
+# Then put the provisioned NLB hostname into dev_isaiah
+# (AUDIO_UDP_ADVERTISED_HOST) and redeploy cloud-isaiah, or clients keep
+# advertising a dead host and silently fall back to WS audio.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cloud-isaiah-audio-udp
+  namespace: default
+  labels:
+    porter.run/app-name: cloud-isaiah
+    app.kubernetes.io/managed-by: kubectl
+  annotations:
+    description: "UDP LoadBalancer for cloud-v2 isaiah runtime audio (not managed by Porter)"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
+spec:
+  type: LoadBalancer
+  selector:
+    porter.run/app-name: cloud-isaiah
+    porter.run/service-name: runtime
+  ports:
+    - name: udp-audio
+      protocol: UDP
+      port: 8000
+      targetPort: 8000
+  externalTrafficPolicy: Local

--- a/cloud-v2/deploy/audio-udp-nlb.yaml
+++ b/cloud-v2/deploy/audio-udp-nlb.yaml
@@ -1,22 +1,13 @@
-# Network Load Balancer for the audio service's UDP port.
+# LEGACY: do not apply. This manifest predates the per-environment app split
+# and selects `porter.run/app-name: cloud-v2`, an app name that no longer
+# deploys (envs are now cloud-dev / cloud-debug / cloud-staging / cloud-prod).
+# Use audio-udp-nlb-debug.yaml as the per-env template instead, swapping the
+# app name. Kept only as annotated reference for the NLB annotations and the
+# externalTrafficPolicy rationale below.
 #
-# Porter's `additionalPorts:` in porter.yaml only exposes the port on the
-# container — it does NOT create a separate k8s Service or AWS NLB. UDP
-# traffic from the public internet needs an NLB; AWS ELBv2's NLB supports
-# UDP listeners (ALB does not).
-#
-# Apply via:
-#   porter kubectl apply -f deploy/audio-udp-nlb.yaml
-#
-# After applying, get the NLB hostname:
-#   porter kubectl get svc cloud-v2-audio-udp -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-#
-# Then update Doppler with that hostname:
-#   doppler secrets set "AUDIO_UDP_ADVERTISED_HOST=<nlb-hostname>" --config dev_aws
-# And redeploy: porter apply -f porter.yaml
-#
-# Selector matches the Porter-managed audio pods (labels set by their
-# Helm chart — see `porter kubectl describe svc cloud-v2-audio`).
+# See docs/runbooks/deploy/udp-nlb-aws.md for current provisioning steps.
+# Note: applying requires direct kubectl (aws eks update-kubeconfig);
+# `porter kubectl` is read-only and cannot create Services.
 
 apiVersion: v1
 kind: Service

--- a/cloud-v2/docs/issues/019-mentra-account-auth/README.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/README.md
@@ -23,6 +23,52 @@ external system that calls `/api/oem/*`). For Mentra's consumer app, that role
 is currently played by Supabase plus legacy Cloud V1. This issue brings
 "Mentra's own OEM backend" into Cloud V2.
 
+## Why the old system needs replacing (motivation)
+
+This is not just a "move to V2" cleanup. The current login stack has real
+security and reliability problems, several of which we hit directly during the
+2026-07 debug-environment incidents. Ranked by impact:
+
+1. **Symmetric shared secrets: any backend can forge any user.** Core verifies
+   Supabase sessions with `SUPABASE_JWT_SECRET` and legacy tokens with
+   `MENTRA_CORE_JWT_SECRET`, both HS256. Symmetric verification means the verify
+   key is the mint key, and those secrets sit in every environment's Doppler
+   config (including throwaway debug). A compromise of any environment forges
+   identities valid everywhere, because HS tokens carry no issuer key identity
+   and pin no environment. The V2 OEM path (asymmetric, per-env JWKS) exists to
+   fix exactly this; Mentra's own login is the last thing not using it.
+2. **Three token systems glued together on the client.** The phone juggles a
+   Supabase session, a legacy core token, and the V2 access/refresh/runtime/
+   miniapp stack, and mobile is the integration point. The failures chased this
+   month were all seams between them (refresh 400 -> "re-auth required" ->
+   running miniapps stuck on stale tokens; the bug-hunt "cloud token refresh"
+   icon failure; "connect button fails after app restart"). Client-side identity
+   assembly means every seam failure ships to users and needs an app release.
+3. **Long-lived credentials at rest on the device and in URLs.** The full
+   Supabase session (access + refresh + profile) sits in plain MMKV storage, and
+   the legacy WS connects with the token in the query string
+   (`/glasses-ws?token=...`), which lands in logs and proxies. Server-mediated
+   auth shrinks what the device ever holds.
+4. **No central revocation / session control.** Supabase refresh happens
+   client-side against Supabase directly, so the server cannot kill sessions;
+   legacy tokens are verify-only symmetric. "Log out everywhere" today spans
+   three uncoordinated systems (the same revocation gap as issue 018, item 1).
+5. **Third-party coupled into the app binary.** `supabase-js`, the Supabase URL,
+   and the anon key are baked into the client, so key rotation or flow changes
+   require an app-store release. Behind a core-owned `/api/account/*` surface,
+   they become a server deploy.
+
+In fairness, the old design was reasonable V1 pragmatism (Supabase gave OAuth,
+email verification, and password reset for free). The debt came from bolting V2
+alongside it rather than under it. That is why Phase 1 keeps Supabase (do not
+rebuild what works) but moves the seam server-side, which removes the whole
+client-glue failure class.
+
+Scope honesty: items 1 and 2 justify this project on their own. Some of the July
+pain (E11000 sign-in failures, the chimera UDP host, the debug/dev DB mixup) was
+environment and ops drift, NOT login architecture; issue 019 does not fix those
+(see the env-hygiene notes) and should not be sold as doing so.
+
 ## Placement decision (made)
 
 The account module lives **inside `packages/core`** as a clearly bounded module

--- a/cloud-v2/docs/issues/019-mentra-account-auth/README.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/README.md
@@ -1,7 +1,19 @@
 # 019 - Mentra account auth: mobile login on Cloud V2
 
-**Status:** Planning. This issue frames the work; the deliverables are three docs
-in this folder (spike.md, spec.md, design.md), each gated on the previous one.
+**Status:** Spike in progress. This issue frames the work; the deliverables are
+three docs in this folder (spike.md, spec.md, design.md), each gated on the
+previous one.
+
+## Goal (the actual headline)
+
+**Make it possible to build a version of the MentraOS mobile app with zero
+dependency on legacy Cloud V1.** Replacing the login system is the first and
+enabling cut: identity is the thing every other legacy connection's auth flows
+through, so nothing else can move off V1 while V1 still owns login. But the
+end state is a V1-free build, and the spike inventories the FULL V1 surface
+(not just auth) so the remaining cuts can be sequenced. Today no build flag or
+code path exists that could even express "V2 only"; creating that is part of
+the work.
 
 ## Problem
 

--- a/cloud-v2/docs/issues/019-mentra-account-auth/README.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/README.md
@@ -140,6 +140,7 @@ Questions the spike must answer, with evidence:
   from core? keep dual login temporarily?).
 - Migration: what happens to existing logged-in users on app update (silent
   re-exchange vs forced re-login), and the account-recovery story.
+  (RESOLVED in spike.md decision 4: forced re-login, no migration ramp.)
 
 ### 2. spec.md - the contract
 

--- a/cloud-v2/docs/issues/019-mentra-account-auth/README.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/README.md
@@ -1,0 +1,133 @@
+# 019 - Mentra account auth: mobile login on Cloud V2
+
+**Status:** Planning. This issue frames the work; the deliverables are three docs
+in this folder (spike.md, spec.md, design.md), each gated on the previous one.
+
+## Problem
+
+The MentraOS mobile app's login is a Cloud V1 era stack. The app embeds
+`supabase-js` directly (`mobile/src/utils/auth/provider/supabaseClient.ts`:
+password sign-in, Google OAuth, session refresh, reset flows), and legacy Cloud
+V1 (`api.mentra.glass`) sits in the auth chain as the issuer of the legacy
+"core token" (`MENTRA_CORE_JWT_SECRET`). Cloud V2's token exchange accepts both
+of those as subject tokens (the symmetric branch of `resolveSubjectIdentity` in
+`packages/core/src/services/session.service.ts`), resolving to the built-in
+`mentra` tenant, while real OEMs use the asymmetric JWKS path.
+
+We want mobile login to be a Cloud V2 concern: the app should talk only to
+Cloud V2 for auth, and Cloud V1 should drop out of the chain entirely.
+
+In V2's own architecture language, the component that authenticates end users
+and issues subject tokens is "the OEM's backend" (the auth spec treats it as an
+external system that calls `/api/oem/*`). For Mentra's consumer app, that role
+is currently played by Supabase plus legacy Cloud V1. This issue brings
+"Mentra's own OEM backend" into Cloud V2.
+
+## Placement decision (made)
+
+The account module lives **inside `packages/core`** as a clearly bounded module
+(`api/account/*` + `services/account/*`), NOT a separate deployable package.
+
+Rationale:
+- Every new deployable is a new Porter service x 4 environments, more domains,
+  more Doppler configs, more env-group drift. The July debug-environment
+  incident (stale env snapshots, shadowed vars, DB mix-ups) is the standing
+  argument against growing that surface.
+- Core already owns the identity domain: the `users` collection, session
+  minting, the RFC 8693 exchange, Supabase verification, JWKS serving, and
+  WorkOS console auth.
+- The OEM model can still be dogfooded from inside core: the account module
+  signs real Ed25519 subject tokens under a `mentra` issuer and pushes them
+  through the same exchange path OEMs use, instead of growing the special-case
+  HS256 branch.
+- If PII/compliance/scale ever demands isolation, a well bounded module lifts
+  out into a package later. The reverse (collapsing a premature service) never
+  happens.
+
+## Phasing decision (made)
+
+- **Phase 1 - move the surface, keep Supabase behind it.** Mobile stops
+  embedding `supabase-js` and stops touching legacy Cloud V1. It talks only to
+  `core.../api/account/*` (signup, login, logout, forgot/change password,
+  Google OAuth start/callback, session). Core drives Supabase server side and
+  mints the V2 session directly. This removes Cloud V1 from the auth chain
+  without rebuilding password storage, email delivery, and OAuth.
+- **Phase 2 (optional, later) - swap the credential store** behind that same
+  surface (native store, or WorkOS AuthKit like the consoles, pending a
+  consumer-scale pricing look). Mobile does not change again.
+
+## Deliverables
+
+### 1. spike.md - answer the unknowns first
+
+Questions the spike must answer, with evidence:
+- Everything mobile currently uses auth for: full inventory of
+  `authClient.ts` / `supabaseClient.ts` call sites, the legacy core-token
+  consumers (legacy WS, anything else), and which surfaces assume a Supabase
+  session object (posthog identity, sentry, bug reports, etc.).
+- What Supabase features are load-bearing: email/password, Google, Apple?,
+  magic links, email verification, password reset emails, account deletion.
+  Which are actually enabled and used in production.
+- Can core drive Supabase fully server side (admin API vs GoTrue endpoints):
+  sign-in, sign-up, OAuth code exchange, reset emails. What breaks with
+  captive-portal style OAuth on mobile (deep links / app links back into the
+  app).
+- Session model: does mobile keep ONE session (V2 access+refresh) with the
+  Supabase session held server side, or does it still hold the Supabase
+  refresh token? Recommendation with tradeoffs (offline login, token lifetime,
+  revocation).
+- Legacy coexistence: during rollout, legacy Cloud V1 still needs to
+  authenticate the same user (captions v1, store, anything not yet on V2).
+  How does a V2-logged-in app talk to legacy (mint a legacy-compatible token
+  from core? keep dual login temporarily?).
+- Migration: what happens to existing logged-in users on app update (silent
+  re-exchange vs forced re-login), and the account-recovery story.
+
+### 2. spec.md - the contract
+
+Must cover:
+- The full `/api/account/*` endpoint surface with request/response shapes and
+  error taxonomy (RFC-shaped errors like the existing auth endpoints).
+- Token/claims design: what the account module issues, how it feeds the
+  existing exchange (`mentra` issuer Ed25519 subject token through the OEM
+  path), TTLs, refresh, revocation.
+- Mobile client contract: the `authClient.ts` interface the app codes against
+  (so mobile work can proceed against a stub).
+- Security requirements: rate limiting, credential handling rules, jti replay
+  protection (exists), device binding if any, logout-everywhere.
+- Rollout/compat requirements: minimum app version gating
+  (`GET /api/client/min-version` exists), feature flag, kill switch back to
+  the old flow.
+
+### 3. design.md - how it is built
+
+Must cover:
+- Module layout in core (`api/account/*`, `services/account/*`), what is
+  shared with session.service vs new.
+- Supabase server-side integration design (keys, which env vars per
+  environment, error mapping).
+- OAuth redirect flow end to end (mobile deep link scheme, state/PKCE,
+  the `x-mentra-public-origin` pattern the consoles use).
+- Mobile changes: replace `supabaseClient.ts` provider behind the existing
+  `authClient.ts` abstraction; what dies in the legacy connection path.
+- Test plan: integration tests against a mocked GoTrue, e2e on device against
+  debug env, migration test for existing sessions.
+- Rollout plan across debug -> dev -> staging -> prod, with the legacy
+  coexistence switch.
+
+## Non-goals (this issue)
+
+- Replacing Supabase as the credential store (Phase 2, separate decision).
+- Console/portal auth (already WorkOS, unaffected).
+- Enterprise trusted-issuer path (unaffected; it is the model we are
+  mirroring).
+
+## References
+
+- `cloud-v2/docs/issues/001-cloud-core/auth/spec.md` (exchange, caller
+  convention, `/api/oem/*`)
+- `packages/core/src/services/session.service.ts` (`resolveSubjectIdentity`
+  symmetric branch this work will eventually retire)
+- `mobile/src/utils/auth/` (authClient + supabase provider)
+- Issue 014 (enterprise portal / trusted issuers), issue 017 (JWKS fallback),
+  issue 018 item 1 (session revocation gap, relevant to logout-everywhere)

--- a/cloud-v2/docs/issues/019-mentra-account-auth/README.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/README.md
@@ -1,8 +1,8 @@
 # 019 - Mentra account auth: mobile login on Cloud V2
 
-**Status:** Spike in progress. This issue frames the work; the deliverables are
-three docs in this folder (spike.md, spec.md, design.md), each gated on the
-previous one.
+**Status:** Docs complete, ready for review. spike.md (V1 dependency ledger +
+decisions), spec.md (the /api/account contract), and design.md (implementation
+plan) are all in this folder. Implementation not started.
 
 ## Goal (the actual headline)
 

--- a/cloud-v2/docs/issues/019-mentra-account-auth/design.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/design.md
@@ -144,7 +144,45 @@ user-facing request (the user's V2 identity is already gone).
    branch usage remnants, SocketComms/WebSocketManager/RestComms, and work the
    spike section 6 ledger.
 
-## 9. Phase 2 seam (for the record)
+## 9. OEM reference parity (a hard requirement, not a nicety)
+
+The account module is a REFERENCE implementation of "how to build an OEM
+backend." Mentra must not be a privileged tenant: everything the module does
+must be doable by an external OEM against public surfaces, so this code can be
+handed to OEMs as the example for both their backend and their mobile client.
+
+The mapping:
+
+| Account module does | An external OEM does |
+|---|---|
+| verifies credentials via GoTrue | verifies credentials however they like |
+| holds `MENTRA_ACCOUNT_JWT_PRIVATE_KEY` | holds their own signing key |
+| `mentra` oems row (static public key, seeded by migration) | their oems row, registered with Mentra |
+| signs subject JWT `iss/aud = mentra`, sub, jti, iat, exp | signs the identical shape with `iss = <their tenantId>` |
+| calls `createSession(subjectToken)` in-process | POSTs the token to the PUBLIC `/api/client/auth/exchange` (either from their backend, server-side broker style, or from their app) |
+| returns the V2 TokenResponse from `/api/account/login` | returns the V2 TokenResponse from their own `/login` |
+
+The only difference is topological: an in-process function call instead of an
+HTTP hop to the exchange endpoint, and `createSession` IS that endpoint's
+implementation, so the semantics are identical.
+
+Enforced by tests in `tests/account-auth.integration.test.ts`:
+- "OEM parity: the mentra subject token works through the PUBLIC exchange
+  endpoint" - if Mentra ever grows a private path the public endpoint cannot
+  serve, this fails.
+- "OEM parity: a DISABLED mentra oems row blocks refresh like any OEM" -
+  refresh authorization goes through the same oems-row check as every OEM (the
+  old `mentra` early-return is now only a transitional fallback for
+  environments whose seed migration has not run, and dies at the V1 cutover).
+
+The `/api/account/*` endpoints themselves are Mentra's OEM-backend surface
+(mounted in core for ops reasons, per the README placement decision); an
+external OEM builds their equivalents on their own backend and never calls
+ours. The mobile client pattern is likewise symmetric: the app calls "my OEM
+backend's login," stores V2 tokens, and hands them to cloud-client; nothing in
+the client knows Mentra's backend is special.
+
+## 10. Phase 2 seam (for the record)
 
 Everything Supabase-specific is behind `gotrue.client.ts` + the
 `tenantUserId = Supabase user id` mapping. A Phase 2 credential-store swap

--- a/cloud-v2/docs/issues/019-mentra-account-auth/design.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/design.md
@@ -20,6 +20,12 @@ Mounted under `/api/account` in `api/app.ts`. Rate limiting via a small
 middleware over a Mongo TTL counter (no new infra; swap for Redis later if
 needed).
 
+Note: while implementing this, `session.service.ts` was split — the crypto key
+loading + JWKS moved to `services/signing-keys.service.ts` (it had accreted key
+management alongside session lifecycle). The account subject-token key lives
+there with the access/miniapp keys. Dependency direction: signing-keys <- token
+minting <- session.
+
 ## 2. GoTrue (Supabase) server-side integration
 
 Core talks to GoTrue with two credentials, both server-only Doppler secrets

--- a/cloud-v2/docs/issues/019-mentra-account-auth/design.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/design.md
@@ -112,14 +112,14 @@ app                core                        Supabase/provider
 - V1 surfaces broken by this (dashboard, V1 bridge, settings sync, feeds) are
   NOT patched here; they are the spike section 6 ledger for the V1-removal PR.
 
-## 6. Account deletion fan-out
+## 6. Account deletion
 
-`delete/confirm` runs, in order: revoke all V2 sessions, delete V2 user row,
-delete GoTrue user (admin API), then while V1 exists call V1's internal
-deletion endpoint server-to-server (env `LEGACY_CORE_URL` +
-`LEGACY_DELETE_SECRET`; both live only in core's Doppler). V1 fan-out failures
-are logged and retried by a small reconciliation job rather than failing the
-user-facing request (the user's V2 identity is already gone).
+`delete/confirm` runs, in order: revoke all V2 sessions, delete the V2 user
+row, delete the GoTrue user (admin API). Cloud V1 is a separate system with
+its own database and cloud-v2 code has no knowledge of it: there is no
+server-to-server fan-out, no legacy env vars, no reconciliation job. If V1
+records need cleanup while V1 still exists, that is handled on the V1 side
+as an operational task.
 
 ## 7. Testing
 

--- a/cloud-v2/docs/issues/019-mentra-account-auth/design.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/design.md
@@ -1,0 +1,153 @@
+# 019 design: how the account module is built
+
+**Status:** Draft for review. Implements spec.md; decisions in spike.md 5.
+
+## 1. Module layout (packages/core)
+
+```
+src/api/account/
+  account.api.ts        // signup/login/logout/me/password/email/delete routes
+  oauth.api.ts          // /oauth/:provider/start, /oauth/callback, /oauth/complete
+src/services/account/
+  account.service.ts    // orchestration: gotrue calls -> subject token -> session
+  gotrue.client.ts      // typed server-side Supabase GoTrue client + error map
+  one-time-code.service.ts // OTC + email codes (reset, deletion, oauth otc)
+src/models/
+  account-code.model.ts // hashed one-time codes, TTL-indexed like refreshTokens
+```
+
+Mounted under `/api/account` in `api/app.ts`. Rate limiting via a small
+middleware over a Mongo TTL counter (no new infra; swap for Redis later if
+needed).
+
+## 2. GoTrue (Supabase) server-side integration
+
+Core talks to GoTrue with two credentials, both server-only Doppler secrets
+per environment: `SUPABASE_URL`, `SUPABASE_ANON_KEY` (token grant), and
+`SUPABASE_SERVICE_ROLE_KEY` (admin API). The anon key stops shipping in the
+app entirely.
+
+| Need | GoTrue call |
+|---|---|
+| verify email+password | `POST /auth/v1/token?grant_type=password` (transient; response discarded after identity read) |
+| signup | `POST /auth/v1/signup` (GoTrue sends the verification email) |
+| resend verification | `POST /auth/v1/resend` |
+| password reset code | `POST /auth/v1/admin/generate_link` type `recovery` (core emails the code via Resend rather than the raw link) |
+| password/email change | `PUT /auth/v1/admin/users/{id}` |
+| OAuth authorize | `GET /auth/v1/authorize?provider=...&redirect_to=<core callback>` |
+| OAuth code exchange | `POST /auth/v1/token?grant_type=pkce` (core-held verifier for the core<->GoTrue leg) |
+| delete user | `DELETE /auth/v1/admin/users/{id}` |
+
+Error mapping lives in `gotrue.client.ts` (GoTrue error -> spec error code);
+nothing GoTrue-shaped leaks past the service layer, which is what makes the
+Phase 2 credential-store swap a service-internal change.
+
+## 3. Keys, identity, and session minting
+
+- New per-env keypair `MENTRA_ACCOUNT_JWT_PRIVATE_KEY` /
+  `MENTRA_ACCOUNT_JWT_PUBLIC_KEY` (Ed25519, kid `mentra-account-1`), added to
+  each environment's Doppler config and served in the well-known JWKS.
+- A startup migration inserts the `oems` row for tenantId `mentra`
+  (`publicKeyMode: "static"`, the account public key), idempotent like the
+  existing startup migrations.
+- `account.service.ts` flow for any successful verification:
+  1. read identity from GoTrue (user id, email, verified flag),
+  2. mint a 60s Ed25519 subject token (iss `mentra`, sub = Supabase user id,
+     jti, exp),
+  3. call the existing `createSession({subjectToken})` so jti replay
+     protection, findOrCreateUser (tenantId `mentra`, tenantUserId = Supabase
+     user id: SAME identity mapping as today, so existing V2 user rows are
+     reused, not duplicated), and refresh-token persistence all run unchanged.
+- Cleanup in the same PR (enabled by no-migration, spike decision 4): delete
+  the symmetric Supabase/legacy branch of `resolveSubjectIdentity` and the
+  `MENTRA_OEM_ID` refresh special case (the new oems row covers it).
+
+## 4. OAuth end to end
+
+```
+app                core                        Supabase/provider
+ |-- generate verifier+challenge
+ |-- open browser: GET /api/account/oauth/google/start?state&code_challenge
+ |                  |-- persist {state, challenge} (account-code, 10m)
+ |                  |-- 302 --> GoTrue /authorize?provider=google
+ |                                     ... Google login ...
+ |                  <-- 302 callback?code=...   (redirect_to = core)
+ |                  |-- exchange code with GoTrue (server side)
+ |                  |-- identity -> subject token -> V2 session
+ |                  |-- store TokenResponse under OTC (60s, single use,
+ |                  |     bound to code_challenge)
+ |                  |-- 302 --> com.mentra://auth/callback?code=OTC&state
+ |<-- deep link opens app
+ |-- POST /oauth/complete {code: OTC, code_verifier}
+ |                  |-- verify S256(verifier) == challenge, burn OTC
+ |<-- TokenResponse (V2 access+refresh)
+```
+
+- The public callback URL is built from `x-mentra-public-origin` when proxied
+  (same pattern as the console Pages proxy) or `CORE_PUBLIC_URL` otherwise.
+- Browser: Android Custom Tabs / iOS ASWebAuthenticationSession via
+  `expo-web-browser` (already an Expo app); scheme `com.mentra` is registered.
+- Apple provider is the same route pair; Supabase handles the Apple client
+  secret; required by App Store review because Google login is offered.
+
+## 5. Mobile changes
+
+- New `CoreAccountAuthProvider` implementing the existing `authClient.ts`
+  interface (mapping table in spec.md), backed by `/api/account/*` and the
+  cloud-client token store. Screens keep calling `authClient`.
+- Deleted: `mobile/src/utils/auth/provider/supabaseClient.ts`, `supabase-js`
+  dependency, the anon key from config, `restComms.exchangeToken()` call in
+  `app/index.tsx` (`handleTokenExchange` becomes "ensure V2 session").
+- First-boot cutover: if legacy/Supabase auth material exists in storage, wipe
+  it and route to login (spike decision 4). One-line version gate: the release
+  also bumps the server `min-version` floor.
+- Identity side-channels (posthog, sentry, bug reports) read `GET /me` state
+  keyed on `mentraUserId` (spike decision 5); single sweep of call sites.
+- V1 surfaces broken by this (dashboard, V1 bridge, settings sync, feeds) are
+  NOT patched here; they are the spike section 6 ledger for the V1-removal PR.
+
+## 6. Account deletion fan-out
+
+`delete/confirm` runs, in order: revoke all V2 sessions, delete V2 user row,
+delete GoTrue user (admin API), then while V1 exists call V1's internal
+deletion endpoint server-to-server (env `LEGACY_CORE_URL` +
+`LEGACY_DELETE_SECRET`; both live only in core's Doppler). V1 fan-out failures
+are logged and retried by a small reconciliation job rather than failing the
+user-facing request (the user's V2 identity is already gone).
+
+## 7. Testing
+
+- **Integration (bun test, mock GoTrue):** a `Bun.serve` GoTrue stub (same
+  pattern as the trusted-issuer JWKS test) covering: signup/verify/login happy
+  path, invalid_credentials uniformity, reset revokes other sessions, OAuth
+  complete with good/bad verifier, OTC single-use and expiry, deletion
+  cascade, and that login mints a session whose refresh works (regression
+  for the enterprise-refresh class of bug).
+- **Contract tests:** the new provider's authClient methods against a live
+  local core (mirrors the existing e2e harness scripts under
+  `cloud-v2/scripts`).
+- **Device e2e (debug env):** fresh install -> signup -> verify -> login ->
+  glasses connect -> logout everywhere; Google OAuth round trip through the
+  real browser; password reset from email code; account deletion.
+- **Negative proof discipline:** each security assertion (OTC replay, PKCE
+  mismatch, enumeration uniformity) gets a test that fails when the guard is
+  removed, per this repo's established practice.
+
+## 8. Rollout
+
+1. Server lands dark on debug -> dev (additive endpoints; nothing calls them).
+2. Device e2e on debug (the account module exercises debug's own DB).
+3. Server to staging -> prod via the normal branch flow.
+4. Mobile release flips to `/api/account/*`; same release wipes legacy auth
+   state on first boot; server `min-version` floor raised.
+5. Post-cutover cleanup PR (the V1-removal PR): delete symmetric exchange
+   branch usage remnants, SocketComms/WebSocketManager/RestComms, and work the
+   spike section 6 ledger.
+
+## 9. Phase 2 seam (for the record)
+
+Everything Supabase-specific is behind `gotrue.client.ts` + the
+`tenantUserId = Supabase user id` mapping. A Phase 2 credential-store swap
+(native store or WorkOS AuthKit) replaces that client and keeps
+`tenantUserId` stable by importing the same subject ids, with no mobile or
+session-model change. Not scheduled; recorded so the boundary is respected.

--- a/cloud-v2/docs/issues/019-mentra-account-auth/spec.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/spec.md
@@ -1,0 +1,148 @@
+# 019 spec: the /api/account contract
+
+**Status:** Draft for review. Gated on spike.md (complete); design.md describes
+implementation. All decisions referenced here are spike.md section 5.
+
+## Principles
+
+- Same conventions as the existing auth endpoints: JSON bodies, RFC-shaped
+  errors `{ error: <code>, error_description: <text> }` (oauth.types), and the
+  standard `TokenResponse` (`access_token`, `refresh_token`, `token_type:
+  "Bearer"`, `expires_in`) so mobile reuses the cloud-client token store
+  unchanged (1h access, 30d rolling refresh).
+- The device ends up holding V2 tokens only. No Supabase material ever reaches
+  the client (spike decision 2).
+- Login endpoints never reveal whether an email exists (uniform errors and
+  uniform timing on `login`, `password/forgot`, `signup` conflicts).
+- Every account endpoint is rate limited per IP and per email (design.md picks
+  the mechanism; the contract just guarantees 429 with `rate_limited`).
+
+## Error codes
+
+Reused: `invalid_request`, `invalid_grant`, `unauthorized_client`,
+`server_error`. Added for account flows:
+
+| code | meaning | HTTP |
+|---|---|---|
+| `invalid_credentials` | wrong email/password (never distinguishes which) | 401 |
+| `verification_required` | account exists but email not verified | 403 |
+| `weak_password` | GoTrue policy rejection, description passes through | 400 |
+| `email_taken` | signup conflict (only after verified-email check; see note) | 409 |
+| `code_invalid` | OTC/reset/deletion code wrong, expired, or used | 400 |
+| `rate_limited` | too many attempts | 429 |
+
+Note on `email_taken` vs enumeration: signup returns the same
+"check your email" success shape whether the address is new or already
+registered; `email_taken` is only returned for authenticated email-change
+conflicts.
+
+## Endpoints
+
+All under `/api/account`. "auth" means a valid V2 access token (Bearer).
+
+### Credentials
+
+| Endpoint | Auth | Body | Returns |
+|---|---|---|---|
+| `POST /signup` | none | `{email, password}` | `202 {status: "verification_sent"}` (uniform; see enumeration note) |
+| `POST /verify/resend` | none | `{email}` | `202` uniform |
+| `POST /login` | none | `{email, password}` | `200 TokenResponse` or `invalid_credentials` / `verification_required` |
+| `POST /logout` | auth | `{everywhere?: boolean}` | `204`; `everywhere` revokes all of the user's refresh tokens |
+| `GET /me` | auth | - | `200 {mentraUserId, email, name?, avatarUrl?}` (spike decision 5) |
+
+### Password and email
+
+| Endpoint | Auth | Body | Returns |
+|---|---|---|---|
+| `POST /password/forgot` | none | `{email}` | `202` uniform (sends code email) |
+| `POST /password/reset` | none | `{email, code, newPassword}` | `200 TokenResponse` (reset logs the user in; all other sessions revoked) |
+| `POST /password/change` | auth | `{currentPassword, newPassword}` | `204`; other sessions revoked |
+| `POST /email/change` | auth | `{newEmail, password}` | `202 {status: "verification_sent"}`; applies on verified click |
+
+### OAuth (Google, Apple)
+
+Flow (spike decision 1): system browser, core-hosted, PKCE between app and
+core, one-time code back via deep link.
+
+| Endpoint | Auth | Params | Returns |
+|---|---|---|---|
+| `GET /oauth/:provider/start` | none | `state`, `code_challenge` (S256) | `302` into the provider flow (via Supabase authorize) |
+| `GET /oauth/callback` | none | provider params | `302 com.mentra://auth/callback?code=<otc>&state=<state>` |
+| `POST /oauth/complete` | none | `{code, code_verifier}` | `200 TokenResponse` |
+
+- `provider` is `google` or `apple` (Apple is required by App Store policy
+  once Google is offered).
+- The one-time code is single use, 60 second TTL, bound to the
+  `code_challenge` from `start`. `complete` verifies the `code_verifier`
+  against it (PKCE), so an intercepted deep link is useless without the
+  in-app verifier.
+- The callback deep link uses the existing app scheme `com.mentra` (from
+  `mobile/app.config.ts`).
+
+### Account deletion (spike decision 6; ships in Phase 1)
+
+| Endpoint | Auth | Body | Returns |
+|---|---|---|---|
+| `POST /delete/request` | auth | - | `202` (sends confirmation code email) |
+| `POST /delete/confirm` | auth | `{code}` | `204`; deletes Supabase user, V2 user + sessions, fans out to V1 deletion server side while V1 exists |
+
+## Token and identity design
+
+- Internally, a successful credential/OAuth verification mints a short-lived
+  (60s, jti-bearing) **Ed25519 `mentra-account` subject token** and feeds it
+  through the SAME code path as OEM token exchange, producing the standard V2
+  session. No new session semantics; the account module is "Mentra's OEM
+  backend" running in-process (README placement decision).
+- The `mentra` tenant gets a real `oems` row (static public key = the account
+  signing key). Refresh authorization then works through the normal OEM check,
+  and the `MENTRA_OEM_ID` special case plus the symmetric Supabase/legacy
+  branch of `resolveSubjectIdentity` are deleted (spike decision 4: no
+  migration ramp, so nothing needs them).
+- `/.well-known/jwks.json` gains the `mentra-account-1` public key (audit
+  visibility; verification is in-process).
+
+## Mobile client contract
+
+The existing `authClient.ts` interface is kept; a new provider implements it
+against `/api/account/*` so screens change minimally:
+
+| authClient method | maps to |
+|---|---|
+| `signUp` | `POST /signup` |
+| `resendSignupEmail` | `POST /verify/resend` |
+| `signInWithPassword` | `POST /login` |
+| `resetPasswordForEmail` | `POST /password/forgot` |
+| `resetPasswordByCode` | `POST /password/reset` |
+| `updateUserPassword` | `POST /password/change` |
+| `updateUserEmail` | `POST /email/change` |
+| `googleSignIn` / `appleSignIn` | `GET /oauth/:provider/start` -> browser -> `POST /oauth/complete` |
+| `getUser` / `getSession` | `GET /me` + local V2 token state |
+| `signOut` | `POST /logout` |
+| `startAutoRefresh` / `stopAutoRefresh` | cloud-client refresh loop (already exists); no separate auth refresher |
+| `onAuthStateChange` | driven by local token-state transitions |
+
+Removed from mobile: `supabase-js`, the anon key, `restComms.exchangeToken`,
+`updateSessionWithTokens` (Supabase deep-link session hand-off).
+
+## Rollout and compatibility
+
+- This is a breaking-cutover app release (spike decisions 3 and 4): on first
+  boot the app wipes stored Supabase/legacy auth material and shows the new
+  login screen. No dual-stack window in the client.
+- Server ships first, dark, to all environments (new endpoints are additive).
+- The app release that switches to `/api/account` sets the forced-upgrade
+  floor via the existing `GET /api/client/min-version` so stragglers on the
+  old flow are upgraded rather than half-broken.
+- The breakage ledger (spike section 6) is the accepted V1 fallout list; only
+  account deletion is exempt (it moves with this work).
+
+## Security requirements summary
+
+- PKCE mandatory on OAuth; state validated; one-time codes single-use/60s.
+- No tokens in URLs except the single-use OTC in the deep link (bound to PKCE).
+- Uniform responses/timing on unauthenticated email-bearing endpoints.
+- Password reset and change revoke all other sessions.
+- `logout everywhere` supported from day one (refresh-token deletion by user).
+- jti replay protection on account subject tokens (mechanism already exists
+  for exchange).
+- Rate limiting on all unauthenticated endpoints (per IP and per email).

--- a/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
@@ -1,8 +1,8 @@
 # 019 spike: the Cloud V1 dependency ledger and the auth chain
 
-**Status:** First pass complete (code inventory, 2026-07-08, branch
-`mentra-account-auth` @ dev f77623007). Remaining spike questions are listed at
-the bottom; they need product answers or live-system checks, not more grepping.
+**Status:** Complete (2026-07-08). Code inventory done, all open questions
+resolved into decisions (section 5), and the accepted-breakage ledger for the
+V1-removal PR is recorded (section 6). spec.md is unblocked.
 
 ## Purpose
 
@@ -121,24 +121,70 @@ Ranked; items 1-2 justify the project on their own.
 Cuts 2-4 are separate issues; this spike scopes them so 019 does not silently
 absorb them.
 
-## 5. Open questions (need answers before spec.md)
+## 5. Decisions (spike resolved 2026-07-08)
 
-- **OAuth redirect mechanics.** Google sign-in server side: core drives the
-  OAuth dance and deep-links back into the app (`state`/PKCE, app links). What
-  does Supabase GoTrue support server side vs what must stay client-initiated?
-  This is the riskiest unknown of Phase 1.
-- **Session model on device.** Does mobile hold ONLY V2 access+refresh (and
-  core holds the Supabase session server side), or keep the Supabase refresh
-  token on device as a recovery root? Tradeoffs: revocation vs offline login
-  vs "logged out after 30 days idle."
-- **Legacy coexistence during rollout.** Until cuts 2-3 land, a V2-logged-in
-  app still needs the V1 websocket. Options: core mints a legacy-compatible
-  coreToken (requires core to hold MENTRA_CORE_JWT_SECRET, extending the
-  symmetric debt temporarily) vs mobile keeps the Supabase session until V1
-  dies. Needs a decision with security signoff.
-- **Migration of logged-in users.** On app update, silent re-exchange from the
-  stored Supabase session vs forced re-login. What percent of sessions survive?
-- **Identity side-channels.** posthog/sentry/bug-report identity currently
-  read the Supabase user object; inventory and re-point them.
-- **Account deletion flow ownership.** V1 owns request/confirm today; the
-  account module must own it before any V1-free build ships to stores.
+1. **OAuth: system browser + core-hosted flow.** Core hosts
+   `GET /api/account/oauth/google/start`; the system browser (Custom Tabs /
+   ASWebAuthenticationSession) runs Supabase's `/auth/v1/authorize`; the
+   callback lands on core, core exchanges the code server side, mints the V2
+   session, and deep-links back into the app with a one-time code. Mirrors the
+   WorkOS PKCE + device flow already built for the console/CLI
+   (`cli-auth.api.ts`), so every moving part has in-repo precedent and no
+   provider secret touches the client. Native Google Sign-In SDK is a later UX
+   optimization, not the foundation. Note: offering Google login means the App
+   Store requires Sign in with Apple; the same core-hosted flow covers it as
+   another provider route.
+2. **Session model: V2 tokens only on device; no Supabase material at all.**
+   Core does NOT persist Supabase sessions: it uses GoTrue's password grant
+   transiently at login (verify, fetch identity, discard) and the GoTrue admin
+   API (service key) for management flows (password/email change, reset links,
+   deletion). The device holds exactly V2 access + refresh. V2 refresh already
+   rolls on rotation, so active users never re-login; only fully-idle-30-days
+   does. TTL stays config-driven if product wants longer.
+3. **No legacy coexistence bridge.** SocketComms is being deprecated and Cloud
+   V1 removal is planned for the PR immediately after this one, so a
+   core-minted legacy coreToken bridge would be engineering for a two-week
+   window. Decision: do not build it. When login moves to V2, the V1 websocket
+   and coreToken-authenticated REST simply stop working, and we track the
+   fallout in the breakage ledger below (section 6) as the work list for the
+   V1-removal PR. One carve-out: account deletion moves in THIS PR (see 5.6),
+   because store compliance cannot be in the broken list.
+4. **Migration: silent bootstrap, then retire the ramp.** On first boot after
+   update, a stored Supabase session is posted to the existing V2 exchange
+   (which already accepts Supabase JWTs), the V2 session is minted, and all
+   Supabase material is wiped from the device. Expired sessions see the login
+   screen, same as today. Instrument with a `migration_source` metric and
+   delete the symmetric exchange branch once usage is ~zero; that is the moment
+   tech-debt item 1 actually dies.
+5. **Identity side-channels: one `GET /api/account/me`.** Returns
+   `{mentraUserId, email, name, avatar}`; posthog/sentry/bug-report identity
+   re-points to it, keyed on `mentraUserId` (stable server id, less PII in
+   third-party tools).
+6. **Account deletion moves in Phase 1.** `request` sends the confirmation
+   email (core already carries `RESEND_API_KEY`), `confirm` deletes the
+   Supabase user (admin API), the V2 user + sessions, and, while V1 lives,
+   calls V1's deletion server-to-server so mobile only ever talks to V2. When
+   V1 dies the fan-out call is deleted.
+
+Remaining sign-off: none blocking. Decision 3 accepts a short window of broken
+V1 features (product call, made 2026-07-08); decision 2's idle-logout TTL is a
+product knob, defaulting to current 30-day rolling.
+
+## 6. Breakage ledger: what stops working when V1 auth goes away
+
+When this PR lands and mobile no longer produces a legacy coreToken, the
+following break by design. This list IS the work list for the V1-removal PR;
+anything discovered broken later gets appended here.
+
+| What breaks | Mechanism | Disposition (next PR) |
+|---|---|---|
+| OS dashboard content (HUD glasses) | dashboard is driven over the V1 WS | move dashboard to Cloud V2 (anticipated in SocketComms comments) |
+| V1 cloud app bridge | display events, photo/stream/video commands, app_started/stopped over V1 WS | V2 runtime already owns these for V2 apps; delete the V1 bridge (SocketComms, WebSocketManager) |
+| V1 audio uplink | `AudioCloudUplink` (island) feeding V1 apps | V2 path exists (cloud-client); delete V1 uplink |
+| Device event routing to V1 | `DeviceEventRouter`, `MantleManager` V1 hooks | re-point or delete with the bridge |
+| Server-synced user settings | `/api/client/user/settings` (coreToken auth) | add V2 settings sync endpoint or accept local-only until then |
+| Calendar / location / notifications feeds | RestComms pushes (coreToken auth) | add V2 client-data endpoints; dashboard/miniapps consuming them move with the dashboard |
+| Error reports | `/app/error` | add V2 equivalent or route to existing report tooling |
+| Legacy `/auth/exchange` + `goodbye` | replaced by the account module | delete client code |
+| Min-version check | `/api/client/min` | already exists on V2 (`/api/client/min-version`); just re-point |
+| Account deletion | `/api/account/request|confirm` | NOT allowed to break; moves in this PR (decision 5.6) |

--- a/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
@@ -149,13 +149,14 @@ absorb them.
    fallout in the breakage ledger below (section 6) as the work list for the
    V1-removal PR. One carve-out: account deletion moves in THIS PR (see 5.6),
    because store compliance cannot be in the broken list.
-4. **Migration: silent bootstrap, then retire the ramp.** On first boot after
-   update, a stored Supabase session is posted to the existing V2 exchange
-   (which already accepts Supabase JWTs), the V2 session is minted, and all
-   Supabase material is wiped from the device. Expired sessions see the login
-   screen, same as today. Instrument with a `migration_source` metric and
-   delete the symmetric exchange branch once usage is ~zero; that is the moment
-   tech-debt item 1 actually dies.
+4. **Migration: none. Everyone logs in again.** On first boot after update,
+   any stored Supabase/legacy material is wiped and the user lands on the new
+   login screen; signing in creates their V2 session and they are migrated.
+   No silent bootstrap, no migration ramp to build or retire. This also means
+   the symmetric Supabase/legacy branch of `resolveSubjectIdentity` can be
+   deleted in the same effort instead of lingering behind a metric (tech-debt
+   item 1 dies immediately). Cost: a one-time re-login for every user on
+   update, accepted as part of the same product call as decision 3.
 5. **Identity side-channels: one `GET /api/account/me`.** Returns
    `{mentraUserId, email, name, avatar}`; posthog/sentry/bug-report identity
    re-points to it, keyed on `mentraUserId` (stable server id, less PII in

--- a/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
@@ -1,0 +1,144 @@
+# 019 spike: the Cloud V1 dependency ledger and the auth chain
+
+**Status:** First pass complete (code inventory, 2026-07-08, branch
+`mentra-account-auth` @ dev f77623007). Remaining spike questions are listed at
+the bottom; they need product answers or live-system checks, not more grepping.
+
+## Purpose
+
+The goal of issue 019 is a mobile build with zero Cloud V1 dependency. This
+spike answers: what exactly does mobile still use V1 for, what is the auth
+chain we are replacing, what already has a V2 equivalent, and what has none.
+
+## 1. The current login chain (what "replace login" replaces)
+
+Boot sequence today (`mobile/src/app/index.tsx` handleTokenExchange):
+
+1. Mobile signs in with **Supabase directly** (`supabase-js` embedded in the
+   app: `mobile/src/utils/auth/provider/supabaseClient.ts`). Email/password,
+   Google OAuth, session refresh, reset flows all run client side against
+   Supabase with the anon key baked into the binary.
+2. Mobile sends the Supabase token to **legacy V1** `POST /auth/exchange`
+   (`restComms.exchangeToken`) and receives the legacy **coreToken**
+   (HS256, `MENTRA_CORE_JWT_SECRET`).
+3. The coreToken authenticates the **V1 websocket** (`/glasses-ws?token=...`,
+   token in the query string) via `socketComms.setAuthCreds`.
+4. Separately, cloud-client connects to **Cloud V2** by exchanging either the
+   Supabase session or that same legacy coreToken at V2
+   `POST /api/client/auth/exchange` (the symmetric `mentra`-tenant branch of
+   `resolveSubjectIdentity`).
+
+So V1 sits in the middle of the chain, and V2 accepts V1's token as an
+identity root. Removing V1 means V2 must root identity itself (Phase 1: core
+drives Supabase server side and mints V2 sessions directly).
+
+## 2. The V1 dependency ledger (everything mobile uses V1 for)
+
+Verified against `mobile/modules/island/src/services/RestComms.ts` (the real
+implementation; `mobile/src/services/RestComms.ts` is a re-export shim) and
+`mobile/src/services/{SocketComms,WebSocketManager}.ts`.
+
+### 2a. Legacy REST (`backend_url`, via RestComms)
+
+| Endpoint | Method(s) | What it does | V2 equivalent today |
+|---|---|---|---|
+| `/auth/exchange` | exchangeToken | Supabase token -> legacy coreToken | Replaced by this issue (account module + existing V2 exchange) |
+| `/api/client/min` | getMinimumClientVersion | forced-upgrade gate | EXISTS: V2 `GET /api/client/min-version` |
+| `/api/client/user/settings` | loadUserSettings / writeUserSettings | server-synced app settings (`saveOnServer` settings) | none on V2 yet |
+| `/api/client/calendar` | sendCalendarData | pushes phone calendar to cloud (dashboard/miniapps) | none on V2 yet |
+| `/api/client/location` | sendLocationData | pushes location | none on V2 yet |
+| `/api/client/notifications` (+`/dismissed`) | notifications feed | phone notifications to cloud | none on V2 yet |
+| `/api/client/goodbye` | goodbye | logout/disconnect signal | V2 has session revoke; wiring differs |
+| `/api/account/request`, `/api/account/confirm` | requestAccountDeletion / confirmAccountDeletion | account deletion flow | none on V2; must be part of the account module (store compliance requirement) |
+| `/app/error` | sendErrorReport | bug/error reports | none on V2 yet |
+
+### 2b. Legacy websocket (`/glasses-ws`, SocketComms + WebSocketManager)
+
+Per the comments in `SocketComms.ts` itself:
+- **The OS dashboard is still driven by Cloud V1** (packageName-level dashboard
+  content). Quote: "The Cloud V1 cloud still drives the OS dashboard ... move
+  it with the websocket itself once the dashboard moves to Cloud V2."
+- **The V1 app bridge**: display events, photo/stream/video commands,
+  `app_state_change` / `app_started` / `app_stopped` for V1 cloud apps.
+- Audio/transcription for V1 cloud apps (V2 apps use cloud-client).
+
+### 2c. Supabase direct (client-embedded)
+
+`supabaseClient.ts` uses: signInWithPassword, sign-up, Google OAuth,
+getSession/getUser, setSession, startAutoRefresh, onAuthStateChange, password
+reset. The bug-hunt checklist ("account creation, forgot password, change
+password, login w/ google") is the live feature set to preserve.
+
+### 2d. Everything else
+
+`backend_url` is also read by dev/UI surfaces (BackendUrl picker, VersionInfo,
+NonProdWarning, app/index boot) which become V2-pointing or vestigial. Rough
+scale: ~99 grep hits for legacy identifiers in `mobile/src`, but the
+load-bearing consumers are the two tables above.
+
+## 3. Tech debt in the old system (why beyond V1-independence)
+
+Ranked; items 1-2 justify the project on their own.
+
+1. **Symmetric shared secrets.** Both identity roots (Supabase session,
+   legacy coreToken) are HS256; the verify key IS the mint key and both
+   secrets exist in every environment's config. Any env compromise forges any
+   user everywhere. V2's asymmetric per-env OEM path exists to fix this;
+   Mentra's own login is the last holdout.
+2. **Client-side identity glue.** Mobile integrates three token systems
+   (Supabase, legacy coreToken, V2 access/refresh/runtime/miniapp). Every seam
+   failure ships to users and needs an app release: the July refresh-400 ->
+   "re-auth required" -> stale-miniapp-token incident, the bug-hunt "cloud
+   token refresh" icon failure, "connect button fails after app restart."
+3. **Credentials at rest and in URLs.** Full Supabase session (access +
+   refresh + profile) in plain MMKV; legacy WS token in the query string,
+   visible in logs.
+4. **No central revocation.** Supabase refresh is client-direct so the server
+   cannot kill sessions; legacy tokens are verify-only. "Log out everywhere"
+   spans three uncoordinated systems (issue 018 item 1 is the same gap).
+5. **Third party baked into the binary.** supabase-js + URL + anon key ship in
+   the app; any rotation or flow change is an app-store release.
+6. **Duplicated per-client logic.** Settings sync, min-version, error
+   reporting all exist once in V1 and will exist again in V2; the migration is
+   the moment to define them once.
+
+## 4. What this implies for sequencing
+
+1. **Cut 1 (this issue): identity.** Account module in core (per README),
+   mobile logs in against `core /api/account/*`, V2 session minted directly,
+   legacy `/auth/exchange` unused. Must include account deletion (2a) because
+   it is a store-compliance feature living on V1 today.
+2. **Cut 2: the client data feeds.** settings sync, calendar, location,
+   notifications, error reports need V2 endpoints (mostly thin; the runtime
+   already has related channels for V2 apps).
+3. **Cut 3: the dashboard + V1 app bridge.** The largest non-auth item; the
+   dashboard has to move to V2 (already anticipated by SocketComms comments).
+4. **Cut 4: the V2-only build flag.** Nothing expresses "V1-free" today. Needs
+   a build-time flag (e.g. `EXPO_PUBLIC_CLOUD_V2_ONLY`) that compiles out
+   SocketComms/WebSocketManager/RestComms and the legacy settings UI, so the
+   V1-free variant is a build target, not a runtime hope.
+
+Cuts 2-4 are separate issues; this spike scopes them so 019 does not silently
+absorb them.
+
+## 5. Open questions (need answers before spec.md)
+
+- **OAuth redirect mechanics.** Google sign-in server side: core drives the
+  OAuth dance and deep-links back into the app (`state`/PKCE, app links). What
+  does Supabase GoTrue support server side vs what must stay client-initiated?
+  This is the riskiest unknown of Phase 1.
+- **Session model on device.** Does mobile hold ONLY V2 access+refresh (and
+  core holds the Supabase session server side), or keep the Supabase refresh
+  token on device as a recovery root? Tradeoffs: revocation vs offline login
+  vs "logged out after 30 days idle."
+- **Legacy coexistence during rollout.** Until cuts 2-3 land, a V2-logged-in
+  app still needs the V1 websocket. Options: core mints a legacy-compatible
+  coreToken (requires core to hold MENTRA_CORE_JWT_SECRET, extending the
+  symmetric debt temporarily) vs mobile keeps the Supabase session until V1
+  dies. Needs a decision with security signoff.
+- **Migration of logged-in users.** On app update, silent re-exchange from the
+  stored Supabase session vs forced re-login. What percent of sessions survive?
+- **Identity side-channels.** posthog/sentry/bug-report identity currently
+  read the Supabase user object; inventory and re-point them.
+- **Account deletion flow ownership.** V1 owns request/confirm today; the
+  account module must own it before any V1-free build ships to stores.

--- a/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/spike.md
@@ -163,9 +163,10 @@ absorb them.
    third-party tools).
 6. **Account deletion moves in Phase 1.** `request` sends the confirmation
    email (core already carries `RESEND_API_KEY`), `confirm` deletes the
-   Supabase user (admin API), the V2 user + sessions, and, while V1 lives,
-   calls V1's deletion server-to-server so mobile only ever talks to V2. When
-   V1 dies the fan-out call is deleted.
+   Supabase user (admin API) and the V2 user + sessions. Cloud V1 is a
+   separate system with its own database; cloud-v2 code never talks to it.
+   Any V1 record cleanup is an operational task on the V1 side, not a
+   cloud-v2 code path.
 
 Remaining sign-off: none blocking. Decision 3 accepts a short window of broken
 V1 features (product call, made 2026-07-08); decision 2's idle-logout TTL is a

--- a/cloud-v2/docs/runbooks/deploy/udp-nlb-aws.md
+++ b/cloud-v2/docs/runbooks/deploy/udp-nlb-aws.md
@@ -33,8 +33,13 @@ the **ALB** (Porter manages it; it's the `*.onporter.run` hostname).
 
 ## What's deployed (verified 2026-07-09)
 
-Short version: **no environment has a working public UDP path right now.**
-Every env runs on the WS audio fallback.
+Per-environment state:
+
+| Env | NLB Service | UDP path |
+| --- | --- | --- |
+| `cloud-isaiah` | `cloud-isaiah-audio-udp` (applied 2026-07-09) | WORKING: probe packets from the internet reach the pod; `AUDIO_UDP_ADVERTISED_HOST` is the raw NLB hostname |
+| `cloud-dev` / `cloud-debug` / `cloud-staging` / `cloud-prod` | none applied | WS fallback only; Doppler advertises `audio-udp.<env>` names that have no DNS record |
+| (legacy) | `cloud-v2-audio-udp` still exists in-cluster | DEAD: selects the retired `cloud-v2` app, zero endpoints, still billing ~$16/mo; candidate for `kubectl delete svc cloud-v2-audio-udp` |
 
 - The apps are now per-environment (`cloud-dev`, `cloud-debug`,
   `cloud-staging`, `cloud-prod`, plus personal envs like `cloud-isaiah`),

--- a/cloud-v2/docs/runbooks/deploy/udp-nlb-aws.md
+++ b/cloud-v2/docs/runbooks/deploy/udp-nlb-aws.md
@@ -31,17 +31,36 @@ a `Service` of `type: LoadBalancer` with the right annotations.
 Our audio path needs **NLB** (UDP, low latency). Our HTTP/WS path stays on
 the **ALB** (Porter manages it; it's the `*.onporter.run` hostname).
 
-## What's deployed
+## What's deployed (verified 2026-07-09)
 
-The NLB lives in front of the audio pods on the dev cluster
-(`aws-us-west-2`, cluster id 5692). Manifest:
-[`deploy/audio-udp-nlb.yaml`](../../../deploy/audio-udp-nlb.yaml).
+Short version: **no environment has a working public UDP path right now.**
+Every env runs on the WS audio fallback.
+
+- The apps are now per-environment (`cloud-dev`, `cloud-debug`,
+  `cloud-staging`, `cloud-prod`, plus personal envs like `cloud-isaiah`),
+  each with a `runtime` service. An NLB Service is also per-environment: its
+  selector pins one app's runtime pods, so one NLB cannot serve two envs.
+- [`deploy/audio-udp-nlb-debug.yaml`](../../../deploy/audio-udp-nlb-debug.yaml)
+  is the per-env template (targets `cloud-debug`). Clone it and swap the
+  app name in `metadata` and `selector` for a new env
+  (`cloud-<env>-audio-udp`).
+- [`deploy/audio-udp-nlb.yaml`](../../../deploy/audio-udp-nlb.yaml) is the
+  LEGACY manifest from before the per-env split: it selects
+  `porter.run/app-name: cloud-v2`, an app name that no longer deploys.
+  Kept for reference; do not apply it.
+- The Doppler configs advertise per-env hostnames (for example `dev_debug`
+  sets `AUDIO_UDP_ADVERTISED_HOST=audio-udp.debug.us-west-2.mentraglass.com`),
+  but as of 2026-07-09 those names have NO Cloudflare record and do not
+  resolve. Clients try UDP, fail, and fall back to WS. If you provision an
+  NLB, fix the advertised host in the same change or the new NLB is unused.
+
+The intended shape, once an env's NLB exists:
 
 ```
 internet
   │
   ▼
-audio-udp.cloud-v2.mentra.glass        ← Cloudflare DNS-only mode (no proxy)
+audio-udp.<env>.us-west-2.mentraglass.com   ← Cloudflare DNS-only (optional for dev-grade envs)
   │
   ▼
 <nlb-hostname>.elb.us-west-2.amazonaws.com  ← AWS NLB (UDP :8000)
@@ -50,7 +69,7 @@ audio-udp.cloud-v2.mentra.glass        ← Cloudflare DNS-only mode (no proxy)
 EKS nodes
   │
   ▼ (k8s Service routes to pods by selector)
-cloud-v2-audio pods (Porter-managed)
+cloud-<env> runtime pods (Porter-managed)
   │
   ▼
 container :8000/udp → Bun.udpSocket → parse → Redis Stream
@@ -62,10 +81,10 @@ container :8000/udp → Bun.udpSocket → parse → Redis Stream
 apiVersion: v1
 kind: Service
 metadata:
-  name: cloud-v2-audio-udp
+  name: cloud-<env>-audio-udp               # per-env: cloud-debug-audio-udp, ...
   namespace: default
   labels:
-    porter.run/app-name: cloud-v2           # match Porter's app labeling
+    porter.run/app-name: cloud-<env>        # match Porter's app labeling
     app.kubernetes.io/managed-by: kubectl   # NOT Porter — kubectl-applied
   annotations:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
@@ -74,13 +93,14 @@ metadata:
 spec:
   type: LoadBalancer
   selector:
-    porter.run/app-name: cloud-v2
-    porter.run/service-name: audio          # audio pods ONLY (NOT core/proxy)
+    porter.run/app-name: cloud-<env>
+    porter.run/service-name: runtime        # runtime pods ONLY (NOT core)
   ports:
     - name: udp-audio
       protocol: UDP
       port: 8000
       targetPort: 8000
+  externalTrafficPolicy: Local              # REQUIRED for UDP (see Gotchas)
 ```
 
 Annotation breakdown:
@@ -98,45 +118,51 @@ Annotation breakdown:
 Selector breakdown:
 
 - Porter labels pods with `porter.run/app-name=<app>` +
-  `porter.run/service-name=<service>`. We want audio pods only.
+  `porter.run/service-name=<service>`. We want one env's runtime pods only.
 - Verify the labels match real pods with:
   ```bash
-  porter kubectl get pods -l porter.run/app-name=cloud-v2,porter.run/service-name=audio --show-labels
+  kubectl get pods -l porter.run/app-name=cloud-<env>,porter.run/service-name=runtime --show-labels
   ```
 
-## How to provision a new NLB (e.g. for a new region)
+## How to provision a new NLB (per environment)
 
 > ⚠️ **Porter's `kubectl` is read-only** — it can't create Services. You need
 > direct kubectl access to the cluster via AWS CLI. See "Getting kubectl
-> write access" below.
+> write access" below. (The auth is SSO-backed on our setup: if kubectl
+> errors with "Token has expired and refresh failed", run `aws sso login`
+> first.)
 
 ```bash
-# 1. Switch Porter context to the target cluster (for the deploy step later).
-porter cluster list                          # find the cluster ID
-porter config set-cluster <ID>
+# 1. Make the env's manifest: clone deploy/audio-udp-nlb-debug.yaml and
+#    replace cloud-debug with cloud-<env> in metadata.name, metadata.labels,
+#    and spec.selector. Keep externalTrafficPolicy: Local (see Gotchas).
 
 # 2. Get kubectl write access via AWS CLI (one-time setup, see section below).
-aws eks update-kubeconfig --region us-west-2 --name <cluster-name>
+aws eks update-kubeconfig --region us-west-2 --name aws-us-west-2
 
 # 3. Apply the manifest with your own kubectl (NOT `porter kubectl`).
-kubectl apply -f deploy/audio-udp-nlb.yaml
+kubectl apply -f deploy/audio-udp-nlb-<env>.yaml
 
-# 3. Wait ~2-4 min for AWS to provision the NLB. Get the hostname:
-porter kubectl get svc cloud-v2-audio-udp \
+# 4. Wait ~2-4 min for AWS to provision the NLB. Get the hostname:
+kubectl get svc cloud-<env>-audio-udp \
   -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
 # → something like: a1b2c3d4...elb.us-west-2.amazonaws.com
 
-# 4. Plug it into Doppler so audio's CONNECTION_ACK advertises the right host.
-doppler secrets set "AUDIO_UDP_ADVERTISED_HOST=<nlb-hostname>" --config dev_aws
+# 5. Plug it into the ENV'S OWN Doppler config so the runtime's
+#    CONNECTION_ACK advertises the right host. For dev-grade envs the raw
+#    NLB hostname is fine (skip the Cloudflare CNAME); for staging/prod add
+#    a DNS-only CNAME first and advertise the friendly name (see DNS below).
+doppler secrets set "AUDIO_UDP_ADVERTISED_HOST=<nlb-hostname>" \
+  --project cloud-v2 --config dev_<env>
 
-# 5. Doppler→Porter integration auto-syncs to the env group (or run the
-#    sync script if you haven't enabled the integration yet).
-
-# 6. Redeploy audio so the new env propagates to the pods.
-porter apply -f porter.yaml
+# 6. The Doppler→Porter integration auto-syncs the env group in ~5s, but
+#    pods do not restart on env changes. Redeploy the env:
+#    trigger its GitHub workflow (cloud-v2-<env>.yml) or
+#    `porter apply -f porter.<env>.yaml` from cloud-v2/.
 
 # 7. Verify UDP reachability from outside the cluster (UDP packet → NLB → pod).
-#    The test-client's smoke script is the easiest way.
+#    The test-client's smoke script is the easiest way. If packets vanish,
+#    check target-group health first (see Gotchas).
 ```
 
 ## Getting kubectl write access
@@ -190,18 +216,18 @@ For dev cluster we can skip DNS and use the raw NLB hostname directly in
 
 ### Selector mismatch → 0 healthy targets
 
-If the selector labels don't exactly match what Porter puts on the audio
+If the selector labels don't exactly match what Porter puts on the runtime
 pods, the NLB has no targets and packets get dropped. Check:
 
 ```bash
-porter kubectl describe svc cloud-v2-audio-udp | grep -E "Selector|Endpoints"
+kubectl describe svc cloud-<env>-audio-udp | grep -E "Selector|Endpoints"
 ```
 
-`Endpoints` should list the audio pod IPs. If it's empty, the selector is
+`Endpoints` should list the runtime pod IPs. If it's empty, the selector is
 wrong. Compare the labels you used against what Porter actually attaches:
 
 ```bash
-porter kubectl get pods -l porter.run/app-name=cloud-v2 --show-labels
+kubectl get pods -l porter.run/app-name=cloud-<env> --show-labels
 ```
 
 (In v1 the porter.run labels were stable; in cloud-v2 we use the same
@@ -209,7 +235,7 @@ ones — see the v1 reference manifest at `cloud/udp-service.yaml`.)
 
 ### NLB hostname is unstable on re-create
 
-If you `kubectl delete svc cloud-v2-audio-udp` and re-apply, AWS gives you
+If you `kubectl delete svc cloud-<env>-audio-udp` and re-apply, AWS gives you
 a NEW hostname. The old one is gone. Anything that hardcoded the old
 hostname (DNS records, Doppler `AUDIO_UDP_ADVERTISED_HOST`) breaks.
 
@@ -228,7 +254,7 @@ becomes available once provisioning completes:
 
 ```bash
 # poll until hostname appears
-while ! porter kubectl get svc cloud-v2-audio-udp \
+while ! kubectl get svc cloud-<env>-audio-udp \
     -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null | \
     grep -q elb; do
   echo "waiting..."
@@ -245,7 +271,7 @@ controller's service-account role is missing
 cluster's IAM policy — not Porter's problem.
 
 ```bash
-porter kubectl describe svc cloud-v2-audio-udp | grep -E "Warning|Event"
+kubectl describe svc cloud-<env>-audio-udp | grep -E "Warning|Event"
 ```
 
 ### Cross-zone load balancing turn-OFF causes uneven routing

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -76,16 +76,21 @@ app.post(
 
 // === Authenticated ===
 
-app.post("/logout", userAuth, async (c) => {
-  const u = c.var.user!;
-  const { everywhere } = await json(c);
-  if (everywhere) {
-    await revokeAllSessionsForUser({ mentraUserId: u.mentraUserId });
-  } else {
-    await revokeSession({ sessionId: u.sessionId });
-  }
-  return c.body(null, 204);
-});
+app.post(
+  "/logout",
+  accountRateLimit({ scope: "logout", limit: 30, windowSec: 60 }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const { everywhere } = await json(c);
+    if (everywhere) {
+      await revokeAllSessionsForUser({ mentraUserId: u.mentraUserId });
+    } else {
+      await revokeSession({ sessionId: u.sessionId });
+    }
+    return c.body(null, 204);
+  },
+);
 
 app.get("/me", userAuth, async (c) => {
   const u = c.var.user!;
@@ -153,12 +158,17 @@ app.post(
   },
 );
 
-app.post("/delete/request", userAuth, async (c) => {
-  const u = c.var.user!;
-  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
-  await account.requestAccountDeletion(email, tenantUserId);
-  return c.json({ status: "verification_sent" }, 202);
-});
+app.post(
+  "/delete/request",
+  accountRateLimit({ scope: "delrequest", limit: 5, windowSec: 300 }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+    await account.requestAccountDeletion(email, tenantUserId);
+    return c.json({ status: "verification_sent" }, 202);
+  },
+);
 
 app.post(
   "/delete/confirm",

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -8,6 +8,7 @@ import { InvalidRequest } from "../../types/oauth.types";
 import { userAuth } from "../middleware/user-auth.middleware";
 import { UserModel } from "../../models/user.model";
 import * as account from "../../services/account/account.service";
+import { AccountError } from "../../services/account/account-error";
 import { accountRateLimit } from "./rate-limit";
 import {
   revokeSession,
@@ -206,6 +207,17 @@ async function emailOnly(c: AppContext): Promise<{ email: string }> {
 async function tenantUserIdFor(mentraUserId: string): Promise<string> {
   const user = await UserModel.findOne({ mentraUserId }).lean();
   if (!user) throw new InvalidRequest("user not found");
+  // Every authenticated account route resolves identity through here, so this
+  // is the single gate keeping external-OEM sessions out of the first-party
+  // account surface. Without it, an OEM-authenticated user could hit
+  // /subject-token and mint themselves a `mentra` session.
+  if (user.tenantId !== "mentra") {
+    throw new AccountError(
+      "unauthorized_client",
+      "account endpoints require a Mentra first-party session",
+      403,
+    );
+  }
   return user.tenantUserId;
 }
 

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -8,7 +8,11 @@ import { InvalidRequest } from "../../types/oauth.types";
 import { userAuth } from "../middleware/user-auth.middleware";
 import { UserModel } from "../../models/user.model";
 import * as account from "../../services/account/account.service";
-import { revokeSession, revokeAllSessionsForUser } from "../../services/session.service";
+import {
+  revokeSession,
+  revokeAllSessionsForUser,
+  mintAccountSubjectToken,
+} from "../../services/session.service";
 
 const app = new Hono<AppEnv>();
 
@@ -63,6 +67,17 @@ app.get("/me", userAuth, async (c) => {
   const u = c.var.user!;
   const tenantUserId = await tenantUserIdFor(u.mentraUserId);
   return c.json(await account.me(u.mentraUserId, tenantUserId));
+});
+
+// The device's cloud-client fetches a fresh short-lived subject token from here
+// (authenticated by the current V2 session) and exchanges it at the public
+// /api/client/auth/exchange, exactly as an external OEM's app would. This is the
+// OEM-backend "mint a subject token for my app" surface.
+app.post("/subject-token", userAuth, async (c) => {
+  const u = c.var.user!;
+  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+  const token = await mintAccountSubjectToken({ tenantUserId });
+  return c.json({ token, type: "oem-jwt" });
 });
 
 app.post("/password/change", userAuth, async (c) => {

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -98,8 +98,18 @@ app.post("/email/change", userAuth, async (c) => {
   const password = str(body.password);
   if (!newEmail || !password) throw new InvalidRequest("newEmail, password required");
   const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
-  await account.changeEmail(u.mentraUserId, tenantUserId, email, password, newEmail);
+  await account.requestEmailChange(tenantUserId, email, password, newEmail);
   return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/email/change/confirm", userAuth, async (c) => {
+  const u = c.var.user!;
+  const body = await json(c);
+  const code = str(body.code);
+  if (!code) throw new InvalidRequest("code required");
+  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+  await account.confirmEmailChange(tenantUserId, code);
+  return c.body(null, 204);
 });
 
 app.post("/delete/request", userAuth, async (c) => {

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -8,6 +8,7 @@ import { InvalidRequest } from "../../types/oauth.types";
 import { userAuth } from "../middleware/user-auth.middleware";
 import { UserModel } from "../../models/user.model";
 import * as account from "../../services/account/account.service";
+import { accountRateLimit } from "./rate-limit";
 import {
   revokeSession,
   revokeAllSessionsForUser,
@@ -17,38 +18,60 @@ import {
 const app = new Hono<AppEnv>();
 
 // === Unauthenticated ===
+// Every route carries per-IP (+ per-email where a body has one) limits per
+// spec.md; credential and email-sending flows get the tightest windows.
 
-app.post("/signup", async (c) => {
-  const { email, password } = await creds(c);
-  await account.signup(email, password);
-  return c.json({ status: "verification_sent" }, 202);
-});
+app.post(
+  "/signup",
+  accountRateLimit({ scope: "signup", limit: 5, windowSec: 300, perEmail: true }),
+  async (c) => {
+    const { email, password } = await creds(c);
+    await account.signup(email, password);
+    return c.json({ status: "verification_sent" }, 202);
+  },
+);
 
-app.post("/verify/resend", async (c) => {
-  const { email } = await emailOnly(c);
-  await account.resendVerification(email);
-  return c.json({ status: "verification_sent" }, 202);
-});
+app.post(
+  "/verify/resend",
+  accountRateLimit({ scope: "resend", limit: 5, windowSec: 300, perEmail: true }),
+  async (c) => {
+    const { email } = await emailOnly(c);
+    await account.resendVerification(email);
+    return c.json({ status: "verification_sent" }, 202);
+  },
+);
 
-app.post("/login", async (c) => {
-  const { email, password } = await creds(c);
-  return c.json(await account.login(email, password));
-});
+app.post(
+  "/login",
+  accountRateLimit({ scope: "login", limit: 10, windowSec: 60, perEmail: true }),
+  async (c) => {
+    const { email, password } = await creds(c);
+    return c.json(await account.login(email, password));
+  },
+);
 
-app.post("/password/forgot", async (c) => {
-  const { email } = await emailOnly(c);
-  await account.requestPasswordReset(email);
-  return c.json({ status: "verification_sent" }, 202);
-});
+app.post(
+  "/password/forgot",
+  accountRateLimit({ scope: "forgot", limit: 5, windowSec: 300, perEmail: true }),
+  async (c) => {
+    const { email } = await emailOnly(c);
+    await account.requestPasswordReset(email);
+    return c.json({ status: "verification_sent" }, 202);
+  },
+);
 
-app.post("/password/reset", async (c) => {
-  const body = await json(c);
-  const email = str(body.email);
-  const code = str(body.code);
-  const newPassword = str(body.newPassword);
-  if (!email || !code || !newPassword) throw new InvalidRequest("email, code, newPassword required");
-  return c.json(await account.resetPassword(email, code, newPassword));
-});
+app.post(
+  "/password/reset",
+  accountRateLimit({ scope: "reset", limit: 10, windowSec: 300, perEmail: true }),
+  async (c) => {
+    const body = await json(c);
+    const email = str(body.email);
+    const code = str(body.code);
+    const newPassword = str(body.newPassword);
+    if (!email || !code || !newPassword) throw new InvalidRequest("email, code, newPassword required");
+    return c.json(await account.resetPassword(email, code, newPassword));
+  },
+);
 
 // === Authenticated ===
 
@@ -80,37 +103,54 @@ app.post("/subject-token", userAuth, async (c) => {
   return c.json({ token, type: "oem-jwt" });
 });
 
-app.post("/password/change", userAuth, async (c) => {
-  const u = c.var.user!;
-  const body = await json(c);
-  const currentPassword = str(body.currentPassword);
-  const newPassword = str(body.newPassword);
-  if (!currentPassword || !newPassword) throw new InvalidRequest("currentPassword, newPassword required");
-  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
-  await account.changePassword(u.mentraUserId, tenantUserId, currentPassword, newPassword, email, u.sessionId);
-  return c.body(null, 204);
-});
+// Authenticated, but still limited: these re-verify a password or consume a
+// short numeric code, so a stolen session must not get unlimited guesses.
+app.post(
+  "/password/change",
+  accountRateLimit({ scope: "pwchange", limit: 10, windowSec: 300 }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const body = await json(c);
+    const currentPassword = str(body.currentPassword);
+    const newPassword = str(body.newPassword);
+    if (!currentPassword || !newPassword) throw new InvalidRequest("currentPassword, newPassword required");
+    const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+    await account.changePassword(u.mentraUserId, tenantUserId, currentPassword, newPassword, email, u.sessionId);
+    return c.body(null, 204);
+  },
+);
 
-app.post("/email/change", userAuth, async (c) => {
-  const u = c.var.user!;
-  const body = await json(c);
-  const newEmail = str(body.newEmail);
-  const password = str(body.password);
-  if (!newEmail || !password) throw new InvalidRequest("newEmail, password required");
-  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
-  await account.requestEmailChange(tenantUserId, email, password, newEmail);
-  return c.json({ status: "verification_sent" }, 202);
-});
+app.post(
+  "/email/change",
+  accountRateLimit({ scope: "emchange", limit: 5, windowSec: 300, perEmail: true }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const body = await json(c);
+    const newEmail = str(body.newEmail);
+    const password = str(body.password);
+    if (!newEmail || !password) throw new InvalidRequest("newEmail, password required");
+    const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+    await account.requestEmailChange(tenantUserId, email, password, newEmail);
+    return c.json({ status: "verification_sent" }, 202);
+  },
+);
 
-app.post("/email/change/confirm", userAuth, async (c) => {
-  const u = c.var.user!;
-  const body = await json(c);
-  const code = str(body.code);
-  if (!code) throw new InvalidRequest("code required");
-  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
-  await account.confirmEmailChange(tenantUserId, code);
-  return c.body(null, 204);
-});
+app.post(
+  "/email/change/confirm",
+  accountRateLimit({ scope: "emconfirm", limit: 10, windowSec: 300 }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const body = await json(c);
+    const code = str(body.code);
+    if (!code) throw new InvalidRequest("code required");
+    const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+    await account.confirmEmailChange(tenantUserId, code);
+    return c.body(null, 204);
+  },
+);
 
 app.post("/delete/request", userAuth, async (c) => {
   const u = c.var.user!;
@@ -119,15 +159,20 @@ app.post("/delete/request", userAuth, async (c) => {
   return c.json({ status: "verification_sent" }, 202);
 });
 
-app.post("/delete/confirm", userAuth, async (c) => {
-  const u = c.var.user!;
-  const body = await json(c);
-  const code = str(body.code);
-  if (!code) throw new InvalidRequest("code required");
-  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
-  await account.confirmAccountDeletion(u.mentraUserId, tenantUserId, code);
-  return c.body(null, 204);
-});
+app.post(
+  "/delete/confirm",
+  accountRateLimit({ scope: "delconfirm", limit: 10, windowSec: 300 }),
+  userAuth,
+  async (c) => {
+    const u = c.var.user!;
+    const body = await json(c);
+    const code = str(body.code);
+    if (!code) throw new InvalidRequest("code required");
+    const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+    await account.confirmAccountDeletion(u.mentraUserId, tenantUserId, code);
+    return c.body(null, 204);
+  },
+);
 
 // === helpers ===
 

--- a/cloud-v2/packages/core/src/api/account/account.api.ts
+++ b/cloud-v2/packages/core/src/api/account/account.api.ts
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Mentra first-party account endpoints (issue 019).
+ * Mounted at /api/account. Contract: docs/issues/019-mentra-account-auth/spec.md.
+ */
+import { Hono } from "hono";
+import type { AppContext, AppEnv } from "../../types/hono.types";
+import { InvalidRequest } from "../../types/oauth.types";
+import { userAuth } from "../middleware/user-auth.middleware";
+import { UserModel } from "../../models/user.model";
+import * as account from "../../services/account/account.service";
+import { revokeSession, revokeAllSessionsForUser } from "../../services/session.service";
+
+const app = new Hono<AppEnv>();
+
+// === Unauthenticated ===
+
+app.post("/signup", async (c) => {
+  const { email, password } = await creds(c);
+  await account.signup(email, password);
+  return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/verify/resend", async (c) => {
+  const { email } = await emailOnly(c);
+  await account.resendVerification(email);
+  return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/login", async (c) => {
+  const { email, password } = await creds(c);
+  return c.json(await account.login(email, password));
+});
+
+app.post("/password/forgot", async (c) => {
+  const { email } = await emailOnly(c);
+  await account.requestPasswordReset(email);
+  return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/password/reset", async (c) => {
+  const body = await json(c);
+  const email = str(body.email);
+  const code = str(body.code);
+  const newPassword = str(body.newPassword);
+  if (!email || !code || !newPassword) throw new InvalidRequest("email, code, newPassword required");
+  return c.json(await account.resetPassword(email, code, newPassword));
+});
+
+// === Authenticated ===
+
+app.post("/logout", userAuth, async (c) => {
+  const u = c.var.user!;
+  const { everywhere } = await json(c);
+  if (everywhere) {
+    await revokeAllSessionsForUser({ mentraUserId: u.mentraUserId });
+  } else {
+    await revokeSession({ sessionId: u.sessionId });
+  }
+  return c.body(null, 204);
+});
+
+app.get("/me", userAuth, async (c) => {
+  const u = c.var.user!;
+  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+  return c.json(await account.me(u.mentraUserId, tenantUserId));
+});
+
+app.post("/password/change", userAuth, async (c) => {
+  const u = c.var.user!;
+  const body = await json(c);
+  const currentPassword = str(body.currentPassword);
+  const newPassword = str(body.newPassword);
+  if (!currentPassword || !newPassword) throw new InvalidRequest("currentPassword, newPassword required");
+  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+  await account.changePassword(u.mentraUserId, tenantUserId, currentPassword, newPassword, email, u.sessionId);
+  return c.body(null, 204);
+});
+
+app.post("/email/change", userAuth, async (c) => {
+  const u = c.var.user!;
+  const body = await json(c);
+  const newEmail = str(body.newEmail);
+  const password = str(body.password);
+  if (!newEmail || !password) throw new InvalidRequest("newEmail, password required");
+  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+  await account.changeEmail(u.mentraUserId, tenantUserId, email, password, newEmail);
+  return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/delete/request", userAuth, async (c) => {
+  const u = c.var.user!;
+  const { tenantUserId, email } = await authedIdentity(u.mentraUserId);
+  await account.requestAccountDeletion(email, tenantUserId);
+  return c.json({ status: "verification_sent" }, 202);
+});
+
+app.post("/delete/confirm", userAuth, async (c) => {
+  const u = c.var.user!;
+  const body = await json(c);
+  const code = str(body.code);
+  if (!code) throw new InvalidRequest("code required");
+  const tenantUserId = await tenantUserIdFor(u.mentraUserId);
+  await account.confirmAccountDeletion(u.mentraUserId, tenantUserId, code);
+  return c.body(null, 204);
+});
+
+// === helpers ===
+
+async function json(c: AppContext): Promise<Record<string, unknown>> {
+  try {
+    const b = await c.req.json();
+    if (b && typeof b === "object") return b as Record<string, unknown>;
+  } catch {
+    // fall through
+  }
+  throw new InvalidRequest("request body must be a JSON object");
+}
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+async function creds(c: AppContext): Promise<{ email: string; password: string }> {
+  const b = await json(c);
+  const email = str(b.email);
+  const password = typeof b.password === "string" ? b.password : "";
+  if (!email || !password) throw new InvalidRequest("email and password required");
+  return { email, password };
+}
+
+async function emailOnly(c: AppContext): Promise<{ email: string }> {
+  const b = await json(c);
+  const email = str(b.email);
+  if (!email) throw new InvalidRequest("email required");
+  return { email };
+}
+
+async function tenantUserIdFor(mentraUserId: string): Promise<string> {
+  const user = await UserModel.findOne({ mentraUserId }).lean();
+  if (!user) throw new InvalidRequest("user not found");
+  return user.tenantUserId;
+}
+
+async function authedIdentity(mentraUserId: string): Promise<{ tenantUserId: string; email: string }> {
+  const tenantUserId = await tenantUserIdFor(mentraUserId);
+  const identity = await account.me(mentraUserId, tenantUserId);
+  if (!identity.email) throw new InvalidRequest("account email unavailable");
+  return { tenantUserId, email: identity.email };
+}
+
+export default app;

--- a/cloud-v2/packages/core/src/api/account/oauth.api.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.ts
@@ -54,7 +54,7 @@ app.get("/:provider/start", async (c) => {
   });
 
   const redirectTo = `${publicOrigin(c)}/api/account/oauth/callback?state=${encodeURIComponent(state)}`;
-  return c.redirect(gotrue.authorizeUrl(provider, redirectTo));
+  return c.redirect(gotrue.authorizeUrl(provider, redirectTo, s256(coreVerifier)));
 });
 
 /** Callback from the provider: exchange the code, mint the session, store it

--- a/cloud-v2/packages/core/src/api/account/oauth.api.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.ts
@@ -14,10 +14,15 @@ import { Hono } from "hono";
 import type { AppContext, AppEnv } from "../../types/hono.types";
 import { InvalidRequest } from "../../types/oauth.types";
 import { gotrue, otc } from "../../services/account/account.service";
+import { accountRateLimit } from "./rate-limit";
 import { mintAccountSubjectToken } from "../../services/session.service";
 import { createSession } from "../../services/session.service";
 
 const app = new Hono<AppEnv>();
+
+// All three legs are unauthenticated; per-IP limits per spec.md. Generous
+// enough for real sign-in flows, tight enough to blunt code/state brute force.
+app.use("/*", accountRateLimit({ scope: "oauth", limit: 30, windowSec: 60 }));
 
 const APP_SCHEME = "com.mentra";
 const PROVIDERS = new Set(["google", "apple"]);

--- a/cloud-v2/packages/core/src/api/account/oauth.api.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.ts
@@ -69,11 +69,11 @@ app.get("/callback", async (c) => {
   const code = c.req.query("code");
   if (!state || !code) throw new InvalidRequest("missing oauth callback params");
 
-  const start = await otc.consumeCode({
-    code: state,
-    purpose: "oauth_handoff",
-    expectSubject: otc.OAUTH_START_SUBJECT,
-  });
+  // Read (don't burn) the start record: the GoTrue exchange below is
+  // irreversible, so the start record is only consumed once everything
+  // succeeds. That keeps a transient failure from stranding a burned record.
+  const start = await otc.peekOAuthStart(state);
+  if (!start) throw new InvalidRequest("oauth start record missing or expired");
   const { coreVerifier, appChallenge } = start.payload as {
     coreVerifier: string;
     appChallenge: string;
@@ -88,6 +88,14 @@ app.get("/callback", async (c) => {
     codeChallenge: appChallenge,
     ttlSec: HANDOFF_TTL_SEC,
     payload: { session },
+  });
+
+  // Everything succeeded: now atomically burn the start record. This also
+  // guards against a duplicate callback re-minting a second session.
+  await otc.consumeCode({
+    code: state,
+    purpose: "oauth_handoff",
+    expectSubject: otc.OAUTH_START_SUBJECT,
   });
 
   return c.redirect(

--- a/cloud-v2/packages/core/src/api/account/oauth.api.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.ts
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Core-hosted OAuth for the account module (issue 019 spec.md §OAuth).
+ * Mounted at /api/account/oauth.
+ *
+ * Flow: the app opens the system browser at /:provider/start with a PKCE
+ * challenge; core redirects into Supabase's authorize; the provider calls back
+ * to /callback; core exchanges the code server side, mints a V2 session, stores
+ * it under a one-time handoff code, and deep-links back to the app; the app
+ * calls /complete with the handoff code + its PKCE verifier to receive the
+ * session. An intercepted deep link is useless without the in-app verifier.
+ */
+import crypto from "node:crypto";
+import { Hono } from "hono";
+import type { AppContext, AppEnv } from "../../types/hono.types";
+import { InvalidRequest } from "../../types/oauth.types";
+import { gotrue, otc } from "../../services/account/account.service";
+import { mintAccountSubjectToken } from "../../services/session.service";
+import { createSession } from "../../services/session.service";
+
+const app = new Hono<AppEnv>();
+
+const APP_SCHEME = "com.mentra";
+const PROVIDERS = new Set(["google", "apple"]);
+const START_TTL_SEC = 10 * 60;
+const HANDOFF_TTL_SEC = 60;
+
+function s256(verifier: string): string {
+  return crypto.createHash("sha256").update(verifier).digest("base64url");
+}
+
+function publicOrigin(c: AppContext): string {
+  return (
+    c.req.header("x-mentra-public-origin") ??
+    process.env.CORE_PUBLIC_URL ??
+    new URL(c.req.url).origin
+  );
+}
+
+/** Start: persist {state, app challenge} + a core<->GoTrue verifier, redirect
+ * into the provider. */
+app.get("/:provider/start", async (c) => {
+  const provider = c.req.param("provider");
+  if (!PROVIDERS.has(provider)) throw new InvalidRequest("unsupported provider");
+  const state = c.req.query("state");
+  const codeChallenge = c.req.query("code_challenge");
+  if (!state || !codeChallenge) throw new InvalidRequest("state and code_challenge required");
+
+  // Core runs its own PKCE leg with GoTrue. The start record is keyed by state.
+  const coreVerifier = crypto.randomBytes(32).toString("base64url");
+  await otc.issueOAuthStart({
+    state,
+    ttlSec: START_TTL_SEC,
+    payload: { appChallenge: codeChallenge, coreVerifier, provider },
+  });
+
+  const redirectTo = `${publicOrigin(c)}/api/account/oauth/callback?state=${encodeURIComponent(state)}`;
+  return c.redirect(gotrue.authorizeUrl(provider, redirectTo));
+});
+
+/** Callback from the provider: exchange the code, mint the session, store it
+ * under a one-time handoff code, deep-link back. */
+app.get("/callback", async (c) => {
+  const state = c.req.query("state");
+  const code = c.req.query("code");
+  if (!state || !code) throw new InvalidRequest("missing oauth callback params");
+
+  const start = await otc.consumeCode({
+    code: state,
+    purpose: "oauth_handoff",
+    expectSubject: otc.OAUTH_START_SUBJECT,
+  });
+  const { coreVerifier, appChallenge } = start.payload as {
+    coreVerifier: string;
+    appChallenge: string;
+  };
+
+  const identity = await gotrue.exchangeOAuthCode(code, coreVerifier);
+  const subjectToken = await mintAccountSubjectToken({ tenantUserId: identity.id });
+  const session = await createSession({ subjectToken });
+
+  // Store the session under a one-time code bound to the APP's PKCE challenge.
+  const handoff = await otc.issueOAuthHandoff({
+    codeChallenge: appChallenge,
+    ttlSec: HANDOFF_TTL_SEC,
+    payload: { session },
+  });
+
+  return c.redirect(
+    `${APP_SCHEME}://auth/callback?code=${encodeURIComponent(handoff)}&state=${encodeURIComponent(state)}`,
+  );
+});
+
+/** Complete: the app swaps the handoff code + its verifier for the V2 session. */
+app.post("/complete", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = (await c.req.json()) as Record<string, unknown>;
+  } catch {
+    throw new InvalidRequest("request body must be a JSON object");
+  }
+  const code = typeof body.code === "string" ? body.code : "";
+  const codeVerifier = typeof body.code_verifier === "string" ? body.code_verifier : "";
+  if (!code || !codeVerifier) throw new InvalidRequest("code and code_verifier required");
+
+  // consumeCode binds by subject == the stored app challenge, so verify PKCE:
+  // recompute S256(verifier) and require it to match the code's subject.
+  const consumed = await otc.consumeCode({
+    code,
+    purpose: "oauth_handoff",
+    expectSubject: s256(codeVerifier),
+  });
+  const { session } = consumed.payload as { session: unknown };
+  return c.json(session);
+});
+
+export default app;

--- a/cloud-v2/packages/core/src/api/account/rate-limit.ts
+++ b/cloud-v2/packages/core/src/api/account/rate-limit.ts
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Rate limiting for the account endpoints (issue 019 spec.md:
+ * "Every account endpoint is rate limited per IP and per email... guarantees
+ * 429 with `rate_limited`").
+ *
+ * Fixed-window, in-memory. Core runs a single replica in every environment
+ * today (see porter.*.yaml `instances: 1`), so per-pod counting IS the global
+ * count. If core ever scales out, limits become per-pod (N x looser) — move
+ * the buckets to Redis before doing that.
+ */
+import type { MiddlewareHandler } from "hono";
+import type { AppEnv } from "../../types/hono.types";
+import { AccountError } from "../../services/account/account-error";
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+const buckets = new Map<string, Bucket>();
+
+/** Reset all counters. Test-only — mirrors resetSigningKeyCache. */
+export function resetAccountRateLimits(): void {
+  buckets.clear();
+}
+
+function hit(key: string, limit: number, windowSec: number): boolean {
+  const now = Date.now();
+  const b = buckets.get(key);
+  if (!b || b.resetAt <= now) {
+    buckets.set(key, { count: 1, resetAt: now + windowSec * 1000 });
+    return true;
+  }
+  b.count += 1;
+  return b.count <= limit;
+}
+
+// Opportunistic prune so long-lived processes don't accumulate dead buckets.
+let lastPrune = 0;
+function maybePrune(): void {
+  const now = Date.now();
+  if (now - lastPrune < 60_000) return;
+  lastPrune = now;
+  for (const [k, b] of buckets) {
+    if (b.resetAt <= now) buckets.delete(k);
+  }
+}
+
+function clientIp(header: string | undefined): string {
+  // Behind the cluster ingress the first x-forwarded-for hop is the client.
+  return header?.split(",")[0]?.trim() || "unknown";
+}
+
+/**
+ * Per-IP (always) and per-email (when the JSON body carries one) fixed-window
+ * limits. Emits the spec's `rate_limited` error code as HTTP 429.
+ *
+ * Reading the body here is safe: Hono caches the parsed body, so the handler's
+ * own `c.req.json()` still works.
+ */
+export function accountRateLimit(opts: {
+  scope: string;
+  limit: number;
+  windowSec: number;
+  perEmail?: boolean;
+}): MiddlewareHandler<AppEnv> {
+  return async (c, next) => {
+    maybePrune();
+    const ip = clientIp(c.req.header("x-forwarded-for"));
+    if (!hit(`${opts.scope}:ip:${ip}`, opts.limit, opts.windowSec)) {
+      throw new AccountError("rate_limited", "too many attempts, try again later", 429);
+    }
+    if (opts.perEmail) {
+      let email = "";
+      try {
+        const body = (await c.req.json()) as Record<string, unknown>;
+        const raw = body?.email ?? body?.newEmail;
+        if (typeof raw === "string") email = raw.trim().toLowerCase();
+      } catch {
+        // No JSON body; the handler will reject it — nothing to key on here.
+      }
+      if (email && !hit(`${opts.scope}:email:${email}`, opts.limit, opts.windowSec)) {
+        throw new AccountError("rate_limited", "too many attempts, try again later", 429);
+      }
+    }
+    await next();
+  };
+}

--- a/cloud-v2/packages/core/src/api/app.ts
+++ b/cloud-v2/packages/core/src/api/app.ts
@@ -23,11 +23,14 @@ import { Hono } from "hono";
 import { createHealthApp, createLogger, type ReadinessCheck } from "@mentra/cloud-shared";
 import type { AppEnv } from "../types/hono.types";
 import { OauthError } from "../types/oauth.types";
+import { AccountError } from "../services/account/account-error";
 import { requestContext } from "./middleware/context.middleware";
 import adminPreinstalled from "./admin/preinstalled.api";
 import clientAuth from "./client/auth.api";
 import clientReports from "./client/reports.api";
 import clientMiniapps from "./client/miniapps.api";
+import accountApi from "./account/account.api";
+import accountOauth from "./account/oauth.api";
 import consoleAuth from "./console/cli-auth.api";
 import portalEnterprise from "./portal/enterprise.api";
 import wellKnown from "./well-known.api";
@@ -77,17 +80,19 @@ export function createApp(opts: CreateAppOptions): Hono<AppEnv> {
   app.route("/api/client/auth", clientAuth);
   app.route("/api/client/reports", clientReports);
   app.route("/api/client/miniapps", clientMiniapps);
+  app.route("/api/account", accountApi);
+  app.route("/api/account/oauth", accountOauth);
   app.route("/api/console", consoleAuth);
   app.route("/api/portal", portalEnterprise);
   app.route("/api/admin", adminPreinstalled);
 
   // Global error translator.
   app.onError((err, c) => {
-    if (err instanceof OauthError) {
+    if (err instanceof OauthError || err instanceof AccountError) {
       return c.json(
         { error: err.code, error_description: err.description },
         // Hono's typing wants a literal status code; cast keeps it loose so
-        // future OauthError subclasses (4xx/5xx) compile without a switch.
+        // future error subclasses (4xx/5xx) compile without a switch.
         err.httpStatus as 400,
       );
     }

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -153,7 +153,12 @@ async function backfillLegacyRefreshTokenTenant(): Promise<void> {
 
 async function dropLegacyUserIdentityIndex(): Promise<void> {
   const collection = mongoose.connection.collection(USERS_COLLECTION);
-  const indexes = await collection.indexes();
+  let indexes;
+  try {
+    indexes = await collection.indexes();
+  } catch {
+    return; // collection does not exist yet (fresh database)
+  }
   const hasLegacyIndex = indexes.some(
     (index) => index.name === LEGACY_USER_IDENTITY_INDEX,
   );

--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -11,6 +11,7 @@ import { DeveloperOrgInvitationModel } from "../models/developer-org-invitation.
 import { DeveloperOrgMembershipModel } from "../models/developer-org-membership.model";
 import { RefreshTokenModel } from "../models/refresh-token.model";
 import { UserModel } from "../models/user.model";
+import { OemModel } from "../models/oem.model";
 
 const logger = createLogger("core").child({ component: "startup-migrations" });
 
@@ -49,6 +50,28 @@ export async function runStartupMigrations(): Promise<void> {
   await safeCreateInvitationIndexes();
   await backfillDeveloperOrgOwners();
   await backfillMembersFromWorkos();
+  await ensureMentraAccountOem();
+}
+
+// Mentra's first-party account backend (issue 019) signs subject tokens that
+// are verified through the normal OEM path, which needs a `mentra` oems row
+// carrying the account signing public key (static mode). Idempotent upsert;
+// skipped (non-fatal) if the account key env var is not configured yet.
+async function ensureMentraAccountOem(): Promise<void> {
+  const pubB64 = process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY?.trim();
+  if (!pubB64) {
+    logger.warn("MENTRA_ACCOUNT_JWT_PUBLIC_KEY not set; skipping mentra account OEM seed");
+    return;
+  }
+  const publicKey = `-----BEGIN PUBLIC KEY-----\n${pubB64}\n-----END PUBLIC KEY-----`;
+  await OemModel.updateOne(
+    { tenantId: "mentra" },
+    {
+      $set: { displayName: "Mentra", publicKeyMode: "static", publicKey, disabled: false },
+    },
+    { upsert: true },
+  );
+  logger.info("ensured mentra account OEM row");
 }
 
 // The invitation collection's (orgId,email) index moved to a partial-unique

--- a/cloud-v2/packages/core/src/models/account-code.model.ts
+++ b/cloud-v2/packages/core/src/models/account-code.model.ts
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview One-time codes for account flows (password reset, email change,
+ * account-deletion confirmation, and the OAuth handoff code).
+ *
+ * Codes are stored HASHED (never plaintext), single-use, and TTL-expired by
+ * Mongo. `purpose` scopes a code so a reset code can't be replayed as a
+ * deletion code. `subject` is the thing the code authorizes (email for reset,
+ * user id for deletion, the PKCE challenge for oauth).
+ */
+import { Schema, model, type InferSchemaType } from "mongoose";
+
+export const ACCOUNT_CODE_PURPOSES = [
+  "password_reset",
+  "email_change",
+  "account_deletion",
+  "oauth_handoff",
+] as const;
+export type AccountCodePurpose = (typeof ACCOUNT_CODE_PURPOSES)[number];
+
+const AccountCodeSchema = new Schema(
+  {
+    /** SHA-256 hash of the code value. The plaintext is emailed/deep-linked once. */
+    codeHash: { type: String, required: true, unique: true },
+    purpose: { type: String, enum: ACCOUNT_CODE_PURPOSES, required: true, index: true },
+    /** What the code authorizes: email, userId, or the PKCE code_challenge. */
+    subject: { type: String, required: true },
+    /** Free-form payload for the flow (e.g. oauth: the stored TokenResponse). */
+    payload: { type: Schema.Types.Mixed, default: null },
+    consumedAt: { type: Date, default: null },
+    expiresAt: { type: Date, required: true },
+  },
+  { timestamps: true, collection: "account_codes" },
+);
+
+// TTL: Mongo deletes the doc once expiresAt passes.
+AccountCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+export type AccountCode = InferSchemaType<typeof AccountCodeSchema>;
+export const AccountCodeModel = model("AccountCode", AccountCodeSchema);

--- a/cloud-v2/packages/core/src/services/account/account-error.ts
+++ b/cloud-v2/packages/core/src/services/account/account-error.ts
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Account-flow error type. Mirrors OauthError shape (code +
+ * description + httpStatus) so the app.ts error handler renders it as the same
+ * RFC-shaped `{ error, error_description }` body. Codes extend the oauth set
+ * with the account-specific ones from spec.md.
+ */
+export type AccountErrorCode =
+  | "invalid_request"
+  | "invalid_grant"
+  | "invalid_credentials"
+  | "verification_required"
+  | "weak_password"
+  | "email_taken"
+  | "code_invalid"
+  | "rate_limited"
+  | "unauthorized_client"
+  | "server_error";
+
+export class AccountError extends Error {
+  constructor(
+    readonly code: AccountErrorCode,
+    description: string,
+    readonly httpStatus: number,
+  ) {
+    super(`${code}: ${description}`);
+    this.name = "AccountError";
+    this.description = description;
+  }
+  readonly description: string;
+}

--- a/cloud-v2/packages/core/src/services/account/account.service.ts
+++ b/cloud-v2/packages/core/src/services/account/account.service.ts
@@ -168,25 +168,12 @@ export async function confirmAccountDeletion(
   code: string,
 ): Promise<void> {
   await otc.consumeCode({ code, purpose: "account_deletion", expectSubject: tenantUserId });
-  // Order: kill V2 sessions, delete the Supabase user, fan out to V1 (best
-  // effort; a reconciliation job retries). The V2 user row is left tombstoned
-  // by session removal; a follow-up may hard-delete it.
+  // Order: kill V2 sessions, then delete the Supabase user. The V2 user row is
+  // left tombstoned by session removal; a follow-up may hard-delete it.
+  // Cloud V1 is a different system with its own database; its data lifecycle
+  // is not a cloud-v2 concern and no code here talks to it.
   await revokeAllSessionsForUser({ mentraUserId });
   await gotrue.deleteUser(tenantUserId);
-  await deleteFromLegacy(tenantUserId).catch(() => {
-    // Non-fatal: the user's V2 identity is already gone. Log-and-reconcile.
-  });
-}
-
-async function deleteFromLegacy(tenantUserId: string): Promise<void> {
-  const url = process.env.LEGACY_CORE_URL?.trim();
-  const secret = process.env.LEGACY_DELETE_SECRET?.trim();
-  if (!url || !secret) return; // V1 removal in progress; nothing to fan out to.
-  await fetch(`${url.replace(/\/+$/, "")}/api/internal/account/delete`, {
-    method: "POST",
-    headers: { authorization: `Bearer ${secret}`, "content-type": "application/json" },
-    body: JSON.stringify({ userId: tenantUserId }),
-  });
 }
 
 export { gotrue, otc };

--- a/cloud-v2/packages/core/src/services/account/account.service.ts
+++ b/cloud-v2/packages/core/src/services/account/account.service.ts
@@ -168,8 +168,15 @@ export async function confirmAccountDeletion(
   code: string,
 ): Promise<void> {
   await otc.consumeCode({ code, purpose: "account_deletion", expectSubject: tenantUserId });
-  // Order: kill V2 sessions, then delete the Supabase user. The V2 user row is
-  // left tombstoned by session removal; a follow-up may hard-delete it.
+  // Order: kill V2 sessions, then delete the Supabase user. Everything
+  // human-identifying (email, password, name) lives in GoTrue and dies here.
+  //
+  // OPEN DECISION (deferred, revisit in a future PR): the Mongo users row
+  // ({mentraUserId, tenantId, tenantUserId}) is intentionally kept as a
+  // tombstone for identifier stability and audit lineage. If we want
+  // gone-means-gone, hard-delete it here. This flow also still needs an
+  // integration test covering the cascade.
+  //
   // Cloud V1 is a different system with its own database; its data lifecycle
   // is not a cloud-v2 concern and no code here talks to it.
   await revokeAllSessionsForUser({ mentraUserId });

--- a/cloud-v2/packages/core/src/services/account/account.service.ts
+++ b/cloud-v2/packages/core/src/services/account/account.service.ts
@@ -17,6 +17,7 @@ import { AccountError } from "./account-error";
 
 const RESET_CODE_TTL_SEC = 15 * 60;
 const DELETE_CODE_TTL_SEC = 15 * 60;
+const EMAIL_CHANGE_CODE_TTL_SEC = 15 * 60;
 
 /** Turn a verified GoTrue identity into a Cloud V2 session (the shared tail of
  * login and oauth). */
@@ -105,16 +106,46 @@ export async function changePassword(
   await revokeAllSessionsForUser({ mentraUserId, exceptSessionId: currentSessionId });
 }
 
-export async function changeEmail(
-  _mentraUserId: string,
+/**
+ * Step 1 of the email change: re-verify the password, then email a one-time
+ * code to the NEW address. The change is only applied by `confirmEmailChange`,
+ * so the user must prove they control the new inbox first. (The GoTrue admin
+ * update applies immediately with no confirmation, so core owns this flow with
+ * the same code mechanism as password reset and account deletion.)
+ */
+export async function requestEmailChange(
   tenantUserId: string,
   currentEmail: string,
   password: string,
   newEmail: string,
 ): Promise<void> {
-  // Re-verify the password, then hand the address change to GoTrue, which
-  // emails the new address a confirmation link and only applies it on click.
   await gotrue.verifyPassword(currentEmail, password);
+  // If the address already belongs to an account, silently no-op: the caller
+  // returns the uniform "verification_sent" either way (anti-enumeration).
+  const taken = await gotrue.findUserByEmail(newEmail);
+  if (taken) return;
+  const code = await otc.issueEmailCode({
+    purpose: "email_change",
+    subject: tenantUserId,
+    ttlSec: EMAIL_CHANGE_CODE_TTL_SEC,
+    payload: { newEmail },
+  });
+  await sendEmail({
+    to: newEmail,
+    subject: "Confirm your new Mentra email address",
+    html: `<p>Your email change code is <b>${code}</b>. It expires in 15 minutes. If you did not request this, ignore this email.</p>`,
+  });
+}
+
+/** Step 2: consume the code (bound to this user) and apply the new address. */
+export async function confirmEmailChange(tenantUserId: string, code: string): Promise<void> {
+  const { payload } = await otc.consumeCode({
+    code,
+    purpose: "email_change",
+    expectSubject: tenantUserId,
+  });
+  const newEmail = (payload as { newEmail?: string })?.newEmail;
+  if (!newEmail) throw new AccountError("code_invalid", "code is invalid", 400);
   await gotrue.setEmail(tenantUserId, newEmail);
 }
 

--- a/cloud-v2/packages/core/src/services/account/account.service.ts
+++ b/cloud-v2/packages/core/src/services/account/account.service.ts
@@ -1,0 +1,161 @@
+/**
+ * @fileoverview Account orchestration: Mentra's first-party consumer identity
+ * provider, running in-process as its own "OEM backend" (issue 019).
+ *
+ * Verifies credentials via GoTrue (server side, transient), then mints a
+ * `mentra` subject token and feeds it through the SAME createSession path OEMs
+ * use, so the device only ever receives a Cloud V2 session. No Supabase
+ * material reaches the client.
+ */
+import type { TokenResponse } from "../../types/oauth.types";
+import { createSession, mintAccountSubjectToken, revokeAllSessionsForUser } from "../session.service";
+import { findOrCreateUser } from "../user.service";
+import { sendEmail } from "../email/email.service";
+import * as gotrue from "./gotrue.client";
+import * as otc from "./one-time-code.service";
+import { AccountError } from "./account-error";
+
+const RESET_CODE_TTL_SEC = 15 * 60;
+const DELETE_CODE_TTL_SEC = 15 * 60;
+
+/** Turn a verified GoTrue identity into a Cloud V2 session (the shared tail of
+ * login and oauth). */
+async function sessionForIdentity(identity: gotrue.GotrueIdentity): Promise<TokenResponse> {
+  const subjectToken = await mintAccountSubjectToken({ tenantUserId: identity.id });
+  return createSession({ subjectToken });
+}
+
+export async function signup(email: string, password: string): Promise<void> {
+  await gotrue.signUp(email, password);
+  // Uniform: caller returns "verification_sent" regardless (anti-enumeration).
+}
+
+export async function resendVerification(email: string): Promise<void> {
+  await gotrue.resendVerification(email);
+}
+
+export async function login(email: string, password: string): Promise<TokenResponse> {
+  const identity = await gotrue.verifyPassword(email, password);
+  return sessionForIdentity(identity);
+}
+
+/** Identity for GET /me. `mentraUserId` comes from the access token; email /
+ * name / avatar come from GoTrue keyed on the Supabase id (our tenantUserId). */
+export async function me(
+  mentraUserId: string,
+  tenantUserId: string,
+): Promise<{ mentraUserId: string; email: string | null; name?: string; avatarUrl?: string }> {
+  const gt = await gotrue.getUserById(tenantUserId).catch(() => null);
+  return {
+    mentraUserId,
+    email: gt?.email ?? null,
+    name: gt?.name,
+    avatarUrl: gt?.avatarUrl,
+  };
+}
+
+export async function requestPasswordReset(email: string): Promise<void> {
+  const user = await gotrue.findUserByEmail(email);
+  if (!user) return; // uniform: pretend success (anti-enumeration)
+  const code = await otc.issueEmailCode({
+    purpose: "password_reset",
+    subject: email.toLowerCase(),
+    ttlSec: RESET_CODE_TTL_SEC,
+    payload: { userId: user.id },
+  });
+  await sendEmail({
+    to: email,
+    subject: "Your Mentra password reset code",
+    html: `<p>Your password reset code is <b>${code}</b>. It expires in 15 minutes.</p>`,
+  });
+}
+
+export async function resetPassword(
+  email: string,
+  code: string,
+  newPassword: string,
+): Promise<TokenResponse> {
+  const { payload } = await otc.consumeCode({
+    code,
+    purpose: "password_reset",
+    expectSubject: email.toLowerCase(),
+  });
+  const userId = (payload as { userId?: string })?.userId;
+  if (!userId) throw new AccountError("code_invalid", "code is invalid", 400);
+  await gotrue.setPassword(userId, newPassword);
+  // Reset kills ALL existing sessions, then logs the user in fresh. Revoke
+  // before minting so the new session is the only survivor.
+  const user = await findOrCreateUser({ tenantId: "mentra", tenantUserId: userId });
+  await revokeAllSessionsForUser({ mentraUserId: user.mentraUserId });
+  const identity = await gotrue.verifyPassword(email, newPassword);
+  return sessionForIdentity(identity);
+}
+
+export async function changePassword(
+  mentraUserId: string,
+  tenantUserId: string,
+  currentPassword: string,
+  newPassword: string,
+  email: string,
+  currentSessionId?: string,
+): Promise<void> {
+  // Re-verify the current password before allowing a change.
+  await gotrue.verifyPassword(email, currentPassword);
+  await gotrue.setPassword(tenantUserId, newPassword);
+  await revokeAllSessionsForUser({ mentraUserId, exceptSessionId: currentSessionId });
+}
+
+export async function changeEmail(
+  _mentraUserId: string,
+  tenantUserId: string,
+  currentEmail: string,
+  password: string,
+  newEmail: string,
+): Promise<void> {
+  // Re-verify the password, then hand the address change to GoTrue, which
+  // emails the new address a confirmation link and only applies it on click.
+  await gotrue.verifyPassword(currentEmail, password);
+  await gotrue.setEmail(tenantUserId, newEmail);
+}
+
+export async function requestAccountDeletion(email: string, tenantUserId: string): Promise<void> {
+  const code = await otc.issueEmailCode({
+    purpose: "account_deletion",
+    subject: tenantUserId,
+    ttlSec: DELETE_CODE_TTL_SEC,
+  });
+  await sendEmail({
+    to: email,
+    subject: "Confirm your Mentra account deletion",
+    html: `<p>Your account deletion code is <b>${code}</b>. It expires in 15 minutes. If you did not request this, ignore this email.</p>`,
+  });
+}
+
+export async function confirmAccountDeletion(
+  mentraUserId: string,
+  tenantUserId: string,
+  code: string,
+): Promise<void> {
+  await otc.consumeCode({ code, purpose: "account_deletion", expectSubject: tenantUserId });
+  // Order: kill V2 sessions, delete the Supabase user, fan out to V1 (best
+  // effort; a reconciliation job retries). The V2 user row is left tombstoned
+  // by session removal; a follow-up may hard-delete it.
+  await revokeAllSessionsForUser({ mentraUserId });
+  await gotrue.deleteUser(tenantUserId);
+  await deleteFromLegacy(tenantUserId).catch(() => {
+    // Non-fatal: the user's V2 identity is already gone. Log-and-reconcile.
+  });
+}
+
+async function deleteFromLegacy(tenantUserId: string): Promise<void> {
+  const url = process.env.LEGACY_CORE_URL?.trim();
+  const secret = process.env.LEGACY_DELETE_SECRET?.trim();
+  if (!url || !secret) return; // V1 removal in progress; nothing to fan out to.
+  await fetch(`${url.replace(/\/+$/, "")}/api/internal/account/delete`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${secret}`, "content-type": "application/json" },
+    body: JSON.stringify({ userId: tenantUserId }),
+  });
+}
+
+export { gotrue, otc };

--- a/cloud-v2/packages/core/src/services/account/gotrue.client.ts
+++ b/cloud-v2/packages/core/src/services/account/gotrue.client.ts
@@ -122,16 +122,32 @@ export async function resendVerification(email: string): Promise<void> {
   // Always uniform; ignore result.
 }
 
-/** Look up a user id by email via the admin API (for reset/change/delete). */
+/**
+ * Look up a user by email via the admin API (for reset/change/delete).
+ *
+ * GoTrue's `filter` narrows by a partial email match when honored, but it is
+ * not a guaranteed exact lookup and older/self-hosted configs ignore it, so
+ * `per_page: 1` could silently return the wrong (or no) user. We page through
+ * results (bounded) and exact-match the email ourselves, so a missing user is
+ * a real miss, not a pagination artifact.
+ */
 export async function findUserByEmail(email: string): Promise<GotrueIdentity | null> {
-  const { status, body } = await gotrue("/admin/users", {
-    method: "GET",
-    admin: true,
-    query: { filter: email, per_page: "1" },
-  });
-  if (status !== 200) return null;
-  const user = (body?.users ?? []).find((u: any) => u.email?.toLowerCase() === email.toLowerCase());
-  return user ? identityFrom(user) : null;
+  const wanted = email.toLowerCase();
+  const PER_PAGE = 200;
+  const MAX_PAGES = 20; // safety cap: 4000 users scanned worst case
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const { status, body } = await gotrue("/admin/users", {
+      method: "GET",
+      admin: true,
+      query: { filter: email, page: String(page), per_page: String(PER_PAGE) },
+    });
+    if (status !== 200) return null;
+    const users: any[] = body?.users ?? [];
+    const match = users.find((u) => u.email?.toLowerCase() === wanted);
+    if (match) return identityFrom(match);
+    if (users.length < PER_PAGE) break; // last page reached, no match
+  }
+  return null;
 }
 
 export async function getUserById(userId: string): Promise<GotrueIdentity | null> {

--- a/cloud-v2/packages/core/src/services/account/gotrue.client.ts
+++ b/cloud-v2/packages/core/src/services/account/gotrue.client.ts
@@ -154,10 +154,15 @@ export async function setPassword(userId: string, password: string): Promise<voi
 }
 
 export async function setEmail(userId: string, email: string): Promise<void> {
+  // Only called AFTER core's own one-time code proved the user controls the
+  // new inbox (confirmEmailChange), so apply it confirmed. Leaving it
+  // unconfirmed would make the next password login hit verification_required
+  // (verifyPassword rejects unverified emails) and could trigger GoTrue's own
+  // redundant confirmation flow.
   const { status } = await gotrue(`/admin/users/${userId}`, {
     method: "PUT",
     admin: true,
-    body: { email, email_confirm: false },
+    body: { email, email_confirm: true },
   });
   if (status !== 200) throw new AccountError("server_error", "email update failed", 502);
 }

--- a/cloud-v2/packages/core/src/services/account/gotrue.client.ts
+++ b/cloud-v2/packages/core/src/services/account/gotrue.client.ts
@@ -170,9 +170,16 @@ export async function deleteUser(userId: string): Promise<void> {
 }
 
 /** Build the GoTrue authorize URL for an OAuth provider (browser is redirected
- * here; the callback lands back on core). */
-export function authorizeUrl(provider: string, redirectTo: string): string {
-  const q = new URLSearchParams({ provider, redirect_to: redirectTo });
+ * here; the callback lands back on core). `codeChallenge` is S256 of core's
+ * verifier: GoTrue only issues a PKCE-exchangeable auth code when the challenge
+ * rides on the authorize request, so omitting it breaks `exchangeOAuthCode`. */
+export function authorizeUrl(provider: string, redirectTo: string, codeChallenge: string): string {
+  const q = new URLSearchParams({
+    provider,
+    redirect_to: redirectTo,
+    code_challenge: codeChallenge,
+    code_challenge_method: "s256",
+  });
   return `${baseUrl()}/auth/v1/authorize?${q}`;
 }
 

--- a/cloud-v2/packages/core/src/services/account/gotrue.client.ts
+++ b/cloud-v2/packages/core/src/services/account/gotrue.client.ts
@@ -1,0 +1,189 @@
+/**
+ * @fileoverview Server-side Supabase GoTrue client.
+ *
+ * This is the ONLY module that knows about Supabase. Everything above it speaks
+ * in account-service terms and spec error codes, so a future credential-store
+ * swap (issue 019 design.md, Phase 2) replaces this file and nothing else.
+ *
+ * Two credentials, both server-only (never shipped to the app):
+ *   - SUPABASE_ANON_KEY   -> the password/pkce token grants
+ *   - SUPABASE_SERVICE_ROLE_KEY -> the admin API (user mutation, delete, links)
+ */
+import { AccountError } from "./account-error";
+
+export interface GotrueIdentity {
+  id: string;
+  email: string;
+  emailVerified: boolean;
+  name?: string;
+  avatarUrl?: string;
+}
+
+function baseUrl(): string {
+  const url = process.env.SUPABASE_URL?.trim();
+  if (!url) throw new AccountError("server_error", "SUPABASE_URL not configured", 500);
+  return url.replace(/\/+$/, "");
+}
+
+function anonKey(): string {
+  const k = process.env.SUPABASE_ANON_KEY?.trim();
+  if (!k) throw new AccountError("server_error", "SUPABASE_ANON_KEY not configured", 500);
+  return k;
+}
+
+function serviceKey(): string {
+  const k = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
+  if (!k) throw new AccountError("server_error", "SUPABASE_SERVICE_ROLE_KEY not configured", 500);
+  return k;
+}
+
+async function gotrue(
+  path: string,
+  init: { method: string; body?: unknown; admin?: boolean; query?: Record<string, string> },
+): Promise<{ status: number; body: any }> {
+  const key = init.admin ? serviceKey() : anonKey();
+  const qs = init.query ? `?${new URLSearchParams(init.query)}` : "";
+  const res = await fetch(`${baseUrl()}/auth/v1${path}${qs}`, {
+    method: init.method,
+    headers: {
+      apikey: key,
+      authorization: `Bearer ${key}`,
+      "content-type": "application/json",
+    },
+    body: init.body === undefined ? undefined : JSON.stringify(init.body),
+  });
+  const text = await res.text();
+  let body: any = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { status: res.status, body };
+}
+
+function identityFrom(user: any): GotrueIdentity {
+  const meta = user?.user_metadata ?? {};
+  return {
+    id: user.id,
+    email: user.email,
+    emailVerified: Boolean(user.email_confirmed_at ?? user.confirmed_at),
+    name: meta.full_name ?? meta.name ?? undefined,
+    avatarUrl: meta.avatar_url ?? meta.picture ?? undefined,
+  };
+}
+
+/**
+ * Verify email + password. Returns identity on success. Never distinguishes
+ * "no such user" from "wrong password" — both surface as invalid_credentials.
+ * The GoTrue password grant is used TRANSIENTLY: we read identity and discard
+ * the Supabase session (the device only ever gets a Cloud V2 session).
+ */
+export async function verifyPassword(email: string, password: string): Promise<GotrueIdentity> {
+  const { status, body } = await gotrue("/token", {
+    method: "POST",
+    query: { grant_type: "password" },
+    body: { email, password },
+  });
+  if (status === 200 && body?.user) {
+    if (!identityFrom(body.user).emailVerified) {
+      throw new AccountError("verification_required", "email not verified", 403);
+    }
+    return identityFrom(body.user);
+  }
+  // 400 invalid_grant, 400 email_not_confirmed, etc. — collapse to uniform error.
+  if (body?.error_code === "email_not_confirmed") {
+    throw new AccountError("verification_required", "email not verified", 403);
+  }
+  throw new AccountError("invalid_credentials", "invalid email or password", 401);
+}
+
+/** Create a user; GoTrue sends the verification email. Idempotent-ish: an
+ * existing address returns a user object without a session (obfuscated by the
+ * caller into the uniform "verification_sent"). */
+export async function signUp(email: string, password: string): Promise<void> {
+  const { status, body } = await gotrue("/signup", {
+    method: "POST",
+    body: { email, password },
+  });
+  if (status === 200 || status === 201) return;
+  if (typeof body?.msg === "string" && /password/i.test(body.msg)) {
+    throw new AccountError("weak_password", body.msg, 400);
+  }
+  if (status === 422 || status === 429) {
+    // 422 often = already registered; keep uniform to avoid enumeration.
+    return;
+  }
+  throw new AccountError("server_error", "signup failed", 502);
+}
+
+export async function resendVerification(email: string): Promise<void> {
+  await gotrue("/resend", { method: "POST", body: { type: "signup", email } });
+  // Always uniform; ignore result.
+}
+
+/** Look up a user id by email via the admin API (for reset/change/delete). */
+export async function findUserByEmail(email: string): Promise<GotrueIdentity | null> {
+  const { status, body } = await gotrue("/admin/users", {
+    method: "GET",
+    admin: true,
+    query: { filter: email, per_page: "1" },
+  });
+  if (status !== 200) return null;
+  const user = (body?.users ?? []).find((u: any) => u.email?.toLowerCase() === email.toLowerCase());
+  return user ? identityFrom(user) : null;
+}
+
+export async function getUserById(userId: string): Promise<GotrueIdentity | null> {
+  const { status, body } = await gotrue(`/admin/users/${userId}`, { method: "GET", admin: true });
+  if (status !== 200 || !body?.id) return null;
+  return identityFrom(body);
+}
+
+export async function setPassword(userId: string, password: string): Promise<void> {
+  const { status, body } = await gotrue(`/admin/users/${userId}`, {
+    method: "PUT",
+    admin: true,
+    body: { password },
+  });
+  if (status === 200) return;
+  if (typeof body?.msg === "string" && /password/i.test(body.msg)) {
+    throw new AccountError("weak_password", body.msg, 400);
+  }
+  throw new AccountError("server_error", "password update failed", 502);
+}
+
+export async function setEmail(userId: string, email: string): Promise<void> {
+  const { status } = await gotrue(`/admin/users/${userId}`, {
+    method: "PUT",
+    admin: true,
+    body: { email, email_confirm: false },
+  });
+  if (status !== 200) throw new AccountError("server_error", "email update failed", 502);
+}
+
+export async function deleteUser(userId: string): Promise<void> {
+  const { status } = await gotrue(`/admin/users/${userId}`, { method: "DELETE", admin: true });
+  if (status !== 200 && status !== 204 && status !== 404) {
+    throw new AccountError("server_error", "user delete failed", 502);
+  }
+}
+
+/** Build the GoTrue authorize URL for an OAuth provider (browser is redirected
+ * here; the callback lands back on core). */
+export function authorizeUrl(provider: string, redirectTo: string): string {
+  const q = new URLSearchParams({ provider, redirect_to: redirectTo });
+  return `${baseUrl()}/auth/v1/authorize?${q}`;
+}
+
+/** Exchange an OAuth `code` (from the GoTrue callback) for the user identity.
+ * Uses the pkce grant; the verifier for the core<->GoTrue leg is held by core. */
+export async function exchangeOAuthCode(code: string, codeVerifier: string): Promise<GotrueIdentity> {
+  const { status, body } = await gotrue("/token", {
+    method: "POST",
+    query: { grant_type: "pkce" },
+    body: { auth_code: code, code_verifier: codeVerifier },
+  });
+  if (status === 200 && body?.user) return identityFrom(body.user);
+  throw new AccountError("invalid_grant", "oauth code exchange failed", 400);
+}

--- a/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
+++ b/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
@@ -27,15 +27,26 @@ export async function issueEmailCode(args: {
   ttlSec: number;
   payload?: unknown;
 }): Promise<string> {
-  const code = numericCode();
-  await AccountCodeModel.create({
-    codeHash: hash(code),
-    purpose: args.purpose,
-    subject: args.subject,
-    payload: args.payload ?? null,
-    expiresAt: new Date(Date.now() + args.ttlSec * 1000),
-  });
-  return code;
+  // codeHash is globally unique but 6-digit codes are not: with enough live
+  // codes two users WILL draw the same number (birthday bound), and the second
+  // insert would 500 an innocent request. Redraw on duplicate-key instead.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    const code = numericCode();
+    try {
+      await AccountCodeModel.create({
+        codeHash: hash(code),
+        purpose: args.purpose,
+        subject: args.subject,
+        payload: args.payload ?? null,
+        expiresAt: new Date(Date.now() + args.ttlSec * 1000),
+      });
+      return code;
+    } catch (err) {
+      const dup = (err as { code?: number })?.code === 11000;
+      if (!dup) throw err;
+    }
+  }
+  throw new AccountError("server_error", "could not allocate a one-time code", 500);
 }
 
 export async function issueOAuthHandoff(args: {

--- a/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
+++ b/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Single-use one-time codes for account flows. Codes are stored
+ * hashed with a purpose scope and TTL; issuing returns the plaintext once
+ * (emailed or deep-linked), consuming verifies+burns atomically.
+ */
+import crypto from "node:crypto";
+import { AccountCodeModel, type AccountCodePurpose } from "../../models/account-code.model";
+import { AccountError } from "./account-error";
+
+function hash(code: string): string {
+  return crypto.createHash("sha256").update(code).digest("hex");
+}
+
+/** 6-digit numeric code for email flows (reset, email change, deletion). */
+function numericCode(): string {
+  return String(crypto.randomInt(0, 1_000_000)).padStart(6, "0");
+}
+
+/** URL-safe opaque code for the oauth deep-link handoff. */
+function opaqueCode(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+export async function issueEmailCode(args: {
+  purpose: Extract<AccountCodePurpose, "password_reset" | "email_change" | "account_deletion">;
+  subject: string;
+  ttlSec: number;
+  payload?: unknown;
+}): Promise<string> {
+  const code = numericCode();
+  await AccountCodeModel.create({
+    codeHash: hash(code),
+    purpose: args.purpose,
+    subject: args.subject,
+    payload: args.payload ?? null,
+    expiresAt: new Date(Date.now() + args.ttlSec * 1000),
+  });
+  return code;
+}
+
+export async function issueOAuthHandoff(args: {
+  codeChallenge: string;
+  ttlSec: number;
+  payload: unknown;
+}): Promise<string> {
+  const code = opaqueCode();
+  await AccountCodeModel.create({
+    codeHash: hash(code),
+    purpose: "oauth_handoff",
+    subject: args.codeChallenge,
+    payload: args.payload,
+    expiresAt: new Date(Date.now() + args.ttlSec * 1000),
+  });
+  return code;
+}
+
+/**
+ * The OAuth "start" record is keyed by the flow `state` (which comes back on
+ * the provider callback), not by a code the app holds. Stored under a fixed
+ * subject so it can't be confused with a handoff record.
+ */
+export async function issueOAuthStart(args: {
+  state: string;
+  ttlSec: number;
+  payload: unknown;
+}): Promise<void> {
+  await AccountCodeModel.create({
+    codeHash: hash(args.state),
+    purpose: "oauth_handoff",
+    subject: OAUTH_START_SUBJECT,
+    payload: args.payload,
+    expiresAt: new Date(Date.now() + args.ttlSec * 1000),
+  });
+}
+
+export const OAUTH_START_SUBJECT = "__oauth_start__";
+
+/**
+ * Verify + burn a code in one atomic update (findOneAndUpdate on consumedAt
+ * null), so a concurrent double-submit can't consume the same code twice.
+ * `expectSubject`, if given, must match (reset code bound to its email, etc.).
+ * Returns the stored payload.
+ */
+export async function consumeCode(args: {
+  code: string;
+  purpose: AccountCodePurpose;
+  expectSubject?: string;
+}): Promise<{ subject: string; payload: unknown }> {
+  const filter: Record<string, unknown> = {
+    codeHash: hash(args.code),
+    purpose: args.purpose,
+    consumedAt: null,
+    expiresAt: { $gt: new Date() },
+  };
+  if (args.expectSubject !== undefined) filter.subject = args.expectSubject;
+
+  const doc = await AccountCodeModel.findOneAndUpdate(
+    filter,
+    { $set: { consumedAt: new Date() } },
+  ).lean();
+  if (!doc) throw new AccountError("code_invalid", "code is invalid, expired, or already used", 400);
+  return { subject: doc.subject, payload: doc.payload };
+}

--- a/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
+++ b/cloud-v2/packages/core/src/services/account/one-time-code.service.ts
@@ -87,6 +87,23 @@ export async function issueOAuthStart(args: {
 export const OAUTH_START_SUBJECT = "__oauth_start__";
 
 /**
+ * Read an OAuth start record by `state` WITHOUT burning it. The callback needs
+ * the stored verifier before it runs the (irreversible) GoTrue exchange; the
+ * record is only consumed once the whole callback succeeds, so a transient
+ * failure mid-callback leaves it intact rather than stranded-and-burned.
+ */
+export async function peekOAuthStart(state: string): Promise<{ payload: unknown } | null> {
+  const doc = await AccountCodeModel.findOne({
+    codeHash: hash(state),
+    purpose: "oauth_handoff",
+    subject: OAUTH_START_SUBJECT,
+    consumedAt: null,
+    expiresAt: { $gt: new Date() },
+  }).lean();
+  return doc ? { payload: doc.payload } : null;
+}
+
+/**
  * Verify + burn a code in one atomic update (findOneAndUpdate on consumedAt
  * null), so a concurrent double-submit can't consume the same code twice.
  * `expectSubject`, if given, must match (reset code bound to its email, etc.).

--- a/cloud-v2/packages/core/src/services/session.service.test.ts
+++ b/cloud-v2/packages/core/src/services/session.service.test.ts
@@ -46,10 +46,14 @@ describe("Core JWKS", () => {
 function setSigningEnv(): void {
   const access = createEd25519Keypair();
   const miniapp = createEd25519Keypair();
+  const account = createEd25519Keypair();
   process.env.MENTRA_JWT_PRIVATE_KEY = access.privateKey;
   process.env.MENTRA_JWT_PUBLIC_KEY = access.publicKey;
   process.env.MENTRA_MINIAPP_JWT_PRIVATE_KEY = miniapp.privateKey;
   process.env.MENTRA_MINIAPP_JWT_PUBLIC_KEY = miniapp.publicKey;
+  // getPublicJwks now also publishes the account-token key (issue 019).
+  process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY = account.privateKey;
+  process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY = account.publicKey;
   resetSigningKeyCache();
 }
 

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -221,18 +221,22 @@ export async function refreshSession(args: {
 /**
  * Mid-session revocation guard for the refresh flow. A session's tenant is one
  * of three kinds, each with its own backing record and "still authorized" rule:
- *   - the built-in "mentra" tenant: no backing record, always allowed,
- *   - an OEM (legacy JWKS issuer): allowed while its `oems` row is not disabled,
+ *   - an OEM: allowed while its `oems` row is not disabled. This INCLUDES the
+ *     `mentra` tenant, whose account module registers a real oems row (issue
+ *     019) so Mentra is validated exactly like any other OEM,
  *   - an enterprise trusted-issuer org: allowed while its `enterprise_orgs` row
  *     has status "active".
  * Enterprise tenants have NO `oems` row (their tenantId comes from EnterpriseOrg,
  * see verifyTrustedIssuerJwt in oem.service), so checking only OemModel would
  * reject every enterprise session on its first refresh once the access token
  * expired. We check OEMs first, then enterprise orgs, then reject.
+ *
+ * Transitional: environments that predate the account rollout have no `mentra`
+ * oems row (the seed migration skips when the account key env is unset), so
+ * `mentra` with NO row falls back to allowed. That fallback dies at the V1
+ * cutover, at which point mentra is a hard oems-row check like everyone.
  */
 async function assertTenantStillAuthorized(tenantId: string): Promise<void> {
-  if (tenantId === MENTRA_OEM_ID) return;
-
   const oem = await OemModel.findOne({ tenantId }).lean();
   if (oem) {
     if (oem.disabled) {
@@ -240,6 +244,7 @@ async function assertTenantStillAuthorized(tenantId: string): Promise<void> {
     }
     return;
   }
+  if (tenantId === MENTRA_OEM_ID) return; // transitional fallback, see above
 
   const enterpriseOrg = await EnterpriseOrgModel.findOne({ tenantId }).lean();
   if (enterpriseOrg) {

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -42,6 +42,25 @@ import {
 } from "../types/oauth.types";
 import { findOrCreateUser } from "./user.service";
 import { recordSeenJti, verifyTenantJwt } from "./oem.service";
+import {
+  MENTRA_ALG,
+  ACCESS_TOKEN_KID,
+  RUNTIME_TOKEN_KID,
+  MINIAPP_TOKEN_KID,
+  ACCOUNT_TOKEN_KID,
+  requireEnv,
+  getMentraKeys,
+  getMiniappKeys,
+  getAccountKeys,
+} from "./signing-keys.service";
+
+// Key management and the public JWKS moved to signing-keys.service.ts. These
+// re-exports keep existing importers (well-known.api, tests) working.
+export {
+  getPublicJwks,
+  resetSigningKeyCache,
+  getAccountPublicKeyPem,
+} from "./signing-keys.service";
 
 const logger = createLogger("core").child({ service: "session.service" });
 
@@ -53,7 +72,6 @@ const REFRESH_TOKEN_TTL_SEC = 30 * 24 * 60 * 60; // 30 days
 
 const CORE_ISSUER = "cloud-core";
 const CORE_AUDIENCE = "cloud-core";
-const MENTRA_ALG = "EdDSA";
 
 // Miniapp-scoped tokens are issued by cloud-core but signed with a separate
 // miniapp-token key. Developer backends verify iss/aud/signature via JWKS.
@@ -69,20 +87,10 @@ const MENTRA_OEM_ID = "mentra";
 // so tests can shorten it without touching code.
 const MINIAPP_TOKEN_DEFAULT_TTL_SEC = 60 * 60; // 1 hour
 
-// JWKS key ids. Each published public key carries a stable `kid` so verifiers
-// (developer backends, internal services) select the right key by header,
-// which is what makes key rotation a no-coordination change. Access and
-// Core-brokered runtime tokens share the Core signing key but have distinct kids
-// because they are distinct token kinds/audiences; miniapp tokens use their own
-// signing key.
-const ACCESS_TOKEN_KID = "mentra-access-1";
-const RUNTIME_TOKEN_KID = "cloud-core-runtime-1";
-const MINIAPP_TOKEN_KID = "mentra-miniapp-1";
-const ACCOUNT_TOKEN_KID = "mentra-account-1";
-// Mentra's own first-party account backend signs subject tokens with this key
-// and pushes them through the SAME exchange path OEMs use (see issue 019). The
-// `mentra` OEM row (startup migration) carries this public key so verifyTenantJwt
-// verifies them. TTL is tiny: the token exists only to cross into createSession.
+// Mentra's own first-party account backend signs subject tokens and pushes them
+// through the SAME exchange path OEMs use (see issue 019). The `mentra` OEM row
+// (startup migration) carries the account public key so verifyTenantJwt verifies
+// them. TTL is tiny: the token exists only to cross into createSession.
 const ACCOUNT_SUBJECT_TOKEN_TTL_SEC = 60;
 
 // === Public API ===
@@ -514,49 +522,6 @@ async function verifyHs256Subject(
 // === Internals: Mentra signing keys ===
 
 /**
- * Lazy-loaded Mentra signing keypair for **access tokens**. We hold both
- * halves on `core` so we can sign and verify in this same process. Audio/proxy
- * will receive only the public half.
- */
-let mentraKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
-
-/**
- * Lazy-loaded Mentra signing keypair for **miniapp tokens**. Kept separate
- * from the access-token key on purpose: per auth/spec.md "Signing keys", two
- * keys limit blast radius, a leak of the miniapp key can't forge access
- * tokens, and vice versa. The public half is published in the JWKS so
- * developer backends can verify miniapp tokens.
- */
-let miniappKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
-
-async function getMentraKeys() {
-  if (!mentraKeys) {
-    mentraKeys = loadMentraKeys();
-  }
-  return mentraKeys;
-}
-
-async function getMiniappKeys() {
-  if (!miniappKeys) {
-    miniappKeys = loadMiniappKeys();
-  }
-  return miniappKeys;
-}
-
-/**
- * Reset the lazy-loaded signing keypair caches. **Test-only.** Production
- * has no reason to rotate keys mid-process; tests that mutate
- * `MENTRA_JWT_*` / `MENTRA_MINIAPP_JWT_*` env vars (e.g. running multiple test
- * files in the same Bun process) need to discard the cached imports so the
- * next call reads the new env.
- */
-export function resetSigningKeyCache(): void {
-  mentraKeys = null;
-  miniappKeys = null;
-  accountKeys = null;
-}
-
-/**
  * Mint a short-lived Ed25519 subject token for Mentra's first-party account
  * backend, issued under the `mentra` tenant. It is fed straight into
  * createSession, where verifyTenantJwt validates it against the `mentra` OEM
@@ -578,112 +543,6 @@ export async function mintAccountSubjectToken(args: { tenantUserId: string }): P
     .sign(privateKey);
 }
 
-let accountKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
-
-async function getAccountKeys() {
-  if (!accountKeys) accountKeys = loadAccountKeys();
-  return accountKeys;
-}
-
-async function loadAccountKeys() {
-  const privB64 = requireEnv("MENTRA_ACCOUNT_JWT_PRIVATE_KEY");
-  const pubB64 = requireEnv("MENTRA_ACCOUNT_JWT_PUBLIC_KEY");
-  const [privateKey, publicKey] = await Promise.all([
-    jose.importPKCS8(toPem(privB64, "PRIVATE KEY"), MENTRA_ALG, { extractable: false }),
-    jose.importSPKI(toPem(pubB64, "PUBLIC KEY"), MENTRA_ALG, { extractable: true }),
-  ]);
-  logger.info("loaded Mentra account-token signing keypair");
-  return { privateKey, publicKey };
-}
-
-/** The account signing public key in SPKI PEM form, for seeding the `mentra`
- * OEM row (static key mode). */
-export async function getAccountPublicKeyPem(): Promise<string> {
-  const pubB64 = requireEnv("MENTRA_ACCOUNT_JWT_PUBLIC_KEY");
-  return toPem(pubB64, "PUBLIC KEY");
-}
-
-async function loadMentraKeys() {
-  const privB64 = requireEnv("MENTRA_JWT_PRIVATE_KEY");
-  const pubB64 = requireEnv("MENTRA_JWT_PUBLIC_KEY");
-  const privatePem = toPem(privB64, "PRIVATE KEY");
-  const publicPem = toPem(pubB64, "PUBLIC KEY");
-  const [privateKey, publicKey] = await Promise.all([
-    // Public key stays extractable so we can export it to JWK form for the
-    // /.well-known/jwks.json endpoint.
-    jose.importPKCS8(privatePem, MENTRA_ALG, { extractable: false }),
-    jose.importSPKI(publicPem, MENTRA_ALG, { extractable: true }),
-  ]);
-  logger.info("loaded Mentra access-token signing keypair");
-  return { privateKey, publicKey };
-}
-
-/**
- * Load the miniapp-token signing keypair from env. Falls back to the
- * access-token key env vars is intentionally NOT done: the keys must be
- * distinct for the blast-radius guarantee, so the miniapp env vars are
- * required in their own right.
- */
-async function loadMiniappKeys() {
-  const privB64 = requireEnv("MENTRA_MINIAPP_JWT_PRIVATE_KEY");
-  const pubB64 = requireEnv("MENTRA_MINIAPP_JWT_PUBLIC_KEY");
-  const privatePem = toPem(privB64, "PRIVATE KEY");
-  const publicPem = toPem(pubB64, "PUBLIC KEY");
-  const [privateKey, publicKey] = await Promise.all([
-    jose.importPKCS8(privatePem, MENTRA_ALG, { extractable: false }),
-    jose.importSPKI(publicPem, MENTRA_ALG, { extractable: true }),
-  ]);
-  logger.info("loaded Mentra miniapp-token signing keypair");
-  return { privateKey, publicKey };
-}
-
-/**
- * Build the public JWKS document Mentra publishes at /.well-known/jwks.json.
- *
- * Contains both public keys, each tagged with its `kid` (and `alg`/`use`), so
- * a verifier picks the right key by the JWT header's `kid`:
- *   - the access-token key, used by internal services to verify access tokens
- *   - the Core-brokered runtime-token key, used by Runtime when it trusts Core
- *   - the miniapp-token key, used by developer backends to verify miniapp tokens
- *
- * Publishing both from day one is what makes key rotation a no-coordination
- * change: a new key is added here alongside the old until old tokens expire.
- */
-export async function getPublicJwks(): Promise<{ keys: jose.JWK[] }> {
-  const [access, miniapp, account] = await Promise.all([
-    getMentraKeys(),
-    getMiniappKeys(),
-    getAccountKeys(),
-  ]);
-  const [accessJwk, miniappJwk, accountJwk] = await Promise.all([
-    jose.exportJWK(access.publicKey),
-    jose.exportJWK(miniapp.publicKey),
-    jose.exportJWK(account.publicKey),
-  ]);
-  return {
-    keys: [
-      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: ACCESS_TOKEN_KID },
-      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: RUNTIME_TOKEN_KID },
-      { ...miniappJwk, alg: MENTRA_ALG, use: "sig", kid: MINIAPP_TOKEN_KID },
-      { ...accountJwk, alg: MENTRA_ALG, use: "sig", kid: ACCOUNT_TOKEN_KID },
-    ],
-  };
-}
-
-/**
- * Reconstruct a PEM block from a stored base64 body. We store only the body
- * to keep env values short and free of `\n` escapes; the wrapper is
- * informationless for Ed25519 (always PKCS#8 / SPKI).
- */
-function toPem(base64Body: string, label: "PRIVATE KEY" | "PUBLIC KEY"): string {
-  return `-----BEGIN ${label}-----\n${base64Body}\n-----END ${label}-----`;
-}
-
-function requireEnv(name: string): string {
-  const v = process.env[name];
-  if (!v) throw new OauthServerError(`env var ${name} is not set`);
-  return v;
-}
 
 // === Internals: token issuance ===
 

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -78,6 +78,12 @@ const MINIAPP_TOKEN_DEFAULT_TTL_SEC = 60 * 60; // 1 hour
 const ACCESS_TOKEN_KID = "mentra-access-1";
 const RUNTIME_TOKEN_KID = "cloud-core-runtime-1";
 const MINIAPP_TOKEN_KID = "mentra-miniapp-1";
+const ACCOUNT_TOKEN_KID = "mentra-account-1";
+// Mentra's own first-party account backend signs subject tokens with this key
+// and pushes them through the SAME exchange path OEMs use (see issue 019). The
+// `mentra` OEM row (startup migration) carries this public key so verifyTenantJwt
+// verifies them. TTL is tiny: the token exists only to cross into createSession.
+const ACCOUNT_SUBJECT_TOKEN_TTL_SEC = 60;
 
 // === Public API ===
 
@@ -277,6 +283,23 @@ export async function revokeAllForOem(tenantId: string): Promise<{ deletedSessio
     { tenantId, deletedSessions: result.deletedCount },
     "bulk-revoked oem sessions",
   );
+  return { deletedSessions: result.deletedCount ?? 0 };
+}
+
+/**
+ * Revoke every refresh token for one user (logout-everywhere, and the
+ * "password change/reset revokes other sessions" requirement). `exceptSessionId`
+ * keeps the current session alive (e.g. logout-everywhere from the active app
+ * without kicking itself). Deleting the refresh token means the session cannot
+ * re-up; the access token dies at its natural expiry.
+ */
+export async function revokeAllSessionsForUser(args: {
+  mentraUserId: string;
+  exceptSessionId?: string;
+}): Promise<{ deletedSessions: number }> {
+  const filter: Record<string, unknown> = { mentraUserId: args.mentraUserId };
+  if (args.exceptSessionId) filter.sessionId = { $ne: args.exceptSessionId };
+  const result = await RefreshTokenModel.deleteMany(filter);
   return { deletedSessions: result.deletedCount ?? 0 };
 }
 
@@ -525,6 +548,54 @@ async function getMiniappKeys() {
 export function resetSigningKeyCache(): void {
   mentraKeys = null;
   miniappKeys = null;
+  accountKeys = null;
+}
+
+/**
+ * Mint a short-lived Ed25519 subject token for Mentra's first-party account
+ * backend, issued under the `mentra` tenant. It is fed straight into
+ * createSession, where verifyTenantJwt validates it against the `mentra` OEM
+ * row's public key. This is how Mentra dogfoods its own OEM path instead of a
+ * bespoke identity branch (issue 019).
+ */
+export async function mintAccountSubjectToken(args: { tenantUserId: string }): Promise<string> {
+  const { privateKey } = await getAccountKeys();
+  return new jose.SignJWT({})
+    .setProtectedHeader({ alg: MENTRA_ALG, kid: ACCOUNT_TOKEN_KID })
+    // iss = the OEM tenantId ("mentra"); aud = "mentra", the value the OEM
+    // verifier (verifySignatureWithOemKey) pins for all OEM subject tokens.
+    .setIssuer(MENTRA_OEM_ID)
+    .setAudience(MENTRA_OEM_ID)
+    .setSubject(args.tenantUserId)
+    .setJti(ulid())
+    .setIssuedAt()
+    .setExpirationTime(`${ACCOUNT_SUBJECT_TOKEN_TTL_SEC}s`)
+    .sign(privateKey);
+}
+
+let accountKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
+
+async function getAccountKeys() {
+  if (!accountKeys) accountKeys = loadAccountKeys();
+  return accountKeys;
+}
+
+async function loadAccountKeys() {
+  const privB64 = requireEnv("MENTRA_ACCOUNT_JWT_PRIVATE_KEY");
+  const pubB64 = requireEnv("MENTRA_ACCOUNT_JWT_PUBLIC_KEY");
+  const [privateKey, publicKey] = await Promise.all([
+    jose.importPKCS8(toPem(privB64, "PRIVATE KEY"), MENTRA_ALG, { extractable: false }),
+    jose.importSPKI(toPem(pubB64, "PUBLIC KEY"), MENTRA_ALG, { extractable: true }),
+  ]);
+  logger.info("loaded Mentra account-token signing keypair");
+  return { privateKey, publicKey };
+}
+
+/** The account signing public key in SPKI PEM form, for seeding the `mentra`
+ * OEM row (static key mode). */
+export async function getAccountPublicKeyPem(): Promise<string> {
+  const pubB64 = requireEnv("MENTRA_ACCOUNT_JWT_PUBLIC_KEY");
+  return toPem(pubB64, "PUBLIC KEY");
 }
 
 async function loadMentraKeys() {
@@ -574,16 +645,22 @@ async function loadMiniappKeys() {
  * change: a new key is added here alongside the old until old tokens expire.
  */
 export async function getPublicJwks(): Promise<{ keys: jose.JWK[] }> {
-  const [access, miniapp] = await Promise.all([getMentraKeys(), getMiniappKeys()]);
-  const [accessJwk, miniappJwk] = await Promise.all([
+  const [access, miniapp, account] = await Promise.all([
+    getMentraKeys(),
+    getMiniappKeys(),
+    getAccountKeys(),
+  ]);
+  const [accessJwk, miniappJwk, accountJwk] = await Promise.all([
     jose.exportJWK(access.publicKey),
     jose.exportJWK(miniapp.publicKey),
+    jose.exportJWK(account.publicKey),
   ]);
   return {
     keys: [
       { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: ACCESS_TOKEN_KID },
       { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: RUNTIME_TOKEN_KID },
       { ...miniappJwk, alg: MENTRA_ALG, use: "sig", kid: MINIAPP_TOKEN_KID },
+      { ...accountJwk, alg: MENTRA_ALG, use: "sig", kid: ACCOUNT_TOKEN_KID },
     ],
   };
 }

--- a/cloud-v2/packages/core/src/services/signing-keys.service.ts
+++ b/cloud-v2/packages/core/src/services/signing-keys.service.ts
@@ -79,6 +79,15 @@ export async function getAccountKeys() {
   return accountKeys;
 }
 
+/** Whether the account signing keypair is configured. Environments deployed
+ * before the account rollout run with the feature dark; everything account-key
+ * dependent (JWKS entry, OEM-row seeding) must degrade gracefully, not 500. */
+export function accountKeysConfigured(): boolean {
+  return Boolean(
+    process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY && process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY,
+  );
+}
+
 /**
  * Reset the lazy-loaded signing keypair caches. **Test-only.** Production has no
  * reason to rotate keys mid-process; tests that mutate the key env vars between
@@ -106,18 +115,23 @@ export function getAccountPublicKeyPem(): string {
  * Publishing keys ahead of need makes rotation a no-coordination change.
  */
 export async function getPublicJwks(): Promise<{ keys: jose.JWK[] }> {
-  const [access, miniapp, account] = await Promise.all([getMentraKeys(), getMiniappKeys(), getAccountKeys()]);
-  const [accessJwk, miniappJwk, accountJwk] = await Promise.all([
+  const [access, miniapp] = await Promise.all([getMentraKeys(), getMiniappKeys()]);
+  const [accessJwk, miniappJwk] = await Promise.all([
     jose.exportJWK(access.publicKey),
     jose.exportJWK(miniapp.publicKey),
-    jose.exportJWK(account.publicKey),
   ]);
-  return {
-    keys: [
-      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: ACCESS_TOKEN_KID },
-      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: RUNTIME_TOKEN_KID },
-      { ...miniappJwk, alg: MENTRA_ALG, use: "sig", kid: MINIAPP_TOKEN_KID },
-      { ...accountJwk, alg: MENTRA_ALG, use: "sig", kid: ACCOUNT_TOKEN_KID },
-    ],
-  };
+  const keys: jose.JWK[] = [
+    { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: ACCESS_TOKEN_KID },
+    { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: RUNTIME_TOKEN_KID },
+    { ...miniappJwk, alg: MENTRA_ALG, use: "sig", kid: MINIAPP_TOKEN_KID },
+  ];
+  // The account key is optional: environments deployed before the account env
+  // vars exist must keep serving the access/runtime/miniapp keys (the startup
+  // migration skips the mentra OEM seed the same way).
+  if (accountKeysConfigured()) {
+    const account = await getAccountKeys();
+    const accountJwk = await jose.exportJWK(account.publicKey);
+    keys.push({ ...accountJwk, alg: MENTRA_ALG, use: "sig", kid: ACCOUNT_TOKEN_KID });
+  }
+  return { keys };
 }

--- a/cloud-v2/packages/core/src/services/signing-keys.service.ts
+++ b/cloud-v2/packages/core/src/services/signing-keys.service.ts
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Signing keys and the public JWKS.
+ *
+ * Owns everything crypto-key: lazy-loading Mentra's Ed25519 signing keypairs
+ * from env (access, miniapp, account), the `kid` constants, and building the
+ * public `/.well-known/jwks.json` document. Split out of session.service so
+ * that file is about session lifecycle, not key management (issue 019).
+ *
+ * Keys are loaded lazily on first use and cached; `resetSigningKeyCache` exists
+ * for tests that mutate the key env vars mid-process.
+ */
+import * as jose from "jose";
+import { createLogger } from "@mentra/cloud-shared";
+import { OauthServerError } from "../types/oauth.types";
+
+const logger = createLogger("core").child({ service: "signing-keys.service" });
+
+export const MENTRA_ALG = "EdDSA";
+
+// Each token type is signed with its own key, tagged by `kid` so verifiers pick
+// the right public key from the JWKS. Distinct keys keep a leak's blast radius
+// to one token type.
+export const ACCESS_TOKEN_KID = "mentra-access-1";
+export const RUNTIME_TOKEN_KID = "cloud-core-runtime-1";
+export const MINIAPP_TOKEN_KID = "mentra-miniapp-1";
+export const ACCOUNT_TOKEN_KID = "mentra-account-1";
+
+export function requireEnv(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new OauthServerError(`env var ${name} is not set`);
+  return v;
+}
+
+/**
+ * Reconstruct a PEM block from a stored base64 body. We store only the body to
+ * keep env values short and free of `\n` escapes; the wrapper is
+ * informationless for Ed25519 (always PKCS#8 / SPKI).
+ */
+function toPem(base64Body: string, label: "PRIVATE KEY" | "PUBLIC KEY"): string {
+  return `-----BEGIN ${label}-----\n${base64Body}\n-----END ${label}-----`;
+}
+
+async function loadKeypair(
+  privEnv: string,
+  pubEnv: string,
+  label: string,
+): Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> {
+  const [privateKey, publicKey] = await Promise.all([
+    jose.importPKCS8(toPem(requireEnv(privEnv), "PRIVATE KEY"), MENTRA_ALG, { extractable: false }),
+    // Public key stays extractable so we can export it to JWK for the JWKS.
+    jose.importSPKI(toPem(requireEnv(pubEnv), "PUBLIC KEY"), MENTRA_ALG, { extractable: true }),
+  ]);
+  logger.info(`loaded Mentra ${label} signing keypair`);
+  return { privateKey, publicKey };
+}
+
+let mentraKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
+let miniappKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
+let accountKeys: Promise<{ privateKey: jose.KeyLike; publicKey: jose.KeyLike }> | null = null;
+
+export async function getMentraKeys() {
+  if (!mentraKeys) mentraKeys = loadKeypair("MENTRA_JWT_PRIVATE_KEY", "MENTRA_JWT_PUBLIC_KEY", "access-token");
+  return mentraKeys;
+}
+
+export async function getMiniappKeys() {
+  // Falling back to the access-token key is intentionally NOT done: the keys
+  // must be distinct for the blast-radius guarantee.
+  if (!miniappKeys) {
+    miniappKeys = loadKeypair("MENTRA_MINIAPP_JWT_PRIVATE_KEY", "MENTRA_MINIAPP_JWT_PUBLIC_KEY", "miniapp-token");
+  }
+  return miniappKeys;
+}
+
+export async function getAccountKeys() {
+  if (!accountKeys) {
+    accountKeys = loadKeypair("MENTRA_ACCOUNT_JWT_PRIVATE_KEY", "MENTRA_ACCOUNT_JWT_PUBLIC_KEY", "account-token");
+  }
+  return accountKeys;
+}
+
+/**
+ * Reset the lazy-loaded signing keypair caches. **Test-only.** Production has no
+ * reason to rotate keys mid-process; tests that mutate the key env vars between
+ * files in the same Bun process need to discard the cached imports.
+ */
+export function resetSigningKeyCache(): void {
+  mentraKeys = null;
+  miniappKeys = null;
+  accountKeys = null;
+}
+
+/** The account signing public key in SPKI PEM form, for seeding the `mentra`
+ * OEM row (static key mode). */
+export function getAccountPublicKeyPem(): string {
+  return toPem(requireEnv("MENTRA_ACCOUNT_JWT_PUBLIC_KEY"), "PUBLIC KEY");
+}
+
+/**
+ * Build the public JWKS document Mentra publishes at /.well-known/jwks.json.
+ * Each public key is tagged with its `kid` so a verifier picks the right one:
+ *   - access-token key (internal services verify access tokens),
+ *   - runtime-token key (Runtime trusts Core-brokered runtime tokens),
+ *   - miniapp-token key (developer backends verify miniapp tokens),
+ *   - account-token key (audit visibility for Mentra's own OEM subject tokens).
+ * Publishing keys ahead of need makes rotation a no-coordination change.
+ */
+export async function getPublicJwks(): Promise<{ keys: jose.JWK[] }> {
+  const [access, miniapp, account] = await Promise.all([getMentraKeys(), getMiniappKeys(), getAccountKeys()]);
+  const [accessJwk, miniappJwk, accountJwk] = await Promise.all([
+    jose.exportJWK(access.publicKey),
+    jose.exportJWK(miniapp.publicKey),
+    jose.exportJWK(account.publicKey),
+  ]);
+  return {
+    keys: [
+      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: ACCESS_TOKEN_KID },
+      { ...accessJwk, alg: MENTRA_ALG, use: "sig", kid: RUNTIME_TOKEN_KID },
+      { ...miniappJwk, alg: MENTRA_ALG, use: "sig", kid: MINIAPP_TOKEN_KID },
+      { ...accountJwk, alg: MENTRA_ALG, use: "sig", kid: ACCOUNT_TOKEN_KID },
+    ],
+  };
+}

--- a/cloud-v2/porter.isaiah.yaml
+++ b/cloud-v2/porter.isaiah.yaml
@@ -1,0 +1,67 @@
+version: v2
+name: cloud-isaiah
+
+envGroups:
+  - cloud-v2-isaiah-doppler
+
+build:
+  method: docker
+  context: ../
+  dockerfile: ./docker/Dockerfile
+
+services:
+  - name: core
+    type: web
+    run: bun packages/core/src/index.ts
+    port: 3000
+    instances: 1
+    cpuCores: 0.25
+    ramMegabytes: 1024
+    domains:
+      - name: core.isaiah.us-west-2.mentraglass.com
+    livenessCheck:
+      enabled: true
+      httpPath: /healthz
+      timeoutSeconds: 3
+      initialDelaySeconds: 15
+    readinessCheck:
+      enabled: true
+      httpPath: /ready
+      timeoutSeconds: 5
+      initialDelaySeconds: 15
+    ingressAnnotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    terminationGracePeriodSeconds: 10
+
+  - name: runtime
+    type: web
+    run: bun packages/runtime/src/index.ts
+    port: 3001
+    instances: 1
+    cpuCores: 0.5
+    ramMegabytes: 2048
+    domains:
+      - name: runtime.isaiah.us-west-2.mentraglass.com
+    env:
+      AUDIO_WORKERS: "1"
+    livenessCheck:
+      enabled: true
+      httpPath: /healthz
+      timeoutSeconds: 3
+      initialDelaySeconds: 15
+    readinessCheck:
+      enabled: true
+      httpPath: /ready
+      timeoutSeconds: 5
+      initialDelaySeconds: 15
+    ingressAnnotations:
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "60"
+    terminationGracePeriodSeconds: 10
+    additionalPorts:
+      - port: 8000
+        protocol: UDP
+        name: udp-audio

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -1,0 +1,245 @@
+/**
+ * @fileoverview Integration tests for the Mentra account module (issue 019),
+ * with a mock GoTrue server so no real Supabase is needed. Prereq: a running
+ * Mongo (override via MONGO_URL). Wipes its own collections.
+ *
+ * Run: bun test tests/account-auth.integration.test.ts
+ */
+import crypto from "node:crypto";
+import http from "node:http";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// Crypto material must be set BEFORE importing core so the lazy key loader picks
+// it up (mirrors the other integration tests).
+{
+  const strip = (pem: string) =>
+    pem.replace(/-----BEGIN [^-]+-----/, "").replace(/-----END [^-]+-----/, "").replace(/\s+/g, "");
+  const mk = () => {
+    const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+    return {
+      priv: strip(privateKey.export({ type: "pkcs8", format: "pem" }).toString()),
+      pub: strip(publicKey.export({ type: "spki", format: "pem" }).toString()),
+    };
+  };
+  const access = mk(), miniapp = mk(), account = mk();
+  process.env.MENTRA_JWT_PRIVATE_KEY = access.priv;
+  process.env.MENTRA_JWT_PUBLIC_KEY = access.pub;
+  process.env.MENTRA_MINIAPP_JWT_PRIVATE_KEY = miniapp.priv;
+  process.env.MENTRA_MINIAPP_JWT_PUBLIC_KEY = miniapp.pub;
+  process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY = account.priv;
+  process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY = account.pub;
+  process.env.REFRESH_TOKEN_PEPPER ??= "test-pepper-not-for-production";
+  process.env.MONGO_URL ??= "mongodb://127.0.0.1:27017/mentra-cloud-v2-test";
+}
+
+// eslint-disable-next-line import/first
+import {
+  connectMongo,
+  disconnectMongo,
+  mongoReadinessCheck,
+} from "../packages/core/src/connections/mongo.connection";
+import { createApp } from "../packages/core/src/api/app";
+import { OemModel } from "../packages/core/src/models/oem.model";
+import { UserModel } from "../packages/core/src/models/user.model";
+import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
+import { AccountCodeModel } from "../packages/core/src/models/account-code.model";
+import { SeenJtiModel } from "../packages/core/src/models/seen-jti.model";
+
+const TEST_EMAIL = "isaiah+android@mentraglass.com";
+const TEST_PASSWORD = "android1";
+const SUPABASE_USER_ID = "sb-user-0001";
+
+let app: ReturnType<typeof createApp>;
+let gotrueServer: http.Server;
+// mutable mock state
+let userVerified = true;
+let storedPassword = TEST_PASSWORD;
+
+beforeAll(async () => {
+  // Mock GoTrue: password grant, admin user lookup/update.
+  gotrueServer = http.createServer((req, res) => {
+    const send = (status: number, body: unknown) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    const url = new URL(req.url ?? "/", "http://localhost");
+    let raw = "";
+    req.on("data", (c) => (raw += c));
+    req.on("end", () => {
+      const body = raw ? JSON.parse(raw) : {};
+      const userObj = {
+        id: SUPABASE_USER_ID,
+        email: TEST_EMAIL,
+        email_confirmed_at: userVerified ? "2026-01-01T00:00:00Z" : null,
+        user_metadata: { full_name: "Isaiah Android" },
+      };
+      // POST /auth/v1/token?grant_type=password
+      if (url.pathname === "/auth/v1/token" && url.searchParams.get("grant_type") === "password") {
+        if (body.email === TEST_EMAIL && body.password === storedPassword) {
+          return send(200, { access_token: "sb", user: userObj });
+        }
+        return send(400, { error: "invalid_grant", error_description: "bad creds" });
+      }
+      // GET /auth/v1/admin/users?filter=email
+      if (url.pathname === "/auth/v1/admin/users" && req.method === "GET") {
+        return send(200, { users: [userObj] });
+      }
+      // GET /auth/v1/admin/users/:id
+      if (url.pathname.startsWith("/auth/v1/admin/users/") && req.method === "GET") {
+        return send(200, userObj);
+      }
+      // PUT /auth/v1/admin/users/:id  (password/email change)
+      if (url.pathname.startsWith("/auth/v1/admin/users/") && req.method === "PUT") {
+        if (body.password) storedPassword = body.password;
+        return send(200, userObj);
+      }
+      if (url.pathname === "/auth/v1/signup") return send(200, userObj);
+      if (url.pathname === "/auth/v1/resend") return send(200, {});
+      return send(404, { error: "not found" });
+    });
+  });
+  await new Promise<void>((r) => gotrueServer.listen(0, "127.0.0.1", r));
+  const addr = gotrueServer.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  process.env.SUPABASE_URL = `http://127.0.0.1:${port}`;
+  process.env.SUPABASE_ANON_KEY = "anon-test";
+  process.env.SUPABASE_SERVICE_ROLE_KEY = "service-test";
+
+  await connectMongo(process.env.MONGO_URL!);
+  await Promise.all([
+    OemModel.syncIndexes(),
+    UserModel.syncIndexes(),
+    RefreshTokenModel.syncIndexes(),
+    AccountCodeModel.syncIndexes(),
+    SeenJtiModel.syncIndexes(),
+  ]);
+  // Seed the mentra OEM row with the account public key (the startup migration
+  // does this in prod).
+  const pub = `-----BEGIN PUBLIC KEY-----\n${process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY}\n-----END PUBLIC KEY-----`;
+  await OemModel.updateOne(
+    { tenantId: "mentra" },
+    { $set: { displayName: "Mentra", publicKeyMode: "static", publicKey: pub, disabled: false } },
+    { upsert: true },
+  );
+  app = createApp({ readinessChecks: [mongoReadinessCheck] });
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => gotrueServer.close(() => r()));
+  await disconnectMongo();
+});
+
+beforeEach(async () => {
+  userVerified = true;
+  storedPassword = TEST_PASSWORD;
+  await Promise.all([
+    UserModel.deleteMany({ tenantId: "mentra" }),
+    RefreshTokenModel.deleteMany({}),
+    AccountCodeModel.deleteMany({}),
+    SeenJtiModel.deleteMany({}),
+  ]);
+});
+
+function post(path: string, body: unknown, token?: string): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        ...(token ? { authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+  );
+}
+
+describe("account auth", () => {
+  test("login with valid credentials returns a V2 session whose refresh works", async () => {
+    const res = await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { access_token: string; refresh_token: string };
+    expect(body.access_token).toBeTruthy();
+    expect(body.refresh_token).toBeTruthy();
+
+    // The session was minted through the OEM path, so a user row exists under
+    // tenant "mentra" keyed on the Supabase id.
+    const user = await UserModel.findOne({ tenantId: "mentra", tenantUserId: SUPABASE_USER_ID }).lean();
+    expect(user).toBeTruthy();
+
+    // And refresh works (regression for the enterprise-refresh bug class).
+    const refresh = await app.fetch(
+      new Request("http://localhost/api/client/auth/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: body.refresh_token }),
+      }),
+    );
+    expect(refresh.status).toBe(200);
+  });
+
+  test("login with wrong password is invalid_credentials (uniform)", async () => {
+    const res = await post("/api/account/login", { email: TEST_EMAIL, password: "wrong" });
+    expect(res.status).toBe(401);
+    expect((await res.json()).error).toBe("invalid_credentials");
+  });
+
+  test("login for an unverified account is verification_required", async () => {
+    userVerified = false;
+    const res = await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error).toBe("verification_required");
+  });
+
+  test("/me returns identity for a logged-in user", async () => {
+    const login = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
+      access_token: string;
+    };
+    const res = await app.fetch(
+      new Request("http://localhost/api/account/me", {
+        headers: { authorization: `Bearer ${login.access_token}` },
+      }),
+    );
+    expect(res.status).toBe(200);
+    const me = (await res.json()) as { email: string; mentraUserId: string };
+    expect(me.email).toBe(TEST_EMAIL);
+    expect(me.mentraUserId).toMatch(/^mu_/);
+  });
+
+  test("password reset consumes a single-use code and revokes other sessions", async () => {
+    // Two active sessions.
+    const s1 = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
+      refresh_token: string;
+    };
+    await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(await RefreshTokenModel.countDocuments({})).toBe(2);
+
+    await post("/api/account/password/forgot", { email: TEST_EMAIL });
+    const codeDoc = await AccountCodeModel.findOne({ purpose: "password_reset" }).lean();
+    expect(codeDoc).toBeTruthy();
+    // We stored a hash; re-issue with a known code by reading the plaintext is
+    // not possible, so drive reset through the service path: fetch the code via
+    // the email side-channel is mocked out, so instead assert single-use by
+    // consuming a fabricated wrong code fails.
+    const bad = await post("/api/account/password/reset", {
+      email: TEST_EMAIL,
+      code: "000000",
+      newPassword: "android2",
+    });
+    expect(bad.status).toBe(400);
+    expect((await bad.json()).error).toBe("code_invalid");
+    // The old sessions are untouched by a failed reset.
+    void s1;
+    expect(await RefreshTokenModel.countDocuments({})).toBe(2);
+  });
+
+  test("logout everywhere clears all of the user's sessions", async () => {
+    const a = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
+      access_token: string;
+    };
+    await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD });
+    expect(await RefreshTokenModel.countDocuments({})).toBe(2);
+    const res = await post("/api/account/logout", { everywhere: true }, a.access_token);
+    expect(res.status).toBe(204);
+    expect(await RefreshTokenModel.countDocuments({})).toBe(0);
+  });
+});

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -232,6 +232,61 @@ describe("account auth", () => {
     expect(await RefreshTokenModel.countDocuments({})).toBe(2);
   });
 
+  test("OEM parity: the mentra subject token works through the PUBLIC exchange endpoint", async () => {
+    // Issue 019 requirement: Mentra must be just another OEM. The account
+    // module's subject token has to be exchangeable at the same public RFC 8693
+    // endpoint any external OEM uses, with no special path. If this test fails,
+    // Mentra has grown a privileged backdoor.
+    const { mintAccountSubjectToken } = await import("../packages/core/src/services/session.service");
+    const subjectToken = await mintAccountSubjectToken({ tenantUserId: SUPABASE_USER_ID });
+
+    const res = await app.fetch(
+      new Request("http://localhost/api/client/auth/exchange", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+          subject_token: subjectToken,
+          subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+        }),
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { access_token?: string; refresh_token?: string };
+    expect(body.access_token).toBeTruthy();
+    expect(body.refresh_token).toBeTruthy();
+
+    // And the resulting session refreshes via the oems-row check (no mentra
+    // special case), because the seeded `mentra` row authorizes it.
+    const refresh = await app.fetch(
+      new Request("http://localhost/api/client/auth/refresh", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: body.refresh_token! }),
+      }),
+    );
+    expect(refresh.status).toBe(200);
+  });
+
+  test("OEM parity: a DISABLED mentra oems row blocks refresh like any OEM", async () => {
+    const login = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
+      refresh_token: string;
+    };
+    await OemModel.updateOne({ tenantId: "mentra" }, { $set: { disabled: true } });
+    try {
+      const refresh = await app.fetch(
+        new Request("http://localhost/api/client/auth/refresh", {
+          method: "POST",
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams({ grant_type: "refresh_token", refresh_token: login.refresh_token }),
+        }),
+      );
+      expect(refresh.status).toBe(401);
+    } finally {
+      await OemModel.updateOne({ tenantId: "mentra" }, { $set: { disabled: false } });
+    }
+  });
+
   test("logout everywhere clears all of the user's sessions", async () => {
     const a = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
       access_token: string;

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -344,6 +344,63 @@ describe("account auth", () => {
     expect(u.searchParams.get("code_challenge_method")).toBe("s256");
   });
 
+  test("external-OEM sessions are rejected by the account endpoints (tenant gate)", async () => {
+    // Stand up a second OEM ("acme-test") exactly the way an external partner
+    // would exist: static-key oems row + a self-signed subject token.
+    const strip = (pem: string) =>
+      pem.replace(/-----BEGIN [^-]+-----/, "").replace(/-----END [^-]+-----/, "").replace(/\s+/g, "");
+    const acme = crypto.generateKeyPairSync("ed25519");
+    await OemModel.updateOne(
+      { tenantId: "acme-test" },
+      {
+        $set: {
+          displayName: "Acme Test",
+          publicKeyMode: "static",
+          publicKey: `-----BEGIN PUBLIC KEY-----\n${strip(acme.publicKey.export({ type: "spki", format: "pem" }).toString())}\n-----END PUBLIC KEY-----`,
+          disabled: false,
+        },
+      },
+      { upsert: true },
+    );
+    // Hand-rolled EdDSA JWS (jose isn't resolvable from tests/ under the
+    // isolated installer; Ed25519 signing is one node:crypto call anyway).
+    const b64u = (b: Buffer | string) => Buffer.from(b).toString("base64url");
+    const now = Math.floor(Date.now() / 1000);
+    const header = b64u(JSON.stringify({ alg: "EdDSA", typ: "JWT" }));
+    const claims = b64u(
+      JSON.stringify({ iss: "acme-test", aud: "mentra", sub: "acme-user-42", jti: "acme-jti-1", iat: now, exp: now + 60 }),
+    );
+    const sig = crypto.sign(null, Buffer.from(`${header}.${claims}`), acme.privateKey);
+    const subjectToken = `${header}.${claims}.${b64u(sig)}`;
+
+    // The public exchange gives the OEM user a perfectly valid session...
+    const ex = await app.fetch(
+      new Request("http://localhost/api/client/auth/exchange", {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
+          subject_token: subjectToken,
+          subject_token_type: "urn:ietf:params:oauth:token-type:jwt",
+        }),
+      }),
+    );
+    expect(ex.status).toBe(200);
+    const { access_token } = (await ex.json()) as { access_token: string };
+
+    // ...but the first-party account surface must reject it. Without the gate,
+    // /subject-token would mint this OEM user a `mentra` session.
+    const st = await post("/api/account/subject-token", {}, access_token);
+    expect(st.status).toBe(403);
+    expect((await st.json()).error).toBe("unauthorized_client");
+    const me = await app.fetch(
+      new Request("http://localhost/api/account/me", {
+        headers: { authorization: `Bearer ${access_token}` },
+      }),
+    );
+    expect(me.status).toBe(403);
+  });
+
   test("login is rate limited per spec: 429 with rate_limited after the window fills", async () => {
     // Limit is 10/min per IP; the 11th attempt in the window must 429.
     let last: Response | null = null;

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -40,6 +40,7 @@ import {
 } from "../packages/core/src/connections/mongo.connection";
 import { createApp } from "../packages/core/src/api/app";
 import { resetSigningKeyCache, getPublicJwks } from "../packages/core/src/services/signing-keys.service";
+import { resetAccountRateLimits } from "../packages/core/src/api/account/rate-limit";
 import { gotrue, otc } from "../packages/core/src/services/account/account.service";
 import { OemModel } from "../packages/core/src/models/oem.model";
 import { UserModel } from "../packages/core/src/models/user.model";
@@ -140,6 +141,7 @@ beforeEach(async () => {
   userVerified = true;
   storedPassword = TEST_PASSWORD;
   storedEmail = TEST_EMAIL;
+  resetAccountRateLimits();
   await Promise.all([
     UserModel.deleteMany({ tenantId: "mentra" }),
     RefreshTokenModel.deleteMany({}),
@@ -340,6 +342,25 @@ describe("account auth", () => {
     expect(u.searchParams.get("provider")).toBe("google");
     expect(u.searchParams.get("code_challenge")).toBe("CHALLENGE-S256");
     expect(u.searchParams.get("code_challenge_method")).toBe("s256");
+  });
+
+  test("login is rate limited per spec: 429 with rate_limited after the window fills", async () => {
+    // Limit is 10/min per IP; the 11th attempt in the window must 429.
+    let last: Response | null = null;
+    for (let i = 0; i < 11; i++) {
+      last = await post("/api/account/login", { email: TEST_EMAIL, password: "wrong-password" });
+    }
+    expect(last!.status).toBe(429);
+    expect((await last!.json()).error).toBe("rate_limited");
+    // A different source IP is not affected by the exhausted bucket.
+    const other = await app.fetch(
+      new Request("http://localhost/api/account/login", {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-forwarded-for": "203.0.113.7" },
+        body: JSON.stringify({ email: "someone-else@example.com", password: "nope" }),
+      }),
+    );
+    expect(other.status).not.toBe(429);
   });
 
   test("JWKS omits the account kid (and does not 500) when account keys are unset", async () => {

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -39,7 +39,8 @@ import {
   mongoReadinessCheck,
 } from "../packages/core/src/connections/mongo.connection";
 import { createApp } from "../packages/core/src/api/app";
-import { resetSigningKeyCache } from "../packages/core/src/services/signing-keys.service";
+import { resetSigningKeyCache, getPublicJwks } from "../packages/core/src/services/signing-keys.service";
+import { gotrue, otc } from "../packages/core/src/services/account/account.service";
 import { OemModel } from "../packages/core/src/models/oem.model";
 import { UserModel } from "../packages/core/src/models/user.model";
 import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
@@ -55,6 +56,7 @@ let gotrueServer: http.Server;
 // mutable mock state
 let userVerified = true;
 let storedPassword = TEST_PASSWORD;
+let storedEmail = TEST_EMAIL;
 
 beforeAll(async () => {
   // Mock GoTrue: password grant, admin user lookup/update.
@@ -70,7 +72,7 @@ beforeAll(async () => {
       const body = raw ? JSON.parse(raw) : {};
       const userObj = {
         id: SUPABASE_USER_ID,
-        email: TEST_EMAIL,
+        email: storedEmail,
         email_confirmed_at: userVerified ? "2026-01-01T00:00:00Z" : null,
         user_metadata: { full_name: "Isaiah Android" },
       };
@@ -92,6 +94,7 @@ beforeAll(async () => {
       // PUT /auth/v1/admin/users/:id  (password/email change)
       if (url.pathname.startsWith("/auth/v1/admin/users/") && req.method === "PUT") {
         if (body.password) storedPassword = body.password;
+        if (body.email) storedEmail = body.email;
         return send(200, userObj);
       }
       if (url.pathname === "/auth/v1/signup") return send(200, userObj);
@@ -136,6 +139,7 @@ afterAll(async () => {
 beforeEach(async () => {
   userVerified = true;
   storedPassword = TEST_PASSWORD;
+  storedEmail = TEST_EMAIL;
   await Promise.all([
     UserModel.deleteMany({ tenantId: "mentra" }),
     RefreshTokenModel.deleteMany({}),
@@ -300,5 +304,63 @@ describe("account auth", () => {
     const res = await post("/api/account/logout", { everywhere: true }, a.access_token);
     expect(res.status).toBe(204);
     expect(await RefreshTokenModel.countDocuments({})).toBe(0);
+  });
+
+  test("email change is verification-gated: request does NOT apply, confirm with the code does", async () => {
+    const a = (await (await post("/api/account/login", { email: TEST_EMAIL, password: TEST_PASSWORD })).json()) as {
+      access_token: string;
+    };
+    const newEmail = "isaiah+new@mentraglass.com";
+
+    // Step 1: request. Issues a code to the new address, applies NOTHING yet.
+    const req = await post("/api/account/email/change", { newEmail, password: TEST_PASSWORD }, a.access_token);
+    expect(req.status).toBe(202);
+    expect(storedEmail).toBe(TEST_EMAIL); // GoTrue untouched — the old bug applied it here
+    expect(await AccountCodeModel.countDocuments({ purpose: "email_change" })).toBe(1);
+
+    // Wrong code is rejected.
+    const bad = await post("/api/account/email/change/confirm", { code: "000000" }, a.access_token);
+    expect(bad.status).toBe(400);
+    expect(storedEmail).toBe(TEST_EMAIL);
+
+    // Step 2: a valid code (minted via the same service the email uses) applies it.
+    const code = await otc.issueEmailCode({
+      purpose: "email_change",
+      subject: SUPABASE_USER_ID,
+      ttlSec: 60,
+      payload: { newEmail },
+    });
+    const ok = await post("/api/account/email/change/confirm", { code }, a.access_token);
+    expect(ok.status).toBe(204);
+    expect(storedEmail).toBe(newEmail);
+  });
+
+  test("OAuth authorize URL carries the PKCE challenge for the core<->GoTrue leg", () => {
+    const u = new URL(gotrue.authorizeUrl("google", "https://core.example/cb", "CHALLENGE-S256"));
+    expect(u.searchParams.get("provider")).toBe("google");
+    expect(u.searchParams.get("code_challenge")).toBe("CHALLENGE-S256");
+    expect(u.searchParams.get("code_challenge_method")).toBe("s256");
+  });
+
+  test("JWKS omits the account kid (and does not 500) when account keys are unset", async () => {
+    const priv = process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY;
+    const pub = process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY;
+    try {
+      delete process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY;
+      delete process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY;
+      resetSigningKeyCache();
+      const jwks = await getPublicJwks();
+      const kids = jwks.keys.map((k) => k.kid);
+      expect(kids).toContain("mentra-access-1");
+      expect(kids).toContain("mentra-miniapp-1");
+      expect(kids).not.toContain("mentra-account-1");
+    } finally {
+      process.env.MENTRA_ACCOUNT_JWT_PRIVATE_KEY = priv;
+      process.env.MENTRA_ACCOUNT_JWT_PUBLIC_KEY = pub;
+      resetSigningKeyCache();
+    }
+    // With the keys restored the account kid is published again.
+    const jwks = await getPublicJwks();
+    expect(jwks.keys.map((k) => k.kid)).toContain("mentra-account-1");
   });
 });

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -39,6 +39,7 @@ import {
   mongoReadinessCheck,
 } from "../packages/core/src/connections/mongo.connection";
 import { createApp } from "../packages/core/src/api/app";
+import { resetSigningKeyCache } from "../packages/core/src/services/signing-keys.service";
 import { OemModel } from "../packages/core/src/models/oem.model";
 import { UserModel } from "../packages/core/src/models/user.model";
 import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
@@ -105,6 +106,9 @@ beforeAll(async () => {
   process.env.SUPABASE_ANON_KEY = "anon-test";
   process.env.SUPABASE_SERVICE_ROLE_KEY = "service-test";
 
+  // Discard any signing keys another test file cached into the shared module
+  // state, so this file's own key env vars are used (mirrors the audio tests).
+  resetSigningKeyCache();
   await connectMongo(process.env.MONGO_URL!);
   await Promise.all([
     OemModel.syncIndexes(),

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -85,9 +85,14 @@ beforeAll(async () => {
         }
         return send(400, { error: "invalid_grant", error_description: "bad creds" });
       }
-      // GET /auth/v1/admin/users?filter=email
+      // GET /auth/v1/admin/users?filter=&page=&per_page=
       if (url.pathname === "/auth/v1/admin/users" && req.method === "GET") {
-        return send(200, { users: [userObj] });
+        const filter = (url.searchParams.get("filter") ?? "").toLowerCase();
+        const page = Number(url.searchParams.get("page") ?? "1");
+        // Page 1 returns the single known user only when the filter matches its
+        // email; every later page is empty (the client stops on a short page).
+        const matches = !filter || storedEmail.toLowerCase().includes(filter);
+        return send(200, { users: page === 1 && matches ? [userObj] : [] });
       }
       // GET /auth/v1/admin/users/:id
       if (url.pathname.startsWith("/auth/v1/admin/users/") && req.method === "GET") {
@@ -407,6 +412,20 @@ describe("account auth", () => {
       }),
     );
     expect(me.status).toBe(403);
+  });
+
+  test("password reset finds the user by exact email (paginated lookup) and issues a code", async () => {
+    // The matching email produces a single-use code...
+    const ok = await post("/api/account/password/forgot", { email: TEST_EMAIL });
+    expect(ok.status).toBe(202);
+    expect(await AccountCodeModel.countDocuments({ purpose: "password_reset" })).toBe(1);
+
+    // ...a non-matching email finds no user, so no code is issued (the response
+    // stays uniform 202 for anti-enumeration).
+    await AccountCodeModel.deleteMany({});
+    const miss = await post("/api/account/password/forgot", { email: "nobody@mentraglass.com" });
+    expect(miss.status).toBe(202);
+    expect(await AccountCodeModel.countDocuments({ purpose: "password_reset" })).toBe(0);
   });
 
   test("login is rate limited per spec: 429 with rate_limited after the window fills", async () => {

--- a/cloud-v2/tests/account-auth.integration.test.ts
+++ b/cloud-v2/tests/account-auth.integration.test.ts
@@ -58,6 +58,7 @@ let gotrueServer: http.Server;
 let userVerified = true;
 let storedPassword = TEST_PASSWORD;
 let storedEmail = TEST_EMAIL;
+let lastEmailConfirmFlag: unknown = null;
 
 beforeAll(async () => {
   // Mock GoTrue: password grant, admin user lookup/update.
@@ -95,7 +96,10 @@ beforeAll(async () => {
       // PUT /auth/v1/admin/users/:id  (password/email change)
       if (url.pathname.startsWith("/auth/v1/admin/users/") && req.method === "PUT") {
         if (body.password) storedPassword = body.password;
-        if (body.email) storedEmail = body.email;
+        if (body.email) {
+          storedEmail = body.email;
+          lastEmailConfirmFlag = body.email_confirm;
+        }
         return send(200, userObj);
       }
       if (url.pathname === "/auth/v1/signup") return send(200, userObj);
@@ -141,6 +145,7 @@ beforeEach(async () => {
   userVerified = true;
   storedPassword = TEST_PASSWORD;
   storedEmail = TEST_EMAIL;
+  lastEmailConfirmFlag = null;
   resetAccountRateLimits();
   await Promise.all([
     UserModel.deleteMany({ tenantId: "mentra" }),
@@ -335,6 +340,9 @@ describe("account auth", () => {
     const ok = await post("/api/account/email/change/confirm", { code }, a.access_token);
     expect(ok.status).toBe(204);
     expect(storedEmail).toBe(newEmail);
+    // Core's code already proved the new inbox, so GoTrue must be told the
+    // address is confirmed - otherwise the next password login rejects it.
+    expect(lastEmailConfirmFlag).toBe(true);
   });
 
   test("OAuth authorize URL carries the PKCE challenge for the core<->GoTrue leg", () => {

--- a/mobile/src/app/auth/forgot-password.tsx
+++ b/mobile/src/app/auth/forgot-password.tsx
@@ -5,7 +5,6 @@ import {Button, Header, Icon, Screen, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {SETTINGS, useSetting} from "@mentra/island"
 import showAlert from "@/utils/AlertUtils"
 import mentraAuth from "@/utils/auth/authClient"
 import {mapAuthError} from "@/utils/auth/authErrors"
@@ -16,7 +15,6 @@ export default function ForgotPasswordScreen() {
 
   const {push, goBack} = useNavigationStore.getState()
   const {theme} = useAppTheme()
-  const [isChina] = useSetting<boolean>(SETTINGS.china_deployment.key)
 
   const isEmailValid = email.includes("@") && email.includes(".")
 
@@ -38,13 +36,9 @@ export default function ForgotPasswordScreen() {
 
     setIsLoading(false)
 
-    if (isChina) {
-      push("/auth/reset-password", {email})
-    } else {
-      showAlert(translate("login:resetEmailSent"), translate("login:checkEmailForReset"), [
-        {text: translate("common:ok"), onPress: () => goBack()},
-      ])
-    }
+    // Both providers now email a numeric code (the account backend replaced
+    // Supabase's magic link), so everyone continues to the code-entry screen.
+    push("/auth/reset-password", {email})
   }
 
   return (
@@ -53,7 +47,7 @@ export default function ForgotPasswordScreen() {
       <ScrollView className="flex-grow" showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
         <View className="flex-1 p-4">
           <Text
-            tx={isChina ? "login:forgotPasswordCodeSubtitle" : "login:forgotPasswordSubtitle"}
+            tx="login:forgotPasswordCodeSubtitle"
             className="text-base text-secondary-foreground text-left mb-6 leading-[22px]"
           />
 

--- a/mobile/src/app/index.tsx
+++ b/mobile/src/app/index.tsx
@@ -134,26 +134,15 @@ export default function InitScreen() {
 
   const handleTokenExchange = async (): Promise<void> => {
     console.log("INDEX: handleTokenExchange()")
-    setBootPhase("Exchanging auth token…")
+    // Cloud V2 cutover (issue 019): the app holds V2 tokens directly. There is no
+    // legacy Cloud V1 exchange; cloud-client obtains and exchanges a subject token
+    // itself via the auth provider. Boot just needs a valid session, then init.
     const token = session?.token
     if (!token) {
       setState("auth")
       return
     }
 
-    let res = await restComms.exchangeToken(token)
-    if (res.is_error()) {
-      console.log("Token exchange failed:", res.error)
-      await checkCustomUrl()
-      setState("connection")
-      return
-    }
-
-    const coreToken = res.value
-    const uid = user?.email || user?.id || ""
-
-    socketComms.setAuthCreds(coreToken, uid)
-    console.log("INDEX: Socket comms auth creds set")
     setBootPhase("Initializing core…")
     await mantle.init()
 

--- a/mobile/src/app/miniapps/settings/change-email.tsx
+++ b/mobile/src/app/miniapps/settings/change-email.tsx
@@ -13,6 +13,10 @@ import {mapAuthError} from "@/utils/auth/authErrors"
 
 export default function ChangeEmailScreen() {
   const [newEmail, setNewEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [code, setCode] = useState("")
+  // Two steps: request (email a code to the NEW address), then confirm with it.
+  const [step, setStep] = useState<"request" | "confirm">("request")
   const [isLoading, setIsLoading] = useState(false)
 
   const {goBack} = useNavigationStore.getState()
@@ -30,10 +34,14 @@ export default function ChangeEmailScreen() {
       showAlert(translate("common:error"), translate("login:invalidEmail"), [{text: translate("common:ok")}])
       return
     }
+    if (!password) {
+      showAlert(translate("common:error"), translate("login:errors.passwordRequired"), [{text: translate("common:ok")}])
+      return
+    }
 
     setIsLoading(true)
 
-    const res = await mentraAuth.updateUserEmail(newEmail)
+    const res = await mentraAuth.updateUserEmail(newEmail, password)
     if (res.is_error()) {
       console.error("Error updating email:", res.error)
       showAlert(translate("common:error"), mapAuthError(res.error), [{text: translate("common:ok")}])
@@ -42,11 +50,23 @@ export default function ChangeEmailScreen() {
     }
 
     setIsLoading(false)
-    showAlert(
-      translate("profileSettings:emailChangeRequested"),
-      translate("profileSettings:checkNewEmailForVerification"),
-      [{text: translate("common:ok"), onPress: () => goBack()}],
-    )
+    setStep("confirm")
+  }
+
+  const handleConfirmCode = async () => {
+    if (!code.trim()) return
+    setIsLoading(true)
+    const res = await mentraAuth.confirmEmailChange(code.trim())
+    if (res.is_error()) {
+      console.error("Error confirming email change:", res.error)
+      showAlert(translate("common:error"), mapAuthError(res.error), [{text: translate("common:ok")}])
+      setIsLoading(false)
+      return
+    }
+    setIsLoading(false)
+    showAlert(translate("common:success"), translate("profileSettings:emailChangeSuccess"), [
+      {text: translate("common:ok"), onPress: () => goBack()},
+    ])
   }
 
   return (
@@ -54,45 +74,104 @@ export default function ChangeEmailScreen() {
       <Header title={translate("profileSettings:changeEmail")} leftIcon="chevron-left" onLeftPress={goBack} />
       <ScrollView contentContainerStyle={themed($scrollContent)} showsVerticalScrollIndicator={false}>
         <View style={themed($card)}>
-          <Text style={themed($subtitle)}>{translate("profileSettings:changeEmailSubtitle")}</Text>
+          <Text style={themed($subtitle)}>
+            {step === "request"
+              ? translate("profileSettings:changeEmailSubtitle")
+              : translate("profileSettings:emailChangeCodeSubtitle")}
+          </Text>
 
-          <View style={themed($form)}>
-            <View style={themed($inputGroup)}>
-              <Text style={themed($inputLabel)}>{translate("profileSettings:newEmailPlaceholder")}</Text>
-              <View style={themed($enhancedInputContainer)}>
-                <TextInput
-                  hitSlop={{top: 16, bottom: 16}}
-                  style={themed($enhancedInput)}
-                  placeholder={translate("profileSettings:newEmailPlaceholder")}
-                  value={newEmail}
-                  autoCapitalize="none"
-                  keyboardType="email-address"
-                  autoComplete="email"
-                  onChangeText={setNewEmail}
-                  placeholderTextColor={theme.colors.textDim}
-                  autoFocus={true}
-                />
+          {step === "request" ? (
+            <View style={themed($form)}>
+              <View style={themed($inputGroup)}>
+                <Text style={themed($inputLabel)}>{translate("profileSettings:newEmailPlaceholder")}</Text>
+                <View style={themed($enhancedInputContainer)}>
+                  <TextInput
+                    hitSlop={{top: 16, bottom: 16}}
+                    style={themed($enhancedInput)}
+                    placeholder={translate("profileSettings:newEmailPlaceholder")}
+                    value={newEmail}
+                    autoCapitalize="none"
+                    keyboardType="email-address"
+                    autoComplete="email"
+                    onChangeText={setNewEmail}
+                    placeholderTextColor={theme.colors.textDim}
+                    autoFocus={true}
+                  />
+                </View>
               </View>
+
+              <View style={themed($inputGroup)}>
+                <Text style={themed($inputLabel)}>{translate("login:password")}</Text>
+                <View style={themed($enhancedInputContainer)}>
+                  <TextInput
+                    hitSlop={{top: 16, bottom: 16}}
+                    style={themed($enhancedInput)}
+                    placeholder={translate("login:passwordPlaceholder")}
+                    value={password}
+                    autoCapitalize="none"
+                    secureTextEntry={true}
+                    onChangeText={setPassword}
+                    placeholderTextColor={theme.colors.textDim}
+                  />
+                </View>
+              </View>
+
+              <Spacer height={spacing.s6} />
+
+              <Button
+                text={translate("profileSettings:sendVerificationEmail")}
+                style={themed($primaryButton)}
+                pressedStyle={themed($pressedButton)}
+                textStyle={themed($buttonText)}
+                onPress={handleChangeEmail}
+                disabled={!newEmail.trim() || !password || isLoading}
+                {...(isLoading
+                  ? {
+                      LeftAccessory: () => (
+                        <ActivityIndicator size="small" color={theme.colors.foreground} style={{marginRight: 8}} />
+                      ),
+                    }
+                  : {})}
+              />
             </View>
+          ) : (
+            <View style={themed($form)}>
+              <View style={themed($inputGroup)}>
+                <Text style={themed($inputLabel)}>{translate("profileSettings:emailChangeCodePlaceholder")}</Text>
+                <View style={themed($enhancedInputContainer)}>
+                  <TextInput
+                    hitSlop={{top: 16, bottom: 16}}
+                    style={themed($enhancedInput)}
+                    placeholder={translate("profileSettings:emailChangeCodePlaceholder")}
+                    value={code}
+                    autoCapitalize="none"
+                    keyboardType="number-pad"
+                    onChangeText={setCode}
+                    placeholderTextColor={theme.colors.textDim}
+                    autoFocus={true}
+                  />
+                </View>
+              </View>
 
-            <Spacer height={spacing.s6} />
+              <Spacer height={spacing.s6} />
 
-            <Button
-              text={translate("profileSettings:sendVerificationEmail")}
-              style={themed($primaryButton)}
-              pressedStyle={themed($pressedButton)}
-              textStyle={themed($buttonText)}
-              onPress={handleChangeEmail}
-              disabled={!newEmail.trim() || isLoading}
-              {...(isLoading
-                ? {
-                    LeftAccessory: () => (
-                      <ActivityIndicator size="small" color={theme.colors.foreground} style={{marginRight: 8}} />
-                    ),
-                  }
-                : {})}
-            />
-          </View>
+              <Button
+                text={translate("profileSettings:confirmEmailChange")}
+                style={themed($primaryButton)}
+                pressedStyle={themed($pressedButton)}
+                textStyle={themed($buttonText)}
+                onPress={handleConfirmCode}
+                disabled={!code.trim() || isLoading}
+                {...(isLoading
+                  ? {
+                      LeftAccessory: () => (
+                        <ActivityIndicator size="small" color={theme.colors.foreground} style={{marginRight: 8}} />
+                      ),
+                    }
+                  : {})}
+              />
+            </View>
+          )}
         </View>
       </ScrollView>
     </Screen>

--- a/mobile/src/app/miniapps/settings/change-password.tsx
+++ b/mobile/src/app/miniapps/settings/change-password.tsx
@@ -13,9 +13,11 @@ import mentraAuth from "@/utils/auth/authClient"
 import {mapAuthError} from "@/utils/auth/authErrors"
 
 export default function ChangePasswordScreen() {
+  const [currentPassword, setCurrentPassword] = useState("")
   const [newPassword, setNewPassword] = useState("")
   const [confirmPassword, setConfirmPassword] = useState("")
   const [isLoading, setIsLoading] = useState(false)
+  const [showCurrentPassword, setShowCurrentPassword] = useState(false)
   const [showNewPassword, setShowNewPassword] = useState(false)
   const [showConfirmPassword, setShowConfirmPassword] = useState(false)
 
@@ -23,7 +25,7 @@ export default function ChangePasswordScreen() {
   const {theme, themed} = useAppTheme()
 
   const passwordsMatch = newPassword === confirmPassword && newPassword.length > 0
-  const isFormValid = passwordsMatch && newPassword.length >= 6
+  const isFormValid = passwordsMatch && newPassword.length >= 6 && currentPassword.length > 0
 
   const handleUpdatePassword = async () => {
     // Validation checks with specific error messages
@@ -39,7 +41,8 @@ export default function ChangePasswordScreen() {
 
     setIsLoading(true)
 
-    const res = await mentraAuth.updateUserPassword(newPassword)
+    // The account backend re-verifies the current password before applying.
+    const res = await mentraAuth.updateUserPassword(newPassword, currentPassword)
     if (res.is_error()) {
       console.error("Error updating password:", res.error)
       showAlert(translate("common:error"), mapAuthError(res.error), [{text: translate("common:ok")}])
@@ -60,6 +63,29 @@ export default function ChangePasswordScreen() {
           <Text tx="profileSettings:changePasswordSubtitle" style={themed($subtitle)} />
 
           <View style={themed($form)}>
+            <View style={themed($inputGroup)}>
+              <Text tx="profileSettings:currentPassword" style={themed($inputLabel)} />
+              <View style={themed($enhancedInputContainer)}>
+                <FontAwesome name="lock" size={16} color={theme.colors.text} />
+                <Spacer width={spacing.s1} />
+                <TextInput
+                  hitSlop={{top: 16, bottom: 16}}
+                  style={themed($enhancedInput)}
+                  placeholder={translate("profileSettings:enterCurrentPassword")}
+                  value={currentPassword}
+                  autoCapitalize="none"
+                  onChangeText={setCurrentPassword}
+                  secureTextEntry={!showCurrentPassword}
+                  placeholderTextColor={theme.colors.textDim}
+                />
+                <TouchableOpacity
+                  hitSlop={{top: 16, bottom: 16, left: 16, right: 16}}
+                  onPress={() => setShowCurrentPassword(!showCurrentPassword)}>
+                  <FontAwesome name={showCurrentPassword ? "eye" : "eye-slash"} size={18} color={theme.colors.text} />
+                </TouchableOpacity>
+              </View>
+            </View>
+
             <View style={themed($inputGroup)}>
               <Text tx="profileSettings:newPassword" style={themed($inputLabel)} />
               <View style={themed($enhancedInputContainer)}>

--- a/mobile/src/app/miniapps/settings/confirm-deletion.tsx
+++ b/mobile/src/app/miniapps/settings/confirm-deletion.tsx
@@ -1,0 +1,154 @@
+import {useState} from "react"
+import {View, TextInput, ActivityIndicator, ScrollView, ViewStyle, TextStyle} from "react-native"
+
+import {Button, Header, Screen, Text} from "@/components/ignite"
+import {Spacer} from "@/components/ui/Spacer"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {useNavigationStore} from "@/stores/navigation"
+import {translate} from "@/i18n"
+import {ThemedStyle, spacing} from "@/theme"
+import showAlert from "@/utils/AlertUtils"
+import mentraAuth from "@/utils/auth/authClient"
+import {mapAuthError} from "@/utils/auth/authErrors"
+import {LogoutUtils} from "@/utils/LogoutUtils"
+
+/**
+ * Final step of account deletion (issue 019): the backend emailed a one-time
+ * code; entering it here destroys the account. Reached only through the
+ * triple-warning flow in profile.tsx.
+ */
+export default function ConfirmDeletionScreen() {
+  const [code, setCode] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
+
+  const {goBack, replaceAll} = useNavigationStore.getState()
+  const {theme, themed} = useAppTheme()
+
+  const handleConfirm = async () => {
+    if (!code.trim()) return
+    setIsLoading(true)
+    const res = await mentraAuth.confirmAccountDeletion(code.trim())
+    if (res.is_error()) {
+      console.error("Error confirming account deletion:", res.error)
+      showAlert(translate("common:error"), mapAuthError(res.error), [{text: translate("common:ok")}])
+      setIsLoading(false)
+      return
+    }
+    // Account is gone server-side; clear everything device-side too.
+    try {
+      await LogoutUtils.performCompleteLogout()
+    } catch (error) {
+      console.error("ConfirmDeletion: logout cleanup failed:", error)
+    }
+    setIsLoading(false)
+    showAlert(
+      translate("profileSettings:deleteAccountSuccessTitle"),
+      translate("profileSettings:deleteAccountSuccessMessage"),
+      [{text: translate("common:ok"), onPress: () => replaceAll("/auth/start")}],
+      {cancelable: false},
+    )
+  }
+
+  return (
+    <Screen preset="fixed">
+      <Header title={translate("profileSettings:deleteAccountTitle")} leftIcon="chevron-left" onLeftPress={goBack} />
+      <ScrollView contentContainerStyle={themed($scrollContent)} showsVerticalScrollIndicator={false}>
+        <View style={themed($card)}>
+          <Text style={themed($subtitle)}>{translate("profileSettings:deleteAccountCodeSubtitle")}</Text>
+
+          <View style={themed($inputGroup)}>
+            <Text style={themed($inputLabel)}>{translate("profileSettings:deleteAccountCodePlaceholder")}</Text>
+            <View style={themed($enhancedInputContainer)}>
+              <TextInput
+                hitSlop={{top: 16, bottom: 16}}
+                style={themed($enhancedInput)}
+                placeholder={translate("profileSettings:deleteAccountCodePlaceholder")}
+                value={code}
+                autoCapitalize="none"
+                keyboardType="number-pad"
+                onChangeText={setCode}
+                placeholderTextColor={theme.colors.textDim}
+                autoFocus={true}
+              />
+            </View>
+          </View>
+
+          <Spacer height={spacing.s6} />
+
+          <Button
+            text={translate("profileSettings:deleteAccountConfirmButton")}
+            style={themed($primaryButton)}
+            pressedStyle={themed($pressedButton)}
+            textStyle={themed($buttonText)}
+            onPress={handleConfirm}
+            disabled={!code.trim() || isLoading}
+            {...(isLoading
+              ? {
+                  LeftAccessory: () => (
+                    <ActivityIndicator size="small" color={theme.colors.foreground} style={{marginRight: 8}} />
+                  ),
+                }
+              : {})}
+          />
+        </View>
+      </ScrollView>
+    </Screen>
+  )
+}
+
+// Themed styles - matching the change-email screen
+const $scrollContent: ThemedStyle<ViewStyle> = () => ({
+  flexGrow: 1,
+})
+
+const $card: ThemedStyle<ViewStyle> = ({spacing}) => ({
+  flex: 1,
+  padding: spacing.s4,
+})
+
+const $subtitle: ThemedStyle<TextStyle> = ({spacing, colors}) => ({
+  fontSize: 16,
+  color: colors.text,
+  textAlign: "left",
+  marginBottom: spacing.s6,
+})
+
+const $inputGroup: ThemedStyle<ViewStyle> = ({spacing}) => ({
+  marginBottom: spacing.s3,
+})
+
+const $inputLabel: ThemedStyle<TextStyle> = ({colors}) => ({
+  fontSize: 14,
+  fontWeight: "500",
+  color: colors.text,
+  marginBottom: 8,
+})
+
+const $enhancedInputContainer: ThemedStyle<ViewStyle> = ({colors, spacing, isDark}) => ({
+  flexDirection: "row",
+  alignItems: "center",
+  height: 48,
+  borderWidth: 1,
+  borderColor: colors.border,
+  borderRadius: 8,
+  paddingHorizontal: spacing.s3,
+  backgroundColor: isDark ? colors.palette.transparent : colors.background,
+})
+
+const $enhancedInput: ThemedStyle<TextStyle> = ({colors}) => ({
+  flex: 1,
+  fontSize: 16,
+  color: colors.text,
+})
+
+const $primaryButton: ThemedStyle<ViewStyle> = () => ({})
+
+const $pressedButton: ThemedStyle<ViewStyle> = () => ({
+  opacity: 0.9,
+})
+
+const $buttonText: ThemedStyle<TextStyle> = ({colors}) => ({
+  color: colors.textAlt,
+  fontSize: 16,
+  fontWeight: "bold",
+})

--- a/mobile/src/app/miniapps/settings/profile.tsx
+++ b/mobile/src/app/miniapps/settings/profile.tsx
@@ -10,11 +10,10 @@ import {useAuth} from "@/contexts/AuthContext"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import restComms from "@/services/RestComms"
 import {ThemedStyle} from "@/theme"
 import showAlert from "@/utils/AlertUtils"
-import {LogoutUtils} from "@/utils/LogoutUtils"
 import mentraAuth from "@/utils/auth/authClient"
+import {mapAuthError} from "@/utils/auth/authErrors"
 
 // Default user icon component for profile pictures
 const DefaultUserIcon = ({size = 100, color = "#999"}: {size?: number; color?: string}) => {
@@ -152,56 +151,17 @@ export default function ProfileSettingsPage() {
   const proceedWithAccountDeletion = async () => {
     console.log("Profile: User confirmed account deletion - proceeding")
 
-    let deleteRequestSuccessful = false
-
-    console.log("Profile: Requesting account deletion from server")
-    const result = await restComms.requestAccountDeletion()
-
-    // Check if the result indicates success
-    if (result.is_ok()) {
-      deleteRequestSuccessful = true
-      console.log("Profile: Account deletion request successful")
-    } else {
+    // Account backend flow (issue 019): request emails a one-time code; the
+    // account is only destroyed when the code is confirmed. Keep the session
+    // alive here — the confirm call needs it — and finish (including logout)
+    // on the confirm-deletion screen.
+    const result = await mentraAuth.requestAccountDeletion()
+    if (result.is_error()) {
       console.error("Profile: Error requesting account deletion:", result.error)
-      deleteRequestSuccessful = false
+      showAlert(translate("common:error"), mapAuthError(result.error), [{text: translate("common:ok")}])
+      return
     }
-
-    // Always perform logout regardless of deletion request success
-    try {
-      console.log("Profile: Starting comprehensive logout")
-      await LogoutUtils.performCompleteLogout()
-      console.log("Profile: Logout completed successfully")
-    } catch (logoutError) {
-      console.error("Profile: Error during logout:", logoutError)
-      // Continue with navigation even if logout fails
-    }
-
-    // Show appropriate message based on deletion request result
-    if (deleteRequestSuccessful) {
-      showAlert(
-        translate("profileSettings:deleteAccountSuccessTitle"),
-        translate("profileSettings:deleteAccountSuccessMessage"),
-        [
-          {
-            text: translate("common:ok"),
-            onPress: () => replace("/"),
-          },
-        ],
-        {cancelable: false},
-      )
-    } else {
-      showAlert(
-        translate("profileSettings:deleteAccountPendingTitle"),
-        translate("profileSettings:deleteAccountPendingMessage"),
-        [
-          {
-            text: translate("common:ok"),
-            onPress: () => replace("/"),
-          },
-        ],
-        {cancelable: false},
-      )
-    }
+    push("/miniapps/settings/confirm-deletion")
   }
 
   const handleSignOut = async () => {

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -195,6 +195,31 @@ const deepLinkRoutes: DeepLinkRoute[] = [
         }
       }
 
+      // Account OAuth handoff (issue 019): core deep-links ?code=&state= query
+      // params (no fragment). Swap the one-time code + in-app PKCE verifier for
+      // the V2 session; an intercepted link is useless without the verifier.
+      const query = new URLSearchParams(url.split("?")[1]?.split("#")[0] ?? "")
+      const handoffCode = params.code ?? query.get("code")
+      const handoffState = params.state ?? query.get("state")
+      if (handoffCode && handoffState && !url.includes("#")) {
+        const res = await mentraAuth.completeOAuthHandoff({code: handoffCode, state: handoffState})
+        try {
+          WebBrowser.dismissBrowser()
+        } catch {
+          // browser might not be open
+        }
+        if (res.is_error()) {
+          console.error("[LOGIN DEBUG] OAuth handoff failed:", res.error)
+          nav.replace(`/auth/start?authError=oauth_failed`)
+          return
+        }
+        BgTimer.setTimeout(() => {
+          nav.setAnimation("none")
+          nav.replaceAll("/")
+        }, 100)
+        return
+      }
+
       const authParams = parseAuthParams(url)
 
       // Check if there's an error in the URL (e.g., expired verification link)

--- a/mobile/src/contexts/DeeplinkContext.tsx
+++ b/mobile/src/contexts/DeeplinkContext.tsx
@@ -231,18 +231,12 @@ const deepLinkRoutes: DeepLinkRoute[] = [
       }
 
       if (authParams && authParams.access_token && authParams.refresh_token) {
-        // Update the Supabase session manually
-        const res = await mentraAuth.updateSessionWithTokens({
-          access_token: authParams.access_token,
-          refresh_token: authParams.refresh_token,
-        })
-        if (res.is_error()) {
-          console.error("Error setting session:", res.error)
-          return
-        }
-        // console.log("Session updated:", data.session)
-        // console.log("[LOGIN DEBUG] Session set successfully, data.session exists:", !!data.session)
-        console.log("[LOGIN DEBUG] Session set successfully")
+        // Fragment tokens come from GoTrue links (email verification, legacy
+        // magic links). They are SUPABASE tokens: adopting them as V2 tokens
+        // via updateSessionWithTokens would persist a broken session (every
+        // core call rejects them). The account backend never hands tokens over
+        // deep links, so just confirm the verification and route to login.
+        console.log("[LOGIN DEBUG] GoTrue fragment link (type:", authParams.type, ") — routing to login")
         // Dismiss the WebView after successful authentication (non-blocking)
         console.log("[LOGIN DEBUG] About to dismiss browser, platform:", Platform.OS)
         try {
@@ -258,21 +252,17 @@ const deepLinkRoutes: DeepLinkRoute[] = [
           // Ignore - browser might not be open or function might not exist
         }
 
-        // Small delay to ensure auth state propagates
+        // The email is now verified server-side; the user signs in normally.
         // Use replace() instead of replaceAll() to avoid POP_TO_TOP errors
-        // when the navigation stack is empty (coming back from browser)
-        console.log("[LOGIN DEBUG] About to set timeout for navigation")
+        // when the navigation stack is empty (coming back from browser).
         BgTimer.setTimeout(() => {
-          console.log("[LOGIN DEBUG] Inside setTimeout, navigating to index")
           try {
             nav.setAnimation("none")
-            nav.replaceAll("/")
-            console.log("[LOGIN DEBUG] router.replace called successfully")
+            nav.replace("/auth/start")
           } catch (navError) {
-            console.error("[LOGIN DEBUG] Error calling router.replace:", navError)
+            console.error("[LOGIN DEBUG] Error navigating to login:", navError)
           }
         }, 100)
-        console.log("[LOGIN DEBUG] setTimeout scheduled")
         return // Don't do the navigation below
       }
 

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -657,6 +657,8 @@ const en = {
     createdAt: "Created At",
     provider: "Provider",
     changePassword: "Change Password",
+    currentPassword: "Current Password",
+    enterCurrentPassword: "Enter your current password",
     newPassword: "New Password",
     enterNewPassword: "Enter your new password",
     confirmPassword: "Confirm Password",
@@ -704,12 +706,16 @@ const en = {
     passwordUpdatedSuccess: "Password updated successfully",
     // Change email
     changeEmail: "Change Email",
-    changeEmailSubtitle: "Enter your new email address. We'll send a verification link to confirm the change.",
+    changeEmailSubtitle: "Enter your new email address and your password. We'll email a code to the new address to confirm the change.",
     newEmailPlaceholder: "New email address",
     sendVerificationEmail: "Send Verification Email",
     emailChangeRequested: "Verification Email Sent",
     checkNewEmailForVerification:
       "Please check your new email address and click the verification link to complete the change.",
+    emailChangeCodeSubtitle: "Enter the code we emailed to your new address.",
+    emailChangeCodePlaceholder: "Verification code",
+    confirmEmailChange: "Confirm Email Change",
+    emailChangeSuccess: "Email updated successfully",
   },
   login: {
     title: "MentraOS",

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -697,6 +697,10 @@ const en = {
       "This will PERMANENTLY DELETE:\n• All your data\n• All your settings\n• All your app configurations\n• Your entire account history\n\nThere is NO way to recover this data!",
     deleteAccountSuccessTitle: "Account Deleted",
     deleteAccountSuccessMessage: "Your account has been successfully deleted.",
+    deleteAccountCodeSubtitle:
+      "We emailed you a confirmation code. Enter it below to permanently delete your account.",
+    deleteAccountCodePlaceholder: "Confirmation code",
+    deleteAccountConfirmButton: "Delete My Account",
     deleteAccountPendingTitle: "Account Deletion Requested",
     deleteAccountPendingMessage:
       "Your account deletion request has been received and will be processed within 2-3 business days.",

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -255,7 +255,10 @@ class MantleManager {
   }
 
   private async initServices() {
-    socketComms.connectWebsocket()
+    // Cloud V1 websocket intentionally NOT started: post-cutover there is no
+    // V1 coreToken, so it would dial prod with `token=` and retry-loop forever
+    // (burning battery on every boot). SocketComms/WSM removal lands in the
+    // V1-ripout PR; until then the path is dormant, not broken.
     gallerySyncService.initialize()
 
     // Bootstrap MentraJS — wires MentraJSRouter + MentraUIRouter +

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -125,11 +125,13 @@ class MantleManager {
     toolkit.configure({
       auth: {
         getSubjectToken: async () => {
-          const res = await mentraAuth.getSession()
+          // Cloud V2 (issue 019): the provider mints a fresh `mentra` OEM subject
+          // token which cloud-client exchanges at /api/client/auth/exchange.
+          const res = await mentraAuth.getSubjectToken()
           if (res.is_error() || !res.value.token) {
-            throw new Error("toolkit.configure: no session token available")
+            throw new Error("toolkit.configure: no subject token available")
           }
-          return {token: res.value.token, type: "supabase"}
+          return {token: res.value.token, type: res.value.type}
         },
         onStateChange: (callback) => mentraAuth.onAuthStateChange((event, session) => callback(event, session)),
       },

--- a/mobile/src/utils/auth/authClient.ts
+++ b/mobile/src/utils/auth/authClient.ts
@@ -48,6 +48,16 @@ export abstract class AuthClient {
     return Res.error_async(new Error("Method not implemented"))
   }
 
+  /** Start account deletion: the backend emails a confirmation code. */
+  public requestAccountDeletion(): AsyncResult<void, Error> {
+    return Res.error_async(new Error("Method not implemented"))
+  }
+
+  /** Finish account deletion with the emailed code. Destroys the account. */
+  public confirmAccountDeletion(_code: string): AsyncResult<void, Error> {
+    return Res.error_async(new Error("Method not implemented"))
+  }
+
   public getSession(): AsyncResult<MentraAuthSession, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }

--- a/mobile/src/utils/auth/authClient.ts
+++ b/mobile/src/utils/auth/authClient.ts
@@ -35,11 +35,16 @@ export abstract class AuthClient {
     return Res.error_async(new Error("Method not implemented"))
   }
 
-  public updateUserPassword(_password: string): AsyncResult<void, Error> {
+  public updateUserPassword(_password: string, _currentPassword?: string): AsyncResult<void, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }
 
-  public updateUserEmail(_email: string): AsyncResult<void, Error> {
+  public updateUserEmail(_email: string, _password?: string): AsyncResult<void, Error> {
+    return Res.error_async(new Error("Method not implemented"))
+  }
+
+  /** Second step of the email change: the code emailed to the NEW address. */
+  public confirmEmailChange(_code: string): AsyncResult<void, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }
 
@@ -75,6 +80,12 @@ export abstract class AuthClient {
    * Providers back this differently (Supabase session token vs a minted OEM
    * subject token). */
   public getSubjectToken(): AsyncResult<{token: string; type: string}, Error> {
+    return Res.error_async(new Error("Method not implemented"))
+  }
+
+  /** Finish an OAuth flow: the deep link handed back `?code&state`; swap the
+   * handoff code + the in-app PKCE verifier for a session. */
+  public completeOAuthHandoff(_params: {code: string; state: string}): AsyncResult<void, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }
 }

--- a/mobile/src/utils/auth/authClient.ts
+++ b/mobile/src/utils/auth/authClient.ts
@@ -4,7 +4,7 @@ import {AsyncResult, result as Res, Result} from "typesafe-ts"
 import {SETTINGS, toolkit} from "@mentra/island"
 import {MentraAuthSession, MentraAuthUser, MentraSigninResponse} from "@/utils/auth/authProvider.types"
 import {AuthingWrapperClient} from "@/utils/auth/provider/authingClient"
-import {SupabaseWrapperClient} from "@/utils/auth/provider/supabaseClient"
+import {AccountAuthProvider} from "@/utils/auth/provider/accountClient"
 
 export abstract class AuthClient {
   public onAuthStateChange(_callback: (event: string, session: MentraAuthSession) => void): Result<any, Error> {
@@ -70,6 +70,13 @@ export abstract class AuthClient {
   public googleSignIn(): AsyncResult<string, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }
+
+  /** Return a token cloud-client can exchange at /api/client/auth/exchange.
+   * Providers back this differently (Supabase session token vs a minted OEM
+   * subject token). */
+  public getSubjectToken(): AsyncResult<{token: string; type: string}, Error> {
+    return Res.error_async(new Error("Method not implemented"))
+  }
 }
 
 function createLazyAuthClient(): AuthClient {
@@ -83,7 +90,9 @@ function createLazyAuthClient(): AuthClient {
         if (isChina) {
           client = await AuthingWrapperClient.getInstance()
         } else {
-          client = await SupabaseWrapperClient.getInstance()
+          // Cloud V2 account auth (issue 019): Mentra's own OEM backend, no
+          // embedded Supabase, no legacy Cloud V1 exchange.
+          client = await AccountAuthProvider.getInstance()
         }
         return client
       })()

--- a/mobile/src/utils/auth/pkce.ts
+++ b/mobile/src/utils/auth/pkce.ts
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview PKCE helpers for the account OAuth flow (issue 019).
+ *
+ * Pure-JS SHA-256: React Native's Hermes has no WebCrypto `subtle`, and the app
+ * does not ship expo-crypto. PKCE only hashes a PUBLIC verifier string, so a
+ * compact JS digest is fine here — do NOT reach for this for anything keyed.
+ * Randomness comes from crypto.getRandomValues (react-native-get-random-values,
+ * polyfilled first thing in _layout.tsx).
+ */
+
+/** URL-safe base64 (RFC 4648 §5, no padding) of a byte array. */
+function base64url(bytes: Uint8Array): string {
+  const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+  let out = ""
+  for (let i = 0; i < bytes.length; i += 3) {
+    const b0 = bytes[i]
+    const b1 = i + 1 < bytes.length ? bytes[i + 1] : undefined
+    const b2 = i + 2 < bytes.length ? bytes[i + 2] : undefined
+    out += alphabet[b0 >> 2]
+    out += alphabet[((b0 & 3) << 4) | ((b1 ?? 0) >> 4)]
+    if (b1 !== undefined) out += alphabet[((b1 & 15) << 2) | ((b2 ?? 0) >> 6)]
+    if (b2 !== undefined) out += alphabet[b2 & 63]
+  }
+  return out
+}
+
+/** Cryptographically random URL-safe string from `byteLength` bytes. */
+export function randomUrlSafe(byteLength = 32): string {
+  const bytes = new Uint8Array(byteLength)
+  crypto.getRandomValues(bytes)
+  return base64url(bytes)
+}
+
+// SHA-256 (FIPS 180-4), operating on a UTF-8 encoded string. Standard compact
+// implementation: message schedule + compression over 512-bit blocks.
+const K = [
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+]
+
+function utf8Bytes(str: string): Uint8Array {
+  const out: number[] = []
+  for (let i = 0; i < str.length; i++) {
+    let cp = str.codePointAt(i)!
+    if (cp > 0xffff) i++ // surrogate pair consumed
+    if (cp < 0x80) out.push(cp)
+    else if (cp < 0x800) out.push(0xc0 | (cp >> 6), 0x80 | (cp & 63))
+    else if (cp < 0x10000) out.push(0xe0 | (cp >> 12), 0x80 | ((cp >> 6) & 63), 0x80 | (cp & 63))
+    else out.push(0xf0 | (cp >> 18), 0x80 | ((cp >> 12) & 63), 0x80 | ((cp >> 6) & 63), 0x80 | (cp & 63))
+  }
+  return new Uint8Array(out)
+}
+
+export function sha256Bytes(input: string): Uint8Array {
+  const msg = utf8Bytes(input)
+  const bitLen = msg.length * 8
+  // Pad: 0x80, zeros, 64-bit big-endian length, to a multiple of 64 bytes.
+  const padded = new Uint8Array((((msg.length + 8) >> 6) + 1) << 6)
+  padded.set(msg)
+  padded[msg.length] = 0x80
+  const dv = new DataView(padded.buffer)
+  dv.setUint32(padded.length - 4, bitLen >>> 0)
+  dv.setUint32(padded.length - 8, Math.floor(bitLen / 0x100000000))
+
+  const h = [0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19]
+  const w = new Array<number>(64)
+  const rotr = (x: number, n: number) => (x >>> n) | (x << (32 - n))
+
+  for (let off = 0; off < padded.length; off += 64) {
+    for (let t = 0; t < 16; t++) w[t] = dv.getUint32(off + t * 4)
+    for (let t = 16; t < 64; t++) {
+      const s0 = rotr(w[t - 15], 7) ^ rotr(w[t - 15], 18) ^ (w[t - 15] >>> 3)
+      const s1 = rotr(w[t - 2], 17) ^ rotr(w[t - 2], 19) ^ (w[t - 2] >>> 10)
+      w[t] = (w[t - 16] + s0 + w[t - 7] + s1) | 0
+    }
+    let [a, b, c, d, e, f, g, hh] = h
+    for (let t = 0; t < 64; t++) {
+      const S1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25)
+      const ch = (e & f) ^ (~e & g)
+      const t1 = (hh + S1 + ch + K[t] + w[t]) | 0
+      const S0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22)
+      const maj = (a & b) ^ (a & c) ^ (b & c)
+      const t2 = (S0 + maj) | 0
+      hh = g; g = f; f = e
+      e = (d + t1) | 0
+      d = c; c = b; b = a
+      a = (t1 + t2) | 0
+    }
+    h[0] = (h[0] + a) | 0; h[1] = (h[1] + b) | 0; h[2] = (h[2] + c) | 0; h[3] = (h[3] + d) | 0
+    h[4] = (h[4] + e) | 0; h[5] = (h[5] + f) | 0; h[6] = (h[6] + g) | 0; h[7] = (h[7] + hh) | 0
+  }
+
+  const digest = new Uint8Array(32)
+  const outView = new DataView(digest.buffer)
+  for (let i = 0; i < 8; i++) outView.setUint32(i * 4, h[i] >>> 0)
+  return digest
+}
+
+/** S256 code challenge: base64url(SHA-256(verifier)) per RFC 7636 §4.2. */
+export function s256Challenge(verifier: string): string {
+  return base64url(sha256Bytes(verifier))
+}

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -86,6 +86,13 @@ export class AccountAuthProvider extends AuthClient {
     return t
   }
 
+  /** Core's userAuth rejects an expired/invalid access token as the RFC
+   * `invalid_grant` shape — HTTP 400, not 401 — so both statuses mean
+   * "token no longer accepted, try the refresh grant". */
+  private static tokenRejected(status: number): boolean {
+    return status === 400 || status === 401
+  }
+
   /** Return a valid access token, refreshing once via the V2 refresh grant if
    * the stored one is rejected. Throws if there is no usable session. */
   private async ensureFreshAccess(): Promise<string> {
@@ -94,7 +101,7 @@ export class AccountAuthProvider extends AuthClient {
     const probe = await fetch(core("/api/account/me"), {
       headers: {authorization: `Bearer ${tokens.access}`},
     })
-    if (probe.status !== 401) return tokens.access
+    if (!AccountAuthProvider.tokenRejected(probe.status)) return tokens.access
     const refreshed = await this.refreshTokens(tokens.refresh)
     if (!refreshed) {
       clearTokens()
@@ -111,7 +118,7 @@ export class AccountAuthProvider extends AuthClient {
       let meRes = await fetch(core("/api/account/me"), {
         headers: {authorization: `Bearer ${access}`},
       }).catch(() => null) // null = offline; keep tokens, report no user
-      if (meRes?.status === 401) {
+      if (meRes && AccountAuthProvider.tokenRejected(meRes.status)) {
         // Access token expired (1h TTL): silently refresh, then retry /me, so a
         // cold boot after an hour restores the session instead of bouncing the
         // user to /auth/start while their refresh token is still good.

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -70,6 +70,22 @@ export class AccountAuthProvider extends AuthClient {
     return Res.ok({unsubscribe: () => (stateCb = null)})
   }
 
+  /** Run the V2 refresh grant. Returns the new tokens, or null if the server
+   * definitively rejected the refresh token (revoked / expired session).
+   * Throws on network failure so callers can tell "offline" from "signed out". */
+  private async refreshTokens(refresh: string): Promise<Tokens | null> {
+    const res = await fetch(core("/api/client/auth/refresh"), {
+      method: "POST",
+      headers: {"content-type": "application/x-www-form-urlencoded"},
+      body: new URLSearchParams({grant_type: "refresh_token", refresh_token: refresh}),
+    })
+    if (!res.ok) return null
+    const body = (await res.json()) as {access_token: string; refresh_token: string}
+    const t = {access: body.access_token, refresh: body.refresh_token}
+    saveTokens(t)
+    return t
+  }
+
   /** Return a valid access token, refreshing once via the V2 refresh grant if
    * the stored one is rejected. Throws if there is no usable session. */
   private async ensureFreshAccess(): Promise<string> {
@@ -79,33 +95,49 @@ export class AccountAuthProvider extends AuthClient {
       headers: {authorization: `Bearer ${tokens.access}`},
     })
     if (probe.status !== 401) return tokens.access
-    const refreshed = await fetch(core("/api/client/auth/refresh"), {
-      method: "POST",
-      headers: {"content-type": "application/x-www-form-urlencoded"},
-      body: new URLSearchParams({grant_type: "refresh_token", refresh_token: tokens.refresh}),
-    })
-    if (!refreshed.ok) {
+    const refreshed = await this.refreshTokens(tokens.refresh)
+    if (!refreshed) {
       clearTokens()
       throw new Error("session expired")
     }
-    const body = (await refreshed.json()) as {access_token: string; refresh_token: string}
-    saveTokens({access: body.access_token, refresh: body.refresh_token})
-    return body.access_token
+    return refreshed.access
   }
 
   public getSession(): AsyncResult<MentraAuthSession, Error> {
     return Res.try_async(async () => {
       const tokens = loadTokens()
       if (!tokens) return {token: undefined}
-      const meRes = await fetch(core("/api/account/me"), {
-        headers: {authorization: `Bearer ${tokens.access}`},
-      }).catch(() => null)
+      let access = tokens.access
+      let meRes = await fetch(core("/api/account/me"), {
+        headers: {authorization: `Bearer ${access}`},
+      }).catch(() => null) // null = offline; keep tokens, report no user
+      if (meRes?.status === 401) {
+        // Access token expired (1h TTL): silently refresh, then retry /me, so a
+        // cold boot after an hour restores the session instead of bouncing the
+        // user to /auth/start while their refresh token is still good.
+        let refreshed: Tokens | null = null
+        let offline = false
+        try {
+          refreshed = await this.refreshTokens(tokens.refresh)
+        } catch {
+          offline = true // network failure: not a rejection, keep tokens
+        }
+        if (refreshed) {
+          access = refreshed.access
+          meRes = await fetch(core("/api/account/me"), {
+            headers: {authorization: `Bearer ${access}`},
+          }).catch(() => null)
+        } else if (!offline) {
+          clearTokens()
+          return {token: undefined}
+        }
+      }
       let user: MentraAuthUser | undefined
       if (meRes?.ok) {
         const me = (await meRes.json()) as {mentraUserId: string; email?: string; name?: string; avatarUrl?: string}
         user = {id: me.mentraUserId, email: me.email, name: me.name ?? me.email ?? "", avatarUrl: me.avatarUrl}
       }
-      return {token: tokens.access, user}
+      return {token: access, user}
     })
   }
 

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -18,6 +18,7 @@ import {storage} from "@/utils/storage"
 
 const ACCESS_KEY = "mentra.account.accessToken"
 const REFRESH_KEY = "mentra.account.refreshToken"
+const PROFILE_KEY = "mentra.account.userProfile"
 const OAUTH_STATE_KEY = "mentra.account.oauth.state"
 const OAUTH_VERIFIER_KEY = "mentra.account.oauth.verifier"
 
@@ -38,6 +39,24 @@ function saveTokens(t: Tokens): void {
 function clearTokens(): void {
   storage.remove(ACCESS_KEY)
   storage.remove(REFRESH_KEY)
+  storage.remove(PROFILE_KEY)
+}
+
+/** Last successful /me result, cached so an OFFLINE cold start can restore the
+ * signed-in identity instead of bouncing to /auth/start (home boot requires a
+ * user, not just a token). */
+function loadCachedProfile(): MentraAuthUser | undefined {
+  const raw = storage.load<string>(PROFILE_KEY)
+  if (raw.is_error() || !raw.value) return undefined
+  try {
+    return JSON.parse(raw.value) as MentraAuthUser
+  } catch {
+    return undefined
+  }
+}
+
+function saveCachedProfile(user: MentraAuthUser): void {
+  storage.save(PROFILE_KEY, JSON.stringify(user))
 }
 
 function core(path: string): string {
@@ -70,16 +89,19 @@ export class AccountAuthProvider extends AuthClient {
     return Res.ok({unsubscribe: () => (stateCb = null)})
   }
 
-  /** Run the V2 refresh grant. Returns the new tokens, or null if the server
-   * definitively rejected the refresh token (revoked / expired session).
-   * Throws on network failure so callers can tell "offline" from "signed out". */
+  /** Run the V2 refresh grant. Returns the new tokens, or null ONLY when the
+   * server definitively rejected the refresh token (400/401: revoked or
+   * expired session). Throws on network failure AND transient server errors
+   * (5xx, 429) so callers keep the tokens instead of signing the user out
+   * during a brief core outage. */
   private async refreshTokens(refresh: string): Promise<Tokens | null> {
     const res = await fetch(core("/api/client/auth/refresh"), {
       method: "POST",
       headers: {"content-type": "application/x-www-form-urlencoded"},
       body: new URLSearchParams({grant_type: "refresh_token", refresh_token: refresh}),
     })
-    if (!res.ok) return null
+    if (AccountAuthProvider.tokenRejected(res.status)) return null
+    if (!res.ok) throw new Error(`refresh failed transiently: HTTP ${res.status}`)
     const body = (await res.json()) as {access_token: string; refresh_token: string}
     const t = {access: body.access_token, refresh: body.refresh_token}
     saveTokens(t)
@@ -143,6 +165,12 @@ export class AccountAuthProvider extends AuthClient {
       if (meRes?.ok) {
         const me = (await meRes.json()) as {mentraUserId: string; email?: string; name?: string; avatarUrl?: string}
         user = {id: me.mentraUserId, email: me.email, name: me.name ?? me.email ?? "", avatarUrl: me.avatarUrl}
+        saveCachedProfile(user)
+      } else {
+        // /me unreachable (offline boot) or transiently failing: restore the
+        // last known identity so home boot (which requires a user, not just a
+        // token) doesn't dump a signed-in user at /auth/start.
+        user = loadCachedProfile()
       }
       return {token: access, user}
     })

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -12,11 +12,14 @@ import {AsyncResult, result as Res, Result} from "typesafe-ts"
 
 import {AuthClient} from "@/utils/auth/authClient"
 import {MentraAuthSession, MentraAuthUser, MentraSigninResponse} from "@/utils/auth/authProvider.types"
+import {randomUrlSafe, s256Challenge} from "@/utils/auth/pkce"
 import {resolvedEndpoints} from "@/services/cloudClient"
 import {storage} from "@/utils/storage"
 
 const ACCESS_KEY = "mentra.account.accessToken"
 const REFRESH_KEY = "mentra.account.refreshToken"
+const OAUTH_STATE_KEY = "mentra.account.oauth.state"
+const OAUTH_VERIFIER_KEY = "mentra.account.oauth.verifier"
 
 type Tokens = {access: string; refresh: string}
 
@@ -201,6 +204,93 @@ export class AccountAuthProvider extends AuthClient {
     return Res.try_async(async () => {
       saveTokens({access: tokens.access_token, refresh: tokens.refresh_token})
       this.notify("TOKEN_REFRESHED")
+    })
+  }
+
+  public updateUserPassword(newPassword: string, currentPassword?: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      // The account backend re-verifies the current password server side; a
+      // stolen session alone must not be enough to rotate the credential.
+      if (!currentPassword) throw new Error("current password required")
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/password/change"), {
+        method: "POST",
+        headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+        body: JSON.stringify({currentPassword, newPassword}),
+      })
+      if (!res.ok) await throwApiError(res)
+    })
+  }
+
+  public updateUserEmail(newEmail: string, password?: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      if (!password) throw new Error("password required")
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/email/change"), {
+        method: "POST",
+        headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+        body: JSON.stringify({newEmail, password}),
+      })
+      if (!res.ok && res.status !== 202) await throwApiError(res)
+    })
+  }
+
+  public confirmEmailChange(code: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/email/change/confirm"), {
+        method: "POST",
+        headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+        body: JSON.stringify({code}),
+      })
+      if (!res.ok) await throwApiError(res)
+      this.notify("USER_UPDATED")
+    })
+  }
+
+  /** Build the OAuth start URL for the system browser. The PKCE verifier and
+   * state stay in MMKV; only the S256 challenge leaves the device, so an
+   * intercepted deep link cannot be completed without the verifier. */
+  private oauthStartUrl(provider: "google" | "apple"): string {
+    const state = randomUrlSafe(16)
+    const verifier = randomUrlSafe(32)
+    storage.save(OAUTH_STATE_KEY, state)
+    storage.save(OAUTH_VERIFIER_KEY, verifier)
+    const q = new URLSearchParams({state, code_challenge: s256Challenge(verifier)})
+    return core(`/api/account/oauth/${provider}/start?${q}`)
+  }
+
+  public googleSignIn(): AsyncResult<string, Error> {
+    return Res.try_async(async () => this.oauthStartUrl("google"))
+  }
+
+  public appleSignIn(): AsyncResult<string, Error> {
+    return Res.try_async(async () => this.oauthStartUrl("apple"))
+  }
+
+  /** Deep link landed with ?code&state: verify state, swap the handoff code +
+   * verifier for the V2 session at /oauth/complete. */
+  public completeOAuthHandoff(params: {code: string; state: string}): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const expectedState = storage.load<string>(OAUTH_STATE_KEY)
+      const verifier = storage.load<string>(OAUTH_VERIFIER_KEY)
+      if (expectedState.is_error() || verifier.is_error() || !expectedState.value || !verifier.value) {
+        throw new Error("no oauth flow in progress")
+      }
+      if (params.state !== expectedState.value) throw new Error("oauth state mismatch")
+      storage.remove(OAUTH_STATE_KEY)
+      storage.remove(OAUTH_VERIFIER_KEY)
+      const res = await fetch(core("/api/account/oauth/complete"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({code: params.code, code_verifier: verifier.value}),
+      })
+      if (!res.ok) await throwApiError(res)
+      const body = (await res.json()) as {access_token: string; refresh_token: string}
+      if (!body?.access_token || !body?.refresh_token) throw new Error("oauth completion returned no session")
+      saveTokens({access: body.access_token, refresh: body.refresh_token})
+      const session = await this.getSession()
+      stateCb?.("SIGNED_IN", session.is_ok() ? session.value : {token: body.access_token})
     })
   }
 

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -372,13 +372,22 @@ export class AccountAuthProvider extends AuthClient {
         throw new Error("no oauth flow in progress")
       }
       if (params.state !== expectedState.value) throw new Error("oauth state mismatch")
+      // Keep state+verifier until the server definitively answers: a transient
+      // network failure here must leave the deep link retryable (the handoff
+      // code is unconsumed server-side). Clear on success or on a definitive
+      // rejection (the code is burned either way).
+      let res: Response
+      try {
+        res = await fetch(core("/api/account/oauth/complete"), {
+          method: "POST",
+          headers: {"content-type": "application/json"},
+          body: JSON.stringify({code: params.code, code_verifier: verifier.value}),
+        })
+      } catch (err) {
+        throw err instanceof Error ? err : new Error(String(err))
+      }
       storage.remove(OAUTH_STATE_KEY)
       storage.remove(OAUTH_VERIFIER_KEY)
-      const res = await fetch(core("/api/account/oauth/complete"), {
-        method: "POST",
-        headers: {"content-type": "application/json"},
-        body: JSON.stringify({code: params.code, code_verifier: verifier.value}),
-      })
       if (!res.ok) await throwApiError(res)
       const body = (await res.json()) as {access_token: string; refresh_token: string}
       if (!body?.access_token || !body?.refresh_token) throw new Error("oauth completion returned no session")
@@ -399,11 +408,18 @@ export class AccountAuthProvider extends AuthClient {
     return Res.try_async(async () => {
       const tokens = loadTokens()
       if (tokens) {
-        await fetch(core("/api/account/logout"), {
-          method: "POST",
-          headers: {"content-type": "application/json", authorization: `Bearer ${tokens.access}`},
-          body: JSON.stringify({}),
-        }).catch(() => null)
+        // Refresh first if the access token expired (1h TTL): revoking with a
+        // stale token 400s and would leave the server session alive even
+        // though the device forgets it. Best-effort — a dead session throws
+        // in ensureFreshAccess (already cleared) and offline just skips.
+        const access = await this.ensureFreshAccess().catch(() => null)
+        if (access) {
+          await fetch(core("/api/account/logout"), {
+            method: "POST",
+            headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+            body: JSON.stringify({}),
+          }).catch(() => null)
+        }
       }
       clearTokens()
       this.notify("SIGNED_OUT")

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -1,0 +1,228 @@
+/**
+ * @fileoverview AccountAuthProvider — talks to Cloud V2's first-party account
+ * backend (`/api/account/*`), replacing the embedded Supabase client and the
+ * legacy Cloud V1 token exchange (issue 019).
+ *
+ * The device holds ONLY Cloud V2 tokens (access + refresh). Login exchanges
+ * credentials server-side; the app never sees Supabase material. cloud-client
+ * gets a fresh short-lived subject token from `getSubjectToken()` and exchanges
+ * it, exactly as an external OEM's app would — Mentra is just another OEM.
+ */
+import {AsyncResult, result as Res, Result} from "typesafe-ts"
+
+import {AuthClient} from "@/utils/auth/authClient"
+import {MentraAuthSession, MentraAuthUser, MentraSigninResponse} from "@/utils/auth/authProvider.types"
+import {resolvedEndpoints} from "@/services/cloudClient"
+import {storage} from "@/utils/storage"
+
+const ACCESS_KEY = "mentra.account.accessToken"
+const REFRESH_KEY = "mentra.account.refreshToken"
+
+type Tokens = {access: string; refresh: string}
+
+function loadTokens(): Tokens | null {
+  const a = storage.load<string>(ACCESS_KEY)
+  const r = storage.load<string>(REFRESH_KEY)
+  if (a.is_error() || r.is_error() || !a.value || !r.value) return null
+  return {access: a.value, refresh: r.value}
+}
+
+function saveTokens(t: Tokens): void {
+  storage.save(ACCESS_KEY, t.access)
+  storage.save(REFRESH_KEY, t.refresh)
+}
+
+function clearTokens(): void {
+  storage.remove(ACCESS_KEY)
+  storage.remove(REFRESH_KEY)
+}
+
+function core(path: string): string {
+  return `${resolvedEndpoints().core.replace(/\/+$/, "")}${path}`
+}
+
+async function throwApiError(res: Response): Promise<never> {
+  const body = await res.json().catch(() => ({}) as any)
+  throw new Error(body?.error_description || body?.error || `HTTP ${res.status}`)
+}
+
+let stateCb: ((event: string, session: MentraAuthSession) => void) | null = null
+
+export class AccountAuthProvider extends AuthClient {
+  private static instance: AccountAuthProvider
+
+  public static async getInstance(): Promise<AccountAuthProvider> {
+    if (!AccountAuthProvider.instance) AccountAuthProvider.instance = new AccountAuthProvider()
+    return AccountAuthProvider.instance
+  }
+
+  private notify(event: string): void {
+    void this.getSession().then((r) => {
+      if (r.is_ok()) stateCb?.(event, r.value)
+    })
+  }
+
+  public onAuthStateChange(callback: (event: string, session: MentraAuthSession) => void): Result<any, Error> {
+    stateCb = callback
+    return Res.ok({unsubscribe: () => (stateCb = null)})
+  }
+
+  /** Return a valid access token, refreshing once via the V2 refresh grant if
+   * the stored one is rejected. Throws if there is no usable session. */
+  private async ensureFreshAccess(): Promise<string> {
+    const tokens = loadTokens()
+    if (!tokens) throw new Error("not signed in")
+    const probe = await fetch(core("/api/account/me"), {
+      headers: {authorization: `Bearer ${tokens.access}`},
+    })
+    if (probe.status !== 401) return tokens.access
+    const refreshed = await fetch(core("/api/client/auth/refresh"), {
+      method: "POST",
+      headers: {"content-type": "application/x-www-form-urlencoded"},
+      body: new URLSearchParams({grant_type: "refresh_token", refresh_token: tokens.refresh}),
+    })
+    if (!refreshed.ok) {
+      clearTokens()
+      throw new Error("session expired")
+    }
+    const body = (await refreshed.json()) as {access_token: string; refresh_token: string}
+    saveTokens({access: body.access_token, refresh: body.refresh_token})
+    return body.access_token
+  }
+
+  public getSession(): AsyncResult<MentraAuthSession, Error> {
+    return Res.try_async(async () => {
+      const tokens = loadTokens()
+      if (!tokens) return {token: undefined}
+      const meRes = await fetch(core("/api/account/me"), {
+        headers: {authorization: `Bearer ${tokens.access}`},
+      }).catch(() => null)
+      let user: MentraAuthUser | undefined
+      if (meRes?.ok) {
+        const me = (await meRes.json()) as {mentraUserId: string; email?: string; name?: string; avatarUrl?: string}
+        user = {id: me.mentraUserId, email: me.email, name: me.name ?? me.email ?? "", avatarUrl: me.avatarUrl}
+      }
+      return {token: tokens.access, user}
+    })
+  }
+
+  public getUser(): AsyncResult<MentraAuthUser, Error> {
+    return Res.try_async(async () => {
+      const s = await this.getSession()
+      if (s.is_error() || !s.value.user) throw new Error("no user")
+      return s.value.user
+    })
+  }
+
+  /** cloud-client calls this to get a token to exchange. We mint a fresh
+   * short-lived `mentra` subject token from the account backend (the OEM
+   * "mint a subject token for my app" surface). */
+  public getSubjectToken(): AsyncResult<{token: string; type: string}, Error> {
+    return Res.try_async(async () => {
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/subject-token"), {
+        method: "POST",
+        headers: {authorization: `Bearer ${access}`},
+      })
+      if (!res.ok) await throwApiError(res)
+      const body = (await res.json()) as {token: string; type: string}
+      return {token: body.token, type: body.type}
+    })
+  }
+
+  public signInWithPassword(credentials: {email: string; password: string}): AsyncResult<MentraSigninResponse, Error> {
+    return Res.try_async(async () => {
+      const res = await fetch(core("/api/account/login"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify(credentials),
+      })
+      if (!res.ok) await throwApiError(res)
+      const body = (await res.json()) as {access_token: string; refresh_token: string}
+      saveTokens({access: body.access_token, refresh: body.refresh_token})
+      const session = await this.getSession()
+      const value = session.is_ok() ? session.value : {token: body.access_token}
+      // Notify synchronously with the session we already fetched (rather than via
+      // notify()'s extra async /me round-trip) so AuthContext.user is populated
+      // before this call resolves and the login screen navigates to "/". Otherwise
+      // the home-boot auth check races the async listener and bounces to /auth/start.
+      stateCb?.("SIGNED_IN", value)
+      return {session: value, user: value.user ?? null}
+    })
+  }
+
+  public signUp(credentials: {email: string; password: string}): AsyncResult<MentraSigninResponse, Error> {
+    return Res.try_async(async () => {
+      const res = await fetch(core("/api/account/signup"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify(credentials),
+      })
+      if (!res.ok && res.status !== 202) await throwApiError(res)
+      return {session: null, user: null}
+    })
+  }
+
+  public resendSignupEmail(email: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      await fetch(core("/api/account/verify/resend"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({email}),
+      })
+    })
+  }
+
+  public resetPasswordForEmail(email: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      await fetch(core("/api/account/password/forgot"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({email}),
+      })
+    })
+  }
+
+  public resetPasswordByCode(email: string, code: string, newPassword: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const res = await fetch(core("/api/account/password/reset"), {
+        method: "POST",
+        headers: {"content-type": "application/json"},
+        body: JSON.stringify({email, code, newPassword}),
+      })
+      if (!res.ok) await throwApiError(res)
+      const body = (await res.json()) as {access_token: string; refresh_token: string}
+      saveTokens({access: body.access_token, refresh: body.refresh_token})
+      this.notify("SIGNED_IN")
+    })
+  }
+
+  public updateSessionWithTokens(tokens: {access_token: string; refresh_token: string}): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      saveTokens({access: tokens.access_token, refresh: tokens.refresh_token})
+      this.notify("TOKEN_REFRESHED")
+    })
+  }
+
+  public startAutoRefresh(): AsyncResult<void, Error> {
+    return Res.try_async(async () => {})
+  }
+  public stopAutoRefresh(): AsyncResult<void, Error> {
+    return Res.try_async(async () => {})
+  }
+
+  public signOut(): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const tokens = loadTokens()
+      if (tokens) {
+        await fetch(core("/api/account/logout"), {
+          method: "POST",
+          headers: {"content-type": "application/json", authorization: `Bearer ${tokens.access}`},
+          body: JSON.stringify({}),
+        }).catch(() => null)
+      }
+      clearTokens()
+      this.notify("SIGNED_OUT")
+    })
+  }
+}

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -315,6 +315,33 @@ export class AccountAuthProvider extends AuthClient {
     })
   }
 
+  public requestAccountDeletion(): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/delete/request"), {
+        method: "POST",
+        headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+        body: JSON.stringify({}),
+      })
+      if (!res.ok && res.status !== 202) await throwApiError(res)
+    })
+  }
+
+  public confirmAccountDeletion(code: string): AsyncResult<void, Error> {
+    return Res.try_async(async () => {
+      const access = await this.ensureFreshAccess()
+      const res = await fetch(core("/api/account/delete/confirm"), {
+        method: "POST",
+        headers: {"content-type": "application/json", authorization: `Bearer ${access}`},
+        body: JSON.stringify({code}),
+      })
+      if (!res.ok) await throwApiError(res)
+      // The account is gone; the server revoked every session already.
+      clearTokens()
+      stateCb?.("SIGNED_OUT", {token: undefined})
+    })
+  }
+
   /** Build the OAuth start URL for the system browser. The PKCE verifier and
    * state stay in MMKV; only the S256 challenge leaves the device, so an
    * intercepted deep link cannot be completed without the verifier. */

--- a/mobile/src/utils/auth/provider/authingClient.ts
+++ b/mobile/src/utils/auth/provider/authingClient.ts
@@ -362,6 +362,22 @@ export class AuthingWrapperClient extends AuthClient {
   public googleSignIn(): AsyncResult<string, Error> {
     return Res.error_async(new Error("Method not implemented"))
   }
+
+  /** cloud-client subject token for the China deployment. Reproduces the
+   * pre-cutover MantleManager behavior exactly: hand over the session token
+   * with the "supabase" type tag, which the China cloud's exchange accepts.
+   * (The 019 cutover moved this seam from MantleManager into the providers;
+   * without this override China sign-in worked but cloud-client could never
+   * authenticate.) */
+  public getSubjectToken(): AsyncResult<{token: string; type: string}, Error> {
+    return Res.try_async(async () => {
+      const res = await this.getSession()
+      if (res.is_error() || !res.value.token) {
+        throw new Error("getSubjectToken: no session token available")
+      }
+      return {token: res.value.token, type: "supabase"}
+    })
+  }
 }
 
 export const authingClient = AuthingWrapperClient.getInstance()


### PR DESCRIPTION
## Issue 019 — replace the mobile login system so the app has zero dependency on legacy Cloud V1

Mentra becomes **just another OEM** against Cloud V2: no embedded Supabase client, no legacy V1 token exchange on the device. The mobile app authenticates entirely against Cloud V2's first-party account backend, and the same path an external OEM would use.

### Server (cloud-v2/core)
- **Account module** (prior commits): `/api/account/*` — signup, verify/resend, login, password forgot/reset/change, logout, `/me`, email change, account deletion, and OAuth start/callback/complete. Only `gotrue.client.ts` is Supabase-aware; everything else is provider-agnostic.
- **`POST /api/account/subject-token`** (this PR): authenticated by the current V2 session, mints a short-lived `mentra` subject token that the device exchanges at the **public** `/api/client/auth/exchange`. No privileged Mentra-only path — OEM parity, enforced by tests.
- **Signing-keys split**: key management extracted from `session.service.ts` into `signing-keys.service.ts`.
- **Fresh-DB migration guard**: `dropLegacyUserIdentityIndex` no longer crashes boot on a database with no `users` collection.

### Mobile
- **`AccountAuthProvider`** replaces the Supabase provider. The device holds only V2 tokens (MMKV); `cloud-client` mints a fresh subject token via `getSubjectToken()` and exchanges it — identical to an external OEM app.
- `authClient.ts`: default (non-China) provider is now `AccountAuthProvider`; adds `getSubjectToken()` to the contract.
- `MantleManager.ts`: `toolkit.configure` `getSubjectToken` sources from the provider.
- `index.tsx`: boot needs only a valid V2 session, then `mantle.init()`; drops the `restComms`/`socketComms` V1 exchange.

### Verification
- **Integration tests** (mock GoTrue): login+refresh, uniform `invalid_credentials`, `verification_required`, `/me`, single-use reset codes, logout-everywhere, **+ 2 OEM-parity tests** (subject token through the public exchange; a disabled `mentra` OEM row blocks refresh).
- **Live e2e — local core vs real Supabase**: full chain `login → subject-token → exchange → runtime-token → /me` all HTTP 200; runtime WebSocket handshake returns `101 Switching Protocols` for a Core-brokered `aud=cloud-runtime` token.
- **Android emulator**: fresh dev build, logged in through the app UI with test creds → V2 session → onboarding → home. Session persists across relaunch (auto-restore from MMKV).

### Migration note
No migration of logged-in users: on update they are logged out once, log back in, and are migrated. Legacy `SocketComms` (still dialing prod `glasses-ws`) is dead V1 wiring flagged for a follow-up cleanup PR.

### Docs
`cloud-v2/docs/issues/019-mentra-account-auth/{README,spike,spec,design}.md` — design.md §9 is the OEM reference-parity table.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> This is a breaking auth cutover (forced re-login) touching credential verification, token minting, OAuth PKCE, session revocation, and mobile boot paths; mistakes could lock users out or weaken OEM parity guarantees.
> 
> **Overview**
> **Issue 019** moves consumer mobile login off embedded Supabase and legacy Cloud V1 onto Cloud V2’s first-party **`/api/account/*`** surface, with the device holding **V2 access/refresh only** and cloud-client exchanging **minted `mentra` OEM subject tokens** at the public `/api/client/auth/exchange`.
> 
> **Core** adds the account module (GoTrue behind `gotrue.client.ts`, hashed one-time codes, rate limits, OAuth with dual PKCE and deep-link handoff), mounts **`POST /api/account/subject-token`**, gates account routes to **`tenantId === "mentra"`**, seeds a **`mentra` OEM row** when account keys are set, and splits signing/JWKS into **`signing-keys.service.ts`** (optional `mentra-account-1` kid). Session refresh now treats **`mentra` like other OEMs** when an `oems` row exists, with a transitional allow when it does not.
> 
> **Mobile** switches the default provider to **`AccountAuthProvider`**, adds **`getSubjectToken()` / `completeOAuthHandoff()`**, drops boot-time V1 **`restComms.exchangeToken`** and **`socketComms` auth**, stops starting the V1 websocket, routes forgot-password and email change through **numeric codes**, and adds **in-app account deletion** (request → confirm). Deep links handle **OAuth handoff** and no longer adopt GoTrue fragment tokens as V2 sessions.
> 
> **Infra/docs**: **`cloud-isaiah`** Porter deploy workflow, per-env UDP NLB template + runbook updates, and issue **019** design docs. Integration tests cover OEM parity, tenant gate, rate limits, and JWKS behavior when account keys are unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb721cbe3b1f88362c2cb20d8f4099033611ce5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced mobile login with Cloud V2 first‑party account auth and removed all Cloud V1 + embedded Supabase paths. Improves reliability (verified email changes, resilient OAuth handoff, stricter rate limits, consistent logout) and fixes reset email lookup and OAuth callback robustness; users are logged out once on update.

- **New Features**
  - Core: `cloud-v2` account module at `/api/account/*` (signup/login/password/email/delete/logout/`/me`, OAuth with PKCE), `POST /api/account/subject-token`, signing keys split to `signing-keys.service.ts` with JWKS publishing when set, startup seeding a `mentra` OEM row, Mentra‑tenant gate on account endpoints, and per‑IP/email rate limits. Email change applies with `email_confirm: true`; one‑time code issuance retries on duplicate collisions. Removed V1 deletion fan‑out and related env flags.
  - Mobile: switched to `AccountAuthProvider` (MMKV V2 tokens only) with `getSubjectToken()`, Google/Apple OAuth with PKCE and deep‑link handoff, password change requires current password, two‑step email change (request + confirm code), in‑app account deletion (request code → confirm code), silent refresh on boot, offline restore of last `/me`, deep links no longer adopt GoTrue fragment tokens, OAuth handoff retry‑safe, sign‑out refreshes an expired access token before `/logout`, and the legacy Cloud V1 websocket no longer starts. China `AuthingWrapperClient.getSubjectToken()` preserves the `"supabase"` flow.
  - Hardening/tests/infra/docs: uniform errors; JWKS omits the account key when unset; integration tests for OEM parity, PKCE params, email‑change gating, JWKS, rate‑limits, and tenant gates; `cloud-isaiah` sandbox + per‑env UDP NLB template/runbook updates; docs note the user‑row deletion tombstone as an open decision.

- **Bug Fixes**
  - Password reset: reliable email lookup via exact match across GoTrue admin pages (no silent 202 without a code).
  - OAuth: callback now consumes the start record only after a successful exchange to avoid stranded flows.

<sup>Written for commit 1bb721cbe3b1f88362c2cb20d8f4099033611ce5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

