### PR TITLE
Release Mentra Live 0.1.19 OTA docs to frozen-docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-* @Mentra-Community/core
+# The last matching CODEOWNERS pattern wins, so keep @aisraelov on each narrower rule.
+* @aisraelov
+
+miniapps/ @aisraelov @AryanFP @isaiahb
+mobile/ @aisraelov @AryanFP
+cloud-v2/ @aisraelov @AryanFP @isaiahb
+cloud/ @aisraelov @isaiahb
+mintlify-docs/ @aisraelov @isaiahb
+mintlify-docs/mentra-live/ @aisraelov @isaiahb @PhilippeFerreiraDeSousa
+mobile/modules/bluetooth-sdk/ @aisraelov @AryanFP @PhilippeFerreiraDeSousa

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -144,6 +144,7 @@
             "icon": "bluetooth",
             "pages": [
               "mentra-live/overview",
+              "mentra-live/software-update",
               "mentra-live/ai-ide-integration",
               "mentra-live/quickstart",
               "mentra-live/examples"

--- a/docs/mentra-live/android.mdx
+++ b/docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.19")
 }
 ```
 

--- a/docs/mentra-live/api-reference.mdx
+++ b/docs/mentra-live/api-reference.mdx
@@ -453,7 +453,9 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Mentra Live OTA installation is glasses-owned. The SDK checks the configured manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.19` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+
+Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 
 | API | Purpose |
 | --- | --- |

--- a/docs/mentra-live/examples.mdx
+++ b/docs/mentra-live/examples.mdx
@@ -6,6 +6,8 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.19` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git
 cd Mentra-Bluetooth-SDK-Starter-Kit
@@ -14,6 +16,7 @@ cd Mentra-Bluetooth-SDK-Starter-Kit
 ## What The Examples Demonstrate
 
 - Scanning for Mentra Live, connecting, disconnecting, and reconnecting to a saved/default device.
+- Checking for and installing the glasses software release that matches the SDK version.
 - Reading typed glasses and Bluetooth status snapshots.
 - Handling button, touch, swipe, head-up, battery, Wi-Fi, hotspot, stream, photo, video upload, audio, and SDK log events.
 - Controlling Mentra Live features such as gallery mode, photo capture defaults, video recording defaults, speaker playback, RGB LED patterns, Wi-Fi, hotspot, microphone, camera, and streaming.

--- a/docs/mentra-live/ios.mdx
+++ b/docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.18`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.19`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.18"
+  from: "0.1.19"
 )
 ```
 

--- a/docs/mentra-live/overview.mdx
+++ b/docs/mentra-live/overview.mdx
@@ -27,13 +27,21 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.19`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
 - React Native / Expo apps must use a development build or production native build. Expo Go cannot load the native SDK.
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
+<Warning>
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.19` must use the matching Mentra Live `0.1.19` software release.
+</Warning>
+
 <CardGroup cols={2}>
+  <Card title="Update Mentra Live" icon="download" href="/mentra-live/software-update">
+    Install the glasses software that matches your Bluetooth SDK release.
+  </Card>
   <Card title="Quickstart" icon="rocket" href="/mentra-live/quickstart">
     Install the SDK, connect to Mentra Live, and read glasses status.
   </Card>

--- a/docs/mentra-live/quickstart.mdx
+++ b/docs/mentra-live/quickstart.mdx
@@ -10,13 +10,17 @@ This quickstart shows the shortest path from package install to connecting to Me
 Use a physical phone for Bluetooth testing. Simulators and emulators are useful for UI and compile checks, but they do not provide the real Bluetooth path.
 </Warning>
 
+<Warning>
+This quickstart uses Bluetooth SDK `0.1.19`. Before testing SDK features, [install the matching Mentra Live `0.1.19` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+</Warning>
+
 ## Step 1: Install The SDK
 
 <Tabs>
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk
+bun add @mentra/bluetooth-sdk@0.1.19
 bunx expo install expo-build-properties
 ```
 
@@ -91,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.18")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.19")
 }
 ```
 
@@ -108,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.18`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.19`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.18"
+  from: "0.1.19"
 )
 ```
 
@@ -349,6 +353,9 @@ final class GlassesController: NSObject, MentraBluetoothSDKDelegate {
 ## Next Steps
 
 <CardGroup cols={2}>
+  <Card title="Update Mentra Live" icon="download" href="/mentra-live/software-update">
+    Match the glasses software release to your SDK version.
+  </Card>
   <Card title="Run Example Apps" icon="mobile" href="/mentra-live/examples">
     Start from complete Android, iOS, and React Native examples.
   </Card>

--- a/docs/mentra-live/react-native-expo.mdx
+++ b/docs/mentra-live/react-native-expo.mdx
@@ -10,10 +10,14 @@ React Native apps use the JavaScript package `@mentra/bluetooth-sdk`. The packag
 Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the SDK's native modules.
 </Warning>
 
+<Warning>
+SDK `0.1.19` requires the matching Mentra Live `0.1.19` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+</Warning>
+
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk
+bun add @mentra/bluetooth-sdk@0.1.19
 bunx expo install expo-build-properties
 ```
 

