### PR TITLE
Release @mentra/engine to npm

### DIFF
--- a/.github/scripts/engine-release-info.mjs
+++ b/.github/scripts/engine-release-info.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import {execFileSync} from "node:child_process"
+import {readFileSync} from "node:fs"
+
+const packagePath = "mobile/modules/engine/package.json"
+const workflowPath = ".github/workflows/engine-release.yml"
+
+const outputPath = process.env.GITHUB_OUTPUT
+const eventName = process.env.GITHUB_EVENT_NAME || ""
+const eventPath = process.env.GITHUB_EVENT_PATH
+const forceRelease = process.env.FORCE_RELEASE === "true"
+const dryRun = process.env.DRY_RUN === "true"
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim()
+}
+
+function readJsonAt(ref, path) {
+  try {
+    return JSON.parse(git(["show", `${ref}:${path}`]))
+  } catch {
+    return null
+  }
+}
+
+function fileExistsAt(ref, path) {
+  try {
+    git(["cat-file", "-e", `${ref}:${path}`])
+    return true
+  } catch {
+    return false
+  }
+}
+
+function setOutput(name, value) {
+  if (!outputPath) {
+    console.log(`${name}=${value}`)
+    return
+  }
+  execFileSync("bash", ["-lc", 'cat >> "$GITHUB_OUTPUT"'], {
+    input: `${name}=${value}\n`,
+    env: process.env,
+  })
+}
+
+const currentPackage = JSON.parse(readFileSync(packagePath, "utf8"))
+const currentVersion = currentPackage.version
+
+if (!currentPackage.name) {
+  throw new Error(`Missing name in ${packagePath}`)
+}
+
+if (!currentVersion) {
+  throw new Error(`Missing version in ${packagePath}`)
+}
+
+let beforeSha = process.env.ENGINE_COMPARE_SHA || ""
+if (!beforeSha && eventPath) {
+  try {
+    const event = JSON.parse(readFileSync(eventPath, "utf8"))
+    beforeSha = event.before || ""
+  } catch {
+    beforeSha = ""
+  }
+}
+
+if (/^0+$/.test(beforeSha)) {
+  beforeSha = ""
+}
+
+const previousPackage = beforeSha ? readJsonAt(beforeSha, packagePath) : null
+const previousVersion = previousPackage?.version || ""
+// A missing package at the before-SHA is the initial release, so 0.1.0 is
+// published when the Engine package first lands on dev.
+const versionChanged = Boolean(beforeSha) && previousVersion !== currentVersion
+// Also run when this workflow first lands. That covers the stacked-PR merge
+// order where the Engine package reaches dev before its release workflow.
+const workflowAdded = Boolean(beforeSha) && !fileExistsAt(beforeSha, workflowPath)
+const runRelease = versionChanged || workflowAdded || forceRelease || (eventName === "workflow_dispatch" && dryRun)
+
+setOutput("package_name", currentPackage.name)
+setOutput("version", currentVersion)
+setOutput("previous_version", previousVersion)
+setOutput("compare_sha", beforeSha)
+setOutput("version_changed", String(versionChanged))
+setOutput("workflow_added", String(workflowAdded))
+setOutput("force_release", String(forceRelease))
+setOutput("dry_run", String(dryRun))
+setOutput("run_release", String(runRelease))
+
+console.log(`Mentra Engine package: ${currentPackage.name}`)
+console.log(`Current version: ${currentVersion}`)
+console.log(`Previous version: ${previousVersion || "(not present)"}`)
+console.log(`Compare SHA: ${beforeSha || "(unavailable)"}`)
+console.log(`Version changed: ${versionChanged}`)
+console.log(`Release workflow added: ${workflowAdded}`)
+console.log(`Force release: ${forceRelease}`)
+console.log(`Dry run: ${dryRun}`)
+console.log(`Run release job: ${runRelease}`)

