### PR TITLE
npm channel promotion: CI derives versions, merging is the release

### DIFF
--- a/.github/scripts/engine-release-info.mjs
+++ b/.github/scripts/engine-release-info.mjs
@@ -1,29 +1,32 @@
 #!/usr/bin/env node
-import {execFileSync} from "node:child_process"
-import {appendFileSync, readFileSync} from "node:fs"
+// Release decision for @mentra/engine under the channel-promotion scheme
+// (npm-channel.mjs): git holds a prerelease base version (only edited on dev),
+// and the branch decides what publishes — dev -> X.Y.Z-dev.N (dev tag),
+// staging -> X.Y.Z-beta.N (beta tag), main -> X.Y.Z (latest tag). Merging IS
+// promoting; no version edits ride the branches.
+//
+// The engine publishes when its DERIVED version for this branch is absent from
+// npm (registry-state detection — promotion merges don't change the version
+// field, so git-diff detection cannot see them). Fail-closed rules, same as
+// the miniapp pipeline:
+//   - E404 is the only "absent" signal (enforced in npm-channel.mjs); any
+//     other npm error fails the run.
+//   - The first-ever publish never fires off a push: the workflow's bootstrap
+//     gate requires a supervised workflow_dispatch with force_release=true.
+//   - The main channel (latest = npm's default install) is additionally held
+//     behind the NPM_MAIN_CHANNEL repository variable until the team opens it.
+import {readFileSync, appendFileSync} from "node:fs"
+import {channelFor, deriveVersion, publishedVersions, CHANNEL_MANIFESTS} from "./npm-channel.mjs"
 
-const packagePath = "mobile/modules/engine/package.json"
+const packageName = "@mentra/engine"
+const packagePath = CHANNEL_MANIFESTS[packageName]
 
 const outputPath = process.env.GITHUB_OUTPUT
 const eventName = process.env.GITHUB_EVENT_NAME || ""
-const eventPath = process.env.GITHUB_EVENT_PATH
+const branch = process.env.GITHUB_REF_NAME || ""
 const forceRelease = process.env.FORCE_RELEASE === "true"
 const dryRun = process.env.DRY_RUN === "true"
