### PR TITLE
Add swappable text ROI detector pipeline

### DIFF
--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -382,6 +382,9 @@ dependencies {
     //location services
     implementation 'com.google.android.gms:play-services-location:18.0.0'
 
+    // Bundled/offline text localization for Mentra Live text-mode photos.
+    implementation 'com.google.mlkit:text-recognition:16.0.1'
+
     //websocket
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
 

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -255,6 +255,18 @@ android {
                 if (textDetectOutputDir != null) {
                     systemProperty 'textdetect.outputDir', textDetectOutputDir
                 }
+                [
+                    'textroi.inputDir',
+                    'textroi.outputDir',
+                    'textroi.modelDir',
+                    'textroi.detectors',
+                    'textroi.bleBytesPerSecond'
+                ].each { propertyName ->
+                    def propertyValue = System.getProperty(propertyName)
+                    if (propertyValue != null) {
+                        systemProperty propertyName, propertyValue
+                    }
+                }
             }
         }
     }
@@ -347,6 +359,8 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0'
     // Desktop OpenCV natives for offline text-detect harness (JVM unit tests on dev machine)
     testImplementation 'org.openpnp:opencv:4.9.0-0'
+    // Desktop ONNX Runtime for the swappable text-ROI benchmark harness.
+    testImplementation 'com.microsoft.onnxruntime:onnxruntime:1.27.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test:runner:1.5.2'
     androidTestImplementation 'androidx.test:rules:1.5.0'
@@ -388,6 +402,8 @@ dependencies {
     
     // OpenCV for BLE text-region detection (adaptive threshold, morphology, connected components)
     implementation 'org.opencv:opencv:4.13.0'
+    // Detection-only text models used before BLE encoding. Sessions are cached for service life.
+    implementation 'com.microsoft.onnxruntime:onnxruntime-android:1.27.0'
 
     // AVIF encoding/decoding support
     implementation 'com.github.awxkee:avif-coder:1.7.3'

--- a/asg_client/app/build.gradle
+++ b/asg_client/app/build.gradle
@@ -74,6 +74,25 @@ def asgVersionNameValue = (
 ).toString()
 
 /**
+ * Whether to package the ONNX Runtime Android native libraries (used only by the optional
+ * PP-OCR/FAST/EAST/YOLO text-ROI detectors) into this build's APK. Off by default: the shipped
+ * text-crop path uses the classical detector or bundled ML Kit, neither of which needs ONNX
+ * Runtime, and no .onnx model is committed to this repo (see docs/agents/TEXTROI_MODELS.md).
+ * Bundling ONNX Runtime's native libraries unconditionally would grow every default APK/AAB by
+ * its full multi-ABI native-library size for a code path that never executes.
+ *
+ * Enable only for local/CI builds that actually exercise an ONNX detector, e.g.:
+ *   ./gradlew assembleDebug -PenableTextRoiOnnx=true
+ * or with ENABLE_TEXT_ROI_ONNX=true in the environment.
+ */
+def enableTextRoiOnnx = (
+        project.findProperty("enableTextRoiOnnx") ?: System.getenv("ENABLE_TEXT_ROI_ONNX")
+)?.toString()?.toBoolean() ?: false
+logger.lifecycle(
+        "Text-ROI ONNX Runtime native libraries: "
+                + (enableTextRoiOnnx ? "INCLUDED (-PenableTextRoiOnnx=true)" : "excluded (default)"))
+
+/**
  * Release signing credentials from environment variables
  */
 def asgStorePassword = project.hasProperty("ASG_STORE_PASSWORD") ? project.property("ASG_STORE_PASSWORD") : ""
@@ -405,8 +424,17 @@ dependencies {
     
     // OpenCV for BLE text-region detection (adaptive threshold, morphology, connected components)
     implementation 'org.opencv:opencv:4.13.0'
+
     // Detection-only text models used before BLE encoding. Sessions are cached for service life.
-    implementation 'com.microsoft.onnxruntime:onnxruntime-android:1.27.0'
+    // compileOnly always makes the ai.onnxruntime API resolvable so the ONNX detector classes
+    // compile in every build; it does NOT package the native libraries. Only the opt-in
+    // enableTextRoiOnnx build additionally packages the real runtime. TextRoiDetectorFactory
+    // already catches LinkageError/NoClassDefFoundError and falls back to the classical
+    // detector, so a build without the real runtime present is safe by construction.
+    compileOnly 'com.microsoft.onnxruntime:onnxruntime-android:1.27.0'
+    if (enableTextRoiOnnx) {
+        implementation 'com.microsoft.onnxruntime:onnxruntime-android:1.27.0'
+    }
 
     // AVIF encoding/decoding support
     implementation 'com.github.awxkee:avif-coder:1.7.3'

--- a/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorBenchmarkTest.java
+++ b/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorBenchmarkTest.java
@@ -1,0 +1,50 @@
+package com.mentra.asg_client.io.media.core.textdetect;
+
+import static org.junit.Assert.assertNotNull;
+
+import android.util.Log;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import java.io.File;
+import java.nio.file.Files;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Manual MT8766 benchmark. Push a sensor JPEG to /sdcard/Download/mlkit-benchmark.jpg first. */
+@RunWith(AndroidJUnit4.class)
+public class MlKitTextRoiDetectorBenchmarkTest {
+    private static final String TAG = "MLKIT_BENCH";
+
+    @Test
+    public void benchmarkAnalysisSizes() throws Exception {
+        File input = new File("/sdcard/Download/mlkit-benchmark.jpg");
+        byte[] jpeg = Files.readAllBytes(input.toPath());
+        assertNotNull(jpeg);
+
+        for (int longEdge : new int[] {480, 640, 800, 960, 1280}) {
+            try (MlKitTextRoiDetector detector = new MlKitTextRoiDetector(longEdge)) {
+                detector.warmUp();
+                for (int run = 1; run <= 3; run++) {
+                    MlKitTextRoiDetector.Detection result = detector.detect(jpeg);
+                    Log.i(
+                            TAG,
+                            "edge="
+                                    + longEdge
+                                    + " run="
+                                    + run
+                                    + " elapsedMs="
+                                    + result.elapsedMs
+                                    + " lines="
+                                    + result.lineCount
+                                    + " reason="
+                                    + result.reason
+                                    + " analysis="
+                                    + result.analysisWidth
+                                    + "x"
+                                    + result.analysisHeight
+                                    + " roi="
+                                    + (result.roi != null ? result.roi.toShortString() : "full"));
+                }
+            }
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -1,5 +1,7 @@
 package com.mentra.asg_client;
 
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
+
 public class AsgConstants {
     public static String appName = "AugmentOS ASG Client";
     public static int augmentOsSdkVerion = 1;
@@ -74,6 +76,12 @@ public class AsgConstants {
      * mode == "text"}.
      */
     public static final boolean ENABLE_TEXT_REGION_CROP = false;
+
+    /** Use the selected ONNX text detector instead of the classical OpenCV detector. */
+    public static final boolean ENABLE_MODEL_TEXT_CROP = false;
+
+    /** Text-region detector selected when {@link #ENABLE_MODEL_TEXT_CROP} is enabled. */
+    public static final TextCropModel TEXT_CROP_MODEL = TextCropModel.PPOCR_V5_MOBILE_DET;
 
     /**
      * Dump text-detect intermediates to {@code textdetect_debug/} on every detection run. Adds

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -81,7 +81,39 @@ public class AsgConstants {
     public static final boolean ENABLE_MODEL_TEXT_CROP = false;
 
     /** Text-region detector selected when {@link #ENABLE_MODEL_TEXT_CROP} is enabled. */
-    public static final TextCropModel TEXT_CROP_MODEL = TextCropModel.PPOCR_V5_MOBILE_DET;
+    public static final TextCropModel TEXT_CROP_MODEL = TextCropModel.ML_KIT;
+
+    /** Long-edge size used for on-glasses ML Kit text localization. */
+    // 1280 is the smallest tested size that consistently retained stylized/low-contrast label
+    // text on real 4032x3024 Mentra Live captures while remaining below the 1s detector budget.
+    public static final int TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE = 1280;
+
+    /** Minimum source-pixel padding around the union of ML Kit text lines. */
+    public static final int TEXT_MODE_MLKIT_MIN_PADDING_PX = 32;
+
+    /** Horizontal padding relative to the detected text-union width. */
+    public static final float TEXT_MODE_MLKIT_PADDING_X_FRACTION = 0.12f;
+
+    /** Vertical padding relative to the detected text-union height. */
+    public static final float TEXT_MODE_MLKIT_PADDING_Y_FRACTION = 0.25f;
+
+    // A lone OCR line is weak evidence for the complete text-bearing object. Keep generous
+    // surrounding context so a small conventional label can pull in nearby stylized text that
+    // the recognizer did not box (validated on curved product labels).
+    public static final float TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_X_HEIGHTS = 3f;
+    public static final float TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_TOP_HEIGHTS = 4f;
+    public static final float TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_BOTTOM_HEIGHTS = 11f;
+
+    /** Hard timeout for one local ML Kit request; failure preserves the full frame. */
+    public static final long TEXT_MODE_MLKIT_TIMEOUT_MS = 5000L;
+
+    /**
+     * Max wait for the deferred background photo write ({@code CapturedPhoto.persistence}) when a
+     * BLE photo consumer needs the file on disk (gallery save, text-mode canonical crop, cleanup).
+     * Generous: the write runs concurrently with capture-to-transfer work and normally finishes
+     * long before anyone awaits it.
+     */
+    public static final long BLE_PHOTO_PERSISTENCE_AWAIT_TIMEOUT_MS = 10_000;
 
     /**
      * Dump text-detect intermediates to {@code textdetect_debug/} on every detection run. Adds

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -91,8 +91,8 @@ public class AsgConstants {
 
     /**
      * Emit {@code ⏱️ [BLE PHOTO]} timing logs for the full take_photo → AVIF/JPEG compress → BLE
-     * transfer pipeline. Filter logcat on tag {@code BlePhotoTiming} or prefix {@code ⏱️ [BLE PHOTO]}.
-     * Keep false in production.
+     * transfer pipeline. Filter logcat on tag {@code BlePhotoTiming} or prefix {@code ⏱️ [BLE
+     * PHOTO]}. Keep false in production.
      */
     public static final boolean ENABLE_PHOTO_TIMING_LOGS = true;
 
@@ -116,7 +116,9 @@ public class AsgConstants {
      */
     public static final String BLE_PHOTO_CODEC = "JPEG_FAST";
 
-    /** JPEG quality for all BLE photo payloads when {@link #BLE_PHOTO_CODEC} is {@code JPEG_FAST}. */
+    /**
+     * JPEG quality for all BLE photo payloads when {@link #BLE_PHOTO_CODEC} is {@code JPEG_FAST}.
+     */
     public static final int BLE_PHOTO_JPEG_FAST_QUALITY = 80;
 
     // BLE size-tier downscale caps (long edge; aspect ratio preserved) and AVIF quality

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -29,9 +29,9 @@ import com.mentra.asg_client.camera.lifecycle.CameraServiceNotification;
 import com.mentra.asg_client.camera.lifecycle.HandlerExecutor;
 import com.mentra.asg_client.camera.lifecycle.ImageReaderTwin;
 import com.mentra.asg_client.camera.lifecycle.PhotoSession;
-import org.json.JSONObject;
 import com.mentra.asg_client.camera.lifecycle.VideoRecordingSession;
 import com.mentra.asg_client.camera.model.CameraOperationError;
+import com.mentra.asg_client.camera.model.CapturedPhoto;
 import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequest;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequestQueue;
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import org.json.JSONObject;
 
 public class CameraNeoService extends LifecycleService {
     private static final String TAG = "CameraNeo";
@@ -169,6 +170,18 @@ public class CameraNeoService extends LifecycleService {
 
         void onPhotoCaptured(String filePath, @Nullable JSONObject captureMetadata);
 
+        /**
+         * RAM-first result delivery. Classic file-backed callbacks keep using the two-argument
+         * overload; consumers that request deferred persistence receive the capture directly so
+         * queued callbacks cannot lose it through a process-global side channel.
+         */
+        default void onPhotoCaptured(
+                String filePath,
+                @Nullable JSONObject captureMetadata,
+                @Nullable CapturedPhoto capturedPhoto) {
+            onPhotoCaptured(filePath, captureMetadata);
+        }
+
         void onPhotoError(String errorMessage);
 
         default void onPhotoError(CameraOperationError error) {
@@ -180,7 +193,8 @@ public class CameraNeoService extends LifecycleService {
     public interface CameraWarmUpCallback {
         /**
          * Warm-up accepted — the camera is spinning up. Emitted only once the request is committed
-         * (not for a busy rejection), so callers never see {@code warming} followed by {@code error}.
+         * (not for a busy rejection), so callers never see {@code warming} followed by {@code
+         * error}.
          */
         void onWarming();
 
@@ -416,8 +430,8 @@ public class CameraNeoService extends LifecycleService {
      *       still in progress — a rapid second press simply queues behind it (see {@code
      *       enqueuePhotoRequest}) and runs without a cold ISP start, so we must NOT gate on the
      *       shot state being idle.
-     *   <li>The open session won't be reconfigured for this request. A differing size, SDK flag,
-     *       or manual exposure forces a close + reopen (see {@code
+     *   <li>The open session won't be reconfigured for this request. A differing size, SDK flag, or
+     *       manual exposure forces a close + reopen (see {@code
      *       PhotoSession#willReuseConfiguredCamera}), which is effectively a cold start.
      * </ul>
      *
@@ -604,6 +618,67 @@ public class CameraNeoService extends LifecycleService {
             Integer iso,
             PhotoCaptureSettings captureSettings,
             PhotoCaptureCallback callback) {
+        enqueuePhotoRequest(
+                context,
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                false,
+                callback);
+    }
+
+    /**
+     * @param deferDiskWrite when {@code true}, {@code onPhotoCaptured} receives a {@link
+     *     CapturedPhoto} as soon as the JPEG bytes are in memory; the disk write runs in the
+     *     background. Callers that need the file MUST gate access on its persistence future. See
+     *     {@link QueuedPhotoRequest#deferDiskWrite}.
+     */
+    public static void enqueuePhotoRequest(
+            Context context,
+            String filePath,
+            String size,
+            boolean enableLed,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean deferDiskWrite,
+            PhotoCaptureCallback callback) {
+        enqueuePhotoRequest(
+                context,
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                deferDiskWrite,
+                true,
+                callback);
+    }
+
+    /**
+     * RAM-first capture entry point.
+     *
+     * @param persistToDisk whether the in-memory JPEG should also become a durable photo artifact
+     */
+    public static void enqueuePhotoRequest(
+            Context context,
+            String filePath,
+            String size,
+            boolean enableLed,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean deferDiskWrite,
+            boolean persistToDisk,
+            PhotoCaptureCallback callback) {
         synchronized (SERVICE_LOCK) {
             // Create and queue the request immediately
             QueuedPhotoRequest request =
@@ -615,6 +690,8 @@ public class CameraNeoService extends LifecycleService {
                             exposureTimeNs,
                             iso,
                             captureSettings,
+                            deferDiskWrite,
+                            persistToDisk,
                             callback);
             QueuedPhotoRequestQueue.getInstance().offer(request);
 
@@ -639,9 +716,7 @@ public class CameraNeoService extends LifecycleService {
                             + " iso="
                             + iso
                             + " captureTuning={"
-                            + (captureSettings != null
-                                    ? captureSettings.describeForLog()
-                                    : "null")
+                            + (captureSettings != null ? captureSettings.describeForLog() : "null")
                             + "}");
 
             // Check current service state and act accordingly
@@ -684,7 +759,8 @@ public class CameraNeoService extends LifecycleService {
      * Warm up the camera without taking a photo: open (if needed) + configure the capture session +
      * start the preview (powering the ISP/sensor and running AE), then hold it warm for {@code
      * durationMs} under the keep-alive timer. A subsequent {@link #enqueuePhotoRequest} of the same
-     * {@code size}/{@code exposureTimeNs} reuses the configured session and captures near-instantly.
+     * {@code size}/{@code exposureTimeNs} reuses the configured session and captures
+     * near-instantly.
      *
      * <p>Re-invoking while already warm simply restarts the keep-alive (that IS "keep alive"). No
      * capture, shutter sound, or file is produced.
@@ -707,8 +783,7 @@ public class CameraNeoService extends LifecycleService {
                     sInstance != null && sInstance.cameraCoordinator.hasConfiguredCamera();
             boolean idle =
                     sInstance != null
-                            && sInstance.photoSession.shotState()
-                                    == AeStateMachine.ShotState.IDLE;
+                            && sInstance.photoSession.shotState() == AeStateMachine.ShotState.IDLE;
             boolean warmUpInFlight =
                     (sInstance != null && sInstance.photoSession.isWarmingUp())
                             || !sPendingWarmCallbacks.isEmpty();
@@ -765,7 +840,8 @@ public class CameraNeoService extends LifecycleService {
         }
         // Fire outside the lock (this sends a camera_status over BLE). Only the busy rejection is
         // settled here; an accepted warm-up emits `warming` later in performWarmUp, once
-        // PhotoSession.setupWarmUp clears its own busy check and actually starts. Emitting `warming`
+        // PhotoSession.setupWarmUp clears its own busy check and actually starts. Emitting
+        // `warming`
         // at the entry gate could race a capture that starts before setupWarmUp runs, letting the
         // phone see `warming` immediately followed by `error` (camera_busy).
         if (rejectBusy != null) {
@@ -918,9 +994,11 @@ public class CameraNeoService extends LifecycleService {
      * expiry emits {@code stopped} (see {@link #startWarmKeepAliveTimer}).
      */
     private void performWarmUp(String size, Long exposureTimeNs, long durationMs) {
-        // Bind the pending callback(s) AND drive setupWarmUp under one continuous SERVICE_LOCK hold,
+        // Bind the pending callback(s) AND drive setupWarmUp under one continuous SERVICE_LOCK
+        // hold,
         // so warmUpRequest is set before the lock is released. Splitting them lets a second
-        // warmUpCamera slip through the entry guard in the gap between clearing the pending list and
+        // warmUpCamera slip through the entry guard in the gap between clearing the pending list
+        // and
         // setupWarmUp setting warmUpRequest; its busy-reject (fireWarmError) would then fail the
         // first caller's callback too. setupWarmUp re-acquires SERVICE_LOCK reentrantly.
         final List<CameraWarmUpCallback> warming;
@@ -1159,10 +1237,21 @@ public class CameraNeoService extends LifecycleService {
                 // For photos, find the closest available JPEG size to our target
                 Size[] jpegSizes = CameraOpener.jpegOutputSizes(map);
                 if (jpegSizes != null) {
-                    Log.d(TAG, "AAACamera " + this.cameraId + " JPEG output sizes: " + Arrays.toString(jpegSizes));
+                    Log.d(
+                            TAG,
+                            "AAACamera "
+                                    + this.cameraId
+                                    + " JPEG output sizes: "
+                                    + Arrays.toString(jpegSizes));
                     for (Size size : jpegSizes) {
-                        Log.d(TAG, "Camera " + this.cameraId + " JPEG size: " +
-                            size.getWidth() + "x" + size.getHeight());
+                        Log.d(
+                                TAG,
+                                "Camera "
+                                        + this.cameraId
+                                        + " JPEG size: "
+                                        + size.getWidth()
+                                        + "x"
+                                        + size.getHeight());
                     }
                 }
                 if (jpegSizes == null || jpegSizes.length == 0) {
@@ -1396,7 +1485,8 @@ public class CameraNeoService extends LifecycleService {
                                 // During a warm-up the synthetic warm request is already the active
                                 // capture; polling here would let a take_photo that raced in hijack
                                 // it and then get dropped when warm-up parks. Skip the poll while
-                                // warming — finishWarmUpReady() dispatches any queued photo after the
+                                // warming — finishWarmUpReady() dispatches any queued photo after
+                                // the
                                 // session is warm.
                                 if (!photoSession.isWarmingUp()) {
                                     photoSession.pollFirstQueuedRequestIntoCurrent();
@@ -1601,11 +1691,11 @@ public class CameraNeoService extends LifecycleService {
     }
 
     /**
-     * Arm the keep-alive that should run after a photo settles. If a {@code camera_warm_up} lease is
-     * still within its TTL, re-arm the warm keep-alive for the lease's remaining time (never shorter
-     * than the normal photo keep-alive) so a take_photo taken inside the warm window doesn't shorten
-     * the lease the caller reserved or swallow its {@code stopped} event. Otherwise use the normal
-     * short photo keep-alive.
+     * Arm the keep-alive that should run after a photo settles. If a {@code camera_warm_up} lease
+     * is still within its TTL, re-arm the warm keep-alive for the lease's remaining time (never
+     * shorter than the normal photo keep-alive) so a take_photo taken inside the warm window
+     * doesn't shorten the lease the caller reserved or swallow its {@code stopped} event. Otherwise
+     * use the normal short photo keep-alive.
      */
     private void startPostCaptureKeepAlive() {
         long remaining = warmLeaseDeadlineMs - System.currentTimeMillis();
@@ -1615,7 +1705,8 @@ public class CameraNeoService extends LifecycleService {
             if (warmLeaseDeadlineMs > 0) {
                 // The warm lease expired while a capture was in flight — the warm keep-alive had
                 // been cancelled for the capture, so its expiry never fired notifyWarmStopped. Emit
-                // the lease's stopped event now so clients still see the lease end per the contract,
+                // the lease's stopped event now so clients still see the lease end per the
+                // contract,
                 // then fall back to the normal short photo keep-alive for rapid-fire grace.
                 warmLeaseDeadlineMs = 0;
                 notifyWarmStopped();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriter.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriter.java
@@ -64,16 +64,20 @@ public final class PhotoExifMetadataWriter {
     }
 
     /**
-     * Stamp the capture ID (the capture directory name, e.g. {@code IMG_..._<requestId>})
-     * into EXIF ImageUniqueID so the request correlation survives file renames and
-     * camera-roll export. Derived from the file's own path, which covers every capture
-     * flow (SDK and button, gallery and transient) without threading IDs through the
-     * camera layer. No-op for files that don't live in a capture directory. Best-effort:
-     * a capture must never fail over metadata.
+     * Stamp the capture ID (the capture directory name, e.g. {@code IMG_..._<requestId>}) into EXIF
+     * ImageUniqueID so the request correlation survives file renames and camera-roll export.
+     * Derived from the file's own path, which covers every capture flow (SDK and button, gallery
+     * and transient) without threading IDs through the camera layer. No-op for files that don't
+     * live in a capture directory. Best-effort: a capture must never fail over metadata.
      */
     public static void writeCaptureIdFromPath(String jpegPath) {
+        writeCaptureIdFromPath(jpegPath, jpegPath);
+    }
+
+    /** Writes capture correlation from an intended gallery path onto another JPEG. */
+    public static void writeCaptureIdFromPath(String jpegPath, String intendedCapturePath) {
         try {
-            File parent = new File(jpegPath).getParentFile();
+            File parent = new File(intendedCapturePath).getParentFile();
             String captureId = parent != null ? parent.getName() : null;
             if (captureId == null
                     || !(captureId.startsWith("IMG_") || captureId.startsWith("VID_"))) {
@@ -93,8 +97,7 @@ public final class PhotoExifMetadataWriter {
         try {
             String json = readImuJsonFromJpeg(sourcePath);
             String uniqueId =
-                    new ExifInterface(sourcePath)
-                            .getAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID);
+                    new ExifInterface(sourcePath).getAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID);
             boolean hasJson = json != null && !json.isEmpty();
             boolean hasUniqueId = uniqueId != null && !uniqueId.isEmpty();
             if (!hasJson && !hasUniqueId) {
@@ -138,11 +141,43 @@ public final class PhotoExifMetadataWriter {
      * AvifWriter.addExifData.
      */
     public static byte[] buildExifApp1Segment(JSONObject imuPayload) throws IOException {
+        byte[] segment = buildCaptureExifApp1Segment(imuPayload, null);
+        if (segment == null) {
+            throw new IOException("Could not build IMU EXIF segment");
+        }
+        return segment;
+    }
+
+    /**
+     * Builds EXIF for a RAM-first capture from its in-memory IMU payload and intended gallery path.
+     * The path need not exist; its capture-directory name supplies ImageUniqueID.
+     */
+    @Nullable
+    public static byte[] buildCaptureExifApp1Segment(
+            @Nullable JSONObject imuPayload, @Nullable String intendedCapturePath)
+            throws IOException {
+        String captureId = captureIdFromPath(intendedCapturePath);
+        if (imuPayload == null && captureId == null) {
+            return null;
+        }
         File tempDir = new File(System.getProperty("java.io.tmpdir"));
-        File tempJpeg = File.createTempFile("imu_exif_", ".jpg", tempDir);
+        File tempJpeg = File.createTempFile("capture_exif_", ".jpg", tempDir);
         try {
             writeMinimalJpeg(tempJpeg);
-            writeImuPayload(tempJpeg.getAbsolutePath(), imuPayload);
+            ExifInterface exif = new ExifInterface(tempJpeg.getAbsolutePath());
+            if (imuPayload != null) {
+                try {
+                    exif.setAttribute(
+                            ExifInterface.TAG_USER_COMMENT,
+                            trimPayloadForExif(imuPayload).toString());
+                } catch (JSONException e) {
+                    throw new IOException("Invalid IMU payload JSON", e);
+                }
+            }
+            if (captureId != null) {
+                exif.setAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID, captureId);
+            }
+            exif.saveAttributes();
             return extractExifApp1Segment(tempJpeg);
         } finally {
             if (!tempJpeg.delete()) {
@@ -151,20 +186,31 @@ public final class PhotoExifMetadataWriter {
         }
     }
 
+    @Nullable
+    private static String captureIdFromPath(@Nullable String capturePath) {
+        if (capturePath == null) {
+            return null;
+        }
+        File parent = new File(capturePath).getParentFile();
+        String captureId = parent != null ? parent.getName() : null;
+        return captureId != null && (captureId.startsWith("IMG_") || captureId.startsWith("VID_"))
+                ? captureId
+                : null;
+    }
+
     /**
      * Builds an EXIF APP1 segment (including the {@code FFE1} marker and length) carrying the
      * source capture's IMU UserComment and/or ImageUniqueID, for splicing into an in-memory
-     * re-encoded JPEG without round-tripping the full image through a temp file. Returns
-     * {@code null} when the source carries neither attribute. The only disk I/O is the same
-     * 2x2-pixel scratch JPEG {@link #buildExifApp1Segment} already uses, because
-     * {@link ExifInterface} can only write to files.
+     * re-encoded JPEG without round-tripping the full image through a temp file. Returns {@code
+     * null} when the source carries neither attribute. The only disk I/O is the same 2x2-pixel
+     * scratch JPEG {@link #buildExifApp1Segment} already uses, because {@link ExifInterface} can
+     * only write to files.
      */
     @Nullable
     public static byte[] buildCaptureExifApp1Segment(String sourceJpegPath) throws IOException {
         String imuJson = readImuJsonFromJpeg(sourceJpegPath);
         String uniqueId =
-                new ExifInterface(sourceJpegPath)
-                        .getAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID);
+                new ExifInterface(sourceJpegPath).getAttribute(ExifInterface.TAG_IMAGE_UNIQUE_ID);
         boolean hasJson = imuJson != null && !imuJson.isEmpty();
         boolean hasUniqueId = uniqueId != null && !uniqueId.isEmpty();
         if (!hasJson && !hasUniqueId) {
@@ -197,84 +243,118 @@ public final class PhotoExifMetadataWriter {
      */
     public static byte[] encodeAvifForBle(Bitmap bitmap, int quality, String sourceJpegPath)
             throws Exception {
-        long encodeStartMs = System.currentTimeMillis();
-        boolean hasImu = hasImuMetadata(sourceJpegPath);
+        JSONObject payload = null;
+        if (hasImuMetadata(sourceJpegPath)) {
+            String json = readImuJsonFromJpeg(sourceJpegPath);
+            if (json == null) {
+                Log.w(
+                        TAG,
+                        "encodeAvifForBle: hasImuMetadata true but readImuJsonFromJpeg returned"
+                                + " null");
+            } else {
+                try {
+                    payload = new JSONObject(json);
+                } catch (JSONException e) {
+                    Log.w(TAG, "encodeAvifForBle: source IMU EXIF is not valid JSON", e);
+                }
+            }
+        }
         Log.d(
                 TAG,
                 "encodeAvifForBle: source="
                         + sourceJpegPath
                         + " hasImuMetadata="
-                        + hasImu
+                        + (payload != null)
                         + " quality="
                         + quality);
+        return encodeAvifForBle(bitmap, quality, payload, sourceJpegPath);
+    }
+
+    /**
+     * In-memory variant: encodes AVIF with EXIF built from an already-assembled IMU payload,
+     * avoiding any disk reads of the source capture.
+     */
+    public static byte[] encodeAvifForBle(
+            Bitmap bitmap, int quality, @Nullable JSONObject imuPayload) throws Exception {
+        return encodeAvifForBle(bitmap, quality, imuPayload, null);
+    }
+
+    /** RAM-first AVIF variant that also preserves capture-ID correlation from the intended path. */
+    public static byte[] encodeAvifForBle(
+            Bitmap bitmap,
+            int quality,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath)
+            throws Exception {
+        long encodeStartMs = System.currentTimeMillis();
         HeifCoder heifCoder = new HeifCoder();
-        if (hasImu) {
-            String json = readImuJsonFromJpeg(sourceJpegPath);
-            if (json == null) {
-                Log.w(
-                        TAG,
-                        "encodeAvifForBle: hasImuMetadata true but readImuJsonFromJpeg returned null");
-            } else {
-                try {
-                    JSONObject payload = new JSONObject(json);
-                    byte[] exifSegment = buildExifApp1Segment(payload);
-                    byte[] exifTiff = Arrays.copyOfRange(exifSegment, 4, exifSegment.length);
+        byte[] captureExif = null;
+        try {
+            captureExif = buildCaptureExifApp1Segment(imuPayload, intendedCapturePath);
+        } catch (Exception exifBuildError) {
+            Log.w(
+                    TAG,
+                    "encodeAvifForBle: capture EXIF build failed, sending plain AVIF: "
+                            + exifBuildError.getMessage());
+        }
+        if (captureExif != null) {
+            try {
+                byte[] exifTiff = Arrays.copyOfRange(captureExif, 4, captureExif.length);
 
-                    if (isAv1EncoderAvailable()) {
-                        try {
-                            byte[] withExif = encodeAvifWithExif(bitmap, quality, payload);
-                            logAvifEncodeTiming(encodeStartMs, "avifwriter_exif", withExif.length);
-                            Log.d(
-                                    TAG,
-                                    "encodeAvifForBle: AvifWriter+EXIF, "
-                                            + withExif.length
-                                            + " bytes, rawHasExifMarker="
-                                            + containsExifMarker(withExif));
-                            return withExif;
-                        } catch (Exception e) {
-                            Log.w(
-                                    TAG,
-                                    "AvifWriter+EXIF failed, using HeifCoder+BMFF EXIF inject: "
-                                            + e.getMessage());
-                        }
-                    } else {
-                        Log.d(
-                                TAG,
-                                "encodeAvifForBle: no AV1 encoder; using HeifCoder+BMFF EXIF inject");
-                    }
-
-                    byte[] avif = heifCoder.encodeAvif(bitmap, quality, PreciseMode.LOSSY);
+                if (isAv1EncoderAvailable()) {
                     try {
-                        byte[] withExif = AvifBmffExifInjector.injectExif(avif, exifTiff);
-                        logAvifEncodeTiming(encodeStartMs, "heifcoder_bmff_exif", withExif.length);
+                        byte[] withExif = encodeAvifWithExif(bitmap, quality, captureExif);
+                        logAvifEncodeTiming(encodeStartMs, "avifwriter_exif", withExif.length);
                         Log.d(
                                 TAG,
-                                "encodeAvifForBle: HeifCoder+EXIF, "
+                                "encodeAvifForBle: AvifWriter+EXIF, "
                                         + withExif.length
                                         + " bytes, rawHasExifMarker="
                                         + containsExifMarker(withExif));
                         return withExif;
-                    } catch (Exception injectError) {
+                    } catch (Exception e) {
                         Log.w(
                                 TAG,
-                                "BMFF EXIF inject failed, sending plain AVIF: "
-                                        + injectError.getMessage());
-                        logAvifEncodeTiming(encodeStartMs, "heifcoder_plain_fallback", avif.length);
-                        return avif;
+                                "AvifWriter+EXIF failed, using HeifCoder+BMFF EXIF inject: "
+                                        + e.getMessage());
                     }
-                } catch (Exception exifPathError) {
+                } else {
+                    Log.d(
+                            TAG,
+                            "encodeAvifForBle: no AV1 encoder; using HeifCoder+BMFF EXIF inject");
+                }
+
+                byte[] avif = heifCoder.encodeAvif(bitmap, quality, PreciseMode.LOSSY);
+                try {
+                    byte[] withExif = AvifBmffExifInjector.injectExif(avif, exifTiff);
+                    logAvifEncodeTiming(encodeStartMs, "heifcoder_bmff_exif", withExif.length);
+                    Log.d(
+                            TAG,
+                            "encodeAvifForBle: HeifCoder+EXIF, "
+                                    + withExif.length
+                                    + " bytes, rawHasExifMarker="
+                                    + containsExifMarker(withExif));
+                    return withExif;
+                } catch (Exception injectError) {
                     Log.w(
                             TAG,
-                            "encodeAvifForBle: IMU EXIF path failed, sending plain AVIF: "
-                                    + exifPathError.getMessage());
+                            "BMFF EXIF inject failed, sending plain AVIF: "
+                                    + injectError.getMessage());
+                    logAvifEncodeTiming(encodeStartMs, "heifcoder_plain_fallback", avif.length);
+                    return avif;
                 }
+            } catch (Exception exifPathError) {
+                Log.w(
+                        TAG,
+                        "encodeAvifForBle: capture EXIF path failed, sending plain AVIF: "
+                                + exifPathError.getMessage());
             }
         }
         byte[] plain = heifCoder.encodeAvif(bitmap, quality, PreciseMode.LOSSY);
         logAvifEncodeTiming(encodeStartMs, "heifcoder_plain", plain.length);
         Log.d(
                 TAG,
-                "encodeAvifForBle: HeifCoder (no IMU), "
+                "encodeAvifForBle: HeifCoder (no capture EXIF), "
                         + plain.length
                         + " bytes, rawHasExifMarker="
                         + containsExifMarker(plain));
@@ -315,9 +395,13 @@ public final class PhotoExifMetadataWriter {
 
     public static byte[] encodeAvifWithExif(Bitmap bitmap, int quality, JSONObject imuPayload)
             throws Exception {
+        return encodeAvifWithExif(bitmap, quality, buildExifApp1Segment(imuPayload));
+    }
+
+    private static byte[] encodeAvifWithExif(Bitmap bitmap, int quality, byte[] exifSegment)
+            throws Exception {
         int width = bitmap.getWidth();
         int height = bitmap.getHeight();
-        byte[] exifSegment = buildExifApp1Segment(imuPayload);
         byte[] exifPayload = Arrays.copyOfRange(exifSegment, 4, exifSegment.length);
 
         File tempFile = File.createTempFile("ble_avif_", ".avif");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -17,6 +17,7 @@ import com.mentra.asg_client.camera.CameraSettings;
 import com.mentra.asg_client.camera.diagnostics.CameraDiagnosticsLog;
 import com.mentra.asg_client.camera.model.ActivePhotoCapture;
 import com.mentra.asg_client.camera.model.CameraOperationError;
+import com.mentra.asg_client.camera.model.CapturedPhoto;
 import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequest;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequestQueue;
@@ -37,9 +38,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import org.json.JSONObject;
-
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -89,8 +92,8 @@ public final class PhotoSession {
     /**
      * When non-null, the open session is being held "warm" (ISP/sensor powered, preview running)
      * for a {@code camera_warm_up} request rather than captured. The session is configured exactly
-     * as a same-size SDK photo would be (so {@link #willReuseConfiguredCamera} returns true) but the
-     * precapture/still path is never run — the camera parks at IDLE under the keep-alive timer.
+     * as a same-size SDK photo would be (so {@link #willReuseConfiguredCamera} returns true) but
+     * the precapture/still path is never run — the camera parks at IDLE under the keep-alive timer.
      */
     @Nullable private volatile WarmUpRequest warmUpRequest;
 
@@ -99,23 +102,28 @@ public final class PhotoSession {
     private volatile Long mLastStillSensorTimestampNs;
 
     private final HdrBurstCapture hdrBurstCapture = new HdrBurstCapture();
+
+    /**
+     * Background writer for deferred-persistence captures ({@link
+     * ActivePhotoCapture#deferDiskWrite}). Single thread keeps writes ordered; daemon so it never
+     * blocks process exit. Created lazily — classic captures never spin it up.
+     */
+    @Nullable private volatile ExecutorService persistenceExecutor;
+
     private final Object captureMetadataLock = new Object();
-    @Nullable
-    private JSONObject pendingStillCaptureMetadata;
-    @Nullable
-    private String pendingCapturedFilePath;
-    @Nullable
-    private CameraNeoService.PhotoCaptureCallback pendingCapturedCallback;
+    @Nullable private JSONObject pendingStillCaptureMetadata;
+    @Nullable private String pendingCapturedFilePath;
+    @Nullable private CameraNeoService.PhotoCaptureCallback pendingCapturedCallback;
+    @Nullable private CapturedPhoto pendingCapturedPhoto;
     private long pendingCapturedStartTimeMs;
-    @Nullable
-    private Runnable pendingCaptureMetadataTimeout;
+    @Nullable private Runnable pendingCaptureMetadataTimeout;
     private boolean photoCapturedCallbackSent;
 
     /**
      * Bumped every time capture metadata state is reset (i.e. a new shot begins). A {@link
-     * StillCaptureCallback} captures the generation in flight when it is created; a late
-     * {@code onCaptureCompleted} from a previous shot is then dropped instead of being attached to
-     * the next photo's {@code captured} status/callback.
+     * StillCaptureCallback} captures the generation in flight when it is created; a late {@code
+     * onCaptureCompleted} from a previous shot is then dropped instead of being attached to the
+     * next photo's {@code captured} status/callback.
      */
     private long captureMetadataGeneration;
 
@@ -306,15 +314,13 @@ public final class PhotoSession {
     }
 
     private PhotoCaptureSettings currentCaptureSettings() {
-        return activeCapture != null
-                ? activeCapture.captureSettings
-                : PhotoCaptureSettings.EMPTY;
+        return activeCapture != null ? activeCapture.captureSettings : PhotoCaptureSettings.EMPTY;
     }
 
     /**
-     * Explicit {@code zsl} on the request wins; otherwise let the global device setting apply.
-     * ZSL and MFNR are independent capabilities — ZSL being off should not be implied by MFNR
-     * being off, as ZSL reduces shutter lag regardless of multi-frame processing.
+     * Explicit {@code zsl} on the request wins; otherwise let the global device setting apply. ZSL
+     * and MFNR are independent capabilities — ZSL being off should not be implied by MFNR being
+     * off, as ZSL reduces shutter lag regardless of multi-frame processing.
      */
     private static Boolean resolveRequestZsl(PhotoCaptureSettings captureSettings) {
         if (captureSettings != null && captureSettings.zsl != null) {
@@ -552,12 +558,13 @@ public final class PhotoSession {
     /**
      * Prepare and hold the camera "warm" for {@code durationMs} without capturing a photo. The
      * session is opened/reused and configured with the SAME parameters a same-size SDK photo would
-     * use ({@code isFromSdk=true}, the requested {@code size}, optional {@code exposureTimeNs}), so a
-     * later {@code take_photo} of that size reuses the configured session — see {@link
-     * #willReuseConfiguredCamera}. No precapture, still capture, shutter sound, or file is produced.
+     * use ({@code isFromSdk=true}, the requested {@code size}, optional {@code exposureTimeNs}), so
+     * a later {@code take_photo} of that size reuses the configured session — see {@link
+     * #willReuseConfiguredCamera}. No precapture, still capture, shutter sound, or file is
+     * produced.
      *
-     * <p>If the camera is already configured and idle for the same params, only the keep-alive timer
-     * is restarted (re-warming) and {@code onReady} fires immediately.
+     * <p>If the camera is already configured and idle for the same params, only the keep-alive
+     * timer is restarted (re-warming) and {@code onReady} fires immediately.
      *
      * @param size requested resolution tier (already normalized)
      * @param exposureTimeNs optional manual shutter (nanoseconds); {@code null} = auto
@@ -574,11 +581,14 @@ public final class PhotoSession {
             Runnable onReady,
             java.util.function.Consumer<CameraOperationError> onError) {
         synchronized (hooks.serviceLock()) {
-            // Serialize warm-ups: the camera is a single shared resource. If a capture is in flight,
+            // Serialize warm-ups: the camera is a single shared resource. If a capture is in
+            // flight,
             // or another warm-up is still opening, reject with a retryable busy error rather than
             // racing or deferring. The caller retries — and since the camera is about to be warm
-            // anyway, the retry usually hits the already-warm fast path. This keeps a single warm-up
-            // in flight at a time and avoids the concurrency hazards of overlapping/deferred starts.
+            // anyway, the retry usually hits the already-warm fast path. This keeps a single
+            // warm-up
+            // in flight at a time and avoids the concurrency hazards of overlapping/deferred
+            // starts.
             if (isWarmingUp() || shotState != AeStateMachine.ShotState.IDLE) {
                 Log.d(
                         TAG,
@@ -594,7 +604,8 @@ public final class PhotoSession {
             }
 
             WarmUpRequest req =
-                    new WarmUpRequest(size, exposureTimeNs, captureSettings, durationMs, onReady, onError);
+                    new WarmUpRequest(
+                            size, exposureTimeNs, captureSettings, durationMs, onReady, onError);
 
             // Build a synthetic queued request so the open/configure path and the
             // configured-camera baseline match a same-size SDK photo exactly.
@@ -652,7 +663,8 @@ public final class PhotoSession {
             hooks.executor().execute(req.onReady);
         }
         // A take_photo may have raced in while the camera was opening for warm-up; onConfigured
-        // skips the queue poll during warm-up so it isn't dropped. Take it now on the freshly warmed
+        // skips the queue poll during warm-up so it isn't dropped. Take it now on the freshly
+        // warmed
         // session instead of stranding it on the queue until the lease expires.
         if (!QueuedPhotoRequestQueue.getInstance().isEmpty()) {
             dispatchNextPhotoRequest();
@@ -728,7 +740,7 @@ public final class PhotoSession {
                     bytes.length
                             + " bytes in "
                             + (System.currentTimeMillis() - imageAvailableStartMs)
-                            + "ms; starting file write");
+                            + "ms; routing captured bytes");
 
             String currentPath = currentFilePath();
             String targetPath = (currentPath != null) ? currentPath : listenerFallbackPhotoPath;
@@ -756,6 +768,14 @@ public final class PhotoSession {
                             // from capture callbacks.
                         }
                     })) {
+                return;
+            }
+
+            ActivePhotoCapture capture = activeCapture;
+            if (capture != null && capture.deferDiskWrite) {
+                // RAM-first path: publish the bytes and fire the callback now. Saving, when
+                // requested, happens in the background; save=false never persists the JPEG.
+                handleDeferredPersistenceCapture(bytes, targetPath, capture.persistToDisk);
                 return;
             }
 
@@ -810,6 +830,12 @@ public final class PhotoSession {
                             + "ms");
             return;
         }
+        writeImuArtifacts(photoPath, payload, imu);
+    }
+
+    /** Writes IMU EXIF + sidecar for an already-assembled payload. Safe to run off-thread. */
+    private void writeImuArtifacts(String photoPath, JSONObject payload, ImuRecorder imu) {
+        long imuStartMs = System.currentTimeMillis();
         try {
             PhotoExifMetadataWriter.writeImuPayload(photoPath, payload);
             BlePhotoTimingLog.event(
@@ -832,6 +858,82 @@ public final class PhotoSession {
                         + "ms; total metadata finalization="
                         + (System.currentTimeMillis() - imuStartMs)
                         + "ms");
+    }
+
+    /**
+     * Deferred-persistence capture ({@link ActivePhotoCapture#deferDiskWrite}): stop the IMU
+     * recorder and assemble its payload in memory, then fire {@code onPhotoCaptured} with the
+     * complete capture attached. When persistence is requested, the JPEG + EXIF + IMU-sidecar write
+     * runs on the background executor; otherwise no capture artifact is created.
+     */
+    private void handleDeferredPersistenceCapture(
+            byte[] bytes, String targetPath, boolean persistToDisk) {
+        ImuRecorder imu = hooks.imuRecorderOrNull();
+        JSONObject payload = imu != null ? imu.stopRecordingAndBuildPayload() : null;
+        if (payload != null && payload.optInt("sampleCount", 0) <= 0) {
+            payload = null;
+        }
+        final JSONObject imuPayload = payload;
+        final JSONObject callbackImuPayload = copyJsonPayload(imuPayload);
+        Future<Boolean> persistence;
+        if (persistToDisk) {
+            persistence =
+                    persistenceExecutor()
+                            .submit(
+                                    () -> {
+                                        boolean ok = saveImageDataToFile(bytes, targetPath);
+                                        if (!ok) {
+                                            Log.e(
+                                                    TAG,
+                                                    "Deferred photo persistence failed: "
+                                                            + targetPath);
+                                            return false;
+                                        }
+                                        if (imuPayload != null && imu != null) {
+                                            writeImuArtifacts(targetPath, imuPayload, imu);
+                                        }
+                                        Log.d(TAG, "Deferred photo persisted: " + targetPath);
+                                        return true;
+                                    });
+        } else {
+            persistence = CompletableFuture.completedFuture(false);
+            Log.d(TAG, "RAM-only photo capture; persistence skipped: " + targetPath);
+        }
+        notifyPhotoCaptured(targetPath, new CapturedPhoto(bytes, callbackImuPayload, persistence));
+    }
+
+    /** Isolates the callback/encoder from the mutable payload used by background persistence. */
+    @Nullable
+    private static JSONObject copyJsonPayload(@Nullable JSONObject payload) {
+        if (payload == null) {
+            return null;
+        }
+        try {
+            return new JSONObject(payload.toString());
+        } catch (org.json.JSONException error) {
+            Log.w(TAG, "Could not copy IMU payload for RAM-first callback", error);
+            return null;
+        }
+    }
+
+    private ExecutorService persistenceExecutor() {
+        ExecutorService executor = persistenceExecutor;
+        if (executor == null) {
+            synchronized (this) {
+                executor = persistenceExecutor;
+                if (executor == null) {
+                    executor =
+                            Executors.newSingleThreadExecutor(
+                                    r -> {
+                                        Thread t = new Thread(r, "PhotoPersistence");
+                                        t.setDaemon(true);
+                                        return t;
+                                    });
+                    persistenceExecutor = executor;
+                }
+            }
+        }
+        return executor;
     }
 
     private boolean saveImageDataToFile(byte[] data, String filePath) {
@@ -897,6 +999,7 @@ public final class PhotoSession {
             pendingStillCaptureMetadata = null;
             pendingCapturedFilePath = null;
             pendingCapturedCallback = null;
+            pendingCapturedPhoto = null;
             pendingCapturedStartTimeMs = 0L;
             pendingCaptureMetadataTimeout = null;
             photoCapturedCallbackSent = false;
@@ -913,18 +1016,23 @@ public final class PhotoSession {
     private void emitPhotoCaptured(
             String filePath,
             @Nullable JSONObject captureMetadata,
+            @Nullable CapturedPhoto capturedPhoto,
             @Nullable CameraNeoService.PhotoCaptureCallback callback,
             long startMs) {
         long e2eTimeMs = (startMs > 0) ? (System.currentTimeMillis() - startMs) : -1L;
         Log.i(
                 TAG,
-                "📸 PHOTO E2E: Photo captured and saved in "
+                "📸 PHOTO E2E: Photo capture completed in "
                         + e2eTimeMs
-                        + "ms (e2e) | Path: "
+                        + "ms (e2e) | Capture key: "
                         + filePath);
 
         if (callback != null) {
-            hooks.executor().execute(() -> callback.onPhotoCaptured(filePath, captureMetadata));
+            hooks.executor()
+                    .execute(
+                            () ->
+                                    callback.onPhotoCaptured(
+                                            filePath, captureMetadata, capturedPhoto));
         }
         finishSuccessfulPhotoCapture();
     }
@@ -943,7 +1051,11 @@ public final class PhotoSession {
     }
 
     private void notifyPhotoCaptured(String filePath) {
-        notifyPhotoCaptured(filePath, true);
+        notifyPhotoCaptured(filePath, null, true);
+    }
+
+    private void notifyPhotoCaptured(String filePath, CapturedPhoto capturedPhoto) {
+        notifyPhotoCaptured(filePath, capturedPhoto, true);
     }
 
     /**
@@ -954,6 +1066,11 @@ public final class PhotoSession {
      *     timeout.
      */
     private void notifyPhotoCaptured(String filePath, boolean waitForStillMetadata) {
+        notifyPhotoCaptured(filePath, null, waitForStillMetadata);
+    }
+
+    private void notifyPhotoCaptured(
+            String filePath, @Nullable CapturedPhoto capturedPhoto, boolean waitForStillMetadata) {
         long startMs = currentStartTimeMs();
         CameraNeoService.PhotoCaptureCallback callback =
                 activeCapture != null ? activeCapture.callback : null;
@@ -979,6 +1096,7 @@ public final class PhotoSession {
                     }
                     pendingCapturedFilePath = filePath;
                     pendingCapturedCallback = callback;
+                    pendingCapturedPhoto = capturedPhoto;
                     pendingCapturedStartTimeMs = startMs;
                     scheduleCaptureMetadataTimeoutLocked(filePath);
                     return;
@@ -990,36 +1108,40 @@ public final class PhotoSession {
                 photoCapturedCallbackSent = true;
             }
         }
-        emitPhotoCaptured(filePath, metadataToSend, callback, startMs);
+        emitPhotoCaptured(filePath, metadataToSend, capturedPhoto, callback, startMs);
     }
 
     private void scheduleCaptureMetadataTimeoutLocked(String filePath) {
         if (pendingCaptureMetadataTimeout != null) {
             return;
         }
-        Runnable timeout = () -> {
-            CameraNeoService.PhotoCaptureCallback callback;
-            long startMs;
-            synchronized (captureMetadataLock) {
-                if (!Objects.equals(pendingCapturedFilePath, filePath)
-                        || photoCapturedCallbackSent) {
-                    return;
-                }
-                callback = pendingCapturedCallback;
-                startMs = pendingCapturedStartTimeMs;
-                pendingCapturedFilePath = null;
-                pendingCapturedCallback = null;
-                pendingCapturedStartTimeMs = 0L;
-                pendingCaptureMetadataTimeout = null;
-                photoCapturedCallbackSent = true;
-            }
-            Log.w(
-                    TAG,
-                    "Still capture metadata was not available within "
-                            + CAPTURE_METADATA_WAIT_TIMEOUT_MS
-                            + "ms; emitting captured status without captureMetadata");
-            emitPhotoCaptured(filePath, null, callback, startMs);
-        };
+        Runnable timeout =
+                () -> {
+                    CameraNeoService.PhotoCaptureCallback callback;
+                    CapturedPhoto capturedPhoto;
+                    long startMs;
+                    synchronized (captureMetadataLock) {
+                        if (!Objects.equals(pendingCapturedFilePath, filePath)
+                                || photoCapturedCallbackSent) {
+                            return;
+                        }
+                        callback = pendingCapturedCallback;
+                        capturedPhoto = pendingCapturedPhoto;
+                        startMs = pendingCapturedStartTimeMs;
+                        pendingCapturedFilePath = null;
+                        pendingCapturedCallback = null;
+                        pendingCapturedPhoto = null;
+                        pendingCapturedStartTimeMs = 0L;
+                        pendingCaptureMetadataTimeout = null;
+                        photoCapturedCallbackSent = true;
+                    }
+                    Log.w(
+                            TAG,
+                            "Still capture metadata was not available within "
+                                    + CAPTURE_METADATA_WAIT_TIMEOUT_MS
+                                    + "ms; emitting captured status without captureMetadata");
+                    emitPhotoCaptured(filePath, null, capturedPhoto, callback, startMs);
+                };
         pendingCaptureMetadataTimeout = timeout;
 
         Handler h = hooks.backgroundHandler();
@@ -1033,6 +1155,7 @@ public final class PhotoSession {
     private void recordStillCaptureMetadata(long captureGeneration, JSONObject captureMetadata) {
         String filePathToNotify = null;
         CameraNeoService.PhotoCaptureCallback callback = null;
+        CapturedPhoto capturedPhoto = null;
         long startMs = 0L;
         Runnable timeoutToCancel = null;
 
@@ -1057,10 +1180,12 @@ public final class PhotoSession {
             }
             filePathToNotify = pendingCapturedFilePath;
             callback = pendingCapturedCallback;
+            capturedPhoto = pendingCapturedPhoto;
             startMs = pendingCapturedStartTimeMs;
             timeoutToCancel = pendingCaptureMetadataTimeout;
             pendingCapturedFilePath = null;
             pendingCapturedCallback = null;
+            pendingCapturedPhoto = null;
             pendingCapturedStartTimeMs = 0L;
             pendingCaptureMetadataTimeout = null;
             pendingStillCaptureMetadata = null;
@@ -1073,7 +1198,7 @@ public final class PhotoSession {
                 h.removeCallbacks(timeoutToCancel);
             }
         }
-        emitPhotoCaptured(filePathToNotify, captureMetadata, callback, startMs);
+        emitPhotoCaptured(filePathToNotify, captureMetadata, capturedPhoto, callback, startMs);
     }
 
     private void notifyPhotoError(String errorMessage) {
@@ -1089,7 +1214,8 @@ public final class PhotoSession {
         }
     }
 
-    private static void putIfNotNull(JSONObject json, String key, Object value) throws JSONException {
+    private static void putIfNotNull(JSONObject json, String key, Object value)
+            throws JSONException {
         if (value != null) {
             json.put(key, value);
         }
@@ -1112,31 +1238,45 @@ public final class PhotoSession {
         putIfNotNull(metered, "iso", mLastMeteredIso);
         putIfNotNull(metered, "exposureTimeNs", mLastMeteredExposureNs);
         if (mLastMeteredIso != null && mLastMeteredExposureNs != null) {
-            metered.put("totalLightProxy",
+            metered.put(
+                    "totalLightProxy",
                     (mLastMeteredExposureNs / 1_000_000.0) * mLastMeteredIso.doubleValue());
         }
         return metered.length() > 0 ? metered : null;
     }
 
     @Nullable
-    private JSONObject buildRequestedCaptureConfig(CaptureRequest captureRequest, boolean useManual) throws JSONException {
+    private JSONObject buildRequestedCaptureConfig(CaptureRequest captureRequest, boolean useManual)
+            throws JSONException {
         if (captureRequest == null) {
             return null;
         }
         JSONObject requested = new JSONObject();
         requested.put("manual", useManual);
-        putIfNotNull(requested, "exposureTimeNs", captureRequest.get(CaptureRequest.SENSOR_EXPOSURE_TIME));
+        putIfNotNull(
+                requested,
+                "exposureTimeNs",
+                captureRequest.get(CaptureRequest.SENSOR_EXPOSURE_TIME));
         putIfNotNull(requested, "iso", captureRequest.get(CaptureRequest.SENSOR_SENSITIVITY));
-        putIfNotNull(requested, "frameDurationNs", captureRequest.get(CaptureRequest.SENSOR_FRAME_DURATION));
+        putIfNotNull(
+                requested,
+                "frameDurationNs",
+                captureRequest.get(CaptureRequest.SENSOR_FRAME_DURATION));
         putIfNotNull(requested, "aeMode", captureRequest.get(CaptureRequest.CONTROL_AE_MODE));
         putIfNotNull(requested, "aeLock", captureRequest.get(CaptureRequest.CONTROL_AE_LOCK));
-        putIfNotNull(requested, "aeExposureCompensation",
+        putIfNotNull(
+                requested,
+                "aeExposureCompensation",
                 captureRequest.get(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION));
-        putIfNotNull(requested, "noiseReductionMode", captureRequest.get(CaptureRequest.NOISE_REDUCTION_MODE));
+        putIfNotNull(
+                requested,
+                "noiseReductionMode",
+                captureRequest.get(CaptureRequest.NOISE_REDUCTION_MODE));
         putIfNotNull(requested, "edgeMode", captureRequest.get(CaptureRequest.EDGE_MODE));
         putIfNotNull(requested, "afMode", captureRequest.get(CaptureRequest.CONTROL_AF_MODE));
         putIfNotNull(requested, "zsl", captureRequest.get(CaptureRequest.CONTROL_ENABLE_ZSL));
-        JSONObject fpsRange = rangeToJson(captureRequest.get(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE));
+        JSONObject fpsRange =
+                rangeToJson(captureRequest.get(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE));
         if (fpsRange != null) {
             requested.put("aeTargetFpsRange", fpsRange);
         }
@@ -1149,11 +1289,15 @@ public final class PhotoSession {
     }
 
     private void notifyPhotoCapturing(
-            @Nullable JSONObject requestedCaptureConfig,
-            @Nullable JSONObject meteredPreview) {
-        CameraNeoService.PhotoCaptureCallback callback = activeCapture != null ? activeCapture.callback : null;
+            @Nullable JSONObject requestedCaptureConfig, @Nullable JSONObject meteredPreview) {
+        CameraNeoService.PhotoCaptureCallback callback =
+                activeCapture != null ? activeCapture.callback : null;
         if (callback != null) {
-            hooks.executor().execute(() -> callback.onPhotoCapturing(requestedCaptureConfig, meteredPreview));
+            hooks.executor()
+                    .execute(
+                            () ->
+                                    callback.onPhotoCapturing(
+                                            requestedCaptureConfig, meteredPreview));
         }
     }
 
@@ -1165,7 +1309,8 @@ public final class PhotoSession {
     }
 
     public void notifyPhotoConfigured(Size size, int jpegQuality) {
-        CameraNeoService.PhotoCaptureCallback callback = activeCapture != null ? activeCapture.callback : null;
+        CameraNeoService.PhotoCaptureCallback callback =
+                activeCapture != null ? activeCapture.callback : null;
         if (callback == null || size == null) {
             return;
         }
@@ -1499,7 +1644,8 @@ public final class PhotoSession {
             shotState = AeStateMachine.ShotState.SHOOTING;
 
             ImuRecorder imu = hooks.ensureImuRecorder();
-            String imuStartPath = (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
+            String imuStartPath =
+                    (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
             imu.startRecording(imuStartPath);
 
             CaptureRequest.Builder stillBuilder =
@@ -1564,8 +1710,7 @@ public final class PhotoSession {
                             + displayOrientation);
 
             if (hooks.cameraSettings() != null) {
-                Boolean requestMfnr =
-                        captureSettings.mfnr != null ? captureSettings.mfnr : null;
+                Boolean requestMfnr = captureSettings.mfnr != null ? captureSettings.mfnr : null;
                 Boolean requestZsl = resolveRequestZsl(captureSettings);
                 if (!useManual) {
                     if (requestMfnr != null || requestZsl != null) {
@@ -1597,8 +1742,7 @@ public final class PhotoSession {
                                 + ")");
             }
 
-            Boolean requestMfnrForLog =
-                    captureSettings.mfnr != null ? captureSettings.mfnr : null;
+            Boolean requestMfnrForLog = captureSettings.mfnr != null ? captureSettings.mfnr : null;
             Boolean requestZslForLog = resolveRequestZsl(captureSettings);
             boolean globalMfnr =
                     hooks.cameraSettings() != null
@@ -1611,12 +1755,8 @@ public final class PhotoSession {
                     captureSettings,
                     useManual,
                     mLastMeteredExposureNs,
-                    useManual
-                            ? Long.valueOf(manualClampedNs)
-                            : currentExposureTimeNs(),
-                    useManual
-                            ? manualIso
-                            : captureRequest.get(CaptureRequest.SENSOR_SENSITIVITY),
+                    useManual ? Long.valueOf(manualClampedNs) : currentExposureTimeNs(),
+                    useManual ? manualIso : captureRequest.get(CaptureRequest.SENSOR_SENSITIVITY),
                     requestMfnrForLog,
                     requestZslForLog,
                     globalMfnr,
@@ -1755,7 +1895,8 @@ public final class PhotoSession {
             shotState = AeStateMachine.ShotState.SHOOTING;
 
             ImuRecorder imu = hooks.ensureImuRecorder();
-            String imuStartPath = (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
+            String imuStartPath =
+                    (currentFilePath() != null) ? currentFilePath() : listenerFallbackPhotoPath;
             imu.startRecording(imuStartPath);
 
             Log.i(
@@ -1865,7 +2006,9 @@ public final class PhotoSession {
             this.onError = onError;
         }
 
-        /** Transient placeholder path; warm-up never writes a file, but the open path expects one. */
+        /**
+         * Transient placeholder path; warm-up never writes a file, but the open path expects one.
+         */
         String warmFilePath() {
             return "warmup_" + System.currentTimeMillis() + ".jpg";
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/ActivePhotoCapture.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/ActivePhotoCapture.java
@@ -1,36 +1,47 @@
 package com.mentra.asg_client.camera.model;
 
+import com.mentra.asg_client.camera.CameraNeoService;
 import java.util.Objects;
 
-import com.mentra.asg_client.camera.CameraNeoService;
-
 /**
- * Immutable snapshot of the photo capture currently executing in {@link com.mentra.asg_client.camera.lifecycle.PhotoSession}.
+ * Immutable snapshot of the photo capture currently executing in {@link
+ * com.mentra.asg_client.camera.lifecycle.PhotoSession}.
  *
  * <p><b>Lifecycle role:</b> Set when a {@link QueuedPhotoRequest} is dequeued and capture begins
- * ({@code activateQueuedRequest}); cleared when the shot finishes or errors ({@code clearActiveCapture}).
- * While non-null, AE wait, still capture, and JPEG save read exposure/size/callback from here.
+ * ({@code activateQueuedRequest}); cleared when the shot finishes or errors ({@code
+ * clearActiveCapture}). While non-null, AE wait, still capture, and JPEG save read
+ * exposure/size/callback from here.
  *
  * <p><b>Why not merge with {@link QueuedPhotoRequest}?</b> The queue item can be mutated (callback
  * binding) and carries {@link QueuedPhotoRequest#requestId} for FIFO bookkeeping. This type is a
  * frozen copy of only what Camera2 needs, without queue identity — so in-flight code cannot observe
  * late registry updates.
  *
- * <p><b>Field naming:</b> {@link #ledEnabled} mirrors {@link QueuedPhotoRequest#enableLed};
- * {@link #startTimeMs} mirrors {@link QueuedPhotoRequest#enqueuedAtMs} (capture clock starts at dequeue).
+ * <p><b>Field naming:</b> {@link #ledEnabled} mirrors {@link QueuedPhotoRequest#enableLed}; {@link
+ * #startTimeMs} mirrors {@link QueuedPhotoRequest#enqueuedAtMs} (capture clock starts at dequeue).
  */
 public final class ActivePhotoCapture {
 
     public final String filePath;
     public final String size;
     public final boolean isFromSdk;
+
     /** {@code null} = auto exposure for this shot. */
     public final Long exposureTimeNs;
+
     /** {@code null} = derive ISO from preview metering for manual exposure captures. */
     public final Integer iso;
+
     public final PhotoCaptureSettings captureSettings;
     public final boolean ledEnabled;
     public final long startTimeMs;
+
+    /** Mirrors {@link QueuedPhotoRequest#deferDiskWrite}. */
+    public final boolean deferDiskWrite;
+
+    /** Mirrors {@link QueuedPhotoRequest#persistToDisk}. */
+    public final boolean persistToDisk;
+
     public final CameraNeoService.PhotoCaptureCallback callback;
 
     public ActivePhotoCapture(
@@ -41,7 +52,16 @@ public final class ActivePhotoCapture {
             boolean ledEnabled,
             long startTimeMs,
             CameraNeoService.PhotoCaptureCallback callback) {
-        this(filePath, size, isFromSdk, exposureTimeNs, null, PhotoCaptureSettings.EMPTY, ledEnabled, startTimeMs, callback);
+        this(
+                filePath,
+                size,
+                isFromSdk,
+                exposureTimeNs,
+                null,
+                PhotoCaptureSettings.EMPTY,
+                ledEnabled,
+                startTimeMs,
+                callback);
     }
 
     public ActivePhotoCapture(
@@ -53,7 +73,16 @@ public final class ActivePhotoCapture {
             boolean ledEnabled,
             long startTimeMs,
             CameraNeoService.PhotoCaptureCallback callback) {
-        this(filePath, size, isFromSdk, exposureTimeNs, iso, PhotoCaptureSettings.EMPTY, ledEnabled, startTimeMs, callback);
+        this(
+                filePath,
+                size,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                PhotoCaptureSettings.EMPTY,
+                ledEnabled,
+                startTimeMs,
+                callback);
     }
 
     public ActivePhotoCapture(
@@ -66,6 +95,57 @@ public final class ActivePhotoCapture {
             boolean ledEnabled,
             long startTimeMs,
             CameraNeoService.PhotoCaptureCallback callback) {
+        this(
+                filePath,
+                size,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                ledEnabled,
+                startTimeMs,
+                false,
+                true,
+                callback);
+    }
+
+    public ActivePhotoCapture(
+            String filePath,
+            String size,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean ledEnabled,
+            long startTimeMs,
+            boolean deferDiskWrite,
+            CameraNeoService.PhotoCaptureCallback callback) {
+        this(
+                filePath,
+                size,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                ledEnabled,
+                startTimeMs,
+                deferDiskWrite,
+                true,
+                callback);
+    }
+
+    public ActivePhotoCapture(
+            String filePath,
+            String size,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean ledEnabled,
+            long startTimeMs,
+            boolean deferDiskWrite,
+            boolean persistToDisk,
+            CameraNeoService.PhotoCaptureCallback callback) {
         this.filePath = filePath;
         this.size = size;
         this.isFromSdk = isFromSdk;
@@ -75,12 +155,14 @@ public final class ActivePhotoCapture {
                 captureSettings != null ? captureSettings : PhotoCaptureSettings.EMPTY;
         this.ledEnabled = ledEnabled;
         this.startTimeMs = startTimeMs;
+        this.deferDiskWrite = deferDiskWrite;
+        this.persistToDisk = persistToDisk;
         this.callback = callback;
     }
 
     /**
-     * Promote a dequeued {@link QueuedPhotoRequest} to the in-flight snapshot.
-     * Call once per shot, before starting AE/capture.
+     * Promote a dequeued {@link QueuedPhotoRequest} to the in-flight snapshot. Call once per shot,
+     * before starting AE/capture.
      */
     public static ActivePhotoCapture fromQueued(QueuedPhotoRequest queued) {
         return new ActivePhotoCapture(
@@ -92,6 +174,8 @@ public final class ActivePhotoCapture {
                 queued.captureSettings,
                 queued.enableLed,
                 queued.enqueuedAtMs,
+                queued.deferDiskWrite,
+                queued.persistToDisk,
                 queued.callback);
     }
 
@@ -107,6 +191,8 @@ public final class ActivePhotoCapture {
         return isFromSdk == that.isFromSdk
                 && ledEnabled == that.ledEnabled
                 && startTimeMs == that.startTimeMs
+                && deferDiskWrite == that.deferDiskWrite
+                && persistToDisk == that.persistToDisk
                 && Objects.equals(filePath, that.filePath)
                 && Objects.equals(size, that.size)
                 && Objects.equals(exposureTimeNs, that.exposureTimeNs)
@@ -116,6 +202,16 @@ public final class ActivePhotoCapture {
 
     @Override
     public int hashCode() {
-        return Objects.hash(filePath, size, isFromSdk, exposureTimeNs, iso, ledEnabled, startTimeMs, callback);
+        return Objects.hash(
+                filePath,
+                size,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                ledEnabled,
+                startTimeMs,
+                deferDiskWrite,
+                persistToDisk,
+                callback);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/CapturedPhoto.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/CapturedPhoto.java
@@ -1,0 +1,91 @@
+package com.mentra.asg_client.camera.model;
+
+import androidx.annotation.Nullable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.json.JSONObject;
+
+/**
+ * In-memory result of a photo capture: the sensor JPEG bytes plus the assembled IMU payload, handed
+ * directly to consumers (BLE compression). Sensor-JPEG persistence is optional. Text mode keeps it
+ * disabled even for save=true so the consumer can persist only its final crop (or a full-frame
+ * fallback); save=false also uses a completed false future.
+ *
+ * <p>Produced by {@code PhotoSession} for captures enqueued with {@code deferDiskWrite=true} and
+ * delivered directly through {@code PhotoCaptureCallback}. The {@link #persistence} future tracks
+ * the background optional JPEG + EXIF + IMU-sidecar write; any consumer that needs the file on disk
+ * must gate on {@link #awaitPersistence} instead of touching the path directly.
+ */
+public final class CapturedPhoto {
+
+    /** Complete sensor JPEG as delivered by the camera HAL. */
+    public final byte[] jpegBytes;
+
+    /** Assembled IMU payload for EXIF embedding, or {@code null} when no samples were captured. */
+    @Nullable public final JSONObject imuPayload;
+
+    /**
+     * Persistence result: {@code true} once the JPEG (and IMU artifacts, if any) are on disk,
+     * {@code false} when persistence was intentionally skipped or failed.
+     */
+    public final Future<Boolean> persistence;
+
+    public CapturedPhoto(
+            byte[] jpegBytes, @Nullable JSONObject imuPayload, Future<Boolean> persistence) {
+        this.jpegBytes = jpegBytes;
+        this.imuPayload = imuPayload;
+        this.persistence = persistence;
+    }
+
+    /**
+     * Block until the background disk write finishes.
+     *
+     * @return true when the file is on disk, false on write failure or timeout
+     */
+    public boolean awaitPersistence(long timeoutMs) {
+        try {
+            return Boolean.TRUE.equals(persistence.get(timeoutMs, TimeUnit.MILLISECONDS));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        } catch (ExecutionException | TimeoutException | CancellationException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Waits for a required gallery write to reach a terminal result. Interrupts are restored after
+     * the write resolves so callers never report a save failure while the same write is still able
+     * to publish the file.
+     */
+    public boolean awaitPersistenceCompletion() {
+        boolean interrupted = false;
+        try {
+            while (true) {
+                try {
+                    return Boolean.TRUE.equals(persistence.get());
+                } catch (InterruptedException e) {
+                    interrupted = true;
+                } catch (ExecutionException | CancellationException e) {
+                    return false;
+                }
+            }
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    /**
+     * Try to cancel the background write for photos that will never be kept (save=false). Returns
+     * true when the write was cancelled before starting — nothing was or will be written. When
+     * cancellation loses the race, the caller must await and clean the file up as usual.
+     */
+    public boolean cancelPersistence() {
+        return persistence.cancel(false);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/QueuedPhotoRequest.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/model/QueuedPhotoRequest.java
@@ -6,14 +6,14 @@ import com.mentra.asg_client.camera.CameraNeoService;
  * A photo capture job waiting in the global FIFO ({@link QueuedPhotoRequestQueue}).
  *
  * <p><b>Lifecycle role:</b> This type represents the <em>waiting</em> phase. Callers enqueue via
- * {@link CameraNeoService#enqueuePhotoRequest}; {@link com.mentra.asg_client.camera.lifecycle.PhotoSession}
- * later {@link QueuedPhotoRequestQueue#poll() polls} the head and promotes it to an
- * {@link ActivePhotoCapture} while Camera2 runs AE/capture.
+ * {@link CameraNeoService#enqueuePhotoRequest}; {@link
+ * com.mentra.asg_client.camera.lifecycle.PhotoSession} later {@link QueuedPhotoRequestQueue#poll()
+ * polls} the head and promotes it to an {@link ActivePhotoCapture} while Camera2 runs AE/capture.
  *
  * <p><b>Why not merge with {@link ActivePhotoCapture}?</b> Queue entries may sit for a long time,
- * survive service restarts (callbacks re-bound by {@code requestId}), and have their
- * {@link #callback} patched after enqueue. The in-flight capture uses a separate immutable snapshot
- * so AE/capture never sees mid-flight mutation.
+ * survive service restarts (callbacks re-bound by {@code requestId}), and have their {@link
+ * #callback} patched after enqueue. The in-flight capture uses a separate immutable snapshot so
+ * AE/capture never sees mid-flight mutation.
  *
  * <p><b>Immutability:</b> All fields except {@link #callback} are {@code final}. The callback may
  * be {@code null} at enqueue time and filled from {@link QueuedPhotoRequestQueue}'s registry before
@@ -43,18 +43,33 @@ public final class QueuedPhotoRequest {
     public final boolean isFromSdk;
 
     /**
-     * Optional manual shutter for this shot only (Camera2 {@code SENSOR_EXPOSURE_TIME}, nanoseconds).
-     * {@code null} means auto exposure.
+     * Optional manual shutter for this shot only (Camera2 {@code SENSOR_EXPOSURE_TIME},
+     * nanoseconds). {@code null} means auto exposure.
      */
     public final Long exposureTimeNs;
 
     /**
-     * Optional ISO / Camera2 {@code SENSOR_SENSITIVITY} for manual exposure captures only.
-     * {@code null} means derive ISO from preview metering.
+     * Optional ISO / Camera2 {@code SENSOR_SENSITIVITY} for manual exposure captures only. {@code
+     * null} means derive ISO from preview metering.
      */
     public final Integer iso;
 
-    /** Wall-clock time when this entry was enqueued; copied to {@link ActivePhotoCapture#startTimeMs}. */
+    /**
+     * When {@code true}, the capture callback receives a {@link CapturedPhoto} as soon as the JPEG
+     * bytes are in memory, and the disk write (JPEG + EXIF + IMU sidecar) runs on a background
+     * thread whose result rides on {@link CapturedPhoto#persistence}. Callers that need the file
+     * MUST gate access on that future. {@code false} keeps the classic write-then-callback
+     * behavior.
+     */
+    public final boolean deferDiskWrite;
+
+    /** Whether the deferred in-memory capture should also be persisted as a gallery artifact. */
+    public final boolean persistToDisk;
+
+    /**
+     * Wall-clock time when this entry was enqueued; copied to {@link
+     * ActivePhotoCapture#startTimeMs}.
+     */
     public final long enqueuedAtMs;
 
     /**
@@ -70,7 +85,15 @@ public final class QueuedPhotoRequest {
             boolean isFromSdk,
             Long exposureTimeNs,
             CameraNeoService.PhotoCaptureCallback callback) {
-        this(filePath, size, enableLed, isFromSdk, exposureTimeNs, null, PhotoCaptureSettings.EMPTY, callback);
+        this(
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                null,
+                PhotoCaptureSettings.EMPTY,
+                callback);
     }
 
     public QueuedPhotoRequest(
@@ -81,7 +104,15 @@ public final class QueuedPhotoRequest {
             Long exposureTimeNs,
             Integer iso,
             CameraNeoService.PhotoCaptureCallback callback) {
-        this(filePath, size, enableLed, isFromSdk, exposureTimeNs, iso, PhotoCaptureSettings.EMPTY, callback);
+        this(
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                PhotoCaptureSettings.EMPTY,
+                callback);
     }
 
     public QueuedPhotoRequest(
@@ -93,6 +124,53 @@ public final class QueuedPhotoRequest {
             Integer iso,
             PhotoCaptureSettings captureSettings,
             CameraNeoService.PhotoCaptureCallback callback) {
+        this(
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                false,
+                true,
+                callback);
+    }
+
+    public QueuedPhotoRequest(
+            String filePath,
+            String size,
+            boolean enableLed,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean deferDiskWrite,
+            CameraNeoService.PhotoCaptureCallback callback) {
+        this(
+                filePath,
+                size,
+                enableLed,
+                isFromSdk,
+                exposureTimeNs,
+                iso,
+                captureSettings,
+                deferDiskWrite,
+                true,
+                callback);
+    }
+
+    public QueuedPhotoRequest(
+            String filePath,
+            String size,
+            boolean enableLed,
+            boolean isFromSdk,
+            Long exposureTimeNs,
+            Integer iso,
+            PhotoCaptureSettings captureSettings,
+            boolean deferDiskWrite,
+            boolean persistToDisk,
+            CameraNeoService.PhotoCaptureCallback callback) {
         this.requestId = "photo_" + System.currentTimeMillis() + "_" + filePath.hashCode();
         this.filePath = filePath;
         this.size = size;
@@ -102,6 +180,8 @@ public final class QueuedPhotoRequest {
         this.iso = iso;
         this.captureSettings =
                 captureSettings != null ? captureSettings : PhotoCaptureSettings.EMPTY;
+        this.deferDiskWrite = deferDiskWrite;
+        this.persistToDisk = persistToDisk;
         this.callback = callback;
         this.enqueuedAtMs = System.currentTimeMillis();
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/core/BaseBluetoothManager.java
@@ -2,14 +2,10 @@ package com.mentra.asg_client.io.bluetooth.core;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
 import com.mentra.asg_client.io.bluetooth.interfaces.TransportListener;
 import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.receiver.IntentResponseBroadcaster;
-
-import org.json.JSONObject;
-
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,10 +15,11 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
+import org.json.JSONObject;
 
 /**
  * Base implementation of the IBluetoothManager interface. Provides common functionality for all
@@ -306,8 +303,7 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         }
     }
 
-    private static void notifySendMessageCallback(
-            SendMessageCallback callback, boolean success) {
+    private static void notifySendMessageCallback(SendMessageCallback callback, boolean success) {
         if (callback == null) {
             return;
         }
@@ -556,16 +552,35 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
         if (path == null || path.isEmpty()) {
             return false;
         }
+        return startFileTransfer(() -> sendFileInternal(path));
+    }
 
+    /**
+     * Send an in-memory payload using the file-transfer protocol without requiring it to exist on
+     * disk. Same outbound-worker serialization and start-timeout semantics as the path-based {@link
+     * #sendFile(String)}.
+     */
+    @Override
+    public final boolean sendFile(byte[] data, String fileName) {
+        if (data == null || data.length == 0 || fileName == null || fileName.isEmpty()) {
+            return false;
+        }
+        return startFileTransfer(() -> sendFileInternal(data, fileName));
+    }
+
+    private boolean startFileTransfer(Callable<Boolean> startAction) {
         if (Boolean.TRUE.equals(outboundBleWorkerThread.get())) {
-            return sendFileInternal(path);
+            try {
+                return startAction.call();
+            } catch (Exception e) {
+                Log.e(TAG, "Outbound BLE file transfer start failed on worker", e);
+                return false;
+            }
         }
 
         Future<Boolean> future = null;
         try {
-            future =
-                    outboundBleExecutor.submit(
-                            () -> callOnOutboundBleWorker(() -> sendFileInternal(path)));
+            future = outboundBleExecutor.submit(() -> callOnOutboundBleWorker(startAction));
             return future.get(OUTBOUND_FILE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         } catch (RejectedExecutionException e) {
             Log.e(TAG, "Rejected outbound BLE file transfer start", e);
@@ -619,6 +634,11 @@ public abstract class BaseBluetoothManager implements ICompanionTransport {
 
     protected boolean sendFileInternal(String path) {
         Log.w(TAG, "sendFile not implemented in " + getClass().getSimpleName());
+        return false;
+    }
+
+    protected boolean sendFileInternal(byte[] data, String fileName) {
+        Log.w(TAG, "sendFile(byte[]) not implemented in " + getClass().getSimpleName());
         return false;
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/IBluetoothManager.java
@@ -70,6 +70,19 @@ public interface IBluetoothManager {
     boolean sendFile(String filePath);
 
     /**
+     * Send an in-memory payload to the connected device using the file-transfer protocol, without
+     * requiring the payload to exist on disk. Default returns false for transports without
+     * file-transfer support.
+     *
+     * @param data payload bytes
+     * @param fileName wire name for the transfer (the K900 protocol caps this at 16 chars)
+     * @return true if transfer start was accepted after earlier outbound messages drained
+     */
+    default boolean sendFile(byte[] data, String fileName) {
+        return false;
+    }
+
+    /**
      * @return true if a transfer is active, false otherwise
      */
     boolean isFileTransferInProgress();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2,7 +2,6 @@ package com.mentra.asg_client.io.bluetooth.managers;
 
 import android.content.Context;
 import android.util.Log;
-
 import com.mentra.asg_client.io.bluetooth.core.BaseBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesMessageParser;
@@ -17,9 +16,6 @@ import com.mentra.asg_client.reporting.domains.BluetoothReporting;
 import com.mentra.asg_client.service.core.AsgClientService;
 import com.mentra.asg_client.service.core.processors.ChunkReassembler;
 import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrategy;
-
-import org.json.JSONObject;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -31,6 +27,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import org.json.JSONObject;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -115,6 +112,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private int effectiveUartPackSize() {
         return BesWireFormat.getFilePackSize();
     }
+
     private static final long SIGNIFICANT_CHUNK_TRACE_DURATION_MS = 250;
     private static final long SIGNIFICANT_CHUNK_SEND_DURATION_MS = 250;
     private static final long SIGNIFICANT_CHUNK_SPACING_MS = PACING_DELAY_MS + 150;
@@ -130,10 +128,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     /** Feature switch for the runtime UART baud upgrade. */
     private static final boolean UART_BAUD_SWITCH_ENABLED = true;
 
-    /** Baud rate to upgrade the BES UART link to. 1152000 is the measured hardware
-     * ceiling: 1.5M/2M/3M all negotiated fine but carried zero data (probe silent,
-     * both sides auto-reverted) - without flow control the clocking above 1.152M
-     * doesn't survive the wire. Tested 2026-07-05. */
+    /**
+     * Baud rate to upgrade the BES UART link to. 1152000 is the measured hardware ceiling:
+     * 1.5M/2M/3M all negotiated fine but carried zero data (probe silent, both sides auto-reverted)
+     * - without flow control the clocking above 1.152M doesn't survive the wire. Tested 2026-07-05.
+     */
     private static final int TARGET_UART_BAUD = 1152000;
 
     /** Minimum BES firmware version (sr_syvr "dpj" dotted string) that supports cs_baud. */
@@ -1163,9 +1162,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             if (payloadSize > BesWireFormat.FILE_PACK_SIZE_LEGACY) {
                 phoneSupportsFilePayloadV2 = true;
             }
-            if ("coc".equals(transport)
-                    && besWireCapsFilePayloadV2
-                    && phoneSupportsFilePayloadV2) {
+            if ("coc".equals(transport) && besWireCapsFilePayloadV2 && phoneSupportsFilePayloadV2) {
                 if (fileTransportCoc
                         && currentFileTransfer != null
                         && currentFileTransfer.packSize > payloadSize) {
@@ -1339,9 +1336,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     /**
      * Compare two dotted version strings numerically, component by component. Missing components
-     * count as 0. Each component is read as its leading numeric prefix so hotfix-suffixed
-     * firmware strings (e.g. "17.26.7.5-fix1") compare as their base version instead of
-     * throwing and silently disabling the transport feature gates.
+     * count as 0. Each component is read as its leading numeric prefix so hotfix-suffixed firmware
+     * strings (e.g. "17.26.7.5-fix1") compare as their base version instead of throwing and
+     * silently disabling the transport feature gates.
      *
      * @return negative if a &lt; b, 0 if equal, positive if a &gt; b
      */
@@ -1409,8 +1406,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     /**
-     * Handle sr_baud response from the BES. Called early in the serial read pipeline (same place
-     * as sr_syvr) since the negotiation lives entirely in this class.
+     * Handle sr_baud response from the BES. Called early in the serial read pipeline (same place as
+     * sr_syvr) since the negotiation lives entirely in this class.
      *
      * @param payload The JSON payload bytes
      * @return true if this was an sr_baud response and was consumed, false otherwise
@@ -1469,9 +1466,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             + BAUD_REOPEN_DELAY_MS
                             + "ms");
             baudSwitchExecutor.schedule(
-                    this::reopenAtTargetBaudAndProbe,
-                    BAUD_REOPEN_DELAY_MS,
-                    TimeUnit.MILLISECONDS);
+                    this::reopenAtTargetBaudAndProbe, BAUD_REOPEN_DELAY_MS, TimeUnit.MILLISECONDS);
             return true;
         } catch (Exception e) {
             Log.e(BAUD_TAG, "Error parsing sr_baud response", e);
@@ -1583,8 +1578,13 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             + (besSupportsBatchedAcks ? "ENABLED" : "disabled")
                             + ", big packs "
                             + (besSupportsBigPacks ? "ENABLED" : "disabled")
-                            + " (fw " + version + ", window " + effectivePushWindow()
-                            + ", packSize " + effectiveUartPackSize() + ")");
+                            + " (fw "
+                            + version
+                            + ", window "
+                            + effectivePushWindow()
+                            + ", packSize "
+                            + effectiveUartPackSize()
+                            + ")");
         } catch (Exception e) {
             besSupportsBatchedAcks = false;
         }
@@ -1859,8 +1859,51 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return false;
         }
 
-        // Create file transfer session
-        String fileName = file.getName();
+        return startFileTransferSession(filePath, file.getName(), fileData);
+    }
+
+    /**
+     * Send an in-memory payload over the K900 file-transfer protocol without a backing file.
+     * Everything after session creation (packet pump, acks, retries) already operates on the
+     * in-memory {@code fileData} buffer, so no disk artifact is required.
+     *
+     * @param data payload bytes
+     * @param fileName wire name for the transfer (truncated to the 16-char protocol cap)
+     * @return true if transfer started successfully
+     */
+    @Override
+    protected boolean sendFileInternal(byte[] data, String fileName) {
+        if (!isSerialOpen) {
+            Log.e(TAG, "Cannot send in-memory file - serial port not open");
+            BluetoothReporting.reportFileTransferFailure(
+                    context, memoryReportPath(fileName), "send_file", "serial_port_not_open", null);
+            return false;
+        }
+
+        if (currentFileTransfer != null && currentFileTransfer.isActive) {
+            Log.e(TAG, "File transfer already in progress");
+            BluetoothReporting.reportFileTransferFailure(
+                    context,
+                    memoryReportPath(fileName),
+                    "send_file",
+                    "transfer_already_in_progress",
+                    null);
+            return false;
+        }
+
+        return startFileTransferSession(null, fileName, data);
+    }
+
+    /** Synthetic identifier for Sentry reports on transfers that never touch disk. */
+    private static String memoryReportPath(String fileName) {
+        return "mem:" + fileName;
+    }
+
+    /**
+     * Create the transfer session and start the packet pump. {@code filePath} is {@code null} for
+     * in-memory transfers; it is only used for post-transfer cleanup and failure reporting.
+     */
+    private boolean startFileTransferSession(String filePath, String fileName, byte[] fileData) {
         if (fileName.length() > 16) {
             fileName = fileName.substring(0, 16); // Truncate to 16 chars max
         }
@@ -1885,7 +1928,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + fileData.length
                         + " bytes, "
                         + currentFileTransfer.totalPackets
-                        + " packets)");
+                        + " packets, "
+                        + (filePath != null ? "disk-backed" : "in-memory")
+                        + ")");
 
         notificationManager.showDebugNotification(
                 "File Transfer",
@@ -1905,9 +1950,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     /**
-     * Pump file packets in push mode: stream up to FILE_PUSH_WINDOW packets ahead of the
-     * highest BES ack instead of waiting one ack round trip per packet. Completion fires
-     * once the acks (not the sends) have covered every packet.
+     * Pump file packets in push mode: stream up to FILE_PUSH_WINDOW packets ahead of the highest
+     * BES ack instead of waiting one ack round trip per packet. Completion fires once the acks (not
+     * the sends) have covered every packet.
      */
     private void sendNextFilePacket() {
         if (currentFileTransfer == null || !currentFileTransfer.isActive) {
@@ -1918,9 +1963,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             // All packets sent and ACKed by MCU
             long transferDuration = System.currentTimeMillis() - currentFileTransfer.startTime;
             BlePhotoTimingLog.recordUartTransfer(
-                    currentFileTransfer.fileName,
-                    currentFileTransfer.fileSize,
-                    transferDuration);
+                    currentFileTransfer.fileName, currentFileTransfer.fileSize, transferDuration);
             int rateKbps =
                     transferDuration > 0
                             ? (int) (currentFileTransfer.fileSize * 1000L / transferDuration / 1024)
@@ -2028,7 +2071,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (!sent) {
             Log.e(TAG, "Failed to write file packet " + packetIndex + " to UART");
             BluetoothReporting.reportFileTransferFailure(
-                    context, currentFileTransfer.filePath, "send_file", "uart_write_failed", null);
+                    context, transferReportPath(), "send_file", "uart_write_failed", null);
             notificationManager.showDebugNotification(
                     "File Transfer Failed", "UART write failed at packet " + packetIndex);
             notifyTransferFailedToPhone("uart_write_failed");
@@ -2099,7 +2142,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
                 // Report file transfer failure
                 BluetoothReporting.reportFileTransferFailure(
-                        context, currentFileTransfer.filePath, "send_file", "packet_timeout", null);
+                        context, transferReportPath(), "send_file", "packet_timeout", null);
 
                 notificationManager.showDebugNotification(
                         "File Transfer Failed", "Packet " + packetIndex + " timeout");
@@ -2158,7 +2201,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         phoneSupportsFilePayloadV2 = false;
         fileTransportCoc = false;
         resetPhoneWireProtocolState();
-        Log.i(TAG, "📦 Transport reset - file pack size and wire protocol state restored to defaults");
+        Log.i(
+                TAG,
+                "📦 Transport reset - file pack size and wire protocol state restored to defaults");
     }
 
     @Override
@@ -2223,8 +2268,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
             // Reset consecutive failure counter on success
             consecutiveFailures = 0;
-            if (pendingFailureRetryIndex >= 0
-                    && ackedPacketIndex >= pendingFailureRetryIndex) {
+            if (pendingFailureRetryIndex >= 0 && ackedPacketIndex >= pendingFailureRetryIndex) {
                 pendingFailureRetryIndex = -1;
                 failureRetryScheduled = false;
             }
@@ -2277,7 +2321,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 // Report the failure
                 BluetoothReporting.reportFileTransferFailure(
                         context,
-                        currentFileTransfer.filePath,
+                        transferReportPath(),
                         "send_file",
                         "ble_tx_stuck_consecutive_failures",
                         null);
@@ -2563,9 +2607,23 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
+    /** Identifier for failure reports on the active transfer (synthetic for in-memory sends). */
+    private String transferReportPath() {
+        if (currentFileTransfer == null) {
+            return "mem:unknown";
+        }
+        return currentFileTransfer.filePath != null
+                ? currentFileTransfer.filePath
+                : memoryReportPath(currentFileTransfer.fileName);
+    }
+
     /** Delete file after successful transfer */
     private void deleteFileAfterSuccess() {
         if (currentFileTransfer == null) {
+            return;
+        }
+        if (currentFileTransfer.filePath == null) {
+            // In-memory transfer - nothing was ever written to disk.
             return;
         }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/AvifBleEncoder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/AvifBleEncoder.java
@@ -1,13 +1,15 @@
 package com.mentra.asg_client.io.media.core;
 
 import android.graphics.Bitmap;
+import androidx.annotation.Nullable;
 import com.mentra.asg_client.camera.lifecycle.PhotoExifMetadataWriter;
+import org.json.JSONObject;
 
 /**
- * AVIF BLE payload encoder. Thin adapter over the established
- * {@link PhotoExifMetadataWriter#encodeAvifForBle} path (HeifCoder software AV1, or
- * AvifWriter+MediaCodec where an AV1 hardware encoder exists), so AVIF stays fully available
- * as a selectable codec and as the fallback when {@link JpegFastBleEncoder} fails.
+ * AVIF BLE payload encoder. Thin adapter over the established {@link
+ * PhotoExifMetadataWriter#encodeAvifForBle} path (HeifCoder software AV1, or AvifWriter+MediaCodec
+ * where an AV1 hardware encoder exists), so AVIF stays fully available as a selectable codec and as
+ * the fallback when {@link JpegFastBleEncoder} fails.
  */
 final class AvifBleEncoder implements BlePhotoEncoder {
     @Override
@@ -16,10 +18,22 @@ final class AvifBleEncoder implements BlePhotoEncoder {
     }
 
     @Override
-    public EncodeResult encode(Bitmap bitmap, int quality, String sourceJpegPath)
-            throws Exception {
+    public EncodeResult encode(Bitmap bitmap, int quality, String sourceJpegPath) throws Exception {
         long start = System.currentTimeMillis();
         byte[] avif = PhotoExifMetadataWriter.encodeAvifForBle(bitmap, quality, sourceJpegPath);
+        return new EncodeResult(avif, BleCodec.AVIF, System.currentTimeMillis() - start);
+    }
+
+    EncodeResult encode(
+            Bitmap bitmap,
+            int quality,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath)
+            throws Exception {
+        long start = System.currentTimeMillis();
+        byte[] avif =
+                PhotoExifMetadataWriter.encodeAvifForBle(
+                        bitmap, quality, imuPayload, intendedCapturePath);
         return new EncodeResult(avif, BleCodec.AVIF, System.currentTimeMillis() - start);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/BlePhotoEncoders.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/BlePhotoEncoders.java
@@ -1,6 +1,8 @@
 package com.mentra.asg_client.io.media.core;
 
 import android.graphics.Bitmap;
+import androidx.annotation.Nullable;
+import org.json.JSONObject;
 
 /**
  * Selector over the concrete {@link BlePhotoEncoder} implementations. Callers pick a codec (via
@@ -16,16 +18,25 @@ final class BlePhotoEncoders {
         return codec == BleCodec.JPEG_FAST ? JPEG_FAST : AVIF;
     }
 
-    /** Encode {@code bitmap} with the selected codec without silently switching codecs. */
+    /** Encode a RAM-first capture without consulting the source JPEG path for IMU metadata. */
     static BlePhotoEncoder.EncodeResult encode(
             Bitmap bitmap,
             BleCodec codec,
             int quality,
-            String sourceJpegPath)
+            @Nullable String sourceJpegPath,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath)
             throws Exception {
+        // A null source path explicitly identifies a RAM-first capture, including the valid case
+        // where the IMU recorder produced no samples. Never probe a path that was intentionally
+        // not persisted.
         if (codec == BleCodec.JPEG_FAST) {
-            return JPEG_FAST.encode(bitmap, quality, sourceJpegPath);
+            return sourceJpegPath == null
+                    ? JPEG_FAST.encode(bitmap, quality, imuPayload, intendedCapturePath)
+                    : JPEG_FAST.encode(bitmap, quality, sourceJpegPath);
         }
-        return AVIF.encode(bitmap, quality, sourceJpegPath);
+        return sourceJpegPath == null
+                ? AVIF.encode(bitmap, quality, imuPayload, intendedCapturePath)
+                : AVIF.encode(bitmap, quality, sourceJpegPath);
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/GrayscaleBleProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/GrayscaleBleProcessor.java
@@ -20,10 +20,10 @@ import java.io.IOException;
  * the previous pipeline spent most of its ~35MB peak per photo.
  *
  * <p>Chroma is never allocated on our side, but the AVIF encoder itself still emits a YUV420
- * (color) bitstream internally - true YUV400-only encode requires a native libavif/libaom shim
- * that this library doesn't expose (Phase 2, out of scope here). The wire-size win from skipping
- * chroma is small regardless (flat chroma planes already compress to near-nothing in AV1); the
- * real payoff of this pass is the ~3x RAM reduction and matching increase in decode/encode speed.
+ * (color) bitstream internally - true YUV400-only encode requires a native libavif/libaom shim that
+ * this library doesn't expose (Phase 2, out of scope here). The wire-size win from skipping chroma
+ * is small regardless (flat chroma planes already compress to near-nothing in AV1); the real payoff
+ * of this pass is the ~3x RAM reduction and matching increase in decode/encode speed.
  */
 final class GrayscaleBleProcessor {
     private static final String TAG = "GrayscaleBleProcessor";
@@ -45,32 +45,51 @@ final class GrayscaleBleProcessor {
      */
     static Bitmap process(String jpegPath, @Nullable Rect roi, int targetWidth, int targetHeight)
             throws IOException {
+        return process(null, jpegPath, roi, targetWidth, targetHeight);
+    }
+
+    /** In-memory variant of {@link #process(String, Rect, int, int)} - no disk reads. */
+    static Bitmap process(byte[] jpegBytes, @Nullable Rect roi, int targetWidth, int targetHeight)
+            throws IOException {
+        return process(jpegBytes, "in-memory JPEG", roi, targetWidth, targetHeight);
+    }
+
+    private static Bitmap process(
+            @Nullable byte[] jpegBytes,
+            String jpegSource,
+            @Nullable Rect roi,
+            int targetWidth,
+            int targetHeight)
+            throws IOException {
         long start = System.currentTimeMillis();
 
         BitmapFactory.Options bounds = new BitmapFactory.Options();
         bounds.inJustDecodeBounds = true;
-        BitmapFactory.decodeFile(jpegPath, bounds);
+        decodeJpeg(jpegBytes, jpegSource, bounds);
         int srcWidth = bounds.outWidth;
         int srcHeight = bounds.outHeight;
         if (srcWidth <= 0 || srcHeight <= 0) {
-            throw new IOException("Failed to read JPEG bounds: " + jpegPath);
+            throw new IOException("Failed to read JPEG bounds: " + jpegSource);
         }
 
         Rect region =
-                (roi != null) ? clampRect(roi, srcWidth, srcHeight) : new Rect(0, 0, srcWidth, srcHeight);
+                (roi != null)
+                        ? clampRect(roi, srcWidth, srcHeight)
+                        : new Rect(0, 0, srcWidth, srcHeight);
 
         // Decode at the smallest power-of-two sample size that still comfortably covers the
         // target resolution - we never materialize a full-res ARGB bitmap here.
-        int sampleSize = computeSampleSize(region.width(), region.height(), targetWidth, targetHeight);
+        int sampleSize =
+                computeSampleSize(region.width(), region.height(), targetWidth, targetHeight);
 
         BitmapFactory.Options decodeOpts = new BitmapFactory.Options();
         decodeOpts.inSampleSize = sampleSize;
         // Source JPEG has no alpha; RGB_565 halves decode memory vs ARGB_8888 (2B/px vs 4B/px)
         // and loses nothing we need since we reduce to luma immediately below.
         decodeOpts.inPreferredConfig = Bitmap.Config.RGB_565;
-        Bitmap decoded = BitmapFactory.decodeFile(jpegPath, decodeOpts);
+        Bitmap decoded = decodeJpeg(jpegBytes, jpegSource, decodeOpts);
         if (decoded == null) {
-            throw new IOException("Failed to decode JPEG: " + jpegPath);
+            throw new IOException("Failed to decode JPEG: " + jpegSource);
         }
 
         float scale = 1f / sampleSize;
@@ -116,6 +135,20 @@ final class GrayscaleBleProcessor {
                         + (System.currentTimeMillis() - start)
                         + "ms");
         return gray;
+    }
+
+    /**
+     * Decodes from the in-memory JPEG when present, else from the file path in {@code jpegSource}.
+     * Returns null (with populated bounds when {@code inJustDecodeBounds}) exactly like {@link
+     * BitmapFactory}.
+     */
+    @Nullable
+    private static Bitmap decodeJpeg(
+            @Nullable byte[] jpegBytes, String jpegSource, BitmapFactory.Options opts) {
+        if (jpegBytes != null) {
+            return BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.length, opts);
+        }
+        return BitmapFactory.decodeFile(jpegSource, opts);
     }
 
     private static Rect clampRect(Rect r, int width, int height) {
@@ -178,14 +211,10 @@ final class GrayscaleBleProcessor {
     }
 
     private static int[] fitWithinAspect(int width, int height, int targetWidth, int targetHeight) {
-        float aspect = (float) width / height;
-        int outWidth = targetWidth;
-        int outHeight = targetHeight;
-        if (aspect > (float) targetWidth / targetHeight) {
-            outHeight = Math.max(1, Math.round(targetWidth / aspect));
-        } else {
-            outWidth = Math.max(1, Math.round(targetHeight * aspect));
-        }
+        float scale =
+                Math.min(1f, Math.min(targetWidth / (float) width, targetHeight / (float) height));
+        int outWidth = Math.max(1, Math.round(width * scale));
+        int outHeight = Math.max(1, Math.round(height * scale));
         return new int[] {outWidth, outHeight};
     }
 
@@ -272,14 +301,17 @@ final class GrayscaleBleProcessor {
     }
 
     /**
-     * Result of {@link #extractDetectionLuma}: a subsampled full-frame luma buffer plus the
-     * true source-JPEG dimensions, so a caller running detection on this buffer can scale the
-     * returned crop back up to source-pixel coordinates via {@link #scaleDetectionRoi}.
+     * Result of {@link #extractDetectionLuma}: a subsampled full-frame luma buffer plus the true
+     * source-JPEG dimensions, so a caller running detection on this buffer can scale the returned
+     * crop back up to source-pixel coordinates via {@link #scaleDetectionRoi}.
      *
      * <p>{@code srcWidth}/{@code srcHeight} are carried explicitly because {@code
-     * BitmapFactory.inSampleSize} decoding uses integer division — the decoded dimensions are
-     * often not exactly {@code src / sampleSize}, so multiplying back by {@code sampleSize}
-     * would misalign the crop.
+     * BitmapFactory.inSampleSize} decoding uses integer division — the decoded dimensions are often
+     * not exactly {@code src / sampleSize}, so multiplying back by {@code sampleSize} would
+     * misalign the crop.
+     *
+     * <p>Only the classical and ONNX {@code TextRoiDetector} implementations use luma input; the ML
+     * Kit detector decodes the sensor JPEG bytes directly and does not go through this path.
      */
     static final class DetectionLuma {
         final byte[] luma;
@@ -302,18 +334,31 @@ final class GrayscaleBleProcessor {
 
     /**
      * Decodes {@code jpegPath} at the smallest sample size that still comfortably covers {@code
-     * analysisWidth}, then reduces it to a single-channel luma buffer. Used to feed {@code
-     * TextRegionDetector} a small analysis frame without ever allocating a full-resolution
-     * bitmap. Independent of {@link #process}, which performs its own separate decode.
+     * analysisWidth}, then reduces it to a single-channel luma buffer. Used to feed classical/ONNX
+     * {@code TextRoiDetector} implementations a small analysis frame without ever allocating a
+     * full-resolution bitmap. Independent of {@link #process}, which performs its own separate
+     * decode.
      */
-    static DetectionLuma extractDetectionLuma(String jpegPath, int analysisWidth) throws IOException {
+    static DetectionLuma extractDetectionLuma(String jpegPath, int analysisWidth)
+            throws IOException {
+        return extractDetectionLuma(null, jpegPath, analysisWidth);
+    }
+
+    /** In-memory variant of {@link #extractDetectionLuma(String, int)} - no disk reads. */
+    static DetectionLuma extractDetectionLuma(byte[] jpegBytes, int analysisWidth)
+            throws IOException {
+        return extractDetectionLuma(jpegBytes, "in-memory JPEG", analysisWidth);
+    }
+
+    private static DetectionLuma extractDetectionLuma(
+            @Nullable byte[] jpegBytes, String jpegSource, int analysisWidth) throws IOException {
         BitmapFactory.Options bounds = new BitmapFactory.Options();
         bounds.inJustDecodeBounds = true;
-        BitmapFactory.decodeFile(jpegPath, bounds);
+        decodeJpeg(jpegBytes, jpegSource, bounds);
         int srcWidth = bounds.outWidth;
         int srcHeight = bounds.outHeight;
         if (srcWidth <= 0 || srcHeight <= 0) {
-            throw new IOException("Failed to read JPEG bounds: " + jpegPath);
+            throw new IOException("Failed to read JPEG bounds: " + jpegSource);
         }
 
         // computeSampleSize doubles the sample size while both dimensions stay >= target; passing
@@ -325,9 +370,9 @@ final class GrayscaleBleProcessor {
         BitmapFactory.Options decodeOpts = new BitmapFactory.Options();
         decodeOpts.inSampleSize = sampleSize;
         decodeOpts.inPreferredConfig = Bitmap.Config.RGB_565;
-        Bitmap decoded = BitmapFactory.decodeFile(jpegPath, decodeOpts);
+        Bitmap decoded = decodeJpeg(jpegBytes, jpegSource, decodeOpts);
         if (decoded == null) {
-            throw new IOException("Failed to decode JPEG: " + jpegPath);
+            throw new IOException("Failed to decode JPEG: " + jpegSource);
         }
 
         int width = decoded.getWidth();
@@ -340,13 +385,14 @@ final class GrayscaleBleProcessor {
     }
 
     /**
-     * Scales a {@code TextRegionDetector} crop (computed against the subsampled dimensions
-     * returned by {@link #extractDetectionLuma}) back up to true source-JPEG pixel coordinates.
+     * Scales a classical/ONNX {@code TextRoiDetector} crop (computed against the subsampled
+     * dimensions returned by {@link #extractDetectionLuma}) back up to true source-JPEG pixel
+     * coordinates.
      *
      * <p>Uses the actual decoded-to-source dimension ratio rather than multiplying by {@code
      * sampleSize}: {@code BitmapFactory.inSampleSize} decoding rounds dimensions with integer
-     * division, so {@code decoded * sampleSize} can overshoot the real source size and misalign
-     * the crop. The result is clamped to the source bounds.
+     * division, so {@code decoded * sampleSize} can overshoot the real source size and misalign the
+     * crop. The result is clamped to the source bounds.
      */
     static Rect scaleDetectionRoi(CropRect roi, DetectionLuma input) {
         float scaleX = input.srcWidth / (float) Math.max(1, input.width);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/JpegFastBleEncoder.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/JpegFastBleEncoder.java
@@ -2,17 +2,18 @@ package com.mentra.asg_client.io.media.core;
 
 import android.graphics.Bitmap;
 import android.util.Log;
+import androidx.annotation.Nullable;
 import com.mentra.asg_client.camera.lifecycle.PhotoExifMetadataWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import org.json.JSONObject;
 
 /**
  * Low-latency BLE payload encoder: baseline JPEG via {@link Bitmap#compress} (Skia's bundled
  * libjpeg-turbo with NEON). The whole encode happens in memory - no temp files, no read-back -
- * unlike the previous flow that compressed to disk, rewrote EXIF in place, and read the bytes
- * back. Capture EXIF (IMU UserComment / ImageUniqueID) is carried over by splicing a
- * pre-built APP1 segment into the encoded stream right after SOI; a metadata failure never
- * fails the encode.
+ * unlike the previous flow that compressed to disk, rewrote EXIF in place, and read the bytes back.
+ * Capture EXIF (IMU UserComment / ImageUniqueID) is carried over by splicing a pre-built APP1
+ * segment into the encoded stream right after SOI; a metadata failure never fails the encode.
  */
 final class JpegFastBleEncoder implements BlePhotoEncoder {
     private static final String TAG = "JpegFastBleEncoder";
@@ -28,6 +29,25 @@ final class JpegFastBleEncoder implements BlePhotoEncoder {
     @Override
     public EncodeResult encode(Bitmap bitmap, int quality, String sourceJpegPath)
             throws IOException {
+        return encodeInternal(bitmap, quality, sourceJpegPath, null, null);
+    }
+
+    EncodeResult encode(
+            Bitmap bitmap,
+            int quality,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath)
+            throws IOException {
+        return encodeInternal(bitmap, quality, null, imuPayload, intendedCapturePath);
+    }
+
+    private EncodeResult encodeInternal(
+            Bitmap bitmap,
+            int quality,
+            @Nullable String sourceJpegPath,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath)
+            throws IOException {
         long start = System.currentTimeMillis();
         // Bitmap.compress caps its own output; 1/4 byte per pixel comfortably covers q75-q95
         // text crops and avoids ByteArrayOutputStream regrowing mid-encode.
@@ -36,7 +56,9 @@ final class JpegFastBleEncoder implements BlePhotoEncoder {
         if (!bitmap.compress(Bitmap.CompressFormat.JPEG, quality, baos)) {
             throw new IOException("Bitmap JPEG compress failed");
         }
-        byte[] jpeg = spliceCaptureExif(baos.toByteArray(), sourceJpegPath);
+        byte[] jpeg =
+                spliceCaptureExif(
+                        baos.toByteArray(), sourceJpegPath, imuPayload, intendedCapturePath);
         long encodeMs = System.currentTimeMillis() - start;
         Log.d(
                 TAG,
@@ -56,12 +78,23 @@ final class JpegFastBleEncoder implements BlePhotoEncoder {
 
     /**
      * Inserts the source capture's EXIF APP1 segment (IMU samples + capture ID) after the SOI
-     * marker. Best-effort: returns the plain JPEG if the source has no metadata or the splice
-     * fails - the payload must never be lost over metadata.
+     * marker. Best-effort: returns the plain JPEG if the source has no metadata or the splice fails
+     * - the payload must never be lost over metadata.
      */
-    private static byte[] spliceCaptureExif(byte[] jpeg, String sourceJpegPath) {
+    private static byte[] spliceCaptureExif(
+            byte[] jpeg,
+            @Nullable String sourceJpegPath,
+            @Nullable JSONObject imuPayload,
+            @Nullable String intendedCapturePath) {
+        if (sourceJpegPath == null && imuPayload == null && intendedCapturePath == null) {
+            return jpeg;
+        }
         try {
-            byte[] app1 = PhotoExifMetadataWriter.buildCaptureExifApp1Segment(sourceJpegPath);
+            byte[] app1 =
+                    sourceJpegPath != null
+                            ? PhotoExifMetadataWriter.buildCaptureExifApp1Segment(sourceJpegPath)
+                            : PhotoExifMetadataWriter.buildCaptureExifApp1Segment(
+                                    imuPayload, intendedCapturePath);
             if (app1 == null
                     || jpeg.length < SOI_LENGTH
                     || (jpeg[0] & 0xFF) != 0xFF

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -11,18 +11,15 @@ import androidx.annotation.Nullable;
 import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.audio.AudioAssets;
 import com.mentra.asg_client.camera.CameraNeoService;
+import com.mentra.asg_client.camera.lifecycle.PhotoExifMetadataWriter;
 import com.mentra.asg_client.camera.model.CameraOperationError;
 import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
 import com.mentra.asg_client.camera.policy.PhotoMode;
-import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.camera.policy.PhotoSizeTier;
-import com.mentra.asg_client.camera.lifecycle.PhotoExifMetadataWriter;
 import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.hardware.interfaces.RgbLedConstants;
-import com.mentra.asg_client.io.media.interfaces.ServiceCallbackInterface;
-import com.mentra.asg_client.io.media.managers.MediaUploadQueueManager;
 import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
 import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
 import com.mentra.asg_client.io.media.core.textdetect.TextDetectDebugWriter;
@@ -31,6 +28,8 @@ import com.mentra.asg_client.io.media.core.textdetect.roi.DetectionInput;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
+import com.mentra.asg_client.io.media.interfaces.ServiceCallbackInterface;
+import com.mentra.asg_client.io.media.managers.MediaUploadQueueManager;
 import com.mentra.asg_client.io.media.upload.MediaUploadService;
 import com.mentra.asg_client.io.storage.StorageManager;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
@@ -40,6 +39,7 @@ import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.service.core.CameraRestartCooldown;
 import com.mentra.asg_client.service.core.constants.BatteryConstants;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.settings.VideoSettings;
 import com.mentra.asg_client.utils.CaptureRequestId;
 import com.mentra.asg_client.utils.GalleryStatusHelper;
@@ -106,9 +106,11 @@ public class MediaCaptureService {
     // Stop-time upload decision, bound to the recording's captureId (its capture-dir name, which is
     // unique per recording). Registered when the recording is stopped and consumed exactly once by
     // that recording's onRecordingStopped. Keying by captureId — instead of shared mutable fields —
-    // means: the FIRST stop for a recording wins (putIfAbsent), so a user stop that races or follows
+    // means: the FIRST stop for a recording wins (putIfAbsent), so a user stop that races or
+    // follows
     // an auto-stop can't turn a "no upload" auto-stop into an upload; a new recording (different
-    // captureId) can't overwrite a prior recording's still-pending target; and every onRecordingStopped
+    // captureId) can't overwrite a prior recording's still-pending target; and every
+    // onRecordingStopped
     // exit path removes its own entry, so a target can't leak into a later recording.
     private final ConcurrentHashMap<String, UploadTarget> uploadTargetsByCaptureId =
             new ConcurrentHashMap<>();
@@ -134,7 +136,9 @@ public class MediaCaptureService {
 
     private StopReason mCurrentStopReason = null;
 
-    /** Stop-time upload target bound to a specific recording. Empty/null webhook = keep on device. */
+    /**
+     * Stop-time upload target bound to a specific recording. Empty/null webhook = keep on device.
+     */
     private static final class UploadTarget {
         final String webhookUrl;
         final String authToken;
@@ -154,6 +158,7 @@ public class MediaCaptureService {
 
     // Default BLE params (used if size unspecified)
     public static final int bleImageTargetWidth = 480;
+
     private static class BleParams {
         final int targetWidth;
         final int targetHeight;
@@ -216,9 +221,9 @@ public class MediaCaptureService {
 
     /**
      * Classifies whether a {@code TextRegionDetector} result represents a genuine detected text
-     * region, or one of the detector's own safety-net fallbacks (see {@code TextRegionDetector}
-     * and {@code TextDetectConfig} for the exact reason strings). Purely for logging/diagnostics -
-     * does not affect which ROI is actually used.
+     * region, or one of the detector's own safety-net fallbacks (see {@code TextRegionDetector} and
+     * {@code TextDetectConfig} for the exact reason strings). Purely for logging/diagnostics - does
+     * not affect which ROI is actually used.
      */
     private static String classifyTextCropOutcome(
             DetectionResult.Confidence confidence,
@@ -273,19 +278,17 @@ public class MediaCaptureService {
      * Resolves an adb-pullable directory for {@link TextDetectDebugWriter} output for a given
      * detection run: {@code <externalFilesDir>/textdetect_debug/<capture-name>_<millis>_<seq>/}.
      *
-     * <p>The capture request's own directory name (the parent of {@code originalPath}, e.g.
-     * {@code IMG_20260713_070810_747_124_photo-1783926490251}) is included for correlation with
-     * the original JPEG, but is <em>not</em> relied on for uniqueness - a wall-clock timestamp
-     * plus a monotonic sequence number are appended so every call gets its own folder even if the
-     * same originalPath/requestId is reused for multiple detection runs.
+     * <p>The capture request's own directory name (the parent of {@code originalPath}, e.g. {@code
+     * IMG_20260713_070810_747_124_photo-1783926490251}) is included for correlation with the
+     * original JPEG, but is <em>not</em> relied on for uniqueness - a wall-clock timestamp plus a
+     * monotonic sequence number are appended so every call gets its own folder even if the same
+     * originalPath/requestId is reused for multiple detection runs.
      */
     private File resolveTextDetectDebugDir(String originalPath) {
         File parent = new File(originalPath).getParentFile();
         String captureName = parent != null ? parent.getName() : "unknown_capture";
         String uniqueSuffix =
-                System.currentTimeMillis()
-                        + "_"
-                        + TEXT_DETECT_DEBUG_SEQUENCE.incrementAndGet();
+                System.currentTimeMillis() + "_" + TEXT_DETECT_DEBUG_SEQUENCE.incrementAndGet();
         File base = new File(mContext.getExternalFilesDir(null), "textdetect_debug");
         return new File(base, captureName + "_" + uniqueSuffix);
     }
@@ -309,26 +312,25 @@ public class MediaCaptureService {
     }
 
     /**
-     * allowSingleComponentLines + cropFromTopLineOnly: a short, tightly-kerned word (e.g. a
-     * single price tag or label) commonly fuses into one connected component via morphological
-     * closing and can never satisfy minComponentsPerLine on its own; without these, such text is
-     * silently dropped while unrelated multi-blob clutter elsewhere in frame (cable loops, device
-     * corners) wins by default and/or drags the crop away from the real text via the
-     * union-of-all-lines bounds.
+     * allowSingleComponentLines + cropFromTopLineOnly: a short, tightly-kerned word (e.g. a single
+     * price tag or label) commonly fuses into one connected component via morphological closing and
+     * can never satisfy minComponentsPerLine on its own; without these, such text is silently
+     * dropped while unrelated multi-blob clutter elsewhere in frame (cable loops, device corners)
+     * wins by default and/or drags the crop away from the real text via the union-of-all-lines
+     * bounds.
      *
-     * <p>enableStructureFilter: periodic non-text patterns (spiral notebook binding holes,
-     * speaker grilles, perforated metal) satisfy the line-scoring formula's
+     * <p>enableStructureFilter: periodic non-text patterns (spiral notebook binding holes, speaker
+     * grilles, perforated metal) satisfy the line-scoring formula's
      * height-consistency/spacing-regularity terms extremely well and can out-score real text on
      * component count alone; round/radially-symmetric blobs have gradient magnitude spread across
-     * all orientation bins (unlike glyph strokes) so this filters them out before they ever form
-     * a line.
+     * all orientation bins (unlike glyph strokes) so this filters them out before they ever form a
+     * line.
      *
-     * <p>See {@code TextRegionDetectorSyntheticTest}'s {@code detect_fusedWordVsNoiseCluster_*}
-     * and {@code detect_fusedWordVsPeriodicDotRow_*} tests.
+     * <p>See {@code TextRegionDetectorSyntheticTest}'s {@code detect_fusedWordVsNoiseCluster_*} and
+     * {@code detect_fusedWordVsPeriodicDotRow_*} tests.
      */
     private TextDetectConfig buildTextDetectConfig() {
-        return TextDetectConfig.defaults()
-                .toBuilder()
+        return TextDetectConfig.defaults().toBuilder()
                 .allowSingleComponentLines(AsgConstants.TEXT_DETECT_ALLOW_SINGLE_COMPONENT_LINES)
                 .cropFromTopLineOnly(AsgConstants.TEXT_DETECT_CROP_FROM_TOP_LINE_ONLY)
                 .enableStructureFilter(AsgConstants.TEXT_DETECT_ENABLE_STRUCTURE_FILTER)
@@ -370,8 +372,7 @@ public class MediaCaptureService {
             TextRoiDetector detector = getTextRoiDetector();
             DetectionResult result =
                     detector.detect(new DetectionInput(input.luma, input.width, input.height));
-            android.graphics.Rect roi =
-                    GrayscaleBleProcessor.scaleDetectionRoi(result.roi, input);
+            android.graphics.Rect roi = GrayscaleBleProcessor.scaleDetectionRoi(result.roi, input);
             String outcome =
                     classifyTextCropOutcome(
                             result.confidence,
@@ -395,17 +396,14 @@ public class MediaCaptureService {
                             + " crop="
                             + java.util.Arrays.toString(
                                     roi != null
-                                            ? new int[] {
-                                                roi.left, roi.top, roi.right, roi.bottom
-                                            }
+                                            ? new int[] {roi.left, roi.top, roi.right, roi.bottom}
                                             : null));
             Log.i(TAG, "✂️ CROP OUTCOME: " + outcome);
             if (AsgConstants.SAVE_TEXT_DETECT_DEBUG_ARTIFACTS) {
                 File debugDir = resolveTextDetectDebugDir(originalPath);
                 TextDetectDebugWriter.save(debugDir, result, outcome);
             }
-            return new TextRegionDetection(
-                    roi, result.confidence, result.fallbackReason, outcome);
+            return new TextRegionDetection(roi, result.confidence, result.fallbackReason, outcome);
         } catch (Throwable t) {
             Log.w(TAG, "TextRegionDetector failed, falling back to full-frame ROI", t);
             String outcome = "FAILED (exception: " + t + ")";
@@ -450,11 +448,7 @@ public class MediaCaptureService {
 
         android.graphics.Bitmap cropped =
                 android.graphics.Bitmap.createBitmap(
-                        original,
-                        clamped.left,
-                        clamped.top,
-                        clamped.width(),
-                        clamped.height());
+                        original, clamped.left, clamped.top, clamped.width(), clamped.height());
         if (cropped != original) {
             original.recycle();
         }
@@ -475,7 +469,8 @@ public class MediaCaptureService {
                                 100.0
                                         * (1.0
                                                 - (cropped.getWidth() * cropped.getHeight())
-                                                        / (double) (originalWidth * originalHeight)))
+                                                        / (double)
+                                                                (originalWidth * originalHeight)))
                         + "% pixel reduction) - outcome: "
                         + textCropOutcome);
         return cropped;
@@ -489,15 +484,13 @@ public class MediaCaptureService {
             Log.w(TAG, "Text-mode detector returned no ROI; preserving the camera JPEG");
             return null;
         }
-        android.graphics.Bitmap original =
-                android.graphics.BitmapFactory.decodeFile(originalPath);
+        android.graphics.Bitmap original = android.graphics.BitmapFactory.decodeFile(originalPath);
         if (original == null) {
             return null;
         }
         android.graphics.Bitmap cropped =
                 cropBitmapToDetectedRoi(original, roi, "WiFi text-mode upload crop");
-        String croppedPath =
-                originalPath.replace(".jpg", "_textcrop_" + requestId + ".jpg");
+        String croppedPath = originalPath.replace(".jpg", "_textcrop_" + requestId + ".jpg");
         try (java.io.FileOutputStream fos = new java.io.FileOutputStream(croppedPath)) {
             if (!cropped.compress(
                     android.graphics.Bitmap.CompressFormat.JPEG,
@@ -526,18 +519,14 @@ public class MediaCaptureService {
         TextRegionDetection detection = runTextRegionDetection(photoFilePath);
         try {
             String croppedPath =
-                    writeCroppedBitmapToTempJpeg(
-                            photoFilePath, detection.roi, requestId);
+                    writeCroppedBitmapToTempJpeg(photoFilePath, detection.roi, requestId);
             if (croppedPath != null) {
                 PhotoArtifactFiles.promoteToCanonical(photoFilePath, croppedPath);
                 photoTextCropPrepared.put(requestId, true);
                 return photoFilePath;
             }
         } catch (java.io.IOException e) {
-            Log.w(
-                    TAG,
-                    "Text-mode crop failed, transferring original frame: " + e.getMessage(),
-                    e);
+            Log.w(TAG, "Text-mode crop failed, transferring original frame: " + e.getMessage(), e);
         }
         return photoFilePath;
     }
@@ -641,20 +630,26 @@ public class MediaCaptureService {
 
     // Per-request timing instrumentation (gated by AsgConstants.ENABLE_PHOTO_TIMING_LOGS)
     private final Map<String, Map<String, Long>> photoTimings = new ConcurrentHashMap<>();
+
     /** Wall-clock start for BLE photo pipeline (request received on glasses). */
     private final Map<String, Long> blePhotoPipelineStartMs = new ConcurrentHashMap<>();
+
     /** Maps BLE transfer filename (bleImgId) back to the originating requestId. */
     private final Map<String, String> bleImgIdToRequestId = new ConcurrentHashMap<>();
+
     /**
      * Counts BLE payload encode invocations per request. There should only ever be exactly one
      * (whichever codec {@link BlePhotoEncodingPolicy} selects) — this exists purely to detect and
      * quantify a regression back to the old dual JPEG+AVIF encode path.
      */
     private final Map<String, Integer> bleEncodeInvocationCount = new ConcurrentHashMap<>();
+
     /** Cumulative encoder time (ms) actually spent per request, across all encode calls. */
     private final Map<String, Long> bleEncodeTotalMs = new ConcurrentHashMap<>();
+
     /** Original captured JPEG size on disk (bytes) per request. */
     private final Map<String, Long> bleOriginalBytes = new ConcurrentHashMap<>();
+
     /** Compressed BLE payload size (bytes) per request. */
     private final Map<String, Long> bleCompressedBytes = new ConcurrentHashMap<>();
 
@@ -802,8 +797,7 @@ public class MediaCaptureService {
         // short "hot" sound matches the quick capture. A cold capture needs a longer "cold" sound
         // that spans the camera/ISP warmup so the user keeps still until the photo actually lands.
         boolean cameraWarm = CameraNeoService.isCameraWarm(size, isFromSdk, exposureTimeNs);
-        String shutterAsset =
-                cameraWarm ? AudioAssets.TAKE_PHOTO_HOT : AudioAssets.TAKE_PHOTO_COLD;
+        String shutterAsset = cameraWarm ? AudioAssets.TAKE_PHOTO_HOT : AudioAssets.TAKE_PHOTO_COLD;
         Log.d(TAG, "📸 Playing " + (cameraWarm ? "HOT (short)" : "COLD (long)") + " shutter sound");
         hardwareManager.playAudioAsset(shutterAsset);
     }
@@ -1320,8 +1314,10 @@ public class MediaCaptureService {
                                             ? captureIdFromCallback
                                             : captureIdAtStart;
 
-                            // Consume this recording's upload decision exactly once, up front, so it
-                            // is dropped on every exit path below (null file path, cleanup, integrity
+                            // Consume this recording's upload decision exactly once, up front, so
+                            // it
+                            // is dropped on every exit path below (null file path, cleanup,
+                            // integrity
                             // failure) and can never leak into a later recording.
                             final UploadTarget uploadTarget =
                                     captureId != null
@@ -1390,7 +1386,8 @@ public class MediaCaptureService {
                                                             // captureId; null = keep on device.
                                                             final String uploadWebhookUrl =
                                                                     uploadTarget != null
-                                                                            ? uploadTarget.webhookUrl
+                                                                            ? uploadTarget
+                                                                                    .webhookUrl
                                                                             : null;
                                                             final String uploadAuthToken =
                                                                     uploadTarget != null
@@ -1582,13 +1579,14 @@ public class MediaCaptureService {
     /**
      * Stop video recording with a reason and an optional upload target.
      *
-     * <p>The reason guard + {@code mCurrentStopReason} write are serialized under {@link #mStopLock}.
-     * The upload target is registered only once the stop is actually dispatched to the recorder
-     * (below the "not recording" guard), keyed by the recording's captureId via {@code putIfAbsent}
-     * (first-stop-wins): only a {@code USER_REQUESTED} stop carries a webhook, and a stop already in
-     * progress — or a user stop racing/following an auto-stop that already committed to "no upload" —
-     * can't flip the outcome. The entry is consumed in {@code onRecordingStopped} and dropped on
-     * every other terminal path ({@code onRecordingError}, the catch below, {@code cleanup}).
+     * <p>The reason guard + {@code mCurrentStopReason} write are serialized under {@link
+     * #mStopLock}. The upload target is registered only once the stop is actually dispatched to the
+     * recorder (below the "not recording" guard), keyed by the recording's captureId via {@code
+     * putIfAbsent} (first-stop-wins): only a {@code USER_REQUESTED} stop carries a webhook, and a
+     * stop already in progress — or a user stop racing/following an auto-stop that already
+     * committed to "no upload" — can't flip the outcome. The entry is consumed in {@code
+     * onRecordingStopped} and dropped on every other terminal path ({@code onRecordingError}, the
+     * catch below, {@code cleanup}).
      *
      * @param reason Why recording is stopping
      * @param webhookUrl Upload target (USER_REQUESTED only); null/empty keeps the video on device
@@ -1657,11 +1655,13 @@ public class MediaCaptureService {
 
             stopVideoRecordingLed(); // Stop white LED when video recording stops
 
-            // Bind the upload decision to this recording's captureId, first-stop-wins, only now that
+            // Bind the upload decision to this recording's captureId, first-stop-wins, only now
+            // that
             // the stop is actually being dispatched to the recorder — so an early-return above can
             // never orphan it. Only a USER_REQUESTED stop may upload; any auto-stop
             // (battery/max-duration/error) registers a "no upload" decision. putIfAbsent means a
-            // later or racing stop (e.g. a user stop landing after an auto-stop already committed to
+            // later or racing stop (e.g. a user stop landing after an auto-stop already committed
+            // to
             // "no upload", once the stop-reason guard has reset) cannot flip the outcome. The entry
             // is consumed once in onRecordingStopped and dropped on every terminal path
             // (onRecordingError, the catch below, cleanup) so it can never leak.
@@ -1687,7 +1687,8 @@ public class MediaCaptureService {
             }
 
             // Reset state in case of error. No camera callback will fire after a failed dispatch,
-            // so drop this recording's upload target here to mirror onRecordingStopped/onRecordingError.
+            // so drop this recording's upload target here to mirror
+            // onRecordingStopped/onRecordingError.
             isRecordingVideo = false;
             currentVideoId = null;
             currentVideoPath = null;
@@ -1717,9 +1718,10 @@ public class MediaCaptureService {
     }
 
     /**
-     * Stop the active recording and upload the result to {@code webhookUrl} via multipart, mirroring
-     * the photo snapshot flow. The webhook URL + auth token are supplied at STOP time so the token
-     * is fresh when the upload runs. An empty/null webhook keeps the video on device (no upload).
+     * Stop the active recording and upload the result to {@code webhookUrl} via multipart,
+     * mirroring the photo snapshot flow. The webhook URL + auth token are supplied at STOP time so
+     * the token is fresh when the upload runs. An empty/null webhook keeps the video on device (no
+     * upload).
      */
     public void stopVideoRecording(String webhookUrl, String authToken) {
         stopVideoRecording(StopReason.USER_REQUESTED, webhookUrl, authToken);
@@ -1886,7 +1888,8 @@ public class MediaCaptureService {
 
         AsgSettings asgSettings = new AsgSettings(mContext);
         PhotoCaptureSettings captureSettings =
-                PhotoCaptureSettings.mergeWithStoredDefaults(PhotoCaptureSettings.EMPTY, asgSettings);
+                PhotoCaptureSettings.mergeWithStoredDefaults(
+                        PhotoCaptureSettings.EMPTY, asgSettings);
         Boolean storedSound = asgSettings.getButtonPhotoSound();
         boolean effectiveSound = storedSound != null ? storedSound : enableSound;
 
@@ -2048,8 +2051,7 @@ public class MediaCaptureService {
                     @Override
                     public void onPhotoError(CameraOperationError error) {
                         Log.e(TAG, "Failed to capture offline photo: " + error.message());
-                        sendPhotoStatus(
-                                requestId, "failed", null, error.code(), error.message());
+                        sendPhotoStatus(requestId, "failed", null, error.code(), error.message());
 
                         // LED is now managed by CameraNeoService and will turn off when camera
                         // closes
@@ -2065,12 +2067,12 @@ public class MediaCaptureService {
     }
 
     /**
-     * Capture a photo that is only saved to the gallery: an SDK take_photo with save=true
-     * and no upload target. There is no delivery leg (no webhook upload, no BLE transfer),
-     * so this bypasses the single-flight photo-job gate and enqueues straight into the
-     * camera queue, exactly like button photos — rapid bursts serialize at the camera
-     * instead of failing CAMERA_BUSY. The terminal photo_response carries the captureId
-     * (the requestId-stamped capture directory name) for sync-time correlation.
+     * Capture a photo that is only saved to the gallery: an SDK take_photo with save=true and no
+     * upload target. There is no delivery leg (no webhook upload, no BLE transfer), so this
+     * bypasses the single-flight photo-job gate and enqueues straight into the camera queue,
+     * exactly like button photos — rapid bursts serialize at the camera instead of failing
+     * CAMERA_BUSY. The terminal photo_response carries the captureId (the requestId-stamped capture
+     * directory name) for sync-time correlation.
      */
     public boolean takePhotoForLocalSave(
             String photoFilePath,
@@ -2231,8 +2233,8 @@ public class MediaCaptureService {
     }
 
     /**
-     * Terminal success for a local-save capture: no uploadUrl (nothing was delivered);
-     * carries the captureId so the caller can match the file at gallery-sync time.
+     * Terminal success for a local-save capture: no uploadUrl (nothing was delivered); carries the
+     * captureId so the caller can match the file at gallery-sync time.
      */
     private void sendLocalSaveSuccessResponse(String requestId, String captureId) {
         try {
@@ -2555,9 +2557,9 @@ public class MediaCaptureService {
 
                             if (mMediaCaptureListener != null) {
                                 mMediaCaptureListener.onMediaError(
-                                    requestId,
-                                    error.message(),
-                                    MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
+                                        requestId,
+                                        error.message(),
+                                        MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
                             }
                         }
                     });
@@ -2723,7 +2725,8 @@ public class MediaCaptureService {
     }
 
     /**
-     * Record a timing checkpoint for a photo request. No-op if AsgConstants.ENABLE_PHOTO_TIMING_LOGS is false.
+     * Record a timing checkpoint for a photo request. No-op if
+     * AsgConstants.ENABLE_PHOTO_TIMING_LOGS is false.
      */
     private void recordTiming(String requestId, String phase) {
         if (!AsgConstants.ENABLE_PHOTO_TIMING_LOGS) return;
@@ -2793,8 +2796,8 @@ public class MediaCaptureService {
     }
 
     /**
-     * Emits per-stage {@code COMPRESS:} timing lines for the BLE compression pipeline, e.g.
-     * {@code COMPRESS: JPEG encode finished (+412ms total, +38ms this step)}. Gated on
+     * Emits per-stage {@code COMPRESS:} timing lines for the BLE compression pipeline, e.g. {@code
+     * COMPRESS: JPEG encode finished (+412ms total, +38ms this step)}. Gated on
      * ENABLE_PHOTO_TIMING_LOGS like the rest of the photo timing instrumentation.
      */
     private static final class CompressStageTimer {
@@ -2834,10 +2837,10 @@ public class MediaCaptureService {
     }
 
     /**
-     * Largest power-of-two JPEG subsampling factor that still keeps the decoded region at or
-     * above the BLE target box, so the follow-up {@code createScaledBitmap} only ever shrinks.
-     * Decoding 4032x3024 at inSampleSize=2 cuts the ARGB working set 4x with no quality cost
-     * at a 1920px output cap.
+     * Largest power-of-two JPEG subsampling factor that still keeps the decoded region at or above
+     * the BLE target box, so the follow-up {@code createScaledBitmap} only ever shrinks. Decoding
+     * 4032x3024 at inSampleSize=2 cuts the ARGB working set 4x with no quality cost at a 1920px
+     * output cap.
      */
     private static int computeBleDecodeSampleSize(
             int regionWidth, int regionHeight, int targetWidth, int targetHeight) {
@@ -3375,7 +3378,8 @@ public class MediaCaptureService {
                                 android.graphics.BitmapFactory.Options boundsOnly =
                                         new android.graphics.BitmapFactory.Options();
                                 boundsOnly.inJustDecodeBounds = true;
-                                android.graphics.BitmapFactory.decodeFile(photoFilePath, boundsOnly);
+                                android.graphics.BitmapFactory.decodeFile(
+                                        photoFilePath, boundsOnly);
                                 Log.i(
                                         TAG,
                                         "📤➡️📱 Sending photo to phone: "
@@ -3558,9 +3562,7 @@ public class MediaCaptureService {
                                     // No BLE fallback available
                                     dumpTimings(requestId);
                                     sendPhotoErrorResponse(
-                                            requestId,
-                                            "UPLOAD_FAILED",
-                                            errorMessage);
+                                            requestId, "UPLOAD_FAILED", errorMessage);
                                     Log.d(
                                             TAG,
                                             "❌ No BLE fallback available, handling as normal failure");
@@ -3705,16 +3707,16 @@ public class MediaCaptureService {
     }
 
     /**
-     * Upload a recorded video to a webhook URL via multipart/form-data, mirroring the photo snapshot
-     * upload in {@link #performDirectUpload}. Runs on a background thread.
+     * Upload a recorded video to a webhook URL via multipart/form-data, mirroring the photo
+     * snapshot upload in {@link #performDirectUpload}. Runs on a background thread.
      *
      * <p>Unlike photos there is no BLE fallback — video files are far too large for BLE — so a
      * failed upload is terminal. Timeouts are much larger than the photo path: write/read are
      * per-stall (idle) timeouts and {@code callTimeout} bounds the whole upload end-to-end.
      *
-     * <p>The receiving server gets a multipart body with: {@code video} (the .mp4 file),
-     * {@code requestId}, {@code type=video_upload}, {@code success=true}, plus an optional
-     * {@code Authorization: Bearer <authToken>} header.
+     * <p>The receiving server gets a multipart body with: {@code video} (the .mp4 file), {@code
+     * requestId}, {@code type=video_upload}, {@code success=true}, plus an optional {@code
+     * Authorization: Bearer <authToken>} header.
      */
     private void performDirectVideoUpload(
             String videoFilePath,
@@ -3759,7 +3761,8 @@ public class MediaCaptureService {
                                 // aborted mid-transfer on long recordings — it only guards against
                                 // a connection that never stalls yet never finishes. A flat cap
                                 // (e.g. 300s) would routinely fail multi-minute uploads even at
-                                // healthy speeds, and video has no BLE fallback so that is terminal.
+                                // healthy speeds, and video has no BLE fallback so that is
+                                // terminal.
                                 long minThroughputBytesPerSec = 64L * 1024L; // ~0.5 Mbps floor
                                 long callTimeoutSeconds =
                                         60L + (videoFile.length() / minThroughputBytesPerSec);
@@ -3844,7 +3847,8 @@ public class MediaCaptureService {
                                     }
 
                                     if (mMediaCaptureListener != null) {
-                                        mMediaCaptureListener.onVideoUploaded(requestId, webhookUrl);
+                                        mMediaCaptureListener.onVideoUploaded(
+                                                requestId, webhookUrl);
                                     }
                                 } else {
                                     String errorMessage =
@@ -4275,9 +4279,7 @@ public class MediaCaptureService {
                         ? blePhotoPipelineStartMs.get(requestId)
                         : null;
         final long requestStartTimeMs =
-                existingPipelineStart != null
-                        ? existingPipelineStart
-                        : System.currentTimeMillis();
+                existingPipelineStart != null ? existingPipelineStart : System.currentTimeMillis();
         if (AsgConstants.ENABLE_PHOTO_TIMING_LOGS && existingPipelineStart == null) {
             blePhotoPipelineStartMs.put(requestId, requestStartTimeMs);
             logBlePhotoStep(requestId, "request_received");
@@ -4323,7 +4325,8 @@ public class MediaCaptureService {
         }
 
         // STORAGE CHECK: Reject if insufficient storage
-        logBlePhotoStep(requestId, "storage_check", "checking storage required for the captured JPEG");
+        logBlePhotoStep(
+                requestId, "storage_check", "checking storage required for the captured JPEG");
         StorageManager storageManager = StorageManager.getInstance(mContext);
         if (!storageManager.canTakePhoto()) {
             Log.w(TAG, "🚫 Photo rejected - insufficient storage");
@@ -4524,9 +4527,9 @@ public class MediaCaptureService {
 
                             if (mMediaCaptureListener != null) {
                                 mMediaCaptureListener.onMediaError(
-                                    requestId,
-                                    error.message(),
-                                    MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
+                                        requestId,
+                                        error.message(),
+                                        MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
                             }
                         }
                     });
@@ -4603,9 +4606,7 @@ public class MediaCaptureService {
                             CompressStageTimer stage = new CompressStageTimer();
                             recordTiming(requestId, "ble_compress_start");
                             logBlePhotoStep(
-                                    requestId,
-                                    "ble_compress_thread_start",
-                                    "bleImgId=" + bleImgId);
+                                    requestId, "ble_compress_thread_start", "bleImgId=" + bleImgId);
                             sendPhotoStatus(
                                     requestId,
                                     isWifiFallback ? "ble_fallback_compression" : "compressing");
@@ -4667,7 +4668,8 @@ public class MediaCaptureService {
                                                 + ", quality="
                                                 + (codec == BleCodec.AVIF
                                                         ? bleParams.avifQuality
-                                                        : AsgConstants.BLE_PHOTO_JPEG_FAST_QUALITY));
+                                                        : AsgConstants
+                                                                .BLE_PHOTO_JPEG_FAST_QUALITY));
                                 logBlePhotoStep(
                                         requestId,
                                         "text_mode_prepare",
@@ -4718,13 +4720,14 @@ public class MediaCaptureService {
                                         textCropAlreadyPrepared
                                                 ? "PREPARED_CANONICAL_CROP"
                                                 : shouldCrop
-                                                ? "NOT_ATTEMPTED (pending detection)"
-                                                : "NOT_ATTEMPTED"
-                                                        + " (ENABLE_TEXT_REGION_CROP="
-                                                        + AsgConstants.ENABLE_TEXT_REGION_CROP
-                                                        + ", mode="
-                                                        + requestedMode
-                                                        + ")";
+                                                        ? "NOT_ATTEMPTED (pending detection)"
+                                                        : "NOT_ATTEMPTED"
+                                                                + " (ENABLE_TEXT_REGION_CROP="
+                                                                + AsgConstants
+                                                                        .ENABLE_TEXT_REGION_CROP
+                                                                + ", mode="
+                                                                + requestedMode
+                                                                + ")";
 
                                 android.graphics.Rect roi = null;
                                 if (shouldCrop && !textCropAlreadyPrepared) {
@@ -4792,8 +4795,7 @@ public class MediaCaptureService {
                                     android.graphics.BitmapFactory.Options bounds =
                                             new android.graphics.BitmapFactory.Options();
                                     bounds.inJustDecodeBounds = true;
-                                    android.graphics.BitmapFactory.decodeFile(
-                                            originalPath, bounds);
+                                    android.graphics.BitmapFactory.decodeFile(originalPath, bounds);
                                     int srcWidth = bounds.outWidth;
                                     int srcHeight = bounds.outHeight;
                                     if (srcWidth <= 0 || srcHeight <= 0) {
@@ -4855,7 +4857,9 @@ public class MediaCaptureService {
                                             requestId,
                                             "crop_start",
                                             "cropping to "
-                                                    + (roi != null ? roi.toShortString() : "full image"));
+                                                    + (roi != null
+                                                            ? roi.toShortString()
+                                                            : "full image"));
                                     android.graphics.Bitmap cropped =
                                             cropBitmapToDetectedRoi(
                                                     original,
@@ -4888,10 +4892,7 @@ public class MediaCaptureService {
                                     logBlePhotoStep(
                                             requestId,
                                             "resize_start",
-                                            "resizing to fit "
-                                                    + targetWidth
-                                                    + "x"
-                                                    + targetHeight);
+                                            "resizing to fit " + targetWidth + "x" + targetHeight);
                                     android.graphics.Bitmap scaled =
                                             android.graphics.Bitmap.createScaledBitmap(
                                                     cropped, targetWidth, targetHeight, true);
@@ -4970,8 +4971,7 @@ public class MediaCaptureService {
                                 // encoder cost — see BlePhotoEncoders.encode(), which is the
                                 // single call site for BLE payload encoding.
                                 int encodeCallNumber =
-                                        bleEncodeInvocationCount.merge(
-                                                requestId, 1, Integer::sum);
+                                        bleEncodeInvocationCount.merge(requestId, 1, Integer::sum);
                                 stage.start(codec + " encode");
                                 BlePhotoEncoder.EncodeResult encodeResult;
                                 try {
@@ -4994,9 +4994,7 @@ public class MediaCaptureService {
                                                     resized, codec, encodeQuality, originalPath);
                                     long cumulativeEncodeMs =
                                             bleEncodeTotalMs.merge(
-                                                    requestId,
-                                                    encodeResult.encodeMs,
-                                                    Long::sum);
+                                                    requestId, encodeResult.encodeMs, Long::sum);
                                     logBlePhotoStep(
                                             requestId,
                                             "encode_done",
@@ -5052,7 +5050,8 @@ public class MediaCaptureService {
                                         TAG,
                                         "Successfully encoded as " + bleEncodedFormat + " for BLE");
 
-                                long compressionTime = System.currentTimeMillis() - compressThreadStart;
+                                long compressionTime =
+                                        System.currentTimeMillis() - compressThreadStart;
                                 File originalFileForSize = new File(originalPath);
                                 long originalSizeBytes = originalFileForSize.length();
                                 double originalSizeKb = originalSizeBytes / 1024.0;
@@ -5115,8 +5114,7 @@ public class MediaCaptureService {
                                                 + "x"
                                                 + bleResizedHeight
                                                 + ", "
-                                                + String.format(
-                                                        Locale.US, "%.1f", compressedSizeKb)
+                                                + String.format(Locale.US, "%.1f", compressedSizeKb)
                                                 + " KB ("
                                                 + bleEncodedFormat
                                                 + ", requestId="
@@ -5126,10 +5124,7 @@ public class MediaCaptureService {
                                 // 6. Send via BLE using K900BluetoothManager
                                 recordTiming(requestId, "ble_send_start");
                                 sendCompressedPhotoViaBle(
-                                        compressedPath,
-                                        bleImgId,
-                                        requestId,
-                                        compressThreadStart);
+                                        compressedPath, bleImgId, requestId, compressThreadStart);
 
                             } catch (Exception e) {
                                 Log.e(TAG, "Error compressing photo for BLE", e);
@@ -5173,9 +5168,7 @@ public class MediaCaptureService {
     private void sendCompressedPhotoViaBle(
             String compressedPath, String bleImgId, String requestId, long transferStartTime) {
         logBlePhotoStep(
-                requestId,
-                "ble_send_start",
-                "bleImgId=" + bleImgId + ", file=" + compressedPath);
+                requestId, "ble_send_start", "bleImgId=" + bleImgId + ", file=" + compressedPath);
 
         // TESTING: Check for fake BLE transfer failure
         if (PhotoCaptureTestHooks.shouldFail("BLE_TRANSFER")) {
@@ -5355,15 +5348,16 @@ public class MediaCaptureService {
     }
 
     /**
-     * Open + configure + preview the camera and hold it warm for {@code durationMs} without taking a
-     * photo, so a later {@code take_photo} of the same {@code size}/{@code exposureTimeNs} reuses the
-     * warm session and is near-instant. Emits {@code camera_status}: {@code warming} on accept,
+     * Open + configure + preview the camera and hold it warm for {@code durationMs} without taking
+     * a photo, so a later {@code take_photo} of the same {@code size}/{@code exposureTimeNs} reuses
+     * the warm session and is near-instant. Emits {@code camera_status}: {@code warming} on accept,
      * {@code ready} once preview/AE is running, {@code stopped} when the keep-alive expires, and
      * {@code error} on failure.
      *
      * <p><b>Shared-camera safety:</b> if a video recording or RTMP/SRT/WHIP stream already owns the
      * camera the camera is already warm — emit {@code ready} immediately and do not take ownership.
-     * If a photo job is mid-flight, reject with {@code error} so the in-flight capture is undisturbed.
+     * If a photo job is mid-flight, reject with {@code error} so the in-flight capture is
+     * undisturbed.
      *
      * @param requestId echoed in every {@code camera_status} event (required)
      * @param size resolution tier matching the warmed config ("low"/"medium"/"high"/"max")
@@ -5404,10 +5398,7 @@ public class MediaCaptureService {
         if (isPhotoJobInFlight()) {
             Log.w(TAG, "camera_warm_up rejected - photo job in flight");
             sendCameraStatus(
-                    requestId,
-                    "error",
-                    "photo_capture_in_progress",
-                    "Photo capture in progress");
+                    requestId, "error", "photo_capture_in_progress", "Photo capture in progress");
             return false;
         }
         if (isBleTransferInProgress()) {
@@ -5470,8 +5461,7 @@ public class MediaCaptureService {
                         if (warmUpDispatching.get()) {
                             rejectedSynchronously.set(true);
                         }
-                        sendCameraStatus(
-                                requestId, "error", error.code(), error.message());
+                        sendCameraStatus(requestId, "error", error.code(), error.message());
                     }
 
                     @Override
@@ -5698,7 +5688,8 @@ public class MediaCaptureService {
         }
     }
 
-    private void copyFirstJsonField(JSONObject target, JSONObject source, String targetKey, String... sourceKeys)
+    private void copyFirstJsonField(
+            JSONObject target, JSONObject source, String targetKey, String... sourceKeys)
             throws JSONException {
         for (String sourceKey : sourceKeys) {
             if (source.has(sourceKey) && !source.isNull(sourceKey)) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -26,7 +26,11 @@ import com.mentra.asg_client.io.media.managers.MediaUploadQueueManager;
 import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
 import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
 import com.mentra.asg_client.io.media.core.textdetect.TextDetectDebugWriter;
-import com.mentra.asg_client.io.media.core.textdetect.TextRegionDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.AndroidAssetModelSource;
+import com.mentra.asg_client.io.media.core.textdetect.roi.DetectionInput;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
 import com.mentra.asg_client.io.media.upload.MediaUploadService;
 import com.mentra.asg_client.io.storage.StorageManager;
 import com.mentra.asg_client.io.streaming.services.RtmpStreamingService;
@@ -85,6 +89,7 @@ public class MediaCaptureService {
     private MediaCaptureListener mMediaCaptureListener;
     private ServiceCallbackInterface mServiceCallback;
     private final IHardwareManager hardwareManager;
+    @Nullable private volatile TextRoiDetector textRoiDetector;
 
     // Track current video recording
     private boolean isRecordingVideo = false;
@@ -333,6 +338,28 @@ public class MediaCaptureService {
                 .build();
     }
 
+    private TextRoiDetector getTextRoiDetector() {
+        TextRoiDetector current = textRoiDetector;
+        if (current != null) {
+            return current;
+        }
+        synchronized (this) {
+            if (textRoiDetector == null) {
+                TextCropModel selected =
+                        AsgConstants.ENABLE_MODEL_TEXT_CROP
+                                ? AsgConstants.TEXT_CROP_MODEL
+                                : TextCropModel.CLASSICAL;
+                textRoiDetector =
+                        TextRoiDetectorFactory.create(
+                                selected,
+                                buildTextDetectConfig(),
+                                new AndroidAssetModelSource(mContext.getAssets(), "textroi"));
+                Log.i(TAG, "Text ROI detector initialized: " + textRoiDetector.id());
+            }
+            return textRoiDetector;
+        }
+    }
+
     @Nullable
     private TextRegionDetection runTextRegionDetection(String originalPath) {
         try {
@@ -340,9 +367,9 @@ public class MediaCaptureService {
             GrayscaleBleProcessor.DetectionLuma input =
                     GrayscaleBleProcessor.extractDetectionLuma(
                             originalPath, detectConfig.analysisWidth);
+            TextRoiDetector detector = getTextRoiDetector();
             DetectionResult result =
-                    TextRegionDetector.detect(
-                            input.luma, input.width, input.height, detectConfig);
+                    detector.detect(new DetectionInput(input.luma, input.width, input.height));
             android.graphics.Rect roi =
                     GrayscaleBleProcessor.scaleDetectionRoi(result.roi, input);
             String outcome =
@@ -353,7 +380,9 @@ public class MediaCaptureService {
                             result.lineCount);
             Log.d(
                     TAG,
-                    "TextRegionDetector: confidence="
+                    "TextRegionDetector: detector="
+                            + detector.id()
+                            + " confidence="
                             + result.confidence
                             + " reason="
                             + result.fallbackReason
@@ -5814,6 +5843,12 @@ public class MediaCaptureService {
             if (mBatteryMonitorHandler != null) {
                 mBatteryMonitorHandler.removeCallbacksAndMessages(null);
                 mBatteryMonitorHandler = null;
+            }
+
+            TextRoiDetector detector = textRoiDetector;
+            textRoiDetector = null;
+            if (detector != null) {
+                detector.close();
             }
 
             videoIntegrityExecutor.shutdown();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -13,6 +13,7 @@ import com.mentra.asg_client.audio.AudioAssets;
 import com.mentra.asg_client.camera.CameraNeoService;
 import com.mentra.asg_client.camera.lifecycle.PhotoExifMetadataWriter;
 import com.mentra.asg_client.camera.model.CameraOperationError;
+import com.mentra.asg_client.camera.model.CapturedPhoto;
 import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
 import com.mentra.asg_client.camera.policy.PhotoMode;
 import com.mentra.asg_client.camera.policy.PhotoSizeTier;
@@ -20,9 +21,9 @@ import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.hardware.core.HardwareManagerFactory;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.hardware.interfaces.RgbLedConstants;
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
 import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
 import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
-import com.mentra.asg_client.io.media.core.textdetect.TextDetectDebugWriter;
 import com.mentra.asg_client.io.media.core.textdetect.roi.AndroidAssetModelSource;
 import com.mentra.asg_client.io.media.core.textdetect.roi.DetectionInput;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
@@ -89,6 +90,14 @@ public class MediaCaptureService {
     private MediaCaptureListener mMediaCaptureListener;
     private ServiceCallbackInterface mServiceCallback;
     private final IHardwareManager hardwareManager;
+
+    /**
+     * Cached, lazily initialized text-ROI detector for text-mode BLE crops. Selected once per
+     * service lifecycle via {@link AsgConstants#ENABLE_MODEL_TEXT_CROP} / {@link
+     * AsgConstants#TEXT_CROP_MODEL} (default {@link TextCropModel#ML_KIT}); an unavailable/failed
+     * model falls back to the classical detector. Never construct a new detector per photo - ML Kit
+     * and ONNX sessions are expensive to initialize.
+     */
     @Nullable private volatile TextRoiDetector textRoiDetector;
 
     // Track current video recording
@@ -219,89 +228,15 @@ public class MediaCaptureService {
                 AsgConstants.TEXT_MODE_AVIF_QUALITY);
     }
 
-    /**
-     * Classifies whether a {@code TextRegionDetector} result represents a genuine detected text
-     * region, or one of the detector's own safety-net fallbacks (see {@code TextRegionDetector} and
-     * {@code TextDetectConfig} for the exact reason strings). Purely for logging/diagnostics - does
-     * not affect which ROI is actually used.
-     */
-    private static String classifyTextCropOutcome(
-            DetectionResult.Confidence confidence,
-            String fallbackReason,
-            int acceptedComponentCount,
-            int lineCount) {
-        boolean isCenterFallback =
-                fallbackReason != null
-                        && (fallbackReason.contains("untrustworthy_detection_center_fallback")
-                                || fallbackReason.contains("no_valid_polarity"));
-
-        if (confidence == DetectionResult.Confidence.NONE) {
-            return "FAILED (no valid polarity detected - crop is a generous center box, not"
-                    + " text-based)";
-        }
-        if (isCenterFallback) {
-            return "FALLBACK (detector rejected its own candidate crop as untrustworthy -"
-                    + " using a 75% center-crop safety net, NOT a real text detection)";
-        }
-        if (confidence == DetectionResult.Confidence.HIGH) {
-            return "SUCCESS (high confidence, "
-                    + acceptedComponentCount
-                    + " components across "
-                    + lineCount
-                    + " line(s))";
-        }
-        if (confidence == DetectionResult.Confidence.MEDIUM) {
-            return "SUCCESS (medium confidence, "
-                    + acceptedComponentCount
-                    + " components across "
-                    + lineCount
-                    + " line(s), extra padding applied)";
-        }
-        // LOW confidence but not a center-fallback: a real (weak) detection - e.g. low score or
-        // polarity disagreement - still text-based, just less trustworthy than HIGH/MEDIUM.
-        return "DEGRADED (low confidence, reason="
-                + fallbackReason
-                + ", "
-                + acceptedComponentCount
-                + " components across "
-                + lineCount
-                + " line(s) - real detection, but weak)";
-    }
-
-    // Monotonic per-process counter appended to every text-detect debug folder name so repeated
-    // detection runs never collide, even when the upstream capture reuses the same originalPath
-    // or requestId (observed on emulators/test harnesses that replay a cached capture request).
-    private static final java.util.concurrent.atomic.AtomicLong TEXT_DETECT_DEBUG_SEQUENCE =
-            new java.util.concurrent.atomic.AtomicLong();
-
-    /**
-     * Resolves an adb-pullable directory for {@link TextDetectDebugWriter} output for a given
-     * detection run: {@code <externalFilesDir>/textdetect_debug/<capture-name>_<millis>_<seq>/}.
-     *
-     * <p>The capture request's own directory name (the parent of {@code originalPath}, e.g. {@code
-     * IMG_20260713_070810_747_124_photo-1783926490251}) is included for correlation with the
-     * original JPEG, but is <em>not</em> relied on for uniqueness - a wall-clock timestamp plus a
-     * monotonic sequence number are appended so every call gets its own folder even if the same
-     * originalPath/requestId is reused for multiple detection runs.
-     */
-    private File resolveTextDetectDebugDir(String originalPath) {
-        File parent = new File(originalPath).getParentFile();
-        String captureName = parent != null ? parent.getName() : "unknown_capture";
-        String uniqueSuffix =
-                System.currentTimeMillis() + "_" + TEXT_DETECT_DEBUG_SEQUENCE.incrementAndGet();
-        File base = new File(mContext.getExternalFilesDir(null), "textdetect_debug");
-        return new File(base, captureName + "_" + uniqueSuffix);
-    }
-
     private static final class TextRegionDetection {
         @Nullable final android.graphics.Rect roi;
-        @Nullable final DetectionResult.Confidence confidence;
+        @Nullable final String confidence;
         @Nullable final String reason;
         final String outcome;
 
         TextRegionDetection(
                 @Nullable android.graphics.Rect roi,
-                @Nullable DetectionResult.Confidence confidence,
+                @Nullable String confidence,
                 @Nullable String reason,
                 String outcome) {
             this.roi = roi;
@@ -312,22 +247,8 @@ public class MediaCaptureService {
     }
 
     /**
-     * allowSingleComponentLines + cropFromTopLineOnly: a short, tightly-kerned word (e.g. a single
-     * price tag or label) commonly fuses into one connected component via morphological closing and
-     * can never satisfy minComponentsPerLine on its own; without these, such text is silently
-     * dropped while unrelated multi-blob clutter elsewhere in frame (cable loops, device corners)
-     * wins by default and/or drags the crop away from the real text via the union-of-all-lines
-     * bounds.
-     *
-     * <p>enableStructureFilter: periodic non-text patterns (spiral notebook binding holes, speaker
-     * grilles, perforated metal) satisfy the line-scoring formula's
-     * height-consistency/spacing-regularity terms extremely well and can out-score real text on
-     * component count alone; round/radially-symmetric blobs have gradient magnitude spread across
-     * all orientation bins (unlike glyph strokes) so this filters them out before they ever form a
-     * line.
-     *
-     * <p>See {@code TextRegionDetectorSyntheticTest}'s {@code detect_fusedWordVsNoiseCluster_*} and
-     * {@code detect_fusedWordVsPeriodicDotRow_*} tests.
+     * Builds classical/ONNX detector tunables from production {@code AsgConstants} flags. Only
+     * consulted when the selected detector actually needs them (ML Kit ignores this config).
      */
     private TextDetectConfig buildTextDetectConfig() {
         return TextDetectConfig.defaults().toBuilder()
@@ -340,6 +261,10 @@ public class MediaCaptureService {
                 .build();
     }
 
+    /**
+     * Returns the cached text-ROI detector, creating it on first use. Selected once per service
+     * lifecycle - never construct a new detector (ML Kit recognizer / ONNX session) per photo.
+     */
     private TextRoiDetector getTextRoiDetector() {
         TextRoiDetector current = textRoiDetector;
         if (current != null) {
@@ -364,52 +289,76 @@ public class MediaCaptureService {
 
     @Nullable
     private TextRegionDetection runTextRegionDetection(String originalPath) {
+        return runTextRegionDetection(null, originalPath);
+    }
+
+    /** Runs detection from the in-memory JPEG when available, else from {@code originalPath}. */
+    @Nullable
+    private TextRegionDetection runTextRegionDetection(
+            @Nullable byte[] jpegBytes, String originalPath) {
+        TextRoiDetector detector = getTextRoiDetector();
         try {
-            TextDetectConfig detectConfig = buildTextDetectConfig();
-            GrayscaleBleProcessor.DetectionLuma input =
-                    GrayscaleBleProcessor.extractDetectionLuma(
-                            originalPath, detectConfig.analysisWidth);
-            TextRoiDetector detector = getTextRoiDetector();
-            DetectionResult result =
-                    detector.detect(new DetectionInput(input.luma, input.width, input.height));
-            android.graphics.Rect roi = GrayscaleBleProcessor.scaleDetectionRoi(result.roi, input);
+            GrayscaleBleProcessor.DetectionLuma luma =
+                    jpegBytes != null
+                            ? GrayscaleBleProcessor.extractDetectionLuma(
+                                    jpegBytes, AsgConstants.TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE)
+                            : GrayscaleBleProcessor.extractDetectionLuma(
+                                    originalPath, AsgConstants.TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE);
+            DetectionInput input =
+                    new DetectionInput(luma.luma, luma.width, luma.height, jpegBytes);
+            DetectionResult result = detector.detect(input);
+
+            android.graphics.Rect scaledRoi =
+                    detector.returnsNativeCoordinates()
+                            ? toAndroidRect(result.roi)
+                            : GrayscaleBleProcessor.scaleDetectionRoi(result.roi, luma);
+            // A DetectionResult always carries a non-null CropRect, but a full-frame result (e.g.
+            // ML Kit's "no text found, preserve everything" fallback) means no crop is actually
+            // warranted. Treat that as no ROI so downstream skips the wasted re-decode/crop/
+            // re-encode round trip and forwards the original bytes directly, same as before.
+            boolean isFullFrame =
+                    scaledRoi.left <= 0
+                            && scaledRoi.top <= 0
+                            && scaledRoi.width() >= luma.srcWidth
+                            && scaledRoi.height() >= luma.srcHeight;
+            android.graphics.Rect roi = isFullFrame ? null : scaledRoi;
+            boolean isFallback = result.fallbackReason != null;
             String outcome =
-                    classifyTextCropOutcome(
-                            result.confidence,
-                            result.fallbackReason,
-                            result.acceptedComponentCount,
-                            result.lineCount);
-            Log.d(
+                    !isFallback
+                            ? "SUCCESS ("
+                                    + detector.id()
+                                    + " localized "
+                                    + result.acceptedComponentCount
+                                    + " region(s) in "
+                                    + result.detectionTimeMs
+                                    + "ms)"
+                            : "FULL_FRAME ("
+                                    + detector.id()
+                                    + " reason="
+                                    + result.fallbackReason
+                                    + ", "
+                                    + result.detectionTimeMs
+                                    + "ms)";
+            Log.i(
                     TAG,
-                    "TextRegionDetector: detector="
-                            + detector.id()
-                            + " confidence="
-                            + result.confidence
-                            + " reason="
-                            + result.fallbackReason
-                            + " ms="
-                            + result.detectionTimeMs
-                            + " components="
-                            + result.acceptedComponentCount
-                            + " lines="
-                            + result.lineCount
-                            + " crop="
-                            + java.util.Arrays.toString(
-                                    roi != null
-                                            ? new int[] {roi.left, roi.top, roi.right, roi.bottom}
-                                            : null));
-            Log.i(TAG, "✂️ CROP OUTCOME: " + outcome);
-            if (AsgConstants.SAVE_TEXT_DETECT_DEBUG_ARTIFACTS) {
-                File debugDir = resolveTextDetectDebugDir(originalPath);
-                TextDetectDebugWriter.save(debugDir, result, outcome);
-            }
-            return new TextRegionDetection(roi, result.confidence, result.fallbackReason, outcome);
-        } catch (Throwable t) {
-            Log.w(TAG, "TextRegionDetector failed, falling back to full-frame ROI", t);
-            String outcome = "FAILED (exception: " + t + ")";
-            Log.i(TAG, "✂️ CROP OUTCOME: " + outcome);
-            return new TextRegionDetection(null, null, null, outcome);
+                    "✂️ TEXT ROI CROP OUTCOME: "
+                            + outcome
+                            + " roi="
+                            + (roi != null ? roi.toShortString() : "full"));
+            return new TextRegionDetection(
+                    roi, result.confidence.name(), result.fallbackReason, outcome);
+        } catch (Exception e) {
+            Log.w(TAG, "Text-region detection failed, preserving full frame", e);
+            return new TextRegionDetection(
+                    null,
+                    "NONE",
+                    "detection_exception:" + e.getClass().getSimpleName(),
+                    "FULL_FRAME (detection threw: " + e + ")");
         }
+    }
+
+    private static android.graphics.Rect toAndroidRect(CropRect rect) {
+        return new android.graphics.Rect(rect.left, rect.top, rect.right, rect.bottom);
     }
 
     private android.graphics.Bitmap cropBitmapToDetectedRoi(
@@ -501,8 +450,9 @@ public class MediaCaptureService {
         } finally {
             if (cropped != original) {
                 cropped.recycle();
+            } else {
+                original.recycle();
             }
-            original.recycle();
         }
         PhotoExifMetadataWriter.copyImuMetadata(originalPath, croppedPath);
         return croppedPath;
@@ -529,6 +479,119 @@ public class MediaCaptureService {
             Log.w(TAG, "Text-mode crop failed, transferring original frame: " + e.getMessage(), e);
         }
         return photoFilePath;
+    }
+
+    /**
+     * Persists the final text-mode selection without first writing the sensor JPEG. A successful
+     * detection writes only the full-resolution ROI. Detection/crop failure is the one case that
+     * writes the retained sensor JPEG as the safe full-frame fallback.
+     */
+    private boolean persistTextModeSelectionFromMemory(
+            CapturedPhoto capturedPhoto,
+            String canonicalPath,
+            String requestId,
+            @Nullable android.graphics.Rect roi) {
+        return persistTextModeSelectionFromMemory(
+                capturedPhoto, canonicalPath, canonicalPath, requestId, roi, true);
+    }
+
+    private boolean persistTextModeSelectionFromMemory(
+            CapturedPhoto capturedPhoto,
+            String canonicalPath,
+            String intendedCapturePath,
+            String requestId,
+            @Nullable android.graphics.Rect roi,
+            boolean writeSidecar) {
+        String preparedPath = canonicalPath.replace(".jpg", "_textselected_" + requestId + ".jpg");
+        File preparedFile = new File(preparedPath);
+        File parent = preparedFile.getParentFile();
+        if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            Log.e(TAG, "Could not create text-mode gallery directory: " + parent);
+            return false;
+        }
+
+        boolean wroteCrop = false;
+        android.graphics.Bitmap selected = null;
+        if (roi != null) {
+            try {
+                android.graphics.BitmapFactory.Options bounds =
+                        new android.graphics.BitmapFactory.Options();
+                bounds.inJustDecodeBounds = true;
+                android.graphics.BitmapFactory.decodeByteArray(
+                        capturedPhoto.jpegBytes, 0, capturedPhoto.jpegBytes.length, bounds);
+                if (bounds.outWidth > 0 && bounds.outHeight > 0) {
+                    android.graphics.Rect sourceRegion =
+                            clampRoiToBounds(roi, bounds.outWidth, bounds.outHeight);
+                    selected =
+                            decodeJpegRegion(
+                                    capturedPhoto.jpegBytes,
+                                    canonicalPath,
+                                    sourceRegion,
+                                    new android.graphics.BitmapFactory.Options());
+                }
+                if (selected != null) {
+                    try (FileOutputStream output = new FileOutputStream(preparedFile)) {
+                        wroteCrop =
+                                selected.compress(
+                                        android.graphics.Bitmap.CompressFormat.JPEG,
+                                        AsgConstants.TEXT_MODE_BLE_JPEG_QUALITY,
+                                        output);
+                    }
+                }
+            } catch (Exception error) {
+                Log.w(TAG, "Could not persist text ROI; saving full-frame fallback", error);
+            } finally {
+                if (selected != null) {
+                    selected.recycle();
+                }
+            }
+        }
+
+        try {
+            if (!wroteCrop) {
+                try (FileOutputStream output = new FileOutputStream(preparedFile)) {
+                    output.write(capturedPhoto.jpegBytes);
+                }
+                Log.w(
+                        TAG,
+                        "Text mode saved retained full frame because no usable ROI was available");
+            }
+
+            // Metadata is best-effort; failure must not discard an otherwise valid selected image.
+            PhotoExifMetadataWriter.writeCaptureIdFromPath(preparedPath, intendedCapturePath);
+            if (capturedPhoto.imuPayload != null) {
+                try {
+                    PhotoExifMetadataWriter.writeImuPayload(preparedPath, capturedPhoto.imuPayload);
+                } catch (java.io.IOException metadataError) {
+                    Log.w(TAG, "Could not embed IMU metadata in text-mode photo", metadataError);
+                }
+            }
+
+            PhotoArtifactFiles.promoteToCanonical(canonicalPath, preparedPath);
+            if (writeSidecar && capturedPhoto.imuPayload != null && parent != null) {
+                File sidecar = new File(parent, "imu.json");
+                try (FileOutputStream output = new FileOutputStream(sidecar)) {
+                    output.write(
+                            capturedPhoto
+                                    .imuPayload
+                                    .toString()
+                                    .getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                } catch (java.io.IOException sidecarError) {
+                    Log.w(TAG, "Could not persist text-mode IMU sidecar", sidecarError);
+                }
+            }
+            photoTextCropPrepared.put(requestId, true);
+            Log.i(
+                    TAG,
+                    wroteCrop
+                            ? "Text mode persisted cropped gallery output: " + canonicalPath
+                            : "Text mode persisted full-frame fallback: " + canonicalPath);
+            return true;
+        } catch (java.io.IOException error) {
+            Log.e(TAG, "Could not persist final text-mode photo", error);
+            PhotoArtifactFiles.deleteTransportTemporary(canonicalPath, preparedPath);
+            return false;
+        }
     }
 
     // Track which photos should be saved to gallery
@@ -620,6 +683,20 @@ public class MediaCaptureService {
                         t.setPriority(Thread.NORM_PRIORITY - 1);
                         return t;
                     });
+
+    /**
+     * Keeps ML Kit and final-crop persistence off CameraNeo's shared callback executor. A single
+     * worker preserves burst ordering and avoids running multiple memory-heavy full-resolution
+     * crops at once.
+     */
+    private final ExecutorService textModeProcessingExecutor =
+            Executors.newSingleThreadExecutor(
+                    r -> {
+                        Thread t = new Thread(r, "TextModeProcessing");
+                        t.setPriority(Thread.NORM_PRIORITY - 1);
+                        return t;
+                    });
+
     // Safety timeout covers the full job (capture + upload/BLE-handoff). Sized to outlast a
     // slow webhook upload on flaky WiFi so we don't prematurely free the flag while the upload
     // is still grinding. Force-resets isPhotoJobInFlight if no terminal callback fires.
@@ -865,7 +942,8 @@ public class MediaCaptureService {
             hardwareManager.setRgbLedSolidWhite(1800000, brightness); // 30 minute solid white LED
             Log.i(
                     TAG,
-                    "🎥 Video recording LED (solid white) triggered via hardware manager at brightness "
+                    "🎥 Video recording LED (solid white) triggered via hardware manager at"
+                            + " brightness "
                             + brightness);
         } else {
             Log.w(TAG, "⚠️ RGB LED not supported on this device");
@@ -1262,7 +1340,8 @@ public class MediaCaptureService {
                                                                 TAG,
                                                                 "⏱️ Max recording time reached ("
                                                                         + maxRecordingTimeMinutes
-                                                                        + " minutes), stopping recording");
+                                                                        + " minutes), stopping"
+                                                                        + " recording");
                                                         stopVideoRecording(
                                                                 StopReason.MAX_DURATION); // ← USE
                                                         // REASON
@@ -1365,7 +1444,8 @@ public class MediaCaptureService {
                             if (isCleaningUp.get()) {
                                 Log.w(
                                         TAG,
-                                        "Skipping video integrity check because cleanup is already in progress");
+                                        "Skipping video integrity check because cleanup is already"
+                                                + " in progress");
                                 sendGalleryStatusUpdate();
                                 return;
                             }
@@ -1416,21 +1496,41 @@ public class MediaCaptureService {
                                                                             && !bad.delete()) {
                                                                         Log.w(
                                                                                 TAG,
-                                                                                "Could not delete failed video file: "
+                                                                                "Could not delete"
+                                                                                        + " failed"
+                                                                                        + " video file:"
+                                                                                        + " "
                                                                                         + filePath);
                                                                     }
                                                                 } else {
                                                                     Log.w(
                                                                             TAG,
-                                                                            "Skipping failed video deletion because cleanup is in progress");
+                                                                            "Skipping failed video"
+                                                                                    + " deletion"
+                                                                                    + " because cleanup"
+                                                                                    + " is in"
+                                                                                    + " progress");
                                                                 }
                                                                 if (mMediaCaptureListener != null) {
                                                                     mMediaCaptureListener
                                                                             .onMediaError(
                                                                                     pendingRequestId,
                                                                                     cleaningUp
-                                                                                            ? "Video integrity check aborted during cleanup; file preserved"
-                                                                                            : "Video file failed integrity check and was removed",
+                                                                                            ? "Video"
+                                                                                                    + " integrity"
+                                                                                                    + " check"
+                                                                                                    + " aborted"
+                                                                                                    + " during"
+                                                                                                    + " cleanup;"
+                                                                                                    + " file"
+                                                                                                    + " preserved"
+                                                                                            : "Video"
+                                                                                                    + " file"
+                                                                                                    + " failed"
+                                                                                                    + " integrity"
+                                                                                                    + " check"
+                                                                                                    + " and was"
+                                                                                                    + " removed",
                                                                                     MediaUploadQueueManager
                                                                                             .MEDIA_TYPE_VIDEO);
                                                                 }
@@ -1440,7 +1540,8 @@ public class MediaCaptureService {
                                             } catch (Throwable t) {
                                                 Log.e(
                                                         TAG,
-                                                        "Unexpected error during video integrity check",
+                                                        "Unexpected error during video integrity"
+                                                                + " check",
                                                         t);
                                                 mainHandler.post(
                                                         () -> {
@@ -1449,7 +1550,8 @@ public class MediaCaptureService {
                                                             if (mMediaCaptureListener != null) {
                                                                 mMediaCaptureListener.onMediaError(
                                                                         pendingRequestId,
-                                                                        "Video integrity check error: "
+                                                                        "Video integrity check"
+                                                                                + " error: "
                                                                                 + t.getMessage(),
                                                                         MediaUploadQueueManager
                                                                                 .MEDIA_TYPE_VIDEO);
@@ -1461,7 +1563,8 @@ public class MediaCaptureService {
                             } catch (RejectedExecutionException e) {
                                 Log.w(
                                         TAG,
-                                        "Video integrity check rejected because cleanup is in progress",
+                                        "Video integrity check rejected because cleanup is in"
+                                                + " progress",
                                         e);
                                 videoCaptureIdsPendingIntegrityCheck.remove(captureId);
                                 mainHandler.post(
@@ -1469,7 +1572,8 @@ public class MediaCaptureService {
                                             if (mMediaCaptureListener != null) {
                                                 mMediaCaptureListener.onMediaError(
                                                         pendingRequestId,
-                                                        "Video integrity check unavailable during cleanup",
+                                                        "Video integrity check unavailable during"
+                                                                + " cleanup",
                                                         MediaUploadQueueManager.MEDIA_TYPE_VIDEO);
                                             }
                                             sendGalleryStatusUpdate();
@@ -2068,11 +2172,11 @@ public class MediaCaptureService {
 
     /**
      * Capture a photo that is only saved to the gallery: an SDK take_photo with save=true and no
-     * upload target. There is no delivery leg (no webhook upload, no BLE transfer), so this
-     * bypasses the single-flight photo-job gate and enqueues straight into the camera queue,
-     * exactly like button photos — rapid bursts serialize at the camera instead of failing
-     * CAMERA_BUSY. The terminal photo_response carries the captureId (the requestId-stamped capture
-     * directory name) for sync-time correlation.
+     * upload target. Ordinary photos bypass the single-flight photo-job gate and enqueue straight
+     * into the camera queue, exactly like button photos. Text mode remains single-flight through
+     * detection and final persistence so bursts cannot retain an unbounded queue of sensor JPEGs.
+     * The terminal photo_response carries the captureId (the requestId-stamped capture directory
+     * name) for sync-time correlation.
      */
     public boolean takePhotoForLocalSave(
             String photoFilePath,
@@ -2087,6 +2191,7 @@ public class MediaCaptureService {
         if (captureSettings == null) {
             captureSettings = PhotoCaptureSettings.EMPTY;
         }
+        final boolean textModeRequested = PhotoMode.TEXT.equals(mode);
         String captureSize = PhotoMode.TEXT.equals(mode) ? PhotoSizeTier.normalize("max") : size;
 
         // Photos cannot interrupt streams
@@ -2113,6 +2218,16 @@ public class MediaCaptureService {
                     "INSUFFICIENT_STORAGE",
                     "Insufficient storage space for photo capture");
             return false;
+        }
+
+        if (textModeRequested && !acquirePhotoJob(requestId)) {
+            Log.w(TAG, "Text-mode local-save job already in flight: " + requestId);
+            sendPhotoErrorResponse(requestId, "CAMERA_BUSY", "Another photo job is in progress");
+            return false;
+        }
+        if (textModeRequested) {
+            startCaptureSafetyTimeout(requestId);
+            getTextRoiDetector().warmUp();
         }
 
         Log.i(
@@ -2154,6 +2269,8 @@ public class MediaCaptureService {
                     exposureTimeNs,
                     iso,
                     captureSettings,
+                    textModeRequested,
+                    !textModeRequested,
                     new CameraNeoService.PhotoCaptureCallback() {
                         @Override
                         public void onPhotoConfigured(JSONObject resolvedConfig) {
@@ -2186,23 +2303,69 @@ public class MediaCaptureService {
 
                         @Override
                         public void onPhotoCaptured(String filePath, JSONObject captureMetadata) {
-                            Log.d(TAG, "Local-save photo captured: " + filePath);
-                            sendPhotoStatus(
-                                    requestId,
-                                    "captured",
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    null,
-                                    captureMetadata);
+                            onPhotoCaptured(filePath, captureMetadata, null);
+                        }
 
-                            if (mMediaCaptureListener != null) {
-                                mMediaCaptureListener.onPhotoCaptured(requestId, filePath);
+                        @Override
+                        public void onPhotoCaptured(
+                                String filePath,
+                                JSONObject captureMetadata,
+                                CapturedPhoto capturedPhoto) {
+                            if (textModeRequested) {
+                                if (capturedPhoto == null) {
+                                    try {
+                                        sendPhotoErrorResponse(
+                                                requestId,
+                                                "PHOTO_SAVE_FAILED",
+                                                "Text-mode capture was not available in memory");
+                                    } finally {
+                                        releasePhotoJob(requestId);
+                                    }
+                                    return;
+                                }
+                                try {
+                                    textModeProcessingExecutor.execute(
+                                            () -> {
+                                                try {
+                                                    TextRegionDetection detection =
+                                                            runTextRegionDetection(
+                                                                    capturedPhoto.jpegBytes,
+                                                                    filePath);
+                                                    if (!persistTextModeSelectionFromMemory(
+                                                            capturedPhoto,
+                                                            filePath,
+                                                            requestId,
+                                                            detection.roi)) {
+                                                        sendPhotoErrorResponse(
+                                                                requestId,
+                                                                "PHOTO_SAVE_FAILED",
+                                                                "Could not save final text-mode"
+                                                                        + " output");
+                                                        return;
+                                                    }
+                                                    finishLocalSavePhoto(
+                                                            requestId,
+                                                            captureId,
+                                                            filePath,
+                                                            captureMetadata);
+                                                } finally {
+                                                    releasePhotoJob(requestId);
+                                                }
+                                            });
+                                } catch (RejectedExecutionException executorClosed) {
+                                    try {
+                                        sendPhotoErrorResponse(
+                                                requestId,
+                                                "PHOTO_SAVE_FAILED",
+                                                "Text-mode processing stopped during service"
+                                                        + " cleanup");
+                                    } finally {
+                                        releasePhotoJob(requestId);
+                                    }
+                                }
+                                return;
                             }
-
-                            sendLocalSaveSuccessResponse(requestId, captureId);
-                            sendGalleryStatusUpdate();
+                            finishLocalSavePhoto(requestId, captureId, filePath, captureMetadata);
                         }
 
                         @Override
@@ -2212,23 +2375,56 @@ public class MediaCaptureService {
 
                         @Override
                         public void onPhotoError(CameraOperationError error) {
-                            Log.e(TAG, "Failed to capture local-save photo: " + error.message());
-                            sendPhotoErrorResponse(requestId, error.code(), error.message());
+                            try {
+                                Log.e(
+                                        TAG,
+                                        "Failed to capture local-save photo: " + error.message());
+                                sendPhotoErrorResponse(requestId, error.code(), error.message());
 
-                            if (mMediaCaptureListener != null) {
-                                mMediaCaptureListener.onMediaError(
-                                        requestId,
-                                        error.message(),
-                                        MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
+                                if (mMediaCaptureListener != null) {
+                                    mMediaCaptureListener.onMediaError(
+                                            requestId,
+                                            error.message(),
+                                            MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
+                                }
+                            } finally {
+                                if (textModeRequested) {
+                                    releasePhotoJob(requestId);
+                                }
                             }
                         }
                     });
             return true;
         } catch (Exception e) {
-            Log.e(TAG, "Error taking local-save photo", e);
-            sendPhotoErrorResponse(
-                    requestId, "CAMERA_CAPTURE_FAILED", "Error taking photo: " + e.getMessage());
+            try {
+                Log.e(TAG, "Error taking local-save photo", e);
+                sendPhotoErrorResponse(
+                        requestId,
+                        "CAMERA_CAPTURE_FAILED",
+                        "Error taking photo: " + e.getMessage());
+            } finally {
+                if (textModeRequested) {
+                    releasePhotoJob(requestId);
+                }
+            }
             return false;
+        }
+    }
+
+    private void finishLocalSavePhoto(
+            String requestId, String captureId, String filePath, JSONObject captureMetadata) {
+        try {
+            Log.d(TAG, "Local-save photo captured: " + filePath);
+            sendPhotoStatus(requestId, "captured", null, null, null, null, null, captureMetadata);
+
+            if (mMediaCaptureListener != null) {
+                mMediaCaptureListener.onPhotoCaptured(requestId, filePath);
+            }
+
+            sendLocalSaveSuccessResponse(requestId, captureId);
+            sendGalleryStatusUpdate();
+        } finally {
+            clearPhotoRequestTracking(requestId);
         }
     }
 
@@ -2294,7 +2490,11 @@ public class MediaCaptureService {
         if (captureSettings == null) {
             captureSettings = PhotoCaptureSettings.EMPTY;
         }
-        String captureSize = PhotoMode.TEXT.equals(mode) ? PhotoSizeTier.normalize("max") : size;
+        final boolean textModeRequested = PhotoMode.TEXT.equals(mode);
+        if (textModeRequested) {
+            getTextRoiDetector().warmUp();
+        }
+        String captureSize = textModeRequested ? PhotoSizeTier.normalize("max") : size;
         // Start timing for end-to-end photo capture performance measurement
         final long requestStartTimeMs = System.currentTimeMillis();
         recordTiming(requestId, "request_start");
@@ -2438,13 +2638,16 @@ public class MediaCaptureService {
                     exposureTimeNs,
                     iso,
                     captureSettings,
+                    textModeRequested,
+                    !textModeRequested,
                     new CameraNeoService.PhotoCaptureCallback() {
                         @Override
                         public void onPhotoConfigured(JSONObject resolvedConfig) {
                             logBlePhotoStep(
                                     requestId,
                                     "capture_configured",
-                                    "camera configuration resolved for the requested size and exposure");
+                                    "camera configuration resolved for the requested size and"
+                                            + " exposure");
                             sendPhotoStatus(
                                     requestId,
                                     "configuring",
@@ -2502,7 +2705,6 @@ public class MediaCaptureService {
                             }
 
                             Log.d(TAG, "Photo captured successfully at: " + filePath);
-                            prepareTextModePhotoPath(filePath, requestId);
                             sendPhotoStatus(
                                     requestId,
                                     "captured",
@@ -2533,6 +2735,67 @@ public class MediaCaptureService {
                                 sendPhotoSuccessResponse(requestId, "");
                                 clearPhotoTracking(requestId);
                                 releasePhotoJob(requestId);
+                            }
+                        }
+
+                        @Override
+                        public void onPhotoCaptured(
+                                String filePath,
+                                JSONObject captureMetadata,
+                                CapturedPhoto capturedPhoto) {
+                            if (!textModeRequested) {
+                                onPhotoCaptured(filePath, captureMetadata);
+                                return;
+                            }
+                            if (capturedPhoto == null) {
+                                cleanupPhotoArtifacts(requestId, filePath, false);
+                                clearPhotoTracking(requestId);
+                                releasePhotoJob(requestId);
+                                sendPhotoErrorResponse(
+                                        requestId,
+                                        "PHOTO_SAVE_FAILED",
+                                        "Text-mode capture was not available in memory");
+                                return;
+                            }
+                            try {
+                                textModeProcessingExecutor.execute(
+                                        () -> {
+                                            TextRegionDetection detection =
+                                                    runTextRegionDetection(
+                                                            capturedPhoto.jpegBytes, filePath);
+                                            String outputPath =
+                                                    save
+                                                            ? filePath
+                                                            : transientTextUploadPath(filePath);
+                                            if (!persistTextModeSelectionFromMemory(
+                                                    capturedPhoto,
+                                                    outputPath,
+                                                    filePath,
+                                                    requestId,
+                                                    detection.roi,
+                                                    save)) {
+                                                cleanupPhotoArtifacts(requestId, filePath, false);
+                                                clearPhotoTracking(requestId);
+                                                releasePhotoJob(requestId);
+                                                sendPhotoErrorResponse(
+                                                        requestId,
+                                                        "PHOTO_SAVE_FAILED",
+                                                        "Could not prepare text-mode upload");
+                                                return;
+                                            }
+                                            if (!save) {
+                                                photoOriginalPaths.put(requestId, outputPath);
+                                            }
+                                            onPhotoCaptured(outputPath, captureMetadata);
+                                        });
+                            } catch (RejectedExecutionException executorClosed) {
+                                cleanupPhotoArtifacts(requestId, filePath, false);
+                                clearPhotoTracking(requestId);
+                                releasePhotoJob(requestId);
+                                sendPhotoErrorResponse(
+                                        requestId,
+                                        "PHOTO_SAVE_FAILED",
+                                        "Text-mode processing stopped during service cleanup");
                             }
                         }
 
@@ -2580,6 +2843,16 @@ public class MediaCaptureService {
             }
             return false;
         }
+    }
+
+    private String transientTextUploadPath(String intendedCapturePath) {
+        File cacheDir = new File(mContext.getCacheDir(), "text_mode_uploads");
+        if (!cacheDir.exists() && !cacheDir.mkdirs()) {
+            Log.w(TAG, "Could not create text-mode upload cache: " + cacheDir);
+        }
+        File captureDir = new File(intendedCapturePath).getParentFile();
+        String captureId = captureDir != null ? captureDir.getName() : "capture";
+        return new File(cacheDir, captureId + ".jpg").getAbsolutePath();
     }
 
     /**
@@ -2838,18 +3111,62 @@ public class MediaCaptureService {
 
     /**
      * Largest power-of-two JPEG subsampling factor that still keeps the decoded region at or above
-     * the BLE target box, so the follow-up {@code createScaledBitmap} only ever shrinks. Decoding
-     * 4032x3024 at inSampleSize=2 cuts the ARGB working set 4x with no quality cost at a 1920px
-     * output cap.
+     * the aspect-fitted BLE output, so the follow-up {@code createScaledBitmap} only ever shrinks.
+     * The configured dimensions are caps, not the literal output dimensions. Decoding 4032x3024 at
+     * inSampleSize=2 cuts the ARGB working set 4x with no quality cost at a 1920px output cap.
      */
-    private static int computeBleDecodeSampleSize(
+    static int computeBleDecodeSampleSize(
             int regionWidth, int regionHeight, int targetWidth, int targetHeight) {
+        float outputScale =
+                Math.min(
+                        1f,
+                        Math.min(
+                                targetWidth / (float) regionWidth,
+                                targetHeight / (float) regionHeight));
+        int outputWidth = Math.max(1, Math.round(regionWidth * outputScale));
+        int outputHeight = Math.max(1, Math.round(regionHeight * outputScale));
         int sample = 1;
-        while ((regionWidth / (sample * 2)) >= targetWidth
-                && (regionHeight / (sample * 2)) >= targetHeight) {
+        while ((regionWidth / (sample * 2)) >= outputWidth
+                && (regionHeight / (sample * 2)) >= outputHeight) {
             sample *= 2;
         }
         return sample;
+    }
+
+    private static android.graphics.Rect clampRoiToBounds(
+            android.graphics.Rect roi, int width, int height) {
+        android.graphics.Rect clamped = new android.graphics.Rect(roi);
+        if (!clamped.intersect(0, 0, width, height)
+                || clamped.width() <= 0
+                || clamped.height() <= 0) {
+            return new android.graphics.Rect(0, 0, width, height);
+        }
+        return clamped;
+    }
+
+    /** Decodes only the selected JPEG region; returns null so the caller can fall back safely. */
+    @Nullable
+    private static android.graphics.Bitmap decodeJpegRegion(
+            @Nullable byte[] jpegBytes,
+            String jpegPath,
+            android.graphics.Rect sourceRegion,
+            android.graphics.BitmapFactory.Options options) {
+        android.graphics.BitmapRegionDecoder decoder = null;
+        try {
+            decoder =
+                    jpegBytes != null
+                            ? android.graphics.BitmapRegionDecoder.newInstance(
+                                    jpegBytes, 0, jpegBytes.length, false)
+                            : android.graphics.BitmapRegionDecoder.newInstance(jpegPath, false);
+            return decoder.decodeRegion(sourceRegion, options);
+        } catch (Exception error) {
+            Log.w(TAG, "JPEG region decode failed; falling back to full sampled decode", error);
+            return null;
+        } finally {
+            if (decoder != null) {
+                decoder.recycle();
+            }
+        }
     }
 
     /** Maps a source-pixel ROI onto the subsampled decode's coordinate space. */
@@ -3517,7 +3834,8 @@ public class MediaCaptureService {
                                     if (bleImgId != null) {
                                         Log.d(
                                                 TAG,
-                                                "📱 Webhook upload failed, attempting BLE fallback");
+                                                "📱 Webhook upload failed, attempting BLE"
+                                                        + " fallback");
                                         Log.d(TAG, "🔄 BLE Image ID: " + bleImgId);
                                         tracePhotoUploadFallback(
                                                 requestId,
@@ -3565,7 +3883,8 @@ public class MediaCaptureService {
                                             requestId, "UPLOAD_FAILED", errorMessage);
                                     Log.d(
                                             TAG,
-                                            "❌ No BLE fallback available, handling as normal failure");
+                                            "❌ No BLE fallback available, handling as normal"
+                                                    + " failure");
 
                                     cleanupPhotoArtifacts(
                                             requestId,
@@ -3800,7 +4119,8 @@ public class MediaCaptureService {
                                     requestBuilder.header("Authorization", "Bearer " + authToken);
                                     Log.d(
                                             TAG,
-                                            "🔐 Adding Authorization header to video webhook request");
+                                            "🔐 Adding Authorization header to video webhook"
+                                                    + " request");
                                 } else {
                                     Log.d(
                                             TAG,
@@ -3832,7 +4152,8 @@ public class MediaCaptureService {
                                             if (videoFile.delete()) {
                                                 Log.d(
                                                         TAG,
-                                                        "🗑️ Deleted video file after successful upload");
+                                                        "🗑️ Deleted video file after successful"
+                                                                + " upload");
                                             } else {
                                                 Log.w(TAG, "⚠️ Failed to delete video file");
                                             }
@@ -4164,6 +4485,9 @@ public class MediaCaptureService {
             Long exposureTimeNs,
             Integer iso,
             PhotoCaptureSettings captureSettings) {
+        if (PhotoMode.TEXT.equals(mode)) {
+            getTextRoiDetector().warmUp();
+        }
         // Check if camera HAL is restarting after FOV change
         if (CameraRestartCooldown.isActive()) {
             Log.w(TAG, "Cannot take photo - camera HAL restarting after FOV change");
@@ -4262,6 +4586,9 @@ public class MediaCaptureService {
         if (captureSettings == null) {
             captureSettings = PhotoCaptureSettings.EMPTY;
         }
+        if (PhotoMode.TEXT.equals(mode)) {
+            getTextRoiDetector().warmUp();
+        }
         String captureSize = PhotoMode.TEXT.equals(mode) ? PhotoSizeTier.normalize("max") : size;
         Log.i(
                 TAG,
@@ -4324,11 +4651,16 @@ public class MediaCaptureService {
             Log.w(TAG, "⚠️ StateManager not initialized - skipping battery check for BLE transfer");
         }
 
-        // STORAGE CHECK: Reject if insufficient storage
+        // A save=false BLE capture keeps the large JPEG in RAM, so low persistent storage is
+        // irrelevant (the small IMU recorder scratch file remains unchanged).
         logBlePhotoStep(
-                requestId, "storage_check", "checking storage required for the captured JPEG");
+                requestId,
+                "storage_check",
+                save
+                        ? "checking storage required for the saved sensor JPEG"
+                        : "skipped for RAM-only JPEG capture");
         StorageManager storageManager = StorageManager.getInstance(mContext);
-        if (!storageManager.canTakePhoto()) {
+        if (save && !storageManager.canTakePhoto()) {
             Log.w(TAG, "🚫 Photo rejected - insufficient storage");
             playStorageFullSound();
             sendPhotoErrorResponse(
@@ -4418,13 +4750,19 @@ public class MediaCaptureService {
                     exposureTimeNs,
                     iso,
                     captureSettings,
+                    // RAM-first: the callback receives the JPEG bytes in memory. Text mode never
+                    // persists the sensor JPEG up front;
+                    // save=true writes only the selected crop, or the full-frame fallback.
+                    true,
+                    save && !PhotoMode.TEXT.equals(mode),
                     new CameraNeoService.PhotoCaptureCallback() {
                         @Override
                         public void onPhotoConfigured(JSONObject resolvedConfig) {
                             logBlePhotoStep(
                                     requestId,
                                     "capture_configured",
-                                    "camera configuration resolved for the requested size and exposure");
+                                    "camera configuration resolved for the requested size and"
+                                            + " exposure");
                             sendPhotoStatus(
                                     requestId,
                                     "configuring",
@@ -4458,11 +4796,25 @@ public class MediaCaptureService {
 
                         @Override
                         public void onPhotoCaptured(String filePath, JSONObject captureMetadata) {
+                            onPhotoCaptured(filePath, captureMetadata, null);
+                        }
+
+                        @Override
+                        public void onPhotoCaptured(
+                                String filePath,
+                                JSONObject captureMetadata,
+                                CapturedPhoto capturedPhoto) {
                             // NOTE: do NOT clear isPhotoJobInFlight here — the job continues
                             // through BLE compression + handoff. Flag is cleared in
                             // compressAndSendViaBle's finally block.
                             BlePhotoTimingLog.unbindPhaseSink(capturePhaseSink);
-                            long capturedBytes = new File(filePath).length();
+                            // The in-memory capture (JPEG bytes + IMU payload + optional
+                            // persistence future). For save=false the file intentionally does not
+                            // exist.
+                            long capturedBytes =
+                                    capturedPhoto != null
+                                            ? capturedPhoto.jpegBytes.length
+                                            : new File(filePath).length();
                             if (capturedBytes > 0) {
                                 bleOriginalBytes.put(requestId, capturedBytes);
                             }
@@ -4481,7 +4833,6 @@ public class MediaCaptureService {
                                             + "KB)");
 
                             Log.d(TAG, "Photo captured successfully for BLE transfer: " + filePath);
-                            prepareTextModePhotoPath(filePath, requestId);
                             sendPhotoStatus(
                                     requestId,
                                     "captured",
@@ -4502,7 +4853,8 @@ public class MediaCaptureService {
 
                             // Compress and send via BLE
                             logBlePhotoStep(requestId, "start_compress_for_ble");
-                            compressAndSendViaBle(filePath, requestId, bleImgId);
+                            compressAndSendViaBle(
+                                    filePath, requestId, bleImgId, false, capturedPhoto);
                         }
 
                         @Override
@@ -4593,16 +4945,29 @@ public class MediaCaptureService {
     }
 
     /** Compress photo and send via BLE */
-    private void compressAndSendViaBle(String originalPath, String requestId, String bleImgId) {
-        compressAndSendViaBle(originalPath, requestId, bleImgId, false);
-    }
-
-    /** Compress photo and send via BLE */
     private void compressAndSendViaBle(
             String originalPath, String requestId, String bleImgId, boolean isWifiFallback) {
+        compressAndSendViaBle(originalPath, requestId, bleImgId, isWifiFallback, null);
+    }
+
+    /**
+     * Compress photo and send via BLE.
+     *
+     * @param capturedPhoto in-memory capture (JPEG bytes + IMU payload + persistence future) for
+     *     RAM-first captures; {@code null} for file-based flows (WiFi-fallback reuse), which read
+     *     {@code originalPath} from disk as before
+     */
+    private void compressAndSendViaBle(
+            String originalPath,
+            String requestId,
+            String bleImgId,
+            boolean isWifiFallback,
+            @Nullable CapturedPhoto capturedPhoto) {
         new Thread(
                         () -> {
                             long compressThreadStart = System.currentTimeMillis();
+                            boolean bleTransferStarted = false;
+                            android.graphics.Rect detectedTextRoi = null;
                             CompressStageTimer stage = new CompressStageTimer();
                             recordTiming(requestId, "ble_compress_start");
                             logBlePhotoStep(
@@ -4618,6 +4983,10 @@ public class MediaCaptureService {
                                         requestId,
                                         PhotoCaptureTestHooks.getErrorCode(),
                                         PhotoCaptureTestHooks.getErrorMessage());
+                                if (capturedPhoto != null) {
+                                    // Never let cleanup race the background write.
+                                    capturedPhoto.awaitPersistenceCompletion();
+                                }
                                 cleanupPhotoArtifacts(
                                         requestId,
                                         originalPath,
@@ -4642,7 +5011,12 @@ public class MediaCaptureService {
                                 String requestedMode =
                                         PhotoMode.normalize(photoRequestedModes.get(requestId));
                                 boolean textModeRequested = PhotoMode.TEXT.equals(requestedMode);
-                                if (textModeRequested) {
+                                if (textModeRequested && capturedPhoto == null) {
+                                    // File-based flow (WiFi fallback): prepare the canonical
+                                    // cropped JPEG up front as before. RAM-first captures crop
+                                    // from the detection ROI in-memory below and only write the
+                                    // canonical crop for gallery-saved photos, after the BLE
+                                    // handoff.
                                     prepareTextModePhotoPath(originalPath, requestId);
                                 }
                                 boolean textCropAlreadyPrepared =
@@ -4708,14 +5082,13 @@ public class MediaCaptureService {
                                                 + requestId);
 
                                 android.graphics.Bitmap resized;
-                                DetectionResult.Confidence textCropConfidence = null;
+                                String textCropConfidence = null;
                                 String textCropReason = null;
                                 // 2a. Text-region ROI detection. Independent of the grayscale
                                 // flag: it only decides WHERE to crop, not how the pixels are
                                 // processed afterwards.
-                                // Human-readable verdict for whether the ROI below represents a
-                                // genuine detected text region vs. a safety-net fallback. See
-                                // classifyTextCropOutcome() for the exact rules.
+                                // Human-readable verdict for whether ML Kit found a usable text
+                                // region or the transfer is preserving the full frame.
                                 String textCropOutcome =
                                         textCropAlreadyPrepared
                                                 ? "PREPARED_CANONICAL_CROP"
@@ -4734,8 +5107,13 @@ public class MediaCaptureService {
                                     stage.start("text-region detection");
                                     logBlePhotoStep(requestId, "text_region_detection_start");
                                     TextRegionDetection detection =
-                                            runTextRegionDetection(originalPath);
+                                            runTextRegionDetection(
+                                                    capturedPhoto != null
+                                                            ? capturedPhoto.jpegBytes
+                                                            : null,
+                                                    originalPath);
                                     roi = detection.roi;
+                                    detectedTextRoi = roi;
                                     textCropConfidence = detection.confidence;
                                     textCropReason = detection.reason;
                                     textCropOutcome = detection.outcome;
@@ -4762,13 +5140,20 @@ public class MediaCaptureService {
                                     logBlePhotoStep(
                                             requestId,
                                             "grayscale_process_start",
-                                            "processing luma pixels through crop, resize, and sharpen");
+                                            "processing luma pixels through crop, resize, and"
+                                                    + " sharpen");
                                     resized =
-                                            GrayscaleBleProcessor.process(
-                                                    originalPath,
-                                                    roi,
-                                                    bleParams.targetWidth,
-                                                    bleParams.targetHeight);
+                                            capturedPhoto != null
+                                                    ? GrayscaleBleProcessor.process(
+                                                            capturedPhoto.jpegBytes,
+                                                            roi,
+                                                            bleParams.targetWidth,
+                                                            bleParams.targetHeight)
+                                                    : GrayscaleBleProcessor.process(
+                                                            originalPath,
+                                                            roi,
+                                                            bleParams.targetWidth,
+                                                            bleParams.targetHeight);
                                     stage.finish(
                                             "grayscale decode+crop+resize+sharpen",
                                             "output "
@@ -4791,11 +5176,21 @@ public class MediaCaptureService {
                                     logBlePhotoStep(
                                             requestId,
                                             "input_decode_start",
-                                            "decoding the captured JPEG with a memory-saving sample size");
+                                            "decoding the captured JPEG with a memory-saving sample"
+                                                    + " size");
                                     android.graphics.BitmapFactory.Options bounds =
                                             new android.graphics.BitmapFactory.Options();
                                     bounds.inJustDecodeBounds = true;
-                                    android.graphics.BitmapFactory.decodeFile(originalPath, bounds);
+                                    if (capturedPhoto != null) {
+                                        android.graphics.BitmapFactory.decodeByteArray(
+                                                capturedPhoto.jpegBytes,
+                                                0,
+                                                capturedPhoto.jpegBytes.length,
+                                                bounds);
+                                    } else {
+                                        android.graphics.BitmapFactory.decodeFile(
+                                                originalPath, bounds);
+                                    }
                                     int srcWidth = bounds.outWidth;
                                     int srcHeight = bounds.outHeight;
                                     if (srcWidth <= 0 || srcHeight <= 0) {
@@ -4817,9 +5212,35 @@ public class MediaCaptureService {
                                     android.graphics.BitmapFactory.Options decodeOpts =
                                             new android.graphics.BitmapFactory.Options();
                                     decodeOpts.inSampleSize = sampleSize;
-                                    android.graphics.Bitmap original =
-                                            android.graphics.BitmapFactory.decodeFile(
-                                                    originalPath, decodeOpts);
+                                    android.graphics.Bitmap original = null;
+                                    boolean regionDecoded = false;
+                                    if (roi != null) {
+                                        android.graphics.Rect sourceRegion =
+                                                clampRoiToBounds(roi, srcWidth, srcHeight);
+                                        original =
+                                                decodeJpegRegion(
+                                                        capturedPhoto != null
+                                                                ? capturedPhoto.jpegBytes
+                                                                : null,
+                                                        originalPath,
+                                                        sourceRegion,
+                                                        decodeOpts);
+                                        regionDecoded = original != null;
+                                    }
+                                    if (original == null) {
+                                        original =
+                                                capturedPhoto != null
+                                                        ? android.graphics.BitmapFactory
+                                                                .decodeByteArray(
+                                                                        capturedPhoto.jpegBytes,
+                                                                        0,
+                                                                        capturedPhoto
+                                                                                .jpegBytes
+                                                                                .length,
+                                                                        decodeOpts)
+                                                        : android.graphics.BitmapFactory.decodeFile(
+                                                                originalPath, decodeOpts);
+                                    }
                                     if (original == null) {
                                         throw new Exception("Failed to decode image file");
                                     }
@@ -4835,6 +5256,8 @@ public class MediaCaptureService {
                                                     + original.getHeight()
                                                     + " (inSampleSize="
                                                     + sampleSize
+                                                    + ", regionDecoded="
+                                                    + regionDecoded
                                                     + ")");
                                     logBlePhotoStep(
                                             requestId,
@@ -4861,10 +5284,12 @@ public class MediaCaptureService {
                                                             ? roi.toShortString()
                                                             : "full image"));
                                     android.graphics.Bitmap cropped =
-                                            cropBitmapToDetectedRoi(
-                                                    original,
-                                                    scaleRoiToDecoded(roi, sampleSize),
-                                                    textCropOutcome);
+                                            regionDecoded
+                                                    ? original
+                                                    : cropBitmapToDetectedRoi(
+                                                            original,
+                                                            scaleRoiToDecoded(roi, sampleSize),
+                                                            textCropOutcome);
                                     stage.finish(
                                             "crop",
                                             "cropped "
@@ -4879,15 +5304,25 @@ public class MediaCaptureService {
                                                     + "x"
                                                     + cropped.getHeight());
 
-                                    int targetWidth = bleParams.targetWidth;
-                                    int targetHeight = bleParams.targetHeight;
-                                    float aspectRatio =
-                                            (float) cropped.getWidth() / cropped.getHeight();
-                                    if (aspectRatio > targetWidth / (float) targetHeight) {
-                                        targetHeight = (int) (targetWidth / aspectRatio);
-                                    } else {
-                                        targetWidth = (int) (targetHeight * aspectRatio);
-                                    }
+                                    // The configured dimensions are caps, not a request to enlarge
+                                    // a small ROI. Upscaling cannot recover text detail and wastes
+                                    // both CPU and BLE bytes.
+                                    float resizeScale =
+                                            Math.min(
+                                                    1f,
+                                                    Math.min(
+                                                            bleParams.targetWidth
+                                                                    / (float) cropped.getWidth(),
+                                                            bleParams.targetHeight
+                                                                    / (float) cropped.getHeight()));
+                                    int targetWidth =
+                                            Math.max(
+                                                    1,
+                                                    Math.round(cropped.getWidth() * resizeScale));
+                                    int targetHeight =
+                                            Math.max(
+                                                    1,
+                                                    Math.round(cropped.getHeight() * resizeScale));
 
                                     logBlePhotoStep(
                                             requestId,
@@ -4949,7 +5384,8 @@ public class MediaCaptureService {
 
                                 // 3. Encode with the policy-selected BLE codec. Text mode and
                                 // ordinary size-tier photos share this exact codec/quality
-                                // resolution — there is no per-mode branch here by design.
+                                // resolution. RAM-first captures pass their in-memory IMU payload
+                                // to the selected encoder instead of consulting a source file.
                                 int encodeQuality =
                                         codec == BleCodec.AVIF
                                                 ? bleParams.avifQuality
@@ -4963,8 +5399,10 @@ public class MediaCaptureService {
                                                 + " quality="
                                                 + encodeQuality
                                                 + " hasImuMetadata="
-                                                + PhotoExifMetadataWriter.hasImuMetadata(
-                                                        originalPath));
+                                                + (capturedPhoto != null
+                                                        ? capturedPhoto.imuPayload != null
+                                                        : PhotoExifMetadataWriter.hasImuMetadata(
+                                                                originalPath)));
                                 // Verification instrumentation: confirm exactly one encoder runs
                                 // per request. A count > 1 here would mean the old dual
                                 // JPEG+AVIF encode path regressed back in, silently doubling
@@ -4991,7 +5429,14 @@ public class MediaCaptureService {
                                                     + " for this request)");
                                     encodeResult =
                                             BlePhotoEncoders.encode(
-                                                    resized, codec, encodeQuality, originalPath);
+                                                    resized,
+                                                    codec,
+                                                    encodeQuality,
+                                                    capturedPhoto != null ? null : originalPath,
+                                                    capturedPhoto != null
+                                                            ? capturedPhoto.imuPayload
+                                                            : null,
+                                                    originalPath);
                                     long cumulativeEncodeMs =
                                             bleEncodeTotalMs.merge(
                                                     requestId, encodeResult.encodeMs, Long::sum);
@@ -5052,8 +5497,10 @@ public class MediaCaptureService {
 
                                 long compressionTime =
                                         System.currentTimeMillis() - compressThreadStart;
-                                File originalFileForSize = new File(originalPath);
-                                long originalSizeBytes = originalFileForSize.length();
+                                long originalSizeBytes =
+                                        capturedPhoto != null
+                                                ? capturedPhoto.jpegBytes.length
+                                                : new File(originalPath).length();
                                 double originalSizeKb = originalSizeBytes / 1024.0;
                                 double compressedSizeKb = compressedData.length / 1024.0;
                                 logBlePhotoStep(
@@ -5068,17 +5515,6 @@ public class MediaCaptureService {
                                                 compressionTime));
                                 recordTiming(requestId, "ble_compress_done");
 
-                                // 5. Save compressed data to temporary file with bleImgId as name
-                                // (no extension in filename due to 16-char limit)
-                                String compressedPath =
-                                        fileManager.getDefaultMediaDirectory() + "/" + bleImgId;
-                                stage.start("payload file write");
-                                logBlePhotoStep(requestId, "write_compressed_file_start");
-                                try (java.io.FileOutputStream fos =
-                                        new java.io.FileOutputStream(compressedPath)) {
-                                    fos.write(compressedData);
-                                }
-                                stage.finish("payload file write", compressedPath);
                                 if (AsgConstants.ENABLE_PHOTO_TIMING_LOGS) {
                                     Log.i(
                                             TAG,
@@ -5094,11 +5530,10 @@ public class MediaCaptureService {
                                 }
                                 logBlePhotoStep(
                                         requestId,
-                                        "write_compressed_file_done",
-                                        "saved "
+                                        "ble_payload_ready",
+                                        "retained "
                                                 + compressedData.length
-                                                + " bytes to "
-                                                + compressedPath);
+                                                + " encoded bytes in memory");
                                 bleCompressedBytes.put(requestId, (long) compressedData.length);
                                 if (originalSizeBytes > 0) {
                                     bleOriginalBytes.put(requestId, originalSizeBytes);
@@ -5109,7 +5544,7 @@ public class MediaCaptureService {
 
                                 Log.i(
                                         TAG,
-                                        "📤➡️📱 Sending photo to phone (BLE): "
+                                        "📦 BLE photo payload ready: "
                                                 + bleResizedWidth
                                                 + "x"
                                                 + bleResizedHeight
@@ -5121,29 +5556,90 @@ public class MediaCaptureService {
                                                 + requestId
                                                 + ")");
 
-                                // 6. Send via BLE using K900BluetoothManager
+                                // 5. A requested gallery save is part of this operation's success
+                                // contract. Resolve it before notifying the phone that BLE transfer
+                                // has started, so one request can never report both transfer
+                                // success
+                                // and a later save failure.
+                                boolean savePhotoRequested =
+                                        Boolean.TRUE.equals(photoSaveFlags.get(requestId));
+                                if (capturedPhoto != null && savePhotoRequested) {
+                                    boolean persisted =
+                                            textModeRequested
+                                                    ? persistTextModeSelectionFromMemory(
+                                                            capturedPhoto,
+                                                            originalPath,
+                                                            requestId,
+                                                            roi)
+                                                    : capturedPhoto.awaitPersistenceCompletion();
+                                    if (!persisted) {
+                                        sendPhotoErrorResponse(
+                                                requestId,
+                                                "PHOTO_SAVE_FAILED",
+                                                textModeRequested
+                                                        ? "Could not save final text-mode output"
+                                                        : "Could not save captured photo");
+                                        return;
+                                    }
+                                }
+
+                                // 6. Hand the compressed payload straight to the BLE transport.
+                                // The K900 packet pump streams from an in-memory buffer (including
+                                // retries), so no transport artifact is written to disk. bleImgId
+                                // is the wire name (16-char protocol cap, no extension).
                                 recordTiming(requestId, "ble_send_start");
-                                sendCompressedPhotoViaBle(
-                                        compressedPath, bleImgId, requestId, compressThreadStart);
+                                bleTransferStarted =
+                                        sendCompressedPhotoViaBle(
+                                                compressedData,
+                                                bleImgId,
+                                                requestId,
+                                                compressThreadStart);
 
                             } catch (Exception e) {
+                                if (capturedPhoto != null
+                                        && PhotoMode.TEXT.equals(
+                                                PhotoMode.normalize(
+                                                        photoRequestedModes.get(requestId)))
+                                        && Boolean.TRUE.equals(photoSaveFlags.get(requestId))
+                                        && !new File(originalPath).exists()) {
+                                    persistTextModeSelectionFromMemory(
+                                            capturedPhoto,
+                                            originalPath,
+                                            requestId,
+                                            detectedTextRoi);
+                                }
                                 Log.e(TAG, "Error compressing photo for BLE", e);
                                 dumpTimings(requestId);
                                 clearBlePhotoPipelineTracking(requestId, bleImgId);
                                 sendPhotoErrorResponse(
                                         requestId, "BLE_TRANSFER_FAILED", e.getMessage());
                             } finally {
-                                cleanupPhotoArtifacts(
-                                        requestId,
-                                        originalPath,
-                                        Boolean.TRUE.equals(photoSaveFlags.get(requestId)));
                                 logBlePhotoStep(
                                         requestId,
                                         "cleanup_start",
                                         "cleaning up local capture and request state");
-                                // The BLE transport owns the file after a successful handoff. Keep
-                                // timing state alive until transfer_complete; every failed handoff
-                                // clears it inside sendCompressedPhotoViaBle().
+                                boolean savePhoto =
+                                        Boolean.TRUE.equals(photoSaveFlags.get(requestId));
+                                if (capturedPhoto != null) {
+                                    // Non-text save=true captures may still have a background
+                                    // sensor-JPEG write. Text mode uses a completed no-persistence
+                                    // future and writes only its final selection above.
+                                    if (!(!savePhoto && capturedPhoto.cancelPersistence())) {
+                                        if (savePhoto) {
+                                            capturedPhoto.awaitPersistenceCompletion();
+                                        } else {
+                                            capturedPhoto.awaitPersistence(
+                                                    AsgConstants
+                                                            .BLE_PHOTO_PERSISTENCE_AWAIT_TIMEOUT_MS);
+                                        }
+                                    }
+                                }
+                                cleanupPhotoArtifacts(requestId, originalPath, savePhoto);
+                                // Keep timing state only when the BLE transport actually accepted
+                                // the payload; transfer_complete owns it from that point forward.
+                                if (!bleTransferStarted) {
+                                    clearBlePhotoPipelineTracking(requestId, bleImgId);
+                                }
                                 clearPhotoRequestTracking(requestId);
                                 // BLE compress + handoff (or its failure) ends our authority over
                                 // the photo
@@ -5154,21 +5650,31 @@ public class MediaCaptureService {
                                 logBlePhotoStep(
                                         requestId,
                                         "cleanup_done",
-                                        "photo job released after BLE handoff");
+                                        bleTransferStarted
+                                                ? "photo job released after BLE handoff"
+                                                : "photo job released without BLE handoff");
                                 Log.d(
                                         TAG,
-                                        "📡 BLE handoff complete - photo job released: "
+                                        "📡 Photo pipeline complete (BLE started="
+                                                + bleTransferStarted
+                                                + ") - photo job released: "
                                                 + requestId);
                             }
                         })
                 .start();
     }
 
-    /** Send compressed photo via BLE */
-    private void sendCompressedPhotoViaBle(
-            String compressedPath, String bleImgId, String requestId, long transferStartTime) {
+    /** Send compressed photo via BLE, streaming the payload directly from memory. */
+    private boolean sendCompressedPhotoViaBle(
+            byte[] compressedData, String bleImgId, String requestId, long transferStartTime) {
         logBlePhotoStep(
-                requestId, "ble_send_start", "bleImgId=" + bleImgId + ", file=" + compressedPath);
+                requestId,
+                "ble_send_start",
+                "bleImgId="
+                        + bleImgId
+                        + ", payload="
+                        + compressedData.length
+                        + " bytes (in-memory)");
 
         // TESTING: Check for fake BLE transfer failure
         if (PhotoCaptureTestHooks.shouldFail("BLE_TRANSFER")) {
@@ -5178,7 +5684,7 @@ public class MediaCaptureService {
                     PhotoCaptureTestHooks.getErrorCode(),
                     PhotoCaptureTestHooks.getErrorMessage());
             clearBlePhotoPipelineTracking(requestId, bleImgId);
-            return;
+            return false;
         }
 
         // TESTING: Add fake delay for BLE transfer
@@ -5195,7 +5701,8 @@ public class MediaCaptureService {
                 if (mServiceCallback.isBleTransferInProgress()) {
                     Log.e(
                             TAG,
-                            "❌ BLE transfer already in progress - queuing error message to avoid BES2700 overload");
+                            "❌ BLE transfer already in progress - queuing error message to avoid"
+                                    + " BES2700 overload");
 
                     // Send error response immediately
                     sendPhotoErrorResponse(
@@ -5211,7 +5718,7 @@ public class MediaCaptureService {
                                 "BLE transfer busy - another transfer in progress",
                                 MediaUploadQueueManager.MEDIA_TYPE_PHOTO);
                     }
-                    return;
+                    return false;
                 }
 
                 // BLE is available - send the ready message first (phone expects this for timing
@@ -5220,7 +5727,7 @@ public class MediaCaptureService {
                         requestId,
                         "ble_ready_msg",
                         "notified phone that compressed photo is ready");
-                sendBlePhotoReadyMsg(compressedPath, bleImgId, requestId, transferStartTime);
+                sendBlePhotoReadyMsg(bleImgId, requestId, transferStartTime);
 
                 // Brief delay so the ble_photo_ready JSON drains ahead of file packets.
                 // Was 200ms; the firmware TX window now queues both in order (and the
@@ -5240,7 +5747,7 @@ public class MediaCaptureService {
 
                 // Then try to start the file transfer
                 logBlePhotoStep(requestId, "ble_file_transfer_start", "starting UART packet pump");
-                transferStarted = mServiceCallback.sendFileViaBluetooth(compressedPath);
+                transferStarted = mServiceCallback.sendFileViaBluetooth(compressedData, bleImgId);
 
                 if (transferStarted) {
                     logBlePhotoStep(
@@ -5264,31 +5771,17 @@ public class MediaCaptureService {
                         requestId, "BLE_TRANSFER_FAILED", "Service callback not available");
             }
         } finally {
-            // Critical: Clean up compressed file if transfer didn't start
+            // The payload only ever lived in RAM - nothing to clean up on disk. Just clear
+            // pipeline tracking if the transfer never started.
             if (!transferStarted) {
                 clearBlePhotoPipelineTracking(requestId, bleImgId);
-                try {
-                    File compressedFile = new File(compressedPath);
-                    if (compressedFile.exists()) {
-                        if (compressedFile.delete()) {
-                            Log.d(
-                                    TAG,
-                                    "🗑️ Deleted compressed file after BLE transfer failure: "
-                                            + compressedPath);
-                        } else {
-                            Log.w(TAG, "⚠️ Failed to delete compressed file: " + compressedPath);
-                        }
-                    }
-                } catch (Exception e) {
-                    Log.e(TAG, "Error deleting compressed file: " + compressedPath, e);
-                }
             }
         }
+        return transferStarted;
     }
 
     /** Request BLE file transfer through AsgClientService */
-    private void sendBlePhotoReadyMsg(
-            String filePath, String bleImgId, String requestId, long transferStartTime) {
+    private void sendBlePhotoReadyMsg(String bleImgId, String requestId, long transferStartTime) {
         try {
             // Calculate compression duration on glasses side
             long compressionDuration = System.currentTimeMillis() - transferStartTime;
@@ -5738,7 +6231,8 @@ public class MediaCaptureService {
         if (mStateManager == null) {
             Log.w(
                     TAG,
-                    "⚠️ StateManager not set - cannot start battery monitoring (will retry if StateManager becomes available)");
+                    "⚠️ StateManager not set - cannot start battery monitoring (will retry if"
+                            + " StateManager becomes available)");
             // Note: We don't return here because the runnable will check again later
             // This allows monitoring to start even if StateManager is set after recording begins
         }
@@ -5759,7 +6253,8 @@ public class MediaCaptureService {
                             if (hardwareManager == null) {
                                 Log.w(
                                         TAG,
-                                        "⚠️ HardwareManager not available during battery monitoring - skipping check");
+                                        "⚠️ HardwareManager not available during battery monitoring"
+                                                + " - skipping check");
                                 if (isRecordingVideo && mBatteryMonitorHandler != null) {
                                     mBatteryMonitorHandler.postDelayed(
                                             this, BatteryConstants.BATTERY_CHECK_INTERVAL_MS);
@@ -5836,12 +6331,6 @@ public class MediaCaptureService {
                 mBatteryMonitorHandler = null;
             }
 
-            TextRoiDetector detector = textRoiDetector;
-            textRoiDetector = null;
-            if (detector != null) {
-                detector.close();
-            }
-
             videoIntegrityExecutor.shutdown();
             try {
                 if (!videoIntegrityExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
@@ -5851,11 +6340,25 @@ public class MediaCaptureService {
                 videoIntegrityExecutor.shutdownNow();
                 Thread.currentThread().interrupt();
             }
+            textModeProcessingExecutor.shutdown();
+            try {
+                if (!textModeProcessingExecutor.awaitTermination(3, TimeUnit.SECONDS)) {
+                    textModeProcessingExecutor.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                textModeProcessingExecutor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
             videoCaptureIdsInFlight.clear();
             videoCaptureIdsPendingIntegrityCheck.clear();
             // Defensive: drop any pending upload targets so no auth token survives teardown and the
             // map can't grow without bound if a terminal path ever failed to consume its entry.
             uploadTargetsByCaptureId.clear();
+            TextRoiDetector detector = textRoiDetector;
+            textRoiDetector = null;
+            if (detector != null) {
+                detector.close();
+            }
 
             Log.d(TAG, "✅ MediaCaptureService cleanup complete");
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/DetectionResult.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/DetectionResult.java
@@ -22,7 +22,7 @@ public final class DetectionResult {
 
     @Nullable public final DebugArtifacts debug;
 
-    DetectionResult(
+    public DetectionResult(
             CropRect roi,
             Confidence confidence,
             String selectedPolarity,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
@@ -1,0 +1,375 @@
+package com.mentra.asg_client.io.media.core.textdetect;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.os.SystemClock;
+import android.util.Log;
+import androidx.annotation.Nullable;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.Tasks;
+import com.google.mlkit.vision.common.InputImage;
+import com.google.mlkit.vision.text.Text;
+import com.google.mlkit.vision.text.TextRecognition;
+import com.google.mlkit.vision.text.TextRecognizer;
+import com.google.mlkit.vision.text.latin.TextRecognizerOptions;
+import com.mentra.asg_client.AsgConstants;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Bundled, offline ML Kit text localizer for Mentra Live text-mode photos.
+ *
+ * <p>The sensor JPEG remains the source of truth. This class decodes only a sampled analysis
+ * bitmap, scales it to the configured analysis long edge, and maps ML Kit line boxes back into
+ * source-pixel coordinates. A missing/invalid result is represented by a {@code null} ROI so
+ * callers preserve and transmit the full frame.
+ */
+public final class MlKitTextRoiDetector implements AutoCloseable {
+    private static final String TAG = "MlKitTextRoi";
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+    private final TextRecognizer recognizer;
+    private final int analysisLongEdge;
+
+    private final AtomicReference<Task<Text>> warmupTask = new AtomicReference<>();
+    private volatile boolean closed;
+
+    public MlKitTextRoiDetector() {
+        this(AsgConstants.TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE);
+    }
+
+    /** Visible for the on-device benchmark harness. */
+    MlKitTextRoiDetector(int analysisLongEdge) {
+        this(analysisLongEdge, TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS));
+    }
+
+    /** Visible for unit tests that exercise recognizer lifecycle failures. */
+    MlKitTextRoiDetector(int analysisLongEdge, TextRecognizer recognizer) {
+        this.analysisLongEdge = analysisLongEdge;
+        this.recognizer = recognizer;
+    }
+
+    /** Starts model initialization while the camera is capturing. Safe to call repeatedly. */
+    public void warmUp() {
+        synchronized (warmupTask) {
+            if (closed || warmupTask.get() != null) {
+                return;
+            }
+            Bitmap blank = Bitmap.createBitmap(64, 64, Bitmap.Config.ARGB_8888);
+            blank.eraseColor(Color.WHITE);
+            long startMs = SystemClock.elapsedRealtime();
+            Task<Text> task = recognizer.process(InputImage.fromBitmap(blank, 0));
+            warmupTask.set(task);
+            task.addOnCompleteListener(
+                    completedTask -> {
+                        blank.recycle();
+                        handleWarmupCompletion(completedTask);
+                        Log.i(
+                                TAG,
+                                "ML Kit warmup finished in "
+                                        + (SystemClock.elapsedRealtime() - startMs)
+                                        + "ms success="
+                                        + completedTask.isSuccessful());
+                    });
+        }
+    }
+
+    private void handleWarmupCompletion(Task<Text> completedTask) {
+        if (!completedTask.isSuccessful()) {
+            warmupTask.compareAndSet(completedTask, null);
+        }
+    }
+
+    /** Detects a padded source-pixel ROI from an in-memory JPEG. */
+    public synchronized Detection detect(byte[] jpegBytes) {
+        if (jpegBytes == null || jpegBytes.length == 0) {
+            return Detection.fullFrame("empty_jpeg", 0, 0, 0);
+        }
+        return detectInternal(jpegBytes, null);
+    }
+
+    /** Detects a padded source-pixel ROI from a file-backed JPEG fallback flow. */
+    public synchronized Detection detect(String jpegPath) {
+        if (jpegPath == null || jpegPath.isEmpty()) {
+            return Detection.fullFrame("empty_path", 0, 0, 0);
+        }
+        return detectInternal(null, jpegPath);
+    }
+
+    private Detection detectInternal(@Nullable byte[] jpegBytes, @Nullable String jpegPath) {
+        long startMs = SystemClock.elapsedRealtime();
+        if (closed) {
+            return Detection.fullFrame("detector_closed", 0, 0, 0);
+        }
+
+        Bitmap decoded = null;
+        Bitmap analysis = null;
+        Task<Text> detectionTask = null;
+        try {
+            warmUp();
+            Task<Text> taskToAwait = warmupTask.get();
+            if (taskToAwait != null) {
+                try {
+                    Tasks.await(
+                            taskToAwait,
+                            AsgConstants.TEXT_MODE_MLKIT_TIMEOUT_MS,
+                            TimeUnit.MILLISECONDS);
+                } catch (Throwable warmupError) {
+                    // A transient model-init failure or timeout must not poison every later text
+                    // capture. Only clear the task we actually awaited; an older completion must
+                    // never clear a newer retry.
+                    warmupTask.compareAndSet(taskToAwait, null);
+                    throw warmupError;
+                }
+            }
+
+            BitmapFactory.Options bounds = new BitmapFactory.Options();
+            bounds.inJustDecodeBounds = true;
+            decode(jpegBytes, jpegPath, bounds);
+            int sourceWidth = bounds.outWidth;
+            int sourceHeight = bounds.outHeight;
+            if (sourceWidth <= 0 || sourceHeight <= 0) {
+                return Detection.fullFrame(
+                        "invalid_jpeg_bounds",
+                        SystemClock.elapsedRealtime() - startMs,
+                        sourceWidth,
+                        sourceHeight);
+            }
+
+            BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inSampleSize = computeSampleSize(sourceWidth, sourceHeight, analysisLongEdge);
+            decoded = decode(jpegBytes, jpegPath, options);
+            if (decoded == null) {
+                return Detection.fullFrame(
+                        "jpeg_decode_failed",
+                        SystemClock.elapsedRealtime() - startMs,
+                        sourceWidth,
+                        sourceHeight);
+            }
+
+            analysis = scaleLongEdge(decoded, analysisLongEdge);
+            detectionTask = recognizer.process(InputImage.fromBitmap(analysis, 0));
+            Text text =
+                    Tasks.await(
+                            detectionTask,
+                            AsgConstants.TEXT_MODE_MLKIT_TIMEOUT_MS,
+                            TimeUnit.MILLISECONDS);
+
+            List<Rect> sourceLineBoxes = mapLineBoxes(text, analysis, sourceWidth, sourceHeight);
+            Rect roi = buildPaddedUnion(sourceLineBoxes, sourceWidth, sourceHeight);
+            long elapsedMs = SystemClock.elapsedRealtime() - startMs;
+            if (roi == null) {
+                return Detection.fullFrame("no_text_lines", elapsedMs, sourceWidth, sourceHeight);
+            }
+            return new Detection(
+                    roi,
+                    "mlkit_lines",
+                    sourceLineBoxes.size(),
+                    elapsedMs,
+                    sourceWidth,
+                    sourceHeight,
+                    analysis.getWidth(),
+                    analysis.getHeight());
+        } catch (Throwable error) {
+            Log.w(TAG, "ML Kit detection failed; preserving full frame", error);
+            return Detection.fullFrame(
+                    "mlkit_error:" + error.getClass().getSimpleName(),
+                    SystemClock.elapsedRealtime() - startMs,
+                    0,
+                    0);
+        } finally {
+            recycleBitmapsAfterTask(detectionTask, analysis, decoded);
+        }
+    }
+
+    /** Defers recycling when a timed-out ML Kit task may still be reading its input bitmap. */
+    static void recycleBitmapsAfterTask(
+            @Nullable Task<?> task, @Nullable Bitmap analysis, @Nullable Bitmap decoded) {
+        if (task != null && !task.isComplete()) {
+            task.addOnCompleteListener(
+                    DIRECT_EXECUTOR, ignored -> recycleBitmaps(analysis, decoded));
+            return;
+        }
+        recycleBitmaps(analysis, decoded);
+    }
+
+    private static void recycleBitmaps(@Nullable Bitmap analysis, @Nullable Bitmap decoded) {
+        if (analysis != null && analysis != decoded) {
+            analysis.recycle();
+        }
+        if (decoded != null) {
+            decoded.recycle();
+        }
+    }
+
+    @Nullable
+    private static Bitmap decode(
+            @Nullable byte[] jpegBytes, @Nullable String jpegPath, BitmapFactory.Options options) {
+        if (jpegBytes != null) {
+            return BitmapFactory.decodeByteArray(jpegBytes, 0, jpegBytes.length, options);
+        }
+        return BitmapFactory.decodeFile(jpegPath, options);
+    }
+
+    private static int computeSampleSize(int width, int height, int targetLongEdge) {
+        int longEdge = Math.max(width, height);
+        int sampleSize = 1;
+        while (longEdge / (sampleSize * 2) >= targetLongEdge) {
+            sampleSize *= 2;
+        }
+        return sampleSize;
+    }
+
+    private static Bitmap scaleLongEdge(Bitmap bitmap, int targetLongEdge) {
+        int width = bitmap.getWidth();
+        int height = bitmap.getHeight();
+        int longEdge = Math.max(width, height);
+        if (longEdge <= targetLongEdge) {
+            return bitmap;
+        }
+        float scale = targetLongEdge / (float) longEdge;
+        return Bitmap.createScaledBitmap(
+                bitmap, Math.round(width * scale), Math.round(height * scale), true);
+    }
+
+    private static List<Rect> mapLineBoxes(
+            Text text, Bitmap analysis, int sourceWidth, int sourceHeight) {
+        float scaleX = sourceWidth / (float) analysis.getWidth();
+        float scaleY = sourceHeight / (float) analysis.getHeight();
+        List<Rect> boxes = new ArrayList<>();
+        for (Text.TextBlock block : text.getTextBlocks()) {
+            for (Text.Line line : block.getLines()) {
+                Rect box = line.getBoundingBox();
+                if (box == null || box.width() <= 0 || box.height() <= 0) {
+                    continue;
+                }
+                Rect mapped =
+                        new Rect(
+                                clamp(Math.round(box.left * scaleX), 0, sourceWidth),
+                                clamp(Math.round(box.top * scaleY), 0, sourceHeight),
+                                clamp(Math.round(box.right * scaleX), 0, sourceWidth),
+                                clamp(Math.round(box.bottom * scaleY), 0, sourceHeight));
+                if (mapped.width() > 0 && mapped.height() > 0) {
+                    boxes.add(mapped);
+                }
+            }
+        }
+        return boxes;
+    }
+
+    @Nullable
+    static Rect buildPaddedUnion(List<Rect> boxes, int sourceWidth, int sourceHeight) {
+        if (boxes == null || boxes.isEmpty() || sourceWidth <= 0 || sourceHeight <= 0) {
+            return null;
+        }
+        int left = sourceWidth;
+        int top = sourceHeight;
+        int right = 0;
+        int bottom = 0;
+        for (Rect box : boxes) {
+            left = Math.min(left, box.left);
+            top = Math.min(top, box.top);
+            right = Math.max(right, box.right);
+            bottom = Math.max(bottom, box.bottom);
+        }
+        if (right <= left || bottom <= top) {
+            return null;
+        }
+        int paddingX =
+                Math.max(
+                        AsgConstants.TEXT_MODE_MLKIT_MIN_PADDING_PX,
+                        Math.round(
+                                (right - left) * AsgConstants.TEXT_MODE_MLKIT_PADDING_X_FRACTION));
+        int paddingY =
+                Math.max(
+                        AsgConstants.TEXT_MODE_MLKIT_MIN_PADDING_PX,
+                        Math.round(
+                                (bottom - top) * AsgConstants.TEXT_MODE_MLKIT_PADDING_Y_FRACTION));
+        int paddingTop = paddingY;
+        int paddingBottom = paddingY;
+        if (boxes.size() == 1) {
+            int lineHeight = bottom - top;
+            paddingX =
+                    Math.max(
+                            paddingX,
+                            Math.round(
+                                    lineHeight
+                                            * AsgConstants
+                                                    .TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_X_HEIGHTS));
+            paddingTop =
+                    Math.max(
+                            paddingTop,
+                            Math.round(
+                                    lineHeight
+                                            * AsgConstants
+                                                    .TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_TOP_HEIGHTS));
+            paddingBottom =
+                    Math.max(
+                            paddingBottom,
+                            Math.round(
+                                    lineHeight
+                                            * AsgConstants
+                                                    .TEXT_MODE_MLKIT_SINGLE_LINE_PADDING_BOTTOM_HEIGHTS));
+        }
+        return new Rect(
+                Math.max(0, left - paddingX),
+                Math.max(0, top - paddingTop),
+                Math.min(sourceWidth, right + paddingX),
+                Math.min(sourceHeight, bottom + paddingBottom));
+    }
+
+    private static int clamp(int value, int min, int max) {
+        return Math.max(min, Math.min(max, value));
+    }
+
+    @Override
+    public synchronized void close() {
+        synchronized (warmupTask) {
+            if (!closed) {
+                closed = true;
+                recognizer.close();
+            }
+        }
+    }
+
+    /** Immutable detector result; a {@code null} ROI means transmit the full frame. */
+    public static final class Detection {
+        @Nullable public final Rect roi;
+        public final String reason;
+        public final int lineCount;
+        public final long elapsedMs;
+        public final int sourceWidth;
+        public final int sourceHeight;
+        public final int analysisWidth;
+        public final int analysisHeight;
+
+        private Detection(
+                @Nullable Rect roi,
+                String reason,
+                int lineCount,
+                long elapsedMs,
+                int sourceWidth,
+                int sourceHeight,
+                int analysisWidth,
+                int analysisHeight) {
+            this.roi = roi;
+            this.reason = reason;
+            this.lineCount = lineCount;
+            this.elapsedMs = elapsedMs;
+            this.sourceWidth = sourceWidth;
+            this.sourceHeight = sourceHeight;
+            this.analysisWidth = analysisWidth;
+            this.analysisHeight = analysisHeight;
+        }
+
+        private static Detection fullFrame(
+                String reason, long elapsedMs, int sourceWidth, int sourceHeight) {
+            return new Detection(null, reason, 0, elapsedMs, sourceWidth, sourceHeight, 0, 0);
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AbstractOnnxRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AbstractOnnxRoiDetector.java
@@ -1,0 +1,157 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import ai.onnxruntime.OnnxTensor;
+import ai.onnxruntime.OnnxValue;
+import ai.onnxruntime.OrtEnvironment;
+import ai.onnxruntime.OrtException;
+import ai.onnxruntime.OrtSession;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.io.IOException;
+import java.nio.FloatBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/** Base class that owns one persistent ONNX Runtime session and shared image preprocessing. */
+public abstract class AbstractOnnxRoiDetector implements TextRoiDetector {
+    private static final float[] IMAGENET_MEAN = {0.485f, 0.456f, 0.406f};
+    private static final float[] IMAGENET_STD = {0.229f, 0.224f, 0.225f};
+
+    private final TextCropModel model;
+    private final OrtEnvironment environment;
+    private final OrtSession session;
+    private final String inputName;
+    private volatile boolean closed;
+
+    /**
+     * Loads and initializes one model session.
+     *
+     * @param model neural model metadata
+     * @param source source containing the model asset
+     * @throws IOException when model bytes cannot be loaded
+     * @throws OrtException when ONNX Runtime cannot initialize the model
+     */
+    protected AbstractOnnxRoiDetector(TextCropModel model, ModelSource source)
+            throws IOException, OrtException {
+        this.model = Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(source, "source");
+        if (model.assetFilename() == null) {
+            throw new IllegalArgumentException("Model has no ONNX asset: " + model);
+        }
+        byte[] modelBytes = source.load(model.assetFilename());
+        environment = OrtEnvironment.getEnvironment();
+        OrtSession createdSession;
+        try (OrtSession.SessionOptions options = new OrtSession.SessionOptions()) {
+            createdSession = environment.createSession(modelBytes, options);
+        }
+        String discoveredInput =
+                createdSession.getInputNames().stream().findFirst().orElse(null);
+        if (discoveredInput == null) {
+            createdSession.close();
+            throw new IllegalArgumentException("ONNX model has no inputs");
+        }
+        session = createdSession;
+        inputName = discoveredInput;
+    }
+
+    /** Returns the selected model's stable identifier. */
+    @Override
+    public final String id() {
+        return model.id();
+    }
+
+    /** Returns false after this detector has been closed. */
+    @Override
+    public final boolean isReady() {
+        return !closed;
+    }
+
+    /** Closes the owned model session. */
+    @Override
+    public final void close() {
+        if (!closed) {
+            closed = true;
+            try {
+                session.close();
+            } catch (OrtException ignored) {
+                // Closing is best-effort and the interface cannot surface checked failures.
+            }
+        }
+    }
+
+    final TextCropModel model() {
+        return model;
+    }
+
+    final DetectionResult runInference(
+            DetectionInput input, InferencePostprocessor postprocessor) {
+        Objects.requireNonNull(input, "input");
+        if (closed) {
+            throw new IllegalStateException("Detector is closed");
+        }
+        long start = System.currentTimeMillis();
+        float[] normalized = resizeAndNormalize(input, model.inputWidth(), model.inputHeight());
+        long[] shape = {1, 3, model.inputHeight(), model.inputWidth()};
+        try (OnnxTensor tensor =
+                        OnnxTensor.createTensor(
+                                environment, FloatBuffer.wrap(normalized), shape);
+                OrtSession.Result result = session.run(Map.of(inputName, tensor))) {
+            List<Object> outputs = new ArrayList<>(result.size());
+            for (int i = 0; i < result.size(); i++) {
+                OnnxValue value = result.get(i);
+                outputs.add(value.getValue());
+            }
+            return postprocessor.process(
+                    outputs, System.currentTimeMillis() - start);
+        } catch (OrtException | RuntimeException exception) {
+            return RoiPostprocessor.fallback(
+                    input.width(),
+                    input.height(),
+                    id(),
+                    System.currentTimeMillis() - start,
+                    "onnx_inference_failed");
+        }
+    }
+
+    private static float[] resizeAndNormalize(
+            DetectionInput input, int outputWidth, int outputHeight) {
+        int planeSize = outputWidth * outputHeight;
+        float[] output = new float[planeSize * 3];
+        byte[] luma = input.lumaUnsafe();
+        for (int y = 0; y < outputHeight; y++) {
+            float sourceY = ((y + 0.5f) * input.height() / outputHeight) - 0.5f;
+            int y0 = Math.max(0, Math.min(input.height() - 1, (int) Math.floor(sourceY)));
+            int y1 = Math.min(input.height() - 1, y0 + 1);
+            float yWeight = Math.max(0, sourceY - y0);
+            for (int x = 0; x < outputWidth; x++) {
+                float sourceX = ((x + 0.5f) * input.width() / outputWidth) - 0.5f;
+                int x0 = Math.max(0, Math.min(input.width() - 1, (int) Math.floor(sourceX)));
+                int x1 = Math.min(input.width() - 1, x0 + 1);
+                float xWeight = Math.max(0, sourceX - x0);
+                float top =
+                        unsigned(luma[y0 * input.width() + x0]) * (1f - xWeight)
+                                + unsigned(luma[y0 * input.width() + x1]) * xWeight;
+                float bottom =
+                        unsigned(luma[y1 * input.width() + x0]) * (1f - xWeight)
+                                + unsigned(luma[y1 * input.width() + x1]) * xWeight;
+                float value = (top * (1f - yWeight) + bottom * yWeight) / 255f;
+                int pixel = y * outputWidth + x;
+                for (int channel = 0; channel < 3; channel++) {
+                    output[channel * planeSize + pixel] =
+                            (value - IMAGENET_MEAN[channel]) / IMAGENET_STD[channel];
+                }
+            }
+        }
+        return output;
+    }
+
+    private static int unsigned(byte value) {
+        return value & 0xff;
+    }
+
+    @FunctionalInterface
+    interface InferencePostprocessor {
+        DetectionResult process(List<Object> outputs, long elapsedMs);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AbstractOnnxRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AbstractOnnxRoiDetector.java
@@ -45,8 +45,7 @@ public abstract class AbstractOnnxRoiDetector implements TextRoiDetector {
         try (OrtSession.SessionOptions options = new OrtSession.SessionOptions()) {
             createdSession = environment.createSession(modelBytes, options);
         }
-        String discoveredInput =
-                createdSession.getInputNames().stream().findFirst().orElse(null);
+        String discoveredInput = createdSession.getInputNames().stream().findFirst().orElse(null);
         if (discoveredInput == null) {
             createdSession.close();
             throw new IllegalArgumentException("ONNX model has no inputs");
@@ -84,8 +83,7 @@ public abstract class AbstractOnnxRoiDetector implements TextRoiDetector {
         return model;
     }
 
-    final DetectionResult runInference(
-            DetectionInput input, InferencePostprocessor postprocessor) {
+    final DetectionResult runInference(DetectionInput input, InferencePostprocessor postprocessor) {
         Objects.requireNonNull(input, "input");
         if (closed) {
             throw new IllegalStateException("Detector is closed");
@@ -94,16 +92,14 @@ public abstract class AbstractOnnxRoiDetector implements TextRoiDetector {
         float[] normalized = resizeAndNormalize(input, model.inputWidth(), model.inputHeight());
         long[] shape = {1, 3, model.inputHeight(), model.inputWidth()};
         try (OnnxTensor tensor =
-                        OnnxTensor.createTensor(
-                                environment, FloatBuffer.wrap(normalized), shape);
+                        OnnxTensor.createTensor(environment, FloatBuffer.wrap(normalized), shape);
                 OrtSession.Result result = session.run(Map.of(inputName, tensor))) {
             List<Object> outputs = new ArrayList<>(result.size());
             for (int i = 0; i < result.size(); i++) {
                 OnnxValue value = result.get(i);
                 outputs.add(value.getValue());
             }
-            return postprocessor.process(
-                    outputs, System.currentTimeMillis() - start);
+            return postprocessor.process(outputs, System.currentTimeMillis() - start);
         } catch (OrtException | RuntimeException exception) {
             return RoiPostprocessor.fallback(
                     input.width(),

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AndroidAssetModelSource.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/AndroidAssetModelSource.java
@@ -1,0 +1,51 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import android.content.res.AssetManager;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+/** Loads ONNX models from an Android application's assets. */
+public final class AndroidAssetModelSource implements ModelSource {
+    private final AssetManager assetManager;
+    private final String directory;
+
+    /**
+     * Creates an Android asset source.
+     *
+     * @param assetManager application asset manager
+     * @param directory optional asset directory, such as {@code models}; blank means asset root
+     */
+    public AndroidAssetModelSource(AssetManager assetManager, String directory) {
+        this.assetManager = Objects.requireNonNull(assetManager, "assetManager");
+        this.directory = directory == null ? "" : trimSlashes(directory);
+    }
+
+    /** Loads the named asset into memory. */
+    @Override
+    public byte[] load(String assetName) throws IOException {
+        String path = directory.isEmpty() ? assetName : directory + "/" + assetName;
+        try (InputStream input = assetManager.open(path)) {
+            ByteArrayOutputStream output = new ByteArrayOutputStream();
+            byte[] buffer = new byte[8192];
+            int count;
+            while ((count = input.read(buffer)) != -1) {
+                output.write(buffer, 0, count);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    private static String trimSlashes(String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && value.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(start, end);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ClassicalRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ClassicalRoiDetector.java
@@ -1,0 +1,34 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import com.mentra.asg_client.io.media.core.textdetect.TextRegionDetector;
+import java.util.Objects;
+
+/** Adapter exposing the existing classical text-region detector through the ROI detector API. */
+public final class ClassicalRoiDetector implements TextRoiDetector {
+    private final TextDetectConfig config;
+
+    /**
+     * Creates a classical detector.
+     *
+     * @param config classical detector configuration
+     */
+    public ClassicalRoiDetector(TextDetectConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    /** Detects a crop with the classical text-region pipeline. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        Objects.requireNonNull(input, "input");
+        return TextRegionDetector.detect(
+                input.lumaUnsafe(), input.width(), input.height(), config);
+    }
+
+    /** Returns {@code classical}. */
+    @Override
+    public String id() {
+        return TextCropModel.CLASSICAL.id();
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ClassicalRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ClassicalRoiDetector.java
@@ -22,8 +22,7 @@ public final class ClassicalRoiDetector implements TextRoiDetector {
     @Override
     public DetectionResult detect(DetectionInput input) {
         Objects.requireNonNull(input, "input");
-        return TextRegionDetector.detect(
-                input.lumaUnsafe(), input.width(), input.height(), config);
+        return TextRegionDetector.detect(input.lumaUnsafe(), input.width(), input.height(), config);
     }
 
     /** Returns {@code classical}. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/DetectionInput.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/DetectionInput.java
@@ -1,0 +1,57 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Immutable single-channel luminance image supplied to a text ROI detector. */
+public final class DetectionInput {
+    private final byte[] luma;
+    private final int width;
+    private final int height;
+
+    /**
+     * Creates an input image, defensively copying its luminance bytes.
+     *
+     * @param luma one byte per pixel in row-major order
+     * @param width image width in pixels
+     * @param height image height in pixels
+     * @throws NullPointerException when {@code luma} is null
+     * @throws IllegalArgumentException when dimensions are invalid or the buffer length differs
+     */
+    public DetectionInput(byte[] luma, int width, int height) {
+        Objects.requireNonNull(luma, "luma");
+        if (width <= 0 || height <= 0) {
+            throw new IllegalArgumentException("width and height must be positive");
+        }
+        long expectedLength = (long) width * height;
+        if (expectedLength > Integer.MAX_VALUE || luma.length != (int) expectedLength) {
+            throw new IllegalArgumentException(
+                    "luma length must equal width * height: expected "
+                            + expectedLength
+                            + ", got "
+                            + luma.length);
+        }
+        this.luma = Arrays.copyOf(luma, luma.length);
+        this.width = width;
+        this.height = height;
+    }
+
+    /** Returns a defensive copy of the row-major luminance bytes. */
+    public byte[] luma() {
+        return Arrays.copyOf(luma, luma.length);
+    }
+
+    /** Returns the image width in pixels. */
+    public int width() {
+        return width;
+    }
+
+    /** Returns the image height in pixels. */
+    public int height() {
+        return height;
+    }
+
+    byte[] lumaUnsafe() {
+        return luma;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/DetectionInput.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/DetectionInput.java
@@ -1,13 +1,19 @@
 package com.mentra.asg_client.io.media.core.textdetect.roi;
 
+import androidx.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Objects;
 
-/** Immutable single-channel luminance image supplied to a text ROI detector. */
+/**
+ * Immutable single-channel luminance image supplied to a text ROI detector, with an optional
+ * reference to the original sensor JPEG bytes for detectors (such as ML Kit) that decode and
+ * analyze the source image themselves instead of consuming pre-extracted luma.
+ */
 public final class DetectionInput {
     private final byte[] luma;
     private final int width;
     private final int height;
+    @Nullable private final byte[] jpegBytes;
 
     /**
      * Creates an input image, defensively copying its luminance bytes.
@@ -19,6 +25,21 @@ public final class DetectionInput {
      * @throws IllegalArgumentException when dimensions are invalid or the buffer length differs
      */
     public DetectionInput(byte[] luma, int width, int height) {
+        this(luma, width, height, null);
+    }
+
+    /**
+     * Creates an input image that also carries the original sensor JPEG bytes, so a detector that
+     * decodes color/full-resolution data itself (e.g. ML Kit) does not need a second JPEG read.
+     *
+     * @param luma one byte per pixel in row-major order
+     * @param width image width in pixels
+     * @param height image height in pixels
+     * @param jpegBytes original sensor JPEG bytes, or {@code null} when unavailable
+     * @throws NullPointerException when {@code luma} is null
+     * @throws IllegalArgumentException when dimensions are invalid or the buffer length differs
+     */
+    public DetectionInput(byte[] luma, int width, int height, @Nullable byte[] jpegBytes) {
         Objects.requireNonNull(luma, "luma");
         if (width <= 0 || height <= 0) {
             throw new IllegalArgumentException("width and height must be positive");
@@ -34,6 +55,7 @@ public final class DetectionInput {
         this.luma = Arrays.copyOf(luma, luma.length);
         this.width = width;
         this.height = height;
+        this.jpegBytes = jpegBytes == null ? null : Arrays.copyOf(jpegBytes, jpegBytes.length);
     }
 
     /** Returns a defensive copy of the row-major luminance bytes. */
@@ -51,7 +73,21 @@ public final class DetectionInput {
         return height;
     }
 
+    /**
+     * Returns a defensive copy of the original sensor JPEG bytes, or {@code null} when this input
+     * was constructed without them.
+     */
+    @Nullable
+    public byte[] jpegBytes() {
+        return jpegBytes == null ? null : Arrays.copyOf(jpegBytes, jpegBytes.length);
+    }
+
     byte[] lumaUnsafe() {
         return luma;
+    }
+
+    @Nullable
+    byte[] jpegBytesUnsafe() {
+        return jpegBytes;
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/FileSystemModelSource.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/FileSystemModelSource.java
@@ -1,0 +1,30 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+
+/** Loads ONNX models from a filesystem directory. */
+public final class FileSystemModelSource implements ModelSource {
+    private final Path directory;
+
+    /**
+     * Creates a filesystem model source.
+     *
+     * @param directory directory containing model assets
+     */
+    public FileSystemModelSource(Path directory) {
+        this.directory = Objects.requireNonNull(directory, "directory").toAbsolutePath().normalize();
+    }
+
+    /** Loads the named file while preventing traversal outside the configured directory. */
+    @Override
+    public byte[] load(String assetName) throws IOException {
+        Path modelPath = directory.resolve(assetName).normalize();
+        if (!modelPath.startsWith(directory)) {
+            throw new IOException("Model path escapes source directory: " + assetName);
+        }
+        return Files.readAllBytes(modelPath);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/FileSystemModelSource.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/FileSystemModelSource.java
@@ -15,7 +15,8 @@ public final class FileSystemModelSource implements ModelSource {
      * @param directory directory containing model assets
      */
     public FileSystemModelSource(Path directory) {
-        this.directory = Objects.requireNonNull(directory, "directory").toAbsolutePath().normalize();
+        this.directory =
+                Objects.requireNonNull(directory, "directory").toAbsolutePath().normalize();
     }
 
     /** Loads the named file while preventing traversal outside the configured directory. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MlKitRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MlKitRoiDetector.java
@@ -1,0 +1,113 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import androidx.annotation.Nullable;
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.MlKitTextRoiDetector;
+
+/**
+ * Adapter that exposes the bundled ML Kit text localizer through the swappable {@link
+ * TextRoiDetector} contract.
+ *
+ * <p>Unlike the classical and ONNX detectors, ML Kit decodes and analyzes the original sensor JPEG
+ * bytes directly rather than pre-extracted luma, so this adapter requires {@link
+ * DetectionInput#jpegBytes()} to be present. When bytes are unavailable, or when ML Kit finds no
+ * text, this adapter's fallback is the full frame (matching ML Kit's own "preserve the full frame
+ * on uncertainty" policy) rather than the classical/ONNX detectors' 75% center-crop fallback.
+ */
+public final class MlKitRoiDetector implements TextRoiDetector {
+    private final MlKitTextRoiDetector delegate;
+    private volatile boolean closed;
+
+    /** Creates an adapter that owns one persistent ML Kit recognizer client. */
+    public MlKitRoiDetector() {
+        this.delegate = new MlKitTextRoiDetector();
+    }
+
+    /** Starts ML Kit model initialization ahead of the first real detection. Safe to repeat. */
+    @Override
+    public void warmUp() {
+        delegate.warmUp();
+    }
+
+    /** Detects a padded source-pixel ROI from the input's sensor JPEG bytes. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        long start = System.currentTimeMillis();
+        byte[] jpegBytes = input.jpegBytesUnsafe();
+        if (jpegBytes == null || jpegBytes.length == 0) {
+            return fullFrame(
+                    input.width(),
+                    input.height(),
+                    System.currentTimeMillis() - start,
+                    "missing_jpeg_bytes");
+        }
+        MlKitTextRoiDetector.Detection detection = delegate.detect(jpegBytes);
+        if (detection.roi == null) {
+            // detection.sourceWidth/Height come from decoding jpegBytes itself, so they are the
+            // authoritative source-pixel size here - not input.width()/height(), which is the
+            // separate subsampled analysis-luma buffer's own dimensions.
+            return fullFrame(
+                    detection.sourceWidth > 0 ? detection.sourceWidth : input.width(),
+                    detection.sourceHeight > 0 ? detection.sourceHeight : input.height(),
+                    detection.elapsedMs,
+                    detection.reason);
+        }
+        CropRect roi =
+                CropRect.clamp(
+                        new CropRect(
+                                detection.roi.left,
+                                detection.roi.top,
+                                detection.roi.right,
+                                detection.roi.bottom),
+                        detection.sourceWidth,
+                        detection.sourceHeight);
+        return new DetectionResult(
+                roi,
+                DetectionResult.Confidence.MEDIUM,
+                id(),
+                detection.lineCount,
+                detection.lineCount > 0 ? 1 : 0,
+                detection.elapsedMs,
+                null,
+                null);
+    }
+
+    /** Returns {@code ml_kit}. */
+    @Override
+    public String id() {
+        return TextCropModel.ML_KIT.id();
+    }
+
+    /** ML Kit decodes and analyzes the sensor JPEG itself, so its crop is already source-pixel. */
+    @Override
+    public boolean returnsNativeCoordinates() {
+        return true;
+    }
+
+    /** Returns false after this detector has been closed. */
+    @Override
+    public boolean isReady() {
+        return !closed;
+    }
+
+    /** Closes the owned ML Kit recognizer client. */
+    @Override
+    public void close() {
+        closed = true;
+        delegate.close();
+    }
+
+    private DetectionResult fullFrame(
+            int width, int height, long elapsedMs, @Nullable String reason) {
+        return new DetectionResult(
+                new CropRect(0, 0, width, height),
+                DetectionResult.Confidence.NONE,
+                id(),
+                0,
+                0,
+                elapsedMs,
+                reason,
+                null);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ModelSource.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/ModelSource.java
@@ -1,0 +1,16 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import java.io.IOException;
+
+/** Source of serialized neural-network model assets. */
+@FunctionalInterface
+public interface ModelSource {
+    /**
+     * Loads an entire model asset.
+     *
+     * @param assetName model filename
+     * @return serialized model bytes
+     * @throws IOException when the asset cannot be read
+     */
+    byte[] load(String assetName) throws IOException;
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MserOnlyRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MserOnlyRoiDetector.java
@@ -65,10 +65,7 @@ public final class MserOnlyRoiDetector implements TextRoiDetector {
                 if (accept(rect, regionArea, analysisWidth, analysisHeight)) {
                     accepted.add(
                             new CropRect(
-                                    rect.x,
-                                    rect.y,
-                                    rect.x + rect.width,
-                                    rect.y + rect.height));
+                                    rect.x, rect.y, rect.x + rect.width, rect.y + rect.height));
                     heightTotal += rect.height;
                 }
             }
@@ -146,8 +143,7 @@ public final class MserOnlyRoiDetector implements TextRoiDetector {
         return TextCropModel.MSER_ONLY.id();
     }
 
-    private boolean accept(
-            Rect rect, double regionArea, int analysisWidth, int analysisHeight) {
+    private boolean accept(Rect rect, double regionArea, int analysisWidth, int analysisHeight) {
         if (rect.width <= 0 || rect.height <= 0) {
             return false;
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MserOnlyRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/MserOnlyRoiDetector.java
@@ -1,0 +1,175 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.CvInit;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.MatOfRect;
+import org.opencv.core.Rect;
+import org.opencv.core.Size;
+import org.opencv.features2d.MSER;
+import org.opencv.imgproc.Imgproc;
+
+/** Standalone OpenCV MSER detector that does not depend on package-private CV primitives. */
+public final class MserOnlyRoiDetector implements TextRoiDetector {
+    private final TextDetectConfig config;
+
+    /**
+     * Creates an MSER-only detector.
+     *
+     * @param config geometry, fill, analysis-size, and padding constraints
+     */
+    public MserOnlyRoiDetector(TextDetectConfig config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    /** Detects and unions MSER regions that satisfy the configured text geometry constraints. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        Objects.requireNonNull(input, "input");
+        CvInit.ensureLoaded();
+        long start = System.currentTimeMillis();
+        int analysisWidth = config.analysisWidth;
+        int analysisHeight =
+                Math.max(1, Math.round(input.height() * analysisWidth / (float) input.width()));
+        Mat source = new Mat(input.height(), input.width(), CvType.CV_8UC1);
+        Mat analysis = new Mat();
+        source.put(0, 0, input.lumaUnsafe());
+        Imgproc.resize(
+                source,
+                analysis,
+                new Size(analysisWidth, analysisHeight),
+                0,
+                0,
+                Imgproc.INTER_AREA);
+        source.release();
+
+        MSER mser = MSER.create();
+        List<MatOfPoint> regions = new ArrayList<>();
+        MatOfRect boundingBoxes = new MatOfRect();
+        try {
+            mser.detectRegions(analysis, regions, boundingBoxes);
+            Rect[] rectangles = boundingBoxes.toArray();
+            List<CropRect> accepted = new ArrayList<>();
+            int heightTotal = 0;
+            for (int i = 0; i < rectangles.length; i++) {
+                Rect rect = rectangles[i];
+                double regionArea =
+                        i < regions.size() ? Imgproc.contourArea(regions.get(i)) : rect.area();
+                if (accept(rect, regionArea, analysisWidth, analysisHeight)) {
+                    accepted.add(
+                            new CropRect(
+                                    rect.x,
+                                    rect.y,
+                                    rect.x + rect.width,
+                                    rect.y + rect.height));
+                    heightTotal += rect.height;
+                }
+            }
+            long elapsed = System.currentTimeMillis() - start;
+            if (accepted.isEmpty()) {
+                return RoiPostprocessor.fallback(
+                        input.width(), input.height(), id(), elapsed, "no_mser_regions");
+            }
+
+            CropRect raw = accepted.get(0);
+            for (int i = 1; i < accepted.size(); i++) {
+                raw = CropRect.union(raw, accepted.get(i));
+            }
+            float areaFraction = raw.pixelCount() / (float) (analysisWidth * analysisHeight);
+            if (areaFraction < config.minCropAreaFraction
+                    || areaFraction > 0.90f
+                    || touchesBoundary(raw, analysisWidth, analysisHeight)) {
+                return RoiPostprocessor.fallback(
+                        input.width(), input.height(), id(), elapsed, "untrustworthy_mser_union");
+            }
+
+            float medianLikeHeight = heightTotal / (float) accepted.size();
+            int padX =
+                    Math.round(
+                            Math.max(
+                                    raw.width() * config.paddingHorizontalFraction,
+                                    medianLikeHeight * config.paddingHorizontalHeightFactor));
+            int padY =
+                    Math.round(
+                            Math.max(
+                                    raw.height() * config.paddingVerticalFraction,
+                                    medianLikeHeight * config.paddingVerticalHeightFactor));
+            CropRect padded =
+                    CropRect.clamp(
+                            new CropRect(
+                                    raw.left - padX,
+                                    raw.top - padY,
+                                    raw.right + padX,
+                                    raw.bottom + padY),
+                            analysisWidth,
+                            analysisHeight);
+            float scaleX = input.width() / (float) analysisWidth;
+            float scaleY = input.height() / (float) analysisHeight;
+            CropRect mapped =
+                    CropRect.clamp(
+                            new CropRect(
+                                    Math.round(padded.left * scaleX),
+                                    Math.round(padded.top * scaleY),
+                                    Math.round(padded.right * scaleX),
+                                    Math.round(padded.bottom * scaleY)),
+                            input.width(),
+                            input.height());
+            return new DetectionResult(
+                    mapped,
+                    DetectionResult.Confidence.MEDIUM,
+                    id(),
+                    accepted.size(),
+                    1,
+                    elapsed,
+                    null,
+                    null);
+        } finally {
+            for (MatOfPoint region : regions) {
+                region.release();
+            }
+            boundingBoxes.release();
+            mser.clear();
+            analysis.release();
+        }
+    }
+
+    /** Returns {@code mser_only}. */
+    @Override
+    public String id() {
+        return TextCropModel.MSER_ONLY.id();
+    }
+
+    private boolean accept(
+            Rect rect, double regionArea, int analysisWidth, int analysisHeight) {
+        if (rect.width <= 0 || rect.height <= 0) {
+            return false;
+        }
+        float widthFraction = rect.width / (float) analysisWidth;
+        float heightFraction = rect.height / (float) analysisHeight;
+        float aspect = rect.width / (float) rect.height;
+        float fill = (float) (regionArea / Math.max(1.0, rect.area()));
+        return widthFraction >= config.minWidthFraction
+                && widthFraction <= config.maxWidthFraction
+                && heightFraction >= config.minHeightFraction
+                && heightFraction <= config.maxHeightFraction
+                && aspect >= config.minAspectRatio
+                && aspect <= config.maxAspectRatio
+                && fill >= config.minFillRatio
+                && fill <= config.maxFillRatio;
+    }
+
+    private static boolean touchesBoundary(CropRect crop, int width, int height) {
+        int margin = 2;
+        return crop.left <= margin
+                || crop.top <= margin
+                || crop.right >= width - margin
+                || crop.bottom >= height - margin;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxDbNetRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxDbNetRoiDetector.java
@@ -1,0 +1,102 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import ai.onnxruntime.OrtException;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.io.IOException;
+import java.util.List;
+
+/** ONNX detector for PaddleOCR DBNet-style text segmentation models. */
+public final class OnnxDbNetRoiDetector extends AbstractOnnxRoiDetector {
+    /**
+     * Loads a PaddleOCR detector model.
+     *
+     * @param model one of the PPOCR detector models
+     * @param source model byte source
+     * @throws IOException when the model cannot be loaded
+     * @throws OrtException when the model cannot be initialized
+     */
+    public OnnxDbNetRoiDetector(TextCropModel model, ModelSource source)
+            throws IOException, OrtException {
+        super(requireDbNet(model), source);
+    }
+
+    /** Runs inference and DBNet probability-map postprocessing. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        return runInference(
+                input,
+                (outputs, elapsed) -> {
+                    float[][] map = firstProbabilityMap(outputs);
+                    return RoiPostprocessor.postprocessProbabilityMap(
+                            map,
+                            input.width(),
+                            input.height(),
+                            0.3f,
+                            0.5f,
+                            1.5f,
+                            id(),
+                            elapsed);
+                });
+    }
+
+    /**
+     * Postprocesses a DBNet probability map without creating an ONNX session.
+     *
+     * @param probabilityMap text probabilities indexed by row and column
+     * @param inputWidth source image width
+     * @param inputHeight source image height
+     * @param elapsedMs elapsed inference time to record
+     * @return detected or fallback crop
+     */
+    public static DetectionResult postprocess(
+            float[][] probabilityMap, int inputWidth, int inputHeight, long elapsedMs) {
+        return RoiPostprocessor.postprocessProbabilityMap(
+                probabilityMap,
+                inputWidth,
+                inputHeight,
+                0.3f,
+                0.5f,
+                1.5f,
+                "dbnet",
+                elapsedMs);
+    }
+
+    /**
+     * Extracts a two-dimensional map from standard {@code [1][1][H][W]} or {@code [1][H][W]}
+     * output.
+     *
+     * @param output ONNX tensor value
+     * @return probability map, or {@code null} for an unsupported shape
+     */
+    public static float[][] extractProbabilityMap(Object output) {
+        if (output instanceof float[][][][]) {
+            float[][][][] value = (float[][][][]) output;
+            return value.length > 0 && value[0].length > 0 ? value[0][0] : null;
+        }
+        if (output instanceof float[][][]) {
+            float[][][] value = (float[][][]) output;
+            return value.length > 0 ? value[0] : null;
+        }
+        if (output instanceof float[][]) {
+            return (float[][]) output;
+        }
+        return null;
+    }
+
+    private static float[][] firstProbabilityMap(List<Object> outputs) {
+        for (Object output : outputs) {
+            float[][] map = extractProbabilityMap(output);
+            if (map != null) {
+                return map;
+            }
+        }
+        return null;
+    }
+
+    private static TextCropModel requireDbNet(TextCropModel model) {
+        if (model == null || !"dbnet".equals(model.family())) {
+            throw new IllegalArgumentException("A PPOCR DBNet model is required");
+        }
+        return model;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxDbNetRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxDbNetRoiDetector.java
@@ -28,14 +28,7 @@ public final class OnnxDbNetRoiDetector extends AbstractOnnxRoiDetector {
                 (outputs, elapsed) -> {
                     float[][] map = firstProbabilityMap(outputs);
                     return RoiPostprocessor.postprocessProbabilityMap(
-                            map,
-                            input.width(),
-                            input.height(),
-                            0.3f,
-                            0.5f,
-                            1.5f,
-                            id(),
-                            elapsed);
+                            map, input.width(), input.height(), 0.3f, 0.5f, 1.5f, id(), elapsed);
                 });
     }
 
@@ -51,14 +44,7 @@ public final class OnnxDbNetRoiDetector extends AbstractOnnxRoiDetector {
     public static DetectionResult postprocess(
             float[][] probabilityMap, int inputWidth, int inputHeight, long elapsedMs) {
         return RoiPostprocessor.postprocessProbabilityMap(
-                probabilityMap,
-                inputWidth,
-                inputHeight,
-                0.3f,
-                0.5f,
-                1.5f,
-                "dbnet",
-                elapsedMs);
+                probabilityMap, inputWidth, inputHeight, 0.3f, 0.5f, 1.5f, "dbnet", elapsedMs);
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxEastRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxEastRoiDetector.java
@@ -1,0 +1,196 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import ai.onnxruntime.OrtException;
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** ONNX detector for EAST score-and-geometry text models. */
+public final class OnnxEastRoiDetector extends AbstractOnnxRoiDetector {
+    /**
+     * Loads an EAST detector model.
+     *
+     * @param model {@link TextCropModel#EAST_LITE}
+     * @param source model byte source
+     * @throws IOException when the model cannot be loaded
+     * @throws OrtException when the model cannot be initialized
+     */
+    public OnnxEastRoiDetector(TextCropModel model, ModelSource source)
+            throws IOException, OrtException {
+        super(requireEast(model), source);
+    }
+
+    /** Runs inference and decodes EAST score and geometry tensors. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        return runInference(
+                input,
+                (outputs, elapsed) -> {
+                    float[][] score = null;
+                    float[][][] geometry = null;
+                    for (Object output : outputs) {
+                        if (!(output instanceof float[][][][])) {
+                            continue;
+                        }
+                        float[][][][] tensor = (float[][][][]) output;
+                        if (tensor.length == 0) {
+                            continue;
+                        }
+                        if (tensor[0].length == 1) {
+                            score = tensor[0][0];
+                        } else if (tensor[0].length >= 5) {
+                            geometry = tensor[0];
+                        }
+                    }
+                    return postprocess(
+                            score,
+                            geometry,
+                            model().inputWidth(),
+                            model().inputHeight(),
+                            input.width(),
+                            input.height(),
+                            elapsed,
+                            id());
+                });
+    }
+
+    /**
+     * Decodes standard EAST outputs without creating an ONNX session.
+     *
+     * @param scores score map in {@code [H][W]} layout
+     * @param geometry geometry channels in {@code [5][H][W]} layout
+     * @param modelWidth model input width
+     * @param modelHeight model input height
+     * @param inputWidth source image width
+     * @param inputHeight source image height
+     * @param elapsedMs elapsed inference time to record
+     * @param detectorId detector identifier
+     * @return detected or fallback crop
+     */
+    public static DetectionResult postprocess(
+            float[][] scores,
+            float[][][] geometry,
+            int modelWidth,
+            int modelHeight,
+            int inputWidth,
+            int inputHeight,
+            long elapsedMs,
+            String detectorId) {
+        if (!valid(scores, geometry)) {
+            return RoiPostprocessor.fallback(
+                    inputWidth, inputHeight, detectorId, elapsedMs, "unsupported_east_output");
+        }
+        int rows = scores.length;
+        int columns = scores[0].length;
+        float strideX = modelWidth / (float) columns;
+        float strideY = modelHeight / (float) rows;
+        List<CropRect> boxes = new ArrayList<>();
+        for (int y = 0; y < rows; y++) {
+            for (int x = 0; x < columns; x++) {
+                if (scores[y][x] < 0.5f) {
+                    continue;
+                }
+                float top = geometry[0][y][x];
+                float right = geometry[1][y][x];
+                float bottom = geometry[2][y][x];
+                float left = geometry[3][y][x];
+                float angle = geometry[4][y][x];
+                float originX = x * strideX;
+                float originY = y * strideY;
+                CropRect box =
+                        enclosingRotatedBox(
+                                originX,
+                                originY,
+                                left,
+                                top,
+                                right,
+                                bottom,
+                                angle,
+                                modelWidth,
+                                modelHeight);
+                if (box.width() >= 3 && box.height() >= 3) {
+                    boxes.add(box);
+                }
+            }
+        }
+        return RoiPostprocessor.resultFromBoxes(
+                boxes,
+                modelWidth,
+                modelHeight,
+                inputWidth,
+                inputHeight,
+                detectorId,
+                elapsedMs,
+                "no_east_boxes");
+    }
+
+    private static CropRect enclosingRotatedBox(
+            float originX,
+            float originY,
+            float left,
+            float top,
+            float right,
+            float bottom,
+            float angle,
+            int width,
+            int height) {
+        float cosine = (float) Math.cos(angle);
+        float sine = (float) Math.sin(angle);
+        float[] localX = {-left, right, right, -left};
+        float[] localY = {-top, -top, bottom, bottom};
+        float minX = Float.POSITIVE_INFINITY;
+        float minY = Float.POSITIVE_INFINITY;
+        float maxX = Float.NEGATIVE_INFINITY;
+        float maxY = Float.NEGATIVE_INFINITY;
+        for (int i = 0; i < 4; i++) {
+            float x = originX + localX[i] * cosine - localY[i] * sine;
+            float y = originY + localX[i] * sine + localY[i] * cosine;
+            minX = Math.min(minX, x);
+            minY = Math.min(minY, y);
+            maxX = Math.max(maxX, x);
+            maxY = Math.max(maxY, y);
+        }
+        return CropRect.clamp(
+                new CropRect(
+                        (int) Math.floor(minX),
+                        (int) Math.floor(minY),
+                        (int) Math.ceil(maxX),
+                        (int) Math.ceil(maxY)),
+                width,
+                height);
+    }
+
+    private static boolean valid(float[][] scores, float[][][] geometry) {
+        if (scores == null
+                || scores.length == 0
+                || scores[0] == null
+                || scores[0].length == 0
+                || geometry == null
+                || geometry.length < 5) {
+            return false;
+        }
+        int rows = scores.length;
+        int columns = scores[0].length;
+        for (int channel = 0; channel < 5; channel++) {
+            if (geometry[channel] == null || geometry[channel].length != rows) {
+                return false;
+            }
+            for (int row = 0; row < rows; row++) {
+                if (geometry[channel][row] == null
+                        || geometry[channel][row].length != columns) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static TextCropModel requireEast(TextCropModel model) {
+        if (model != TextCropModel.EAST_LITE) {
+            throw new IllegalArgumentException("EAST_LITE model is required");
+        }
+        return model;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxEastRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxEastRoiDetector.java
@@ -178,8 +178,7 @@ public final class OnnxEastRoiDetector extends AbstractOnnxRoiDetector {
                 return false;
             }
             for (int row = 0; row < rows; row++) {
-                if (geometry[channel][row] == null
-                        || geometry[channel][row].length != columns) {
+                if (geometry[channel][row] == null || geometry[channel][row].length != columns) {
                     return false;
                 }
             }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxFastRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxFastRoiDetector.java
@@ -1,0 +1,53 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import ai.onnxruntime.OrtException;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.io.IOException;
+
+/** ONNX detector for FAST text segmentation models. */
+public final class OnnxFastRoiDetector extends AbstractOnnxRoiDetector {
+    /**
+     * Loads a FAST detector model.
+     *
+     * @param model {@link TextCropModel#FAST_TINY} or {@link TextCropModel#FAST_SMALL}
+     * @param source model byte source
+     * @throws IOException when the model cannot be loaded
+     * @throws OrtException when the model cannot be initialized
+     */
+    public OnnxFastRoiDetector(TextCropModel model, ModelSource source)
+            throws IOException, OrtException {
+        super(requireFast(model), source);
+    }
+
+    /** Runs inference and FAST segmentation-map postprocessing. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        return runInference(
+                input,
+                (outputs, elapsed) -> {
+                    float[][] map = null;
+                    for (Object output : outputs) {
+                        map = OnnxDbNetRoiDetector.extractProbabilityMap(output);
+                        if (map != null) {
+                            break;
+                        }
+                    }
+                    return RoiPostprocessor.postprocessProbabilityMap(
+                            map,
+                            input.width(),
+                            input.height(),
+                            0.5f,
+                            0.5f,
+                            1.25f,
+                            id(),
+                            elapsed);
+                });
+    }
+
+    private static TextCropModel requireFast(TextCropModel model) {
+        if (model == null || !"fast".equals(model.family())) {
+            throw new IllegalArgumentException("A FAST model is required");
+        }
+        return model;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxFastRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxFastRoiDetector.java
@@ -33,14 +33,7 @@ public final class OnnxFastRoiDetector extends AbstractOnnxRoiDetector {
                         }
                     }
                     return RoiPostprocessor.postprocessProbabilityMap(
-                            map,
-                            input.width(),
-                            input.height(),
-                            0.5f,
-                            0.5f,
-                            1.25f,
-                            id(),
-                            elapsed);
+                            map, input.width(), input.height(), 0.5f, 0.5f, 1.25f, id(), elapsed);
                 });
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxYoloRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxYoloRoiDetector.java
@@ -1,0 +1,237 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import ai.onnxruntime.OrtException;
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+/** ONNX detector for YOLO text-box models. */
+public final class OnnxYoloRoiDetector extends AbstractOnnxRoiDetector {
+    /**
+     * Loads a YOLO text detector.
+     *
+     * @param model {@link TextCropModel#YOLO_NANO_TEXT}
+     * @param source model byte source
+     * @throws IOException when the model cannot be loaded
+     * @throws OrtException when the model cannot be initialized
+     */
+    public OnnxYoloRoiDetector(TextCropModel model, ModelSource source)
+            throws IOException, OrtException {
+        super(requireYolo(model), source);
+    }
+
+    /** Runs inference, confidence filtering, and IoU non-maximum suppression. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        return runInference(
+                input,
+                (outputs, elapsed) -> {
+                    float[][] predictions = null;
+                    for (Object output : outputs) {
+                        if (output instanceof float[][][]) {
+                            float[][][] tensor = (float[][][]) output;
+                            if (tensor.length > 0) {
+                                predictions = tensor[0];
+                                break;
+                            }
+                        } else if (output instanceof float[][]) {
+                            predictions = (float[][]) output;
+                            break;
+                        }
+                    }
+                    return postprocess(
+                            predictions,
+                            model().inputWidth(),
+                            model().inputHeight(),
+                            input.width(),
+                            input.height(),
+                            elapsed,
+                            id());
+                });
+    }
+
+    /**
+     * Parses either {@code [N][5+]} or transposed {@code [4+C][N]} YOLO predictions.
+     *
+     * <p>Each returned row is {@code [left, top, right, bottom, confidence]} in model-input
+     * coordinates after confidence filtering and 0.45-IoU non-maximum suppression.
+     *
+     * @param output unbatched YOLO output
+     * @param modelWidth model input width
+     * @param modelHeight model input height
+     * @return retained boxes
+     */
+    public static List<float[]> parseDetections(
+            float[][] output, int modelWidth, int modelHeight) {
+        List<float[]> candidates = new ArrayList<>();
+        if (output == null || output.length == 0 || output[0] == null) {
+            return candidates;
+        }
+        boolean transposed =
+                output[0].length < 5
+                        || (output.length >= 5 && output.length < output[0].length);
+        if (transposed) {
+            int channels = output.length;
+            int count = output[0].length;
+            if (channels < 5 || !rectangular(output, count)) {
+                return candidates;
+            }
+            for (int index = 0; index < count; index++) {
+                float confidence = 0;
+                for (int channel = 4; channel < channels; channel++) {
+                    confidence = Math.max(confidence, output[channel][index]);
+                }
+                addCandidate(
+                        candidates,
+                        output[0][index],
+                        output[1][index],
+                        output[2][index],
+                        output[3][index],
+                        confidence,
+                        modelWidth,
+                        modelHeight);
+            }
+        } else {
+            for (float[] prediction : output) {
+                if (prediction == null || prediction.length < 5) {
+                    continue;
+                }
+                float confidence = prediction[4];
+                if (prediction.length > 5) {
+                    float classScore = 0;
+                    for (int channel = 5; channel < prediction.length; channel++) {
+                        classScore = Math.max(classScore, prediction[channel]);
+                    }
+                    confidence *= classScore;
+                }
+                addCandidate(
+                        candidates,
+                        prediction[0],
+                        prediction[1],
+                        prediction[2],
+                        prediction[3],
+                        confidence,
+                        modelWidth,
+                        modelHeight);
+            }
+        }
+        candidates.sort(Comparator.comparingDouble(box -> -box[4]));
+        List<float[]> retained = new ArrayList<>();
+        for (float[] candidate : candidates) {
+            boolean suppressed = false;
+            for (float[] accepted : retained) {
+                if (iou(candidate, accepted) > 0.45f) {
+                    suppressed = true;
+                    break;
+                }
+            }
+            if (!suppressed) {
+                retained.add(candidate);
+            }
+        }
+        return retained;
+    }
+
+    /**
+     * Produces a source-image crop from an unbatched YOLO output without creating a session.
+     *
+     * @param output unbatched YOLO output
+     * @param modelWidth model input width
+     * @param modelHeight model input height
+     * @param inputWidth source image width
+     * @param inputHeight source image height
+     * @param elapsedMs elapsed inference time to record
+     * @param detectorId detector identifier
+     * @return detected or fallback crop
+     */
+    public static DetectionResult postprocess(
+            float[][] output,
+            int modelWidth,
+            int modelHeight,
+            int inputWidth,
+            int inputHeight,
+            long elapsedMs,
+            String detectorId) {
+        List<CropRect> boxes = new ArrayList<>();
+        for (float[] box : parseDetections(output, modelWidth, modelHeight)) {
+            boxes.add(
+                    CropRect.clamp(
+                            new CropRect(
+                                    (int) Math.floor(box[0]),
+                                    (int) Math.floor(box[1]),
+                                    (int) Math.ceil(box[2]),
+                                    (int) Math.ceil(box[3])),
+                            modelWidth,
+                            modelHeight));
+        }
+        return RoiPostprocessor.resultFromBoxes(
+                boxes,
+                modelWidth,
+                modelHeight,
+                inputWidth,
+                inputHeight,
+                detectorId,
+                elapsedMs,
+                "no_yolo_boxes");
+    }
+
+    private static void addCandidate(
+            List<float[]> candidates,
+            float centerX,
+            float centerY,
+            float width,
+            float height,
+            float confidence,
+            int modelWidth,
+            int modelHeight) {
+        if (confidence < 0.4f || width <= 0 || height <= 0) {
+            return;
+        }
+        if (Math.abs(centerX) <= 2f
+                && Math.abs(centerY) <= 2f
+                && width <= 2f
+                && height <= 2f) {
+            centerX *= modelWidth;
+            width *= modelWidth;
+            centerY *= modelHeight;
+            height *= modelHeight;
+        }
+        float left = Math.max(0, centerX - width * 0.5f);
+        float top = Math.max(0, centerY - height * 0.5f);
+        float right = Math.min(modelWidth, centerX + width * 0.5f);
+        float bottom = Math.min(modelHeight, centerY + height * 0.5f);
+        if (right - left >= 1 && bottom - top >= 1) {
+            candidates.add(new float[] {left, top, right, bottom, confidence});
+        }
+    }
+
+    private static float iou(float[] first, float[] second) {
+        float intersectionWidth =
+                Math.max(0, Math.min(first[2], second[2]) - Math.max(first[0], second[0]));
+        float intersectionHeight =
+                Math.max(0, Math.min(first[3], second[3]) - Math.max(first[1], second[1]));
+        float intersection = intersectionWidth * intersectionHeight;
+        float firstArea = (first[2] - first[0]) * (first[3] - first[1]);
+        float secondArea = (second[2] - second[0]) * (second[3] - second[1]);
+        return intersection / Math.max(1e-6f, firstArea + secondArea - intersection);
+    }
+
+    private static boolean rectangular(float[][] values, int columns) {
+        for (float[] row : values) {
+            if (row == null || row.length != columns) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static TextCropModel requireYolo(TextCropModel model) {
+        if (model != TextCropModel.YOLO_NANO_TEXT) {
+            throw new IllegalArgumentException("YOLO_NANO_TEXT model is required");
+        }
+        return model;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxYoloRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/OnnxYoloRoiDetector.java
@@ -64,15 +64,13 @@ public final class OnnxYoloRoiDetector extends AbstractOnnxRoiDetector {
      * @param modelHeight model input height
      * @return retained boxes
      */
-    public static List<float[]> parseDetections(
-            float[][] output, int modelWidth, int modelHeight) {
+    public static List<float[]> parseDetections(float[][] output, int modelWidth, int modelHeight) {
         List<float[]> candidates = new ArrayList<>();
         if (output == null || output.length == 0 || output[0] == null) {
             return candidates;
         }
         boolean transposed =
-                output[0].length < 5
-                        || (output.length >= 5 && output.length < output[0].length);
+                output[0].length < 5 || (output.length >= 5 && output.length < output[0].length);
         if (transposed) {
             int channels = output.length;
             int count = output[0].length;
@@ -190,10 +188,7 @@ public final class OnnxYoloRoiDetector extends AbstractOnnxRoiDetector {
         if (confidence < 0.4f || width <= 0 || height <= 0) {
             return;
         }
-        if (Math.abs(centerX) <= 2f
-                && Math.abs(centerY) <= 2f
-                && width <= 2f
-                && height <= 2f) {
+        if (Math.abs(centerX) <= 2f && Math.abs(centerY) <= 2f && width <= 2f && height <= 2f) {
             centerX *= modelWidth;
             width *= modelWidth;
             centerY *= modelHeight;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/RoiPostprocessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/RoiPostprocessor.java
@@ -41,7 +41,8 @@ public final class RoiPostprocessor {
                 || probabilityMap.length == 0
                 || probabilityMap[0] == null
                 || probabilityMap[0].length == 0) {
-            return fallback(inputWidth, inputHeight, detectorId, elapsedMs, "empty_probability_map");
+            return fallback(
+                    inputWidth, inputHeight, detectorId, elapsedMs, "empty_probability_map");
         }
         CvInit.ensureLoaded();
         int mapHeight = probabilityMap.length;
@@ -55,8 +56,7 @@ public final class RoiPostprocessor {
                         inputWidth, inputHeight, detectorId, elapsedMs, "ragged_probability_map");
             }
             for (int x = 0; x < mapWidth; x++) {
-                bytes[y * mapWidth + x] =
-                        probabilityMap[y][x] >= threshold ? (byte) 255 : (byte) 0;
+                bytes[y * mapWidth + x] = probabilityMap[y][x] >= threshold ? (byte) 255 : (byte) 0;
             }
         }
         mask.put(0, 0, bytes);
@@ -68,9 +68,7 @@ public final class RoiPostprocessor {
         List<CropRect> boxes = new ArrayList<>();
         for (MatOfPoint contour : contours) {
             Rect rect = Imgproc.boundingRect(contour);
-            if (rect.width >= 3
-                    && rect.height >= 3
-                    && mean(probabilityMap, rect) >= minimumScore) {
+            if (rect.width >= 3 && rect.height >= 3 && mean(probabilityMap, rect) >= minimumScore) {
                 boxes.add(expand(rect, expansion, mapWidth, mapHeight));
             }
             contour.release();
@@ -163,8 +161,7 @@ public final class RoiPostprocessor {
         return count == 0 ? 0 : (float) (total / count);
     }
 
-    private static CropRect expand(
-            Rect rect, float expansion, int mapWidth, int mapHeight) {
+    private static CropRect expand(Rect rect, float expansion, int mapWidth, int mapHeight) {
         float extraX = rect.width * Math.max(0, expansion - 1f) * 0.5f;
         float extraY = rect.height * Math.max(0, expansion - 1f) * 0.5f;
         return CropRect.clamp(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/RoiPostprocessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/RoiPostprocessor.java
@@ -1,0 +1,179 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.CvInit;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import java.util.ArrayList;
+import java.util.List;
+import org.opencv.core.CvType;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfPoint;
+import org.opencv.core.Rect;
+import org.opencv.imgproc.Imgproc;
+
+/** Shared geometry and probability-map postprocessing for neural ROI detectors. */
+public final class RoiPostprocessor {
+    private RoiPostprocessor() {}
+
+    /**
+     * Converts a segmentation probability map into one padded union crop.
+     *
+     * @param probabilityMap row-major probabilities
+     * @param inputWidth original image width
+     * @param inputHeight original image height
+     * @param threshold segmentation threshold
+     * @param minimumScore minimum mean probability inside a candidate box
+     * @param expansion box expansion factor before union
+     * @param detectorId detector identifier recorded as the selected strategy
+     * @param elapsedMs inference and postprocessing time
+     * @return detected union crop or the standard center fallback
+     */
+    public static DetectionResult postprocessProbabilityMap(
+            float[][] probabilityMap,
+            int inputWidth,
+            int inputHeight,
+            float threshold,
+            float minimumScore,
+            float expansion,
+            String detectorId,
+            long elapsedMs) {
+        if (probabilityMap == null
+                || probabilityMap.length == 0
+                || probabilityMap[0] == null
+                || probabilityMap[0].length == 0) {
+            return fallback(inputWidth, inputHeight, detectorId, elapsedMs, "empty_probability_map");
+        }
+        CvInit.ensureLoaded();
+        int mapHeight = probabilityMap.length;
+        int mapWidth = probabilityMap[0].length;
+        Mat mask = new Mat(mapHeight, mapWidth, CvType.CV_8UC1);
+        byte[] bytes = new byte[mapWidth * mapHeight];
+        for (int y = 0; y < mapHeight; y++) {
+            if (probabilityMap[y] == null || probabilityMap[y].length != mapWidth) {
+                mask.release();
+                return fallback(
+                        inputWidth, inputHeight, detectorId, elapsedMs, "ragged_probability_map");
+            }
+            for (int x = 0; x < mapWidth; x++) {
+                bytes[y * mapWidth + x] =
+                        probabilityMap[y][x] >= threshold ? (byte) 255 : (byte) 0;
+            }
+        }
+        mask.put(0, 0, bytes);
+
+        List<MatOfPoint> contours = new ArrayList<>();
+        Mat hierarchy = new Mat();
+        Imgproc.findContours(
+                mask, contours, hierarchy, Imgproc.RETR_LIST, Imgproc.CHAIN_APPROX_SIMPLE);
+        List<CropRect> boxes = new ArrayList<>();
+        for (MatOfPoint contour : contours) {
+            Rect rect = Imgproc.boundingRect(contour);
+            if (rect.width >= 3
+                    && rect.height >= 3
+                    && mean(probabilityMap, rect) >= minimumScore) {
+                boxes.add(expand(rect, expansion, mapWidth, mapHeight));
+            }
+            contour.release();
+        }
+        hierarchy.release();
+        mask.release();
+        return resultFromBoxes(
+                boxes,
+                mapWidth,
+                mapHeight,
+                inputWidth,
+                inputHeight,
+                detectorId,
+                elapsedMs,
+                "no_text_boxes");
+    }
+
+    static DetectionResult resultFromBoxes(
+            List<CropRect> boxes,
+            int coordinateWidth,
+            int coordinateHeight,
+            int inputWidth,
+            int inputHeight,
+            String detectorId,
+            long elapsedMs,
+            String emptyReason) {
+        if (boxes == null || boxes.isEmpty()) {
+            return fallback(inputWidth, inputHeight, detectorId, elapsedMs, emptyReason);
+        }
+        CropRect union = boxes.get(0);
+        for (int i = 1; i < boxes.size(); i++) {
+            union = CropRect.union(union, boxes.get(i));
+        }
+        int horizontalPadding = Math.max(1, Math.round(union.width() * 0.05f));
+        int verticalPadding = Math.max(1, Math.round(union.height() * 0.05f));
+        CropRect padded =
+                new CropRect(
+                        union.left - horizontalPadding,
+                        union.top - verticalPadding,
+                        union.right + horizontalPadding,
+                        union.bottom + verticalPadding);
+        float scaleX = inputWidth / (float) coordinateWidth;
+        float scaleY = inputHeight / (float) coordinateHeight;
+        CropRect mapped =
+                CropRect.clamp(
+                        new CropRect(
+                                Math.round(padded.left * scaleX),
+                                Math.round(padded.top * scaleY),
+                                Math.round(padded.right * scaleX),
+                                Math.round(padded.bottom * scaleY)),
+                        inputWidth,
+                        inputHeight);
+        return new DetectionResult(
+                mapped,
+                DetectionResult.Confidence.MEDIUM,
+                detectorId,
+                boxes.size(),
+                boxes.isEmpty() ? 0 : 1,
+                elapsedMs,
+                null,
+                null);
+    }
+
+    static DetectionResult fallback(
+            int width, int height, String detectorId, long elapsedMs, String reason) {
+        int cropWidth = Math.max(1, Math.round(width * 0.75f));
+        int cropHeight = Math.max(1, Math.round(height * 0.75f));
+        int left = (width - cropWidth) / 2;
+        int top = (height - cropHeight) / 2;
+        return new DetectionResult(
+                new CropRect(left, top, left + cropWidth, top + cropHeight),
+                DetectionResult.Confidence.LOW,
+                detectorId,
+                0,
+                0,
+                elapsedMs,
+                reason,
+                null);
+    }
+
+    private static float mean(float[][] map, Rect rect) {
+        double total = 0;
+        int count = 0;
+        for (int y = rect.y; y < rect.y + rect.height; y++) {
+            for (int x = rect.x; x < rect.x + rect.width; x++) {
+                total += map[y][x];
+                count++;
+            }
+        }
+        return count == 0 ? 0 : (float) (total / count);
+    }
+
+    private static CropRect expand(
+            Rect rect, float expansion, int mapWidth, int mapHeight) {
+        float extraX = rect.width * Math.max(0, expansion - 1f) * 0.5f;
+        float extraY = rect.height * Math.max(0, expansion - 1f) * 0.5f;
+        return CropRect.clamp(
+                new CropRect(
+                        Math.round(rect.x - extraX),
+                        Math.round(rect.y - extraY),
+                        Math.round(rect.x + rect.width + extraX),
+                        Math.round(rect.y + rect.height + extraY)),
+                mapWidth,
+                mapHeight);
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/SwtRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/SwtRoiDetector.java
@@ -34,8 +34,7 @@ public final class SwtRoiDetector implements TextRoiDetector {
     @Override
     public DetectionResult detect(DetectionInput input) {
         Objects.requireNonNull(input, "input");
-        return TextRegionDetector.detect(
-                input.lumaUnsafe(), input.width(), input.height(), config);
+        return TextRegionDetector.detect(input.lumaUnsafe(), input.width(), input.height(), config);
     }
 
     /** Returns {@code swt}. */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/SwtRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/SwtRoiDetector.java
@@ -1,0 +1,46 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import com.mentra.asg_client.io.media.core.textdetect.TextRegionDetector;
+import java.util.Objects;
+
+/**
+ * Stroke-width-filtered variant of the classical detector.
+ *
+ * <p>This intentionally reuses the maintained classical pipeline rather than implementing a
+ * separate stroke-width transform.
+ */
+public final class SwtRoiDetector implements TextRoiDetector {
+    private final TextDetectConfig config;
+
+    /**
+     * Creates a stroke-width-filtered detector while preserving all supplied configuration.
+     *
+     * @param config base classical detector configuration
+     */
+    public SwtRoiDetector(TextDetectConfig config) {
+        Objects.requireNonNull(config, "config");
+        this.config =
+                config.toBuilder()
+                        .enableStrokeWidthFilter(true)
+                        .maxStrokeWidthCv(0.6f)
+                        .cropFromTopLineOnly(true)
+                        .improvedCropAccuracy(true)
+                        .build();
+    }
+
+    /** Detects a crop with the stroke-width-filtered classical pipeline. */
+    @Override
+    public DetectionResult detect(DetectionInput input) {
+        Objects.requireNonNull(input, "input");
+        return TextRegionDetector.detect(
+                input.lumaUnsafe(), input.width(), input.height(), config);
+    }
+
+    /** Returns {@code swt}. */
+    @Override
+    public String id() {
+        return TextCropModel.SWT.id();
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
@@ -1,0 +1,59 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+/** Available classical and neural text-crop implementations. */
+public enum TextCropModel {
+    CLASSICAL("classical", "classical", null, 0, 0),
+    SWT("swt", "classical", null, 0, 0),
+    MSER_ONLY("mser_only", "classical", null, 0, 0),
+    PPOCR_V6_TINY_DET("ppocr_v6_tiny_det", "dbnet", "ppocr_v6_tiny_det.onnx", 640, 640),
+    PPOCR_V5_MOBILE_DET("ppocr_v5_mobile_det", "dbnet", "ppocr_v5_mobile_det.onnx", 640, 640),
+    PPOCR_V6_SMALL_DET("ppocr_v6_small_det", "dbnet", "ppocr_v6_small_det.onnx", 640, 640),
+    FAST_TINY("fast_tiny", "fast", "fast_tiny.onnx", 640, 640),
+    FAST_SMALL("fast_small", "fast", "fast_small.onnx", 640, 640),
+    EAST_LITE("east_lite", "east", "east_lite.onnx", 320, 320),
+    YOLO_NANO_TEXT("yolo_nano_text", "yolo", "yolo_nano_text.onnx", 640, 640);
+
+    private final String id;
+    private final String family;
+    private final String assetFilename;
+    private final int inputWidth;
+    private final int inputHeight;
+
+    TextCropModel(
+            String id,
+            String family,
+            String assetFilename,
+            int inputWidth,
+            int inputHeight) {
+        this.id = id;
+        this.family = family;
+        this.assetFilename = assetFilename;
+        this.inputWidth = inputWidth;
+        this.inputHeight = inputHeight;
+    }
+
+    /** Returns the stable lowercase model identifier. */
+    public String id() {
+        return id;
+    }
+
+    /** Returns the detector architecture family. */
+    public String family() {
+        return family;
+    }
+
+    /** Returns the model asset filename, or {@code null} for non-neural detectors. */
+    public String assetFilename() {
+        return assetFilename;
+    }
+
+    /** Returns the neural model input width, or zero for non-neural detectors. */
+    public int inputWidth() {
+        return inputWidth;
+    }
+
+    /** Returns the neural model input height, or zero for non-neural detectors. */
+    public int inputHeight() {
+        return inputHeight;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
@@ -5,6 +5,7 @@ public enum TextCropModel {
     CLASSICAL("classical", "classical", null, 0, 0),
     SWT("swt", "classical", null, 0, 0),
     MSER_ONLY("mser_only", "classical", null, 0, 0),
+    ML_KIT("ml_kit", "ml_kit", null, 0, 0),
     PPOCR_V6_TINY_DET("ppocr_v6_tiny_det", "dbnet", "ppocr_v6_tiny_det.onnx", 640, 640),
     PPOCR_V5_MOBILE_DET("ppocr_v5_mobile_det", "dbnet", "ppocr_v5_mobile_det.onnx", 640, 640),
     PPOCR_V6_SMALL_DET("ppocr_v6_small_det", "dbnet", "ppocr_v6_small_det.onnx", 640, 640),

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextCropModel.java
@@ -19,12 +19,7 @@ public enum TextCropModel {
     private final int inputWidth;
     private final int inputHeight;
 
-    TextCropModel(
-            String id,
-            String family,
-            String assetFilename,
-            int inputWidth,
-            int inputHeight) {
+    TextCropModel(String id, String family, String assetFilename, int inputWidth, int inputHeight) {
         this.id = id;
         this.family = family;
         this.assetFilename = assetFilename;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetector.java
@@ -1,0 +1,26 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+
+/** Swappable strategy for locating a likely text crop in a luminance image. */
+public interface TextRoiDetector extends AutoCloseable {
+    /**
+     * Detects a text region.
+     *
+     * @param input validated luminance image
+     * @return a non-null crop result in input-image coordinates
+     */
+    DetectionResult detect(DetectionInput input);
+
+    /** Returns the stable identifier of this detector. */
+    String id();
+
+    /** Returns whether this detector is initialized and available for inference. */
+    default boolean isReady() {
+        return true;
+    }
+
+    /** Releases detector resources. */
+    @Override
+    default void close() {}
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetector.java
@@ -20,6 +20,27 @@ public interface TextRoiDetector extends AutoCloseable {
         return true;
     }
 
+    /**
+     * Whether {@link #detect}'s returned {@code CropRect} is already expressed in the original
+     * full-resolution source-image coordinates.
+     *
+     * <p>Classical and ONNX detectors analyze a subsampled luma buffer sized by {@code
+     * TextDetectConfig#analysisWidth} and return the crop in that subsampled space, so the caller
+     * must still scale the result up to source-pixel coordinates (see {@code
+     * GrayscaleBleProcessor#scaleDetectionRoi}). ML Kit decodes and analyzes the original sensor
+     * JPEG bytes itself and already returns a source-pixel crop, so it overrides this to {@code
+     * true} and callers must not scale its result again.
+     */
+    default boolean returnsNativeCoordinates() {
+        return false;
+    }
+
+    /**
+     * Starts model initialization ahead of the first real {@link #detect} call, so cold-start
+     * latency does not land on the capture path. Safe to call repeatedly; a no-op by default.
+     */
+    default void warmUp() {}
+
     /** Releases detector resources. */
     @Override
     default void close() {}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetectorFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetectorFactory.java
@@ -31,8 +31,21 @@ public final class TextRoiDetectorFactory {
                 return new SwtRoiDetector(config);
             case MSER_ONLY:
                 return new MserOnlyRoiDetector(config);
+            case ML_KIT:
+                return createMlKitOrFallback(config);
             default:
                 return createOnnxOrFallback(model, config, source);
+        }
+    }
+
+    private static TextRoiDetector createMlKitOrFallback(TextDetectConfig config) {
+        try {
+            MlKitRoiDetector detector = new MlKitRoiDetector();
+            detector.warmUp();
+            return detector;
+        } catch (Exception | LinkageError exception) {
+            return new ClassicalFallbackDetector(
+                    TextCropModel.ML_KIT.id(), new ClassicalRoiDetector(config));
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetectorFactory.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/roi/TextRoiDetectorFactory.java
@@ -1,0 +1,84 @@
+package com.mentra.asg_client.io.media.core.textdetect.roi;
+
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import java.util.Objects;
+
+/** Creates text ROI detectors and provides classical fallback for unavailable ONNX models. */
+public final class TextRoiDetectorFactory {
+    private TextRoiDetectorFactory() {}
+
+    /**
+     * Creates the selected detector.
+     *
+     * <p>{@code source} may be null for classical models. Neural model loading or initialization
+     * failures return a detector retaining the requested identifier while delegating detection to
+     * the classical implementation.
+     *
+     * @param model selected detector model
+     * @param config classical and MSER configuration
+     * @param source ONNX model source, required only for neural models
+     * @return initialized detector or a classical fallback wrapper
+     */
+    public static TextRoiDetector create(
+            TextCropModel model, TextDetectConfig config, ModelSource source) {
+        Objects.requireNonNull(model, "model");
+        Objects.requireNonNull(config, "config");
+        switch (model) {
+            case CLASSICAL:
+                return new ClassicalRoiDetector(config);
+            case SWT:
+                return new SwtRoiDetector(config);
+            case MSER_ONLY:
+                return new MserOnlyRoiDetector(config);
+            default:
+                return createOnnxOrFallback(model, config, source);
+        }
+    }
+
+    private static TextRoiDetector createOnnxOrFallback(
+            TextCropModel model, TextDetectConfig config, ModelSource source) {
+        try {
+            switch (model.family()) {
+                case "dbnet":
+                    return new OnnxDbNetRoiDetector(model, source);
+                case "fast":
+                    return new OnnxFastRoiDetector(model, source);
+                case "east":
+                    return new OnnxEastRoiDetector(model, source);
+                case "yolo":
+                    return new OnnxYoloRoiDetector(model, source);
+                default:
+                    throw new IllegalArgumentException(
+                            "Unsupported text detector family: " + model.family());
+            }
+        } catch (Exception | LinkageError exception) {
+            return new ClassicalFallbackDetector(model.id(), new ClassicalRoiDetector(config));
+        }
+    }
+
+    private static final class ClassicalFallbackDetector implements TextRoiDetector {
+        private final String requestedId;
+        private final ClassicalRoiDetector delegate;
+
+        ClassicalFallbackDetector(String requestedId, ClassicalRoiDetector delegate) {
+            this.requestedId = requestedId;
+            this.delegate = delegate;
+        }
+
+        @Override
+        public DetectionResult detect(DetectionInput input) {
+            return delegate.detect(input);
+        }
+
+        @Override
+        public String id() {
+            return requestedId + "->classical";
+        }
+
+        @Override
+        public void close() {
+            delegate.close();
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/interfaces/ServiceCallbackInterface.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/interfaces/ServiceCallbackInterface.java
@@ -1,25 +1,36 @@
 package com.mentra.asg_client.io.media.interfaces;
 
-/**
- * Interface for communication between MediaCaptureService and AsgClientService
- */
+/** Interface for communication between MediaCaptureService and AsgClientService */
 public interface ServiceCallbackInterface {
     /**
      * Send data through Bluetooth connection
+     *
      * @param data The data to send
      */
     void sendThroughBluetooth(byte[] data);
-    
+
     /**
      * Send a file via Bluetooth using the K900 file transfer protocol
+     *
      * @param filePath The path to the file to send
      * @return true if file transfer started successfully, false otherwise
      */
     boolean sendFileViaBluetooth(String filePath);
-    
+
+    /**
+     * Send an in-memory payload via Bluetooth using the K900 file transfer protocol, without
+     * writing it to disk first.
+     *
+     * @param data payload bytes
+     * @param fileName wire name for the transfer (K900 protocol caps this at 16 chars)
+     * @return true if file transfer started successfully, false otherwise
+     */
+    boolean sendFileViaBluetooth(byte[] data, String fileName);
+
     /**
      * Check if a BLE file transfer is currently in progress
+     *
      * @return true if a transfer is active, false otherwise
      */
     boolean isBleTransferInProgress();
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -87,8 +87,8 @@ public class AsgClientService extends Service implements NetworkStateListener, T
     @Inject Provider<ICompanionTransport> companionTransportProvider;
 
     /**
-     * Provider for the device-appropriate network manager, deferred for the same reason as
-     * {@link #companionTransportProvider}.
+     * Provider for the device-appropriate network manager, deferred for the same reason as {@link
+     * #companionTransportProvider}.
      */
     @Inject Provider<INetworkManager> networkManagerProvider;
 
@@ -1399,6 +1399,35 @@ public class AsgClientService extends Service implements NetworkStateListener, T
                         Log.i(TAG, "✅ BLE file transfer started successfully for: " + filePath);
                     } else {
                         Log.e(TAG, "❌ Failed to start BLE file transfer for: " + filePath);
+                    }
+                    return started;
+                } else {
+                    Log.w(TAG, "⚠️ Bluetooth manager is null - cannot send file");
+                    return false;
+                }
+            }
+
+            @Override
+            public boolean sendFileViaBluetooth(byte[] data, String fileName) {
+                Log.d(
+                        TAG,
+                        "📁 sendFileViaBluetooth(byte[]) called - "
+                                + (data != null ? data.length : 0)
+                                + " bytes as "
+                                + fileName);
+
+                if (serviceInitializer.getServiceManager().getBluetoothManager() != null) {
+                    boolean started =
+                            serviceInitializer
+                                    .getServiceManager()
+                                    .getBluetoothManager()
+                                    .sendFile(data, fileName);
+                    if (started) {
+                        Log.i(TAG, "✅ In-memory BLE file transfer started for: " + fileName);
+                    } else {
+                        Log.e(
+                                TAG,
+                                "❌ Failed to start in-memory BLE file transfer for: " + fileName);
                     }
                     return started;
                 } else {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriterTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoExifMetadataWriterTest.java
@@ -58,8 +58,29 @@ public class PhotoExifMetadataWriterTest {
 
         androidx.exifinterface.media.ExifInterface exif =
                 new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
-        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+        assertThat(
+                        exif.getAttribute(
+                                androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
                 .isEqualTo("IMG_20260709_120000_123_456_photoReq99");
+    }
+
+    @Test
+    public void writeCaptureIdCanUseIntendedCapturePathForCachedJpeg() throws Exception {
+        File cacheDir = tempFolder.newFolder("text_mode_uploads");
+        File cachedJpeg = new File(cacheDir, "transient.jpg");
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_cachedReq");
+        File intendedJpeg = new File(captureDir, "base.jpg");
+        PhotoExifMetadataWriter.writeMinimalJpegForTest(cachedJpeg);
+
+        PhotoExifMetadataWriter.writeCaptureIdFromPath(
+                cachedJpeg.getAbsolutePath(), intendedJpeg.getAbsolutePath());
+
+        androidx.exifinterface.media.ExifInterface exif =
+                new androidx.exifinterface.media.ExifInterface(cachedJpeg.getAbsolutePath());
+        assertThat(
+                        exif.getAttribute(
+                                androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+                .isEqualTo("IMG_20260709_120000_123_456_cachedReq");
     }
 
     @Test
@@ -71,7 +92,9 @@ public class PhotoExifMetadataWriterTest {
 
         androidx.exifinterface.media.ExifInterface exif =
                 new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
-        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+        assertThat(
+                        exif.getAttribute(
+                                androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
                 .isNull();
     }
 
@@ -88,7 +111,9 @@ public class PhotoExifMetadataWriterTest {
 
         androidx.exifinterface.media.ExifInterface exif =
                 new androidx.exifinterface.media.ExifInterface(dest.getAbsolutePath());
-        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+        assertThat(
+                        exif.getAttribute(
+                                androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
                 .isEqualTo("IMG_20260709_120000_123_456_reqA");
     }
 
@@ -106,7 +131,9 @@ public class PhotoExifMetadataWriterTest {
 
         androidx.exifinterface.media.ExifInterface exif =
                 new androidx.exifinterface.media.ExifInterface(jpeg.getAbsolutePath());
-        assertThat(exif.getAttribute(androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
+        assertThat(
+                        exif.getAttribute(
+                                androidx.exifinterface.media.ExifInterface.TAG_IMAGE_UNIQUE_ID))
                 .isEqualTo("IMG_20260709_120000_123_456_reqB");
         assertThat(PhotoExifMetadataWriter.hasImuMetadata(jpeg.getAbsolutePath())).isTrue();
     }
@@ -149,6 +176,32 @@ public class PhotoExifMetadataWriterTest {
         assertThat(segment).isNotNull();
         assertThat(new String(segment, java.nio.charset.StandardCharsets.ISO_8859_1))
                 .contains("IMG_20260709_120000_123_456_reqC");
+    }
+
+    @Test
+    public void ramFirstExifSegmentCarriesPayloadAndIntendedCaptureId() throws Exception {
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_ramReq");
+        String intendedPath = new File(captureDir, "base.jpg").getAbsolutePath();
+
+        byte[] segment =
+                PhotoExifMetadataWriter.buildCaptureExifApp1Segment(samplePayload(2), intendedPath);
+
+        assertThat(segment).isNotNull();
+        String bytes = new String(segment, java.nio.charset.StandardCharsets.ISO_8859_1);
+        assertThat(bytes).contains("IMG_20260709_120000_123_456_ramReq");
+        assertThat(bytes).contains("sampleCount");
+    }
+
+    @Test
+    public void ramFirstExifSegmentCarriesCaptureIdWithoutImu() throws Exception {
+        File captureDir = tempFolder.newFolder("IMG_20260709_120000_123_456_noImu");
+        String intendedPath = new File(captureDir, "base.jpg").getAbsolutePath();
+
+        byte[] segment = PhotoExifMetadataWriter.buildCaptureExifApp1Segment(null, intendedPath);
+
+        assertThat(segment).isNotNull();
+        assertThat(new String(segment, java.nio.charset.StandardCharsets.ISO_8859_1))
+                .contains("IMG_20260709_120000_123_456_noImu");
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoSessionTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoSessionTest.java
@@ -17,12 +17,14 @@ import android.hardware.camera2.CaptureRequest;
 import android.os.Handler;
 import com.mentra.asg_client.camera.CameraNeoService;
 import com.mentra.asg_client.camera.model.CameraOperationError;
+import com.mentra.asg_client.camera.model.CapturedPhoto;
 import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequest;
 import com.mentra.asg_client.camera.model.QueuedPhotoRequestQueue;
 import com.mentra.asg_client.camera.policy.AeStateMachine;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 import org.json.JSONObject;
@@ -222,7 +224,9 @@ public class PhotoSessionTest {
         notifyPhotoCaptured(session, "/tmp/second.jpg");
         timeout.run();
 
-        verify(callback).onPhotoCaptured(eq("/tmp/first.jpg"), (JSONObject) isNull());
+        verify(callback)
+                .onPhotoCaptured(
+                        eq("/tmp/first.jpg"), (JSONObject) isNull(), (CapturedPhoto) isNull());
         assertThat(activeCapture(session)).isNull();
         assertThat(session.shotState()).isEqualTo(AeStateMachine.ShotState.IDLE);
         verify(hooks).startPostCaptureKeepAlive();
@@ -242,7 +246,9 @@ public class PhotoSessionTest {
         // HDR completion never records still metadata; it must not arm the wait timeout.
         notifyPhotoCaptured(session, "/tmp/hdr.jpg", false);
 
-        verify(callback).onPhotoCaptured(eq("/tmp/hdr.jpg"), (JSONObject) isNull());
+        verify(callback)
+                .onPhotoCaptured(
+                        eq("/tmp/hdr.jpg"), (JSONObject) isNull(), (CapturedPhoto) isNull());
         assertThat(pendingCaptureMetadataTimeout(session)).isNull();
         assertThat(activeCapture(session)).isNull();
         assertThat(session.shotState()).isEqualTo(AeStateMachine.ShotState.IDLE);
@@ -278,7 +284,42 @@ public class PhotoSessionTest {
         Runnable timeout = pendingCaptureMetadataTimeout(session);
         timeout.run();
 
-        verify(callback).onPhotoCaptured(eq("/tmp/second.jpg"), (JSONObject) isNull());
+        verify(callback)
+                .onPhotoCaptured(
+                        eq("/tmp/second.jpg"), (JSONObject) isNull(), (CapturedPhoto) isNull());
+    }
+
+    @Test
+    public void notifyPhotoCaptured_ramFirstCaptureSurvivesMetadataWait() throws Exception {
+        PhotoSession.Hooks hooks = mockConfiguredCameraHooks();
+        CameraNeoService.PhotoCaptureCallback callback =
+                mock(CameraNeoService.PhotoCaptureCallback.class);
+        QueuedPhotoRequest request =
+                new QueuedPhotoRequest("/tmp/ram.jpg", "large", false, true, null, callback);
+        PhotoSession session = new PhotoSession(hooks);
+        activateQueuedRequest(session, request);
+        CapturedPhoto capturedPhoto =
+                new CapturedPhoto(
+                        new byte[] {1, 2, 3}, null, CompletableFuture.completedFuture(false));
+
+        notifyPhotoCaptured(session, "/tmp/ram.jpg", capturedPhoto);
+        pendingCaptureMetadataTimeout(session).run();
+
+        verify(callback)
+                .onPhotoCaptured(eq("/tmp/ram.jpg"), (JSONObject) isNull(), eq(capturedPhoto));
+    }
+
+    @Test
+    public void copyJsonPayload_isolatesRamCallbackFromPersistencePayload() throws Exception {
+        JSONObject persistencePayload = new JSONObject().put("sampleCount", 2);
+        Method copy = PhotoSession.class.getDeclaredMethod("copyJsonPayload", JSONObject.class);
+        copy.setAccessible(true);
+
+        JSONObject callbackPayload = (JSONObject) copy.invoke(null, persistencePayload);
+        persistencePayload.put("sampleCount", 99);
+
+        assertThat(callbackPayload).isNotSameAs(persistencePayload);
+        assertThat(callbackPayload.optInt("sampleCount")).isEqualTo(2);
     }
 
     private static PhotoSession.Hooks mockConfiguredCameraHooks() {
@@ -318,6 +359,15 @@ public class PhotoSessionTest {
         Method notify = PhotoSession.class.getDeclaredMethod("notifyPhotoCaptured", String.class);
         notify.setAccessible(true);
         notify.invoke(session, filePath);
+    }
+
+    private static void notifyPhotoCaptured(
+            PhotoSession session, String filePath, CapturedPhoto capturedPhoto) throws Exception {
+        Method notify =
+                PhotoSession.class.getDeclaredMethod(
+                        "notifyPhotoCaptured", String.class, CapturedPhoto.class);
+        notify.setAccessible(true);
+        notify.invoke(session, filePath, capturedPhoto);
     }
 
     private static void notifyPhotoCaptured(

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/model/CapturedPhotoTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/model/CapturedPhotoTest.java
@@ -1,0 +1,83 @@
+package com.mentra.asg_client.camera.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/** Persistence semantics for RAM-first photo captures. */
+public class CapturedPhotoTest {
+
+    private static CapturedPhoto photo(Future<Boolean> persistence) {
+        return new CapturedPhoto(new byte[] {1, 2, 3}, null, persistence);
+    }
+
+    @Test
+    public void awaitPersistenceReflectsWriteResult() {
+        assertThat(photo(CompletableFuture.completedFuture(true)).awaitPersistence(1000)).isTrue();
+        assertThat(photo(CompletableFuture.completedFuture(false)).awaitPersistence(1000))
+                .isFalse();
+
+        CompletableFuture<Boolean> failed = new CompletableFuture<>();
+        failed.completeExceptionally(new RuntimeException("disk full"));
+        assertThat(photo(failed).awaitPersistence(1000)).isFalse();
+    }
+
+    @Test
+    public void cancelPersistencePreventsQueuedWrite() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            CountDownLatch blockFirstTask = new CountDownLatch(1);
+            executor.submit(
+                    () -> {
+                        blockFirstTask.await();
+                        return null;
+                    });
+            Future<Boolean> queuedWrite = executor.submit(() -> true);
+            CapturedPhoto photo = photo(queuedWrite);
+
+            assertThat(photo.cancelPersistence()).isTrue();
+            blockFirstTask.countDown();
+            assertThat(photo.awaitPersistence(1000)).isFalse();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    public void awaitPersistenceCompletionDoesNotFalseFailRunningWrite() throws Exception {
+        ExecutorService writer = Executors.newSingleThreadExecutor();
+        ExecutorService waiter = Executors.newSingleThreadExecutor();
+        CountDownLatch writeStarted = new CountDownLatch(1);
+        CountDownLatch finishWrite = new CountDownLatch(1);
+        try {
+            Future<Boolean> runningWrite =
+                    writer.submit(
+                            () -> {
+                                writeStarted.countDown();
+                                finishWrite.await();
+                                return true;
+                            });
+            Future<Boolean> result =
+                    waiter.submit(() -> photo(runningWrite).awaitPersistenceCompletion());
+            assertThat(writeStarted.await(1, TimeUnit.SECONDS)).isTrue();
+
+            assertThatThrownBy(() -> result.get(50, TimeUnit.MILLISECONDS))
+                    .isInstanceOf(TimeoutException.class);
+
+            finishWrite.countDown();
+            assertThat(result.get(1, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            finishWrite.countDown();
+            writer.shutdownNow();
+            waiter.shutdownNow();
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
@@ -1,0 +1,661 @@
+package com.mentra.asg_client.camera.textdetect;
+
+import static org.junit.Assume.assumeTrue;
+
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.CvInit;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import com.mentra.asg_client.io.media.core.textdetect.roi.DetectionInput;
+import com.mentra.asg_client.io.media.core.textdetect.roi.FileSystemModelSource;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfByte;
+import org.opencv.core.MatOfInt;
+import org.opencv.core.Point;
+import org.opencv.core.Rect;
+import org.opencv.core.Scalar;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Manual offline benchmark for comparing classical and ONNX text ROI detectors.
+ *
+ * <p>Run from {@code asg_client} with, for example:
+ *
+ * <pre>
+ * ./gradlew :app:testDebugUnitTest \
+ *   --tests "*TextRoiBenchmarkHarnessTest" \
+ *   -Dtextroi.inputDir=/path/to/images \
+ *   -Dtextroi.modelDir=/path/to/models \
+ *   -Dtextroi.detectors=classical,ppocr_v5_mobile_det
+ * </pre>
+ */
+@RunWith(JUnit4.class)
+public class TextRoiBenchmarkHarnessTest {
+    private static final String INPUT_DIR_PROPERTY = "textroi.inputDir";
+    private static final String OUTPUT_DIR_PROPERTY = "textroi.outputDir";
+    private static final String MODEL_DIR_PROPERTY = "textroi.modelDir";
+    private static final String DETECTORS_PROPERTY = "textroi.detectors";
+    private static final String BLE_RATE_PROPERTY = "textroi.bleBytesPerSecond";
+    private static final double DEFAULT_BLE_BYTES_PER_SECOND = 87040.0;
+    private static final int JPEG_QUALITY = 80;
+
+    /** Loads desktop OpenCV before the benchmark can run. */
+    @BeforeClass
+    public static void loadOpenCv() {
+        CvInit.ensureLoaded();
+    }
+
+    /** Runs the benchmark when {@code textroi.inputDir} is explicitly configured. */
+    @Test
+    public void benchmarkConfiguredImages() throws Exception {
+        String inputValue = System.getProperty(INPUT_DIR_PROPERTY);
+        assumeTrue(
+                "Set -D" + INPUT_DIR_PROPERTY + " to a directory of JPEG/PNG images",
+                inputValue != null && !inputValue.trim().isEmpty());
+
+        Path inputDirectory = Paths.get(inputValue).toAbsolutePath().normalize();
+        assumeTrue(
+                "Input directory does not exist: " + inputDirectory,
+                Files.isDirectory(inputDirectory));
+        List<Path> images = listImages(inputDirectory);
+        assumeTrue("No JPEG/PNG images found in " + inputDirectory, !images.isEmpty());
+
+        Path outputDirectory = resolveOutputDirectory(inputDirectory);
+        Path modelDirectory = resolveModelDirectory(inputDirectory);
+        double bleBytesPerSecond = parseBleRate();
+        List<TextCropModel> requestedModels = parseRequestedModels();
+        Files.createDirectories(outputDirectory);
+        Files.createDirectories(outputDirectory.resolve("_originals"));
+
+        TextDetectConfig config = productionEquivalentConfig();
+        FileSystemModelSource modelSource = new FileSystemModelSource(modelDirectory);
+        Map<TextCropModel, TextRoiDetector> detectors = new LinkedHashMap<>();
+        List<BenchmarkResult> results = new ArrayList<>();
+        try {
+            for (TextCropModel model : requestedModels) {
+                detectors.put(model, TextRoiDetectorFactory.create(model, config, modelSource));
+            }
+            for (Path image : images) {
+                boolean saveOriginal = true;
+                for (Map.Entry<TextCropModel, TextRoiDetector> entry : detectors.entrySet()) {
+                    BenchmarkResult result =
+                            benchmarkImage(
+                                    image,
+                                    outputDirectory,
+                                    entry.getKey(),
+                                    entry.getValue(),
+                                    bleBytesPerSecond,
+                                    saveOriginal);
+                    results.add(result);
+                    saveOriginal = false;
+                }
+            }
+            writeSummaries(outputDirectory, requestedModels, results);
+            writeIndex(outputDirectory, images, requestedModels, results);
+        } finally {
+            for (TextRoiDetector detector : detectors.values()) {
+                detector.close();
+            }
+        }
+    }
+
+    private static BenchmarkResult benchmarkImage(
+            Path image,
+            Path outputDirectory,
+            TextCropModel requested,
+            TextRoiDetector detector,
+            double bleBytesPerSecond,
+            boolean saveOriginal)
+            throws Exception {
+        Mat color = null;
+        Mat crop = null;
+        Mat overlay = null;
+        try {
+            color = Imgcodecs.imread(image.toString(), Imgcodecs.IMREAD_COLOR);
+            if (color.empty()) {
+                throw new IOException("Failed to decode image: " + image);
+            }
+            int width = color.cols();
+            int height = color.rows();
+            DetectionInput input = new DetectionInput(toLuma(color), width, height);
+
+            if (requested.assetFilename() != null && detector.id().equals(requested.id())) {
+                DetectionResult warmup = detector.detect(input);
+                releaseDebug(warmup);
+            }
+
+            long startNanos = System.nanoTime();
+            DetectionResult detection = detector.detect(input);
+            double detectionMs = (System.nanoTime() - startNanos) / 1_000_000.0;
+            try {
+                CropRect roi = CropRect.clamp(detection.roi, width, height);
+                crop = color.submat(new Rect(roi.left, roi.top, roi.width(), roi.height()));
+                overlay = color.clone();
+                Imgproc.rectangle(
+                        overlay,
+                        new Point(roi.left, roi.top),
+                        new Point(roi.right - 1, roi.bottom - 1),
+                        new Scalar(0, 0, 255),
+                        Math.max(2, Math.round(Math.min(width, height) / 300f)));
+
+                byte[] fullJpeg = encodeJpeg(color);
+                byte[] cropJpeg = encodeJpeg(crop);
+                byte[] overlayJpeg = encodeJpeg(overlay);
+                String stem = stem(image.getFileName().toString());
+                Path resultDirectory = outputDirectory.resolve(requested.id()).resolve(stem);
+                Files.createDirectories(resultDirectory);
+                Files.write(resultDirectory.resolve("crop.jpg"), cropJpeg);
+                Files.write(resultDirectory.resolve("overlay.jpg"), overlayJpeg);
+                if (saveOriginal) {
+                    Files.write(
+                            outputDirectory.resolve("_originals").resolve(stem + ".jpg"), fullJpeg);
+                }
+
+                BenchmarkResult result =
+                        BenchmarkResult.create(
+                                image.getFileName().toString(),
+                                stem,
+                                requested,
+                                detector.id(),
+                                detection,
+                                roi,
+                                width,
+                                height,
+                                detectionMs,
+                                fullJpeg.length,
+                                cropJpeg.length,
+                                bleBytesPerSecond);
+                writeUtf8(resultDirectory.resolve("result.json"), result.toJson().toString(2));
+                return result;
+            } finally {
+                releaseDebug(detection);
+            }
+        } finally {
+            if (overlay != null) {
+                overlay.release();
+            }
+            if (crop != null) {
+                crop.release();
+            }
+            if (color != null) {
+                color.release();
+            }
+        }
+    }
+
+    private static List<Path> listImages(Path inputDirectory) throws IOException {
+        try (Stream<Path> files = Files.list(inputDirectory)) {
+            return files.filter(Files::isRegularFile)
+                    .filter(TextRoiBenchmarkHarnessTest::isImage)
+                    .sorted(
+                            Comparator.comparing(
+                                            (Path path) ->
+                                                    path.getFileName()
+                                                            .toString()
+                                                            .toLowerCase(Locale.US))
+                                    .thenComparing(path -> path.getFileName().toString()))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private static boolean isImage(Path path) {
+        String name = path.getFileName().toString().toLowerCase(Locale.US);
+        return name.endsWith(".jpg") || name.endsWith(".jpeg") || name.endsWith(".png");
+    }
+
+    private static List<TextCropModel> parseRequestedModels() {
+        String configured = System.getProperty(DETECTORS_PROPERTY, TextCropModel.CLASSICAL.id());
+        Map<String, TextCropModel> modelsByName = new LinkedHashMap<>();
+        for (TextCropModel model : TextCropModel.values()) {
+            modelsByName.put(model.id(), model);
+            modelsByName.put(model.name().toLowerCase(Locale.US), model);
+        }
+        LinkedHashMap<TextCropModel, Boolean> selected = new LinkedHashMap<>();
+        for (String token : configured.split(",")) {
+            String key = token.trim().toLowerCase(Locale.US);
+            if (key.isEmpty()) {
+                continue;
+            }
+            TextCropModel model = modelsByName.get(key);
+            if (model == null) {
+                throw new IllegalArgumentException(
+                        "Unknown textroi detector '"
+                                + token.trim()
+                                + "'. Valid ids: "
+                                + modelsByName.keySet());
+            }
+            selected.put(model, Boolean.TRUE);
+        }
+        if (selected.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "textroi.detectors must select at least one detector");
+        }
+        return new ArrayList<>(selected.keySet());
+    }
+
+    private static TextDetectConfig productionEquivalentConfig() {
+        return TextDetectConfig.defaults().toBuilder()
+                .allowSingleComponentLines(true)
+                .cropFromTopLineOnly(true)
+                .enableStructureFilter(true)
+                .improvedCropAccuracy(true)
+                .minCropAreaFraction(0.004f)
+                .build();
+    }
+
+    private static Path resolveOutputDirectory(Path inputDirectory) {
+        String configured = System.getProperty(OUTPUT_DIR_PROPERTY);
+        return configured == null || configured.trim().isEmpty()
+                ? inputDirectory.resolve("_textroi_benchmark_output")
+                : Paths.get(configured).toAbsolutePath().normalize();
+    }
+
+    private static Path resolveModelDirectory(Path inputDirectory) {
+        String configured = System.getProperty(MODEL_DIR_PROPERTY);
+        return configured == null || configured.trim().isEmpty()
+                ? inputDirectory
+                : Paths.get(configured).toAbsolutePath().normalize();
+    }
+
+    private static double parseBleRate() {
+        double value =
+                Double.parseDouble(
+                        System.getProperty(
+                                BLE_RATE_PROPERTY, Double.toString(DEFAULT_BLE_BYTES_PER_SECOND)));
+        if (!Double.isFinite(value) || value <= 0) {
+            throw new IllegalArgumentException(BLE_RATE_PROPERTY + " must be positive");
+        }
+        return value;
+    }
+
+    private static byte[] toLuma(Mat color) {
+        Mat gray = new Mat();
+        try {
+            Imgproc.cvtColor(color, gray, Imgproc.COLOR_BGR2GRAY);
+            byte[] luma = new byte[(int) gray.total()];
+            gray.get(0, 0, luma);
+            return luma;
+        } finally {
+            gray.release();
+        }
+    }
+
+    private static byte[] encodeJpeg(Mat image) throws IOException {
+        MatOfByte encoded = new MatOfByte();
+        MatOfInt parameters = new MatOfInt(Imgcodecs.IMWRITE_JPEG_QUALITY, JPEG_QUALITY);
+        try {
+            if (!Imgcodecs.imencode(".jpg", image, encoded, parameters)) {
+                throw new IOException("OpenCV failed to encode JPEG");
+            }
+            return encoded.toArray();
+        } finally {
+            parameters.release();
+            encoded.release();
+        }
+    }
+
+    private static void releaseDebug(DetectionResult result) {
+        if (result != null && result.debug != null) {
+            result.debug.release();
+        }
+    }
+
+    private static void writeSummaries(
+            Path outputDirectory,
+            List<TextCropModel> requestedModels,
+            List<BenchmarkResult> results)
+            throws IOException {
+        JSONArray summaries = new JSONArray();
+        StringBuilder csv =
+                new StringBuilder(
+                        "requested_id,detector_id,count,mean_detection_ms,p50_detection_ms,"
+                                + "p95_detection_ms,mean_byte_savings_percent,fallback_rate\n");
+        for (TextCropModel model : requestedModels) {
+            List<BenchmarkResult> detectorResults =
+                    results.stream()
+                            .filter(result -> result.requested == model)
+                            .collect(Collectors.toList());
+            DetectorSummary summary = DetectorSummary.create(model, detectorResults);
+            summaries.put(summary.toJson());
+            csv.append(csv(summary.requestedId))
+                    .append(',')
+                    .append(csv(summary.detectorId))
+                    .append(',')
+                    .append(summary.count)
+                    .append(',')
+                    .append(format(summary.meanDetectionMs))
+                    .append(',')
+                    .append(format(summary.p50DetectionMs))
+                    .append(',')
+                    .append(format(summary.p95DetectionMs))
+                    .append(',')
+                    .append(format(summary.meanByteSavingsPercent))
+                    .append(',')
+                    .append(format(summary.fallbackRate))
+                    .append('\n');
+        }
+        writeUtf8(outputDirectory.resolve("summary.csv"), csv.toString());
+        writeUtf8(
+                outputDirectory.resolve("summary.json"),
+                new JSONObject().put("detectors", summaries).toString(2));
+    }
+
+    private static void writeIndex(
+            Path outputDirectory,
+            List<Path> images,
+            List<TextCropModel> requestedModels,
+            List<BenchmarkResult> results)
+            throws IOException {
+        Map<String, Map<TextCropModel, BenchmarkResult>> byImage = new LinkedHashMap<>();
+        for (BenchmarkResult result : results) {
+            byImage.computeIfAbsent(result.image, ignored -> new LinkedHashMap<>())
+                    .put(result.requested, result);
+        }
+        StringBuilder html =
+                new StringBuilder(
+                        "<!doctype html><html><head><meta charset=\"utf-8\">"
+                                + "<title>Text ROI benchmark</title><style>"
+                                + "body{font:14px sans-serif;margin:24px;color:#222}"
+                                + "table{border-collapse:collapse;width:100%;margin-bottom:32px}"
+                                + "th,td{border:1px solid #bbb;padding:8px;vertical-align:top}"
+                                + "th{background:#eee}img{max-width:320px;max-height:240px;"
+                                + "display:block;margin:0 0 8px}.metrics{white-space:pre-line}"
+                                + "</style></head><body><h1>Text ROI benchmark</h1>");
+        for (Path image : images) {
+            String imageName = image.getFileName().toString();
+            String imageStem = stem(imageName);
+            html.append("<h2>")
+                    .append(html(imageName))
+                    .append("</h2><table><thead><tr>")
+                    .append("<th>Original</th>");
+            for (TextCropModel model : requestedModels) {
+                html.append("<th>").append(html(model.id())).append("</th>");
+            }
+            html.append("</tr></thead><tbody><tr><td><img src=\"")
+                    .append(html("_originals/" + imageStem + ".jpg"))
+                    .append("\" alt=\"Original\"></td>");
+            for (TextCropModel model : requestedModels) {
+                BenchmarkResult result = byImage.get(imageName).get(model);
+                String base = model.id() + "/" + imageStem + "/";
+                html.append("<td><img src=\"")
+                        .append(html(base + "crop.jpg"))
+                        .append("\" alt=\"Crop\"><img src=\"")
+                        .append(html(base + "overlay.jpg"))
+                        .append("\" alt=\"Overlay\"><div class=\"metrics\">")
+                        .append(html(result.metricsText()))
+                        .append("</div></td>");
+            }
+            html.append("</tr></tbody></table>");
+        }
+        html.append("</body></html>");
+        writeUtf8(outputDirectory.resolve("index.html"), html.toString());
+    }
+
+    private static void writeUtf8(Path path, String value) throws IOException {
+        Files.write(path, value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static String stem(String filename) {
+        int dot = filename.lastIndexOf('.');
+        return dot > 0 ? filename.substring(0, dot) : filename;
+    }
+
+    private static String html(String value) {
+        return value.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private static String csv(String value) {
+        return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+
+    private static String format(double value) {
+        return String.format(Locale.US, "%.3f", value);
+    }
+
+    private static double percentile(List<Double> sorted, double percentile) {
+        if (sorted.isEmpty()) {
+            return 0;
+        }
+        int index = Math.max(0, (int) Math.ceil(percentile * sorted.size()) - 1);
+        return sorted.get(Math.min(index, sorted.size() - 1));
+    }
+
+    private static final class BenchmarkResult {
+        final String image;
+        final String stem;
+        final TextCropModel requested;
+        final String detectorId;
+        final double detectionMs;
+        final CropRect roi;
+        final DetectionResult.Confidence confidence;
+        final String fallbackReason;
+        final boolean fallback;
+        final double pixelFraction;
+        final double pixelReductionPercent;
+        final int fullBytes;
+        final int cropBytes;
+        final int bytesSaved;
+        final double bytesSavedPercent;
+        final double estimatedBleSecondsSaved;
+
+        private BenchmarkResult(
+                String image,
+                String stem,
+                TextCropModel requested,
+                String detectorId,
+                double detectionMs,
+                CropRect roi,
+                DetectionResult.Confidence confidence,
+                String fallbackReason,
+                boolean fallback,
+                double pixelFraction,
+                double pixelReductionPercent,
+                int fullBytes,
+                int cropBytes,
+                int bytesSaved,
+                double bytesSavedPercent,
+                double estimatedBleSecondsSaved) {
+            this.image = image;
+            this.stem = stem;
+            this.requested = requested;
+            this.detectorId = detectorId;
+            this.detectionMs = detectionMs;
+            this.roi = roi;
+            this.confidence = confidence;
+            this.fallbackReason = fallbackReason;
+            this.fallback = fallback;
+            this.pixelFraction = pixelFraction;
+            this.pixelReductionPercent = pixelReductionPercent;
+            this.fullBytes = fullBytes;
+            this.cropBytes = cropBytes;
+            this.bytesSaved = bytesSaved;
+            this.bytesSavedPercent = bytesSavedPercent;
+            this.estimatedBleSecondsSaved = estimatedBleSecondsSaved;
+        }
+
+        static BenchmarkResult create(
+                String image,
+                String stem,
+                TextCropModel requested,
+                String detectorId,
+                DetectionResult detection,
+                CropRect roi,
+                int width,
+                int height,
+                double detectionMs,
+                int fullBytes,
+                int cropBytes,
+                double bleBytesPerSecond) {
+            long fullPixels = (long) width * height;
+            double pixelFraction = roi.pixelCount() / (double) fullPixels;
+            int bytesSaved = fullBytes - cropBytes;
+            double bytesSavedPercent = bytesSaved * 100.0 / fullBytes;
+            boolean fallback = detectorId.contains("->") || detection.fallbackReason != null;
+            return new BenchmarkResult(
+                    image,
+                    stem,
+                    requested,
+                    detectorId,
+                    detectionMs,
+                    roi,
+                    detection.confidence,
+                    detection.fallbackReason,
+                    fallback,
+                    pixelFraction,
+                    (1.0 - pixelFraction) * 100.0,
+                    fullBytes,
+                    cropBytes,
+                    bytesSaved,
+                    bytesSavedPercent,
+                    bytesSaved / bleBytesPerSecond);
+        }
+
+        JSONObject toJson() {
+            return new JSONObject()
+                    .put("image", image)
+                    .put("requested_enum", requested.name())
+                    .put("requested_id", requested.id())
+                    .put("detector_id", detectorId)
+                    .put("detection_ms", detectionMs)
+                    .put("roi", new JSONArray(roi.toArray()))
+                    .put("confidence", confidence.name())
+                    .put("fallback", fallback)
+                    .put(
+                            "fallback_reason",
+                            fallbackReason == null ? JSONObject.NULL : fallbackReason)
+                    .put("pixel_fraction", pixelFraction)
+                    .put("pixel_reduction_percent", pixelReductionPercent)
+                    .put("full_bytes", fullBytes)
+                    .put("crop_bytes", cropBytes)
+                    .put("bytes_saved", bytesSaved)
+                    .put("bytes_saved_percent", bytesSavedPercent)
+                    .put("estimated_ble_seconds_saved", estimatedBleSecondsSaved);
+        }
+
+        String metricsText() {
+            return "detector: "
+                    + detectorId
+                    + "\ndetection: "
+                    + format(detectionMs)
+                    + " ms\nROI: "
+                    + java.util.Arrays.toString(roi.toArray())
+                    + "\nconfidence: "
+                    + confidence
+                    + "\nfallback: "
+                    + fallback
+                    + (fallbackReason == null ? "" : " (" + fallbackReason + ")")
+                    + "\npixels reduced: "
+                    + format(pixelReductionPercent)
+                    + "%\nbytes: "
+                    + cropBytes
+                    + " / "
+                    + fullBytes
+                    + "\nbytes saved: "
+                    + bytesSaved
+                    + " ("
+                    + format(bytesSavedPercent)
+                    + "%)\nBLE time saved: "
+                    + format(estimatedBleSecondsSaved)
+                    + " s";
+        }
+    }
+
+    private static final class DetectorSummary {
+        final String requestedId;
+        final String detectorId;
+        final int count;
+        final double meanDetectionMs;
+        final double p50DetectionMs;
+        final double p95DetectionMs;
+        final double meanByteSavingsPercent;
+        final double fallbackRate;
+
+        private DetectorSummary(
+                String requestedId,
+                String detectorId,
+                int count,
+                double meanDetectionMs,
+                double p50DetectionMs,
+                double p95DetectionMs,
+                double meanByteSavingsPercent,
+                double fallbackRate) {
+            this.requestedId = requestedId;
+            this.detectorId = detectorId;
+            this.count = count;
+            this.meanDetectionMs = meanDetectionMs;
+            this.p50DetectionMs = p50DetectionMs;
+            this.p95DetectionMs = p95DetectionMs;
+            this.meanByteSavingsPercent = meanByteSavingsPercent;
+            this.fallbackRate = fallbackRate;
+        }
+
+        static DetectorSummary create(TextCropModel requested, List<BenchmarkResult> results) {
+            List<Double> times =
+                    results.stream()
+                            .map(result -> result.detectionMs)
+                            .sorted()
+                            .collect(Collectors.toList());
+            double meanTime =
+                    results.stream().mapToDouble(result -> result.detectionMs).average().orElse(0);
+            double meanSavings =
+                    results.stream()
+                            .mapToDouble(result -> result.bytesSavedPercent)
+                            .average()
+                            .orElse(0);
+            double fallbackRate =
+                    results.stream().filter(result -> result.fallback).count()
+                            / (double) Math.max(1, results.size());
+            String detectorId = results.isEmpty() ? requested.id() : results.get(0).detectorId;
+            return new DetectorSummary(
+                    requested.id(),
+                    detectorId,
+                    results.size(),
+                    meanTime,
+                    percentile(times, 0.50),
+                    percentile(times, 0.95),
+                    meanSavings,
+                    fallbackRate);
+        }
+
+        JSONObject toJson() {
+            return new JSONObject()
+                    .put("requested_id", requestedId)
+                    .put("detector_id", detectorId)
+                    .put("count", count)
+                    .put("mean_detection_ms", meanDetectionMs)
+                    .put("p50_detection_ms", p50DetectionMs)
+                    .put("p95_detection_ms", p95DetectionMs)
+                    .put("mean_byte_savings_percent", meanByteSavingsPercent)
+                    .put("fallback_rate", fallbackRate);
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
@@ -11,22 +11,6 @@ import com.mentra.asg_client.io.media.core.textdetect.roi.FileSystemModelSource;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
-
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-import org.opencv.core.Mat;
-import org.opencv.core.MatOfByte;
-import org.opencv.core.MatOfInt;
-import org.opencv.core.Point;
-import org.opencv.core.Rect;
-import org.opencv.core.Scalar;
-import org.opencv.imgcodecs.Imgcodecs;
-import org.opencv.imgproc.Imgproc;
-
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -40,6 +24,21 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfByte;
+import org.opencv.core.MatOfInt;
+import org.opencv.core.Point;
+import org.opencv.core.Rect;
+import org.opencv.core.Scalar;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.opencv.imgproc.Imgproc;
 
 /**
  * Manual offline benchmark for comparing classical and ONNX text ROI detectors.
@@ -329,7 +328,7 @@ public class TextRoiBenchmarkHarnessTest {
             Path outputDirectory,
             List<TextCropModel> requestedModels,
             List<BenchmarkResult> results)
-            throws IOException {
+            throws Exception {
         JSONArray summaries = new JSONArray();
         StringBuilder csv =
                 new StringBuilder(
@@ -539,7 +538,7 @@ public class TextRoiBenchmarkHarnessTest {
                     bytesSaved / bleBytesPerSecond);
         }
 
-        JSONObject toJson() {
+        JSONObject toJson() throws JSONException {
             return new JSONObject()
                     .put("image", image)
                     .put("requested_enum", requested.name())
@@ -646,7 +645,7 @@ public class TextRoiBenchmarkHarnessTest {
                     fallbackRate);
         }
 
-        JSONObject toJson() {
+        JSONObject toJson() throws JSONException {
             return new JSONObject()
                     .put("requested_id", requestedId)
                     .put("detector_id", detectorId)

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiBenchmarkHarnessTest.java
@@ -141,9 +141,13 @@ public class TextRoiBenchmarkHarnessTest {
             }
             int width = color.cols();
             int height = color.rows();
-            DetectionInput input = new DetectionInput(toLuma(color), width, height);
+            // ML Kit decodes the original sensor JPEG bytes directly rather than pre-extracted
+            // luma, so the harness also reads the file's raw bytes for detectors that need them.
+            byte[] jpegBytes = requested == TextCropModel.ML_KIT ? Files.readAllBytes(image) : null;
+            DetectionInput input = new DetectionInput(toLuma(color), width, height, jpegBytes);
 
-            if (requested.assetFilename() != null && detector.id().equals(requested.id())) {
+            if ((requested.assetFilename() != null || requested == TextCropModel.ML_KIT)
+                    && detector.id().equals(requested.id())) {
                 DetectionResult warmup = detector.detect(input);
                 releaseDebug(warmup);
             }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiDetectorTest.java
@@ -18,16 +18,14 @@ import com.mentra.asg_client.io.media.core.textdetect.roi.OnnxYoloRoiDetector;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
 import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
-
-import org.junit.BeforeClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 /** Focused contract tests for swappable text ROI detectors and static neural postprocessing. */
 @RunWith(JUnit4.class)

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/textdetect/TextRoiDetectorTest.java
@@ -1,0 +1,168 @@
+package com.mentra.asg_client.camera.textdetect;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import com.mentra.asg_client.io.media.core.textdetect.CropRect;
+import com.mentra.asg_client.io.media.core.textdetect.CvInit;
+import com.mentra.asg_client.io.media.core.textdetect.DetectionResult;
+import com.mentra.asg_client.io.media.core.textdetect.TextDetectConfig;
+import com.mentra.asg_client.io.media.core.textdetect.TextRegionDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.DetectionInput;
+import com.mentra.asg_client.io.media.core.textdetect.roi.FileSystemModelSource;
+import com.mentra.asg_client.io.media.core.textdetect.roi.OnnxDbNetRoiDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.OnnxYoloRoiDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextCropModel;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetector;
+import com.mentra.asg_client.io.media.core.textdetect.roi.TextRoiDetectorFactory;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+/** Focused contract tests for swappable text ROI detectors and static neural postprocessing. */
+@RunWith(JUnit4.class)
+public class TextRoiDetectorTest {
+    /** Loads desktop OpenCV before detector tests execute. */
+    @BeforeClass
+    public static void loadOpenCv() {
+        CvInit.ensureLoaded();
+    }
+
+    /** Verifies that the classical adapter preserves every deterministic result field. */
+    @Test
+    public void classicalWrapper_matchesDirectDetectorFieldForField() {
+        int width = 160;
+        int height = 96;
+        byte[] luma = syntheticLuma(width, height);
+        TextDetectConfig config = productionConfig();
+
+        DetectionResult direct = TextRegionDetector.detect(luma, width, height, config);
+        DetectionResult wrapped;
+        try (TextRoiDetector detector =
+                TextRoiDetectorFactory.create(TextCropModel.CLASSICAL, config, null)) {
+            wrapped = detector.detect(new DetectionInput(luma, width, height));
+        }
+
+        assertResultFieldsEqual(direct, wrapped);
+        assertTrue(direct.detectionTimeMs >= 0);
+        assertTrue(wrapped.detectionTimeMs >= 0);
+    }
+
+    /** Verifies that an absent PPOCR model produces an identified classical fallback. */
+    @Test
+    public void factory_missingModel_fallsBackToMatchingClassical() throws Exception {
+        int width = 160;
+        int height = 96;
+        byte[] luma = syntheticLuma(width, height);
+        DetectionInput input = new DetectionInput(luma, width, height);
+        TextDetectConfig config = productionConfig();
+        Path emptyModelDirectory = Files.createTempDirectory("text-roi-models");
+
+        DetectionResult expected = TextRegionDetector.detect(luma, width, height, config);
+        try (TextRoiDetector detector =
+                TextRoiDetectorFactory.create(
+                        TextCropModel.PPOCR_V5_MOBILE_DET,
+                        config,
+                        new FileSystemModelSource(emptyModelDirectory))) {
+            assertEquals("ppocr_v5_mobile_det->classical", detector.id());
+            assertResultFieldsEqual(expected, detector.detect(input));
+        } finally {
+            Files.deleteIfExists(emptyModelDirectory);
+        }
+    }
+
+    /** Verifies that a positive DBNet map produces a genuine, non-fallback crop. */
+    @Test
+    public void dbNetPostprocess_positiveRectangle_returnsDetection() {
+        float[][] probabilities = new float[16][16];
+        for (int y = 5; y < 11; y++) {
+            Arrays.fill(probabilities[y], 4, 12, 0.9f);
+        }
+
+        DetectionResult result = OnnxDbNetRoiDetector.postprocess(probabilities, 160, 160, 7);
+
+        assertNull(result.fallbackReason);
+        assertEquals(DetectionResult.Confidence.MEDIUM, result.confidence);
+        assertTrue(result.acceptedComponentCount > 0);
+        assertTrue(result.roi.pixelCount() < 160 * 160);
+    }
+
+    /** Verifies that an all-background DBNet map uses the standard fallback. */
+    @Test
+    public void dbNetPostprocess_blankMap_returnsFallback() {
+        DetectionResult result = OnnxDbNetRoiDetector.postprocess(new float[16][16], 160, 160, 3);
+
+        assertEquals("no_text_boxes", result.fallbackReason);
+        assertEquals(DetectionResult.Confidence.LOW, result.confidence);
+        assertArrayEquals(new int[] {20, 20, 120, 120}, result.roi.toArray());
+    }
+
+    /** Verifies YOLO confidence filtering and overlap suppression in one basic case. */
+    @Test
+    public void yoloParseDetections_filtersConfidenceAndAppliesNms() {
+        float[][] predictions = {
+            {50f, 50f, 40f, 20f, 0.90f},
+            {52f, 50f, 40f, 20f, 0.80f},
+            {15f, 15f, 10f, 10f, 0.39f},
+            {85f, 80f, 12f, 10f, 0.70f}
+        };
+
+        List<float[]> retained = OnnxYoloRoiDetector.parseDetections(predictions, 100, 100);
+
+        assertEquals(2, retained.size());
+        assertArrayEquals(new float[] {30f, 40f, 70f, 60f, 0.90f}, retained.get(0), 0.0001f);
+        assertArrayEquals(new float[] {79f, 75f, 91f, 85f, 0.70f}, retained.get(1), 0.0001f);
+    }
+
+    private static TextDetectConfig productionConfig() {
+        return TextDetectConfig.defaults().toBuilder()
+                .allowSingleComponentLines(true)
+                .cropFromTopLineOnly(true)
+                .enableStructureFilter(true)
+                .improvedCropAccuracy(true)
+                .minCropAreaFraction(0.004f)
+                .build();
+    }
+
+    private static byte[] syntheticLuma(int width, int height) {
+        byte[] luma = new byte[width * height];
+        Arrays.fill(luma, (byte) 255);
+        for (int glyphLeft = 28; glyphLeft < 126; glyphLeft += 14) {
+            fill(luma, width, glyphLeft, 38, glyphLeft + 3, 58);
+            fill(luma, width, glyphLeft + 7, 38, glyphLeft + 10, 58);
+            fill(luma, width, glyphLeft, 47, glyphLeft + 10, 50);
+        }
+        return luma;
+    }
+
+    private static void fill(byte[] luma, int width, int left, int top, int right, int bottom) {
+        for (int y = top; y < bottom; y++) {
+            Arrays.fill(luma, y * width + left, y * width + right, (byte) 0);
+        }
+    }
+
+    private static void assertResultFieldsEqual(DetectionResult expected, DetectionResult actual) {
+        assertCropEquals(expected.roi, actual.roi);
+        assertEquals(expected.confidence, actual.confidence);
+        assertEquals(expected.selectedPolarity, actual.selectedPolarity);
+        assertEquals(expected.acceptedComponentCount, actual.acceptedComponentCount);
+        assertEquals(expected.lineCount, actual.lineCount);
+        assertEquals(expected.fallbackReason, actual.fallbackReason);
+        assertEquals(expected.debug, actual.debug);
+    }
+
+    private static void assertCropEquals(CropRect expected, CropRect actual) {
+        assertFalse("expected crop must be non-empty", expected.pixelCount() == 0);
+        assertArrayEquals(expected.toArray(), actual.toArray());
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/MediaCaptureServiceDecodeSamplingTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/MediaCaptureServiceDecodeSamplingTest.java
@@ -1,0 +1,32 @@
+package com.mentra.asg_client.io.media.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class MediaCaptureServiceDecodeSamplingTest {
+
+    @Test
+    public void subsamplesLandscapeSensorFrameToSquareCap() {
+        assertThat(MediaCaptureService.computeBleDecodeSampleSize(4032, 3024, 1920, 1920))
+                .isEqualTo(2);
+    }
+
+    @Test
+    public void subsamplesPortraitSensorFrameToSquareCap() {
+        assertThat(MediaCaptureService.computeBleDecodeSampleSize(3024, 4032, 1920, 1920))
+                .isEqualTo(2);
+    }
+
+    @Test
+    public void usesAspectFittedOutputRatherThanFullTargetBox() {
+        assertThat(MediaCaptureService.computeBleDecodeSampleSize(4000, 1000, 1920, 1920))
+                .isEqualTo(2);
+    }
+
+    @Test
+    public void doesNotSubsampleRegionSmallerThanTargetCap() {
+        assertThat(MediaCaptureService.computeBleDecodeSampleSize(824, 1216, 1920, 1920))
+                .isEqualTo(1);
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
@@ -1,0 +1,161 @@
+package com.mentra.asg_client.io.media.core.textdetect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.graphics.Bitmap;
+import android.graphics.Rect;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import com.google.mlkit.vision.text.Text;
+import com.google.mlkit.vision.text.TextRecognizer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class MlKitTextRoiDetectorTest {
+
+    @Test
+    public void paddedUnionCombinesLinesAndKeepsContext() {
+        Rect roi =
+                MlKitTextRoiDetector.buildPaddedUnion(
+                        Arrays.asList(new Rect(100, 200, 300, 240), new Rect(120, 260, 420, 300)),
+                        1000,
+                        800);
+
+        // Union is [100,200]-[420,300]. Padding is max(32px, 12%/25% of union size).
+        assertThat(roi).isEqualTo(new Rect(62, 168, 458, 332));
+    }
+
+    @Test
+    public void paddedUnionClampsToSourceBounds() {
+        Rect roi =
+                MlKitTextRoiDetector.buildPaddedUnion(
+                        Collections.singletonList(new Rect(5, 8, 95, 92)), 100, 100);
+
+        assertThat(roi).isEqualTo(new Rect(0, 0, 100, 100));
+    }
+
+    @Test
+    public void singleLineKeepsGenerousSurroundingContext() {
+        Rect roi =
+                MlKitTextRoiDetector.buildPaddedUnion(
+                        Collections.singletonList(new Rect(400, 500, 700, 550)), 1200, 1000);
+
+        // A 50px-high lone line gets 3x height horizontally, 4x above, and 11x below.
+        assertThat(roi).isEqualTo(new Rect(250, 300, 850, 1000));
+    }
+
+    @Test
+    public void paddedUnionRejectsMissingOrInvalidBoxes() {
+        assertThat(MlKitTextRoiDetector.buildPaddedUnion(Collections.emptyList(), 100, 100))
+                .isNull();
+        assertThat(
+                        MlKitTextRoiDetector.buildPaddedUnion(
+                                Collections.singletonList(new Rect(20, 20, 20, 40)), 100, 100))
+                .isNull();
+    }
+
+    @Test
+    public void failedWarmupCompletionClearsOnlyCurrentTask() throws Exception {
+        TextRecognizer recognizer = mock(TextRecognizer.class);
+        MlKitTextRoiDetector detector = new MlKitTextRoiDetector(1280, recognizer);
+        Task<Text> currentTask = mock(Task.class);
+        Task<Text> staleTask = mock(Task.class);
+        when(currentTask.isSuccessful()).thenReturn(false);
+        when(staleTask.isSuccessful()).thenReturn(false);
+        Field warmupTask = MlKitTextRoiDetector.class.getDeclaredField("warmupTask");
+        warmupTask.setAccessible(true);
+        Method handleCompletion =
+                MlKitTextRoiDetector.class.getDeclaredMethod("handleWarmupCompletion", Task.class);
+        handleCompletion.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        AtomicReference<Task<Text>> warmupTaskReference =
+                (AtomicReference<Task<Text>>) warmupTask.get(detector);
+        warmupTaskReference.set(currentTask);
+
+        handleCompletion.invoke(detector, staleTask);
+        assertThat(warmupTaskReference.get()).isSameAs(currentTask);
+
+        handleCompletion.invoke(detector, currentTask);
+        assertThat(warmupTaskReference.get()).isNull();
+        detector.close();
+    }
+
+    @Test
+    public void pendingDetectionTaskDefersBitmapRecycleUntilCompletion() {
+        Bitmap decoded = Bitmap.createBitmap(32, 24, Bitmap.Config.ARGB_8888);
+        Bitmap analysis = Bitmap.createBitmap(16, 12, Bitmap.Config.ARGB_8888);
+        TaskCompletionSource<Text> pending = new TaskCompletionSource<>();
+
+        MlKitTextRoiDetector.recycleBitmapsAfterTask(pending.getTask(), analysis, decoded);
+
+        assertThat(analysis.isRecycled()).isFalse();
+        assertThat(decoded.isRecycled()).isFalse();
+
+        pending.setResult(mock(Text.class));
+
+        assertThat(analysis.isRecycled()).isTrue();
+        assertThat(decoded.isRecycled()).isTrue();
+    }
+
+    @Test
+    public void completedDetectionTaskRecyclesBitmapsImmediately() {
+        Bitmap decoded = Bitmap.createBitmap(32, 24, Bitmap.Config.ARGB_8888);
+        TaskCompletionSource<Text> completed = new TaskCompletionSource<>();
+        completed.setResult(mock(Text.class));
+
+        MlKitTextRoiDetector.recycleBitmapsAfterTask(completed.getTask(), decoded, decoded);
+
+        assertThat(decoded.isRecycled()).isTrue();
+    }
+
+    @Test
+    public void warmupDoesNotWaitForDetectionMonitor() throws Exception {
+        TextRecognizer recognizer = mock(TextRecognizer.class);
+        MlKitTextRoiDetector detector = new MlKitTextRoiDetector(1280, recognizer);
+        Field warmupTaskField = MlKitTextRoiDetector.class.getDeclaredField("warmupTask");
+        warmupTaskField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        AtomicReference<Task<Text>> warmupTaskReference =
+                (AtomicReference<Task<Text>>) warmupTaskField.get(detector);
+        warmupTaskReference.set(mock(Task.class));
+        CountDownLatch monitorHeld = new CountDownLatch(1);
+        CountDownLatch releaseMonitor = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> holder =
+                    executor.submit(
+                            () -> {
+                                synchronized (detector) {
+                                    monitorHeld.countDown();
+                                    releaseMonitor.await();
+                                }
+                                return null;
+                            });
+            assertThat(monitorHeld.await(1, TimeUnit.SECONDS)).isTrue();
+
+            Future<?> warmup = executor.submit(detector::warmUp);
+            warmup.get(1, TimeUnit.SECONDS);
+
+            releaseMonitor.countDown();
+            holder.get(1, TimeUnit.SECONDS);
+        } finally {
+            releaseMonitor.countDown();
+            executor.shutdownNow();
+            detector.close();
+        }
+    }
+}

--- a/asg_client/docs/agents/TEXTROI_BENCHMARK_FINDINGS.md
+++ b/asg_client/docs/agents/TEXTROI_BENCHMARK_FINDINGS.md
@@ -10,7 +10,9 @@ Test device: Mentra Live, Android 11 (API 30), MediaTek MT8766B/MT6761 class SoC
 
 The detector interface, factory, model source abstraction, cached-session intent, documentation, and artifact-producing benchmark harness are useful scaffolding. Keep those ideas.
 
-Do not enable or ship the neural crop path in its current form, and do not treat the current benchmark as a model bakeoff. The implementation does not use the official preprocessing or DB postprocessing for the PaddleOCR models; the fallback deletes the outer 25% of the image precisely when detection is uncertain; the benchmark has no text-retention ground truth; and the tested ONNX path is too slow and memory-heavy on Mentra Live.
+Do not enable or ship the PR's neural crop path in its current form, and do not treat the current benchmark as a model bakeoff. The implementation does not use the official preprocessing or DB postprocessing for the PaddleOCR models; the fallback deletes the outer 25% of the image precisely when detection is uncertain; and the benchmark has no text-retention ground truth.
+
+Sub-second on-glasses detection is achievable. An independent implementation of the official PP-OCRv6 tiny pipeline ran a correct 480-long-edge case in about 266 ms warm on Mentra Live, versus about 900 ms for the PR path. ML Kit at 640 long edge ran in about 97-151 ms after the camera settled and 462-634 ms immediately after real capture/camera teardown. ML Kit 640 is the current practical leader, but the image set is much too small for a production accuracy decision.
 
 The current PR should remain a draft or receive changes before merge. A safe merge would need to be explicitly framed as disabled experimental scaffolding, with the issues below tracked and no claim that the listed model families have been validated.
 
@@ -25,6 +27,9 @@ All tests used the PR code at commit `0028ce33180ac7578f78c7836d029d29de90b67c` 
 - Bundled ML Kit Latin text recognition as an external, turnkey baseline.
 - Clean `origin/dev` versus PR APK-size builds.
 - Official PaddleOCR-style preprocessing and DB postprocessing on the host for PP-OCRv5 mobile and PP-OCRv6 tiny.
+- An independent detector-only port of the current official PaddleOCR Android preprocessing, DB postprocessing, and PP-OCRv6 tiny model on the physical glasses at 320/480/640/960 long edge and 1/2/4 CPU threads.
+- ML Kit and official PP-OCRv6 tiny against a new 1280x960 SDK-medium capture containing several small text regions.
+- Two complete cold camera-request-to-encoded-ROI runs using ML Kit at 640 long edge, including camera release and immediate post-capture contention.
 - One attempted physical BLE transfer. It timed out after packet 88 of 893, so it is not reported as completed goodput.
 
 This is a diagnostic benchmark, not an accuracy study. The image set is far too small to rank models for production.
@@ -93,16 +98,62 @@ The official Android implementation uses color-aware input, aspect-preserving re
 
 Both found the real printed line, and PP-OCRv6 tiny returned no boxes on the no-text frame. These Mac host times are not comparable to the A53 device times. The qualitative result is the important part: the model can work on the image when its intended pipeline is used. The current PR's fixed-square grayscale path is the primary correctness problem, not evidence that PaddleOCR itself is unsuitable.
 
-### ML Kit baseline
+### Official PP-OCRv6 tiny on Mentra Live
 
-Bundled ML Kit Latin text recognition 16.0.1 was run six times on the same frame:
+An independent instrumentation app used the current official Android preprocessing and DB postprocessing, detection only, aspect-preserving resize aligned to 32, ONNX Runtime CPU, and a generous padded crop. The input was the same 1920x1080 JPEG containing one printed line. Each row is three warm measured calls after one warmup.
+
+| Threads | Long edge | Detector times | Result |
+| ---: | ---: | --- | --- |
+| 1 | 480 | 474, 459, 456 ms | Correct line box |
+| 2 | 480 | 327, 319, 314 ms | Correct line box |
+| 4 | 320 | 164, 160, 161 ms | Rejected: clipped most of the line |
+| 4 | 480 | 273, 266, 265 ms | Correct line box; 5 ms encode; 17,109 B payload |
+| 4 | 640 | 445, 432, 432 ms | Correct line box; 5 ms encode; 18,981 B payload |
+| 4 | 960 | 962, 919, 913 ms | Correct, but no useful latency tradeoff |
+
+JPEG decode was 38 ms. The winning correct 480/4-thread path therefore took about 309 ms from existing JPEG bytes to encoded ROI. Model/session load was about 262-266 ms after the first-ever load and should occur before capture, not on the critical path. At 480/4 threads the two no-text frames returned zero boxes in 312-329 ms; full-frame fallback encoding took another 21-38 ms.
+
+This is the critical diagnosis: PP-OCRv6 tiny is not intrinsically a one-second detector on this device. The PR made it slow and inaccurate by distorting every frame to 640x640, discarding color, using a generic connected-component postprocessor, leaving CPU options untuned, and allocating/copying through the Java path. The official 480 tensor was 1x3x352x480, about 41% of the PR's 640x640 pixel count.
+
+The result is not a universal win. On a second 1280x960 capture with several much smaller text regions, 480 returned no boxes in 327-330 ms. At 640 it took 575-622 ms and returned an overly large region. Paddle would need threshold/input-size tuning and a real recall dataset before production use.
+
+### ML Kit baseline and current leader
+
+Bundled ML Kit Latin text recognition 16.0.1 was run repeatedly. Recognition strings were poor, but recognition accuracy is irrelevant if only localization boxes are consumed.
 
 | Input | Timings | Warm median | Output |
 | --- | --- | ---: | --- |
-| 1920x1080 | 667, 317, 220, 226, 308, 219 ms | 226 ms | 1 block, 1 line, 2 elements; approximate text `SWEE ENER` |
-| 640x360 | 205, 185, 437, 295, 308, 261 ms | 295 ms | 1 block, 1 line, 1 element; approximate text `5WEELNEB` |
+| 1920x1080 printed-line frame | 255, 220, 219, 288, 253 ms | 253 ms | Correct line box |
+| 960x540 printed-line frame | 93, 115, 156, 338, 258 ms | 156 ms | Correct line box |
+| 640x360 printed-line frame | 97, 97, 95, 106, 94 ms | 97 ms | Correct line box; recognition poor |
+| 1280x960 small-text frame | 304, 247, 178, 175, 179 ms | 179 ms | Three text lines localized |
+| 768x576 small-text frame | 93, 88, 91, 84, 87 ms | 88 ms | Missed a separate lower text region |
+| 640x480 small-text frame | 140, 146, 142, 146, 151 ms | 146 ms | Two regions whose padded union retained the relevant text |
+| 512x384 small-text frame | 151, 101, 104, 515, 300 ms | 151 ms | Zero boxes; reject |
+| 480x360 small-text frame | 67, 69, 70, 66, 69 ms | 69 ms | Zero boxes; reject |
 
-ML Kit localized the printed line and was much faster than the PR's ONNX path, but recognition was poor and the lower-resolution run was not faster in this small sample. The bundled dependency increased this monorepo's universal APK by about 20 MB in the test build, larger than Google's approximately 4 MB-per-script-per-architecture guidance because both native ABIs were packaged. It is a useful baseline, not an automatic winner.
+ML Kit returned zero boxes on both no-text frames. At 640 long edge, decode + scale + warm detection + padded crop encode was about 150-200 ms on the saved frames. The bundled dependency increased this monorepo's universal APK by about 20 MB in the test build, larger than Google's approximately 4 MB-per-script-per-architecture guidance because both native ABIs were packaged.
+
+ML Kit 640 is the best candidate measured so far: materially faster than official PP-OCRv6, no separate ONNX runtime integration, and better small-text behavior in the new capture. This is a provisional engineering choice, not a production accuracy conclusion.
+
+### Camera request to ready payload
+
+Two cold SDK-medium (1280x960) captures were measured from `enqueuePhotoRequest` through an encoded ML Kit-selected JPEG payload. The recognizer was initialized and warmed before the request.
+
+| Stage | Run 1 | Run 2 |
+| --- | ---: | ---: |
+| Cold camera request to saved JPEG callback | 2,237 ms | 3,007 ms |
+| Wait for post-photo camera state and request close | 442 ms | 182 ms |
+| JPEG decode | 38 ms | 50 ms |
+| Scale to 640x480 | 13 ms | 13 ms |
+| Immediate post-camera ML Kit detection | 634 ms | 462 ms |
+| Padded crop encode | 2 ms | 9 ms |
+| Callback to ready payload | about 1,129 ms | about 716 ms |
+| Full request to ready payload | 3,367 ms | 3,725 ms |
+
+The camera's 2.2-3.0 second cold startup/capture is pre-existing and dominates total latency. It must not be attributed to text detection. The same captured frame ran at a 140-151 ms detector time after the camera settled, proving that the 462-634 ms immediate result is camera/ISP teardown and CPU contention rather than image difficulty.
+
+The architecture should remain entirely on-glasses: retain the captured full-resolution JPEG, run a warmed detector locally on a downscaled bitmap (or correlated YUV analysis frame), then crop and transmit once. No phone preview round trip and no double image transfer are required. For a one-shot text ROI request, the camera keep-alive should be disabled or released promptly so the ISP does not compete with inference.
 
 ### APK footprint
 
@@ -137,7 +188,7 @@ Use or faithfully port the official PaddleOCR Android detector preprocessing and
 
 Every empty map, no-box result, inference exception, or untrustworthy classical result returns a centered 75%-by-75% crop. That removes the outer 12.5% on every side when the system has the least evidence about where text is. Edge text is a normal glasses-camera case.
 
-On uncertainty, send the full frame. If bandwidth requires a degraded fallback, send a lower-quality full-frame preview and allow a phone/server decision or a second capture. A center crop must not be called a safety fallback.
+On uncertainty, send the retained full frame once at the chosen quality. A center crop must not be called a safety fallback. A phone-assisted preview/coordinate round trip is inappropriate here because BLE image transfer itself takes seconds and would create a second transfer before the useful payload.
 
 ### 3. The benchmark rewards destructive crops
 
@@ -145,9 +196,9 @@ The harness reports latency, crop size, JPEG byte savings, and an estimated BLE 
 
 The primary release gate must be text retention: all readable ground-truth polygons contained with a margin, plus explicit accounting for clipped and missed text. Byte savings and latency are secondary after correctness.
 
-### 4. Current latency, memory, and package cost are not viable
+### 4. The PR implementation's latency, memory, and package cost are not viable
 
-On this Cortex-A53 device, the fastest neural result was about 900 ms warm before JPEG crop/encode, versus roughly 123-242 ms for classical approaches and 226 ms warm for the ML Kit baseline. ONNX Runtime added about 47.6 MiB to the universal release APK, and inference produced large PSS/native-heap increases.
+On this Cortex-A53 device, the PR's fastest neural result was about 900 ms warm before JPEG crop/encode. The corrected official PP-OCRv6 path reached 266 ms and ML Kit reached 97-151 ms on saved frames, proving the PR path is the problem rather than a fundamental device limit. The PR's ONNX Runtime dependency still added about 47.6 MiB to the universal release APK, and its inference produced large PSS/native-heap increases.
 
 This cost can exceed the transfer time saved unless the crop is both very small and correct. The only extremely small payload observed was not correct enough to ship.
 
@@ -183,12 +234,12 @@ Primary metrics:
 
 ### Candidate matrix
 
-1. Official PaddleOCR Android pipeline, detection only:
+1. Bundled ML Kit Latin at 640 long edge as the current leader, fed Camera2 YUV rather than a decoded bitmap where safe correlation with the retained still is possible.
+2. Official PaddleOCR Android pipeline, detection only:
    - PP-OCRv6 tiny at aspect-preserved 640 and 960 long edge.
    - PP-OCRv5 mobile at the same sizes.
    - PP-OCRv6 small only if accuracy materially improves enough to justify its measured 1.73 s warm latency.
-2. Bundled ML Kit Latin as the turnkey baseline, fed Camera2 YUV rather than a decoded bitmap where possible.
-3. Runtime bakeoff for the winning Paddle model:
+3. Runtime bakeoff only if a Paddle candidate beats ML Kit on the ground-truthed recall set:
    - ONNX Runtime default CPU with measured thread counts.
    - A reduced-operator/custom ONNX Runtime arm64 build.
    - ncnn CPU/NEON and Vulkan.
@@ -201,10 +252,10 @@ Do not invest in NNAPI on this hardware: no vendor NNAPI service/driver was visi
 
 1. Analyze an aspect-preserved low-resolution frame.
 2. If every detected polygon passes confidence/geometry checks, transmit their union with generous fixed and relative padding.
-3. If there is no text or any uncertainty, transmit the full frame, optionally at lower quality, or send a coarse full preview followed by a phone/server retry decision.
+3. If there is no text or any uncertainty, transmit the retained full frame once at the selected quality.
 4. Record the detector, model/runtime version, confidence, fallback reason, ROI, stage timings, memory, encoded bytes, and final transfer result for every capture.
 
-An initial performance target should be under 200 ms detector time on Mentra Live, subject to the zero-clipped-text gate. The current ONNX implementation is about 4-9x beyond that target.
+An initial steady-state target should be under 200 ms detector time and under 700 ms p50 from saved-JPEG callback to encoded payload on Mentra Live, subject to the zero-clipped-text gate. Also measure immediate post-camera p95/p99: the first two runs were 462-634 ms for inference because the active camera/ISP competed for this small SoC.
 
 ## Primary references
 
@@ -223,4 +274,4 @@ An initial performance target should be under 200 ms detector time on Mentra Liv
 
 ## Bottom line
 
-The PR brings the right architectural question—make text ROI detection replaceable and measurable—but the current implementation answers the model question before defining or measuring the safety objective. Preserve the abstraction and benchmark artifacts; replace the Paddle pipeline with the official algorithm, make uncertainty full-frame-safe, build a ground-truthed Mentra dataset, and then select model/runtime based on text retention first and end-to-end device cost second.
+The PR brings the right architectural question—make text ROI detection replaceable and measurable—but its PP-OCR path is technically incorrect and creates a false impression that light on-glasses inference must take more than a second. It does not. The best measured path is currently warmed ML Kit at a 640-pixel long edge, with a generous padded crop and full-frame-on-uncertainty fallback; official PP-OCRv6 is a slower second candidate. Keep the full-resolution JPEG on the glasses, detect locally, and transmit exactly once. Preserve the abstraction and benchmark artifacts, but do not ship the PR's detector implementation without a ground-truthed Mentra recall set and immediate post-camera latency distribution.

--- a/asg_client/docs/agents/TEXTROI_BENCHMARK_FINDINGS.md
+++ b/asg_client/docs/agents/TEXTROI_BENCHMARK_FINDINGS.md
@@ -1,0 +1,226 @@
+# Text ROI detector benchmark and review findings
+
+Date: 2026-07-16
+
+PR: #3463, `cursor/swappable-text-roi-9c21`
+
+Test device: Mentra Live, Android 11 (API 30), MediaTek MT8766B/MT6761 class SoC, 4x Cortex-A53, 2 GB RAM, PowerVR GE8300 GPU
+
+## Executive decision
+
+The detector interface, factory, model source abstraction, cached-session intent, documentation, and artifact-producing benchmark harness are useful scaffolding. Keep those ideas.
+
+Do not enable or ship the neural crop path in its current form, and do not treat the current benchmark as a model bakeoff. The implementation does not use the official preprocessing or DB postprocessing for the PaddleOCR models; the fallback deletes the outer 25% of the image precisely when detection is uncertain; the benchmark has no text-retention ground truth; and the tested ONNX path is too slow and memory-heavy on Mentra Live.
+
+The current PR should remain a draft or receive changes before merge. A safe merge would need to be explicitly framed as disabled experimental scaffolding, with the issues below tracked and no claim that the listed model families have been validated.
+
+## What was tested
+
+All tests used the PR code at commit `0028ce33180ac7578f78c7836d029d29de90b67c` unless explicitly marked as an external baseline. Test-only model assets and instrumentation were not committed.
+
+- Host harness on three real Mentra captures: one 1920x1080 frame containing a printed line, and two 960x720 low/no-text frames.
+- Full capture/compress path on the physical glasses for the three classical options and PP-OCRv6 tiny.
+- Direct on-device detector runs against the same 1920x1080 captured frame for PP-OCRv5 mobile, PP-OCRv6 tiny, and PP-OCRv6 small. Each model had one cold-ish measured iteration followed by three warm iterations.
+- ONNX Runtime CPU default versus the documented XNNPACK configuration for PP-OCRv6 tiny.
+- Bundled ML Kit Latin text recognition as an external, turnkey baseline.
+- Clean `origin/dev` versus PR APK-size builds.
+- Official PaddleOCR-style preprocessing and DB postprocessing on the host for PP-OCRv5 mobile and PP-OCRv6 tiny.
+- One attempted physical BLE transfer. It timed out after packet 88 of 893, so it is not reported as completed goodput.
+
+This is a diagnostic benchmark, not an accuracy study. The image set is far too small to rank models for production.
+
+## Results
+
+### Existing host harness
+
+| Detector | Mean detection | p50 | p95 | Mean JPEG-byte savings | Fallback rate |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Classical | 14.236 ms | 6.726 ms | 30.897 ms | 71.692% | 66.7% |
+| SWT | 10.081 ms | 7.133 ms | 17.855 ms | 62.262% | 100% |
+| MSER | 17.657 ms | 15.341 ms | 22.916 ms | 62.308% | 66.7% |
+
+These numbers look favorable but are misleading without ground truth:
+
+- Classical reported `HIGH` confidence and 74.5% byte savings on the text frame, but visual inspection showed that its crop began below the only printed text line.
+- SWT included the text band but clipped its top/left portion and then failed its polarity trust check.
+- MSER fell back on the text frame and falsely selected bright reflections on a no-text frame.
+- A single warmup and one measured call per image cannot produce meaningful percentile estimates.
+
+### Full capture/compress path on Mentra Live
+
+The first four rows used adjacent 1920x1080 captures of the same desk/cup scene. The XNNPACK rows used adjacent 4032x3024 captures after app data was reset by instrumentation.
+
+| Detector/runtime | Detector time | Result | Encoded transfer payload | Observation |
+| --- | ---: | --- | ---: | --- |
+| Classical | 229 ms | Untrustworthy; 75% center fallback | 339,136 B | Detected components but rejected its own result |
+| SWT | 242 ms | Polarity disagreement; 75% center fallback | 339,246 B | No reliable crop |
+| MSER | 123 ms | Untrustworthy; 75% center fallback | 357,310 B | No reliable crop |
+| PP-OCRv6 tiny, ORT CPU, first | 1,138 ms | Zero boxes; 75% center fallback | 347,589 B | Session initialization was about 575 ms |
+| PP-OCRv6 tiny, ORT CPU, next | 1,037 ms | One 236x32 crop, upscaled to 1920x260 | 34,436 B | Crop contained the printed line but clipped it badly and omitted other visible writing |
+| PP-OCRv6 tiny, ORT CPU, 4K | 1,198 / 1,051 ms | 24 then 43 components | 410,582 / 307,249 B | Large and unstable union crops on the same scene |
+| PP-OCRv6 tiny, XNNPACK, 4K | 1,627 / 1,504 ms | Large horizontal band | about 356-359 KB | Slower than default CPU and still clipped text |
+
+JPEG crop/resize/encode took another roughly 422-466 ms in these runs. The XNNPACK result is model/device-specific, but it disproves the assumption that registering XNNPACK and four threads automatically improves this workload.
+
+### Direct neural detector comparison on Mentra Live
+
+All three models used the PR's exact grayscale-to-three-channel, fixed 640x640 preprocessing and generic postprocessor. The input was the same saved 1920x1080 Mentra capture.
+
+| Model | Model size | Detector times, ms | Warm median | Reported ROI `[x,y,w,h]` | Outcome |
+| --- | ---: | --- | ---: | --- | --- |
+| PP-OCRv6 tiny | 1.7 MiB | 1031, 923, 900, 900 | 900 ms | `[240,135,1440,810]` | Zero boxes; center fallback |
+| PP-OCRv5 mobile | 4.5 MiB | 1299, 1188, 1160, 1157 | 1160 ms | `[0,76,633,67]` | Narrow band touches frame edge and vertically clips the official-model box |
+| PP-OCRv6 small | 9.4 MiB | 1865, 1768, 1729, 1729 | 1729 ms | `[0,71,717,78]` | Narrow band touches frame edge and clips the official-model box |
+
+Process PSS before initialization, after initialization, and after four inferences was:
+
+| Model | Before | Initialized | After inference |
+| --- | ---: | ---: | ---: |
+| PP-OCRv6 tiny | 67,886 KiB | 100,501 KiB | 196,098 KiB |
+| PP-OCRv5 mobile | 67,824 KiB | 105,320 KiB | 234,949 KiB |
+| PP-OCRv6 small | 67,904 KiB | 117,888 KiB | 235,455 KiB |
+
+The final column includes input/output allocations and test-process overhead, so it is not a pure session-footprint measurement. It still demonstrates material peak-memory pressure on a 2 GB device. In the real capture process, PP-OCRv6 tiny increased PSS by about 125 MB and native heap by about 94 MB after inference.
+
+### Official PaddleOCR pipeline cross-check
+
+The official Android implementation uses color-aware input, aspect-preserving resize aligned to 32, dynamic model shape, polygon scoring, rotated minimum-area boxes, and polygon unclipping. A host script reproducing those important steps at a 640-pixel long edge produced:
+
+| Model | Tensor shape | Host inference | Detected rotated box |
+| --- | --- | ---: | --- |
+| PP-OCRv6 tiny | 1x3x352x640 | 16.1 ms | `[[62,65],[601,48],[604,146],[65,164]]` |
+| PP-OCRv5 mobile | 1x3x352x640 | 12.9 ms | `[[71,78],[580,54],[583,131],[74,154]]` |
+
+Both found the real printed line, and PP-OCRv6 tiny returned no boxes on the no-text frame. These Mac host times are not comparable to the A53 device times. The qualitative result is the important part: the model can work on the image when its intended pipeline is used. The current PR's fixed-square grayscale path is the primary correctness problem, not evidence that PaddleOCR itself is unsuitable.
+
+### ML Kit baseline
+
+Bundled ML Kit Latin text recognition 16.0.1 was run six times on the same frame:
+
+| Input | Timings | Warm median | Output |
+| --- | --- | ---: | --- |
+| 1920x1080 | 667, 317, 220, 226, 308, 219 ms | 226 ms | 1 block, 1 line, 2 elements; approximate text `SWEE ENER` |
+| 640x360 | 205, 185, 437, 295, 308, 261 ms | 295 ms | 1 block, 1 line, 1 element; approximate text `5WEELNEB` |
+
+ML Kit localized the printed line and was much faster than the PR's ONNX path, but recognition was poor and the lower-resolution run was not faster in this small sample. The bundled dependency increased this monorepo's universal APK by about 20 MB in the test build, larger than Google's approximately 4 MB-per-script-per-architecture guidance because both native ABIs were packaged. It is a useful baseline, not an automatic winner.
+
+### APK footprint
+
+Clean, apples-to-apples builds with the same StreamPackLite checkout:
+
+| Build | `origin/dev` | PR with PP-OCRv6 tiny asset | Delta |
+| --- | ---: | ---: | ---: |
+| Debug APK | 126.74 MiB | 174.37 MiB | +47.62 MiB (+37.57%) |
+| Release APK | 121.41 MiB | 169.02 MiB | +47.61 MiB (+39.22%) |
+
+The model is only 1.7 MiB. Most of the increase is the full two-ABI ONNX Runtime package: approximately 26.7 MiB for arm64 `libonnxruntime.so` and 19.1 MiB for armv7. The PR adds the runtime even when model cropping is disabled and no model asset is present.
+
+### BLE
+
+The harness assumes 87,040 B/s, while another document example uses 30,000 B/s. An injected physical transfer initially moved approximately 70 KB/s for the first 88 400-byte packets, then timed out and exhausted retries at packet 88 of 893. This is not a completed throughput measurement. Transfer savings should be calculated from a distribution of completed real transfers rather than a constant.
+
+### Thermal observation
+
+Short capture runs raised reported CPU temperature to roughly 36.9 C, while Android thermal status stayed at 0. This was not a soak test and says nothing about battery impact or sustained throttling.
+
+## Blocking correctness findings
+
+### 1. PaddleOCR preprocessing and postprocessing do not match the model
+
+`AbstractOnnxRoiDetector` resizes every image to a fixed square, takes luma only, replicates it into three channels, and applies ImageNet channel normalization. This distorts 16:9 and 4:3 captures and discards color cues. The official model is dynamic and the official Android pipeline defaults to BGR, aspect-preserving resize, and dimensions aligned to 32.
+
+`OnnxDbNetRoiDetector` then feeds the probability map into a generic connected-component/axis-aligned-box postprocessor. It does not perform the official DB polygon score, rotated minimum-area rectangle, or polygon unclip. This explains the frame-edge bands and vertical clipping observed on device.
+
+Use or faithfully port the official PaddleOCR Android detector preprocessing and DB postprocessing before comparing models. For this device, cap the long edge at 640 or 960 while preserving aspect ratio; do not copy the official demo's generic minimum-side default without measuring it.
+
+### 2. Failure deletes image content
+
+Every empty map, no-box result, inference exception, or untrustworthy classical result returns a centered 75%-by-75% crop. That removes the outer 12.5% on every side when the system has the least evidence about where text is. Edge text is a normal glasses-camera case.
+
+On uncertainty, send the full frame. If bandwidth requires a degraded fallback, send a lower-quality full-frame preview and allow a phone/server decision or a second capture. A center crop must not be called a safety fallback.
+
+### 3. The benchmark rewards destructive crops
+
+The harness reports latency, crop size, JPEG byte savings, and an estimated BLE time, but has no annotated text polygons and no recall/coverage metric. It therefore rewarded a crop that visually missed the only printed line.
+
+The primary release gate must be text retention: all readable ground-truth polygons contained with a margin, plus explicit accounting for clipped and missed text. Byte savings and latency are secondary after correctness.
+
+### 4. Current latency, memory, and package cost are not viable
+
+On this Cortex-A53 device, the fastest neural result was about 900 ms warm before JPEG crop/encode, versus roughly 123-242 ms for classical approaches and 226 ms warm for the ML Kit baseline. ONNX Runtime added about 47.6 MiB to the universal release APK, and inference produced large PSS/native-heap increases.
+
+This cost can exceed the transfer time saved unless the crop is both very small and correct. The only extremely small payload observed was not correct enough to ship.
+
+## Additional implementation findings
+
+1. `MediaCaptureService.cleanup()` can close the cached ONNX session while a background compression task is inside `session.run()`. The `closed` check is not synchronized with close, and `getTextRoiDetector()` can recreate a detector during teardown. Give detector lifecycle to one executor, stop accepting work, drain/cancel it, then close.
+2. Factory initialization failures and `LinkageError`s silently return classical detection. The identifier exposes `requested->classical`, but the root cause is lost. This happened on the host when the native ONNX library architecture did not match the JVM. Log and metric the exception and fail the neural benchmark explicitly.
+3. The PR creates default `SessionOptions`; it does not configure XNNPACK, NNAPI, or thread counts. XNNPACK was slower in the device test, so runtime/provider tuning must be benchmarked per model rather than assumed.
+4. Input construction copies the full luma frame, then allocates roughly 4.7 MiB of float input for 640x640x3, materializes Java output arrays, and causes significant GC/native pressure.
+5. The pipeline decodes JPEG to luma, then decodes/crops/resizes/encodes again. Prefer analysis from a camera YUV stream if it can be correlated safely with the still capture. ML Kit also documents direct YUV input as the efficient Camera2 path.
+6. A single union rectangle becomes nearly full-frame when text is separated across the image. Preserve multiple polygons internally; consider a multi-crop/mosaic protocol only if layout semantics and receiver compatibility are defined.
+7. Selection is compile-time only (`ENABLE_MODEL_TEXT_CROP` and `TEXT_CROP_MODEL`). The abstraction is swappable in code, but not operationally swappable for remote configuration or an A/B rollout.
+8. FAST, EAST, and YOLO entries are adapter placeholders. The PR includes no weights, model provenance, license, hashes, or exact tensor contract, so they cannot be reproduced or benchmarked. FAST's published speed relies heavily on GPU/TensorRT and GPU-parallel postprocessing, which is not equivalent to this generic CPU path.
+9. The JUnit harness is gated by `assumeTrue`; a green CI run does not mean the benchmark executed. A fresh checkout also required an undocumented StreamPackLite checkout/state.
+10. After canonical crop preparation, later logs replace the detector confidence/reason with `PREPARED_CANONICAL_CROP`, reducing observability of false positives and fallback frequency.
+
+## Recommended evaluation plan
+
+### Objective and dataset
+
+Define the objective as preserving all readable text while reducing end-to-end transfer time, not maximizing crop savings.
+
+Build an annotated set of at least 150-300 real Mentra captures covering documents, labels, street/store signs, screens, handwriting, small/large text, rotations, blur, glare, low light, text at every edge/corner, text in separated regions, and no-text scenes. Keep a held-out set and version the annotations.
+
+Primary metrics:
+
+- Ground-truth polygon/box recall and percentage fully contained by the transmitted region plus margin.
+- Count of clipped or missed readable text; target zero for a release candidate.
+- False crop rate on no-text and uncertain frames.
+- Actual transmitted bytes and completed BLE goodput/time.
+- Cold and warm preprocess/inference/postprocess/crop/encode p50, p95, and p99.
+- Peak PSS/native heap, APK/AAB delivery size, battery drain, temperature, and throttling over at least 50 consecutive captures.
+
+### Candidate matrix
+
+1. Official PaddleOCR Android pipeline, detection only:
+   - PP-OCRv6 tiny at aspect-preserved 640 and 960 long edge.
+   - PP-OCRv5 mobile at the same sizes.
+   - PP-OCRv6 small only if accuracy materially improves enough to justify its measured 1.73 s warm latency.
+2. Bundled ML Kit Latin as the turnkey baseline, fed Camera2 YUV rather than a decoded bitmap where possible.
+3. Runtime bakeoff for the winning Paddle model:
+   - ONNX Runtime default CPU with measured thread counts.
+   - A reduced-operator/custom ONNX Runtime arm64 build.
+   - ncnn CPU/NEON and Vulkan.
+   - Paddle Lite if its current mobile model path remains supported.
+4. Classical high-recall baseline after fixing its trust/fallback behavior.
+
+Do not invest in NNAPI on this hardware: no vendor NNAPI service/driver was visible on the device, and Android has deprecated NNAPI in Android 15 in favor of newer runtimes. The PowerVR Vulkan path makes ncnn Vulkan worth measuring, but not assuming.
+
+### Safe transmission policy
+
+1. Analyze an aspect-preserved low-resolution frame.
+2. If every detected polygon passes confidence/geometry checks, transmit their union with generous fixed and relative padding.
+3. If there is no text or any uncertainty, transmit the full frame, optionally at lower quality, or send a coarse full preview followed by a phone/server retry decision.
+4. Record the detector, model/runtime version, confidence, fallback reason, ROI, stage timings, memory, encoded bytes, and final transfer result for every capture.
+
+An initial performance target should be under 200 ms detector time on Mentra Live, subject to the zero-clipped-text gate. The current ONNX implementation is about 4-9x beyond that target.
+
+## Primary references
+
+- [PaddleOCR official Android deployment and benchmark](https://www.paddleocr.ai/latest/en/version3.x/inference_deployment/cross_platform/android_deployment.html)
+- [PaddleOCR official Android implementation](https://github.com/PaddlePaddle/PaddleOCR/tree/main/deploy/ppocr-android)
+- [PaddleOCR text-detection model list](https://www.paddleocr.ai/main/en/version3.x/module_usage/text_detection.html)
+- [PaddleOCR ONNX model conversion](https://www.paddleocr.ai/main/en/version3.x/inference_deployment/others/obtaining_onnx_models.html)
+- [PaddleOCR on-device deployment with Paddle Lite](https://www.paddleocr.ai/v3.0.2/en/version3.x/deployment/on_device_deployment.html)
+- [ONNX Runtime mobile](https://onnxruntime.ai/docs/tutorials/mobile/)
+- [ONNX Runtime XNNPACK provider](https://onnxruntime.ai/docs/execution-providers/Xnnpack-ExecutionProvider.html)
+- [ONNX Runtime custom builds](https://onnxruntime.ai/docs/build/custom.html) and [reduced operator configuration](https://onnxruntime.ai/docs/reference/operators/reduced-operator-config-file.html)
+- [ML Kit Text Recognition v2 for Android](https://developers.google.com/ml-kit/vision/text-recognition/v2/android)
+- [Android NNAPI documentation](https://developer.android.com/ndk/guides/neuralnetworks) and [migration guide](https://developer.android.com/ndk/guides/neuralnetworks/migration-guide)
+- [ncnn official repository and deployment features](https://github.com/Tencent/ncnn)
+- [FAST paper](https://arxiv.org/abs/2111.02394)
+
+## Bottom line
+
+The PR brings the right architectural question—make text ROI detection replaceable and measurable—but the current implementation answers the model question before defining or measuring the safety objective. Preserve the abstraction and benchmark artifacts; replace the Paddle pipeline with the official algorithm, make uncertainty full-frame-safe, build a ground-truthed Mentra dataset, and then select model/runtime based on text retention first and end-to-end device cost second.

--- a/asg_client/docs/agents/TEXTROI_MODELS.md
+++ b/asg_client/docs/agents/TEXTROI_MODELS.md
@@ -20,6 +20,7 @@ The stable detector ids are:
 | `classical` | Existing OpenCV pipeline | None |
 | `swt` | Stroke Width Transform / classical | None |
 | `mser_only` | MSER / classical | None |
+| `ml_kit` | Bundled/offline Google ML Kit text recognizer | None (bundled model, no asset) |
 | `ppocr_v6_tiny_det` | PaddleOCR DBNet | `ppocr_v6_tiny_det.onnx` |
 | `ppocr_v5_mobile_det` | PaddleOCR DBNet | `ppocr_v5_mobile_det.onnx` |
 | `ppocr_v6_small_det` | PaddleOCR DBNet | `ppocr_v6_small_det.onnx` |
@@ -28,9 +29,20 @@ The stable detector ids are:
 | `east_lite` | EAST | `east_lite.onnx` |
 | `yolo_nano_text` | YOLO | `yolo_nano_text.onnx` |
 
-Only the code adapters and runners ship in this repository. Model `.onnx` files
-are intentionally **not committed**. For an Android/device build, place the
-needed files, with the exact names above, under:
+`ml_kit` requires no model file: it uses Google's bundled/offline ML Kit text
+recognizer (`com.google.mlkit:text-recognition`), which ships its model inside
+the app and needs no Play Services or network access. It decodes and analyzes
+the original sensor JPEG bytes itself (see `MlKitTextRoiDetector` and its
+`roi/MlKitRoiDetector` adapter) rather than pre-extracted luma, and its
+crop is already in source-pixel coordinates
+(`TextRoiDetector#returnsNativeCoordinates()` returns `true`), unlike the
+classical/ONNX detectors, which analyze a subsampled luma buffer and need the
+caller to scale their result back up.
+
+Only the code adapters and runners for the ONNX-based models ship in this
+repository. Model `.onnx` files are intentionally **not committed**. For an
+Android/device build, place the needed files, with the exact names above,
+under:
 
 ```text
 app/src/main/assets/textroi/
@@ -101,9 +113,12 @@ To compare neural models and estimate transfer time at a measured BLE rate:
   --input "/path/to/text photos" \
   --output "/tmp/textroi results" \
   --model-dir "/path/to/onnx models" \
-  --detectors classical,ppocr_v5_mobile_det,fast_tiny,east_lite,yolo_nano_text \
+  --detectors classical,ml_kit,ppocr_v5_mobile_det,fast_tiny,east_lite,yolo_nano_text \
   --ble-bytes-per-second 30000
 ```
+
+`ml_kit` needs no `--model-dir` entry - it runs from the bundled model as soon
+as it is included in `--detectors`.
 
 The wrapper runs:
 
@@ -125,16 +140,17 @@ crop correctness.
 
 `AsgConstants.ENABLE_MODEL_TEXT_CROP` controls whether
 `AsgConstants.TEXT_CROP_MODEL` is selected. When the flag is `false`, the
-service uses `classical` regardless of `TEXT_CROP_MODEL`. When a requested ONNX
-model cannot be loaded or initialized, the detector falls back to the classical
-pipeline and reports that explicitly:
+service uses `classical` regardless of `TEXT_CROP_MODEL`. When `true` (the
+default in production), `TEXT_CROP_MODEL` currently selects `ml_kit`. When a
+requested ML Kit or ONNX model cannot be loaded or initialized, the detector
+falls back to the classical pipeline and reports that explicitly:
 
 ```text
 <requested-model-id>->classical
 ```
 
-Treat the arrow in a reported detector id as a failed neural-model run, not as
-performance from the requested model.
+Treat the arrow in a reported detector id as a failed model run, not as
+performance from the requested detector.
 
 The service lazily creates and caches its detector, including the ONNX Runtime
 session, for the `MediaCaptureService` lifetime. Cleanup closes the detector and

--- a/asg_client/docs/agents/TEXTROI_MODELS.md
+++ b/asg_client/docs/agents/TEXTROI_MODELS.md
@@ -156,6 +156,39 @@ The service lazily creates and caches its detector, including the ONNX Runtime
 session, for the `MediaCaptureService` lifetime. Cleanup closes the detector and
 its session. Do not create a new ONNX session for every photo.
 
+## ONNX Runtime is excluded from the default build
+
+`app/build.gradle` declares the Android ONNX Runtime artifact as `compileOnly`,
+not `implementation`. This keeps `ai.onnxruntime.*` resolvable so the ONNX
+detector classes always compile, but its native libraries (`libonnxruntime.so`,
+`libonnxruntime4j_jni.so`, tens of MB per ABI) are **not packaged** into a
+default APK/AAB, since the shipped text-crop path uses the classical detector
+or bundled ML Kit, neither of which needs ONNX Runtime, and no `.onnx` model is
+committed to this repo.
+
+Enable packaging only for a build that will actually exercise an ONNX
+detector:
+
+```bash
+./gradlew assembleDebug -PenableTextRoiOnnx=true
+# or
+ENABLE_TEXT_ROI_ONNX=true ./gradlew assembleDebug
+```
+
+Measured on this repo's debug build: a default `assembleDebug` packages no
+`libonnxruntime*.so` at all; `assembleDebug -PenableTextRoiOnnx=true` adds
+about 46 MB (`arm64-v8a` + `armeabi-v7a` combined) versus the default build.
+Because a debug APK is unstripped and uncompressed, a release AAB's per-ABI
+download size will differ; re-measure with `assembleRelease` /
+`bundleRelease` before relying on a specific number.
+
+If a build without `enableTextRoiOnnx` ever selects an ONNX `TextCropModel`
+(e.g. a misconfigured `AsgConstants.TEXT_CROP_MODEL`), `OrtEnvironment`/
+`OrtSession` construction throws `NoClassDefFoundError` (a `LinkageError`)
+because the real classes were never packaged; `TextRoiDetectorFactory` already
+catches `Exception | LinkageError` and falls back to the classical detector,
+so this is safe by construction, not just by convention.
+
 ## MT8766 physical-device validation
 
 Before enabling a model for Mentra Live, validate a representative photo set on

--- a/asg_client/docs/agents/TEXTROI_MODELS.md
+++ b/asg_client/docs/agents/TEXTROI_MODELS.md
@@ -1,0 +1,161 @@
+# Swappable text ROI models
+
+## Objective
+
+The text ROI pipeline finds the area of a photo that contains text. It does **not**
+recognize or transcribe the text: there is no OCR step. On Mentra Live, detection
+and cropping run on the glasses before encoding and BLE transfer so that fewer
+image bytes need to cross BLE.
+
+The desktop benchmark makes detector choices comparable before validating them
+on the MT8766 hardware. Desktop timings are comparative only; they do not
+predict on-device latency, memory use, or thermal behavior.
+
+## Detector roster
+
+The stable detector ids are:
+
+| Detector id | Family | Expected ONNX filename |
+| --- | --- | --- |
+| `classical` | Existing OpenCV pipeline | None |
+| `swt` | Stroke Width Transform / classical | None |
+| `mser_only` | MSER / classical | None |
+| `ppocr_v6_tiny_det` | PaddleOCR DBNet | `ppocr_v6_tiny_det.onnx` |
+| `ppocr_v5_mobile_det` | PaddleOCR DBNet | `ppocr_v5_mobile_det.onnx` |
+| `ppocr_v6_small_det` | PaddleOCR DBNet | `ppocr_v6_small_det.onnx` |
+| `fast_tiny` | FAST | `fast_tiny.onnx` |
+| `fast_small` | FAST | `fast_small.onnx` |
+| `east_lite` | EAST | `east_lite.onnx` |
+| `yolo_nano_text` | YOLO | `yolo_nano_text.onnx` |
+
+Only the code adapters and runners ship in this repository. Model `.onnx` files
+are intentionally **not committed**. For an Android/device build, place the
+needed files, with the exact names above, under:
+
+```text
+app/src/main/assets/textroi/
+```
+
+For the desktop harness, keep models outside the repository if desired and pass
+their containing directory with `--model-dir`.
+
+## Preparing models
+
+Model provenance, licensing, and accuracy must be reviewed before distribution.
+Do not rename an arbitrary model to one of the expected filenames: each adapter
+has an input and output contract.
+
+For PP-OCR detection models, obtain the appropriate Paddle inference model and
+convert it with a compatible Paddle-to-ONNX tool. A command template is:
+
+```bash
+paddle2onnx \
+  --model_dir <paddle-inference-model-dir> \
+  --model_filename <inference-model-file> \
+  --params_filename <inference-params-file> \
+  --save_file <expected-name>.onnx \
+  --opset_version <supported-opset> \
+  --enable_onnx_checker True
+```
+
+Before using the result, inspect it with an ONNX checker/runtime and verify the
+actual contract. The current DBNet runner supplies normalized NCHW float input
+at `640x640` and expects a probability map shaped like `[1,1,H,W]`,
+`[1,H,W]`, or `[H,W]`. Export options, preprocessing, output activation, and
+tensor layout must match the source model; conversion success alone is not
+contract verification.
+
+Export FAST, EAST, and YOLO from their original framework using that
+framework's supported ONNX exporter, then simplify or optimize only if the
+result remains numerically equivalent. Verify each exported graph in ONNX
+Runtime against known images:
+
+- FAST uses normalized NCHW float input at `640x640` and must expose a
+  segmentation probability map compatible with the DBNet-style shapes above.
+- EAST uses normalized NCHW float input at `320x320` and must expose a
+  `[1,1,H,W]` score tensor plus a `[1,5,H,W]` geometry tensor.
+- YOLO uses normalized NCHW float input at `640x640` and must expose detections
+  compatible with `[1,N,5+]` / `[N,5+]` or transposed `[1,4+C,N]` /
+  `[4+C,N]` output. Generic object-detection weights are unsuitable:
+  `yolo_nano_text.onnx` must use text-trained weights.
+
+For every family, confirm channel order, normalization, resizing behavior,
+dynamic/static dimensions, output tensor order and shape, coordinate units,
+confidence semantics, and representative output against the corresponding
+runner before device testing.
+
+## Run the desktop benchmark
+
+From `asg_client/`:
+
+```bash
+./scripts/textroi-benchmark.sh \
+  --input "/path/to/text photos" \
+  --detectors classical,swt,mser_only
+```
+
+To compare neural models and estimate transfer time at a measured BLE rate:
+
+```bash
+./scripts/textroi-benchmark.sh \
+  --input "/path/to/text photos" \
+  --output "/tmp/textroi results" \
+  --model-dir "/path/to/onnx models" \
+  --detectors classical,ppocr_v5_mobile_det,fast_tiny,east_lite,yolo_nano_text \
+  --ble-bytes-per-second 30000
+```
+
+The wrapper runs:
+
+```bash
+./gradlew :app:testDebugUnitTest --tests '*TextRoiBenchmarkHarnessTest'
+```
+
+and forwards the selected paths, detector ids, and optional BLE rate as
+`-Dtextroi.*` system properties. It prints the output directory before and
+after the run. The harness writes per-image detector results and aggregate
+benchmark data there. Review detector id (including fallback), detection
+outcome, ROI coordinates and dimensions, source/cropped byte counts, crop
+ratio, inference/detection latency, and estimated BLE transfer and total
+detection-plus-transfer time. Also inspect the generated crop/overlay artifacts
+for missed, clipped, or excessive regions; aggregate metrics alone cannot prove
+crop correctness.
+
+## Device selection and lifetime
+
+`AsgConstants.ENABLE_MODEL_TEXT_CROP` controls whether
+`AsgConstants.TEXT_CROP_MODEL` is selected. When the flag is `false`, the
+service uses `classical` regardless of `TEXT_CROP_MODEL`. When a requested ONNX
+model cannot be loaded or initialized, the detector falls back to the classical
+pipeline and reports that explicitly:
+
+```text
+<requested-model-id>->classical
+```
+
+Treat the arrow in a reported detector id as a failed neural-model run, not as
+performance from the requested model.
+
+The service lazily creates and caches its detector, including the ONNX Runtime
+session, for the `MediaCaptureService` lifetime. Cleanup closes the detector and
+its session. Do not create a new ONNX session for every photo.
+
+## MT8766 physical-device validation
+
+Before enabling a model for Mentra Live, validate a representative photo set on
+physical MT8766 glasses:
+
+- Confirm crop correctness for small, rotated, low-contrast, distant, and
+  edge-of-frame text, plus scenes with no text.
+- Measure cold initialization and warm per-photo detection latency.
+- Measure end-to-end crop, encode, and BLE total time at realistic throughput;
+  a smaller crop is not beneficial if detection costs more time than it saves.
+- Soak repeated captures and monitor sustained latency, CPU load, temperature,
+  and thermal throttling.
+- Record native/Java memory before initialization, at steady state, and after
+  service cleanup; check for growth across captures and service restarts.
+- Compare debug/release APK size with every candidate model asset included.
+- Verify missing, corrupt, and incompatible model files produce a reported
+  `<requested-model-id>->classical` fallback and still return a safe crop.
+- Confirm service cleanup releases ONNX resources and subsequent service startup
+  can initialize the detector again.

--- a/asg_client/scripts/textroi-benchmark.sh
+++ b/asg_client/scripts/textroi-benchmark.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: textroi-benchmark.sh --input PATH [options]
+
+Run the desktop text-ROI detector benchmark.
+
+Required:
+  --input PATH                   Input image or directory of images
+
+Options:
+  --output DIR                  Output directory
+                                (default: <asg_client>/build/textroi-benchmark)
+  --model-dir DIR               Directory containing optional ONNX models
+  --detectors IDS               Comma-separated detector ids (default: classical)
+  --ble-bytes-per-second RATE   BLE throughput used for transfer estimates
+  -h, --help                    Show this help
+EOF
+}
+
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_DIR="$(CDPATH= cd -- "${SCRIPT_DIR}/.." && pwd -P)"
+
+input_path=""
+output_dir="${REPO_DIR}/build/textroi-benchmark"
+model_dir=""
+detectors="classical"
+ble_bytes_per_second=""
+
+while (($# > 0)); do
+  case "$1" in
+    --input|--output|--model-dir|--detectors|--ble-bytes-per-second)
+      if (($# < 2)) || [[ -z "$2" ]]; then
+        echo "Error: $1 requires a value." >&2
+        usage >&2
+        exit 2
+      fi
+      case "$1" in
+        --input) input_path="$2" ;;
+        --output) output_dir="$2" ;;
+        --model-dir) model_dir="$2" ;;
+        --detectors) detectors="$2" ;;
+        --ble-bytes-per-second) ble_bytes_per_second="$2" ;;
+      esac
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Error: unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$input_path" ]]; then
+  echo "Error: --input is required." >&2
+  usage >&2
+  exit 2
+fi
+if [[ ! -e "$input_path" ]]; then
+  echo "Error: input does not exist: $input_path" >&2
+  exit 2
+fi
+if [[ -n "$model_dir" && ! -d "$model_dir" ]]; then
+  echo "Error: model directory does not exist: $model_dir" >&2
+  exit 2
+fi
+if [[ -n "$ble_bytes_per_second" && ! "$ble_bytes_per_second" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Error: --ble-bytes-per-second must be a positive integer." >&2
+  exit 2
+fi
+
+absolute_path() {
+  local path="$1"
+  local parent
+  parent="$(CDPATH= cd -- "$(dirname -- "$path")" && pwd -P)"
+  printf '%s/%s\n' "$parent" "$(basename -- "$path")"
+}
+
+input_path="$(absolute_path "$input_path")"
+if [[ -n "$model_dir" ]]; then
+  model_dir="$(CDPATH= cd -- "$model_dir" && pwd -P)"
+fi
+mkdir -p -- "$output_dir"
+output_dir="$(CDPATH= cd -- "$output_dir" && pwd -P)"
+
+gradle_properties=(
+  "-Dtextroi.inputDir=${input_path}"
+  "-Dtextroi.outputDir=${output_dir}"
+  "-Dtextroi.detectors=${detectors}"
+)
+if [[ -n "$model_dir" ]]; then
+  gradle_properties+=("-Dtextroi.modelDir=${model_dir}")
+fi
+if [[ -n "$ble_bytes_per_second" ]]; then
+  gradle_properties+=("-Dtextroi.bleBytesPerSecond=${ble_bytes_per_second}")
+fi
+
+echo "Text ROI benchmark output: ${output_dir}"
+(
+  cd -- "$REPO_DIR"
+  ./gradlew :app:testDebugUnitTest \
+    --tests '*TextRoiBenchmarkHarnessTest' \
+    "${gradle_properties[@]}"
+)
+echo "Text ROI benchmark output: ${output_dir}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Scope
- add a common text-ROI detector interface and factory for classical, SWT, MSER, PP-OCR/DBNet, FAST, EAST, YOLO, and ML Kit detector families
- **ML Kit is the new default `TEXT_CROP_MODEL`** — `MlKitRoiDetector` wraps the bundled/offline ML Kit text recognizer behind the same `TextRoiDetector` contract as every other detector
- cache detector sessions across captures and close native resources during media-service cleanup
- add constants for selecting model cropping while preserving a classical fallback when a selected model fails to load/initialize
- **adopt the RAM-first BLE photo pipeline** from #3472 (`agent/mlkit-text-mode`): `CapturedPhoto` keeps the sensor JPEG in memory with deferred/optional disk persistence, camera/photo-session/bluetooth plumbing threads `byte[]` payloads end-to-end, and BLE file transfer sends bytes directly instead of always round-tripping through a temp file — reducing the extra disk read/write steps in the previous text-mode capture path
- add an offline benchmark harness with crop/overlay artifacts, JSON/CSV summaries, and a side-by-side HTML report (now also exercises `ml_kit`)
- **the ONNX Runtime Android dependency is `compileOnly` by default** — its native libraries are only packaged into the APK with an explicit `-PenableTextRoiOnnx=true` (or `ENABLE_TEXT_ROI_ONNX=true`) build flag, so the default build pays no size cost for a detector family that isn't shipped/enabled
- document external ONNX model placement, conversion contracts, ML Kit's native-coordinate contract, the ONNX packaging flag, and MT8766 validation

## Design notes
- `TextRoiDetector` gained `returnsNativeCoordinates()` (classical/ONNX detectors analyze a subsampled buffer and need their crop scaled back up; ML Kit already returns source-pixel coordinates) and `warmUp()` (so any detector's model init can be triggered ahead of capture, not just ML Kit's)
- classical/SWT/MSER/ONNX detectors, OpenCV, and the offline benchmark harness are all preserved — the registry keeps growing rather than replacing itself
- `TextRoiDetectorFactory` already catches `LinkageError`, so a default build (ONNX classes present at compile time via `compileOnly`, but native libs absent at runtime) safely falls back to classical if an ONNX model is ever selected without the packaging flag

## Safety
- an unavailable/failed selected detector (ML Kit or ONNX) falls back to the classical detector, reported as `<requested-id>->classical`
- ONNX model files are not committed
- ONNX Runtime native libraries are not packaged by default (see above)

## Tests
- `./gradlew :app:spotlessJavaCheck :app:testDebugUnitTest` (500 tests, 0 failures)
- `./gradlew :app:compileDebugAndroidTestJavaWithJavac`
- `./scripts/check-android-compile.sh asg`
- `./gradlew :app:assembleDebug` and `./gradlew :app:assembleDebug -PenableTextRoiOnnx=true` — confirmed the default APK packages zero `libonnxruntime*.so` files and the flagged build adds ~46MB (measured, debug build, `arm64-v8a` + `armeabi-v7a` combined)

All passed locally after installing the Android 34 SDK and required StreamPackLite checkout.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-65a45cf4-468f-4601-b5fd-ce1c12789c21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-65a45cf4-468f-4601-b5fd-ce1c12789c21"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