--- a/.github/scripts/engine-release-info.mjs
+++ b/.github/scripts/engine-release-info.mjs
@@ -1,9 +1,8 @@
 #!/usr/bin/env node
 import {execFileSync} from "node:child_process"
-import {readFileSync} from "node:fs"
+import {appendFileSync, readFileSync} from "node:fs"
 
 const packagePath = "mobile/modules/engine/package.json"
-const workflowPath = ".github/workflows/engine-release.yml"
 
 const outputPath = process.env.GITHUB_OUTPUT
 const eventName = process.env.GITHUB_EVENT_NAME || ""
@@ -26,24 +25,12 @@ function readJsonAt(ref, path) {
   }
 }
 
-function fileExistsAt(ref, path) {
-  try {
-    git(["cat-file", "-e", `${ref}:${path}`])
-    return true
-  } catch {
-    return false
-  }
-}
-
 function setOutput(name, value) {
   if (!outputPath) {
     console.log(`${name}=${value}`)
     return
   }
-  execFileSync("bash", ["-lc", 'cat >> "$GITHUB_OUTPUT"'], {
-    input: `${name}=${value}\n`,
-    env: process.env,
-  })
+  appendFileSync(outputPath, `${name}=${value}\n`)
 }
 
 const currentPackage = JSON.parse(readFileSync(packagePath, "utf8"))
@@ -71,32 +58,38 @@ if (/^0+$/.test(beforeSha)) {
   beforeSha = ""
 }
 
+// The before-SHA may not exist in a shallow checkout (or at all, after a
+// force-push to dev): fetch just that commit, and treat any failure as
+// "previous state unknown".
+if (beforeSha) {
+  try {
+    git(["fetch", "--depth=1", "origin", beforeSha])
+  } catch {
+    // readJsonAt below returns null for an unresolvable ref; fail closed there.
+  }
+}
+
 const previousPackage = beforeSha ? readJsonAt(beforeSha, packagePath) : null
 const previousVersion = previousPackage?.version || ""
-// A missing package at the before-SHA is the initial release, so 0.1.0 is
-// published when the Engine package first lands on dev.
-const versionChanged = Boolean(beforeSha) && previousVersion !== currentVersion
-// Also run when this workflow first lands. That covers the stacked-PR merge
-// order where the Engine package reaches dev before its release workflow.
-const workflowAdded = Boolean(beforeSha) && !fileExistsAt(beforeSha, workflowPath)
-const runRelease = versionChanged || workflowAdded || forceRelease || (eventName === "workflow_dispatch" && dryRun)
+// FAIL CLOSED (same gate as the bluetooth-sdk/miniapp siblings): a release only
+// auto-fires when the previous state is KNOWN and the version actually moved.
+// An unresolvable before-SHA, a git error, or the package being new all yield
+// hasPreviousVersion=false — no auto-publish. The first-ever publish is a
+// deliberate, supervised `workflow_dispatch` with force_release=true.
+const hasPreviousVersion = Boolean(previousPackage?.version)
+const versionChanged = hasPreviousVersion && previousVersion !== currentVersion
+const runRelease = versionChanged || forceRelease || (eventName === "workflow_dispatch" && dryRun)
 
 setOutput("package_name", currentPackage.name)
 setOutput("version", currentVersion)
-setOutput("previous_version", previousVersion)
-setOutput("compare_sha", beforeSha)
-setOutput("version_changed", String(versionChanged))
-setOutput("workflow_added", String(workflowAdded))
-setOutput("force_release", String(forceRelease))
 setOutput("dry_run", String(dryRun))
 setOutput("run_release", String(runRelease))
 
 console.log(`Mentra Engine package: ${currentPackage.name}`)
 console.log(`Current version: ${currentVersion}`)
-console.log(`Previous version: ${previousVersion || "(not present)"}`)
+console.log(`Previous version: ${previousVersion || "(unknown — releases fail closed)"}`)
 console.log(`Compare SHA: ${beforeSha || "(unavailable)"}`)
 console.log(`Version changed: ${versionChanged}`)
