### PR TITLE
Thunderbird field fixes: hotspot readiness, WiFi security, charging flag, save-only photo routing

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -1639,6 +1639,190 @@ public class MediaCaptureService {
     }
 
     /**
+     * Capture a photo that is only saved to the gallery: an SDK take_photo with save=true
+     * and no upload target. There is no delivery leg (no webhook upload, no BLE transfer),
+     * so this bypasses the single-flight photo-job gate and enqueues straight into the
+     * camera queue, exactly like button photos — rapid bursts serialize at the camera
+     * instead of failing CAMERA_BUSY. The terminal photo_response carries the captureId
+     * (the requestId-stamped capture directory name) for sync-time correlation.
+     */
+    public boolean takePhotoForLocalSave(
+            String photoFilePath,
+            String requestId,
+            String size,
+            boolean enableFlash,
+            boolean enableSound,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings) {
+        if (captureSettings == null) {
+            captureSettings = PhotoCaptureSettings.EMPTY;
+        }
+
+        // Photos cannot interrupt streams
+        if (RtmpStreamingService.isStreaming()
+                || SrtStreamingService.isStreaming()
+                || WhipStreamingService.isStreaming()) {
+            Log.e(TAG, "Cannot take local-save photo - streaming active");
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera busy with streaming");
+            return false;
+        }
+
+        if (CameraRestartCooldown.isActive()) {
+            Log.w(TAG, "Cannot take local-save photo - camera HAL restarting after FOV change");
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Camera restarting after FOV change");
+            return false;
+        }
+
+        StorageManager storageManager = StorageManager.getInstance(mContext);
+        if (!storageManager.canTakePhoto()) {
+            Log.w(TAG, "🚫 Local-save photo rejected - insufficient storage");
+            playStorageFullSound();
+            sendPhotoErrorResponse(
+                    requestId,
+                    "INSUFFICIENT_STORAGE",
+                    "Insufficient storage space for photo capture");
+            return false;
+        }
+
+        Log.i(
+                TAG,
+                "📸 take_photo (local-save) accepted requestId="
+                        + requestId
+                        + " size="
+                        + size
+                        + " path="
+                        + photoFilePath);
+        sendPhotoStatus(requestId, "queued");
+
+        // The capture directory name is the stable capture_id exposed by gallery sync.
+        File captureDirFile = new File(photoFilePath).getParentFile();
+        final String captureId = captureDirFile != null ? captureDirFile.getName() : "";
+
+        if (!shouldSuppressPhotoFeedback()) {
+            triggerPhotoFlashLed();
+            if (enableSound) {
+                // Local-save SDK photo: isFromSdk=true, matching the enqueue below.
+                playShutterSound(size, true, exposureTimeNs);
+            }
+            if (enableFlash) {
+                flashPrivacyLedForPhoto();
+            }
+        }
+
+        try {
+            CameraNeoService.enqueuePhotoRequest(
+                    mContext,
+                    photoFilePath,
+                    size,
+                    enableFlash,
+                    true, // isFromSdk — honor the SDK size tier
+                    exposureTimeNs,
+                    iso,
+                    captureSettings,
+                    new CameraNeoService.PhotoCaptureCallback() {
+                        @Override
+                        public void onPhotoConfigured(JSONObject resolvedConfig) {
+                            sendPhotoStatus(
+                                    requestId,
+                                    "configuring",
+                                    addPhotoTransferDetails(resolvedConfig, true, "local", "none"),
+                                    null,
+                                    null);
+                        }
+
+                        @Override
+                        public void onPhotoCapturing(
+                                JSONObject requestedCaptureConfig, JSONObject meteredPreview) {
+                            sendPhotoStatus(
+                                    requestId,
+                                    "capturing",
+                                    null,
+                                    null,
+                                    null,
+                                    requestedCaptureConfig,
+                                    meteredPreview,
+                                    null);
+                        }
+
+                        @Override
+                        public void onPhotoCaptured(String filePath) {
+                            onPhotoCaptured(filePath, null);
+                        }
+
+                        @Override
+                        public void onPhotoCaptured(String filePath, JSONObject captureMetadata) {
+                            Log.d(TAG, "Local-save photo captured: " + filePath);
+                            sendPhotoStatus(
+                                    requestId,
+                                    "captured",
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    null,
+                                    captureMetadata);
+
+                            if (mMediaCaptureListener != null) {
+                                mMediaCaptureListener.onPhotoCaptured(requestId, filePath);
+                            }
+
+                            sendLocalSaveSuccessResponse(requestId, captureId);
+                            sendGalleryStatusUpdate();
+                        }
+
+                        @Override
+                        public void onPhotoError(String errorMessage) {
+                            Log.e(TAG, "Failed to capture local-save photo: " + errorMessage);
+                            sendPhotoErrorResponse(
+                                    requestId, "CAMERA_CAPTURE_FAILED", errorMessage);
+
+                            if (mMediaCaptureListener != null) {
+                                mMediaCaptureListener.onMediaError(
+                                        requestId,
+                                        errorMessage,
+                                        MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
+                            }
+                        }
+                    });
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "Error taking local-save photo", e);
+            sendPhotoErrorResponse(
+                    requestId, "CAMERA_CAPTURE_FAILED", "Error taking photo: " + e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Terminal success for a local-save capture: no uploadUrl (nothing was delivered);
+     * carries the captureId so the caller can match the file at gallery-sync time.
+     */
+    private void sendLocalSaveSuccessResponse(String requestId, String captureId) {
+        try {
+            JSONObject json = new JSONObject();
+            json.put("type", "photo_response");
+            json.put("requestId", requestId);
+            json.put("state", "success");
+            json.put("success", true);
+            json.put("saved", true);
+            json.put("captureId", captureId);
+            json.put("timestamp", System.currentTimeMillis());
+
+            Log.i(TAG, "📸 SENDING LOCAL-SAVE COMPLETE: requestId=" + requestId);
+
+            if (mServiceCallback != null) {
+                mServiceCallback.sendThroughBluetooth(json.toString().getBytes());
+                Log.i(TAG, "📸 SENT VIA BLE: " + json);
+            } else {
+                Log.e(TAG, "❌ Service callback not available for local-save photo response");
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "❌ Error creating local-save photo response", e);
+        }
+    }
+
+    /**
      * Take a photo and upload it to the specified destination
      *
      * @param photoFilePath Local path where photo will be saved

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
@@ -860,7 +860,7 @@ public abstract class BaseNetworkManager implements INetworkController {
     }
 
     /** Check if WiFi tethering is currently active */
-    private boolean isWifiTetheringActive() {
+    protected boolean isWifiTetheringActive() {
         try {
             ConnectivityManager cm =
                     (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -10,6 +10,7 @@ import android.os.Looper;
 import android.provider.Settings;
 import android.util.Log;
 import com.mentra.asg_client.io.network.core.BaseNetworkManager;
+import com.mentra.asg_client.io.network.utils.WifiSecurityChooser;
 import com.mentra.asg_client.io.network.interfaces.IWifiScanCallback;
 import com.mentra.asg_client.io.network.utils.DebugNotificationManager;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
@@ -474,14 +475,36 @@ public class K900NetworkManager extends BaseNetworkManager {
             }
         }
 
-        // Create new WiFi config
+        // Create new WiFi config. Security is derived from the AP's advertised capabilities
+        // (the glasses scanned this network moments ago in the provisioning flow) rather
+        // than inferred from password presence — see WifiSecurityChooser.
         android.net.wifi.WifiConfiguration config = new android.net.wifi.WifiConfiguration();
         config.SSID = quotedSsid;
-        if (password != null && !password.isEmpty()) {
-            config.preSharedKey = "\"" + password + "\"";
-            config.allowedKeyManagement.set(android.net.wifi.WifiConfiguration.KeyMgmt.WPA_PSK);
-        } else {
-            config.allowedKeyManagement.set(android.net.wifi.WifiConfiguration.KeyMgmt.NONE);
+        String capabilities = findScanCapabilitiesForSsid(ssid);
+        WifiSecurityChooser.Security security = WifiSecurityChooser.choose(password, capabilities);
+        Log.i(
+                TAG,
+                "📶 Configuring "
+                        + security
+                        + " for "
+                        + ssid
+                        + " (scan caps="
+                        + capabilities
+                        + ")");
+        switch (security) {
+            case OPEN:
+                config.allowedKeyManagement.set(android.net.wifi.WifiConfiguration.KeyMgmt.NONE);
+                break;
+            case SAE:
+                // setSecurityParams(SAE) sets SAE key management + required PMF.
+                config.setSecurityParams(android.net.wifi.WifiConfiguration.SECURITY_TYPE_SAE);
+                config.preSharedKey = "\"" + password + "\"";
+                break;
+            case PSK:
+            default:
+                config.setSecurityParams(android.net.wifi.WifiConfiguration.SECURITY_TYPE_PSK);
+                config.preSharedKey = "\"" + password + "\"";
+                break;
         }
 
         int netId = wifiManager.addNetwork(config);
@@ -505,6 +528,31 @@ public class K900NetworkManager extends BaseNetworkManager {
                         + ", netId="
                         + netId
                         + ")");
+    }
+
+    /**
+     * Latest scan capabilities string for an SSID (strongest BSS wins), or null when the
+     * SSID is not in current scan results.
+     */
+    private String findScanCapabilitiesForSsid(String ssid) {
+        try {
+            List<android.net.wifi.ScanResult> results = wifiManager.getScanResults();
+            if (results == null) {
+                return null;
+            }
+            String best = null;
+            int bestLevel = Integer.MIN_VALUE;
+            for (android.net.wifi.ScanResult result : results) {
+                if (ssid.equals(result.SSID) && result.level > bestLevel) {
+                    bestLevel = result.level;
+                    best = result.capabilities;
+                }
+            }
+            return best;
+        } catch (Exception e) {
+            Log.w(TAG, "📶 ⚠️ Could not read scan results for security detection", e);
+            return null;
+        }
     }
 
     @Override

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -389,6 +389,17 @@ public class K900NetworkManager extends BaseNetworkManager {
         // AP up (including hotspots enabled outside asg_client). That broadcast can precede
         // the AP interface holding its gateway IP, so route through the readiness watch —
         // listeners only hear "enabled" once clients can actually join.
+        synchronized (hotspotWatchLock) {
+            if (hotspotStopRequested) {
+                // Teardown echo: after a deliberate stop the framework AP can still look
+                // active for a beat, and this broadcast fires while xy_ssid and the gateway
+                // IP may linger. Restarting the watch here would clear the stop flag and
+                // re-announce "enabled" right after the user disabled the AP. Only a real
+                // startHotspot() re-arms the watch.
+                Log.d(TAG, "🔥 ⛔ Ignoring tethering-active echo after hotspot stop");
+                return;
+            }
+        }
         beginHotspotReadinessWatch();
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -49,6 +49,12 @@ public class K900NetworkManager extends BaseNetworkManager {
     private long hotspotReadinessStartMs = 0;
     private long hotspotReadinessDeadlineMs = 0;
 
+    // Watch ticks run on the main looper but stopHotspot can run on a command-processing
+    // thread. The lock + stop flag prevent a mid-flight tick from reporting "enabled"
+    // after the user disabled the AP (removeCallbacks alone can't cancel a running tick).
+    private final Object hotspotWatchLock = new Object();
+    private boolean hotspotStopRequested = false;
+
     /**
      * Create a new K900NetworkManager
      *
@@ -241,20 +247,32 @@ public class K900NetworkManager extends BaseNetworkManager {
      * generous multiple of that.
      */
     private void beginHotspotReadinessWatch() {
-        if (pendingHotspotReadinessRunnable != null) {
-            Log.d(TAG, "🔥 ⏳ Hotspot readiness watch already running");
-            return;
+        synchronized (hotspotWatchLock) {
+            hotspotStopRequested = false;
+            if (pendingHotspotReadinessRunnable != null) {
+                Log.d(TAG, "🔥 ⏳ Hotspot readiness watch already running");
+                return;
+            }
+            hotspotReadinessStartMs = System.currentTimeMillis();
+            hotspotReadinessDeadlineMs = hotspotReadinessStartMs + HOTSPOT_READINESS_TIMEOUT_MS;
         }
-        hotspotReadinessStartMs = System.currentTimeMillis();
-        hotspotReadinessDeadlineMs = hotspotReadinessStartMs + HOTSPOT_READINESS_TIMEOUT_MS;
         Log.d(TAG, "🔥 ⏳ Watching for hotspot readiness (AP state + gateway IP + SSID)...");
         checkHotspotReadiness();
     }
 
     /** One tick of the readiness watch; reschedules itself until ready, timeout, or cancel. */
     private void checkHotspotReadiness() {
-        pendingHotspotReadinessRunnable = null;
+        synchronized (hotspotWatchLock) {
+            pendingHotspotReadinessRunnable = null;
+            if (hotspotStopRequested) {
+                Log.d(TAG, "🔥 ⛔ Hotspot stopped - abandoning readiness check");
+                return;
+            }
+            checkHotspotReadinessLocked();
+        }
+    }
 
+    private void checkHotspotReadinessLocked() {
         // Gate on the direct signal: the tethering state machine assigns the gateway IP to
         // the AP interface only after hostapd reports AP-ENABLED, so gatewayUp implies the
         // AP accepts clients. The framework AP state (reflection, hidden API) is logged as
@@ -406,8 +424,12 @@ public class K900NetworkManager extends BaseNetworkManager {
             // Clear hotspot state immediately
             clearHotspotState();
 
-            // Cancel any pending readiness checks
-            cancelHotspotReadinessWatch();
+            // Cancel any pending readiness checks. The flag also stops a tick that is
+            // already executing on the main looper from reporting a late "enabled".
+            synchronized (hotspotWatchLock) {
+                hotspotStopRequested = true;
+                cancelHotspotReadinessWatch();
+            }
 
             Log.d(TAG, "🔥 ✅ K900 hotspot disable intent sent");
             notificationManager.showHotspotStateNotification(false);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -365,6 +365,11 @@ public class K900NetworkManager extends BaseNetworkManager {
     private void failHotspotStartup(String errorMessage) {
         Log.e(TAG, "🔥 ❌ " + errorMessage + " - disabling hotspot");
 
+        // This is a stop: the disable intent below produces its own teardown echo on the
+        // tethering broadcast, which must not restart the watch off lingering ssid/gateway.
+        // Runs under hotspotWatchLock (called from the watch tick).
+        hotspotStopRequested = true;
+
         try {
             Intent disableIntent = new Intent();
             disableIntent.setAction("com.xy.xsetting.action");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -36,9 +36,17 @@ public class K900NetworkManager extends BaseNetworkManager {
     private BroadcastReceiver wifiStateReceiver;
     private final boolean isSystemApp;
 
-    // Hotspot SSID retry tracking
-    private final Handler ssidRetryHandler = new Handler(Looper.getMainLooper());
-    private Runnable pendingSsidRetryRunnable = null;
+    // Hotspot readiness watch. The ap_start intent returns immediately and the SSID in
+    // Settings.Global persists across sessions, so neither proves the AP is up. The watch
+    // polls the real signals (framework AP state + gateway IP on the AP interface + SSID)
+    // and only then reports the hotspot as enabled — the phone treats that message as
+    // "safe to join", so sending it early causes iOS "Unable to Join" failures.
+    private static final int HOTSPOT_READINESS_POLL_MS = 200;
+    private static final int HOTSPOT_READINESS_TIMEOUT_MS = 12000;
+    private final Handler hotspotReadinessHandler = new Handler(Looper.getMainLooper());
+    private Runnable pendingHotspotReadinessRunnable = null;
+    private long hotspotReadinessStartMs = 0;
+    private long hotspotReadinessDeadlineMs = 0;
 
     /**
      * Create a new K900NetworkManager
@@ -210,12 +218,12 @@ public class K900NetworkManager extends BaseNetworkManager {
             context.sendBroadcast(intent);
             Log.d(TAG, "🔥 ✅ K900 hotspot enable intent sent");
 
-            // Try to read SSID from Settings.Global
-            // Note: There may be a race condition where the SSID isn't immediately available
-            // after sending the enable intent. We'll retry with delays if needed.
-            tryReadHotspotSSID(0);
+            // Do NOT report the hotspot as enabled yet — wait until the AP is actually
+            // accepting clients. The watch notifies listeners (and thus the phone) only
+            // once AP state, gateway IP, and SSID are all confirmed.
+            beginHotspotReadinessWatch();
 
-            Log.i(TAG, "🔥 ✅ K900 hotspot start initiated");
+            Log.i(TAG, "🔥 ✅ K900 hotspot start initiated (awaiting readiness)");
         } catch (Exception e) {
             Log.e(TAG, "🔥 💥 Error starting K900 hotspot", e);
             clearHotspotState();
@@ -225,200 +233,155 @@ public class K900NetworkManager extends BaseNetworkManager {
     }
 
     /**
-     * Attempts to read the K900 hotspot SSID from Settings.Global with retries This handles the
-     * race condition where the SSID may not be immediately available after sending the hotspot
-     * enable intent
-     *
-     * @param attemptNumber Current attempt number (0-based)
+     * Starts (or restarts nothing if already running) the hotspot readiness watch. The watch
+     * polls until the framework reports the AP enabled, the AP interface holds the gateway IP,
+     * and the SSID is readable — only then are listeners told the hotspot is enabled. Measured
+     * on-device, readiness lands ~0.4-1.0s after the ap_start intent; the timeout is a
+     * generous multiple of that.
      */
-    private void tryReadHotspotSSID(int attemptNumber) {
-        final int MAX_ATTEMPTS = 5;
-        final int[] RETRY_DELAYS_MS = {0, 200, 500, 1000, 2000}; // Progressive backoff
+    private void beginHotspotReadinessWatch() {
+        if (pendingHotspotReadinessRunnable != null) {
+            Log.d(TAG, "🔥 ⏳ Hotspot readiness watch already running");
+            return;
+        }
+        hotspotReadinessStartMs = System.currentTimeMillis();
+        hotspotReadinessDeadlineMs = hotspotReadinessStartMs + HOTSPOT_READINESS_TIMEOUT_MS;
+        Log.d(TAG, "🔥 ⏳ Watching for hotspot readiness (AP state + gateway IP + SSID)...");
+        checkHotspotReadiness();
+    }
 
+    /** One tick of the readiness watch; reschedules itself until ready, timeout, or cancel. */
+    private void checkHotspotReadiness() {
+        pendingHotspotReadinessRunnable = null;
+
+        // Gate on the direct signal: the tethering state machine assigns the gateway IP to
+        // the AP interface only after hostapd reports AP-ENABLED, so gatewayUp implies the
+        // AP accepts clients. The framework AP state (reflection, hidden API) is logged as
+        // corroboration but not required — it is unavailable to non-system dev builds.
+        boolean apEnabled = isWifiTetheringActive();
+        boolean gatewayUp = hasHotspotGatewayIp();
+        String ssid = null;
         try {
-            String ssid = Settings.Global.getString(context.getContentResolver(), "xy_ssid");
+            ssid = Settings.Global.getString(context.getContentResolver(), "xy_ssid");
+        } catch (Exception e) {
+            Log.w(TAG, "🔥 ⚠️ Error reading xy_ssid during readiness check", e);
+        }
+        boolean ssidReady = ssid != null && !ssid.isEmpty();
 
-            if (ssid != null && !ssid.isEmpty()) {
-                // Success! Update state and notify
-                Log.d(
-                        TAG,
-                        "🔥 ✅ Got K900 hotspot SSID from Settings.Global: "
-                                + ssid
-                                + " (attempt "
-                                + (attemptNumber + 1)
-                                + "/"
-                                + MAX_ATTEMPTS
-                                + ")");
+        if (gatewayUp && ssidReady) {
+            long elapsedMs = System.currentTimeMillis() - hotspotReadinessStartMs;
+            Log.i(
+                    TAG,
+                    "🔥 ✅ K900 hotspot READY after "
+                            + elapsedMs
+                            + "ms (apEnabled="
+                            + apEnabled
+                            + "): "
+                            + ssid);
 
-                // Clear pending retry since we succeeded
-                pendingSsidRetryRunnable = null;
+            updateHotspotState(true, ssid, K900_HOTSPOT_PASSWORD);
+            notifyHotspotStateChanged(true);
 
-                updateHotspotState(true, ssid, K900_HOTSPOT_PASSWORD);
-                notifyHotspotStateChanged(true);
+            notificationManager.showHotspotStateNotification(true);
+            notificationManager.showDebugNotification(
+                    "K900 Hotspot Active", ssid + " | " + K900_HOTSPOT_PASSWORD);
+            return;
+        }
 
-                notificationManager.showHotspotStateNotification(true);
-                notificationManager.showDebugNotification(
-                        "K900 Hotspot Active", ssid + " | " + K900_HOTSPOT_PASSWORD);
+        if (System.currentTimeMillis() >= hotspotReadinessDeadlineMs) {
+            failHotspotStartup(
+                    "Hotspot did not become ready within "
+                            + HOTSPOT_READINESS_TIMEOUT_MS
+                            + "ms (apEnabled="
+                            + apEnabled
+                            + ", gatewayUp="
+                            + gatewayUp
+                            + ", ssidReady="
+                            + ssidReady
+                            + ")");
+            return;
+        }
 
-                Log.i(TAG, "🔥 ✅ K900 hotspot active: " + ssid);
-            } else {
-                // SSID not available yet
-                if (attemptNumber < MAX_ATTEMPTS - 1) {
-                    // Retry with delay
-                    int nextAttempt = attemptNumber + 1;
-                    int delayMs = RETRY_DELAYS_MS[nextAttempt];
+        Log.d(
+                TAG,
+                "🔥 ⏳ Hotspot not ready yet (apEnabled="
+                        + apEnabled
+                        + ", gatewayUp="
+                        + gatewayUp
+                        + ", ssidReady="
+                        + ssidReady
+                        + "), rechecking in "
+                        + HOTSPOT_READINESS_POLL_MS
+                        + "ms");
+        pendingHotspotReadinessRunnable = this::checkHotspotReadiness;
+        hotspotReadinessHandler.postDelayed(
+                pendingHotspotReadinessRunnable, HOTSPOT_READINESS_POLL_MS);
+    }
 
-                    Log.w(
-                            TAG,
-                            "🔥 ⚠️ SSID not available yet (attempt "
-                                    + (attemptNumber + 1)
-                                    + "/"
-                                    + MAX_ATTEMPTS
-                                    + "), retrying in "
-                                    + delayMs
-                                    + "ms...");
-
-                    // Cancel any previous pending retry
-                    cancelPendingSsidRetries();
-
-                    // Schedule new retry and track it
-                    pendingSsidRetryRunnable = () -> tryReadHotspotSSID(nextAttempt);
-                    ssidRetryHandler.postDelayed(pendingSsidRetryRunnable, delayMs);
-                } else {
-                    // Max attempts reached - disable hotspot and notify phone of failure
-                    Log.e(
-                            TAG,
-                            "🔥 ❌ Failed to read K900 SSID after "
-                                    + MAX_ATTEMPTS
-                                    + " attempts - disabling hotspot");
-
-                    // Clear pending retry
-                    pendingSsidRetryRunnable = null;
-
-                    // Send disable intent to K900 to clean up
-                    try {
-                        Intent disableIntent = new Intent();
-                        disableIntent.setAction("com.xy.xsetting.action");
-                        disableIntent.setPackage("com.android.systemui");
-                        disableIntent.putExtra("cmd", "ap_start");
-                        disableIntent.putExtra("enable", false);
-                        context.sendBroadcast(disableIntent);
-                        Log.d(TAG, "🔥 📡 Sent disable intent to clean up failed hotspot");
-                    } catch (Exception ex) {
-                        Log.e(TAG, "🔥 💥 Error sending disable intent", ex);
+    /** True when any up interface holds the hotspot gateway IP (192.168.43.1). */
+    private boolean hasHotspotGatewayIp() {
+        try {
+            String gatewayIp = getHotspotGatewayIp();
+            java.util.Enumeration<java.net.NetworkInterface> ifaces =
+                    java.net.NetworkInterface.getNetworkInterfaces();
+            while (ifaces != null && ifaces.hasMoreElements()) {
+                java.net.NetworkInterface iface = ifaces.nextElement();
+                if (!iface.isUp()) {
+                    continue;
+                }
+                java.util.Enumeration<java.net.InetAddress> addrs = iface.getInetAddresses();
+                while (addrs.hasMoreElements()) {
+                    if (gatewayIp.equals(addrs.nextElement().getHostAddress())) {
+                        return true;
                     }
-
-                    // Clear local hotspot state
-                    clearHotspotState();
-
-                    // Notify listeners that hotspot is disabled
-                    notifyHotspotStateChanged(false);
-
-                    // Also send specific error message
-                    String errorMessage =
-                            "Failed to read hotspot SSID after " + MAX_ATTEMPTS + " attempts";
-                    notifyHotspotError(errorMessage);
-
-                    notificationManager.showDebugNotification("Hotspot Failed", errorMessage);
                 }
             }
         } catch (Exception e) {
-            Log.e(
-                    TAG,
-                    "🔥 💥 Error reading K900 SSID from Settings.Global (attempt "
-                            + (attemptNumber + 1)
-                            + "): "
-                            + e.getMessage(),
-                    e);
-
-            // On exception, retry if attempts remaining
-            if (attemptNumber < MAX_ATTEMPTS - 1) {
-                int nextAttempt = attemptNumber + 1;
-                int delayMs = RETRY_DELAYS_MS[nextAttempt];
-
-                Log.w(TAG, "🔥 ⚠️ Retrying in " + delayMs + "ms...");
-
-                // Cancel any previous pending retry
-                cancelPendingSsidRetries();
-
-                // Schedule new retry and track it
-                pendingSsidRetryRunnable = () -> tryReadHotspotSSID(nextAttempt);
-                ssidRetryHandler.postDelayed(pendingSsidRetryRunnable, delayMs);
-            } else {
-                // Max attempts reached due to exceptions - disable hotspot and notify phone of
-                // failure
-                Log.e(
-                        TAG,
-                        "🔥 ❌ Failed to read SSID after "
-                                + MAX_ATTEMPTS
-                                + " attempts due to errors - disabling hotspot");
-
-                // Clear pending retry
-                pendingSsidRetryRunnable = null;
-
-                // Send disable intent to K900 to clean up
-                try {
-                    Intent disableIntent = new Intent();
-                    disableIntent.setAction("com.xy.xsetting.action");
-                    disableIntent.setPackage("com.android.systemui");
-                    disableIntent.putExtra("cmd", "ap_start");
-                    disableIntent.putExtra("enable", false);
-                    context.sendBroadcast(disableIntent);
-                    Log.d(TAG, "🔥 📡 Sent disable intent to clean up failed hotspot");
-                } catch (Exception ex) {
-                    Log.e(TAG, "🔥 💥 Error sending disable intent", ex);
-                }
-
-                // Clear local hotspot state
-                clearHotspotState();
-
-                // Notify listeners that hotspot is disabled
-                notifyHotspotStateChanged(false);
-
-                // Also send specific error message
-                String errorMessage = "Failed to read hotspot SSID: " + e.getMessage();
-                notifyHotspotError(errorMessage);
-
-                notificationManager.showDebugNotification("Hotspot Error", errorMessage);
-            }
+            Log.w(TAG, "🔥 ⚠️ Error checking hotspot gateway interface", e);
         }
+        return false;
+    }
+
+    /** Cleans up a hotspot start that never became ready: disable AP, clear state, notify. */
+    private void failHotspotStartup(String errorMessage) {
+        Log.e(TAG, "🔥 ❌ " + errorMessage + " - disabling hotspot");
+
+        try {
+            Intent disableIntent = new Intent();
+            disableIntent.setAction("com.xy.xsetting.action");
+            disableIntent.setPackage("com.android.systemui");
+            disableIntent.putExtra("cmd", "ap_start");
+            disableIntent.putExtra("enable", false);
+            context.sendBroadcast(disableIntent);
+            Log.d(TAG, "🔥 📡 Sent disable intent to clean up failed hotspot");
+        } catch (Exception ex) {
+            Log.e(TAG, "🔥 💥 Error sending disable intent", ex);
+        }
+
+        clearHotspotState();
+        notifyHotspotStateChanged(false);
+        notifyHotspotError(errorMessage);
+        notificationManager.showDebugNotification("Hotspot Failed", errorMessage);
     }
 
     @Override
     protected void refreshHotspotCredentials() {
-        // K900 specific: Read SSID from Settings.Global
-        try {
-            String ssid = Settings.Global.getString(context.getContentResolver(), "xy_ssid");
-
-            if (ssid != null && !ssid.isEmpty()) {
-                Log.d(TAG, "🔥 ✅ Refreshed K900 hotspot SSID from Settings.Global: " + ssid);
-                updateHotspotState(true, ssid, K900_HOTSPOT_PASSWORD);
-                notifyHotspotStateChanged(true);
-
-                notificationManager.showHotspotStateNotification(true);
-                notificationManager.showDebugNotification(
-                        "K900 Hotspot Active", ssid + " | " + K900_HOTSPOT_PASSWORD);
-            } else {
-                Log.e(TAG, "🔥 ❌ Failed to refresh K900 SSID from Settings.Global");
-                clearHotspotState();
-                notifyHotspotStateChanged(false);
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "🔥 💥 Error refreshing K900 SSID from Settings.Global", e);
-            clearHotspotState();
-            notifyHotspotStateChanged(false);
-        }
+        // Called from the tethering-state broadcast when the framework starts bringing the
+        // AP up (including hotspots enabled outside asg_client). That broadcast can precede
+        // the AP interface holding its gateway IP, so route through the readiness watch —
+        // listeners only hear "enabled" once clients can actually join.
+        beginHotspotReadinessWatch();
     }
 
     /**
-     * Cancels any pending SSID retry attempts Called when hotspot is stopped to prevent stale
-     * callbacks from firing
+     * Cancels any pending hotspot readiness checks. Called when the hotspot is stopped to
+     * prevent stale callbacks from firing.
      */
-    private void cancelPendingSsidRetries() {
-        if (pendingSsidRetryRunnable != null) {
-            Log.d(TAG, "🔥 ⛔ Cancelling pending SSID retry");
-            ssidRetryHandler.removeCallbacks(pendingSsidRetryRunnable);
-            pendingSsidRetryRunnable = null;
+    private void cancelHotspotReadinessWatch() {
+        if (pendingHotspotReadinessRunnable != null) {
+            Log.d(TAG, "🔥 ⛔ Cancelling hotspot readiness watch");
+            hotspotReadinessHandler.removeCallbacks(pendingHotspotReadinessRunnable);
+            pendingHotspotReadinessRunnable = null;
         }
     }
 
@@ -442,8 +405,8 @@ public class K900NetworkManager extends BaseNetworkManager {
             // Clear hotspot state immediately
             clearHotspotState();
 
-            // Cancel any pending SSID retry attempts
-            cancelPendingSsidRetries();
+            // Cancel any pending readiness checks
+            cancelHotspotReadinessWatch();
 
             Log.d(TAG, "🔥 ✅ K900 hotspot disable intent sent");
             notificationManager.showHotspotStateNotification(false);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/WifiSecurityChooser.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/utils/WifiSecurityChooser.java
@@ -1,0 +1,44 @@
+package com.mentra.asg_client.io.network.utils;
+
+/**
+ * Chooses the WiFi security configuration for a connect attempt from the AP's advertised
+ * scan capabilities instead of inferring it from password presence. Password-presence
+ * inference configures WPA3-only networks as legacy PSK (never associates) and can never
+ * express SAE; the closed K900 SystemUI path guesses and has saved WPA2/WPA3-transition
+ * networks as OPEN in the field.
+ *
+ * <p>Pure logic, separated from {@code K900NetworkManager} so it is unit-testable on the
+ * JVM (the join itself needs a system-signed build on hardware).
+ */
+public final class WifiSecurityChooser {
+
+    public enum Security {
+        /** No password supplied — open (or OWE-transition open leg) network. */
+        OPEN,
+        /** WPA2, or WPA2/WPA3-transition where the PSK leg associates on both. */
+        PSK,
+        /** WPA3-only AP — legacy PSK association is rejected; needs SAE with PMF. */
+        SAE
+    }
+
+    private WifiSecurityChooser() {}
+
+    /**
+     * @param password the password supplied by the user (may be null/empty)
+     * @param scanCapabilities the matching ScanResult's capabilities string, or null when
+     *     the SSID was not found in current scan results (hidden network, stale scan)
+     */
+    public static Security choose(String password, String scanCapabilities) {
+        boolean hasPassword = password != null && !password.isEmpty();
+        if (!hasPassword) {
+            return Security.OPEN;
+        }
+        if (scanCapabilities != null
+                && scanCapabilities.contains("SAE")
+                && !scanCapabilities.contains("PSK")) {
+            return Security.SAE;
+        }
+        // WPA2, WPA2/WPA3-transition, or unknown SSID (fall back to the widest-compat PSK).
+        return Security.PSK;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/interfaces/ICommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/interfaces/ICommunicationManager.java
@@ -14,6 +14,16 @@ public interface ICommunicationManager {
      * @param isConnected WiFi connection status
      */
     void sendWifiStatusOverBle(boolean isConnected);
+
+    /**
+     * Send WiFi status over Bluetooth with a failure reason. The error is included in the
+     * wifi_status message so the phone can show why a provisioning attempt failed instead
+     * of silently reporting "not connected".
+     *
+     * @param isConnected WiFi connection status
+     * @param error Failure reason (e.g. "connect_timeout"), or null when not applicable
+     */
+    void sendWifiStatusOverBle(boolean isConnected, String error);
     
     /**
      * Send battery status over Bluetooth

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -78,10 +78,15 @@ public class CommunicationManager
 
     @Override
     public void sendWifiStatusOverBle(boolean isConnected) {
+        sendWifiStatusOverBle(isConnected, null);
+    }
+
+    @Override
+    public void sendWifiStatusOverBle(boolean isConnected, String error) {
         Log.d(TAG, "🔄 =========================================");
         Log.d(TAG, "🔄 SEND WIFI STATUS OVER BLE");
         Log.d(TAG, "🔄 =========================================");
-        Log.d(TAG, "🔄 WiFi connected: " + isConnected);
+        Log.d(TAG, "🔄 WiFi connected: " + isConnected + (error != null ? ", error: " + error : ""));
 
         if (transport != null && transport.isConnected()) {
             Log.d(TAG, "🔄 ✅ Transport available and connected");
@@ -91,6 +96,9 @@ public class CommunicationManager
                 // Use proper type for reliable sending
                 wifiStatus.put("type", "wifi_status");
                 wifiStatus.put("connected", isConnected);
+                if (error != null && !error.isEmpty()) {
+                    wifiStatus.put("error", error);
+                }
                 if (isConnected && networkManager != null) {
                     String ssid = networkManager.getCurrentWifiSsid();
                     String localIp = networkManager.getLocalIpAddress();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -286,6 +286,35 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
                 return false;
             }
 
+            // ARCHIVAL CAPTURE: a save-only request (no upload target) has no delivery leg —
+            // no webhook upload, no BLE transfer — so there is nothing for the single-flight
+            // photo-job gate to protect. Route it down the button-photo path: camera-queue
+            // serialized, no CAMERA_BUSY, so SDK callers can burst-save to the gallery and
+            // pull the files later over WiFi sync (each stamped with its requestId).
+            // transferMethod is deliberately not consulted: it is always "auto" in practice
+            // and the phone app always supplies a webhookUrl, so this shape is only ever
+            // produced by direct BT-SDK callers that want exactly this behavior.
+            if (save && webhookUrl.isEmpty()) {
+                Log.i(
+                        TAG,
+                        "PHOTO PIPELINE [ASG 3/3] Local-save capture (no upload target)"
+                                + " requestId="
+                                + requestId);
+                boolean accepted =
+                        captureService.takePhotoForLocalSave(
+                                photoFilePath,
+                                requestId,
+                                size,
+                                flash,
+                                sound,
+                                exposureTimeNs,
+                                iso,
+                                captureSettings);
+                logCommandResult(
+                        "take_photo", accepted, accepted ? null : "Local-save capture rejected");
+                return accepted;
+            }
+
             // COOLDOWN CHECK: Reject photo requests if BLE transfer is in progress
             if (captureService.isBleTransferInProgress()) {
                 Log.w(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -122,9 +122,17 @@ public class WifiCommandHandler implements ICommandHandler {
 
                     // Send status if connected to target network, or if we've reached final attempt
                     if ((isConnected && currentSsid.equals(targetSsid)) || i == 3) {
+                        boolean connectedToTarget = isConnected && currentSsid.equals(targetSsid);
+                        // Surface why provisioning failed instead of a bare connected=false —
+                        // "never associates, no error shown" was a field complaint.
+                        String error = null;
+                        if (!connectedToTarget) {
+                            error = isConnected ? "connected_to_other_network" : "connect_timeout";
+                        }
                         Log.d(TAG, "📶 ✅ Sending WiFi status update: " +
-                                (isConnected ? "CONNECTED to " + currentSsid : "DISCONNECTED"));
-                        communicationManager.sendWifiStatusOverBle(isConnected);
+                                (isConnected ? "CONNECTED to " + currentSsid : "DISCONNECTED") +
+                                (error != null ? " (error=" + error + ")" : ""));
+                        communicationManager.sendWifiStatusOverBle(isConnected, error);
                         break;
                     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/BatteryEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/BatteryEventSubscriber.java
@@ -61,7 +61,11 @@ public final class BatteryEventSubscriber implements IPeripheralBus.McuEventList
 
     /** Send battery status over BLE */
     private void sendBatteryStatusOverBle(int batteryPercentage, int batteryVoltage) {
-        // Calculate charging status based on voltage
+        // hm_batv carries no charge bit, so charging cannot be known here. The voltage
+        // heuristic (>3900mV) is wrong for most of a Li-ion cell's range — a discharging
+        // full pack reads "charging". Internal state keeps the heuristic (log-only
+        // consumers), but the BLE message omits the flag: the phone sources charging
+        // exclusively from the PMU charg bit in the sr_hrt heartbeat.
         boolean isCharging = batteryVoltage > 3900;
 
         // Always update local state, regardless of BLE connection
@@ -77,7 +81,6 @@ public final class BatteryEventSubscriber implements IPeripheralBus.McuEventList
             try {
                 JSONObject obj = new JSONObject();
                 obj.put("type", "battery_status");
-                obj.put("charging", isCharging);
                 obj.put("percent", batteryPercentage);
                 String jsonString = obj.toString();
                 Log.d(TAG, "Formatted battery status message: " + jsonString);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/WifiSecurityChooserTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/utils/WifiSecurityChooserTest.java
@@ -1,0 +1,47 @@
+package com.mentra.asg_client.io.network.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import com.mentra.asg_client.io.network.utils.WifiSecurityChooser.Security;
+import org.junit.Test;
+
+public class WifiSecurityChooserTest {
+
+    @Test
+    public void noPassword_isOpen_regardlessOfCapabilities() {
+        assertEquals(Security.OPEN, WifiSecurityChooser.choose(null, "[ESS]"));
+        assertEquals(Security.OPEN, WifiSecurityChooser.choose("", "[WPA2-PSK-CCMP][ESS]"));
+        assertEquals(Security.OPEN, WifiSecurityChooser.choose("", null));
+    }
+
+    @Test
+    public void wpa2Only_isPsk() {
+        assertEquals(
+                Security.PSK,
+                WifiSecurityChooser.choose("pw", "[WPA2-PSK-CCMP][RSN-PSK-CCMP][ESS]"));
+    }
+
+    @Test
+    public void wpa2Wpa3Transition_isPsk() {
+        // Transition APs advertise both legs; the PSK leg associates on both, so PSK is
+        // the widest-compatibility correct choice (the field bug saved these as OPEN).
+        assertEquals(
+                Security.PSK,
+                WifiSecurityChooser.choose(
+                        "pw", "[WPA2-PSK+SAE-CCMP][RSN-PSK+SAE-CCMP][ESS][MFPC]"));
+    }
+
+    @Test
+    public void wpa3Only_isSae() {
+        assertEquals(
+                Security.SAE,
+                WifiSecurityChooser.choose("pw", "[RSN-SAE-CCMP][ESS][MFPC][MFPR]"));
+    }
+
+    @Test
+    public void unknownSsid_fallsBackToPsk() {
+        // Hidden network / stale scan: no capabilities available. PSK preserves the
+        // pre-fix behavior for password-protected networks.
+        assertEquals(Security.PSK, WifiSecurityChooser.choose("pw", null));
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -4704,6 +4704,11 @@ class MentraLive : SGCManager() {
      * pattern
      */
     private fun updateBatteryStatus(level: Int, isCharging: Boolean) {
+        // Keep the field in sync: percent-only messages (battery_status/sr_batv) re-pass
+        // it as the last-known charging state, so a stale field would clobber the value
+        // the sr_hrt PMU charg bit established.
+        this.isCharging = isCharging
+
         // Update parent SGCManager fields
         DeviceStore.apply("glasses", "batteryLevel", level)
         DeviceStore.apply("glasses", "charging", isCharging)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3177,6 +3177,14 @@ class MentraLive : SGCManager() {
                 val ssid = json.optString("ssid", "")
                 val localIp = json.optString("local_ip", "")
 
+                // Provisioning failure reason (e.g. connect_timeout); empty when connected
+                // or on older glasses firmware that doesn't send it.
+                val wifiError = json.optString("error", "")
+                if (wifiError.isNotEmpty()) {
+                    Bridge.log("LIVE: 🌐 WiFi provisioning error from glasses: $wifiError")
+                }
+                DeviceStore.apply("glasses", "wifiError", wifiError)
+
                 updateWifiStatus(wifiConnectedStatus, ssid, localIp)
             }
             "hotspot_status_update" -> {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3179,13 +3179,17 @@ class MentraLive : SGCManager() {
                 val ssid = json.optString("ssid", "")
                 val localIp = json.optString("local_ip", "")
 
-                // Provisioning failure reason (e.g. connect_timeout); empty when connected
-                // or on older glasses firmware that doesn't send it.
+                // Provisioning failure reason (e.g. connect_timeout). Sticky: routine
+                // error-less status updates (link-state debounce, request_wifi_status)
+                // must not clear a failure nothing recovered from — only a newer error
+                // or a successful connection overwrites it.
                 val wifiError = json.optString("error", "")
                 if (wifiError.isNotEmpty()) {
                     Bridge.log("LIVE: 🌐 WiFi provisioning error from glasses: $wifiError")
+                    DeviceStore.apply("glasses", "wifiError", wifiError)
+                } else if (wifiConnectedStatus) {
+                    DeviceStore.apply("glasses", "wifiError", "")
                 }
-                DeviceStore.apply("glasses", "wifiError", wifiError)
 
                 updateWifiStatus(wifiConnectedStatus, ssid, localIp)
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3155,10 +3155,12 @@ class MentraLive : SGCManager() {
                     )
             "speaking_status" -> handleSpeakingStatus(json.optBoolean("speaking", false))
             "battery_status" -> {
-                // Process battery status
+                // Percent only. battery_status derives from hm_batv, which carries no charge
+                // bit — older glasses fabricate `charging` from a voltage threshold (>3.9V)
+                // that reads "charging" for most of a discharging pack's range. Charging
+                // state comes exclusively from the PMU charg bit in the sr_hrt heartbeat.
                 val percent = json.optInt("percent", batteryLevel)
-                val charging = json.optBoolean("charging", isCharging)
-                updateBatteryStatus(percent, charging)
+                updateBatteryStatus(percent, isCharging)
             }
             "pong" ->
                     // Process heartbeat pong response
@@ -4395,11 +4397,10 @@ class MentraLive : SGCManager() {
                                         "%"
                         )
 
-                        // Determine charging status based on voltage (K900 typical charging voltage
-                        // is >4.0V)
-                        val isCharging = voltageMillivolts > 4000
-
-                        // Update battery status using the existing method
+                        // Percent only. sr_batv carries just voltage+percent; inferring
+                        // charging from voltage (>4.0V) reads "not charging" for most of a
+                        // genuinely-charging pack's range. Charging state comes exclusively
+                        // from the PMU charg bit in the sr_hrt heartbeat.
                         updateBatteryStatus(batteryPercentage, isCharging)
                     }
                 } catch (e: Exception) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2225,9 +2225,12 @@ class MentraLive: NSObject, SGCManager {
             handleGlassesReady()
 
         case "battery_status":
-            let level = json["level"] as? Int ?? batteryLevel
-            let isCharging = json["charging"] as? Bool ?? charging
-            updateBatteryStatus(level: level, isCharging: isCharging)
+            // Percent only (the glasses send it as "percent"; the old "level" read never
+            // matched). battery_status derives from hm_batv, which carries no charge bit —
+            // older glasses fabricate `charging` from a voltage threshold. Charging state
+            // comes exclusively from the PMU charg bit in the sr_hrt heartbeat.
+            let level = json["percent"] as? Int ?? json["level"] as? Int ?? batteryLevel
+            updateBatteryStatus(level: level, isCharging: charging)
 
         case "voice_activity_detection_status":
             let enabled = json["voiceActivityDetectionEnabled"] as? Bool
@@ -2627,10 +2630,13 @@ class MentraLive: NSObject, SGCManager {
             if let bodyObj = json["B"] as? [String: Any] {
                 let readyResponse = bodyObj["ready"] as? Int ?? 0
 
-                // Extract battery info from heartbeat
+                // Extract battery info from heartbeat. charg is the PMU charging bit — the
+                // only truthful charging source in the protocol. Old firmware omits it;
+                // keep the last known state then instead of defaulting to not-charging.
                 let percentage = bodyObj["pt"] as? Int ?? 0
                 let voltage = bodyObj["vt"] as? Int ?? 0
-                let charging = (bodyObj["charg"] as? Int ?? 0) == 1
+                let chargBit = bodyObj["charg"] as? Int
+                let charging = chargBit != nil ? (chargBit == 1) : self.charging
 
                 // SOC is still booting
                 if readyResponse == 0 {
@@ -2678,12 +2684,15 @@ class MentraLive: NSObject, SGCManager {
                let percentage = body["pt"] as? Int
             {
                 let voltageVolts = Double(voltage) / 1000.0
-                let isCharging = voltage > 4000
 
                 Bridge.log(
                     "🔋 K900 Battery Status - Voltage: \(voltageVolts)V, Level: \(percentage)%"
                 )
-                updateBatteryStatus(level: percentage, isCharging: isCharging)
+                // Percent only. sr_batv carries just voltage+percent; inferring charging
+                // from voltage (>4.0V) reads "not charging" for most of a genuinely-charging
+                // pack's range. Charging state comes exclusively from the PMU charg bit in
+                // the sr_hrt heartbeat.
+                updateBatteryStatus(level: percentage, isCharging: charging)
             }
 
         case "sr_getvol":

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2242,6 +2242,13 @@ class MentraLive: NSObject, SGCManager {
             let connected = json["connected"] as? Bool ?? false
             let ssid = json["ssid"] as? String ?? ""
             let ip = json["local_ip"] as? String ?? ""
+            // Provisioning failure reason (e.g. connect_timeout); empty when connected
+            // or on older glasses firmware that doesn't send it.
+            let wifiError = json["error"] as? String ?? ""
+            if !wifiError.isEmpty {
+                Bridge.log("LIVE: 🌐 WiFi provisioning error from glasses: \(wifiError)")
+            }
+            DeviceStore.shared.apply("glasses", "wifiError", wifiError)
             updateWifiStatus(connected: connected, ssid: ssid, ip: ip)
 
         case "hotspot_status_update":

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2245,13 +2245,17 @@ class MentraLive: NSObject, SGCManager {
             let connected = json["connected"] as? Bool ?? false
             let ssid = json["ssid"] as? String ?? ""
             let ip = json["local_ip"] as? String ?? ""
-            // Provisioning failure reason (e.g. connect_timeout); empty when connected
-            // or on older glasses firmware that doesn't send it.
+            // Provisioning failure reason (e.g. connect_timeout). Sticky: routine
+            // error-less status updates (link-state debounce, request_wifi_status)
+            // must not clear a failure nothing recovered from — only a newer error
+            // or a successful connection overwrites it.
             let wifiError = json["error"] as? String ?? ""
             if !wifiError.isEmpty {
                 Bridge.log("LIVE: 🌐 WiFi provisioning error from glasses: \(wifiError)")
+                DeviceStore.shared.apply("glasses", "wifiError", wifiError)
+            } else if connected {
+                DeviceStore.shared.apply("glasses", "wifiError", "")
             }
-            DeviceStore.shared.apply("glasses", "wifiError", wifiError)
             updateWifiStatus(connected: connected, ssid: ssid, ip: ip)
 
         case "hotspot_status_update":


### PR DESCRIPTION
## Scope

Field-reported Mentra Live issues from the Thunderbird enterprise deployment, implemented and hardware-verified over ADB on a Mentra Live (Android 11, system-app build). One commit per issue. (#3384 — requestId stamping + EXIF ImageUniqueID — has merged to dev; this branch carries a dev merge-back.)

**Note on burst behavior:** an earlier commit queued burst photo requests behind the in-flight job; it was implemented, hardware-verified, and then **deliberately reverted** after review discussion — deterministic fail-fast CAMERA_BUSY is the intended contract for photos with a delivery leg (a photo arriving nondeterministically 20-40s late reads as broken). What ships instead is the save-only routing below, which removes the gate exactly where it protects nothing.

## 1. Hotspot reports "enabled" before the AP accepts clients

Stock declares the hotspot up the instant the SSID string is readable from `Settings.Global[xy_ssid]` — which **persists across sessions**, so on repeat enables the phone hears "enabled" at ~0ms while hostapd takes 0.4-1s+ (3-8s reported in the field under load). iOS joins into the dead window → "Unable to Join". The premature flag also made the real framework readiness event (`TETHER_STATE_CHANGED`) compare equal and get swallowed.

Fix: a readiness watch polls the real signals (gateway IP present on an up interface + SSID; framework AP state logged as corroboration) and only then notifies — no protocol change, old phones fixed for free. 12s deadline → teardown + `hotspot_error`.

**E2E:** stock baseline measured (enable intent → hostapd +0.4s → ap0+gateway +0.66s vs "active" at ~0ms); fixed build logs `K900 hotspot READY after 1252ms (apEnabled=true)` and only then emits `hotspot_status_update` — ap0 verified up with 192.168.43.1 at that moment.

## 2. WiFi security inferred from password presence; failures silent

Security was inferred from password presence (non-empty → legacy `WPA_PSK`, never SAE/PMF), so WPA3-only APs could never associate, and the closed K900 SystemUI fallback guesses on its own (field report: WPA2/WPA3-transition saved as OPEN). No error ever surfaced.

Fix: the native path (the live path — Mentra Live runs asg_client as a system app) derives security from the AP's advertised scan capabilities via a new pure `WifiSecurityChooser` (WPA3-only → SAE+PMF, WPA2/transition → PSK, unknown SSID → PSK fallback, no password → OPEN). `wifi_status` now carries an `error` field (`connect_timeout` / `connected_to_other_network`); both phone platforms parse, log, and stash it in DeviceStore (`glasses/wifiError`).

**E2E:** bogus SSID → `Configuring PSK ... (scan caps=null)`, `setSecurityParams` validated at runtime on API 30, then `{"type":"wifi_status","connected":false,"error":"connect_timeout"}` on the wire. Real WPA2 AP → `Configuring PSK for Mentra (scan caps=[WPA2-PSK-CCMP]...)` → associated ~6s → `wifi_status connected:true` with SSID+IP. Chooser table: 5/5 JVM tests. **Open:** WPA3-only/transition AP join (bench has WPA2 only).

## 3. Charging flag wrong in 2 of 3 sources

Verified in BES firmware source: `sr_hrt` carries the real SY5502 PMU charging bit; `hm_batv`/`sr_batv` carry only voltage+percent — the `>3900mV` (glasses) and `>4000mV` (phone) thresholds were fabrications on opposite sides of a Li-ion cell's normal range, producing exactly the customer's opposite-direction errors. On-device proof the MTK can't know: Android's battery service reported `USB powered:false, level 91` while the BES gauge was simultaneously charging at 57%.

Fix: glasses omit the fabricated `charging` field from `battery_status` (both phone parsers preserve last state when absent — old apps unaffected); both phone parsers update percent-only from `battery_status`/`sr_batv`; charging comes exclusively from `sr_hrt`'s `charg` bit. Also fixed: iOS read `level` where glasses send `percent` (dead code until now), and iOS forced not-charging when old firmware omits `charg` (now preserves last state, matching Android).

## 4. Save-only SDK photos no longer hit CAMERA_BUSY

Thunderbird's fleet uses the SDK purely for archival capture: `take_photo` with `save:true` and no upload target, files pulled later over WiFi sync. Those requests were still hitting the single-flight CAMERA_BUSY gate, which exists to protect the **delivery leg** (webhook upload / BLE transfer) — a leg these requests don't have. Button photos already prove the gateless path: they enqueue straight into the camera queue and serialize at any press rate.

Fix: infer the archival shape from `save && webhookUrl empty` (no new params; `transferMethod` deliberately not consulted — always "auto" in practice, and the phone app always supplies a webhookUrl, so this shape is only produced by direct BT-SDK callers). Such requests bypass the busy gates and enqueue into the camera queue like button photos; the terminal `photo_response` carries `saved:true` + `captureId` (the requestId-stamped capture directory name) for sync-time correlation. Photos with a delivery leg keep the deterministic one-at-a-time CAMERA_BUSY contract.

**E2E:** hardware verification in progress (bench cable flake mid-install); will confirm burst-of-4 save-only captures with per-request success responses before merge.

## Test evidence

- `check-android-compile.sh asg` + `check-android-compile.sh bluetooth-sdk` — BUILD SUCCESSFUL
- `bun compile` (mobile TS) — clean
- JVM suites: `WifiSecurityChooserTest` 5/5, `CaptureRequestIdTest` 7/7
- Hardware E2E per issue above; full evidence transcript in workspace `.context/thunderbird-e2e-evidence.md`

## Remaining before ship

- Local-save burst E2E on hardware (in progress)
- WPA3/transition association test on a real AP
- Bench note: enabling/disabling the hotspot drops the wlan0 STA association and it does not rejoin on its own (not even at reboot) until re-provisioned — pre-existing firmware behavior, worth its own ticket
- Follow-up ticket: reliable-path delivery of CAMERA_BUSY rejections (the residual field bug for delivery photos: rejects lost on saturated BLE → opaque CAPTURE_TIMEOUT)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hotspot timing, WiFi join security, and BLE protocol fields used during provisioning and pairing; behavior changes are intentional but affect critical connectivity paths on K900 hardware.
> 
> **Overview**
> Addresses Mentra Live field issues across glasses firmware, K900 networking, and iOS/Android SDK parsers.
> 
> **Hotspot:** K900 no longer marks the AP enabled when `xy_ssid` is readable (which can be immediate and stale). A readiness watch polls until the gateway IP is on an up interface and the SSID is present, then notifies listeners; 12s timeout tears down and reports `hotspot_error`. Stop/teardown is synchronized so late ticks cannot re-announce “enabled.”
> 
> **WiFi provisioning:** Join security is chosen from scan capabilities via new `WifiSecurityChooser` (WPA3-only → SAE, else PSK/open) instead of password presence. `wifi_status` can include `error` (`connect_timeout`, `connected_to_other_network`); mobile SDK stores sticky `glasses/wifiError` until connect succeeds.
> 
> **Charging:** Glasses stop sending a voltage-guessed `charging` on `battery_status`. Phones treat percent-only battery messages as preserving last charging state; **charging updates only from `sr_hrt`’s PMU `charg` bit** (iOS also fixes `percent` vs `level` and missing-`charg` handling).
> 
> **Photos:** `take_photo` with `save` and no webhook routes to new `takePhotoForLocalSave`—camera queue like button photos, bypassing single-flight CAMERA_BUSY; success `photo_response` includes `saved` and `captureId` for gallery sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fcdbb7efbc6921e907da196208ea3bf6a9e27e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->