### PR TITLE
Checkpoint: Add iOS-compatible BLE photo fast path

### DIFF
--- a/agents/ble_file_transfer_implementation.md
+++ b/agents/ble_file_transfer_implementation.md
@@ -65,10 +65,15 @@ The implementation achieves remarkable speed (13KB in ~600ms) because:
 
 ### 3. BES ACK Index Behavior (MANDATORY)
 
-- BES sends `index = packet_index + 1`
-- For packet 0, BES sends index=1
-- For packet 1, BES sends index=2
-- This is NOT an error - it's the expected behavior
+BES response indices are asymmetric:
+
+- Success (`state=1`) is cumulative and sends the next expected index. For example,
+  `index=16` acknowledges packets 0 through 15, so the sender maps it to packet 15.
+- Failure (`state=0`) sends the exact zero-based packet BES still expects. For example,
+  `index=16` means resend packet 16; do not subtract one.
+
+Treating a failure index as one-based causes the sender to retry an already-ACKed packet,
+discard the failure as stale, and eventually time out every packet after the gap.
 
 ### 4. Phone-Side Changes Required in MentraLiveSGC.java
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -135,6 +135,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final long SIGNIFICANT_CHUNK_SEND_DURATION_MS = 250;
     private static final long SIGNIFICANT_CHUNK_SPACING_MS = PACING_DELAY_MS + 150;
     private int consecutiveFailures = 0;
+    private volatile int pendingFailureRetryIndex = -1;
+    private volatile boolean failureRetryScheduled = false;
     private final AtomicLong bleChunkTraceSequence = new AtomicLong(1);
 
     // ---- Runtime UART baud switch (cs_baud / sr_baud negotiation with the BES2700) ----
@@ -1796,6 +1798,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         currentFileTransfer = new FileTransferSession(filePath, fileName, fileData, effectiveUartPackSize());
         pendingPackets.clear();
         consecutiveFailures = 0; // Reset failure counter for new transfer
+        pendingFailureRetryIndex = -1;
+        failureRetryScheduled = false;
 
         Log.d(
                 TAG,
@@ -2066,15 +2070,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return;
         }
 
-        // BES uses 1-based ACK indexing for BOTH success and failure: it sends
-        // index = packet_index + 1 (see agents/ble_file_transfer_implementation.md, "BES ACK
-        // Index Behavior"). Convert to our 0-based packet index. On success this is the accepted
-        // packet; on failure it is the packet to resend.
-        // NOTE: a prior revision treated the failure index as already 0-based (retry = index),
-        // which skipped the failed packet and resent the next one, corrupting flow-control
-        // retries and truncating BLE photos.
-        int ackedPacketIndex = index - 1;
-        int retryPacketIndex = index - 1;
+        // BES response indices are intentionally asymmetric. A success is a cumulative
+        // "next expected" index, so index=16 acknowledges packets 0..15. A failure is the exact
+        // zero-based packet BES still expects, so state=0/index=16 must resend packet 16.
+        int ackedPacketIndex = BesWireFormat.fileAckPacketIndex(1, index);
+        int retryPacketIndex = BesWireFormat.fileAckPacketIndex(0, index);
         int trackedPacketIndex = state == 1 ? ackedPacketIndex : retryPacketIndex;
 
         // Calculate time since packet was sent
@@ -2113,6 +2113,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
             // Reset consecutive failure counter on success
             consecutiveFailures = 0;
+            if (pendingFailureRetryIndex >= 0
+                    && ackedPacketIndex >= pendingFailureRetryIndex) {
+                pendingFailureRetryIndex = -1;
+                failureRetryScheduled = false;
+            }
 
             // Advance the ack high-water mark and prune everything at or below it
             // (BES acks are sequential, so a higher ack implies the earlier packets landed)
@@ -2139,6 +2144,16 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 return;
             }
 
+            // One missing packet can make every later packet in the pushed window receive the
+            // same NAK. Coalesce that burst into one recovery so we do not hit the failure limit
+            // before the first retry has even run.
+            if (retryPacketIndex == pendingFailureRetryIndex && failureRetryScheduled) {
+                Log.d(TAG, "Coalescing duplicate failure ACK for packet " + retryPacketIndex);
+                return;
+            }
+
+            pendingFailureRetryIndex = retryPacketIndex;
+            failureRetryScheduled = true;
             consecutiveFailures++;
 
             // Check if we've hit the failure limit - BLE TX may be permanently stuck
@@ -2172,6 +2187,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 currentFileTransfer = null;
                 pendingPackets.clear();
                 consecutiveFailures = 0;
+                pendingFailureRetryIndex = -1;
+                failureRetryScheduled = false;
                 return;
             }
 
@@ -2193,11 +2210,19 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             + "ms");
 
             currentFileTransfer.currentPacketIndex = retryPacketIndex;
