### PR TITLE
Document MTK OTA version format as MentraLive_YYYYMMDD

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -1662,7 +1662,9 @@ public class OtaHelper {
      * Find MTK firmware patch matching the current version.
      * MTK requires sequential updates - must find patch starting from current version.
      * @param patches Array of patch objects with start_firmware, end_firmware, url
-     * @param currentVersion Current MTK firmware version string (e.g., "20241130")
+     * @param currentVersion Current MTK firmware version as reported by
+     *     {@code ro.custom.ota.version}, e.g. "MentraLive_20260626"; both sides are
+     *     normalized before comparison, so a bare "20260626" would also match
      * @return Matching patch object, or null if no match or version unknown
      */
     private JSONObject findMatchingMtkPatch(JSONArray patches, String currentVersion) {
@@ -1690,6 +1692,11 @@ public class OtaHelper {
         return null;
     }
 
+    /**
+     * Reduce an MTK version string to its bare date so manifest entries and the device
+     * property match regardless of any "MentraLive_"-style prefix. Both normally carry the
+     * prefix; this is defensive so a bare-date value on either side still matches.
+     */
     private String normalizeMtkFirmwareVersion(String version) {
         if (version == null) {
             return "";
@@ -1737,7 +1744,9 @@ public class OtaHelper {
 
     /**
      * Compare two version strings.
-     * Supports formats like "17.26.1.14" (BES) or "20241130" (MTK date format).
+     * Supports dotted formats like "17.26.1.14" (BES) or bare dates like "20241130".
+     * MTK patch matching does not use this - it uses normalized exact equality in
+     * {@link #findMatchingMtkPatch}.
      * @param version1 First version string
      * @param version2 Second version string
      * @return positive if version1 > version2, negative if version1 < version2, 0 if equal

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
@@ -29,6 +29,11 @@ public interface ISystemController {
 
     void restartCameraHal();
 
+    /**
+     * Current MTK firmware version from {@code ro.custom.ota.version}, returned verbatim.
+     * Mentra Live firmware reports "MentraLive_YYYYMMDD" (e.g. "MentraLive_20260626"), the
+     * same form OTA manifest {@code start_firmware} entries use.
+     */
     String getSystemOtaVersion();
 
     void setHotspot5GEnabled(boolean enable);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/MentraLiveSystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/MentraLiveSystemController.java
@@ -88,6 +88,8 @@ public class MentraLiveSystemController implements ISystemController {
             Log.w(TAG, "Error reading system OTA version property", e);
         }
         if (ver == null || ver.length() < 8) {
+            // Bare-date default inherited from K900 vendor code; real firmware reports
+            // "MentraLive_YYYYMMDD", so this value matches no manifest entry.
             ver = "20241130";
             Log.d(TAG, "System OTA version not available, using default: " + ver);
         }


### PR DESCRIPTION
## Scope

Comment-only change. Corrects stale docs claiming `ro.custom.ota.version` is a bare `YYYYMMDD` date:

- `ISystemController.getSystemOtaVersion()`: new Javadoc documenting the verbatim `MentraLive_YYYYMMDD` format, matching the manifest `start_firmware` form.
- `MentraLiveSystemController`: note that the `20241130` fallback is a bare-date default inherited from K900 vendor code, which matches no manifest entry.
- `OtaHelper`: `findMatchingMtkPatch` param doc now shows the real format and that both sides are normalized; `normalizeMtkFirmwareVersion` gets a Javadoc explaining the prefix stripping is defensive; `compareVersions` doc clarifies MTK patch matching does not use it.

## Why

These stale comments (inherited from K900 vendor sample code via the old `SysControl` Javadoc) led automated review on #3383 to flag the prefixed manifest `start_firmware` entries as unmatchable (see [this thread](https://github.com/Mentra-Community/MentraOS/pull/3383#discussion_r3553565330)). Device evidence shows `mtkFirmwareVersion: "MentraLive_20260525"` reported verbatim, and no firmware has been observed reporting a bare date — every `start_firmware` entry ever shipped in the OTA manifests is prefixed (the only bare entries, `20241130`/`20250115` in `live_version.json`, were committed 2026-01-28 and replaced by prefixed ones a day later). The docs were wrong, not the manifest.

## Test evidence

Javadoc/comment-only; no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment and Javadoc updates only; OTA matching logic is unchanged.
> 
> **Overview**
> **Javadoc and comments only** — no runtime behavior changes.
> 
> Updates stale MTK OTA version documentation that implied `ro.custom.ota.version` and manifest `start_firmware` were bare `YYYYMMDD` dates. Docs now state Mentra Live reports **`MentraLive_YYYYMMDD`** verbatim (e.g. `MentraLive_20260626`), aligned with manifest entries, and that **`OtaHelper.normalizeMtkFirmwareVersion`** strips the prefix so either side can still match defensively.
> 
> **`ISystemController.getSystemOtaVersion()`** gains Javadoc for the property format. **`MentraLiveSystemController`** notes the `20241130` fallback is legacy bare-date vendor default and won’t match prefixed manifest rows. **`OtaHelper`** clarifies that MTK patch selection uses normalized equality in **`findMatchingMtkPatch`**, not **`compareVersions`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 912303d33317f45246ac783ef4a94051b2054adf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->