### PR TITLE
Document gallery-mode photo request IDs

### DIFF
--- a/docs/mentra-live/camera-streaming.mdx
+++ b/docs/mentra-live/camera-streaming.mdx
@@ -304,6 +304,63 @@ Use `setGalleryModeEnabled(false)` when you want the action button to report eve
 
 Action-button photos emitted by the glasses use the same `photo_status` metadata shape when the phone SDK is connected. These local captures report `resolvedConfig.source: "button"` and `resolvedConfig.transferMethod: "local"`, then expose `requestedCaptureConfig` / `meteredPreview` on `capturing` and `captureMetadata` on `captured`.
 
+### Gallery Photo Request IDs
+
+In gallery mode, photos are saved on the glasses instead of being uploaded to a webhook. Because nothing is uploaded, there is no response that returns the `requestId`. Instead, read the `requestId` from `photo_status` events. Action-button captures set `resolvedConfig.source` to `"button"`, so you can filter for them. When your own app starts the capture, you set the `requestId` yourself by passing it to `requestPhoto({requestId, save: true, webhookUrl: null})`.
+
+<Tabs>
+  <Tab title="React Native">
+
+```ts
+import {useBluetoothEvent} from '@mentra/bluetooth-sdk/react';
+
+useBluetoothEvent('photo_status', (event) => {
+  if (event.resolvedConfig?.source === 'button') {
+    console.log('gallery photo requestId', event.requestId);
+  }
+});
+```
+
+  </Tab>
+  <Tab title="Android">
+
+```kotlin
+override fun onPhotoStatus(event: PhotoStatusEvent) {
+    if (event.resolvedConfig?.source == "button") {
+        Log.d("Mentra", "gallery photo requestId: ${event.requestId}")
+    }
+}
+```
+
+  </Tab>
+  <Tab title="iOS">
+
+```swift
+func mentraBluetoothSDK(_ sdk: MentraBluetoothSDK, didReceive event: BluetoothEvent) {
+    if case let .photoStatus(status) = event,
+       status.resolvedConfig?.source == "button" {
+        print("gallery photo requestId: \(status.requestId)")
+    }
+}
+```
+
+  </Tab>
+</Tabs>
+
+To find the saved photo file, connect to the glasses Wi-Fi hotspot and request the gallery list. Each photo includes `request_id`, `name`, `url`, `mime_type`, and `size`. Match on `request_id` to find your capture:
+
+```ts
+const gallery = await fetch(`${galleryBaseUrl}/api/gallery?limit=100`).then((res) => res.json());
+const savedPhoto = gallery.data.photos.find((p) => p.request_id === requestId);
+console.log('saved as', savedPhoto?.name, 'at', savedPhoto?.url);
+```
+
+<Warning>
+  The gallery server is only reachable over the glasses Wi-Fi hotspot. Connect the phone to that hotspot before querying `/api/gallery`.
+</Warning>
+
+### Action-Button Photo Defaults
+
 `setPhotoCaptureDefaults(...)` controls action-button photo defaults. Omitted fields leave the existing defaults unchanged. Pass `resetCaptureTuning: true` to restore the optional tuning fields to standard capture behavior; this does not change photo size unless you also pass `size`. If you include other fields in the same call, those fields become the new defaults after the reset.
 
 | Default field | Behavior |


### PR DESCRIPTION
Add a "Gallery Photo Request IDs" subsection to Camera And Streaming explaining how to obtain a capture's requestId in gallery mode: read it from photo_status events (source: "button") or set it yourself, then look the photo up on the glasses gallery server by request_id. Also add an "Action-Button Photo Defaults" heading for the setPhotoCaptureDefaults section so it gets its own nav entry.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to Mentra Live camera streaming guides with no runtime or API behavior changes.
> 
> **Overview**
> Adds a **Gallery Photo Request IDs** section under Gallery Mode in `camera-streaming.mdx`, explaining that gallery saves skip webhook upload so `requestId` must come from `photo_status` (filter `resolvedConfig.source === "button"`) or from `requestPhoto({ requestId, save: true, webhookUrl: null })`. Includes RN/Android/iOS listener examples, a `/api/gallery` lookup by `request_id`, and a warning that the gallery server is only on the glasses Wi-Fi hotspot.
> 
> Introduces an **Action-Button Photo Defaults** `###` heading ahead of the existing `setPhotoCaptureDefaults` table so that section gets its own doc nav entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5302ef51434e90ce6a8eb63d2a047b2e447520a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->