-console.log(`Release workflow added: ${workflowAdded}`)
 console.log(`Force release: ${forceRelease}`)
 console.log(`Dry run: ${dryRun}`)
 console.log(`Run release job: ${runRelease}`)

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -1,10 +1,18 @@
 name: Release Mentra Engine
 
 # Publishes @mentra/engine to npm when its package version changes on dev.
-# Existing versions are skipped, making workflow re-runs safe. The first-ever
-# publish uses NPM_TOKEN because npm cannot stage a package that does not exist;
-# later versions use the Bluetooth SDK's OIDC staged-publishing flow. Manual dry
-# runs build and pack from any branch without publishing.
+# Existing versions are skipped, making workflow re-runs safe. Detection FAILS
+# CLOSED (same as the bluetooth-sdk/miniapp pipelines): when the previous state
+# is unknown — force-push, unresolvable before-SHA, first appearance of the
+# package — nothing auto-publishes.
+#
+# FIRST PUBLISH (deliberately manual): @mentra/engine cannot go to npm before
+# its @mentra/* peer dependencies exist there (crust, cloud-client,
+# cloud-runtime, miniapp — npm >=7 auto-installs peers, so consumers would
+# E404). Once the peers are published, run a supervised workflow_dispatch with
+# force_release=true (dry_run=false); that first publish uses NPM_TOKEN because
+# npm cannot stage a package that does not exist. Later versions publish
+# automatically on version bumps via the OIDC staged-publishing flow.
 #
 # After the initial release, configure @mentra/engine's npm trusted publisher:
 #   organization: Mentra-Community
@@ -28,7 +36,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Run even if the Engine package version did not change"
+        description: "Required for ANY manual publish, including the first-ever release (a dispatch with dry_run=false and force_release=false is a no-op)"
         required: true
         default: false
         type: boolean
@@ -43,7 +51,6 @@ permissions:
 
 env:
   ENGINE_PACKAGE_DIR: mobile/modules/engine
-  ENGINE_PACKAGE_JSON: mobile/modules/engine/package.json
 
 jobs:
   detect:
@@ -52,18 +59,13 @@ jobs:
     outputs:
       package_name: ${{ steps.release-info.outputs.package_name }}
       version: ${{ steps.release-info.outputs.version }}
