### PR TITLE
Add photo mode controls to camera tester

### DIFF
--- a/miniapps/example-miniapp/src/ui/pages/tester/CameraPage.tsx
+++ b/miniapps/example-miniapp/src/ui/pages/tester/CameraPage.tsx
@@ -9,7 +9,12 @@ import {MiniappHeader} from "@mentra/miniapp/ui"
 import {useTester} from "../../hooks/useTester"
 import {Shell} from "../Shell"
 import {Button} from "../../components/button"
+import {Label} from "../../components/label"
+import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "../../components/select"
 import {ErrorRow, Row} from "./_TesterRow"
+
+type PhotoSize = "low" | "medium" | "high" | "max"
+type PhotoMode = "photo" | "text"
 
 interface PhotoResult {
   photoUrl?: string
@@ -21,9 +26,11 @@ export default function CameraPage() {
   const navigate = useNavigate()
   const {invoke, lastError} = useTester("camera")
   const [result, setResult] = useState<PhotoResult | undefined>(undefined)
+  const [size, setSize] = useState<PhotoSize>("medium")
+  const [mode, setMode] = useState<PhotoMode>("photo")
 
-  const takePhoto = (size: "small" | "medium" | "large") => {
-    invoke("takePhoto", [{size}])
+  const takePhoto = () => {
+    invoke("takePhoto", [{size, mode}])
       .then((r) => setResult(r as PhotoResult))
       .catch(() => {
         /* error already surfaced via lastError → ErrorRow */
@@ -35,20 +42,39 @@ export default function CameraPage() {
       <MiniappHeader title="session.camera" onBack={() => navigate("/")} />
       <div className="flex-1 overflow-y-auto px-4 pb-6">
         <p className="mb-3 text-[13px] text-muted-foreground">
-          Capture a photo through the glasses camera. Requires{" "}
-          <code className="mx-1">CAMERA</code> in the manifest. The returned URL
-          is a short-TTL (~24h) Cloudflare R2 signed URL.
+          Capture a photo through the glasses camera. Requires <code className="mx-1">CAMERA</code> in the manifest. The
+          returned URL is a short-TTL (~24h) Cloudflare R2 signed URL.
         </p>
-        <div className="mt-1 flex flex-col gap-2">
-          <Button onClick={() => takePhoto("small")}>takePhoto(small)</Button>
-          <Button onClick={() => takePhoto("medium")}>takePhoto(medium)</Button>
-          <Button onClick={() => takePhoto("large")}>takePhoto(large)</Button>
+        <div className="mt-1 flex flex-col gap-3">
+          <div>
+            <Label htmlFor="photo-size">size</Label>
+            <Select value={size} onValueChange={(value) => setSize(value as PhotoSize)}>
+              <SelectTrigger id="photo-size">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="low">low</SelectItem>
+                <SelectItem value="medium">medium</SelectItem>
+                <SelectItem value="high">high</SelectItem>
+                <SelectItem value="max">max</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="photo-mode">mode</Label>
+            <Select value={mode} onValueChange={(value) => setMode(value as PhotoMode)}>
+              <SelectTrigger id="photo-mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="photo">photo</SelectItem>
+                <SelectItem value="text">text</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <Button onClick={takePhoto}>takePhoto({`{ size: "${size}", mode: "${mode}" }`})</Button>
         </div>
-        <Row
-          emoji="🖼️"
-          label="latest photoUrl"
-          value={result?.photoUrl ?? "(no photo yet)"}
-        />
+        <Row emoji="🖼️" label="latest photoUrl" value={result?.photoUrl ?? "(no photo yet)"} />
         {result?.photoUrl && (
           <div className="mt-2 overflow-hidden rounded-xl border border-border">
             <img src={result.photoUrl} alt="Photo captured by the glasses camera" className="w-full" />


### PR DESCRIPTION
## What changed

- Replace the camera tester's separate legacy-size buttons with a current SDK size selector.
- Add an explicit photo/text mode selector.
- Send both selected values through `session.camera.takePhoto()` and display the exact request on the capture button.

## Why

Text mode is opt-in and defaults to ordinary photo mode when omitted. The example miniapp previously sent only a size, so its camera tester could not exercise the newly added text capture path.

## Impact

Developers can now test `low`, `medium`, `high`, and `max` captures in ordinary photo mode or text mode directly from the example miniapp.

## Validation

- `cd miniapps/example-miniapp && bun run build`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add size and mode controls to the example miniapp camera tester. Developers can now capture `low`/`medium`/`high`/`max` in `photo` or `text` mode and see the exact request sent.

- **New Features**
  - Replaced legacy buttons with an SDK size selector (`low`, `medium`, `high`, `max`).
  - Added a mode selector (`photo`, `text`) to test the text capture path.
  - `session.camera.takePhoto()` now receives `{ size, mode }`, and the capture button displays this payload.

<sup>Written for commit fa10a80dedb00a05beab4e75a5868fc8765e2fc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in the example miniapp tester; no production SDK or camera pipeline logic is modified.
> 
> **Overview**
> The example miniapp **camera tester** no longer fires three fixed `takePhoto` buttons with legacy sizes (`small` / `medium` / `large`). It now uses **dropdowns** for current SDK **`size`** (`low`, `medium`, `high`, `max`) and **`mode`** (`photo`, `text`), then calls `takePhoto` with **`{ size, mode }`**. The capture button label shows the exact payload being sent so developers can exercise **text capture** as well as normal photos.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa10a80dedb00a05beab4e75a5868fc8765e2fc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->