### PR TITLE
Link all Bluetooth SDK OTA artifacts

### DIFF
--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -65,7 +65,9 @@ The example app uses the release-specific OTA manifest selected by SDK `0.1.19`,
 
 Use this path when the software currently installed on Mentra Live cannot run the SDK OTA flow.
 
-Download the matching [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
+All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
+
+For the latest `0.1.19` release, download [`asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk`](https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/asg-client-sdk-0.1.19-vc48128864-ad1d0263.apk).
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 


### PR DESCRIPTION
## Summary

- link the persistent Bluetooth SDK OTA Artifacts release page from the Mentra Live ADB bootstrap instructions
- explain how to choose an `asg-client-sdk-<sdk-version>-...apk` matching the app's Bluetooth SDK dependency
- retain the direct download for the latest `0.1.19` ASG client

## Why

The existing guide provided only the latest version-specific APK URL. Developers working with another supported SDK release also need a discoverable place to find its matching ASG client APK.

## Validation

- verified the release page currently contains matching ASG client APKs and manifests for SDK `0.1.13` through `0.1.19`
- `git diff --check`
- parsed `mintlify-docs/docs.json` as JSON
- `bunx --bun mint export --output /tmp/mentraos-all-ota-artifacts-docs.zip`
- verified the generated `/mentra-live/software-update` page contains the release-page URL and filename pattern

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Mentra Live software update instructions with no runtime or API impact.
> 
> **Overview**
> The **Bootstrap The Update With ADB** section no longer relies on a single hard-coded ASG client download. It now points readers to the persistent [Bluetooth SDK OTA Artifacts](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) release page and explains how to pick an `asg-client-sdk-<sdk-version>-...apk` that matches the app’s Bluetooth SDK dependency.
> 
> A direct download link for the latest `0.1.19` ASG client is kept as a convenience example; the surrounding ADB install steps are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c584eec1776778314052019a8d9280690bbb28f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->