### PR TITLE
Fix Mentra Live video settings sync and report lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ Bug reports and feedback filed from the Mentra App land in the Cloud V2 reports 
 1. Get the report id (from Slack, the admin console, or the user)
 2. Fetch it: `./scripts/fetch-incident-logs.sh {reportId}` — downloads `report.json` plus every artifact into `./incident-logs/{reportId}/`
 3. Requires `MENTRA_ADMIN_TOKEN` in your environment: an org API key (`msk_...`) whose synthetic email is allowlisted via `CLOUD_CORE_ADMIN_EMAILS`, or a WorkOS access token of an admin user
-4. Defaults to prod; use `--env dev|staging` or `MENTRA_CORE_URL` for other environments
+4. Without an environment override, the script tries prod, dev, then staging and reports which backend succeeded. Use `--env prod|dev|staging` or `MENTRA_CORE_URL` to target one backend explicitly.
 
 What you get:
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceStore.kt
@@ -292,6 +292,11 @@ object DeviceStore {
             "bluetooth" to "camera_fov" -> {
                 DeviceManager.getInstance().sgc?.sendCameraFovSetting()
             }
+            "bluetooth" to "button_video_settings" -> {
+                DeviceManager.getInstance().sgc?.sendButtonVideoRecordingSettings()
+            }
+            // Legacy scalar keys remain supported for older hosts. New code should write the
+            // canonical button_video_settings object so width/height/fps update atomically.
             "bluetooth" to "button_video_width",
             "bluetooth" to "button_video_height",
             "bluetooth" to "button_video_fps" -> {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -534,6 +534,12 @@ class MentraBluetoothSdk private constructor(
         performSettingsCommand(
             setting = "button_video_recording",
             updateStore = { _ ->
+                DeviceStore.set(
+                    ObservableStore.BLUETOOTH_CATEGORY,
+                    "button_video_settings",
+                    mapOf("width" to defaults.width, "height" to defaults.height, "fps" to defaults.fps),
+                )
+                // Keep legacy cache keys readable for older internal callers during migration.
                 DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_width", defaults.width)
                 DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_height", defaults.height)
                 DeviceStore.set(ObservableStore.BLUETOOTH_CATEGORY, "button_video_fps", defaults.fps)

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceStore.swift
@@ -263,6 +263,11 @@ class DeviceStore {
         case ("bluetooth", "camera_fov"):
             DeviceManager.shared.sgc?.sendCameraFovSetting()
 
+        case ("bluetooth", "button_video_settings"):
+            DeviceManager.shared.sgc?.sendButtonVideoRecordingSettings()
+
+        // Legacy scalar keys remain supported for older hosts. New code should write the
+        // canonical button_video_settings object so width/height/fps update atomically.
         case ("bluetooth", "button_video_width"), ("bluetooth", "button_video_height"),
              ("bluetooth", "button_video_fps"):
             DeviceManager.shared.sgc?.sendButtonVideoRecordingSettings()

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -550,6 +550,12 @@ public final class MentraBluetoothSDK {
         try await performSettingsCommand(
             setting: "button_video_recording",
             updateStore: { _ in
+                DeviceStore.shared.set(
+                    ObservableStore.bluetoothCategory,
+                    "button_video_settings",
+                    ["width": defaults.width, "height": defaults.height, "fps": defaults.fps]
+                )
+                // Keep legacy cache keys readable for older internal callers during migration.
                 DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_width", defaults.width)
                 DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_height", defaults.height)
                 DeviceStore.shared.set(ObservableStore.bluetoothCategory, "button_video_fps", defaults.fps)

--- a/mobile/modules/engine/src/stores/__tests__/bluetoothSettingKeys.test.ts
+++ b/mobile/modules/engine/src/stores/__tests__/bluetoothSettingKeys.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+
+import {MENTRA_LIVE_SETTING_KEYS} from "../bluetoothSettingKeys"
+
+describe("MENTRA_LIVE_SETTING_KEYS", () => {
+  test("syncs button video settings through the canonical atomic object", () => {
+    expect(MENTRA_LIVE_SETTING_KEYS).toContain("button_video_settings")
+    expect(MENTRA_LIVE_SETTING_KEYS).not.toContain("button_video_width")
+    expect(MENTRA_LIVE_SETTING_KEYS).not.toContain("button_video_height")
+    expect(MENTRA_LIVE_SETTING_KEYS).not.toContain("button_video_fps")
+  })
+})

--- a/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
+++ b/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
@@ -1,5 +1,6 @@
 import * as RNFS from "@dr.pogodin/react-native-fs"
-import {parse} from "exifr"
+import {Buffer} from "@craftzdog/react-native-buffer"
+import {parse} from "exifr/dist/lite.esm.js"
 
 import {PhotoInfo} from "@/types/asg"
 
@@ -34,8 +35,7 @@ export async function loadMediaMetadata(photo: PhotoInfo): Promise<LoadedMediaMe
 
   try {
     const base64 = await RNFS.readFile(path, "base64")
-    const mimeType = photo.mime_type?.startsWith("image/") ? photo.mime_type : "image/jpeg"
-    const exif = await parse(`data:${mimeType};base64,${base64}`)
+    const exif = await parse(Buffer.from(base64, "base64"))
     return {actualSize, exif: exif && typeof exif === "object" ? (exif as Record<string, unknown>) : null}
   } catch (error) {
     // A valid image often has no EXIF block. Keep the core file details usable

--- a/mobile/src/types/untyped-modules.d.ts
+++ b/mobile/src/types/untyped-modules.d.ts
@@ -7,6 +7,10 @@ declare module "bzip2" {
   export default bzip2
 }
 
+declare module "exifr/dist/lite.esm.js" {
+  export {parse} from "exifr"
+}
+
 declare module "tar-js" {
   export interface TarEntry {
     name: string

--- a/scripts/fetch-incident-logs.sh
+++ b/scripts/fetch-incident-logs.sh
@@ -12,7 +12,7 @@
 # Options:
 #   -o, --out DIR    Output directory (default: ./incident-logs/<reportId>)
 #   --json           Print the raw report JSON to stdout, skip artifact downloads
-#   --env ENV        prod | staging | dev (default: prod)
+#   --env ENV        prod | staging | dev (default: auto-discover)
 #   --kind KIND      (--list) bug | feedback | automatic
 #   --status STATUS  (--list) collecting | ready | closed
 #   --limit N        (--list) max reports to return (1-200, default 50)
@@ -22,7 +22,8 @@
 #                       key (msk_...) whose synthetic email is allowlisted in
 #                       CLOUD_CORE_ADMIN_EMAILS, or a WorkOS access token of
 #                       an admin user.
-#   MENTRA_CORE_URL     (optional) Core API base URL; overrides --env.
+#   MENTRA_CORE_URL     (optional) Core API base URL; disables auto-discovery
+#                       and overrides --env.
 
 set -euo pipefail
 
@@ -40,7 +41,8 @@ command -v jq >/dev/null || { err "jq is required (brew install jq)"; exit 1; }
 REPORT_ID=""
 OUT_DIR=""
 MODE="fetch"
-ENV_NAME="prod"
+ENV_NAME=""
+ENV_EXPLICIT=0
 LIST_KIND=""
 LIST_STATUS=""
 LIST_LIMIT=""
@@ -50,7 +52,7 @@ while [ $# -gt 0 ]; do
     --list) MODE="list" ;;
     --json) MODE="json" ;;
     -o|--out) OUT_DIR="${2:?--out requires a directory}"; shift ;;
-    --env) ENV_NAME="${2:?--env requires prod|staging|dev}"; shift ;;
+    --env) ENV_NAME="${2:?--env requires prod|staging|dev}"; ENV_EXPLICIT=1; shift ;;
     --kind) LIST_KIND="${2:?--kind requires a value}"; shift ;;
     --status) LIST_STATUS="${2:?--status requires a value}"; shift ;;
     --limit) LIST_LIMIT="${2:?--limit requires a number}"; shift ;;
@@ -64,14 +66,39 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-case "$ENV_NAME" in
-  prod) DEFAULT_CORE_URL="https://core.mentraglass.com" ;;
-  staging) DEFAULT_CORE_URL="https://core.staging.us-west-2.mentraglass.com" ;;
-  dev) DEFAULT_CORE_URL="https://core.dev.us-west-2.mentraglass.com" ;;
-  *) err "--env must be prod, staging, or dev (got: $ENV_NAME)"; exit 1 ;;
-esac
-CORE_URL="${MENTRA_CORE_URL:-$DEFAULT_CORE_URL}"
-CORE_URL="${CORE_URL%/}"
+if [ "$ENV_EXPLICIT" -eq 1 ]; then
+  case "$ENV_NAME" in
+    prod|staging|dev) ;;
+    *) err "--env must be prod, staging, or dev (got: $ENV_NAME)"; exit 1 ;;
+  esac
+fi
+
+core_url_for_env() {
+  case "$1" in
+    prod) echo "https://core.mentraglass.com" ;;
+    staging) echo "https://core.staging.us-west-2.mentraglass.com" ;;
+    dev) echo "https://core.dev.us-west-2.mentraglass.com" ;;
+    *) return 1 ;;
+  esac
+}
+
+CANDIDATE_NAMES=()
+CANDIDATE_URLS=()
+if [ -n "${MENTRA_CORE_URL:-}" ]; then
+  CANDIDATE_NAMES+=("custom")
+  CANDIDATE_URLS+=("${MENTRA_CORE_URL%/}")
+elif [ "$ENV_EXPLICIT" -eq 1 ]; then
+  CANDIDATE_NAMES+=("$ENV_NAME")
+  CANDIDATE_URLS+=("$(core_url_for_env "$ENV_NAME")")
+else
+  for candidate_env in prod dev staging; do
+    CANDIDATE_NAMES+=("$candidate_env")
+    CANDIDATE_URLS+=("$(core_url_for_env "$candidate_env")")
+  done
+fi
+
+CORE_URL=""
+SELECTED_ENV=""
 
 if [ "$MODE" != "list" ] && [ -z "$REPORT_ID" ]; then
   usage
