### PR TITLE
Bump Bluetooth SDK to 0.1.19

### DIFF
--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -155,8 +155,7 @@ jobs:
           NOW_SECONDS=$(git show -s --format=%ct HEAD)
           VERSION_CODE=$((BASELINE + NOW_SECONDS - EPOCH_OFFSET_SECONDS))
           SHORT_SHA=$(git rev-parse --short HEAD)
-          BUILD_TIMESTAMP=$(date -u -r "$NOW_SECONDS" +%Y%m%d.%H%M%S)
-          VERSION_NAME="sdk.${SDK_VERSION}.${BUILD_TIMESTAMP}.${SHORT_SHA}"
+          VERSION_NAME="${SDK_VERSION}"
 
           echo "version_code=${VERSION_CODE}" >> "$GITHUB_OUTPUT"
           echo "version_name=${VERSION_NAME}" >> "$GITHUB_OUTPUT"

--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.19")
 }
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.18`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.19`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.18"
+  from: "0.1.19"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -91,7 +91,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.19")
 }
 ```
 
@@ -108,14 +108,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.19`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.18"
+  from: "0.1.19"
 )
 ```
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -230,7 +230,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -475,7 +475,7 @@ For bare native iOS apps, use the public SwiftPM repository:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.19`, then add the `MentraBluetoothSDK` product to your app target.
 
 For local SDK development, add this package folder directly in Xcode:
 

--- a/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_IOS_SPM.md
@@ -76,7 +76,7 @@ already contains the version being tagged before exporting.
 
 ## Commit and Tag
 
-Use the same version format as existing SwiftPM tags, for example `0.1.18`
+Use the same version format as existing SwiftPM tags, for example `0.1.19`
 without a leading `v`.
 
 ```bash

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -247,7 +247,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",


### PR DESCRIPTION
## Summary

- Bumps `@mentra/bluetooth-sdk` from `0.1.18` to `0.1.19`.
- Updates the matching `mobile/bun.lock` and `sdk/bun.lock` workspace metadata.
- Updates Mentra Live Android, iOS, and quickstart install documentation to reference `0.1.19`.
- Updates the package README and SwiftPM release notes to reference `0.1.19`.

## Why

This prepares the next Bluetooth SDK release while keeping every package, workspace lockfile, and customer-facing installation reference aligned. It follows the same scoped release-bump pattern as #3328.

Merging this PR into `dev` is expected to trigger publication of the 0.1.19 npm, Maven, and SwiftPM artifacts. The Starter Kit examples cannot resolve 0.1.19 from those registries until this release completes.

## iOS packaging checks

The npm packaging path injected `0.1.19` into the packed iOS `BluetoothSdkDefaults.swift`, and the `postpack` hook restored the source placeholder afterward.

The SwiftPM export path generated a README using `from: "0.1.19"` and an exported `BluetoothSdkDefaults.swift` containing `swiftPackageSdkVersion = "0.1.19"`.

## Validation

- `bun install --frozen-lockfile --ignore-scripts` in `sdk`
- `bun install --frozen-lockfile --ignore-scripts` in `mobile`
- `npm pack --json --pack-destination <tmp>` in `mobile/modules/bluetooth-sdk`
- `scripts/export-bluetooth-sdk-ios-spm.sh --target <tmp>/mentra-bluetooth-sdk-ios`
- Confirmed no remaining `0.1.18` references in the scoped release files
- `git diff --check`

## Risk

Low. This PR changes release metadata, lockfile workspace versions, and documentation only; it does not modify SDK runtime behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly version and documentation alignment; the ASG OTA `versionName` format change affects release metadata labeling only, not SDK runtime code in this diff.
> 
> **Overview**
> Prepares the **0.1.19** Bluetooth SDK release by bumping `@mentra/bluetooth-sdk` in `package.json` and aligning `mobile/bun.lock` and `sdk/bun.lock` workspace metadata.
> 
> Customer-facing install references move from **0.1.18** to **0.1.19** in Mentra Live Android/iOS/quickstart Mintlify docs, the module README, and SwiftPM release notes.
> 
> In **`.github/workflows/bluetooth-sdk-release.yml`**, the SDK-pinned ASG build no longer sets `versionName` to `sdk.<version>.<timestamp>.<sha>`; it now uses **`${SDK_VERSION}`** only (for example `0.1.19`). `version_code` and short SHA outputs are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 971ff1050d20c006d549a72e411c579a6399a64d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->