### PR TITLE
Keep boosted glasses volume after audio playback

### DIFF
--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -2,6 +2,8 @@ import {createAudioPlayer, AudioPlayer, AudioStatus, setAudioModeAsync} from "ex
 import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
 import {BgTimer} from "../utils/timers"
 
+const RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK = false
+
 interface AudioPlayRequest {
   requestId: string
   audioUrl: string
@@ -158,9 +160,11 @@ class AudioPlaybackService {
       await this.setGlassesMediaVolumeWithTiming(AudioPlaybackService.GLASSES_VOLUME_FLOOR)
       if (this.currentPlayback === playback && !playback.completed) {
         this.glassesVolumeRestoreLevel = level
-      } else {
+      } else if (RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK) {
         console.log("AUDIO: Restoring glasses volume immediately; playback ended during volume bump")
         await this.setGlassesMediaVolumeWithTiming(level)
+      } else {
+        console.log("AUDIO: Leaving bumped glasses media volume unchanged after playback")
       }
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e)
@@ -174,6 +178,11 @@ class AudioPlaybackService {
   private async restoreGlassesMediaVolume(): Promise<void> {
     const restoreLevel = this.glassesVolumeRestoreLevel
     if (restoreLevel === null) {
+      return
+    }
+    if (!RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK) {
+      this.glassesVolumeRestoreLevel = null
+      console.log("AUDIO: Leaving bumped glasses media volume unchanged after playback")
       return
     }
 

--- a/mobile/src/services/AudioPlaybackService.test.ts
+++ b/mobile/src/services/AudioPlaybackService.test.ts
@@ -59,7 +59,7 @@ describe("AudioPlaybackService", () => {
     jest.useRealTimers()
   })
 
-  it("bumps low Mentra Live volume, suspends mic while playing, then restores on finish", async () => {
+  it("bumps low Mentra Live volume, suspends mic while playing, and leaves the volume bumped", async () => {
     const onComplete = jest.fn()
 
     await audioPlaybackService.play(
@@ -88,7 +88,8 @@ describe("AudioPlaybackService", () => {
 
     expect(mockPlayer.pause).not.toHaveBeenCalled()
     expect(onComplete).toHaveBeenCalledWith("audio-1", true, null, 2000)
-    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenCalledTimes(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(9)
 
     jest.advanceTimersByTime(900)
     expect(mockPlayer.pause).toHaveBeenCalled()
@@ -98,7 +99,7 @@ describe("AudioPlaybackService", () => {
     expect(BluetoothSdk.setOwnAppAudioPlaying).toHaveBeenLastCalledWith(false)
   })
 
-  it("interrupts existing playback without restoring bumped volume until the replacement finishes", async () => {
+  it("interrupts existing playback without restoring bumped volume after the replacement finishes", async () => {
     const firstComplete = jest.fn()
     const secondComplete = jest.fn()
 
@@ -115,7 +116,8 @@ describe("AudioPlaybackService", () => {
     statusListener({didJustFinish: true, duration: 1})
 
     expect(secondComplete).toHaveBeenCalledWith("second", true, null, 1000)
-    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenCalledTimes(1)
+    expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenLastCalledWith(9)
   })
 
   it("starts playback without waiting for a slow glasses volume response", async () => {


### PR DESCRIPTION
## Summary

- add a hardcoded `RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK` flag, defaulted to `false`
- leave the glasses media volume boosted after playback completes, including when the volume bump finishes after playback
- preserve the existing restore implementation behind the flag for easy re-enabling
- update focused playback tests for the disabled restore path

## Why

Audio playback raises very low Mentra Live media volume so prompts are audible. Restoring the prior level afterward causes the volume to drop again, which is not the desired behavior right now.

## Validation

- `bun run test --runInBand src/services/AudioPlaybackService.test.ts`
- `bun run compile`
- `bunx eslint modules/engine/src/services/AudioPlaybackService.ts`
- `git diff --check`

## Notes

Focused linting of the existing test file still reports its pre-existing restricted relative import for `../../modules/engine/src/services/AudioPlaybackService`; this change does not modify that import.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep boosted glasses media volume after prompts instead of restoring it, so subsequent audio stays audible. This behavior is gated by `RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK`, which defaults to false to leave the boosted volume in place.

- **New Features**
  - Added hardcoded `RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK` flag (default: false).
  - Leave bumped volume unchanged when playback ends, including if the bump finishes after playback.
  - Preserved the old restore path behind the flag; updated tests to reflect the non-restore behavior.

<sup>Written for commit f9013d7bf3b9996799986386b49968b3cf586378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is localized to Mentra Live BLE media volume after app audio; no auth or data paths, and restore can be re-enabled via the flag.
> 
> **Overview**
> **Mentra Live A2DP playback** still bumps very low glasses media volume to the floor before prompts, but it **no longer restores** the user’s prior step level when playback ends.
> 
> A module-level flag `RESTORE_GLASSES_VOLUME_AFTER_PLAYBACK` defaults to **`false`**, so `restoreGlassesMediaVolume()` clears internal state without calling `setGlassesMediaVolume` with the saved level. If the volume bump finishes after playback has already ended, the service also **skips** an immediate restore unless the flag is enabled. The previous restore behavior remains available by flipping the flag.
> 
> Unit tests now expect a single `setGlassesMediaVolume(9)` bump and **no** restore to the original level (e.g. `1`) after finish or when interrupting and replacing playback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9013d7bf3b9996799986386b49968b3cf586378. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->