### PR TITLE
ASG: owner-keyed wake leases with lifecycle tracing; fresh awake window per W:1 command

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -47,6 +47,16 @@ public class AsgConstants {
      */
     public static final long PHONE_WAKE_COMMAND_WINDOW_MS = 15000;
 
+    /**
+     * Rolling wake-lease window re-armed on confirmed BES OTA segments. The BES UART
+     * transfer dies when the vendor display-sleep hook fires mid-flight even with a CPU
+     * lock held (2026-07-08 incident: frozen between segments at 80% with 4:40 left on
+     * the lock), so the transfer holds BOTH cpu and screen leases and re-arms them while
+     * segments keep confirming: progress keeps the device awake, a wedged transfer lets
+     * it sleep within this window (aligned with the phone's 120s stall watchdog).
+     */
+    public static final long BES_OTA_SEGMENT_LEASE_WINDOW_MS = 120000;
+
     // RGB LED Control Constants (Glasses BES Chipset - Remote Control via Bluetooth)
     // NOTE: These are different from the local MTK recording LED
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -36,6 +36,17 @@ public class AsgConstants {
     public static final String ACTION_GLASSES_BATTERY_STATUS =
             "com.mentra.recovery.ACTION_GLASSES_BATTERY_STATUS";
 
+    /**
+     * Awake window granted per wake-flagged phone command ("W":1 string wrapper or FLAG_WAKE
+     * binary frame). The BES only pulses the MTK power key for these when the SoC is already
+     * asleep, so a command landing mid-awake-window gets no extra time — this window is the
+     * in-band equivalent. Must outlive the longest command follow-up that runs on
+     * suspend-frozen clocks: the wifi credentials flow sends its failure verdict at ~12.4s
+     * (3s + 3x3s status polls), so 15s covers it with margin. Acquired extend-only, so it
+     * never shortens a longer-lived lock (BES/MTK OTA).
+     */
+    public static final long PHONE_WAKE_COMMAND_WINDOW_MS = 15000;
+
     // RGB LED Control Constants (Glasses BES Chipset - Remote Control via Bluetooth)
     // NOTE: These are different from the local MTK recording LED
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/BootstrapActivity.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/BootstrapActivity.java
@@ -11,6 +11,7 @@ import android.os.Looper;
 import android.os.PowerManager;
 import android.util.Log;
 import com.mentra.asg_client.logging.BleTraceLogger;
+import com.mentra.asg_client.utils.WakeLockManager;
 import com.mentra.asg_client.service.core.AsgClientService;
 
 /**
@@ -32,12 +33,9 @@ public class BootstrapActivity extends Activity {
             // Log boot information for debugging
             logBootInfo();
             
-            // Create PowerManager WakeLock to ensure we stay awake during service start
-            PowerManager powerManager = (PowerManager) getSystemService(Context.POWER_SERVICE);
-            PowerManager.WakeLock wakeLock = powerManager.newWakeLock(
-                PowerManager.PARTIAL_WAKE_LOCK,
-                "AugmentOS:BootstrapWakeLock");
-            wakeLock.acquire(60000); // 60 second timeout as safety
+            // Keep the SoC awake through service start via the owner-keyed lease manager
+            // (self-expires; BOOTSTRAP owns it so no other subsystem can revoke it early)
+            WakeLockManager.acquireCpu(this, WakeLockManager.WakeOwner.BOOTSTRAP, 60000);
             
             // Wait a moment to let system services fully initialize, then start our service
             new Handler(Looper.getMainLooper()).postDelayed(() -> {
@@ -62,9 +60,7 @@ public class BootstrapActivity extends Activity {
                     // Wait a moment to ensure the service starts properly, then finish
                     new Handler(Looper.getMainLooper()).postDelayed(() -> {
                         Log.e(TAG, "AsgClientService started, finishing BootstrapActivity");
-                        if (wakeLock.isHeld()) {
-                            wakeLock.release();
-                        }
+                        WakeLockManager.release(WakeLockManager.WakeOwner.BOOTSTRAP);
                         BleTraceLogger.logLifecycle(this, "BootstrapActivity", "activity_finish");
                         finish();
                     }, FINISH_DELAY_MS);
@@ -72,9 +68,7 @@ public class BootstrapActivity extends Activity {
                 } catch (Exception e) {
                     Log.e(TAG, "ERROR starting AsgClientService: " + e.getMessage(), e);
                     recordServiceStartAttempt(false);
-                    if (wakeLock.isHeld()) {
-                        wakeLock.release();
-                    }
+                    WakeLockManager.release(WakeLockManager.WakeOwner.BOOTSTRAP);
                     finish();
                 }
             }, STARTUP_DELAY_MS);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1632,14 +1632,14 @@ public class CameraNeoService extends LifecycleService {
     /** Release wake locks to avoid battery drain */
     private void releaseWakeLocks() {
         // Use the WakeLockManager to release all wake locks
-        WakeLockManager.releaseAllWakeLocks();
+        WakeLockManager.release(WakeLockManager.WakeOwner.CAMERA);
     }
 
     /** Force the screen to turn on so camera can be accessed */
     private void wakeUpScreen() {
         Log.d(TAG, "Waking up screen for camera access");
         // Use the WakeLockManager to acquire both CPU and screen wake locks
-        WakeLockManager.acquireFullWakeLockAndBringToForeground(this, 180000, 5000);
+        WakeLockManager.acquireFullWakeLockAndBringToForeground(this, WakeLockManager.WakeOwner.CAMERA, 180000, 5000);
     }
 
     /** Attempt to restart the camera service with different parameters if needed */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -499,9 +499,12 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         bWait4Confirm = false;
         // Progress-coupled lease: while segments keep confirming, the transfer's wake
         // protection never expires; a wedged transfer stops re-arming and the device may
-        // sleep once the window runs out.
+        // sleep once the window runs out. Gated on isBesOtaInProgress so a late UART
+        // segment-verify arriving after cleanup() cannot re-acquire leases nothing will
+        // ever release.
         long nowMs = android.os.SystemClock.elapsedRealtime();
-        if (nowMs - lastLeaseArmMs > AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS / 2) {
+        if (isBesOtaInProgress
+                && nowMs - lastLeaseArmMs > AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS / 2) {
             lastLeaseArmMs = nowMs;
             WakeLockManager.acquireFull(mContext, WakeLockManager.WakeOwner.BES_OTA,
                     AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -9,6 +9,7 @@ import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.SerialPor
 import com.mentra.asg_client.io.bluetooth.utils.ByteUtil;
 import com.mentra.asg_client.io.ota.interfaces.IBesOtaController;
 import com.mentra.asg_client.service.core.handlers.K900CommandHandler;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.utils.WakeLockManager;
 import java.io.File;
 import java.io.FileInputStream;
@@ -254,9 +255,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             return false;
         }
 
-        // Acquire wakelock to prevent CPU sleep during firmware transfer
-        WakeLockManager.acquireCpu(mContext, WakeLockManager.WakeOwner.BES_OTA, WAKELOCK_TIMEOUT_MS);
-        Log.i(TAG, "BES OTA wakelock acquired for " + WAKELOCK_TIMEOUT_MS + "ms");
+        // The transfer needs the vendor "screen on" state, not just CPU: the display-sleep
+        // hook wedges the UART transfer state machine mid-flight even with a CPU lock held
+        // (2026-07-08 incident, frozen between segments at 80%). Hold BOTH leases; the
+        // initial window covers authorization + handshake, then confirmed segments re-arm
+        // them (see crc32ConfirmSuccess).
+        WakeLockManager.acquireFull(mContext, WakeLockManager.WakeOwner.BES_OTA,
+                WAKELOCK_TIMEOUT_MS, WAKELOCK_TIMEOUT_MS);
+        lastLeaseArmMs = android.os.SystemClock.elapsedRealtime();
+        Log.i(TAG, "BES OTA cpu+screen leases acquired for " + WAKELOCK_TIMEOUT_MS + "ms");
 
         // Set waiting for authorization flag (NOT in OTA mode yet!)
         isWaitingForAuthorization = true;
@@ -482,10 +489,24 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         sentPos += size;
     }
 
+    // Deadline of the last lease re-arm; segment confirms arrive ~1/s, so re-arm at most
+    // every half window to avoid per-segment lock churn and wake_extend trace spam.
+    private long lastLeaseArmMs = 0;
+
     public void crc32ConfirmSuccess() {
         confirmTimes++;
         confirmSentPos = sentPos;
         bWait4Confirm = false;
+        // Progress-coupled lease: while segments keep confirming, the transfer's wake
+        // protection never expires; a wedged transfer stops re-arming and the device may
+        // sleep once the window runs out.
+        long nowMs = android.os.SystemClock.elapsedRealtime();
+        if (nowMs - lastLeaseArmMs > AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS / 2) {
+            lastLeaseArmMs = nowMs;
+            WakeLockManager.acquireFull(mContext, WakeLockManager.WakeOwner.BES_OTA,
+                    AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS,
+                    AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS);
+        }
         Log.i(
                 TAG,
                 "✅ CRC32 verification successful - confirmTimes="

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -255,7 +255,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         }
 
         // Acquire wakelock to prevent CPU sleep during firmware transfer
-        WakeLockManager.acquireCpuWakeLock(mContext, WAKELOCK_TIMEOUT_MS);
+        WakeLockManager.acquireCpu(mContext, WakeLockManager.WakeOwner.BES_OTA, WAKELOCK_TIMEOUT_MS);
         Log.i(TAG, "BES OTA wakelock acquired for " + WAKELOCK_TIMEOUT_MS + "ms");
 
         // Set waiting for authorization flag (NOT in OTA mode yet!)
@@ -327,7 +327,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         operationStartTime = 0;
 
         // Release wakelock
-        WakeLockManager.releaseCpuWakeLock();
+        WakeLockManager.release(WakeLockManager.WakeOwner.BES_OTA);
         Log.i(TAG, "BES OTA wakelock released");
 
         isBesOtaInProgress = false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -335,11 +335,13 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
         operationStartTime = 0;
 
-        // Release wakelock
-        WakeLockManager.release(WakeLockManager.WakeOwner.BES_OTA);
+        // Flag-clear and lease release are one atomic step against the segment-confirm
+        // re-arm (see mLeaseGate): after this block no stale confirm can re-acquire.
+        synchronized (mLeaseGate) {
+            isBesOtaInProgress = false;
+            WakeLockManager.release(WakeLockManager.WakeOwner.BES_OTA);
+        }
         Log.i(TAG, "BES OTA wakelock released");
-
-        isBesOtaInProgress = false;
         isWaitingForAuthorization = false;
         if (comManager != null) {
             comManager.setOtaUpdating(false);
@@ -495,6 +497,11 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     // every half window to avoid per-segment lock churn and wake_extend trace spam.
     private long lastLeaseArmMs = 0;
 
+    // Serializes the transfer's lease lifecycle: a UART segment-confirm that passed the
+    // isBesOtaInProgress check must not interleave with cleanup() releasing the leases,
+    // or it would re-acquire protection nothing will ever release.
+    private final Object mLeaseGate = new Object();
+
     public void crc32ConfirmSuccess() {
         confirmTimes++;
         confirmSentPos = sentPos;
@@ -505,12 +512,14 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         // segment-verify arriving after cleanup() cannot re-acquire leases nothing will
         // ever release.
         long nowMs = android.os.SystemClock.elapsedRealtime();
-        if (isBesOtaInProgress
-                && nowMs - lastLeaseArmMs > AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS / 2) {
-            lastLeaseArmMs = nowMs;
-            WakeLockManager.acquireFull(mContext, WakeLockManager.WakeOwner.BES_OTA,
-                    AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS,
-                    AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS);
+        synchronized (mLeaseGate) {
+            if (isBesOtaInProgress
+                    && nowMs - lastLeaseArmMs > AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS / 2) {
+                lastLeaseArmMs = nowMs;
+                WakeLockManager.acquireFull(mContext, WakeLockManager.WakeOwner.BES_OTA,
+                        AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS,
+                        AsgConstants.BES_OTA_SEGMENT_LEASE_WINDOW_MS);
+            }
         }
         Log.i(
                 TAG,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -31,7 +31,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
     // Wakelock timeout for BES OTA to prevent CPU sleep during firmware transfer
     private static final long WAKELOCK_TIMEOUT_MS = 300000; // 5 minutes
-    private static final long BES_TOTAL_TIMEOUT_MS = 300000; // 5 minutes total operation timeout
+    // Intentional hard cap: a healthy BES OTA must finish within 5 minutes. If it runs
+    // longer, treat the transfer as failed rather than extending the operation timeout.
+    private static final long BES_TOTAL_TIMEOUT_MS = 300000;
     private static final long BES_AUTH_TIMEOUT_MS = 30000; // 30 seconds authorization timeout
     private Context mContext;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -51,9 +51,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private final ChunkedMessageProtocolStrategy inboundBinaryStrategy =
             new ChunkedMessageProtocolStrategy(inboundBinaryReassembler);
     private boolean wireV2HandshakeSent = false;
-    // A FLAG_WAKE fragment arrived and its message is still reassembling; on completion the
-    // wake window is granted again so follow-up work gets the full window (see above).
-    private boolean pendingBinaryWake = false;
+    // Message ids whose FLAG_WAKE fragment arrived and are still reassembling; on THAT
+    // message's completion the wake window is granted again so follow-up work gets the
+    // full window (see handleInboundBinaryFrame). Keyed by msgId because the reassembler
+    // interleaves messages. Bounded: abandoned reassemblies would leak entries, so the set
+    // is cleared when it exceeds a size no legitimate interleave reaches.
+    private final java.util.Set<Integer> pendingBinaryWakeMsgIds = new java.util.HashSet<>();
     private volatile boolean besWireCapsK900Le = false;
     private volatile boolean besWireCapsBinary = false;
     private volatile boolean besWireCapsFilePayloadV2 = false;
@@ -597,7 +600,10 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // work needs its full window from completion, not from the first fragment (a slow
         // multi-fragment reassembly must not eat into it). Extend-only merges the grants.
         if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
-            pendingBinaryWake = true;
+            if (pendingBinaryWakeMsgIds.size() > 16) {
+                pendingBinaryWakeMsgIds.clear();
+            }
+            pendingBinaryWakeMsgIds.add(header.msgId);
             WakeLockManager.acquireCpu(
                     context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
@@ -607,8 +613,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return true;
         }
 
-        if (pendingBinaryWake) {
-            pendingBinaryWake = false;
+        if (pendingBinaryWakeMsgIds.remove(header.msgId)) {
             WakeLockManager.acquireCpu(
                     context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -56,7 +56,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // full window (see handleInboundBinaryFrame). Keyed by msgId because the reassembler
     // interleaves messages. Bounded: abandoned reassemblies would leak entries, so the set
     // is cleared when it exceeds a size no legitimate interleave reaches.
-    private final java.util.Set<Integer> pendingBinaryWakeMsgIds = new java.util.HashSet<>();
+    private final java.util.Set<Integer> pendingBinaryWakeMsgIds = new java.util.LinkedHashSet<>();
     private volatile boolean besWireCapsK900Le = false;
     private volatile boolean besWireCapsBinary = false;
     private volatile boolean besWireCapsFilePayloadV2 = false;
@@ -601,7 +601,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // multi-fragment reassembly must not eat into it). Extend-only merges the grants.
         if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
             if (pendingBinaryWakeMsgIds.size() > 16) {
-                pendingBinaryWakeMsgIds.clear();
+                // Evict only the OLDEST entry (insertion order): it belongs to the most
+                // stale abandoned reassembly, while newer in-flight wake messages keep
+                // their completion-time grant.
+                java.util.Iterator<Integer> eldest = pendingBinaryWakeMsgIds.iterator();
+                eldest.next();
+                eldest.remove();
             }
             pendingBinaryWakeMsgIds.add(header.msgId);
             WakeLockManager.acquireCpu(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -591,8 +591,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // path gets the same grant from CommandProcessor via the "W":1 wrapper field, which
         // binary frames do not carry.
         if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
-            WakeLockManager.acquireCpuWakeLock(
-                    context, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
+            WakeLockManager.acquireCpu(
+                    context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
 
         byte[] reassembled = inboundBinaryStrategy.processBinaryWireFrame(message);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -444,6 +444,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     public void resetPhoneWireProtocolState() {
         BesWireFormat.resetBinaryProtocol();
         inboundBinaryReassembler.clear();
+        // Pending wake grants die with the reassemblies they belong to: a new session
+        // reusing an old msgId must not inherit a stale completion-time wake grant.
+        pendingBinaryWakeMsgIds.clear();
         wireV2HandshakeSent = false;
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -17,6 +17,7 @@ import com.mentra.asg_client.reporting.domains.BluetoothReporting;
 import com.mentra.asg_client.service.core.AsgClientService;
 import com.mentra.asg_client.service.core.processors.ChunkReassembler;
 import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrategy;
+import com.mentra.asg_client.utils.WakeLockManager;
 
 import org.json.JSONObject;
 
@@ -582,6 +583,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 }
             }
             return true;
+        }
+
+        // Wake-flagged frame: grant a fresh awake window (see PHONE_WAKE_COMMAND_WINDOW_MS —
+        // the BES power-key pulse never extends a window already in progress). The string-frame
+        // path gets the same grant from CommandProcessor via the "W":1 wrapper field, which
+        // binary frames do not carry.
+        if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
+            WakeLockManager.acquireCpuWakeLock(
+                    context, WakeLockManager.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
 
         byte[] reassembled = inboundBinaryStrategy.processBinaryWireFrame(message);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -51,6 +51,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private final ChunkedMessageProtocolStrategy inboundBinaryStrategy =
             new ChunkedMessageProtocolStrategy(inboundBinaryReassembler);
     private boolean wireV2HandshakeSent = false;
+    // A FLAG_WAKE fragment arrived and its message is still reassembling; on completion the
+    // wake window is granted again so follow-up work gets the full window (see above).
+    private boolean pendingBinaryWake = false;
     private volatile boolean besWireCapsK900Le = false;
     private volatile boolean besWireCapsBinary = false;
     private volatile boolean besWireCapsFilePayloadV2 = false;
@@ -589,8 +592,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // Wake-flagged frame: grant a fresh awake window (see AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS —
         // the BES power-key pulse never extends a window already in progress). The string-frame
         // path gets the same grant from CommandProcessor via the "W":1 wrapper field, which
-        // binary frames do not carry.
+        // binary frames do not carry. FLAG_WAKE rides only the FIRST fragment of a message,
+        // so remember it and grant AGAIN when reassembly completes: the command's follow-up
+        // work needs its full window from completion, not from the first fragment (a slow
+        // multi-fragment reassembly must not eat into it). Extend-only merges the grants.
         if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
+            pendingBinaryWake = true;
             WakeLockManager.acquireCpu(
                     context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
@@ -598,6 +605,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         byte[] reassembled = inboundBinaryStrategy.processBinaryWireFrame(message);
         if (reassembled == null) {
             return true;
+        }
+
+        if (pendingBinaryWake) {
+            pendingBinaryWake = false;
+            WakeLockManager.acquireCpu(
+                    context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
 
         BleTraceLogger.logWireMetrics(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -3,6 +3,7 @@ package com.mentra.asg_client.io.bluetooth.managers;
 import android.content.Context;
 import android.util.Log;
 
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bluetooth.core.BaseBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesMessageParser;
@@ -585,13 +586,13 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return true;
         }
 
-        // Wake-flagged frame: grant a fresh awake window (see PHONE_WAKE_COMMAND_WINDOW_MS —
+        // Wake-flagged frame: grant a fresh awake window (see AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS —
         // the BES power-key pulse never extends a window already in progress). The string-frame
         // path gets the same grant from CommandProcessor via the "W":1 wrapper field, which
         // binary frames do not carry.
         if ((header.flags & BesWireFormat.FLAG_WAKE) != 0) {
             WakeLockManager.acquireCpuWakeLock(
-                    context, WakeLockManager.PHONE_WAKE_COMMAND_WINDOW_MS);
+                    context, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
         }
 
         byte[] reassembled = inboundBinaryStrategy.processBinaryWireFrame(message);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -418,7 +418,7 @@ public class OtaHelper {
         }
 
         // Acquire wakelock to prevent CPU sleep during OTA download/install
-        WakeLockManager.acquireCpuWakeLock(context, OTA_WAKELOCK_TIMEOUT_MS);
+        WakeLockManager.acquireCpu(context, WakeLockManager.WakeOwner.MTK_OTA, OTA_WAKELOCK_TIMEOUT_MS);
         Log.i(TAG, "📱 OTA wakelock acquired for " + (OTA_WAKELOCK_TIMEOUT_MS / 1000) + " seconds");
 
         isPhoneInitiatedOta = true;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -1618,7 +1618,7 @@ public class RtmpStreamingService extends Service {
                 Log.d(TAG, "Resetting stream timeout for streamId: " + streamId +
                         ", active: " + sInstance.mIsStreamingActive +
                         ", state: " + sInstance.mStreamState);
-                WakeLockManager.acquireFullWakeLockAndBringToForeground(sInstance.getApplicationContext(), 2180000, 5000); // 3 min CPU, 5 sec screen
+                WakeLockManager.acquireFullWakeLockAndBringToForeground(sInstance.getApplicationContext(), WakeLockManager.WakeOwner.STREAMING, 2180000, 5000); // 36 min CPU, 5 sec screen
                 sInstance.scheduleStreamTimeout(streamId); // Reschedule with fresh timeout
                 return true;
             } else {
@@ -1763,14 +1763,14 @@ public class RtmpStreamingService extends Service {
         // Use the WakeLockManager to acquire both CPU and screen wake locks AND bring app to foreground
         // This prevents "Camera disabled by policy" errors when app is backgrounded
         // For streaming we use longer timeout for CPU wake lock than for photo capture
-        WakeLockManager.acquireFullWakeLockAndBringToForeground(this, 2180000, 5000); // 3 min CPU, 5 sec screen
+        WakeLockManager.acquireFullWakeLockAndBringToForeground(this, WakeLockManager.WakeOwner.STREAMING, 2180000, 5000); // 36 min CPU, 5 sec screen
     }
 
     /**
      * Release any held wake locks
      */
     private void releaseWakeLocks() {
-        WakeLockManager.releaseAllWakeLocks();
+        WakeLockManager.release(WakeLockManager.WakeOwner.STREAMING);
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -950,7 +950,7 @@ public class SrtStreamingService extends Service {
   public static boolean resetStreamTimeout(String streamId) {
     if (sInstance != null) {
       if (sInstance.mCurrentStreamId != null && sInstance.mCurrentStreamId.equals(streamId) && sInstance.mIsStreamingActive) {
-        WakeLockManager.acquireFullWakeLockAndBringToForeground(sInstance.getApplicationContext(), 2180000, 5000);
+        WakeLockManager.acquireFullWakeLockAndBringToForeground(sInstance.getApplicationContext(), WakeLockManager.WakeOwner.STREAMING, 2180000, 5000);
         sInstance.scheduleStreamTimeout(streamId);
         return true;
       }
@@ -1000,11 +1000,11 @@ public class SrtStreamingService extends Service {
   }
 
   private void wakeUpScreen() {
-    WakeLockManager.acquireFullWakeLockAndBringToForeground(this, 2180000, 5000);
+    WakeLockManager.acquireFullWakeLockAndBringToForeground(this, WakeLockManager.WakeOwner.STREAMING, 2180000, 5000);
   }
 
   private void releaseWakeLocks() {
-    WakeLockManager.releaseAllWakeLocks();
+    WakeLockManager.release(WakeLockManager.WakeOwner.STREAMING);
   }
 
   private static String formatDuration(long durationMs) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -278,7 +278,7 @@ public class WhipStreamingService extends Service {
 
     // Acquire wake lock to prevent device sleep during streaming
     WakeLockManager.acquireFullWakeLockAndBringToForeground(
-        getApplicationContext(), 2180000, 5000);
+        getApplicationContext(), WakeLockManager.WakeOwner.STREAMING, 2180000, 5000);
 
     if (!mIsReconnecting) {
       mReconnectAttempts = 0;
@@ -341,7 +341,7 @@ public class WhipStreamingService extends Service {
       }
       mIsReconnecting = false;
       mReconnectAttempts = 0;
-      WakeLockManager.releaseAllWakeLocks();
+      WakeLockManager.release(WakeLockManager.WakeOwner.STREAMING);
       resetState();
       notifyStopped();
       updateNotification("Stream stopped");
@@ -864,7 +864,7 @@ public class WhipStreamingService extends Service {
     }
     mIsReconnecting = false;
     mReconnectAttempts = 0;
-    WakeLockManager.releaseAllWakeLocks();
+    WakeLockManager.release(WakeLockManager.WakeOwner.STREAMING);
     resetState();
     updateNotification("Stream failed");
   }
@@ -1174,7 +1174,7 @@ public class WhipStreamingService extends Service {
       sInstance.scheduleStreamTimeout(streamId);
       // Re-acquire wake lock on keep-alive
       WakeLockManager.acquireFullWakeLockAndBringToForeground(
-          sInstance.getApplicationContext(), 2180000, 5000);
+          sInstance.getApplicationContext(), WakeLockManager.WakeOwner.STREAMING, 2180000, 5000);
     }
     return matches;
   }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -235,8 +235,8 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
                 Log.d(
                         TAG,
                         "🔋 Device is asleep, acquiring short wake lock for battery announcement");
-                WakeLockManager.acquireScreenWakeLock(
-                        context, 5000); // 5 seconds for query + audio
+                WakeLockManager.acquireScreen(
+                        context, WakeLockManager.WakeOwner.BATTERY_ANNOUNCE, 5000); // 5 seconds for query + audio
             }
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -38,6 +38,7 @@ import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
 import com.mentra.asg_client.service.media.interfaces.IMediaManager;
 import com.mentra.asg_client.service.system.interfaces.IConfigurationManager;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.utils.WakeLockManager;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -179,6 +180,16 @@ public class CommandProcessor {
 
         Log.d(TAG, "📊 processJsonCommand() started" + json.toString());
         try {
+            // Wake-flagged command ("W":1): grant a fresh awake window so its follow-up work
+            // survives the 12s screen timeout — the BES power-key pulse for W=1 only fires
+            // when the SoC is already asleep, never extending a window already in progress.
+            // Extend-only: never shortens a longer-lived lock (BES/MTK OTA). Binary wire-v2
+            // frames carry the same flag in the frame header; K900BluetoothManager grants it.
+            if (json.optInt("W", 0) == 1) {
+                WakeLockManager.acquireCpuWakeLock(
+                        context, WakeLockManager.PHONE_WAKE_COMMAND_WINDOW_MS);
+            }
+
             // Check for ACK first (from phone acknowledging our sent messages)
             String type = json.optString("type", json.optString("t", ""));
             if ("msg_ack".equals(type)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -2,6 +2,7 @@ package com.mentra.asg_client.service.core.processors;
 
 import android.content.Context;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.bes.log.BesTracePoller;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.peripheral.IPeripheralBus;
@@ -187,7 +188,7 @@ public class CommandProcessor {
             // frames carry the same flag in the frame header; K900BluetoothManager grants it.
             if (json.optInt("W", 0) == 1) {
                 WakeLockManager.acquireCpuWakeLock(
-                        context, WakeLockManager.PHONE_WAKE_COMMAND_WINDOW_MS);
+                        context, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
             }
 
             // Check for ACK first (from phone acknowledging our sent messages)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -187,8 +187,8 @@ public class CommandProcessor {
             // Extend-only: never shortens a longer-lived lock (BES/MTK OTA). Binary wire-v2
             // frames carry the same flag in the frame header; K900BluetoothManager grants it.
             if (json.optInt("W", 0) == 1) {
-                WakeLockManager.acquireCpuWakeLock(
-                        context, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
+                WakeLockManager.acquireCpu(
+                        context, WakeLockManager.WakeOwner.PHONE_COMMAND, AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS);
             }
 
             // Check for ACK first (from phone acknowledging our sent messages)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
@@ -28,6 +28,14 @@ public class WakeLockManager {
     // Default timeouts
     private static final long DEFAULT_CPU_TIMEOUT_MS = 60000; // 60 seconds
     private static final long DEFAULT_SCREEN_TIMEOUT_MS = 15000; // 15 seconds
+
+    // Awake window granted per wake-flagged phone command ("W":1 string wrapper or FLAG_WAKE
+    // binary frame). The BES only pulses the MTK power key for these when the SoC is already
+    // asleep, so a command landing mid-awake-window gets no extra time — this window is the
+    // in-band equivalent. Must outlive the longest command follow-up that runs on
+    // suspend-frozen clocks: the wifi credentials flow sends its failure verdict at ~12.4s
+    // (3s + 3x3s status polls), so 15s covers it with margin.
+    public static final long PHONE_WAKE_COMMAND_WINDOW_MS = 15000;
     
     // Static wake lock instances for sharing across the app
     private static PowerManager.WakeLock sCpuWakeLock;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
@@ -28,14 +28,6 @@ public class WakeLockManager {
     // Default timeouts
     private static final long DEFAULT_CPU_TIMEOUT_MS = 60000; // 60 seconds
     private static final long DEFAULT_SCREEN_TIMEOUT_MS = 15000; // 15 seconds
-
-    // Awake window granted per wake-flagged phone command ("W":1 string wrapper or FLAG_WAKE
-    // binary frame). The BES only pulses the MTK power key for these when the SoC is already
-    // asleep, so a command landing mid-awake-window gets no extra time — this window is the
-    // in-band equivalent. Must outlive the longest command follow-up that runs on
-    // suspend-frozen clocks: the wifi credentials flow sends its failure verdict at ~12.4s
-    // (3s + 3x3s status polls), so 15s covers it with margin.
-    public static final long PHONE_WAKE_COMMAND_WINDOW_MS = 15000;
     
     // Static wake lock instances for sharing across the app
     private static PowerManager.WakeLock sCpuWakeLock;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
@@ -3,6 +3,8 @@ package com.mentra.asg_client.utils;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.content.Intent;
+import android.os.Handler;
+import android.os.Looper;
 import android.os.PowerManager;
 import android.os.SystemClock;
 import android.util.Log;
@@ -10,319 +12,279 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 
 import com.mentra.asg_client.MainActivity;
+import com.mentra.asg_client.logging.BleTraceLogger;
 
+import org.json.JSONObject;
+
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * Utility class for managing wake locks across the application.
- * Provides methods to acquire and release different types of wake locks
- * to keep the device CPU running or screen on for specific operations.
+ * Owner-keyed wake leases. Every subsystem that needs the SoC (or screen) awake holds its
+ * OWN lease, backed by its own {@link PowerManager.WakeLock}: the kernel keeps the CPU up
+ * while ANY lease is held and lets it sleep when the last one ends, so no arbitration logic
+ * lives here. {@link #release(WakeOwner)} can only end that owner's leases — the historical
+ * single shared lock let any subsystem's release (notably the old releaseAllWakeLocks())
+ * silently revoke every other subsystem's protection, which is exactly what put the SoC to
+ * sleep mid-OTA and mid-upload.
+ *
+ * Acquires are extend-only per owner: a shorter acquire never cuts short a longer-lived
+ * lease already held by the same owner; a longer one pushes the deadline out.
+ *
+ * Every lease transition (acquire / extend / release / expiry) is emitted on the lifecycle
+ * trace channel (BleTraceLogger.logLifecycle, component "WakeLockManager") with the full
+ * set of currently-held leases, so incident logs show exactly which lease died and what
+ * was left holding when the device slept.
  */
 public class WakeLockManager {
     private static final String TAG = "WakeLockManager";
-    
-    // Default tag prefixes for wake locks
-    private static final String DEFAULT_CPU_WAKE_LOCK_TAG = "AugmentOS:CpuWakeLock";
-    private static final String DEFAULT_SCREEN_WAKE_LOCK_TAG = "AugmentOS:ScreenWakeLock";
-    
-    // Default timeouts
-    private static final long DEFAULT_CPU_TIMEOUT_MS = 60000; // 60 seconds
-    private static final long DEFAULT_SCREEN_TIMEOUT_MS = 15000; // 15 seconds
-    
-    // Static wake lock instances for sharing across the app
-    private static PowerManager.WakeLock sCpuWakeLock;
-    private static PowerManager.WakeLock sScreenWakeLock;
 
-    // Guards acquire/release so the extend-only deadline checks below are race-free when called
-    // from multiple threads (OTA worker, main looper, camera/streaming threads).
+    /**
+     * Every wake-lease owner in asg_client. One entry per subsystem: release(owner) can
+     * only end that owner's leases, and per-owner lock tags (AugmentOS:Cpu:CAMERA, ...)
+     * make dumpsys power / batterystats attribute wake time to the right subsystem.
+     */
+    public enum WakeOwner {
+        /** Wake-flagged (W:1) phone command grant — see AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS. */
+        PHONE_COMMAND,
+        /** Camera open/capture window (CameraNeoService). */
+        CAMERA,
+        /** RTMP/SRT/WHIP streaming session. */
+        STREAMING,
+        /** BES firmware UART transfer (BesOtaManager). */
+        BES_OTA,
+        /** MTK/APK OTA install (OtaHelper). */
+        MTK_OTA,
+        /** Battery announcement while asleep (ButtonEventSubscriber). */
+        BATTERY_ANNOUNCE,
+        /** Boot-time service startup window (BootstrapActivity). */
+        BOOTSTRAP,
+    }
+
+    private static final class Lease {
+        final PowerManager.WakeLock lock;
+        final long deadlineMs; // SystemClock.elapsedRealtime()-based
+
+        Lease(PowerManager.WakeLock lock, long deadlineMs) {
+            this.lock = lock;
+            this.deadlineMs = deadlineMs;
+        }
+    }
+
+    // Guards the lease maps so extend-only deadline checks are race-free across the
+    // threads that acquire (command processors, camera/streaming/OTA workers).
     private static final Object LOCK = new Object();
 
-    // Absolute deadlines (SystemClock.elapsedRealtime() based) for the currently-held locks.
-    // Used to implement extend-only acquisition: a shorter acquire never shortens a longer-lived
-    // lock that is already held. 0 means "no deadline tracked / not held".
-    private static long sCpuWakeLockDeadlineMs = 0;
-    private static long sScreenWakeLockDeadlineMs = 0;
+    private static final Map<WakeOwner, Lease> sCpuLeases = new EnumMap<>(WakeOwner.class);
+    private static final Map<WakeOwner, Lease> sScreenLeases = new EnumMap<>(WakeOwner.class);
+
+    // Expiry watcher: WakeLock.acquire(timeout) expires inside the OS with no callback,
+    // so a main-looper check at each lease's deadline emits the wake_expire trace event.
+    private static final Handler sExpiryHandler = new Handler(Looper.getMainLooper());
+
+    // Application context captured on first acquire so release()/expiry can emit trace
+    // events without every caller having to thread a Context through.
+    private static volatile Context sAppContext;
 
     /**
-     * Acquire a CPU wake lock to keep the processor running.
-     * This is useful for background operations that need to continue
-     * even when the screen is off.
+     * Acquire (or extend) the owner's CPU lease. Extend-only: if the owner already holds
+     * a CPU lease whose deadline is at or beyond the requested one, the existing lease is
+     * kept and this call is a no-op.
      *
-     * @param context Application context
-     * @return true if the wake lock was successfully acquired
+     * @return true if the owner holds a CPU lease covering at least timeoutMs on return
      */
-    public static boolean acquireCpuWakeLock(@NonNull Context context) {
-        return acquireCpuWakeLock(context, DEFAULT_CPU_TIMEOUT_MS, DEFAULT_CPU_WAKE_LOCK_TAG);
+    public static boolean acquireCpu(@NonNull Context context, @NonNull WakeOwner owner, long timeoutMs) {
+        return acquire(context, owner, timeoutMs, false);
     }
 
     /**
-     * Acquire a CPU wake lock with a custom timeout.
-     *
-     * @param context Application context
-     * @param timeoutMs Timeout in milliseconds
-     * @return true if the wake lock was successfully acquired
+     * Acquire (or extend) the owner's screen lease (turns the screen on and keeps it on).
+     * Same extend-only semantics as {@link #acquireCpu}.
      */
-    public static boolean acquireCpuWakeLock(@NonNull Context context, long timeoutMs) {
-        return acquireCpuWakeLock(context, timeoutMs, DEFAULT_CPU_WAKE_LOCK_TAG);
+    public static boolean acquireScreen(@NonNull Context context, @NonNull WakeOwner owner, long timeoutMs) {
+        return acquire(context, owner, timeoutMs, true);
+    }
+
+    /** Acquire both CPU and screen leases for the owner. */
+    public static boolean acquireFull(@NonNull Context context, @NonNull WakeOwner owner,
+                                      long cpuTimeoutMs, long screenTimeoutMs) {
+        boolean cpu = acquireCpu(context, owner, cpuTimeoutMs);
+        boolean screen = acquireScreen(context, owner, screenTimeoutMs);
+        return cpu && screen;
     }
 
     /**
-     * Acquire a CPU wake lock with a custom timeout and tag.
+     * Release the owner's leases (CPU and screen). Other owners' leases are untouched —
+     * the device stays awake until the LAST lease is released or expires.
      *
-     * @param context Application context
-     * @param timeoutMs Timeout in milliseconds
-     * @param tag Tag for the wake lock (for debugging)
-     * @return true if the wake lock was successfully acquired
+     * @return true if no lease remains held by this owner on return
      */
-    public static boolean acquireCpuWakeLock(@NonNull Context context, long timeoutMs, String tag) {
-        synchronized (LOCK) {
-            try {
-                PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-                if (powerManager == null) {
-                    Log.e(TAG, "PowerManager is null");
-                    return false;
-                }
-
-                long now = SystemClock.elapsedRealtime();
-                long requestedDeadlineMs = now + timeoutMs;
-
-                // Extend-only: if a CPU wake lock is already held and its deadline is at or beyond
-                // the one being requested, keep the existing (longer-lived) lock and ignore this
-                // shorter acquire. Without this, a short acquire (e.g. a 60s camera/util lock)
-                // stomps a long in-flight operation (e.g. a 10-min OTA) and lets the CPU — and the
-                // MTK SoC — sleep mid-update, which is exactly what stalls OTA. We never shorten;
-                // we only ever push the deadline further out.
-                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()
-                        && requestedDeadlineMs <= sCpuWakeLockDeadlineMs) {
-                    Log.d(TAG, "Keeping existing CPU wake lock (remaining "
-                            + (sCpuWakeLockDeadlineMs - now) + "ms) >= requested " + timeoutMs
-                            + "ms; ignoring shorter acquire");
-                    return true;
-                }
-
-                // Extending to a later deadline: release the shorter-lived lock first.
-                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
-                    sCpuWakeLock.release();
-                    Log.d(TAG, "Released existing CPU wake lock to extend deadline");
-                }
-
-                // Create and acquire a new wake lock
-                sCpuWakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, tag);
-                sCpuWakeLock.acquire(timeoutMs);
-                sCpuWakeLockDeadlineMs = requestedDeadlineMs;
-                Log.d(TAG, "CPU wake lock acquired with timeout: " + timeoutMs + "ms");
-                return true;
-            } catch (Exception e) {
-                Log.e(TAG, "Error acquiring CPU wake lock", e);
-                return false;
-            }
-        }
+    public static boolean release(@NonNull WakeOwner owner) {
+        boolean cpuOk = releaseOne(owner, false);
+        boolean screenOk = releaseOne(owner, true);
+        return cpuOk && screenOk;
     }
 
     /**
-     * Acquire a screen wake lock to turn on and keep the screen on.
-     * This is useful for operations that require the screen to be on
-     * such as camera operations on some Android devices.
-     *
-     * @param context Application context
-     * @return true if the wake lock was successfully acquired
+     * Acquire both leases for the owner and bring the app to the foreground if needed.
+     * Camera operations require the app to be in the foreground to avoid "Camera disabled
+     * by policy" errors.
      */
-    public static boolean acquireScreenWakeLock(@NonNull Context context) {
-        return acquireScreenWakeLock(context, DEFAULT_SCREEN_TIMEOUT_MS, DEFAULT_SCREEN_WAKE_LOCK_TAG);
-    }
-
-    /**
-     * Acquire a screen wake lock with a custom timeout.
-     *
-     * @param context Application context
-     * @param timeoutMs Timeout in milliseconds
-     * @return true if the wake lock was successfully acquired
-     */
-    public static boolean acquireScreenWakeLock(@NonNull Context context, long timeoutMs) {
-        return acquireScreenWakeLock(context, timeoutMs, DEFAULT_SCREEN_WAKE_LOCK_TAG);
-    }
-
-    /**
-     * Acquire a screen wake lock with a custom timeout and tag.
-     *
-     * @param context Application context
-     * @param timeoutMs Timeout in milliseconds
-     * @param tag Tag for the wake lock (for debugging)
-     * @return true if the wake lock was successfully acquired
-     */
-    public static boolean acquireScreenWakeLock(@NonNull Context context, long timeoutMs, String tag) {
-        synchronized (LOCK) {
-            try {
-                PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
-                if (powerManager == null) {
-                    Log.e(TAG, "PowerManager is null");
-                    return false;
-                }
-
-                long now = SystemClock.elapsedRealtime();
-                long requestedDeadlineMs = now + timeoutMs;
-
-                // Extend-only: keep the existing screen lock if it already outlives this request
-                // (see acquireCpuWakeLock for the rationale — a shorter acquire must not cut a
-                // longer-lived one short).
-                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()
-                        && requestedDeadlineMs <= sScreenWakeLockDeadlineMs) {
-                    Log.d(TAG, "Keeping existing screen wake lock (remaining "
-                            + (sScreenWakeLockDeadlineMs - now) + "ms) >= requested " + timeoutMs
-                            + "ms; ignoring shorter acquire");
-                    return true;
-                }
-
-                // Extending to a later deadline: release the shorter-lived lock first.
-                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
-                    sScreenWakeLock.release();
-                    Log.d(TAG, "Released existing screen wake lock to extend deadline");
-                }
-
-                // Create and acquire a new wake lock with flags to turn screen on
-                sScreenWakeLock = powerManager.newWakeLock(
-                        PowerManager.FULL_WAKE_LOCK |
-                        PowerManager.ACQUIRE_CAUSES_WAKEUP |
-                        PowerManager.ON_AFTER_RELEASE,
-                        tag);
-                sScreenWakeLock.acquire(timeoutMs);
-                sScreenWakeLockDeadlineMs = requestedDeadlineMs;
-                Log.d(TAG, "Screen wake lock acquired with timeout: " + timeoutMs + "ms");
-                return true;
-            } catch (Exception e) {
-                Log.e(TAG, "Error acquiring screen wake lock", e);
-                return false;
-            }
-        }
-    }
-
-    /**
-     * Acquire both CPU and screen wake locks at once.
-     * This is a convenience method for operations that need
-     * both the CPU to stay active and the screen to stay on.
-     *
-     * @param context Application context
-     * @param cpuTimeoutMs Timeout for CPU wake lock in milliseconds
-     * @param screenTimeoutMs Timeout for screen wake lock in milliseconds
-     * @return true if both wake locks were successfully acquired
-     */
-    public static boolean acquireFullWakeLock(@NonNull Context context, long cpuTimeoutMs, long screenTimeoutMs) {
-        boolean cpuSuccess = acquireCpuWakeLock(context, cpuTimeoutMs);
-        boolean screenSuccess = acquireScreenWakeLock(context, screenTimeoutMs);
-        return cpuSuccess && screenSuccess;
-    }
-
-    /**
-     * Acquire both CPU and screen wake locks with default timeouts.
-     *
-     * @param context Application context
-     * @return true if both wake locks were successfully acquired
-     */
-    public static boolean acquireFullWakeLock(@NonNull Context context) {
-        return acquireFullWakeLock(context, DEFAULT_CPU_TIMEOUT_MS, DEFAULT_SCREEN_TIMEOUT_MS);
-    }
-
-    /**
-     * Release the CPU wake lock if it is currently held.
-     *
-     * @return true if the wake lock was released or wasn't held
-     */
-    public static boolean releaseCpuWakeLock() {
-        synchronized (LOCK) {
-            try {
-                if (sCpuWakeLock != null && sCpuWakeLock.isHeld()) {
-                    sCpuWakeLock.release();
-                    Log.d(TAG, "CPU wake lock released");
-                }
-                sCpuWakeLock = null;
-                sCpuWakeLockDeadlineMs = 0;
-                return true;
-            } catch (Exception e) {
-                Log.e(TAG, "Error releasing CPU wake lock", e);
-                return false;
-            }
-        }
-    }
-
-    /**
-     * Release the screen wake lock if it is currently held.
-     *
-     * @return true if the wake lock was released or wasn't held
-     */
-    public static boolean releaseScreenWakeLock() {
-        synchronized (LOCK) {
-            try {
-                if (sScreenWakeLock != null && sScreenWakeLock.isHeld()) {
-                    sScreenWakeLock.release();
-                    Log.d(TAG, "Screen wake lock released");
-                }
-                sScreenWakeLock = null;
-                sScreenWakeLockDeadlineMs = 0;
-                return true;
-            } catch (Exception e) {
-                Log.e(TAG, "Error releasing screen wake lock", e);
-                return false;
-            }
-        }
-    }
-
-    /**
-     * Release all wake locks (both CPU and screen).
-     *
-     * @return true if all wake locks were released successfully
-     */
-    public static boolean releaseAllWakeLocks() {
-        boolean cpuSuccess = releaseCpuWakeLock();
-        boolean screenSuccess = releaseScreenWakeLock();
-        return cpuSuccess && screenSuccess;
-    }
-
-    /**
-     * Acquire both CPU and screen wake locks and bring the app to foreground if needed.
-     * This is specifically designed for camera operations that require the app to be
-     * in the foreground to avoid "Camera disabled by policy" errors.
-     *
-     * @param context Application context
-     * @param cpuTimeoutMs Timeout for CPU wake lock in milliseconds
-     * @param screenTimeoutMs Timeout for screen wake lock in milliseconds
-     * @return true if wake locks were acquired and app brought to foreground successfully
-     */
-    public static boolean acquireFullWakeLockAndBringToForeground(@NonNull Context context, long cpuTimeoutMs, long screenTimeoutMs) {
+    public static boolean acquireFullWakeLockAndBringToForeground(@NonNull Context context,
+                                                                  @NonNull WakeOwner owner,
+                                                                  long cpuTimeoutMs,
+                                                                  long screenTimeoutMs) {
         try {
-            // First, try to bring app to foreground if not already there
             if (!isAppInForeground(context)) {
                 Log.d(TAG, "App not in foreground, attempting to bring to front");
                 if (!bringAppToForeground(context)) {
-                    Log.w(TAG, "Failed to bring app to foreground, continuing with wake locks");
+                    Log.w(TAG, "Failed to bring app to foreground, continuing with wake leases");
                 }
-            } else {
-                Log.d(TAG, "App already in foreground");
             }
-
-            // Then acquire the wake locks as usual
-            return acquireFullWakeLock(context, cpuTimeoutMs, screenTimeoutMs);
         } catch (Exception e) {
-            Log.e(TAG, "Error in acquireFullWakeLockAndBringToForeground", e);
-            // Fallback to just acquiring wake locks
-            return acquireFullWakeLock(context, cpuTimeoutMs, screenTimeoutMs);
+            Log.e(TAG, "Error checking/bringing app to foreground", e);
         }
+        return acquireFull(context, owner, cpuTimeoutMs, screenTimeoutMs);
+    }
+
+    private static boolean acquire(@NonNull Context context, @NonNull WakeOwner owner,
+                                   long timeoutMs, boolean screen) {
+        sAppContext = context.getApplicationContext();
+        synchronized (LOCK) {
+            try {
+                PowerManager powerManager =
+                        (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+                if (powerManager == null) {
+                    Log.e(TAG, "PowerManager is null");
+                    return false;
+                }
+
+                Map<WakeOwner, Lease> leases = screen ? sScreenLeases : sCpuLeases;
+                long now = SystemClock.elapsedRealtime();
+                long requestedDeadlineMs = now + timeoutMs;
+
+                Lease existing = leases.get(owner);
+                boolean extend = existing != null && existing.lock.isHeld();
+                if (extend && requestedDeadlineMs <= existing.deadlineMs) {
+                    // Extend-only: a shorter acquire must not cut short the owner's
+                    // longer-lived lease (e.g. a 60s utility acquire during a 10-min OTA).
+                    Log.d(TAG, kind(screen) + " lease for " + owner + " keeps existing deadline (remaining "
+                            + (existing.deadlineMs - now) + "ms >= requested " + timeoutMs + "ms)");
+                    return true;
+                }
+                if (extend) {
+                    existing.lock.release();
+                }
+
+                int flags = screen
+                        ? PowerManager.FULL_WAKE_LOCK
+                                | PowerManager.ACQUIRE_CAUSES_WAKEUP
+                                | PowerManager.ON_AFTER_RELEASE
+                        : PowerManager.PARTIAL_WAKE_LOCK;
+                String tag = "AugmentOS:" + (screen ? "Screen:" : "Cpu:") + owner;
+                PowerManager.WakeLock lock = powerManager.newWakeLock(flags, tag);
+                lock.acquire(timeoutMs);
+                leases.put(owner, new Lease(lock, requestedDeadlineMs));
+                scheduleExpiryCheck(owner, screen, requestedDeadlineMs);
+
+                traceLease(extend ? "wake_extend" : "wake_acquire", owner, screen, timeoutMs);
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error acquiring " + kind(screen) + " lease for " + owner, e);
+                return false;
+            }
+        }
+    }
+
+    private static boolean releaseOne(@NonNull WakeOwner owner, boolean screen) {
+        synchronized (LOCK) {
+            try {
+                Map<WakeOwner, Lease> leases = screen ? sScreenLeases : sCpuLeases;
+                Lease lease = leases.remove(owner);
+                if (lease == null) {
+                    return true;
+                }
+                long remainingMs =
+                        Math.max(0, lease.deadlineMs - SystemClock.elapsedRealtime());
+                if (lease.lock.isHeld()) {
+                    lease.lock.release();
+                    traceLease("wake_release", owner, screen, remainingMs);
+                }
+                return true;
+            } catch (Exception e) {
+                Log.e(TAG, "Error releasing " + kind(screen) + " lease for " + owner, e);
+                return false;
+            }
+        }
+    }
+
+    private static void scheduleExpiryCheck(WakeOwner owner, boolean screen, long deadlineMs) {
+        long delayMs = Math.max(0, deadlineMs - SystemClock.elapsedRealtime()) + 250;
+        sExpiryHandler.postDelayed(() -> {
+            synchronized (LOCK) {
+                Map<WakeOwner, Lease> leases = screen ? sScreenLeases : sCpuLeases;
+                Lease lease = leases.get(owner);
+                // Only the watcher for the lease's CURRENT deadline reports; an extend
+                // re-schedules its own watcher and this stale one must stay silent.
+                if (lease != null && lease.deadlineMs == deadlineMs && !lease.lock.isHeld()) {
+                    leases.remove(owner);
+                    traceLease("wake_expire", owner, screen, 0);
+                }
+            }
+        }, delayMs);
+    }
+
+    /** Emit a lease transition on the lifecycle trace channel. Never throws. */
+    private static void traceLease(String event, WakeOwner owner, boolean screen, long timeoutOrRemainingMs) {
+        try {
+            JSONObject extra = new JSONObject();
+            extra.put("owner", owner.name());
+            extra.put("kind", kind(screen));
+            extra.put("ms", timeoutOrRemainingMs);
+            extra.put("held", heldLeasesLocked());
+            BleTraceLogger.logLifecycle(sAppContext, "WakeLockManager", event, extra);
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to trace lease event " + event, e);
+        }
+    }
+
+    /** Comma-joined "OWNER:kind" list of currently held leases. Caller holds LOCK. */
+    private static String heldLeasesLocked() {
+        StringBuilder held = new StringBuilder();
+        for (Map.Entry<WakeOwner, Lease> e : sCpuLeases.entrySet()) {
+            if (e.getValue().lock.isHeld()) {
+                if (held.length() > 0) held.append(',');
+                held.append(e.getKey().name()).append(":cpu");
+            }
+        }
+        for (Map.Entry<WakeOwner, Lease> e : sScreenLeases.entrySet()) {
+            if (e.getValue().lock.isHeld()) {
+                if (held.length() > 0) held.append(',');
+                held.append(e.getKey().name()).append(":screen");
+            }
+        }
+        return held.length() == 0 ? "none" : held.toString();
+    }
+
+    private static String kind(boolean screen) {
+        return screen ? "screen" : "cpu";
     }
 
     /**
      * Check if the application is currently in the foreground.
-     *
-     * @param context Application context
-     * @return true if the app is in the foreground, false otherwise
      */
     private static boolean isAppInForeground(@NonNull Context context) {
         try {
-            ActivityManager activityManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+            ActivityManager activityManager =
+                    (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
             if (activityManager == null) {
                 Log.w(TAG, "ActivityManager is null, assuming app not in foreground");
                 return false;
             }
 
-            List<ActivityManager.RunningAppProcessInfo> processes = activityManager.getRunningAppProcesses();
+            List<ActivityManager.RunningAppProcessInfo> processes =
+                    activityManager.getRunningAppProcesses();
             if (processes == null) {
                 Log.w(TAG, "Running processes list is null");
                 return false;
@@ -331,8 +293,10 @@ public class WakeLockManager {
             String packageName = context.getPackageName();
             for (ActivityManager.RunningAppProcessInfo process : processes) {
                 if (packageName.equals(process.processName)) {
-                    boolean isInForeground = process.importance == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
-                    Log.d(TAG, "App foreground status: " + isInForeground + " (importance: " + process.importance + ")");
+                    boolean isInForeground = process.importance
+                            == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND;
+                    Log.d(TAG, "App foreground status: " + isInForeground
+                            + " (importance: " + process.importance + ")");
                     return isInForeground;
                 }
             }
@@ -346,15 +310,12 @@ public class WakeLockManager {
 
     /**
      * Bring the application to the foreground by starting the MainActivity.
-     *
-     * @param context Application context
-     * @return true if the intent was successfully started, false otherwise
      */
     private static boolean bringAppToForeground(@NonNull Context context) {
         try {
             Intent intent = new Intent(context, MainActivity.class);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-            
+
             context.startActivity(intent);
             Log.d(TAG, "Started MainActivity to bring app to foreground");
             return true;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/utils/WakeLockManager.java
@@ -219,6 +219,12 @@ public class WakeLockManager {
         }
     }
 
+    // OBSERVATIONAL ONLY: if the expiring CPU lease was the last partial wake lock, the
+    // device can suspend right at the kernel deadline and this main-looper callback runs
+    // only on the next wake (lateMs in the event shows the gap), or not at all if a
+    // re-acquire lands first. The authoritative expiry moment is the deadlineWallMs
+    // advertised in the wake_acquire / wake_extend event; treat wake_expire as a
+    // best-effort confirmation, never as the primary signal.
     private static void scheduleExpiryCheck(WakeOwner owner, boolean screen, long deadlineMs) {
         long delayMs = Math.max(0, deadlineMs - SystemClock.elapsedRealtime()) + 250;
         sExpiryHandler.postDelayed(() -> {
@@ -229,7 +235,12 @@ public class WakeLockManager {
                 // re-schedules its own watcher and this stale one must stay silent.
                 if (lease != null && lease.deadlineMs == deadlineMs && !lease.lock.isHeld()) {
                     leases.remove(owner);
-                    traceLease("wake_expire", owner, screen, 0);
+                    traceLease(
+                            "wake_expire",
+                            owner,
+                            screen,
+                            0,
+                            SystemClock.elapsedRealtime() - deadlineMs);
                 }
             }
         }, delayMs);
@@ -237,11 +248,24 @@ public class WakeLockManager {
 
     /** Emit a lease transition on the lifecycle trace channel. Never throws. */
     private static void traceLease(String event, WakeOwner owner, boolean screen, long timeoutOrRemainingMs) {
+        traceLease(event, owner, screen, timeoutOrRemainingMs, null);
+    }
+
+    private static void traceLease(
+            String event, WakeOwner owner, boolean screen, long timeoutOrRemainingMs, Long lateMs) {
         try {
             JSONObject extra = new JSONObject();
             extra.put("owner", owner.name());
             extra.put("kind", kind(screen));
             extra.put("ms", timeoutOrRemainingMs);
+            if ("wake_acquire".equals(event) || "wake_extend".equals(event)) {
+                // Authoritative expiry moment for this lease; wake_expire is observational
+                // (may fire late across a suspend, or be absorbed by a re-acquire).
+                extra.put("deadlineWallMs", System.currentTimeMillis() + timeoutOrRemainingMs);
+            }
+            if (lateMs != null) {
+                extra.put("lateMs", lateMs);
+            }
             extra.put("held", heldLeasesLocked());
             BleTraceLogger.logLifecycle(sAppContext, "WakeLockManager", event, extra);
         } catch (Exception e) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/utils/WakeLockManagerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/utils/WakeLockManagerTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import android.app.Application;
 import android.os.PowerManager;
 import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.utils.WakeLockManager.WakeOwner;
 import java.time.Duration;
 import org.junit.After;
 import org.junit.Before;
@@ -16,13 +17,16 @@ import org.robolectric.shadows.ShadowPowerManager;
 import org.robolectric.shadows.ShadowSystemClock;
 
 /**
- * Verifies the extend-only ("longest deadline wins") behavior of {@link WakeLockManager}.
+ * Pins the owner-keyed lease contract of {@link WakeLockManager}:
  *
- * <p>The shared static CPU wake lock used to be replaced on every acquire, so a short acquire
- * (e.g. a 60s camera/util lock) could cut an in-flight long operation (e.g. a 10-min OTA) short
- * and let the CPU — and the MTK SoC — sleep mid-update. These tests pin the new contract: a
- * shorter acquire never shortens a longer lock that is already held; only a later deadline
- * swaps the lock.
+ * <p>1. Extend-only per owner ("longest deadline wins"): a shorter acquire never shortens a
+ * longer lease the same owner already holds; only a later deadline swaps the lock. The shared
+ * static lock used to be replaced on every acquire, letting a short acquire cut a 10-min OTA
+ * short and put the MTK SoC to sleep mid-update.
+ *
+ * <p>2. Ownership isolation: release(owner) ends ONLY that owner's leases. The historical
+ * releaseAllWakeLocks() let camera close / stream cleanup revoke every other subsystem's
+ * protection (BES OTA mid-transfer, W:1 command windows, in-flight uploads).
  */
 @RunWith(RobolectricTestRunner.class)
 @Config(application = Application.class, sdk = 33)
@@ -33,37 +37,43 @@ public class WakeLockManagerTest {
     @Before
     public void setUp() {
         app = ApplicationProvider.getApplicationContext();
-        // WakeLockManager keeps process-static state that Robolectric does not reset between
-        // tests; clear it so each test starts with no held lock and no tracked deadline.
-        WakeLockManager.releaseAllWakeLocks();
+        releaseEveryOwner();
     }
 
     @After
     public void tearDown() {
-        WakeLockManager.releaseAllWakeLocks();
+        releaseEveryOwner();
+    }
+
+    // WakeLockManager keeps process-static state that Robolectric does not reset between
+    // tests; clear every owner so each test starts with no held lease.
+    private static void releaseEveryOwner() {
+        for (WakeOwner owner : WakeOwner.values()) {
+            WakeLockManager.release(owner);
+        }
     }
 
     @Test
-    public void shorterAcquire_doesNotReplaceLongerHeldCpuLock() {
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue(); // 10 min
+    public void shorterAcquire_doesNotReplaceLongerHeldCpuLease() {
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 600_000)).isTrue(); // 10 min
         PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
         assertThat(first.isHeld()).isTrue();
 
-        // 1 minute later, a 2-minute acquire must be ignored — the original lock still outlives it.
+        // 1 minute later, a 2-minute acquire must be ignored — the original lease still outlives it.
         ShadowSystemClock.advanceBy(Duration.ofMinutes(1));
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 120_000)).isTrue(); // 2 min
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 120_000)).isTrue(); // 2 min
 
-        // No new lock was created; the original 10-min lock is still the active one.
+        // No new lock was created; the original 10-min lease is still the active one.
         assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(first);
         assertThat(first.isHeld()).isTrue();
     }
 
     @Test
-    public void longerAcquire_extendsCpuLock() {
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 120_000)).isTrue(); // 2 min
+    public void longerAcquire_extendsCpuLease() {
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 120_000)).isTrue(); // 2 min
         PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
 
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue(); // 10 min
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 600_000)).isTrue(); // 10 min
         PowerManager.WakeLock second = ShadowPowerManager.getLatestWakeLock();
 
         // Extending to a later deadline swaps in a fresh, longer lock and releases the old one.
@@ -73,29 +83,59 @@ public class WakeLockManagerTest {
     }
 
     @Test
-    public void release_thenShorterAcquire_startsFreshLock() {
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 600_000)).isTrue();
+    public void release_thenShorterAcquire_startsFreshLease() {
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 600_000)).isTrue();
         PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
 
-        WakeLockManager.releaseCpuWakeLock();
+        WakeLockManager.release(WakeOwner.MTK_OTA);
         assertThat(first.isHeld()).isFalse();
 
         // An explicit release clears the tracked deadline, so a short acquire is honored again.
-        assertThat(WakeLockManager.acquireCpuWakeLock(app, 60_000)).isTrue();
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.MTK_OTA, 60_000)).isTrue();
         PowerManager.WakeLock second = ShadowPowerManager.getLatestWakeLock();
         assertThat(second).isNotSameAs(first);
         assertThat(second.isHeld()).isTrue();
     }
 
     @Test
-    public void screenLock_isExtendOnlyToo() {
-        assertThat(WakeLockManager.acquireScreenWakeLock(app, 60_000)).isTrue();
+    public void screenLease_isExtendOnlyToo() {
+        assertThat(WakeLockManager.acquireScreen(app, WakeOwner.CAMERA, 60_000)).isTrue();
         PowerManager.WakeLock first = ShadowPowerManager.getLatestWakeLock();
 
         ShadowSystemClock.advanceBy(Duration.ofSeconds(1));
-        assertThat(WakeLockManager.acquireScreenWakeLock(app, 5_000)).isTrue(); // shorter
+        assertThat(WakeLockManager.acquireScreen(app, WakeOwner.CAMERA, 5_000)).isTrue(); // shorter
 
         assertThat(ShadowPowerManager.getLatestWakeLock()).isSameAs(first);
         assertThat(first.isHeld()).isTrue();
+    }
+
+    @Test
+    public void releaseOfOneOwner_doesNotTouchAnotherOwnersLease() {
+        // The collision this rework exists to prevent: camera close releasing its leases
+        // must not revoke a concurrent BES OTA transfer's protection.
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.BES_OTA, 300_000)).isTrue();
+        PowerManager.WakeLock otaLock = ShadowPowerManager.getLatestWakeLock();
+        assertThat(WakeLockManager.acquireFull(app, WakeOwner.CAMERA, 180_000, 5_000)).isTrue();
+
+        WakeLockManager.release(WakeOwner.CAMERA);
+
+        assertThat(otaLock.isHeld()).isTrue();
+
+        WakeLockManager.release(WakeOwner.BES_OTA);
+        assertThat(otaLock.isHeld()).isFalse();
+    }
+
+    @Test
+    public void sameKindLeases_areIndependentPerOwner() {
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.PHONE_COMMAND, 15_000)).isTrue();
+        PowerManager.WakeLock commandLock = ShadowPowerManager.getLatestWakeLock();
+        assertThat(WakeLockManager.acquireCpu(app, WakeOwner.STREAMING, 2_180_000)).isTrue();
+        PowerManager.WakeLock streamingLock = ShadowPowerManager.getLatestWakeLock();
+
+        // Two owners hold two distinct kernel locks concurrently; the extend-only rule is
+        // scoped per owner, so the streaming acquire did not touch the command lease.
+        assertThat(streamingLock).isNotSameAs(commandLock);
+        assertThat(commandLock.isHeld()).isTrue();
+        assertThat(streamingLock.isHeld()).isTrue();
     }
 }


### PR DESCRIPTION
Two changes that together make the glasses' wake behavior correct and observable: a fresh awake window per wake-flagged phone command (the original scope), and a rework of `WakeLockManager` into **owner-keyed wake leases** after review surfaced that the shared-lock design lets any subsystem revoke any other's protection.

## Part 1 — a fresh MTK awake window per wake-flagged (W:1) command

Root cause of `sendWifiCredentials` results arriving at 16-25s in the field (measured on hardware):

- The glasses' screen timeout is **12s**; with no wakelock held, the MTK suspends when it expires.
- The BES wakes the MTK for wake-flagged commands by pulsing the power key — but **only when the SoC is already asleep** (`lxy_glass_force_wakeup_mtk` is GPIO-gated). A command landing mid-awake-window gets **no extra time**.
- The wifi flow's status machinery (`Thread.sleep` polls, debounce Handler) runs on clocks that **freeze across suspend**, and SDK heartbeats are `wakeup=false`, so a mid-flow suspend stalls the result until the next unrelated wake — the 16-25s tail.

Fix: every W:1 command (string-wrapper `"W":1` in `CommandProcessor`; binary `FLAG_WAKE` in `K900BluetoothManager`) grants a **15s CPU lease** (`AsgConstants.PHONE_WAKE_COMMAND_WINDOW_MS`, sized to outlive the wifi failure verdict at ~12.4s). W:0 traffic (30s heartbeats) grants nothing, so idle battery behavior is unchanged. The BES translates binary-wire FLAG_WAKE to `"W":1` when re-packing onto UART, so the CommandProcessor path covers both wire modes today.

## Part 2 — owner-keyed wake leases (review finding by @aisraelov)

The manager held ONE shared static `WakeLock` per kind. Extend-only protected against shorter *acquires*, but any subsystem's *release* — notably `releaseAllWakeLocks()`, called by camera close and every streaming cleanup — silently revoked every other subsystem's protection. Inventory of what could collide:

| Owner | CPU timeout | Release path (before) |
|---|---|---|
| Camera | 180s | `releaseAllWakeLocks()` ×2 |
| RTMP/SRT/WHIP streaming | 36 min | `releaseAllWakeLocks()` ×4 (WHIP before its final "stopped" notification) |
| BES OTA | 5 min | `releaseCpuWakeLock()` |
| MTK OTA | 10 min | timeout-only |
| Battery announce | 5s screen | timeout-only |
| W:1 commands (new) | 15s | timeout-only |
| Bootstrap | 60s (raw lock outside the manager) | manual |

Concrete self-collisions: `stop_video_recording` (W:1) → camera close releases all locks mid-upload; photo keep-alive close during webhook/BLE fallback; `stop_stream` cleanup killing a concurrent BES OTA's lock — a plausible contributor to the known "MTK sleeps mid-BES-update" stalls.

**Design:** one lease per owner (`PHONE_COMMAND, CAMERA, STREAMING, BES_OTA, MTK_OTA, BATTERY_ANNOUNCE, BOOTSTRAP`), each backed by its own `PowerManager.WakeLock`. The kernel keeps the CPU up while ANY lease is held and sleeps after the last one ends — the OS is the arbiter, no arbitration logic in the manager. `release(owner)` can only end that owner's leases; `releaseAllWakeLocks()` is **deleted** and each caller now releases exactly the lease it owns (which is what every call site meant). Acquires stay extend-only, per owner. Per-owner tags (`AugmentOS:Cpu:CAMERA`, …) make `dumpsys power` / batterystats attribution per-subsystem. `BootstrapActivity`'s raw lock joins the manager as `BOOTSTRAP`.

## Part 3 — BES OTA holds a screen lease, re-armed on segment progress

The 2026-07-08 field failure proved a CPU lease is **not sufficient** for the BES UART transfer: the transfer froze between segments at 80% with the 5-minute CPU lock still held (4:40 remaining) the moment the device's display-sleep transition fired ("Going to sleep due to timeout" — the vendor sleep hook wedges the transfer state machine). The vendor "screen on" state is the protection the transfer actually needs — the same one the streaming services already hold.

`BesOtaManager` now acquires **both** cpu and screen leases at transfer start (5-min initial window covering authorization + handshake) and re-arms them on confirmed segments (`BES_OTA_SEGMENT_LEASE_WINDOW_MS` = 120s rolling, at most every 60s): a live transfer never expires its protection regardless of total duration — closing the >5-minute exposure of the old one-shot lock — while a wedged transfer stops re-arming and lets the device sleep within the window, aligned with the phone's 120s stall watchdog. (The verify-wait timeout / breakpoint-resume recovery inside the transfer state machine is tracked separately.)

## Observability

Every lease transition rides the existing lifecycle trace channel (`BleTraceLogger.logLifecycle`, component `WakeLockManager` — same yellow channel as the service start events, flows into incident logs):

- `wake_acquire` / `wake_extend` — `{owner, kind, ms, held}`
- `wake_release` — with remaining ms at release
- `wake_expire` — deadline watcher (timeouts expire in the OS without callback)

`held` is the full set of currently-held leases, so "why did the MTK sleep at T?" is answerable from one grep: which lease died, when, and what was left holding.

## Test evidence

- `:app:compileDebugJavaWithJavac` clean; all 11 call sites ported, no references to the old API remain.
- Part 1 hardware-verified before the rework: W:1 → lock held (`dumpsys power`), auto-release at 15s, no lock for W:0 pings, wifi join over BLE at 3.3s e2e.
- **On-device verification of the lease manager (Mentra Live hardware, test starting from a sleeping device):**
  - Three concurrent per-owner kernel locks with per-owner tags (`AugmentOS:Cpu:CAMERA`, `AugmentOS:Screen:CAMERA`, `AugmentOS:Cpu:PHONE_COMMAND` in `dumpsys power`); PowerManagerService even attributes the wake to the owner (`Waking up ... details=AugmentOS:Screen:CAMERA`).
  - **Ownership isolation (the review's collision case):** camera close released its own leases while a W:1 command lease was active — the `wake_release owner=CAMERA` trace shows `held="PHONE_COMMAND:cpu"`, i.e. the command lease survived. Under the old shared lock this exact sequence revoked it.
  - W:1 lease duration kernel-verified twice via the wake-lock event history: `ACQ → REL` at exactly 15.01s, lock present in every 2s dumpsys sample in between.
  - Trace channel captured every transition (`wake_acquire` / `wake_release` / `wake_expire`) with the full held-lease set.
  - Still pending: a battery-powered (non-USB) wifi join for the field 16-25s tail, and a real BES OTA under the new progress-coupled leases.

## Notes for reviewers

- 15s per user-action-driven command is the battery cost of part 1; heartbeats unaffected.
- The SDK-side wrong-password/error surfacing is #3459/#3460; this PR is glasses-only and helps every app (manager included) with no phone-side changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core power/awake behavior across OTA, camera, streaming, and BLE command handling; regressions could cause mid-operation sleep or extra battery drain, though the design directly targets known production stalls.
> 
> **Overview**
> Reworks **`WakeLockManager`** from one shared CPU/screen lock into **per-subsystem leases** (`WakeOwner`: camera, streaming, BES/MTK OTA, phone commands, bootstrap, etc.). Each owner holds its own `PowerManager.WakeLock`; **`release(owner)`** only drops that owner’s leases, and **`releaseAllWakeLocks()`** is removed so camera/stream cleanup can’t revoke another subsystem’s protection. Acquires stay **extend-only** per owner; lease transitions are traced via **`BleTraceLogger`** (`wake_acquire` / `wake_extend` / `wake_release` / `wake_expire` with the full `held` set).
> 
> **Wake-flagged phone commands** (`"W":1` in **`CommandProcessor`**, **`FLAG_WAKE`** on binary wire in **`K900BluetoothManager`**) now grant a **15s** CPU lease (`PHONE_WAKE_COMMAND_WINDOW_MS`) so follow-up work (e.g. wifi credential polls) isn’t cut off by the 12s screen timeout when the BES power pulse doesn’t extend an already-awake window. Binary wake grants fire on the first fragment and again when reassembly completes.
> 
> **BES OTA** holds **CPU + screen** leases (display sleep was wedging UART mid-transfer) and **re-arms** them on segment CRC confirms (`BES_OTA_SEGMENT_LEASE_WINDOW_MS`), with **`mLeaseGate`** so post-cleanup UART confirms can’t re-acquire orphaned leases. Boot, MTK OTA, camera, streaming, and battery-announce paths are ported to the new API; **`WakeLockManagerTest`** adds ownership-isolation coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d63bd10d8c5e7b1b292d293b122270bc47aea375. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


