### PR TITLE
Allow transient iOS stream recovery

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1415,9 +1415,15 @@ public final class MentraBluetoothSDK {
             case .streaming:
                 pendingStreamStarts.removeValue(forKey: streamId)
                 pending.resolve(event)
-            case .error, .reconnectFailed, .stopped:
+            case .reconnectFailed, .stopped:
                 pendingStreamStarts.removeValue(forKey: streamId)
                 pending.reject(streamStatusError(event, code: "stream_start_failed"))
+            case .error:
+                // The glasses publisher automatically retries transient transport
+                // errors. Keep the start pending so a subsequent `streaming`
+                // status can resolve it; `reconnectFailed` or the request timeout
+                // still terminates a publisher that cannot recover.
+                break
             default:
                 break
             }


### PR DESCRIPTION
## Summary

- keep an iOS stream-start request pending through transient publisher errors
- continue to terminate startup on `reconnect_failed`, `stopped`, or the existing timeout

## Root cause

Incident `rep_01KXHBV5THAF6WR2MD9JAQ14RJ` showed the glasses emitting a transient SRT error during startup and subsequently recovering to `streaming`. The iOS SDK rejected the pending start on the first error, so Livestreamer displayed a failure before the publisher recovered.

This aligns the native start request with the coordinator's existing recovery behavior: transient transport errors remain observable status events but are not terminal.

## Validation

- `swiftc -parse mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift`
- `cd mobile && bun run compile`
- `cd mobile && bun test modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts` (17 passed)

Livestreamer error formatting was updated separately on `Mentra-Community/Livestreamer-Miniapp` main in commit `dcd04e4` (version `1.0.5`).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep iOS stream-start requests pending through transient publisher errors so the stream can recover to `streaming`. This prevents false start failures in Livestreamer when the glasses recover after a brief SRT hiccup.

- **Bug Fixes**
  - In `MentraBluetoothSDK`, treat `.error` during startup as non-terminal; only fail on `.reconnectFailed`, `.stopped`, or the existing timeout.

<sup>Written for commit df48c214ada5e0b3ea4fdb39a9e21e21541fcd12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to iOS stream-start completion logic; terminal failure paths and timeouts are unchanged.
> 
> **Overview**
> **iOS stream-start** no longer fails on the first `stream_status` **`.error`** while waiting for glasses to reach **`streaming`**.
> 
> In `handleStreamStatusForRequests`, transient **`.error`** events during startup are ignored for the pending `startStream` promise so a later **`streaming`** status can still resolve it. Startup still fails on **`reconnectFailed`**, **`stopped`**, or the existing **30s** request timeout—matching automatic publisher retry on the glasses side and avoiding false Livestreamer failures after brief SRT hiccups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df48c214ada5e0b3ea4fdb39a9e21e21541fcd12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->