### PR TITLE
Enable Vietnamese translation output

### DIFF
--- a/miniapps/translation/miniapp.json
+++ b/miniapps/translation/miniapp.json
@@ -40,7 +40,7 @@
         "properties": {
           "targetLanguage": {
             "type": "string",
-            "description": "The language the user wants to read the translation in, as a BCP-47 code (e.g. 'en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh', 'ko', 'ar', 'hi'). Omit to keep the user's saved target language."
+            "description": "The language the user wants to read the translation in, as a BCP-47 code (e.g. 'en', 'es', 'fr', 'de', 'pt', 'it', 'ja', 'zh', 'ko', 'ar', 'hi', 'vi'). Omit to keep the user's saved target language."
           }
         }
       }

--- a/miniapps/translation/src/ui/lib/languages.ts
+++ b/miniapps/translation/src/ui/lib/languages.ts
@@ -17,6 +17,7 @@ export const TARGET_LANGUAGES: Language[] = [
   {code: "ko", name: "Korean", nativeName: "한국어", flag: "🇰🇷"},
   {code: "ar", name: "Arabic", nativeName: "العربية", flag: "🇸🇦"},
   {code: "hi", name: "Hindi", nativeName: "हिन्दी", flag: "🇮🇳"},
+  {code: "vi", name: "Vietnamese", nativeName: "Tiếng Việt", flag: "🇻🇳"},
 ]
 
 export function getLanguageName(code: string): string {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
@@ -2841,7 +2841,7 @@ class G1 : SGCManager() {
     private fun chunkTextForTransmission(text: String?): List<ByteArray> {
         // Handle empty or whitespace-only text by sending at least a space
         // This ensures the display gets updated/cleared properly
-        val textToSend = if (text == null || text.trim().isEmpty()) " " else text
+        val textToSend = if (text == null || text.trim().isEmpty()) " " else sanitizeG1DisplayText(text)
         val textBytes = textToSend.toByteArray(StandardCharsets.UTF_8)
         val totalChunks = Math.ceil(textBytes.size.toDouble() / MAX_CHUNK_SIZE).toInt()
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizer.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizer.kt
@@ -1,0 +1,16 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import java.text.Normalizer
+
+private val G1_COMBINING_MARKS = Regex("\\p{M}+")
+
+/**
+ * Converts text to the base Latin glyphs available in the Even Realities G1 firmware.
+ *
+ * G1 does not ship glyphs for combining diacritics. Normalize at the device boundary so
+ * miniapps can retain the real text everywhere else and newer glasses receive it unchanged.
+ */
+internal fun sanitizeG1DisplayText(text: String): String {
+    return Normalizer.normalize(text.replace('Đ', 'D').replace('đ', 'd'), Normalizer.Form.NFD)
+        .replace(G1_COMBINING_MARKS, "")
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizer.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizer.kt
@@ -11,6 +11,28 @@ private val G1_COMBINING_MARKS = Regex("\\p{M}+")
  * miniapps can retain the real text everywhere else and newer glasses receive it unchanged.
  */
 internal fun sanitizeG1DisplayText(text: String): String {
-    return Normalizer.normalize(text.replace('Đ', 'D').replace('đ', 'd'), Normalizer.Form.NFD)
+    val expanded = buildString(text.length) {
+        text.forEach { character ->
+            when (character) {
+                'Đ', 'Ð' -> append('D')
+                'đ', 'ð' -> append('d')
+                'Ł' -> append('L')
+                'ł' -> append('l')
+                'Ø' -> append('O')
+                'ø' -> append('o')
+                'Æ' -> append("AE")
+                'æ' -> append("ae")
+                'Œ' -> append("OE")
+                'œ' -> append("oe")
+                'ẞ' -> append("SS")
+                'ß' -> append("ss")
+                'Þ' -> append("TH")
+                'þ' -> append("th")
+                else -> append(character)
+            }
+        }
+    }
+
+    return Normalizer.normalize(expanded, Normalizer.Form.NFD)
         .replace(G1_COMBINING_MARKS, "")
 }

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizerTest.kt
@@ -18,6 +18,12 @@ class G1TextSanitizerTest {
     }
 
     @Test
+    fun `expands Latin letters that do not decompose into combining marks`() {
+        assertThat(sanitizeG1DisplayText("Øresund Łódź Æsir Œuvre Straße Ðingvellir Þingvellir"))
+            .isEqualTo("Oresund Lodz AEsir OEuvre Strasse Dingvellir THingvellir")
+    }
+
+    @Test
     fun `leaves text without diacritics unchanged`() {
         assertThat(sanitizeG1DisplayText("Hello, world! 123"))
             .isEqualTo("Hello, world! 123")

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/sgcs/G1TextSanitizerTest.kt
@@ -1,0 +1,25 @@
+package com.mentra.bluetoothsdk.sgcs
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class G1TextSanitizerTest {
+
+    @Test
+    fun `strips Vietnamese diacritics unsupported by G1`() {
+        assertThat(sanitizeG1DisplayText("Tiếng Việt: Đặng, Nguyễn, phở bò"))
+            .isEqualTo("Tieng Viet: Dang, Nguyen, pho bo")
+    }
+
+    @Test
+    fun `handles decomposed marks and preserves layout`() {
+        assertThat(sanitizeG1DisplayText("Cafe\u0301\nĐa Nang"))
+            .isEqualTo("Cafe\nDa Nang")
+    }
+
+    @Test
+    fun `leaves text without diacritics unchanged`() {
+        assertThat(sanitizeG1DisplayText("Hello, world! 123"))
+            .isEqualTo("Hello, world! 123")
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -739,7 +739,7 @@ class G1: NSObject, SGCManager {
 
     @objc func RN_sendText(_ text: String) {
         Task {
-            let displayText = "\(text)"
+            let displayText = G1Text.sanitizeForDisplay(text)
             guard let textData = displayText.data(using: .utf8) else { return }
 
             var command: [UInt8] = [

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/G1Text.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/G1Text.swift
@@ -27,9 +27,27 @@ class G1Text {
     /// Converts text to the base Latin glyphs available in G1 firmware.
     /// Newer glasses bypass this G1-only transport and keep the original text.
     static func sanitizeForDisplay(_ text: String) -> String {
-        return text
-            .replacingOccurrences(of: "Đ", with: "D")
-            .replacingOccurrences(of: "đ", with: "d")
+        let expanded = text.reduce(into: "") { result, character in
+            switch character {
+            case "Đ", "Ð": result.append("D")
+            case "đ", "ð": result.append("d")
+            case "Ł": result.append("L")
+            case "ł": result.append("l")
+            case "Ø": result.append("O")
+            case "ø": result.append("o")
+            case "Æ": result.append("AE")
+            case "æ": result.append("ae")
+            case "Œ": result.append("OE")
+            case "œ": result.append("oe")
+            case "ẞ": result.append("SS")
+            case "ß": result.append("ss")
+            case "Þ": result.append("TH")
+            case "þ": result.append("th")
+            default: result.append(character)
+            }
+        }
+
+        return expanded
             .folding(options: .diacriticInsensitive, locale: Locale(identifier: "en_US_POSIX"))
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/G1Text.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/G1Text.swift
@@ -24,6 +24,15 @@ class G1Text {
 
     init() {}
 
+    /// Converts text to the base Latin glyphs available in G1 firmware.
+    /// Newer glasses bypass this G1-only transport and keep the original text.
+    static func sanitizeForDisplay(_ text: String) -> String {
+        return text
+            .replacingOccurrences(of: "Đ", with: "D")
+            .replacingOccurrences(of: "đ", with: "d")
+            .folding(options: .diacriticInsensitive, locale: Locale(identifier: "en_US_POSIX"))
+    }
+
     // MARK: - Text Wall Methods
 
     //    func displayTextWall(_ text: String) {
@@ -72,7 +81,9 @@ class G1Text {
     func chunkTextForTransmission(_ text: String) -> [[UInt8]] {
         // Handle empty or whitespace-only text by sending at least a space
         // This ensures the display gets updated/cleared properly
-        let textToSend = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? " " : text
+        let textToSend = text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            ? " "
+            : G1Text.sanitizeForDisplay(text)
         guard let textData = textToSend.data(using: .utf8) else { return [] }
         let textBytes = [UInt8](textData)
         let totalChunks = Int(ceil(Double(textBytes.count) / Double(G1Text.MAX_CHUNK_SIZE)))


### PR DESCRIPTION
## Summary

- add Vietnamese as a Translation miniapp target language
- preserve Vietnamese diacritics on G2, Z100/Mach1, and other capable displays
- transliterate unsupported diacritics to base Latin glyphs only at the Even Realities G1 native display boundary on Android and iOS
- expand non-decomposing Latin letters on G1 (`ø→o`, `ł→l`, `æ→ae`, `œ→oe`, `ß→ss`, `ð→d`, `þ→th`)
- cover Android G1 transliteration for Vietnamese, decomposed Unicode marks, non-decomposing Latin letters, and unchanged ASCII

## Why

Vietnamese translation was hidden because G1 firmware lacks the required diacritic glyphs, even though newer glasses can render them. Applying the fallback inside the G1 SGC lets the Translation miniapp offer Vietnamese everywhere without degrading output on capable hardware. Expanding the remaining common extended-Latin letters keeps G1 output readable even when Unicode normalization cannot decompose a character.

## Validation

- `cd miniapps/translation && bun run build`
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `:mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.sgcs.G1TextSanitizerTest`
- `swiftc -parse` on the modified G1 Swift sources
- `swiftformat --lint` on `G1Text.swift`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> All G1 caption text now passes through transliteration at send time, which can change visible wording on G1 but is isolated to that device path and covered by unit tests.
> 
> **Overview**
> Adds **Vietnamese** (`vi`) as a Translation miniapp target in the language picker and `start_translation` action docs.
> 
> Because G1 firmware cannot render combining diacritics, **G1-only** sanitization runs at the BLE text boundary on **Android** (`sanitizeG1DisplayText` in `chunkTextForTransmission`) and **iOS** (`G1Text.sanitizeForDisplay` in `RN_sendText` and chunking). Miniapps and capable glasses still get full Unicode; G1 users see base Latin (Vietnamese tones stripped, plus expansions like `Đ→D`, `ø→o`, `æ→ae`, `ß→ss`).
> 
> Android coverage includes `G1TextSanitizerTest` for Vietnamese, decomposed marks, extended Latin, and plain ASCII.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e9438eff88e7fb7b3f60ab9d8ada6510f2e7f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->