### PR TITLE
Set ASG client versionCode to 0 in the frozen v1 manifest (OS-1697)

### DIFF
--- a/asg_client/ota_website/prod_live_version.json
+++ b/asg_client/ota_website/prod_live_version.json
@@ -1,7 +1,7 @@
 {
   "apps": {
     "com.mentra.asg_client": {
-      "versionCode": 37,
+      "versionCode": 0,
       "versionName": "37.0",
       "apkUrl": "https://github.com/Mentra-Community/MentraOS/releases/download/asg-client/asg-client-37.apk",
       "sha256": "a637d23919ffde6e92025249ad91fde7befd6f4900c80c4be86cde2e75ae3564"


### PR DESCRIPTION
## Scope

One-line change to the frozen v1 OTA manifest (`asg_client/ota_website/prod_live_version.json`, served at https://ota.mentraglass.com/prod_live_version.json): set `apps['com.mentra.asg_client'].versionCode` from `37` to `0`, mirroring the existing `com.augmentos.otaupdater` placeholder pattern. `versionName`, `apkUrl`, and `sha256` are kept so the rescue pin is restorable by reverting a single number.

## Why

Updating Mentra Live glasses from April firmware (ASG client 36, MTK 20260418, BES 17.26.1.13) currently takes **two OTA passes** (OS-1697):

- Legacy ASG builds <39 always fetch this frozen v1 manifest (`OtaConstants.VERSION_JSON_URL` at v36, commit `49f327daf2`).
- Pass 1 burns on the APK hop 36→37: in the v36 `OtaHelper.processAppsSequentially`, the firmware phase only runs `if (!apkUpdateNeeded)`, and the freshly installed 37 waits for a new `ota_start`.
- Pass 2 then installs MTK 20260709 + BES 17.26.07.09.

With `versionCode: 0`, the v36 check `serverVersion > currentVersion` (`0 > 36`) skips the APK step, so the **same pass proceeds directly to MTK + BES**. The 20260709 MTK slot's `/system` ships ASG client 39 plus the first-boot heal script (#3383 / OS-1650), which delivers the client update instead of the APK hop.

## Safety analysis

- The `versionCode: 0` placeholder pattern is already exercised in production: every legacy client parses the `com.augmentos.otaupdater` entry (also `0`) through the exact same loop and comparison, so there is no new parse path.
- Nothing downloads or installs from the entry unless `versionCode > installed`, so the stale `apkUrl`/`sha256` fields are inert.
- Live manifest at ota.mentraglass.com verified identical to this file before the change (2026-07-15).

## Trade-off: this disables the network rescue pin

The pin at 37 was frozen as a "legacy rescue manifest" (commit `42f7d1984d`) so a legacy unit with a corrupted/missing `/data` client could reinstall a known-good APK via the `com.augmentos.otaupdater` watchdog's manifest path. After this change:

- The watchdog's **local backup rescue** (`reinstallApkFromBackup`, `asg_client_backup.apk`) is unaffected.
- The **network rescue** via this manifest no longer fires (`0 > 0` for a missing client). Units that take the MTK OTA get healed by the first-boot script instead; a corrupted unit that never starts an MTK OTA loses the manifest-driven reinstall.

## Before merging/deploying

1. **Team confirmation needed**: agree that the MTK first-boot heal supersedes the rescue-manifest purpose of the pinned APK 37 (see trade-off above).
2. **Hardware verification needed**: run one v36 unit (April firmware) through `ota_start` against a staged copy of this manifest and confirm MTK→BES completes in a single session when no APK step precedes them — per the v36 code, MTK starts first and the phone triggers BES in the follow-up round of the same session, but that path has never been exercised on v36.

Deploys to ota.mentraglass.com from `main` (Cloudflare Pages) after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production OTA behavior for legacy glasses on April firmware and removes the manifest-based APK 37 rescue path; MTK-first-boot heal is the intended replacement but needs staged hardware verification.
> 
> **Overview**
> Sets **`com.mentra.asg_client.versionCode`** from **37** to **0** in the frozen v1 OTA manifest (`prod_live_version.json`). **`versionName`**, **`apkUrl`**, and **`sha256`** stay unchanged so the rescue pin can be restored by reverting one field.
> 
> Legacy ASG builds (&lt;39) that read this manifest will no longer treat the APK as newer than installed client 36 (`0 > 36` is false), so a single **`ota_start`** can go straight to **MTK + BES** instead of requiring a separate 36→37 APK pass before firmware. Client refresh is expected from the MTK **`20260709`** image (ASG 39 + first-boot heal) rather than this manifest APK hop.
> 
> **Trade-off:** manifest-driven **network rescue** reinstall of APK 37 no longer runs for units that relied on that pin; local backup rescue and post-MTK heal paths are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ff6664c3729b0dc35267d973801ffb7b7861da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->