### PR TITLE
ASG: report wrong_password from the supplicant at ~7s instead of connect_timeout at 12s

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Handler for WiFi-related commands.
@@ -31,6 +32,17 @@ public class WifiCommandHandler implements ICommandHandler {
     private final AsgClientServiceManager serviceManager;
     private final ICommunicationManager communicationManager;
     private final IStateManager stateManager;
+
+    /** Verdict sources for one connect attempt: the status poll and the supplicant listener. */
+    private static final class ConnectAttempt {
+        final AtomicBoolean verdictSent = new AtomicBoolean(false);
+        volatile BroadcastReceiver authFailureReceiver;
+    }
+
+    // The single in-flight connect attempt. A new set_wifi_credentials supersedes the
+    // previous attempt (its poll and receiver are silenced) so a single supplicant
+    // auth-failure broadcast can never produce more than one wrong_password verdict.
+    private final AtomicReference<ConnectAttempt> activeConnectAttempt = new AtomicReference<>();
 
     public WifiCommandHandler(AsgClientServiceManager serviceManager,
                               ICommunicationManager communicationManager,
@@ -110,9 +122,18 @@ public class WifiCommandHandler implements ICommandHandler {
      */
     private void scheduleWifiStatusCheck(String targetSsid) {
         // One verdict per connect attempt: either the supplicant's fast wrong-password
-        // signal below or this poll reports, never both.
-        AtomicBoolean verdictSent = new AtomicBoolean(false);
-        BroadcastReceiver authFailureReceiver = registerAuthFailureReceiver(verdictSent);
+        // signal below or this poll reports, never both. A new attempt supersedes any
+        // in-flight one - silencing the old verdict flag also makes its still-registered
+        // receiver and poll thread no-ops until they tear down.
+        ConnectAttempt attempt = new ConnectAttempt();
+        ConnectAttempt previous = activeConnectAttempt.getAndSet(attempt);
+        if (previous != null) {
+            previous.verdictSent.set(true);
+            unregisterAuthFailureReceiver(previous.authFailureReceiver);
+            previous.authFailureReceiver = null;
+        }
+        AtomicBoolean verdictSent = attempt.verdictSent;
+        attempt.authFailureReceiver = registerAuthFailureReceiver(verdictSent);
         new Thread(() -> {
             try {
                 // Wait for WiFi connection to establish (3 seconds initial, then poll)
@@ -161,7 +182,9 @@ public class WifiCommandHandler implements ICommandHandler {
             } catch (Exception e) {
                 Log.e(TAG, "📶 💥 Error during WiFi status check", e);
             } finally {
-                unregisterAuthFailureReceiver(authFailureReceiver);
+                unregisterAuthFailureReceiver(attempt.authFailureReceiver);
+                attempt.authFailureReceiver = null;
+                activeConnectAttempt.compareAndSet(attempt, null);
             }
         }).start();
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -158,7 +158,12 @@ public class WifiCommandHandler implements ICommandHandler {
                     if ((isConnected && currentSsid.equals(targetSsid)) || i == 3) {
                         boolean connectedToTarget = isConnected && currentSsid.equals(targetSsid);
                         // Surface why provisioning failed instead of a bare connected=false —
-                        // "never associates, no error shown" was a field complaint.
+                        // "never associates, no error shown" was a field complaint. The error is
+                        // an ATTEMPT verdict riding on a truthful LINK snapshot, so
+                        // connected_to_other_network is deliberately sent with connected=true:
+                        // the join failed and auto-join left the glasses on (or returned them
+                        // to) a different SSID, so the link is genuinely up while the request
+                        // genuinely failed.
                         String error = null;
                         if (!connectedToTarget) {
                             error = isConnected ? "connected_to_other_network" : "connect_timeout";

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -1,5 +1,10 @@
 package com.mentra.asg_client.service.core.handlers;
 
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.wifi.WifiManager;
 import android.util.Log;
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.interfaces.IWifiScanCallback;
@@ -14,6 +19,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Handler for WiFi-related commands.
@@ -103,6 +109,10 @@ public class WifiCommandHandler implements ICommandHandler {
      * even if NETWORK_STATE_CHANGED broadcast doesn't fire reliably
      */
     private void scheduleWifiStatusCheck(String targetSsid) {
+        // One verdict per connect attempt: either the supplicant's fast wrong-password
+        // signal below or this poll reports, never both.
+        AtomicBoolean verdictSent = new AtomicBoolean(false);
+        BroadcastReceiver authFailureReceiver = registerAuthFailureReceiver(verdictSent);
         new Thread(() -> {
             try {
                 // Wait for WiFi connection to establish (3 seconds initial, then poll)
@@ -111,6 +121,9 @@ public class WifiCommandHandler implements ICommandHandler {
 
                 // Poll WiFi status multiple times over 12 seconds (total 15s)
                 for (int i = 0; i < 4; i++) {
+                    if (verdictSent.get()) {
+                        return; // supplicant already reported wrong_password
+                    }
                     boolean isConnected = stateManager.isConnectedToWifi();
                     String currentSsid = serviceManager.getNetworkManager() != null ?
                             serviceManager.getNetworkManager().getCurrentWifiSsid() : "";
@@ -129,6 +142,9 @@ public class WifiCommandHandler implements ICommandHandler {
                         if (!connectedToTarget) {
                             error = isConnected ? "connected_to_other_network" : "connect_timeout";
                         }
+                        if (!verdictSent.compareAndSet(false, true)) {
+                            return; // supplicant verdict won the race
+                        }
                         Log.d(TAG, "📶 ✅ Sending WiFi status update: " +
                                 (isConnected ? "CONNECTED to " + currentSsid : "DISCONNECTED") +
                                 (error != null ? " (error=" + error + ")" : ""));
@@ -144,8 +160,61 @@ public class WifiCommandHandler implements ICommandHandler {
                 Thread.currentThread().interrupt();
             } catch (Exception e) {
                 Log.e(TAG, "📶 💥 Error during WiFi status check", e);
+            } finally {
+                unregisterAuthFailureReceiver(authFailureReceiver);
             }
         }).start();
+    }
+
+    /**
+     * Listens for the supplicant's authentication-failure signal during a connect attempt
+     * so a wrong password is reported in ~5-7s (when the 4-way handshake fails) instead of
+     * the generic connect_timeout at the end of the 12s poll window - and with a reason the
+     * app can distinguish from out-of-range. Fast-path only: the broadcast is deprecated
+     * (still delivered on Android 11, where asg_client runs as a system app), so if it never
+     * fires the poll verdict above remains the fallback. The broadcast carries no SSID, but
+     * the connect sequence just disabled all other configured networks (enableNetwork
+     * disableOthers=true), so an auth failure inside this window belongs to this attempt.
+     */
+    private BroadcastReceiver registerAuthFailureReceiver(AtomicBoolean verdictSent) {
+        Context context = serviceManager.getService();
+        if (context == null) {
+            return null;
+        }
+        BroadcastReceiver receiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                int supplicantError = intent.getIntExtra(WifiManager.EXTRA_SUPPLICANT_ERROR, -1);
+                if (supplicantError == WifiManager.ERROR_AUTHENTICATING
+                        && verdictSent.compareAndSet(false, true)) {
+                    Log.i(TAG, "📶 ❌ Supplicant authentication failure - sending wrong_password verdict");
+                    communicationManager.sendWifiStatusOverBle(false, "wrong_password");
+                }
+            }
+        };
+        try {
+            context.registerReceiver(receiver,
+                    new IntentFilter(WifiManager.SUPPLICANT_STATE_CHANGED_ACTION));
+            return receiver;
+        } catch (Exception e) {
+            Log.w(TAG, "📶 ⚠️ Could not register supplicant auth-failure listener", e);
+            return null;
+        }
+    }
+
+    private void unregisterAuthFailureReceiver(BroadcastReceiver receiver) {
+        if (receiver == null) {
+            return;
+        }
+        Context context = serviceManager.getService();
+        if (context == null) {
+            return;
+        }
+        try {
+            context.unregisterReceiver(receiver);
+        } catch (IllegalArgumentException e) {
+            Log.w(TAG, "📶 ⚠️ Auth-failure receiver already unregistered", e);
+        }
     }
 
     /**


### PR DESCRIPTION
## Problem

A wrong WiFi password currently surfaces as `error: connect_timeout` at the fixed end of the 12s status-poll window in `WifiCommandHandler.scheduleWifiStatusCheck` — indistinguishable from an out-of-range network, and later than the glasses actually knew. Measured on Mentra Live hardware during the wifi-latency investigation:

- Credentials arrive → association starts ~3s in → **wpa_supplicant declares the failure at ~7s** (`4-Way Handshake failed - pre-shared key may be incorrect`, `CTRL-EVENT-SSID-TEMP-DISABLED ... reason=WRONG_KEY`).
- asg_client ignores that signal and reports the generic timeout at **12.4s**.

Wrong password vs out-of-range are exactly the two cases a user can act on differently, and today's payload can't distinguish them.

## Change

`WifiCommandHandler` registers a `SUPPLICANT_STATE_CHANGED_ACTION` listener for the duration of the connect attempt. When the broadcast carries `EXTRA_SUPPLICANT_ERROR == ERROR_AUTHENTICATING`, the glasses immediately send `wifi_status {connected: false, error: "wrong_password"}`.

- **One verdict per attempt**: a shared `AtomicBoolean` makes the supplicant signal and the existing poll mutually exclusive — the poll exits early if the supplicant already reported, and the supplicant path no-ops if the poll already sent success/timeout.
- **Fast-path only, safe fallback**: the broadcast is deprecated (still delivered on Android 11, where asg_client runs as a system app). If it never fires, the existing `connect_timeout` verdict at 12s is unchanged. If registration fails, behavior is exactly as before.
- **Attribution**: the broadcast carries no SSID, but the connect sequence just disabled every other configured network (`enableNetwork` with `disableOthers=true`), so an auth failure inside this ≤15s window belongs to the current attempt.
- The receiver is unregistered in the poll thread's `finally`, bounding its lifetime to the attempt.

## New error value

`wrong_password` joins `connect_timeout` / `connected_to_other_network` in the `wifi_status.error` vocabulary introduced in `18eea86790`. The SDK-side companion PR (reject pending connect on the error field) treats error codes as a passthrough, so this value reaches apps without further SDK changes.

## Test evidence

- `:app:compileDebugJavaWithJavac` clean.
- The supplicant signal itself was verified on hardware (wrong password → `WRONG_KEY` at ~7s in logcat, reproduced twice); the end-to-end receiver path needs one on-device wrong-password run to confirm the broadcast delivery on the K900 build — the fallback keeps current behavior if it doesn't fire.

## Notes for reviewers

- Independent of, but complementary to, the W:1 awake-window PR (#3458): with both, a wrong password reports at ~7s inside a guaranteed-awake window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to WiFi provisioning status reporting on glasses; race handling and fallback preserve prior timeout behavior if the broadcast path fails.
> 
> **Overview**
> **WiFi provisioning** now surfaces a wrong password in roughly 5–7s via the supplicant instead of waiting for the 12s poll to emit `connect_timeout`.
> 
> During each `set_wifi_credentials` connect attempt, `WifiCommandHandler` registers for `SUPPLICANT_STATE_CHANGED_ACTION` and, on `ERROR_AUTHENTICATING`, sends `wifi_status` with `error: "wrong_password"` over BLE. A shared **`ConnectAttempt`** / `AtomicBoolean` ensures the supplicant path and the existing status poll send **at most one** verdict; a new credentials command **supersedes** the prior attempt (silencing its poll and unregistering its receiver).
> 
> If the deprecated broadcast never fires or registration fails, behavior falls back to the existing poll (`connect_timeout`, success, `connected_to_other_network`). Receivers are torn down in the poll thread’s `finally`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 143ddbe95ba2b70cd937b17297e962c169c439b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->