### PR TITLE
Bluetooth SDK: emit terminal 'complete' for a BES-final OTA pass

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -4457,7 +4457,20 @@ class MentraLive : SGCManager() {
 
                         val syntheticStatus: String
                         if ("FINISHED" == besOtaStatus) {
-                            syntheticStatus = "step_complete"
+                            // The glasses power-cycle right after the final BES tick, so a
+                            // session whose BES step is the LAST step never gets a follow-up
+                            // ota_status from the glasses — consumers mapping on this synthetic
+                            // status would otherwise never see a terminal state. Emit "complete"
+                            // for the final step; mid-session BES steps keep "step_complete" so
+                            // session-level trackers advance normally. Unknown sessions
+                            // (cachedOtaTotalSteps == 0, e.g. legacy glasses that never sent an
+                            // ota_status) conservatively keep "step_complete".
+                            syntheticStatus =
+                                    if (cachedOtaTotalSteps > 0 &&
+                                                    cachedOtaCurrentStep >= cachedOtaTotalSteps
+                                    )
+                                            "complete"
+                                    else "step_complete"
                         } else if ("FAILED" == besOtaStatus) {
                             syntheticStatus = "failed"
                         } else {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2885,7 +2885,17 @@ class MentraLive: NSObject, SGCManager {
 
                 let syntheticStatus: String
                 if besOtaStatus == "FINISHED" {
-                    syntheticStatus = "step_complete"
+                    // The glasses power-cycle right after the final BES tick, so a session
+                    // whose BES step is the LAST step never gets a follow-up ota_status from
+                    // the glasses — consumers mapping on this synthetic status would otherwise
+                    // never see a terminal state. Emit "complete" for the final step;
+                    // mid-session BES steps keep "step_complete" so session-level trackers
+                    // advance normally. Unknown sessions (cachedOtaTotalSteps == 0, e.g.
+                    // legacy glasses that never sent an ota_status) conservatively keep
+                    // "step_complete".
+                    syntheticStatus = (cachedOtaTotalSteps > 0 && cachedOtaCurrentStep >= cachedOtaTotalSteps)
+                        ? "complete"
+                        : "step_complete"
                 } else if besOtaStatus == "FAILED" {
                     syntheticStatus = "failed"
                 } else {


### PR DESCRIPTION
## Problem

`MentraLive` maps the BES `sr_adota` FINISHED tick to a synthetic `ota_status` with status `step_complete` — emitted moments before the glasses power-cycle for the BES firmware swap. For a session whose **BES step is the last step**, no follow-up `ota_status` ever arrives after the reboot (the session context died with the power cycle), so consumers tracking the synthetic status stream never see a terminal state: the last thing they observe is `step_complete` at 100%.

The example app was recently taught to tolerate the reboot heuristically; this fixes the signal at the source for every other SDK consumer.

## Change

When the cached OTA session context says the BES step is the final one (`cachedOtaCurrentStep >= cachedOtaTotalSteps`), map FINISHED to **`complete`** instead of `step_complete`.

- Mid-session BES steps (e.g. `bes` followed by `apk`) keep `step_complete`, so session-level trackers advance normally.
- Sessions with no cached context (`cachedOtaTotalSteps == 0`, e.g. legacy glasses that never sent an `ota_status`) conservatively keep the old `step_complete` behavior.
- Applied to both the Android (`MentraLive.kt`) and iOS (`MentraLive.swift`) mappings, which mirror each other line-for-line.

## Test evidence

- `scripts/check-android-compile.sh bluetooth-sdk` passes.
- The failure mode (BES-final pass ends on `step_complete`, then silence through the power-cycle) was observed on hardware during the Mentra Live OTA investigation; an on-device BES-final OTA run is the definitive end-to-end check for the new mapping.

## Notes for reviewers

- One of several independent pick-and-choose PRs from the wifi/OTA latency investigation (#3458, #3459, #3460).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow OTA status mapping change with conservative fallback when session metadata is missing; no auth or data-path impact.
> 
> **Overview**
> **`MentraLive`** on Android and iOS now maps a BES `sr_adota` **FINISHED** tick to synthetic **`complete`** when cached session metadata shows the BES step is the **last** step (`cachedOtaCurrentStep >= cachedOtaTotalSteps` and `cachedOtaTotalSteps > 0`). Previously every FINISHED tick used **`step_complete`**, which left BES-final sessions stuck without a terminal status after the glasses power-cycle.
> 
> Mid-session BES steps still emit **`step_complete`**. Sessions with no cached step count (`cachedOtaTotalSteps == 0`) keep **`step_complete`** for backward compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f361f3a9aeefdeb33338272f27f1a4bd6e78f86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->