### PR TITLE
Derive OAuth public origin from x-forwarded-proto instead of CORE_PUBLIC_URL

### DIFF
--- a/cloud-v2/docs/issues/019-mentra-account-auth/design.md
+++ b/cloud-v2/docs/issues/019-mentra-account-auth/design.md
@@ -90,7 +90,11 @@ app                core                        Supabase/provider
 ```
 
 - The public callback URL is built from `x-mentra-public-origin` when proxied
-  (same pattern as the console Pages proxy) or `CORE_PUBLIC_URL` otherwise.
+  (same pattern as the console Pages proxy); otherwise it is derived from the
+  request as `x-forwarded-proto` + Host. TLS terminates at the ingress (the
+  pod sees plain http), but ingress-nginx sets `x-forwarded-proto` itself —
+  overwriting any client-supplied value — and preserves Host, so this yields
+  the public https origin with zero per-environment config.
 - Browser: Android Custom Tabs / iOS ASWebAuthenticationSession via
   `expo-web-browser` (already an Expo app); scheme `com.mentra` is registered.
 - Apple provider is the same route pair; Supabase handles the Apple client

--- a/cloud-v2/packages/core/src/api/account/oauth.api.test.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../../types/hono.types";
+import { publicOrigin } from "./oauth.api";
+
+async function originFor(url: string, headers: Record<string, string> = {}): Promise<string> {
+  const app = new Hono<AppEnv>();
+  app.get("/probe", (c) => c.text(publicOrigin(c)));
+  const res = await app.request(url, { headers });
+  return res.text();
+}
+
+describe("publicOrigin", () => {
+  test("derives https from x-forwarded-proto behind the TLS-terminating ingress", async () => {
+    expect(
+      await originFor("http://core.dev.us-west-2.mentraglass.com/probe", {
+        "x-forwarded-proto": "https",
+      }),
+    ).toBe("https://core.dev.us-west-2.mentraglass.com");
+  });
+
+  test("falls back to the request protocol when x-forwarded-proto is absent", async () => {
+    expect(await originFor("http://localhost:8002/probe")).toBe("http://localhost:8002");
+  });
+
+  test("prefers x-mentra-public-origin over the derived origin", async () => {
+    expect(
+      await originFor("http://core.internal/probe", {
+        "x-mentra-public-origin": "https://api.mentra.glass",
+        "x-forwarded-proto": "https",
+      }),
+    ).toBe("https://api.mentra.glass");
+  });
+});

--- a/cloud-v2/packages/core/src/api/account/oauth.api.ts
+++ b/cloud-v2/packages/core/src/api/account/oauth.api.ts
@@ -33,12 +33,17 @@ function s256(verifier: string): string {
   return crypto.createHash("sha256").update(verifier).digest("base64url");
 }
 
-function publicOrigin(c: AppContext): string {
-  return (
-    c.req.header("x-mentra-public-origin") ??
-    process.env.CORE_PUBLIC_URL ??
-    new URL(c.req.url).origin
-  );
+/** Exported for tests. */
+export function publicOrigin(c: AppContext): string {
+  const proxied = c.req.header("x-mentra-public-origin");
+  if (proxied) return proxied;
+  // TLS terminates at the ingress, so the pod sees plain http. ingress-nginx
+  // sets x-forwarded-proto itself (overwriting any client-supplied value) and
+  // preserves Host, so the derived origin is the real public one — no per-env
+  // config. GoTrue's redirect allowlist stays the fail-closed backstop.
+  const url = new URL(c.req.url);
+  const proto = c.req.header("x-forwarded-proto") ?? url.protocol.replace(":", "");
+  return `${proto}://${url.host}`;
 }
 
 /** Start: persist {state, app challenge} + a core<->GoTrue verifier, redirect


### PR DESCRIPTION
## Scope

Fixes the core-hosted account OAuth flow (issue 019) silently dead-ending on GoTrue's Site URL in every deployed environment.

`publicOrigin()` in `oauth.api.ts` resolved the public origin as `x-mentra-public-origin` header → `CORE_PUBLIC_URL` env → `new URL(c.req.url).origin`. Behind Porter's TLS-terminating nginx ingress the pod sees plain http, so the request-URL fallback emitted an `http://` `redirect_to` that GoTrue rejects against the https-only redirect allowlist (confirmed on dev 2026-07-10 by curling `https://core.dev.us-west-2.mentraglass.com/api/account/oauth/google/start` and inspecting the `Location` header). `CORE_PUBLIC_URL` is not set in any Doppler config and nothing else references it, so the broken fallback was the effective behavior everywhere.

## Change

- The origin is now derived from the request instead of requiring an env var: `x-mentra-public-origin` header when proxied, otherwise `${x-forwarded-proto ?? url.protocol}://${url.host}`. ingress-nginx sets `x-forwarded-proto` itself (overwriting any client-supplied value) and preserves Host, so this yields the correct public https origin with zero per-environment config — including per-developer Porter deployments. GoTrue's redirect allowlist remains the fail-closed backstop.
- Removed the `CORE_PUBLIC_URL` reference entirely.
- Updated the §4 bullet in `docs/issues/019-mentra-account-auth/design.md` to describe the derived origin. The "Deployment prerequisites" subsection added by #3396 is updated on that PR's branch to match (separate commit there, so the two PRs don't conflict).
- `cli-auth.api.ts` uses the same `x-mentra-public-origin` header but falls back to the `WORKOS_REDIRECT_URI` env var, never the request URL, so it does not share this flaw; left unchanged.

## Test evidence

New `oauth.api.test.ts` covering the derivation (x-forwarded-proto wins over the pod-local http protocol, protocol fallback without the header, header precedence):

```
bun test src/api/account/oauth.api.test.ts
 3 pass, 0 fail
```

Full `packages/core` suite: 29 pass, 0 fail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the account OAuth redirect URL used for GoTrue authorize/callback; behavior change is narrow and covered by tests, with GoTrue’s redirect allowlist as a backstop.
> 
> **Overview**
> Fixes deployed account OAuth **start** redirects building an `http://` callback URL behind TLS-terminating ingress, which GoTrue rejects against its https redirect allowlist.
> 
> **`publicOrigin()`** in `oauth.api.ts` no longer falls back to `CORE_PUBLIC_URL` or raw `new URL(c.req.url).origin`. After `x-mentra-public-origin`, it now builds `${x-forwarded-proto ?? request protocol}://${host}` so ingress-supplied `x-forwarded-proto` yields the public https origin without per-env config. The helper is **exported** for unit tests.
> 
> Adds **`oauth.api.test.ts`** for ingress https derivation, localhost protocol fallback, and proxy header precedence. **design.md** §4 documents the derived-origin behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626584500e22d8bf15bf15161a80e71e5890682f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->