### PR TITLE
Report empty MTK OTA version instead of vendor sentinel

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/interfaces/ISystemController.java
@@ -32,7 +32,9 @@ public interface ISystemController {
     /**
      * Current MTK firmware version from {@code ro.custom.ota.version}, returned verbatim.
      * Mentra Live firmware reports "MentraLive_YYYYMMDD" (e.g. "MentraLive_20260626"), the
-     * same form OTA manifest {@code start_firmware} entries use.
+     * same form OTA manifest {@code start_firmware} entries use. Returns an empty string
+     * when the version is unavailable; the phone-side OTA checkers treat that as unknown
+     * and offer no MTK update.
      */
     String getSystemOtaVersion();
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/MentraLiveSystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/MentraLiveSystemController.java
@@ -88,10 +88,10 @@ public class MentraLiveSystemController implements ISystemController {
             Log.w(TAG, "Error reading system OTA version property", e);
         }
         if (ver == null || ver.length() < 8) {
-            // Bare-date default inherited from K900 vendor code; real firmware reports
-            // "MentraLive_YYYYMMDD", so this value matches no manifest entry.
-            ver = "20241130";
-            Log.d(TAG, "System OTA version not available, using default: " + ver);
+            // Report unknown honestly instead of the bare-date sentinel K900 vendor code
+            // used ("20241130") - the phone treats an empty version as "no MTK update".
+            Log.w(TAG, "System OTA version unavailable (property missing or malformed: '" + ver + "')");
+            return "";
         }
         return ver;
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/NoOpSystemController.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/system/managers/NoOpSystemController.java
@@ -35,7 +35,7 @@ public class NoOpSystemController implements ISystemController {
 
     @Override
     public String getSystemOtaVersion() {
-        return "20241130";
+        return "";
     }
 
     @Override

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/system/core/SystemControllerFactoryTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/system/core/SystemControllerFactoryTest.java
@@ -37,6 +37,6 @@ public class SystemControllerFactoryTest {
         ISystemController controller = SystemControllerFactory.get(context);
 
         assertThat(controller).isInstanceOf(NoOpSystemController.class);
-        assertThat(controller.getSystemOtaVersion()).isEqualTo("20241130");
+        assertThat(controller.getSystemOtaVersion()).isEmpty();
     }
 }


### PR DESCRIPTION
## Scope

Follow-up to #3386. When `ro.custom.ota.version` is missing or malformed (`< 8` chars), `getSystemOtaVersion()` fabricated the K900 vendor sample value `"20241130"` instead of admitting the version is unknown. This flows into `version_info_3.mtk_fw_version`, so the phone, UI, and telemetry saw a plausible-looking fake version, silently masking a broken device state.

- `MentraLiveSystemController`: return `""` (with a warn log) when the property is unavailable.
- `NoOpSystemController`: return `""` (MTK version is meaningless off Mentra Live hardware).
- `ISystemController` Javadoc: document the empty-string contract.
- `SystemControllerFactoryTest`: assert the NoOp controller reports empty.

## Why it's safe

The glasses-side OTA matcher never used this fallback — `OtaHelper` reads the property directly and already handles empty ("Cannot match MTK patch - current version unknown"). Every phone-side consumer treats empty as unknown:

- iOS `OtaManifestChecker.hasMtkUpdate`: `guard !currentVersion.isEmpty else { return false }` (plus a bounded wait for version info before checking)
- Android `OtaManifest.hasMtkUpdate`: `if (currentVersion.isBlank()) return false`
- Mobile `OtaUpdateChecker.tsx`: guards on truthy `mtkFirmwareVersion`
- Status merging (iOS `GlassesStatus` merge / Android `ifBlank`): an empty incoming value never overwrites a known one

The sentinel was also a latent hazard: the phone checkers strip the `MentraLive_` prefix when comparing, so a broken-property device would have matched a hypothetical manifest entry for real 20241130 firmware.

## Test evidence

`./gradlew :app:testDebugUnitTest --tests "*SystemControllerFactoryTest*"` passes (compiles app + test sources, runs the updated assertions).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small contract clarification on version reporting; empty MTK version is already handled as unknown on phone OTA paths, reducing incorrect update matching risk.
> 
> **Overview**
> **`getSystemOtaVersion()`** no longer fabricates the K900 vendor placeholder **`"20241130"`** when `ro.custom.ota.version` is missing or too short. **`MentraLiveSystemController`** returns **`""`** and logs a warning; **`NoOpSystemController`** also returns **`""`** instead of the same sentinel.
> 
> The **`ISystemController`** contract is documented: empty means unknown, and phone-side OTA logic should treat that as **no MTK update**. **`SystemControllerFactoryTest`** expects an empty version from the NoOp controller.
> 
> This affects **`version_info_3.mtk_fw_version`** (via **`AsgClientService`**) so UI and telemetry no longer show a plausible fake firmware date when the property is broken.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d51bc59f675d53104fd1b1bbc948b16cafc658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->