-
-function git(args) {
-  return execFileSync("git", args, {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  }).trim()
-}
-
-function readJsonAt(ref, path) {
-  try {
-    return JSON.parse(git(["show", `${ref}:${path}`]))
-  } catch {
-    return null
-  }
-}
+const mainChannelEnabled = process.env.MAIN_CHANNEL_ENABLED === "true"
 
 function setOutput(name, value) {
   if (!outputPath) {
@@ -34,79 +37,52 @@ function setOutput(name, value) {
 }
 
 const currentPackage = JSON.parse(readFileSync(packagePath, "utf8"))
-const currentVersion = currentPackage.version
-
-if (!currentPackage.name) {
-  throw new Error(`Missing name in ${packagePath}`)
+if (currentPackage.name !== packageName) {
+  throw new Error(`${packagePath}: expected ${packageName}, found ${currentPackage.name}`)
 }
 
-if (!currentVersion) {
-  throw new Error(`Missing version in ${packagePath}`)
-}
+const {tag} = channelFor(branch) // throws on non-channel branches
+const derived = deriveVersion(currentPackage.version, branch) // validates the base is a prerelease
 
-let beforeSha = process.env.ENGINE_COMPARE_SHA || ""
-if (!beforeSha && eventPath) {
-  try {
-    const event = JSON.parse(readFileSync(eventPath, "utf8"))
-    beforeSha = event.before || ""
-  } catch {
-    beforeSha = ""
+const published = publishedVersions(packageName)
+const packageExists = published !== null
+const versionExists = packageExists && published.includes(derived)
+
+let runRelease = false
+let reason
+if (versionExists) {
+  reason = "already on npm"
+  if (branch === "main") {
+    console.log(
+      `::notice::${packageName}@${derived} is already on npm — to cut a new public release, ` +
+        `bump the base version on dev and merge it up.`,
+    )
   }
+} else if (branch === "main" && !mainChannelEnabled && !forceRelease) {
+  reason = "main channel disabled — set repo variable NPM_MAIN_CHANNEL=true"
+  console.log(`::notice::${packageName}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`)
+} else {
+  // The absent-from-npm bootstrap case still reaches the npm job: its
+  // bootstrap gate skips with a notice unless this is a force_release
+  // dispatch (and the job also handles dry-run packs).
+  runRelease = true
+  reason = forceRelease ? "force_release" : "derived version absent from npm"
+}
+if (!runRelease && eventName === "workflow_dispatch" && dryRun) {
+  runRelease = true // dry-run dispatches always get a build+pack preview
+  reason = `dry run (${reason})`
 }
 
-if (/^0+$/.test(beforeSha)) {
-  beforeSha = ""
-}
-
-// The before-SHA may not exist in a shallow checkout (or at all, after a
-// force-push to dev): fetch just that commit, and treat any failure as
-// "previous state unknown".
-if (beforeSha) {
-  try {
-    git(["fetch", "--depth=1", "origin", beforeSha])
-  } catch {
-    // readJsonAt below returns null for an unresolvable ref; fail closed there.
-  }
-}
-
-const previousPackage = beforeSha ? readJsonAt(beforeSha, packagePath) : null
-const previousVersion = previousPackage?.version || ""
-// FAIL CLOSED (same gate as the bluetooth-sdk/miniapp siblings): a release only
-// auto-fires when the previous state is KNOWN and the version actually moved.
-// An unresolvable before-SHA, a git error, or the package being new all yield
-// hasPreviousVersion=false — no auto-publish. The first-ever publish is a
-// deliberate, supervised `workflow_dispatch` with force_release=true.
-const hasPreviousVersion = Boolean(previousPackage?.version)
-const versionChanged = hasPreviousVersion && previousVersion !== currentVersion
-const runRelease = versionChanged || forceRelease || (eventName === "workflow_dispatch" && dryRun)
-
-// Dist-tag derived from the prerelease label, same convention as the
-// bluetooth-sdk/miniapp pipelines: 1.2.3-dev.4 -> dev, 1.2.3-beta.4 -> beta.
-// The engine publishes from dev only (workflow-enforced), so a plain version —
-// which would take the `latest` dist-tag, npm's default install — is refused
-// outright until a main release channel exists.
-const dash = currentVersion.indexOf("-")
-const distTag = dash === -1 ? "latest" : currentVersion.slice(dash + 1).split(".")[0].toLowerCase() || "latest"
-if (runRelease && distTag === "latest") {
-  throw new Error(
-    `${currentPackage.name}@${currentVersion} would publish to the "latest" dist-tag, but engine releases ` +
-      `ship from dev. Use a prerelease version (-dev.N / -beta.N) until a main release channel exists.`,
-  )
-}
-
-setOutput("package_name", currentPackage.name)
-setOutput("version", currentVersion)
-setOutput("dist_tag", distTag)
+setOutput("package_name", packageName)
+setOutput("version", derived)
+setOutput("dist_tag", tag)
 setOutput("dry_run", String(dryRun))
 setOutput("run_release", String(runRelease))
 setOutput("force_release", String(forceRelease))
 
-console.log(`Mentra Engine package: ${currentPackage.name}`)
-console.log(`Current version: ${currentVersion}`)
-console.log(`Dist-tag: ${distTag}`)
-console.log(`Previous version: ${previousVersion || "(unknown — releases fail closed)"}`)
-console.log(`Compare SHA: ${beforeSha || "(unavailable)"}`)
-console.log(`Version changed: ${versionChanged}`)
-console.log(`Force release: ${forceRelease}`)
-console.log(`Dry run: ${dryRun}`)
-console.log(`Run release job: ${runRelease}`)
+console.log(`Mentra Engine package: ${packageName}`)
+console.log(`Base version: ${currentPackage.version}`)
+console.log(`Derived version for ${branch}: ${derived} (dist-tag ${tag})`)
+console.log(`On npm already: ${versionExists} (package exists: ${packageExists})`)
+console.log(`Run release job: ${runRelease} (${reason})`)
+console.log(`Force release: ${forceRelease}. Dry run: ${dryRun}.`)

--- a/.github/scripts/engine-release-info.mjs
+++ b/.github/scripts/engine-release-info.mjs
@@ -48,6 +48,24 @@ const published = publishedVersions(packageName)
 const packageExists = published !== null
 const versionExists = packageExists && published.includes(derived)
 
+// Installability gate: every internal peer/dep the stamp will pin must be
+// LIVE on this channel before the engine ships — the engine and miniapp
+// pipelines run independently, so an engine-only push (or an engine job
+// outrunning the peer matrix) must not publish/stage an engine whose peer
+// ranges resolve to 404s. Note "live" means approved: staged-but-unapproved
+// versions are not in the registry, so on beta/latest the engine waits for
+// the peers' approvals (approve bottom-up, then re-run this workflow).
+const missingPeers = []
+for (const field of ["dependencies", "peerDependencies"]) {
+  for (const dep of Object.keys(currentPackage[field] || {})) {
+    if (!(dep in CHANNEL_MANIFESTS) || dep === packageName) continue
+    if (currentPackage.peerDependenciesMeta?.[dep]?.optional) continue
+    const depBase = JSON.parse(readFileSync(CHANNEL_MANIFESTS[dep], "utf8")).version
+    const depDerived = deriveVersion(depBase, branch)
+    if (!publishedVersions(dep)?.includes(depDerived)) missingPeers.push(`${dep}@${depDerived}`)
+  }
+}
+
 let runRelease = false
 let reason
 if (versionExists) {
@@ -58,9 +76,14 @@ if (versionExists) {
         `bump the base version on dev and merge it up.`,
     )
   }
-} else if (branch === "main" && !mainChannelEnabled && !forceRelease) {
+} else if (branch === "main" && !mainChannelEnabled && !dryRun) {
+  // Deliberately NOT bypassable by force_release — opening the public channel
+  // is a separate decision from forcing a publish.
   reason = "main channel disabled — set repo variable NPM_MAIN_CHANNEL=true"
   console.log(`::notice::${packageName}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`)
+} else if (missingPeers.length > 0 && !dryRun) {
+  reason = `waits for ${missingPeers.join(", ")} to be live on this channel`
+  console.log(`::notice::${packageName}@${derived} skipped: ${reason}. Publish/approve the peers, then re-run this workflow.`)
 } else {
   // The absent-from-npm bootstrap case still reaches the npm job: its
   // bootstrap gate skips with a notice unless this is a force_release

--- a/.github/scripts/engine-release-info.mjs
+++ b/.github/scripts/engine-release-info.mjs
@@ -13,8 +13,9 @@
 //     other npm error fails the run.
 //   - The first-ever publish never fires off a push: the workflow's bootstrap
 //     gate requires a supervised workflow_dispatch with force_release=true.
-//   - The main channel (latest = npm's default install) is additionally held
-//     behind the NPM_MAIN_CHANNEL repository variable until the team opens it.
+//   - beta/latest publishes land in npm's staging queue (see the workflow):
+//     a maintainer approves each version before it goes live, so merging to
+//     main IS the go signal and the approval is the only remaining gate.
 import {readFileSync, appendFileSync} from "node:fs"
 import {channelFor, deriveVersion, publishedVersions, CHANNEL_MANIFESTS} from "./npm-channel.mjs"
 
@@ -26,7 +27,6 @@ const eventName = process.env.GITHUB_EVENT_NAME || ""
 const branch = process.env.GITHUB_REF_NAME || ""
 const forceRelease = process.env.FORCE_RELEASE === "true"
 const dryRun = process.env.DRY_RUN === "true"
-const mainChannelEnabled = process.env.MAIN_CHANNEL_ENABLED === "true"
 
 function setOutput(name, value) {
   if (!outputPath) {
@@ -76,11 +76,6 @@ if (versionExists) {
         `bump the base version on dev and merge it up.`,
     )
   }
-} else if (branch === "main" && !mainChannelEnabled && !dryRun) {
-  // Deliberately NOT bypassable by force_release — opening the public channel
-  // is a separate decision from forcing a publish.
-  reason = "main channel disabled — set repo variable NPM_MAIN_CHANNEL=true"
-  console.log(`::notice::${packageName}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`)
 } else if (missingPeers.length > 0 && !dryRun) {
   reason = `waits for ${missingPeers.join(", ")} to be live on this channel`
   console.log(`::notice::${packageName}@${derived} skipped: ${reason}. Publish/approve the peers, then re-run this workflow.`)

--- a/.github/scripts/miniapp-sdk-release-info.mjs
+++ b/.github/scripts/miniapp-sdk-release-info.mjs
@@ -1,22 +1,26 @@
 #!/usr/bin/env node
 // Decides which miniapp SDK packages should be published on this push, and at
-// which npm dist-tag. Mirrors the bluetooth-sdk-release-info.mjs convention:
-// publish a package only when the `version` field in its package.json changed
-// between the push's before-SHA and HEAD (or when force-released via dispatch).
+// which npm dist-tag, under the channel-promotion scheme (npm-channel.mjs):
+// git holds one prerelease base version per package (only edited on dev), and
+// the branch decides what publishes — dev -> X.Y.Z-dev.N (dev tag), staging ->
+// X.Y.Z-beta.N (beta tag), main -> X.Y.Z (latest tag). Merging IS promoting;
+// no version edits ride the branches.
 //
-// The dist-tag is derived from the version's prerelease label so the tag can
-// never drift from the version — matching how @mentra/sdk already ships:
-//   1.2.3            -> latest      (production)
-//   1.2.3-beta.4     -> beta        (staging)
-//   1.2.3-dev.4      -> dev         (dev)
-//   1.2.3-alpha.4    -> alpha
-//   1.2.3-<label>.N  -> <label>
+// A package publishes when its DERIVED version for this branch is absent from
+// npm (registry-state detection — a promotion merge does not change the
+// version field, so git-diff detection cannot see it). Fail-closed rules:
+//   - E404 is the only "absent" signal; any other npm error fails the run.
+//   - A package that has NEVER been published does not auto-release: its first
+//     publish is a supervised workflow_dispatch with force_release=true.
+//   - The main channel (latest = npm's default install) is additionally held
+//     behind the NPM_MAIN_CHANNEL repository variable until the team opens it.
+//   - A package only ships when every internal dep it pins will resolve on
+//     this channel (already on npm, or earlier in this run's matrix).
 //
-// Packages are emitted in dependency order (miniapp, cli, scaffolder) so a
-// max-parallel:1 matrix publishes them in an order where the scaffolder's
-// template pins resolve once it runs.
-import {execFileSync} from 'node:child_process';
-import {readFileSync} from 'node:fs';
+// Packages are emitted in dependency order (leaves first) so a max-parallel:1
+// matrix publishes them in an order where cross-package pins resolve.
+import {readFileSync, appendFileSync} from 'node:fs';
+import {channelFor, deriveVersion, publishedVersions, CHANNEL_MANIFESTS} from './npm-channel.mjs';
 
 // Ordered by dependency so a max-parallel:1 matrix publishes in an order where
 // downstream pins resolve once their base lands:
@@ -27,30 +31,33 @@ import {readFileSync} from 'node:fs';
 const PACKAGES = [
   {
     key: 'miniapp',
-    path: 'mobile/modules/miniapp/package.json',
+    name: '@mentra/miniapp',
     dir: 'mobile/modules/miniapp',
     installDir: 'mobile',
     buildCmd: 'bun run build',
   },
   {
     key: 'miniapp-cli',
-    path: 'sdk/miniapp-cli/package.json',
+    name: '@mentra/miniapp-cli',
     dir: 'sdk/miniapp-cli',
     installDir: 'sdk',
     buildCmd: 'bun run build',
   },
   {
     key: 'create',
-    path: 'sdk/create-mentra-miniapp/package.json',
+    name: 'create-mentra-miniapp',
     dir: 'sdk/create-mentra-miniapp',
     installDir: 'sdk',
     buildCmd: '',
+    // The scaffolder's template pins these (stamp-template-versions.mjs), so a
+    // scaffolded project can only install once they exist on this channel.
+    alsoRequires: ['@mentra/miniapp', '@mentra/miniapp-cli'],
   },
   {
     // Cloud V2 auth helper for miniapp backends (JWKS token verification).
     // Leaf package, compiled to dist/ via `tsc -b`, Node-compatible.
     key: 'auth',
-    path: 'cloud-v2/packages/auth/package.json',
+    name: '@mentra/auth',
     dir: 'cloud-v2/packages/auth',
     installDir: 'cloud-v2',
     buildCmd: 'bun run build',
@@ -62,7 +69,7 @@ const PACKAGES = [
     // on @mentra/miniapp-cli is rewritten to an exact version before packing, so
     // it must come after miniapp-cli in this list.
     key: 'cli',
-    path: 'cloud-v2/packages/cli/package.json',
+    name: '@mentra/cli',
     dir: 'cloud-v2/packages/cli',
     installDir: 'cloud-v2',
     buildCmd: '',
@@ -76,7 +83,7 @@ const PACKAGES = [
     // relative path that resolves identically in the monorepo and under an
     // npm-installed @mentra/* sibling layout.
     key: 'jspolyfill',
-    path: 'mobile/modules/jspolyfill/package.json',
+    name: '@mentra/jspolyfill',
     dir: 'mobile/modules/jspolyfill',
     installDir: 'mobile',
     buildCmd: 'bun run build',
@@ -85,7 +92,7 @@ const PACKAGES = [
     // Native expo module (QuickJS runtime, navigation, device utilities) +
     // its config plugin carrying the Android build contract.
     key: 'crust',
-    path: 'mobile/modules/crust/package.json',
+    name: '@mentra/crust',
     dir: 'mobile/modules/crust',
     installDir: 'mobile',
     buildCmd: 'bun run build',
@@ -95,14 +102,14 @@ const PACKAGES = [
     // cloud-client/engine consumers don't drag the server runtime's deps
     // (ioredis, @soniox/node, hono stay private to the server).
     key: 'cloud-protocol',
-    path: 'cloud-v2/packages/protocol/package.json',
+    name: '@mentra/cloud-protocol',
     dir: 'cloud-v2/packages/protocol',
     installDir: 'cloud-v2',
     buildCmd: '',
   },
   {
     key: 'cloud-client',
-    path: 'cloud-v2/packages/cloud-client/package.json',
+    name: '@mentra/cloud-client',
     dir: 'cloud-v2/packages/cloud-client',
     installDir: 'cloud-v2',
     buildCmd: '',
@@ -110,91 +117,106 @@ const PACKAGES = [
 ];
 
 const outputPath = process.env.GITHUB_OUTPUT;
-const eventName = process.env.GITHUB_EVENT_NAME || '';
-const eventPath = process.env.GITHUB_EVENT_PATH;
 const branch = process.env.GITHUB_REF_NAME || '';
 const forceRelease = process.env.FORCE_RELEASE === 'true';
 const dryRun = process.env.DRY_RUN === 'true';
-
-function git(args, options = {}) {
-  return execFileSync('git', args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', options.allowFailure ? 'ignore' : 'pipe'],
-  }).trim();
-}
-
-function readJsonAt(ref, path) {
-  try {
-    return JSON.parse(git(['show', `${ref}:${path}`]));
-  } catch {
-    return null;
-  }
-}
+const mainChannelEnabled = process.env.MAIN_CHANNEL_ENABLED === 'true';
 
 function setOutput(name, value) {
   if (!outputPath) {
     console.log(`${name}=${value}`);
     return;
   }
-  execFileSync('bash', ['-lc', 'cat >> "$GITHUB_OUTPUT"'], {
-    input: `${name}=${value}\n`,
-    env: process.env,
-  });
+  appendFileSync(outputPath, `${name}=${value}\n`);
 }
 
-// 1.2.3 -> latest, 1.2.3-beta.4 -> beta, 1.2.3-dev.1 -> dev, etc.
-function distTagFor(version) {
-  const dash = version.indexOf('-');
-  if (dash === -1) return 'latest';
-  const label = version.slice(dash + 1).split('.')[0].toLowerCase();
-  return label || 'latest';
-}
+const {tag} = channelFor(branch); // throws on non-channel branches (e.g. a stray dispatch ref)
 
-let beforeSha = '';
-if (eventPath) {
-  try {
-    const event = JSON.parse(readFileSync(eventPath, 'utf8'));
-    beforeSha = event.before || '';
-  } catch {
-    beforeSha = '';
-  }
+// First pass: read every family manifest and its registry state once (also
+// covers members outside this pipeline, like the engine, so dep checks can see
+// their bases — though nothing here depends on the engine).
+const family = {};
+// Derived versions guaranteed installable after this run: already on npm, or
+// published earlier in this run's max-parallel:1 matrix.
+const willExist = new Set();
+for (const [name, manifestPath] of Object.entries(CHANNEL_MANIFESTS)) {
+  const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  const derived = deriveVersion(manifest.version, branch); // validates the base is a prerelease
+  const published = publishedVersions(name);
+  family[name] = {manifest, derived, published};
+  if (published?.includes(derived)) willExist.add(`${name}@${derived}`);
 }
-if (/^0+$/.test(beforeSha)) beforeSha = '';
 
 const matrix = [];
 const summaryRows = [];
 
 for (const pkg of PACKAGES) {
-  const current = JSON.parse(readFileSync(pkg.path, 'utf8'));
-  if (!current.name) throw new Error(`Missing name in ${pkg.path}`);
-  if (!current.version) throw new Error(`Missing version in ${pkg.path}`);
+  const entry = family[pkg.name];
+  if (!entry) throw new Error(`${pkg.name} is missing from CHANNEL_MANIFESTS`);
+  const base = entry.manifest.version;
+  const derived = entry.derived;
 
-  const previous = beforeSha ? readJsonAt(beforeSha, pkg.path) : null;
-  const previousVersion = previous?.version || '';
-  const versionChanged = Boolean(previousVersion) && previousVersion !== current.version;
-  const include = versionChanged || forceRelease;
+  const packageExists = entry.published !== null;
+  const versionExists = willExist.has(`${pkg.name}@${derived}`);
 
-  const tag = distTagFor(current.version);
-
-  // Guardrail: a plain (non-prerelease) version publishes to `latest`, which is
-  // what `npm install` resolves by default. Never let that happen off `main`.
-  if (include && tag === 'latest' && branch && branch !== 'main') {
-    throw new Error(
-      `${current.name}@${current.version} would publish to the "latest" dist-tag from branch "${branch}". ` +
-        `Production releases (no prerelease label) must land on main. Use a -dev / -beta prerelease here.`,
+  let include = false;
+  let reason;
+  if (versionExists) {
+    reason = 'already on npm';
+  } else if (!packageExists && !forceRelease) {
+    // Bootstrap gate: a first-ever publish never fires off a push.
+    reason = 'not on npm yet — bootstrap via workflow_dispatch force_release=true';
+    console.log(`::notice::${pkg.name} is not on npm yet; skipping auto-publish. ${reason}.`);
+  } else if (branch === 'main' && !mainChannelEnabled && !forceRelease) {
+    // `latest` is npm's default install: hold the public channel behind an
+    // explicit repo variable until the team opens it.
+    reason = 'main channel disabled — set repo variable NPM_MAIN_CHANNEL=true';
+    console.log(
+      `::notice::${pkg.name}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`,
     );
+  } else {
+    include = true;
+    reason = forceRelease ? 'force_release' : 'derived version absent from npm';
   }
-  if (include && branch === 'staging' && tag !== 'beta') {
-    console.log(`::warning::${current.name}@${current.version} on staging resolves to dist-tag "${tag}" (expected "beta").`);
+
+  // Installability gate: a package ships only when every internal dep it pins
+  // (dependencies + non-optional peers + template pins) will resolve on this
+  // channel — either already on npm or published earlier in this same run.
+  // Publishing past a bootstrap-gated dep would ship an uninstallable tarball
+  // (e.g. @mentra/cli pinning a @mentra/miniapp-cli that is not on npm yet).
+  if (include) {
+    const required = new Set(pkg.alsoRequires || []);
+    for (const field of ['dependencies', 'peerDependencies']) {
+      for (const dep of Object.keys(entry.manifest[field] || {})) {
+        if (!(dep in CHANNEL_MANIFESTS)) continue;
+        if (entry.manifest.peerDependenciesMeta?.[dep]?.optional) continue;
+        required.add(dep);
+      }
+    }
+    for (const dep of required) {
+      const depDerived = `${dep}@${family[dep].derived}`;
+      if (!willExist.has(depDerived)) {
+        include = false;
+        reason = `waits for ${depDerived} to exist on this channel`;
+        console.log(`::notice::${pkg.name}@${derived} skipped: ${reason}.`);
+        break;
+      }
+    }
   }
-  if (include && branch === 'dev' && !['dev', 'alpha'].includes(tag)) {
-    console.log(`::warning::${current.name}@${current.version} on dev resolves to dist-tag "${tag}" (expected "dev" or "alpha").`);
+
+  if (include) willExist.add(`${pkg.name}@${derived}`);
+
+  if (branch === 'main' && versionExists) {
+    console.log(
+      `::notice::${pkg.name}@${derived} is already on npm — to cut a new public release, ` +
+        `bump the base version on dev and merge it up.`,
+    );
   }
 
   if (include) {
     matrix.push({
-      name: current.name,
-      version: current.version,
+      name: pkg.name,
+      version: derived,
       tag,
       dir: pkg.dir,
       installDir: pkg.installDir,
@@ -203,9 +225,8 @@ for (const pkg of PACKAGES) {
   }
 
   summaryRows.push(
-    `${current.name}: ${previousVersion || '(none)'} -> ${current.version} | changed=${versionChanged} | tag=${tag} | publish=${include}`,
+    `${pkg.name}: base ${base} -> ${derived} | tag=${tag} | publish=${include}${include ? '' : ` (${reason})`}`,
   );
-  console.log(summaryRows[summaryRows.length - 1]);
 }
 
 setOutput('matrix', JSON.stringify(matrix));
@@ -213,10 +234,6 @@ setOutput('has_publishes', String(matrix.length > 0));
 setOutput('dry_run', String(dryRun));
 setOutput('force_release', String(forceRelease));
 
-if (outputPath) {
-  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
-  if (summaryPath) {
-    const body = ['## Miniapp SDK release decision', '', '```', ...summaryRows, '```', ''].join('\n');
-    execFileSync('bash', ['-lc', 'cat >> "$GITHUB_STEP_SUMMARY"'], {input: body, env: process.env});
-  }
-}
+console.log(`Branch: ${branch} (dist-tag ${tag})`);
+for (const row of summaryRows) console.log(row);
+console.log(`Publishing ${matrix.length}/${PACKAGES.length} package(s). Dry run: ${dryRun}. Force: ${forceRelease}.`);

--- a/.github/scripts/miniapp-sdk-release-info.mjs
+++ b/.github/scripts/miniapp-sdk-release-info.mjs
@@ -12,8 +12,9 @@
 //   - E404 is the only "absent" signal; any other npm error fails the run.
 //   - A package that has NEVER been published does not auto-release: its first
 //     publish is a supervised workflow_dispatch with force_release=true.
-//   - The main channel (latest = npm's default install) is additionally held
-//     behind the NPM_MAIN_CHANNEL repository variable until the team opens it.
+//   - beta/latest publishes land in npm's staging queue (see the workflow):
+//     a maintainer approves each version before it goes live, so merging to
+//     main IS the go signal and the approval is the only remaining gate.
 //   - A package only ships when every internal dep it pins will resolve on
 //     this channel (already on npm, or earlier in this run's matrix).
 //
@@ -120,7 +121,6 @@ const outputPath = process.env.GITHUB_OUTPUT;
 const branch = process.env.GITHUB_REF_NAME || '';
 const forceRelease = process.env.FORCE_RELEASE === 'true';
 const dryRun = process.env.DRY_RUN === 'true';
-const mainChannelEnabled = process.env.MAIN_CHANNEL_ENABLED === 'true';
 
 function setOutput(name, value) {
   if (!outputPath) {
@@ -169,15 +169,6 @@ for (const pkg of PACKAGES) {
     // build+pack preview is the point of a dry run.
     reason = 'not on npm yet — bootstrap via workflow_dispatch force_release=true';
     console.log(`::notice::${pkg.name} is not on npm yet; skipping auto-publish. ${reason}.`);
-  } else if (branch === 'main' && !mainChannelEnabled && !dryRun) {
-    // `latest` is npm's default install: hold the public channel behind an
-    // explicit repo variable until the team opens it. Deliberately NOT
-    // bypassable by force_release — opening the public channel is a separate
-    // decision from forcing a publish.
-    reason = 'main channel disabled — set repo variable NPM_MAIN_CHANNEL=true';
-    console.log(
-      `::notice::${pkg.name}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`,
-    );
   } else {
     include = true;
     reason = forceRelease ? 'force_release' : 'derived version absent from npm';

--- a/.github/scripts/miniapp-sdk-release-info.mjs
+++ b/.github/scripts/miniapp-sdk-release-info.mjs
@@ -163,13 +163,17 @@ for (const pkg of PACKAGES) {
   let reason;
   if (versionExists) {
     reason = 'already on npm';
-  } else if (!packageExists && !forceRelease) {
-    // Bootstrap gate: a first-ever publish never fires off a push.
+  } else if (!packageExists && !forceRelease && !dryRun) {
+    // Bootstrap gate: a first-ever publish never fires off a push. Dry runs
+    // may still include it — the publish steps are dry_run-gated, and the
+    // build+pack preview is the point of a dry run.
     reason = 'not on npm yet — bootstrap via workflow_dispatch force_release=true';
     console.log(`::notice::${pkg.name} is not on npm yet; skipping auto-publish. ${reason}.`);
-  } else if (branch === 'main' && !mainChannelEnabled && !forceRelease) {
+  } else if (branch === 'main' && !mainChannelEnabled && !dryRun) {
     // `latest` is npm's default install: hold the public channel behind an
-    // explicit repo variable until the team opens it.
+    // explicit repo variable until the team opens it. Deliberately NOT
+    // bypassable by force_release — opening the public channel is a separate
+    // decision from forcing a publish.
     reason = 'main channel disabled — set repo variable NPM_MAIN_CHANNEL=true';
     console.log(
       `::notice::${pkg.name}@${derived} would ship to "latest" but the main channel is disabled. ${reason}.`,

--- a/.github/scripts/npm-channel.mjs
+++ b/.github/scripts/npm-channel.mjs
@@ -1,0 +1,102 @@
+// Channel promotion: how a base version in git becomes a published version.
+//
+// Git holds ONE version per package, only ever edited on dev, always a
+// prerelease: X.Y.Z-<label>.N. CI derives the published version from the
+// branch, so merging a branch up the chain IS the promotion — no source edits
+// ride dev -> staging -> main:
+//
+//   dev      -> X.Y.Z-dev.N   (dist-tag dev)
+//   staging  -> X.Y.Z-beta.N  (dist-tag beta)
+//   main     -> X.Y.Z         (dist-tag latest, npm's default install)
+//
+// The prerelease NUMBER is preserved across channels (0.1.0-dev.3 promotes to
+// 0.1.0-beta.3) so a beta is traceable to the dev build it came from. After a
+// plain X.Y.Z ships from main, cutting a new release means bumping the base on
+// dev (X.Y.(Z+1)-dev.0) — the derived plain version already existing on npm is
+// how the pipeline knows a base is spent.
+//
+// This module is shared by the release detect scripts and the publish-time
+// manifest stamp so version derivation can never drift between them.
+import {execFileSync} from "node:child_process";
+
+// Every npm-published package that follows the channel scheme, name -> manifest
+// path. EXPLICIT list, not a glob: the workspace also holds private packages
+// (cloud-runtime, cloud-shared) and packages on other release models
+// (@mentra/bluetooth-sdk ships plain versions from its own pipeline) that must
+// never be channel-derived.
+export const CHANNEL_MANIFESTS = {
+  "@mentra/miniapp": "mobile/modules/miniapp/package.json",
+  "@mentra/miniapp-cli": "sdk/miniapp-cli/package.json",
+  "create-mentra-miniapp": "sdk/create-mentra-miniapp/package.json",
+  "@mentra/auth": "cloud-v2/packages/auth/package.json",
+  "@mentra/cli": "cloud-v2/packages/cli/package.json",
+  "@mentra/jspolyfill": "mobile/modules/jspolyfill/package.json",
+  "@mentra/crust": "mobile/modules/crust/package.json",
+  "@mentra/cloud-protocol": "cloud-v2/packages/protocol/package.json",
+  "@mentra/cloud-client": "cloud-v2/packages/cloud-client/package.json",
+  "@mentra/engine": "mobile/modules/engine/package.json",
+};
+
+const CHANNELS = {
+  dev: {label: "dev", tag: "dev"},
+  staging: {label: "beta", tag: "beta"},
+  main: {label: null, tag: "latest"},
+};
+
+const BASE_RE = /^(\d+\.\d+\.\d+)-[0-9a-z]+\.(\d+)$/i;
+
+export function channelFor(branch) {
+  const channel = CHANNELS[branch];
+  if (!channel) {
+    throw new Error(
+      `No npm release channel for branch "${branch}" — releases ship from dev (dev tag), ` +
+        `staging (beta tag) or main (latest tag).`,
+    );
+  }
+  return channel;
+}
+
+// 0.1.0-dev.3 on staging -> 0.1.0-beta.3; on main -> 0.1.0.
+export function deriveVersion(baseVersion, branch) {
+  const match = BASE_RE.exec(baseVersion);
+  if (!match) {
+    throw new Error(
+      `Base version "${baseVersion}" must be a X.Y.Z-<label>.N prerelease — the branch decides ` +
+        `the published label (dev/beta/none), git only holds the base.`,
+    );
+  }
+  const [, core, n] = match;
+  const {label} = channelFor(branch);
+  return label ? `${core}-${label}.${n}` : core;
+}
+
+// The range a sibling package's manifest should carry for `name` on this
+// channel. Caret over the derived version: on main that floats patches
+// (^0.1.0); on prerelease channels it pins the exact tuple (prerelease carets
+// only match their own patch tuple), which is what makes the published set
+// self-consistent.
+export function deriveRange(baseVersion, branch) {
+  return `^${deriveVersion(baseVersion, branch)}`;
+}
+
+// Registry state, E404-strict: a 404 is the ONLY signal that a package is
+// absent; any other npm failure (5xx, network, auth) throws rather than being
+// read as "absent". Returns null when the package does not exist, else the
+// array of published versions.
+export function publishedVersions(name) {
+  let out;
+  try {
+    out = execFileSync(
+      "npm",
+      ["view", name, "versions", "--json", "--registry=https://registry.npmjs.org"],
+      {encoding: "utf8", stdio: ["ignore", "pipe", "pipe"]},
+    );
+  } catch (err) {
+    const text = `${err.stdout || ""}${err.stderr || ""}`;
+    if (/"code": *"E404"/.test(text) || /code E404/.test(text)) return null;
+    throw new Error(`npm view ${name} failed with a non-404 error — refusing to guess registry state:\n${text}`);
+  }
+  const parsed = JSON.parse(out);
+  // npm view returns a bare string when exactly one version exists.
+  return Array.isArray(parsed) ? parsed : [parsed];
+}

--- a/.github/scripts/stamp-channel-manifests.mjs
+++ b/.github/scripts/stamp-channel-manifests.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Stamps every channel-released manifest in the CI checkout with its DERIVED
+// version for the current branch, and rewrites internal ranges to match — the
+// publish-time half of the channel-promotion scheme (see npm-channel.mjs).
+//
+// Two rewrites per manifest:
+//   - version: base X.Y.Z-dev.N -> the channel's derived version
+//   - dependencies/peerDependencies/optionalDependencies ranges pointing at
+//     OTHER channel-released packages -> ^<that package's derived version>
+//     (devDependencies are not shipped; `workspace:*`, `file:` and `*` ranges
+//     are left for the existing rewrite-file-deps.mjs / npm semantics)
+//
+// Stamping the WHOLE family at once (not just the package being packed) keeps
+// every later reader consistent: rewrite-file-deps.mjs pins `file:` deps from
+// the referenced manifest's (now derived) version, and
+// stamp-template-versions.mjs reads the (now derived) miniapp/miniapp-cli
+// versions for the scaffolder template.
+//
+// Mutates the checkout that gets packed/published — NEVER committed. Run it
+// AFTER `bun install` (a frozen install would reject the changed version
+// fields) and before pack/publish.
+//
+// Usage: node stamp-channel-manifests.mjs   (branch from GITHUB_REF_NAME)
+import {readFileSync, writeFileSync} from "node:fs";
+import {CHANNEL_MANIFESTS, deriveVersion, deriveRange} from "./npm-channel.mjs";
+
+const branch = process.env.GITHUB_REF_NAME || "";
+const RANGE_FIELDS = ["dependencies", "peerDependencies", "optionalDependencies"];
+
+const baseVersions = {};
+const manifests = {};
+for (const [name, path] of Object.entries(CHANNEL_MANIFESTS)) {
+  const manifest = JSON.parse(readFileSync(path, "utf8"));
+  if (manifest.name !== name) {
+    throw new Error(`${path}: expected package ${name}, found ${manifest.name}`);
+  }
+  manifests[name] = {path, manifest};
+  baseVersions[name] = manifest.version;
+}
+
+for (const [name, {path, manifest}] of Object.entries(manifests)) {
+  const derived = deriveVersion(baseVersions[name], branch);
+  const lines = [];
+  if (manifest.version !== derived) {
+    lines.push(`  version ${manifest.version} -> ${derived}`);
+    manifest.version = derived;
+  }
+  for (const field of RANGE_FIELDS) {
+    const deps = manifest[field];
+    if (!deps) continue;
+    for (const dep of Object.keys(deps)) {
+      if (!(dep in CHANNEL_MANIFESTS)) continue;
+      const range = deps[dep];
+      if (range === "*" || range.startsWith("workspace:") || range.startsWith("file:")) continue;
+      const derivedRange = deriveRange(baseVersions[dep], branch);
+      if (range === derivedRange) continue;
+      lines.push(`  ${field}.${dep} ${range} -> ${derivedRange}`);
+      deps[dep] = derivedRange;
+    }
+  }
+  if (lines.length) {
+    writeFileSync(path, JSON.stringify(manifest, null, 2) + "\n");
+    console.log(`${name} (${path}):\n${lines.join("\n")}`);
+  } else {
+    console.log(`${name}: already at channel state for "${branch}"`);
+  }
+}

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -1,18 +1,25 @@
 name: Release Mentra Engine
 
-# Publishes @mentra/engine to npm when its package version changes on dev.
-# Existing versions are skipped, making workflow re-runs safe. Detection FAILS
-# CLOSED (same as the bluetooth-sdk/miniapp pipelines): when the previous state
-# is unknown — force-push, unresolvable before-SHA, first appearance of the
-# package — nothing auto-publishes.
+# Publishes @mentra/engine to npm under the channel-promotion scheme (see
+# .github/scripts/npm-channel.mjs): git holds one prerelease base version
+# (X.Y.Z-dev.N, only edited on dev) and the branch derives what publishes —
+# dev -> X.Y.Z-dev.N (dev tag), staging -> X.Y.Z-beta.N (beta tag), main ->
+# X.Y.Z (latest tag). Merging up the chain IS the promotion; no version edits
+# ride the branches. A release fires when the derived version is absent from
+# npm (E404-strict), so re-runs and re-merges are no-ops.
+#
+# The main channel (latest = npm's default install) additionally requires the
+# NPM_MAIN_CHANNEL repository variable to be "true" — the public switch stays
+# with a human until the team opens it.
 #
 # FIRST PUBLISH (deliberately manual): @mentra/engine cannot go to npm before
 # its @mentra/* peer dependencies exist there (crust, cloud-client,
 # cloud-protocol, miniapp — npm >=7 auto-installs peers, so consumers would
 # E404). Once the peers are published, run a supervised workflow_dispatch with
 # force_release=true (dry_run=false); that first publish uses NPM_TOKEN because
-# npm cannot stage a package that does not exist. Later versions publish
-# automatically on version bumps via the OIDC staged-publishing flow.
+# npm cannot stage a package that does not exist. Later derived versions
+# publish automatically via the OIDC staged-publishing flow (held for human
+# approval).
 #
 # After the initial release, configure @mentra/engine's npm trusted publisher:
 #   organization: Mentra-Community
@@ -24,8 +31,12 @@ on:
   push:
     branches:
       - dev
+      - staging
+      - main
     paths:
       - ".github/scripts/engine-release-info.mjs"
+      - ".github/scripts/npm-channel.mjs"
+      - ".github/scripts/stamp-channel-manifests.mjs"
       - ".github/workflows/engine-release.yml"
       - "mobile/modules/engine/**"
   workflow_dispatch:
@@ -66,15 +77,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        # Depth 1: the detect script reads two blobs at the before-SHA and
-        # fetches that single commit itself; full history is ~1 GiB of waste.
+        # Depth 1 is fine: the decision reads the working tree + the npm
+        # registry, never git history.
 
-      - name: Detect package version change
+      - name: Decide release for this channel
         id: release-info
         run: node .github/scripts/engine-release-info.mjs
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
+          MAIN_CHANNEL_ENABLED: ${{ vars.NPM_MAIN_CHANNEL || 'false' }}
 
       - name: Summarize release decision
         run: |
@@ -82,7 +94,7 @@ jobs:
             echo "## Mentra Engine release decision"
             echo ""
             echo "- Package: \`${{ steps.release-info.outputs.package_name }}\`"
-            echo "- Current version: \`${{ steps.release-info.outputs.version }}\`"
+            echo "- Derived version: \`${{ steps.release-info.outputs.version }}\` (dist-tag \`${{ steps.release-info.outputs.dist_tag }}\`)"
             echo "- Dry run: \`${{ steps.release-info.outputs.dry_run }}\`"
             echo "- Run release job: \`${{ steps.release-info.outputs.run_release }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -93,12 +105,6 @@ jobs:
     if: needs.detect.outputs.run_release == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: Refuse non-dev publish
-        if: needs.detect.outputs.dry_run != 'true' && github.ref_name != 'dev'
-        run: |
-          echo "Mentra Engine releases must publish from the dev branch." >&2
-          exit 1
-
       - name: Checkout source
         uses: actions/checkout@v4
 
@@ -132,6 +138,13 @@ jobs:
       - name: Install mobile dependencies
         working-directory: mobile
         run: bun install --frozen-lockfile
+
+      # After the frozen install (which would reject changed version fields):
+      # stamp every channel-released manifest to this branch's derived versions
+      # so the packed engine carries the right version and peer ranges. Packed
+      # checkout only — never committed.
+      - name: Stamp channel versions
+        run: node .github/scripts/stamp-channel-manifests.mjs
 
       - name: Build package
         working-directory: ${{ env.ENGINE_PACKAGE_DIR }}

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -8,16 +8,13 @@ name: Release Mentra Engine
 # ride the branches. A release fires when the derived version is absent from
 # npm (E404-strict), so re-runs and re-merges are no-ops.
 #
-# The main channel (latest = npm's default install) additionally requires the
-# NPM_MAIN_CHANNEL repository variable to be "true" — the public switch stays
-# with a human until the team opens it.
-#
 # Publish mode per channel (same policy as the miniapp pipeline): dev publishes
 # DIRECTLY (fast internal iteration); beta and latest go through npm's staging
 # queue (`npm stage publish`) and a maintainer must approve each version in the
 # npm UI before it goes live. The engine's peer ranges are carets, so its peers
 # stage on those channels too — every version that can float into an approved
-# engine gets its own approval.
+# engine gets its own approval. That approval is the only gate past merge:
+# merging to main IS the go signal.
 #
 # FIRST PUBLISH (deliberately manual): @mentra/engine cannot go to npm before
 # its @mentra/* peer dependencies exist there (crust, cloud-client,
@@ -52,7 +49,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Bootstrap the first-ever release (a package absent from npm never auto-publishes). Does NOT bypass the NPM_MAIN_CHANNEL gate or the peer-availability gate."
+        description: "Bootstrap the first-ever release (a package absent from npm never auto-publishes). Does NOT bypass the peer-availability gate."
         required: true
         default: false
         type: boolean
@@ -91,7 +88,6 @@ jobs:
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
-          MAIN_CHANNEL_ENABLED: ${{ vars.NPM_MAIN_CHANNEL || 'false' }}
 
       - name: Summarize release decision
         run: |

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -29,18 +29,18 @@ name: Release Mentra Engine
 #   workflow: engine-release.yml
 #   allowed action: npm stage publish
 
+# No paths filter, deliberately: detection is registry-state ("publish when
+# the derived version is absent from npm"), so the trigger must be too — a
+# promotion merge often doesn't touch the engine tree at all, and the engine
+# regularly needs a later, unrelated push to retry (e.g. after its peers'
+# staged versions get approved). Every push reconciles; the detect job is a
+# few seconds and no-ops when nothing is missing.
 on:
   push:
     branches:
       - dev
       - staging
       - main
-    paths:
-      - ".github/scripts/engine-release-info.mjs"
-      - ".github/scripts/npm-channel.mjs"
-      - ".github/scripts/stamp-channel-manifests.mjs"
-      - ".github/workflows/engine-release.yml"
-      - "mobile/modules/engine/**"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -12,14 +12,19 @@ name: Release Mentra Engine
 # NPM_MAIN_CHANNEL repository variable to be "true" — the public switch stays
 # with a human until the team opens it.
 #
+# Publish mode per channel (same policy as the miniapp pipeline): dev publishes
+# DIRECTLY (fast internal iteration); beta and latest go through npm's staging
+# queue (`npm stage publish`) and a maintainer must approve each version in the
+# npm UI before it goes live. The engine's peer ranges are carets, so its peers
+# stage on those channels too — every version that can float into an approved
+# engine gets its own approval.
+#
 # FIRST PUBLISH (deliberately manual): @mentra/engine cannot go to npm before
 # its @mentra/* peer dependencies exist there (crust, cloud-client,
 # cloud-protocol, miniapp — npm >=7 auto-installs peers, so consumers would
 # E404). Once the peers are published, run a supervised workflow_dispatch with
 # force_release=true (dry_run=false); that first publish uses NPM_TOKEN because
-# npm cannot stage a package that does not exist. Later derived versions
-# publish automatically via the OIDC staged-publishing flow (held for human
-# approval).
+# npm cannot stage a package that does not exist.
 #
 # After the initial release, configure @mentra/engine's npm trusted publisher:
 #   organization: Mentra-Community
@@ -206,32 +211,54 @@ jobs:
         if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true' && needs.detect.outputs.force_release != 'true'
         run: echo "::notice::${{ needs.detect.outputs.package_name }} does not exist on npm yet; skipping auto-publish. Bootstrap it with a supervised workflow_dispatch (force_release=true)."
 
-      - name: Check initial publish token
-        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true' && needs.detect.outputs.force_release == 'true'
+      - name: Check publish token
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.version_exists != 'true' && (github.ref_name == 'dev' && steps.npm-registry.outputs.package_exists == 'true' || steps.npm-registry.outputs.package_exists != 'true' && needs.detect.outputs.force_release == 'true')
         run: |
           if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
-            echo "::error::Set the NPM_TOKEN repository secret to bootstrap the first @mentra/engine release."
+            echo "::error::Set the NPM_TOKEN repository secret (needed for the bootstrap and dev-channel publishes)."
             exit 1
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Publish initial npm package
-        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists != 'true' && steps.npm-registry.outputs.version_exists != 'true' && needs.detect.outputs.force_release == 'true'
+      # Direct publish covers the dev channel (fast internal iteration) and the
+      # bootstrap (npm cannot stage a package that does not exist; that path is
+      # a supervised force_release dispatch). beta/latest go through the
+      # staging queue below — same policy as the miniapp pipeline.
+      - name: Publish npm package (dev channel / bootstrap)
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.version_exists != 'true' && (github.ref_name == 'dev' && steps.npm-registry.outputs.package_exists == 'true' || steps.npm-registry.outputs.package_exists != 'true' && needs.detect.outputs.force_release == 'true')
         working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
         # access/registry come from the package's publishConfig. The dist-tag is
-        # derived from the version's prerelease label — without --tag, npm
-        # defaults a prerelease onto `latest`.
+        # derived from the channel — without --tag, npm defaults any version
+        # onto `latest`.
         run: npm publish --tag "${{ needs.detect.outputs.dist_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Stage npm package
-        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists == 'true' && steps.npm-registry.outputs.version_exists != 'true'
+      - name: Stage npm package for approval (beta/latest channels)
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.package_exists == 'true' && steps.npm-registry.outputs.version_exists != 'true' && github.ref_name != 'dev'
         working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
         # Same --tag logic as npm publish; the tag is immutable once staged, so
-        # it must be right here, not at approval time.
-        run: npm stage publish --tag "${{ needs.detect.outputs.dist_tag }}"
+        # it must be right here, not at approval time. A staged version is not
+        # live yet (npm view won't list it), so a re-merge before anyone
+        # approves re-attempts the stage — tolerate that one error.
+        run: |
+          set +e
+          out=$(npm stage publish --tag "${{ needs.detect.outputs.dist_tag }}" 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          if [[ $code -ne 0 ]]; then
+            if echo "$out" | grep -qi "already"; then
+              echo "::notice::${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }} is already in the staging queue — approve or reject it in the npm UI."
+            else
+              exit $code
+            fi
+          else
+            echo "::notice::${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }} staged for '${{ needs.detect.outputs.dist_tag }}' — a maintainer must approve it in the npm UI before it goes live."
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Skip npm stage publish
         if: steps.npm-registry.outputs.version_exists == 'true'

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -195,7 +195,9 @@ jobs:
           fi
 
       - name: Dry-run npm package
-        if: steps.npm-registry.outputs.version_exists != 'true'
+        # Also on dry-run dispatches whose derived version already exists —
+        # the tarball preview is the whole point of a dry run.
+        if: steps.npm-registry.outputs.version_exists != 'true' || needs.detect.outputs.dry_run == 'true'
         working-directory: ${{ env.ENGINE_PACKAGE_DIR }}
         run: npm pack --dry-run
 

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -52,7 +52,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Required for ANY manual publish, including the first-ever release (a dispatch with dry_run=false and force_release=false is a no-op)"
+        description: "Bootstrap the first-ever release (a package absent from npm never auto-publishes). Does NOT bypass the NPM_MAIN_CHANNEL gate or the peer-availability gate."
         required: true
         default: false
         type: boolean

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -4,19 +4,23 @@ name: Release Miniapp SDK
 # npm: @mentra/miniapp, @mentra/miniapp-cli, create-mentra-miniapp, @mentra/auth,
 # and @mentra/cli.
 #
-# Channel = branch -> dist-tag (derived from the package version's prerelease label):
-#   main     -> latest   (X.Y.Z)
-#   staging  -> beta     (X.Y.Z-beta.N)
-#   dev      -> dev      (X.Y.Z-dev.N)
-#   (any other -<label>.N -> <label>, e.g. -alpha.N -> alpha)
+# Channel promotion (see .github/scripts/npm-channel.mjs): git holds one
+# prerelease base version per package (X.Y.Z-dev.N, only edited on dev) and the
+# branch derives what publishes:
+#   dev      -> X.Y.Z-dev.N   (dev tag)
+#   staging  -> X.Y.Z-beta.N  (beta tag)
+#   main     -> X.Y.Z         (latest tag)
+# Merging up the chain IS the promotion; no version edits ride the branches. A
+# package publishes when its derived version is absent from npm (E404-strict),
+# so re-runs and re-merges are no-ops. First-ever publishes require a
+# supervised workflow_dispatch with force_release=true, and the main channel
+# (latest = npm's default install) additionally requires the NPM_MAIN_CHANNEL
+# repository variable to be "true".
 #
-# A package publishes only when the `version` field in its package.json changes
-# on the push (same gate as bluetooth-sdk-release.yml). Bump the version, merge
-# to the channel branch, and CI ships it. Existing versions are skipped, so
-# re-runs are safe.
-#
-# Before packing, workspace `file:` deps are rewritten to exact published versions
-# (rewrite-file-deps.mjs) so wrappers like @mentra/cli install cleanly for users.
+# Before packing, manifests are stamped to the channel's derived versions and
+# ranges (stamp-channel-manifests.mjs), then workspace `file:` deps are
+# rewritten to exact published versions (rewrite-file-deps.mjs) so wrappers
+# like @mentra/cli install cleanly for users.
 #
 # Requires repo secret NPM_TOKEN: an npm *automation* token (bypasses 2FA) for
 # an account with publish rights on the @mentra org. See sdk/PUBLISHING.md.
@@ -35,6 +39,8 @@ on:
       - "cloud-v2/packages/auth/**"
       - "cloud-v2/packages/cli/**"
       - ".github/scripts/miniapp-sdk-release-info.mjs"
+      - ".github/scripts/npm-channel.mjs"
+      - ".github/scripts/stamp-channel-manifests.mjs"
       - ".github/scripts/rewrite-file-deps.mjs"
       - ".github/scripts/stamp-template-versions.mjs"
       - ".github/workflows/miniapp-sdk-release.yml"
@@ -70,15 +76,16 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # Depth 1 is fine: the decision reads the working tree + the npm
+        # registry, never git history.
 
-      - name: Detect package version changes
+      - name: Decide releases for this channel
         id: info
         run: node .github/scripts/miniapp-sdk-release-info.mjs
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
+          MAIN_CHANNEL_ENABLED: ${{ vars.NPM_MAIN_CHANNEL || 'false' }}
 
   publish:
     name: Publish ${{ matrix.pkg.name }}@${{ matrix.pkg.version }}
@@ -124,9 +131,16 @@ jobs:
         working-directory: ${{ matrix.pkg.dir }}
         run: ${{ matrix.pkg.buildCmd }}
 
+      # After install+build (a frozen install would reject changed version
+      # fields): stamp every channel-released manifest to this branch's derived
+      # versions and cross-package ranges. The later rewrite/stamp steps read
+      # the stamped manifests, so their pins come out channel-correct. This
+      # only mutates the checkout that gets packed/published — never committed.
+      - name: Stamp channel versions
+        run: node .github/scripts/stamp-channel-manifests.mjs
+
       # Rewrite workspace `file:` deps to exact published versions so the tarball
-      # installs for end users (no-op for packages without them). This only
-      # mutates the checkout that gets packed/published — it is never committed.
+      # installs for end users (no-op for packages without them).
       - name: "Rewrite workspace file: deps"
         run: node .github/scripts/rewrite-file-deps.mjs "${{ matrix.pkg.dir }}"
 

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -31,25 +31,15 @@ name: Release Miniapp SDK
 # Requires repo secret NPM_TOKEN: an npm *automation* token (bypasses 2FA) for
 # an account with publish rights on the @mentra org. See sdk/PUBLISHING.md.
 
+# No paths filter, deliberately: detection is registry-state ("publish when
+# the derived version is absent from npm"), so the trigger must be too — a
+# promotion merge doesn't necessarily touch any package tree, and missing
+# versions (e.g. after a failed or gated run) should heal on the next push.
+# Every push reconciles; the detect job is a few seconds and no-ops when
+# nothing is missing.
 on:
   push:
     branches: [main, staging, dev]
-    paths:
-      - "mobile/modules/miniapp/**"
-      - "mobile/modules/jspolyfill/**"
-      - "mobile/modules/crust/**"
-      - "cloud-v2/packages/protocol/**"
-      - "cloud-v2/packages/cloud-client/**"
-      - "sdk/miniapp-cli/**"
-      - "sdk/create-mentra-miniapp/**"
-      - "cloud-v2/packages/auth/**"
-      - "cloud-v2/packages/cli/**"
-      - ".github/scripts/miniapp-sdk-release-info.mjs"
-      - ".github/scripts/npm-channel.mjs"
-      - ".github/scripts/stamp-channel-manifests.mjs"
-      - ".github/scripts/rewrite-file-deps.mjs"
-      - ".github/scripts/stamp-template-versions.mjs"
-      - ".github/workflows/miniapp-sdk-release.yml"
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -59,7 +59,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Publish even if the package version did not change"
+        description: "Bootstrap first-ever publishes (packages absent from npm never auto-release). Does NOT bypass the NPM_MAIN_CHANNEL gate."
         required: true
         default: false
         type: boolean
@@ -102,8 +102,13 @@ jobs:
     strategy:
       # Sequential + dependency-ordered: the scaffolder's template pins
       # @mentra/miniapp and @mentra/miniapp-cli, so those publish first.
+      # fail-fast: the detect script admits a package on the promise that its
+      # deps publish earlier in this run — if an upstream job fails, later
+      # packages would ship pins to versions that never landed, so the whole
+      # matrix stops. Re-running after a fix is safe: already-published
+      # versions skip.
       max-parallel: 1
-      fail-fast: false
+      fail-fast: true
       matrix:
         pkg: ${{ fromJSON(needs.detect.outputs.matrix) }}
     steps:

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -13,16 +13,15 @@ name: Release Miniapp SDK
 # Merging up the chain IS the promotion; no version edits ride the branches. A
 # package publishes when its derived version is absent from npm (E404-strict),
 # so re-runs and re-merges are no-ops. First-ever publishes require a
-# supervised workflow_dispatch with force_release=true, and the main channel
-# (latest = npm's default install) additionally requires the NPM_MAIN_CHANNEL
-# repository variable to be "true".
+# supervised workflow_dispatch with force_release=true.
 #
 # Publish mode per channel: dev publishes DIRECTLY (fast internal iteration);
 # beta and latest go through npm's STAGING QUEUE (`npm stage publish`) and a
 # maintainer must approve each version in the npm UI before it goes live. Why:
 # the engine's peer ranges are carets, so a new peer version floats into
 # already-approved engine installs on the same channel — every version that
-# can reach beta/latest therefore needs its own human approval.
+# can reach beta/latest therefore needs its own human approval. That approval
+# is the only gate past merge: merging to main IS the go signal.
 #
 # Before packing, manifests are stamped to the channel's derived versions and
 # ranges (stamp-channel-manifests.mjs), then workspace `file:` deps are
@@ -59,7 +58,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Bootstrap first-ever publishes (packages absent from npm never auto-release). Does NOT bypass the NPM_MAIN_CHANNEL gate."
+        description: "Bootstrap first-ever publishes (packages absent from npm never auto-release)."
         required: true
         default: false
         type: boolean
@@ -92,7 +91,6 @@ jobs:
         env:
           DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           FORCE_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.force_release || false }}
-          MAIN_CHANNEL_ENABLED: ${{ vars.NPM_MAIN_CHANNEL || 'false' }}
 
   publish:
     name: Publish ${{ matrix.pkg.name }}@${{ matrix.pkg.version }}

--- a/.github/workflows/miniapp-sdk-release.yml
+++ b/.github/workflows/miniapp-sdk-release.yml
@@ -17,6 +17,13 @@ name: Release Miniapp SDK
 # (latest = npm's default install) additionally requires the NPM_MAIN_CHANNEL
 # repository variable to be "true".
 #
+# Publish mode per channel: dev publishes DIRECTLY (fast internal iteration);
+# beta and latest go through npm's STAGING QUEUE (`npm stage publish`) and a
+# maintainer must approve each version in the npm UI before it goes live. Why:
+# the engine's peer ranges are carets, so a new peer version floats into
+# already-approved engine installs on the same channel — every version that
+# can reach beta/latest therefore needs its own human approval.
+#
 # Before packing, manifests are stamped to the channel's derived versions and
 # ranges (stamp-channel-manifests.mjs), then workspace `file:` deps are
 # rewritten to exact published versions (rewrite-file-deps.mjs) so wrappers
@@ -114,6 +121,15 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Use npm with staged publishing support
+        # beta/latest publishes go through npm's staging queue for human
+        # approval. `npm stage publish` needs npm >=11.15.0; pin the major so
+        # the release path doesn't pick up whatever npm shipped this morning.
+        if: github.ref_name != 'dev'
+        run: |
+          npm install -g npm@11
+          npm stage --help >/dev/null 2>&1 || { echo "::error::this npm ($(npm --version)) lacks 'npm stage' — staged publishing needs >=11.15.0."; exit 1; }
+
       - name: Cache Bun cache
         uses: actions/cache@v4
         with:
@@ -197,10 +213,41 @@ jobs:
         run: |
           echo "::notice::${{ matrix.pkg.name }} is not on npm yet — skipping auto-publish. Bootstrap it with a workflow_dispatch (force_release=true)."
 
-      - name: Publish to npm
-        if: needs.detect.outputs.dry_run != 'true' && steps.registry.outputs.exists != 'true' && (steps.registry.outputs.package_exists == 'true' || needs.detect.outputs.force_release == 'true')
+      # Direct publish covers the dev channel (fast internal iteration) and
+      # bootstraps (npm cannot stage a package that does not exist — those are
+      # supervised force_release dispatches anyway). Everything else on
+      # beta/latest goes through the staging queue below: engine peer ranges
+      # are carets, so a new peer version FLOATS into already-approved engine
+      # installs — every version that can reach those channels needs its own
+      # human approval.
+      - name: Publish to npm (dev channel / bootstrap)
+        if: needs.detect.outputs.dry_run != 'true' && steps.registry.outputs.exists != 'true' && (github.ref_name == 'dev' || steps.registry.outputs.package_exists != 'true') && (steps.registry.outputs.package_exists == 'true' || needs.detect.outputs.force_release == 'true')
         working-directory: ${{ matrix.pkg.dir }}
         run: npm publish --tag "${{ matrix.pkg.tag }}" --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Stage for approval (beta/latest channels)
+        if: needs.detect.outputs.dry_run != 'true' && steps.registry.outputs.exists != 'true' && steps.registry.outputs.package_exists == 'true' && github.ref_name != 'dev'
+        working-directory: ${{ matrix.pkg.dir }}
+        # The tag is immutable once staged, so it must be right here. A staged
+        # version is not live yet (npm view won't list it), so a re-merge before
+        # anyone approves re-attempts the stage — tolerate that one error.
+        run: |
+          set +e
+          out=$(npm stage publish --tag "${{ matrix.pkg.tag }}" --access public 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          if [[ $code -ne 0 ]]; then
+            if echo "$out" | grep -qi "already"; then
+              echo "::notice::${{ matrix.pkg.name }}@${{ matrix.pkg.version }} is already in the staging queue — approve or reject it in the npm UI."
+            else
+              exit $code
+            fi
+          else
+            echo "::notice::${{ matrix.pkg.name }}@${{ matrix.pkg.version }} staged for '${{ matrix.pkg.tag }}' — a maintainer must approve it in the npm UI before it goes live."
+          fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/cloud-v2/packages/cloud-client/package.json
+++ b/cloud-v2/packages/cloud-client/package.json
@@ -30,7 +30,10 @@
   "files": [
     "src",
     "react-native",
-    "node"
+    "node",
+    "!src/**/*.test.ts",
+    "!react-native/**/*.test.ts",
+    "!node/**/*.test.ts"
   ],
   "publishConfig": {
     "access": "public"

--- a/cloud-v2/packages/protocol/package.json
+++ b/cloud-v2/packages/protocol/package.json
@@ -8,7 +8,8 @@
     "./*": "./src/*.ts"
   },
   "files": [
-    "src"
+    "src",
+    "!src/**/*.test.ts"
   ],
   "scripts": {
     "test": "bun test"

--- a/mobile/modules/jspolyfill/package.json
+++ b/mobile/modules/jspolyfill/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mentra/jspolyfill",
   "version": "0.1.0-dev.0",
-  "description": "MentraJS polyfill bundle — installed into each per-miniapp JSContext (iOS-JSC, Android-QuickJS) at spawn time. Provides browser-like globals (console, timers, fetch, WebSocket, localStorage, crypto.subtle) over a single __dispatch native bridge, plus the __deliver / signalReady plumbing the host runtime relies on.",
+  "description": "MentraJS polyfill bundle \u2014 installed into each per-miniapp JSContext (iOS-JSC, Android-QuickJS) at spawn time. Provides browser-like globals (console, timers, fetch, WebSocket, localStorage, crypto.subtle) over a single __dispatch native bridge, plus the __deliver / signalReady plumbing the host runtime relies on.",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "scripts": {
@@ -13,7 +13,8 @@
   "files": [
     "src",
     "dist",
-    "assets"
+    "assets",
+    "!src/**/*.test.ts"
   ],
   "keywords": [
     "mentra",

--- a/mobile/modules/miniapp/package.json
+++ b/mobile/modules/miniapp/package.json
@@ -63,7 +63,8 @@
   },
   "files": [
     "dist",
-    "src"
+    "src",
+    "!src/**/*.test.ts"
   ],
   "keywords": [
     "mentra",

--- a/sdk/PUBLISHING.md
+++ b/sdk/PUBLISHING.md
@@ -40,6 +40,16 @@ promotion. The `main` channel is additionally held behind the
 Actions → Variables): until it is `true`, merges to main skip publishing with a
 notice, so opening the public channel stays a deliberate human act.
 
+**Publish mode per channel:** `dev` publishes **directly** (fast internal
+iteration). `beta` and `latest` go through **npm's staging queue**
+(`npm stage publish`) — a maintainer must approve each version in the npm UI
+(2FA) before it goes live. Why: internal ranges are carets, so a new peer
+version *floats into already-approved `@mentra/engine` installs on the same
+channel* — every version that can reach beta/latest therefore needs its own
+approval. A staged-but-unapproved version isn't live (`npm view` won't list
+it), so a re-merge before approval just re-attempts the stage (tolerated);
+**approve or reject staged versions promptly** to keep the queue meaningful.
+
 ## One-time setup (required before the first publish)
 
 1. **npm org access.** The `@mentra` org already owns `@mentra/sdk`,

--- a/sdk/PUBLISHING.md
+++ b/sdk/PUBLISHING.md
@@ -13,25 +13,32 @@ one workflow ([`miniapp-sdk-release.yml`](../.github/workflows/miniapp-sdk-relea
 
 `@mentra/miniapp`, `@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/auth`
 are not on npm yet. `@mentra/cli` has a legacy `1.0.3` on the `latest` tag (the
-v1 CLI); the Cloud V2 rewrite here is `2.0.0-alpha.*` and publishes to the `alpha`
-tag, so it does **not** disturb `latest` — see the collision note below. This doc
-is how they get to npm and stay there.
+v1 CLI); the Cloud V2 rewrite here has base `2.0.0-dev.*` and publishes to the
+`dev`/`beta` channel tags, so it does **not** disturb `latest` — see the
+collision note below. This doc is how they get to npm and stay there.
 
-## Channels (branch → dist-tag)
+## Channels (branch → derived version → dist-tag)
 
-Same model as the websites and the mobile app: each long-lived branch maps to an
-npm dist-tag, and the tag is derived from the package **version's prerelease
-label** (so the tag can never drift from the version — this matches how
-`@mentra/sdk` already ships).
+Git holds **one prerelease base version per package** (`X.Y.Z-dev.N`), only ever
+edited on `dev`. CI derives the published version from the branch at publish
+time ([`npm-channel.mjs`](../.github/scripts/npm-channel.mjs) +
+[`stamp-channel-manifests.mjs`](../.github/scripts/stamp-channel-manifests.mjs)),
+so **merging a branch up the chain IS the promotion** — no version edits ride
+`dev → staging → main`:
 
-| Branch | Version shape | dist-tag | `npm install` resolves it when… |
-| --- | --- | --- | --- |
-| `main` | `1.2.3` | `latest` | `npm i @mentra/miniapp` (default) |
-| `staging` | `1.2.3-beta.4` | `beta` | `npm i @mentra/miniapp@beta` |
-| `dev` | `1.2.3-dev.4` | `dev` | `npm i @mentra/miniapp@dev` |
+| Branch | Base in git | Published as | dist-tag | `npm install` resolves it when… |
+| --- | --- | --- | --- | --- |
+| `dev` | `1.2.3-dev.4` | `1.2.3-dev.4` | `dev` | `npm i @mentra/miniapp@dev` |
+| `staging` | `1.2.3-dev.4` | `1.2.3-beta.4` | `beta` | `npm i @mentra/miniapp@beta` |
+| `main` | `1.2.3-dev.4` | `1.2.3` | `latest` | `npm i @mentra/miniapp` (default) |
 
-`-alpha.N` → `alpha` and any other `-<label>.N` → `<label>` also work, so you can
-cut a one-off channel without touching CI.
+The prerelease number carries across channels (`-dev.3` promotes to `-beta.3`)
+so a beta is traceable to the dev build it came from. Each channel's artifact is
+a **rebuild of that branch's code** — npm has no re-tag-the-same-bytes
+promotion. The `main` channel is additionally held behind the
+`NPM_MAIN_CHANNEL` repository variable (Settings → Secrets and variables →
+Actions → Variables): until it is `true`, merges to main skip publishing with a
+notice, so opening the public channel stays a deliberate human act.
 
 ## One-time setup (required before the first publish)
 
@@ -51,15 +58,24 @@ cut a one-off channel without touching CI.
 
 Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/miniapp-sdk-release.yml).
 
-- **Trigger:** push to `main` / `staging` / `dev` that touches any of the three
-  package dirs (or the workflow/script itself). Also `workflow_dispatch`.
-- **Gate:** a package publishes **only when the `version` field in its
-  `package.json` changes** on that push (detected by
-  [`.github/scripts/miniapp-sdk-release-info.mjs`](../.github/scripts/miniapp-sdk-release-info.mjs),
-  which diffs the version against the push's before-SHA). Bumping one package
-  does not republish the others.
-- **Idempotent:** before publishing it runs `npm view <pkg>@<version>` and skips
-  if that exact version already exists. Re-running a workflow is safe.
+- **Trigger:** push to `main` / `staging` / `dev` that touches any of the
+  package dirs (or the workflow/scripts themselves). Also `workflow_dispatch`.
+- **Gate:** a package publishes **when its derived version for the branch is
+  absent from npm** (decided by
+  [`.github/scripts/miniapp-sdk-release-info.mjs`](../.github/scripts/miniapp-sdk-release-info.mjs)
+  — registry-state detection; a promotion merge doesn't change the version
+  field, so git-diffing can't see it). E404 is the only "absent" signal — any
+  other npm error fails the run rather than guessing. Extra gates: a package
+  that has **never** been published only ships via a supervised
+  `workflow_dispatch` with `force_release=true`; the main channel needs
+  `NPM_MAIN_CHANNEL=true`; and a package is held back (with a notice) while any
+  internal dep it pins doesn't yet exist on the channel.
+- **Idempotent:** the derived version already existing on npm means "nothing to
+  do" — re-running a workflow or re-merging a branch is safe.
+- **Version stamp:** before packing, [`stamp-channel-manifests.mjs`](../.github/scripts/stamp-channel-manifests.mjs)
+  rewrites every family manifest in the CI checkout to the branch's derived
+  versions, including cross-package ranges (`^0.1.0-dev.0` → `^0.1.0` on main).
+  Checkout-only; never committed — the repo keeps the base versions.
 - **Ordered:** packages publish sequentially in dependency order
   (`@mentra/miniapp` → `@mentra/miniapp-cli` → `create-mentra-miniapp` →
   `@mentra/auth` → `@mentra/cli`) so downstream pins resolve once their base lands
@@ -76,23 +92,23 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
   the **exact versions being published this run** (prerelease → exact, stable →
   caret). This is why a project scaffolded from *any* channel installs — see
   below. No-op for packages without a `template/`; never committed.
-- **Guardrail:** a plain (non-prerelease) version resolves to the `latest`
-  dist-tag — the workflow refuses to publish that from any branch other than
-  `main`, so a `-dev` build can never accidentally become what `npm install`
-  hands every developer.
+- **Guardrail:** the `latest` dist-tag (npm's default install) only ever ships
+  from `main`, and only with `NPM_MAIN_CHANNEL=true` — structurally, because
+  only the main channel derives a plain version.
 - **Dry run:** `workflow_dispatch` defaults to `dry_run: true`, which builds and
   `npm pack --dry-run`s without publishing. Use it to validate the tarball
   contents before a real release.
 
 ### Cutting a release
 
-1. On the channel branch, bump `version` in the package(s) you're shipping:
-   - dev: `0.4.0-dev.1`, `0.4.0-dev.2`, …
-   - staging: `0.4.0-beta.1`, …
-   - production: `0.4.0`
-2. Merge to the branch. CI publishes the changed packages at the matching tag.
-3. Promotion is a version bump, not a re-tag: land `0.4.0-beta.1` on `staging`,
-   then land `0.4.0` on `main`.
+1. On `dev`, bump the base `version` of the package(s) you're shipping:
+   `0.4.0-dev.0`, `0.4.0-dev.1`, … CI publishes `0.4.0-dev.N` to the `dev` tag.
+2. Merge `dev → staging`: CI publishes `0.4.0-beta.N` to `beta`. Nothing to edit.
+3. Merge `staging → main`: CI publishes `0.4.0` to `latest` (once
+   `NPM_MAIN_CHANNEL=true`). Nothing to edit.
+4. After a plain `0.4.0` has shipped, the base is **spent**: start the next
+   cycle by bumping `dev` to `0.4.1-dev.0` (or `0.5.0-dev.0`). Until then,
+   further merges to main are no-ops for that package.
 
 ## Publish order & the template stamp
 
@@ -135,21 +151,21 @@ runtime/library packages are Node-compatible: `@mentra/miniapp` (compiled JS +
 types) and `@mentra/auth` (compiled `dist/`). **Published docs must say `bunx` /
 `bun` for anything that invokes a CLI.**
 
-## ⚠️ `@mentra/cli` version collision (1.x latest vs 2.x alpha)
+## ⚠️ `@mentra/cli` version collision (1.x latest vs 2.x prereleases)
 
 `@mentra/cli@1.0.3` already sits on the `latest` tag on npm — that's the v1 CLI
 (same maintainers, so we own the name). The Cloud V2 rewrite in
-`cloud-v2/packages/cli` is `2.0.0-alpha.*` and, because of its prerelease label,
-publishes to the **`alpha`** tag. So:
+`cloud-v2/packages/cli` has base `2.0.0-dev.*`, so it ships to the `dev` and
+`beta` channel tags. So:
 
 - `npm i @mentra/cli` (or `bun add`) still resolves the old `1.0.3`.
-- `bun add @mentra/cli@alpha` gets the Cloud V2 CLI.
+- `bun add @mentra/cli@dev` (or `@beta`) gets the Cloud V2 CLI.
 
-This is intentional during the alpha. **Do not** ship a bare `2.0.0` (no
-prerelease) until the team decides to promote v2 to `latest` — that would replace
-what every plain install resolves. When ready, that promotion is just a version
-bump to `2.0.0` merged to `main` (the workflow's `latest`-only-on-`main` guardrail
-still applies).
+This holds until v2 is deliberately promoted: a `2.0.0` on `latest` (replacing
+what every plain install resolves) requires its base to reach `main` **and**
+`NPM_MAIN_CHANNEL=true`. Note this means opening the main channel promotes v2
+over the legacy 1.0.3 — that's part of the decision the variable exists to
+gate.
 
 ## Manual publishing (fallback)
 
@@ -179,8 +195,13 @@ npm publish --tag <alpha|dev|beta|latest> --access public
 #    Rewrite its file: dep to the published miniapp-cli version first.
 cd ../cli
 node ../../../.github/scripts/rewrite-file-deps.mjs .
-npm publish --tag alpha --access public   # keep on alpha; do NOT publish a bare 2.0.0
+npm publish --tag dev --access public     # channel tag only; do NOT publish a bare 2.0.0
 git checkout -- package.json               # undo the rewrite locally
+
+# When publishing by hand for a non-dev channel, stamp the derived versions
+# first (from the repo root): GITHUB_REF_NAME=<staging|main> \
+#   node .github/scripts/stamp-channel-manifests.mjs
+# then undo with: git checkout -- <the stamped package.json files>
 ```
 
 You need `npm login` (or `NPM_TOKEN` in `~/.npmrc`) with `@mentra` publish

--- a/sdk/PUBLISHING.md
+++ b/sdk/PUBLISHING.md
@@ -35,20 +35,19 @@ so **merging a branch up the chain IS the promotion** — no version edits ride
 The prerelease number carries across channels (`-dev.3` promotes to `-beta.3`)
 so a beta is traceable to the dev build it came from. Each channel's artifact is
 a **rebuild of that branch's code** — npm has no re-tag-the-same-bytes
-promotion. The `main` channel is additionally held behind the
-`NPM_MAIN_CHANNEL` repository variable (Settings → Secrets and variables →
-Actions → Variables): until it is `true`, merges to main skip publishing with a
-notice, so opening the public channel stays a deliberate human act.
+promotion.
 
 **Publish mode per channel:** `dev` publishes **directly** (fast internal
 iteration). `beta` and `latest` go through **npm's staging queue**
 (`npm stage publish`) — a maintainer must approve each version in the npm UI
-(2FA) before it goes live. Why: internal ranges are carets, so a new peer
-version *floats into already-approved `@mentra/engine` installs on the same
-channel* — every version that can reach beta/latest therefore needs its own
-approval. A staged-but-unapproved version isn't live (`npm view` won't list
-it), so a re-merge before approval just re-attempts the stage (tolerated);
-**approve or reject staged versions promptly** to keep the queue meaningful.
+(2FA) before it goes live; that approval is the only gate past merge, so
+**merging to main IS the go signal**. Why the queue: internal ranges are
+carets, so a new peer version *floats into already-approved `@mentra/engine`
+installs on the same channel* — every version that can reach beta/latest
+therefore needs its own approval. A staged-but-unapproved version isn't live
+(`npm view` won't list it), so a re-merge before approval just re-attempts the
+stage (tolerated); **approve or reject staged versions promptly** to keep the
+queue meaningful.
 
 ## One-time setup (required before the first publish)
 
@@ -77,9 +76,9 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
   field, so git-diffing can't see it). E404 is the only "absent" signal — any
   other npm error fails the run rather than guessing. Extra gates: a package
   that has **never** been published only ships via a supervised
-  `workflow_dispatch` with `force_release=true`; the main channel needs
-  `NPM_MAIN_CHANNEL=true`; and a package is held back (with a notice) while any
-  internal dep it pins doesn't yet exist on the channel.
+  `workflow_dispatch` with `force_release=true`, and a package is held back
+  (with a notice) while any internal dep it pins doesn't yet exist on the
+  channel.
 - **Idempotent:** the derived version already existing on npm means "nothing to
   do" — re-running a workflow or re-merging a branch is safe.
 - **Version stamp:** before packing, [`stamp-channel-manifests.mjs`](../.github/scripts/stamp-channel-manifests.mjs)
@@ -103,8 +102,8 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
   caret). This is why a project scaffolded from *any* channel installs — see
   below. No-op for packages without a `template/`; never committed.
 - **Guardrail:** the `latest` dist-tag (npm's default install) only ever ships
-  from `main`, and only with `NPM_MAIN_CHANNEL=true` — structurally, because
-  only the main channel derives a plain version.
+  from `main` — structurally, because only the main channel derives a plain
+  version — and only after a maintainer approves the staged version.
 - **Dry run:** `workflow_dispatch` defaults to `dry_run: true`, which builds and
   `npm pack --dry-run`s without publishing. Use it to validate the tarball
   contents before a real release.
@@ -113,9 +112,10 @@ Workflow: [`.github/workflows/miniapp-sdk-release.yml`](../.github/workflows/min
 
 1. On `dev`, bump the base `version` of the package(s) you're shipping:
    `0.4.0-dev.0`, `0.4.0-dev.1`, … CI publishes `0.4.0-dev.N` to the `dev` tag.
-2. Merge `dev → staging`: CI publishes `0.4.0-beta.N` to `beta`. Nothing to edit.
-3. Merge `staging → main`: CI publishes `0.4.0` to `latest` (once
-   `NPM_MAIN_CHANNEL=true`). Nothing to edit.
+2. Merge `dev → staging`: CI stages `0.4.0-beta.N` for `beta` — approve it in
+   the npm UI to go live. Nothing to edit.
+3. Merge `staging → main`: CI stages `0.4.0` for `latest` — approve it in the
+   npm UI to go live. Nothing to edit.
 4. After a plain `0.4.0` has shipped, the base is **spent**: start the next
    cycle by bumping `dev` to `0.4.1-dev.0` (or `0.5.0-dev.0`). Until then,
    further merges to main are no-ops for that package.
@@ -172,10 +172,10 @@ types) and `@mentra/auth` (compiled `dist/`). **Published docs must say `bunx` /
 - `bun add @mentra/cli@dev` (or `@beta`) gets the Cloud V2 CLI.
 
 This holds until v2 is deliberately promoted: a `2.0.0` on `latest` (replacing
-what every plain install resolves) requires its base to reach `main` **and**
-`NPM_MAIN_CHANNEL=true`. Note this means opening the main channel promotes v2
-over the legacy 1.0.3 — that's part of the decision the variable exists to
-gate.
+what every plain install resolves) requires its base to reach `main` and a
+maintainer to **approve the staged version in the npm UI**. Approving it
+promotes v2 over the legacy 1.0.3 — reject the staged version if that's not
+intended yet.
 
 ## Manual publishing (fallback)
 


### PR DESCRIPTION
## Why

Stacked on #3453. The team wants prerelease publishes now and public releases later — **without re-editing versions up `dev → staging → main`**. npm has no re-tag-the-same-bytes promotion (and trusted publishers can't run `dist-tag add`), so the closest possible thing is what this PR builds: **CI derives the published version from the branch**, and merging becomes the promotion.

## The scheme

Git holds **one prerelease base version per package** (`X.Y.Z-dev.N`), only ever edited on dev:

| Branch | Base in git | Publishes | dist-tag |
|---|---|---|---|
| `dev` | `0.1.0-dev.4` | `0.1.0-dev.4` | `dev` |
| `staging` | `0.1.0-dev.4` | `0.1.0-beta.4` | `beta` |
| `main` | `0.1.0-dev.4` | `0.1.0` | `latest` |

The prerelease number carries across channels (`-dev.3` → `-beta.3`) for traceability. After a plain `X.Y.Z` ships from main, the base is spent — the next cycle starts with one bump on dev. Cutting a full release = bump once on dev, then merge, merge.

## Mechanics

- **`npm-channel.mjs`** — shared derivation + E404-strict registry reads + the explicit family list (excludes private packages and `bluetooth-sdk`, which keeps its own model).
- **`stamp-channel-manifests.mjs`** — publish-time rewrite of every family manifest in the CI checkout: version **and** cross-package ranges (`^0.1.0-dev.0` → `^0.1.0` on main). Never committed; local dev and the repo's workspace ranges are untouched. `rewrite-file-deps.mjs` / `stamp-template-versions.mjs` run after it and read channel-correct values.
- **Registry-state detection** replaces git-diff detection in both detect scripts (a promotion merge doesn't change the version field): publish when the derived version is absent from npm. Re-merges and re-runs are no-ops.

## Gates (all fail-closed, all tested against the real registry)

1. **Bootstrap**: a never-published package only ships via `workflow_dispatch` `force_release=true` (unchanged).
2. **Staging approval on beta/latest**: every version that can reach those channels lands in npm's staging queue and needs a maintainer's 2FA approval to go live — merging to main IS the go signal, the approval is the only gate past it. (An earlier `NPM_MAIN_CHANNEL` repo-variable gate was removed as redundant with this.)
3. **Installability (new)**: a package is held back while any internal dep it pins (deps, non-optional peers, scaffolder template pins) doesn't exist on the channel. Caught live: `@mentra/cli` is already on npm at `1.0.3`, and without this gate the first dev push would have published `2.0.0-dev.0` pinning a `@mentra/miniapp-cli` that isn't on npm yet — an uninstallable tarball.
4. Stray branches (a dispatch on a feature ref) hard-error in derivation.

## Consequences to be aware of

- **`@mentra/cli` v1→v2 promotion rides the approval**: once its base reaches main, `2.0.0` sits staged for `latest`; approving it replaces the legacy `1.0.3` default install — reject if not intended yet. Documented in PUBLISHING.md.
- Engine now releases from all three branches (staged-publish + human approval unchanged); its packed peer ranges come out channel-correct (`^0.1.0` on main).
- Each channel's artifact is a **rebuild of that branch's code** — inherent to npm; the beta→public step re-builds from main.

## Verified locally (real registry)

dev/staging/main pushes all publish 0/9 today (bootstrap + channel + dep gates hold); force dispatch previews 9/9 in dependency order; engine derives `0.1.0-dev.0`/`0.1.0-beta.0`/`0.1.0` with main held behind the variable; main/staging stamps produce the expected manifests end-to-end (engine peers `^0.1.0`/`^0.3.0`, cli's `file:` dep → exact `0.1.0-beta.0`, template pins exact prerelease / caret stable); both workflows yaml-lint clean.

## Publish mode per channel (added after review discussion)

The engine's caret peer ranges **float**: an approved engine install picks up *later* peer publishes on the same channel (`^0.1.0` matches `0.1.5`; `^0.1.0-dev.0` matches `0.1.0-dev.4` — semver-verified). So the engine's staged publish gated only the engine artifact, not the set its ranges resolve to. Policy: **dev publishes directly** (fast internal iteration; floats only reach the team); **beta and latest go through npm's staging queue** (`npm stage publish`, npm ≥11.15) — a maintainer approves each version in the npm UI (2FA) before it goes live, for both pipelines. Bootstraps stay direct (npm can't stage a nonexistent package; they're supervised dispatches). A staged-but-unapproved version isn't live, so a re-merge re-attempts the stage — tolerated with a notice; approve or reject promptly.

## Runbook changes

The #3453 bootstrap runbook is unchanged (force_release dispatches on dev). New afterwards: **beta testing = merge to staging** (betas publish automatically), **public release = merge to main**. On staging/main, publishes land in npm's staging queue — approve them in the npm UI to go live.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core npm release mechanics for many `@mentra/*` packages—wrong derivation, registry handling, or dep gates could block releases or ship uninstallable tarballs; beta/latest staging and `@mentra/cli` v2→`latest` promotion need careful maintainer approval.
> 
> **Overview**
> Replaces **git-diff version bumps** with **channel promotion**: each package keeps a single prerelease base (`X.Y.Z-dev.N`) edited only on `dev`; CI derives what ships per branch (`dev` / `staging` / `main` → `dev` / `beta` / `latest` tags). **Merging up the branch chain is the release**—no version edits on promote.
> 
> Adds shared **`npm-channel.mjs`** (derivation, E404-strict `npm view`) and **`stamp-channel-manifests.mjs`** (checkout-only rewrite of versions and internal `^` ranges before pack). **Engine** and **miniapp SDK** detect scripts now publish when the **derived version is missing from npm**, with fail-closed bootstrap (`force_release`), **installability gates** (deps/peers/template pins must exist on the channel), and engine peer checks against **live** registry (staged-but-unapproved counts as absent).
> 
> Workflows drop **path filters** (promotion merges often touch no package trees), shallow checkout, **`stamp-channel-manifests`** after install, **`@mentra/engine` on all three branches**, **direct publish on `dev`** vs **`npm stage publish` on beta/latest**, and miniapp matrix **`fail-fast: true`**. Tarballs exclude `**/*.test.ts`; **`sdk/PUBLISHING.md`** documents the new cut/promote runbook and staging approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b26400a277cf00de6ca0b196a5797fe2879b193c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->