### PR TITLE
docs: spec doc for the VAD-blind mic reinit watchdog

### DIFF
--- a/notes/mic-reinit-watchdog-vad-blind-spot.md
+++ b/notes/mic-reinit-watchdog-vad-blind-spot.md
@@ -1,115 +1,180 @@
-# Mic reinit watchdog fires on normal VAD silence (OS-1712)
+# Mic reinit watchdog is VAD-blind (OS-1712)
 
-Fix spec for a native-code bug (Kotlin + Swift). Not implemented here — this
-document is the handoff for whoever picks up OS-1712.
+Investigation and implementation handoff for a native-code bug in the Android
+and iOS Bluetooth SDKs. This document separates the code path that is confirmed
+from the Mentra Live firmware behavior that still needs an A/B hardware test.
+No runtime fix is included in this PR.
 
-## Symptom
+## Observed symptom
 
-On a physical Pixel 8 + Mentra Live, this log line fires every 10 seconds,
-continuously, indefinitely, for the entire lifetime of a connected session:
+On a physical Pixel 8 paired with Mentra Live, this log line fired every
+~10.01 seconds for more than 15 minutes while the user was quiet:
 
-```
+```text
 CORE: MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic
 ```
 
-Each occurrence re-sends an `enable_custom_audio_tx` BLE command to the
-glasses. This isn't a one-off blip — it was observed firing every ~10.01s for
-15+ minutes straight in a single session with no gaps.
+For Mentra Live, each occurrence calls `setMicEnabled(true)` and immediately
+re-sends the `enable_custom_audio_tx` command over BLE.
 
-## Root cause
+## Confirmed code path
 
-The watchdog is purely a packet-arrival timer with no awareness of voice
-activity detection (VAD).
+The watchdog is a packet-arrival timer with no awareness of voice activity:
 
-- Android: `DeviceManager.checkAndReinitGlassesMic()` —
-  `mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt:326-341`.
-  Condition: `System.currentTimeMillis() - (lastLc3Event ?: 0L) > 5000`, gated
-  only by `glassesMicEnabled && glassesConnected`. Runs on a repeating
-  `Runnable` set up in `init()` (lines 314-323), firing every 10s.
-- iOS: equivalent `checkAndReinitGlassesMic()` —
-  `mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift:802-813`, same
-  5s-threshold / 10s-interval pattern.
-- `lastLc3Event` is stamped unconditionally at the top of
-  `handleGlassesMicData()` (Android `DeviceManager.kt:715`, before any
-  decode/validation) whenever *any* glasses SGC pushes a raw LC3 audio chunk
-  — called from `G1.kt:637`, `G2.kt:4924`, `MentraNex.kt:1237`,
-  `MentraLive.kt:9091`, `RemoteHarness.kt:203` (iOS analogues at
-  `G1.swift:1229`, `G2.swift:4983`, `MentraLive.swift:3274`,
-  `MentraNex.swift:2061`, `RemoteHarness.swift:243`). None of these paths
-  check speech vs. silence — it's a byte/packet-count-style timer, not
-  content-aware.
-- The watchdog lives in the shared `DeviceManager`, not per-SGC code, and
-  runs identically for every connected model (G1, G2, MentraLive, MentraNex,
-  ...) as long as mic is enabled and glasses are connected. The
-  `enable_custom_audio_tx` BLE command it re-sends
-  (`MentraLive.kt:6465-6486`) is MentraLive-specific plumbing, but the
-  trigger logic deciding *when* to fire it is model-agnostic.
+- Android schedules `DeviceManager.checkAndReinitGlassesMic()` every 10 seconds
+  from `DeviceManager.init()`. If the glasses are connected, their mic is
+  enabled, and `lastLc3Event` is more than five seconds old, it calls
+  `sgc?.setMicEnabled(true)`. A missing timestamp is treated as `0`, so Android
+  also attempts recovery when no audio frame has ever arrived.
+- iOS schedules the equivalent method every 10 seconds from
+  `DeviceManager.init()`. Its five-second check starts only after the first LC3
+  frame because `lastLc3Event ?? Date()` evaluates to a fresh time on every
+  check while the value is `nil`. Whether iOS should recover when the stream
+  never starts is a separate parity decision the implementation should make
+  explicit.
+- Android and iOS stamp `lastLc3Event` at the start of
+  `DeviceManager.handleGlassesMicData()`, before decode or validation. Raw LC3
+  reaches that method from the G1, G2, Mentra Live, and Mentra Nex SGCs. Android
+  Nimo reports equivalent liveness through
+  `DeviceManager.reportGlassesAudioActivity()` because it decodes Opus inside
+  its SGC. There are no `RemoteHarness` SGC files in the current tree.
+- The trigger is shared by all SGCs. Its effect is model-specific because it
+  dispatches through `SGCManager.setMicEnabled(true)`. Mentra Live's
+  implementation starts its micbeat path, which sends
+  `enable_custom_audio_tx`; other models use their own microphone command.
 
-Mentra Live does have a real on-device VAD channel that the watchdog never
-consults: `sr_vad` K900 messages -> `handleSpeakingStatus()`
-(`MentraLive.kt:4362-4372`, `4676-4685`), which only forwards to
-`Bridge.sendSpeakingStatus(speaking)` for JS/UI consumption. There's also
-`voice_activity_detection_enabled` in `DeviceStore` (`MentraLive.kt:4687-4690`)
-and a phone-side Silero VAD (`VadGateSpeechPolicy`, wired in
-`DeviceManager.kt:290-312`) reporting `Bridge.sendVoiceActivityDetectionStatus`.
-Both exist and are plumbed to JS, but neither is read by
-`checkAndReinitGlassesMic()`.
+Relevant symbols:
 
-## Why this matters
+- Android:
+  `mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt`
+  (`init`, `checkAndReinitGlassesMic`, `handleGlassesMicData`,
+  `reportGlassesAudioActivity`)
+- iOS: `mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift`
+  (`init`, `checkAndReinitGlassesMic`, `handleGlassesMicData`)
+- Mentra Live Android:
+  `mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt`
+  (`setMicEnabled`, `startMicBeat`, `sendEnableCustomAudioTxMessage`,
+  `handleSpeakingStatus`)
+- Mentra Live iOS:
+  `mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift`
+  (the same symbols)
 
-If Mentra Live's firmware suppresses packet transmission during confirmed
-silence (VAD-gated), then 5+ seconds of a user simply not talking trips this
-exact code path and fires a spurious, harmless-but-noisy `enable_custom_audio_tx`
-resend — a false-positive "reinit," not evidence of a dead mic. For G2 (no
-confirmed VAD gating on this codepath), the same logic is more plausibly a
-genuine recovery mechanism for real mic dropouts, so the watchdog can't simply
-be deleted — it needs to distinguish "silence because VAD says so" from
-"silence because the mic actually died."
+## VAD hypothesis (not yet proven)
 
-Continuously re-sending a BLE command every 10s for the lifetime of every
-session has a real cost even when harmless: unnecessary radio wake-ups /
-battery drain, and log noise that can mask a real reinit when one is needed.
+Mentra Live receives on-device VAD state through `sr_vad` K900 messages and
+forwards it from `handleSpeakingStatus()` as a `speaking_status` event. The
+watchdog does not consult that state.
 
-## Suggested fix
+The working hypothesis is that, when glasses-side VAD is enabled, firmware
+intentionally suppresses LC3 packets after `sr_vad` reports `on=0`. If so,
+normal silence is indistinguishable from a dead microphone to the current
+watchdog, and the repeated re-enable is a false positive.
 
-Before firing the reinit in `checkAndReinitGlassesMic()`, check the model's
-own VAD state and skip the reinit if the model reports VAD-confirmed silence
-rather than "no signal at all."
+The existing observation does not prove that causal link. Battery, heartbeat,
+or other healthy BLE traffic proves that the connection is alive, not that the
+microphone path is healthy or that VAD intentionally stopped LC3. Do not ship a
+VAD-based suppression rule until the validation below confirms the firmware
+behavior on the affected firmware version.
 
-Note that this state does not exist yet and must be added first:
-`voice_activity_detection_enabled` in `DeviceStore` is only the
-enable/disable SETTING, and the `sr_vad` handler
-(`MentraLive.kt:4676-4684`) just forwards each event via
-`Bridge.sendSpeakingStatus(speaking)` without persisting anything. The
-implementation therefore needs to record the latest VAD speaking status and
-its timestamp somewhere the watchdog can read (e.g. a
-`lastVadStatus`/`lastVadStatusAtMs` pair updated from the `sr_vad` handler,
-in `DeviceManager` or `DeviceStore`). Do NOT gate on the
-`voice_activity_detection_enabled` setting itself; that would suppress real
-mic recovery whenever VAD is merely enabled. Concretely:
+The two similarly named status sources are not substitutes for this evidence:
 
-- For SGCs that expose a reliable VAD/speaking-status channel (confirmed:
-  Mentra Live via `sr_vad`), gate the 5s-silence check on "no VAD status
-  update either," not just "no raw audio packet."
-- For SGCs without a confirmed VAD channel (G2), leave the existing
-  packet-timer behavior as the sole recovery mechanism — don't accidentally
-  suppress real recovery for a model that needs it.
-- This likely means adding a per-model capability flag (something like
-  `hasReliableVad: Boolean` on the SGC registry entry introduced in the
-  Phase 2 `SGCManager` refactor) rather than hardcoding a model check inline
-  in `DeviceManager`.
+- `voice_activity_detection_enabled` in `DeviceStore` is the requested
+  enable/disable setting, not the current speaking state.
+- Android's phone-side `VadGateSpeechPolicy` configures a callback, but the
+  current `DeviceManager` never calls `processAudioBytes()`. It is not an
+  active liveness signal for this watchdog.
 
-## Repro
+## Required hardware validation
 
-Pair a phone to Mentra Live, sit quietly (don't talk) for 15+ seconds with
-the mic enabled, and watch:
+Record the phone model, OS version, Mentra App build, Mentra Live firmware
+versions, and whether the glasses-side VAD setting is enabled.
+
+Run an A/B test without changing any other microphone setting:
+
+1. With glasses-side VAD disabled, confirm whether LC3 packets continue through
+   quiet periods and whether the watchdog remains silent.
+2. With glasses-side VAD enabled, correlate each `sr_vad on=0` and `on=1`
+   transition with LC3 packet cessation and resumption.
+3. Confirm that speaking after a quiet period resumes LC3 without needing an
+   `enable_custom_audio_tx` retry. If it does not, the symptom may be a real
+   recovery case rather than intentional VAD gating.
+4. Repeat across disconnect/reconnect and VAD disable/re-enable boundaries to
+   establish whether `sr_vad` is a transition-only event or a periodic
+   heartbeat and whether its last value survives those boundaries.
+
+Only treat VAD-confirmed silence as the cause if the enabled/disabled comparison
+and packet correlation are repeatable. Otherwise keep investigating the audio
+transport failure.
+
+## Implementation constraints after validation
+
+Do not delete the shared watchdog. Models without confirmed VAD-gated audio,
+including G2, still need packet-based recovery. Do not gate recovery on the
+`voice_activity_detection_enabled` setting alone.
+
+If the hardware validation confirms the hypothesis:
+
+- Express the behavior on the current SGC abstraction, for example with a
+  conservative `hasReliableVadStatus` or `usesVadGatedAudio` property on
+  Android's `SGCManager` and the iOS `SGCManager` protocol. Default it to
+  `false`; opt Mentra Live in only for validated firmware behavior. There is no
+  separate SGC registry in the current implementation.
+- Persist the latest speaking value and its receive time in connection-scoped
+  native state that the watchdog can read. Clear it when the mic is disabled,
+  VAD is disabled, the model changes, or the device disconnects/reconnects.
+- A `speaking=true` state plus missing audio must remain a recovery condition.
+  Missing, cleared, or stale VAD state must fall back to packet-based recovery.
+- Do not treat one `speaking=false` transition as proof of liveness forever.
+  If firmware supplies a documented periodic VAD heartbeat, use a freshness
+  limit derived from its maximum interval. If `sr_vad` is transition-only, use
+  a bounded silence grace followed by a rate-limited probe/re-enable; do not
+  either resume the current 10-second loop or suppress recovery indefinitely.
+- Track the last recovery attempt separately and use a bounded retry/backoff
+  policy so a persistent failure cannot send a command every watchdog tick.
+
+## Secondary Android micbeat bug
+
+The repeated watchdog call exposes a separate timer-lifecycle bug in Mentra
+Live's Android `startMicBeat()`:
+
+1. It assigns a new object to `micBeatRunnable`.
+2. It calls `removeCallbacks(micBeatRunnable)` on that new, never-posted object.
+3. The previously scheduled runnable remains queued, while the new one is also
+   posted for 30 minutes later.
+
+Every watchdog retry can therefore add another self-rescheduling micbeat. After
+30 minutes those callbacks begin sending additional
+`enable_custom_audio_tx(true)` commands, and `stopMicBeat()` can remove only the
+most recently stored runnable. The native fix must make `startMicBeat()`
+idempotent by removing the previous runnable before replacing it (or by reusing
+one stable runnable), and `stopMicBeat()` must leave no callback able to
+re-enable the mic. iOS already invalidates its previous `Timer` before creating
+a replacement.
+
+## Regression coverage
+
+Extract the watchdog decision into a small testable policy where practical and
+cover at least:
+
+- recent audio: no recovery;
+- no VAD capability: preserve packet-timer recovery;
+- `speaking=true` plus missing audio: recover;
+- validated VAD silence: no 10-second retry loop;
+- stale or cleared VAD state: recovery eventually resumes;
+- disconnect, model change, mic disable, and VAD disable clear the state;
+- repeated Android `setMicEnabled(true)` calls leave exactly one micbeat
+  callback, and disabling the mic leaves none; and
+- the chosen iOS behavior when no first LC3 frame ever arrives.
+
+## Diagnostic command
+
+For the default development package, start with:
 
 ```bash
