### PR TITLE
OS-1691: fix concurrent token refresh race causing spurious logout

### DIFF
--- a/mobile/src/utils/auth/provider/accountClient.race.test.ts
+++ b/mobile/src/utils/auth/provider/accountClient.race.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Reproduces and guards against a concurrent-refresh race in
+ * AccountAuthProvider. Two callers (e.g. AuthContext's getSession() and
+ * CloudClientService's getSubjectToken()) can both see a rejected access
+ * token and both call refreshTokens() with the same stored refresh token.
+ * Core enforces single-use rotation (session.service.ts refreshSession):
+ * only one concurrent refresh wins; the loser gets a legitimate 400
+ * invalid_grant. Before the fix, the loser's 400 makes the client call
+ * clearTokens() unconditionally, wiping out the winner's freshly-saved
+ * tokens, even though a valid session was just established.
+ *
+ * This is a LIVE integration test, opt-in via env var so the normal Jest
+ * run (and CI, which has no local core) skips it instead of failing:
+ *
+ *   1. cd cloud-v2 && bash scripts/dev-local.sh   (core on :3000)
+ *   2. cd mobile && RUN_LIVE_AUTH_TESTS=1 \
+ *        MENTRA_LIVE_TEST_EMAIL=<standing e2e test account> \
+ *        MENTRA_LIVE_TEST_PASSWORD=<its password> \
+ *        bunx jest accountClient.race
+ *
+ * Credentials come from env, not hardcoded: dev-local.sh points core at the
+ * real (shared, dev-tier) Supabase project via Doppler, so a real account
+ * password belongs in an untracked local shell env or Doppler, never in a
+ * public repo's git history.
+ */
+jest.mock("@/services/cloudClient", () => ({
+  resolvedEndpoints: () => ({core: "http://localhost:3000", runtime: "ws://localhost:3001"}),
+}))
+
+// authClient.ts and accountClient.ts import each other (AuthClient base class
+// vs AccountAuthProvider), which breaks under Jest's CJS module resolution
+// (AuthClient is still undefined when accountClient.ts's `extends AuthClient`
+// clause runs). AccountAuthProvider overrides every method AuthClient stubs,
+// so a trivial extendable class is behaviorally equivalent for this test.
+jest.mock("@/utils/auth/authClient", () => ({AuthClient: class {}}))
+
+import {AccountAuthProvider} from "./accountClient"
+import {storage} from "@/utils/storage"
+
+const CORE = "http://localhost:3000"
+const TEST_EMAIL = process.env.MENTRA_LIVE_TEST_EMAIL
+const TEST_PASSWORD = process.env.MENTRA_LIVE_TEST_PASSWORD
+
+const ACCESS_KEY = "mentra.account.accessToken"
+const REFRESH_KEY = "mentra.account.refreshToken"
+
+async function loginForRealTokens(): Promise<{access: string; refresh: string}> {
+  if (!TEST_EMAIL || !TEST_PASSWORD) {
+    throw new Error(
+      "RUN_LIVE_AUTH_TESTS is set but MENTRA_LIVE_TEST_EMAIL / MENTRA_LIVE_TEST_PASSWORD are not. " +
+        "Set them to the standing e2e test account before running this suite.",
+    )
+  }
+  const res = await fetch(`${CORE}/api/account/login`, {
+    method: "POST",
+    headers: {"content-type": "application/json"},
+    body: JSON.stringify({email: TEST_EMAIL, password: TEST_PASSWORD}),
+  })
+  if (!res.ok) throw new Error(`login failed: HTTP ${res.status} ${await res.text()}`)
+  const body = (await res.json()) as {access_token: string; refresh_token: string}
+  return {access: body.access_token, refresh: body.refresh_token}
+}
+
+// Opt-in gate: the normal Jest run (and CI, which has no local core) skips
+// this suite entirely instead of failing on the unreachable dependency.
+const describeLive = process.env.RUN_LIVE_AUTH_TESTS ? describe : describe.skip
+
+describeLive("AccountAuthProvider concurrent refresh (live, RUN_LIVE_AUTH_TESTS=1 + local core on :3000)", () => {
+  beforeAll(async () => {
+    const health = await fetch(`${CORE}/api/client/min-version`).catch(() => null)
+    if (!health || !health.ok) {
+      throw new Error(
+        "RUN_LIVE_AUTH_TESTS is set but local Cloud V2 core is not reachable at " +
+          "http://localhost:3000. Run `cd cloud-v2 && bash scripts/dev-local.sh` first.",
+      )
+    }
+  })
+
+  test("two concurrent session checks against an expired access token do not both survive", async () => {
+    const real = await loginForRealTokens()
+
+    // Deliberately invalid access token: forces BOTH concurrent calls below to
+    // hit the /api/account/me probe, get rejected, and attempt a refresh with
+    // the same (real, valid, unused) refresh token — faithfully reproducing
+    // "access token expired after backgrounding" without waiting out a TTL.
+    storage.save(ACCESS_KEY, "garbage-expired-access-token")
+    storage.save(REFRESH_KEY, real.refresh)
+
+    const provider = new AccountAuthProvider()
+
+    // Two independent entry points that both bottom out in refreshTokens():
+    // getSession() (AuthContext on mount) and getSubjectToken() (CloudClientService
+    // reconnect via ensureFreshAccess()) — fired concurrently, exactly as they
+    // would be on a cold resume after the access token's 1h TTL has elapsed.
+    const [sessionResult, subjectResult] = await Promise.all([provider.getSession(), provider.getSubjectToken()])
+
+    const tokensAfter = {
+      access: storage.load<string>(ACCESS_KEY),
+      refresh: storage.load<string>(REFRESH_KEY),
+    }
+    const survived = tokensAfter.access.is_ok() && tokensAfter.refresh.is_ok()
+
+    console.log("session result:", sessionResult.is_ok() ? "ok" : sessionResult.error.message)
+    console.log("subjectToken result:", subjectResult.is_ok() ? "ok" : subjectResult.error.message)
+    console.log("tokens survived in storage after the race:", survived)
+
+    // The fix under test: a valid session existed (the server accepted exactly
+    // one of the two concurrent refreshes) and it must still be in storage
+    // afterward. Before the fix, the losing call's clearTokens() wipes it.
+    expect(survived).toBe(true)
+  })
+
+  test("a caller presenting an already-rotated refresh token does not wipe the winner's session", async () => {
+    const real = await loginForRealTokens()
+    storage.save(ACCESS_KEY, real.access)
+    storage.save(REFRESH_KEY, real.refresh)
+
+    const provider = new AccountAuthProvider() as any
+
+    // Caller A's full cycle completes first: rotates the refresh token and
+    // saves the new pair. refreshInFlight is cleared by the time this
+    // resolves, so it does NOT protect a later, independent call.
+    const afterA = await provider.performRefresh(real.refresh)
+    expect(afterA).not.toBeNull()
+
+    // Caller B snapshotted the refresh token before A ran (the realistic
+    // case: both callers call loadTokens() around the same moment, but B's
+    // own /me probe + dispatch to refreshTokens() is slightly slower than
+    // A's full round trip). B now presents that stale token on its own,
+    // independent call, well after A's in-flight promise is gone.
+    const afterB = await provider.performRefresh(real.refresh)
+
+    const stored = {
+      access: storage.load<string>(ACCESS_KEY),
+      refresh: storage.load<string>(REFRESH_KEY),
+    }
+    const survived = stored.access.is_ok() && stored.refresh.is_ok()
+
+    console.log("caller B result:", afterB ? "recovered current session" : "null (would clearTokens)")
+    console.log("tokens survived after the stale caller:", survived)
+
+    // Before the fix: the stale token gets a real 400 invalid_grant,
+    // performRefresh returns null, and ensureFreshAccess()/getSession() would
+    // clearTokens() on that null, wiping out A's still-valid session. After
+    // the fix: performRefresh notices storage already moved on and hands back
+    // the current tokens instead of reporting a hard failure.
+    expect(afterB).not.toBeNull()
+    expect(survived).toBe(true)
+  })
+})

--- a/mobile/src/utils/auth/provider/accountClient.race.test.ts
+++ b/mobile/src/utils/auth/provider/accountClient.race.test.ts
@@ -13,15 +13,14 @@
  * run (and CI, which has no local core) skips it instead of failing:
  *
  *   1. cd cloud-v2 && bash scripts/dev-local.sh   (core on :3000)
- *   2. cd mobile && RUN_LIVE_AUTH_TESTS=1 \
- *        MENTRA_LIVE_TEST_EMAIL=<standing e2e test account> \
- *        MENTRA_LIVE_TEST_PASSWORD=<its password> \
- *        bunx jest accountClient.race
+ *   2. cd mobile && RUN_LIVE_AUTH_TESTS=1 doppler run --project mentra-sre \
+ *        --config dev -- bunx jest accountClient.race
  *
- * Credentials come from env, not hardcoded: dev-local.sh points core at the
- * real (shared, dev-tier) Supabase project via Doppler, so a real account
- * password belongs in an untracked local shell env or Doppler, never in a
- * public repo's git history.
+ * Credentials come from MENTRA_LIVE_TEST_EMAIL / MENTRA_LIVE_TEST_PASSWORD
+ * env vars, not hardcoded: dev-local.sh points core at the real (shared,
+ * dev-tier) Supabase project via Doppler, so a real account password
+ * belongs in Doppler (mentra-sre, config dev), never in a public repo's
+ * git history.
  */
 jest.mock("@/services/cloudClient", () => ({
   resolvedEndpoints: () => ({core: "http://localhost:3000", runtime: "ws://localhost:3001"}),

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -89,18 +89,53 @@ export class AccountAuthProvider extends AuthClient {
     return Res.ok({unsubscribe: () => (stateCb = null)})
   }
 
+  /** Core rotates refresh tokens on every use and enforces single-use: a
+   * second concurrent grant with the same (now-superseded) token gets a
+   * legitimate 400 invalid_grant, even though the first grant succeeded.
+   * Without this guard, two callers racing on the same expired access token
+   * (e.g. AuthContext's getSession() and CloudClientService's reconnect via
+   * getSubjectToken(), both firing on cold resume) would both call
+   * refreshTokens() with the same stored refresh token; the loser's 400
+   * would make ensureFreshAccess()/getSession() clearTokens(), wiping out
+   * the winner's freshly-saved session. Sharing one in-flight promise across
+   * all callers means only one grant is ever sent per rotation. */
+  private refreshInFlight: Promise<Tokens | null> | null = null
+
   /** Run the V2 refresh grant. Returns the new tokens, or null ONLY when the
    * server definitively rejected the refresh token (400/401: revoked or
    * expired session). Throws on network failure AND transient server errors
    * (5xx, 429) so callers keep the tokens instead of signing the user out
    * during a brief core outage. */
   private async refreshTokens(refresh: string): Promise<Tokens | null> {
+    if (this.refreshInFlight) return this.refreshInFlight
+    const inFlight = this.performRefresh(refresh).finally(() => {
+      if (this.refreshInFlight === inFlight) this.refreshInFlight = null
+    })
+    this.refreshInFlight = inFlight
+    return inFlight
+  }
+
+  private async performRefresh(refresh: string): Promise<Tokens | null> {
     const res = await fetch(core("/api/client/auth/refresh"), {
       method: "POST",
       headers: {"content-type": "application/x-www-form-urlencoded"},
       body: new URLSearchParams({grant_type: "refresh_token", refresh_token: refresh}),
     })
-    if (AccountAuthProvider.tokenRejected(res.status)) return null
+    if (AccountAuthProvider.tokenRejected(res.status)) {
+      // The in-flight guard above only covers callers that both call
+      // refreshTokens() while ONE request is still pending. A caller that
+      // snapshotted this exact refresh token earlier (via loadTokens()) but
+      // only got here after a DIFFERENT concurrent call already completed
+      // and rotated it will land here with a legitimate rejection for a
+      // token that is simply stale, not dead. Distinguish the two: if
+      // storage now holds a different refresh token than the one we just
+      // presented, someone else already won the rotation and saved a live
+      // session, so hand that back instead of reporting a hard failure that
+      // would make the caller clearTokens() out from under it.
+      const current = loadTokens()
+      if (current && current.refresh !== refresh) return current
+      return null
+    }
     if (!res.ok) throw new Error(`refresh failed transiently: HTTP ${res.status}`)
     const body = (await res.json()) as {access_token: string; refresh_token: string}
     const t = {access: body.access_token, refresh: body.refresh_token}


### PR DESCRIPTION
## Summary

Fixes OS-1691, the Mentra 3.0 report of users getting logged out often when opening MentraOS.

Two callers can race on an expired access token: AuthContext's getSession() on mount, and CloudClientService's reconnect flow via getSubjectToken(). Both independently call AccountAuthProvider's refreshTokens() with the same stored refresh token. Cloud V2 core enforces single-use refresh rotation (session.service.ts), so exactly one of the two concurrent grants succeeds and the other gets a legitimate 400 invalid_grant. The client treated that 400 as a definitive rejection and called clearTokens() unconditionally, which wiped out the winning call's freshly saved session. Net effect: the user is logged out even though a valid session was issued microseconds earlier.

## Fix

AccountAuthProvider now shares a single in-flight refresh promise across all callers, so only one refresh request is ever sent per rotation regardless of how many code paths try to trigger it at once.

## Verification

Reproduced and verified against a local Cloud V2 core with a real test account, not mocked.

1. Raw concurrent POST to /api/client/auth/refresh with the same refresh token, no client code involved: one request got 200 with fresh tokens, the other got 400 invalid_grant. Confirms the server side race is real.
2. Added mobile/src/utils/auth/provider/accountClient.race.test.ts, which drives the real AccountAuthProvider against the local core: corrupts the stored access token, fires getSession() and getSubjectToken() concurrently, and checks whether tokens survive.
   - Before the fix: reliably reproduced. tokens survived: false, test failed.
   - After the fix: passes consistently, ran 5 times in a row, all green, tokens survive, both callers succeed.
3. Full mobile test suite after the fix: 54/54 suites, 427/427 tests pass. tsc clean.

## Test plan

- [x] Server side concurrent refresh proven via raw curl against local core
- [x] Client race reproduced against real AccountAuthProvider before the fix
- [x] Same test passes after the fix, 5/5 runs
- [x] Full mobile jest suite passes with no regressions
- [x] tsc clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication session persistence and refresh error handling; incorrect behavior could still sign users out or accept stale sessions, but the scope is localized to mobile token refresh.
> 
> **Overview**
> Fixes **OS-1691** spurious logouts on cold app open when `getSession()` and `getSubjectToken()` both refresh against an expired access token.
> 
> **`AccountAuthProvider`** now shares a single **`refreshInFlight`** promise so concurrent callers reuse one refresh grant instead of racing with the same refresh token (core single-use rotation makes the loser get `400 invalid_grant`). Refresh logic is split into **`performRefresh`**: on `400/401`, if storage already holds a **different** refresh token, the client returns that session instead of `null` and **`clearTokens()`**.
> 
> Adds opt-in live integration coverage in **`accountClient.race.test.ts`** (`RUN_LIVE_AUTH_TESTS=1`, local core, Doppler credentials) for simultaneous and staggered refresh races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0406fd5a14743308ba91f639e586787e301c3d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a token refresh race that logged users out on app open. Addresses OS-1691 (Mentra 3.0) by deduping concurrent refreshes and preserving sessions when a stale refresh token is used.

- **Bug Fixes**
  - Deduplicate refreshes in `AccountAuthProvider` via a shared `refreshInFlight` promise so only one refresh runs per rotation.
  - In `performRefresh`, on 400/401 from a stale refresh token, return the current stored session instead of clearing tokens (protects staggered callers).
  - Add opt-in live race tests `mobile/src/utils/auth/provider/accountClient.race.test.ts` (`RUN_LIVE_AUTH_TESTS=1`; credentials via Doppler `MENTRA_LIVE_TEST_EMAIL`, `MENTRA_LIVE_TEST_PASSWORD`).

<sup>Written for commit 0406fd5a14743308ba91f639e586787e301c3d95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3449?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

