### PR TITLE
Honor forwarded protocol for photo URLs

### DIFF
--- a/cloud-v2/packages/runtime/src/api/camera.api.test.ts
+++ b/cloud-v2/packages/runtime/src/api/camera.api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+
+import { publicOrigin } from "./camera.api";
+
+async function originFor(url: string, headers: Record<string, string> = {}): Promise<string> {
+  const app = new Hono();
+  app.get("/probe", (c) => c.text(publicOrigin(c)));
+  const response = await app.request(url, { headers });
+  return response.text();
+}
+
+describe("camera publicOrigin", () => {
+  test("derives HTTPS from the TLS-terminating ingress", async () => {
+    expect(
+      await originFor("http://runtime.dev.us-west-2.mentraglass.com/probe", {
+        "x-forwarded-proto": "https",
+      }),
+    ).toBe("https://runtime.dev.us-west-2.mentraglass.com");
+  });
+
+  test("uses the first protocol when multiple trusted proxies append values", async () => {
+    expect(
+      await originFor("http://runtime.internal/probe", {
+        "x-forwarded-proto": "https, http",
+      }),
+    ).toBe("https://runtime.internal");
+  });
+
+  test("falls back to the request protocol for direct local requests", async () => {
+    expect(await originFor("http://localhost:3001/probe")).toBe("http://localhost:3001");
+    expect(await originFor("https://runtime.example.com/probe")).toBe(
+      "https://runtime.example.com",
+    );
+  });
+
+  test("ignores unsupported forwarded protocols", async () => {
+    expect(
+      await originFor("http://runtime.example.com/probe", {
+        "x-forwarded-proto": "javascript",
+      }),
+    ).toBe("http://runtime.example.com");
+  });
+});

--- a/cloud-v2/packages/runtime/src/api/camera.api.ts
+++ b/cloud-v2/packages/runtime/src/api/camera.api.ts
@@ -35,6 +35,25 @@ const WEBHOOK_SECRET = process.env.CAMERA_WEBHOOK_SECRET;
 
 export const cameraApi = new Hono();
 
+/**
+ * Return the public origin that reached the TLS-terminating ingress.
+ *
+ * Runtime receives plain HTTP from ingress-nginx after TLS termination, while
+ * devices must use the original HTTPS origin for generated photo URLs. The
+ * ingress overwrites x-forwarded-proto and preserves Host, so no per-cluster
+ * public URL configuration is required. Direct local requests have no
+ * forwarded header and keep their actual protocol.
+ */
+export function publicOrigin(c: Context): string {
+  const url = new URL(c.req.url);
+  const forwardedProto = c.req.header("x-forwarded-proto")?.split(",", 1)[0]?.trim().toLowerCase();
+  const proto =
+    forwardedProto === "http" || forwardedProto === "https"
+      ? forwardedProto
+      : url.protocol.replace(":", "");
+  return `${proto}://${url.host}`;
+}
+
 /** Verify the Bearer access token; returns the mentraUserId or an error Response. */
 async function authUser(
   c: Context,
@@ -74,7 +93,7 @@ cameraApi.post("/photo", async (c) => {
 
   // The local provider builds absolute URLs back at this runtime; pass the
   // origin the client used so the device/test can reach them.
-  const origin = new URL(c.req.url).origin;
+  const origin = publicOrigin(c);
   const result = await camera.requestPhoto(auth.mentraUserId, parsed.data, origin);
   return c.json(result, 200);
 });


### PR DESCRIPTION
## What changed

- derive Runtime's public camera origin from the ingress-provided `X-Forwarded-Proto` value
- preserve the request protocol for direct local development
- accept only `http` and `https`, including the first value from a multi-proxy header
- add regression coverage for hosted HTTPS, direct local requests, proxy chains, and unsupported protocols

## Why

TLS terminates at ingress-nginx, so the Runtime pod receives the forwarded request over HTTP. The local camera storage provider previously used `new URL(c.req.url).origin`, causing shared dev to return `http://runtime.dev...` upload and read URLs even though the phone reached Runtime over HTTPS.

On iOS, the BLE photo arrived successfully but App Transport Security rejected the subsequent insecure upload. Both dev incident reports show the same failure after intact BLE delivery:

- `rep_01KXCCA76WM71HW286BK9YJZ31`
- `rep_01KXCFPCTJJ5JQ3CESP4NB8YVM`

Ingress-nginx overwrites `X-Forwarded-Proto` and preserves `Host`, matching the existing Cloud V2 Core OAuth origin pattern. This avoids per-environment public URL configuration and keeps local Runtime behavior unchanged.

## Validation

- `bun test src` in `cloud-v2/packages/runtime`: 59 passed, 0 failed
- `bun run typecheck` in `cloud-v2`: passed
- `git diff --check`: passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor `X-Forwarded-Proto` to generate correct HTTPS camera photo URLs behind ingress, fixing iOS ATS upload failures while keeping local development behavior unchanged.

- **Bug Fixes**
  - Derive public origin from `X-Forwarded-Proto` (first value) and `Host`; accept only `http`/`https`, else fall back to request protocol.
  - Use `publicOrigin(c)` in the photo endpoint so the local provider builds correct absolute URLs.
  - Add tests for hosted HTTPS, direct local requests, multi-proxy chains, and unsupported protocols.

<sup>Written for commit 1eada044ec39e3d87b9cedb38470a615951ac880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to origin string construction for the photo endpoint with allowlisted protocols and regression tests; no auth or storage logic changes.
> 
> **Overview**
> Fixes **camera photo upload/read URLs** behind TLS-terminating ingress by deriving the public origin from **`X-Forwarded-Proto`** and **`Host`** instead of the pod’s internal `http` request URL.
> 
> Adds exported **`publicOrigin(c)`** on the camera API: uses the **first** comma-separated forwarded protocol when it is `http` or `https`, otherwise keeps the request’s actual scheme (local dev). **`POST /api/camera/photo`** now passes this origin into `requestPhoto` so the local storage provider emits **HTTPS** links clients can reach.
> 
> New **`camera.api.test.ts`** covers ingress HTTPS, multi-proxy headers, direct local requests, and rejected forwarded values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1eada044ec39e3d87b9cedb38470a615951ac880. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->