### PR TITLE
Add gallery media metadata sheet

### DIFF
--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -39,6 +39,7 @@
         "babel-plugin-module-resolver": "5.0.0",
         "date-fns": "^4.1.0",
         "dotenv": "^17.3.1",
+        "exifr": "^7.1.3",
         "expo": "~55.0.24",
         "expo-application": "~55.0.15",
         "expo-asset": "~55.0.17",
@@ -356,6 +357,7 @@
   "patchedDependencies": {
     "react-native-draggable-masonry@1.3.0": "patches/react-native-draggable-masonry@1.3.0.patch",
     "react-native-webview@13.16.0": "patches/react-native-webview@13.16.0.patch",
+    "react-native-awesome-gallery@0.4.3": "patches/react-native-awesome-gallery@0.4.3.patch",
     "react-native-inner-shadow@2.4.0": "patches/react-native-inner-shadow@2.4.0.patch",
   },
   "packages": {
@@ -1722,6 +1724,8 @@
     "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "exifr": ["exifr@7.1.3", "", {}, "sha512-g/aje2noHivrRSLbAUtBPWFbxKdKhgj/xr1vATDdUXPOFYJlQ62Ft0oy+72V6XLIpDJfHs6gXLbBLAolqOXYRw=="],
 
     "exit": ["exit@0.1.2", "", {}, "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="],
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -122,6 +122,7 @@
     "expo-task-manager": "~55.0.16",
     "expo-video": "~55.0.17",
     "expo-web-browser": "~55.0.16",
+    "exifr": "^7.1.3",
     "i18next": "^25.8.17",
     "intl-pluralrules": "^2.0.1",
     "lucide-react-native": "^0.553.0",
@@ -203,6 +204,7 @@
     }
   },
   "patchedDependencies": {
+    "react-native-awesome-gallery@0.4.3": "patches/react-native-awesome-gallery@0.4.3.patch",
     "react-native-draggable-masonry@1.3.0": "patches/react-native-draggable-masonry@1.3.0.patch",
     "react-native-executorch@0.7.2": "patches/react-native-executorch@0.7.2.patch",
     "expo-speech-transcriber@0.1.9": "patches/expo-speech-transcriber@0.1.9.patch",

--- a/mobile/patches/react-native-awesome-gallery@0.4.3.patch
+++ b/mobile/patches/react-native-awesome-gallery@0.4.3.patch
@@ -1,0 +1,21 @@
+diff --git a/src/index.tsx b/src/index.tsx
+index 38357aa..278d32f 100644
+--- a/src/index.tsx
++++ b/src/index.tsx
+@@ -519 +519 @@
+-          onTranslationYChange(Math.abs(ty), shouldClose.value);
++          onTranslationYChange(ty, shouldClose.value);
+diff --git a/lib/commonjs/index.js b/lib/commonjs/index.js
+index 38ff3dc..c02a5d3 100644
+--- a/lib/commonjs/index.js
++++ b/lib/commonjs/index.js
+@@ -431 +431 @@
+-        onTranslationYChange(Math.abs(ty), shouldClose.value);
++        onTranslationYChange(ty, shouldClose.value);
+diff --git a/lib/module/index.js b/lib/module/index.js
+index 07f595e..c3200c1 100644
+--- a/lib/module/index.js
++++ b/lib/module/index.js
+@@ -406 +406 @@
+-        onTranslationYChange(Math.abs(ty), shouldClose.value);
++        onTranslationYChange(ty, shouldClose.value);

--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
@@ -4,6 +4,7 @@
  */
 
 import Slider from "@react-native-community/slider"
+import BottomSheet from "@gorhom/bottom-sheet"
 import {Image} from "expo-image"
 import {useState, useRef, useEffect, useCallback, useMemo, memo, type ElementRef} from "react"
 // eslint-disable-next-line no-restricted-imports
@@ -12,10 +13,14 @@ import Gallery, {GalleryRef} from "react-native-awesome-gallery"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons"
 import Video from "react-native-video"
+import {scheduleOnRN} from "react-native-worklets"
 
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {ThemedStyle} from "@/theme"
 import {PhotoInfo} from "@/types/asg"
+
+import {MediaMetadataSheet} from "./MediaMetadataSheet"
+import {MediaDimensions} from "./mediaMetadata"
 
 // Screen dimensions are now obtained via useWindowDimensions() hook for rotation support
 
@@ -31,18 +36,25 @@ interface VideoPlayerItemProps {
   photo: PhotoInfo
   isActive: boolean
   onSeekingChange?: (seeking: boolean) => void
+  onDimensions: (dimensions: MediaDimensions) => void
 }
 
 interface ImageItemProps {
   photo: PhotoInfo
   setImageDimensions: (dimensions: {width: number; height: number}) => void
   isActive: boolean // Whether this is the currently visible image
+  onDimensions: (dimensions: MediaDimensions) => void
 }
 
 /**
  * Video player component for gallery items
  */
-const VideoPlayerItem = memo(function VideoPlayerItem({photo, isActive, onSeekingChange}: VideoPlayerItemProps) {
+const VideoPlayerItem = memo(function VideoPlayerItem({
+  photo,
+  isActive,
+  onSeekingChange,
+  onDimensions,
+}: VideoPlayerItemProps) {
   const {themed} = useAppTheme()
   const {width: screenWidth, height: screenHeight} = useWindowDimensions()
   const videoRef = useRef<ElementRef<typeof Video>>(null)
@@ -162,6 +174,7 @@ const VideoPlayerItem = memo(function VideoPlayerItem({photo, isActive, onSeekin
           setHasError(false)
           if (naturalSize?.width && naturalSize?.height && naturalSize.height > 0) {
             setVideoAspectRatio(naturalSize.width / naturalSize.height)
+            onDimensions({width: naturalSize.width, height: naturalSize.height})
           }
         }}
         onBuffer={({isBuffering: buffering}) => {
@@ -322,7 +335,12 @@ const VideoPlayerItem = memo(function VideoPlayerItem({photo, isActive, onSeekin
 /**
  * Image component for gallery items
  */
-const ImageItem = memo(function ImageItem({photo, setImageDimensions, isActive: _isActive}: ImageItemProps) {
+const ImageItem = memo(function ImageItem({
+  photo,
+  setImageDimensions,
+  isActive: _isActive,
+  onDimensions,
+}: ImageItemProps) {
   const {width: screenWidth, height: screenHeight} = useWindowDimensions()
   const hasReportedDimensions = useRef(false)
 
@@ -360,6 +378,7 @@ const ImageItem = memo(function ImageItem({photo, setImageDimensions, isActive: 
               width: e.source.width,
               height: e.source.height,
             })
+            onDimensions({width: e.source.width, height: e.source.height})
           }
         }}
       />
@@ -406,7 +425,11 @@ function CustomOverlay({onClose, currentIndex, total, onShare}: CustomOverlayPro
 export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, onShare}: AwesomeGalleryViewerProps) {
   const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [isVideoSeeking, setIsVideoSeeking] = useState(false)
+  const [isMetadataOpen, setIsMetadataOpen] = useState(false)
+  const [mediaDimensions, setMediaDimensions] = useState<Record<string, MediaDimensions>>({})
   const galleryRef = useRef<GalleryRef>(null)
+  const metadataSheetRef = useRef<BottomSheet>(null)
+  const verticalSwipeActionRef = useRef<"metadata" | null>(null)
 
   console.log("🎨 [AwesomeGalleryViewer] === RENDER START ===")
   console.log("🎨 [AwesomeGalleryViewer] visible:", visible)
@@ -422,12 +445,30 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
     if (visible) {
       console.log("🎨 [AwesomeGalleryViewer] Modal opened, setting index to:", initialIndex)
       setCurrentIndex(initialIndex)
+      setIsMetadataOpen(false)
+      verticalSwipeActionRef.current = null
+      metadataSheetRef.current?.close()
       // Reset gallery to initial position
       setTimeout(() => {
         galleryRef.current?.setIndex(initialIndex, false)
       }, 50)
     }
   }, [visible, initialIndex])
+
+  const recordDimensions = useCallback((name: string, dimensions: MediaDimensions) => {
+    setMediaDimensions((current) => {
+      const existing = current[name]
+      if (existing?.width === dimensions.width && existing.height === dimensions.height) return current
+      return {...current, [name]: dimensions}
+    })
+  }, [])
+
+  const handleVerticalSwipeThreshold = useCallback((translationY: number) => {
+    if (translationY >= 0 || verticalSwipeActionRef.current === "metadata") return
+    verticalSwipeActionRef.current = "metadata"
+    metadataSheetRef.current?.snapToIndex(0)
+    galleryRef.current?.reset(true)
+  }, [])
 
   // Memoized renderItem to prevent unnecessary re-renders of gallery items
   // Pass isActive to both videos and images for optimal loading
@@ -456,12 +497,26 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
       )
 
       if (isVideo) {
-        return <VideoPlayerItem photo={item} isActive={isActiveItem} onSeekingChange={setIsVideoSeeking} />
+        return (
+          <VideoPlayerItem
+            photo={item}
+            isActive={isActiveItem}
+            onSeekingChange={setIsVideoSeeking}
+            onDimensions={(dimensions) => recordDimensions(item.name, dimensions)}
+          />
+        )
       }
 
-      return <ImageItem photo={item} setImageDimensions={setImageDimensions} isActive={isActiveItem} />
+      return (
+        <ImageItem
+          photo={item}
+          setImageDimensions={setImageDimensions}
+          isActive={isActiveItem}
+          onDimensions={(dimensions) => recordDimensions(item.name, dimensions)}
+        />
+      )
     },
-    [currentIndex, setIsVideoSeeking],
+    [currentIndex, recordDimensions],
   )
 
   // Memoized keyExtractor
@@ -483,8 +538,22 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
           setCurrentIndex(newIndex)
         }}
         onSwipeToClose={() => {
+          if (verticalSwipeActionRef.current === "metadata") {
+            verticalSwipeActionRef.current = null
+            galleryRef.current?.reset(true)
+            return
+          }
           console.log("🎨 [AwesomeGalleryViewer] Swipe to close triggered")
           onClose()
+        }}
+        onPanStart={() => {
+          verticalSwipeActionRef.current = null
+        }}
+        onTranslationYChange={(translationY, shouldClose) => {
+          "worklet"
+          // Open before the gallery's close threshold so the JS-side action is
+          // recorded before onSwipeToClose runs at the end of a fast upward flick.
+          if (translationY < -40 || shouldClose) scheduleOnRN(handleVerticalSwipeThreshold, translationY)
         }}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
@@ -493,9 +562,9 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
         maxScale={3}
         doubleTapScale={2}
         pinchEnabled={true}
-        swipeEnabled={!isVideoSeeking}
+        swipeEnabled={!isVideoSeeking && !isMetadataOpen}
         doubleTapEnabled={true}
-        disableVerticalSwipe={true}
+        disableVerticalSwipe={isMetadataOpen}
         disableTransitionOnScaledImage={true}
         loop={false}
         onTap={() => {
@@ -509,6 +578,23 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
         currentIndex={currentIndex}
         total={photos.length}
         onShare={onShare ? () => onShare(photos[currentIndex]) : undefined}
+      />
+
+      {!isMetadataOpen && (
+        <View style={$metadataHint} pointerEvents="none">
+          <MaterialCommunityIcons name="chevron-up" size={20} color="rgba(255,255,255,0.78)" />
+          <Text style={$metadataHintText}>Swipe up for details</Text>
+        </View>
+      )}
+
+      <MediaMetadataSheet
+        bottomSheetRef={metadataSheetRef}
+        photo={photos[currentIndex]}
+        dimensions={mediaDimensions[photos[currentIndex].name]}
+        onChange={(index) => {
+          setIsMetadataOpen(index >= 0)
+          if (index < 0) verticalSwipeActionRef.current = null
+        }}
       />
     </Modal>
   )
@@ -545,6 +631,21 @@ const $counterText: ThemedStyle<any> = ({spacing}) => ({
   fontWeight: "600",
   marginLeft: spacing.s3,
 })
+
+const $metadataHint = {
+  position: "absolute" as const,
+  bottom: 24,
+  left: 0,
+  right: 0,
+  alignItems: "center" as const,
+  zIndex: 90,
+}
+
+const $metadataHintText = {
+  color: "rgba(255,255,255,0.78)",
+  fontSize: 12,
+  fontWeight: "500" as const,
+}
 
 // Video player styles (dynamic dimensions now inlined via useWindowDimensions)
 

--- a/mobile/src/components/glasses/Gallery/MediaMetadataSheet.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaMetadataSheet.tsx
@@ -1,0 +1,156 @@
+import BottomSheet, {BottomSheetBackdrop, BottomSheetScrollView} from "@gorhom/bottom-sheet"
+import {useCallback, useEffect, useMemo, useState} from "react"
+import {ActivityIndicator, View} from "react-native"
+import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons"
+
+import {Text} from "@/components/ignite"
+import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {PhotoInfo} from "@/types/asg"
+
+import {loadMediaMetadata, LoadedMediaMetadata} from "./loadMediaMetadata"
+import {buildMediaDetails, flattenExifMetadata, MediaDimensions, MetadataRow} from "./mediaMetadata"
+
+interface MediaMetadataSheetProps {
+  bottomSheetRef: React.RefObject<BottomSheet | null>
+  photo: PhotoInfo
+  dimensions?: MediaDimensions
+  onChange: (index: number) => void
+}
+
+function MetadataRows({rows}: {rows: MetadataRow[]}) {
+  const {theme} = useAppTheme()
+
+  return (
+    <View>
+      {rows.map((row, index) => (
+        <View
+          key={`${row.label}-${index}`}
+          style={{
+            flexDirection: "row",
+            gap: 16,
+            paddingVertical: 12,
+            borderBottomWidth: index === rows.length - 1 ? 0 : 1,
+            borderBottomColor: theme.colors.border,
+          }}>
+          <Text style={{width: 118, color: theme.colors.muted_foreground, fontSize: 14}}>{row.label}</Text>
+          <Text selectable style={{flex: 1, color: theme.colors.foreground, fontSize: 14, lineHeight: 20}}>
+            {row.value}
+          </Text>
+        </View>
+      ))}
+    </View>
+  )
+}
+
+export function MediaMetadataSheet({bottomSheetRef, photo, dimensions, onChange}: MediaMetadataSheetProps) {
+  const {theme} = useAppTheme()
+  const insets = useSaferAreaInsets()
+  const snapPoints = useMemo(() => ["62%", "92%"], [])
+  const [loaded, setLoaded] = useState<LoadedMediaMetadata | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [hasOpened, setHasOpened] = useState(false)
+
+  useEffect(() => {
+    setLoaded(null)
+    setHasOpened(false)
+    setIsLoading(false)
+  }, [photo.name])
+
+  useEffect(() => {
+    if (!hasOpened || loaded) return
+
+    let cancelled = false
+    setIsLoading(true)
+    void loadMediaMetadata(photo)
+      .then((metadata) => {
+        if (!cancelled) setLoaded(metadata)
+      })
+      .catch((error) => {
+        console.warn(`[GalleryMetadata] Could not load metadata for ${photo.name}:`, error)
+        if (!cancelled) setLoaded({exif: null})
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [hasOpened, loaded, photo])
+
+  const handleChange = useCallback(
+    (index: number) => {
+      if (index >= 0) setHasOpened(true)
+      onChange(index)
+    },
+    [onChange],
+  )
+
+  const renderBackdrop = useCallback(
+    (props: any) => (
+      <BottomSheetBackdrop {...props} appearsOnIndex={0} disappearsOnIndex={-1} opacity={0.45} pressBehavior="close" />
+    ),
+    [],
+  )
+
+  const details = buildMediaDetails(photo, dimensions, loaded?.actualSize)
+  const exifRows = flattenExifMetadata(loaded?.exif)
+
+  return (
+    <BottomSheet
+      ref={bottomSheetRef}
+      index={-1}
+      snapPoints={snapPoints}
+      enableDynamicSizing={false}
+      enablePanDownToClose
+      backdropComponent={renderBackdrop}
+      onChange={handleChange}
+      style={{zIndex: 200}}
+      backgroundStyle={{backgroundColor: theme.colors.background}}
+      handleIndicatorStyle={{backgroundColor: theme.colors.muted_foreground, width: 48}}>
+      <BottomSheetScrollView contentContainerStyle={{paddingHorizontal: 24, paddingBottom: insets.bottom + 32}}>
+        <View style={{flexDirection: "row", alignItems: "center", gap: 12, marginBottom: 18}}>
+          <View
+            style={{
+              width: 42,
+              height: 42,
+              borderRadius: 21,
+              alignItems: "center",
+              justifyContent: "center",
+              backgroundColor: theme.colors.primary_foreground,
+            }}>
+            <MaterialCommunityIcons
+              name={photo.is_video ? "video-outline" : "image-outline"}
+              size={22}
+              color={theme.colors.foreground}
+            />
+          </View>
+          <View style={{flex: 1}}>
+            <Text style={{color: theme.colors.foreground, fontSize: 20, fontWeight: "700"}}>Media details</Text>
+            <Text numberOfLines={1} style={{color: theme.colors.muted_foreground, fontSize: 13, marginTop: 2}}>
+              {photo.name}
+            </Text>
+          </View>
+        </View>
+
+        <MetadataRows rows={details} />
+
+        <Text style={{color: theme.colors.foreground, fontSize: 17, fontWeight: "700", marginTop: 28, marginBottom: 4}}>
+          EXIF metadata
+        </Text>
+        {isLoading ? (
+          <View style={{flexDirection: "row", alignItems: "center", gap: 10, paddingVertical: 18}}>
+            <ActivityIndicator color={theme.colors.foreground} />
+            <Text style={{color: theme.colors.muted_foreground}}>Reading original file…</Text>
+          </View>
+        ) : exifRows.length > 0 ? (
+          <MetadataRows rows={exifRows} />
+        ) : (
+          <Text style={{color: theme.colors.muted_foreground, fontSize: 14, paddingVertical: 14}}>
+            {photo.is_video ? "EXIF data is not available for videos." : "No EXIF metadata found in this file."}
+          </Text>
+        )}
+      </BottomSheetScrollView>
+    </BottomSheet>
+  )
+}

--- a/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
+++ b/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
@@ -1,0 +1,46 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+import {parse} from "exifr"
+
+import {PhotoInfo} from "@/types/asg"
+
+export interface LoadedMediaMetadata {
+  actualSize?: number
+  exif: Record<string, unknown> | null
+}
+
+function getLocalFilePath(photo: PhotoInfo): string | null {
+  const uri = photo.filePath || photo.download || photo.url
+  if (!uri || (!uri.startsWith("/") && !uri.startsWith("file://"))) return null
+  const path = uri.replace(/^file:\/\//, "")
+  try {
+    return decodeURIComponent(path)
+  } catch {
+    return path
+  }
+}
+
+export async function loadMediaMetadata(photo: PhotoInfo): Promise<LoadedMediaMetadata> {
+  const path = getLocalFilePath(photo)
+  if (!path) return {exif: null}
+
+  let actualSize: number | undefined
+  try {
+    actualSize = Number((await RNFS.stat(path)).size)
+  } catch (error) {
+    console.warn(`[GalleryMetadata] Could not stat ${photo.name}:`, error)
+  }
+
+  if (photo.is_video || photo.mime_type?.startsWith("video/")) return {actualSize, exif: null}
+
+  try {
+    const base64 = await RNFS.readFile(path, "base64")
+    const mimeType = photo.mime_type?.startsWith("image/") ? photo.mime_type : "image/jpeg"
+    const exif = await parse(`data:${mimeType};base64,${base64}`)
+    return {actualSize, exif: exif && typeof exif === "object" ? (exif as Record<string, unknown>) : null}
+  } catch (error) {
+    // A valid image often has no EXIF block. Keep the core file details usable
+    // and treat parser failures as an empty EXIF section.
+    console.info(`[GalleryMetadata] No readable EXIF metadata for ${photo.name}:`, error)
+    return {actualSize, exif: null}
+  }
+}

--- a/mobile/src/components/glasses/Gallery/mediaMetadata.test.ts
+++ b/mobile/src/components/glasses/Gallery/mediaMetadata.test.ts
@@ -1,0 +1,52 @@
+import {buildMediaDetails, flattenExifMetadata, formatFileSize, formatMediaDuration} from "./mediaMetadata"
+
+describe("gallery media metadata", () => {
+  it("formats file sizes and video durations", () => {
+    expect(formatFileSize(512)).toBe("512 B")
+    expect(formatFileSize(1_572_864)).toBe("1.50 MB")
+    expect(formatMediaDuration(65_000)).toBe("1:05")
+    expect(formatMediaDuration(3_665_000)).toBe("1:01:05")
+  })
+
+  it("builds the core details available for every gallery item", () => {
+    const rows = buildMediaDetails(
+      {
+        name: "capture/IMG_123.jpg",
+        url: "file:///photos/IMG_123.jpg",
+        download: "file:///photos/IMG_123.jpg",
+        filePath: "/photos/IMG_123.jpg",
+        size: 1000,
+        modified: "2026-01-01T12:00:00.000Z",
+        mime_type: "image/jpeg",
+        glassesModel: "Mentra Live",
+      },
+      {width: 4032, height: 3024},
+      2048,
+    )
+
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        {label: "Filename", value: "IMG_123.jpg"},
+        {label: "Resolution", value: "4032 × 3024"},
+        {label: "File size", value: "2.00 KB"},
+        {label: "Captured with", value: "Mentra Live"},
+      ]),
+    )
+  })
+
+  it("shows scalar EXIF fields while omitting binary payloads", () => {
+    expect(
+      flattenExifMetadata({
+        Make: "Mentra",
+        FNumber: 2.8,
+        GPSLatitude: [37, 46, 30],
+        MakerNote: new Uint8Array([1, 2, 3]),
+        Empty: undefined,
+      }),
+    ).toEqual([
+      {label: "FNumber", value: "2.8"},
+      {label: "GPSLatitude", value: "37, 46, 30"},
+      {label: "Make", value: "Mentra"},
+    ])
+  })
+})

--- a/mobile/src/components/glasses/Gallery/mediaMetadata.ts
+++ b/mobile/src/components/glasses/Gallery/mediaMetadata.ts
@@ -1,0 +1,98 @@
+import {PhotoInfo} from "@/types/asg"
+
+export interface MediaDimensions {
+  width: number
+  height: number
+}
+
+export interface MetadataRow {
+  label: string
+  value: string
+}
+
+const BINARY_EXIF_FIELDS = new Set(["MakerNote", "UserComment", "thumbnail", "Thumbnail", "image"])
+
+export function formatFileSize(bytes?: number): string {
+  if (bytes == null || !Number.isFinite(bytes) || bytes < 0) return "Unknown"
+  if (bytes < 1024) return `${bytes} B`
+
+  const units = ["KB", "MB", "GB"]
+  let value = bytes / 1024
+  let unitIndex = 0
+  while (value >= 1024 && unitIndex < units.length - 1) {
+    value /= 1024
+    unitIndex += 1
+  }
+  return `${value >= 10 ? value.toFixed(1) : value.toFixed(2)} ${units[unitIndex]}`
+}
+
+export function formatMediaDuration(milliseconds?: number): string | null {
+  if (milliseconds == null || !Number.isFinite(milliseconds) || milliseconds < 0) return null
+  const totalSeconds = Math.round(milliseconds / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+  return hours > 0
+    ? `${hours}:${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`
+    : `${minutes}:${seconds.toString().padStart(2, "0")}`
+}
+
+export function formatMediaDate(value?: string | number): string | null {
+  if (value == null) return null
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toLocaleString()
+}
+
+export function getMediaFilename(photo: PhotoInfo): string {
+  const path = photo.filePath || photo.download || photo.url
+  const pathFilename = path?.split(/[\\/]/).pop()?.split("?")[0]
+  return pathFilename || photo.name.split(/[\\/]/).pop() || photo.name
+}
+
+function humanizeExifLabel(key: string): string {
+  return key
+    .replace(/([a-z\d])([A-Z])/g, "$1 $2")
+    .replace(/_/g, " ")
+    .replace(/^./, (letter) => letter.toUpperCase())
+}
+
+function stringifyExifValue(value: unknown): string | null {
+  if (value == null) return null
+  if (value instanceof Date) return value.toLocaleString()
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    const text = String(value).trim()
+    return text.length > 0 ? text : null
+  }
+  if (Array.isArray(value)) {
+    const values = value.map(stringifyExifValue).filter((item): item is string => item != null)
+    return values.length > 0 ? values.join(", ") : null
+  }
+  return null
+}
+
+export function flattenExifMetadata(exif: Record<string, unknown> | null | undefined): MetadataRow[] {
+  if (!exif) return []
+
+  return Object.entries(exif)
+    .filter(([key]) => !BINARY_EXIF_FIELDS.has(key))
+    .map(([key, value]) => ({label: humanizeExifLabel(key), value: stringifyExifValue(value)}))
+    .filter((row): row is MetadataRow => row.value != null)
+    .sort((a, b) => a.label.localeCompare(b.label))
+}
+
+export function buildMediaDetails(photo: PhotoInfo, dimensions?: MediaDimensions, actualSize?: number): MetadataRow[] {
+  const rows: Array<MetadataRow | null> = [
+    {label: "Filename", value: getMediaFilename(photo)},
+    {label: "Media type", value: photo.mime_type || (photo.is_video ? "video/mp4" : "image/jpeg")},
+    dimensions ? {label: "Resolution", value: `${dimensions.width} × ${dimensions.height}`} : null,
+    {label: "File size", value: formatFileSize(actualSize ?? photo.size)},
+    formatMediaDate(photo.modified) ? {label: "Captured", value: formatMediaDate(photo.modified)!} : null,
+    photo.downloaded_at && formatMediaDate(photo.downloaded_at)
+      ? {label: "Downloaded", value: formatMediaDate(photo.downloaded_at)!}
+      : null,
+    photo.glassesModel ? {label: "Captured with", value: photo.glassesModel} : null,
+    formatMediaDuration(photo.duration) ? {label: "Duration", value: formatMediaDuration(photo.duration)!} : null,
+  ]
+
+  return rows.filter((row): row is MetadataRow => row != null)
+}


### PR DESCRIPTION
## Summary

- open a media details bottom sheet when the user swipes up in the fullscreen Mentra Gallery viewer
- show filename, MIME type, resolution, actual file size, capture/download timestamps, glasses model, and video duration when available
- lazily read and display scalar EXIF fields from original local photos without adding work to gallery loading or playback
- preserve swipe-down-to-close, horizontal paging, zoom, video seeking, and sheet drag-to-dismiss behavior

## Implementation notes

- Adds a small Bun patch for `react-native-awesome-gallery` so its vertical translation callback preserves direction; upstream currently applies `Math.abs`, which otherwise makes swipe-up indistinguishable from swipe-down.
- Binary EXIF payloads such as maker notes and thumbnails are intentionally omitted from the UI, while readable scalar and array fields are displayed.
- Videos show container/player metadata available to the app; EXIF parsing is photo-only.

## Validation

- `cd mobile && bun install --frozen-lockfile --ignore-scripts`
- `cd mobile && bun run compile`
- `cd mobile && bun run test -- --runInBand src/components/glasses/Gallery/mediaMetadata.test.ts`
- targeted ESLint on all touched TypeScript files (no errors; existing inline-style warning class only)
- `git diff --check`

## Manual verification

- Open Mentra Gallery, select a photo, and swipe up to confirm the details sheet opens and EXIF fields load.
- Repeat with a video and confirm resolution/duration display, playback controls still work, and swiping down closes the viewer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a swipe-up media details bottom sheet to the fullscreen Mentra Gallery viewer, showing core info and lazy-loaded EXIF for photos. Patches `react-native-awesome-gallery` to preserve vertical swipe direction while keeping existing gestures and playback intact.

- New Features
  - Swipe up to open details; drag or swipe down to dismiss.
  - Shows filename, MIME type, resolution, file size (actual when available), captured/downloaded dates, glasses model, and video duration.
  - Lazily reads EXIF from local photo files using `exifr`; omits binary payloads (e.g., maker notes, thumbnails).
  - Maintains horizontal paging, zoom, swipe-to-close, and video seeking; disables vertical swipe only while the sheet is open.
  - Adds a small in-view hint: “Swipe up for details.”
  - Unit tests cover size/duration formatting and EXIF filtering.

- Dependencies
  - Added `exifr@^7.1.3` for EXIF parsing.
  - Patched `react-native-awesome-gallery@0.4.3` to pass signed `translationY` to `onTranslationYChange` (enables detecting swipe-up vs swipe-down).

<sup>Written for commit cb53934cd5d3a2245d69b213d5c2b39beff7f787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Gallery UI and local-file metadata reads only; main risk is gesture edge cases from the patched third-party gallery dependency.
> 
> **Overview**
> The fullscreen **Mentra Gallery** viewer now supports **swipe up** to open a **media details** bottom sheet, with a small on-screen hint. The sheet shows filename, MIME type, resolution (from image/video load), file size (preferring on-disk `stat` when local), capture/download times, glasses model, and video duration; **EXIF** for photos is loaded **lazily** after the sheet opens via **`exifr`** on the local file, with binary EXIF fields filtered out.
> 
> **`AwesomeGalleryViewer`** wires vertical pan handling through **`onTranslationYChange`** (worklet → **`scheduleOnRN`**) so upward swipes open the sheet before swipe-to-close fires; **`onSwipeToClose`** is suppressed when the metadata action was taken. While the sheet is open, horizontal swipe and vertical gallery dismiss are constrained so paging, zoom, and video seeking stay usable when closed.
> 
> A **Bun patch** on **`react-native-awesome-gallery`** stops using **`Math.abs`** on vertical translation so swipe-up vs swipe-down can be distinguished. New helpers (**`mediaMetadata`**, **`loadMediaMetadata`**, **`MediaMetadataSheet`**) and unit tests cover formatting and EXIF row building.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb53934cd5d3a2245d69b213d5c2b39beff7f787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->