### PR TITLE
Allow a per-call timeout override on CameraModule.takePhoto()

### DIFF
--- a/mobile/modules/miniapp/src/modules/camera.test.ts
+++ b/mobile/modules/miniapp/src/modules/camera.test.ts
@@ -8,18 +8,20 @@ import {CameraModule, type CameraFovResult, type PhotoTaken} from "./camera"
 
 function mockSession<T>(result: T) {
   const requestCalls: object[] = []
+  const requestOptions: (object | undefined)[] = []
   const session = {
     _hasManifestPermission: () => true,
     sendOneShot: () => {
       throw new Error("setFov should use sendRequest")
     },
-    sendRequest: (payload: object) => {
+    sendRequest: (payload: object, options?: object) => {
       requestCalls.push(payload)
+      requestOptions.push(options)
       return Promise.resolve(result)
     },
   } as unknown as MiniappSession
 
-  return {session, requestCalls}
+  return {session, requestCalls, requestOptions}
 }
 
 describe("CameraModule", () => {
@@ -74,6 +76,24 @@ describe("CameraModule", () => {
     await camera.takePhoto({mode: "text"})
 
     expect(requestCalls[0]).toMatchObject({mode: "text"})
+  })
+
+  test("takePhoto forwards timeoutMs as the sendRequest options argument", async () => {
+    const {session, requestOptions} = mockSession({})
+    const camera = new CameraModule(session)
+
+    await camera.takePhoto({timeoutMs: 1_200})
+
+    expect(requestOptions).toEqual([{timeoutMs: 1_200}])
+  })
+
+  test("takePhoto omits the options argument when timeoutMs is unset", async () => {
+    const {session, requestOptions} = mockSession({})
+    const camera = new CameraModule(session)
+
+    await camera.takePhoto({})
+
+    expect(requestOptions).toEqual([undefined])
   })
 
   test("warmUp forwards size and default duration", async () => {

--- a/mobile/modules/miniapp/src/modules/camera.ts
+++ b/mobile/modules/miniapp/src/modules/camera.ts
@@ -42,6 +42,16 @@ export interface TakePhotoOptions {
    * manual exposure; ignored otherwise.
    */
   exposureTimeNs?: number
+  /**
+   * Override the SDK's default 60s request timeout for this capture only.
+   * Leave unset for a normal user-triggered capture (the full 60s ceiling is
+   * appropriate there). Callers that speculatively fire a capture and may
+   * abandon it if the result isn't needed (e.g. a short-lived non-visual
+   * assistant turn racing a capture against a ~1s latency cap) should pass a
+   * short value here so the abandoned `takePhoto()` promise settles quickly
+   * instead of sitting on the default 60s ceiling.
+   */
+  timeoutMs?: number
 }
 
 export interface PhotoTaken {
@@ -122,15 +132,18 @@ export class CameraModule {
    * `session.capabilities.hasCamera` before calling.
    */
   async takePhoto(options: TakePhotoOptions = {}): Promise<PhotoTaken> {
-    return this.session.sendRequest<PhotoTaken>({
-      type: MiniappRequestType.PHOTO,
-      size: options.size ?? "medium",
-      mode: options.mode ?? "photo",
-      compress: options.compress ?? "none",
-      sound: options.sound ?? true,
-      saveToGallery: options.saveToGallery ?? false,
-      exposureTimeNs: options.exposureTimeNs,
-    })
+    return this.session.sendRequest<PhotoTaken>(
+      {
+        type: MiniappRequestType.PHOTO,
+        size: options.size ?? "medium",
+        mode: options.mode ?? "photo",
+        compress: options.compress ?? "none",
+        sound: options.sound ?? true,
+        saveToGallery: options.saveToGallery ?? false,
+        exposureTimeNs: options.exposureTimeNs,
+      },
+      options.timeoutMs != null ? {timeoutMs: options.timeoutMs} : undefined,
+    )
   }
 
   /**


### PR DESCRIPTION
SDK-side plumbing for OS-1701 (sub-issue of OS-1687).

## Problem

`session.sendRequest()` defaults to a 60s timeout for every request type, including photo capture. A caller that speculatively fires a capture and may abandon it before it resolves (e.g. a miniapp racing a capture against a short latency cap for non-visual queries) has no way to bound its own wait: the abandoned `takePhoto()` promise sits against the full 60s ceiling.

## Scope (what this does and does not fix)

This change bounds only the miniapp-side promise. When the shorter timeout fires, `sendRequest()` removes the local pending entry and rejects; nothing is sent to the host, and the host-side capture pipeline (`LocalMiniappRuntime.handlePhoto()` awaiting `PhonePhotoCoordinator.takePhoto()`) keeps running under its own timeouts until it completes or expires.

The cross-request stall originally observed alongside this (an unrelated `location.getOnce()` freezing behind an in-flight capture) turned out to be the Android Expo-queue head-of-line blocking fixed in #3474, not the abandoned promise itself. Post #3474 the JS layers are concurrent: `handlePhoto` dispatch is fire-and-forget and the coordinator tracks requests in a requestId-keyed map, so an abandoned capture holds only its own coordinator entry, its cloud waiter, and the glasses camera, which arbitrates its own request queue on-device.

Propagating a correlated cancel to the host so an abandoned capture also releases those host-side resources is deliberately out of scope for this PR and tracked as a follow-up (PHOTO_CANCEL, see OS-1714 review discussion).

## Change

`TakePhotoOptions` gains an optional `timeoutMs`, passed through to `sendRequest()`. Unset (the default for a normal user-triggered capture) keeps the existing 60s ceiling. Scoped to the photo-capture path only; no other request type's default changes. Unit tests assert the timeout is forwarded as the second `sendRequest` argument and that the options argument is omitted when unset.

## Consumer

The Mentra AI miniapp's `PhotoManager.takePhoto()` will pass a bounded `timeoutMs` for its speculative non-visual capture once this lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional API on photo capture only; default timeout path is unchanged.
> 
> **Overview**
> Adds optional **`timeoutMs`** on **`TakePhotoOptions`** so **`takePhoto()`** can pass a custom timeout into **`session.sendRequest()`** instead of always using the default **60s** ceiling.
> 
> When **`timeoutMs`** is omitted, behavior is unchanged (no second argument to **`sendRequest`**). When set, only that capture uses the override—intended for speculative captures that may be abandoned so the promise settles quickly and does not block other in-flight requests on the shared transport.
> 
> Tests cover forwarding **`timeoutMs`** in the options argument and passing **`undefined`** when it is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a0206d61c88b8ceb37500aead7dbf2ee648713. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a per-call timeout override to `CameraModule.takePhoto()` to let speculative captures fail fast and avoid blocking other requests. Keeps the 60s default for normal captures and fixes OS-1701’s pipeline stall.

- **New Features**
  - Added optional `timeoutMs` to `TakePhotoOptions`; forwarded as the `sendRequest` options arg and omitted when unset.
  - Default 60s unchanged; photo-only; enables the Mentra AI miniapp to cap abandoned captures (~1–2.5s) per OS-1701.
  - Tests now record `sendRequest` options and assert both forwarding and omission to prevent regressions.

<sup>Written for commit 85a0206d61c88b8ceb37500aead7dbf2ee648713. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

