### PR TITLE
Fix photo details crash

### DIFF
--- a/mobile/src/components/glasses/Gallery/loadMediaMetadata.test.ts
+++ b/mobile/src/components/glasses/Gallery/loadMediaMetadata.test.ts
@@ -1,0 +1,69 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+import {parse} from "exifr/src/bundles/nano.mjs"
+
+import {PhotoInfo} from "@/types/asg"
+
+import {loadMediaMetadata} from "./loadMediaMetadata"
+
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  read: jest.fn(),
+  stat: jest.fn(),
+}))
+
+jest.mock("exifr/src/bundles/nano.mjs", () => ({
+  parse: jest.fn(),
+}))
+
+jest.mock("exifr/src/dicts/tiff-exif-keys.mjs", () => ({}))
+jest.mock("exifr/src/dicts/tiff-exif-values.mjs", () => ({}))
+jest.mock("exifr/src/dicts/tiff-gps-keys.mjs", () => ({}))
+jest.mock("exifr/src/dicts/tiff-ifd0-keys.mjs", () => ({}))
+jest.mock("exifr/src/dicts/tiff-ifd0-values.mjs", () => ({}))
+jest.mock("exifr/src/dicts/tiff-revivers.mjs", () => ({}))
+
+const PHOTO: PhotoInfo = {
+  name: "IMG_test",
+  url: "file:///tmp/IMG_test.jpg",
+  download: "file:///tmp/IMG_test.jpg",
+  filePath: "/tmp/IMG_test.jpg",
+  size: 4 * 1024 * 1024,
+  modified: 0,
+  mime_type: "image/jpeg",
+}
+
+describe("loadMediaMetadata", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("parses a bounded prefix instead of loading the entire photo", async () => {
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: PHOTO.size})
+    ;(RNFS.read as jest.Mock).mockResolvedValue(Buffer.from("jpeg header").toString("base64"))
+    ;(parse as jest.Mock).mockResolvedValue({Make: "Mentra"})
+
+    await expect(loadMediaMetadata(PHOTO)).resolves.toEqual({
+      actualSize: PHOTO.size,
+      exif: {Make: "Mentra"},
+    })
+
+    expect(RNFS.read).toHaveBeenCalledWith(PHOTO.filePath, 512 * 1024, 0, "base64")
+    expect(parse).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not initialize the photo parser for videos", async () => {
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 1024})
+
+    await expect(
+      loadMediaMetadata({
+        ...PHOTO,
+        name: "VID_test",
+        filePath: "/tmp/VID_test.mp4",
+        is_video: true,
+        mime_type: "video/mp4",
+      }),
+    ).resolves.toEqual({actualSize: 1024, exif: null})
+
+    expect(RNFS.read).not.toHaveBeenCalled()
+    expect(parse).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
+++ b/mobile/src/components/glasses/Gallery/loadMediaMetadata.ts
@@ -1,6 +1,12 @@
 import * as RNFS from "@dr.pogodin/react-native-fs"
 import {Buffer} from "@craftzdog/react-native-buffer"
-import {parse} from "exifr/dist/lite.esm.js"
+import {parse} from "exifr/src/bundles/nano.mjs"
+import "exifr/src/dicts/tiff-exif-keys.mjs"
+import "exifr/src/dicts/tiff-exif-values.mjs"
+import "exifr/src/dicts/tiff-gps-keys.mjs"
+import "exifr/src/dicts/tiff-ifd0-keys.mjs"
+import "exifr/src/dicts/tiff-ifd0-values.mjs"
+import "exifr/src/dicts/tiff-revivers.mjs"
 
 import {PhotoInfo} from "@/types/asg"
 
@@ -8,6 +14,11 @@ export interface LoadedMediaMetadata {
   actualSize?: number
   exif: Record<string, unknown> | null
 }