--- a/docs/mentra-live/software-update.mdx
+++ b/docs/mentra-live/software-update.mdx
@@ -1,0 +1,101 @@
+---
+title: "Update Mentra Live"
+description: "Install the Mentra Live glasses software that matches your Bluetooth SDK release."
+icon: "download"
+---
+
+Each Bluetooth SDK release has a matching Mentra Live glasses software release. Your mobile app and glasses must use the same release version.
+
+The latest matching pair is:
+
+| Mobile app dependency | Required glasses software |
+| --- | --- |
+| React Native `@mentra/bluetooth-sdk@0.1.19` | Mentra Live software `0.1.19` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.19` | Mentra Live software `0.1.19` |
+| iOS `MentraBluetoothSDK` version `0.1.19` | Mentra Live software `0.1.19` |
+
+<Warning>
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.19`, but SDK features may fail or behave incorrectly. Install the matching `0.1.19` glasses software before testing SDK features.
+</Warning>
+
+## How Version Matching Works
+
+When your app calls `checkForOtaUpdate()`, the SDK checks the OTA manifest matching its own version. The manifest describes the ASG client, MTK system software, and BES firmware required by that SDK release. Calling `startOtaUpdate()` installs the available components after the user accepts the update.
+
+When you upgrade your app to a new Bluetooth SDK release, run the OTA check again and require the matching glasses software before enabling SDK features.
+
+## Recommended: Update With An Example App
+
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install one of the prebuilt Android `0.1.19` apps:
+
+- [React Native example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
+- [Native Android example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-android.apk)
+
+### Install A Prebuilt App On Android
+
+The simplest installation path is to open an APK link on the Android phone:
+
+1. Download the APK using the phone's browser.
+2. Open the downloaded file.
+3. If Android asks for permission, allow the browser or Files app to install unknown apps.
+4. Tap **Install**, then open the example app.
+
+You can alternatively install the APK from a computer. Install [ADB](https://developer.android.com/tools/adb), enable USB debugging on the phone, and connect it with a data-capable USB cable:
+
+```bash
+adb devices
+adb -s <phone-serial> install -r "$HOME/Downloads/mentra-example-react-native.apk"
+```
+
+Use the serial shown by `adb devices`. If only one Android device is connected, you can omit `-s <phone-serial>`.
+
+### Install The Matching Glasses Software
+
+1. Pair and connect the example app to Mentra Live.
+2. Open the **System** tab and connect the glasses to Wi-Fi.
+3. Open the **Device** tab and tap **Check OTA**.
+4. If an update is available, tap **Start OTA**.
+5. Keep the app connected and avoid using other glasses features while the update is running.
+6. Wait until the app reports that the update is complete. The glasses may restart during installation.
+7. Reconnect and run **Check OTA** again to confirm that no update remains.
+
+The example app uses the release-specific OTA manifest selected by SDK `0.1.19`, so it installs the glasses software components matching that SDK release.
+
+## Bootstrap The Update With ADB
+
+Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
+
+Download the matching [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
+
+Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
+
+```bash
+adb devices
+```
+
+Install the ASG client using the glasses serial shown by that command:
+
+```bash
+adb -s <glasses-serial> install -r \
+  "$HOME/Downloads/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk"
+```
+
+If only the glasses are connected, you can omit `-s <glasses-serial>`.
+
+<Warning>
+This command installs only the `0.1.19` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.19` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+</Warning>
+
+## Add The OTA Requirement To Your App
+
+Every app using the Bluetooth SDK must manage the glasses software release that matches its SDK dependency:
+
+1. Connect to Mentra Live and ensure the glasses have Wi-Fi access.
+2. Call `checkForOtaUpdate()`.
+3. If an update is available, explain that the matching glasses software is required and ask the user for confirmation.
+4. Call `startOtaUpdate()` after the user accepts.
+5. Display progress from `ota_status` until the update reaches `complete` or `failed`.
+6. Avoid sending unrelated SDK commands while the update is running.
+7. Do not enable features that require the matching glasses software until the OTA check succeeds with no update remaining.
+
+See [OTA Updates in the API Reference](/mentra-live/api-reference#ota-updates) for the Android, iOS, and React Native APIs and events.

--- a/docs/mentra-live/software-update.mdx
+++ b/docs/mentra-live/software-update.mdx
@@ -26,10 +26,11 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 ## Recommended: Update With An Example App
 
-The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install one of the prebuilt Android `0.1.19` apps:
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the prebuilt React Native Android app. The React Native example is the recommended prebuilt app because it receives the most testing and verification.
 
-- [React Native example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
-- [Native Android example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-android.apk)
+- [Download the React Native example APK for SDK `0.1.19`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
+
+For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
 ### Install A Prebuilt App On Android
 

--- a/docs/mentra-live/software-update.mdx
+++ b/docs/mentra-live/software-update.mdx
@@ -65,7 +65,9 @@ The example app uses the release-specific OTA manifest selected by SDK `0.1.19`,
 
 Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
 
-Download the matching [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
+All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
+
+For the latest `0.1.19` release, download [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 

--- a/docs/mentra-live/software-update.mdx
+++ b/docs/mentra-live/software-update.mdx
@@ -26,7 +26,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 ## Recommended: Update With An Example App
 
-The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the prebuilt React Native Android app. The React Native example is the recommended prebuilt app because it receives the most testing and verification.
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
 - [Download the React Native example APK for SDK `0.1.19`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
 

--- a/docs/mentra-live/troubleshooting.mdx
+++ b/docs/mentra-live/troubleshooting.mdx
@@ -58,6 +58,12 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 - Confirm the hardware feature is available on the connected model.
 - Watch SDK log callbacks for native diagnostics.
 
+## Connected But SDK Features Fail
+
+Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
+
+If your app uses SDK `0.1.19`, [install the matching Mentra Live `0.1.19` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+
 ## Optional Local Stream Preview Does Not Show Video
 
 - The local demo cloud is only needed when the starter app's Stream screen has **Use cloud server** enabled. If you are using that optional local stream preview, confirm the local demo cloud or MediaMTX helper is running.


### PR DESCRIPTION
## Summary

- sync the merged Mentra Live docs from `dev` into the `frozen-docs` publishing tree
- publish the new SDK-to-glasses version matching guide and the complete `0.1.19` OTA/ADB installation instructions
- update Android, iOS, and React Native package examples to SDK `0.1.19`
- add `/mentra-live/software-update` to the Mentra Live Getting Started navigation while preserving `/mentra-live/overview` as the tab root

This carries the documentation merged in #3404 into the frozen production-docs branch.

## Validation

- verified `docs/mentra-live` matches `origin/dev:mintlify-docs/mentra-live` byte-for-byte with `diff -ru`
- verified the Mentra Live navigation in `docs/docs.json` matches the merged dev navigation
- `git diff --check`
- parsed `docs/docs.json` as JSON
- `bunx --bun mint export --output /tmp/mentraos-os-1662-frozen-docs.zip`
- verified the export generated 75 pages, kept the Mentra Live tab at `/mentra-live/overview`, and rendered `/mentra-live/software-update`

The export reports the existing unrelated parser warnings in `LC3-BITRATE-UPGRADE-PLAN.md` and `issues/docs-overhaul/spec.md`, but completes successfully.

## Example app release

The docs recommend the React Native example as the prebuilt OTA path. Its SDK `0.1.19` APK is live, and the Starter Kit tags page links developers to the downloads for other matching SDK versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CODEOWNERS only; no runtime, auth, or SDK code changes.
> 
> **Overview**
> Syncs Mentra Live documentation into the frozen production docs tree: a new **Update Mentra Live** page (`/mentra-live/software-update`), navigation entry under Getting Started, and cross-links from overview, quickstart, examples, API reference, and troubleshooting.
> 
> **SDK `0.1.19` alignment:** Android, iOS, and React Native install snippets and dependency pins move from `0.1.18` to `0.1.19`. Docs now state that the Bluetooth SDK and glasses software must share the same release version, with warnings that BLE connection alone does not prove compatibility.
> 
> **OTA guidance:** The new page documents version-matched OTA (`checkForOtaUpdate` / `startOtaUpdate`), Starter Kit example APK install, in-app OTA steps, ADB bootstrap for the ASG client when OTA cannot run, and app requirements to gate features until OTA reports no update left.
> 
> **CODEOWNERS:** Replaces the broad `@Mentra-Community/core` default with `@aisraelov` and path-specific owners for `miniapps/`, `mobile/`, `cloud/`, `mintlify-docs/`, and related areas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b116392e66a5ca5c5e1763b9f390e74ae3c5c3e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->