### PR TITLE
Add Mentra context to cloud-v2 Soniox

### DIFF
--- a/cloud-v2/packages/runtime/src/services/audio/providers/soniox.test.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/providers/soniox.test.ts
@@ -179,6 +179,37 @@ async function makeProvider(): Promise<{
   return { session, events, provider };
 }
 
+describe("SonioxProvider session configuration", () => {
+  test("sends the Mentra activation phrase as recognition context", async () => {
+    const session = new FakeSession();
+    let sessionConfig: Record<string, unknown> | undefined;
+    const client = {
+      realtime: {
+        stt: (config: Record<string, unknown>) => {
+          sessionConfig = config;
+          return session;
+        },
+      },
+    };
+
+    const provider = await createSonioxProvider({
+      scope: "user_test",
+      language: "auto",
+      client: client as never,
+      onTranscript: () => {},
+    });
+
+    expect(sessionConfig).toMatchObject({
+      context: {
+        terms: ["Mentra", "Hey Mentra"],
+        text: "Mentra, Hey Mentra (an AI assistant)",
+      },
+    });
+
+    await provider.close();
+  });
+});
+
 describe("SonioxProvider utterance lifecycle", () => {
   test("does not churn finals/utteranceIds when the rolling window's speaker flips mid-utterance", async () => {
     const { session, events, provider } = await makeProvider();

--- a/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
@@ -145,6 +145,10 @@ export async function createSonioxProvider(
     max_endpoint_delay_ms: 2_000,
     language_hints:
       opts.language && opts.language !== "auto" ? [opts.language] : undefined,
+    context: {
+      terms: ["Mentra", "Hey Mentra"],
+      text: "Mentra, Hey Mentra (an AI assistant)",
+    },
     // For translation subs, configure Soniox's one-way translation. Result
     // tokens then carry `translation_status: "original" | "translation"`
     // and we filter to the translation half.


### PR DESCRIPTION
## Summary

- add `Mentra` and `Hey Mentra` as Soniox recognition context in the cloud-v2 runtime
- describe Mentra as an AI assistant to improve phrase recognition
- add a focused regression test that verifies the context sent to the Soniox SDK

## Root cause

The v1 Soniox SDK path included recognition context for the Mentra activation phrase, but the cloud-v2 provider did not carry that configuration forward. As a result, Soniox had no product-specific context when transcribing “Hey Mentra.”

## Impact

Cloud-v2 Soniox sessions now receive the same activation-phrase context as the existing cloud provider, improving recognition of “Hey Mentra.”

## Validation

- `bun test packages/runtime/src/services/audio/providers/soniox.test.ts` — 14 passed
- `bun run typecheck` — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mentra recognition context to `cloud-v2` Soniox so the wake phrase "Hey Mentra" is recognized more reliably, matching the v1 provider. Adds a regression test that asserts the context is sent to the SDK.

<sup>Written for commit 1ddc25bd8312b21ae1d1f16452c55124853dd0dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small STT tuning change with no auth, data, or API contract impact; behavior is covered by a focused unit test.
> 
> **Overview**
> Cloud-v2 Soniox realtime STT sessions now send **recognition context** for the Mentra wake phrase, aligning with the v1 Soniox path that was missing here.
> 
> Each `createSonioxProvider` session config includes `context.terms` (`Mentra`, `Hey Mentra`) and descriptive `context.text` so Soniox can bias toward **“Hey Mentra”** and treat Mentra as an AI assistant. Self-heal reconnects reuse the same `sessionConfig`, so context applies on replacement sessions too.
> 
> A new unit test captures the config passed to `client.realtime.stt()` and asserts the Mentra context object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ddc25bd8312b21ae1d1f16452c55124853dd0dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->