### PR TITLE
Ship the MentraLive_20260709 MTK + BES OTA to prod manifests (OS-1650)

### DIFF
--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -58,8 +58,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.03",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.03.bin",
-    "sha256": "a652466b5fefab820f76434eee545e52cc481ba1920cb7a00770b9e9360a7133"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   }
 }

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,40 +15,46 @@
   },
   "mtk_patches": [
     {
-      "start_firmware": "MentraLive_20260525",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
-      "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
-    },
-    {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260626.zip",
-      "sha256": "29f6e576d64af5cbf9b1876b6b4bc4e8dbfe0282d2b55770868835802d588f0c"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260626.zip",
-      "sha256": "b0e03742d7a7f5969a625f9cb96864efb27a4b42c2075e0dff51457724cb5ea2"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260626.zip",
-      "sha256": "7be3fcc0b287a1675d7aee69cd1e8869443041d9eb53dc0f4078406c44720864"
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
     },
     {
       "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260626.zip",
-      "sha256": "cc58004dc60ddd48a16dae64cb1d1babe2168f04f1ff973f6de3228e0745d554"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
     },
     {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260626.zip",
-      "sha256": "69430f579c5a2b8d553a1529a7379687a18d71f8ff09239f4cac130f358730d3"
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
+      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
+    },
+    {
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -14,6 +14,48 @@
     }
   },
   "mtk_patches": [
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
+    },
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
+      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
+    },
+    {
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
+    }
   ],
   "bes_firmware": {
     "version": "17.26.05.22",

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -58,9 +58,9 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   },
   "remediation": {
     "enabled": false,


### PR DESCRIPTION
## What

Ship the new **20260709** firmware set (MTK heal patches + paired BES bump) to the production OTA website manifests, for [OS-1650](https://linear.app/mentralabs/issue/OS-1650/mtk-patch-heal-stuck-asg-client-37-39-by-reinstalling-system-apk-to). The MTK firmware ships ASG Client 39 in `/system` **plus the first-boot heal script** that reinstalls it over the stale `/data` 37 overlay, so units stuck running 37 (with 39 masked in `/system`) recover automatically.

## 1. MTK patches → `MentraLive_20260709`

Both manifests now expose one patch per starting firmware, all targeting `MentraLive_20260709`:

| start firmware | → end |
|---|---|
| 20260113 | 20260709 |
| 20260204 | 20260709 |
| 20260418 | 20260709 |
| 20260421 | 20260709 |
| 20260513 | 20260709 |
| 20260525 | 20260709 |
| 20260626 | 20260709 |

- **`prod_live_version.json`** (legacy): replaced the six `→ MentraLive_20260626` patches with the seven `→ MentraLive_20260709` above.
- **`prod_live_version_v2.json`** (current — read by the on-device OTA updater / recovery worker / mobile prod path): populated the previously-empty `mtk_patches` with the same seven.

Every starting firmware appears exactly once — no starting point has two candidate updates.

## 2. BES → `17.26.07.09` (the reboot trigger)

Same trick as the 07.03 bump (`80364ca62c`, OS-1644): the BES step runs **after** the MTK patch and triggers the automatic device power-cycle that **applies the staged MTK slot**. Without a BES bump the healed `/system` 39 image is staged but never booted.

- **`prod_live_version.json`**: `17.26.07.03 → 17.26.07.09`.
- **`prod_live_version_v2.json`**: `17.26.05.22 → 17.26.07.09`. The 07.03 bump was V1-only because V2 had no MTK patches then; V2 now carries the 20260709 patches, so it needs the reboot trigger too.

The manifest `.bin` is `update_ota.bin` extracted from `bes_mentra_20260709.zip`, uploaded raw as `bes_firmware_17.26.07.09.bin` — matching how every prior BES asset is published (the client streams the file to the chip without unzipping; the full zip exceeds the 2 MiB / `BesOtaUtil` cap).

## Release assets (`asg-client`)

Uploaded and URL-verified (HTTP 200):
- 7× `mtk_ota_update_<start>_20260709.zip`
- `bes_firmware_17.26.07.09.bin` (= `update_ota.bin`, sha `4daaf2a4…`)
- `bes_mentra_20260709.zip` (source archive, provenance)

Every `sha256` in both manifests was verified against the actual uploaded asset.

## Notes

- Based on `main` and targeting `main` (production OTA is served from `main`), per request.
- Version `17.26.07.09` follows the date convention (`bes_mentra_20260703.zip → 17.26.07.03`); it isn't embedded as ASCII in the binary, so worth a sanity check.
- **Do not merge yet** — for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes live fleet OTA metadata (MTK patch URLs, hashes, and BES firmware); incorrect values could block or mis-apply device updates until reverted.
> 
> **Overview**
> Updates production OTA manifests so **MTK incremental patches** all target **`MentraLive_20260709`** instead of **`MentraLive_20260626`**, with new GitHub release ZIP URLs and **sha256** values. **`prod_live_version.json`** replaces the previous six `→ 20260626` entries with **seven** one-per-start-firmware paths (including **`20260626 → 20260709`**). **`prod_live_version_v2.json`** fills the previously empty **`mtk_patches`** array with the same seven entries.
> 
> Both files also bump **`bes_firmware`** to **`17.26.07.09`** (new `.bin` URL and sha256); **`apps`** / **`remediation`** in v2 are unchanged in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d12b4bfd908ff252b050512f94fefd7fcf85be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->