### PR TITLE
Fix Recorder playback and trailing audio cutoff

### DIFF
--- a/miniapps/recorder/src/background/controllers/RecorderController.test.ts
+++ b/miniapps/recorder/src/background/controllers/RecorderController.test.ts
@@ -1,0 +1,75 @@
+import {describe, expect, it, mock} from "bun:test"
+
+import {RecorderController} from "./RecorderController"
+
+function makeHarness(stopTailDrainMs = 0) {
+  const writes: Uint8Array[] = []
+  let audioHandler: ((data: {data: string; sampleRate?: number}) => void) | null = null
+  const writer = {
+    key: "rec-test",
+    write: mock(async (bytes: Uint8Array) => {
+      writes.push(bytes)
+    }),
+    writeAt: mock(async () => {}),
+    close: mock(async () => {}),
+    abort: mock(async () => {}),
+  }
+  const send = mock(() => {})
+  const speakerStop = mock(() => {})
+  const session = {
+    blob: {
+      createWriteStream: mock(async () => writer),
+      list: mock(async () => []),
+      usage: mock(async () => ({bytes: 0, count: 0, quotaBytes: 1024})),
+    },
+    mic: {
+      onAudioChunk: mock((handler: typeof audioHandler) => {
+        audioHandler = handler
+        return () => {}
+      }),
+    },
+    transcription: {on: mock(() => () => {})},
+    speaker: {stop: speakerStop},
+    display: {render: mock(async () => ({status: "rendered"}))},
+  }
+  const controller = new RecorderController(session as never, stopTailDrainMs)
+  ;(controller as unknown as {ui: {send: typeof send}}).ui = {send}
+
+  return {
+    controller: controller as unknown as {
+      startRecording(): Promise<void>
+      stopRecording(): Promise<void>
+      playingId: string | null
+    },
+    getAudioHandler: () => audioHandler,
+    send,
+    speakerStop,
+    writer,
+    writes,
+  }
+}
+
+describe("RecorderController recording edges", () => {
+  it("stops active playback before starting a recording", async () => {
+    const h = makeHarness()
+    h.controller.playingId = "old-recording"
+
+    await h.controller.startRecording()
+
+    expect(h.speakerStop).toHaveBeenCalledTimes(1)
+    expect(h.send).toHaveBeenCalledWith("rec:playback", {playingId: null})
+  })
+
+  it("accepts audio arriving during the stop tail-drain window", async () => {
+    const h = makeHarness(20)
+    await h.controller.startRecording()
+
+    const stopping = h.controller.stopRecording()
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    h.getAudioHandler()?.({data: "AQIDBA==", sampleRate: 16000})
+    await stopping
+
+    expect(h.writes.some((bytes) => Array.from(bytes).join(",") === "1,2,3,4")).toBe(true)
+    expect(h.writer.close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/miniapps/recorder/src/background/controllers/RecorderController.ts
+++ b/miniapps/recorder/src/background/controllers/RecorderController.ts
@@ -43,6 +43,13 @@ const WAV_SOFTWARE = "Mentra Recorder"
 const FLUSH_BYTES = 48 * 1024
 /** Throttle UI status pushes to ~5/sec (keyed off captured audio ms, not a timer). */
 const PROGRESS_MS = 200
+/**
+ * Keep accepting PCM briefly after the user taps stop. Glasses audio crosses
+ * BLE and two JS/native bridges, so the newest frames can still be in flight
+ * when the UI command reaches this controller. Unsubscribing immediately drops
+ * that tail even though it was spoken before the tap.
+ */
+const STOP_TAIL_DRAIN_MS = 1500
 
 export class RecorderController {
   private started = false
@@ -87,7 +94,10 @@ export class RecorderController {
   private recordings: RecordingItem[] = []
   private usage: Usage = EMPTY_USAGE
 
-  constructor(private readonly session: MiniappSession) {}
+  constructor(
+    private readonly session: MiniappSession,
+    private readonly stopTailDrainMs = STOP_TAIL_DRAIN_MS,
+  ) {}
 
   // ── Lifecycle ────────────────────────────────────────────────────────────
 
@@ -187,6 +197,9 @@ export class RecorderController {
 
   private async startRecording(): Promise<void> {
     if (this.recordingId || this.finalizing) return
+    // Recording and playback are mutually exclusive. Stop synchronously before
+    // opening the writer so no old clip keeps playing over the new capture.
+    this.stopPlay()
     try {
       // One timestamp drives the filename, the display title, and the WAV's
       // ICRD date tag so they all agree.
@@ -412,7 +425,10 @@ export class RecorderController {
     // (pcmBytes/sampleRate/buffers) while we flush + write the header.
     this.finalizing = true
     try {
-      // Stop the feeds first so no more chunks/transcript arrive, then finalize.
+      // Audio spoken just before the tap may still be crossing BLE/native
+      // bridges. Keep the subscriptions alive for a short tail-drain window so
+      // those frames land before we freeze and finalize the WAV.
+      await delay(this.stopTailDrainMs)
       try {
         this.micUnsub?.()
       } catch {
@@ -766,4 +782,8 @@ function fmtClock(ms: number): string {
   const m = Math.floor(s / 60)
   const r = s % 60
   return `${m}:${r.toString().padStart(2, "0")}`
+}
+
+function delay(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve()
 }


### PR DESCRIPTION
## Summary
Stop active playback before opening a new Recorder capture.
Preserve PCM frames still crossing BLE and native bridges by draining the audio tail for 1.5 seconds before finalizing the WAV, fixing recordings that lost their final spoken seconds.
Add regression coverage for playback interruption and in-flight tail audio.

## Validation
`bun test src/background/controllers/RecorderController.test.ts src/background/wav.test.ts`, `bun run build`, and `bun x tsc --noEmit -p tsconfig.json`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Recorder playback overlap and trailing audio cutoff so new recordings start clean and the final spoken seconds aren’t lost.

- **Bug Fixes**
  - Stop active playback before starting a new recording to prevent overlap.
  - Drain in-flight PCM for 1.5s on stop before unsubscribing and finalizing the WAV, capturing frames still crossing BLE/native bridges.
  - Add regression tests for playback interruption and tail-drain behavior.

<sup>Written for commit 5c0dfc6eb1cf3584a8eb12e8eccccec40b6af0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stop/finalize timing for every recording (adds ~1.5s before finalize) and capture/playback interaction; scope is limited to the Recorder miniapp controller.
> 
> **Overview**
> Fixes two Recorder capture bugs: **playback overlapping a new recording** and **lost audio at the end of a clip**.
> 
> **Start recording** now calls `stopPlay()` before opening the blob writer so an in-progress clip cannot keep playing over a new capture; the UI gets `rec:playback` with `playingId: null`.
> 
> **Stop recording** no longer tears down the mic (and transcription) immediately. It waits **1.5s** (`STOP_TAIL_DRAIN_MS`) so PCM still in flight over BLE/native bridges can land, then unsubscribes, drains buffers, and finalizes the WAV. `stopTailDrainMs` is constructor-injectable (default unchanged) for tests.
> 
> Adds **regression tests** for playback interruption and chunks accepted during the tail-drain window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c0dfc6eb1cf3584a8eb12e8eccccec40b6af0b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->