### PR TITLE
Mainto staging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,10 @@
-* @Mentra-Community/core
+# The last matching CODEOWNERS pattern wins, so keep @aisraelov on each narrower rule.
+* @aisraelov
+
+miniapps/ @aisraelov @AryanFP @isaiahb
+mobile/ @aisraelov @AryanFP
+cloud-v2/ @aisraelov @AryanFP @isaiahb
+cloud/ @aisraelov @isaiahb
+mintlify-docs/ @aisraelov @isaiahb
+mintlify-docs/mentra-live/ @aisraelov @isaiahb @PhilippeFerreiraDeSousa
+mobile/modules/bluetooth-sdk/ @aisraelov @AryanFP @PhilippeFerreiraDeSousa

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -192,8 +192,8 @@ android {
 
         minSdk 28
         targetSdk 33
-        versionCode 38
-        versionName "38.0"
+        versionCode 39
+        versionName "39.0"
 
         ndk {
             abiFilters "armeabi-v7a", "arm64-v8a"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -3,7 +3,6 @@ package com.mentra.asg_client.io.ota.helpers;
 import android.content.Context;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -106,17 +105,6 @@ public class OtaHelper {
     private static final String UPDATE_TYPE_MTK = "mtk";
     private static final String UPDATE_TYPE_BES = "bes";
     private static final String[] UPDATE_ORDER = {UPDATE_TYPE_APK, UPDATE_TYPE_MTK, UPDATE_TYPE_BES};
-    private static final String CACHE_PREFS_NAME = "ota_cache_state";
-    private static final String CACHE_FLAG_READY = "ready";
-    private static final String CACHE_FIELD_PATH = "path";
-    private static final String CACHE_FIELD_SHA256 = "sha256";
-    private static final String CACHE_FIELD_VERSION = "version";
-    private static final String CACHE_FIELD_TIMESTAMP = "timestamp";
-    private static final String CACHE_FIELD_SIZE = "size";
-    private static final String CACHE_KEY_APK_ASG = "apk_com.mentra.asg_client";
-    private static final String CACHE_KEY_APK_UPDATER = "apk_com.augmentos.otaupdater";
-    private static final String CACHE_KEY_MTK = "mtk_main";
-    private static final String CACHE_KEY_BES = "bes_main";
     
     // ⚠️ DEBUG FLAG: Set to true to skip all checks and install MTK firmware from local file
     // This will bypass version checking, downloading, and directly install /storage/emulated/0/asg/mtk_firmware.zip
@@ -147,10 +135,6 @@ public class OtaHelper {
     // the prefetch→install retry loop re-uses the same URL instead of
     // falling back to the compiled-in default (which would break test flows).
     private volatile String lastVersionJsonUrl = OtaConstants.VERSION_JSON_URL;
-
-    // Cached version JSON from the last successful prefetch. Allows ota_start
-    // to skip the network re-fetch when all artifacts are already cached.
-    private volatile JSONObject cachedVersionJson = null;
 
     /**
      * Set the phone-initiated OTA flag. Used by DebugApkOtaReceiver to force
@@ -186,6 +170,8 @@ public class OtaHelper {
     private volatile boolean rebootAfterMtkInstall = false;
 
     private volatile boolean pendingPhoneInstall = false;
+    private volatile String pendingPhoneInstallVersionJsonUrl = null;
+    private final Object pendingPhoneInstallLock = new Object();
 
     /** Snapshot for {@link #buildMinimalOtaStatusJson()} when no OTA session exists (aligns with {@link #sendMtkInstallProgress} shape). */
     private String lastOtaPhoneStage;
@@ -380,192 +366,8 @@ public class OtaHelper {
         Log.d(TAG, "Phone disconnected - reset OTA notification flag");
     }
 
-    private SharedPreferences getCachePrefs() {
-        return context.getSharedPreferences(CACHE_PREFS_NAME, Context.MODE_PRIVATE);
-    }
-
-    private String cacheField(String cacheKey, String field) {
-        return cacheKey + "_" + field;
-    }
-
     private String getApkFilename(String packageName) {
         return packageName.equals("com.mentra.asg_client") ? "asg_client_update.apk" : "ota_updater_update.apk";
-    }
-
-    private String getApkCacheKey(String packageName) {
-        return packageName.equals("com.mentra.asg_client") ? CACHE_KEY_APK_ASG : CACHE_KEY_APK_UPDATER;
-    }
-
-    private void markCachedArtifactReady(String cacheKey, String updateType, String localPath, JSONObject metadata) {
-        try {
-            SharedPreferences.Editor editor = getCachePrefs().edit();
-            editor.putBoolean(cacheField(cacheKey, CACHE_FLAG_READY), true);
-            editor.putString(cacheField(cacheKey, CACHE_FIELD_PATH), localPath);
-            editor.putString(cacheField(cacheKey, CACHE_FIELD_SHA256), metadata.optString("sha256", ""));
-            editor.putString(cacheField(cacheKey, CACHE_FIELD_VERSION), metadata.optString("versionName", ""));
-            editor.putLong(cacheField(cacheKey, CACHE_FIELD_TIMESTAMP), System.currentTimeMillis());
-            editor.putLong(cacheField(cacheKey, CACHE_FIELD_SIZE), new File(localPath).length());
-            editor.putString(cacheField(cacheKey, "type"), updateType);
-            editor.apply();
-            Log.i(TAG, "📦 Cache ready: " + cacheKey + " at " + localPath);
-        } catch (Exception e) {
-            Log.e(TAG, "Failed to mark cached artifact ready: " + cacheKey, e);
-        }
-    }
-
-    private String getCachedPath(String cacheKey) {
-        return getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_PATH), null);
-    }
-
-    private boolean isCachedReady(String cacheKey) {
-        return getCachePrefs().getBoolean(cacheField(cacheKey, CACHE_FLAG_READY), false);
-    }
-
-    private boolean isCachedArtifactValid(String cacheKey, String updateType, String localPath, JSONObject metadata) {
-        try {
-            if (!isCachedReady(cacheKey)) {
-                return false;
-            }
-            File file = new File(localPath);
-            if (!file.exists() || !file.canRead()) {
-                return false;
-            }
-
-            // Fast path: if the stored SHA256 matches the expected hash from metadata AND the file
-            // has not been modified since it was verified, skip the expensive full re-hash.
-            // This avoids re-reading large firmware files on every 30-minute periodic check.
-            String storedHash = getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_SHA256), "");
-            long storedTimestamp = getCachePrefs().getLong(cacheField(cacheKey, CACHE_FIELD_TIMESTAMP), 0);
-            String expectedHash = metadata.optString("sha256", "");
-
-            if (!storedHash.isEmpty()
-                    && storedHash.equalsIgnoreCase(expectedHash)
-                    && file.lastModified() <= storedTimestamp) {
-                Log.d(TAG, "Cache fast-path hit for " + cacheKey + " - skipping re-hash");
-                return true;
-            }
-
-            // Slow path: stored hash absent, mismatched, or file was modified — full verify.
-            boolean hashOk;
-            switch (updateType) {
-                case UPDATE_TYPE_APK:
-                    hashOk = verifyApkFile(localPath, metadata);
-                    break;
-                case UPDATE_TYPE_MTK:
-                    hashOk = verifyMtkFirmwareChecksum(localPath, metadata);
-                    break;
-                case UPDATE_TYPE_BES:
-                    hashOk = verifyFirmwareFile(localPath, metadata);
-                    break;
-                default:
-                    hashOk = false;
-                    break;
-            }
-            if (!hashOk) {
-                Log.w(TAG, "Cached artifact failed verification: " + cacheKey);
-            }
-            return hashOk;
-        } catch (Exception e) {
-            Log.e(TAG, "Error validating cache for " + cacheKey, e);
-            return false;
-        }
-    }
-
-    public void clearCachedArtifact(String cacheKey, String updateType) {
-        try {
-            String path = getCachedPath(cacheKey);
-            if (path != null) {
-                File file = new File(path);
-                if (file.exists() && !file.delete()) {
-                    Log.w(TAG, "Failed deleting cached artifact file: " + path);
-                }
-            }
-
-            SharedPreferences.Editor editor = getCachePrefs().edit();
-            editor.remove(cacheField(cacheKey, CACHE_FLAG_READY));
-            editor.remove(cacheField(cacheKey, CACHE_FIELD_PATH));
-            editor.remove(cacheField(cacheKey, CACHE_FIELD_SHA256));
-            editor.remove(cacheField(cacheKey, CACHE_FIELD_VERSION));
-            editor.remove(cacheField(cacheKey, CACHE_FIELD_TIMESTAMP));
-            editor.remove(cacheField(cacheKey, CACHE_FIELD_SIZE));
-            editor.remove(cacheField(cacheKey, "type"));
-            editor.apply();
-            Log.i(TAG, "🧹 Cleared cached artifact: " + cacheKey + " (" + updateType + ")");
-        } catch (Exception e) {
-            Log.e(TAG, "Failed clearing cached artifact: " + cacheKey, e);
-        }
-    }
-
-    public void clearCachedArtifactsForType(String updateType) {
-        if (UPDATE_TYPE_APK.equals(updateType)) {
-            clearCachedArtifact(CACHE_KEY_APK_ASG, UPDATE_TYPE_APK);
-            clearCachedArtifact(CACHE_KEY_APK_UPDATER, UPDATE_TYPE_APK);
-            return;
-        }
-        if (UPDATE_TYPE_MTK.equals(updateType)) {
-            clearCachedArtifact(CACHE_KEY_MTK, UPDATE_TYPE_MTK);
-            File backup = new File(OtaConstants.MTK_BACKUP_PATH);
-            if (backup.exists() && !backup.delete()) {
-                Log.w(TAG, "Failed deleting MTK backup cache: " + OtaConstants.MTK_BACKUP_PATH);
-            }
-            return;
-        }
-        if (UPDATE_TYPE_BES.equals(updateType)) {
-            clearCachedArtifact(CACHE_KEY_BES, UPDATE_TYPE_BES);
-            File backup = new File(OtaConstants.BES_BACKUP_PATH);
-            if (backup.exists() && !backup.delete()) {
-                Log.w(TAG, "Failed deleting BES backup cache: " + OtaConstants.BES_BACKUP_PATH);
-            }
-        }
-    }
-
-    public void clearAllCachedArtifacts() {
-        clearCachedArtifactsForType(UPDATE_TYPE_APK);
-        clearCachedArtifactsForType(UPDATE_TYPE_MTK);
-        clearCachedArtifactsForType(UPDATE_TYPE_BES);
-    }
-
-    public void pruneInvalidCachedArtifactsOnStartup() {
-        try {
-            pruneOneCacheEntry(CACHE_KEY_APK_ASG, UPDATE_TYPE_APK);
-            pruneOneCacheEntry(CACHE_KEY_APK_UPDATER, UPDATE_TYPE_APK);
-            pruneOneCacheEntry(CACHE_KEY_MTK, UPDATE_TYPE_MTK);
-            if (!BesOtaManager.isBesOtaInProgress) {
-                pruneOneCacheEntry(CACHE_KEY_BES, UPDATE_TYPE_BES);
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "Failed pruning invalid cached artifacts", e);
-        }
-    }
-
-    private void pruneOneCacheEntry(String cacheKey, String updateType) {
-        if (!isCachedReady(cacheKey)) {
-            return;
-        }
-        String path = getCachedPath(cacheKey);
-        if (path == null) {
-            clearCachedArtifact(cacheKey, updateType);
-            return;
-        }
-        File file = new File(path);
-        if (!file.exists() || file.length() <= 0) {
-            clearCachedArtifact(cacheKey, updateType);
-            return;
-        }
-        long storedSize = getCachePrefs().getLong(cacheField(cacheKey, CACHE_FIELD_SIZE), -1);
-        if (storedSize > 0 && file.length() != storedSize) {
-            Log.w(TAG, "Size mismatch for " + cacheKey + ": expected " + storedSize + " but got " + file.length() + " — clearing corrupt entry");
-            file.delete();
-            clearCachedArtifact(cacheKey, updateType);
-            return;
-        }
-        String storedHash = getCachePrefs().getString(cacheField(cacheKey, CACHE_FIELD_SHA256), "");
-        if (storedHash.isEmpty()) {
-            Log.w(TAG, "No stored hash for " + cacheKey + " — clearing stale entry");
-            clearCachedArtifact(cacheKey, updateType);
-            return;
-        }
-        Log.i(TAG, "Keeping valid cached artifact on startup: " + cacheKey);
     }
 
     // Wakelock timeout for OTA process (10 minutes)
