### PR TITLE
Document Mapbox token setup for mobile builds

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -105,6 +105,26 @@ bun ios
 - Port forwarding: `bun adb` (sets up tcp:9090, tcp:3000, tcp:9001, tcp:8081)
 - Bluetooth functionality for glasses pairing
 
+## Mapbox tokens (two different credentials!)
+
+- **Public token (`pk.…`)** — runtime map rendering. Lives in `.env` as
+  `EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN`. Safe to ship in the app.
+- **Downloads token (`sk.…`, secret scope `Downloads:Read`)** — build time only,
+  authenticates downloading Mapbox's binary SDKs. Never shipped. It must live in:
+  - `~/.netrc` for iOS (SPM reads it): `machine api.mapbox.com login mapbox password sk.…`
+  - `MAPBOX_DOWNLOADS_TOKEN` env var for Android (Gradle maven repo auth)
+  - GitHub Actions secret `MAPBOX_DOWNLOADS_TOKEN` for CI
+
+Gotchas learned the hard way (2026-07):
+
+- Most Mapbox package downloads are unauthenticated, but the **Navigation SDK
+  binaries (`dash-native`) return 401 without a valid token from an account with
+  an active (billing-enabled) subscription** — "an active subscription is
+  required" means add a payment method + activate Navigation, not a token issue.
+- Secret token values are shown **once** at creation. Store them in the company
+  password manager, under a **shared org Mapbox account** — a departed
+  employee's personal account once held our only working token.
+
 ## Sentry Configuration (iOS)
 
 Sentry source map and debug symbol uploads are **disabled by default** to prevent build failures when the `SENTRY_AUTH_TOKEN` is not configured.


### PR DESCRIPTION
Documents the two-token distinction (runtime `pk.` vs build-time `sk.` downloads token), where the downloads token must live (`~/.netrc` for iOS/SPM, `MAPBOX_DOWNLOADS_TOKEN` for Gradle and CI), the Navigation-SDK "active subscription required" gotcha, and account-custody guidance — written up after this week's orphaned-account fire drill where the only working downloads token belonged to a departed employee's personal Mapbox account.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to AGENTS.md with no runtime or build script modifications.
> 
> **Overview**
> Adds a **Mapbox tokens** section to `mobile/AGENTS.md` so mobile contributors can distinguish the runtime **public token** (`pk.…` in `EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN`) from the **build-time downloads token** (`sk.…`, `Downloads:Read`).
> 
> The new docs spell out where the secret must be configured: `~/.netrc` for iOS/SPM, `MAPBOX_DOWNLOADS_TOKEN` for Android Gradle, and the same name as a GitHub Actions secret for CI. It also records operational gotchas—Navigation SDK `dash-native` 401s tied to an active billing/subscription, one-time display of secret values, and keeping tokens on a shared org Mapbox account rather than personal accounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf4d2e6abc079c83810101e4cb989fd81af6d05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Document how to configure Mapbox tokens for mobile builds: distinguish runtime `pk.` vs build-time `sk.` downloads token and where to set each for iOS, Android, and CI. Also note the Navigation SDK requires an active subscription and recommend using a shared org Mapbox account for token custody.

- **Migration**
  - iOS: add to `~/.netrc` — `machine api.mapbox.com login mapbox password sk.…`
  - Android/CI: set `MAPBOX_DOWNLOADS_TOKEN` for Gradle and in GitHub Actions
  - If Navigation SDK downloads return 401, ensure the org Mapbox account has an active Navigation subscription; store all tokens in the shared password manager under the org account

<sup>Written for commit bf4d2e6abc079c83810101e4cb989fd81af6d05e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