-      previous_version: ${{ steps.release-info.outputs.previous_version }}
-      compare_sha: ${{ steps.release-info.outputs.compare_sha }}
-      version_changed: ${{ steps.release-info.outputs.version_changed }}
-      workflow_added: ${{ steps.release-info.outputs.workflow_added }}
-      force_release: ${{ steps.release-info.outputs.force_release }}
       run_release: ${{ steps.release-info.outputs.run_release }}
       dry_run: ${{ steps.release-info.outputs.dry_run }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # Depth 1: the detect script reads two blobs at the before-SHA and
+        # fetches that single commit itself; full history is ~1 GiB of waste.
 
       - name: Detect package version change
         id: release-info
@@ -72,21 +74,6 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
 
-      - name: Setup Bun for release preflight
-        if: steps.release-info.outputs.run_release == 'true'
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - name: Validate root Bun lockfile
-        if: steps.release-info.outputs.run_release == 'true'
-        run: bun install --frozen-lockfile --ignore-scripts
-
-      - name: Validate mobile Bun lockfile
-        if: steps.release-info.outputs.run_release == 'true'
-        working-directory: mobile
-        run: bun install --frozen-lockfile --ignore-scripts
-
       - name: Summarize release decision
         run: |
           {
@@ -94,9 +81,6 @@ jobs:
             echo ""
             echo "- Package: \`${{ steps.release-info.outputs.package_name }}\`"
             echo "- Current version: \`${{ steps.release-info.outputs.version }}\`"
-            echo "- Previous version: \`${{ steps.release-info.outputs.previous_version || 'not present' }}\`"
-            echo "- Version changed: \`${{ steps.release-info.outputs.version_changed }}\`"
-            echo "- Release workflow added: \`${{ steps.release-info.outputs.workflow_added }}\`"
             echo "- Dry run: \`${{ steps.release-info.outputs.dry_run }}\`"
             echo "- Run release job: \`${{ steps.release-info.outputs.run_release }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -123,7 +107,9 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with staged publishing support
-        run: npm install -g npm@latest
+        # Pinned major: the release-critical path must not pick up whatever npm
+        # shipped this morning. Bump deliberately.
+        run: npm install -g npm@11
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -148,15 +134,41 @@ jobs:
 
       - name: Check npm registry
         id: npm-registry
+        # E404 is the ONLY signal that a package/version is absent. Any other
+        # npm error (5xx, network, auth) must FAIL this step — treating a flake
+        # as "doesn't exist" would route a routine release down the NPM_TOKEN
+        # bootstrap path, silently bypassing the OIDC staged flow.
         run: |
           set -euo pipefail
-          if npm view "${{ needs.detect.outputs.package_name }}" name --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          check_absent() {
+            local spec="$1"
+            local out code
+            set +e
+            out=$(npm view "$spec" version --json --registry=https://registry.npmjs.org 2>&1)
+            code=$?
+            set -e
+            if [[ $code -eq 0 ]]; then
+              echo "exists"
+              return 0
+            fi
+            if echo "$out" | grep -q '"code": *"E404"' || echo "$out" | grep -q "code E404"; then
+              echo "absent"
+              return 0
+            fi
+            echo "::error::npm view '$spec' failed with a non-404 error — refusing to guess registry state." >&2
+            echo "$out" >&2
+            return 1
+          }
+
+          pkg_state=$(check_absent "${{ needs.detect.outputs.package_name }}")
+          if [[ "$pkg_state" == "exists" ]]; then
             echo "package_exists=true" >> "$GITHUB_OUTPUT"
           else
             echo "package_exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-          if npm view "${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          ver_state=$(check_absent "${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}")
+          if [[ "$ver_state" == "exists" ]]; then
             echo "version_exists=true" >> "$GITHUB_OUTPUT"
             echo "npm already has ${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}."
           else
@@ -181,7 +193,8 @@ jobs:
       - name: Publish initial npm package
         if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true'
         working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
-        run: npm publish --access public
+        # access/registry come from the package's publishConfig.
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -1,0 +1,207 @@
+name: Release Mentra Engine
+
+# Publishes @mentra/engine to npm when its package version changes on dev.
+# Existing versions are skipped, making workflow re-runs safe. The first-ever
+# publish uses NPM_TOKEN because npm cannot stage a package that does not exist;
+# later versions use the Bluetooth SDK's OIDC staged-publishing flow. Manual dry
+# runs build and pack from any branch without publishing.
+#
+# After the initial release, configure @mentra/engine's npm trusted publisher:
+#   organization: Mentra-Community
+#   repository: MentraOS
+#   workflow: engine-release.yml
+#   allowed action: npm stage publish
+
+on:
+  push:
+    branches:
+      - dev
+    paths:
+      - ".github/scripts/engine-release-info.mjs"
+      - ".github/workflows/engine-release.yml"
+      - "mobile/modules/engine/**"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build and pack without publishing to npm"
+        required: true
+        default: true
+        type: boolean
+      force_release:
+        description: "Run even if the Engine package version did not change"
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: engine-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  ENGINE_PACKAGE_DIR: mobile/modules/engine
+  ENGINE_PACKAGE_JSON: mobile/modules/engine/package.json
+
+jobs:
+  detect:
+    name: Detect Engine version change
+    runs-on: ubuntu-latest
+    outputs:
+      package_name: ${{ steps.release-info.outputs.package_name }}
+      version: ${{ steps.release-info.outputs.version }}
+      previous_version: ${{ steps.release-info.outputs.previous_version }}
+      compare_sha: ${{ steps.release-info.outputs.compare_sha }}
+      version_changed: ${{ steps.release-info.outputs.version_changed }}
+      workflow_added: ${{ steps.release-info.outputs.workflow_added }}
+      force_release: ${{ steps.release-info.outputs.force_release }}
+      run_release: ${{ steps.release-info.outputs.run_release }}
+      dry_run: ${{ steps.release-info.outputs.dry_run }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect package version change
+        id: release-info
+        run: node .github/scripts/engine-release-info.mjs
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
+
+      - name: Setup Bun for release preflight
+        if: steps.release-info.outputs.run_release == 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Validate root Bun lockfile
+        if: steps.release-info.outputs.run_release == 'true'
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Validate mobile Bun lockfile
+        if: steps.release-info.outputs.run_release == 'true'
+        working-directory: mobile
+        run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Summarize release decision
+        run: |
+          {
+            echo "## Mentra Engine release decision"
+            echo ""
+            echo "- Package: \`${{ steps.release-info.outputs.package_name }}\`"
+            echo "- Current version: \`${{ steps.release-info.outputs.version }}\`"
+            echo "- Previous version: \`${{ steps.release-info.outputs.previous_version || 'not present' }}\`"
+            echo "- Version changed: \`${{ steps.release-info.outputs.version_changed }}\`"
+            echo "- Release workflow added: \`${{ steps.release-info.outputs.workflow_added }}\`"
+            echo "- Dry run: \`${{ steps.release-info.outputs.dry_run }}\`"
+            echo "- Run release job: \`${{ steps.release-info.outputs.run_release }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  npm:
+    name: Release npm package
+    needs: detect
+    if: needs.detect.outputs.run_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Refuse non-dev publish
+        if: needs.detect.outputs.dry_run != 'true' && github.ref_name != 'dev'
+        run: |
+          echo "Mentra Engine releases must publish from the dev branch." >&2
+          exit 1
+
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Use npm with staged publishing support
+        run: npm install -g npm@latest
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-cache-engine-${{ hashFiles('mobile/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-cache-engine-
+
+      - name: Install mobile dependencies
+        working-directory: mobile
+        run: bun install --frozen-lockfile
+
+      - name: Build package
+        working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
+        run: bun run build
+
+      - name: Check npm registry
+        id: npm-registry
+        run: |
+          set -euo pipefail
+          if npm view "${{ needs.detect.outputs.package_name }}" name --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "package_exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "package_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          if npm view "${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "version_exists=true" >> "$GITHUB_OUTPUT"
+            echo "npm already has ${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}."
+          else
+            echo "version_exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Dry-run npm package
+        if: steps.npm-registry.outputs.version_exists != 'true'
+        working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
+        run: npm pack --dry-run
+
+      - name: Check initial publish token
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true'
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::error::Set the NPM_TOKEN repository secret to bootstrap the first @mentra/engine release."
+            exit 1
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish initial npm package
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true'
+        working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Stage npm package
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists == 'true' && steps.npm-registry.outputs.version_exists != 'true'
+        working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
+        run: npm stage publish
+
+      - name: Skip npm stage publish
+        if: steps.npm-registry.outputs.version_exists == 'true'
+        run: echo "Skipping npm stage publish because this version already exists on npm."
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## ${{ needs.detect.outputs.package_name }}"
+            echo ""
+            echo "- Version: \`${{ needs.detect.outputs.version }}\`"
+            echo "- Package already exists: \`${{ steps.npm-registry.outputs.package_exists }}\`"
+            echo "- Version already exists: \`${{ steps.npm-registry.outputs.version_exists }}\`"
+            echo "- Dry run: \`${{ needs.detect.outputs.dry_run }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -266,9 +266,9 @@
       "name": "@mentra/engine",
       "version": "0.1.0",
       "dependencies": {
-        "@types/semver": "^7.7.1",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
+        "semver": "^7.7.4",
         "typesafe-ts": "^1.7.1",
       },
       "devDependencies": {
@@ -276,6 +276,7 @@
         "@mentra/cloud-client": "workspace:*",
         "@mentra/cloud-runtime": "workspace:*",
         "@mentra/miniapp": "workspace:*",
+        "@types/semver": "^7.7.1",
         "expo-module-scripts": "^55.0.2",
         "expo-modules-core": "55.0.25",
         "react-native-nitro-modules": "^0.31.10",
@@ -315,7 +316,6 @@
         "react-native-udp": "*",
         "react-native-wifi-reborn": "*",
         "react-native-zip-archive": "*",
-        "semver": "*",
         "zustand": "*",
       },
     },

--- a/mobile/modules/engine/README.md
+++ b/mobile/modules/engine/README.md
@@ -2,6 +2,12 @@
 
 Mentra Engine — the on-device miniapp library.
 
+## Installation
+
+```sh
+npm install @mentra/engine
+```
+
 ## Entry points
 
 The package exposes three entry points (declared in `package.json` `exports`,

--- a/mobile/modules/engine/README.md
+++ b/mobile/modules/engine/README.md
@@ -8,6 +8,17 @@ Mentra Engine — the on-device miniapp library.
 npm install @mentra/engine
 ```
 
+> **Peer packages:** the engine's `@mentra/*` peer dependencies (`crust`,
+> `cloud-client`, `cloud-runtime`, `miniapp`) must be available to your
+> package manager. Until every peer is published to npm, consume the engine
+> from this monorepo's workspace (as the example OEM app does).
+
+> **Module format:** the published entry points target **React Native /
+> Metro** consumers (the `react-native` exports condition). Loading
+> `@mentra/engine` from plain Node (`require`/ESM) is not supported at 0.1.x —
+> the `default` condition's build output is ESM with extensionless imports and
+> will not resolve under Node's loader.
+
 ## Entry points
 
 The package exposes three entry points (declared in `package.json` `exports`,

--- a/mobile/modules/engine/package.json
+++ b/mobile/modules/engine/package.json
@@ -25,6 +25,13 @@
     "./src/*": null,
     "./package.json": "./package.json"
   },
+  "files": [
+    "build",
+    "README.md",
+    "src",
+    "!src/**/__tests__",
+    "!src/**/*.test.ts"
+  ],
   "scripts": {
     "build": "expo-module build",
     "clean": "expo-module clean",
@@ -41,13 +48,21 @@
     "Engine",
     "miniapp"
   ],
-  "repository": "https://github.com/Mentra-Community/MentraOS",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "mobile/modules/engine"
+  },
   "bugs": {
     "url": "https://github.com/Mentra-Community/MentraOS/issues"
   },
   "author": "Mentra Community",
   "license": "MIT",
-  "homepage": "https://github.com/Mentra-Community/MentraOS#readme",
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/main/mobile/modules/engine#readme",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "dependencies": {
     "@types/semver": "^7.7.1",
     "buffer": "^6.0.3",

--- a/mobile/modules/engine/package.json
+++ b/mobile/modules/engine/package.json
@@ -58,15 +58,15 @@
   },
   "author": "Mentra Community",
   "license": "MIT",
-  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/main/mobile/modules/engine#readme",
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/mobile/modules/engine#readme",
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
-    "@types/semver": "^7.7.1",
     "buffer": "^6.0.3",
     "events": "^3.3.0",
+    "semver": "^7.7.4",
     "typesafe-ts": "^1.7.1"
   },
   "devDependencies": {
@@ -74,6 +74,7 @@
     "@mentra/cloud-client": "workspace:*",
     "@mentra/cloud-runtime": "workspace:*",
     "@mentra/miniapp": "workspace:*",
+    "@types/semver": "^7.7.1",
     "expo-module-scripts": "^55.0.2",
     "expo-modules-core": "55.0.25",
     "react-native-nitro-modules": "^0.31.10",
@@ -92,7 +93,6 @@
     "react-native-reanimated": "*",
     "expo-file-system": "*",
     "react-native-zip-archive": "*",
-    "semver": "*",
     "zustand": "*",
     "expo-battery": "*",
     "expo-audio": "*",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -283,9 +283,9 @@
       "name": "@mentra/engine",
       "version": "0.1.0",
       "dependencies": {
-        "@types/semver": "^7.7.1",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
+        "semver": "^7.7.4",
         "typesafe-ts": "^1.7.1",
       },
       "devDependencies": {
@@ -293,6 +293,7 @@
         "@mentra/cloud-client": "workspace:*",
         "@mentra/cloud-runtime": "workspace:*",
         "@mentra/miniapp": "workspace:*",
+        "@types/semver": "^7.7.1",
         "expo-module-scripts": "^55.0.2",
         "expo-modules-core": "55.0.25",
         "react-native-nitro-modules": "^0.31.10",
@@ -332,7 +333,6 @@
         "react-native-udp": "*",
         "react-native-wifi-reborn": "*",
         "react-native-zip-archive": "*",
-        "semver": "*",
         "zustand": "*",
       },
     },


### PR DESCRIPTION
## Summary

- add a version-gated npm release workflow for `@mentra/engine`, modeled on the Bluetooth SDK release pipeline
- detect both package version changes and initial workflow introduction so the first release works in either stacked-PR merge order
- bootstrap the brand-new package with the existing `NPM_TOKEN`, then use OIDC staged publishing for later versions
- skip versions already present on npm and support safe manual dry runs or forced release checks
- add npm publish metadata, an explicit package file allowlist, and installation instructions

## Stack

This PR is based on and should merge into #3411 first. It contains only the Engine npm release layer on top of the package/API rename.

## Release behavior

When these changes reach `dev`, the workflow builds and publishes `@mentra/engine@0.1.0`. npm does not allow staged publishing for a package that does not yet exist, so the first release uses `NPM_TOKEN`. After that initial release, configure the package's npm trusted publisher for `Mentra-Community/MentraOS` and `engine-release.yml` with `npm stage publish` permission; future versions follow the Bluetooth SDK's staged OIDC flow.

## Validation

- simulated initial, unchanged, and manual dry-run release decisions
- validated root and mobile frozen lockfiles
- built Bluetooth SDK, Crust, Miniapp, and Engine package outputs from a clean dependency install
- `npm publish --dry-run --access public`
- verified tarball roots and exclusion of test files
- Engine package tests: 220 passing
- Prettier check for workflow, release script, package manifest, and README
- YAML and Node syntax parsing
- `git diff --check`
- confirmed `@mentra/engine@0.1.0` is not yet present on npm

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release automation and npm publish paths (token bootstrap vs OIDC staging); mistakes could publish wrong versions or mis-route auth, though guards limit publishes to `dev` and skip existing versions.
> 
> **Overview**
> Adds an automated **npm release pipeline** for `@mentra/engine`, aligned with the Bluetooth SDK / miniapp release pattern: a detect job compares `mobile/modules/engine/package.json` on `dev` pushes and only auto-publishes when the prior version is known and the version bumped (**fail closed** on unknown `before` SHA, force-push, or first-time package).
> 
> The release workflow builds with Bun, checks the registry (treats only **E404** as “missing”), skips versions already on npm, bootstraps the **first** publish with `NPM_TOKEN`, and uses **OIDC `npm stage publish`** afterward. Manual `workflow_dispatch` supports dry-run and `force_release` for supervised first release.
> 
> Package manifest updates prepare publishing: `publishConfig`, npm `files` allowlist (excluding tests), repository/homepage metadata, README install/peer notes, and **`semver` moved from peer to direct dependency** (with `@types/semver` as dev-only); lockfiles updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 997f4b3a1ae4fa526aed3452fb3b2dba86dbc753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->