-adb logcat -v time --pid=$(adb shell pidof com.mentra.mentra) | grep -i "reinitializing glasses mic"
+adb logcat -v time --pid=$(adb shell pidof com.mentra.mentra) | grep -Ei "sr_vad|reinitializing glasses mic|enable_custom_audio_tx"
 ```
 
-One line every ~10s, indefinitely, confirms the bug. To rule out a dead mic
-as the actual cause, correlate with BLE traffic (`enable_custom_audio_tx`
-being re-sent each time with no gap where the glasses stayed connected and
-otherwise healthy — battery/heartbeat traffic still flowing normally in
-between).
+The stable and China variants use different package identifiers, so replace
+`com.mentra.mentra` when testing one of those builds. Add temporary LC3 packet
+counters or the structured BLE trace if the current log level does not expose
+packet arrival clearly enough for the required correlation.

--- a/notes/mic-reinit-watchdog-vad-blind-spot.md
+++ b/notes/mic-reinit-watchdog-vad-blind-spot.md
@@ -1,0 +1,104 @@
+# Mic reinit watchdog fires on normal VAD silence (OS-1712)
+
+Fix spec for a native-code bug (Kotlin + Swift). Not implemented here — this
+document is the handoff for whoever picks up OS-1712.
+
+## Symptom
+
+On a physical Pixel 8 + Mentra Live, this log line fires every 10 seconds,
+continuously, indefinitely, for the entire lifetime of a connected session:
+
+```
+CORE: MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic
+```
+
+Each occurrence re-sends an `enable_custom_audio_tx` BLE command to the
+glasses. This isn't a one-off blip — it was observed firing every ~10.01s for
+15+ minutes straight in a single session with no gaps.
+
+## Root cause
+
+The watchdog is purely a packet-arrival timer with no awareness of voice
+activity detection (VAD).
+
+- Android: `DeviceManager.checkAndReinitGlassesMic()` —
+  `mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt:326-341`.
+  Condition: `System.currentTimeMillis() - (lastLc3Event ?: 0L) > 5000`, gated
+  only by `glassesMicEnabled && glassesConnected`. Runs on a repeating
+  `Runnable` set up in `init()` (lines 314-323), firing every 10s.
+- iOS: equivalent `checkAndReinitGlassesMic()` —
+  `mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift:802-813`, same
+  5s-threshold / 10s-interval pattern.
+- `lastLc3Event` is stamped unconditionally at the top of
+  `handleGlassesMicData()` (Android `DeviceManager.kt:715`, before any
+  decode/validation) whenever *any* glasses SGC pushes a raw LC3 audio chunk
+  — called from `G1.kt:637`, `G2.kt:4924`, `MentraNex.kt:1237`,
+  `MentraLive.kt:9091`, `RemoteHarness.kt:203` (iOS analogues at
+  `G1.swift:1229`, `G2.swift:4983`, `MentraLive.swift:3274`,
+  `MentraNex.swift:2061`, `RemoteHarness.swift:243`). None of these paths
+  check speech vs. silence — it's a byte/packet-count-style timer, not
+  content-aware.
+- The watchdog lives in the shared `DeviceManager`, not per-SGC code, and
+  runs identically for every connected model (G1, G2, MentraLive, MentraNex,
+  ...) as long as mic is enabled and glasses are connected. The
+  `enable_custom_audio_tx` BLE command it re-sends
+  (`MentraLive.kt:6465-6486`) is MentraLive-specific plumbing, but the
+  trigger logic deciding *when* to fire it is model-agnostic.
+
+Mentra Live does have a real on-device VAD channel that the watchdog never
+consults: `sr_vad` K900 messages -> `handleSpeakingStatus()`
+(`MentraLive.kt:4362-4372`, `4676-4685`), which only forwards to
+`Bridge.sendSpeakingStatus(speaking)` for JS/UI consumption. There's also
+`voice_activity_detection_enabled` in `DeviceStore` (`MentraLive.kt:4687-4690`)
+and a phone-side Silero VAD (`VadGateSpeechPolicy`, wired in
+`DeviceManager.kt:290-312`) reporting `Bridge.sendVoiceActivityDetectionStatus`.
+Both exist and are plumbed to JS, but neither is read by
+`checkAndReinitGlassesMic()`.
+
+## Why this matters
+
+If Mentra Live's firmware suppresses packet transmission during confirmed
+silence (VAD-gated), then 5+ seconds of a user simply not talking trips this
+exact code path and fires a spurious, harmless-but-noisy `enable_custom_audio_tx`
+resend — a false-positive "reinit," not evidence of a dead mic. For G2 (no
+confirmed VAD gating on this codepath), the same logic is more plausibly a
+genuine recovery mechanism for real mic dropouts, so the watchdog can't simply
+be deleted — it needs to distinguish "silence because VAD says so" from
+"silence because the mic actually died."
+
+Continuously re-sending a BLE command every 10s for the lifetime of every
+session has a real cost even when harmless: unnecessary radio wake-ups /
+battery drain, and log noise that can mask a real reinit when one is needed.
+
+## Suggested fix
+
+Before firing the reinit in `checkAndReinitGlassesMic()`, check the model's
+own VAD state (already available via the `voice_activity_detection_enabled`
+/ `sr_vad`-derived signal in `DeviceStore`) and skip the reinit if the model
+reports VAD-confirmed silence rather than "no signal at all." Concretely:
+
+- For SGCs that expose a reliable VAD/speaking-status channel (confirmed:
+  Mentra Live via `sr_vad`), gate the 5s-silence check on "no VAD status
+  update either," not just "no raw audio packet."
+- For SGCs without a confirmed VAD channel (G2), leave the existing
+  packet-timer behavior as the sole recovery mechanism — don't accidentally
+  suppress real recovery for a model that needs it.
+- This likely means adding a per-model capability flag (something like
+  `hasReliableVad: Boolean` on the SGC registry entry introduced in the
+  Phase 2 `SGCManager` refactor) rather than hardcoding a model check inline
+  in `DeviceManager`.
+
+## Repro
+
+Pair a phone to Mentra Live, sit quietly (don't talk) for 15+ seconds with
+the mic enabled, and watch:
+
+```bash
+adb logcat -v time --pid=$(adb shell pidof com.mentra.mentra) | grep -i "reinitializing glasses mic"
+```
+
+One line every ~10s, indefinitely, confirms the bug. To rule out a dead mic
+as the actual cause, correlate with BLE traffic (`enable_custom_audio_tx`
+being re-sent each time with no gap where the glasses stayed connected and
+otherwise healthy — battery/heartbeat traffic still flowing normally in
+between).

--- a/notes/mic-reinit-watchdog-vad-blind-spot.md
+++ b/notes/mic-reinit-watchdog-vad-blind-spot.md
@@ -73,9 +73,20 @@ battery drain, and log noise that can mask a real reinit when one is needed.
 ## Suggested fix
 
 Before firing the reinit in `checkAndReinitGlassesMic()`, check the model's
-own VAD state (already available via the `voice_activity_detection_enabled`
-/ `sr_vad`-derived signal in `DeviceStore`) and skip the reinit if the model
-reports VAD-confirmed silence rather than "no signal at all." Concretely:
+own VAD state and skip the reinit if the model reports VAD-confirmed silence
+rather than "no signal at all."
+
+Note that this state does not exist yet and must be added first:
+`voice_activity_detection_enabled` in `DeviceStore` is only the
+enable/disable SETTING, and the `sr_vad` handler
+(`MentraLive.kt:4676-4684`) just forwards each event via
+`Bridge.sendSpeakingStatus(speaking)` without persisting anything. The
+implementation therefore needs to record the latest VAD speaking status and
+its timestamp somewhere the watchdog can read (e.g. a
+`lastVadStatus`/`lastVadStatusAtMs` pair updated from the `sr_vad` handler,
+in `DeviceManager` or `DeviceStore`). Do NOT gate on the
+`voice_activity_detection_enabled` setting itself; that would suppress real
+mic recovery whenever VAD is merely enabled. Concretely:
 
 - For SGCs that expose a reliable VAD/speaking-status channel (confirmed:
   Mentra Live via `sr_vad`), gate the 5s-silence check on "no VAD status


### PR DESCRIPTION
Documentation-only investigation and implementation handoff for OS-1712; no runtime code changes.

The confirmed bug is a shared native mic watchdog that checks only audio-packet arrival and re-runs model-specific mic enablement every ~10 seconds when packets stop. On Mentra Live this re-sends `enable_custom_audio_tx`.

The updated handoff now:
- separates the confirmed watchdog mechanism from the still-unproven firmware VAD-gating hypothesis;
- requires an A/B hardware test correlating `sr_vad` transitions with LC3 packet flow before a VAD-based fix ships;
- defines safe stale-VAD, reset, retry/backoff, per-SGC capability, and regression-test constraints;
- documents an Android micbeat runnable fan-out exposed by repeated watchdog retries;
- records the iOS first-frame behavior difference; and
- replaces stale/nonexistent source references with current symbols.

Companion to OS-1712 (sub-issue of OS-1687).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or SDK behavior impact.
> 
> **Overview**
> Adds **`notes/mic-reinit-watchdog-vad-blind-spot.md`** as a docs-only OS-1712 handoff (no native code in this PR).
> 
> The note documents **Mentra Live** firing `checkAndReinitGlassesMic()` ~every 10s during quiet use, re-sending **`enable_custom_audio_tx`** because recovery is keyed only on **`lastLc3Event`**, not glasses **`sr_vad`** / **`speaking_status`**. It maps the shared Android/iOS **`DeviceManager`** path and Mentra Live **`setMicEnabled`** / micbeat behavior, calls out **Android vs iOS** differences when no LC3 has arrived, and states the **VAD-gated LC3** hypothesis is **unproven** until hardware A/B validation.
> 
> It also specifies post-validation constraints (keep packet-based recovery for models like **G2**, optional per-SGC VAD awareness, persisted speaking state, backoff), documents a **secondary Android `startMicBeat()`** timer bug exposed by repeated reinit, lists regression cases, and includes an **`adb logcat`** diagnostic command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2db476c92228c2130ef90bfda5ac90648628f0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `notes/mic-reinit-watchdog-vad-blind-spot.md` documenting that `DeviceManager.checkAndReinitGlassesMic()` is a packet-only timer that re-sends `enable_custom_audio_tx` every ~10s during quiet on Mentra Live (OS-1712).

The spec proposes a per-model VAD-aware gate (keeps G2 recovery), requires persisting speaking status (not in `DeviceStore`), clarifies VAD-gated silence is a hypothesis needing hardware validation, notes an Android `startMicBeat()` idempotency bug, and includes exact file refs plus repro/`adb` logs; docs only.

<sup>Written for commit b2db476c92228c2130ef90bfda5ac90648628f0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

