### PR TITLE
Link report Slack posts to the admin console and restore the System line

### DIFF
--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -9,6 +9,7 @@ const savedEnv = {
   CLOUD_REPORTS_SLACK_WEBHOOK_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL,
   CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
   CLOUD_CORE_ENVIRONMENT: process.env.CLOUD_CORE_ENVIRONMENT,
+  CLOUD_ADMIN_CONSOLE_URL: process.env.CLOUD_ADMIN_CONSOLE_URL,
 };
 const realFetch = globalThis.fetch;
 
@@ -19,6 +20,7 @@ let fetchMock: ReturnType<typeof mock<FetchCall>>;
 beforeEach(() => {
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL;
+  delete process.env.CLOUD_ADMIN_CONSOLE_URL;
   process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
   fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -32,6 +34,7 @@ afterEach(() => {
     savedEnv.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
   );
   restoreEnv("CLOUD_CORE_ENVIRONMENT", savedEnv.CLOUD_CORE_ENVIRONMENT);
+  restoreEnv("CLOUD_ADMIN_CONSOLE_URL", savedEnv.CLOUD_ADMIN_CONSOLE_URL);
 });
 
 describe("notifyReportSlack", () => {
@@ -104,6 +107,79 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain("glasses stuck on boot screen");
     expect(blocksJson).toContain("*Artifacts:*\\n3");
     expect(blocksJson).toContain("*Env:*\\ntest-env");
+  });
+
+  test("links the report to the admin console for known environments", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_CORE_ENVIRONMENT = "dev";
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain(
+      "<https://admin.dev.mentraglass.com/?report=rep_TEST123|Open incident>",
+    );
+    expect(payload.text).toContain("https://admin.dev.mentraglass.com/?report=rep_TEST123");
+  });
+
+  test("prefers CLOUD_ADMIN_CONSOLE_URL over the derived console link", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_ADMIN_CONSOLE_URL = "https://admin.example.test/";
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("<https://admin.example.test/?report=rep_TEST123|Open incident>");
+  });
+
+  test("omits the console link and System line when environment and context are unknown", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).not.toContain("Open incident");
+    expect(blocksJson).not.toContain("*System:*");
+  });
+
+  test("renders a System line from the toolkit-collected context", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack(
+      bugNotification({
+        context: {
+          app: { appVersion: "2.11.0" },
+          phone: { platform: "android", deviceName: "SM-S948U", osVersion: "android 36" },
+          glasses: { connected: true, modelName: "Mentra Live" },
+          settings: { defaultWearable: "Mentra Live" },
+        },
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain(
+      "*System:* App: 2.11.0 | Platform: android | Device: SM-S948U | OS: android 36 | Glasses: Connected (Mentra Live) | Wearable: Mentra Live",
+    );
+  });
+
+  test("escapes client-sourced context values in the System line", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack(
+      bugNotification({
+        context: { phone: { deviceName: "SM<S&>948", platform: 42, network: null } },
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("Device: SM&lt;S&amp;&gt;948");
+    expect(blocksJson).not.toContain("Platform: 42");
   });
 
   test("truncates long user-authored text", async () => {

--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -146,16 +146,19 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).not.toContain("*System:*");
   });
 
-  test("renders a System line from the toolkit-collected context", async () => {
+  test("renders a System line from the raw mobile toolkit context", async () => {
     process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
 
+    // Shape as the mobile island's collectDiagnosticContext actually sends it:
+    // the glasses store state with a GlassesConnectionStatus object and
+    // deviceModel, not a normalized connected/modelName pair.
     await notifyReportSlack(
       bugNotification({
         context: {
           app: { appVersion: "2.11.0" },
           phone: { platform: "android", deviceName: "SM-S948U", osVersion: "android 36" },
-          glasses: { connected: true, modelName: "Mentra Live" },
-          settings: { defaultWearable: "Mentra Live" },
+          glasses: { connection: { state: "connected" }, deviceModel: "Even Realities G2" },
+          settings: { defaultWearable: "Even Realities G2" },
         },
       }),
     );
@@ -163,8 +166,22 @@ describe("notifyReportSlack", () => {
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
     expect(blocksJson).toContain(
-      "*System:* App: 2.11.0 | Platform: android | Device: SM-S948U | OS: android 36 | Glasses: Connected (Mentra Live) | Wearable: Mentra Live",
+      "*System:* App: 2.11.0 | Platform: android | Device: SM-S948U | OS: android 36 | Glasses: Connected (Even Realities G2) | Wearable: Even Realities G2",
     );
+  });
+
+  test("accepts a normalized glasses shape in the System line", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack(
+      bugNotification({
+        context: { glasses: { connected: false, modelName: "Mentra Live" } },
+      }),
+    );
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("*System:* Glasses: Disconnected (Mentra Live)");
   });
 
   test("escapes client-sourced context values in the System line", async () => {

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -52,6 +52,9 @@ export interface ReportSlackNotification {
     contactEmail?: string;
   } | null;
   feedback?: Record<string, unknown> | null;
+  /** Toolkit-collected diagnostic context (Mixed in Mongo, read defensively);
+   * feeds the compact System line. */
+  context?: Record<string, unknown> | null;
   /** Set on ready-time notifications: how many artifacts were attached. */
   artifactCount?: number;
 }
@@ -145,6 +148,7 @@ function buildSlackMessage(notification: ReportSlackNotification): {
     timeZone: "America/Los_Angeles",
   });
 
+  const consoleUrl = adminConsoleReportUrl(reportId);
   const identityFields = [
     { type: "mrkdwn", text: `*User:*\n${slackText(mentraUserId, SHORT_TEXT_MAX)}` },
     { type: "mrkdwn", text: `*Report ID:*\n\`${slackText(reportId, SHORT_TEXT_MAX)}\`` },
@@ -152,6 +156,9 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   ];
   if (artifactCount !== undefined) {
     identityFields.push({ type: "mrkdwn", text: `*Artifacts:*\n${artifactCount}` });
+  }
+  if (consoleUrl) {
+    identityFields.push({ type: "mrkdwn", text: `*Console:*\n<${consoleUrl}|Open incident>` });
   }
 
   const blocks: SlackBlock[] = [
@@ -184,6 +191,15 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   }
 
   blocks.push(...buildBodyBlocks(notification));
+
+  const systemLine = formatSystemLine(notification.context);
+  if (systemLine) {
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: `*System:* ${slackText(systemLine, BEHAVIOR_TEXT_MAX)}` },
+    });
+  }
+
   blocks.push({
     type: "section",
     text: { type: "mrkdwn", text: `_Submitted: ${timestamp}_` },
@@ -192,6 +208,7 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   const fallbackParts = [
     `New ${kind} report from ${mentraUserId} (${env})`,
     `Report ID: ${reportId}`,
+    ...(consoleUrl ? [`Console: ${consoleUrl}`] : []),
     ...(typeof trigger?.reason === "string"
       ? [`Trigger: ${truncate(trigger.reason, TRIGGER_TEXT_MAX)}`]
       : []),
@@ -300,6 +317,67 @@ function formatSourceApplet(trigger: ReportSlackNotification["trigger"]): string
  */
 function environmentLabel(): string {
   return process.env.CLOUD_CORE_ENVIRONMENT || "unknown";
+}
+
+/**
+ * Deep link to this report in the admin console (Incident system page).
+ * An explicit CLOUD_ADMIN_CONSOLE_URL wins; otherwise the URL is derived from
+ * the deployment environment per docs/runbooks/cloudflare/pages-websites.md
+ * (admin.<env>.mentraglass.com, admin.mentraglass.com for prod). Unknown
+ * environments get no link rather than a wrong one.
+ */
+function adminConsoleReportUrl(reportId: string): string | null {
+  const env = process.env.CLOUD_CORE_ENVIRONMENT;
+  const base =
+    process.env.CLOUD_ADMIN_CONSOLE_URL ||
+    (env === "prod" || env === "production"
+      ? "https://admin.mentraglass.com"
+      : env === "dev" || env === "staging"
+        ? `https://admin.${env}.mentraglass.com`
+        : null);
+  if (!base) return null;
+  return `${base.replace(/\/+$/, "")}/?report=${encodeURIComponent(reportId)}`;
+}
+
+/**
+ * Compact V1-style system summary built from the toolkit-collected context
+ * (see mobile island diagnosticContext). Context is client-sourced Mixed
+ * data, so every field is read defensively and value lengths are capped;
+ * the assembled line is escaped by the caller via slackText.
+ */
+function formatSystemLine(context: Record<string, unknown> | null | undefined): string | null {
+  if (!context || typeof context !== "object") return null;
+  const app = asRecord(context.app);
+  const phone = asRecord(context.phone);
+  const glasses = asRecord(context.glasses);
+  const settings = asRecord(context.settings);
+
+  const parts: string[] = [];
+  const push = (label: string, value: unknown) => {
+    if (typeof value === "string" && value.trim()) {
+      parts.push(`${label}: ${truncate(value.trim(), 80)}`);
+    }
+  };
+  push("App", app?.appVersion);
+  push("Platform", phone?.platform);
+  push("Device", phone?.deviceName);
+  push("OS", phone?.osVersion);
+  if (typeof glasses?.connected === "boolean") {
+    const model =
+      typeof glasses.modelName === "string" && glasses.modelName.trim()
+        ? ` (${truncate(glasses.modelName.trim(), 80)})`
+        : "";
+    parts.push(`Glasses: ${glasses.connected ? "Connected" : "Disconnected"}${model}`);
+  }
+  push("Wearable", settings?.defaultWearable);
+
+  return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
 }
 
 /**

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -362,16 +362,44 @@ function formatSystemLine(context: Record<string, unknown> | null | undefined): 
   push("Platform", phone?.platform);
   push("Device", phone?.deviceName);
   push("OS", phone?.osVersion);
-  if (typeof glasses?.connected === "boolean") {
-    const model =
-      typeof glasses.modelName === "string" && glasses.modelName.trim()
-        ? ` (${truncate(glasses.modelName.trim(), 80)})`
-        : "";
-    parts.push(`Glasses: ${glasses.connected ? "Connected" : "Disconnected"}${model}`);
+  if (glasses) {
+    const connection = glassesConnectionLabel(glasses);
+    const model = firstNonEmptyString(glasses.deviceModel, glasses.modelName);
+    if (connection || model) {
+      const suffix = model ? ` (${truncate(model, 80)})` : "";
+      parts.push(`Glasses: ${connection ?? "Unknown"}${suffix}`);
+    }
   }
   push("Wearable", settings?.defaultWearable);
 
   return parts.length > 0 ? parts.join(" | ") : null;
+}
+
+/**
+ * Human label for the glasses link state. The mobile toolkit sends the raw
+ * glasses store state, where `connection` is a `{ state: "connected" | ... }`
+ * object (btsdk GlassesConnectionStatus); a plain string or a normalized
+ * `connected` boolean are accepted for robustness against client versions.
+ */
+function glassesConnectionLabel(glasses: Record<string, unknown>): string | null {
+  if (typeof glasses.connected === "boolean") {
+    return glasses.connected ? "Connected" : "Disconnected";
+  }
+  const connection = glasses.connection;
+  const state =
+    typeof connection === "string" ? connection : asRecord(connection)?.state;
+  if (typeof state === "string" && state.trim()) {
+    const label = truncate(state.trim(), 40);
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  }
+  return null;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -123,6 +123,7 @@ export async function submitReport(input: SubmitReportInput): Promise<SubmitRepo
       mentraUserId: input.mentraUserId,
       kind: input.kind,
       feedback,
+      context: input.context,
     }).catch(() => {});
   }
 
@@ -189,6 +190,7 @@ export async function markReportReady(input: {
       trigger: before.trigger,
       report: before.report,
       feedback: before.feedback,
+      context: before.context,
       artifactCount: before.artifacts?.length ?? 0,
     }).catch(() => {});
   }

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -149,14 +149,15 @@ export function App() {
 }
 
 // Deep link used by report Slack notifications: /?report=rep_… lands on the
-// Incident system page with that report open. Read once at load; the param is
-// cleared from the address bar after it is consumed.
-const deepLinkReportId = new URLSearchParams(window.location.search).get("report");
+// Incident system page with that report open. Consumed exactly once by the
+// first ReportsPage mount, which also clears the param from the address bar,
+// so navigating away and back starts unselected.
+let pendingDeepLinkReportId = new URLSearchParams(window.location.search).get("report");
 
 function AdminPage() {
   const qc = useQueryClient();
   const env = ENVIRONMENT;
-  const [page, setPage] = useState<AdminPageKey>(deepLinkReportId ? "incidents" : "home");
+  const [page, setPage] = useState<AdminPageKey>(pendingDeepLinkReportId ? "incidents" : "home");
   const [selectedReleaseIds, setSelectedReleaseIds] = useState<Set<string>>(new Set());
   const [detailReleaseId, setDetailReleaseId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -362,7 +363,7 @@ function AdminPage() {
 
       {page === "audit" ? <AuditPage events={auditEvents} loading={audit.isLoading} /> : null}
 
-      {page === "incidents" ? <ReportsPage initialReportId={deepLinkReportId} /> : null}
+      {page === "incidents" ? <ReportsPage /> : null}
 
       {detailRelease ? (
         <SubmissionDetail
@@ -824,16 +825,19 @@ function AuditRow({ event, compact = false }: { event: AuditEvent; compact?: boo
   );
 }
 
-function ReportsPage({ initialReportId = null }: { initialReportId?: string | null }) {
+function ReportsPage() {
   const [kind, setKind] = useState<"all" | ReportKind>("all");
   const [status, setStatus] = useState<"all" | ReportStatus>("all");
-  const [detailId, setDetailId] = useState<string | null>(initialReportId);
+  const [detailId, setDetailId] = useState<string | null>(pendingDeepLinkReportId);
 
   useEffect(() => {
-    // Consume the deep link so refreshes and later visits to this page do not
-    // keep reopening the same report.
-    if (initialReportId) window.history.replaceState(null, "", window.location.pathname);
-  }, [initialReportId]);
+    // Consume the deep link: later mounts of this page start unselected and
+    // the address bar loses the parameter.
+    if (pendingDeepLinkReportId) {
+      pendingDeepLinkReportId = null;
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, []);
 
   const reports = useQuery({
     queryKey: ["admin-reports", kind, status],

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertCircle, Bug, Check, ClipboardList, CloudUpload, FileText, History, Home, Loader2, MessageSquareWarning, PackageCheck, RefreshCcw, RotateCcw, ShieldCheck, X } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AppShell, type NavItem } from "@/components/app-shell";
 import { Button } from "@/components/ui/button";
 import mentraLogo from "./assets/mentra-logo.svg";
@@ -148,10 +148,15 @@ export function App() {
   );
 }
 
+// Deep link used by report Slack notifications: /?report=rep_… lands on the
+// Incident system page with that report open. Read once at load; the param is
+// cleared from the address bar after it is consumed.
+const deepLinkReportId = new URLSearchParams(window.location.search).get("report");
+
 function AdminPage() {
   const qc = useQueryClient();
   const env = ENVIRONMENT;
-  const [page, setPage] = useState<AdminPageKey>("home");
+  const [page, setPage] = useState<AdminPageKey>(deepLinkReportId ? "incidents" : "home");
   const [selectedReleaseIds, setSelectedReleaseIds] = useState<Set<string>>(new Set());
   const [detailReleaseId, setDetailReleaseId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -357,7 +362,7 @@ function AdminPage() {
 
       {page === "audit" ? <AuditPage events={auditEvents} loading={audit.isLoading} /> : null}
 
-      {page === "incidents" ? <ReportsPage /> : null}
+      {page === "incidents" ? <ReportsPage initialReportId={deepLinkReportId} /> : null}
 
       {detailRelease ? (
         <SubmissionDetail
@@ -819,10 +824,16 @@ function AuditRow({ event, compact = false }: { event: AuditEvent; compact?: boo
   );
 }
 
-function ReportsPage() {
+function ReportsPage({ initialReportId = null }: { initialReportId?: string | null }) {
   const [kind, setKind] = useState<"all" | ReportKind>("all");
   const [status, setStatus] = useState<"all" | ReportStatus>("all");
-  const [detailId, setDetailId] = useState<string | null>(null);
+  const [detailId, setDetailId] = useState<string | null>(initialReportId);
+
+  useEffect(() => {
+    // Consume the deep link so refreshes and later visits to this page do not
+    // keep reopening the same report.
+    if (initialReportId) window.history.replaceState(null, "", window.location.pathname);
+  }, [initialReportId]);
 
   const reports = useQuery({
     queryKey: ["admin-reports", kind, status],

--- a/cloud-v2/websites/admin/src/App.tsx
+++ b/cloud-v2/websites/admin/src/App.tsx
@@ -149,15 +149,17 @@ export function App() {
 }
 
 // Deep link used by report Slack notifications: /?report=rep_… lands on the
-// Incident system page with that report open. Consumed exactly once by the
-// first ReportsPage mount, which also clears the param from the address bar,
-// so navigating away and back starts unselected.
+// Incident system page with that report open. AdminPage captures the id into
+// state and clears the URL only once the session is confirmed — while logged
+// out the param must stay in the address bar so LoginGate's return_to brings
+// it back through the auth round-trip. Navigating between pages spends it.
 let pendingDeepLinkReportId = new URLSearchParams(window.location.search).get("report");
 
 function AdminPage() {
   const qc = useQueryClient();
   const env = ENVIRONMENT;
   const [page, setPage] = useState<AdminPageKey>(pendingDeepLinkReportId ? "incidents" : "home");
+  const [deepLinkReportId, setDeepLinkReportId] = useState<string | null>(pendingDeepLinkReportId);
   const [selectedReleaseIds, setSelectedReleaseIds] = useState<Set<string>>(new Set());
   const [detailReleaseId, setDetailReleaseId] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -178,6 +180,16 @@ function AdminPage() {
     queryFn: () => api<{ authenticated: true; admin: true; user: AdminUser | null }>("/api/admin/me"),
     retry: false,
   });
+
+  useEffect(() => {
+    // The deep link is safe in state now, so drop it from the address bar —
+    // but only once signed in; before that, LoginGate's return_to still needs
+    // the parameter to survive the auth round-trip. Idempotent on re-runs.
+    if (me.isSuccess && pendingDeepLinkReportId) {
+      pendingDeepLinkReportId = null;
+      window.history.replaceState(null, "", window.location.pathname);
+    }
+  }, [me.isSuccess]);
   const submissions = useQuery({
     queryKey: ["admin-submissions"],
     queryFn: () => api<{ submissions: ReleaseSummary[] }>("/api/admin/submissions"),
@@ -307,7 +319,12 @@ function AdminPage() {
       badge={<EnvBadge env={env} />}
       nav={ADMIN_NAV}
       activeKey={page}
-      onSelect={key => setPage(key as AdminPageKey)}
+      onSelect={key => {
+        setPage(key as AdminPageKey);
+        // Any navigation spends the deep link: coming back to the Incident
+        // system page starts unselected.
+        setDeepLinkReportId(null);
+      }}
       title={pageMeta[page].title}
       description={pageMeta[page].body}
       userEmail={me.data?.user?.email ?? "Admin"}
@@ -363,7 +380,7 @@ function AdminPage() {
 
       {page === "audit" ? <AuditPage events={auditEvents} loading={audit.isLoading} /> : null}
 
-      {page === "incidents" ? <ReportsPage /> : null}
+      {page === "incidents" ? <ReportsPage initialReportId={deepLinkReportId} /> : null}
 
       {detailRelease ? (
         <SubmissionDetail
@@ -825,19 +842,10 @@ function AuditRow({ event, compact = false }: { event: AuditEvent; compact?: boo
   );
 }
 
-function ReportsPage() {
+function ReportsPage({ initialReportId = null }: { initialReportId?: string | null }) {
   const [kind, setKind] = useState<"all" | ReportKind>("all");
   const [status, setStatus] = useState<"all" | ReportStatus>("all");
-  const [detailId, setDetailId] = useState<string | null>(pendingDeepLinkReportId);
-
-  useEffect(() => {
-    // Consume the deep link: later mounts of this page start unselected and
-    // the address bar loses the parameter.
-    if (pendingDeepLinkReportId) {
-      pendingDeepLinkReportId = null;
-      window.history.replaceState(null, "", window.location.pathname);
-    }
-  }, []);
+  const [detailId, setDetailId] = useState<string | null>(initialReportId);
 
   const reports = useQuery({
     queryKey: ["admin-reports", kind, status],
@@ -1228,7 +1236,9 @@ function formatDate(value: string | null | undefined): string {
 }
 
 function LoginGate({ denied = false }: { denied?: boolean }) {
-  const loginUrl = `/api/console/auth/login?return_to=${encodeURIComponent(`${window.location.origin}/`)}`;
+  // The full URL (not just the origin) so a /?report=… deep link survives the
+  // login round-trip; safeReturnTo on Core validates the origin either way.
+  const loginUrl = `/api/console/auth/login?return_to=${encodeURIComponent(window.location.href)}`;
 
   async function signOutAndReload() {
     try {


### PR DESCRIPTION
Follow-up to #3377 (report Slack notifier) and #3378 (admin incident console), addressing the two gaps in the Cloud V2 Slack posts compared to V1: no way to open the incident, and none of the device context.

## What changed

**Console link.** Report posts now carry an *Open incident* link (and the fallback text carries the raw URL). The admin console base URL is derived from `CLOUD_CORE_ENVIRONMENT` per the documented hostnames (`admin.dev.mentraglass.com`, `admin.staging.mentraglass.com`, `admin.mentraglass.com`), with `CLOUD_ADMIN_CONSOLE_URL` as an explicit override; unknown environments get no link rather than a wrong one. No new Doppler config is required for dev/staging/prod.

**Deep link.** The admin console consumes `/?report=rep_…`: it opens the Incident system page with that report's detail and then clears the query param so refreshes don't re-open it.

**System line.** Posts include the V1-style summary — `App: 2.11.0 | Platform: android | Device: SM-S948U | OS: android 36 | Glasses: Connected (Mentra Live) | Wearable: Mentra Live` — built from the toolkit-collected report context, which the notifier previously never received. Context is client-sourced Mixed data, so every field is read defensively, values are length-capped, and the line goes through the same escaping/caps as other client text.

**Not addressed here: account email.** V1 posts showed the user's email; Cloud V2 deliberately keeps the `users` collection PII-free and the mobile toolkit explicitly redacts `auth_email` from report context, so the server has nothing to show. Surfacing an email needs a product decision: have the feedback UI prefill `contactEmail` (already rendered by the notifier when present) or add the account email to the toolkit report context.

## Tests
Five new notifier unit tests: derived console link per environment, `CLOUD_ADMIN_CONSOLE_URL` override, link+System omitted when unknown, System line composition, and escaping of client-sourced context values. `bun run typecheck`, the reports integration suite, and the admin site build all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Slack message formatting, passing stored report context into notifications, and admin UI deep-link behavior; client context is escaped and console URLs are omitted for unknown environments.
> 
> **Overview**
> Report Slack notifications now include an **Open incident** link to the admin console (derived from `CLOUD_CORE_ENVIRONMENT` or overridden by `CLOUD_ADMIN_CONSOLE_URL`; omitted when the environment is unknown) and a V1-style **System** line built from toolkit diagnostic **context**, which `report.service` now passes into `notifyReportSlack` for feedback and ready-time bug/automatic posts. Client context is parsed defensively with length caps and the same Slack escaping as other user-facing fields.
> 
> The admin site handles `/?report=rep_…`: it opens the Incident system page with that report selected, keeps the query param through login via `return_to` on the full URL, then strips it from the address bar after the session is confirmed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b16f2d2f91e9985434aecb0615c5dd469a5a908. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->