### PR TITLE
Clean up camera settings copy and navigation

### DIFF
--- a/mobile/src/app/miniapps/settings/camera.tsx
+++ b/mobile/src/app/miniapps/settings/camera.tsx
@@ -29,7 +29,7 @@ const PHOTO_SIZE_OPTIONS = [
   {key: "low" as PhotoSize, label: "Low (960×720)"},
   {key: "medium" as PhotoSize, label: "Medium (1440×1088)"},
   {key: "high" as PhotoSize, label: "High (3264×2448)"},
-  {key: "max" as PhotoSize, label: "Max (camera maximum)"},
+  {key: "max" as PhotoSize, label: "Max (4032×3024)"},
 ]
 
 function normalizeButtonPhotoSize(value?: string): PhotoSize {
@@ -54,9 +54,9 @@ const VIDEO_RESOLUTION_OPTIONS = [
 ]
 
 const VIDEO_FPS_OPTIONS = [
-  {key: "30" as VideoFps, label: "30 fps", subtitle: "Smoothest motion"},
-  {key: "15" as VideoFps, label: "15 fps", subtitle: "Cooler, smaller files"},
-  {key: "5" as VideoFps, label: "5 fps", subtitle: "Coolest — best for long recordings"},
+  {key: "30" as VideoFps, label: "30 fps"},
+  {key: "15" as VideoFps, label: "15 fps"},
+  {key: "5" as VideoFps, label: "5 fps"},
 ]
 
 const MAX_RECORDING_TIME_OPTIONS = [
@@ -246,10 +246,7 @@ export default function CameraSettingsScreen() {
 
         <View style={themed($section)}>
           <Text style={themed($sectionTitle)}>Action Button Video Frame Rate</Text>
-          <Text style={themed($sectionSubtitle)}>
-            Lower frame rates keep the glasses cooler and produce smaller files — ideal for long recordings where smooth
-            motion isn&apos;t needed.
-          </Text>
+          <Text style={themed($sectionSubtitle)}>Choose how many frames are captured per second.</Text>
           <OptionList options={VIDEO_FPS_OPTIONS} selected={videoFps} onSelect={handleVideoFpsChange} />
         </View>
 

--- a/mobile/src/components/miniapp/offlineAppRegistry.ts
+++ b/mobile/src/components/miniapp/offlineAppRegistry.ts
@@ -10,12 +10,7 @@
  */
 import type {ComponentType} from "react"
 
-import {
-  cameraPackageName,
-  feedbackPackageName,
-  mirrorPackageName,
-  settingsPackageName,
-} from "@/constants/miniapps"
+import {cameraPackageName, feedbackPackageName, mirrorPackageName, settingsPackageName} from "@/constants/miniapps"
 import {OFFLINE_HOSTED_PACKAGES} from "./offlineHostedPackages"
 
 import GalleryScreen from "@/app/asg/gallery"
@@ -94,6 +89,7 @@ export const offlineAppRegistry: Record<string, OfflineAppDef> = {
     routes: {
       "/asg/gallery": GalleryScreen,
       "/asg/gallery-settings": GallerySettingsScreen,
+      "/miniapps/settings/camera": CameraSettings,
     },
   },
   [feedbackPackageName]: {


### PR DESCRIPTION
## What changed

- Show the concrete `4032×3024` resolution for the Max action-button photo option.
- Replace the video frame-rate helper text with a neutral description of frame rate.
- Remove descriptive subtitles from the 30, 15, and 5 fps options.
- Register Camera Settings in the Camera miniapp's internal route table.

## Why

The existing copy was inconsistent and overexplained the frame-rate choices. Camera Settings was also only registered to the Settings miniapp, so opening it from Gallery Settings was treated as external navigation: the Camera miniapp was minimized and Back returned to Home.

## Impact

Camera settings copy is shorter and clearer. Navigating from Camera → Gallery Settings → Camera Settings now stays within the Camera miniapp, so Back returns to Gallery Settings and then the Gallery.

## Validation

- `bun compile`
- `bunx eslint src/app/miniapps/settings/camera.tsx` (passes with three pre-existing warnings)
- `bunx eslint src/components/miniapp/offlineAppRegistry.ts`
- `bun test -- --runInBand src/__tests__/app/miniapps/settings/camera.test.tsx`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI tweaks plus a routing registration for an existing screen; no auth, data, or device-setting logic changes.
> 
> **Overview**
> **Camera settings** copy is tightened for consistency: the Max photo option now shows **4032×3024** like the other size labels, the frame-rate section uses a short neutral subtitle, and per-option fps subtitles about cooling and file size are removed. **No setting keys or handlers change.**
> 
> The **camera offline miniapp** registry now maps **`/miniapps/settings/camera`** so opening camera settings from gallery settings resolves on the offline host stack (same path as `push` from gallery settings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7a1ee596ecd86bffd581a90f0f8389ff3a833d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->