@@ -114,6 +141,38 @@ fail_for_status() {
   exit 1
 }
 
+# discover_get PATH OUTFILE WHAT
+#
+# Uses a single backend when --env or MENTRA_CORE_URL is explicit. Otherwise,
+# tries each Cloud V2 environment until the request succeeds. This matters for
+# environment-pinned msk_<env>_* API keys and report ids whose origin is not
+# known when copied from a notification.
+discover_get() {
+  local path="$1" body="$2" what="$3"
+  local i status attempts=""
+
+  for ((i = 0; i < ${#CANDIDATE_URLS[@]}; i++)); do
+    CORE_URL="${CANDIDATE_URLS[$i]}"
+    SELECTED_ENV="${CANDIDATE_NAMES[$i]}"
+    note "Trying $SELECTED_ENV reports backend: $CORE_URL"
+    STATUS=$(api_get "$path" "$body") || STATUS="000"
+    status="$STATUS"
+    if printf '%s' "$status" | grep -q '^2'; then
+      note "Using reports backend: $SELECTED_ENV ($CORE_URL)"
+      return 0
+    fi
+
+    attempts="${attempts}${attempts:+, }$SELECTED_ENV=HTTP $status"
+    if [ "${#CANDIDATE_URLS[@]}" -eq 1 ]; then
+      fail_for_status "$status" "$body" "$what"
+    fi
+  done
+
+  err "could not fetch $what from any reports backend ($attempts)"
+  if [ -s "$body" ]; then jq . "$body" >&2 2>/dev/null || cat "$body" >&2; fi
+  exit 1
+}
+
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
@@ -123,18 +182,16 @@ if [ "$MODE" = "list" ]; then
   [ -n "$LIST_STATUS" ] && QUERY="$QUERY&status=$LIST_STATUS"
   [ -n "$LIST_LIMIT" ] && QUERY="$QUERY&limit=$LIST_LIMIT"
   QUERY="${QUERY#&}"
-  note "Listing reports from $CORE_URL${QUERY:+ ($QUERY)}"
+  note "Listing reports${QUERY:+ ($QUERY)}"
   BODY="$TMP_DIR/list.json"
-  STATUS=$(api_get "/api/admin/reports${QUERY:+?$QUERY}" "$BODY")
-  fail_for_status "$STATUS" "$BODY" "report list"
+  discover_get "/api/admin/reports${QUERY:+?$QUERY}" "$BODY" "report list"
   jq . "$BODY"
   exit 0
 fi
 
-note "Fetching report $REPORT_ID from $CORE_URL"
+note "Fetching report $REPORT_ID"
 DETAIL="$TMP_DIR/detail.json"
-STATUS=$(api_get "/api/admin/reports/$REPORT_ID" "$DETAIL")
-fail_for_status "$STATUS" "$DETAIL" "report $REPORT_ID"
+discover_get "/api/admin/reports/$REPORT_ID" "$DETAIL" "report $REPORT_ID"
 
 if [ "$MODE" = "json" ]; then
   jq . "$DETAIL"


### PR DESCRIPTION
## Summary

- send canonical `button_video_settings` changes to connected Mentra Live glasses immediately on both Android and iOS
- cache the canonical width/height/FPS object after acknowledged typed SDK writes while retaining legacy scalar compatibility
- add regression coverage for the atomic Mentra Live video-settings contract
- make the incident-log helper try prod, dev, and staging automatically and report the backend that contains the report

## Root cause

The mobile settings engine writes video resolution and FPS as the canonical `button_video_settings` object. The native Bluetooth stores only attached the BLE side effect to the older scalar keys, so the store changed but no command was sent until a later reconnect or resync.

## Validation

- `cd mobile && bun compile`
- `cd mobile && bun test modules/engine/src` (221 pass)
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile && bunx expo export --platform android` (Hermes bytecode generated)
- `cd mobile && bunx expo export --platform ios` (Hermes bytecode generated)
- `bash -n scripts/fetch-incident-logs.sh`
- `git diff --check origin/dev...HEAD`
- verified automatic report lookup selected dev for `rep_01KXA2T0X67GN8A5SJ4ZPFQ2AB`

No connected glasses were modified or used during validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live BLE settings sync for Mentra Live video defaults (user-visible hardware behavior); gallery EXIF and the incident-log script are lower risk but touch on-device parsing and admin API access patterns.
> 
> **Overview**
> Fixes **Mentra Live button video settings** not reaching glasses when the settings engine writes the canonical `button_video_settings` object: Android and iOS `DeviceStore` now trigger `sendButtonVideoRecordingSettings()` on that key (legacy `button_video_*` scalars still work). Typed SDK `setVideoRecordingDefaults` also caches the atomic object after ack while keeping legacy cache keys for migration.
> 
> Adds a **regression test** that live BLE sync keys use `button_video_settings` only, not the old width/height/fps scalars.
> 
> **Gallery EXIF** parsing switches to `exifr` lite with a `Buffer` from file bytes instead of a data-URL parse path, plus a module declaration for the lite import.
> 
> **`fetch-incident-logs.sh`** no longer defaults to prod only: without `--env` or `MENTRA_CORE_URL`, it tries prod → dev → staging and prints which backend succeeded; explicit env or URL still pins a single backend. **AGENTS.md** documents the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa81cc1398e8c5394d13217a71f6277cb466d0a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->