+
+// JPEG EXIF data lives in APP1 segments, whose payload is limited to 64 KiB.
+// Leave room for other leading JPEG segments without copying the entire image
+// into a base64 string and then into a second binary buffer.
+const MAX_METADATA_READ_BYTES = 512 * 1024
 
 function getLocalFilePath(photo: PhotoInfo): string | null {
   const uri = photo.filePath || photo.download || photo.url
@@ -34,7 +45,11 @@ export async function loadMediaMetadata(photo: PhotoInfo): Promise<LoadedMediaMe
   if (photo.is_video || photo.mime_type?.startsWith("video/")) return {actualSize, exif: null}
 
   try {
-    const base64 = await RNFS.readFile(path, "base64")
+    const bytesToRead = Math.min(
+      actualSize && actualSize > 0 ? actualSize : MAX_METADATA_READ_BYTES,
+      MAX_METADATA_READ_BYTES,
+    )
+    const base64 = await RNFS.read(path, bytesToRead, 0, "base64")
     const exif = await parse(Buffer.from(base64, "base64"))
     return {actualSize, exif: exif && typeof exif === "object" ? (exif as Record<string, unknown>) : null}
   } catch (error) {

--- a/mobile/src/types/untyped-modules.d.ts
+++ b/mobile/src/types/untyped-modules.d.ts
@@ -7,9 +7,11 @@ declare module "bzip2" {
   export default bzip2
 }
 
-declare module "exifr/dist/lite.esm.js" {
+declare module "exifr/src/bundles/nano.mjs" {
   export {parse} from "exifr"
 }
+
+declare module "exifr/src/dicts/*.mjs"
 
 declare module "tar-js" {
   export interface TarEntry {


### PR DESCRIPTION
## Summary

- use the parser-only exifr bundle that does not execute browser orientation detection
- preserve translated EXIF keys and values through the required dictionary modules
- read at most 512 KiB of a photo for metadata instead of loading and decoding the entire file
- add focused coverage for bounded photo reads and the video fast path

## Root cause

The prebuilt `exifr/dist/lite.esm.js` bundle executes browser orientation detection during module initialization. React Native exposes `navigator` without a `userAgent` string, so the bundle called `includes` on `undefined` when photo details first accessed the lazily loaded parser. Videos returned before accessing the parser, which is why the crash only affected photos.

The previous implementation also read the complete original photo into a base64 string and decoded it into a second buffer. Bounding the read removes that avoidable memory spike.

## User impact

Swiping up from a photo now opens media details without terminating the Mentra App. Video details behavior is unchanged.

## Validation

- `bun run test --runInBand src/components/glasses/Gallery/loadMediaMetadata.test.ts src/components/glasses/Gallery/mediaMetadata.test.ts`
- `bun run compile`
- ESLint and Prettier checks for changed files
- successful Expo Metro iOS export
- direct parser initialization and parse with a React Native-like `navigator` lacking `userAgent`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when opening photo details by switching to the parser-only `exifr` bundle and limiting metadata reads to 512 KiB. Video details are unchanged and memory spikes from full-image reads are removed.

- **Bug Fixes**
  - Replaced `exifr/dist/lite.esm.js` with `exifr/src/bundles/nano.mjs` to avoid browser orientation detection that accessed `navigator.userAgent` in React Native and crashed on photos.
  - Imported `exifr` dict modules (`exifr/src/dicts/*.mjs`) to keep translated EXIF keys and values.

- **Refactors**
  - Read at most 512 KiB via `@dr.pogodin/react-native-fs.read` and skip EXIF parsing for videos to reduce I/O and memory.
  - Added focused tests for bounded photo reads and the video fast path, and updated typings for the new `exifr` imports.

<sup>Written for commit 4792c7758f08a7eeb5c0ac7e1a75f39497f9b151. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized gallery metadata loading change with tests; no auth, payments, or shared infrastructure impact.
> 
> **Overview**
> Fixes a crash when opening **photo details** in the gallery by changing how EXIF is loaded in `loadMediaMetadata`.
> 
> The prebuilt `exifr/dist/lite.esm.js` bundle runs browser orientation logic at import time and touches `navigator.userAgent`, which React Native does not provide—photos hit that path when details load; videos already skipped parsing.
> 
> **EXIF loading** now uses the parser-only `exifr/src/bundles/nano.mjs` plus the required `exifr/src/dicts/*.mjs` modules so translated EXIF keys/values still work. Photo reads use `RNFS.read` with a **512 KiB cap** instead of `readFile` on the whole image, cutting memory spikes on large files. Videos still return after `stat` with no read/parse.
> 
> Adds unit tests for bounded photo reads and the video fast path, and updates `untyped-modules.d.ts` for the new import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4792c7758f08a7eeb5c0ac7e1a75f39497f9b151. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->