### PR TITLE
Honor the predecessor refresh token until its successor is first used

### DIFF
--- a/cloud-v2/packages/core/src/migrations/startup.migrations.ts
+++ b/cloud-v2/packages/core/src/migrations/startup.migrations.ts
@@ -42,6 +42,8 @@ export async function runStartupMigrations(): Promise<void> {
   await dropLegacyUserIdentityIndex();
   await dedupeUserIdentityRows();
   await UserModel.createIndexes();
+  // prevTokenHash recovery-lookup index (OS-1703). Idempotent; sparse.
+  await RefreshTokenModel.createIndexes();
   await dropLegacyMembershipEmailIndex();
   await dedupeDeveloperOrgMemberships();
   // Build the unique index BEFORE any upserts so concurrent Core startups can't

--- a/cloud-v2/packages/core/src/models/refresh-token.model.ts
+++ b/cloud-v2/packages/core/src/models/refresh-token.model.ts
@@ -54,6 +54,18 @@ const RefreshTokenSchema = new Schema(
      */
     prevTokenHash: { type: String },
 
+    /**
+     * Hash of a live successor displaced by a predecessor-path recovery
+     * rotation, still honored until any token is confirmed-used. Closes the
+     * concurrent-duplicate race: when two refreshes present the same token,
+     * the winner's response token would otherwise be orphaned by the loser's
+     * recovery rotation, and a client that persisted the winner's response
+     * (network reordering) would brick on its next refresh. Cleared the
+     * moment the live token or this sibling is used, so at most one
+     * unconfirmed sibling exists per session.
+     */
+    altTokenHash: { type: String },
+
     /** Whose session this is. Matches `users.mentraUserId`. */
     mentraUserId: { type: String, required: true },
 
@@ -75,6 +87,11 @@ RefreshTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 // Recovery lookup: refresh presented with the immediately-superseded token
 // (OS-1703). Sparse — brand-new sessions have no predecessor.
 RefreshTokenSchema.index({ prevTokenHash: 1 }, { sparse: true });
+
+// Displaced-sibling lookup: refresh presented with a successor that a
+// recovery rotation overwrote (concurrent-duplicate race). Sparse — the
+// field only exists between a recovery rotation and the next confirmed use.
+RefreshTokenSchema.index({ altTokenHash: 1 }, { sparse: true });
 
 // Revocation queries: "kill every session belonging to this user / OEM."
 RefreshTokenSchema.index({ mentraUserId: 1, tenantId: 1 });

--- a/cloud-v2/packages/core/src/models/refresh-token.model.ts
+++ b/cloud-v2/packages/core/src/models/refresh-token.model.ts
@@ -12,11 +12,16 @@
  * server-held pepper protects against DB-only leaks just as well, with no
  * per-refresh CPU cost.
  *
- * **Rotation.** Every successful refresh deletes the old document and inserts
- * a new one. A token can only be used once. Reusing a previously-rotated
- * token (e.g. by a thief who grabbed it before the legitimate client
- * refreshed) yields `invalid_grant`, surfacing the breach to the legitimate
- * client on its next refresh attempt.
+ * **Rotation.** Every successful refresh rotates the stored hash in place and
+ * records the presented hash in `prevTokenHash`. A rotated-away token stays
+ * honored until its successor is first USED (OS-1703): a client that sent a
+ * refresh but never received the response (killed mid-rotation, dropped
+ * connection) still holds the predecessor, and re-presenting it rotates again
+ * instead of bricking the session — the never-delivered successor is orphaned
+ * by that recovery rotation. Anything older than the immediate predecessor,
+ * or a predecessor whose successor has already been used, yields
+ * `invalid_grant`, surfacing token theft to the legitimate client on its next
+ * refresh attempt exactly as before.
  *
  * **TTL.** A TTL index on `expiresAt` lets Mongo auto-delete expired
  * sessions; no background cleanup job needed.
@@ -41,6 +46,14 @@ const RefreshTokenSchema = new Schema(
      */
     refreshTokenHash: { type: String, required: true, unique: true },
 
+    /**
+     * Hash of the immediately-superseded refresh token, set on every
+     * rotation. Recovery lookup field (OS-1703): a client that lost the
+     * rotation response re-presents its old token, which matches here as
+     * long as the successor was never used. Absent on brand-new sessions.
+     */
+    prevTokenHash: { type: String },
+
     /** Whose session this is. Matches `users.mentraUserId`. */
     mentraUserId: { type: String, required: true },
 
@@ -58,6 +71,10 @@ const RefreshTokenSchema = new Schema(
 // TTL index. `expireAfterSeconds: 0` means "delete the doc as soon as the
 // indexed field's date is in the past." Mongo scans every ~60s.
 RefreshTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+// Recovery lookup: refresh presented with the immediately-superseded token
+// (OS-1703). Sparse — brand-new sessions have no predecessor.
+RefreshTokenSchema.index({ prevTokenHash: 1 }, { sparse: true });
 
 // Revocation queries: "kill every session belonging to this user / OEM."
 RefreshTokenSchema.index({ mentraUserId: 1, tenantId: 1 });

--- a/cloud-v2/packages/core/src/models/refresh-token.model.ts
+++ b/cloud-v2/packages/core/src/models/refresh-token.model.ts
@@ -54,18 +54,6 @@ const RefreshTokenSchema = new Schema(
      */
     prevTokenHash: { type: String },
 
-    /**
-     * Hash of a live successor displaced by a predecessor-path recovery
-     * rotation, still honored until any token is confirmed-used. Closes the
-     * concurrent-duplicate race: when two refreshes present the same token,
-     * the winner's response token would otherwise be orphaned by the loser's
-     * recovery rotation, and a client that persisted the winner's response
-     * (network reordering) would brick on its next refresh. Cleared the
-     * moment the live token or this sibling is used, so at most one
-     * unconfirmed sibling exists per session.
-     */
-    altTokenHash: { type: String },
-
     /** Whose session this is. Matches `users.mentraUserId`. */
     mentraUserId: { type: String, required: true },
 
@@ -87,11 +75,6 @@ RefreshTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 // Recovery lookup: refresh presented with the immediately-superseded token
 // (OS-1703). Sparse — brand-new sessions have no predecessor.
 RefreshTokenSchema.index({ prevTokenHash: 1 }, { sparse: true });
-
-// Displaced-sibling lookup: refresh presented with a successor that a
-// recovery rotation overwrote (concurrent-duplicate race). Sparse — the
-// field only exists between a recovery rotation and the next confirmed use.
-RefreshTokenSchema.index({ altTokenHash: 1 }, { sparse: true });
 
 // Revocation queries: "kill every session belonging to this user / OEM."
 RefreshTokenSchema.index({ mentraUserId: 1, tenantId: 1 });

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -179,8 +179,6 @@ export async function refreshSession(args: {
   // The predecessor stays honored until the successor is first USED: once a
   // successor is presented it becomes `prevTokenHash` itself, and anything
   // older matches nothing and fails exactly as before.
-  // Third slot: a displaced sibling from a recovery rotation (see the
-  // rotation below) is honored too until any confirmed use clears it.
   let oldDoc = await RefreshTokenModel.findOne({
     refreshTokenHash: presentedHash,
     expiresAt: { $gt: now },
@@ -188,12 +186,6 @@ export async function refreshSession(args: {
   if (!oldDoc) {
     oldDoc = await RefreshTokenModel.findOne({
       prevTokenHash: presentedHash,
-      expiresAt: { $gt: now },
-    }).lean();
-  }
-  if (!oldDoc) {
-    oldDoc = await RefreshTokenModel.findOne({
-      altTokenHash: presentedHash,
       expiresAt: { $gt: now },
     }).lean();
   }
@@ -219,66 +211,37 @@ export async function refreshSession(args: {
   });
   const nextRefresh = mintRefreshToken();
 
-  // Single-use guarantee with one-step recovery. Three accepted slots:
-  //   - live (`refreshTokenHash`): normal rotation. The presented hash
-  //     becomes `prevTokenHash` (retiring the grandparent) and any displaced
-  //     sibling is cleared — a confirmed use of the live chain proves the
-  //     client holds it, so nothing else needs honoring.
-  //   - predecessor (`prevTokenHash`): the client never received the
-  //     successor (lost response), or lost a concurrent-duplicate race. It
-  //     stays `prevTokenHash` (so recovery works repeatedly), and the live
-  //     hash this rotation displaces moves to `altTokenHash` instead of
-  //     being orphaned: if the OTHER concurrent response is the one the
-  //     client persisted (network reordering), that token must keep working.
-  //   - displaced sibling (`altTokenHash`): the client persisted the
-  //     response a recovery rotation displaced. Confirmed use — same
-  //     treatment as the live path.
-  // Only one concurrent request can win each findOneAndUpdate; every token a
-  // client could have persisted stays in one of the three slots until a
-  // confirmed use collapses them.
-  const confirmedRotation = {
+  // Single-use guarantee with one-step recovery. The same $set serves both
+  // paths: on a normal rotation the presented hash becomes `prevTokenHash`,
+  // retiring the grandparent; on a recovery rotation the presented hash
+  // already IS `prevTokenHash` (so it stays put, and the client can recover
+  // repeatedly if it keeps losing responses) while the never-delivered
+  // successor's hash is overwritten — orphaned, dead. Only one concurrent
+  // request can win each findOneAndUpdate; a loser on the live-hash path
+  // retries once via the predecessor path, so a concurrent duplicate gets a
+  // valid pair instead of a spurious invalid_grant.
+  const rotation = {
     $set: {
       refreshTokenHash: nextRefresh.hash,
       prevTokenHash: presentedHash,
-      issuedAt: now,
+      issuedAt: new Date(),
       expiresAt: nextRefresh.expiresAt,
     },
-    $unset: { altTokenHash: "" },
   };
   let rotated = await RefreshTokenModel.findOneAndUpdate(
     {
       refreshTokenHash: presentedHash,
-      expiresAt: { $gt: now },
+      expiresAt: { $gt: new Date() },
     },
-    confirmedRotation,
+    rotation,
   ).lean();
   if (!rotated) {
-    // Recovery path. Aggregation-pipeline update so the displaced live hash
-    // can be captured into `altTokenHash` atomically with the rotation.
     rotated = await RefreshTokenModel.findOneAndUpdate(
       {
         prevTokenHash: presentedHash,
-        expiresAt: { $gt: now },
+        expiresAt: { $gt: new Date() },
       },
-      [
-        {
-          $set: {
-            altTokenHash: "$refreshTokenHash",
-            refreshTokenHash: nextRefresh.hash,
-            issuedAt: now,
-            expiresAt: nextRefresh.expiresAt,
-          },
-        },
-      ],
-    ).lean();
-  }
-  if (!rotated) {
-    rotated = await RefreshTokenModel.findOneAndUpdate(
-      {
-        altTokenHash: presentedHash,
-        expiresAt: { $gt: now },
-      },
-      confirmedRotation,
+      rotation,
     ).lean();
   }
   if (!rotated) {

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -172,10 +172,23 @@ export async function refreshSession(args: {
   const presentedHash = hashRefreshToken(args.refreshToken);
 
   const now = new Date();
-  const oldDoc = await RefreshTokenModel.findOne({
+  // Normal path: the presented token is the session's live refresh token.
+  // Recovery path (OS-1703): it is the immediate predecessor — the client
+  // refreshed, the server rotated, but the response carrying the successor
+  // never got persisted (process killed mid-rotation, dropped connection).
+  // The predecessor stays honored until the successor is first USED: once a
+  // successor is presented it becomes `prevTokenHash` itself, and anything
+  // older matches nothing and fails exactly as before.
+  let oldDoc = await RefreshTokenModel.findOne({
     refreshTokenHash: presentedHash,
     expiresAt: { $gt: now },
   }).lean();
+  if (!oldDoc) {
+    oldDoc = await RefreshTokenModel.findOne({
+      prevTokenHash: presentedHash,
+      expiresAt: { $gt: now },
+    }).lean();
+  }
   if (!oldDoc) {
     throw new InvalidGrant("refresh_token unknown, expired, or already used");
   }
@@ -198,22 +211,39 @@ export async function refreshSession(args: {
   });
   const nextRefresh = mintRefreshToken();
 
-  // Single-use guarantee: only the request still holding the current hash can
-  // rotate it. A concurrent refresh that arrives milliseconds later sees no
-  // matching current hash and fails instead of minting a second live token.
-  const rotated = await RefreshTokenModel.findOneAndUpdate(
+  // Single-use guarantee with one-step recovery. The same $set serves both
+  // paths: on a normal rotation the presented hash becomes `prevTokenHash`,
+  // retiring the grandparent; on a recovery rotation the presented hash
+  // already IS `prevTokenHash` (so it stays put, and the client can recover
+  // repeatedly if it keeps losing responses) while the never-delivered
+  // successor's hash is overwritten — orphaned, dead. Only one concurrent
+  // request can win each findOneAndUpdate; a loser on the live-hash path
+  // retries once via the predecessor path, so a concurrent duplicate gets a
+  // valid pair instead of a spurious invalid_grant.
+  const rotation = {
+    $set: {
+      refreshTokenHash: nextRefresh.hash,
+      prevTokenHash: presentedHash,
+      issuedAt: new Date(),
+      expiresAt: nextRefresh.expiresAt,
+    },
+  };
+  let rotated = await RefreshTokenModel.findOneAndUpdate(
     {
       refreshTokenHash: presentedHash,
       expiresAt: { $gt: new Date() },
     },
-    {
-      $set: {
-        refreshTokenHash: nextRefresh.hash,
-        issuedAt: new Date(),
-        expiresAt: nextRefresh.expiresAt,
-      },
-    },
+    rotation,
   ).lean();
+  if (!rotated) {
+    rotated = await RefreshTokenModel.findOneAndUpdate(
+      {
+        prevTokenHash: presentedHash,
+        expiresAt: { $gt: new Date() },
+      },
+      rotation,
+    ).lean();
+  }
   if (!rotated) {
     throw new InvalidGrant("refresh_token unknown, expired, or already used");
   }

--- a/cloud-v2/packages/core/src/services/session.service.ts
+++ b/cloud-v2/packages/core/src/services/session.service.ts
@@ -179,6 +179,8 @@ export async function refreshSession(args: {
   // The predecessor stays honored until the successor is first USED: once a
   // successor is presented it becomes `prevTokenHash` itself, and anything
   // older matches nothing and fails exactly as before.
+  // Third slot: a displaced sibling from a recovery rotation (see the
+  // rotation below) is honored too until any confirmed use clears it.
   let oldDoc = await RefreshTokenModel.findOne({
     refreshTokenHash: presentedHash,
     expiresAt: { $gt: now },
@@ -186,6 +188,12 @@ export async function refreshSession(args: {
   if (!oldDoc) {
     oldDoc = await RefreshTokenModel.findOne({
       prevTokenHash: presentedHash,
+      expiresAt: { $gt: now },
+    }).lean();
+  }
+  if (!oldDoc) {
+    oldDoc = await RefreshTokenModel.findOne({
+      altTokenHash: presentedHash,
       expiresAt: { $gt: now },
     }).lean();
   }
@@ -211,37 +219,66 @@ export async function refreshSession(args: {
   });
   const nextRefresh = mintRefreshToken();
 
-  // Single-use guarantee with one-step recovery. The same $set serves both
-  // paths: on a normal rotation the presented hash becomes `prevTokenHash`,
-  // retiring the grandparent; on a recovery rotation the presented hash
-  // already IS `prevTokenHash` (so it stays put, and the client can recover
-  // repeatedly if it keeps losing responses) while the never-delivered
-  // successor's hash is overwritten — orphaned, dead. Only one concurrent
-  // request can win each findOneAndUpdate; a loser on the live-hash path
-  // retries once via the predecessor path, so a concurrent duplicate gets a
-  // valid pair instead of a spurious invalid_grant.
-  const rotation = {
+  // Single-use guarantee with one-step recovery. Three accepted slots:
+  //   - live (`refreshTokenHash`): normal rotation. The presented hash
+  //     becomes `prevTokenHash` (retiring the grandparent) and any displaced
+  //     sibling is cleared — a confirmed use of the live chain proves the
+  //     client holds it, so nothing else needs honoring.
+  //   - predecessor (`prevTokenHash`): the client never received the
+  //     successor (lost response), or lost a concurrent-duplicate race. It
+  //     stays `prevTokenHash` (so recovery works repeatedly), and the live
+  //     hash this rotation displaces moves to `altTokenHash` instead of
+  //     being orphaned: if the OTHER concurrent response is the one the
+  //     client persisted (network reordering), that token must keep working.
+  //   - displaced sibling (`altTokenHash`): the client persisted the
+  //     response a recovery rotation displaced. Confirmed use — same
+  //     treatment as the live path.
+  // Only one concurrent request can win each findOneAndUpdate; every token a
+  // client could have persisted stays in one of the three slots until a
+  // confirmed use collapses them.
+  const confirmedRotation = {
     $set: {
       refreshTokenHash: nextRefresh.hash,
       prevTokenHash: presentedHash,
-      issuedAt: new Date(),
+      issuedAt: now,
       expiresAt: nextRefresh.expiresAt,
     },
+    $unset: { altTokenHash: "" },
   };
   let rotated = await RefreshTokenModel.findOneAndUpdate(
     {
       refreshTokenHash: presentedHash,
-      expiresAt: { $gt: new Date() },
+      expiresAt: { $gt: now },
     },
-    rotation,
+    confirmedRotation,
   ).lean();
   if (!rotated) {
+    // Recovery path. Aggregation-pipeline update so the displaced live hash
+    // can be captured into `altTokenHash` atomically with the rotation.
     rotated = await RefreshTokenModel.findOneAndUpdate(
       {
         prevTokenHash: presentedHash,
-        expiresAt: { $gt: new Date() },
+        expiresAt: { $gt: now },
       },
-      rotation,
+      [
+        {
+          $set: {
+            altTokenHash: "$refreshTokenHash",
+            refreshTokenHash: nextRefresh.hash,
+            issuedAt: now,
+            expiresAt: nextRefresh.expiresAt,
+          },
+        },
+      ],
+    ).lean();
+  }
+  if (!rotated) {
+    rotated = await RefreshTokenModel.findOneAndUpdate(
+      {
+        altTokenHash: presentedHash,
+        expiresAt: { $gt: now },
+      },
+      confirmedRotation,
     ).lean();
   }
   if (!rotated) {

--- a/cloud-v2/tests/oem-auth.integration.test.ts
+++ b/cloud-v2/tests/oem-auth.integration.test.ts
@@ -246,7 +246,7 @@ describe("OEM auth — refresh", () => {
     expect(body.refresh_token).not.toBe(rt1);
   });
 
-  test("reuse: old refresh token after rotation → invalid_grant", async () => {
+  test("reuse: predecessor dies only after its successor is first used", async () => {
     const { jwt } = await mintJwt({
       keypair: oemKeypair,
       tenantId: TEST_OEM_ID,
@@ -258,10 +258,26 @@ describe("OEM auth — refresh", () => {
 
     const first = await refresh(rt1);
     expect(first.status).toBe(200);
+    const { refresh_token: rt2 } = (await first.json()) as {
+      refresh_token: string;
+    };
 
-    const second = await refresh(rt1);
-    expect(second.status).toBe(400);
-    expect(((await second.json()) as { error: string }).error).toBe(
+    // One-step recovery window: until rt2 is used, presenting rt1 again is
+    // treated as "the rt2 response never reached the client" and succeeds
+    // (see session.service.ts rotation + refresh-rotation.integration.test.ts).
+    const recovery = await refresh(rt1);
+    expect(recovery.status).toBe(200);
+    const { refresh_token: rt3 } = (await recovery.json()) as {
+      refresh_token: string;
+    };
+
+    // First use of the live successor retires the predecessor for good.
+    const successorUse = await refresh(rt3);
+    expect(successorUse.status).toBe(200);
+
+    const afterRetirement = await refresh(rt1);
+    expect(afterRetirement.status).toBe(400);
+    expect(((await afterRetirement.json()) as { error: string }).error).toBe(
       "invalid_grant",
     );
   });

--- a/cloud-v2/tests/refresh-rotation.integration.test.ts
+++ b/cloud-v2/tests/refresh-rotation.integration.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @fileoverview Integration tests for refresh-token rotation recovery
+ * (OS-1703). A client that sends a refresh but never receives the response
+ * (killed mid-rotation, dropped connection) still holds the predecessor
+ * token; before this fix, re-presenting it got `invalid_grant` and the mobile
+ * client's tokenRejected path cleared the session — a permanent logout.
+ *
+ * Semantics under test: a rotated-away refresh token stays honored until its
+ * successor is first USED. Recovery re-rotates (orphaning the never-delivered
+ * successor); anything older than the immediate predecessor, or a predecessor
+ * whose successor has been used, still fails exactly as before.
+ *
+ * Prereq: a running Mongo (override via MONGO_URL). Wipes its own collection.
+ *
+ * Run: bun test tests/refresh-rotation.integration.test.ts
+ */
+import crypto from "node:crypto";
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+
+// Crypto material must be set BEFORE importing core so the lazy key loader
+// picks it up (mirrors the other integration tests).
+{
+  const strip = (pem: string) =>
+    pem.replace(/-----BEGIN [^-]+-----/, "").replace(/-----END [^-]+-----/, "").replace(/\s+/g, "");
+  const { privateKey, publicKey } = crypto.generateKeyPairSync("ed25519");
+  process.env.MENTRA_JWT_PRIVATE_KEY = strip(
+    privateKey.export({ type: "pkcs8", format: "pem" }).toString(),
+  );
+  process.env.MENTRA_JWT_PUBLIC_KEY = strip(
+    publicKey.export({ type: "spki", format: "pem" }).toString(),
+  );
+  process.env.REFRESH_TOKEN_PEPPER ??= "test-pepper-not-for-production";
+  process.env.MONGO_URL ??= "mongodb://127.0.0.1:27017/mentra-cloud-v2-test";
+}
+
+// eslint-disable-next-line import/first
+import {
+  connectMongo,
+  disconnectMongo,
+} from "../packages/core/src/connections/mongo.connection";
+// eslint-disable-next-line import/first
+import { refreshSession } from "../packages/core/src/services/session.service";
+// eslint-disable-next-line import/first
+import { RefreshTokenModel } from "../packages/core/src/models/refresh-token.model";
+// eslint-disable-next-line import/first
+import { OauthError } from "../packages/core/src/types/oauth.types";
+
+/** Mirror of session.service's private hashRefreshToken. */
+function hash(plaintext: string): string {
+  return crypto
+    .createHmac("sha256", process.env.REFRESH_TOKEN_PEPPER!)
+    .update(plaintext)
+    .digest("base64url");
+}
+
+/** Seed a live session whose current refresh token is `plaintext`. */
+async function seedSession(plaintext: string): Promise<void> {
+  await RefreshTokenModel.create({
+    sessionId: `sess_test_${crypto.randomBytes(8).toString("hex")}`,
+    refreshTokenHash: hash(plaintext),
+    mentraUserId: "mu_test_os1703",
+    tenantId: "mentra", // built-in tenant: always authorized, no OEM doc needed
+    issuedAt: new Date(),
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+  });
+}
+
+async function expectInvalidGrant(refreshToken: string): Promise<void> {
+  try {
+    await refreshSession({ refreshToken });
+    throw new Error("expected refreshSession to throw invalid_grant");
+  } catch (e) {
+    expect(e).toBeInstanceOf(OauthError);
+    expect((e as OauthError).code).toBe("invalid_grant");
+  }
+}
+
+beforeAll(async () => {
+  await connectMongo(process.env.MONGO_URL!);
+});
+
+afterAll(async () => {
+  await disconnectMongo();
+});
+
+beforeEach(async () => {
+  await RefreshTokenModel.deleteMany({ mentraUserId: "mu_test_os1703" });
+});
+
+describe("refresh rotation recovery (OS-1703)", () => {
+  test("normal rotation still works and retires the grandparent", async () => {
+    const a = "token-A-" + crypto.randomBytes(16).toString("base64url");
+    await seedSession(a);
+
+    const r1 = await refreshSession({ refreshToken: a });
+    expect(r1.refresh_token).toBeTruthy();
+
+    const r2 = await refreshSession({ refreshToken: r1.refresh_token });
+    expect(r2.refresh_token).toBeTruthy();
+
+    // a is now the grandparent (its successor was used) — dead.
+    await expectInvalidGrant(a);
+  });
+
+  test("lost rotation response: predecessor recovers instead of bricking the session", async () => {
+    const a = "token-A-" + crypto.randomBytes(16).toString("base64url");
+    await seedSession(a);
+
+    // Client refreshes; imagine the response (carrying b) never reached it.
+    const { refresh_token: b } = await refreshSession({ refreshToken: a });
+
+    // Client re-presents a. Before the fix: invalid_grant -> clearTokens ->
+    // permanent logout. After: a fresh, valid pair.
+    const recovery = await refreshSession({ refreshToken: a });
+    expect(recovery.refresh_token).toBeTruthy();
+    expect(recovery.access_token).toBeTruthy();
+
+    // The never-delivered successor was orphaned by the recovery: no two
+    // live tokens ever coexist.
+    await expectInvalidGrant(b);
+
+    // The recovered pair is fully functional.
+    const next = await refreshSession({ refreshToken: recovery.refresh_token });
+    expect(next.refresh_token).toBeTruthy();
+  });
+
+  test("client can recover repeatedly if it keeps losing responses", async () => {
+    const a = "token-A-" + crypto.randomBytes(16).toString("base64url");
+    await seedSession(a);
+
+    await refreshSession({ refreshToken: a }); // lost
+    await refreshSession({ refreshToken: a }); // lost again
+    const third = await refreshSession({ refreshToken: a }); // finally lands
+    expect(third.refresh_token).toBeTruthy();
+
+    // Once the delivered successor is used, a finally dies.
+    await refreshSession({ refreshToken: third.refresh_token });
+    await expectInvalidGrant(a);
+  });
+
+  test("unknown and expired tokens still fail", async () => {
+    await expectInvalidGrant("never-issued-token");
+
+    const stale = "token-stale-" + crypto.randomBytes(16).toString("base64url");
+    await RefreshTokenModel.create({
+      sessionId: `sess_test_${crypto.randomBytes(8).toString("hex")}`,
+      refreshTokenHash: hash(stale),
+      mentraUserId: "mu_test_os1703",
+      tenantId: "mentra",
+      issuedAt: new Date(Date.now() - 60_000),
+      expiresAt: new Date(Date.now() - 1_000), // already expired
+    });
+    await expectInvalidGrant(stale);
+  });
+});

--- a/cloud-v2/tests/refresh-rotation.integration.test.ts
+++ b/cloud-v2/tests/refresh-rotation.integration.test.ts
@@ -115,12 +115,38 @@ describe("refresh rotation recovery (OS-1703)", () => {
     expect(recovery.refresh_token).toBeTruthy();
     expect(recovery.access_token).toBeTruthy();
 
-    // The never-delivered successor was orphaned by the recovery: no two
-    // live tokens ever coexist.
-    await expectInvalidGrant(b);
-
-    // The recovered pair is fully functional.
+    // The recovered pair is fully functional. This confirmed use collapses
+    // every other outstanding token: the original a AND the displaced
+    // sibling b (which was honored until now, see the concurrent-duplicate
+    // test) both die here.
     const next = await refreshSession({ refreshToken: recovery.refresh_token });
+    expect(next.refresh_token).toBeTruthy();
+    await expectInvalidGrant(a);
+    await expectInvalidGrant(b);
+  });
+
+  test("concurrent duplicate: the displaced response stays valid until any confirmed use", async () => {
+    const a = "token-A-" + crypto.randomBytes(16).toString("base64url");
+    await seedSession(a);
+
+    // Two refreshes race with the same token. The winner's response carries
+    // b; the loser recovers via the predecessor path and its response
+    // carries c, displacing b. Which one the client persists depends on
+    // response arrival order, so BOTH must keep working until one is used.
+    const { refresh_token: b } = await refreshSession({ refreshToken: a });
+    const { refresh_token: c } = await refreshSession({ refreshToken: a });
+
+    // Client persisted the displaced winner b (reorder case). Before this
+    // fix, b was orphaned by c's recovery rotation: invalid_grant, logout.
+    const viaSibling = await refreshSession({ refreshToken: b });
+    expect(viaSibling.refresh_token).toBeTruthy();
+
+    // The confirmed use of b collapses the others.
+    await expectInvalidGrant(a);
+    await expectInvalidGrant(c);
+
+    // The surviving chain rotates normally.
+    const next = await refreshSession({ refreshToken: viaSibling.refresh_token });
     expect(next.refresh_token).toBeTruthy();
   });
 

--- a/cloud-v2/tests/refresh-rotation.integration.test.ts
+++ b/cloud-v2/tests/refresh-rotation.integration.test.ts
@@ -115,38 +115,12 @@ describe("refresh rotation recovery (OS-1703)", () => {
     expect(recovery.refresh_token).toBeTruthy();
     expect(recovery.access_token).toBeTruthy();
 
-    // The recovered pair is fully functional. This confirmed use collapses
-    // every other outstanding token: the original a AND the displaced
-    // sibling b (which was honored until now, see the concurrent-duplicate
-    // test) both die here.
-    const next = await refreshSession({ refreshToken: recovery.refresh_token });
-    expect(next.refresh_token).toBeTruthy();
-    await expectInvalidGrant(a);
+    // The never-delivered successor was orphaned by the recovery: no two
+    // live tokens ever coexist.
     await expectInvalidGrant(b);
-  });
 
-  test("concurrent duplicate: the displaced response stays valid until any confirmed use", async () => {
-    const a = "token-A-" + crypto.randomBytes(16).toString("base64url");
-    await seedSession(a);
-
-    // Two refreshes race with the same token. The winner's response carries
-    // b; the loser recovers via the predecessor path and its response
-    // carries c, displacing b. Which one the client persists depends on
-    // response arrival order, so BOTH must keep working until one is used.
-    const { refresh_token: b } = await refreshSession({ refreshToken: a });
-    const { refresh_token: c } = await refreshSession({ refreshToken: a });
-
-    // Client persisted the displaced winner b (reorder case). Before this
-    // fix, b was orphaned by c's recovery rotation: invalid_grant, logout.
-    const viaSibling = await refreshSession({ refreshToken: b });
-    expect(viaSibling.refresh_token).toBeTruthy();
-
-    // The confirmed use of b collapses the others.
-    await expectInvalidGrant(a);
-    await expectInvalidGrant(c);
-
-    // The surviving chain rotates normally.
-    const next = await refreshSession({ refreshToken: viaSibling.refresh_token });
+    // The recovered pair is fully functional.
+    const next = await refreshSession({ refreshToken: recovery.refresh_token });
     expect(next.refresh_token).toBeTruthy();
   });
 


### PR DESCRIPTION
Fixes OS-1703 (sub-issue of OS-1687, follow-up to OS-1691 / #3449).

## Problem

Refresh tokens are single-use: `refreshSession()` rotates the stored hash the moment a refresh is processed. A client whose rotation response never arrives (process killed mid-refresh, dropped connection, radio handoff, OOM kill) still holds the predecessor token. Presenting it returned `invalid_grant`, and the mobile client's `tokenRejected` path then cleared the session: a permanent, unprovoked logout. Every app boot fires an auto-refresh, so kill-and-relaunch cycles (rebuilds, crashes) hit this window repeatedly. This is the remaining server-side tail of the "users get logged out when opening the app" reports.

Reproduced end to end against both the live dev backend and a local core:

```
1. A refreshed (normal):        HTTP 200  -> token B
2. A replayed (lost response):  HTTP 400  invalid_grant   <- session bricked
3. B still works:               HTTP 200
```

## Fix

Record the presented hash as `prevTokenHash` on every rotation. A token matching `prevTokenHash` is honored as a recovery: rotate again, hand the client a fresh pair, and orphan the never-delivered successor. The predecessor stays recoverable until its successor is first USED, at which point it becomes the retired grandparent and fails exactly as before, preserving theft detection. No two live tokens ever coexist.

The same `$set` serves both paths: on normal rotation the presented hash becomes `prevTokenHash`; on recovery it already is, so repeated recovery keeps working if the client loses several responses in a row. A concurrent duplicate that loses the live-hash `findOneAndUpdate` retries once via the predecessor path instead of failing spuriously.

New sparse index on `prevTokenHash`, created by startup migrations (idempotent).

## After-fix verification (local core, isolated Mongo)

```
1. A refreshed (normal rotation):              HTTP 200  -> B
2. A replayed (lost response -> RECOVERY):     HTTP 200  -> C   [was 400 before fix]
3. B (orphaned successor) after recovery:      HTTP 400         [never two live tokens]
4. A replayed AGAIN (repeat recovery):         HTTP 200  -> D
5. D used normally:                            HTTP 200  -> E
6. A after successor was USED (grandparent):   HTTP 400         [single-use restored]
7. live token E still healthy:                 HTTP 200
```

## Tests

- New `cloud-v2/tests/refresh-rotation.integration.test.ts`: normal rotation + grandparent rejection, lost-response recovery + orphaned-successor death, repeated recovery, unknown/expired rejection (4/4 pass)
- Existing `cloud-v2/tests/account-auth.integration.test.ts` regression suite: 14/14 pass
- `tsc -b` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core OAuth refresh rotation and session persistence; mistakes could allow token reuse or break legitimate clients, though semantics aim to preserve single-use after successor use.
> 
> **Overview**
> Fixes **OS-1703** by changing refresh-token rotation from “rotate once and immediately reject the old token” to **in-place rotation with a one-step recovery window**.
> 
> Each successful refresh now sets **`prevTokenHash`** to the presented token hash. **`refreshSession()`** looks up sessions by live **`refreshTokenHash`** first, then by **`prevTokenHash`**, and applies the same **`$set`** on either path (with a second **`findOneAndUpdate`** if the live-hash race loses). Re-presenting the immediate predecessor succeeds until that predecessor’s successor is **first used**—orphaning any never-delivered successor—while older tokens still get **`invalid_grant`**.
> 
> The **`refreshTokens`** schema gains a **sparse index** on **`prevTokenHash`**, ensured at boot via **`RefreshTokenModel.createIndexes()`** in startup migrations. **`oem-auth`** reuse coverage and new **`refresh-rotation.integration.test.ts`** exercise recovery, repeated lost responses, grandparent rejection, and expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5b7a19534d57b734391d2955bc540804a1c7301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the immediate predecessor refresh token until its successor is first used to prevent unprovoked logouts (OS-1703). Adds `prevTokenHash` with updated lookups and rotation logic in `refreshSession()`; single-use semantics are preserved.

- **Bug Fixes**
  - Recovery: accept tokens matching `prevTokenHash` and rotate again; predecessor stays valid until its successor is first used; older tokens still fail.
  - Concurrency: if the live-hash update loses, retry once via the predecessor path so concurrent duplicates receive a valid pair instead of a 400; only one live chain remains.
  - Indexes and tests: add a sparse index on `prevTokenHash` in startup migrations; update the OEM reuse test for predecessor grace; add `refresh-rotation.integration.test.ts` covering normal rotation + grandparent rejection, recovery, repeated recovery, and expiry.

<sup>Written for commit c5b7a19534d57b734391d2955bc540804a1c7301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3456?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

