### PR TITLE
Fix native Android crashes when SDK requests reject

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -1,3 +1,5 @@
+@file:Suppress("FunctionName")
+
 package com.mentra.bluetoothsdk
 
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
@@ -6,8 +8,84 @@ import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.modules.ModuleDefinitionBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+
+// Expo has no module-level error mapper, so SDK-backed registrations translate
+// core exceptions here while keeping Expo types out of the native SDK API.
+private inline fun <T> withExpoSdkError(block: () -> T): T =
+        try {
+            block()
+        } catch (error: BluetoothSdkException) {
+            throw CodedException(error.code, error.message ?: error.code, error)
+        }
+
+private suspend inline fun <T> withExpoSdkErrorSuspend(crossinline block: suspend () -> T): T =
+        try {
+            block()
+        } catch (error: BluetoothSdkException) {
+            throw CodedException(error.code, error.message ?: error.code, error)
+        }
+
+private inline fun <reified R> ModuleDefinitionBuilder.SdkAsyncFunction(
+    name: String,
+    crossinline body: () -> R,
+) = AsyncFunction<R>(name) { withExpoSdkError { body() } }
+
+private inline fun <reified R, reified P0> ModuleDefinitionBuilder.SdkAsyncFunction(
+    name: String,
+    crossinline body: (P0) -> R,
+) = AsyncFunction<R, P0>(name) { p0 -> withExpoSdkError { body(p0) } }
+
+private inline fun <reified R, reified P0, reified P1> ModuleDefinitionBuilder.SdkAsyncFunction(
+    name: String,
+    crossinline body: (P0, P1) -> R,
+) = AsyncFunction<R, P0, P1>(name) { p0, p1 -> withExpoSdkError { body(p0, p1) } }
+
+private inline fun <reified R, reified P0, reified P1, reified P2> ModuleDefinitionBuilder.SdkAsyncFunction(
+    name: String,
+    crossinline body: (P0, P1, P2) -> R,
+) = AsyncFunction<R, P0, P1, P2>(name) { p0, p1, p2 -> withExpoSdkError { body(p0, p1, p2) } }
+
+private inline fun <reified R, reified P0, reified P1, reified P2, reified P3>
+    ModuleDefinitionBuilder.SdkAsyncFunction(
+        name: String,
+        crossinline body: (P0, P1, P2, P3) -> R,
+    ) = AsyncFunction<R, P0, P1, P2, P3>(name) { p0, p1, p2, p3 ->
+        withExpoSdkError { body(p0, p1, p2, p3) }
+    }
+
+private inline fun <
+    reified R,
+    reified P0,
+    reified P1,
+    reified P2,
+    reified P3,
+    reified P4,
+    reified P5,
+    reified P6,
+> ModuleDefinitionBuilder.SdkAsyncFunction(
+    name: String,
+    crossinline body: (P0, P1, P2, P3, P4, P5, P6) -> R,
+) = AsyncFunction<R, P0, P1, P2, P3, P4, P5, P6>(name) { p0, p1, p2, p3, p4, p5, p6 ->
+    withExpoSdkError { body(p0, p1, p2, p3, p4, p5, p6) }
+}
+
+private inline fun <reified R> ModuleDefinitionBuilder.SdkFunction(
+    name: String,
+    crossinline body: () -> R,
+) = Function<R>(name) { withExpoSdkError { body() } }
+
+private inline fun <reified R, reified P0> ModuleDefinitionBuilder.SdkFunction(
+    name: String,
+    crossinline body: (P0) -> R,
+) = Function<R, P0>(name) { p0 -> withExpoSdkError { body(p0) } }
+
+private inline fun <reified R> ModuleDefinitionBuilder.SdkCoroutineFunction(
+    name: String,
+    crossinline body: suspend () -> R,
+) = AsyncFunction(name) Coroutine { -> withExpoSdkErrorSuspend { body() } }
 
 class BluetoothSdkModule : Module() {
     private var sdk: MentraBluetoothSdk? = null
@@ -190,13 +268,6 @@ class BluetoothSdkModule : Module() {
                             null,
                     )
 
-    private inline fun <T> withExpoSdkError(block: () -> T): T =
-            try {
-                block()
-            } catch (error: BluetoothSdkException) {
-                throw CodedException(error.code, error.message ?: error.code, error)
-            }
-
     override fun definition() = ModuleDefinition {
         Name("BluetoothSdk")
 
@@ -344,52 +415,48 @@ class BluetoothSdkModule : Module() {
 
         // MARK: - Display Commands
 
-        AsyncFunction("displayEvent") { params: Map<String, Any> ->
-            withExpoSdkError { sdk?.displayEvent(DisplayEventRequest(params)) }
+        SdkAsyncFunction("displayEvent") { params: Map<String, Any> ->
+            sdk?.displayEvent(DisplayEventRequest(params))
         }
 
-        AsyncFunction("displayText") { text: String, x: Int?, y: Int?, size: Int? ->
-            withExpoSdkError {
-                sdk?.displayText(
-                        text = text,
-                        x = x ?: 0,
-                        y = y ?: 0,
-                        size = size ?: 24,
-                )
-            }
+        SdkAsyncFunction("displayText") { text: String, x: Int?, y: Int?, size: Int? ->
+            sdk?.displayText(
+                    text = text,
+                    x = x ?: 0,
+                    y = y ?: 0,
+                    size = size ?: 24,
+            )
         }
 
-        AsyncFunction("clearDisplay") { withExpoSdkError { sdk?.clearDisplay() } }
+        SdkAsyncFunction("clearDisplay") { -> sdk?.clearDisplay() }
 
         // MARK: - Connection Commands
 
-        AsyncFunction("connectDefault") { withExpoSdkError { sdk?.connectDefault() } }
+        SdkAsyncFunction("connectDefault") { -> sdk?.connectDefault() }
 
-        AsyncFunction("connectDefaultWithOptions") { options: Map<String, Any> ->
-            withExpoSdkError { sdk?.connectDefault(options.toMentraConnectOptions()) }
+        SdkAsyncFunction("connectDefaultWithOptions") { options: Map<String, Any> ->
+            sdk?.connectDefault(options.toMentraConnectOptions())
         }
 
-        AsyncFunction("setDefaultDevice") { device: Map<String, Any>? ->
-            withExpoSdkError { sdk?.setDefaultDevice(device.toMentraDevice()) }
+        SdkAsyncFunction("setDefaultDevice") { device: Map<String, Any>? ->
+            sdk?.setDefaultDevice(device.toMentraDevice())
         }
 
-        AsyncFunction("clearDefaultDevice") { withExpoSdkError { sdk?.clearDefaultDevice() } }
+        SdkAsyncFunction("clearDefaultDevice") { -> sdk?.clearDefaultDevice() }
 
-        AsyncFunction("connectWithOptions") { device: Map<String, Any>, options: Map<String, Any> ->
-            withExpoSdkError {
-                sdk?.connect(
-                        device.toMentraDevice()
-                                ?: throw IllegalArgumentException("connect requires a Device with model and name."),
-                        options.toMentraConnectOptions(),
-                )
-            }
+        SdkAsyncFunction("connectWithOptions") { device: Map<String, Any>, options: Map<String, Any> ->
+            sdk?.connect(
+                    device.toMentraDevice()
+                            ?: throw IllegalArgumentException("connect requires a Device with model and name."),
+                    options.toMentraConnectOptions(),
+            )
         }
 
-        AsyncFunction("connectSimulated") { withExpoSdkError { sdk?.connectSimulated() } }
+        SdkAsyncFunction("connectSimulated") { -> sdk?.connectSimulated() }
 
-        AsyncFunction("disconnect") { withExpoSdkError { sdk?.disconnect() } }
+        SdkAsyncFunction("disconnect") { -> sdk?.disconnect() }
 
-        AsyncFunction("forget") { withExpoSdkError { sdk?.forget() } }
+        SdkAsyncFunction("forget") { -> sdk?.forget() }
 
         AsyncFunction("connectDefaultController") { deviceManager?.connectDefaultController() }
 
@@ -397,15 +464,15 @@ class BluetoothSdkModule : Module() {
 
         AsyncFunction("forgetController") { deviceManager?.forgetController() }
 
-        AsyncFunction("startScan") { model: String ->
-            withExpoSdkError { sdk?.startScan(DeviceModel.fromDeviceType(model)) }
+        SdkAsyncFunction("startScan") { model: String ->
+            sdk?.startScan(DeviceModel.fromDeviceType(model))
         }
 
-        AsyncFunction("stopScan") { withExpoSdkError { sdk?.stopScan() } }
+        SdkAsyncFunction("stopScan") { -> sdk?.stopScan() }
 
-        AsyncFunction("cancelConnectionAttempt") { withExpoSdkError { sdk?.cancelConnectionAttempt() } }
+        SdkAsyncFunction("cancelConnectionAttempt") { -> sdk?.cancelConnectionAttempt() }
 
-        AsyncFunction("showDashboard") { withExpoSdkError { sdk?.showDashboard() } }
+        SdkAsyncFunction("showDashboard") { -> sdk?.showDashboard() }
 
         AsyncFunction("ping") { deviceManager?.ping() }
 
@@ -423,76 +490,68 @@ class BluetoothSdkModule : Module() {
 
         // MARK: - Incident Reporting
 
-        AsyncFunction("sendIncidentId") { incidentId: String, apiBaseUrl: String? ->
-            withExpoSdkError { sdk?.sendIncidentId(incidentId, apiBaseUrl) }
+        SdkAsyncFunction("sendIncidentId") { incidentId: String, apiBaseUrl: String? ->
+            sdk?.sendIncidentId(incidentId, apiBaseUrl)
         }
 
         // MARK: - WiFi Commands
 
-        AsyncFunction("requestWifiScan") {
-            withExpoSdkError { requireSdk().requestWifiScan().map { it.toMap() } }
+        SdkAsyncFunction("requestWifiScan") { -> requireSdk().requestWifiScan().map { it.toMap() } }
+
+        SdkAsyncFunction("sendWifiCredentials") { ssid: String, password: String ->
+            requireSdk().sendWifiCredentials(ssid, password).values
         }
 
-        AsyncFunction("sendWifiCredentials") { ssid: String, password: String ->
-            withExpoSdkError { requireSdk().sendWifiCredentials(ssid, password).values }
+        SdkAsyncFunction("forgetWifiNetwork") { ssid: String ->
+            requireSdk().forgetWifiNetwork(ssid).values
         }
 
-        AsyncFunction("forgetWifiNetwork") { ssid: String ->
-            withExpoSdkError { requireSdk().forgetWifiNetwork(ssid).values }
+        SdkAsyncFunction("setHotspotState") { enabled: Boolean ->
+            requireSdk().setHotspotState(enabled).values
         }
 
-        AsyncFunction("setHotspotState") { enabled: Boolean ->
-            withExpoSdkError { requireSdk().setHotspotState(enabled).values }
-        }
-
-        AsyncFunction("setSystemTime") { timestampMs: Double ->
-            withExpoSdkError { sdk?.setSystemTime(timestampMs.toLong()) }
+        SdkAsyncFunction("setSystemTime") { timestampMs: Double ->
+            sdk?.setSystemTime(timestampMs.toLong())
         }
 
         // MARK: - Gallery Commands
 
-        AsyncFunction("setGalleryModeEnabled") { enabled: Boolean ->
-            withExpoSdkError { requireSdk().setGalleryModeEnabled(enabled).values }
+        SdkAsyncFunction("setGalleryModeEnabled") { enabled: Boolean ->
+            requireSdk().setGalleryModeEnabled(enabled).values
         }
 
-        AsyncFunction("setVoiceActivityDetectionEnabled") { enabled: Boolean ->
-            withExpoSdkError { sdk?.setVoiceActivityDetectionEnabled(enabled) }
+        SdkAsyncFunction("setVoiceActivityDetectionEnabled") { enabled: Boolean ->
+            sdk?.setVoiceActivityDetectionEnabled(enabled)
         }
 
-        AsyncFunction("setPhotoCaptureDefaults") { params: Map<String, Any?> ->
-            withExpoSdkError {
-                requireSdk().setPhotoCaptureDefaults(params.toPhotoCaptureDefaults()).values
-            }
+        SdkAsyncFunction("setPhotoCaptureDefaults") { params: Map<String, Any?> ->
+            requireSdk().setPhotoCaptureDefaults(params.toPhotoCaptureDefaults()).values
         }
 
-        AsyncFunction("setVideoRecordingDefaults") { width: Int, height: Int, fps: Int ->
-            withExpoSdkError {
-                requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
-            }
+        SdkAsyncFunction("setVideoRecordingDefaults") { width: Int, height: Int, fps: Int ->
+            requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
         }
 
-        AsyncFunction("setMaxVideoRecordingDuration") { minutes: Int ->
-            withExpoSdkError { requireSdk().setMaxVideoRecordingDuration(minutes).values }
+        SdkAsyncFunction("setMaxVideoRecordingDuration") { minutes: Int ->
+            requireSdk().setMaxVideoRecordingDuration(minutes).values
         }
 
-        AsyncFunction("setCameraFov") { fov: Map<String, Any> ->
+        SdkAsyncFunction("setCameraFov") { fov: Map<String, Any> ->
             val value = (fov["fov"] as? Number)?.toInt() ?: CameraFov.DEFAULT_FOV
             val roiPosition = CameraRoiPosition.fromValue(
                 (fov["roiPosition"] as? Number)?.toInt()
                     ?: (fov["roi_position"] as? Number)?.toInt(),
             )
-            withExpoSdkError { requireSdk().setCameraFov(CameraFov(value, roiPosition)).values }
+            requireSdk().setCameraFov(CameraFov(value, roiPosition)).values
         }
 
-        AsyncFunction("setCameraTuningConfig") { anrOn: Boolean, gainOn: Boolean ->
-            withExpoSdkError { requireSdk().setCameraTuningConfig(anrOn, gainOn).values }
+        SdkAsyncFunction("setCameraTuningConfig") { anrOn: Boolean, gainOn: Boolean ->
+            requireSdk().setCameraTuningConfig(anrOn, gainOn).values
         }
 
-        AsyncFunction("queryGalleryStatus") {
-            withExpoSdkError { requireSdk().queryGalleryStatus().values }
-        }
+        SdkAsyncFunction("queryGalleryStatus") { -> requireSdk().queryGalleryStatus().values }
 
-        AsyncFunction("requestPhoto") { params: Map<String, Any?> ->
+        SdkAsyncFunction("requestPhoto") { params: Map<String, Any?> ->
             // JS may pass null for optional fields; Map<String, Any> rejects null values at the bridge.
             val sanitized =
                     params.mapNotNull { (key, value) ->
@@ -502,10 +561,10 @@ class BluetoothSdkModule : Module() {
             Bridge.log(
                     "NATIVE: PHOTO PIPELINE [3/6] BluetoothSdk.requestPhoto requestId=${req.requestId} size=${req.size} compress=${req.compress} sound=${req.sound} exposureTimeNs=${req.exposureTimeNs} iso=${req.iso}"
             )
-            withExpoSdkError { requireSdk().requestPhoto(req).values }
+            requireSdk().requestPhoto(req).values
         }
 
-        AsyncFunction("warmUpCamera") { params: Map<String, Any?> ->
+        SdkAsyncFunction("warmUpCamera") { params: Map<String, Any?> ->
             val requestId = params["requestId"] as? String
             val size = PhotoSize.fromValue(params["size"] as? String)
             val exposureRaw = (params["exposureTimeNs"] as? Number)?.toDouble()
@@ -513,57 +572,47 @@ class BluetoothSdkModule : Module() {
                 if (exposureRaw != null && exposureRaw.isFinite() && exposureRaw > 0) exposureRaw.toLong() else null
             val durationRaw = (params["durationMs"] as? Number)?.toInt() ?: 0
             val durationMs = if (durationRaw > 0) durationRaw else 15000
-            withExpoSdkError {
-                requireSdk().warmUpCamera(requestId, size, exposureTimeNs, durationMs).values
-            }
+            requireSdk().warmUpCamera(requestId, size, exposureTimeNs, durationMs).values
         }
 
         // MARK: - OTA Commands
 
-        Function("setOtaVersionUrl") { otaVersionUrl: String ->
-            withExpoSdkError { requireSdk().setOtaVersionUrl(otaVersionUrl) }
+        SdkFunction("setOtaVersionUrl") { otaVersionUrl: String ->
+            requireSdk().setOtaVersionUrl(otaVersionUrl)
         }
 
-        Function("getOtaVersionUrl") { withExpoSdkError { requireSdk().getOtaVersionUrl() } }
+        SdkFunction("getOtaVersionUrl") { -> requireSdk().getOtaVersionUrl() }
 
         // Runs on Dispatchers.IO, not the shared Expo AsyncFunctionQueue:
         // manifest fetches and version waits can block for several seconds.
-        AsyncFunction("checkForOtaUpdate") Coroutine { ->
-            withContext(Dispatchers.IO) {
-                withExpoSdkError { requireSdk().checkForOtaUpdate() }
+        SdkCoroutineFunction("checkForOtaUpdate") {
+            withContext(Dispatchers.IO) { requireSdk().checkForOtaUpdate() }
+        }
+
+        SdkAsyncFunction("startOtaUpdate") { otaVersionUrl: String? ->
+            val sdk = requireSdk()
+            if (otaVersionUrl.isNullOrBlank()) {
+                sdk.startOtaUpdate().values
+            } else {
+                sdk.startOtaUpdate(otaVersionUrl).values
             }
         }
 
-        AsyncFunction("startOtaUpdate") { otaVersionUrl: String? ->
-            withExpoSdkError {
-                val sdk = requireSdk()
-                if (otaVersionUrl.isNullOrBlank()) {
-                    sdk.startOtaUpdate().values
-                } else {
-                    sdk.startOtaUpdate(otaVersionUrl).values
-                }
-            }
-        }
-
-        AsyncFunction("sendOtaQueryStatus") {
-            withExpoSdkError { requireSdk().sendOtaQueryStatus().values }
-        }
+        SdkAsyncFunction("sendOtaQueryStatus") { -> requireSdk().sendOtaQueryStatus().values }
 
         // MARK: - Version Info Commands
 
-        AsyncFunction("requestVersionInfo") {
-            withExpoSdkError { requireSdk().requestVersionInfo().toMap() }
-        }
+        SdkAsyncFunction("requestVersionInfo") { -> requireSdk().requestVersionInfo().toMap() }
 
         // MARK: - Power Control Commands
 
-        AsyncFunction("sendShutdown") { withExpoSdkError { sdk?.sendShutdown() } }
+        SdkAsyncFunction("sendShutdown") { -> sdk?.sendShutdown() }
 
-        AsyncFunction("sendReboot") { withExpoSdkError { sdk?.sendReboot() } }
+        SdkAsyncFunction("sendReboot") { -> sdk?.sendReboot() }
 
         // MARK: - Video Recording Commands
 
-        AsyncFunction("startVideoRecording") {
+        SdkAsyncFunction("startVideoRecording") {
                 requestId: String,
                 save: Boolean,
                 sound: Boolean,
@@ -572,67 +621,57 @@ class BluetoothSdkModule : Module() {
             // the glasses treat as "use the saved button-video default". JS numbers
             // arrive as Double across the bridge, so coerce to Int.
             fun dim(key: String): Int = (settings?.get(key) as? Number)?.toInt() ?: 0
-            withExpoSdkError {
-                requireSdk().startVideoRecording(
-                        VideoRecordingRequest(
-                                requestId,
-                                save,
-                                sound,
-                                dim("width"),
-                                dim("height"),
-                                dim("fps"),
-                                dim("maxRecordingTimeMinutes"),
-                        )
-                ).values
-            }
+            requireSdk().startVideoRecording(
+                    VideoRecordingRequest(
+                            requestId,
+                            save,
+                            sound,
+                            dim("width"),
+                            dim("height"),
+                            dim("fps"),
+                            dim("maxRecordingTimeMinutes"),
+                    )
+            ).values
         }
 
         // webhookUrl/authToken are supplied at stop (not start) so the token is
         // fresh when the upload runs. Empty/null webhook = keep on device.
-        AsyncFunction("stopVideoRecording") {
+        SdkAsyncFunction("stopVideoRecording") {
                 requestId: String,
                 webhookUrl: String?,
                 authToken: String? ->
-            withExpoSdkError {
-                requireSdk().stopVideoRecording(requestId, webhookUrl, authToken).values
-            }
+            requireSdk().stopVideoRecording(requestId, webhookUrl, authToken).values
         }
 
         // MARK: - Stream Commands
 
-        AsyncFunction("startStream") { params: Map<String, Any> ->
-            withExpoSdkError { requireSdk().startStream(StreamRequest.fromMap(params)).values }
+        SdkAsyncFunction("startStream") { params: Map<String, Any> ->
+            requireSdk().startStream(StreamRequest.fromMap(params)).values
         }
 
-        AsyncFunction("startExternallyManagedStream") { params: Map<String, Any> ->
-            withExpoSdkError {
-                requireSdk().startExternallyManagedStream(StreamRequest.fromMap(params)).values
-            }
+        SdkAsyncFunction("startExternallyManagedStream") { params: Map<String, Any> ->
+            requireSdk().startExternallyManagedStream(StreamRequest.fromMap(params)).values
         }
 
-        AsyncFunction("stopStream") { withExpoSdkError { requireSdk().stopStream().values } }
+        SdkAsyncFunction("stopStream") { -> requireSdk().stopStream().values }
 
-        AsyncFunction("sendExternallyManagedStreamKeepAlive") { params: Map<String, Any> ->
-            withExpoSdkError {
-                sdk?.sendExternallyManagedStreamKeepAlive(StreamKeepAliveRequest.fromMap(params))
-            }
+        SdkAsyncFunction("sendExternallyManagedStreamKeepAlive") { params: Map<String, Any> ->
+            sdk?.sendExternallyManagedStreamKeepAlive(StreamKeepAliveRequest.fromMap(params))
         }
 
         // MARK: - Microphone Commands
 
-        AsyncFunction("setMicState") {
+        SdkAsyncFunction("setMicState") {
                 enabled: Boolean,
                 useGlassesMic: Boolean?,
                 sendTranscript: Boolean?,
                 sendLc3Data: Boolean? ->
-            withExpoSdkError {
-                sdk?.setMicState(
-                        enabled = enabled,
-                        useGlassesMic = useGlassesMic ?: true,
-                        sendTranscript = sendTranscript ?: false,
-                        sendLc3Data = sendLc3Data ?: false,
-                )
-            }
+            sdk?.setMicState(
+                    enabled = enabled,
+                    useGlassesMic = useGlassesMic ?: true,
+                    sendTranscript = sendTranscript ?: false,
+                    sendLc3Data = sendLc3Data ?: false,
+            )
         }
 
         // Runs on Dispatchers.IO, not the shared Expo AsyncFunctionQueue: restart()
@@ -644,8 +683,8 @@ class BluetoothSdkModule : Module() {
 
         // MARK: - Audio Playback Monitoring
 
-        AsyncFunction("setOwnAppAudioPlaying") { playing: Boolean ->
-            withExpoSdkError { sdk?.setOwnAppAudioPlaying(playing) }
+        SdkAsyncFunction("setOwnAppAudioPlaying") { playing: Boolean ->
+            sdk?.setOwnAppAudioPlaying(playing)
         }
 
         // *Blocking on Dispatchers.IO, not the shared AsyncFunctionQueue: these wait on
@@ -663,7 +702,7 @@ class BluetoothSdkModule : Module() {
 
         // MARK: - RGB LED Control
 
-        AsyncFunction("rgbLedControl") {
+        SdkAsyncFunction("rgbLedControl") {
                 requestId: String,
                 packageName: String?,
                 action: String,
@@ -671,19 +710,17 @@ class BluetoothSdkModule : Module() {
                 onDurationMs: Int,
                 offDurationMs: Int,
                 count: Int ->
-            withExpoSdkError {
-                requireSdk().rgbLedControl(
-                        RgbLedRequest(
-                                requestId = requestId,
-                                packageName = packageName,
-                                action = RgbLedAction.fromValue(action),
-                                color = RgbLedColor.fromValue(color),
-                                onDurationMs = onDurationMs,
-                                offDurationMs = offDurationMs,
-                                count = count,
-                        )
-                ).values
-            }
+            requireSdk().rgbLedControl(
+                    RgbLedRequest(
+                            requestId = requestId,
+                            packageName = packageName,
+                            action = RgbLedAction.fromValue(action),
+                            color = RgbLedColor.fromValue(color),
+                            onDurationMs = onDurationMs,
+                            offDurationMs = offDurationMs,
+                            count = count,
+                    )
+            ).values
         }
 
         // MARK: - STT Commands

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -2,6 +2,7 @@ package com.mentra.bluetoothsdk
 
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import com.mentra.bluetoothsdk.utils.DeviceTypes
+import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.functions.Coroutine
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
@@ -183,10 +184,18 @@ class BluetoothSdkModule : Module() {
 
     private fun requireSdk(): MentraBluetoothSdk =
             sdk
-                    ?: throw BluetoothSdkException(
+                    ?: throw CodedException(
                             "sdk_not_initialized",
                             "Bluetooth SDK is not initialized.",
+                            null,
                     )
+
+    private inline fun <T> withExpoSdkError(block: () -> T): T =
+            try {
+                block()
+            } catch (error: BluetoothSdkException) {
+                throw CodedException(error.code, error.message ?: error.code, error)
+            }
 
     override fun definition() = ModuleDefinition {
         Name("BluetoothSdk")
@@ -336,46 +345,51 @@ class BluetoothSdkModule : Module() {
         // MARK: - Display Commands
 
         AsyncFunction("displayEvent") { params: Map<String, Any> ->
-            sdk?.displayEvent(DisplayEventRequest(params))
+            withExpoSdkError { sdk?.displayEvent(DisplayEventRequest(params)) }
         }
 
         AsyncFunction("displayText") { text: String, x: Int?, y: Int?, size: Int? ->
-            sdk?.displayText(
-                    text = text,
-                    x = x ?: 0,
-                    y = y ?: 0,
-                    size = size ?: 24,
-            )
+            withExpoSdkError {
+                sdk?.displayText(
+                        text = text,
+                        x = x ?: 0,
+                        y = y ?: 0,
+                        size = size ?: 24,
+                )
+            }
         }
 
-        AsyncFunction("clearDisplay") { sdk?.clearDisplay() }
+        AsyncFunction("clearDisplay") { withExpoSdkError { sdk?.clearDisplay() } }
 
         // MARK: - Connection Commands
 
-        AsyncFunction("connectDefault") { sdk?.connectDefault() }
+        AsyncFunction("connectDefault") { withExpoSdkError { sdk?.connectDefault() } }
 
         AsyncFunction("connectDefaultWithOptions") { options: Map<String, Any> ->
-            sdk?.connectDefault(options.toMentraConnectOptions())
+            withExpoSdkError { sdk?.connectDefault(options.toMentraConnectOptions()) }
         }
 
         AsyncFunction("setDefaultDevice") { device: Map<String, Any>? ->
-            sdk?.setDefaultDevice(device.toMentraDevice())
+            withExpoSdkError { sdk?.setDefaultDevice(device.toMentraDevice()) }
         }
 
-        AsyncFunction("clearDefaultDevice") { sdk?.clearDefaultDevice() }
+        AsyncFunction("clearDefaultDevice") { withExpoSdkError { sdk?.clearDefaultDevice() } }
 
         AsyncFunction("connectWithOptions") { device: Map<String, Any>, options: Map<String, Any> ->
-            sdk?.connect(
-                    device.toMentraDevice() ?: throw IllegalArgumentException("connect requires a Device with model and name."),
-                    options.toMentraConnectOptions(),
-            )
+            withExpoSdkError {
+                sdk?.connect(
+                        device.toMentraDevice()
+                                ?: throw IllegalArgumentException("connect requires a Device with model and name."),
+                        options.toMentraConnectOptions(),
+                )
+            }
         }
 
-        AsyncFunction("connectSimulated") { sdk?.connectSimulated() }
+        AsyncFunction("connectSimulated") { withExpoSdkError { sdk?.connectSimulated() } }
 
-        AsyncFunction("disconnect") { sdk?.disconnect() }
+        AsyncFunction("disconnect") { withExpoSdkError { sdk?.disconnect() } }
 
-        AsyncFunction("forget") { sdk?.forget() }
+        AsyncFunction("forget") { withExpoSdkError { sdk?.forget() } }
 
         AsyncFunction("connectDefaultController") { deviceManager?.connectDefaultController() }
 
@@ -384,14 +398,14 @@ class BluetoothSdkModule : Module() {
         AsyncFunction("forgetController") { deviceManager?.forgetController() }
 
         AsyncFunction("startScan") { model: String ->
-            sdk?.startScan(DeviceModel.fromDeviceType(model))
+            withExpoSdkError { sdk?.startScan(DeviceModel.fromDeviceType(model)) }
         }
 
-        AsyncFunction("stopScan") { sdk?.stopScan() }
+        AsyncFunction("stopScan") { withExpoSdkError { sdk?.stopScan() } }
 
-        AsyncFunction("cancelConnectionAttempt") { sdk?.cancelConnectionAttempt() }
+        AsyncFunction("cancelConnectionAttempt") { withExpoSdkError { sdk?.cancelConnectionAttempt() } }
 
-        AsyncFunction("showDashboard") { sdk?.showDashboard() }
+        AsyncFunction("showDashboard") { withExpoSdkError { sdk?.showDashboard() } }
 
         AsyncFunction("ping") { deviceManager?.ping() }
 
@@ -410,47 +424,55 @@ class BluetoothSdkModule : Module() {
         // MARK: - Incident Reporting
 
         AsyncFunction("sendIncidentId") { incidentId: String, apiBaseUrl: String? ->
-            sdk?.sendIncidentId(incidentId, apiBaseUrl)
+            withExpoSdkError { sdk?.sendIncidentId(incidentId, apiBaseUrl) }
         }
 
         // MARK: - WiFi Commands
 
-        AsyncFunction("requestWifiScan") { requireSdk().requestWifiScan().map { it.toMap() } }
-
-        AsyncFunction("sendWifiCredentials") { ssid: String, password: String ->
-            requireSdk().sendWifiCredentials(ssid, password).values
+        AsyncFunction("requestWifiScan") {
+            withExpoSdkError { requireSdk().requestWifiScan().map { it.toMap() } }
         }
 
-        AsyncFunction("forgetWifiNetwork") { ssid: String -> requireSdk().forgetWifiNetwork(ssid).values }
+        AsyncFunction("sendWifiCredentials") { ssid: String, password: String ->
+            withExpoSdkError { requireSdk().sendWifiCredentials(ssid, password).values }
+        }
+
+        AsyncFunction("forgetWifiNetwork") { ssid: String ->
+            withExpoSdkError { requireSdk().forgetWifiNetwork(ssid).values }
+        }
 
         AsyncFunction("setHotspotState") { enabled: Boolean ->
-            requireSdk().setHotspotState(enabled).values
+            withExpoSdkError { requireSdk().setHotspotState(enabled).values }
         }
 
         AsyncFunction("setSystemTime") { timestampMs: Double ->
-            sdk?.setSystemTime(timestampMs.toLong())
+            withExpoSdkError { sdk?.setSystemTime(timestampMs.toLong()) }
         }
 
         // MARK: - Gallery Commands
 
         AsyncFunction("setGalleryModeEnabled") { enabled: Boolean ->
-            requireSdk().setGalleryModeEnabled(enabled).values
+            withExpoSdkError { requireSdk().setGalleryModeEnabled(enabled).values }
         }
 
         AsyncFunction("setVoiceActivityDetectionEnabled") { enabled: Boolean ->
-            sdk?.setVoiceActivityDetectionEnabled(enabled)
+            withExpoSdkError { sdk?.setVoiceActivityDetectionEnabled(enabled) }
         }
 
         AsyncFunction("setPhotoCaptureDefaults") { params: Map<String, Any?> ->
-            requireSdk().setPhotoCaptureDefaults(params.toPhotoCaptureDefaults()).values
+            withExpoSdkError {
+                requireSdk().setPhotoCaptureDefaults(params.toPhotoCaptureDefaults()).values
+            }
         }
 
         AsyncFunction("setVideoRecordingDefaults") { width: Int, height: Int, fps: Int ->
-            requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
+            withExpoSdkError {
+                requireSdk().setVideoRecordingDefaults(VideoRecordingDefaults(width, height, fps)).values
+            }
         }
 
         AsyncFunction("setMaxVideoRecordingDuration") { minutes: Int ->
-            requireSdk().setMaxVideoRecordingDuration(minutes).values
+            withExpoSdkError { requireSdk().setMaxVideoRecordingDuration(minutes).values }
         }
 
         AsyncFunction("setCameraFov") { fov: Map<String, Any> ->
@@ -459,14 +481,16 @@ class BluetoothSdkModule : Module() {
                 (fov["roiPosition"] as? Number)?.toInt()
                     ?: (fov["roi_position"] as? Number)?.toInt(),
             )
-            requireSdk().setCameraFov(CameraFov(value, roiPosition)).values
+            withExpoSdkError { requireSdk().setCameraFov(CameraFov(value, roiPosition)).values }
         }
 
         AsyncFunction("setCameraTuningConfig") { anrOn: Boolean, gainOn: Boolean ->
-            requireSdk().setCameraTuningConfig(anrOn, gainOn).values
+            withExpoSdkError { requireSdk().setCameraTuningConfig(anrOn, gainOn).values }
         }
 
-        AsyncFunction("queryGalleryStatus") { requireSdk().queryGalleryStatus().values }
+        AsyncFunction("queryGalleryStatus") {
+            withExpoSdkError { requireSdk().queryGalleryStatus().values }
+        }
 
         AsyncFunction("requestPhoto") { params: Map<String, Any?> ->
             // JS may pass null for optional fields; Map<String, Any> rejects null values at the bridge.
@@ -478,7 +502,7 @@ class BluetoothSdkModule : Module() {
             Bridge.log(
                     "NATIVE: PHOTO PIPELINE [3/6] BluetoothSdk.requestPhoto requestId=${req.requestId} size=${req.size} compress=${req.compress} sound=${req.sound} exposureTimeNs=${req.exposureTimeNs} iso=${req.iso}"
             )
-            requireSdk().requestPhoto(req).values
+            withExpoSdkError { requireSdk().requestPhoto(req).values }
         }
 
         AsyncFunction("warmUpCamera") { params: Map<String, Any?> ->
@@ -489,43 +513,53 @@ class BluetoothSdkModule : Module() {
                 if (exposureRaw != null && exposureRaw.isFinite() && exposureRaw > 0) exposureRaw.toLong() else null
             val durationRaw = (params["durationMs"] as? Number)?.toInt() ?: 0
             val durationMs = if (durationRaw > 0) durationRaw else 15000
-            requireSdk().warmUpCamera(requestId, size, exposureTimeNs, durationMs).values
+            withExpoSdkError {
+                requireSdk().warmUpCamera(requestId, size, exposureTimeNs, durationMs).values
+            }
         }
 
         // MARK: - OTA Commands
 
         Function("setOtaVersionUrl") { otaVersionUrl: String ->
-            requireSdk().setOtaVersionUrl(otaVersionUrl)
+            withExpoSdkError { requireSdk().setOtaVersionUrl(otaVersionUrl) }
         }
 
-        Function("getOtaVersionUrl") { requireSdk().getOtaVersionUrl() }
+        Function("getOtaVersionUrl") { withExpoSdkError { requireSdk().getOtaVersionUrl() } }
 
         // Runs on Dispatchers.IO, not the shared Expo AsyncFunctionQueue:
         // manifest fetches and version waits can block for several seconds.
         AsyncFunction("checkForOtaUpdate") Coroutine { ->
-            withContext(Dispatchers.IO) { requireSdk().checkForOtaUpdate() }
-        }
-
-        AsyncFunction("startOtaUpdate") { otaVersionUrl: String? ->
-            val sdk = requireSdk()
-            if (otaVersionUrl.isNullOrBlank()) {
-                sdk.startOtaUpdate().values
-            } else {
-                sdk.startOtaUpdate(otaVersionUrl).values
+            withContext(Dispatchers.IO) {
+                withExpoSdkError { requireSdk().checkForOtaUpdate() }
             }
         }
 
-        AsyncFunction("sendOtaQueryStatus") { requireSdk().sendOtaQueryStatus().values }
+        AsyncFunction("startOtaUpdate") { otaVersionUrl: String? ->
+            withExpoSdkError {
+                val sdk = requireSdk()
+                if (otaVersionUrl.isNullOrBlank()) {
+                    sdk.startOtaUpdate().values
+                } else {
+                    sdk.startOtaUpdate(otaVersionUrl).values
+                }
+            }
+        }
+
+        AsyncFunction("sendOtaQueryStatus") {
+            withExpoSdkError { requireSdk().sendOtaQueryStatus().values }
+        }
 
         // MARK: - Version Info Commands
 
-        AsyncFunction("requestVersionInfo") { requireSdk().requestVersionInfo().toMap() }
+        AsyncFunction("requestVersionInfo") {
+            withExpoSdkError { requireSdk().requestVersionInfo().toMap() }
+        }
 
         // MARK: - Power Control Commands
 
-        AsyncFunction("sendShutdown") { sdk?.sendShutdown() }
+        AsyncFunction("sendShutdown") { withExpoSdkError { sdk?.sendShutdown() } }
 
-        AsyncFunction("sendReboot") { sdk?.sendReboot() }
+        AsyncFunction("sendReboot") { withExpoSdkError { sdk?.sendReboot() } }
 
         // MARK: - Video Recording Commands
 
@@ -538,17 +572,19 @@ class BluetoothSdkModule : Module() {
             // the glasses treat as "use the saved button-video default". JS numbers
             // arrive as Double across the bridge, so coerce to Int.
             fun dim(key: String): Int = (settings?.get(key) as? Number)?.toInt() ?: 0
-            requireSdk().startVideoRecording(
-                    VideoRecordingRequest(
-                            requestId,
-                            save,
-                            sound,
-                            dim("width"),
-                            dim("height"),
-                            dim("fps"),
-                            dim("maxRecordingTimeMinutes"),
-                    )
-            ).values
+            withExpoSdkError {
+                requireSdk().startVideoRecording(
+                        VideoRecordingRequest(
+                                requestId,
+                                save,
+                                sound,
+                                dim("width"),
+                                dim("height"),
+                                dim("fps"),
+                                dim("maxRecordingTimeMinutes"),
+                        )
+                ).values
+            }
         }
 
         // webhookUrl/authToken are supplied at stop (not start) so the token is
@@ -557,23 +593,29 @@ class BluetoothSdkModule : Module() {
                 requestId: String,
                 webhookUrl: String?,
                 authToken: String? ->
-            requireSdk().stopVideoRecording(requestId, webhookUrl, authToken).values
+            withExpoSdkError {
+                requireSdk().stopVideoRecording(requestId, webhookUrl, authToken).values
+            }
         }
 
         // MARK: - Stream Commands
 
         AsyncFunction("startStream") { params: Map<String, Any> ->
-            requireSdk().startStream(StreamRequest.fromMap(params)).values
+            withExpoSdkError { requireSdk().startStream(StreamRequest.fromMap(params)).values }
         }
 
         AsyncFunction("startExternallyManagedStream") { params: Map<String, Any> ->
-            requireSdk().startExternallyManagedStream(StreamRequest.fromMap(params)).values
+            withExpoSdkError {
+                requireSdk().startExternallyManagedStream(StreamRequest.fromMap(params)).values
+            }
         }
 
-        AsyncFunction("stopStream") { requireSdk().stopStream().values }
+        AsyncFunction("stopStream") { withExpoSdkError { requireSdk().stopStream().values } }
 
         AsyncFunction("sendExternallyManagedStreamKeepAlive") { params: Map<String, Any> ->
-            sdk?.sendExternallyManagedStreamKeepAlive(StreamKeepAliveRequest.fromMap(params))
+            withExpoSdkError {
+                sdk?.sendExternallyManagedStreamKeepAlive(StreamKeepAliveRequest.fromMap(params))
+            }
         }
 
         // MARK: - Microphone Commands
@@ -583,12 +625,14 @@ class BluetoothSdkModule : Module() {
                 useGlassesMic: Boolean?,
                 sendTranscript: Boolean?,
                 sendLc3Data: Boolean? ->
-            sdk?.setMicState(
-                    enabled = enabled,
-                    useGlassesMic = useGlassesMic ?: true,
-                    sendTranscript = sendTranscript ?: false,
-                    sendLc3Data = sendLc3Data ?: false,
-            )
+            withExpoSdkError {
+                sdk?.setMicState(
+                        enabled = enabled,
+                        useGlassesMic = useGlassesMic ?: true,
+                        sendTranscript = sendTranscript ?: false,
+                        sendLc3Data = sendLc3Data ?: false,
+                )
+            }
         }
 
         // Runs on Dispatchers.IO, not the shared Expo AsyncFunctionQueue: restart()
@@ -601,7 +645,7 @@ class BluetoothSdkModule : Module() {
         // MARK: - Audio Playback Monitoring
 
         AsyncFunction("setOwnAppAudioPlaying") { playing: Boolean ->
-            sdk?.setOwnAppAudioPlaying(playing)
+            withExpoSdkError { sdk?.setOwnAppAudioPlaying(playing) }
         }
 
         // *Blocking on Dispatchers.IO, not the shared AsyncFunctionQueue: these wait on
@@ -627,17 +671,19 @@ class BluetoothSdkModule : Module() {
                 onDurationMs: Int,
                 offDurationMs: Int,
                 count: Int ->
-            requireSdk().rgbLedControl(
-                    RgbLedRequest(
-                            requestId = requestId,
-                            packageName = packageName,
-                            action = RgbLedAction.fromValue(action),
-                            color = RgbLedColor.fromValue(color),
-                            onDurationMs = onDurationMs,
-                            offDurationMs = offDurationMs,
-                            count = count,
-                    )
-            ).values
+            withExpoSdkError {
+                requireSdk().rgbLedControl(
+                        RgbLedRequest(
+                                requestId = requestId,
+                                packageName = packageName,
+                                action = RgbLedAction.fromValue(action),
+                                color = RgbLedColor.fromValue(color),
+                                onDurationMs = onDurationMs,
+                                offDurationMs = offDurationMs,
+                                count = count,
+                        )
+                ).values
+            }
         }
 
         // MARK: - STT Commands

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/types/DeviceModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/types/DeviceModels.kt
@@ -2,7 +2,6 @@ package com.mentra.bluetoothsdk
 
 import com.mentra.bluetoothsdk.utils.ControllerTypes
 import com.mentra.bluetoothsdk.utils.DeviceTypes
-import expo.modules.kotlin.exception.CodedException
 
 data class MentraBluetoothSdkConfig @JvmOverloads constructor(
     val deliverCallbacksOnMainThread: Boolean = true,
@@ -10,10 +9,10 @@ data class MentraBluetoothSdkConfig @JvmOverloads constructor(
 )
 
 class BluetoothSdkException(
-    code: String,
+    val code: String,
     message: String,
     cause: Throwable? = null,
-) : CodedException(code, message, cause)
+) : IllegalStateException(message, cause)
 
 enum class DeviceModel(val deviceType: String) {
     G1(DeviceTypes.G1),

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/BluetoothSdkExceptionTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/BluetoothSdkExceptionTest.kt
@@ -1,0 +1,18 @@
+package com.mentra.bluetoothsdk
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class BluetoothSdkExceptionTest {
+    @Test
+    fun `exception is usable without the Expo runtime`() {
+        val cause = IllegalArgumentException("cause")
+        val error = BluetoothSdkException("capture_failed", "Capture failed", cause)
+
+        assertThat(error.code).isEqualTo("capture_failed")
+        assertThat(error.message).isEqualTo("Capture failed")
+        assertThat(error.cause).isSameAs(cause)
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error.javaClass.superclass.name).doesNotStartWith("expo.modules")
+    }
+}


### PR DESCRIPTION
## Summary

Fix bare native Android apps crashing whenever a Bluetooth SDK operation rejects.

The published Android SDK currently defines `BluetoothSdkException` as a subclass of Expo's `CodedException`. Expo is intentionally a `compileOnly` dependency for the public Maven artifact, so native Android consumers do not package that class. As soon as an SDK error is constructed, Android fails class resolution and terminates the app with:

```text
java.lang.NoClassDefFoundError: Failed resolution of:
Lexpo/modules/kotlin/exception/CodedException;
```

This is not limited to photo capture. Any native Android SDK path that constructs `BluetoothSdkException` can trigger the same process crash.

## Observed failure

The native Starter Kit app requested a photo. The request reached the glasses and progressed to `capturing`, then the ASG client returned:

```text
photo_status status=failed errorCode=CAMERA_CAPTURE_FAILED errorMessage="Camera disconnected"
photo_response state=error success=false errorCode=CAMERA_CAPTURE_FAILED
```

Instead of surfacing that ordinary SDK failure to the app, the phone process crashed while loading `BluetoothSdkException` because `expo.modules.kotlin.exception.CodedException` was absent from the APK.

## Root cause

`BluetoothSdkException` is part of the native Android SDK API, but it inherited from a React Native adapter type:

```kotlin
class BluetoothSdkException(...) : CodedException(...)
```

At the same time, `expo-modules-core` is correctly declared as `compileOnly` so the public Maven artifact does not force Expo and React Native into native Android apps. Those two choices are incompatible: the core exception cannot have an Expo superclass if Expo is not a runtime dependency.

## Changes

- Make `BluetoothSdkException` a standalone `IllegalStateException` with its existing public `code` value.
- Keep Expo-specific exception handling inside `BluetoothSdkModule`, the React Native adapter boundary.
- Convert core `BluetoothSdkException` instances to Expo `CodedException` instances before React Native promises reject.
- Register SDK-backed Expo entry points through `SdkAsyncFunction`, `SdkFunction`, and `SdkCoroutineFunction`. These helpers centralize conversion while preserving Expo's typed argument conversion and queue behavior.
- Add a regression test that constructs and inspects `BluetoothSdkException` without requiring the Expo runtime.

This preserves both contracts:

- Native Android apps can catch `BluetoothSdkException`, inspect `code`, and never need Expo.
- React Native promises still reject with the intended SDK error code rather than a generic unexpected-error code.

## Validation

- `./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --no-daemon`
  - Full Android SDK unit suite passes.
- `./gradlew :mentra-bluetooth-sdk:publishReleasePublicationToMavenLocal -PmentraPublicSdk=true --no-daemon`
  - Public Maven-shaped release artifact builds and publishes locally.
- Inspected the resulting AAR bytecode with `javap`.
  - `BluetoothSdkException extends java.lang.IllegalStateException`.
  - It retains `getCode()`.
  - Expo references are confined to `BluetoothSdkModule` adapter classes.
- Built and installed the native Android Starter Kit app against the locally published fixed artifact on a physical Samsung SM-F956U1.
- Verified a cloud photo through all states: accepted, queued, configuring, capturing, captured, uploading, uploaded, and successful `photo_response`.
- Verified saved-to-glasses gallery capture end to end:
  - `save=true`
  - `transferMethod=local`
  - successful response with `saved=true` and a capture ID
  - gallery lookup and download completed
  - native app displayed a 4032 x 3024, 3.6 MB preview
- Confirmed the app process remained alive and no `NoClassDefFoundError` or fatal exception was logged.

## Release impact

Published Android SDK `0.1.19` is affected. A subsequent Android SDK release is required for Maven consumers to receive this fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches error propagation across the full Expo Bluetooth module surface; behavior should be equivalent for RN but any missed wrap could change rejection shape.
> 
> **Overview**
> Fixes **native Android app process crashes** (`NoClassDefFoundError` for Expo's `CodedException`) when any SDK operation throws `BluetoothSdkException`, which previously inherited from an Expo-only type while the published Maven artifact keeps Expo as `compileOnly`.
> 
> **`BluetoothSdkException`** now extends **`IllegalStateException`** and exposes **`code`** as a normal SDK type. **`BluetoothSdkModule`** maps those failures to Expo **`CodedException`** via a new **`withExpoSdkError`** helper, and SDK-backed Expo async/sync entry points are wrapped so React Native promise rejections still carry the same codes and messages.
> 
> Adds **`BluetoothSdkExceptionTest`** to assert the core exception works without the Expo runtime.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d91929ea59bf0d1ad7d2b801f94a855d0653f89b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
