### PR TITLE
Bluetooth SDK: reject pending WiFi connect on glasses-reported provisioning error

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -520,11 +520,24 @@ public class Bridge private constructor() {
             sendTypedMessage("glasses_serial_number", body as Map<String, Any>)
         }
 
-        /** Send WiFi status change */
+        /**
+         * Send WiFi status change. [error] is the glasses' provisioning failure reason
+         * (e.g. "connect_timeout", "connected_to_other_network") when this status is the
+         * verdict of a failed connect attempt; null for routine link-state updates.
+         */
         @JvmStatic
-        fun sendWifiStatusChange(connected: Boolean, ssid: String?, localIp: String?) {
+        @JvmOverloads
+        fun sendWifiStatusChange(
+                connected: Boolean,
+                ssid: String?,
+                localIp: String?,
+                error: String? = null
+        ) {
             val status = WifiStatus.fromStoreFields(connected, ssid, localIp) ?: return
-            sendTypedMessage("wifi_status_change", status.toMap())
+            val payload =
+                    if (error != null) status.toMap() + mapOf("error" to error)
+                    else status.toMap()
+            sendTypedMessage("wifi_status_change", payload)
         }
 
         /** Send WiFi scan results */

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1724,6 +1724,26 @@ class MentraBluetoothSdk private constructor(
 
     private fun handleWifiStatusForRequests(event: WifiStatusEvent) {
         val request = synchronized(oneShotLock) { pendingWifiStatus } ?: return
+        // A wifi_status carrying the explicit error field is the glasses' failure
+        // verdict for the in-flight connect: reject now instead of running out the
+        // request timeout. Only the error field counts as failure — the glasses'
+        // connect sequence emits a debounced bare connected=false ~1-2s after
+        // credentials while association is still in progress, and rejecting on that
+        // would kill every connect attempt early.
+        if (request.operation == WifiStatusOperation.CONNECT && event.error != null) {
+            synchronized(oneShotLock) {
+                if (pendingWifiStatus === request) {
+                    pendingWifiStatus = null
+                }
+            }
+            request.pending.reject(
+                BluetoothSdkException(
+                    event.error,
+                    "Glasses failed to join \"${request.ssid}\": ${event.error}",
+                )
+            )
+            return
+        }
         if (!wifiStatusMatches(event.status, request)) return
         synchronized(oneShotLock) {
             if (pendingWifiStatus === request) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3136,7 +3136,12 @@ class MentraLive : SGCManager() {
                     DeviceStore.apply("glasses", "wifiError", "")
                 }
 
-                updateWifiStatus(wifiConnectedStatus, ssid, localIp)
+                updateWifiStatus(
+                        wifiConnectedStatus,
+                        ssid,
+                        localIp,
+                        wifiError.takeIf { it.isNotEmpty() }
+                )
             }
             "hotspot_status_update" -> {
                 // Process hotspot status information (same pattern as "wifi_status")
@@ -4701,7 +4706,12 @@ class MentraLive : SGCManager() {
     /**
      * Update WiFi status and notify listeners Matches iOS MentraLive.swift updateWifiStatus pattern
      */
-    private fun updateWifiStatus(connected: Boolean, ssid: String, localIp: String) {
+    private fun updateWifiStatus(
+            connected: Boolean,
+            ssid: String,
+            localIp: String,
+            error: String? = null
+    ) {
         Bridge.log("LIVE: 🌐 Updating WiFi status - connected: " + connected + ", SSID: " + ssid)
 
         // Update parent SGCManager fields
@@ -4710,7 +4720,7 @@ class MentraLive : SGCManager() {
         DeviceStore.apply("glasses", "wifiLocalIp", localIp)
 
         // Send event to bridge for cloud communication
-        Bridge.sendWifiStatusChange(connected, ssid, localIp)
+        Bridge.sendWifiStatusChange(connected, ssid, localIp, error)
     }
 
     /**

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
@@ -66,7 +66,7 @@ sealed interface WifiStatus {
     }
 }
 
-data class WifiStatusEvent(
+data class WifiStatusEvent @JvmOverloads constructor(
     val status: WifiStatus,
     /**
      * Glasses-reported provisioning failure reason (e.g. "connect_timeout",

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
@@ -69,11 +69,15 @@ sealed interface WifiStatus {
 data class WifiStatusEvent @JvmOverloads constructor(
     val status: WifiStatus,
     /**
-     * Glasses-reported provisioning failure reason (e.g. "connect_timeout",
-     * "connected_to_other_network") when this status is the verdict of a failed
-     * connect attempt; null for routine link-state updates. Sent by ASG client
-     * builds that include the WiFi error surfacing (v40+); older glasses never
-     * set it.
+     * Glasses-reported provisioning failure reason when THIS event is the verdict of a
+     * failed connect attempt; null for routine link-state updates. An attempt property,
+     * not a link property — which is why it lives on the event and not on [WifiStatus]:
+     * "connect_timeout" arrives with a disconnected status (never associated), while
+     * "connected_to_other_network" arrives with a *connected* status — the attempt
+     * failed and Android's auto-join left the glasses on (or returned them to) a
+     * different SSID than requested, so the link is genuinely up while the request
+     * genuinely failed. Sent by ASG client builds that include the WiFi error
+     * surfacing (v40+); older glasses never set it.
      */
     val error: String? = null,
 ) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/status/WifiHotspotStatus.kt
@@ -68,13 +68,25 @@ sealed interface WifiStatus {
 
 data class WifiStatusEvent(
     val status: WifiStatus,
+    /**
+     * Glasses-reported provisioning failure reason (e.g. "connect_timeout",
+     * "connected_to_other_network") when this status is the verdict of a failed
+     * connect attempt; null for routine link-state updates. Sent by ASG client
+     * builds that include the WiFi error surfacing (v40+); older glasses never
+     * set it.
+     */
+    val error: String? = null,
 ) {
-    internal constructor(values: Map<String, Any>) : this(WifiStatus.fromMap(values) ?: WifiStatus.Disconnected)
+    internal constructor(values: Map<String, Any>) : this(
+        WifiStatus.fromMap(values) ?: WifiStatus.Disconnected,
+        stringValue(values, "error")?.takeIf { it.isNotEmpty() },
+    )
     internal constructor(connected: Boolean, ssid: String?, localIp: String?) : this(
         WifiStatus.fromStoreFields(connected, ssid, localIp) ?: WifiStatus.Disconnected
     )
 
-    val values: Map<String, Any> get() = status.toEventMap()
+    val values: Map<String, Any>
+        get() = status.toEventMap() + (error?.let { mapOf("error" to it) } ?: emptyMap())
 }
 
 sealed interface HotspotStatus {

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -400,7 +400,10 @@ class Bridge {
         Bridge.sendTypedMessage("glasses_serial_number", body: body)
     }
 
-    static func sendWifiStatusChange(connected: Bool, ssid: String?, localIp: String?) {
+    /// `error` is the glasses' provisioning failure reason (e.g. "connect_timeout",
+    /// "connected_to_other_network") when this status is the verdict of a failed
+    /// connect attempt; nil for routine link-state updates.
+    static func sendWifiStatusChange(connected: Bool, ssid: String?, localIp: String?, error: String? = nil) {
         guard let status = WifiStatus.fromStoreFields(
             connected: connected,
             ssid: ssid,
@@ -408,7 +411,11 @@ class Bridge {
         ) else {
             return
         }
-        Bridge.sendTypedMessage("wifi_status_change", body: status.values)
+        var body = status.values
+        if let error {
+            body["error"] = error
+        }
+        Bridge.sendTypedMessage("wifi_status_change", body: body)
     }
 
     static func updateWifiScanResults(_ networks: [[String: Any]], scanComplete: Bool) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1617,6 +1617,24 @@ public final class MentraBluetoothSDK {
 
     private func handleWifiStatusForRequests(_ event: WifiStatusEvent) {
         guard let request = pendingWifiStatus else { return }
+        // A wifi_status carrying the explicit error field is the glasses' failure
+        // verdict for the in-flight connect: reject now instead of running out the
+        // request timeout. Only the error field counts as failure — the glasses'
+        // connect sequence emits a debounced bare connected=false ~1-2s after
+        // credentials while association is still in progress, and rejecting on that
+        // would kill every connect attempt early.
+        if request.operation == .connect, let error = event.error {
+            if pendingWifiStatus === request {
+                pendingWifiStatus = nil
+            }
+            request.pending.reject(
+                BluetoothSdkError(
+                    code: error,
+                    message: "Glasses failed to join \"\(request.ssid)\": \(error)"
+                )
+            )
+            return
+        }
         guard wifiStatusMatches(event.status, request: request) else { return }
         if pendingWifiStatus === request {
             pendingWifiStatus = nil

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2355,7 +2355,7 @@ class MentraLive: NSObject, SGCManager {
             } else if connected {
                 DeviceStore.shared.apply("glasses", "wifiError", "")
             }
-            updateWifiStatus(connected: connected, ssid: ssid, ip: ip)
+            updateWifiStatus(connected: connected, ssid: ssid, ip: ip, error: wifiError.isEmpty ? nil : wifiError)
 
         case "hotspot_status_update":
             let enabled = json["hotspot_enabled"] as? Bool ?? false
@@ -4624,12 +4624,12 @@ class MentraLive: NSObject, SGCManager {
         }
     }
 
-    private func updateWifiStatus(connected: Bool, ssid: String, ip: String) {
+    private func updateWifiStatus(connected: Bool, ssid: String, ip: String, error: String? = nil) {
         Bridge.log("LIVE: 🌐 Updating WiFi status - connected: \(connected), ssid: \(ssid)")
         DeviceStore.shared.apply("glasses", "wifiConnected", connected)
         DeviceStore.shared.apply("glasses", "wifiSsid", ssid)
         DeviceStore.shared.apply("glasses", "wifiLocalIp", ip)
-        emitWifiStatusChange()
+        emitWifiStatusChange(error: error)
     }
 
     private func updateHotspotStatus(enabled: Bool, ssid: String, password: String, ip: String) {
@@ -4923,8 +4923,8 @@ class MentraLive: NSObject, SGCManager {
     //   emitEvent("BatteryLevelEvent", body: eventBody)
     // }
 
-    private func emitWifiStatusChange() {
-        Bridge.sendWifiStatusChange(connected: wifiConnected, ssid: wifiSsid, localIp: wifiLocalIp)
+    private func emitWifiStatusChange(error: String? = nil) {
+        Bridge.sendWifiStatusChange(connected: wifiConnected, ssid: wifiSsid, localIp: wifiLocalIp, error: error)
     }
 
     private func emitHotspotStatusChange() {

--- a/mobile/modules/bluetooth-sdk/ios/Source/status/WifiHotspotStatus.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/status/WifiHotspotStatus.swift
@@ -133,11 +133,15 @@ public enum WifiStatus: CustomStringConvertible, Equatable {
 public struct WifiStatusEvent: CustomStringConvertible {
     public let status: WifiStatus
 
-    /// Glasses-reported provisioning failure reason (e.g. "connect_timeout",
-    /// "connected_to_other_network") when this status is the verdict of a failed
-    /// connect attempt; nil for routine link-state updates. Sent by ASG client
-    /// builds that include the WiFi error surfacing (v40+); older glasses never
-    /// set it.
+    /// Glasses-reported provisioning failure reason when THIS event is the verdict of a
+    /// failed connect attempt; nil for routine link-state updates. An attempt property,
+    /// not a link property — which is why it lives on the event and not on `WifiStatus`:
+    /// "connect_timeout" arrives with a disconnected status (never associated), while
+    /// "connected_to_other_network" arrives with a *connected* status — the attempt
+    /// failed and Android's auto-join left the glasses on (or returned them to) a
+    /// different SSID than requested, so the link is genuinely up while the request
+    /// genuinely failed. Sent by ASG client builds that include the WiFi error
+    /// surfacing (v40+); older glasses never set it.
     public let error: String?
 
     public init(status: WifiStatus, error: String? = nil) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/status/WifiHotspotStatus.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/status/WifiHotspotStatus.swift
@@ -133,20 +133,35 @@ public enum WifiStatus: CustomStringConvertible, Equatable {
 public struct WifiStatusEvent: CustomStringConvertible {
     public let status: WifiStatus
 
-    public init(status: WifiStatus) {
+    /// Glasses-reported provisioning failure reason (e.g. "connect_timeout",
+    /// "connected_to_other_network") when this status is the verdict of a failed
+    /// connect attempt; nil for routine link-state updates. Sent by ASG client
+    /// builds that include the WiFi error surfacing (v40+); older glasses never
+    /// set it.
+    public let error: String?
+
+    public init(status: WifiStatus, error: String? = nil) {
         self.status = status
+        self.error = error
     }
 
     init(connected: Bool, ssid: String?, localIp: String?) {
         status = WifiStatus.fromStoreFields(connected: connected, ssid: ssid, localIp: localIp) ?? .disconnected
+        error = nil
     }
 
     init(values: [String: Any]) {
         status = WifiStatus(values: values) ?? .disconnected
+        let rawError = stringValue(values, "error")
+        error = rawError?.isEmpty == false ? rawError : nil
     }
 
     public var values: [String: Any] {
-        status.values.merging(["type": "wifi_status_change"]) { _, new in new }
+        var body = status.values.merging(["type": "wifi_status_change"]) { _, new in new }
+        if let error {
+            body["error"] = error
+        }
+        return body
     }
 
     public var description: String {

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -106,16 +106,7 @@ export type LogEvent = {
   message: string
 }
 
-/**
- * `error` is the glasses-reported provisioning failure reason (e.g. "connect_timeout",
- * "connected_to_other_network") when the status is the verdict of a failed connect
- * attempt; absent on routine link-state updates. Requires ASG client v40+ — older
- * glasses never send it. Note "connected_to_other_network" arrives on a *connected*
- * status (joined a different SSID than requested).
- */
-export type WifiStatus =
-  | {state: "disconnected"; error?: string}
-  | {state: "connected"; ssid: string; localIp?: string; error?: string}
+export type WifiStatus = {state: "disconnected"} | {state: "connected"; ssid: string; localIp?: string}
 
 export type ConnectedWifiStatus = Extract<WifiStatus, {state: "connected"}>
 
@@ -125,6 +116,16 @@ export function isConnectedWifiStatus(status: WifiStatus): status is ConnectedWi
 
 export type WifiStatusChangeEvent = WifiStatus & {
   type: "wifi_status_change"
+  /**
+   * Glasses-reported provisioning failure reason when THIS event is the verdict of a
+   * failed connect attempt; absent on routine link-state updates. An attempt property,
+   * not a link property — which is why it lives on the event, not on WifiStatus:
+   * "connect_timeout" arrives on a disconnected status (never associated), while
+   * "connected_to_other_network" arrives on a *connected* status (the attempt failed
+   * and the glasses ended up on / fell back to a different SSID than requested).
+   * Requires ASG client v40+ — older glasses never send it.
+   */
+  error?: string
 }
 
 export type HotspotStatus = {state: "disabled"} | {state: "enabled"; ssid: string; password: string; localIp: string}

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -106,7 +106,16 @@ export type LogEvent = {
   message: string
 }
 
-export type WifiStatus = {state: "disconnected"} | {state: "connected"; ssid: string; localIp?: string}
+/**
+ * `error` is the glasses-reported provisioning failure reason (e.g. "connect_timeout",
+ * "connected_to_other_network") when the status is the verdict of a failed connect
+ * attempt; absent on routine link-state updates. Requires ASG client v40+ — older
+ * glasses never send it. Note "connected_to_other_network" arrives on a *connected*
+ * status (joined a different SSID than requested).
+ */
+export type WifiStatus =
+  | {state: "disconnected"; error?: string}
+  | {state: "connected"; ssid: string; localIp?: string; error?: string}
 
 export type ConnectedWifiStatus = Extract<WifiStatus, {state: "connected"}>
 


### PR DESCRIPTION
## Problem

`sendWifiCredentials` resolves only on a `wifi_status` that is `connected` with the exact requested SSID. When the glasses *fail* to join (wrong password, out of range, joined a different network), nothing rejects the pending request — apps wait out the full 15s `request_timeout` and then can't tell the user *why* it failed.

The glasses have reported the reason since MentraOS `18eea86790` (ASG v40+): a failed connect attempt sends `wifi_status` with an explicit `error` field (`connect_timeout`, `connected_to_other_network`). Both platforms already parse it into `DeviceStore` (`glasses/wifiError`) — but the pending request and the app-facing event stream never see it.

## Change

Thread the `error` field end-to-end and use it as the failure verdict for the in-flight connect:

- **Event plumbing** (`MentraLive.kt`/`.swift` → `Bridge` → `WifiStatusEvent`): `wifi_status_change` now carries `error` when the glasses attached one. `WifiStatusEvent` gains an optional `error` (Kotlin + Swift), and the TS `WifiStatus` type gains `error?: string` on both variants.
- **Reject the pending connect** (`MentraBluetoothSdk.kt` / `MentraBluetoothSDK.swift`): a status carrying `error` while a CONNECT is pending rejects it immediately with the glasses' reason as the error code (`connect_timeout` / `connected_to_other_network`, forward-compatible with future reasons like `wrong_password`), instead of timing out at 15s.

### What deliberately does NOT reject: bare `connected=false`

The glasses' connect sequence calls `wifiManager.disconnect()` before `enableNetwork`/`reconnect`, and the 1s-debounced link-state broadcast emits a **routine `connected=false` ~1-2s after credentials while association is still in progress** (reproduced on hardware during this investigation). Rejecting on bare disconnected would kill every connect attempt early. Failure is gated **strictly on the explicit `error` field**.

Note `connected_to_other_network` arrives on a *connected* status (joined a different SSID than requested) — the rejection handles both connected and disconnected error-carrying statuses uniformly.

## Compatibility

- Older glasses (≤v39) never send `error`: behavior is unchanged (resolve on match, `request_timeout` otherwise).
- `Bridge.sendWifiStatusChange` keeps its 3-arg form (`@JvmOverloads` / Swift default param); `WifiStatusEvent` constructors keep their existing shapes.
- FORGET requests are unaffected by the error path.

## Test evidence

- `scripts/check-android-compile.sh bluetooth-sdk` passes.
- Glasses-side behavior of the error field verified on hardware during the wifi-latency investigation: wrong password → `wifi_status {connected:false, error:"connect_timeout"}` at 12.4s; the spurious debounced `connected=false` (no error) at ~1.7s confirmed present, and correctly ignored by this gating.
- iOS compiles are not exercised by repo scripts; the Swift change mirrors the Kotlin one line-for-line and needs a CI/Xcode pass.

## Notes for reviewers

- End-to-end value requires ASG v40 in the fleet (v39 predates the glasses-side error fix); the SDK change is safe to ship ahead of it.
- Related PRs from the same investigation, independent and pick-and-choose: W:1 awake-window fix (asg), wrong-password fast-fail (asg), BES final OTA tick (SDK).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WiFi connect promise resolution and app-facing events on both platforms; behavior is gated on the explicit error field to avoid regressing successful connects.
> 
> **Overview**
> **WiFi connect failures** now surface immediately with the glasses’ reason instead of waiting for the 15s request timeout.
> 
> `wifi_status_change` events and `WifiStatusEvent` / `WifiStatusChangeEvent` gain an optional **`error`** field (Kotlin, Swift, TypeScript), threaded from `MentraLive` through `Bridge.sendWifiStatusChange`. When a **CONNECT** is pending and an event includes `error`, `sendWifiCredentials` rejects with that code (e.g. `connect_timeout`, `connected_to_other_network`). **Bare `connected=false` without `error` is ignored** so mid-association debounced disconnects do not abort in-progress connects. Older glasses without `error` behave as before; FORGET is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c56b66ba344669c9450a0a9ba5a15518360cf80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->