+            for (Integer pendingIndex : pendingPackets.keySet()) {
+                if (pendingIndex >= retryPacketIndex) {
+                    pendingPackets.remove(pendingIndex);
+                }
+            }
 
             // Add exponential backoff delay to let BES2700 drain its buffers
             fileTransferExecutor.schedule(
                     () -> {
-                        if (currentFileTransfer != null && currentFileTransfer.isActive) {
+                        if (currentFileTransfer != null
+                                && currentFileTransfer.isActive
+                                && pendingFailureRetryIndex == retryPacketIndex) {
+                            failureRetryScheduled = false;
                             Log.d(
                                     TAG,
                                     "📦 Retrying packet "

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -81,9 +81,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // 32 window). Firmware >= 17.26.7.6 has an 8KB RX buffer and acks every 8th pack
     // (batched), which needs a window comfortably above the batch interval.
     private static final int FILE_PUSH_WINDOW = 3;
-    // 17.26.7.7 firmware: 3.4KB UART RX ring (the HAL rejects single-descriptor
-    // DMA arms over 4095B and 7.7 armed the whole ring at once), acks every 4th
-    // pack - window 8 fits the ring and stays above the batch interval.
+    // Firmware >=17.26.7.14 keeps its 12KB circular DMA receiver armed across
+    // timeout boundaries. A 16-pack window keeps two complete eight-pack ACK
+    // batches in flight while remaining well inside the BES receive ring.
     private static final int FILE_PUSH_WINDOW_BATCHED = 8;
     private static final String MIN_BES_VERSION_FOR_BATCHED_ACKS = "17.26.7.7";
     // 17.26.7.8 firmware: 12KB UART RX ring (arms are margin-sized so the ring is
@@ -116,13 +116,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final boolean BIG_PACKS_ENABLED = false;
 
     /**
-     * Batched acks are DISABLED pending the same firmware burst-loss fix: with the
-     * window-12 blast the BES deterministically loses one early pack (pack 1 at 400B,
-     * pack 0 at 800B) and the reject/rewind interplay collapses throughput (~11KB/s,
-     * frequent packet_timeout aborts). Per-pack acks at window 3 are the
-     * hardware-validated 45-50KB/s configuration.
+     * Firmware 17.26.7.14 keeps circular UART DMA armed across receive timeouts, removing the
+     * re-arm gap that dropped early packets during push bursts. Use conservative 400-byte UART
+     * packets with a two-batch window; 800-byte packets remain independently
+     * disabled until this mode passes hardware stress testing.
      */
-    private static final boolean BATCHED_ACKS_ENABLED = false;
+    private static final boolean BATCHED_ACKS_ENABLED = true;
 
     private int effectiveUartPackSize() {
         if (BIG_PACKS_ENABLED

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormat.java
@@ -67,6 +67,15 @@ public class BesWireFormat {
     // (BES >= 17.26.7.6 then acks every 8th pack instead of each one).
     public static final int FILE_FLAG_PUSH_BATCH_ACK = 0x0001;
     private static int filePackSize = FILE_PACK_SIZE_DEFAULT; // Configurable packet size
+
+    /**
+     * Convert a BES file-transfer response index to the sender's zero-based packet index.
+     * Success responses are cumulative and carry the next expected index. Failure responses
+     * already carry the exact packet index BES needs retransmitted.
+     */
+    public static int fileAckPacketIndex(int state, int responseIndex) {
+        return state == 1 ? responseIndex - 1 : responseIndex;
+    }
     public static final int LENGTH_FILE_START = 2;
 
     /**

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormatTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/BesWireFormatTest.java
@@ -121,6 +121,12 @@ public class BesWireFormatTest {
     }
 
     @Test
+    public void fileAckPacketIndex_usesAsymmetricBesSemantics() {
+        assertThat(BesWireFormat.fileAckPacketIndex(1, 16)).isEqualTo(15);
+        assertThat(BesWireFormat.fileAckPacketIndex(0, 16)).isEqualTo(16);
+    }
+
+    @Test
     public void packJsonCommand_wrapsWithCField() {
         byte[] packed = BesWireFormat.packJsonCommand("{\"type\":\"ping\"}");
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -25,6 +25,7 @@ import android.content.pm.PackageManager
 import android.graphics.Bitmap
 import android.os.Build
 import android.os.Handler
+import android.os.HandlerThread
 import android.os.Looper
 import android.util.Log
 import androidx.core.app.ActivityCompat
@@ -99,6 +100,7 @@ class MentraLive : SGCManager() {
         // PSM. When the phone opens the channel, the glasses send file packets over it instead
         // of GATT FILE_READ notifications. Phone→glasses traffic stays on GATT.
         private const val L2CAP_FILE_PSM = 0x00C9
+        private const val FILE_PACKET_LOG_INTERVAL = 32
 
         // BLE UUIDs - updated to match K900 BES2800 MCU UUIDs for compatibility with both glass
         // types
@@ -242,6 +244,9 @@ class MentraLive : SGCManager() {
     private var lc3ReadCharacteristic: BluetoothGattCharacteristic? = null
     private var lc3WriteCharacteristic: BluetoothGattCharacteristic? = null
     private var handler = Handler(Looper.getMainLooper())
+    private val fileProcessingThread =
+            HandlerThread("MentraLive-FileProcessing").apply { start() }
+    private val fileProcessingHandler = Handler(fileProcessingThread.looper)
     private var scheduler: ScheduledExecutorService? = null
     private var isScanning = false
     private var isConnecting = false
@@ -321,7 +326,7 @@ class MentraLive : SGCManager() {
     private var activeFileTransfers = ConcurrentHashMap<String, FileTransferSession>()
 
     // BLE photo transfer tracking
-    private var blePhotoTransfers: MutableMap<String, BlePhotoTransfer> = HashMap()
+    private var blePhotoTransfers: MutableMap<String, BlePhotoTransfer> = ConcurrentHashMap()
 
     /** Expected incident log relay files from glasses (B… firmware, L… logcat). */
     private val bleIncidentLogRelays = ConcurrentHashMap<String, BleIncidentLogRelay>()
@@ -1440,6 +1445,15 @@ class MentraLive : SGCManager() {
         )
     }
 
+    private fun phyLabel(phy: Int): String {
+        return when (phy) {
+            BluetoothDevice.PHY_LE_1M -> "1M"
+            BluetoothDevice.PHY_LE_2M -> "2M"
+            BluetoothDevice.PHY_LE_CODED -> "coded"
+            else -> "unknown($phy)"
+        }
+    }
+
     /** GATT callback for BLE operations */
     private val gattCallback: BluetoothGattCallback =
             object : BluetoothGattCallback() {
@@ -1462,25 +1476,6 @@ class MentraLive : SGCManager() {
                             isConnecting = false
                             isConnected = true
                             connectedDevice = gatt.device
-
-                            // High-priority connection interval (~11-15ms vs 30-50ms
-                            // default) and 2M PHY, as MentraNex and G2 already do. The
-                            // BES firmware only *prefers* 2M PHY; the central has to
-                            // request the switch or the link stays on 1M.
-                            try {
-                                gatt.requestConnectionPriority(
-                                        BluetoothGatt.CONNECTION_PRIORITY_HIGH
-                                )
-                                gatt.setPreferredPhy(
-                                        BluetoothDevice.PHY_LE_2M_MASK,
-                                        BluetoothDevice.PHY_LE_2M_MASK,
-                                        BluetoothDevice.PHY_OPTION_NO_PREFERRED
-                                )
-                            } catch (e: SecurityException) {
-                                Bridge.log(
-                                        "LIVE: requestConnectionPriority/setPreferredPhy denied: ${e.message}"
-                                )
-                            }
 
                             DeviceStore.apply("glasses", "bluetoothName", connectedDevice!!.name)
                             // Persist MAC so reconnection can use direct GATT instead of scanning
@@ -1580,6 +1575,8 @@ class MentraLive : SGCManager() {
 
                             // Close the L2CAP file channel (if the fast path was open)
                             closeL2capFileChannel()
+                            fileProcessingHandler.removeCallbacksAndMessages(null)
+                            clearFilePacketBuffer()
 
                             // Clean up GATT resources
                             closeGattQuietly(false)
@@ -1635,6 +1632,8 @@ class MentraLive : SGCManager() {
 
                         // Close the L2CAP file channel (if the fast path was open)
                         closeL2capFileChannel()
+                        fileProcessingHandler.removeCallbacksAndMessages(null)
+                        clearFilePacketBuffer()
 
                         // Clean up resources
                         closeGattQuietly(false)
@@ -1645,6 +1644,38 @@ class MentraLive : SGCManager() {
                             handleReconnection()
                         }
                     }
+                }
+
+                override fun onPhyUpdate(
+                        gatt: BluetoothGatt,
+                        txPhy: Int,
+                        rxPhy: Int,
+                        status: Int
+                ) {
+                    Bridge.log(
+                            "LIVE: PHY update tx=" +
+                                    phyLabel(txPhy) +
+                                    ", rx=" +
+                                    phyLabel(rxPhy) +
+                                    ", status=" +
+                                    status
+                    )
+                }
+
+                override fun onPhyRead(
+                        gatt: BluetoothGatt,
+                        txPhy: Int,
+                        rxPhy: Int,
+                        status: Int
+                ) {
+                    Bridge.log(
+                            "LIVE: PHY read tx=" +
+                                    phyLabel(txPhy) +
+                                    ", rx=" +
+                                    phyLabel(rxPhy) +
+                                    ", status=" +
+                                    status
+                    )
                 }
 
                 override fun onServicesDiscovered(gatt: BluetoothGatt, status: Int) {
@@ -2631,18 +2662,6 @@ class MentraLive : SGCManager() {
         var iterations = 0
         val MAX_ITERATIONS = 100
 
-        // Debug: Log hex dump of first 40 bytes
-        val hexFirst = StringBuilder()
-        for (i in 0 until Math.min(40, filePacketBufferSize)) {
-            hexFirst.append(String.format("%02X ", filePacketBuffer[i]))
-        }
-        Bridge.log(
-                "LIVE: 📦 extractCompleteFilePackets: buffer has " +
-                        filePacketBufferSize +
-                        " bytes, first 40: " +
-                        hexFirst.toString()
-        )
-
         while (pos < filePacketBufferSize && iterations++ < MAX_ITERATIONS) {
             // Find start marker ## (0x23 0x23)
             var startPos = -1
@@ -2677,11 +2696,6 @@ class MentraLive : SGCManager() {
 
             // Need at least 5 bytes to read type and packSize: ## (2) + type (1) + packSize (2)
             if (filePacketBufferSize - pos < 5) {
-                Bridge.log(
-                        "LIVE: 📦 Not enough data for header, have " +
-                                (filePacketBufferSize - pos) +
-                                " bytes, need 5"
-                )
                 break
             }
 
@@ -2691,33 +2705,9 @@ class MentraLive : SGCManager() {
                     ((filePacketBuffer[packSizeOffset].toInt() and 0xFF) shl 8) or
                             (filePacketBuffer[packSizeOffset + 1].toInt() and 0xFF)
 
-            // Also try little-endian for comparison
-            val packSizeLE =
-                    (filePacketBuffer[packSizeOffset].toInt() and 0xFF) or
-                            ((filePacketBuffer[packSizeOffset + 1].toInt() and 0xFF) shl 8)
-            Bridge.log(
-                    "LIVE: 📦 Header bytes 3-4: 0x" +
-                            String.format(
-                                    "%02X%02X",
-                                    filePacketBuffer[packSizeOffset],
-                                    filePacketBuffer[packSizeOffset + 1]
-                            ) +
-                            " -> packSize BE=" +
-                            packSize +
-                            ", LE=" +
-                            packSizeLE
-            )
-
             // Validate packSize
             if (packSize < 0 || packSize > K900ProtocolUtils.FILE_PACK_SIZE) {
-                Log.w(
-                        TAG,
-                        "Invalid packSize " +
-                                packSize +
-                                " (LE would be " +
-                                packSizeLE +
-                                "), skipping start marker"
-                )
+                Log.w(TAG, "Invalid packSize $packSize, skipping start marker")
                 pos = startPos + 1
                 continue
             }
@@ -2730,42 +2720,13 @@ class MentraLive : SGCManager() {
             // Check if we have the complete packet
             val availableBytes = filePacketBufferSize - pos
             if (availableBytes < expectedPacketSize) {
-                // Not enough data yet, wait for more fragments
-                Bridge.log(
-                        "LIVE: 📦 Waiting for more data: have " +
-                                availableBytes +
-                                " of " +
-                                expectedPacketSize +
-                                " bytes (packSize=" +
-                                packSize +
-                                ")"
-                )
-                break // IMPORTANT: break here, don't continue looking for end marker
+                break
             }
 
             // Verify end marker $$ at expected position
             val endMarkerPos = pos + expectedPacketSize - 2
             val endByte1 = filePacketBuffer[endMarkerPos]
             val endByte2 = filePacketBuffer[endMarkerPos + 1]
-
-            // Debug: Show bytes around expected end marker position
-            val endContext = StringBuilder()
-            for (i in
-                    Math.max(0, endMarkerPos - 5)..Math.min(
-                                    filePacketBufferSize - 1,
-                                    endMarkerPos + 5
-                            )) {
-                if (i == endMarkerPos) endContext.append("[")
-                endContext.append(String.format("%02X", filePacketBuffer[i]))
-                if (i == endMarkerPos + 1) endContext.append("]")
-                endContext.append(" ")
-            }
-            Bridge.log(
-                    "LIVE: 📦 End marker check at pos " +
-                            endMarkerPos +
-                            ": " +
-                            endContext.toString()
-            )
 
             if (endByte1 != 0x24.toByte() || endByte2 != 0x24.toByte()) {
                 // End marker not found - could be corrupted packet or wrong packSize interpretation
@@ -2791,22 +2752,10 @@ class MentraLive : SGCManager() {
             val completePacket = ByteArray(expectedPacketSize)
             System.arraycopy(filePacketBuffer, pos, completePacket, 0, expectedPacketSize)
 
-            Bridge.log(
-                    "LIVE: 📦 ✅ Complete file packet reassembled: " + expectedPacketSize + " bytes"
-            )
-
             // Process the complete packet
             val packetInfo = K900ProtocolUtils.extractFilePacket(completePacket)
             if (packetInfo != null && packetInfo.isValid) {
-                Bridge.log(
-                        "LIVE: 📦 ✅ Packet validated: index=" +
-                                packetInfo.packIndex +
-                                ", fileName=" +
-                                packetInfo.fileName
-                )
-                // Post to handler to process outside the lock
-                val finalPacketInfo = packetInfo
-                handler.post { processFilePacket(finalPacketInfo) }
+                enqueueFilePacket(packetInfo)
             } else {
                 Log.e(TAG, "Failed to extract/validate reassembled file packet")
             }
@@ -2819,13 +2768,6 @@ class MentraLive : SGCManager() {
             val remaining = filePacketBufferSize - pos
             System.arraycopy(filePacketBuffer, pos, filePacketBuffer, 0, remaining)
             filePacketBufferSize = remaining
-            Bridge.log(
-                    "LIVE: 📦 Removed " +
-                            pos +
-                            " bytes, " +
-                            remaining +
-                            " bytes remaining in buffer"
-            )
         } else if (pos >= filePacketBufferSize) {
             filePacketBufferSize = 0
         }
@@ -2942,7 +2884,7 @@ class MentraLive : SGCManager() {
                 // structure
                 val packetInfo = K900ProtocolUtils.extractFilePacket(data)
                 if (packetInfo != null && packetInfo.isValid) {
-                    processFilePacket(packetInfo)
+                    enqueueFilePacket(packetInfo)
                 } else {
                     Log.e(TAG, "Thread-" + threadId + ": Failed to extract or validate file packet")
                     // BES chip handles ACKs automatically
@@ -6178,6 +6120,7 @@ class MentraLive : SGCManager() {
 
         // Cancel any pending handlers
         handler.removeCallbacksAndMessages(null)
+        fileProcessingHandler.removeCallbacksAndMessages(null)
         heartbeatHandler.removeCallbacksAndMessages(null)
         rssiReadHandler.removeCallbacksAndMessages(null)
         micBeatHandler.removeCallbacksAndMessages(null)
@@ -6209,6 +6152,7 @@ class MentraLive : SGCManager() {
 
         // Clear file packet reassembly buffer
         clearFilePacketBuffer()
+        fileProcessingThread.quitSafely()
 
         // Reset state variables
         reconnectAttempts = 0
@@ -8126,6 +8070,11 @@ class MentraLive : SGCManager() {
     // File Transfer Methods
     // ---------------------------------------
 
+    /** Keep file assembly ordered without blocking BLE callbacks or the Android main looper. */
+    private fun enqueueFilePacket(packetInfo: K900ProtocolUtils.FilePacketInfo) {
+        fileProcessingHandler.post { processFilePacket(packetInfo) }
+    }
+
     /** Process a received file packet */
     private fun processFilePacket(packetInfo: K900ProtocolUtils.FilePacketInfo) {
         // Calculate total packets based on actual pack size (not hardcoded FILE_PACK_SIZE)
@@ -8133,18 +8082,15 @@ class MentraLive : SGCManager() {
                 if (packetInfo.packSize > 0)
                         (packetInfo.fileSize + packetInfo.packSize - 1) / packetInfo.packSize
                 else 1
-        Bridge.log(
-                "LIVE: 📦 Processing file packet: " +
-                        packetInfo.fileName +
-                        " [" +
-                        packetInfo.packIndex +
-                        "/" +
-                        (totalPackets - 1) +
-                        "]" +
-                        " (" +
-                        packetInfo.packSize +
-                        " bytes)"
-        )
+        if (packetInfo.packIndex % FILE_PACKET_LOG_INTERVAL == 0 ||
+                        packetInfo.packIndex == totalPackets - 1
+        ) {
+            Log.d(
+                    TAG,
+                    "File transfer ${packetInfo.fileName}: " +
+                            "${packetInfo.packIndex + 1}/$totalPackets packets"
+            )
+        }
 
         // Check if this is a BLE photo transfer we're tracking
         // The filename might have an extension (.avif or .jpg), but we track by ID only
@@ -8153,8 +8099,6 @@ class MentraLive : SGCManager() {
         if (dotIndex > 0) {
             bleImgId = bleImgId.substring(0, dotIndex)
         }
-
-        Bridge.log("LIVE: 📦 BLE photo transfer packet for requestId: " + bleImgId)
 
         val incidentRelay = bleIncidentLogRelays[bleImgId]
         if (incidentRelay != null) {
@@ -8209,18 +8153,8 @@ class MentraLive : SGCManager() {
         }
 
         val photoTransfer = blePhotoTransfers[bleImgId]
-        Bridge.log(
-                "LIVE: 📦 BLE photo transfer for requestId: " +
-                        bleImgId +
-                        " found: " +
-                        (photoTransfer != null)
-        )
         if (photoTransfer != null) {
             // This is a BLE photo transfer
-            Bridge.log(
-                    "LIVE: 📦 BLE photo transfer packet for requestId: " + photoTransfer.requestId
-            )
-
             // Get or create session for this transfer
             if (photoTransfer.session == null) {
                 photoTransfer.session =
@@ -8332,13 +8266,6 @@ class MentraLive : SGCManager() {
         val added = session.addPacket(packetInfo.packIndex, packetInfo.data)
 
         if (added) {
-            // BES chip handles ACKs automatically
-            Bridge.log(
-                    "LIVE: 📦 Packet " +
-                            packetInfo.packIndex +
-                            " received successfully (BES will auto-ACK)"
-            )
-
             // Check completion when final packet arrives or transfer is complete
             if (session.shouldCheckCompletion(packetInfo.packIndex)) {
                 if (session.isComplete) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/K900ProtocolUtils.java
@@ -274,9 +274,6 @@ public class K900ProtocolUtils {
             return false;
         }
 
-        Log.d("K900ProtocolUtils", "isK900ProtocolFormat: " + data[0] + " " + data[1]);
-        Log.d("K900ProtocolUtils", "CMD_START_CODE: " + CMD_START_CODE[0] + " " + CMD_START_CODE[1]);
-        
         return data[0] == CMD_START_CODE[0] && 
                data[1] == CMD_START_CODE[1];
     }
@@ -792,7 +789,9 @@ public class K900ProtocolUtils {
             Log.e("K900ProtocolUtils", "File packet checksum failed. Expected: " +
                   String.format("%02X", info.verifyCode) + ", Calculated: " +
                   String.format("%02X", calculatedVerify));
-        } else {
+        } else if (info.packIndex == 0
+                || info.packIndex % 32 == 0
+                || info.packIndex == (info.fileSize + FILE_PACK_SIZE - 1) / FILE_PACK_SIZE - 1) {
             Log.d("K900ProtocolUtils", "File packet extracted successfully: index=" + info.packIndex +
                   ", size=" + info.packSize + ", fileName=" + info.fileName);
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -618,13 +618,21 @@ private enum K900ProtocolUtils {
             print(
                 "K900ProtocolUtils: File packet checksum failed. Expected: \(String(format: "%02X", info.verifyCode)), Calculated: \(String(format: "%02X", calculatedVerify))"
             )
-        } else {
+        } else if shouldLogFilePacket(info) {
             print(
                 "K900ProtocolUtils: File packet extracted successfully: index=\(info.packIndex), size=\(info.packSize), fileName=\(info.fileName)"
             )
         }
 
         return info
+    }
+
+    static func shouldLogFilePacket(_ info: FilePacketInfo) -> Bool {
+        let totalPackets =
+            (Int(info.fileSize) + FILE_PACK_SIZE - 1) / FILE_PACK_SIZE
+        return info.packIndex == 0
+            || info.packIndex % 32 == 0
+            || Int(info.packIndex) >= max(totalPackets - 1, 0)
     }
 }
 
@@ -921,6 +929,7 @@ extension MentraLive: CBCentralManagerDelegate {
             self.rgbLedAuthorityClaimed = false
 
             self.stopAllTimers()
+            self.closeL2capFileChannel()
 
             // Clean up characteristics
             self.txCharacteristic = nil
@@ -941,6 +950,7 @@ extension MentraLive: CBCentralManagerDelegate {
 
             self.stopConnectionTimeout()
             self.isConnecting = false
+            self.closeL2capFileChannel()
             self.connectedPeripheral = nil
             self.updateConnectionState(ConnTypes.DISCONNECTED)
 
@@ -1085,6 +1095,29 @@ extension MentraLive: CBPeripheralDelegate {
                 }
                 self.centralManager?.cancelPeripheralConnection(peripheral)
             }
+        }
+    }
+
+    nonisolated func peripheral(
+        _ peripheral: CBPeripheral, didOpen channel: CBL2CAPChannel?, error: Error?
+    ) {
+        let errorDescription = error?.localizedDescription
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.l2capFileChannelOpening = false
+
+            if let errorDescription {
+                Bridge.log(
+                    "LIVE: L2CAP: unavailable, staying on GATT (\(errorDescription))"
+                )
+                return
+            }
+            guard peripheral === self.connectedPeripheral, let channel else {
+                Bridge.log("LIVE: L2CAP: open completed for a stale connection")
+                return
+            }
+
+            self.attachL2capFileChannel(channel)
         }
     }
 
@@ -1328,6 +1361,7 @@ class MentraLive: NSObject, SGCManager {
     private let TX_CHAR_UUID = CBUUID(string: "000071FF-0000-1000-8000-00805f9b34fb") // Central transmits on peripheral's RX
     private let FILE_READ_UUID = CBUUID(string: "000072FF-0000-1000-8000-00805f9b34fb")
     private let FILE_WRITE_UUID = CBUUID(string: "000073FF-0000-1000-8000-00805f9b34fb")
+    private let L2CAP_FILE_PSM: CBL2CAPPSM = 0x00C9
 
     // LC3 Audio UUIDs (for K901+ devices with microphone support)
     private let LC3_READ_UUID = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
@@ -1341,6 +1375,9 @@ class MentraLive: NSObject, SGCManager {
     private var activeFileTransfers = [String: FileTransferSession]()
     private var blePhotoTransfers = [String: BlePhotoTransfer]()
     private var bleIncidentLogRelays = [String: BleIncidentLogRelayEntry]()
+    private var l2capFileChannel: MentraLiveL2capChannel?
+    private var l2capFileChannelId: UUID?
+    private var l2capFileChannelOpening = false
     private var rgbLedAuthorityClaimed = false
 
     // LC3 Audio properties
@@ -2067,6 +2104,56 @@ class MentraLive: NSObject, SGCManager {
         )
     }
 
+    // MARK: - L2CAP file channel
+
+    /// Open the BES file CoC. CoreBluetooth does not expose PHY or connection-priority
+    /// controls, so BES owns those link updates when this channel is established.
+    /// Any open failure leaves FILE_READ GATT notifications active as the fallback.
+    private func openL2capFileChannel() {
+        guard !l2capFileChannelOpening, l2capFileChannel == nil else { return }
+        guard let peripheral = connectedPeripheral else { return }
+
+        l2capFileChannelOpening = true
+        Bridge.log("LIVE: L2CAP: opening file channel (PSM 0xC9)")
+        peripheral.openL2CAPChannel(L2CAP_FILE_PSM)
+    }
+
+    private func attachL2capFileChannel(_ channel: CBL2CAPChannel) {
+        closeL2capFileChannel()
+
+        let channelId = UUID()
+        l2capFileChannelId = channelId
+        let reader = MentraLiveL2capChannel(
+            channel: channel,
+            onFileFrame: { [weak self] frame in
+                // The reader thread keeps draining the stream (and returning CoC credits)
+                // while the existing transfer state remains serialized on the main actor.
+                DispatchQueue.main.async {
+                    self?.processReceivedData(frame)
+                }
+            },
+            onClose: { [weak self] in
+                DispatchQueue.main.async {
+                    guard let self, self.l2capFileChannelId == channelId else { return }
+                    self.l2capFileChannel = nil
+                    self.l2capFileChannelId = nil
+                    Bridge.log("LIVE: L2CAP: channel closed; using GATT fallback")
+                }
+            }
+        )
+        l2capFileChannel = reader
+        reader.start()
+        Bridge.log("LIVE: L2CAP: channel open (PSM 0xC9)")
+    }
+
+    private func closeL2capFileChannel() {
+        l2capFileChannelOpening = false
+        l2capFileChannelId = nil
+        let reader = l2capFileChannel
+        l2capFileChannel = nil
+        reader?.close()
+    }
+
     // MARK: - Data Processing
 
     private func processReceivedData(_ data: Data) {
@@ -2105,10 +2192,6 @@ class MentraLive: NSObject, SGCManager {
             || commandType == K900ProtocolUtils.CMD_TYPE_AUDIO
             || commandType == K900ProtocolUtils.CMD_TYPE_DATA
         {
-            Bridge.log(
-                "📦 DETECTED FILE TRANSFER PACKET (type: 0x\(String(format: "%02X", commandType)))"
-            )
-
             // Debug: Log the raw data
             // let hexDump = data.prefix(64).map { String(format: "%02X ", $0) }.joined()
             // Bridge.log("📦 Raw file packet data length=\(data.count), first 64 bytes: \(hexDump)")
@@ -3020,6 +3103,7 @@ class MentraLive: NSObject, SGCManager {
         Bridge.log("LIVE: 🎉 Received glasses_ready message - SOC is booted and ready!")
 
         stopReadinessCheckLoop()
+        openL2capFileChannel()
         sendBleMtuConfig()
 
         // Invalidate any version fields from a prior link session so the next version_info
@@ -3336,7 +3420,9 @@ class MentraLive: NSObject, SGCManager {
         }
 
         if let incidentRelay = bleIncidentLogRelays[bleImgId] {
-            Bridge.log("LIVE: 📦 BLE incident log relay packet for: \(bleImgId)")
+            if K900ProtocolUtils.shouldLogFilePacket(packetInfo) {
+                Bridge.log("LIVE: 📦 BLE incident log relay packet for: \(bleImgId)")
+            }
 
             if incidentRelay.session == nil {
                 activeFileTransfers.removeValue(forKey: packetInfo.fileName)
@@ -3386,7 +3472,9 @@ class MentraLive: NSObject, SGCManager {
 
         if var photoTransfer = blePhotoTransfers[bleImgId] {
             // This is a BLE photo transfer
-            Bridge.log("📦 BLE photo transfer packet for requestId: \(photoTransfer.requestId)")
+            if K900ProtocolUtils.shouldLogFilePacket(packetInfo) {
+                Bridge.log("📦 BLE photo transfer packet for requestId: \(photoTransfer.requestId)")
+            }
 
             // Get or create session for this transfer
             if photoTransfer.session == nil {
@@ -3482,9 +3570,11 @@ class MentraLive: NSObject, SGCManager {
             activeFileTransfers[packetInfo.fileName] = sess
 
             if added {
-                Bridge.log(
-                    "LIVE: 📦 Packet \(packetInfo.packIndex) received successfully (BES will auto-ACK)"
-                )
+                if K900ProtocolUtils.shouldLogFilePacket(packetInfo) {
+                    Bridge.log(
+                        "LIVE: 📦 Packet \(packetInfo.packIndex) received successfully (BES will auto-ACK)"
+                    )
+                }
 
                 if sess.isComplete {
                     Bridge.log("LIVE: 📦 File transfer complete: \(packetInfo.fileName)")
@@ -4906,6 +4996,7 @@ class MentraLive: NSObject, SGCManager {
         peerK900Le = false
         peerWireCapsBinary = false
         BleJsonCompact.resetSession()
+        closeL2capFileChannel()
 
         // Disconnect BLE
         if let peripheral = connectedPeripheral {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLiveL2capChannel.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLiveL2capChannel.swift
@@ -1,0 +1,183 @@
+import CoreBluetooth
+import Foundation
+
+/// Read-only LE L2CAP CoC fast path for Mentra Live file transfers.
+///
+/// BES sends the same K900 file frames over this channel that it otherwise
+/// sends through the FILE_READ GATT characteristic. The stream is drained on
+/// a dedicated thread so CoreBluetooth credits are returned independently of
+/// React Native and main-thread work.
+final class MentraLiveL2capChannel: NSObject, StreamDelegate {
+    private static let readChunkSize = 4096
+    private static let maxBufferSize = 64 * 1024
+    private static let frameHeaderSize = 5
+    private static let frameOverhead = 32
+    private static let maxFilePayloadSize = 400
+
+    private let channel: CBL2CAPChannel
+    private let onFileFrame: (Data) -> Void
+    private let onClose: () -> Void
+    private let stateLock = NSLock()
+
+    private var receiveBuffer = [UInt8]()
+    private var worker: Thread?
+    private var closed = false
+    private var closeNotified = false
+
+    init(
+        channel: CBL2CAPChannel,
+        onFileFrame: @escaping (Data) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.channel = channel
+        self.onFileFrame = onFileFrame
+        self.onClose = onClose
+        super.init()
+    }
+
+    func start() {
+        guard worker == nil else { return }
+        let thread = Thread { [weak self] in
+            self?.runReadLoop()
+        }
+        thread.name = "MentraLive-L2CAP"
+        thread.qualityOfService = .userInitiated
+        worker = thread
+        thread.start()
+    }
+
+    func close() {
+        stateLock.lock()
+        let wasClosed = closed
+        closed = true
+        stateLock.unlock()
+
+        guard !wasClosed else { return }
+        channel.inputStream?.close()
+        channel.outputStream?.close()
+    }
+
+    private var isClosed: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return closed
+    }
+
+    private func runReadLoop() {
+        guard let input = channel.inputStream, let output = channel.outputStream else {
+            notifyClosed()
+            return
+        }
+
+        input.delegate = self
+        input.schedule(in: .current, forMode: .default)
+        output.schedule(in: .current, forMode: .default)
+        input.open()
+        output.open()
+
+        while !isClosed {
+            _ = RunLoop.current.run(mode: .default, before: Date(timeIntervalSinceNow: 0.1))
+        }
+
+        input.close()
+        output.close()
+        input.remove(from: .current, forMode: .default)
+        output.remove(from: .current, forMode: .default)
+        input.delegate = nil
+        notifyClosed()
+    }
+
+    func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
+        guard aStream === channel.inputStream else { return }
+
+        switch eventCode {
+        case .hasBytesAvailable:
+            drainInput()
+        case .endEncountered, .errorOccurred:
+            close()
+        default:
+            break
+        }
+    }
+
+    private func drainInput() {
+        guard let input = channel.inputStream else { return }
+        var chunk = [UInt8](repeating: 0, count: Self.readChunkSize)
+
+        while input.hasBytesAvailable, !isClosed {
+            let count = input.read(&chunk, maxLength: chunk.count)
+            if count > 0 {
+                appendAndDispatch(Array(chunk.prefix(count)))
+            } else if count < 0 {
+                close()
+                return
+            } else {
+                break
+            }
+        }
+    }
+
+    private func appendAndDispatch(_ bytes: [UInt8]) {
+        if receiveBuffer.count + bytes.count > Self.maxBufferSize {
+            receiveBuffer.removeAll(keepingCapacity: true)
+        }
+        guard bytes.count <= Self.maxBufferSize else { return }
+        receiveBuffer.append(contentsOf: bytes)
+
+        while true {
+            guard let start = startMarkerIndex() else {
+                if receiveBuffer.last == 0x23 {
+                    receiveBuffer = [0x23]
+                } else {
+                    receiveBuffer.removeAll(keepingCapacity: true)
+                }
+                return
+            }
+
+            if start > 0 {
+                receiveBuffer.removeFirst(start)
+            }
+            guard receiveBuffer.count >= Self.frameHeaderSize else { return }
+
+            let payloadSize = (Int(receiveBuffer[3]) << 8) | Int(receiveBuffer[4])
+            guard payloadSize <= Self.maxFilePayloadSize else {
+                receiveBuffer.removeFirst()
+                continue
+            }
+
+            let frameSize = Self.frameOverhead + payloadSize
+            guard receiveBuffer.count >= frameSize else { return }
+
+            guard receiveBuffer[frameSize - 2] == 0x24,
+                  receiveBuffer[frameSize - 1] == 0x24
+            else {
+                receiveBuffer.removeFirst()
+                continue
+            }
+
+            onFileFrame(Data(receiveBuffer.prefix(frameSize)))
+            receiveBuffer.removeFirst(frameSize)
+        }
+    }
+
+    private func startMarkerIndex() -> Int? {
+        guard receiveBuffer.count >= 2 else { return nil }
+        for index in 0 ..< (receiveBuffer.count - 1)
+            where receiveBuffer[index] == 0x23 && receiveBuffer[index + 1] == 0x23
+        {
+            return index
+        }
+        return nil
+    }
+
+    private func notifyClosed() {
+        stateLock.lock()
+        guard !closeNotified else {
+            stateLock.unlock()
+            return
+        }
+        closeNotified = true
+        stateLock.unlock()
+        onClose()
+    }
+}


### PR DESCRIPTION
## Checkpoint

This is a checkpoint PR for the validated BLE photo throughput work. Commit `a70fddad5c` captures the stable phone/ASG side before further BES UART cumulative-ACK experiments; the second commit adds the independently validated ACK recovery fix.

## What changed

- keep ASG batched ACK push mode at the hardware-validated 8-packet window with 400-byte packets and big packs disabled
- move Android file-frame parsing and transfer assembly off the main looper
- remove hot-path per-frame Android logging while retaining sampled transfer diagnostics
- add an iOS CoreBluetooth L2CAP CoC reader for BES PSM `0x00C9`
- drain the iOS CoC stream on a dedicated thread so flow-control credits do not depend on React Native/main-thread processing
- retain GATT file notifications as the automatic fallback when CoC is unavailable
- sample iOS file-frame logging instead of logging every 400-byte frame
- handle BES response indices correctly: success is cumulative/next-expected, while failure is the exact zero-based packet to resend
- coalesce repeated failure responses for the same missing packet into one recovery attempt
- discard pending timeout state at and above the retransmit point before refilling the sender window
- correct the BES ACK protocol documentation and add regression coverage for the asymmetric index mapping

## Why

iOS exposes no public PHY or connection-priority controls. The compatible design has BES initiate the 2M PHY and fast connection interval after the phone opens the CoC. Android was deliberately tested without its platform-specific PHY/priority requests to validate that architecture.

The earlier Android receive path also performed file work and heavy logging on latency-sensitive threads. Larger bursts could delay CoC reads/credit return and cause multi-second stalls.

## Validation

- Android app, with central-side PHY/priority requests removed: peripheral-initiated 2M confirmed and L2CAP CoC opened
- six consecutive medium BLE photos: 6/6 completed, no transfer retries or timeouts
- combined measured wire throughput: approximately 73.0 KiB/s; individual transfers approximately 68–77 KiB/s
- window-16 fault injection reproduced the previous state-0 deadlock; the corrected sender retransmitted the requested packet and completed successfully
- window A/B: window 16 recovered but averaged approximately 59.5 KiB/s; window 12 averaged approximately 72.6 KiB/s; window 8 remained the best stable setting
- BES cumulative-ACK A/B: batch 4 averaged approximately 67.7 KiB/s versus approximately 73.0 KiB/s for batch 8; experimental firmware was reverted and `17.26.7.16` restored
- ASG: `:app:testDebugUnitTest` and `:app:assembleDebug` passed
- Android Mentra App release build passed
- iOS `MentraBluetoothSDK` simulator build passed after CocoaPods integration
- BES firmware `17.26.7.16` build, image checks, hardware flash, and PR CI passed separately in `fengyue120/mentra-live-bes#6`

## Known follow-up

- validate the new CoreBluetooth CoC path on a physical iPhone
- retain window 8 / batch 8 unless a future UART/BLE scheduling change demonstrates a measurable improvement
- UART baud changes and 800-byte big packs are intentionally out of scope

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core BLE file-transfer flow control and re-enables batched push mode on ASG; iOS L2CAP is new and needs device validation, but failure paths retain GATT and ACK mapping fixes reduce transfer abort risk.
> 
> **Overview**
> Improves **BLE photo throughput** on Mentra Live by fixing glasses-side sender recovery, moving phone receive work off hot threads, and adding an **iOS L2CAP CoC** file path with GATT fallback.
> 
> **ASG (`K900BluetoothManager`)** re-enables **batched ACK push mode** (400-byte packs, window 8) for newer BES firmware and maps BES file ACK indices via `BesWireFormat.fileAckPacketIndex`: success is cumulative (next expected), failure is the exact zero-based packet to resend. Failure handling **coalesces duplicate NAKs** for one gap, clears in-flight pending state from the retransmit point, then retries with backoff—addressing push-window deadlocks from mis-parsed failure indices.
> 
> **Android SDK (`MentraLive.kt`)** parses and assembles file frames on a dedicated **`HandlerThread`**, trims per-packet logging to sampled progress, and drops explicit central **connection priority / 2M PHY** requests on GATT connect (PHY changes are logged only).
> 
> **iOS (`MentraLive.swift` + `MentraLiveL2capChannel`)** opens BES file **L2CAP PSM `0x00C9`** after `glasses_ready`, drains K900 frames on a background thread so CoC credits are not blocked by the main actor/RN, and falls back to **FILE_READ GATT** when CoC fails. Protocol utils on both platforms **sample** successful frame logs instead of logging every packet.
> 
> Docs and a **unit test** document and lock in the asymmetric ACK semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cceb1c744857a88c5637949f4ff2cc70891bd755. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->