### PR TITLE
Recommend the React Native OTA example

### DIFF
--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -26,10 +26,11 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 ## Recommended: Update With An Example App
 
-The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install one of the prebuilt Android `0.1.19` apps:
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the prebuilt React Native Android app. The React Native example is the recommended prebuilt app because it receives the most testing and verification.
 
-- [React Native example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
-- [Native Android example APK](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-android.apk)
+- [Download the React Native example APK for SDK `0.1.19`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
+
+For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
 ### Install A Prebuilt App On Android
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -26,7 +26,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 ## Recommended: Update With An Example App
 
-The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the prebuilt React Native Android app. The React Native example is the recommended prebuilt app because it receives the most testing and verification.
+The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
 - [Download the React Native example APK for SDK `0.1.19`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.19/mentra-example-react-native.apk)
 


### PR DESCRIPTION
## Summary

- recommend the React Native example APK as the prebuilt OTA app
- remove the Native Android APK from the recommended downloads
- link the Starter Kit tags page so developers can choose the `sdk-<version>` matching their SDK and open its **Downloads** section
- retain the direct React Native APK download for SDK `0.1.19`

## Validation

- verified the Starter Kit tags page and the `sdk-0.1.19` React Native APK both return successfully
- verified the dev and frozen-docs copies of `software-update.mdx` are identical
- `git diff --check`
- `bunx --bun mint export --output /tmp/mentraos-rn-example-guidance-dev.zip`
- verified the export generated 62 pages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to download recommendations; no runtime or API behavior changes.
> 
> **Overview**
> Updates **Update Mentra Live** guidance so the prebuilt OTA path centers on the **React Native** example app instead of listing both React Native and Native Android APKs for SDK `0.1.19`.
> 
> The doc keeps a direct download link for the React Native APK at `0.1.19` and adds instructions to use the Starter Kit **tags** page (`sdk-<version>` → **Downloads**) when the SDK version differs. Install steps and the rest of the OTA flow are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b17cb95b3a99094875559787c0b8852cebf232fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->