### PR TITLE
Default mobile theme to light in all builds

### DIFF
--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -292,7 +292,7 @@ export const SETTINGS: Record<string, Setting> = {
   },
   theme_preference: {
     key: "theme_preference",
-    defaultValue: () => (__DEV__ ? "system" : "light"),
+    defaultValue: () => "light",
     // Force light mode - i mode is not complete yet
     // override: () => "light",
     writable: true,


### PR DESCRIPTION
Defaults `theme_preference` to `light` in both development and production builds. Previously, development builds defaulted to `system`, causing the Mentra App to follow a phone's dark appearance even though dark mode is not ready for users. This gives fresh installs and reset settings the same light default regardless of build type; existing persisted theme choices are unchanged. Validation: `git diff --check` passed; focused ESLint could not run because the workspace is missing the mobile dependency that provides `expo/tsconfig.base`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set `theme_preference` default to `light` across development and production so fresh installs and reset settings always start in light mode. Removes the dev-only `system` default that followed the phone’s dark appearance; existing saved preferences are unchanged.

<sup>Written for commit 68f0cf36fc79b428764cfaf9aa8b7accafabd334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single default-value change for a UI setting; no auth, sync, or runtime logic paths are modified beyond first-time/reset behavior.
> 
> **Overview**
> **`theme_preference`** now always defaults to **`light`** instead of using **`system`** in development builds.
> 
> That removes dev-only behavior where new or reset settings followed the phone’s system appearance (often dark) even though dark mode is not ready. **Persisted** user choices are unchanged; only the descriptor default in `settings.ts` changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68f0cf36fc79b428764cfaf9aa8b7accafabd334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->