### PR TITLE
Document Mentra Live OTA version requirements

### DIFF
--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -122,6 +122,7 @@
             "icon": "bluetooth",
             "pages": [
               "mentra-live/overview",
+              "mentra-live/software-update",
               "mentra-live/ai-ide-integration",
               "mentra-live/quickstart",
               "mentra-live/examples"

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -453,7 +453,9 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Mentra Live OTA installation is glasses-owned. The SDK checks the configured manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.19` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+
+Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 
 | API | Purpose |
 | --- | --- |

--- a/mintlify-docs/mentra-live/examples.mdx
+++ b/mintlify-docs/mentra-live/examples.mdx
@@ -6,6 +6,8 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.19` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git
 cd Mentra-Bluetooth-SDK-Starter-Kit
@@ -14,6 +16,7 @@ cd Mentra-Bluetooth-SDK-Starter-Kit
 ## What The Examples Demonstrate
 
 - Scanning for Mentra Live, connecting, disconnecting, and reconnecting to a saved/default device.
+- Checking for and installing the glasses software release that matches the SDK version.
 - Reading typed glasses and Bluetooth status snapshots.
 - Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, video upload, audio, and SDK log events.
 - Controlling Mentra Live features such as gallery mode, photo capture defaults, video recording defaults, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -27,13 +27,21 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.19`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
 - React Native / Expo apps must use a development build or production native build. Expo Go cannot load the native SDK.
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
+<Warning>
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.19` must use the matching Mentra Live `0.1.19` software release.
+</Warning>
+
 <CardGroup cols={2}>
+  <Card title="Update Mentra Live" icon="download" href="/mentra-live/software-update">
+    Install the glasses software that matches your Bluetooth SDK release.
+  </Card>
   <Card title="Quickstart" icon="rocket" href="/mentra-live/quickstart">
     Install the SDK, connect to Mentra Live, and read glasses status.
   </Card>

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -10,13 +10,17 @@ This quickstart shows the shortest path from package install to connecting to Me
 Use a physical phone for Bluetooth testing. Simulators and emulators are useful for UI and compile checks, but they do not provide the real Bluetooth path.
 </Warning>
 
+<Warning>
+This quickstart uses Bluetooth SDK `0.1.19`. Before testing SDK features, [install the matching Mentra Live `0.1.19` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+</Warning>
+
 ## Step 1: Install The SDK
 
 <Tabs>
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk
+bun add @mentra/bluetooth-sdk@0.1.19
 bunx expo install expo-build-properties
 ```
 
@@ -349,6 +353,9 @@ final class GlassesController: NSObject, MentraBluetoothSDKDelegate {
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="Update Mentra Live" icon="download" href="/mentra-live/software-update">
+    Match the glasses software release to your SDK version.
+  </Card>
   <Card title="Run Example Apps" icon="mobile" href="/mentra-live/examples">
     Start from complete Android, iOS, and React Native examples.
   </Card>

--- a/mintlify-docs/mentra-live/react-native-expo.mdx
+++ b/mintlify-docs/mentra-live/react-native-expo.mdx
@@ -10,10 +10,14 @@ React Native apps use the JavaScript package `@mentra/bluetooth-sdk`. The packag
 Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the SDK's native modules.
 </Warning>
 
+<Warning>
+SDK `0.1.19` requires the matching Mentra Live `0.1.19` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+</Warning>
+
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk
+bun add @mentra/bluetooth-sdk@0.1.19
 bunx expo install expo-build-properties
 ```
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -1,0 +1,101 @@
+---
+title: "Update Mentra Live"
+description: "Install the Mentra Live glasses software that matches your Bluetooth SDK release."
+icon: "download"
+---
+
+Each Bluetooth SDK release has a matching Mentra Live glasses software release. Your mobile app and glasses must use the same release version.
+
+The latest matching pair is:
+
+| Mobile app dependency | Required glasses software |
+| --- | --- |
+| React Native `@mentra/bluetooth-sdk@0.1.19` | Mentra Live software `0.1.19` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.19` | Mentra Live software `0.1.19` |
+| iOS `MentraBluetoothSDK` version `0.1.19` | Mentra Live software `0.1.19` |
+
+<Warning>
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.19`, but SDK features may fail or behave incorrectly. Install the matching `0.1.19` glasses software before testing SDK features.
+</Warning>
+
+## How Version Matching Works
+
+When your app calls `checkForOtaUpdate()`, the SDK checks the OTA manifest matching its own version. The manifest describes the ASG client, MTK system software, and BES firmware required by that SDK release. Calling `startOtaUpdate()` installs the available components after the user accepts the update.
+
+When you upgrade your app to a new Bluetooth SDK release, run the OTA check again and require the matching glasses software before enabling SDK features.
+
+## Recommended: Update With An Example App
+
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install one of the prebuilt Android `0.1.19` apps:
+
+- [React Native example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
+- [Native Android example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-android.apk)
+
+### Install A Prebuilt App On Android
+
+The simplest installation path is to open an APK link on the Android phone:
+
+1. Download the APK using the phone's browser.
+2. Open the downloaded file.
+3. If Android asks for permission, allow the browser or Files app to install unknown apps.
+4. Tap **Install**, then open the example app.
+
+You can alternatively install the APK from a computer. Install [ADB](https://developer.android.com/tools/adb), enable USB debugging on the phone, and connect it with a data-capable USB cable:
+
+```bash
+adb devices
+adb -s <phone-serial> install -r "$HOME/Downloads/mentra-example-react-native.apk"
+```
+
+Use the serial shown by `adb devices`. If only one Android device is connected, you can omit `-s <phone-serial>`.
+
+### Install The Matching Glasses Software
+
+1. Pair and connect the example app to Mentra Live.
+2. Open the **System** tab and connect the glasses to Wi-Fi.
+3. Open the **Device** tab and tap **Check OTA**.
+4. If an update is available, tap **Start OTA**.
+5. Keep the app connected and avoid using other glasses features while the update is running.
+6. Wait until the app reports that the update is complete. The glasses may restart during installation.
+7. Reconnect and run **Check OTA** again to confirm that no update remains.
+
+The example app uses the release-specific OTA manifest selected by SDK `0.1.19`, so it installs the glasses software components matching that SDK release.
+
+## Bootstrap The Update With ADB
+
+Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
+
+Download the matching [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
+
+Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
+
+```bash
+adb devices
+```
+
+Install the ASG client using the glasses serial shown by that command:
+
+```bash
+adb -s <glasses-serial> install -r \
+  "$HOME/Downloads/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk"
+```
+
+If only the glasses are connected, you can omit `-s <glasses-serial>`.
+
+<Warning>
+This command installs only the `0.1.19` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.19` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+</Warning>
+
+## Add The OTA Requirement To Your App
+
+Every app using the Bluetooth SDK must manage the glasses software release that matches its SDK dependency:
+
+1. Connect to Mentra Live and ensure the glasses have Wi-Fi access.
+2. Call `checkForOtaUpdate()`.
+3. If an update is available, explain that the matching glasses software is required and ask the user for confirmation.
+4. Call `startOtaUpdate()` after the user accepts.
+5. Display progress from `ota_status` until the update reaches `complete` or `failed`.
+6. Avoid sending unrelated SDK commands while the update is running.
+7. Do not enable features that require the matching glasses software until the OTA check succeeds with no update remaining.
+
+See [OTA Updates in the API Reference](/mentra-live/api-reference#ota-updates) for the Android, iOS, and React Native APIs and events.

--- a/mintlify-docs/mentra-live/troubleshooting.mdx
+++ b/mintlify-docs/mentra-live/troubleshooting.mdx
@@ -58,6 +58,12 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 - Confirm the hardware feature is available on the connected model.
 - Watch SDK log callbacks for native diagnostics.
 
+## Connected But SDK Features Fail
+
+Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
+
+If your app uses SDK `0.1.19`, [install the matching Mentra Live `0.1.19` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+
 ## Optional Local Stream Preview Does Not Show Video
 
 - The local demo cloud is only needed when the starter app's Stream screen has **Use cloud server** enabled. If you are using that optional local stream preview, confirm the local demo cloud or MediaMTX helper is running.


### PR DESCRIPTION
## Summary

- document that every Bluetooth SDK release requires the Mentra Live glasses software release with the same version number
- add a dedicated `0.1.19` update guide covering prebuilt Android example installation, the recommended full OTA flow, and manual ASG client bootstrap with ADB
- surface the requirement from Overview, Quickstart, Example Apps, React Native setup, the OTA API reference, and Troubleshooting
- pin the React Native install examples to `@mentra/bluetooth-sdk@0.1.19` so the documented SDK and glasses versions remain an explicit pair

## Why

Bluetooth can connect even when the mobile SDK and glasses software versions do not match. Developers need to install the matching glasses release before testing SDK features and include the OTA check, confirmation, start, and progress flow in their own apps.

## Validation

- `git diff --check`
- parsed `mintlify-docs/docs.json` as JSON
- `bunx --bun mint export --output /tmp/mentraos-os-1662-docs.zip`
- verified the export generated `/mentra-live/software-update` with the expected `0.1.19` links and content

## Release dependency

The MentraOS `0.1.19` glasses APK is live. The two Starter Kit `sdk-0.1.19` example APK links are intentionally documented at their final versioned URLs while that release workflow completes; they currently return 404 because of the reported CI glitch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mintlify documentation and navigation only; no runtime or SDK code changes.
> 
> **Overview**
> Adds a **Update Mentra Live** page that states each Bluetooth SDK release must match the same-numbered glasses software (`0.1.19`), and walks through example-app OTA, prebuilt Android APKs, ADB ASG bootstrap, and the `checkForOtaUpdate` / `startOtaUpdate` flow apps should implement.
> 
> The page is wired into **Getting Started** in `docs.json` and linked from Overview, Quickstart, Examples, React Native setup, the OTA API section, and a new Troubleshooting section for “connected but features fail.” Warnings stress that BLE connect ≠ version compatibility.
> 
> React Native install snippets in Quickstart and React Native / Expo are pinned to `@mentra/bluetooth-sdk@0.1.19` so docs stay an explicit SDK/glasses pair.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 954d842ea796f1a8a321796ecfb27c91d5d7fe68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->