### PR TITLE
Fix Livestreamer Wi-Fi handoff and SRT recovery

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -399,6 +399,16 @@ public class SrtStreamingService extends Service {
           long streamDuration = mStreamStartTime > 0 ? currentTime - mStreamStartTime : 0;
           Log.e(TAG, "🔴 SRT STREAM DISCONNECTED after " + formatDuration(streamDuration));
           mLastReconnectionTime = currentTime;
+          synchronized (mStateLock) {
+            // StreamPack reports connection loss asynchronously. Mark the
+            // publisher non-streaming while we give its internal recovery a
+            // moment to succeed; otherwise the delayed check below always
+            // sees STREAMING/true and incorrectly concludes it recovered.
+            if (mStreamState == StreamState.STREAMING) {
+              mStreamState = StreamState.STARTING;
+              mIsStreaming = false;
+            }
+          }
           EventBus.getDefault().post(new StreamingEvent.Disconnected());
           StreamingReporting.reportRtmpConnectionLost(SrtStreamingService.this, mSrtUrl, streamDuration, message);
 
@@ -410,6 +420,8 @@ public class SrtStreamingService extends Service {
                 Log.d(TAG, "SRT library recovered internally");
               } else if (mStreamState == StreamState.IDLE || mStreamState == StreamState.STOPPING) {
                 Log.d(TAG, "SRT stream stopped, not reconnecting");
+              } else if (mReconnecting) {
+                Log.d(TAG, "SRT reconnection already scheduled");
               } else {
                 scheduleReconnect("connection_lost");
               }

--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -4,7 +4,7 @@ import mantle from "@/services/MantleManager"
 import {useCoreStore} from "@mentra/engine/internal"
 import {useDisplayStore} from "@mentra/engine/internal"
 import {isGlassesConnected, useGlassesStore} from "../../modules/engine/src/stores/glasses"
-import {SETTINGS} from "@mentra/engine"
+import {engine, SETTINGS} from "@mentra/engine"
 import {useSettingsStore} from "@mentra/engine/internal"
 import {crustModuleMock, emitCrustEvent, resetCrustModuleMock} from "@/test-utils/mockCrustModule"
 import {
@@ -29,6 +29,13 @@ jest.mock("@mentra/crust", () => {
     default: crustModuleMock,
   }
 })
+
+const mockShowAlert = jest.fn()
+jest.mock("@/utils/AlertUtils", () => ({
+  __esModule: true,
+  default: (...args: unknown[]) => mockShowAlert(...args),
+  showAlert: (...args: unknown[]) => mockShowAlert(...args),
+}))
 
 // gallerySyncService moved into @mentra/engine; the global @mentra/engine jest mock
 // already supplies it (gallerySyncService.initialize), so no local mock is needed.
@@ -83,6 +90,8 @@ function resetMantleTestState() {
   useDisplayStore.setState({view: "main"})
 }
 
+let requestWifiSetup: (reason?: string) => Promise<void>
+
 describe("MantleManager", () => {
   beforeAll(async () => {
     jest.useFakeTimers()
@@ -95,6 +104,7 @@ describe("MantleManager", () => {
       settings: {...state.settings, contextual_dashboard: true, auth_email: "from-server@example.com"},
     }))
     await mantle.init()
+    requestWifiSetup = (engine.configure as jest.Mock).mock.calls[0][0].ui.requestWifiSetup
   })
 
   afterEach(() => {
@@ -339,5 +349,23 @@ describe("MantleManager", () => {
     })
     expect(useGlassesStore.getState().otaUpdateAvailable).toBeNull()
     expect(useGlassesStore.getState().otaInProgress).toBe(false)
+  })
+
+  it("prompts before opening Wi-Fi setup and backgrounds the requesting miniapp", async () => {
+    const cancelRequest = requestWifiSetup("Streaming needs Wi-Fi")
+    const [, message, cancelButtons] = mockShowAlert.mock.calls.at(-1)!
+
+    expect(message).toBe("Streaming needs Wi-Fi")
+    expect(engine.miniapps.clearForeground).not.toHaveBeenCalled()
+    cancelButtons[0].onPress()
+    await cancelRequest
+    expect(engine.miniapps.clearForeground).not.toHaveBeenCalled()
+
+    const confirmRequest = requestWifiSetup("Streaming needs Wi-Fi")
+    const confirmButtons = mockShowAlert.mock.calls.at(-1)![2]
+    confirmButtons[1].onPress()
+    await confirmRequest
+
+    expect(engine.miniapps.clearForeground).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -12,7 +12,18 @@ import {CHINA_HIDDEN_APPS, isChinaBuild} from "@/constants/miniapps"
 import {migrate} from "@/services/Migrations"
 import {cloudConfigValues} from "@/services/cloudClient"
 import {engine, BgTimer} from "@mentra/engine"
-import {appRegistry, displayProcessor, gallerySyncService, phoneLocationService, localDisplayManager, localMiniappRuntime, miniappLauncher, localSttFallbackCoordinator, micStateCoordinator, offlineSpeechModelService} from "@mentra/engine/internal"
+import {
+  appRegistry,
+  displayProcessor,
+  gallerySyncService,
+  phoneLocationService,
+  localDisplayManager,
+  localMiniappRuntime,
+  miniappLauncher,
+  localSttFallbackCoordinator,
+  micStateCoordinator,
+  offlineSpeechModelService,
+} from "@mentra/engine/internal"
 import {SETTINGS} from "@mentra/engine"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import {useDebugStore} from "@/stores/debug"
@@ -20,6 +31,7 @@ import {checkFeaturePermissions, PermissionFeatures} from "@/utils/PermissionsUt
 import {attemptReconnectToDefaultWearable} from "@/effects/Reconnect"
 import {ensureDevModeForUser} from "@/utils/dev/devModeAllowlist"
 import mentraAuth from "@/utils/auth/authClient"
+import {showAlert} from "@/utils/AlertUtils"
 import {Buffer} from "@craftzdog/react-native-buffer"
 
 /**
@@ -139,9 +151,23 @@ class MantleManager {
       // Named host-UI seams: island dispatches the miniapp request, the host
       // owns the screen (branding/navigation).
       ui: {
-        requestWifiSetup: (reason?: string) => {
-          router.push({pathname: "/wifi/scan" as any, params: (reason ? {reason} : {}) as any})
-        },
+        requestWifiSetup: (reason?: string) =>
+          new Promise<void>((resolve) => {
+            showAlert("Connect to Wi-Fi", reason || "This miniapp needs your glasses to be connected to Wi-Fi.", [
+              {text: "Cancel", style: "cancel", onPress: resolve},
+              {
+                text: "OK",
+                onPress: () => {
+                  // The Compositor is an app-wide overlay, so navigating
+                  // without clearing foreground leaves the Wi-Fi route
+                  // rendered underneath the requesting miniapp.
+                  engine.miniapps.clearForeground()
+                  router.push({pathname: "/wifi/scan" as any})
+                  resolve()
+                },
+              },
+            ])
+          }),
       },
     })
     await engine.start()
@@ -214,7 +240,6 @@ class MantleManager {
 
     localMiniappRuntime.cleanup()
     micStateCoordinator.cleanup()
-
 
     // Allow a later init() to rebuild everything this cleanup tore down — the
     // logout→login-in-the-same-process path and the dev backend-URL


### PR DESCRIPTION
## Summary

- show the miniapp-provided reason before opening Mentra Live Wi-Fi setup
- clear the foreground miniapp before navigating to the Wi-Fi scanner
- update SRT connection state when the stream is lost so scheduled recovery can run
- let iOS wait through transient publisher errors while the glasses reconnect

## Root causes

The mobile SDK seam navigated directly to the Wi-Fi screen and left the Compositor foreground active, which placed the native screen underneath the miniapp. Separately, the SRT loss callback left the service marked as streaming, so the delayed recovery guard incorrectly concluded that the library had already recovered.

The follow-up incident `rep_01KXHBV5THAF6WR2MD9JAQ14RJ` showed another startup race: the glasses emitted a transient SRT error, then recovered to `streaming`, but iOS rejected the pending start on the first error. The SDK now keeps the request pending through recoverable errors and still terminates on `reconnect_failed`, `stopped`, or its existing timeout.

## Test plan

- `cd mobile && bun run test -- --runInBand --forceExit --silent src/services/MantleManager.test.ts`
- `cd mobile && bun run compile`
- `cd mobile && bun test modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts`
- `./scripts/check-android-compile.sh asg`
- `swiftc -parse mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift`

## Related Livestreamer change

Livestreamer-specific UI and status fixes were published separately to `Mentra-Community/Livestreamer-Miniapp` main in commits `a62dd09` and `dcd04e4` (version `1.0.5`).
