### PR TITLE
Ship the MentraLive_20260709 MTK + BES OTA to the test manifest (OS-1650)

### DIFF
--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -15,6 +15,18 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
+    },
+    {
       "start_firmware": "MentraLive_20260418",
       "end_firmware": "MentraLive_20260709",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
@@ -22,32 +34,32 @@
     },
     {
       "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
     },
     {
       "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
     },
     {
-      "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
-      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
     },
     {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
-      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   }
 }


### PR DESCRIPTION
## What

Mirror the prod-manifest OTA update from **PR #3383** onto the **test manifest** (`asg_client/ota_website/test_bes_ota_prod_live_version.json`), for [OS-1650](https://linear.app/mentralabs/issue/OS-1650). Same **20260709** firmware set (MTK heal patches + paired BES bump), applied to the test channel instead of prod.

Base `main`, targeting `main` (that's where the OTA website is served from), matching PR #3383.

## Context

The test manifest on `main` was in a half-applied state: only the `20260418` patch had been retargeted to `MentraLive_20260709`, while the other four still pointed at `MentraLive_20260525` and BES was still `17.26.05.22`. This PR completes it.

## 1. MTK patches → `MentraLive_20260709`

Every starting firmware now maps to `MentraLive_20260709` exactly once. Expanded from the test manifest's previous 5 start points to the full 7 (matching prod), so any fielded firmware has a heal path:

| start firmware | → end |
|---|---|
| 20260113 | 20260709 |
| 20260204 | 20260709 |
| 20260418 | 20260709 |
| 20260421 | 20260709 |
| 20260513 | 20260709 |
| 20260525 | 20260709 |
| 20260626 | 20260709 |

## 2. BES → `17.26.07.09` (the reboot trigger)

`17.26.05.22 → 17.26.07.09`. The BES step runs **after** the MTK patch and triggers the device power-cycle that **applies the staged MTK slot** — without it the healed `/system` image stages but never boots.

## Verification

- All `url`s and `sha256`s are identical to the assets referenced by PR #3383 (same `asg-client` release, already uploaded/URL-verified there).
- JSON validates; `apps` section is unchanged (still `com.mentra.asg_client` v37 test APK).

## Notes

- **Do not merge yet** — for review, same as PR #3383.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OTA manifest changes drive real device firmware upgrades on the test channel; wrong URLs or hashes could brick or strand devices, though assets mirror an already-reviewed prod release.
> 
> **Overview**
> Finishes the **test** OTA manifest (`test_bes_ota_prod_live_version.json`) so it matches the **20260709** firmware set already defined for prod (PR #3383).
> 
> **MTK patches:** Every listed start firmware (`20260113` through `20260626`) now maps to **`MentraLive_20260709`** with updated zip URLs and SHA256s. Two new start points are added (`20260113`, `20260204`); paths that previously ended at **`20260525`** are retargeted to **`20260709`**, and a **`20260525 → 20260709`** plus **`20260626 → 20260709`** entry is added so each fielded version has a single heal path.
> 
> **BES firmware:** Bumped from **`17.26.05.22`** to **`17.26.07.09`** (new binary URL and hash), pairing with the MTK step so the post-patch reboot can apply the staged system image.
> 
> The **`apps`** block is unchanged (test `asg_client` v37 APK).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c62924d3a15be572ed7f66fc4f537b16454bd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ship the MentraLive_20260709 OTA (MTK heal patches + BES bump) to the test channel to satisfy OS-1650. This aligns the test manifest with prod and ensures every supported start firmware upgrades directly to 20260709 with a BES-triggered reboot to apply the staged slot.

- **Changes**
  - Retargeted all MTK patches so any fielded firmware upgrades to MentraLive_20260709.
  - Bumped BES firmware 17.26.05.22 → 17.26.07.09 (runs after MTK to power-cycle and apply the staged slot).
  - URLs and sha256s match the prod assets; apps section remains unchanged.

<sup>Written for commit 0c62924d3a15be572ed7f66fc4f537b16454bd70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

