### PR TITLE
Set BLE JPEG quality to 80 and restore size-tier targets

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -92,12 +92,12 @@ public class AsgConstants {
     public static final int TEXT_MODE_AE_EXPOSURE_DIVISOR = 3;
 
     /** Long-edge cap for text-mode BLE downscale after crop (aspect ratio preserved). */
-    public static final int TEXT_MODE_BLE_TARGET_WIDTH = 1280;
+    public static final int TEXT_MODE_BLE_TARGET_WIDTH = 1920;
 
-    public static final int TEXT_MODE_BLE_TARGET_HEIGHT = 1280;
+    public static final int TEXT_MODE_BLE_TARGET_HEIGHT = 1920;
 
     /** AVIF quality for the canonical text-mode BLE payload. */
-    public static final int TEXT_MODE_AVIF_QUALITY = 46;
+    public static final int TEXT_MODE_AVIF_QUALITY = 55;
 
     /** JPEG quality for the canonical text-mode crop written to disk (gallery/WiFi upload). */
     public static final int TEXT_MODE_BLE_JPEG_QUALITY = 95;
@@ -106,19 +106,19 @@ public class AsgConstants {
      * Codec for every BLE photo payload — text mode and ordinary size-tier photos alike. Change
      * this one value to {@code AVIF} or {@code JPEG_FAST} to switch both paths at once.
      */
-    public static final String BLE_PHOTO_CODEC = "AVIF";
+    public static final String BLE_PHOTO_CODEC = "JPEG_FAST";
 
     /** JPEG quality for all BLE photo payloads when {@link #BLE_PHOTO_CODEC} is {@code JPEG_FAST}. */
     public static final int BLE_PHOTO_JPEG_FAST_QUALITY = 80;
 
     // BLE size-tier downscale caps (long edge; aspect ratio preserved) and AVIF quality
-    public static final int BLE_PHOTO_LOW_TARGET_PX = 640;
-    public static final int BLE_PHOTO_LOW_AVIF_QUALITY = 46;
-    public static final int BLE_PHOTO_MEDIUM_TARGET_PX = 1024;
-    public static final int BLE_PHOTO_MEDIUM_AVIF_QUALITY = 46;
-    public static final int BLE_PHOTO_HIGH_TARGET_PX = 1280;
-    public static final int BLE_PHOTO_HIGH_AVIF_QUALITY = 46;
-    public static final int BLE_PHOTO_MAX_TARGET_PX = 1600;
+    public static final int BLE_PHOTO_LOW_TARGET_PX = 800;
+    public static final int BLE_PHOTO_LOW_AVIF_QUALITY = 50;
+    public static final int BLE_PHOTO_MEDIUM_TARGET_PX = 1280;
+    public static final int BLE_PHOTO_MEDIUM_AVIF_QUALITY = 50;
+    public static final int BLE_PHOTO_HIGH_TARGET_PX = 1600;
+    public static final int BLE_PHOTO_HIGH_AVIF_QUALITY = 48;
+    public static final int BLE_PHOTO_MAX_TARGET_PX = 1920;
 
     // Text-region detector production flags (see MediaCaptureService.buildTextDetectConfig)
     public static final boolean TEXT_DETECT_ALLOW_SINGLE_COMPONENT_LINES = true;


### PR DESCRIPTION
Keep JPEG_FAST as the BLE codec with quality 80, and restore the pre-experiment text-mode/high-tier resolution and AVIF quality values.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect every BLE photo payload (codec, size, and quality), which can alter transfer time, bandwidth, and OCR legibility without touching application logic.
> 
> **Overview**
> Retunes **BLE photo transfer defaults** in `AsgConstants` after an experiment: the shared payload codec switches from **`AVIF` to `JPEG_FAST`** (still at quality **80**).
> 
> **Text-mode** BLE downscale caps rise from **1280** to **1920** on the long edge, and text-mode AVIF quality goes **46 → 55**. **Size-tier** long-edge caps and AVIF quality knobs are bumped across low/medium/high/max (e.g. max tier **1600 → 1920** px; tier AVIF qualities **46–50** range vs the prior **46**-heavy settings).
> 
> No pipeline code changes—only constants read by `MediaCaptureService` / `BlePhotoEncodingPolicy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 226ca765f615c921ff2cceddd0cfdbcc9413125d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->