### PR TITLE
Stamp SDK requestId into photo capture folder names

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriter.java
@@ -40,18 +40,54 @@ public final class PhotoExifMetadataWriter {
         }
     }
 
+    /**
+     * Stamp the capture ID (the capture directory name, e.g. {@code IMG_..._<requestId>})
+     * into EXIF ImageUniqueID so the request correlation survives file renames and
+     * camera-roll export. Derived from the file's own path, which covers every capture
+     * flow (SDK and button, gallery and transient) without threading IDs through the
+     * camera layer. No-op for files that don't live in a capture directory. Best-effort:
+     * a capture must never fail over metadata.
+     */
+    public static void writeCaptureIdFromPath(String jpegPath) {
+        try {
+            File parent = new File(jpegPath).getParentFile();
+            String captureId = parent != null ? parent.getName() : null;
+            if (captureId == null
+                    || !(captureId.startsWith("IMG_") || captureId.startsWith("VID_"))) {
+                return;
+            }
+            ExifInterface exif = new ExifInterface(jpegPath);
+            exif.setAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID, captureId);
+            exif.saveAttributes();
+            Log.d(TAG, "Wrote ImageUniqueID EXIF to " + jpegPath + ": " + captureId);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to write ImageUniqueID EXIF on " + jpegPath, e);
+        }
+    }
+
+    /** Copies capture metadata (IMU UserComment + ImageUniqueID) onto a re-encoded copy. */
     public static void copyImuMetadata(String sourcePath, String destPath) {
         try {
             String json = readImuJsonFromJpeg(sourcePath);
-            if (json == null || json.isEmpty()) {
+            String uniqueId =
+                    new ExifInterface(sourcePath)
+                            .getAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID);
+            boolean hasJson = json != null && !json.isEmpty();
+            boolean hasUniqueId = uniqueId != null && !uniqueId.isEmpty();
+            if (!hasJson && !hasUniqueId) {
                 return;
             }
             ExifInterface dest = new ExifInterface(destPath);
-            dest.setAttribute(ExifInterface.TAG_USER_COMMENT, json);
+            if (hasJson) {
+                dest.setAttribute(ExifInterface.TAG_USER_COMMENT, json);
+            }
+            if (hasUniqueId) {
+                dest.setAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID, uniqueId);
+            }
             dest.saveAttributes();
-            Log.d(TAG, "Copied IMU EXIF from " + sourcePath + " to " + destPath);
+            Log.d(TAG, "Copied capture EXIF from " + sourcePath + " to " + destPath);
         } catch (IOException e) {
-            Log.w(TAG, "Failed to copy IMU EXIF metadata", e);
+            Log.w(TAG, "Failed to copy capture EXIF metadata", e);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -807,6 +807,11 @@ public final class PhotoSession {
                 output.write(data);
             }
 
+            // Stamp the capture ID (directory name, carries the SDK requestId) into EXIF
+            // ImageUniqueID so the correlation survives renames and camera-roll export.
+            // Runs before finishImuRecording's EXIF pass; saveAttributes preserves it.
+            PhotoExifMetadataWriter.writeCaptureIdFromPath(filePath);
+
             Log.d(TAG, "Saved image to: " + filePath);
             return true;
         } catch (Exception e) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -29,6 +29,7 @@ import com.mentra.asg_client.service.core.CameraRestartCooldown;
 import com.mentra.asg_client.service.core.constants.BatteryConstants;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
 import com.mentra.asg_client.settings.VideoSettings;
+import com.mentra.asg_client.utils.CaptureRequestId;
 import com.mentra.asg_client.utils.GalleryStatusHelper;
 import com.mentra.asg_client.utils.GallerySyncFilter;
 import java.io.File;
