### PR TITLE
Run Recorder as a background miniapp

### DIFF
--- a/miniapps/recorder/miniapp.json
+++ b/miniapps/recorder/miniapp.json
@@ -5,7 +5,7 @@
   "name": "Recorder",
   "description": "Capture the glasses microphone to a real audio file on your phone — record, play back, and export WAV. A debugging tool for the audio system, built on session.recorder + session.blob.",
   "icon": "icon.png",
-  "type": "standard",
+  "type": "background",
   "sdkVersion": "0.3.0",
   "minHostVersion": "1.42.0",
   "port": 3170,


### PR DESCRIPTION
## Summary

- change the Recorder manifest type from `standard` to `background`
- allow Recorder to run as a background miniapp instead of occupying the foreground

## Why

Recorder should continue its audio workflow without being treated as the active foreground miniapp.

## Validation

- parsed `miniapps/recorder/miniapp.json` and confirmed `type` is `background`
- ran `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set the Recorder miniapp to run in the background by changing its manifest type from standard to background. This lets it continue audio capture without occupying the foreground.

<sup>Written for commit 6eba167055334199575896595fa5c5022daa6da5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single manifest field change with no code or permission changes; main risk is host behavior if background miniapps are handled differently for UI or microphone access.
> 
> **Overview**
> Switches the Recorder manifest **`type`** from **`standard`** to **`background`** so the host runs it as a background miniapp instead of holding the foreground slot.
> 
> **`background/index.js`** and **`ui/index.html`** entries are unchanged; only lifecycle/foreground semantics change via the manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eba167055334199575896595fa5c5022daa6da5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->