### PR TITLE
Bluetooth SDK: harden BLE wire v2 negotiation triggers and retry

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -788,16 +788,12 @@ class MentraLive : SGCManager() {
         val isEqual = state == connectionState
         if (isEqual) {
             if (state == ConnTypes.DISCONNECTED) {
-                incomingChunkReassembler.clear()
-                peerWireProtocolVersion = 0
-                useBinaryWireProtocol = false
-                wireHandshakeQueued = false
-                wireHandshakeAttempts = 0
-                wireSessionGeneration++
-                peerK900Le = false
-                peerWireCapsBinary = false
-                peerFilePayloadV2 = false
-                BleJsonCompact.resetSession()
+                resetWireNegotiationState()
+                // Queued writes are session-bound: transmitting them into the NEXT session
+                // (e.g. a stale handshake whose reply activates v2 before the new session
+                // negotiated) is the bug class this clear removes. Higher layers re-send
+                // what still matters via their own ACK/retry tracking.
+                sendQueue.clear()
             }
             return
         }
@@ -825,16 +821,9 @@ class MentraLive : SGCManager() {
             DeviceStore.apply("glasses", "connected", false)
             DeviceStore.apply("glasses", "signalStrength", -1)
             DeviceStore.apply("glasses", "signalStrengthUpdatedAt", 0L)
-            incomingChunkReassembler.clear()
-            peerWireProtocolVersion = 0
-            useBinaryWireProtocol = false
-            wireHandshakeQueued = false
-            wireHandshakeAttempts = 0
-            wireSessionGeneration++
-            peerK900Le = false
-            peerWireCapsBinary = false
-            peerFilePayloadV2 = false
-            BleJsonCompact.resetSession()
+            resetWireNegotiationState()
+            sendQueue.clear() // see the disconnect reset above: stale writes die with the session
+
             // Drop OTA caches when fully disconnected — avoids leaking session/step state
             // from a previous pairing into the next one.
             resetOtaCache()
@@ -3504,10 +3493,12 @@ class MentraLive : SGCManager() {
                 // Glasses SOC has booted and is ready for communication
                 Bridge.log("LIVE: 🎉 Received glasses_ready message - SOC is booted and ready!")
 
-                // Negotiate wire capabilities advertised in the glasses_ready handshake.
-                // Also attempt the v2 handshake here: when the glasses' service restarts
-                // mid-session (OTA install, crash restart) the build number is already
-                // known, and glasses_ready is the message that re-advertises the caps.
+                // glasses_ready is a REMOTE wire-session reset: the glasses ran
+                // onTransportReset() before sending it, so their side is back on legacy
+                // framing regardless of what this side negotiated earlier. Start a fresh
+                // wire epoch (clears v2-active state that would otherwise gate the
+                // handshake off), then negotiate from the caps this message advertises.
+                resetWireNegotiationState()
                 parsePeerWireCaps(json)
                 maybeSendWireHandshake()
 
@@ -7186,6 +7177,27 @@ class MentraLive : SGCManager() {
      * negotiated per-link endianness and binary support. Missing wire_caps leaves the legacy
      * defaults (BE, no binary) untouched so older glasses keep working.
      */
+    /**
+     * Drop every negotiated wire-session artifact and bump the session generation so
+     * scheduled callbacks from the old session stand down. Called on BLE disconnect and on
+     * glasses_ready: the glasses run onTransportReset() before sending glasses_ready, so a
+     * mid-link ASG restart (no BLE disconnect) resets THEIR side to legacy framing - the
+     * phone must treat every glasses_ready as a new wire epoch and renegotiate (bounded by
+     * the per-session handshake attempt cap) instead of trusting stale v2-active state.
+     */
+    private fun resetWireNegotiationState() {
+        incomingChunkReassembler.clear()
+        peerWireProtocolVersion = 0
+        useBinaryWireProtocol = false
+        wireHandshakeQueued = false
+        wireHandshakeAttempts = 0
+        wireSessionGeneration++
+        peerK900Le = false
+        peerWireCapsBinary = false
+        peerFilePayloadV2 = false
+        BleJsonCompact.resetSession()
+    }
+
     private fun parsePeerWireCaps(json: JSONObject) {
         val caps = json.optJSONObject("wire_caps") ?: return
         if (caps.optBoolean("k900_le", false)) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -218,6 +218,9 @@ class MentraLive : SGCManager() {
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
     private var wireHandshakeAttempts = 0
+    // Bumped on every BLE session reset; scheduled handshake-retry callbacks capture it
+    // and no-op if the session changed, so a timer from a dead session can't poke a new one.
+    private var wireSessionGeneration = 0
     // Negotiated K900 STRING length endianness for the phone<->glasses BLE link. Defaults to
     // legacy big-endian; upgraded to little-endian only when the glasses advertise wire_caps.k900_le
     // (or a v2 binary handshake succeeds, which implies wire-v2 LE).
@@ -790,6 +793,7 @@ class MentraLive : SGCManager() {
                 useBinaryWireProtocol = false
                 wireHandshakeQueued = false
                 wireHandshakeAttempts = 0
+                wireSessionGeneration++
                 peerK900Le = false
                 peerWireCapsBinary = false
                 peerFilePayloadV2 = false
@@ -826,6 +830,7 @@ class MentraLive : SGCManager() {
             useBinaryWireProtocol = false
             wireHandshakeQueued = false
             wireHandshakeAttempts = 0
+            wireSessionGeneration++
             peerK900Le = false
             peerWireCapsBinary = false
             peerFilePayloadV2 = false
@@ -7260,9 +7265,11 @@ class MentraLive : SGCManager() {
             // so a peer that advertises binary but never answers doesn't get pinged
             // forever (later caps/version triggers may still retry explicitly).
             wireHandshakeAttempts++
+            val scheduledGeneration = wireSessionGeneration
             handler.postDelayed(
                     {
-                        if (wireHandshakeQueued &&
+                        if (scheduledGeneration == wireSessionGeneration &&
+                                        wireHandshakeQueued &&
                                         peerWireProtocolVersion < BleWireProtocol.PROTOCOL_V2
                         ) {
                             Bridge.log(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -218,6 +218,11 @@ class MentraLive : SGCManager() {
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
     private var wireHandshakeAttempts = 0
+    // Session generation in which the LAST outgoing v2 handshake was sent. A handshake
+    // reply only activates v2 when it answers a handshake from the CURRENT epoch - a
+    // stale handshake that survived in flight across an epoch reset must not flip the
+    // new session to v2 before it negotiated its own build and capabilities.
+    private var wireHandshakeSentGeneration = -1
     // Bumped on every BLE session reset; scheduled handshake-retry callbacks capture it
     // and no-op if the session changed, so a timer from a dead session can't poke a new one.
     private var wireSessionGeneration = 0
@@ -7196,6 +7201,7 @@ class MentraLive : SGCManager() {
         peerWireCapsBinary = false
         peerFilePayloadV2 = false
         BleJsonCompact.resetSession()
+        wireHandshakeSentGeneration = -1
     }
 
     private fun parsePeerWireCaps(json: JSONObject) {
@@ -7269,6 +7275,7 @@ class MentraLive : SGCManager() {
                     )
             Bridge.log("LIVE: Sending BLE wire v2 handshake")
             wireHandshakeQueued = true
+            wireHandshakeSentGeneration = wireSessionGeneration
             queueData(packed, null)
             // The handshake and its reply are fire-and-forget binary frames with no ACK
             // tracking; if either is lost, wireHandshakeQueued would block every future
@@ -7317,6 +7324,10 @@ class MentraLive : SGCManager() {
     }
 
     private fun handlePeerWireHandshake() {
+        if (wireHandshakeSentGeneration != wireSessionGeneration) {
+            Bridge.log("LIVE: Ignoring wire v2 handshake reply from a previous session epoch")
+            return
+        }
         activateBinaryWireV2Session("LIVE: Peer confirmed BLE wire protocol v2")
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -146,6 +146,10 @@ class MentraLive : SGCManager() {
 
         // Heartbeat parameters
         private const val HEARTBEAT_INTERVAL_MS = 30000 // 30 seconds
+        // Grace period before an unanswered BLE wire v2 handshake is re-armed for retry,
+        // and the per-session cap on automatic retries (see sendWireHandshake).
+        private const val WIRE_HANDSHAKE_RETRY_GRACE_MS = 5000L
+        private const val WIRE_HANDSHAKE_MAX_ATTEMPTS = 3
         private const val BATTERY_REQUEST_EVERY_N_HEARTBEATS = 10 // Every 10 heartbeats (5 minutes)
         private const val RSSI_READ_INTERVAL_MS = 10000L // 10 seconds
 
@@ -213,6 +217,7 @@ class MentraLive : SGCManager() {
     private var peerWireProtocolVersion = 0
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
+    private var wireHandshakeAttempts = 0
     // Negotiated K900 STRING length endianness for the phone<->glasses BLE link. Defaults to
     // legacy big-endian; upgraded to little-endian only when the glasses advertise wire_caps.k900_le
     // (or a v2 binary handshake succeeds, which implies wire-v2 LE).
@@ -784,6 +789,7 @@ class MentraLive : SGCManager() {
                 peerWireProtocolVersion = 0
                 useBinaryWireProtocol = false
                 wireHandshakeQueued = false
+                wireHandshakeAttempts = 0
                 peerK900Le = false
                 peerWireCapsBinary = false
                 peerFilePayloadV2 = false
@@ -819,6 +825,7 @@ class MentraLive : SGCManager() {
             peerWireProtocolVersion = 0
             useBinaryWireProtocol = false
             wireHandshakeQueued = false
+            wireHandshakeAttempts = 0
             peerK900Le = false
             peerWireCapsBinary = false
             peerFilePayloadV2 = false
@@ -3493,7 +3500,11 @@ class MentraLive : SGCManager() {
                 Bridge.log("LIVE: 🎉 Received glasses_ready message - SOC is booted and ready!")
 
                 // Negotiate wire capabilities advertised in the glasses_ready handshake.
+                // Also attempt the v2 handshake here: when the glasses' service restarts
+                // mid-session (OTA install, crash restart) the build number is already
+                // known, and glasses_ready is the message that re-advertises the caps.
                 parsePeerWireCaps(json)
+                maybeSendWireHandshake()
 
                 // Set the ready flag to stop any future readiness checks
                 glassesReady = true
@@ -3884,8 +3895,6 @@ class MentraLive : SGCManager() {
                             val buildNumInt = Integer.parseInt(buildNum)
                             buildNumberInt = buildNumInt
                             Bridge.log("LIVE: Parsed build number as integer: " + buildNumInt)
-                            parsePeerWireCaps(json)
-                            maybeSendWireHandshake()
                         } catch (e: NumberFormatException) {
                             buildNumberInt = 0
                             Log.e(TAG, "Failed to parse build number as integer: " + buildNum)
@@ -3952,6 +3961,16 @@ class MentraLive : SGCManager() {
                             DeviceStore.apply("glasses", "systemTimeMs", v.toLong())
                         }
                     }
+
+                    // Negotiate wire caps from ANY version_info chunk, not only the one
+                    // carrying build_number: the glasses put wire_caps in version_info_3
+                    // (firmware chunk) while build_number travels in version_info_1, so
+                    // gating negotiation on build_number silently discards the caps.
+                    // parsePeerWireCaps no-ops without a wire_caps key and
+                    // maybeSendWireHandshake gates on caps + build + not-yet-queued, so
+                    // running them per chunk is safe.
+                    parsePeerWireCaps(json)
+                    maybeSendWireHandshake()
 
                     Bridge.log("LIVE: Processed version_info fields and sent to RN")
                     Bridge.sendVersionInfo(fields)
@@ -7234,6 +7253,35 @@ class MentraLive : SGCManager() {
             Bridge.log("LIVE: Sending BLE wire v2 handshake")
             wireHandshakeQueued = true
             queueData(packed, null)
+            // The handshake and its reply are fire-and-forget binary frames with no ACK
+            // tracking; if either is lost, wireHandshakeQueued would block every future
+            // attempt and the session would silently stay on the legacy string wire.
+            // Re-arm after a grace period so negotiation can retry, bounded per session
+            // so a peer that advertises binary but never answers doesn't get pinged
+            // forever (later caps/version triggers may still retry explicitly).
+            wireHandshakeAttempts++
+            handler.postDelayed(
+                    {
+                        if (wireHandshakeQueued &&
+                                        peerWireProtocolVersion < BleWireProtocol.PROTOCOL_V2
+                        ) {
+                            Bridge.log(
+                                    "LIVE: BLE wire v2 handshake unanswered after " +
+                                            WIRE_HANDSHAKE_RETRY_GRACE_MS +
+                                            "ms (attempt " +
+                                            wireHandshakeAttempts +
+                                            "/" +
+                                            WIRE_HANDSHAKE_MAX_ATTEMPTS +
+                                            ") - re-arming"
+                            )
+                            wireHandshakeQueued = false
+                            if (wireHandshakeAttempts < WIRE_HANDSHAKE_MAX_ATTEMPTS) {
+                                maybeSendWireHandshake()
+                            }
+                        }
+                    },
+                    WIRE_HANDSHAKE_RETRY_GRACE_MS
+            )
         } catch (e: Exception) {
             Log.e(TAG, "Failed to send wire handshake", e)
         }
@@ -7243,6 +7291,7 @@ class MentraLive : SGCManager() {
         peerWireProtocolVersion = BleWireProtocol.PROTOCOL_V2
         useBinaryWireProtocol = true
         wireHandshakeQueued = false
+        wireHandshakeAttempts = 0
         peerK900Le = true
         BleJsonCompact.markSessionConnected(System.currentTimeMillis())
         Bridge.log(logMessage)

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -3902,8 +3902,12 @@ class MentraLive: NSObject, SGCManager {
 
     func queueSend(_ data: Data, id: String, trace: BleWriteTrace?) {
         let significantQueueSize = SIGNIFICANT_BLE_TRACE_QUEUE_SIZE
+        // Capture the epoch at enqueue-request time: the Task body may run after a
+        // session reset, and a pre-reset payload stamped with the new generation would
+        // defeat the stale-write guard in the drain loop.
+        let generation = wireSessionGeneration
         Task {
-            let queueSize = await commandQueue.enqueue(PendingMessage(data: data, id: id, retries: 0, trace: trace, generation: wireSessionGeneration))
+            let queueSize = await commandQueue.enqueue(PendingMessage(data: data, id: id, retries: 0, trace: trace, generation: generation))
             guard trace != nil, queueSize >= significantQueueSize else {
                 return
             }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1271,6 +1271,7 @@ class MentraLive: NSObject, SGCManager {
             peerWireProtocolVersion = 0
             useBinaryWireProtocol = false
             wireHandshakeQueued = false
+            wireHandshakeAttempts = 0
             peerK900Le = false
             peerWireCapsBinary = false
             peerFilePayloadV2 = false
@@ -1453,6 +1454,11 @@ class MentraLive: NSObject, SGCManager {
     private var peerWireProtocolVersion = 0
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
+    private var wireHandshakeAttempts = 0
+    // Grace period before an unanswered BLE wire v2 handshake is re-armed for retry,
+    // and the per-session cap on automatic retries (see sendWireHandshake).
+    private static let wireHandshakeRetryGraceSeconds: TimeInterval = 5
+    private static let wireHandshakeMaxAttempts = 3
     // Negotiated K900 STRING length endianness for the phone<->glasses BLE link. Defaults to legacy
     // big-endian; upgraded to little-endian only when the glasses advertise wire_caps.k900_le (or a
     // v2 binary handshake succeeds, which implies wire-v2 LE).
@@ -2320,7 +2326,12 @@ class MentraLive: NSObject, SGCManager {
 
         switch type {
         case "glasses_ready":
+            // Negotiate wire capabilities advertised in the glasses_ready handshake.
+            // Also attempt the v2 handshake here: when the glasses' service restarts
+            // mid-session (OTA install, crash restart) the build number is already
+            // known, and glasses_ready is the message that re-advertises the caps.
             parsePeerWireCaps(json)
+            maybeSendWireHandshake()
             handleGlassesReady()
 
         case "battery_status":
@@ -2599,8 +2610,6 @@ class MentraLive: NSObject, SGCManager {
                 if let buildNumber = fields["build_number"] as? String {
                     isNewVersion = (Int(buildNumber) ?? 0) >= 5
                     DeviceStore.shared.apply("glasses", "buildNumber", buildNumber)
-                    parsePeerWireCaps(json)
-                    maybeSendWireHandshake()
                 }
                 if let deviceModel = fields["device_model"] as? String {
                     DeviceStore.shared.apply("glasses", "deviceModel", deviceModel)
@@ -2631,6 +2640,16 @@ class MentraLive: NSObject, SGCManager {
                 if let systemTimeMs = fields["system_time_ms"] as? NSNumber {
                     DeviceStore.shared.apply("glasses", "systemTimeMs", systemTimeMs.int64Value)
                 }
+
+                // Negotiate wire caps from ANY version_info chunk, not only the one
+                // carrying build_number: the glasses put wire_caps in version_info_3
+                // (firmware chunk) while build_number travels in version_info_1, so
+                // gating negotiation on build_number silently discards the caps.
+                // parsePeerWireCaps no-ops without a wire_caps key and
+                // maybeSendWireHandshake gates on caps + build + not-yet-queued, so
+                // running them per chunk is safe.
+                parsePeerWireCaps(json)
+                maybeSendWireHandshake()
 
                 Bridge.sendVersionInfo(fields)
             } else {
@@ -4093,12 +4112,33 @@ class MentraLive: NSObject, SGCManager {
         Bridge.log("LIVE: Sending BLE wire v2 handshake")
         wireHandshakeQueued = true
         queueSend(packed, id: "-1")
+        // The handshake and its reply are fire-and-forget binary frames with no ACK
+        // tracking; if either is lost, wireHandshakeQueued would block every future
+        // attempt and the session would silently stay on the legacy string wire.
+        // Re-arm after a grace period so negotiation can retry, bounded per session
+        // so a peer that advertises binary but never answers doesn't get pinged
+        // forever (later caps/version triggers may still retry explicitly).
+        wireHandshakeAttempts += 1
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.wireHandshakeRetryGraceSeconds) { [weak self] in
+            guard let self else { return }
+            if self.wireHandshakeQueued, self.peerWireProtocolVersion < BleWireProtocol.protocolV2 {
+                Bridge.log(
+                    "LIVE: BLE wire v2 handshake unanswered after \(Self.wireHandshakeRetryGraceSeconds)s " +
+                        "(attempt \(self.wireHandshakeAttempts)/\(Self.wireHandshakeMaxAttempts)) - re-arming"
+                )
+                self.wireHandshakeQueued = false
+                if self.wireHandshakeAttempts < Self.wireHandshakeMaxAttempts {
+                    self.maybeSendWireHandshake()
+                }
+            }
+        }
     }
 
     private func activateBinaryWireV2Session(logMessage: String) {
         peerWireProtocolVersion = BleWireProtocol.protocolV2
         useBinaryWireProtocol = true
         wireHandshakeQueued = false
+        wireHandshakeAttempts = 0
         peerK900Le = true
         BleJsonCompact.markSessionConnected(epochMs: Int64(Date().timeIntervalSince1970 * 1000))
         Bridge.log(logMessage)
@@ -5010,6 +5050,7 @@ class MentraLive: NSObject, SGCManager {
         peerWireProtocolVersion = 0
         useBinaryWireProtocol = false
         wireHandshakeQueued = false
+        wireHandshakeAttempts = 0
         peerK900Le = false
         peerWireCapsBinary = false
         peerFilePayloadV2 = false

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1272,6 +1272,7 @@ class MentraLive: NSObject, SGCManager {
             useBinaryWireProtocol = false
             wireHandshakeQueued = false
             wireHandshakeAttempts = 0
+            wireSessionGeneration += 1
             peerK900Le = false
             peerWireCapsBinary = false
             peerFilePayloadV2 = false
@@ -1455,6 +1456,9 @@ class MentraLive: NSObject, SGCManager {
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
     private var wireHandshakeAttempts = 0
+    // Bumped on every BLE session reset; scheduled handshake-retry callbacks capture it
+    // and no-op if the session changed, so a timer from a dead session can't poke a new one.
+    private var wireSessionGeneration = 0
     // Grace period before an unanswered BLE wire v2 handshake is re-armed for retry,
     // and the per-session cap on automatic retries (see sendWireHandshake).
     private static let wireHandshakeRetryGraceSeconds: TimeInterval = 5
@@ -4119,8 +4123,10 @@ class MentraLive: NSObject, SGCManager {
         // so a peer that advertises binary but never answers doesn't get pinged
         // forever (later caps/version triggers may still retry explicitly).
         wireHandshakeAttempts += 1
+        let scheduledGeneration = wireSessionGeneration
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.wireHandshakeRetryGraceSeconds) { [weak self] in
             guard let self else { return }
+            guard scheduledGeneration == self.wireSessionGeneration else { return }
             if self.wireHandshakeQueued, self.peerWireProtocolVersion < BleWireProtocol.protocolV2 {
                 Bridge.log(
                     "LIVE: BLE wire v2 handshake unanswered after \(Self.wireHandshakeRetryGraceSeconds)s " +
@@ -5051,6 +5057,7 @@ class MentraLive: NSObject, SGCManager {
         useBinaryWireProtocol = false
         wireHandshakeQueued = false
         wireHandshakeAttempts = 0
+        wireSessionGeneration += 1
         peerK900Le = false
         peerWireCapsBinary = false
         peerFilePayloadV2 = false

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1451,6 +1451,10 @@ class MentraLive: NSObject, SGCManager {
     private var useBinaryWireProtocol = false
     private var wireHandshakeQueued = false
     private var wireHandshakeAttempts = 0
+    // Session generation in which the LAST outgoing v2 handshake was sent; a reply only
+    // activates v2 when it answers a handshake from the CURRENT epoch (see PendingMessage
+    // .generation for the queue-side guard).
+    private var wireHandshakeSentGeneration = -1
     // Bumped on every BLE session reset; scheduled handshake-retry callbacks capture it
     // and no-op if the session changed, so a timer from a dead session can't poke a new one.
     private var wireSessionGeneration = 0
@@ -1824,17 +1828,24 @@ class MentraLive: NSObject, SGCManager {
     // MARK: - Command Queue
 
     class PendingMessage {
-        init(data: Data, id: String, retries: Int, trace: BleWriteTrace? = nil) {
+        init(data: Data, id: String, retries: Int, trace: BleWriteTrace? = nil, generation: Int = 0) {
             self.data = data
             self.id = id
             self.retries = retries
             self.trace = trace
+            self.generation = generation
         }
 
         let data: Data
         let retries: Int
         let id: String
         let trace: BleWriteTrace?
+        // Wire-session generation at enqueue time; the drain loop drops entries from a
+        // previous session so a stale write (worst case: an old handshake whose reply
+        // would activate v2 pre-negotiation) can never cross a session boundary. This is
+        // the deterministic guard - the async removeAll() on disconnect is best-effort
+        // cleanup that may land after a reconnect has already resumed the drain loop.
+        let generation: Int
     }
 
     struct OutgoingBleCommandTraceInfo {
@@ -1893,7 +1904,12 @@ class MentraLive: NSObject, SGCManager {
                 let pendingIsNil = await MainActor.run { self.pending == nil }
                 if pendingIsNil {
                     if let command = await self.commandQueue.dequeue() {
-                        await self.processSendQueue(command)
+                        let currentGeneration = await MainActor.run { self.wireSessionGeneration }
+                        if command.generation != currentGeneration {
+                            Bridge.log("LIVE: Dropping stale queued write from a previous session epoch (id: \(command.id))")
+                        } else {
+                            await self.processSendQueue(command)
+                        }
                     }
                 }
                 try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
@@ -1969,7 +1985,8 @@ class MentraLive: NSObject, SGCManager {
                 data: pendingMessage.data,
                 id: pendingMessage.id,
                 retries: pendingMessage.retries + 1,
-                trace: pendingMessage.trace
+                trace: pendingMessage.trace,
+                generation: pendingMessage.generation
             )
 
             // Push to front of queue for immediate retry
@@ -3886,7 +3903,7 @@ class MentraLive: NSObject, SGCManager {
     func queueSend(_ data: Data, id: String, trace: BleWriteTrace?) {
         let significantQueueSize = SIGNIFICANT_BLE_TRACE_QUEUE_SIZE
         Task {
-            let queueSize = await commandQueue.enqueue(PendingMessage(data: data, id: id, retries: 0, trace: trace))
+            let queueSize = await commandQueue.enqueue(PendingMessage(data: data, id: id, retries: 0, trace: trace, generation: wireSessionGeneration))
             guard trace != nil, queueSize >= significantQueueSize else {
                 return
             }
@@ -4116,6 +4133,7 @@ class MentraLive: NSObject, SGCManager {
         }
         Bridge.log("LIVE: Sending BLE wire v2 handshake")
         wireHandshakeQueued = true
+        wireHandshakeSentGeneration = wireSessionGeneration
         queueSend(packed, id: "-1")
         // The handshake and its reply are fire-and-forget binary frames with no ACK
         // tracking; if either is lost, wireHandshakeQueued would block every future
@@ -4152,6 +4170,10 @@ class MentraLive: NSObject, SGCManager {
     }
 
     private func handlePeerWireHandshake() {
+        if wireHandshakeSentGeneration != wireSessionGeneration {
+            Bridge.log("LIVE: Ignoring wire v2 handshake reply from a previous session epoch")
+            return
+        }
         activateBinaryWireV2Session(logMessage: "LIVE: Peer confirmed BLE wire protocol v2")
     }
 
@@ -5164,6 +5186,7 @@ extension MentraLive {
         peerWireCapsBinary = false
         peerFilePayloadV2 = false
         BleJsonCompact.resetSession()
+        wireHandshakeSentGeneration = -1
     }
 
     private func parsePeerWireCaps(_ json: [String: Any]) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1267,16 +1267,11 @@ class MentraLive: NSObject, SGCManager {
         // a previous pairing into the next one (would otherwise surface as wrong overall_percent
         // or stale lastBesOtaProgress on the next OTA).
         if state == ConnTypes.DISCONNECTED {
-            incomingChunkReassembler.clear()
-            peerWireProtocolVersion = 0
-            useBinaryWireProtocol = false
-            wireHandshakeQueued = false
-            wireHandshakeAttempts = 0
-            wireSessionGeneration += 1
-            peerK900Le = false
-            peerWireCapsBinary = false
-            peerFilePayloadV2 = false
-            BleJsonCompact.resetSession()
+            resetWireNegotiationState()
+            // Queued writes are session-bound: transmitting them into the NEXT session
+            // (e.g. a stale handshake whose reply activates v2 before the new session
+            // negotiated) is the bug class this clear removes.
+            Task { await commandQueue.removeAll() }
             stopSignalStrengthPolling()
             DeviceStore.shared.apply("glasses", "signalStrength", -1)
             DeviceStore.shared.apply("glasses", "signalStrengthUpdatedAt", 0)
@@ -1885,6 +1880,10 @@ class MentraLive: NSObject, SGCManager {
             guard !commands.isEmpty else { return nil }
             return commands.removeFirst()
         }
+
+        func removeAll() {
+            commands.removeAll()
+        }
     }
 
     private func setupCommandQueue() {
@@ -2330,10 +2329,12 @@ class MentraLive: NSObject, SGCManager {
 
         switch type {
         case "glasses_ready":
-            // Negotiate wire capabilities advertised in the glasses_ready handshake.
-            // Also attempt the v2 handshake here: when the glasses' service restarts
-            // mid-session (OTA install, crash restart) the build number is already
-            // known, and glasses_ready is the message that re-advertises the caps.
+            // glasses_ready is a REMOTE wire-session reset: the glasses ran
+            // onTransportReset() before sending it, so their side is back on legacy
+            // framing regardless of what this side negotiated earlier. Start a fresh
+            // wire epoch (clears v2-active state that would otherwise gate the
+            // handshake off), then negotiate from the caps this message advertises.
+            resetWireNegotiationState()
             parsePeerWireCaps(json)
             maybeSendWireHandshake()
             handleGlassesReady()
@@ -5052,16 +5053,8 @@ class MentraLive: NSObject, SGCManager {
 
         // Stop all timers
         stopAllTimers()
-        incomingChunkReassembler.clear()
-        peerWireProtocolVersion = 0
-        useBinaryWireProtocol = false
-        wireHandshakeQueued = false
-        wireHandshakeAttempts = 0
-        wireSessionGeneration += 1
-        peerK900Le = false
-        peerWireCapsBinary = false
-        peerFilePayloadV2 = false
-        BleJsonCompact.resetSession()
+        resetWireNegotiationState()
+        Task { await commandQueue.removeAll() } // stale writes die with the session
         closeL2capFileChannel()
 
         // Disconnect BLE
@@ -5154,6 +5147,25 @@ extension MentraLive {
      * per-link endianness and binary support. Missing wire_caps leaves the legacy defaults (BE, no
      * binary) untouched so older glasses keep working.
      */
+    /// Drop every negotiated wire-session artifact and bump the session generation so
+    /// scheduled callbacks from the old session stand down. Called on BLE disconnect and on
+    /// glasses_ready: the glasses run onTransportReset() before sending glasses_ready, so a
+    /// mid-link ASG restart (no BLE disconnect) resets THEIR side to legacy framing - the
+    /// phone must treat every glasses_ready as a new wire epoch and renegotiate (bounded by
+    /// the per-session handshake attempt cap) instead of trusting stale v2-active state.
+    private func resetWireNegotiationState() {
+        incomingChunkReassembler.clear()
+        peerWireProtocolVersion = 0
+        useBinaryWireProtocol = false
+        wireHandshakeQueued = false
+        wireHandshakeAttempts = 0
+        wireSessionGeneration += 1
+        peerK900Le = false
+        peerWireCapsBinary = false
+        peerFilePayloadV2 = false
+        BleJsonCompact.resetSession()
+    }
+
     private func parsePeerWireCaps(_ json: [String: Any]) {
         guard let caps = json["wire_caps"] as? [String: Any] else { return }
         if (caps["k900_le"] as? Bool) == true {


### PR DESCRIPTION
## Background

While investigating wifi latency on Mentra Live with live traces (example app + BES 17.26.7.20), we mapped the full BLE wire v2 negotiation and found it works — the BES answers the phone's handshake itself and translates v2 binary frames to K900 string frames on the UART leg — but the SDK-side triggering is fragile in ways that fail **silently**: a session that misses its one negotiation window stays on the legacy string wire with no log or status anywhere.

## Three gaps, three fixes (Android + iOS, which mirror each other)

**1. `wire_caps` arriving in `version_info_3` were never parsed.**
The flexible `version_info*` parser only called `parsePeerWireCaps` inside its `build_number` branch — but the glasses put `wire_caps` in `version_info_3` (firmware chunk) while `build_number` travels in `version_info_1`. The caps that travel with the version exchange were silently discarded, leaving `glasses_ready` as the only real caps source. Now every `version_info` chunk parses caps and attempts the handshake; `parsePeerWireCaps` no-ops without a `wire_caps` key and `maybeSendWireHandshake` gates on caps + build + not-yet-queued, so per-chunk calls are idempotent.

**2. `glasses_ready` parsed caps but never attempted the handshake.**
If the build number is already known when caps (re-)arrive — e.g. the asg service restarts mid-session after an OTA install or a crash, and `glasses_ready` re-advertises the caps — no trigger was left to negotiate. `glasses_ready` now calls `maybeSendWireHandshake()` after parsing caps.

**3. The handshake was one-shot with no retry.**
`wireHandshakeQueued` was cleared only on success or full BLE disconnect, and the handshake + reply are fire-and-forget binary frames with **no ACK tracking** — one lost frame stranded the session on the legacy wire forever, silently. The flag now re-arms after a 5s grace period and retries, capped at **3 automatic attempts per session** (counter resets on disconnect and on activation) so a peer that advertises binary but never answers doesn't get pinged forever. Each re-arm logs, so a stuck negotiation is finally visible.

## Impact

Legacy string framing is fully functional (it's what v39-era pairings use), so these gaps cost the v2 wins (compact JSON framing, LE lengths) rather than correctness — which is exactly why they've been invisible. Fixing the triggers makes negotiation robust to chunk ordering, service restarts, and single lost frames.

## Test evidence

- `scripts/check-android-compile.sh bluetooth-sdk` passes.
- Gap 1 and the silent-stall behavior were observed on hardware during the investigation (glasses advertising `binary:true, proto:2` in `version_info_3`, phone never negotiating within that exchange). iOS mirrors the Android logic line-for-line and needs a CI/Xcode pass.
- Suggested on-device check: connect the example app to July-firmware glasses and confirm `BLE_TRACE ... proto=v2` wire metrics in the Console tab after the version exchange, then restart the asg service mid-session (adb reinstall) and confirm renegotiation on the next `glasses_ready`.

## Notes for reviewers

- One of several independent pick-and-choose PRs from the wifi/OTA latency investigation (#3458, #3459, #3460, #3461). Lowest urgency of the set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BLE framing negotiation and send-queue lifecycle on both platforms; mistakes could affect protocol selection or drop in-flight writes, though legacy wire remains the fallback.
> 
> **Overview**
> **Hardens Mentra Live BLE wire v2 negotiation** on Android and iOS so sessions are less likely to stay on the legacy string wire without any visible failure.
> 
> **Negotiation triggers:** `wire_caps` are now parsed and `maybeSendWireHandshake()` runs on **every** `version_info*` chunk (not only when `build_number` arrives), fixing caps that live in `version_info_3` while build number is in `version_info_1`. **`glasses_ready`** is treated as a remote wire-session reset: negotiation state is cleared, caps are re-parsed, and the handshake is attempted again after mid-link ASG restarts.
> 
> **Retries and session safety:** Unanswered v2 handshakes **re-arm after 5s**, up to **3 attempts per session**, with logging when re-arming. A shared **`resetWireNegotiationState()`** bumps **`wireSessionGeneration`** and clears v2/caps state on disconnect, kill, and `glasses_ready`; handshake replies from a prior epoch are ignored. **Outbound queues** are cleared on disconnect (Android `sendQueue`; iOS `commandQueue.removeAll()`), and iOS queued writes carry a **generation** stamp so stale payloads cannot drain into a new session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dec86b6432bc1fae311d338fc7b96c6588cf2d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->