@@ -581,7 +383,7 @@ public class OtaHelper {
             // This is just a HEAD reachability probe so the actual URL doesn't matter for the
             // probe to work, but it should be kept in sync with the manifest URL when that swaps.
             HttpURLConnection conn = (HttpURLConnection)
-                new URL("https://ota.mentraglass.com/prod_live_version.json").openConnection();
+                new URL(OtaConstants.VERSION_JSON_URL).openConnection();
             conn.setConnectTimeout(REACHABILITY_TIMEOUT_MS);
             conn.setReadTimeout(REACHABILITY_TIMEOUT_MS);
             conn.setRequestMethod("HEAD");
@@ -675,18 +477,28 @@ public class OtaHelper {
      * Called by OtaCommandHandler when phone sends ota_start command.
      */
     public void startOtaFromPhone() {
+        startOtaFromPhone(null);
+    }
+
+    /**
+     * Start OTA update from phone command using a caller-supplied version JSON URL when provided.
+     */
+    public void startOtaFromPhone(String versionJsonUrl) {
+        String requestedVersionJsonUrl = resolveVersionJsonUrl(versionJsonUrl);
         Log.i(TAG, "📱 Starting OTA from phone request");
 
         // Immediately acknowledge receipt so the phone cancels its retry timer.
         sendOtaStartAck();
 
-        // If OTA already in progress, queue the install to fire immediately after prefetch completes.
+        // If an OTA check is already in progress, queue the install to fire immediately after it completes.
         // We cannot change the running thread's local installNow variable, so we set a flag that
-        // the finally block detects and uses to kick off a fresh install pass from the cache.
+        // the finally block detects and uses to kick off a fresh install pass with the requested URL.
         if (versionCheckLock.isLocked()) {
-            Log.i(TAG, "📱 OTA prefetch in progress - queuing install to fire after prefetch completes");
-            pendingPhoneInstall = true;
-            isPhoneInitiatedOta = true;
+            Log.i(TAG, "📱 OTA check in progress - queuing install to fire after check completes");
+            synchronized (pendingPhoneInstallLock) {
+                pendingPhoneInstall = true;
+                pendingPhoneInstallVersionJsonUrl = requestedVersionJsonUrl;
+            }
             // Acquire wakelock early so CPU stays awake for the queued install pass
             WakeLockManager.acquireCpuWakeLock(context, OTA_WAKELOCK_TIMEOUT_MS);
             Log.i(TAG, "📱 OTA wakelock acquired for queued install (" + (OTA_WAKELOCK_TIMEOUT_MS / 1000) + "s)");
@@ -706,58 +518,22 @@ public class OtaHelper {
         lastProgressSentTime = 0;
         lastProgressSentPercent = 0;
 
-        // Fast-path: if background prefetch already fetched and cached the version JSON,
-        // skip the network round-trip entirely and jump straight to install.
-        if (cachedVersionJson != null) {
-            Log.i(TAG, "📱 Cache fast-path: reusing prefetched version JSON (skipping network re-fetch)");
-            startInstallFromCachedJson(context, cachedVersionJson);
-            return;
-        }
-
         Log.i(TAG, "📱 Phone-initiated OTA: starting version check (download STARTED deferred)");
 
-        startVersionCheck(context);
+        startVersionCheckWithUrl(context, requestedVersionJsonUrl);
     }
 
-    /**
-     * Run the install pass using the version JSON that was already fetched by the
-     * background prefetch.  This avoids a redundant network round-trip and the
-     * pre-flight internet check when all artifacts are already cached.
-     */
-    private void startInstallFromCachedJson(Context context, JSONObject json) {
-        new Thread(() -> {
-            try {
-                if (!versionCheckLock.tryLock()) {
-                    Log.w(TAG, "📱 Cache fast-path: version check lock held — falling back to full check");
-                    startVersionCheck(context);
-                    return;
-                }
-                try {
-                    Log.i(TAG, "📱 Cache fast-path: processing cached version JSON (installNow=true)");
-                    if (json.has("apps")) {
-                        processAppsSequentially(json, context, true);
-                    } else {
-                        Log.d(TAG, "Using legacy version.json format (cache fast-path)");
-                        boolean apkUpdated = checkAndUpdateApp("com.mentra.asg_client", json, context, true);
-                        if (!apkUpdated) {
-                            sendProgressToPhone("download", 0, 0, 0, "FAILED",
-                                    "APK update failed after retries. Please check WiFi and try again.");
-                        }
-                    }
-                } catch (Exception e) {
-                    Log.e(TAG, "Exception during cache fast-path install", e);
-                    String errorCode = classifyDownloadError(e);
-                    sendProgressToPhone(currentUpdateStage, 0, 0, 0, "FAILED", errorCode);
-                } finally {
-                    cachedVersionJson = null;
-                    isPhoneInitiatedOta = false;
-                    versionCheckLock.unlock();
-                    Log.d(TAG, "Version check completed (cache fast-path), ready for next check");
-                }
-            } catch (Exception e) {
-                Log.e(TAG, "Failed to acquire lock for cache fast-path", e);
-            }
-        }).start();
+    private String resolveVersionJsonUrl(String versionJsonUrl) {
+        if (versionJsonUrl == null || versionJsonUrl.trim().isEmpty()) {
+            return OtaConstants.VERSION_JSON_URL;
+        }
+        return versionJsonUrl.trim();
+    }
+
+    private boolean hasPendingPhoneInstall() {
+        synchronized (pendingPhoneInstallLock) {
+            return pendingPhoneInstall;
+        }
     }
 
     private void startPeriodicChecks() {
@@ -888,7 +664,7 @@ public class OtaHelper {
             return;
         }
         Log.i(TAG, "⏰ Retrying OTA version check after clock sync from phone");
-        startVersionCheck(context);
+        startVersionCheckWithUrl(context, lastVersionJsonUrl);
     }
 
     public void startVersionCheck(Context context) {
@@ -902,6 +678,7 @@ public class OtaHelper {
      * @param versionJsonUrl URL to fetch the version JSON from (http, https)
      */
     public void startVersionCheckWithUrl(Context context, String versionJsonUrl) {
+        String resolvedVersionJsonUrl = resolveVersionJsonUrl(versionJsonUrl);
         Log.d(TAG, "Check OTA update method init");
         Log.i(TAG, "OTA check trigger -> phoneInitiated=" + isPhoneInitiatedOta
                 + ", autonomousEnabled=" + AUTONOMOUS_OTA_ENABLED
@@ -909,7 +686,7 @@ public class OtaHelper {
                 + ", isUpdating=" + isUpdating
                 + ", mtkInProgress=" + isMtkOtaInProgress
                 + ", besInProgress=" + BesOtaManager.isBesOtaInProgress
-                + ", versionJsonUrl=" + versionJsonUrl);
+                + ", versionJsonUrl=" + resolvedVersionJsonUrl);
 
         // if (!isNetworkAvailable(context)) {
         //     Log.e(TAG, "No WiFi connection available. Skipping OTA check.");
@@ -936,7 +713,7 @@ public class OtaHelper {
 
             // Store the URL under the lock so a concurrent caller can't overwrite it
             // before this check finishes (used by the pendingPhoneInstall retry).
-            lastVersionJsonUrl = versionJsonUrl;
+            lastVersionJsonUrl = resolvedVersionJsonUrl;
 
             // Check if update is in progress (separate from version check)
             if (isUpdating) {
@@ -949,7 +726,7 @@ public class OtaHelper {
             final boolean[] otaCheckReachedSuccessLog = {false};
 
             try {
-                // For autonomous/background prefetch, require WiFi before any network fetch.
+                // For autonomous/background checks, require WiFi before any network fetch.
                 // This avoids noisy fetch exceptions when glasses are offline.
                 if (!isPhoneInitiatedOta) {
                     stage[0] = "background_wifi_gate";
@@ -961,7 +738,7 @@ public class OtaHelper {
 
                 stage[0] = "fetch_version_info";
                 // Fetch version info from URL
-                String versionInfo = fetchVersionInfo(versionJsonUrl);
+                String versionInfo = fetchVersionInfo(resolvedVersionJsonUrl);
                 stage[0] = "parse_version_json";
                 JSONObject json = new JSONObject(versionInfo);
 
@@ -969,17 +746,35 @@ public class OtaHelper {
                         + ", mtk_patches=" + json.has("mtk_patches")
                         + ", bes_firmware=" + json.has("bes_firmware"));
 
-                cachedVersionJson = json;
-
                 if (!isPhoneInitiatedOta) {
                     stage[0] = "background_prefetch_gate";
                     isBackgroundPrefetchInProgress = true;
-                    Log.i(TAG, "📦 Starting background OTA pre-download pass");
+                    Log.i(TAG, "📦 Starting background OTA manifest-only pass");
                 }
 
                 // Check if new format (multiple apps) or legacy format
                 boolean installNow = isPhoneInitiatedOta;
                 Log.i(TAG, "OTA execution mode -> installNow=" + installNow);
+
+                if (!installNow) {
+                    stage[0] = "build_cache_ready_info";
+                    JSONObject cacheReadyInfo = buildCacheReadyUpdateInfo(json);
+                    boolean pendingInstallQueued = hasPendingPhoneInstall();
+                    if (cacheReadyInfo != null && cacheReadyInfo.optBoolean("available", false)
+                            && pendingInstallQueued) {
+                        Log.i(TAG, "📱 Background manifest check found update, but queued ota_start will run next - suppressing stale availability notification");
+                    } else if (cacheReadyInfo != null && cacheReadyInfo.optBoolean("available", false) && isPhoneConnected()) {
+                        stage[0] = "notify_phone_cache_ready";
+                        notifyPhoneUpdateAvailable(cacheReadyInfo);
+                        Log.i(TAG, "📱 Background manifest check found update - prompted phone to install");
+                    } else {
+                        Log.i(TAG, "📦 Background manifest check found no available OTA update");
+                    }
+                    otaCheckReachedSuccessLog[0] = true;
+                    Log.i(TAG, "OTA check completed successfully");
+                    return;
+                }
+
                 stage[0] = "process_updates";
                 if (json.has("apps")) {
                     processAppsSequentially(json, context, installNow);
@@ -994,21 +789,10 @@ public class OtaHelper {
                     }
                 }
 
-                if (!isPhoneInitiatedOta) {
-                    stage[0] = "build_cache_ready_info";
-                    JSONObject cacheReadyInfo = buildCacheReadyUpdateInfo(json);
-                    if (cacheReadyInfo != null && cacheReadyInfo.optBoolean("available", false) && isPhoneConnected()) {
-                        stage[0] = "notify_phone_cache_ready";
-                        notifyPhoneUpdateAvailable(cacheReadyInfo);
-                        Log.i(TAG, "📱 Background pre-download ready - prompted phone to install");
-                    } else {
-                        Log.i(TAG, "📦 Background pre-download complete - updates not fully cache-ready yet");
-                    }
-                }
                 otaCheckReachedSuccessLog[0] = true;
                 Log.i(TAG, "OTA check completed successfully");
             } catch (Exception e) {
-                String urlForLog = versionJsonUrl != null ? versionJsonUrl : lastVersionJsonUrl;
+                String urlForLog = resolvedVersionJsonUrl != null ? resolvedVersionJsonUrl : lastVersionJsonUrl;
                 String rootMsg = e.getMessage() != null ? e.getMessage() : "";
                 String causeInfo = "";
                 if (e.getCause() != null) {
@@ -1022,14 +806,13 @@ public class OtaHelper {
                         + ", isBackgroundPrefetch=" + isBackgroundPrefetchInProgress
                         + ", error=" + e.getClass().getName() + ": " + rootMsg
                         + causeInfo, e);
-                cachedVersionJson = null;
-                // Cancel any queued install — triggering an install pass after a failed prefetch
-                // would attempt to install a potentially corrupt or incomplete cache.
-                pendingPhoneInstall = false;
+                boolean pendingInstallQueued = hasPendingPhoneInstall();
                 // Send failure to phone with semantic error classification
                 String errorCode = classifyDownloadError(e);
                 if (isPhoneInitiatedOta) {
                     sendProgressToPhone(currentUpdateStage, 0, 0, 0, "FAILED", errorCode);
+                } else if (pendingInstallQueued) {
+                    Log.i(TAG, "📱 Background version check failed, but queued ota_start will run next: " + errorCode);
                 } else if (phoneConnectionProvider != null && isPhoneConnected()) {
                     // Autonomous/background version check failed (e.g. DNS while user is on OTA screen).
                     // Still notify the phone so the UI can show no_internet / download_failed — not only
@@ -1043,20 +826,28 @@ public class OtaHelper {
                     Log.i(TAG, "📱 Notified phone of version-check OTA failure (background path): " + errorCode);
                 }
             } finally {
-                // Capture before resetting — if the user tapped Install while prefetch was running,
-                // we need to fire a fresh install pass now that the cache is fully populated.
-                boolean shouldInstallNow = pendingPhoneInstall;
+                // Capture before resetting — if the user tapped Install while a background check was
+                // running, fire a fresh phone-initiated pass now that the lock is free.
+                boolean shouldInstallNow;
+                String pendingVersionJsonUrl;
+                synchronized (pendingPhoneInstallLock) {
+                    shouldInstallNow = pendingPhoneInstall;
+                    pendingVersionJsonUrl = pendingPhoneInstallVersionJsonUrl;
+                    pendingPhoneInstall = false;
+                    pendingPhoneInstallVersionJsonUrl = null;
+                }
                 isBackgroundPrefetchInProgress = false;
                 isPhoneInitiatedOta = false;
-                pendingPhoneInstall = false;
                 versionCheckLock.unlock();
                 Log.d(TAG, "Version check thread finished (reachedSuccessLog=" + otaCheckReachedSuccessLog[0]
                         + ", lastStage=" + stage[0] + "), lock released, ready for next check");
 
                 if (shouldInstallNow) {
-                    Log.i(TAG, "📱 Phone-initiated install was queued during prefetch - firing install pass now");
+                    Log.i(TAG, "📱 Phone-initiated install was queued during background check - firing install pass now");
                     isPhoneInitiatedOta = true;
-                    startVersionCheckWithUrl(context, lastVersionJsonUrl); // fresh pass: same URL, installNow=true, files served from cache
+                    startVersionCheckWithUrl(
+                            context,
+                            pendingVersionJsonUrl != null ? pendingVersionJsonUrl : lastVersionJsonUrl);
                 }
             }
         }).start();
@@ -1132,38 +923,6 @@ public class OtaHelper {
             // "com.augmentos.otaupdater"      // Then OTA updater
         };
 
-        // PHASE 0: Pre-download firmware artifacts BEFORE any APK install.
-        // APK install kills the app process, so MTK/BES firmware files must be cached
-        // beforehand. After restart the install phase can serve files from cache.
-        {
-            try {
-                if (!wasMtkUpdatedThisSession() && !isMtkOtaInProgress() && rootJson.has("mtk_patches")) {
-                    String currentMtkVersion = SysProp.getProperty(context, "ro.custom.ota.version");
-                    JSONObject mtkPatch = findMatchingMtkPatch(rootJson.getJSONArray("mtk_patches"), currentMtkVersion);
-                    if (mtkPatch != null) {
-                        Log.i(TAG, "📦 Phase 0: Pre-downloading MTK firmware before APK install");
-                        checkAndUpdateMtkFirmware(mtkPatch, context, false);
-                    }
-                }
-                if (rootJson.has("bes_firmware")) {
-                    String currentBesVersion = "";
-                    try {
-                        AsgSettings asgSettings = new AsgSettings(context);
-                        currentBesVersion = asgSettings.getBesFirmwareVersion();
-                    } catch (Exception e) {
-                        Log.e(TAG, "Error getting BES firmware version from AsgSettings", e);
-                    }
-                    boolean besNeeded = checkBesUpdate(rootJson.getJSONObject("bes_firmware"), currentBesVersion);
-                    if (besNeeded) {
-                        Log.i(TAG, "📦 Phase 0: Pre-downloading BES firmware before APK install");
-                        checkAndUpdateBesFirmware(rootJson.getJSONObject("bes_firmware"), context, false);
-                    }
-                }
-            } catch (Exception e) {
-                Log.w(TAG, "Phase 0 firmware prefetch failed (non-fatal) - will retry later", e);
-            }
-        }
-        
         boolean apkUpdateNeeded = false;
         boolean apkUpdateFailed = false;
         String failedApkPackage = null;
@@ -1186,7 +945,7 @@ public class OtaHelper {
                 boolean success = checkAndUpdateApp(packageName, appInfo, context, installNow);
                 
                 if (success) {
-                    Log.i(TAG, (installNow ? "Successfully updated " : "Successfully pre-downloaded ") + packageName);
+                    Log.i(TAG, (installNow ? "Successfully updated " : "Update available for ") + packageName);
                     if (installNow) {
                         apkUpdateNeeded = true;
                     }
@@ -1302,12 +1061,6 @@ public class OtaHelper {
                         } else {
                             Log.e(TAG, "MTK firmware update failed to start");
                         }
-                    } else {
-                        // Prefetch mode: download/cache BOTH artifacts now so prompt can be shown as cache-ready.
-                        Log.i(TAG, "Both MTK and BES updates available - pre-downloading both artifacts");
-                        boolean mtkPrefetched = checkAndUpdateMtkFirmware(mtkPatch, context, false);
-                        boolean besPrefetched = checkAndUpdateBesFirmware(rootJson.getJSONObject("bes_firmware"), context, false);
-                        Log.i(TAG, "Prefetch results -> mtk=" + mtkPrefetched + ", bes=" + besPrefetched);
                     }
                 } else if (mtkPatch != null) {
                     // Only MTK - apply normally (stages, needs manual reboot)
@@ -1352,7 +1105,7 @@ public class OtaHelper {
                 }
             }
         } else {
-            Log.i(TAG, "APK update performed - firmware already pre-downloaded in Phase 0, install will happen after restart");
+            Log.i(TAG, "APK update performed - any firmware update will be fetched fresh after restart");
         }
         
         Log.d(TAG, "Sequential updates completed (APK → MTK → BES)");
@@ -1398,48 +1151,31 @@ public class OtaHelper {
             
             if (serverVersion > currentVersion) {
                 String filename = getApkFilename(packageName);
-                String cacheKey = getApkCacheKey(packageName);
                 String localPath = OtaConstants.BASE_DIR + "/" + filename;
 
-                boolean hasValidCache = isCachedArtifactValid(cacheKey, UPDATE_TYPE_APK, localPath, appInfo);
-                if (!hasValidCache) {
-                    if (installNow) {
-                        isUpdating = true;
-                        Log.i(TAG, "Starting update process for " + packageName);
-                    } else {
-                        Log.i(TAG, "📦 Prefetching APK for " + packageName);
-                    }
-
-                    File apkFile = new File(localPath);
-                    if (apkFile.exists() && !apkFile.delete()) {
-                        Log.w(TAG, "Failed deleting old APK before refresh: " + apkFile.getName());
-                    }
-
-                    // Create backup before update install
-                    if (installNow) {
-                        createAppBackup(packageName, context);
-                    }
-
-                    boolean downloadOk = downloadApk(apkUrl, appInfo, context, filename);
-                    if (!downloadOk) {
-                        clearCachedArtifact(cacheKey, UPDATE_TYPE_APK);
-                        isUpdating = false;
-                        Log.d(TAG, "Download failed, cleared isUpdating for next OTA attempt");
-                        return false;
-                    }
-                    markCachedArtifactReady(cacheKey, UPDATE_TYPE_APK, localPath, appInfo);
-                } else {
-                    Log.i(TAG, "📦 Cache hit for " + packageName + " - APK already downloaded, skipping download stage entirely");
-                    if (installNow) {
-                        Log.i(TAG, "⚡ Cache hit + installNow: jumping straight to install (no download UI shown to user)");
-                    }
-                }
-
                 if (!installNow) {
+                    Log.i(TAG, "Manifest-only check - skipping APK download for " + packageName);
                     return true;
                 }
 
-                Log.i(TAG, "📲 Proceeding to install " + packageName + " (source: " + (hasValidCache ? "cache" : "fresh download") + ")");
+                isUpdating = true;
+                Log.i(TAG, "Starting update process for " + packageName);
+
+                File apkFile = new File(localPath);
+                if (apkFile.exists() && !apkFile.delete()) {
+                    Log.w(TAG, "Failed deleting old APK before refresh: " + apkFile.getName());
+                }
+
+                createAppBackup(packageName, context);
+
+                boolean downloadOk = downloadApk(apkUrl, appInfo, context, filename);
+                if (!downloadOk) {
+                    isUpdating = false;
+                    Log.d(TAG, "Download failed, cleared isUpdating for next OTA attempt");
+                    return false;
+                }
+
+                Log.i(TAG, "📲 Proceeding to install " + packageName + " (fresh download)");
                 currentUpdateStage = "install";
                 sendProgressToPhone("install", 0, 0, 0, "STARTED", null);
 
@@ -1463,13 +1199,15 @@ public class OtaHelper {
                         sessionManager.clearRestartGuard();
                     }
                     sendProgressToPhone("install", 0, 0, 0, "FAILED", "install_failed");
-                    clearCachedArtifact(cacheKey, UPDATE_TYPE_APK);
                     return false;
                 }
 
-                // Clean up cached update file after install attempt
+                // Clean up the update file after install attempt.
                 new Handler(Looper.getMainLooper()).postDelayed(() -> {
-                    clearCachedArtifact(cacheKey, UPDATE_TYPE_APK);
+                    File installedApkFile = new File(localPath);
+                    if (installedApkFile.exists() && !installedApkFile.delete()) {
+                        Log.w(TAG, "Failed deleting APK update file after install: " + installedApkFile.getName());
+                    }
                 }, 30000);
 
                 return true;
@@ -1580,8 +1318,7 @@ public class OtaHelper {
         currentUpdateType = "apk";
 
         // Now that we have the real file size, tell the phone the download is starting.
-        // This is deferred from startOtaFromPhone() so cache hits never send this event.
-        Log.i(TAG, "📥 Sending download STARTED to phone (actual download, not cache hit)");
+        Log.i(TAG, "📥 Sending download STARTED to phone");
         sendProgressToPhone("download", 0, 0, fileSize, "STARTED", null);
 
         // Emit download started event
@@ -2103,21 +1840,16 @@ public class OtaHelper {
                 Log.e(TAG, "BES firmware URL missing in JSON (expected 'url' or 'firmwareUrl')");
                 return false;
             }
-            boolean hasValidCache = isCachedArtifactValid(CACHE_KEY_BES, UPDATE_TYPE_BES, OtaConstants.BES_FIRMWARE_PATH, firmwareInfo);
-            if (!hasValidCache) {
-                boolean downloaded = downloadBesFirmware(firmwareUrl, firmwareInfo, context);
-                if (!downloaded) {
-                    Log.e(TAG, "Failed to download BES firmware");
-                    clearCachedArtifact(CACHE_KEY_BES, UPDATE_TYPE_BES);
-                    return false;
-                }
-                markCachedArtifactReady(CACHE_KEY_BES, UPDATE_TYPE_BES, OtaConstants.BES_FIRMWARE_PATH, firmwareInfo);
-            } else {
-                Log.i(TAG, "📦 Cache hit for BES firmware - using pre-downloaded artifact");
-            }
 
             if (!installNow) {
+                Log.i(TAG, "Manifest-only check - skipping BES firmware download");
                 return true;
+            }
+
+            boolean downloaded = downloadBesFirmware(firmwareUrl, firmwareInfo, context);
+            if (!downloaded) {
+                Log.e(TAG, "Failed to download BES firmware");
+                return false;
             }
 
             if (!isPhoneInitiatedOta) {
@@ -2135,15 +1867,12 @@ public class OtaHelper {
                     return true;
                 } else {
                     Log.e(TAG, "Failed to start BES firmware update");
-                    clearCachedArtifact(CACHE_KEY_BES, UPDATE_TYPE_BES);
                 }
             } else {
                 Log.e(TAG, "BesOtaManager not available");
-                clearCachedArtifact(CACHE_KEY_BES, UPDATE_TYPE_BES);
             }
         } catch (Exception e) {
             Log.e(TAG, "Failed to update BES firmware", e);
-            clearCachedArtifact(CACHE_KEY_BES, UPDATE_TYPE_BES);
         }
         return false;
     }
@@ -2385,21 +2114,16 @@ public class OtaHelper {
                 Log.e(TAG, "MTK firmware URL missing in JSON (expected 'url' or 'firmwareUrl')");
                 return false;
             }
-            boolean hasValidCache = isCachedArtifactValid(CACHE_KEY_MTK, UPDATE_TYPE_MTK, OtaConstants.MTK_FIRMWARE_PATH, firmwareInfo);
-            if (!hasValidCache) {
-                boolean downloaded = downloadMtkFirmware(firmwareUrl, firmwareInfo, context);
-                if (!downloaded) {
-                    Log.e(TAG, "Failed to download MTK firmware");
-                    clearCachedArtifact(CACHE_KEY_MTK, UPDATE_TYPE_MTK);
-                    return false;
-                }
-                markCachedArtifactReady(CACHE_KEY_MTK, UPDATE_TYPE_MTK, OtaConstants.MTK_FIRMWARE_PATH, firmwareInfo);
-            } else {
-                Log.i(TAG, "📦 Cache hit for MTK firmware - using pre-downloaded artifact");
-            }
 
             if (!installNow) {
+                Log.i(TAG, "Manifest-only check - skipping MTK firmware download");
                 return true;
+            }
+
+            boolean downloaded = downloadMtkFirmware(firmwareUrl, firmwareInfo, context);
+            if (!downloaded) {
+                Log.e(TAG, "Failed to download MTK firmware");
+                return false;
             }
 
             if (!isPhoneInitiatedOta) {
@@ -2448,7 +2172,6 @@ public class OtaHelper {
         } catch (Exception e) {
             Log.e(TAG, "Failed to update MTK firmware", e);
             isMtkOtaInProgress = false;
-            clearCachedArtifact(CACHE_KEY_MTK, UPDATE_TYPE_MTK);
         }
         return false;
     }
@@ -2754,76 +2477,11 @@ public class OtaHelper {
                 return updateInfo;
             }
 
-            if (!allArtifactsCachedForUpdates(rootJson, updates)) {
-                updateInfo.put("available", false);
-                return updateInfo;
-            }
-
             updateInfo.put("cache_ready", true);
             return updateInfo;
         } catch (Exception e) {
             Log.e(TAG, "Error building cache-ready update info", e);
             return null;
-        }
-    }
-
-    private boolean allArtifactsCachedForUpdates(JSONObject rootJson, JSONArray updates) {
-        try {
-            for (int i = 0; i < updates.length(); i++) {
-                String updateType = updates.optString(i, "");
-                if (UPDATE_TYPE_APK.equals(updateType)) {
-                    JSONObject apps = rootJson.optJSONObject("apps");
-                    if (apps == null) {
-                        return false;
-                    }
-
-                    JSONObject asgInfo = apps.optJSONObject("com.mentra.asg_client");
-                    if (asgInfo != null && asgInfo.optLong("versionCode", 0) > getInstalledVersion("com.mentra.asg_client", context)) {
-                        String asgPath = OtaConstants.BASE_DIR + "/" + getApkFilename("com.mentra.asg_client");
-                        if (!isCachedArtifactValid(CACHE_KEY_APK_ASG, UPDATE_TYPE_APK, asgPath, asgInfo)) {
-                            return false;
-                        }
-                    }
-
-                    JSONObject updaterInfo = apps.optJSONObject("com.augmentos.otaupdater");
-                    if (updaterInfo != null && updaterInfo.optLong("versionCode", 0) > getInstalledVersion("com.augmentos.otaupdater", context)) {
-                        String updaterPath = OtaConstants.BASE_DIR + "/" + getApkFilename("com.augmentos.otaupdater");
-                        if (!isCachedArtifactValid(CACHE_KEY_APK_UPDATER, UPDATE_TYPE_APK, updaterPath, updaterInfo)) {
-                            return false;
-                        }
-                    }
-                    continue;
-                }
-
-                if (UPDATE_TYPE_MTK.equals(updateType)) {
-                    if (!rootJson.has("mtk_patches")) {
-                        return false;
-                    }
-                    String currentMtkVersion = SysProp.getProperty(context, "ro.custom.ota.version");
-                    JSONObject mtkPatch = findMatchingMtkPatch(rootJson.getJSONArray("mtk_patches"), currentMtkVersion);
-                    if (mtkPatch == null) {
-                        continue;
-                    }
-                    if (!isCachedArtifactValid(CACHE_KEY_MTK, UPDATE_TYPE_MTK, OtaConstants.MTK_FIRMWARE_PATH, mtkPatch)) {
-                        return false;
-                    }
-                    continue;
-                }
-
-                if (UPDATE_TYPE_BES.equals(updateType)) {
-                    JSONObject besInfo = rootJson.optJSONObject("bes_firmware");
-                    if (besInfo == null) {
-                        return false;
-                    }
-                    if (!isCachedArtifactValid(CACHE_KEY_BES, UPDATE_TYPE_BES, OtaConstants.BES_FIRMWARE_PATH, besInfo)) {
-                        return false;
-                    }
-                }
-            }
-            return true;
-        } catch (Exception e) {
-            Log.e(TAG, "Error validating cache readiness for updates", e);
-            return false;
         }
     }
 
@@ -2861,12 +2519,12 @@ public class OtaHelper {
         
         updateSessionFromProgress(stage, progress, status, errorMessage);
 
-        // Suppress FINISHED while an install pass is queued. The prefetch thread sends
+        // Suppress FINISHED while an install pass is queued. The background-check thread sends
         // FINISHED(download) for each artifact it completes, but no install follows — only
         // the pending install pass will do that. Letting FINISHED through here would cause
         // the phone UI to prematurely transition to "completed" or start a 12s timer before
         // the real install has begun. The install pass sends its own STARTED/PROGRESS/FINISHED.
-        if (pendingPhoneInstall && "FINISHED".equals(status)) {
+        if (hasPendingPhoneInstall() && "FINISHED".equals(status)) {
             Log.d(TAG, "Suppressing FINISHED - install pass is pending, will send its own completion");
             return;
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/receivers/MtkOtaReceiver.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/receivers/MtkOtaReceiver.java
@@ -75,10 +75,6 @@ public class MtkOtaReceiver extends BroadcastReceiver {
                 Log.e(TAG, "MTK OTA error: " + msg);
                 // Clear in-progress flag on error
                 OtaHelper.setMtkOtaInProgress(false);
-                OtaHelper helper = OtaHelper.getInstance();
-                if (helper != null) {
-                    helper.clearCachedArtifactsForType("mtk");
-                }
                 break;
                 
             case RESULT_CMD_SUCCESS:

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -67,9 +67,6 @@ public class OtaService extends Service {
         // Initialize OTA helper singleton
         otaHelper = OtaHelper.initialize(this);
 
-        // Clean up old firmware files from previous updates
-        cleanupOldFirmwareFiles();
-
         // Check if ASG client was just updated - if so, auto-resume OTA for MTK/BES
         checkAndResumeAfterApkUpdate();
 
@@ -268,7 +265,6 @@ public class OtaService extends Service {
                 // Send FAILED to phone so user knows something went wrong
                 if (otaHelper != null) {
                     otaHelper.sendMtkInstallProgressToPhone("FAILED", 0, event.getMessage());
-                    otaHelper.clearCachedArtifactsForType("mtk");
                 }
                 break;
         }
@@ -327,25 +323,8 @@ public class OtaService extends Service {
                 // Try to notify phone of failure (might work if UART recovers)
                 if (otaHelper != null) {
                     otaHelper.sendBesInstallProgressToPhone("FAILED", 0, event.getErrorMessage());
-                    otaHelper.clearCachedArtifactsForType("bes");
                 }
                 break;
-        }
-    }
-
-    /**
-     * Clean up old firmware files from previous OTA updates.
-     * Called on service startup to remove any leftover files.
-     */
-    private void cleanupOldFirmwareFiles() {
-        try {
-            if (otaHelper != null) {
-                otaHelper.pruneInvalidCachedArtifactsOnStartup();
-            } else {
-                Log.w(TAG, "OtaHelper unavailable for cache pruning on startup");
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "Error cleaning up old firmware files", e);
         }
     }
 
@@ -410,7 +389,7 @@ public class OtaService extends Service {
                 prefs.edit().putLong("last_seen_asg_version", currentVersion).apply();
 
                 if (otaHelper != null) {
-                    Log.i(TAG, "📱 Triggering background OTA pre-download check (first boot or update from old version)");
+                    Log.i(TAG, "📱 Triggering background OTA manifest check (first boot or update from old version)");
                     otaHelper.startVersionCheck(this);
                 }
             } else if (currentVersion > previousVersion) {
@@ -418,7 +397,7 @@ public class OtaService extends Service {
                 prefs.edit().putLong("last_seen_asg_version", currentVersion).apply();
 
                 if (otaHelper != null) {
-                    Log.i(TAG, "📱 Auto-resuming background OTA pre-download check for MTK/BES updates");
+                    Log.i(TAG, "📱 Auto-resuming background OTA manifest check for MTK/BES updates");
                     otaHelper.startVersionCheck(this);
                 }
             } else {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/utils/OtaConstants.java
@@ -7,8 +7,10 @@ public class OtaConstants {
     public static final String TAG = "ASGClientOTA";
 
     // URLs
-    // Production OTA version JSON URL
-    public static final String VERSION_JSON_URL = "https://ota.mentraglass.com/prod_live_version.json";
+    // Production OTA version JSON URL for ASG client 39+.
+    // prod_live_version.json intentionally remains the legacy rescue manifest for
+    // older clients that may be stuck on a corrupted artifact cache.
+    public static final String VERSION_JSON_URL = "https://ota.mentraglass.com/prod_live_version_v2.json";
 
     // Test URLs (uncomment to use for testing)
     // public static final String VERSION_JSON_URL = "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/live_version_test_non_production.json";

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandler.java
@@ -6,6 +6,7 @@ import com.mentra.asg_client.io.ota.helpers.OtaHelper;
 import com.mentra.asg_client.service.legacy.interfaces.ICommandHandler;
 import com.mentra.asg_client.service.communication.interfaces.ICommunicationManager;
 
+import java.net.URI;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -23,6 +24,8 @@ import android.os.Looper;
  */
 public class OtaCommandHandler implements ICommandHandler {
     private static final String TAG = "OtaCommandHandler";
+    private static final String OTA_VERSION_URL_FIELD = "ota_version_url";
+    private static final String INVALID_OTA_VERSION_URL = "invalid_ota_version_url";
     
     // Retry configuration for ota_start when OtaHelper not yet initialized
     private static final int OTA_START_MAX_RETRIES = 4;
@@ -119,11 +122,45 @@ public class OtaCommandHandler implements ICommandHandler {
 
         // Reset retry counter on success
         otaStartRetryCount = 0;
+
+        String otaVersionUrl = getValidatedOtaVersionUrl(data);
+        if (INVALID_OTA_VERSION_URL.equals(otaVersionUrl)) {
+            sendOtaError("Invalid ota_version_url. Must be a non-empty http(s) URL.");
+            return false;
+        }
         
         // Start OTA from phone request
-        otaHelperInstance.startOtaFromPhone();
+        otaHelperInstance.startOtaFromPhone(otaVersionUrl);
         Log.i(TAG, "📱 OTA started from phone command");
         return true;
+    }
+
+    private String getValidatedOtaVersionUrl(JSONObject data) {
+        if (data == null || !data.has(OTA_VERSION_URL_FIELD) || data.isNull(OTA_VERSION_URL_FIELD)) {
+            return null;
+        }
+
+        String rawUrl = data.optString(OTA_VERSION_URL_FIELD, "").trim();
+        if (rawUrl.isEmpty()) {
+            Log.w(TAG, "Rejecting ota_start with empty ota_version_url");
+            return INVALID_OTA_VERSION_URL;
+        }
+
+        try {
+            URI uri = URI.create(rawUrl);
+            String scheme = uri.getScheme();
+            String host = uri.getHost();
+            if ((!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme))
+                    || host == null
+                    || host.isEmpty()) {
+                Log.w(TAG, "Rejecting ota_start with non-http(s) ota_version_url: " + rawUrl);
+                return INVALID_OTA_VERSION_URL;
+            }
+            return rawUrl;
+        } catch (IllegalArgumentException e) {
+            Log.w(TAG, "Rejecting ota_start with malformed ota_version_url: " + rawUrl, e);
+            return INVALID_OTA_VERSION_URL;
+        }
     }
 
     /**
@@ -203,4 +240,4 @@ public class OtaCommandHandler implements ICommandHandler {
             Log.e(TAG, "Error creating OTA error message", e);
         }
     }
-} 
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandlerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/OtaCommandHandlerTest.java
@@ -1,0 +1,61 @@
+package com.mentra.asg_client.service.core.handlers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.lang.reflect.Method;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class OtaCommandHandlerTest {
+
+    @Test
+    public void getValidatedOtaVersionUrl_missingField_returnsNull() throws Exception {
+        assertNull(validate(new JSONObject()));
+    }
+
+    @Test
+    public void getValidatedOtaVersionUrl_validHttps_returnsTrimmedUrl() throws Exception {
+        assertEquals(
+                "https://ota.mentraglass.com/sdk_live_version.json",
+                validate(
+                        new JSONObject()
+                                .put(
+                                        "ota_version_url",
+                                        " https://ota.mentraglass.com/sdk_live_version.json ")));
+    }
+
+    @Test
+    public void getValidatedOtaVersionUrl_validHttp_returnsUrl() throws Exception {
+        assertEquals(
+                "http://192.168.1.2/version.json",
+                validate(
+                        new JSONObject()
+                                .put("ota_version_url", "http://192.168.1.2/version.json")));
+    }
+
+    @Test
+    public void getValidatedOtaVersionUrl_rejectsEmptyUrl() throws Exception {
+        assertEquals(
+                "invalid_ota_version_url", validate(new JSONObject().put("ota_version_url", " ")));
+    }
+
+    @Test
+    public void getValidatedOtaVersionUrl_rejectsNonHttpUrl() throws Exception {
+        assertEquals(
+                "invalid_ota_version_url",
+                validate(new JSONObject().put("ota_version_url", "file:///tmp/version.json")));
+    }
+
+    private String validate(JSONObject data) throws Exception {
+        Method method =
+                OtaCommandHandler.class.getDeclaredMethod("getValidatedOtaVersionUrl", JSONObject.class);
+        method.setAccessible(true);
+        return (String) method.invoke(new OtaCommandHandler(), data);
+    }
+}

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 38,
-      "versionName": "38.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38.apk",
-      "sha256": "ccd334a658f1e6aa2d716dc5a2b2ea2751bead5bda25b8cf43be4faffa9e20a8"
+      "versionCode": 37,
+      "versionName": "37.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
+      "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -14,24 +14,6 @@
     }
   },
   "mtk_patches": [
-    {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
-    },
     {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,6 +15,24 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
+      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
+      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+    },
+    {
       "start_firmware": "MentraLive_20260204",
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -49,6 +49,36 @@
       "end_firmware": "MentraLive_20260626",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
       "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
+    },
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260626.zip",
+      "sha256": "29f6e576d64af5cbf9b1876b6b4bc4e8dbfe0282d2b55770868835802d588f0c"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260626.zip",
+      "sha256": "b0e03742d7a7f5969a625f9cb96864efb27a4b42c2075e0dff51457724cb5ea2"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260626.zip",
+      "sha256": "7be3fcc0b287a1675d7aee69cd1e8869443041d9eb53dc0f4078406c44720864"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260626.zip",
+      "sha256": "cc58004dc60ddd48a16dae64cb1d1babe2168f04f1ff973f6de3228e0745d554"
+    },
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260626.zip",
+      "sha256": "69430f579c5a2b8d553a1529a7379687a18d71f8ff09239f4cac130f358730d3"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -52,8 +52,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.03",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.03.bin",
+    "sha256": "a652466b5fefab820f76434eee545e52cc481ba1920cb7a00770b9e9360a7133"
   }
 }

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -58,8 +58,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.03",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.03.bin",
-    "sha256": "a652466b5fefab820f76434eee545e52cc481ba1920cb7a00770b9e9360a7133"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   }
 }

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,36 +15,6 @@
   },
   "mtk_patches": [
     {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
-    },
-    {
-      "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
-      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
-    },
-    {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
-      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
-    },
-    {
       "start_firmware": "MentraLive_20260525",
       "end_firmware": "MentraLive_20260626",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -43,6 +43,12 @@
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
       "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
+      "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -15,40 +15,46 @@
   },
   "mtk_patches": [
     {
-      "start_firmware": "MentraLive_20260525",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
-      "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
-    },
-    {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260626.zip",
-      "sha256": "29f6e576d64af5cbf9b1876b6b4bc4e8dbfe0282d2b55770868835802d588f0c"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260626.zip",
-      "sha256": "b0e03742d7a7f5969a625f9cb96864efb27a4b42c2075e0dff51457724cb5ea2"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260626.zip",
-      "sha256": "7be3fcc0b287a1675d7aee69cd1e8869443041d9eb53dc0f4078406c44720864"
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
     },
     {
       "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260626.zip",
-      "sha256": "cc58004dc60ddd48a16dae64cb1d1babe2168f04f1ff973f6de3228e0745d554"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
     },
     {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260626.zip",
-      "sha256": "69430f579c5a2b8d553a1529a7379687a18d71f8ff09239f4cac130f358730d3"
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
+      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
+    },
+    {
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -1,0 +1,47 @@
+{
+  "apps": {
+    "com.mentra.asg_client": {
+      "versionCode": 39,
+      "versionName": "39.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-39.apk",
+      "sha256": "9e26dc820864691bc93c2a15d43d41b26342f01aafc4c8a58b530b0b71e739d7"
+    }
+  },
+  "mtk_patches": [
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
+      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
+      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
+      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
+    },
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
+      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
+    }
+  ],
+  "bes_firmware": {
+    "version": "17.26.05.22",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
+    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+  }
+}

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -14,6 +14,48 @@
     }
   },
   "mtk_patches": [
+    {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
+    },
+    {
+      "start_firmware": "MentraLive_20260418",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
+      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
+    },
+    {
+      "start_firmware": "MentraLive_20260421",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
+    },
+    {
+      "start_firmware": "MentraLive_20260513",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
+    },
+    {
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
+    }
   ],
   "bes_firmware": {
     "version": "17.26.05.22",

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -58,9 +58,9 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   },
   "remediation": {
     "enabled": false,

--- a/asg_client/ota_website/prod_live_version_v2.json
+++ b/asg_client/ota_website/prod_live_version_v2.json
@@ -1,5 +1,11 @@
 {
   "apps": {
+    "com.mentra.recovery": {
+      "versionCode": 0,
+      "versionName": "0.0",
+      "apkUrl": "",
+      "sha256": ""
+    },
     "com.mentra.asg_client": {
       "versionCode": 39,
       "versionName": "39.0",
@@ -8,40 +14,19 @@
     }
   },
   "mtk_patches": [
-    {
-      "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
-    },
-    {
-      "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
-    },
-    {
-      "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
-    },
-    {
-      "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
-      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
-    },
-    {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
-      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
-    }
   ],
   "bes_firmware": {
     "version": "17.26.05.22",
     "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
     "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+  },
+  "remediation": {
+    "enabled": false,
+    "packageName": "com.mentra.asg_client",
+    "maxVersionCode": 38,
+    "versionCode": 39,
+    "versionName": "39.0",
+    "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-39.apk",
+    "sha256": ""
   }
 }

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -3,8 +3,8 @@
     "com.mentra.asg_client": {
       "versionCode": 38,
       "versionName": "38.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38.apk",
-      "sha256": "ccd334a658f1e6aa2d716dc5a2b2ea2751bead5bda25b8cf43be4faffa9e20a8"
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk",
+      "sha256": "d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -43,6 +43,12 @@
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
       "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
+    },
+    {
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260624",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260624.zip",
+      "sha256": "329f427e93b5237c6b15eeca58313fd90fb9d203468dd6dd2b52a7dd6f21440d"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -48,7 +48,7 @@
       "start_firmware": "MentraLive_20260525",
       "end_firmware": "MentraLive_20260626",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
-      "sha256": "329f427e93b5237c6b15eeca58313fd90fb9d203468dd6dd2b52a7dd6f21440d"
+      "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -46,8 +46,8 @@
     },
     {
       "start_firmware": "MentraLive_20260525",
-      "end_firmware": "MentraLive_20260624",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260624.zip",
+      "end_firmware": "MentraLive_20260626",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
       "sha256": "329f427e93b5237c6b15eeca58313fd90fb9d203468dd6dd2b52a7dd6f21440d"
     }
   ],

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -1,10 +1,10 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 38,
-      "versionName": "38.0",
-      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-38-test.apk",
-      "sha256": "d504e1f164e50109419c8c2181428f468a393575884294700270fcffe0cc7b59"
+      "versionCode": 37,
+      "versionName": "37.0",
+      "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg_client_37-test.apk",
+      "sha256": "9fe9510a3c92dda9d6d15416303be7625908388caf02ff1be72a918170371628"
     },
     "com.augmentos.otaupdater": {
       "versionCode": 0,
@@ -16,9 +16,9 @@
   "mtk_patches": [
     {
       "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260709",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
-      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
+      "end_firmware": "MentraLive_20260525",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
+      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
     },
     {
       "start_firmware": "MentraLive_20260421",
@@ -43,12 +43,6 @@
       "end_firmware": "MentraLive_20260525",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
       "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
-    },
-    {
-      "start_firmware": "MentraLive_20260525",
-      "end_firmware": "MentraLive_20260626",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260626.zip",
-      "sha256": "0c7e78764e175346cd78343befdd06e3a53c0ce9a1841e451a069d9d7f8a11a6"
     }
   ],
   "bes_firmware": {

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -15,6 +15,18 @@
   },
   "mtk_patches": [
     {
+      "start_firmware": "MentraLive_20260113",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260709.zip",
+      "sha256": "cdfef8953f9b4cbac70a108b49e131aba2df092a6b384f0616356611fb772b47"
+    },
+    {
+      "start_firmware": "MentraLive_20260204",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260709.zip",
+      "sha256": "b280ecb480c21bb8f83fbdd40b766ff1a7e234008ae639b9c6bec96bbae1fe8f"
+    },
+    {
       "start_firmware": "MentraLive_20260418",
       "end_firmware": "MentraLive_20260709",
       "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
@@ -22,32 +34,32 @@
     },
     {
       "start_firmware": "MentraLive_20260421",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260525.zip",
-      "sha256": "07bf1d53f9527a6dc1cb1165d9edd6e3ff8ecb09e9f2f49ff9abdc157774052e"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260421_20260709.zip",
+      "sha256": "e63b01d15141565aed67fd5d4fecc26aeebfcbdcad4366d0e650e06263ba24ca"
     },
     {
       "start_firmware": "MentraLive_20260513",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260525.zip",
-      "sha256": "f9f5b30ce7cbb335a1f51296d16a33e3f44fc51171eb921304ea90089c493619"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260513_20260709.zip",
+      "sha256": "9a1c0f233731e8a6ff6a8c0d484e8ca3398ad2afcc0e658ae1721276399639b7"
     },
     {
-      "start_firmware": "MentraLive_20260204",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260204_20260525.zip",
-      "sha256": "6078863f99b28fa7a6a7988e12e001ee6384f928861a3129f50652bec82bbd27"
+      "start_firmware": "MentraLive_20260525",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260525_20260709.zip",
+      "sha256": "ca688255dd189798bb0ef23e556bb7d897241060d80f438fa1c07f12234c1cbc"
     },
     {
-      "start_firmware": "MentraLive_20260113",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260113_20260525.zip",
-      "sha256": "23b391985ee5da2ac3ec0adca2186e48bcaf5fa8ea50eb2f90a7145fe8d856a7"
+      "start_firmware": "MentraLive_20260626",
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260626_20260709.zip",
+      "sha256": "be75eed47e4eb16644747e7413d132447bcc36e27ac676249d104fa7ed8eba7b"
     }
   ],
   "bes_firmware": {
-    "version": "17.26.05.22",
-    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.05.22.bin",
-    "sha256": "9499b1d132b934d3564c9dadf166595b4e9729cdf865b4be4e55b1d77cc5fa3c"
+    "version": "17.26.07.09",
+    "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/bes_firmware_17.26.07.09.bin",
+    "sha256": "4daaf2a4bc2691bf317bf07512df50edddeb2d811e1dde4d1871a4e38b50ddd5"
   }
 }

--- a/asg_client/ota_website/test_bes_ota_prod_live_version.json
+++ b/asg_client/ota_website/test_bes_ota_prod_live_version.json
@@ -16,9 +16,9 @@
   "mtk_patches": [
     {
       "start_firmware": "MentraLive_20260418",
-      "end_firmware": "MentraLive_20260525",
-      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260525.zip",
-      "sha256": "169e9b94ea4b8ff283dccd2b2db4102966bbb424dc16a188f9ff28dfb202b256"
+      "end_firmware": "MentraLive_20260709",
+      "url": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/mtk_ota_update_20260418_20260709.zip",
+      "sha256": "f82c55c53dd54ffe1b4885ea002f34bc6f7f96e1c30e8c3d717f438722d6925f"
     },
     {
       "start_firmware": "MentraLive_20260421",

--- a/cloud/.env.example
+++ b/cloud/.env.example
@@ -50,6 +50,7 @@ AZURE_SPEECH_KEY=
 
 # Soniox Speech
 SONIOX_API_KEY=
+SONIOX_FALLBACK_API_KEYS=
 
 # =============================================================================
 # LLM Configuration

--- a/cloud/issues/108-soniox-fallback-api-keys/spec.md
+++ b/cloud/issues/108-soniox-fallback-api-keys/spec.md
@@ -1,0 +1,42 @@
+# Spec: Soniox Fallback API Keys
+
+## Environment
+
+Existing:
+
+```bash
+SONIOX_API_KEY=primary-key
+```
+
+New:
+
+```bash
+SONIOX_FALLBACK_API_KEYS=fallback-key-a,fallback-key-b,fallback-key-c
+```
+
+`SONIOX_API_KEY` remains the preferred primary credential. Fallback keys are
+comma-separated, trimmed, and deduplicated. Empty entries are ignored.
+
+## Runtime Behavior
+
+1. New transcription stream creation first tries the primary key when it is not
+   cooling down.
+2. If the primary key is unavailable or stream creation fails with a
+   credential/limit/provider error, stream creation tries fallback keys.
+3. Fallback keys are chosen round-robin among keys that are not cooling down.
+4. No local max-concurrent accounting is used.
+5. Errors are classified into cooldown classes:
+   - concurrent stream limit: very short cooldown
+   - request/rate limit: short cooldown
+   - spend/account quota: long cooldown
+   - invalid key/authentication: disabled for this process
+   - transient/network/server: short cooldown
+6. Logs include credential fingerprints only. Raw API keys must never be logged.
+7. Existing transcription and translation retry behavior remains in place. A
+   retry should create a new stream, which reselects a Soniox key from the pool.
+
+## Non-Goals
+
+- Per-key concurrency env vars.
+- Cross-pod key usage coordination.
+- New external state such as Redis for quota tracking.

--- a/cloud/issues/108-soniox-fallback-api-keys/spike.md
+++ b/cloud/issues/108-soniox-fallback-api-keys/spike.md
@@ -1,0 +1,45 @@
+# Spike: Soniox Fallback API Keys
+
+## Problem
+
+Legacy Cloud v1 currently constructs Soniox transcription and translation
+providers from `SONIOX_API_KEY`. When that Soniox org/key hits an account-level
+limit, every new Soniox transcription or translation stream in production fails
+through the same exhausted credential. The existing provider fallback machinery
+only switches between provider types. It does not support multiple Soniox
+credentials.
+
+## Observed Code Path
+
+- `cloud/packages/cloud/src/services/session/transcription/types.ts`
+  reads `SONIOX_API_KEY` into `DEFAULT_TRANSCRIPTION_CONFIG.soniox.apiKey`.
+- `SonioxTranscriptionProvider` initializes one Soniox SDK client with that key.
+- `TranscriptionManager` creates one Soniox provider for non-China deployments.
+- Stream retry logic retries the same Soniox provider/key after 429, 408, and
+  server errors.
+- `cloud/packages/cloud/src/services/session/translation/types.ts` also reads
+  `SONIOX_API_KEY` into `DEFAULT_TRANSLATION_CONFIG.soniox.apiKey`.
+- `TranslationManager` retries translation streams, but without multiple Soniox
+  credentials it retries the same exhausted key.
+
+## Important Constraint
+
+Do not configure local max-concurrent limits per key. Soniox keys may be shared
+across pods or environments, so a local counter is incomplete and can make a key
+look available when another process already consumed its concurrency quota. The
+source of truth is Soniox accepting or rejecting a stream.
+
+## Failure Classes
+
+- Spend or account quota exhausted: long cooldown. This may not recover until
+  billing quota resets or the org is changed.
+- Request rate limited: short cooldown.
+- Concurrent stream limit: very short cooldown. Capacity may return as soon as
+  another stream closes, possibly in another process.
+- Invalid/auth key: disable for this process.
+- Network/server/transient errors: short cooldown.
+
+## Scope
+
+This hotfix targets Cloud v1 transcription and translation streams that use
+Soniox.

--- a/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
@@ -1,0 +1,227 @@
+import crypto from "crypto";
+
+export type SonioxCredentialRole = "primary" | "fallback";
+
+export interface SonioxCredential {
+  id: string;
+  apiKey: string;
+  role: SonioxCredentialRole;
+}
+
+type SonioxCredentialFailureKind =
+  | "auth"
+  | "concurrency"
+  | "quota"
+  | "rate_limit"
+  | "transient";
+
+interface SonioxCredentialState extends SonioxCredential {
+  cooldownUntil: number;
+  disabled: boolean;
+  failureKind?: SonioxCredentialFailureKind;
+  lastFailureMessage?: string;
+}
+
+export interface SonioxCredentialFailureClassification {
+  kind: SonioxCredentialFailureKind;
+  cooldownMs: number;
+  disabled?: boolean;
+}
+
+const CONCURRENCY_COOLDOWN_MS = 5_000;
+const RATE_LIMIT_COOLDOWN_MS = 60_000;
+const QUOTA_COOLDOWN_MS = 30 * 60_000;
+const TRANSIENT_COOLDOWN_MS = 10_000;
+
+export function parseSonioxFallbackApiKeys(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(",")
+    .map((key) => key.trim())
+    .filter(Boolean);
+}
+
+export function fingerprintSonioxKey(apiKey: string): string {
+  return crypto.createHash("sha256").update(apiKey).digest("hex").slice(0, 12);
+}
+
+export function classifySonioxCredentialFailure(error: Error): SonioxCredentialFailureClassification {
+  const message = error.message || "";
+  const lower = message.toLowerCase();
+  const code = extractSonioxErrorCode(message);
+
+  if (
+    code === 401 ||
+    lower.includes("invalid api key") ||
+    lower.includes("invalid_api_key") ||
+    lower.includes("bad api key") ||
+    lower.includes("unauthorized")
+  ) {
+    return { kind: "auth", cooldownMs: Number.POSITIVE_INFINITY, disabled: true };
+  }
+
+  if (
+    lower.includes("concurrent") ||
+    lower.includes("concurrency") ||
+    lower.includes("connection limit") ||
+    lower.includes("stream limit") ||
+    lower.includes("too many streams") ||
+    lower.includes("maximum streams") ||
+    lower.includes("max streams")
+  ) {
+    return { kind: "concurrency", cooldownMs: CONCURRENCY_COOLDOWN_MS };
+  }
+
+  if (
+    lower.includes("quota") ||
+    lower.includes("credit") ||
+    lower.includes("billing") ||
+    lower.includes("spend") ||
+    lower.includes("balance") ||
+    lower.includes("usage limit") ||
+    lower.includes("monthly limit")
+  ) {
+    return { kind: "quota", cooldownMs: QUOTA_COOLDOWN_MS };
+  }
+
+  if (
+    code === 429 ||
+    lower.includes("rate limit") ||
+    lower.includes("rate_limit") ||
+    lower.includes("too many requests")
+  ) {
+    return { kind: "rate_limit", cooldownMs: RATE_LIMIT_COOLDOWN_MS };
+  }
+
+  return { kind: "transient", cooldownMs: TRANSIENT_COOLDOWN_MS };
+}
+
+export class SonioxKeyPool {
+  private credentials: SonioxCredentialState[];
+  private nextFallbackIndex = 0;
+
+  constructor(primaryApiKey: string, fallbackApiKeys: string[] = []) {
+    const seen = new Set<string>();
+    const credentials: SonioxCredentialState[] = [];
+
+    const addCredential = (apiKey: string, role: SonioxCredentialRole): void => {
+      const trimmed = apiKey.trim();
+      if (!trimmed || seen.has(trimmed)) return;
+      seen.add(trimmed);
+      credentials.push({
+        id: fingerprintSonioxKey(trimmed),
+        apiKey: trimmed,
+        role,
+        cooldownUntil: 0,
+        disabled: false,
+      });
+    };
+
+    addCredential(primaryApiKey, "primary");
+    for (const key of fallbackApiKeys) {
+      addCredential(key, "fallback");
+    }
+
+    this.credentials = credentials;
+  }
+
+  get size(): number {
+    return this.credentials.length;
+  }
+
+  get hasFallbacks(): boolean {
+    return this.credentials.some((credential) => credential.role === "fallback");
+  }
+
+  selectCredential(attempted = new Set<string>(), now = Date.now()): SonioxCredential | null {
+    const primary = this.credentials.find((credential) => credential.role === "primary");
+    if (primary && !attempted.has(primary.id) && this.isAvailable(primary, now)) {
+      return this.toPublicCredential(primary);
+    }
+
+    const fallbackCredentials = this.credentials.filter((credential) => credential.role === "fallback");
+    if (fallbackCredentials.length === 0) return null;
+
+    for (let offset = 0; offset < fallbackCredentials.length; offset++) {
+      const index = (this.nextFallbackIndex + offset) % fallbackCredentials.length;
+      const credential = fallbackCredentials[index];
+      if (attempted.has(credential.id) || !this.isAvailable(credential, now)) continue;
+
+      this.nextFallbackIndex = (index + 1) % fallbackCredentials.length;
+      return this.toPublicCredential(credential);
+    }
+
+    return null;
+  }
+
+  recordSuccess(credentialId: string): void {
+    const credential = this.findCredential(credentialId);
+    if (!credential || credential.disabled) return;
+    credential.cooldownUntil = 0;
+    credential.failureKind = undefined;
+    credential.lastFailureMessage = undefined;
+  }
+
+  recordFailure(credentialId: string, error: Error, now = Date.now()): SonioxCredentialFailureClassification | null {
+    const credential = this.findCredential(credentialId);
+    if (!credential) return null;
+
+    const classification = classifySonioxCredentialFailure(error);
+    credential.failureKind = classification.kind;
+    credential.lastFailureMessage = error.message;
+
+    if (classification.disabled) {
+      credential.disabled = true;
+      credential.cooldownUntil = Number.POSITIVE_INFINITY;
+    } else {
+      credential.cooldownUntil = now + classification.cooldownMs;
+    }
+
+    return classification;
+  }
+
+  describeAvailability(now = Date.now()): Array<{
+    id: string;
+    role: SonioxCredentialRole;
+    available: boolean;
+    disabled: boolean;
+    cooldownRemainingMs: number;
+    failureKind?: SonioxCredentialFailureKind;
+  }> {
+    return this.credentials.map((credential) => ({
+      id: credential.id,
+      role: credential.role,
+      available: this.isAvailable(credential, now),
+      disabled: credential.disabled,
+      cooldownRemainingMs:
+        credential.cooldownUntil === Number.POSITIVE_INFINITY
+          ? Number.POSITIVE_INFINITY
+          : Math.max(0, credential.cooldownUntil - now),
+      failureKind: credential.failureKind,
+    }));
+  }
+
+  private findCredential(credentialId: string): SonioxCredentialState | undefined {
+    return this.credentials.find((credential) => credential.id === credentialId);
+  }
+
+  private isAvailable(credential: SonioxCredentialState, now: number): boolean {
+    return !credential.disabled && credential.cooldownUntil <= now;
+  }
+
+  private toPublicCredential(credential: SonioxCredentialState): SonioxCredential {
+    return {
+      id: credential.id,
+      apiKey: credential.apiKey,
+      role: credential.role,
+    };
+  }
+}
+
+function extractSonioxErrorCode(message: string): number | null {
+  const match = message.match(/Soniox error (\d+):/i);
+  if (!match) return null;
+  const parsed = Number.parseInt(match[1], 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+

--- a/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
@@ -32,6 +32,7 @@ const CONCURRENCY_COOLDOWN_MS = 5_000;
 const RATE_LIMIT_COOLDOWN_MS = 60_000;
 const QUOTA_COOLDOWN_MS = 30 * 60_000;
 const TRANSIENT_COOLDOWN_MS = 10_000;
+const sharedPools = new Map<string, SonioxKeyPool>();
 
 export function parseSonioxFallbackApiKeys(value: string | undefined): string[] {
   if (!value) return [];
@@ -73,7 +74,10 @@ export function classifySonioxCredentialFailure(error: Error): SonioxCredentialF
   }
 
   if (
+    code === 402 ||
     lower.includes("quota") ||
+    lower.includes("budget") ||
+    lower.includes("exhausted") ||
     lower.includes("credit") ||
     lower.includes("billing") ||
     lower.includes("spend") ||
@@ -94,6 +98,24 @@ export function classifySonioxCredentialFailure(error: Error): SonioxCredentialF
   }
 
   return { kind: "transient", cooldownMs: TRANSIENT_COOLDOWN_MS };
+}
+
+export function getSharedSonioxKeyPool(primaryApiKey: string, fallbackApiKeys: string[] = []): SonioxKeyPool {
+  const poolKey = [
+    fingerprintSonioxKey(primaryApiKey.trim()),
+    ...fallbackApiKeys.map((key) => key.trim()).filter(Boolean).map(fingerprintSonioxKey),
+  ].join(":");
+
+  const existing = sharedPools.get(poolKey);
+  if (existing) return existing;
+
+  const pool = new SonioxKeyPool(primaryApiKey, fallbackApiKeys);
+  sharedPools.set(poolKey, pool);
+  return pool;
+}
+
+export function resetSharedSonioxKeyPoolsForTests(): void {
+  sharedPools.clear();
 }
 
 export class SonioxKeyPool {
@@ -224,4 +246,3 @@ function extractSonioxErrorCode(message: string): number | null {
   const parsed = Number.parseInt(match[1], 10);
   return Number.isFinite(parsed) ? parsed : null;
 }
-

--- a/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/SonioxKeyPool.ts
@@ -74,27 +74,26 @@ export function classifySonioxCredentialFailure(error: Error): SonioxCredentialF
   }
 
   if (
-    code === 402 ||
-    lower.includes("quota") ||
-    lower.includes("budget") ||
-    lower.includes("exhausted") ||
-    lower.includes("credit") ||
-    lower.includes("billing") ||
-    lower.includes("spend") ||
-    lower.includes("balance") ||
-    lower.includes("usage limit") ||
-    lower.includes("monthly limit")
-  ) {
-    return { kind: "quota", cooldownMs: QUOTA_COOLDOWN_MS };
-  }
-
-  if (
     code === 429 ||
     lower.includes("rate limit") ||
     lower.includes("rate_limit") ||
     lower.includes("too many requests")
   ) {
     return { kind: "rate_limit", cooldownMs: RATE_LIMIT_COOLDOWN_MS };
+  }
+
+  if (
+    code === 402 ||
+    /\bquota\b/.test(lower) ||
+    /\bbudget\b/.test(lower) ||
+    /\bcredit(?:s)?\b/.test(lower) ||
+    /\bbilling\b/.test(lower) ||
+    /\bspend(?:ing)?\b/.test(lower) ||
+    /\bbalance\b/.test(lower) ||
+    lower.includes("usage limit") ||
+    lower.includes("monthly limit")
+  ) {
+    return { kind: "quota", cooldownMs: QUOTA_COOLDOWN_MS };
   }
 
   return { kind: "transient", cooldownMs: TRANSIENT_COOLDOWN_MS };
@@ -176,9 +175,10 @@ export class SonioxKeyPool {
     return null;
   }
 
-  recordSuccess(credentialId: string): void {
+  recordSuccess(credentialId: string, now = Date.now()): void {
     const credential = this.findCredential(credentialId);
     if (!credential || credential.disabled) return;
+    if (credential.cooldownUntil > now) return;
     credential.cooldownUntil = 0;
     credential.failureKind = undefined;
     credential.lastFailureMessage = undefined;
@@ -196,7 +196,10 @@ export class SonioxKeyPool {
       credential.disabled = true;
       credential.cooldownUntil = Number.POSITIVE_INFINITY;
     } else {
-      credential.cooldownUntil = now + classification.cooldownMs;
+      credential.cooldownUntil = Math.max(
+        credential.cooldownUntil,
+        now + classification.cooldownMs,
+      );
     }
 
     return classification;

--- a/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
@@ -82,6 +82,19 @@ describe("SonioxKeyPool", () => {
 
     expect(second.selectCredential(new Set(), 1000)?.role).toBe("fallback");
   });
+
+  it("does not let overlapping success clear active cooldown", () => {
+    const pool = new SonioxKeyPool("primary", ["fallback"]);
+    const primary = pool.selectCredential(new Set(), 1000)!;
+    pool.recordFailure(primary.id, new Error("Soniox error 402: Organization monthly budget exhausted"), 1000);
+
+    pool.recordSuccess(primary.id, 2000);
+
+    const availability = pool.describeAvailability(2000).find((item) => item.id === primary.id);
+    expect(availability?.failureKind).toBe("quota");
+    expect(availability?.available).toBe(false);
+    expect(pool.selectCredential(new Set(), 2000)?.role).toBe("fallback");
+  });
 });
 
 describe("classifySonioxCredentialFailure", () => {
@@ -90,7 +103,9 @@ describe("classifySonioxCredentialFailure", () => {
     expect(classifySonioxCredentialFailure(new Error("Soniox error 402: Organization monthly budget exhausted")).kind).toBe(
       "quota",
     );
-    expect(classifySonioxCredentialFailure(new Error("Soniox error 429: rate limit")).kind).toBe("rate_limit");
+    expect(classifySonioxCredentialFailure(new Error("Soniox error 429: rate limit exhausted")).kind).toBe(
+      "rate_limit",
+    );
   });
 
   it("treats concurrent stream errors as temporary capacity errors", () => {

--- a/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
@@ -7,8 +7,15 @@ import {
   parseSonioxFallbackApiKeys,
   resetSharedSonioxKeyPoolsForTests,
 } from "../SonioxKeyPool";
+import { SONIOX_MODEL as TRANSCRIPTION_SONIOX_MODEL } from "../../transcription/types";
+import { SONIOX_MODEL as TRANSLATION_SONIOX_MODEL } from "../../translation/types";
 
 describe("SonioxKeyPool", () => {
+  it("defaults legacy Soniox transcription and translation to the current real-time model", () => {
+    expect(TRANSCRIPTION_SONIOX_MODEL).toBe("stt-rt-v5");
+    expect(TRANSLATION_SONIOX_MODEL).toBe("stt-rt-v5");
+  });
+
   it("parses comma-separated fallback keys", () => {
     expect(parseSonioxFallbackApiKeys(" a, b ,, c ")).toEqual(["a", "b", "c"]);
     expect(parseSonioxFallbackApiKeys(undefined)).toEqual([]);

--- a/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+
+import {
+  SonioxKeyPool,
+  classifySonioxCredentialFailure,
+  parseSonioxFallbackApiKeys,
+} from "../SonioxKeyPool";
+
+describe("SonioxKeyPool", () => {
+  it("parses comma-separated fallback keys", () => {
+    expect(parseSonioxFallbackApiKeys(" a, b ,, c ")).toEqual(["a", "b", "c"]);
+    expect(parseSonioxFallbackApiKeys(undefined)).toEqual([]);
+  });
+
+  it("prefers the primary key while available", () => {
+    const pool = new SonioxKeyPool("primary", ["fallback-a", "fallback-b"]);
+
+    const credential = pool.selectCredential(new Set(), 1000);
+
+    expect(credential?.role).toBe("primary");
+  });
+
+  it("round-robins fallback keys when primary is cooling down", () => {
+    const pool = new SonioxKeyPool("primary", ["fallback-a", "fallback-b"]);
+    const primary = pool.selectCredential(new Set(), 1000)!;
+    pool.recordFailure(primary.id, new Error("Soniox error 429: rate limit"), 1000);
+
+    const first = pool.selectCredential(new Set(), 1000);
+    const second = pool.selectCredential(new Set(), 1000);
+    const third = pool.selectCredential(new Set(), 1000);
+
+    expect(first?.role).toBe("fallback");
+    expect(second?.role).toBe("fallback");
+    expect(third?.role).toBe("fallback");
+    expect(first?.id).not.toBe(second?.id);
+    expect(third?.id).toBe(first?.id);
+  });
+
+  it("deduplicates fallback keys that match the primary", () => {
+    const pool = new SonioxKeyPool("primary", ["primary", "fallback"]);
+
+    expect(pool.size).toBe(2);
+  });
+
+  it("makes concurrency failures available again after a short cooldown", () => {
+    const pool = new SonioxKeyPool("primary", ["fallback"]);
+    const primary = pool.selectCredential(new Set(), 1000)!;
+    pool.recordFailure(primary.id, new Error("Soniox error 429: maximum concurrent streams reached"), 1000);
+
+    expect(pool.selectCredential(new Set(), 1000)?.role).toBe("fallback");
+    expect(pool.selectCredential(new Set(), 6_001)?.role).toBe("primary");
+  });
+
+  it("disables invalid keys for the process", () => {
+    const pool = new SonioxKeyPool("primary", ["fallback"]);
+    const primary = pool.selectCredential(new Set(), 1000)!;
+    pool.recordFailure(primary.id, new Error("Soniox error 401: invalid api key"), 1000);
+
+    const availability = pool.describeAvailability(10_000).find((item) => item.id === primary.id);
+
+    expect(availability?.disabled).toBe(true);
+    expect(availability?.available).toBe(false);
+    expect(pool.selectCredential(new Set(), 10_000)?.role).toBe("fallback");
+  });
+});
+
+describe("classifySonioxCredentialFailure", () => {
+  it("classifies quota exhaustion separately from request rate limits", () => {
+    expect(classifySonioxCredentialFailure(new Error("Monthly quota exceeded")).kind).toBe("quota");
+    expect(classifySonioxCredentialFailure(new Error("Soniox error 429: rate limit")).kind).toBe("rate_limit");
+  });
+
+  it("treats concurrent stream errors as temporary capacity errors", () => {
+    expect(classifySonioxCredentialFailure(new Error("Too many concurrent streams")).kind).toBe("concurrency");
+  });
+});

--- a/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
+++ b/cloud/packages/cloud/src/services/session/soniox/__tests__/SonioxKeyPool.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "bun:test";
 import {
   SonioxKeyPool,
   classifySonioxCredentialFailure,
+  getSharedSonioxKeyPool,
   parseSonioxFallbackApiKeys,
+  resetSharedSonioxKeyPoolsForTests,
 } from "../SonioxKeyPool";
 
 describe("SonioxKeyPool", () => {
@@ -62,11 +64,25 @@ describe("SonioxKeyPool", () => {
     expect(availability?.available).toBe(false);
     expect(pool.selectCredential(new Set(), 10_000)?.role).toBe("fallback");
   });
+
+  it("shares cooldown state for the same configured credentials", () => {
+    resetSharedSonioxKeyPoolsForTests();
+    const first = getSharedSonioxKeyPool("primary", ["fallback"]);
+    const second = getSharedSonioxKeyPool("primary", ["fallback"]);
+
+    const primary = first.selectCredential(new Set(), 1000)!;
+    first.recordFailure(primary.id, new Error("Soniox error 402: Organization monthly budget exhausted"), 1000);
+
+    expect(second.selectCredential(new Set(), 1000)?.role).toBe("fallback");
+  });
 });
 
 describe("classifySonioxCredentialFailure", () => {
   it("classifies quota exhaustion separately from request rate limits", () => {
     expect(classifySonioxCredentialFailure(new Error("Monthly quota exceeded")).kind).toBe("quota");
+    expect(classifySonioxCredentialFailure(new Error("Soniox error 402: Organization monthly budget exhausted")).kind).toBe(
+      "quota",
+    );
     expect(classifySonioxCredentialFailure(new Error("Soniox error 429: rate limit")).kind).toBe("rate_limit");
   });
 

--- a/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/TranscriptionManager.ts
@@ -21,6 +21,7 @@ import { estimateArrayBufferBytes, sumEstimatedBytes } from "../../metrics/memor
 import UserSession from "../UserSession";
 
 import { AlibabaTranscriptionProvider } from "./providers/AlibabaTranscriptionProvider";
+import { classifySonioxCredentialFailure } from "../soniox/SonioxKeyPool";
 import { SonioxTranscriptionProvider } from "./providers/SonioxTranscriptionProvider";
 import { ProviderSelector } from "./ProviderSelector";
 import {
@@ -1615,8 +1616,26 @@ export class TranscriptionManager {
       return false;
     }
 
+    if (error.message.includes("No available Soniox credentials")) {
+      this.logger.warn({ message: error.message }, "Soniox credentials cooling down - retrying");
+      return true;
+    }
+
     // Soniox-specific error handling
     if (error.message.includes("Soniox error")) {
+      const credentialFailure = classifySonioxCredentialFailure(error);
+      if (
+        credentialFailure.kind === "quota" ||
+        credentialFailure.kind === "concurrency" ||
+        credentialFailure.kind === "rate_limit"
+      ) {
+        this.logger.warn(
+          { failureKind: credentialFailure.kind, message: error.message },
+          "Soniox credential capacity error - retrying so fallback credentials can be tried",
+        );
+        return true;
+      }
+
       // Extract error code if available
       const errorCodeMatch = error.message.match(/Soniox error (\d+):/);
       if (errorCodeMatch) {

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
@@ -964,7 +964,7 @@ export class SonioxSdkStream implements StreamInstance {
     const enableLanguageIdentification = !(disableLangIdParam === true || disableLangIdParam === "true");
 
     const sessionConfig: SttSessionConfig = {
-      model: this.config.model || "stt-rt-v4",
+      model: this.config.model || "stt-rt-v5",
       audio_format: "pcm_s16le",
       sample_rate: 16000,
       num_channels: 1,

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxSdkStream.ts
@@ -189,6 +189,7 @@ export class SonioxSdkStream implements StreamInstance {
     public readonly logger: Logger,
     private readonly config: SonioxProviderConfig,
     client: SonioxNodeClient,
+    private readonly credentialId?: string,
   ) {
     this.endpointDebounceMs =
       config.endpointDebounceMs ?? SonioxSdkStream.DEFAULT_ENDPOINT_DEBOUNCE_MS;
@@ -854,6 +855,9 @@ export class SonioxSdkStream implements StreamInstance {
     this.metrics.consecutiveFailures++;
 
     this.provider.recordFailure(error);
+    if (this.credentialId) {
+      this.provider.recordCredentialFailure(this.credentialId, error);
+    }
 
     this.logger.error({ error, streamId: this.id, sessionState: this.session.state }, "Soniox SDK stream error");
 

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
@@ -15,7 +15,7 @@ import { SonioxNodeClient } from "@soniox/node";
 import { StreamType, getLanguageInfo, parseLanguageStream, TranscriptionData, SonioxToken } from "@mentra/sdk";
 
 import { SonioxSdkStream } from "./SonioxSdkStream";
-import { SonioxCredential, SonioxKeyPool } from "../../soniox/SonioxKeyPool";
+import { SonioxCredential, SonioxKeyPool, getSharedSonioxKeyPool } from "../../soniox/SonioxKeyPool";
 
 import {
   TranscriptionProvider,
@@ -94,7 +94,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
   ) {
     this.logger = parentLogger.child({ provider: this.name });
     this.useSdk = process.env.SONIOX_USE_SDK !== "false";
-    this.keyPool = new SonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
+    this.keyPool = getSharedSonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
 
     this.healthStatus = {
       isHealthy: true,

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
@@ -15,6 +15,7 @@ import { SonioxNodeClient } from "@soniox/node";
 import { StreamType, getLanguageInfo, parseLanguageStream, TranscriptionData, SonioxToken } from "@mentra/sdk";
 
 import { SonioxSdkStream } from "./SonioxSdkStream";
+import { SonioxCredential, SonioxKeyPool } from "../../soniox/SonioxKeyPool";
 
 import {
   TranscriptionProvider,
@@ -70,6 +71,10 @@ interface SonioxResponse {
   finished?: boolean; // Indicates end of transcription
 }
 
+type InitializableStreamInstance = StreamInstance & {
+  initialize(): Promise<void>;
+};
+
 export class SonioxTranscriptionProvider implements TranscriptionProvider {
   readonly name = ProviderType.SONIOX;
   readonly logger: Logger;
@@ -78,8 +83,9 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
   private failureCount = 0;
   private lastFailureTime = 0;
 
-  /** Soniox Node SDK client — initialized when SONIOX_USE_SDK=true */
-  private sdkClient: SonioxNodeClient | null = null;
+  /** Soniox credential pool: primary key plus optional fallback keys. */
+  private readonly keyPool: SonioxKeyPool;
+  private readonly sdkClients = new Map<string, SonioxNodeClient>();
   private readonly useSdk: boolean;
 
   constructor(
@@ -88,6 +94,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
   ) {
     this.logger = parentLogger.child({ provider: this.name });
     this.useSdk = process.env.SONIOX_USE_SDK !== "false";
+    this.keyPool = new SonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
 
     this.healthStatus = {
       isHealthy: true,
@@ -100,6 +107,8 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
         supportedLanguages: SONIOX_SUPPORTED_LANGUAGES.length,
         languages: SONIOX_SUPPORTED_LANGUAGES,
         useSdk: this.useSdk,
+        credentialCount: this.keyPool.size,
+        hasFallbackCredentials: this.keyPool.hasFallbacks,
       },
       `Soniox provider initialized with ${SONIOX_SUPPORTED_LANGUAGES.length} supported languages (SDK mode: ${this.useSdk})`,
     );
@@ -108,23 +117,16 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
   async initialize(): Promise<void> {
     this.logger.info({ useSdk: this.useSdk }, "Initializing Soniox provider");
 
-    if (!this.config.apiKey) {
+    if (this.keyPool.size === 0) {
       throw new Error("Soniox API key is required");
-    }
-
-    // Initialize SDK client if enabled
-    if (this.useSdk) {
-      this.sdkClient = new SonioxNodeClient({
-        api_key: this.config.apiKey,
-      });
-      this.logger.info("✅ Soniox SDK client initialized");
     }
 
     this.logger.info(
       {
         endpoint: this.config.endpoint,
-        keyLength: this.config.apiKey.length,
         useSdk: this.useSdk,
+        credentialCount: this.keyPool.size,
+        hasFallbackCredentials: this.keyPool.hasFallbacks,
       },
       "Soniox provider initialized",
     );
@@ -132,7 +134,7 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
 
   async dispose(): Promise<void> {
     this.logger.info("Disposing Soniox provider");
-    this.sdkClient = null;
+    this.sdkClients.clear();
   }
 
   async createTranscriptionStream(language: string, options: StreamOptions): Promise<StreamInstance> {
@@ -149,40 +151,59 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
       throw new SonioxProviderError(`Language ${language} not supported by Soniox`, 400);
     }
 
-    // Use SDK-based stream when enabled
-    if (this.useSdk && this.sdkClient) {
-      const stream = new SonioxSdkStream(
-        options.streamId,
-        options.subscription,
-        this,
-        language,
-        undefined,
-        options.callbacks,
-        this.logger.child({ streamId: options.streamId, provider: "soniox-sdk" }),
-        this.config,
-        this.sdkClient,
-      );
+    const attempted = new Set<string>();
+    let lastError: Error | null = null;
 
-      await stream.initialize();
-      return stream;
+    while (attempted.size < this.keyPool.size) {
+      const credential = this.keyPool.selectCredential(attempted);
+      if (!credential) break;
+      attempted.add(credential.id);
+
+      let stream: InitializableStreamInstance | null = null;
+      try {
+        stream = this.createStreamForCredential(credential, language, options);
+        await stream.initialize();
+        this.keyPool.recordSuccess(credential.id);
+        return stream;
+      } catch (error) {
+        lastError = error as Error;
+        const classification = this.keyPool.recordFailure(credential.id, lastError);
+        this.logger.warn(
+          {
+            streamId: options.streamId,
+            credentialId: credential.id,
+            credentialRole: credential.role,
+            failureKind: classification?.kind,
+            error: lastError.message,
+            availableCredentials: this.keyPool.describeAvailability(),
+          },
+          "Soniox credential failed while creating stream; trying another credential if available",
+        );
+        if (stream) {
+          await stream.close().catch((closeError) => {
+            this.logger.debug({ closeError, streamId: options.streamId }, "Ignoring failed Soniox stream cleanup error");
+          });
+        }
+      }
     }
 
-    // Fall back to legacy raw-WebSocket stream
-    const stream = new SonioxTranscriptionStream(
-      options.streamId,
-      options.subscription,
-      this,
-      language,
-      undefined,
-      options.callbacks,
-      this.logger,
-      this.config,
+    throw (
+      lastError ??
+      new Error(`No available Soniox credentials: ${JSON.stringify(this.keyPool.describeAvailability())}`)
     );
+  }
 
-    // Initialize WebSocket connection
-    await stream.initialize();
-
-    return stream;
+  recordCredentialFailure(credentialId: string, error: Error): void {
+    const classification = this.keyPool.recordFailure(credentialId, error);
+    this.logger.warn(
+      {
+        credentialId,
+        failureKind: classification?.kind,
+        error: error.message,
+        availableCredentials: this.keyPool.describeAvailability(),
+      },
+      "Recorded Soniox credential failure",
+    );
   }
 
   // Translation is now handled by a separate TranslationManager
@@ -287,6 +308,71 @@ export class SonioxTranscriptionProvider implements TranscriptionProvider {
     this.logger.debug("Recorded provider success");
   }
 
+  private createStreamForCredential(
+    credential: SonioxCredential,
+    language: string,
+    options: StreamOptions,
+  ): InitializableStreamInstance {
+    const credentialConfig: SonioxProviderConfig = {
+      ...this.config,
+      apiKey: credential.apiKey,
+    };
+
+    const credentialLogger = this.logger.child({
+      streamId: options.streamId,
+      credentialId: credential.id,
+      credentialRole: credential.role,
+    });
+
+    // Use SDK-based stream when enabled
+    if (this.useSdk) {
+      const sdkClient = this.getSdkClient(credential);
+      return new SonioxSdkStream(
+        options.streamId,
+        options.subscription,
+        this,
+        language,
+        undefined,
+        options.callbacks,
+        credentialLogger.child({ provider: "soniox-sdk" }),
+        credentialConfig,
+        sdkClient,
+        credential.id,
+      );
+    }
+
+    // Fall back to legacy raw-WebSocket stream
+    return new SonioxTranscriptionStream(
+      options.streamId,
+      options.subscription,
+      this,
+      language,
+      undefined,
+      options.callbacks,
+      credentialLogger,
+      credentialConfig,
+      credential.id,
+    );
+  }
+
+  private getSdkClient(credential: SonioxCredential): SonioxNodeClient {
+    const existing = this.sdkClients.get(credential.id);
+    if (existing) return existing;
+
+    const client = new SonioxNodeClient({
+      api_key: credential.apiKey,
+    });
+    this.sdkClients.set(credential.id, client);
+    this.logger.info(
+      {
+        credentialId: credential.id,
+        credentialRole: credential.role,
+      },
+      "✅ Soniox SDK client initialized",
+    );
+    return client;
+  }
+
   private getRecentFailureCount(timeWindowMs: number): number {
     const now = Date.now();
     return this.lastFailureTime && now - this.lastFailureTime < timeWindowMs ? this.failureCount : 0;
@@ -381,6 +467,7 @@ class SonioxTranscriptionStream implements StreamInstance {
     public readonly callbacks: StreamCallbacks,
     public readonly logger: Logger,
     private readonly config: SonioxProviderConfig,
+    private readonly credentialId?: string,
   ) {
     this.metrics = {
       totalDuration: 0,
@@ -943,6 +1030,9 @@ class SonioxTranscriptionStream implements StreamInstance {
     this.lastSentInterim = "";
 
     this.provider.recordFailure(error);
+    if (this.credentialId) {
+      this.provider.recordCredentialFailure(this.credentialId, error);
+    }
 
     if (this.callbacks.onError) {
       this.callbacks.onError(error);

--- a/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/providers/SonioxTranscriptionProvider.ts
@@ -623,7 +623,7 @@ class SonioxTranscriptionStream implements StreamInstance {
     const enableLanguageIdentification = !(disableLangIdParam === true || disableLangIdParam === "true");
     const config: any = {
       api_key: this.config.apiKey,
-      model: this.config.model || "stt-rt-v4",
+      model: this.config.model || "stt-rt-v5",
       audio_format: "pcm_s16le",
       sample_rate: 16000,
       num_channels: 1,

--- a/cloud/packages/cloud/src/services/session/transcription/types.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/types.ts
@@ -11,6 +11,7 @@ dotenv.config();
 
 // Environment variables for provider configuration
 export const SONIOX_API_KEY = process.env.SONIOX_API_KEY || "";
+export const SONIOX_FALLBACK_API_KEYS = process.env.SONIOX_FALLBACK_API_KEYS || "";
 export const SONIOX_ENDPOINT = process.env.SONIOX_ENDPOINT || "wss://stt-rt.soniox.com/transcribe-websocket";
 export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v4";
 export const ALIBABA_ENDPOINT = process.env.ALIBABA_ENDPOINT || "wss://dashscope.aliyuncs.com/api-ws/v1/inference";
@@ -72,6 +73,7 @@ export interface TranscriptionConfig {
 
 export interface SonioxProviderConfig {
   apiKey: string;
+  fallbackApiKeys?: string[];
   endpoint: string;
   model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v4'
   maxConnections?: number;
@@ -359,6 +361,9 @@ export const DEFAULT_TRANSCRIPTION_CONFIG: TranscriptionConfig = {
 
   soniox: {
     apiKey: SONIOX_API_KEY,
+    fallbackApiKeys: SONIOX_FALLBACK_API_KEYS.split(",")
+      .map((key) => key.trim())
+      .filter(Boolean),
     endpoint: SONIOX_ENDPOINT,
     model: SONIOX_MODEL,
     // 3000ms = Soniox's max. Higher = Soniox waits longer before

--- a/cloud/packages/cloud/src/services/session/transcription/types.ts
+++ b/cloud/packages/cloud/src/services/session/transcription/types.ts
@@ -13,7 +13,7 @@ dotenv.config();
 export const SONIOX_API_KEY = process.env.SONIOX_API_KEY || "";
 export const SONIOX_FALLBACK_API_KEYS = process.env.SONIOX_FALLBACK_API_KEYS || "";
 export const SONIOX_ENDPOINT = process.env.SONIOX_ENDPOINT || "wss://stt-rt.soniox.com/transcribe-websocket";
-export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v4";
+export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v5";
 export const ALIBABA_ENDPOINT = process.env.ALIBABA_ENDPOINT || "wss://dashscope.aliyuncs.com/api-ws/v1/inference";
 export const ALIBABA_WORKSPACE = process.env.ALIBABA_WORKSPACE || "";
 export const ALIBABA_DASHSCOPE_API_KEY = process.env.ALIBABA_DASHSCOPE_API_KEY || "";
@@ -75,7 +75,7 @@ export interface SonioxProviderConfig {
   apiKey: string;
   fallbackApiKeys?: string[];
   endpoint: string;
-  model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v4'
+  model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v5'
   maxConnections?: number;
   /**
    * Soniox `max_endpoint_delay_ms`. Allowed 500–3000, default 2000.

--- a/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
+++ b/cloud/packages/cloud/src/services/session/translation/TranslationManager.ts
@@ -12,6 +12,7 @@ import {
   parseLanguageStream,
 } from "@mentra/sdk";
 import UserSession from "../UserSession";
+import { classifySonioxCredentialFailure } from "../soniox/SonioxKeyPool";
 import { PosthogService } from "../../logging/posthog.service";
 import { MemoryOwnerStat } from "../../metrics/memory-census";
 import { estimateArrayBufferBytes, sumEstimatedBytes } from "../../metrics/memory-estimate";
@@ -985,6 +986,22 @@ export class TranslationManager {
         sessionId: this.userSession.sessionId,
       });
       return;
+    }
+
+    if (error.message.includes("No available Soniox translation credentials")) {
+      this.logger.warn({ subscription, message: error.message }, "Soniox translation credentials cooling down");
+    } else if (error.message.includes("Soniox error")) {
+      const credentialFailure = classifySonioxCredentialFailure(error);
+      if (
+        credentialFailure.kind === "quota" ||
+        credentialFailure.kind === "concurrency" ||
+        credentialFailure.kind === "rate_limit"
+      ) {
+        this.logger.warn(
+          { subscription, failureKind: credentialFailure.kind, message: error.message },
+          "Soniox translation credential capacity error - retrying so fallback credentials can be tried",
+        );
+      }
     }
 
     // Schedule retry

--- a/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
+++ b/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
@@ -11,6 +11,7 @@ import { TranslationData, StreamType } from "@mentra/sdk";
 import { MemoryOwnerStat } from "../../../metrics/memory-census";
 import { estimateArrayBufferBytes, estimateStringBytes, sumEstimatedBytes } from "../../../metrics/memory-estimate";
 import { ResourceTracker } from "../../../../utils/resource-tracker";
+import { SonioxCredential, SonioxKeyPool } from "../../soniox/SonioxKeyPool";
 import {
   TranslationProvider,
   TranslationProviderType,
@@ -54,7 +55,7 @@ interface SonioxToken {
 class SonioxTranslationStream implements TranslationStreamInstance {
   readonly id: string;
   readonly subscription: string;
-  readonly provider: TranslationProvider;
+  readonly provider: SonioxTranslationProvider;
   readonly logger: Logger;
   readonly sourceLanguage: string;
   readonly targetLanguage: string;
@@ -119,8 +120,9 @@ class SonioxTranslationStream implements TranslationStreamInstance {
 
   constructor(
     options: TranslationStreamOptions,
-    provider: TranslationProvider,
+    provider: SonioxTranslationProvider,
     private config: SonioxTranslationConfig,
+    private readonly credentialId?: string,
   ) {
     this.id = options.streamId;
     this.subscription = options.subscription;
@@ -406,9 +408,11 @@ class SonioxTranslationStream implements TranslationStreamInstance {
         break;
 
       case "error":
+        const errorCode = message.error_code ?? message.code;
+        const errorMessage = message.message || message.error_message || "Unknown error";
         this.handleError(
           new TranslationProviderError(
-            `Soniox error: ${message.message || "Unknown error"}`,
+            errorCode ? `Soniox error ${errorCode}: ${errorMessage}` : `Soniox error: ${errorMessage}`,
             TranslationProviderType.SONIOX,
           ),
         );
@@ -759,6 +763,9 @@ class SonioxTranslationStream implements TranslationStreamInstance {
     this.metrics.errorCount++;
     this.metrics.lastError = error;
     this.state = TranslationStreamState.ERROR;
+    if (this.credentialId) {
+      this.provider.recordCredentialFailure(this.credentialId, error);
+    }
     this.callbacks.onError?.(error);
   }
 
@@ -987,18 +994,20 @@ export class SonioxTranslationProvider implements TranslationProvider {
 
   // Get supported languages from the actual Soniox mappings
   private supportedLanguages = new Set(SonioxTranslationUtils.getSupportedLanguages());
+  private readonly keyPool: SonioxKeyPool;
 
   constructor(
     private config: SonioxTranslationConfig,
     parentLogger: Logger,
   ) {
     this.logger = parentLogger.child({ provider: "soniox-translation" });
+    this.keyPool = new SonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
   }
 
   async initialize(): Promise<void> {
     try {
       // Validate configuration
-      if (!this.config.apiKey) {
+      if (this.keyPool.size === 0) {
         throw new Error("Soniox translation provider requires API key");
       }
 
@@ -1007,7 +1016,13 @@ export class SonioxTranslationProvider implements TranslationProvider {
       }
 
       this.isInitialized = true;
-      this.logger.info("Soniox translation provider initialized");
+      this.logger.info(
+        {
+          credentialCount: this.keyPool.size,
+          hasFallbackCredentials: this.keyPool.hasFallbacks,
+        },
+        "Soniox translation provider initialized",
+      );
     } catch (error) {
       this.logger.error({ error }, "Failed to initialize Soniox translation provider");
       throw error;
@@ -1033,11 +1048,69 @@ export class SonioxTranslationProvider implements TranslationProvider {
       );
     }
 
-    const stream = new SonioxTranslationStream(options, this, this.config);
-    await stream.initialize();
+    const attempted = new Set<string>();
+    let lastError: Error | null = null;
 
-    this.recordSuccess();
-    return stream;
+    while (attempted.size < this.keyPool.size) {
+      const credential = this.keyPool.selectCredential(attempted);
+      if (!credential) break;
+      attempted.add(credential.id);
+
+      const stream = this.createStreamForCredential(options, credential);
+      try {
+        await stream.initialize();
+        this.keyPool.recordSuccess(credential.id);
+        this.recordSuccess();
+        return stream;
+      } catch (error) {
+        lastError = error as Error;
+        const classification = this.keyPool.recordFailure(credential.id, lastError);
+        this.logger.warn(
+          {
+            streamId: options.streamId,
+            credentialId: credential.id,
+            credentialRole: credential.role,
+            failureKind: classification?.kind,
+            error: lastError.message,
+            availableCredentials: this.keyPool.describeAvailability(),
+          },
+          "Soniox translation credential failed while creating stream; trying another credential if available",
+        );
+        await stream.close().catch((closeError) => {
+          this.logger.debug({ closeError, streamId: options.streamId }, "Ignoring failed Soniox translation stream cleanup error");
+        });
+      }
+    }
+
+    throw (
+      lastError ??
+      new Error(`No available Soniox translation credentials: ${JSON.stringify(this.keyPool.describeAvailability())}`)
+    );
+  }
+
+  recordCredentialFailure(credentialId: string, error: Error): void {
+    const classification = this.keyPool.recordFailure(credentialId, error);
+    this.logger.warn(
+      {
+        credentialId,
+        failureKind: classification?.kind,
+        error: error.message,
+        availableCredentials: this.keyPool.describeAvailability(),
+      },
+      "Recorded Soniox translation credential failure",
+    );
+  }
+
+  private createStreamForCredential(
+    options: TranslationStreamOptions,
+    credential: SonioxCredential,
+  ): SonioxTranslationStream {
+    const credentialConfig: SonioxTranslationConfig = {
+      ...this.config,
+      apiKey: credential.apiKey,
+    };
+
+    return new SonioxTranslationStream(options, this, credentialConfig, credential.id);
   }
 
   supportsLanguagePair(source: string, target: string): boolean {

--- a/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
+++ b/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
@@ -331,7 +331,7 @@ class SonioxTranslationStream implements TranslationStreamInstance {
 
     const config = {
       api_key: this.config.apiKey,
-      model: this.config.model || "stt-rt-v4",
+      model: this.config.model || "stt-rt-v5",
       audio_format: "pcm_s16le",
       sample_rate: 16000,
       num_channels: 1,

--- a/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
+++ b/cloud/packages/cloud/src/services/session/translation/providers/SonioxTranslationProvider.ts
@@ -11,7 +11,7 @@ import { TranslationData, StreamType } from "@mentra/sdk";
 import { MemoryOwnerStat } from "../../../metrics/memory-census";
 import { estimateArrayBufferBytes, estimateStringBytes, sumEstimatedBytes } from "../../../metrics/memory-estimate";
 import { ResourceTracker } from "../../../../utils/resource-tracker";
-import { SonioxCredential, SonioxKeyPool } from "../../soniox/SonioxKeyPool";
+import { SonioxCredential, SonioxKeyPool, getSharedSonioxKeyPool } from "../../soniox/SonioxKeyPool";
 import {
   TranslationProvider,
   TranslationProviderType,
@@ -1001,7 +1001,7 @@ export class SonioxTranslationProvider implements TranslationProvider {
     parentLogger: Logger,
   ) {
     this.logger = parentLogger.child({ provider: "soniox-translation" });
-    this.keyPool = new SonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
+    this.keyPool = getSharedSonioxKeyPool(config.apiKey, config.fallbackApiKeys ?? []);
   }
 
   async initialize(): Promise<void> {

--- a/cloud/packages/cloud/src/services/session/translation/types.ts
+++ b/cloud/packages/cloud/src/services/session/translation/types.ts
@@ -10,6 +10,7 @@ dotenv.config();
 
 // Environment variables for provider configuration
 export const SONIOX_API_KEY = process.env.SONIOX_API_KEY || "";
+export const SONIOX_FALLBACK_API_KEYS = process.env.SONIOX_FALLBACK_API_KEYS || "";
 export const SONIOX_ENDPOINT = process.env.SONIOX_ENDPOINT || "wss://stt-rt.soniox.com/transcribe-websocket";
 export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v4";
 
@@ -68,6 +69,7 @@ export interface TranslationConfig {
 
 export interface SonioxTranslationConfig {
   apiKey: string;
+  fallbackApiKeys?: string[];
   endpoint: string;
   model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v4'
   maxConnections?: number;
@@ -289,6 +291,9 @@ export const DEFAULT_TRANSLATION_CONFIG: TranslationConfig = {
 
   soniox: {
     apiKey: SONIOX_API_KEY,
+    fallbackApiKeys: SONIOX_FALLBACK_API_KEYS.split(",")
+      .map((key) => key.trim())
+      .filter(Boolean),
     endpoint: SONIOX_ENDPOINT,
     model: SONIOX_MODEL,
   },

--- a/cloud/packages/cloud/src/services/session/translation/types.ts
+++ b/cloud/packages/cloud/src/services/session/translation/types.ts
@@ -12,7 +12,7 @@ dotenv.config();
 export const SONIOX_API_KEY = process.env.SONIOX_API_KEY || "";
 export const SONIOX_FALLBACK_API_KEYS = process.env.SONIOX_FALLBACK_API_KEYS || "";
 export const SONIOX_ENDPOINT = process.env.SONIOX_ENDPOINT || "wss://stt-rt.soniox.com/transcribe-websocket";
-export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v4";
+export const SONIOX_MODEL = process.env.SONIOX_MODEL || "stt-rt-v5";
 
 export const ALIBABA_ENDPOINT = process.env.ALIBABA_ENDPOINT || "wss://dashscope.aliyuncs.com/api-ws/v1/inference";
 export const ALIBABA_WORKSPACE = process.env.ALIBABA_WORKSPACE || "";
@@ -71,7 +71,7 @@ export interface SonioxTranslationConfig {
   apiKey: string;
   fallbackApiKeys?: string[];
   endpoint: string;
-  model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v4'
+  model?: string; // Default: SONIOX_MODEL env var or 'stt-rt-v5'
   maxConnections?: number;
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ships ASG Client 39 with a safer OTA flow and adds Soniox fallback API keys in Cloud for higher reliability under quota and limit errors. OTA now defaults to a new v2 manifest and routes all MTK updates to MentraLive_20260709 with a BES bump to trigger auto-reboot.

- **New Features**
  - OTA client: default to `prod_live_version_v2.json`, remove brittle artifact cache, and validate optional `ota_version_url` in `OtaCommandHandler` (tests added).
  - OTA manifests: add `prod_live_version_v2.json` (app 39), retarget all MTK patches to MentraLive_20260709, and bump BES to 17.26.07.09; keep legacy `prod_live_version.json` as a rescue path.
  - Cloud (Soniox): add credential pool with `SONIOX_FALLBACK_API_KEYS`, shared cooldowns, better error classification/retry, and default model `stt-rt-v5` (tests included).
  - Misc: update `.github/CODEOWNERS`.

- **Migration**
  - Set `SONIOX_FALLBACK_API_KEYS` in production (comma‑separated). `SONIOX_API_KEY` remains primary.
  - No client action needed; ASG 39+ uses the v2 manifest automatically.
  - Legacy devices stay on the v1 manifest for recovery.

<sup>Written for commit fa014642caf3abcf9e8e1187964a78407ae10bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3429?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