@@ -634,7 +635,13 @@ public class MediaCaptureService {
         String timeStamp =
                 new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
         int randomSuffix = (int) (Math.random() * 1000);
-        String captureDir = "VID_" + timeStamp + "_" + randomSuffix + "_" + requestId;
+        String embeddedRequestId = CaptureRequestId.sanitizeForDirName(requestId);
+        String captureDir =
+                "VID_"
+                        + timeStamp
+                        + "_"
+                        + randomSuffix
+                        + (embeddedRequestId.isEmpty() ? "" : "_" + embeddedRequestId);
         File captureDirFile = new File(fileManager.getDefaultMediaDirectory(), captureDir);
         captureDirFile.mkdirs();
         String videoFilePath = new File(captureDirFile, "base.mp4").getAbsolutePath();
@@ -1468,8 +1475,8 @@ public class MediaCaptureService {
         Log.i(
                 TAG,
                 "📸 take_photo (button/local) resolved params"
-                        + " requestId=local_"
-                        + timeStamp
+                        + " requestId="
+                        + captureDir
                         + " size="
                         + size
                         + " compress="
@@ -1490,8 +1497,10 @@ public class MediaCaptureService {
         // Log test configuration for debugging
         PhotoCaptureTestHooks.logTestConfig();
 
-        // Generate a temporary requestId first
-        String requestId = "local_" + timeStamp;
+        // Button captures have no phone-originated requestId; the capture directory name is
+        // their stable ID (it is what gallery sync exposes as capture_id), so status messages
+        // carry it instead of a throwaway local_<timestamp> string.
+        String requestId = captureDir;
         sendPhotoStatus(requestId, "queued");
 
         // TESTING: Check for fake camera initialization failure

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
@@ -9,6 +9,7 @@ import com.mentra.asg_client.logging.Logger;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.file.core.FileManager.FileMetadata;
 import com.mentra.asg_client.io.file.core.FileManager.FileOperationResult;
+import com.mentra.asg_client.utils.CaptureRequestId;
 import com.mentra.asg_client.utils.GallerySyncFilter;
 
 import java.io.BufferedInputStream;
@@ -392,6 +393,13 @@ public class AsgCameraServer extends AsgServer {
                 photoInfo.put("mime_type", photoMetadata.getMimeType());
                 photoInfo.put("url", "/api/photo?file=" + photoMetadata.getFileName());
                 photoInfo.put("download", "/api/download?file=" + photoMetadata.getFileName());
+
+                // Originating SDK requestId embedded in the capture directory name, when present.
+                String photoRequestId = CaptureRequestId.extractFromCaptureId(
+                        deriveCaptureId(photoMetadata.getFileName()));
+                if (photoRequestId != null) {
+                    photoInfo.put("request_id", photoRequestId);
+                }
                 
                 // Add video-specific information
                 if (isVideoFile(photoMetadata.getFileName())) {
@@ -1437,6 +1445,14 @@ public class AsgCameraServer extends AsgServer {
 
                 Map<String, Object> capture = new HashMap<>();
                 capture.put("capture_id", captureId);
+
+                // Surface the originating SDK requestId (embedded in the capture directory
+                // name) so clients can correlate synced files with photo/video requests
+                // without timestamp matching. Absent for button captures and legacy files.
+                String captureRequestId = CaptureRequestId.extractFromCaptureId(captureId);
+                if (captureRequestId != null) {
+                    capture.put("request_id", captureRequestId);
+                }
 
                 // Determine type from primary file
                 boolean isVideo = captureId.startsWith("VID_") || captureId.startsWith("BUFFER_");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/BaseMediaCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/BaseMediaCommandHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.service.legacy.interfaces.ICommandHandler;
+import com.mentra.asg_client.utils.CaptureRequestId;
 import org.json.JSONObject;
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -127,22 +128,24 @@ public abstract class BaseMediaCommandHandler implements ICommandHandler {
     
     /**
      * Generate a capture directory with base file inside it.
-     * Creates a folder like IMG_20250302_143022_456/ with base.jpg inside.
+     * Creates a folder like IMG_20250302_143022_456_photoReq123/ with base.jpg inside.
+     * The requestId is embedded in the directory name (mirroring the video convention) so
+     * gallery-synced files can be correlated with the originating SDK request without
+     * timestamp matching.
      *
      * @param packageName The package name
      * @param prefix File prefix (e.g., "IMG_", "VID_")
      * @param extension File extension (e.g., ".jpg", ".mp4")
+     * @param requestId Request ID to embed in the directory name (may be empty)
      * @return Full file path to base file inside capture directory, or null if failed
      */
-    protected String generateCaptureFilePath(String packageName, String prefix, String extension) {
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
-        int randomSuffix = (int)(Math.random() * 1000);
-        String captureDir = prefix + timeStamp + "_" + randomSuffix;
+    protected String generateCaptureFilePath(
+            String packageName, String prefix, String extension, String requestId) {
         File packageDir = getPackageDirectory(packageName);
         if (packageDir == null) {
             return null;
         }
-        File captureDirFile = new File(packageDir, captureDir);
+        File captureDirFile = new File(packageDir, generateCaptureDirName(prefix, requestId));
         captureDirFile.mkdirs();
         String filePath = new File(captureDirFile, "base" + extension).getAbsolutePath();
         Log.d(TAG, "Generated capture file path: " + filePath);
@@ -157,20 +160,34 @@ public abstract class BaseMediaCommandHandler implements ICommandHandler {
      * Wi-Fi sync server's listing while the upload is in flight, and the existing periodic
      * {@code cleanupOldFiles} sweep still age-cleans any orphans left by a crash.
      */
-    protected String generateTransientCaptureFilePath(String packageName, String prefix, String extension) {
-        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
-        int randomSuffix = (int)(Math.random() * 1000);
-        String captureDir = prefix + timeStamp + "_" + randomSuffix;
+    protected String generateTransientCaptureFilePath(
+            String packageName, String prefix, String extension, String requestId) {
         File packageDir = getPackageDirectory(packageName);
         if (packageDir == null) {
             return null;
         }
         File pendingRoot = new File(packageDir, FileManager.SDK_PENDING_DIR_NAME);
-        File captureDirFile = new File(pendingRoot, captureDir);
+        File captureDirFile = new File(pendingRoot, generateCaptureDirName(prefix, requestId));
         captureDirFile.mkdirs();
         String filePath = new File(captureDirFile, "base" + extension).getAbsolutePath();
         Log.d(TAG, "Generated transient (sync-hidden) capture file path: " + filePath);
         return filePath;
+    }
+
+    /**
+     * Build a capture directory name: {@code <prefix><timestamp>_<rand>[_<requestId>]}.
+     * The random component keeps names unique in rapid capture; the sanitized requestId
+     * suffix ties the saved capture back to the request that produced it.
+     */
+    private String generateCaptureDirName(String prefix, String requestId) {
+        String timeStamp = new SimpleDateFormat("yyyyMMdd_HHmmss_SSS", Locale.US).format(new Date());
+        int randomSuffix = (int)(Math.random() * 1000);
+        String captureDir = prefix + timeStamp + "_" + randomSuffix;
+        String embeddedId = CaptureRequestId.sanitizeForDirName(requestId);
+        if (!embeddedId.isEmpty()) {
+            captureDir += "_" + embeddedId;
+        }
+        return captureDir;
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -238,8 +238,8 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             // the transient _sdk_pending tree so in-flight SDK photos are invisible to gallery
             // sync and are cleaned up automatically after upload.
             String photoFilePath = save
-                    ? generateCaptureFilePath(packageName, "IMG_", ".jpg")
-                    : generateTransientCaptureFilePath(packageName, "IMG_", ".jpg");
+                    ? generateCaptureFilePath(packageName, "IMG_", ".jpg", requestId)
+                    : generateTransientCaptureFilePath(packageName, "IMG_", ".jpg", requestId);
             if (photoFilePath == null) {
                 logCommandResult("take_photo", false, "Failed to generate file path");
                 captureService.sendPhotoErrorResponse(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/CaptureRequestId.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/CaptureRequestId.java
@@ -1,0 +1,58 @@
+package com.mentra.asg_client.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Helpers for embedding a capture request ID in capture directory names and recovering it later.
+ *
+ * <p>Capture directories are named {@code <IMG|VID>_<yyyyMMdd_HHmmss_SSS>_<rand>[_<requestId>]}.
+ * The optional trailing segment is the sanitized ID of the SDK request that produced the capture,
+ * so files pulled during gallery sync can be correlated with the originating request instead of
+ * being timestamp-matched (which breaks under clock skew and rapid bursts). Button captures have
+ * no originating request; their stable ID is the capture directory name itself.
+ */
+public final class CaptureRequestId {
+
+    /** Matches capture directory names; group(1) is the embedded request ID, if any. */
+    private static final Pattern CAPTURE_DIR_PATTERN =
+            Pattern.compile("^(?:IMG|VID)_\\d{8}_\\d{6}_\\d{3}_\\d{1,3}(?:_(.+))?$");
+
+    private static final int MAX_EMBEDDED_LENGTH = 64;
+
+    private CaptureRequestId() {}
+
+    /**
+     * Sanitize a request ID so it is safe to use as part of a single directory-name segment on
+     * the glasses and on the phone after sync. Returns an empty string when nothing embeddable
+     * remains (callers should then omit the suffix entirely).
+     */
+    public static String sanitizeForDirName(String requestId) {
+        if (requestId == null) {
+            return "";
+        }
+        String sanitized = requestId.replaceAll("[^A-Za-z0-9._-]", "-");
+        // A leading dot could hide the directory from naive listings; strip it.
+        sanitized = sanitized.replaceAll("^\\.+", "");
+        if (sanitized.length() > MAX_EMBEDDED_LENGTH) {
+            sanitized = sanitized.substring(0, MAX_EMBEDDED_LENGTH);
+        }
+        return sanitized;
+    }
+
+    /**
+     * Extract the request ID embedded in a capture ID (capture directory name), or {@code null}
+     * when the capture has none (button captures, legacy flat files).
+     */
+    public static String extractFromCaptureId(String captureId) {
+        if (captureId == null) {
+            return null;
+        }
+        Matcher matcher = CAPTURE_DIR_PATTERN.matcher(captureId);
+        if (!matcher.matches()) {
+            return null;
+        }
+        String embedded = matcher.group(1);
+        return (embedded == null || embedded.isEmpty()) ? null : embedded;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/CaptureRequestId.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/CaptureRequestId.java
@@ -26,16 +26,22 @@ public final class CaptureRequestId {
      * Sanitize a request ID so it is safe to use as part of a single directory-name segment on
      * the glasses and on the phone after sync. Returns an empty string when nothing embeddable
      * remains (callers should then omit the suffix entirely).
+     *
+     * <p>Dots are excluded from the allowlist entirely: a surviving ".." sequence would embed
+     * into the directory name and later be rejected by FileSecurityValidator's path-traversal
+     * check, leaving a capture that syncs into listings but can never be served or deleted.
      */
     public static String sanitizeForDirName(String requestId) {
         if (requestId == null) {
             return "";
         }
-        String sanitized = requestId.replaceAll("[^A-Za-z0-9._-]", "-");
-        // A leading dot could hide the directory from naive listings; strip it.
-        sanitized = sanitized.replaceAll("^\\.+", "");
+        String sanitized = requestId.replaceAll("[^A-Za-z0-9_-]", "-");
         if (sanitized.length() > MAX_EMBEDDED_LENGTH) {
             sanitized = sanitized.substring(0, MAX_EMBEDDED_LENGTH);
+        }
+        // A suffix that is all separators carries no information; omit it.
+        if (sanitized.matches("-+")) {
+            return "";
         }
         return sanitized;
     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriterTest.java
@@ -49,6 +49,69 @@ public class PhotoExifMetadataWriterTest {
     }
 
     @Test
+    public void writeCaptureIdStampsImageUniqueIdFromCaptureDirName() throws Exception {
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_photoReq99");
+        File jpeg = new File(captureDir, "base.jpg");
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(jpeg);
+
+        PhotoExifMetadataWriter.writeCaptureIdFromPath(jpeg.getAbsolutePath());
+
+        androidx.exifinterface.media.ExifInterface exif =
+                new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
+        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+                .isEqualTo("IMG_20260709_120000_123_456_photoReq99");
+    }
+
+    @Test
+    public void writeCaptureIdIsNoOpOutsideCaptureDirectories() throws Exception {
+        File jpeg = tempFolder.newFile("loose.jpg");
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(jpeg);
+
+        PhotoExifMetadataWriter.writeCaptureIdFromPath(jpeg.getAbsolutePath());
+
+        androidx.exifinterface.media.ExifInterface exif =
+                new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
+        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+                .isNull();
+    }
+
+    @Test
+    public void copyImuMetadataAlsoCarriesImageUniqueId() throws Exception {
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_reqA");
+        File source = new File(captureDir, "base.jpg");
+        File dest = tempFolder.newFile("reencoded.jpg");
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(source);
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(dest);
+
+        PhotoExifMetadataWriter.writeCaptureIdFromPath(source.getAbsolutePath());
+        PhotoExifMetadataWriter.copyImuMetadata(source.getAbsolutePath(), dest.getAbsolutePath());
+
+        androidx.exifinterface.media.ExifInterface exif =
+                new androidx.exifinterface.media.ExifInterface(dest.getAbsolutePath());
+        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+                .isEqualTo("IMG_20260709_120000_123_456_reqA");
+    }
+
+    @Test
+    public void imuWriteAfterCaptureIdPreservesImageUniqueId() throws Exception {
+        // Production order: saveImageDataToFile stamps ImageUniqueID, then
+        // finishImuRecording writes the IMU UserComment. The second save must not
+        // clobber the first tag.
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_reqB");
+        File jpeg = new File(captureDir, "base.jpg");
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(jpeg);
+
+        PhotoExifMetadataWriter.writeCaptureIdFromPath(jpeg.getAbsolutePath());
+        PhotoExifMetadataWriter.writeImuPayload(jpeg.getAbsolutePath(), samplePayload(2));
+
+        androidx.exifinterface.media.ExifInterface exif =
+                new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
+        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+                .isEqualTo("IMG_20260709_120000_123_456_reqB");
+        assertThat(PhotoExifMetadataWriter.hasImuMetadata(jpeg.getAbsolutePath())).isTrue();
+    }
+
+    @Test
     public void buildExifApp1SegmentStartsWithExifHeader() throws Exception {
         byte[] segment = PhotoExifMetadataWriter.buildExifApp1Segment(samplePayload(1));
         assertThat(segment.length).isGreaterThan(10);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/utils/CaptureRequestIdTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/utils/CaptureRequestIdTest.java
@@ -19,10 +19,12 @@ public class CaptureRequestIdTest {
 
     @Test
     public void sanitizeForDirName_stripsPathAndUnsafeCharacters() {
-        // Slashes are replaced and leading dots stripped, so no path segment survives.
-        assertEquals("-..-etc-passwd", CaptureRequestId.sanitizeForDirName("../../etc/passwd"));
+        // Dots are not allowlisted: a surviving ".." would trip FileSecurityValidator's
+        // path-traversal check when serving/deleting, stranding the capture.
+        assertEquals("------etc-passwd", CaptureRequestId.sanitizeForDirName("../../etc/passwd"));
         assertEquals("a-b-c", CaptureRequestId.sanitizeForDirName("a/b\\c"));
         assertEquals("", CaptureRequestId.sanitizeForDirName("..."));
+        assertEquals("v1-2-3", CaptureRequestId.sanitizeForDirName("v1.2.3"));
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/utils/CaptureRequestIdTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/utils/CaptureRequestIdTest.java
@@ -1,0 +1,70 @@
+package com.mentra.asg_client.utils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class CaptureRequestIdTest {
+
+    @Test
+    public void sanitizeForDirName_passesThroughTypicalRequestIds() {
+        assertEquals(
+                "photo_1751920000000_abc123",
+                CaptureRequestId.sanitizeForDirName("photo_1751920000000_abc123"));
+        assertEquals(
+                "550e8400-e29b-41d4-a716-446655440000",
+                CaptureRequestId.sanitizeForDirName("550e8400-e29b-41d4-a716-446655440000"));
+    }
+
+    @Test
+    public void sanitizeForDirName_stripsPathAndUnsafeCharacters() {
+        // Slashes are replaced and leading dots stripped, so no path segment survives.
+        assertEquals("-..-etc-passwd", CaptureRequestId.sanitizeForDirName("../../etc/passwd"));
+        assertEquals("a-b-c", CaptureRequestId.sanitizeForDirName("a/b\\c"));
+        assertEquals("", CaptureRequestId.sanitizeForDirName("..."));
+    }
+
+    @Test
+    public void sanitizeForDirName_handlesNullAndEmpty() {
+        assertEquals("", CaptureRequestId.sanitizeForDirName(null));
+        assertEquals("", CaptureRequestId.sanitizeForDirName(""));
+    }
+
+    @Test
+    public void sanitizeForDirName_capsLength() {
+        StringBuilder longId = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            longId.append("a");
+        }
+        assertEquals(64, CaptureRequestId.sanitizeForDirName(longId.toString()).length());
+    }
+
+    @Test
+    public void extractFromCaptureId_readsEmbeddedRequestId() {
+        assertEquals(
+                "photo_1751920000000_abc123",
+                CaptureRequestId.extractFromCaptureId(
+                        "IMG_20260709_143022_456_789_photo_1751920000000_abc123"));
+        assertEquals(
+                "req-42",
+                CaptureRequestId.extractFromCaptureId("VID_20260425_003433_149_402_req-42"));
+    }
+
+    @Test
+    public void extractFromCaptureId_returnsNullForButtonAndLegacyCaptures() {
+        // Button capture: no embedded request ID.
+        assertNull(CaptureRequestId.extractFromCaptureId("IMG_20260709_143022_456_789"));
+        // Legacy flat-file stem without millis/random components.
+        assertNull(CaptureRequestId.extractFromCaptureId("IMG_20250302_143022"));
+        assertNull(CaptureRequestId.extractFromCaptureId("BUFFER_20260709_143022_456_789"));
+        assertNull(CaptureRequestId.extractFromCaptureId(null));
+    }
+
+    @Test
+    public void extractFromCaptureId_roundTripsSanitizedIds() {
+        String sanitized = CaptureRequestId.sanitizeForDirName("photo:1751920000000/abc");
+        String captureId = "IMG_20260709_143022_456_789_" + sanitized;
+        assertEquals(sanitized, CaptureRequestId.extractFromCaptureId(captureId));
+    }
+}

--- a/asg_client/docs/features/camera-web-server.md
+++ b/asg_client/docs/features/camera-web-server.md
@@ -98,6 +98,12 @@ Bulk-delete a list of filenames. Used by the phone app when the user removes ite
 
 Files that don't exist are reported as `success: false` in the per-file results but don't fail the whole request.
 
+### Capture IDs and `request_id`
+
+Captures live in directories named `<IMG|VID>_<yyyyMMdd_HHmmss_SSS>_<rand>[_<requestId>]`. The directory name is the `capture_id` returned by `/api/sync`, and the optional trailing segment is the (sanitized) `requestId` of the SDK `take_photo` / video request that produced the capture — the same convention videos have always used, extended to photos.
+
+When a capture ID embeds a request ID, `/api/sync` capture groups and `/api/gallery` entries include it as an explicit `request_id` field (extracted by `CaptureRequestId.extractFromCaptureId`), so clients can correlate bulk-synced files with the originating photo request instead of timestamp-matching. Button-press captures have no originating request; their stable ID is the `capture_id` itself, which is also used as the `requestId` in the photo status messages the glasses emit during the capture. Legacy files and button captures simply omit `request_id`.
+
 ### Active recording exclusion
 
 `AsgCameraServer.ActiveRecordingProvider` lets the capture service inform the server about videos that are currently being written. The server uses this to:

--- a/asg_client/docs/features/camera-web-server.md
+++ b/asg_client/docs/features/camera-web-server.md
@@ -104,6 +104,8 @@ Captures live in directories named `<IMG|VID>_<yyyyMMdd_HHmmss_SSS>_<rand>[_<req
 
 When a capture ID embeds a request ID, `/api/sync` capture groups and `/api/gallery` entries include it as an explicit `request_id` field (extracted by `CaptureRequestId.extractFromCaptureId`), so clients can correlate bulk-synced files with the originating photo request instead of timestamp-matching. Button-press captures have no originating request; their stable ID is the `capture_id` itself, which is also used as the `requestId` in the photo status messages the glasses emit during the capture. Legacy files and button captures simply omit `request_id`.
 
+The capture ID is also stamped into the photo's EXIF `ImageUniqueID` tag at save time (`PhotoExifMetadataWriter.writeCaptureIdFromPath`), and carried onto re-encoded upload copies, so the correlation survives file renames and camera-roll export where the directory name is lost.
+
 ### Active recording exclusion
 
 `AsgCameraServer.ActiveRecordingProvider` lets the capture service inform the server about videos that are currently being written. The server uses this to:

--- a/mobile/modules/island/src/types/asg.ts
+++ b/mobile/modules/island/src/types/asg.ts
@@ -14,7 +14,8 @@ export interface CaptureFile {
 }
 
 export interface CaptureGroup {
-  capture_id: string // folder name: "IMG_20250302_143022_456_123"
+  capture_id: string // folder name: "IMG_20250302_143022_456_123" or "IMG_..._<requestId>"
+  request_id?: string // originating SDK requestId embedded in the folder name (absent for button captures / legacy files)
   type: "photo" | "video"
   timestamp: number
   total_size: number


### PR DESCRIPTION
## Scope

Customer-reported (Thunderbird): captured photos carry no stable ID tying them back to the BLE `take_photo` requestId, and button-press captures have no ID at all — so bulk gallery import is stuck timestamp-matching, which breaks under clock skew and bursts.

Videos already embed the requestId in their capture directory name (`VID_<ts>_<rand>_<requestId>`); photos simply omitted the suffix. This PR extends the same convention to photos and surfaces the ID through the sync API:

- **Photo capture directories** are now named `IMG_<ts>_<rand>_<sanitizedRequestId>` for SDK `take_photo` requests — both `save:true` gallery captures and transient `save:false` captures.
- **New `CaptureRequestId` util** sanitizes requestIds for safe directory-name embedding (single path segment, 64-char cap) and extracts them back out of capture IDs. The video path now uses the same sanitizer (defense-in-depth; no behavior change for normal IDs).
- **`/api/sync` capture groups and `/api/gallery` entries** expose the embedded ID as an explicit `request_id` field, so clients correlate bulk-synced files with the originating request instead of timestamp-matching. Field is absent for button captures and legacy files.
- **Button captures** have no originating request; their stable ID is the capture directory name itself (== `capture_id` in the sync API). Photo status messages now carry it instead of the old throwaway `local_<timestamp>` string (nothing phone-side special-cases that format — verified).
- Phone-side `CaptureGroup` type gains optional `request_id`; camera-web-server doc updated.

## Compatibility

- All folder-name consumers do `startsWith("IMG_"/"VID_")` checks or use the name opaquely (glasses `deriveCaptureId`, `FileManagerImpl`, phone gallery sync) — verified no structural parsing breaks.
- Old phone app versions ignore the extra `request_id` field and see slightly longer `capture_id`s, which they already treat as opaque.

## Test evidence

- `./scripts/check-android-compile.sh asg` — BUILD SUCCESSFUL
- New `CaptureRequestIdTest` JVM suite — 7/7 pass (`:app:testDebugUnitTest`)
- Not hardware-tested on Mentra Live — needs a device pass: SDK photo with `save:true` → confirm folder name + `request_id` in `/api/sync`; button photo → confirm status messages carry the folder name.

## Follow-ups

- ~~EXIF ImageUniqueID~~ — now included: the capture ID is stamped into EXIF `ImageUniqueID` at save time (derived from the capture directory name at the single choke point where every photo hits disk — no ID threading through the camera layer), and carried onto re-encoded upload copies. Covered by Robolectric tests including the production EXIF write order (9/9 pass).
- Include the capture ID in the `button_press` event for press→photo correlation when connected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes capture directory naming, HTTP gallery/sync payloads, and on-device EXIF writes across SDK, button, and video paths; behavior is backward-compatible but clients and any logic that assumed opaque short `capture_id` values should expect longer names and the new optional field.
> 
> **Overview**
> SDK **`take_photo`** and video captures now use **`IMG|VID_<ts>_<rand>_<sanitizedRequestId>`** folder names via **`CaptureRequestId`**, so bulk gallery sync can tie files to the originating BLE request instead of timestamp matching. **`/api/sync`** and **`/api/gallery`** add optional **`request_id`** when that suffix is present; button captures still omit it but use the folder name as **`requestId`** in photo status messages (replacing **`local_<timestamp>`**).
> 
> **`PhotoExifMetadataWriter`** stamps the capture directory name into EXIF **`ImageUniqueID`** at save time and preserves it (with IMU UserComment) on re-encoded copies. The mobile **`CaptureGroup`** type and camera-web-server docs document **`request_id`** and EXIF correlation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109567ed12c3415613c191d60fcc076dfc640b2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Embed the SDK `requestId` into photo capture folder names and surface it via `/api/sync` and `/api/gallery` for reliable request-to-file correlation. Also stamp the capture ID into EXIF `ImageUniqueID` so the link survives renames/export; button captures use the folder name as their stable ID, and sanitization strips dots to avoid path issues.

- **New Features**
  - Photos save as `IMG_<timestamp>_<rand>_<requestId>` for both `save:true` and transient `save:false`.
  - `/api/sync` capture groups and `/api/gallery` entries include `request_id` when present.
  - Button-press photos use the `capture_id` (folder name) as their `requestId` in status messages.
  - On photo save, write the capture directory name to EXIF `ImageUniqueID` and carry it on re-encodes.

- **Migration**
  - Read optional `request_id` from `/api/sync` and `/api/gallery`; fall back to `capture_id` when absent.
  - Update consumers to `CaptureGroup` with optional `request_id`.

<sup>Written for commit 109567ed12c3415613c191d60fcc076dfc640b2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

