### PR TITLE
Dismiss keyboard on app backgrounding and miniapp switch

### DIFF
--- a/mobile/src/components/home/AllAppsGridSheet.tsx
+++ b/mobile/src/components/home/AllAppsGridSheet.tsx
@@ -64,11 +64,14 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
   // (Home button, app switcher) while the search field is still focused and the
   // sheet never closes, the ReactEditText keeps the IME's served view — Android
   // then re-shows the keyboard over whatever screen is on top on the next
-  // resume. Blur + dismiss on any non-active AppState transition closes that
-  // gap regardless of how the app left the foreground.
+  // resume. Blur + dismiss on the background AppState transition closes that
+  // gap regardless of how the app left the foreground. Only "background"
+  // qualifies: iOS also emits "inactive" for transient interruptions
+  // (Notification Center, app switcher peek, incoming calls) where dropping
+  // focus would wrongly hide the keyboard on return.
   useEffect(() => {
     const sub = AppState.addEventListener("change", (state) => {
-      if (state !== "active") {
+      if (state === "background") {
         searchInputRef.current?.blur()
         Keyboard.dismiss()
       }

--- a/mobile/src/components/home/AllAppsGridSheet.tsx
+++ b/mobile/src/components/home/AllAppsGridSheet.tsx
@@ -68,11 +68,13 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
   // gap regardless of how the app left the foreground. Only "background"
   // qualifies: iOS also emits "inactive" for transient interruptions
   // (Notification Center, app switcher peek, incoming calls) where dropping
-  // focus would wrongly hide the keyboard on return.
+  // focus would wrongly hide the keyboard on return. Check this field's focus
+  // before the global dismiss so a still-mounted sheet cannot blur an input in
+  // another screen or foregrounded miniapp.
   useEffect(() => {
     const sub = AppState.addEventListener("change", (state) => {
-      if (state === "background") {
-        searchInputRef.current?.blur()
+      if (state === "background" && searchInputRef.current?.isFocused()) {
+        searchInputRef.current.blur()
         Keyboard.dismiss()
       }
     })

--- a/mobile/src/components/home/AllAppsGridSheet.tsx
+++ b/mobile/src/components/home/AllAppsGridSheet.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
-import {BackHandler, Keyboard, Platform, TextInput, TouchableOpacity, View} from "react-native"
+import {AppState, BackHandler, Keyboard, Platform, TextInput, TouchableOpacity, View} from "react-native"
 import {Icon} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import BottomSheet, {
@@ -58,6 +58,23 @@ export default function AllAppsGridSheet({bottomSheetRef}: {bottomSheetRef: Reac
     })
     return () => sub.remove()
   }, [isOpen, bottomSheetRef])
+
+  // The sheet's own onChange only fires blur+dismiss when it closes via its own
+  // gesture/programmatic close() path. If the user backgrounds the whole app
+  // (Home button, app switcher) while the search field is still focused and the
+  // sheet never closes, the ReactEditText keeps the IME's served view — Android
+  // then re-shows the keyboard over whatever screen is on top on the next
+  // resume. Blur + dismiss on any non-active AppState transition closes that
+  // gap regardless of how the app left the foreground.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state !== "active") {
+        searchInputRef.current?.blur()
+        Keyboard.dismiss()
+      }
+    })
+    return () => sub.remove()
+  }, [])
 
   return (
     <>

--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -20,7 +20,7 @@
  */
 
 import {useCallback, useEffect, useRef, useState} from "react"
-import {Dimensions, Platform, View} from "react-native"
+import {Dimensions, Keyboard, Platform, View} from "react-native"
 import {Gesture, GestureDetector} from "react-native-gesture-handler"
 import Animated, {
   Easing,
@@ -95,6 +95,12 @@ export default function Compositor() {
     SETTINGS.ios_app_switcher_bottom_swipe.key,
   )
   useEffect(() => {
+    // A TextInput focused in one miniapp/screen can otherwise keep the IME's
+    // served view across a switch to a different app (or back to none on
+    // minimize), causing the keyboard to pop back up over a screen with no
+    // visible input field. This is the single choke point both directions
+    // funnel through, so dismiss unconditionally on every foreground change.
+    Keyboard.dismiss()
     if (foregroundApp) {
       // Only swap renderedApp when a DIFFERENT app is foregrounded. refresh()
       // hands us a new foregroundApp object reference on every poll even when

--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -79,6 +79,9 @@ const GLASS_WARMUP_MS = 10
 
 export default function Compositor() {
   const foregroundApp = useForegroundApp()
+  // Last foregrounded packageName (null = none) — lets the keyboard-dismiss
+  // effect below fire only on real identity changes, not reference churn.
+  const prevForegroundPackageRef = useRef<string | null>(null)
   const didSwipeToExit = useRef(false)
   const viewShotRef = useRef<View | null>(null)
   const insets = useSaferAreaInsets()
@@ -99,8 +102,16 @@ export default function Compositor() {
     // served view across a switch to a different app (or back to none on
     // minimize), causing the keyboard to pop back up over a screen with no
     // visible input field. This is the single choke point both directions
-    // funnel through, so dismiss unconditionally on every foreground change.
-    Keyboard.dismiss()
+    // funnel through. Gate on the foregrounded IDENTITY, not the object:
+    // refresh() hands this effect a new foregroundApp reference on every
+    // store poll even while the same miniapp stays foregrounded, and
+    // dismissing on those would drop the keyboard mid-typing (e.g. an RN
+    // TextInput on a settings screen) with no actual app switch.
+    const currentPackage = foregroundApp?.packageName ?? null
+    if (currentPackage !== prevForegroundPackageRef.current) {
+      prevForegroundPackageRef.current = currentPackage
+      Keyboard.dismiss()
+    }
     if (foregroundApp) {
       // Only swap renderedApp when a DIFFERENT app is foregrounded. refresh()
       // hands us a new foregroundApp object reference on every poll even when


### PR DESCRIPTION
Fixes OS-1702 (sub-issue of OS-1687).

## Problem

Reported: "sometimes I leave the app then come back and the keyboard appears." A `TextInput` left focused in one screen can keep the IME's served view across a switch to a different app or across backgrounding, so the keyboard pops back up unprompted with no visible input field to explain it.

Root cause: `AllAppsGridSheet`'s search field only blurred and dismissed the keyboard when its own bottom sheet closed via its own gesture/`close()` path (`onChange` -> `idx < 0`). If the whole app backgrounded (Home button, app switcher) while the sheet stayed expanded and the field stayed focused, nothing released that focus. Android then re-serves the same stale view on the next resume and the keyboard reappears with zero user interaction.

## Fix

1. `mobile/src/components/home/AllAppsGridSheet.tsx` — added an `AppState` "change" listener that blurs the search input and calls `Keyboard.dismiss()` on any non-`active` transition, closing the backgrounding gap.
2. `mobile/src/effects/Compositor.tsx` — added an unconditional `Keyboard.dismiss()` at the top of the `foregroundApp`-change effect (fires on both switching to a different miniapp and clearing to none on minimize), as a general safety net for any other input left focused across a switch.

## Verification (physical Pixel 8, live before/after toggle)

Dedicated Metro instance serving this branch, phone tunneled to it via `adb reverse`, served bundle checked for the fix's marker strings before testing. Toggled between this commit and its parent via `git checkout` in the served worktree, same device/account, identical repro steps.

**Repro:** open the all-apps sheet -> focus the search field (keyboard up) -> press hardware Home -> reopen the app.

| Step | Pre-fix | With fix |
|---|---|---|
| Search focused | `mInputShown=true` | `mInputShown=true` |
| After Home | `mInputShown=false` | `mInputShown=false` |
| **After resume (no user input)** | **`mInputShown=true` — keyboard visibly reopens itself, cursor in field** | **`mInputShown=false` — stays down** |

Screenshots of both states are attached to the Linear ticket.

Typecheck clean; pre-existing lint warnings in both touched files are unrelated to this change (unused vars / inline styles on lines this diff doesn't touch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7222f57585d0fa75827d90a2588710bd0b08bc9a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dismisses the keyboard on true app backgrounding and real miniapp switches so it doesn’t pop back up without a focused input. Addresses OS-1702.

- **Bug Fixes**
  - `mobile/src/components/home/AllAppsGridSheet.tsx`: Add `AppState` listener; on `state === "background"` if the search input is focused, blur it and call `Keyboard.dismiss()`—avoids iOS “inactive” and doesn’t touch other inputs.
  - `mobile/src/effects/Compositor.tsx`: Dismiss the keyboard only when the foreground app identity changes (track previous `packageName`), covering switches/minimize without dropping the keyboard during reference churn while typing.

<sup>Written for commit 111ac748f50bee77e90ba2b35cc525a166b9039d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

