### PR TITLE
Fix gallery sync reliability and resumable transfers

### DIFF
--- a/agents/gallery-sync-reliability-compatibility-plan.md
+++ b/agents/gallery-sync-reliability-compatibility-plan.md
@@ -1,0 +1,518 @@
+# Gallery Sync Reliability, Performance, and Compatibility Plan
+
+Status: transfer-correctness implementation complete; hotspot/routing work deferred
+Audit date: 2026-07-16
+Audit baseline: `origin/dev` at `0944dafa28f73b3904cd08016392a1cb53d725aa`
+Primary owners: Mentra App gallery sync, `asg_client` camera server, Mentra Live system firmware networking
+
+## Purpose
+
+Make Mentra Live gallery sync durable, recoverable, and fast without breaking released phone apps or released glasses firmware.
+
+This plan covers:
+
+- Photo and video enumeration, download, validation, local persistence, camera-roll export, acknowledgement, and source retention.
+- Long-video interruption and byte-level resume.
+- Lightweight manifests, thumbnail handling, ordering, selection, and throughput.
+- Backward and forward compatibility across mixed phone/glasses versions.
+- Hotspot startup, phone routing, observability, and raw network benchmarking.
+
+It deliberately separates transfer correctness from hotspot/radio performance. A fast network must not be required for correctness, and transport correctness must not hide a slow network.
+
+## Related work
+
+- [OS-1679](https://linear.app/mentralabs/issue/OS-1679/dimenso-benchmarking-video-transfer-speed-via-wifi)
+- [OS-394](https://linear.app/mentralabs/issue/OS-394/improve-mentra-live-wifi-gallery-import-speed-and-reliability)
+- [OS-1011](https://linear.app/mentralabs/issue/OS-1011/fix-mentra-live-gallery-sync-issues)
+- [OS-1177](https://linear.app/mentralabs/issue/OS-1177/gallery-sync-fails-with-decoding-errors)
+- [OS-1384](https://linear.app/mentralabs/issue/OS-1384/long-video-transfers-from-glasses-to-phone-fail-and-become-un-redownloadable-need-resumable-transfer)
+- [OS-1472](https://linear.app/mentralabs/issue/OS-1472/gallery-sync-shows-in-mentra-app-but-not-saved-to-phone-camera-roll)
+- [OS-1087](https://linear.app/mentralabs/issue/OS-1087/mentra-live-switch-hotspot-to-be-5ghz)
+
+## Audit boundaries and confidence
+
+The conclusions in this document are based on a second static pass through the current phone and glasses code, exact bundled dependency source where relevant, and current Linear issue context.
+
+The following limitations remain:
+
+- Sentry production events were not queried because `SENTRY_AUTH_TOKEN` was unavailable.
+- The ADB-connected Mentra Live was intentionally not accessed because another agent owned it.
+- No packet capture or raw radio benchmark was performed.
+
+The code defects below are confirmed. Their relative contribution to the field failure population cannot be assigned without Sentry correlation and device fault injection.
+
+One earlier suspicion was retracted: NanoHTTPD's five-minute accepted-socket timeout is an input/read timeout, not a total outgoing transfer deadline. It should not be treated as the cause of a download dying after five minutes.
+
+## Non-negotiable safety invariant
+
+> Never acknowledge, trash, or physically delete a source capture unless every destination receipt required by the user's settings has been durably committed.
+
+When automatic camera-roll export is enabled, the required receipts are:
+
+1. A verified Mentra App file committed under a relative, portable path.
+2. A camera-roll asset identifier or URI proving export completed.
+
+When automatic camera-roll export is disabled, the verified and indexed Mentra App file may satisfy the destination requirement. Source removal must still use recoverable trash before garbage collection.
+
+## Confirmed defects
+
+### 1. Camera-roll failure does not stop glasses deletion
+
+`mediaProcessingQueue` records `saveToLibrary()` failure but continues through metadata handling and the deletion path. Permission failures and native Photos/MediaStore failures can therefore remove the source from the glasses without a camera-roll copy.
+
+An unmerged commit, `db72411db7`, changes this failure into a throw. That is an appropriate emergency guard but not the complete durable design: the local file should remain indexed as `EXPORT_PENDING`, and export should be retried without downloading again.
+
+### 2. Resume is not byte resume and is effectively disconnected
+
+The current downloader sends no `Range` request, requires status 200, and downloads from byte zero. The saved queue contains filenames and an item index, not byte offsets, source generations, hashes, or verified-file receipts. `resumeSync()` restarts `startSync()`, has no discovered UI caller, and the actual download path does not use the saved queue to skip verified transfers.
+
+### 3. iOS has a hard ten-minute whole-resource deadline
+
+The app passes `backgroundTimeout: 600000` to RNFS. The installed iOS implementation maps this to `URLSessionConfiguration.timeoutIntervalForResource`, which bounds the entire resource transfer. A slow 20-minute recording can fail simply because it has not completed within ten minutes.
+
+### 4. A retry can destroy a valid local copy
+
+The final gallery path is used as the active download destination.
+
+- Android RNFS opens that path with a truncating `FileOutputStream`.
+- iOS uses a temporary download location, but the app's catch path unlinks the destination.
+
+Retries must use a distinct `.partial` or generation-specific segment path and must never touch an existing verified final file until atomic replacement is ready.
+
+### 5. Download HTTP framing is invalid
+
+The server manually sends `Content-Length` and constructs a NanoHTTPD chunked response. NanoHTTPD then also sends `Transfer-Encoding: chunked`. HTTP forbids both framing modes in one response.
+
+The violation is definite. Its production incident share still needs client-error and packet-trace correlation.
+
+### 6. Manifest generation is expensive and duplicated
+
+The phone requests inline thumbnails. The glasses synchronously generate/read thumbnails, base64-encode them, and extract video duration before returning the manifest. The response carries both legacy `changed_files` and capture-oriented `captures`, duplicating primary thumbnail data. The phone logs the parsed payload and persists thumbnail-heavy objects in the sync queue.
+
+The request has a hard 30-second timeout. A large gallery can therefore fail before the first media transfer begins.
+
+### 7. Transfer ordering and concurrency amplify latency
+
+The current capture path processes captures and their files sequentially. The legacy path has a concurrency limit of one plus an inter-file delay. Oldest-first ordering makes users wait through unrelated backlog before seeing the newest capture.
+
+### 8. Gallery path persistence reintroduces absolute paths
+
+Reading downloaded-file metadata reconstructs relative paths as absolute. Saving a later item rewrites the entire collection while only relativizing the new entry, so older entries become absolute again. iOS container paths can change, after which the gallery treats those entries as missing and removes metadata.
+
+A pending branch prevents part of the future rewrite cycle but does not fully recover already-stale absolute paths.
+
+### 9. Camera-roll export has no idempotency receipt
+
+The native export methods already return an iOS Photos identifier or Android MediaStore URI. The JavaScript wrapper discards it and returns a boolean. After an ambiguous failure, retrying export can create duplicate assets because the application cannot prove which export already completed.
+
+### 10. Validation is too weak for irreversible deletion
+
+Validation relies on exact size, basic file signatures, and permissive processed-size comparisons. It lacks a source hash, stable source generation/ETag, and strong media structure validation. Size plus magic bytes is not proof that a large MP4 is complete and decodable.
+
+### 11. Completion and queue semantics can discard failed work
+
+The queue does not model transfer, verification, export, and acknowledgement independently. Progress can advance before asynchronous media processing finishes, and completion cleanup can clear the saved queue despite failures. A timestamp watermark cannot substitute for per-capture durable receipts.
+
+### 12. Server deletion is not transactional
+
+The delete request body is read with a single `read()` instead of a complete-body loop. Child deletion results are ignored, directory deletion is used to infer success, and the phone does not honor the returned `deleted` and `failed` arrays reliably.
+
+### 13. The old storage and queue schemas should not be mutated in place
+
+Changing the meaning or required shape of existing keys risks app downgrade failures and partial migration states. The durable transfer ledger must be versioned separately, with optional additive metadata on legacy records.
+
+## Compatibility strategy
+
+Full resumability is available only when both sides support it, but safety can improve independently on either side.
+
+| Phone | Glasses | Supported behavior |
+| --- | --- | --- |
+| New | New | Full byte resume, hashes, lightweight manifest, export receipts, idempotent acknowledgement, recoverable trash |
+| New | Old | Safe `.partial` handling, durable local/export states, whole-file retry, and conservative legacy deletion; no true byte resume or server hash/trash guarantee |
+| Old | New | Existing endpoint schemas remain valid; corrected framing and transparent server-side trash protect old clients; no client-side resume |
+| Old | Old | Existing behavior remains unchanged |
+
+### Compatibility rules
+
+1. Freeze `/api/sync` at `api_version: 2`.
+   - Current phone code tests for version 2 exactly.
+   - Returning 3 on the existing endpoint can trigger legacy fallback and lose capture grouping or sidecar behavior.
+2. Preserve the existing v2 response shape, duplicate legacy fields, ordering, and unpaginated behavior for released clients.
+3. Add a separate `/api/v3/capabilities` and `/api/v3/manifest`, or equivalent new routes.
+4. Treat absent capabilities or HTTP 404 as an old server and fall back safely.
+5. Preserve `/api/download` as a fixed-length status 200 response when no `Range` header is sent.
+6. Add standards-compliant 206/`Content-Range`/ETag behavior only when a valid `Range` header is present.
+7. If a new phone sends `Range` to an old server and receives status 200, reset the partial file. Never append a full response to an existing partial.
+8. Validate that a 206 range begins at the requested offset before appending.
+9. Keep old delete request and response schemas, but implement deletion internally as an atomic move to hidden trash.
+10. Keep trash outside every old and new live-manifest namespace.
+11. Add optional hashes, durations, generations, and capabilities. Old JSON clients can ignore unknown fields.
+12. Gate concurrency on an advertised server limit. Default to one transfer against old servers.
+13. Use a new versioned transfer-ledger storage key so old application versions can still read their existing metadata after downgrade.
+
+## Durable transfer model
+
+Each capture is tracked by a stable capture ID. Legacy flat media without a capture ID uses a composite identity such as package, filename, size, and modified timestamp.
+
+```text
+DISCOVERED
+  -> TRANSFERRING
+  -> VERIFIED
+  -> INDEXED
+  -> EXPORT_PENDING
+  -> EXPORTED
+  -> ACK_PENDING
+  -> TRASHED
+  -> GARBAGE_COLLECTED
+```
+
+Each state transition is persisted atomically. Failure leaves the capture in the last recoverable state.
+
+Suggested ledger fields:
+
+- Ledger schema version.
+- Capture identity and source filename set.
+- Source generation/ETag.
+- Expected sizes and optional hashes.
+- Partial paths and durable byte offsets.
+- Verified final relative paths.
+- Verification method and timestamp.
+- Camera-roll export requirement.
+- Camera-roll asset identifier/URI.
+- Acknowledgement ID and status.
+- Retry count, last error class, and next retry time.
+- Server capability snapshot.
+
+## Filesystem rules
+
+1. The final gallery path is never an active network destination.
+2. Download to `.partial.<generation>` or immutable segments.
+3. Persist offsets periodically rather than only at file completion.
+4. Validate size, range total, source generation, hash, and media structure.
+5. Flush the completed temporary file before committing it.
+6. Atomically rename into the final path.
+7. Persist only a relative final path.
+8. Commit metadata and the verified ledger transition atomically or in a recoverable two-phase sequence.
+9. Preserve an older valid final file until the replacement is completely verified.
+
+## Resumable protocol
+
+### Capability discovery
+
+The new phone asks for capabilities before requesting a v3 manifest. Useful fields include:
+
+- Transfer protocol version.
+- Range support.
+- Hash algorithms.
+- Manifest version and page limit.
+- Maximum recommended photo/video concurrency.
+- Trash and restore support.
+- Hotspot/network telemetry support.
+
+### Download algorithm
+
+1. Locate a partial file and ledger entry for the same capture and ETag.
+2. Send `Range: bytes=<durableOffset>-` and `If-Range: <etag>`.
+3. On 206, require `Content-Range` to start at the requested offset and append through a non-truncating native writer.
+4. On 200, reset the partial because the server is old, ignored the range, or the source changed.
+5. On 416, compare the declared total against the partial size and verify before considering it complete.
+6. If ETag/source generation changes, discard the old partial and restart safely.
+7. Persist progress every bounded time/byte interval.
+8. Retry transient failures with exponential backoff, jitter, and hotspot reconnection.
+9. Verify and atomically commit.
+10. Retry export and acknowledgement from the ledger without downloading again.
+
+RNFS is not sufficient for a durable Android append path. Implement a small native transfer module using a non-truncating file API and explicit network binding, or download immutable segments and assemble them after verification.
+
+## Export receipts and idempotency
+
+1. Return the native iOS Photos local identifier or Android MediaStore URI to JavaScript.
+2. Persist it as the export receipt before acknowledgement.
+3. Use capture ID, intended display name, size/hash, and stored receipt to decide whether export is already complete.
+4. If the native operation is ambiguous, reconcile with the media library before inserting another asset.
+5. Give native export operations bounded timeouts and cancellation/error reporting; avoid indefinite semaphore waits.
+
+## Manifest v3
+
+The v3 manifest should contain lightweight, precomputed metadata:
+
+- Capture ID.
+- Capture timestamp.
+- File names and media roles.
+- Size.
+- Stable source generation/ETag.
+- Duration.
+- SHA-256 or another negotiated hash.
+- Optional thumbnail resource URL or thumbnail generation token.
+
+It should not inline base64 thumbnail data by default.
+
+Additional requirements:
+
+- Cursor pagination using timestamp plus capture ID/generation, not timestamp alone.
+- Newest-first retrieval.
+- Explicit selected-capture retrieval.
+- Lazy thumbnail endpoints with cache validators.
+- Precompute duration/hash at capture finalization.
+- Batch acknowledgement.
+- Do not use a global timestamp watermark as proof of per-capture completion.
+
+## Source acknowledgement and recoverable trash
+
+1. Add an idempotent v3 acknowledgement endpoint keyed by capture ID and acknowledgement ID.
+2. Acknowledgement atomically moves the complete capture package into hidden trash.
+3. Make the legacy delete endpoint perform the same internal move while preserving its current schema.
+4. Exclude trash from counts, manifests, thumbnail scans, and legacy prefix matching.
+5. Retain trash for at least seven days by default.
+6. Garbage-collect by age and storage high-water mark.
+7. Expose trash list and restore to new clients.
+8. Log every acknowledgement, trash move, restore, and garbage-collection reason.
+
+## Implementation phases
+
+### Phase 0: immediate phone data-safety release
+
+Works against all existing glasses versions.
+
+- Use separate partial paths; never overwrite a verified final file during transfer.
+- Persist/index the verified local file before camera-roll export.
+- Convert export failure into `EXPORT_PENDING` and never delete the source.
+- Preserve native asset identifiers/URIs.
+- Honor actual delete results.
+- Do not report complete or clear work while transfer, export, or acknowledgement is pending.
+- Introduce the versioned ledger and migrate the current queue conservatively.
+- Raise the iOS whole-resource deadline as a short-term mitigation until resume ships.
+- Stop persisting/logging inline thumbnail base64.
+- Request thumbnails only when needed by the current UI.
+- Run the relative-path migration before stale-file cleanup.
+- Quarantine unresolved metadata instead of deleting it on the first missing-path check.
+
+### Phase 1: backward-compatible glasses safety release
+
+- Correct HTTP framing with fixed-length status 200 downloads.
+- Add optional Range/ETag/206/416 support.
+- Add capability discovery.
+- Precompute and persist size, duration, generation, and hashes at capture finalization.
+- Make legacy deletion an atomic trash move.
+- Add idempotent acknowledgement, trash listing, restore, and retention GC.
+- Read request bodies fully and report per-capture results accurately.
+- Preserve all released endpoint schemas.
+
+### Phase 2: new phone v3 transfer client
+
+- Implement the native resumable transfer module or immutable segment transport.
+- Persist byte offsets and generations.
+- Implement safe old-server status-200 fallback.
+- Add bounded retry, reconnection, validation, atomic commit, export receipt, and acknowledgement state transitions.
+- Resume transfer/export/acknowledgement from ledger state after app termination or reboot.
+
+### Phase 3: end-to-end performance
+
+- Add v3 lightweight manifests and pagination.
+- Support newest-first and selected captures.
+- Fetch thumbnails lazily.
+- Batch acknowledgements and other small operations.
+- Add capability-gated adaptive concurrency.
+- Remove avoidable per-file delays.
+- Measure time to first selectable item separately from full-sync duration.
+
+### Phase 4: hotspot and routing
+
+Treat this as a separate workstream from transfer correctness.
+
+- Preserve released SSID behavior and `192.168.43.1` compatibility unless a capability-negotiated replacement is introduced.
+- Determine whether the Mentra Live DHCP server advertises an unwanted default route or DNS server.
+- If firmware supports it, provide a local-only AP profile that advertises the on-link subnet without claiming internet reachability.
+- On Android phones, retain the `Network` returned for the Mentra hotspot and bind only gallery HTTP sockets to it. Do not bind the entire process.
+- On iOS, validate `NEHotspotConfiguration` behavior and on-link routing independently. Do not assume Android's per-network socket model exists on iOS.
+- Log band, channel, frequency, RSSI, negotiated link speed, client IP/prefix, gateway, DNS, active/default network, interface, and route decision.
+- Benchmark raw HTTP independently from manifest, validation, hashing, export, and rendering.
+- Keep hotspot shutdown ownership explicit and idempotent.
+
+The current `asg_client` only asks the firmware-owned SystemUI/tethering stack to start or stop the AP. It cannot currently choose DHCP options, gateway advertisement, or NAT behavior. App-only work can improve phone-side routing and observability; changing the AP's DHCP/router behavior requires a firmware change or a new firmware API exposed to `asg_client`.
+
+#### Current hotspot/routing findings
+
+- Mentra Live `asg_client` sends the vendor SystemUI an `ap_start` broadcast and later observes the AP interface. It does not construct the Soft AP or DHCP configuration itself.
+- The current glasses API calls the AP address `hotspot_gateway_ip` and hardcodes `192.168.43.1`. For compatibility, keep that field, but add an explicit `local_server_ip` in a future capability/version because the glasses should be the local HTTP server without necessarily being the phone's default router.
+- Android 11 AOSP's `IpServer` uses a shared DHCP path for tethered and local-only serving modes and supplies the AP address as both the default router and DNS server. Mentra Live's vendor fork may differ, but merely switching to an API named `LocalOnlyHotspot` is therefore not proof that iOS will preserve cellular as its default route. Inspect the actual Mentra Live DHCP offer and test iOS routing.
+- Android phone builds use `react-native-wifi-reborn` 4.13.6. On Android 10+, its `WifiNetworkSpecifier` request correctly removes the Internet capability, but its `onAvailable` callback then binds the entire Mentra App process to that network. All subsequently created sockets and DNS queries therefore use the no-Internet hotspot until the network is lost or explicitly unbound.
+- Fix Android by retaining the returned `Network`, leaving the process unbound, and constructing the gallery HTTP/downloader client with that network's `SocketFactory` or individually bound sockets. Cloud and unrelated app traffic then continue on the system default, normally cellular.
+- The existing JavaScript `fetch` and RNFS paths cannot receive an Android `Network`/`SocketFactory`. The scoped-routing fix should be part of the native resumable transfer module rather than another global network toggle.
+- On iOS, `react-native-wifi-reborn` uses `NEHotspotConfiguration` with `joinOnce = false`. iOS has no direct equivalent to Android's app-visible `Network` object for binding an ordinary `URLSession` to the selected local WiFi network.
+- For iOS, the preferred architecture is for the accessory network not to claim the default route. The directly connected subnet route then reaches `192.168.43.1` over WiFi while Internet traffic can remain on cellular.
+- Setting `joinOnce = true` can prevent a persistent hotspot profile, but it also disconnects when the app backgrounds for more than roughly 15 seconds, sleeps, quits, or crashes. It is not a substitute for correct DHCP behavior and can conflict with long/background transfers.
+- If firmware cannot stop claiming the default route, iOS app-only workarounds require explicitly routing Internet sessions over cellular or Multipath TCP where applicable. Those workarounds do not fix other apps on the phone and are not the preferred product solution.
+
+#### Phase 4 work split
+
+1. Phone-only Android work:
+   - Replace/fork the current hotspot connection helper so it never calls process-wide `bindProcessToNetwork`.
+   - Keep the `NetworkCallback` and hotspot `Network` alive for the gallery session.
+   - Bind only health, manifest, thumbnail, download, acknowledgement, and benchmark sockets to it.
+   - Explicitly release the callback/network at completion and cancellation.
+2. Glasses application spike on stock firmware:
+   - Determine whether the existing vendor APIs can start a local-only scope while preserving the reported SSID/password and `192.168.43.1`.
+   - Capture the DHCP offer and route behavior. Do not infer behavior from the API name.
+3. Firmware work if the stock platform cannot provide the required DHCP behavior:
+   - Add a vendor SystemUI/tethering command for a gallery local-only profile, analogous to the existing 5 GHz control.
+   - Keep the AP interface/server address `192.168.43.1/24` for old clients.
+   - Do not advertise the glasses as a default Internet router or unusable DNS server for this profile.
+   - Preserve the existing legacy hotspot mode as a fallback selected by capability/version.
+4. iOS work:
+   - Continue using the supported hotspot-configuration entitlement and explicit user join flow.
+   - Validate local HTTP plus simultaneous cellular Internet on every supported iOS version.
+   - Decide between persistent configuration with explicit removal and `joinOnce` based on foreground/background product requirements.
+   - Use a firmware fix, not broad cellular-binding workarounds, as the primary route solution.
+
+### Phase 5: recovery and operations
+
+- Add a user-visible retry/export-pending state.
+- Add trash restore UI.
+- Add storage-pressure warnings and deterministic GC telemetry.
+- Add structured incident fields for every transfer state transition.
+- Consider USB or cloud recovery paths for captures that cannot be retrieved over WiFi.
+
+## Relative-path migration
+
+The migration must run before gallery cleanup and be idempotent.
+
+1. Leave valid relative paths unchanged.
+2. Convert files under the current document directory to relative paths.
+3. For an old iOS container path, extract the suffix after `/Documents/` and test it under the current document directory.
+4. If necessary, locate the expected `MentraPhotos/...` suffix under the current root.
+5. Verify file identity using size and available hash before relinking.
+6. Rewrite recovered entries as relative.
+7. Quarantine unresolved records for later reconciliation rather than deleting them immediately.
+8. Test repeated migration, app upgrade, app downgrade, and missing-file behavior.
+
+## Observability
+
+Every transfer attempt should carry stable correlation fields:
+
+- Sync session ID.
+- Capture ID.
+- Phone app version/platform/OS/device.
+- Glasses app and MTK firmware versions.
+- Protocol/capability versions.
+- Hotspot startup and join durations.
+- Manifest count, byte size, generation time, and parse time.
+- Download offset, requested range, response status, ETag, expected/received bytes, and retry class.
+- Raw throughput sampled over bounded windows.
+- Validation result and duration.
+- Filesystem commit result.
+- Export result and native asset receipt presence.
+- Acknowledgement/trash result.
+- Current network interface, route, band, channel/frequency, RSSI, and link speed when available.
+
+Never log hotspot passwords, camera-roll identifiers in plaintext telemetry, full manifests, thumbnail base64, or media contents.
+
+## Verification matrix
+
+### Version compatibility
+
+- Released old phone against new glasses.
+- New phone against at least two or three released glasses firmware versions.
+- New phone and new glasses.
+- Upgrade from legacy storage/queue state.
+- Downgrade after the new ledger has been created.
+
+### Data sets
+
+- One photo.
+- One short video.
+- Mixed photos, videos, and sidecars.
+- More than 100 captures.
+- A large video.
+- A roughly 20-minute video.
+- Selected newest capture with a large older backlog.
+
+### Fault injection
+
+- Disconnect at 10%, 50%, and 90%.
+- WiFi flap.
+- Bluetooth disconnect while hotspot is running.
+- App background and foreground.
+- App force-kill.
+- Phone reboot.
+- Glasses reboot.
+- Phone storage full.
+- Glasses storage full.
+- Camera-roll permission denied.
+- Native Photos/MediaStore export error.
+- Export operation completes but response is lost.
+- Source changes ETag during retry.
+- Corrupt source.
+- Corrupt partial file.
+- Old server ignores Range and returns 200.
+- Server returns invalid or mismatched `Content-Range`.
+- Delete request body arrives in multiple reads.
+- Trash storage crosses the high-water mark.
+
+### Hotspot/platform matrix
+
+- Current supported iOS versions and representative iPhones.
+- Current supported Android versions and representative Samsung/Pixel devices.
+- Cellular available versus unavailable.
+- Phone initially on another WiFi network versus cellular only.
+- 2.4 GHz fallback versus 5 GHz hotspot.
+- Weak RSSI and interference.
+- Screen lock/background where supported.
+- Verify internet requests continue over cellular while gallery sockets use the hotspot.
+
+## Release gates
+
+- No physical source deletion before the destination-receipt invariant is satisfied.
+- Every injected interruption remains recoverable.
+- A resumed transfer requests only missing bytes, aside from bounded validation/protocol overhead.
+- Retry never truncates or deletes an existing verified file.
+- Export retry does not create duplicate camera-roll assets.
+- No absolute iOS container paths remain after migration.
+- Failed items remain visible and retryable after app restart.
+- Old clients continue parsing and using every legacy endpoint.
+- New clients safely handle old servers returning 200 to a Range request.
+- Large manifests do not spend the majority of time generating inline thumbnails.
+- A 20-minute video either completes in one attempt or resumes to completion after interruption.
+- Raw hotspot throughput and full-pipeline throughput are reported separately.
+
+## Proposed performance measurements
+
+Measure at least:
+
+- Hotspot command to AP ready.
+- AP ready to phone associated.
+- Association to health endpoint reachable.
+- Manifest server generation time, response bytes, transfer time, and client parse time.
+- Time to first thumbnail.
+- Time to first selected/latest media download start.
+- Raw sustained download throughput for a preexisting large file.
+- Hash/validation time.
+- Atomic commit time.
+- Camera-roll export time.
+- Acknowledgement/trash time.
+- End-to-end time for one photo, mixed backlog, 100+ captures, and 20-minute video.
+
+Do not infer radio performance from end-to-end sync time. Benchmark the raw download endpoint with manifest generation and export excluded.
+
+## Open questions
+
+- What exact Sentry issues and error domains dominate current failed long transfers?
+- What DHCP router and DNS options does current Mentra Live firmware advertise?
+- Does current MTK firmware support a true local-only Soft AP profile, or must vendor SystemUI/tethering be extended?
+- What is the cleanest native-module boundary for retaining Android's hotspot `Network` and sharing its scoped `SocketFactory` with manifest and resumable-download clients?
+- How does each supported iOS version route on-link hotspot traffic while keeping cellular as the internet path?
+- What raw TCP/HTTP throughput is achieved on current 5 GHz firmware at controlled RSSI?
+- What trash retention period is acceptable for glasses storage constraints?
+- Should automatic export failure surface as a persistent gallery item, a notification, or both?
+
+## Immediate implementation order
+
+1. Ship phone-side source-deletion barrier and `.partial` safety.
+2. Ship server-side transparent trash and correct HTTP framing.
+3. Ship relative-path recovery before metadata cleanup.
+4. Introduce the versioned transfer ledger and export receipts.
+5. Add Range/hash/capability support to glasses.
+6. Ship the native resumable phone client.
+7. Replace the heavyweight manifest and add selection/pagination.
+8. Implement and benchmark the platform-specific hotspot/routing work.
+9. Add recovery UI and storage-pressure GC.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManager.java
@@ -28,6 +28,12 @@ public interface FileManager extends FileOperations, FileMetadataOperations, Pac
      */
     String SDK_PENDING_DIR_NAME = "_sdk_pending";
 
+    /** Hidden recoverable trash; never expose acknowledged captures to gallery clients. */
+    String GALLERY_TRASH_DIR_NAME = "_gallery_trash";
+
+    /** Cached hashes and other derived transfer metadata; never user-visible media. */
+    String GALLERY_METADATA_DIR_NAME = "_gallery_metadata";
+
     /**
      * File operation result containing success status and metadata
      */
@@ -117,4 +123,4 @@ public interface FileManager extends FileOperations, FileMetadataOperations, Pac
      * @return ThumbnailManager instance
      */
     ThumbnailManager getThumbnailManager();
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManager.java
@@ -24,7 +24,8 @@ public interface FileManager extends FileOperations, FileMetadataOperations, Pac
      * caller asked us NOT to keep ({@code save=false}). Files written under this directory are
      * intentionally hidden from {@link #listFiles(String)} so they cannot leak into gallery
      * counts or Wi-Fi sync responses while their upload is still in flight. The directory is
-     * still walked by {@link #cleanupOldFiles(String, long)} so orphans get age-cleaned.
+     * still walked by {@link #cleanupOldSdkPendingFiles(String, long)} so orphans get age-cleaned
+     * without applying gallery cleanup policy to live captures.
      */
     String SDK_PENDING_DIR_NAME = "_sdk_pending";
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -47,7 +47,7 @@ public class FileManagerImpl implements FileManager {
         this.directoryManager = new DirectoryManager(baseDirectory, logger);
         this.thumbnailManager = new ThumbnailManager(baseDirectory, logger);
         this.operationLogger = new FileOperationLogger(logger);
-        
+
         logger.info(TAG, "FileManagerImpl initialized with base directory: " + baseDirectory.getAbsolutePath());
 
         // Clean up orphaned/empty capture folders left by crashes or failed recordings
@@ -139,7 +139,7 @@ public class FileManagerImpl implements FileManager {
                 Log.w(TAG, "⚠️ Error checking file path security", e);
                 return null;
             }
-            
+
             Log.d(TAG, "✅ File found: " + file.getAbsolutePath() + " (Size: " + file.length() + " bytes)");
             return file;
             
@@ -239,7 +239,7 @@ public class FileManagerImpl implements FileManager {
                 mimeType,
                 packageName
             );
-            
+
             Log.d(TAG, "✅ Metadata created successfully for: " + fileName + " (Size: " + file.length() + " bytes)");
             return metadata;
             
@@ -487,7 +487,7 @@ public class FileManagerImpl implements FileManager {
     @Override
     public int cleanupOldFiles(String packageName, long maxAgeMs) {
         Log.d(TAG, "🧹 cleanupOldFiles() started - Package: " + packageName + ", MaxAge: " + maxAgeMs + "ms");
-        
+
         // Calculate max age in hours for logging
         long maxAgeHours = maxAgeMs / (1000 * 60 * 60);
         Log.d(TAG, "📊 Max age in hours: " + maxAgeHours + " hours");
@@ -571,11 +571,17 @@ public class FileManagerImpl implements FileManager {
 
             // Recursively scan and clean up old files
             int deletedCount = 0;
-            long totalDeletedSize = 0;
+            long[] totalDeletedSize = {0};
 
             deletedCount = cleanupFilesRecursively(packageDir, packageName, cutoffTime, totalDeletedSize);
 
-            Log.i(TAG, "✅ Cleanup completed: " + deletedCount + " files deleted, " + totalDeletedSize + " bytes freed");
+            Log.i(
+                    TAG,
+                    "✅ Cleanup completed: "
+                            + deletedCount
+                            + " files deleted, "
+                            + totalDeletedSize[0]
+                            + " bytes freed");
             return deletedCount;
 
         } catch (Exception e) {
@@ -595,41 +601,83 @@ public class FileManagerImpl implements FileManager {
             }
         }
     }
-    
+
+    @Override
+    public int cleanupOldSdkPendingFiles(String packageName, long maxAgeMs) {
+        if (!securityManager.validateOperation(packageName, null, "SDK_PENDING_CLEANUP")) {
+            Log.e(TAG, "Security validation failed for SDK pending cleanup: " + packageName);
+            return 0;
+        }
+
+        ReadWriteLock lock = null;
+        try {
+            lock = lockManager.acquireWriteLock(packageName, 5000, "SDK_PENDING_CLEANUP");
+            if (lock == null) {
+                Log.w(TAG, "Timed out acquiring lock for SDK pending cleanup: " + packageName);
+                return 0;
+            }
+
+            File packageDir = directoryManager.getPackageDirectory(packageName);
+            File pendingDir = new File(packageDir, FileManager.SDK_PENDING_DIR_NAME);
+            long cutoffTime = System.currentTimeMillis() - maxAgeMs;
+            long[] totalDeletedSize = {0};
+            int deletedCount =
+                    cleanupFilesRecursively(pendingDir, packageName, cutoffTime, totalDeletedSize);
+            removeEmptyDirectories(pendingDir, false);
+
+            Log.i(
+                    TAG,
+                    "SDK pending cleanup completed: "
+                            + deletedCount
+                            + " files deleted, "
+                            + totalDeletedSize[0]
+                            + " bytes freed");
+            return deletedCount;
+        } catch (Exception e) {
+            Log.e(TAG, "Error cleaning SDK pending files for package: " + packageName, e);
+            return 0;
+        } finally {
+            if (lock != null) {
+                lockManager.releaseWriteLock(lock, packageName);
+            }
+        }
+    }
+
     /**
      * Recursively scan and clean up old files in a directory and its subdirectories
+     *
      * @param directory The directory to scan
      * @param packageName The package name for logging
      * @param cutoffTime The cutoff time for file deletion
-     * @param totalDeletedSize Running total of deleted size
+     * @param totalDeletedSize Single-element running total of deleted size
      * @return Number of files deleted
      */
-    private int cleanupFilesRecursively(File directory, String packageName, long cutoffTime, long totalDeletedSize) {
+    private int cleanupFilesRecursively(File directory, String packageName, long cutoffTime, long[] totalDeletedSize) {
         if (!directory.exists() || !directory.isDirectory()) {
             return 0;
         }
-        
+
         int deletedCount = 0;
         File[] items = directory.listFiles();
-        
+
         if (items != null) {
             Log.d(TAG, "🔍 Scanning " + items.length + " items in: " + directory.getName());
-            
+
             for (File item : items) {
                 if (item.isFile()) {
                     long lastModified = item.lastModified();
                     if (lastModified < cutoffTime) {
                         long fileSize = item.length();
                         String relativePath = getRelativePath(directory, item);
-                        
+
                         Log.d(TAG, "🗑️ Deleting old file: " + relativePath + " (last modified: " + new java.util.Date(lastModified) + ", size: " + fileSize + " bytes)");
-                        
+
                         try {
                             if (item.delete()) {
                                 deletedCount++;
-                                totalDeletedSize += fileSize;
+                                totalDeletedSize[0] += fileSize;
                                 Log.d(TAG, "✅ Successfully deleted: " + relativePath);
-                                
+
                                 // Log the deletion
                                 operationLogger.logOperation("DELETE", packageName, relativePath, fileSize, true);
                             } else {
@@ -640,16 +688,43 @@ public class FileManagerImpl implements FileManager {
                         }
                     }
                 } else if (item.isDirectory()) {
+                    if (FileManager.GALLERY_TRASH_DIR_NAME.equals(item.getName())
+                            || FileManager.GALLERY_METADATA_DIR_NAME.equals(item.getName())) {
+                        Log.d(
+                                TAG,
+                                "Skipping gallery-managed directory during legacy cleanup: "
+                                        + item.getAbsolutePath());
+                        continue;
+                    }
                     // Recursively clean up subdirectory
                     Log.d(TAG, "📁 Scanning subdirectory for cleanup: " + item.getName());
                     deletedCount += cleanupFilesRecursively(item, packageName, cutoffTime, totalDeletedSize);
+                    removeEmptyDirectories(item, true);
                 }
             }
         }
-        
+
         return deletedCount;
     }
-    
+
+    private void removeEmptyDirectories(File directory, boolean removeRoot) {
+        if (!directory.exists() || !directory.isDirectory()) {
+            return;
+        }
+        File[] children = directory.listFiles();
+        if (children != null) {
+            for (File child : children) {
+                if (child.isDirectory()) {
+                    removeEmptyDirectories(child, true);
+                }
+            }
+        }
+        File[] remaining = directory.listFiles();
+        if (removeRoot && remaining != null && remaining.length == 0 && !directory.delete()) {
+            Log.w(TAG, "Failed to remove empty cleanup directory: " + directory.getAbsolutePath());
+        }
+    }
+
     // StorageOperations implementation
     @Override
     public long getAvailableSpace() {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/core/FileManagerImpl.java
@@ -342,8 +342,13 @@ public class FileManagerImpl implements FileManager {
                 } else if (item.isDirectory()) {
                     // Skip the transient holding area for SDK no-save photos — those files are
                     // mid-upload and must never appear in gallery counts or Wi-Fi sync listings.
-                    if (FileManager.SDK_PENDING_DIR_NAME.equals(item.getName())) {
-                        Log.d(TAG, "⏭️ Skipping SDK pending dir from listing: " + item.getAbsolutePath());
+                    if (FileManager.SDK_PENDING_DIR_NAME.equals(item.getName())
+                            || FileManager.GALLERY_TRASH_DIR_NAME.equals(item.getName())
+                            || FileManager.GALLERY_METADATA_DIR_NAME.equals(item.getName())) {
+                        Log.d(
+                                TAG,
+                                "⏭️ Skipping internal media dir from listing: "
+                                        + item.getAbsolutePath());
                         continue;
                     }
                     // Recursively scan subdirectory
@@ -753,4 +758,4 @@ public class FileManagerImpl implements FileManager {
             logger.error(TAG, "Error cleaning up orphaned captures", e);
         }
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/file/interfaces/PackageOperations.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/file/interfaces/PackageOperations.java
@@ -28,12 +28,27 @@ public interface PackageOperations {
      * @return Total size in bytes
      */
     long getPackageSize(String packageName);
-    
+
     /**
      * Clean up old files in a package based on age
+     *
      * @param packageName The package name
      * @param maxAgeMs Maximum age in milliseconds
      * @return Number of files cleaned up
      */
     int cleanupOldFiles(String packageName, long maxAgeMs);
-} 
+
+    /**
+     * Clean up orphaned SDK captures from the gallery-hidden pending directory only.
+     *
+     * <p>The default keeps alternate implementations source/binary compatible. Implementations that
+     * use {@code FileManager.SDK_PENDING_DIR_NAME} should override it.
+     *
+     * @param packageName The package name
+     * @param maxAgeMs Maximum age in milliseconds
+     * @return Number of pending files cleaned up
+     */
+    default int cleanupOldSdkPendingFiles(String packageName, long maxAgeMs) {
+        return 0;
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
@@ -140,7 +140,8 @@ public abstract class AsgServer extends NanoHTTPD {
         logger.debug(getTag(), "🔍 =========================================");
 
         // Rate limiting
-        if (!rateLimiter.isAllowed(clientIp)) {
+        boolean rateLimitedRequest = shouldRateLimit(session);
+        if (rateLimitedRequest && !rateLimiter.isAllowed(clientIp)) {
             logger.warn(getTag(), "🚫 Rate limit exceeded for IP: " + clientIp);
             return newFixedLengthResponse(
                 Response.Status.TOO_MANY_REQUESTS, 
@@ -150,7 +151,9 @@ public abstract class AsgServer extends NanoHTTPD {
         }
         
         // Record the request for rate limiting
-        rateLimiter.recordRequest(clientIp);
+        if (rateLimitedRequest) {
+            rateLimiter.recordRequest(clientIp);
+        }
 
         // CORS headers for cross-origin requests
         Map<String, String> headers = new HashMap<>();
@@ -178,6 +181,11 @@ public abstract class AsgServer extends NanoHTTPD {
                 "Internal server error: " + e.getMessage()
             );
         }
+    }
+
+    /** Allow specialized local servers to exempt safe, high-volume transfer requests. */
+    protected boolean shouldRateLimit(IHTTPSession session) {
+        return true;
     }
 
     /**
@@ -284,4 +292,4 @@ public abstract class AsgServer extends NanoHTTPD {
         // This would need to be set when server starts
         return System.currentTimeMillis() - 1000; // Placeholder
     }
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
@@ -978,19 +978,33 @@ public class AsgCameraServer extends AsgServer {
             // Cleanup is restricted to already-acknowledged recoverable trash. Live captures are
             // never age-deleted because a failed phone sync must leave its source retryable.
             long effectiveAgeMs = Math.max(maxAgeMs, MIN_TRASH_RETENTION_MS);
-            int cleanedCount = galleryTrashManager.garbageCollect(effectiveAgeMs);
-            int thumbnailCleanedCount = 0;
+            int captureCleanedCount = galleryTrashManager.garbageCollect(effectiveAgeMs);
+
+            // Preserve the non-gallery maintenance performed by the legacy endpoint. SDK no-save
+            // uploads live under a dedicated hidden tree, so orphan cleanup can be scoped there
+            // without age-deleting live captures or bypassing recoverable-trash retention.
+            int pendingCleanedCount =
+                    fileManager.cleanupOldSdkPendingFiles(
+                            fileManager.getDefaultPackageName(), maxAgeMs);
+            int thumbnailCleanedCount =
+                    fileManager.getThumbnailManager().cleanupOldThumbnails(maxAgeMs);
+            int cleanedCount = captureCleanedCount + pendingCleanedCount;
 
             logger.debug(
                     TAG,
                     "🧹 ✅ Cleanup completed: "
-                            + cleanedCount
-                            + " acknowledged captures permanently removed");
+                            + captureCleanedCount
+                            + " acknowledged captures permanently removed, "
+                            + pendingCleanedCount
+                            + " pending SDK files removed, and "
+                            + thumbnailCleanedCount
+                            + " thumbnails removed");
 
             Map<String, Object> data = new HashMap<>();
             data.put("message", "Cleanup completed successfully");
             data.put("files_removed", cleanedCount);
-            data.put("captures_removed", cleanedCount);
+            data.put("captures_removed", captureCleanedCount);
+            data.put("pending_files_removed", pendingCleanedCount);
             data.put("thumbnails_removed", thumbnailCleanedCount);
             data.put("max_age_hours", maxAgeHours);
             data.put("effective_retention_hours", effectiveAgeMs / (60 * 60 * 1000));

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
@@ -1502,6 +1502,9 @@ public class AsgCameraServer extends AsgServer {
             JSONObject request = readJsonBody(session);
             String captureId = request.getString("capture_id");
             String ackId = request.getString("ack_id");
+            if (captureId.trim().isEmpty() || ackId.trim().isEmpty()) {
+                throw new IllegalArgumentException("Capture and acknowledgement IDs are required");
+            }
             GalleryTrashManager.Result result = galleryTrashManager.trashCapture(captureId, ackId);
             Map<String, Object> data = trashResultData(result);
             data.put("ack_id", ackId);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/AsgCameraServer.java
@@ -2,16 +2,13 @@ package com.mentra.asg_client.io.server.services;
 
 import android.media.MediaMetadataRetriever;
 import android.os.Build;
-
+import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.io.file.core.FileManager.FileMetadata;
 import com.mentra.asg_client.io.server.core.AsgServer;
 import com.mentra.asg_client.io.server.interfaces.*;
 import com.mentra.asg_client.logging.Logger;
-import com.mentra.asg_client.io.file.core.FileManager;
-import com.mentra.asg_client.io.file.core.FileManager.FileMetadata;
-import com.mentra.asg_client.io.file.core.FileManager.FileOperationResult;
 import com.mentra.asg_client.utils.CaptureRequestId;
 import com.mentra.asg_client.utils.GallerySyncFilter;
-
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
@@ -19,40 +16,45 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
-
-// JSON parsing imports
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 /**
- * Enhanced Camera web server for ASG (AugmentOS Smart Glasses) applications.
- * Provides RESTful API for photo capture, gallery browsing, and file downloads.
- * Integrates with the comprehensive file management system for better security,
- * performance, and maintainability.
- * <p>
- * Follows SOLID principles with dependency injection and proper separation of concerns.
+ * Enhanced Camera web server for ASG (AugmentOS Smart Glasses) applications. Provides RESTful API
+ * for photo capture, gallery browsing, and file downloads. Integrates with the comprehensive file
+ * management system for better security, performance, and maintainability.
+ *
+ * <p>Follows SOLID principles with dependency injection and proper separation of concerns.
  */
 public class AsgCameraServer extends AsgServer {
 
     private static final String TAG = AsgCameraServer.class.getName();
     private static final int DEFAULT_PORT = 8089;
+
     /** If phone last_sync_time is this far ahead of glasses clock, treat as full sync. */
     private static final long CLOCK_SKEW_TOLERANCE_MS = 60_000L;
 
+    private static final int MAX_JSON_BODY_BYTES = 1024 * 1024;
+    private static final int DEFAULT_MANIFEST_PAGE_SIZE = 50;
+    private static final int MAX_MANIFEST_PAGE_SIZE = 100;
+    private static final long MIN_TRASH_RETENTION_MS = 7L * 24 * 60 * 60 * 1000;
+
     /**
-     * Provider that returns the capture ID (directory name, e.g. "VID_xxx") of an
-     * actively recording video, or null if idle.
-     * Used to exclude in-progress recordings from sync and download responses.
+     * Provider that returns the capture ID (directory name, e.g. "VID_xxx") of an actively
+     * recording video, or null if idle. Used to exclude in-progress recordings from sync and
+     * download responses.
      */
     public interface ActiveRecordingProvider {
         String getActiveRecordingCaptureId();
 
         /**
-         * Capture IDs whose files must stay off sync/download until post-record validation completes.
+         * Capture IDs whose files must stay off sync/download until post-record validation
+         * completes.
          */
         default Set<String> getPendingVideoIntegrityCaptureIds() {
             return Collections.emptySet();
@@ -61,6 +63,15 @@ public class AsgCameraServer extends AsgServer {
 
     // File management system
     private final FileManager fileManager;
+    private final GalleryTrashManager galleryTrashManager;
+    private final Map<String, String> galleryHashCache =
+            Collections.synchronizedMap(
+                    new LinkedHashMap<String, String>() {
+                        @Override
+                        protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
+                            return size() > 128;
+                        }
+                    });
 
     // Optional provider for currently recording file name
     private ActiveRecordingProvider activeRecordingProvider;
@@ -68,9 +79,7 @@ public class AsgCameraServer extends AsgServer {
     // Cache for latest photo metadata
     private FileMetadata latestPhotoMetadata;
 
-    /**
-     * Callback interface for handling "take-picture" requests.
-     */
+    /** Callback interface for handling "take-picture" requests. */
     public interface OnPictureRequestListener {
         void onPictureRequest();
     }
@@ -78,25 +87,33 @@ public class AsgCameraServer extends AsgServer {
     private OnPictureRequestListener pictureRequestListener;
 
     /**
-     * Constructor for camera web server with dependency injection.
-     * Follows Dependency Inversion Principle by depending on abstractions.
+     * Constructor for camera web server with dependency injection. Follows Dependency Inversion
+     * Principle by depending on abstractions.
      *
-     * @param config          Server configuration
+     * @param config Server configuration
      * @param networkProvider Network information provider
-     * @param cacheManager    Cache manager
-     * @param rateLimiter     Rate limiter
-     * @param logger          Logger
-     * @param fileManager     File manager for secure file operations
+     * @param cacheManager Cache manager
+     * @param rateLimiter Rate limiter
+     * @param logger Logger
+     * @param fileManager File manager for secure file operations
      */
-    public AsgCameraServer(ServerConfig config, NetworkProvider networkProvider,
-                           CacheManager cacheManager, RateLimiter rateLimiter,
-                           Logger logger, FileManager fileManager) {
+    public AsgCameraServer(
+            ServerConfig config,
+            NetworkProvider networkProvider,
+            CacheManager cacheManager,
+            RateLimiter rateLimiter,
+            Logger logger,
+            FileManager fileManager) {
         super(config, networkProvider, cacheManager, rateLimiter, logger);
         this.fileManager = fileManager;
+        this.galleryTrashManager =
+                new GalleryTrashManager(
+                        fileManager.getPackageDirectory(fileManager.getDefaultPackageName()));
 
         logger.info(TAG, "📸 Camera server initialized with file manager");
         logger.info(TAG, "📸 Camera package: " + fileManager.getDefaultPackageName());
-        logger.info(TAG, "📸 Base directory: " + fileManager.getAvailableSpace() + " bytes available");
+        logger.info(
+                TAG, "📸 Base directory: " + fileManager.getAvailableSpace() + " bytes available");
     }
 
     @Override
@@ -104,17 +121,34 @@ public class AsgCameraServer extends AsgServer {
         return TAG;
     }
 
-    /**
-     * Set the listener that will be notified when someone clicks "take picture."
-     */
+    /** Gallery reads include one request per immutable segment and must not exhaust control limits. */
+    @Override
+    protected boolean shouldRateLimit(IHTTPSession session) {
+        if (session.getMethod() != Method.GET) {
+            return true;
+        }
+        switch (session.getUri()) {
+            case "/api/download":
+            case "/api/photo":
+            case "/api/gallery":
+            case "/api/sync":
+            case "/api/sync-status":
+            case "/api/v3/capabilities":
+            case "/api/v3/manifest":
+            case "/api/v3/hash":
+                return false;
+            default:
+                return true;
+        }
+    }
+
+    /** Set the listener that will be notified when someone clicks "take picture." */
     public void setOnPictureRequestListener(OnPictureRequestListener listener) {
         this.pictureRequestListener = listener;
         logger.debug(TAG, "📸 Picture request listener " + (listener != null ? "set" : "cleared"));
     }
 
-    /**
-     * Handle specific camera-related requests with enhanced file management.
-     */
+    /** Handle specific camera-related requests with enhanced file management. */
     @Override
     protected Response handleRequest(IHTTPSession session) {
         String uri = session.getUri();
@@ -159,6 +193,18 @@ public class AsgCameraServer extends AsgServer {
             case "/api/sync-status":
                 logger.debug(TAG, "📊 Serving sync status request");
                 return serveSyncStatus(session);
+            case "/api/v3/capabilities":
+                return serveGalleryCapabilities();
+            case "/api/v3/manifest":
+                return serveV3Manifest(session);
+            case "/api/v3/hash":
+                return serveV3Hash(session);
+            case "/api/v3/ack":
+                return serveV3Ack(session);
+            case "/api/v3/trash":
+                return serveV3Trash();
+            case "/api/v3/restore":
+                return serveV3Restore(session);
             default:
                 // Check if it's a static file request
                 if (uri.startsWith("/static/")) {
@@ -166,14 +212,13 @@ public class AsgCameraServer extends AsgServer {
                     return serveStaticFile(uri, "static");
                 } else {
                     logger.warn(TAG, "❌ Endpoint not found: " + uri);
-                    return createErrorResponse(Response.Status.NOT_FOUND, "Endpoint not found: " + uri);
+                    return createErrorResponse(
+                            Response.Status.NOT_FOUND, "Endpoint not found: " + uri);
                 }
         }
     }
 
-    /**
-     * Handle take picture request with proper response.
-     */
+    /** Handle take picture request with proper response. */
     private Response handleTakePicture() {
         logger.debug(TAG, "📸 =========================================");
         logger.debug(TAG, "📸 TAKE PICTURE REQUEST HANDLER");
@@ -190,13 +235,12 @@ public class AsgCameraServer extends AsgServer {
             return createSuccessResponse(data);
         } else {
             logger.error(TAG, "📸 ❌ Picture listener not available");
-            return createErrorResponse(Response.Status.SERVICE_UNAVAILABLE, "Picture listener not available");
+            return createErrorResponse(
+                    Response.Status.SERVICE_UNAVAILABLE, "Picture listener not available");
         }
     }
 
-    /**
-     * Serve the latest photo using the file management system.
-     */
+    /** Serve the latest photo using the file management system. */
     private Response serveLatestPhoto() {
         logger.debug(TAG, "🖼️ =========================================");
         logger.debug(TAG, "🖼️ LATEST PHOTO REQUEST HANDLER");
@@ -211,7 +255,9 @@ public class AsgCameraServer extends AsgServer {
             }
 
             // Get the file using FileManager
-            File photoFile = fileManager.getFile(fileManager.getDefaultPackageName(), latestPhoto.getFileName());
+            File photoFile =
+                    fileManager.getFile(
+                            fileManager.getDefaultPackageName(), latestPhoto.getFileName());
             if (photoFile == null || !photoFile.exists()) {
                 logger.warn(TAG, "🖼️ ❌ Photo file not found");
                 return createErrorResponse(Response.Status.NOT_FOUND, "Photo file not found");
@@ -223,8 +269,13 @@ public class AsgCameraServer extends AsgServer {
 
             if (cachedData != null) {
                 byte[] cachedBytes = (byte[]) cachedData;
-                logger.debug(TAG, "🖼️ ✅ Serving latest photo from cache (" + cachedBytes.length + " bytes)");
-                return newChunkedResponse(Response.Status.OK, "image/jpeg", new java.io.ByteArrayInputStream(cachedBytes));
+                logger.debug(
+                        TAG,
+                        "🖼️ ✅ Serving latest photo from cache (" + cachedBytes.length + " bytes)");
+                return newChunkedResponse(
+                        Response.Status.OK,
+                        "image/jpeg",
+                        new java.io.ByteArrayInputStream(cachedBytes));
             }
 
             // For small files, read into memory and cache; for large files, stream directly
@@ -239,18 +290,29 @@ public class AsgCameraServer extends AsgServer {
                         fileData = new byte[(int) fileLength];
                         new DataInputStream(fis).readFully(fileData);
                     }
-                    logger.debug(TAG, "🖼️ 📖 File read successfully: " + fileData.length + " bytes");
+                    logger.debug(
+                            TAG, "🖼️ 📖 File read successfully: " + fileData.length + " bytes");
 
                     logger.debug(TAG, "🖼️ 💾 Caching photo data...");
                     cacheManager.put(cacheKey, fileData, 300000); // Cache for 5 minutes
 
-                    logger.debug(TAG, "🖼️ ✅ Serving latest photo: " + latestPhoto.getFileName() + " (" + fileData.length + " bytes)");
-                    return newChunkedResponse(Response.Status.OK, "image/jpeg", new java.io.ByteArrayInputStream(fileData));
+                    logger.debug(
+                            TAG,
+                            "🖼️ ✅ Serving latest photo: "
+                                    + latestPhoto.getFileName()
+                                    + " ("
+                                    + fileData.length
+                                    + " bytes)");
+                    return newChunkedResponse(
+                            Response.Status.OK,
+                            "image/jpeg",
+                            new java.io.ByteArrayInputStream(fileData));
                 }
             } else {
                 // Stream large files directly without loading into memory
                 logger.debug(TAG, "🖼️ 📖 Streaming large photo file: " + fileLength + " bytes");
-                BufferedInputStream bis = new BufferedInputStream(new FileInputStream(photoFile), 65536);
+                BufferedInputStream bis =
+                        new BufferedInputStream(new FileInputStream(photoFile), 65536);
                 return newChunkedResponse(Response.Status.OK, "image/jpeg", bis);
             }
         } catch (Exception e) {
@@ -259,38 +321,32 @@ public class AsgCameraServer extends AsgServer {
         }
     }
 
-    /**
-     * Serve gallery listing using the file management system.
-     */
+    /** Serve gallery listing using the file management system. */
     private Response serveGallery() {
         logger.debug(TAG, "📚 Gallery request started");
         return serveGalleryWithParams(null);
     }
-    
-    /**
-     * Serve gallery listing with pagination support.
-     */
+
+    /** Serve gallery listing with pagination support. */
     private Response serveGallery(IHTTPSession session) {
         logger.debug(TAG, "📚 Gallery request started with params");
         return serveGalleryWithParams(session);
     }
-    
-    /**
-     * Internal method to serve gallery with optional pagination parameters.
-     */
+
+    /** Internal method to serve gallery with optional pagination parameters. */
     private Response serveGalleryWithParams(IHTTPSession session) {
         long startTime = System.currentTimeMillis();
         long timeoutMs = 5000; // 5 second timeout for gallery requests
 
         // Parse pagination parameters
-        int limit = 0;  // 0 means no limit (return all)
+        int limit = 0; // 0 means no limit (return all)
         int offset = 0;
-        
+
         if (session != null) {
             Map<String, String> params = session.getParms();
             String limitParam = params.get("limit");
             String offsetParam = params.get("offset");
-            
+
             if (limitParam != null && !limitParam.isEmpty()) {
                 try {
                     limit = Integer.parseInt(limitParam);
@@ -300,7 +356,7 @@ public class AsgCameraServer extends AsgServer {
                     logger.warn(TAG, "📚 Invalid limit parameter: " + limitParam);
                 }
             }
-            
+
             if (offsetParam != null && !offsetParam.isEmpty()) {
                 try {
                     offset = Integer.parseInt(offsetParam);
@@ -314,10 +370,17 @@ public class AsgCameraServer extends AsgServer {
 
         try {
             // Get all photos using FileManager with timeout
-            List<FileMetadata> photoMetadataList = fileManager.listFiles(fileManager.getDefaultPackageName());
+            List<FileMetadata> photoMetadataList =
+                    fileManager.listFiles(fileManager.getDefaultPackageName());
 
             long fetchTime = System.currentTimeMillis() - startTime;
-            logger.debug(TAG, "📚 Found " + photoMetadataList.size() + " total photos in " + fetchTime + "ms");
+            logger.debug(
+                    TAG,
+                    "📚 Found "
+                            + photoMetadataList.size()
+                            + " total photos in "
+                            + fetchTime
+                            + "ms");
 
             if (photoMetadataList.isEmpty()) {
                 logger.debug(TAG, "📚 No photos found, returning empty gallery");
@@ -331,8 +394,13 @@ public class AsgCameraServer extends AsgServer {
 
             // Check timeout before processing
             if (System.currentTimeMillis() - startTime > timeoutMs) {
-                logger.warn(TAG, "📚 Gallery request timeout after " + (System.currentTimeMillis() - startTime) + "ms");
-                return createErrorResponse(Response.Status.REQUEST_TIMEOUT, "Gallery request timeout");
+                logger.warn(
+                        TAG,
+                        "📚 Gallery request timeout after "
+                                + (System.currentTimeMillis() - startTime)
+                                + "ms");
+                return createErrorResponse(
+                        Response.Status.REQUEST_TIMEOUT, "Gallery request timeout");
             }
 
             // Filter BEFORE pagination so pages have a consistent size and total_count
@@ -340,7 +408,10 @@ public class AsgCameraServer extends AsgServer {
             List<FileMetadata> servableList = new ArrayList<>(photoMetadataList.size());
             for (FileMetadata photoMetadata : photoMetadataList) {
                 if (isAvifTransferArtifact(photoMetadata.getFileName())) {
-                    logger.debug(TAG, "📚 Skipping AVIF transfer artifact in gallery: " + photoMetadata.getFileName());
+                    logger.debug(
+                            TAG,
+                            "📚 Skipping AVIF transfer artifact in gallery: "
+                                    + photoMetadata.getFileName());
                     continue;
                 }
                 if (isImuSidecar(photoMetadata.getFileName())) {
@@ -366,7 +437,14 @@ public class AsgCameraServer extends AsgServer {
             List<FileMetadata> paginatedList = servableList.subList(actualOffset, endIndex);
             boolean hasMore = endIndex < totalCount;
 
-            logger.debug(TAG, "📚 Returning photos " + actualOffset + " to " + endIndex + " of " + totalCount);
+            logger.debug(
+                    TAG,
+                    "📚 Returning photos "
+                            + actualOffset
+                            + " to "
+                            + endIndex
+                            + " of "
+                            + totalCount);
 
             List<Map<String, Object>> photos = new ArrayList<>();
             SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US);
@@ -382,8 +460,13 @@ public class AsgCameraServer extends AsgServer {
             for (FileMetadata photoMetadata : paginatedList) {
                 // Check timeout during processing
                 if (System.currentTimeMillis() - startTime > timeoutMs) {
-                    logger.warn(TAG, "📚 Gallery processing timeout after " + (System.currentTimeMillis() - startTime) + "ms");
-                    return createErrorResponse(Response.Status.REQUEST_TIMEOUT, "Gallery processing timeout");
+                    logger.warn(
+                            TAG,
+                            "📚 Gallery processing timeout after "
+                                    + (System.currentTimeMillis() - startTime)
+                                    + "ms");
+                    return createErrorResponse(
+                            Response.Status.REQUEST_TIMEOUT, "Gallery processing timeout");
                 }
 
                 Map<String, Object> photoInfo = new HashMap<>();
@@ -395,39 +478,49 @@ public class AsgCameraServer extends AsgServer {
                 photoInfo.put("download", "/api/download?file=" + photoMetadata.getFileName());
 
                 // Originating SDK requestId embedded in the capture directory name, when present.
-                String photoRequestId = CaptureRequestId.extractFromCaptureId(
-                        deriveCaptureId(photoMetadata.getFileName()));
+                String photoRequestId =
+                        CaptureRequestId.extractFromCaptureId(
+                                deriveCaptureId(photoMetadata.getFileName()));
                 if (photoRequestId != null) {
                     photoInfo.put("request_id", photoRequestId);
                 }
-                
+
                 // Add video-specific information
                 if (isVideoFile(photoMetadata.getFileName())) {
                     photoInfo.put("is_video", true);
-                    photoInfo.put("thumbnail_url", "/api/photo?file=" + photoMetadata.getFileName());
+                    photoInfo.put(
+                            "thumbnail_url", "/api/photo?file=" + photoMetadata.getFileName());
                 } else {
                     photoInfo.put("is_video", false);
                 }
-                
+
                 photos.add(photoInfo);
                 paginatedSize += photoMetadata.getFileSize();
             }
 
             long totalTime = System.currentTimeMillis() - startTime;
-            logger.debug(TAG, "📚 Gallery served successfully with " + photos.size() + " photos (of " + totalCount + " total) in " + totalTime + "ms");
+            logger.debug(
+                    TAG,
+                    "📚 Gallery served successfully with "
+                            + photos.size()
+                            + " photos (of "
+                            + totalCount
+                            + " total) in "
+                            + totalTime
+                            + "ms");
 
             Map<String, Object> data = new HashMap<>();
             data.put("photos", photos);
-            data.put("total_count", totalCount);  // Total number of all photos
-            data.put("returned_count", photos.size());  // Number returned in this response
-            data.put("total_size", totalSize);  // Total size of all photos
-            data.put("returned_size", paginatedSize);  // Size of returned photos
+            data.put("total_count", totalCount); // Total number of all photos
+            data.put("returned_count", photos.size()); // Number returned in this response
+            data.put("total_size", totalSize); // Total size of all photos
+            data.put("returned_size", paginatedSize); // Size of returned photos
             data.put("offset", actualOffset);
             data.put("limit", limit);
             data.put("has_more", hasMore);
             data.put("package_name", fileManager.getDefaultPackageName());
             data.put("processing_time_ms", totalTime);
-            
+
             // Add keep-alive headers for gallery responses too
             Response response = createSuccessResponse(data);
             response.addHeader("Connection", "keep-alive");
@@ -435,14 +528,17 @@ public class AsgCameraServer extends AsgServer {
             return response;
         } catch (Exception e) {
             long totalTime = System.currentTimeMillis() - startTime;
-            logger.error(TAG, "📚 Error serving gallery after " + totalTime + "ms: " + e.getMessage(), e);
+            logger.error(
+                    TAG,
+                    "📚 Error serving gallery after " + totalTime + "ms: " + e.getMessage(),
+                    e);
             return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error reading gallery");
         }
     }
 
     /**
-     * Serve a specific photo or video thumbnail by filename using the file management system.
-     * For videos, this endpoint serves thumbnails instead of the full video file.
+     * Serve a specific photo or video thumbnail by filename using the file management system. For
+     * videos, this endpoint serves thumbnails instead of the full video file.
      */
     private Response servePhoto(IHTTPSession session) {
         logger.debug(TAG, "🖼️ Photo/Video request started");
@@ -466,7 +562,8 @@ public class AsgCameraServer extends AsgServer {
             }
 
             // Get metadata for MIME type
-            FileMetadata metadata = fileManager.getFileMetadata(fileManager.getDefaultPackageName(), filename);
+            FileMetadata metadata =
+                    fileManager.getFileMetadata(fileManager.getDefaultPackageName(), filename);
             String mimeType = metadata != null ? metadata.getMimeType() : "image/jpeg";
 
             // Check if it's a video file - serve thumbnail instead of full video
@@ -478,44 +575,50 @@ public class AsgCameraServer extends AsgServer {
                 return serveImageFile(mediaFile, filename, mimeType);
             }
         } catch (Exception e) {
-            logger.error(TAG, "🖼️ Error reading media file " + filename + ": " + e.getMessage(), e);
+            logger.error(
+                    TAG, "🖼️ Error reading media file " + filename + ": " + e.getMessage(), e);
             return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error reading media file");
         }
     }
-    
-    /**
-     * Serve video thumbnail
-     */
+
+    /** Serve video thumbnail */
     private Response serveVideoThumbnail(File videoFile, String filename) {
         logger.debug(TAG, "🎥 Generating/serving thumbnail for video: " + filename);
-        
+
         try {
             // Get or create thumbnail
             File thumbnailFile = fileManager.getThumbnailManager().getOrCreateThumbnail(videoFile);
-            
+
             if (thumbnailFile == null || !thumbnailFile.exists()) {
                 logger.warn(TAG, "🎥 Failed to generate thumbnail for video: " + filename);
-                return createErrorResponse(Response.Status.INTERNAL_ERROR, "Failed to generate video thumbnail");
+                return createErrorResponse(
+                        Response.Status.INTERNAL_ERROR, "Failed to generate video thumbnail");
             }
-            
+
             // Use fixed-length response so clients can validate download integrity
             long thumbSize = thumbnailFile.length();
-            logger.debug(TAG, "🎥 Streaming video thumbnail: " + filename + " (" + thumbSize + " bytes)");
-            BufferedInputStream bis = new BufferedInputStream(new FileInputStream(thumbnailFile), 65536);
-            Response response = newFixedLengthResponse(Response.Status.OK, "image/jpeg", bis, thumbSize);
+            logger.debug(
+                    TAG,
+                    "🎥 Streaming video thumbnail: " + filename + " (" + thumbSize + " bytes)");
+            BufferedInputStream bis =
+                    new BufferedInputStream(new FileInputStream(thumbnailFile), 65536);
+            Response response =
+                    newFixedLengthResponse(Response.Status.OK, "image/jpeg", bis, thumbSize);
             response.addHeader("Content-Length", String.valueOf(thumbSize));
             return response;
         } catch (Exception e) {
-            logger.error(TAG, "🎥 Error serving video thumbnail " + filename + ": " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error serving video thumbnail");
+            logger.error(
+                    TAG, "🎥 Error serving video thumbnail " + filename + ": " + e.getMessage(), e);
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Error serving video thumbnail");
         }
     }
-    
-    /**
-     * Serve image file
-     */
+
+    /** Serve image file */
     private Response serveImageFile(File imageFile, String filename, String mimeType) {
-        logger.debug(TAG, "🖼️ Streaming image file: " + filename + " (" + imageFile.length() + " bytes)");
+        logger.debug(
+                TAG,
+                "🖼️ Streaming image file: " + filename + " (" + imageFile.length() + " bytes)");
 
         try {
             // Use fixed-length response with Content-Length so clients can validate
@@ -523,43 +626,39 @@ public class AsgCameraServer extends AsgServer {
             // means a graceful TCP close mid-transfer looks identical to a completed
             // download on Android (HttpURLConnection treats EOF as success).
             long fileSize = imageFile.length();
-            BufferedInputStream bis = new BufferedInputStream(new FileInputStream(imageFile), 65536);
+            BufferedInputStream bis =
+                    new BufferedInputStream(new FileInputStream(imageFile), 65536);
             Response response = newFixedLengthResponse(Response.Status.OK, mimeType, bis, fileSize);
             response.addHeader("Content-Length", String.valueOf(fileSize));
             return response;
         } catch (Exception e) {
-            logger.error(TAG, "🖼️ Error reading image file " + filename + ": " + e.getMessage(), e);
+            logger.error(
+                    TAG, "🖼️ Error reading image file " + filename + ": " + e.getMessage(), e);
             return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error reading image file");
         }
     }
-    
-    /**
-     * Check if a file is a video file
-     */
+
+    /** Check if a file is a video file */
     private boolean isVideoFile(String filename) {
         if (filename == null) return false;
-        
+
         String lowerFilename = filename.toLowerCase();
-        return lowerFilename.endsWith(".mp4") || 
-               lowerFilename.endsWith(".avi") || 
-               lowerFilename.endsWith(".mov") || 
-               lowerFilename.endsWith(".wmv") || 
-               lowerFilename.endsWith(".flv") || 
-               lowerFilename.endsWith(".webm") || 
-               lowerFilename.endsWith(".mkv") || 
-               lowerFilename.endsWith(".3gp");
+        return lowerFilename.endsWith(".mp4")
+                || lowerFilename.endsWith(".avi")
+                || lowerFilename.endsWith(".mov")
+                || lowerFilename.endsWith(".wmv")
+                || lowerFilename.endsWith(".flv")
+                || lowerFilename.endsWith(".webm")
+                || lowerFilename.endsWith(".mkv")
+                || lowerFilename.endsWith(".3gp");
     }
-    
+
     /**
-     * Derive a capture ID from a filename. Groups related files together.
-     * Examples:
-     *   "IMG_xxx/base.jpg"    -> "IMG_xxx"
-     *   "IMG_xxx/ev-2.jpg"    -> "IMG_xxx"
-     *   "IMG_xxx/imu.json"    -> "IMG_xxx"
-     *   "IMG_xxx.jpg"         -> "IMG_xxx" (legacy flat file)
-     *   "IMG_xxx_ev-2.jpg"    -> "IMG_xxx" (legacy bracket)
-     *   "IMG_xxx.imu.json"    -> "IMG_xxx" (legacy sidecar)
-     *   "VID_xxx/base.mp4"    -> "VID_xxx"
+     * Derive a capture ID from a filename. Groups related files together. Examples:
+     * "IMG_xxx/base.jpg" -> "IMG_xxx" "IMG_xxx/ev-2.jpg" -> "IMG_xxx" "IMG_xxx/imu.json" ->
+     * "IMG_xxx" "IMG_xxx.jpg" -> "IMG_xxx" (legacy flat file) "IMG_xxx_ev-2.jpg" -> "IMG_xxx"
+     * (legacy bracket) "IMG_xxx.imu.json" -> "IMG_xxx" (legacy sidecar) "VID_xxx/base.mp4" ->
+     * "VID_xxx"
      */
     private String deriveCaptureId(String name) {
         if (name == null) return "unknown";
@@ -592,6 +691,7 @@ public class AsgCameraServer extends AsgServer {
 
     /**
      * Assign a role to a file within a capture group.
+     *
      * @param fileName The full relative filename (e.g. "IMG_xxx/base.jpg" or "IMG_xxx.jpg")
      * @return "primary", "bracket", or "sidecar"
      */
@@ -599,41 +699,52 @@ public class AsgCameraServer extends AsgServer {
         if (fileName == null) return "primary";
 
         // Get just the leaf filename
-        String leaf = fileName.contains("/") ? fileName.substring(fileName.lastIndexOf('/') + 1) : fileName;
+        String leaf =
+                fileName.contains("/")
+                        ? fileName.substring(fileName.lastIndexOf('/') + 1)
+                        : fileName;
         String lower = leaf.toLowerCase();
 
         // Sidecar files
-        if (lower.equals("imu.json")) return "sidecar";
+        if (lower.equals("imu.json") || lower.endsWith(".imu.json")) return "sidecar";
 
         // Bracket files (ev-2.jpg, ev0.jpg, ev2.jpg)
-        if (lower.matches("ev-?\\d+\\.jpe?g")) return "bracket";
+        if (lower.matches("ev-?\\d+\\.jpe?g") || lower.matches(".*_ev-?\\d+\\.jpe?g")) {
+            return "bracket";
+        }
 
         // Everything else is primary
         return "primary";
     }
 
     /**
-     * Check if a file is an AVIF transfer artifact that should be excluded from sync
-     * AVIF files are temporary transfer artifacts created during BLE photo transfers
-     * and should not be synced to mobile devices.
+     * Check if a file is an AVIF transfer artifact that should be excluded from sync AVIF files are
+     * temporary transfer artifacts created during BLE photo transfers and should not be synced to
+     * mobile devices.
      */
     /**
-     * Check if a file is an IMU sidecar (sensor data bundled with media capture).
-     * These are metadata files, not displayable media.
+     * Check if a file is an IMU sidecar (sensor data bundled with media capture). These are
+     * metadata files, not displayable media.
      */
     private boolean isImuSidecar(String filename) {
         if (filename == null) return false;
-        String leaf = filename.contains("/") ? filename.substring(filename.lastIndexOf('/') + 1) : filename;
+        String leaf =
+                filename.contains("/")
+                        ? filename.substring(filename.lastIndexOf('/') + 1)
+                        : filename;
         return leaf.equalsIgnoreCase("imu.json");
     }
 
     /**
-     * Check if a file is an HDR bracket (individual exposure in a burst set).
-     * Only the merged base file should appear in the gallery, not individual brackets.
+     * Check if a file is an HDR bracket (individual exposure in a burst set). Only the merged base
+     * file should appear in the gallery, not individual brackets.
      */
     private boolean isHdrBracket(String filename) {
         if (filename == null) return false;
-        String leaf = filename.contains("/") ? filename.substring(filename.lastIndexOf('/') + 1) : filename;
+        String leaf =
+                filename.contains("/")
+                        ? filename.substring(filename.lastIndexOf('/') + 1)
+                        : filename;
         // Match folder-based bracket files: ev-2.jpg, ev0.jpg, ev2.jpg
         return leaf.toLowerCase().matches("ev-?\\d+\\.jpe?g");
     }
@@ -645,14 +756,14 @@ public class AsgCameraServer extends AsgServer {
         }
 
         logger.debug(TAG, "🔄 Checking if file is an AVIF transfer artifact: " + filename);
-        
+
         // AVIF transfer artifacts have specific naming patterns:
         // 1. Files without extensions (BLE limitation) - pattern: "I" + digits or "ble_" + digits
         // 2. Files with .avif extension
         // 3. Files matching BLE image ID patterns
-        
+
         String lowerFilename = filename.toLowerCase();
-        
+
         // Check for .avif extension
         if (lowerFilename.endsWith(".avif") || lowerFilename.endsWith(".avifs")) {
             logger.debug(TAG, "🔄 Detected AVIF by extension: " + filename);
@@ -665,31 +776,32 @@ public class AsgCameraServer extends AsgServer {
             logger.debug(TAG, "🔄 Detected AVIF by BLE ID pattern (I+digits): " + filename);
             return true;
         }
-        
+
         // Pattern 2: "ble_" followed by digits (e.g., "ble_1234567890")
         if (filename.matches("^ble_\\d+$")) {
-            logger.debug(TAG, "🔄 Detected AVIF by BLE transfer pattern (ble_+digits): " + filename);
+            logger.debug(
+                    TAG, "🔄 Detected AVIF by BLE transfer pattern (ble_+digits): " + filename);
             return true;
         }
-        
+
         // Pattern 3: Files that are just digits (potential BLE image IDs)
         if (filename.matches("^\\d+$")) {
             logger.debug(TAG, "🔄 Detected AVIF by pure digit pattern: " + filename);
             return true;
         }
-        
+
         // Check file content signature for AVIF detection
         if (hasAvifSignature(filename)) {
             logger.debug(TAG, "🔄 Detected AVIF by content signature: " + filename);
             return true;
         }
-        
+
         return false;
     }
-    
+
     /**
-     * Check if a file has AVIF signature by reading file content
-     * AVIF files start with ISOBMFF container format and have "ftypavif" signature
+     * Check if a file has AVIF signature by reading file content AVIF files start with ISOBMFF
+     * container format and have "ftypavif" signature
      */
     private boolean hasAvifSignature(String filename) {
         try {
@@ -699,49 +811,51 @@ public class AsgCameraServer extends AsgServer {
                 logger.debug(TAG, "🔄 File not found for signature check: " + filename);
                 return false;
             }
-            
+
             // Read first 20 bytes to check file signature
             try (FileInputStream fis = new FileInputStream(file)) {
                 byte[] header = new byte[20];
                 int bytesRead = fis.read(header);
-                
+
                 if (bytesRead < 12) {
                     logger.debug(TAG, "🔄 File too small for AVIF signature check: " + filename);
                     return false;
                 }
-                
+
                 // Check for AVIF signature at positions 4-12
                 // AVIF files have "ftypavif" signature in ISOBMFF container
                 String signature = new String(header, 4, 8, StandardCharsets.UTF_8);
-                
+
                 if ("ftypavif".equals(signature)) {
                     logger.debug(TAG, "🔄 AVIF signature detected in file: " + filename);
                     return true;
                 }
-                
-                logger.debug(TAG, "🔄 No AVIF signature found in file: " + filename + " (signature: " + signature + ")");
+
+                logger.debug(
+                        TAG,
+                        "🔄 No AVIF signature found in file: "
+                                + filename
+                                + " (signature: "
+                                + signature
+                                + ")");
                 return false;
             }
-            
+
         } catch (Exception e) {
-            logger.warn(TAG, "🔄 Error checking AVIF signature for file: " + filename + " - " + e.getMessage());
+            logger.warn(
+                    TAG,
+                    "🔄 Error checking AVIF signature for file: "
+                            + filename
+                            + " - "
+                            + e.getMessage());
             return false;
         }
     }
 
-    /**
-     * Serve photo download with proper headers using the file management system.
-     */
+    /** Serve photo download with proper headers using the file management system. */
     private Response serveDownload(IHTTPSession session) {
-        logger.debug(TAG, "⬇️ ========================================\");\n" +
-                "        logger.debug(TAG, \"⬇\uFE0F DOWNLOAD REQUE=ST HANDLER");
-        logger.debug(TAG, "⬇️ =========================================");
-
         Map<String, String> params = session.getParms();
         String filename = params.get("file");
-
-        logger.debug(TAG, "⬇️ 📝 Requested filename: " + filename);
-        logger.debug(TAG, "⬇️ 📝 All parameters: " + params);
 
         if (filename == null || filename.isEmpty()) {
             logger.warn(TAG, "⬇️ ❌ File parameter missing or empty");
@@ -751,7 +865,8 @@ public class AsgCameraServer extends AsgServer {
         // Block downloads of files that are actively being recorded
         if (isActiveRecording(filename)) {
             logger.warn(TAG, "⬇️ ❌ Blocked download of in-progress recording: " + filename);
-            return createErrorResponse(Response.Status.FORBIDDEN, "File is currently being recorded");
+            return createErrorResponse(
+                    Response.Status.FORBIDDEN, "File is currently being recorded");
         }
 
         try {
@@ -766,60 +881,77 @@ public class AsgCameraServer extends AsgServer {
                     fileManager.getFileMetadata(fileManager.getDefaultPackageName(), filename);
             if (downloadMetadata != null && !shouldExposeServableFile(downloadMetadata)) {
                 logger.warn(TAG, "⬇️ ❌ Blocked download of unservable file: " + filename);
-                return createErrorResponse(Response.Status.CONFLICT, "File is not ready for download");
+                return createErrorResponse(
+                        Response.Status.CONFLICT, "File is not ready for download");
             }
             if (GallerySyncFilter.isZeroBytePrimaryVideo(filename, photoFile.length())) {
                 logger.warn(TAG, "⬇️ ❌ Blocked download of zero-byte video: " + filename);
                 return createErrorResponse(Response.Status.CONFLICT, "Video file is not ready");
             }
 
-            // Get metadata for MIME type
-            FileMetadata metadata = fileManager.getFileMetadata(fileManager.getDefaultPackageName(), filename);
+            FileMetadata metadata =
+                    fileManager.getFileMetadata(fileManager.getDefaultPackageName(), filename);
             String mimeType = metadata != null ? metadata.getMimeType() : "image/jpeg";
-
-            Map<String, String> headers = new HashMap<>();
-            headers.put("Content-Disposition", "attachment; filename=\"" + filename + "\"");
-            headers.put("Content-Type", mimeType);
-            headers.put("Content-Length", String.valueOf(photoFile.length()));
-
-            // Add keep-alive headers to prevent timeout on long downloads
-            headers.put("Connection", "keep-alive");
-            headers.put("Keep-Alive", "timeout=300, max=100"); // 5 minute timeout, max 100 requests
-            
-            logger.debug(TAG, "⬇️ 📋 Response headers: " + headers);
-            logger.debug(TAG, "⬇️ ✅ Starting download: " + filename + " (" + photoFile.length() + " bytes)");
-            
-            // Use BufferedInputStream with 64KB buffer for better performance and memory usage
-            // This prevents memory issues with large files and improves streaming performance
-            FileInputStream fileStream = new FileInputStream(photoFile);
-            java.io.BufferedInputStream bufferedStream = new java.io.BufferedInputStream(fileStream, 65536); // 64KB buffer
-            
-            // For very large files (>100MB), use a keep-alive wrapper to send periodic data
-            // This prevents the connection from timing out during slow transfers
-            java.io.InputStream finalStream = bufferedStream;
-            if (photoFile.length() > 100 * 1024 * 1024) { // 100MB threshold
-                logger.debug(TAG, "⬇️ 🔄 Large file detected, using keep-alive stream wrapper");
-                finalStream = new KeepAliveInputStream(bufferedStream);
+            long fileLength = photoFile.length();
+            String etag =
+                    GalleryTransferProtocol.createEtag(
+                            filename, photoFile.length(), photoFile.lastModified());
+            String rangeHeader = session.getHeaders().get("range");
+            String ifRange = session.getHeaders().get("if-range");
+            if (ifRange != null && !ifRange.trim().equals(etag)) {
+                rangeHeader = null;
             }
-            
-            logger.debug(TAG, "⬇️ 📦 Using 64KB buffered stream for efficient transfer");
-            Response response = newChunkedResponse(Response.Status.OK, mimeType, finalStream);
-            
-            // Add the keep-alive headers to the response
-            for (Map.Entry<String, String> header : headers.entrySet()) {
-                response.addHeader(header.getKey(), header.getValue());
+
+            GalleryTransferProtocol.ByteRange range;
+            try {
+                range = GalleryTransferProtocol.parseRange(rangeHeader, fileLength);
+            } catch (IllegalArgumentException e) {
+                Response response =
+                        createErrorResponse(
+                                Response.Status.RANGE_NOT_SATISFIABLE, "Unsatisfiable byte range");
+                response.addHeader("Content-Range", "bytes */" + fileLength);
+                response.addHeader("Accept-Ranges", "bytes");
+                response.addHeader("ETag", etag);
+                return response;
             }
-            
+
+            long start = range != null ? range.start : 0;
+            long length = range != null ? range.length() : fileLength;
+            Response.Status status =
+                    range != null ? Response.Status.PARTIAL_CONTENT : Response.Status.OK;
+            InputStream stream = GalleryTransferProtocol.open(photoFile, start, length);
+            Response response = newFixedLengthResponse(status, mimeType, stream, length);
+            response.addHeader(
+                    "Content-Disposition",
+                    "attachment; filename=\"" + new File(filename).getName() + "\"");
+            response.addHeader("Accept-Ranges", "bytes");
+            response.addHeader("ETag", etag);
+            response.addHeader("X-Content-Type-Options", "nosniff");
+            if (range != null) {
+                response.addHeader(
+                        "Content-Range",
+                        "bytes " + range.start + "-" + range.end + "/" + fileLength);
+            }
+            logger.debug(
+                    TAG,
+                    "⬇️ Serving "
+                            + filename
+                            + " bytes "
+                            + start
+                            + "-"
+                            + (start + length - 1)
+                            + "/"
+                            + fileLength);
             return response;
         } catch (Exception e) {
-            logger.error(TAG, "⬇️ 💥 Error downloading photo " + filename + ": " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error downloading photo file");
+            logger.error(
+                    TAG, "⬇️ 💥 Error downloading photo " + filename + ": " + e.getMessage(), e);
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Error downloading photo file");
         }
     }
 
-    /**
-     * Serve cleanup request to remove old photos.
-     */
+    /** Serve cleanup request to remove old photos. */
     private Response serveCleanup(IHTTPSession session) {
         logger.debug(TAG, "🧹 =========================================");
         logger.debug(TAG, "🧹 CLEANUP REQUEST HANDLER");
@@ -835,27 +967,33 @@ public class AsgCameraServer extends AsgServer {
                 maxAgeHours = Long.parseLong(maxAgeParam);
             } catch (NumberFormatException e) {
                 logger.warn(TAG, "🧹 ❌ Invalid max_age_hours parameter: " + maxAgeParam);
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid max_age_hours parameter");
+                return createErrorResponse(
+                        Response.Status.BAD_REQUEST, "Invalid max_age_hours parameter");
             }
         }
 
         long maxAgeMs = maxAgeHours * 60 * 60 * 1000; // Convert to milliseconds
 
         try {
-            logger.debug(TAG, "🧹 🗑️ Cleaning up photos older than " + maxAgeHours + " hours...");
-            int cleanedCount = fileManager.cleanupOldFiles(fileManager.getDefaultPackageName(), maxAgeMs);
+            // Cleanup is restricted to already-acknowledged recoverable trash. Live captures are
+            // never age-deleted because a failed phone sync must leave its source retryable.
+            long effectiveAgeMs = Math.max(maxAgeMs, MIN_TRASH_RETENTION_MS);
+            int cleanedCount = galleryTrashManager.garbageCollect(effectiveAgeMs);
+            int thumbnailCleanedCount = 0;
 
-            // Also cleanup old thumbnails
-            logger.debug(TAG, "🧹 🗑️ Cleaning up old thumbnails...");
-            int thumbnailCleanedCount = fileManager.getThumbnailManager().cleanupOldThumbnails(maxAgeMs);
-
-            logger.debug(TAG, "🧹 ✅ Cleanup completed: " + cleanedCount + " files and " + thumbnailCleanedCount + " thumbnails removed");
+            logger.debug(
+                    TAG,
+                    "🧹 ✅ Cleanup completed: "
+                            + cleanedCount
+                            + " acknowledged captures permanently removed");
 
             Map<String, Object> data = new HashMap<>();
             data.put("message", "Cleanup completed successfully");
             data.put("files_removed", cleanedCount);
+            data.put("captures_removed", cleanedCount);
             data.put("thumbnails_removed", thumbnailCleanedCount);
             data.put("max_age_hours", maxAgeHours);
+            data.put("effective_retention_hours", effectiveAgeMs / (60 * 60 * 1000));
             data.put("timestamp", System.currentTimeMillis());
 
             return createSuccessResponse(data);
@@ -866,208 +1004,90 @@ public class AsgCameraServer extends AsgServer {
     }
 
     /**
-     * Serve delete files request to remove specific files.
-     * Accepts POST request with JSON body: {"files": ["file1.jpg", "file2.jpg"]}
+     * Serve delete files request to remove specific files. Accepts POST request with JSON body:
+     * {"files": ["file1.jpg", "file2.jpg"]}
      */
     private Response serveDeleteFiles(IHTTPSession session) {
-        logger.debug(TAG, "🗑️ Delete files request started");
-
-        // Check if it's a POST request
         if (!"POST".equals(session.getMethod().name())) {
-            logger.warn(TAG, "🗑️ Invalid method: " + session.getMethod().name() + " (expected POST)");
-            return createErrorResponse(Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
+            return createErrorResponse(
+                    Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
         }
 
         try {
-            // Read request body
-            Map<String, String> headers = session.getHeaders();
-            int contentLength = Integer.parseInt(headers.getOrDefault("content-length", "0"));
-
-            if (contentLength <= 0) {
-                logger.warn(TAG, "🗑️ Empty request body");
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Request body is required");
+            JSONObject request = readJsonBody(session);
+            JSONArray files = request.getJSONArray("files");
+            if (files.length() == 0) {
+                return createErrorResponse(
+                        Response.Status.BAD_REQUEST, "Files array cannot be empty");
             }
 
-            // Read JSON body
-            byte[] body = new byte[contentLength];
-            InputStream inputStream = session.getInputStream();
-            int bytesRead = inputStream.read(body);
-
-            if (bytesRead != contentLength) {
-                logger.warn(TAG, "🗑️ Incomplete request body: expected " + contentLength + " bytes, got " + bytesRead);
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Incomplete request body");
-            }
-
-            String jsonBody = new String(body, StandardCharsets.UTF_8);
-            logger.debug(TAG, "🗑️ Request body: " + jsonBody);
-
-            // Parse JSON
-            JSONObject jsonObject = new JSONObject(jsonBody);
-            JSONArray filesArray = jsonObject.getJSONArray("files");
-
-            if (filesArray.length() == 0) {
-                logger.warn(TAG, "🗑️ Empty files array");
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Files array cannot be empty");
-            }
-
-            // Process file deletion
+            String legacyAckId =
+                    "legacy-" + request.optString("client_id", "unknown") + "-" + UUID.randomUUID();
+            Map<String, GalleryTrashManager.Result> captureResults = new LinkedHashMap<>();
             List<Map<String, Object>> results = new ArrayList<>();
             int successCount = 0;
             int failureCount = 0;
-            long totalDeletedSize = 0;
+            long totalTrashedSize = 0;
 
-            for (int i = 0; i < filesArray.length(); i++) {
-                String fileName = filesArray.getString(i);
-
-                if (fileName == null || fileName.trim().isEmpty()) {
-                    logger.warn(TAG, "🗑️ Skipping empty filename at index " + i);
-                    Map<String, Object> result = new HashMap<>();
-                    result.put("file", fileName);
-                    result.put("success", false);
-                    result.put("message", "Empty filename");
-                    results.add(result);
+            for (int i = 0; i < files.length(); i++) {
+                String requestedName = files.optString(i, "").trim();
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("file", requestedName);
+                if (requestedName.isEmpty()) {
+                    item.put("success", false);
+                    item.put("message", "Empty filename");
                     failureCount++;
+                    results.add(item);
                     continue;
                 }
 
-                logger.debug(TAG, "🗑️ Deleting file: " + fileName);
-
-                // Check if this is a capture folder (no extension = folder name)
-                boolean isCaptureFolder = !fileName.contains(".") &&
-                    (fileName.startsWith("IMG_") || fileName.startsWith("VID_") || fileName.startsWith("BUFFER_"));
-
-                if (isCaptureFolder) {
-                    // Delete entire capture directory or flat files matching capture ID
-                    File packageDir = fileManager.getPackageDirectory(fileManager.getDefaultPackageName());
-                    File captureDir = new File(packageDir, fileName);
-                    long dirSize = 0;
-                    boolean deleteSuccess = false;
-
-                    if (captureDir.exists() && captureDir.isDirectory()) {
-                        // New folder-based capture: delete entire directory
-                        File[] dirFiles = captureDir.listFiles();
-                        if (dirFiles != null) {
-                            for (File f : dirFiles) {
-                                dirSize += f.length();
-                                if (isVideoFile(f.getName())) {
-                                    fileManager.getThumbnailManager().deleteThumbnailForVideo(f);
-                                }
-                                f.delete();
-                            }
-                        }
-                        deleteSuccess = captureDir.delete();
-                        logger.debug(TAG, "🗑️ Deleted capture folder: " + fileName + " (" + dirSize + " bytes)");
-                    } else {
-                        // Legacy flat files: delete all files matching capture ID prefix
-                        // e.g. for "IMG_xxx", delete IMG_xxx.jpg, IMG_xxx_ev0.jpg, IMG_xxx_ev-2.jpg, IMG_xxx.imu.json
-                        logger.debug(TAG, "🗑️ No capture folder found, trying flat file deletion for: " + fileName);
-                        File[] allFiles = packageDir.listFiles();
-                        int deletedCount = 0;
-                        if (allFiles != null) {
-                            for (File f : allFiles) {
-                                if (f.isFile() && f.getName().startsWith(fileName)) {
-                                    dirSize += f.length();
-                                    if (isVideoFile(f.getName())) {
-                                        fileManager.getThumbnailManager().deleteThumbnailForVideo(f);
-                                    }
-                                    if (f.delete()) {
-                                        deletedCount++;
-                                        logger.debug(TAG, "🗑️ Deleted flat file: " + f.getName());
-                                    }
-                                }
-                            }
-                        }
-                        deleteSuccess = deletedCount > 0;
-                        logger.debug(TAG, "🗑️ Deleted " + deletedCount + " flat files for capture: " + fileName);
+                String captureId = GallerySyncFilter.deriveCaptureId(requestedName);
+                GalleryTrashManager.Result result = captureResults.get(captureId);
+                if (result == null) {
+                    result = galleryTrashManager.trashCapture(captureId, legacyAckId);
+                    captureResults.put(captureId, result);
+                    if (result.success && !result.alreadyTrashed) {
+                        totalTrashedSize += result.totalSize;
                     }
-
-                    Map<String, Object> result = new HashMap<>();
-                    result.put("file", fileName);
-                    result.put("success", deleteSuccess);
-                    result.put("message", deleteSuccess ? "Capture deleted" : "No files found for capture");
-                    result.put("size", dirSize);
-
-                    if (deleteSuccess) {
-                        successCount++;
-                        totalDeletedSize += dirSize;
-                    } else {
-                        failureCount++;
-                        logger.warn(TAG, "🗑️ No files found to delete for capture: " + fileName);
-                    }
-                    results.add(result);
-                } else {
-                    // Individual file deletion (backwards compat)
-                    // Get file metadata before deletion for size calculation
-                    FileMetadata metadata = fileManager.getFileMetadata(fileManager.getDefaultPackageName(), fileName);
-                    long fileSize = metadata != null ? metadata.getFileSize() : 0;
-
-                    // If it's a video file, get the file reference before deletion for thumbnail cleanup
-                    File videoFile = null;
-                    if (isVideoFile(fileName)) {
-                        videoFile = fileManager.getFile(fileManager.getDefaultPackageName(), fileName);
-                    }
-
-                    // Delete the file
-                    FileOperationResult deleteResult = fileManager.deleteFile(fileManager.getDefaultPackageName(), fileName);
-
-                    Map<String, Object> result = new HashMap<>();
-                    result.put("file", fileName);
-                    result.put("success", deleteResult.isSuccess());
-                    result.put("message", deleteResult.getMessage());
-                    result.put("size", fileSize);
-
-                    if (deleteResult.isSuccess()) {
-                        successCount++;
-                        totalDeletedSize += fileSize;
-                        logger.debug(TAG, "🗑️ Successfully deleted: " + fileName + " (" + fileSize + " bytes)");
-
-                        // If it's a video file, also delete its thumbnail
-                        if (videoFile != null) {
-                            logger.debug(TAG, "🗑️ Deleting thumbnail for video: " + fileName);
-                            boolean thumbnailDeleted = fileManager.getThumbnailManager().deleteThumbnailForVideo(videoFile);
-                            if (thumbnailDeleted) {
-                                logger.debug(TAG, "🗑️ Thumbnail deleted for video: " + fileName);
-                            } else {
-                                logger.warn(TAG, "🗑️ Failed to delete thumbnail for video: " + fileName);
-                            }
-                        }
-                    } else {
-                        failureCount++;
-                        logger.warn(TAG, "🗑️ Failed to delete: " + fileName + " - " + deleteResult.getMessage());
-                    }
-
-                    results.add(result);
                 }
+
+                item.put("capture_id", captureId);
+                item.put("success", result.success);
+                item.put("recoverable", result.success);
+                item.put("already_trashed", result.alreadyTrashed);
+                item.put("message", result.message);
+                item.put("size", result.totalSize);
+                if (result.success) {
+                    successCount++;
+                } else {
+                    failureCount++;
+                }
+                results.add(item);
             }
 
-            // Prepare response
-            Map<String, Object> responseData = new HashMap<>();
+            Map<String, Object> responseData = new LinkedHashMap<>();
+            // Preserve the legacy response shape even though delete now means recoverable trash.
             responseData.put("message", "File deletion completed");
-            responseData.put("total_files", filesArray.length());
+            responseData.put("total_files", files.length());
             responseData.put("successful_deletions", successCount);
             responseData.put("failed_deletions", failureCount);
-            responseData.put("total_deleted_size", totalDeletedSize);
+            responseData.put("total_deleted_size", totalTrashedSize);
+            responseData.put("recoverable", true);
             responseData.put("results", results);
             responseData.put("timestamp", System.currentTimeMillis());
-
-            logger.info(TAG, "🗑️ Delete files completed: " + successCount + " successful, " + failureCount + " failed, " + totalDeletedSize + " bytes freed");
+            garbageCollectGalleryTrashBestEffort();
             return createSuccessResponse(responseData);
-
-        } catch (JSONException e) {
-            logger.error(TAG, "🗑️ JSON parsing error: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid JSON format: " + e.getMessage());
+        } catch (JSONException | IllegalArgumentException e) {
+            logger.warn(TAG, "🗑️ Invalid delete request: " + e.getMessage());
+            return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid delete request");
         } catch (IOException e) {
-            logger.error(TAG, "🗑️ IO error reading request body: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error reading request body");
-        } catch (Exception e) {
-            logger.error(TAG, "🗑️ Unexpected error during file deletion: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unexpected error: " + e.getMessage());
+            logger.error(TAG, "🗑️ Unable to move capture to trash", e);
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Unable to move capture to recoverable trash");
         }
     }
 
-    /**
-     * Serve enhanced server status information with file management metrics.
-     */
+    /** Serve enhanced server status information with file management metrics. */
     private Response serveStatus() {
         logger.debug(TAG, "📊 =========================================");
         logger.debug(TAG, "📊 STATUS REQUEST HANDLER");
@@ -1083,14 +1103,20 @@ public class AsgCameraServer extends AsgServer {
 
             // File management metrics
             status.put("package_name", fileManager.getDefaultPackageName());
-            status.put("total_photos", fileManager.listFiles(fileManager.getDefaultPackageName()).size());
-            status.put("package_size", fileManager.getPackageSize(fileManager.getDefaultPackageName()));
+            status.put(
+                    "total_photos",
+                    fileManager.listFiles(fileManager.getDefaultPackageName()).size());
+            status.put(
+                    "package_size",
+                    fileManager.getPackageSize(fileManager.getDefaultPackageName()));
             status.put("available_space", fileManager.getAvailableSpace());
             status.put("total_space", fileManager.getTotalSpace());
-            
+
             // Thumbnail metrics
             status.put("thumbnail_count", fileManager.getThumbnailManager().getThumbnailCount());
-            status.put("thumbnail_directory_size", fileManager.getThumbnailManager().getThumbnailDirectorySize());
+            status.put(
+                    "thumbnail_directory_size",
+                    fileManager.getThumbnailManager().getThumbnailDirectorySize());
 
             // Performance metrics from file manager
             var performanceStats = fileManager.getOperationLogger().getPerformanceStats();
@@ -1104,7 +1130,11 @@ public class AsgCameraServer extends AsgServer {
             logger.debug(TAG, "📊 📈 Package size: " + status.get("package_size") + " bytes");
             logger.debug(TAG, "📊 📈 Available space: " + status.get("available_space") + " bytes");
             logger.debug(TAG, "📊 📈 Thumbnail count: " + status.get("thumbnail_count"));
-            logger.debug(TAG, "📊 📈 Thumbnail directory size: " + status.get("thumbnail_directory_size") + " bytes");
+            logger.debug(
+                    TAG,
+                    "📊 📈 Thumbnail directory size: "
+                            + status.get("thumbnail_directory_size")
+                            + " bytes");
             logger.debug(TAG, "📊 📈 Success rate: " + performanceStats.successRate + "%");
 
             logger.debug(TAG, "📊 ✅ Status served successfully");
@@ -1115,9 +1145,7 @@ public class AsgCameraServer extends AsgServer {
         }
     }
 
-    /**
-     * Serve health check endpoint.
-     */
+    /** Serve health check endpoint. */
     private Response serveHealth() {
         logger.debug(TAG, "❤️ =========================================");
         logger.debug(TAG, "❤️ HEALTH CHECK REQUEST HANDLER");
@@ -1129,13 +1157,10 @@ public class AsgCameraServer extends AsgServer {
         return newFixedLengthResponse(
                 Response.Status.OK,
                 "application/json",
-                "{\"status\":\"healthy\",\"timestamp\":" + timestamp + "}"
-        );
+                "{\"status\":\"healthy\",\"timestamp\":" + timestamp + "}");
     }
 
-    /**
-     * Serve the enhanced index page with gallery and better UI.
-     */
+    /** Serve the enhanced index page with gallery and better UI. */
     private Response serveIndexPage() {
         logger.debug(TAG, "📄 =========================================");
         logger.debug(TAG, "📄 INDEX PAGE REQUEST HANDLER");
@@ -1153,7 +1178,8 @@ public class AsgCameraServer extends AsgServer {
             buffer.flush();
 
             String html = new String(buffer.toByteArray(), StandardCharsets.UTF_8);
-            logger.debug(TAG, "📄 📖 HTML file read successfully: " + html.length() + " characters");
+            logger.debug(
+                    TAG, "📄 📖 HTML file read successfully: " + html.length() + " characters");
 
             // Replace placeholders with dynamic content
             String serverUrl = getServerUrl();
@@ -1163,8 +1189,9 @@ public class AsgCameraServer extends AsgServer {
             logger.debug(TAG, "📄 🔄 Server URL: " + serverUrl);
             logger.debug(TAG, "📄 🔄 Server Port: " + serverPort);
 
-            String finalHtml = html.replace("{{SERVER_URL}}", serverUrl)
-                    .replace("{{SERVER_PORT}}", serverPort);
+            String finalHtml =
+                    html.replace("{{SERVER_URL}}", serverUrl)
+                            .replace("{{SERVER_PORT}}", serverPort);
 
             logger.debug(TAG, "📄 ✅ Index page served successfully");
             logger.debug(TAG, "📄 📄 Final HTML size: " + finalHtml.length() + " characters");
@@ -1172,19 +1199,19 @@ public class AsgCameraServer extends AsgServer {
             return newFixedLengthResponse(Response.Status.OK, "text/html", finalHtml);
         } catch (IOException e) {
             logger.error(TAG, "📄 💥 Error reading index.html from assets", e);
-            return newFixedLengthResponse(Response.Status.INTERNAL_ERROR, "text/plain", "Failed to load index.html");
+            return newFixedLengthResponse(
+                    Response.Status.INTERNAL_ERROR, "text/plain", "Failed to load index.html");
         }
     }
 
-    /**
-     * Get the latest photo metadata with caching.
-     */
+    /** Get the latest photo metadata with caching. */
     private FileMetadata getLatestPhotoMetadata() {
         try {
             // Check if we have a cached latest photo
             if (latestPhotoMetadata != null) {
                 // Verify it still exists
-                if (fileManager.fileExists(fileManager.getDefaultPackageName(), latestPhotoMetadata.getFileName())) {
+                if (fileManager.fileExists(
+                        fileManager.getDefaultPackageName(), latestPhotoMetadata.getFileName())) {
                     return latestPhotoMetadata;
                 }
             }
@@ -1206,9 +1233,7 @@ public class AsgCameraServer extends AsgServer {
         }
     }
 
-    /**
-     * Get the FileManager instance for external access.
-     */
+    /** Get the FileManager instance for external access. */
     public FileManager getFileManager() {
         return fileManager;
     }
@@ -1218,8 +1243,8 @@ public class AsgCameraServer extends AsgServer {
     }
 
     /**
-     * @return true if the given file belongs to a capture that is currently being recorded.
-     *         Derives the capture ID from the file name and compares against the active recording.
+     * @return true if the given file belongs to a capture that is currently being recorded. Derives
+     *     the capture ID from the file name and compares against the active recording.
      */
     private boolean isActiveRecording(String fileName) {
         if (activeRecordingProvider == null || fileName == null) return false;
@@ -1228,9 +1253,7 @@ public class AsgCameraServer extends AsgServer {
         return GallerySyncFilter.isCaptureBlockedFromSync(fileName, activeCaptureId, blocked);
     }
 
-    /**
-     * Whether a file may appear in gallery listings or sync responses.
-     */
+    /** Whether a file may appear in gallery listings or sync responses. */
     private boolean shouldExposeServableFile(FileMetadata metadata) {
         if (metadata == null) {
             return false;
@@ -1246,16 +1269,337 @@ public class AsgCameraServer extends AsgServer {
         return true;
     }
 
-    /**
-     * Get the camera package name.
-     */
+    private Response serveGalleryCapabilities() {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("api_version", 3);
+        data.put("manifest_version", 3);
+        data.put("range_downloads", true);
+        data.put("fixed_length_downloads", true);
+        data.put("etag", true);
+        data.put("sha256", true);
+        data.put("recoverable_trash", true);
+        data.put("idempotent_ack", true);
+        data.put("selected_capture", true);
+        data.put("recommended_segment_bytes", 16 * 1024 * 1024);
+        data.put("max_manifest_page_size", MAX_MANIFEST_PAGE_SIZE);
+        data.put("server_time", System.currentTimeMillis());
+        return createSuccessResponse(data);
+    }
+
+    /** Lightweight, newest-first manifest. Derived thumbnails and hashes stay lazy. */
+    private Response serveV3Manifest(IHTTPSession session) {
+        try {
+            int limit = DEFAULT_MANIFEST_PAGE_SIZE;
+            String limitValue = session.getParms().get("limit");
+            if (limitValue != null) {
+                limit = Integer.parseInt(limitValue);
+            }
+            limit = Math.max(1, Math.min(limit, MAX_MANIFEST_PAGE_SIZE));
+            String cursor = session.getParms().get("cursor");
+            String selectedCaptureId = session.getParms().get("capture_id");
+
+            List<FileMetadata> files =
+                    new ArrayList<>(fileManager.listFiles(fileManager.getDefaultPackageName()));
+            files.removeIf(
+                    metadata ->
+                            !shouldExposeServableFile(metadata)
+                                    || isAvifTransferArtifact(metadata.getFileName()));
+            files.sort(
+                    Comparator.comparingLong(FileMetadata::getLastModified)
+                            .reversed()
+                            .thenComparing(FileMetadata::getFileName, Comparator.reverseOrder()));
+
+            Map<String, List<FileMetadata>> grouped = new HashMap<>();
+            for (FileMetadata metadata : files) {
+                grouped.computeIfAbsent(
+                                GallerySyncFilter.deriveCaptureId(metadata.getFileName()),
+                                ignored -> new ArrayList<>())
+                        .add(metadata);
+            }
+
+            List<Map<String, Object>> allCaptures = new ArrayList<>();
+            for (Map.Entry<String, List<FileMetadata>> entry : grouped.entrySet()) {
+                String captureId = entry.getKey();
+                if (selectedCaptureId != null && !selectedCaptureId.equals(captureId)) {
+                    continue;
+                }
+                List<FileMetadata> captureFiles = entry.getValue();
+                long timestamp =
+                        captureFiles.stream()
+                                .mapToLong(FileMetadata::getLastModified)
+                                .max()
+                                .orElse(0);
+                long totalSize = 0;
+                List<Map<String, Object>> manifestFiles = new ArrayList<>();
+                String thumbnailUrl = null;
+                boolean hasNonEmptyPrimary = false;
+                boolean hasVideoPrimary = false;
+
+                for (FileMetadata metadata : captureFiles) {
+                    String encodedName =
+                            URLEncoder.encode(
+                                    metadata.getFileName(), StandardCharsets.UTF_8.name());
+                    String role = assignFileRole(metadata.getFileName());
+                    Map<String, Object> item = new LinkedHashMap<>();
+                    item.put("name", metadata.getFileName());
+                    item.put("size", metadata.getFileSize());
+                    item.put("modified", metadata.getLastModified());
+                    item.put("mime_type", metadata.getMimeType());
+                    item.put("role", role);
+                    item.put(
+                            "etag",
+                            GalleryTransferProtocol.createEtag(
+                                    metadata.getFileName(),
+                                    metadata.getFileSize(),
+                                    metadata.getLastModified()));
+                    item.put("download_url", "/api/download?file=" + encodedName);
+                    item.put("hash_url", "/api/v3/hash?file=" + encodedName);
+                    manifestFiles.add(item);
+                    totalSize += metadata.getFileSize();
+                    if ("primary".equals(role)) {
+                        hasNonEmptyPrimary |= metadata.getFileSize() > 0;
+                        hasVideoPrimary |= isVideoFile(metadata.getFileName());
+                        thumbnailUrl = "/api/photo?file=" + encodedName;
+                    }
+                }
+
+                if (manifestFiles.isEmpty() || !hasNonEmptyPrimary) {
+                    continue;
+                }
+                Map<String, Object> capture = new LinkedHashMap<>();
+                capture.put("capture_id", captureId);
+                capture.put("type", hasVideoPrimary ? "video" : "photo");
+                capture.put("timestamp", timestamp);
+                capture.put("total_size", totalSize);
+                capture.put("files", manifestFiles);
+                capture.put("cursor", manifestCursor(timestamp, captureId));
+                if (thumbnailUrl != null) {
+                    capture.put("thumbnail_url", thumbnailUrl);
+                }
+                String requestId = CaptureRequestId.extractFromCaptureId(captureId);
+                if (requestId != null) {
+                    capture.put("request_id", requestId);
+                }
+                allCaptures.add(capture);
+            }
+
+            allCaptures.sort(
+                    (left, right) -> {
+                        int timestampOrder =
+                                Long.compare(
+                                        ((Number) right.get("timestamp")).longValue(),
+                                        ((Number) left.get("timestamp")).longValue());
+                        if (timestampOrder != 0) {
+                            return timestampOrder;
+                        }
+                        return ((String) right.get("capture_id"))
+                                .compareTo((String) left.get("capture_id"));
+                    });
+
+            int start = 0;
+            if (cursor != null && !cursor.isEmpty()) {
+                int separator = cursor.indexOf(':');
+                if (separator <= 0 || separator == cursor.length() - 1) {
+                    throw new IllegalArgumentException("Invalid manifest cursor");
+                }
+                long cursorTimestamp = Long.parseLong(cursor.substring(0, separator));
+                String cursorCaptureId = cursor.substring(separator + 1);
+                // Keyset pagination stays stable if the cursor capture is acknowledged or a
+                // newer capture appears between requests. Start at the first item strictly older
+                // than the (timestamp, capture ID) key instead of searching for an exact row.
+                while (start < allCaptures.size()) {
+                    Map<String, Object> candidate = allCaptures.get(start);
+                    long timestamp = ((Number) candidate.get("timestamp")).longValue();
+                    String captureId = (String) candidate.get("capture_id");
+                    if (timestamp < cursorTimestamp
+                            || (timestamp == cursorTimestamp
+                                    && captureId.compareTo(cursorCaptureId) < 0)) {
+                        break;
+                    }
+                    start++;
+                }
+            }
+            int end = Math.min(start + limit, allCaptures.size());
+            List<Map<String, Object>> page =
+                    start <= allCaptures.size()
+                            ? new ArrayList<>(allCaptures.subList(start, end))
+                            : Collections.emptyList();
+
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("api_version", 3);
+            data.put("captures", page);
+            data.put("has_more", end < allCaptures.size());
+            data.put(
+                    "next_cursor",
+                    end < allCaptures.size() && !page.isEmpty()
+                            ? page.get(page.size() - 1).get("cursor")
+                            : JSONObject.NULL);
+            data.put("total_count", allCaptures.size());
+            data.put("server_time", System.currentTimeMillis());
+            return createSuccessResponse(data);
+        } catch (IllegalArgumentException e) {
+            return createErrorResponse(Response.Status.BAD_REQUEST, e.getMessage());
+        } catch (Exception e) {
+            logger.error(TAG, "Unable to build v3 gallery manifest", e);
+            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unable to build manifest");
+        }
+    }
+
+    private Response serveV3Hash(IHTTPSession session) {
+        String fileName = session.getParms().get("file");
+        if (fileName == null || fileName.isEmpty()) {
+            return createErrorResponse(Response.Status.BAD_REQUEST, "File parameter required");
+        }
+        if (isActiveRecording(fileName)) {
+            return createErrorResponse(Response.Status.CONFLICT, "File is not ready");
+        }
+        try {
+            File file = fileManager.getFile(fileManager.getDefaultPackageName(), fileName);
+            if (file == null) {
+                return createErrorResponse(Response.Status.NOT_FOUND, "File not found");
+            }
+            String etag =
+                    GalleryTransferProtocol.createEtag(
+                            fileName, file.length(), file.lastModified());
+            String cacheKey = fileName + "\n" + etag;
+            String hash = galleryHashCache.get(cacheKey);
+            if (hash == null) {
+                hash = GalleryTransferProtocol.sha256(file);
+                galleryHashCache.put(cacheKey, hash);
+            }
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("file", fileName);
+            data.put("size", file.length());
+            data.put("etag", etag);
+            data.put("sha256", hash);
+            return createSuccessResponse(data);
+        } catch (IOException e) {
+            logger.error(TAG, "Unable to hash gallery file " + fileName, e);
+            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unable to hash file");
+        }
+    }
+
+    private Response serveV3Ack(IHTTPSession session) {
+        if (!"POST".equals(session.getMethod().name())) {
+            return createErrorResponse(
+                    Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
+        }
+        try {
+            JSONObject request = readJsonBody(session);
+            String captureId = request.getString("capture_id");
+            String ackId = request.getString("ack_id");
+            GalleryTrashManager.Result result = galleryTrashManager.trashCapture(captureId, ackId);
+            Map<String, Object> data = trashResultData(result);
+            data.put("ack_id", ackId);
+            garbageCollectGalleryTrashBestEffort();
+            return createSuccessResponse(data);
+        } catch (JSONException | IllegalArgumentException e) {
+            return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid acknowledgement");
+        } catch (IOException e) {
+            logger.error(TAG, "Unable to acknowledge gallery capture", e);
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Unable to acknowledge capture");
+        }
+    }
+
+    private Response serveV3Trash() {
+        try {
+            List<Map<String, Object>> captures = new ArrayList<>();
+            for (GalleryTrashManager.TrashedCapture trashed : galleryTrashManager.listTrashed()) {
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("capture_id", trashed.captureId);
+                item.put("file_count", trashed.fileCount);
+                item.put("total_size", trashed.totalSize);
+                item.put("trashed_at", trashed.trashedAt);
+                captures.add(item);
+            }
+            Map<String, Object> data = new LinkedHashMap<>();
+            data.put("captures", captures);
+            data.put("total_count", captures.size());
+            return createSuccessResponse(data);
+        } catch (IOException e) {
+            logger.error(TAG, "Unable to list gallery trash", e);
+            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unable to list trash");
+        }
+    }
+
+    private Response serveV3Restore(IHTTPSession session) {
+        if (!"POST".equals(session.getMethod().name())) {
+            return createErrorResponse(
+                    Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
+        }
+        try {
+            JSONObject request = readJsonBody(session);
+            GalleryTrashManager.Result result =
+                    galleryTrashManager.restoreCapture(request.getString("capture_id"));
+            if (!result.success) {
+                return createErrorResponse(Response.Status.NOT_FOUND, result.message);
+            }
+            return createSuccessResponse(trashResultData(result));
+        } catch (JSONException | IllegalArgumentException e) {
+            return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid restore request");
+        } catch (IOException e) {
+            logger.error(TAG, "Unable to restore gallery capture", e);
+            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unable to restore capture");
+        }
+    }
+
+    private static String manifestCursor(long timestamp, String captureId) {
+        return timestamp + ":" + captureId;
+    }
+
+    private static Map<String, Object> trashResultData(GalleryTrashManager.Result result) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("success", result.success);
+        data.put("capture_id", result.captureId);
+        data.put("already_trashed", result.alreadyTrashed);
+        data.put("recoverable", result.success);
+        data.put("file_count", result.fileCount);
+        data.put("total_size", result.totalSize);
+        data.put("message", result.message);
+        return data;
+    }
+
+    private void garbageCollectGalleryTrashBestEffort() {
+        try {
+            galleryTrashManager.garbageCollect(MIN_TRASH_RETENTION_MS);
+        } catch (IOException e) {
+            logger.warn(TAG, "Deferred gallery trash cleanup failed: " + e.getMessage());
+        }
+    }
+
+    private JSONObject readJsonBody(IHTTPSession session) throws IOException, JSONException {
+        String contentLengthValue = session.getHeaders().get("content-length");
+        int contentLength;
+        try {
+            contentLength = Integer.parseInt(contentLengthValue != null ? contentLengthValue : "0");
+        } catch (NumberFormatException e) {
+            throw new IOException("Invalid Content-Length", e);
+        }
+        if (contentLength <= 0 || contentLength > MAX_JSON_BODY_BYTES) {
+            throw new IOException("Invalid request body length");
+        }
+        byte[] body = new byte[contentLength];
+        InputStream input = session.getInputStream();
+        int offset = 0;
+        while (offset < contentLength) {
+            int read = input.read(body, offset, contentLength - offset);
+            if (read < 0) {
+                throw new IOException("Incomplete request body");
+            }
+            offset += read;
+        }
+        return new JSONObject(new String(body, StandardCharsets.UTF_8));
+    }
+
+    /** Get the camera package name. */
     public String getCameraPackage() {
         return fileManager.getDefaultPackageName();
     }
 
     /**
-     * Serve sync request for efficient client-side synchronization.
-     * Returns only files that have changed since the last sync.
+     * Serve sync request for efficient client-side synchronization. Returns only files that have
+     * changed since the last sync.
      */
     private Response serveSync(IHTTPSession session) {
         logger.debug(TAG, "🔄 =========================================");
@@ -1283,15 +1627,24 @@ public class AsgCameraServer extends AsgServer {
                 lastSyncTime = Long.parseLong(lastSyncTimeParam);
             } catch (NumberFormatException e) {
                 logger.warn(TAG, "🔄 ❌ Invalid last_sync parameter: " + lastSyncTimeParam);
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid last_sync parameter");
+                return createErrorResponse(
+                        Response.Status.BAD_REQUEST, "Invalid last_sync parameter");
             }
         }
 
         long glassesNow = System.currentTimeMillis();
         if (lastSyncTime > glassesNow + CLOCK_SKEW_TOLERANCE_MS) {
-            logger.warn(TAG, "🔄 ⏰ last_sync_time is in the future vs glasses clock (last_sync="
-                    + lastSyncTime + " (" + new Date(lastSyncTime) + "), glasses_now="
-                    + glassesNow + " (" + new Date(glassesNow) + ")); resetting to 0 for full sync");
+            logger.warn(
+                    TAG,
+                    "🔄 ⏰ last_sync_time is in the future vs glasses clock (last_sync="
+                            + lastSyncTime
+                            + " ("
+                            + new Date(lastSyncTime)
+                            + "), glasses_now="
+                            + glassesNow
+                            + " ("
+                            + new Date(glassesNow)
+                            + ")); resetting to 0 for full sync");
             lastSyncTime = 0;
         }
 
@@ -1299,10 +1652,13 @@ public class AsgCameraServer extends AsgServer {
 
         try {
             logger.debug(TAG, "🔄 📊 Processing sync request for client: " + clientId);
-            logger.debug(TAG, "🔄 📊 Last sync time: " + lastSyncTime + " (" + new Date(lastSyncTime) + ")");
+            logger.debug(
+                    TAG,
+                    "🔄 📊 Last sync time: " + lastSyncTime + " (" + new Date(lastSyncTime) + ")");
 
             // Get all files
-            List<FileMetadata> allFiles = fileManager.listFiles(fileManager.getDefaultPackageName());
+            List<FileMetadata> allFiles =
+                    fileManager.listFiles(fileManager.getDefaultPackageName());
 
             // Filter files that have changed since last sync
             List<Map<String, Object>> changedFiles = new ArrayList<>();
@@ -1315,26 +1671,20 @@ public class AsgCameraServer extends AsgServer {
                     // Skip files that are actively being recorded or not yet servable
                     if (!shouldExposeServableFile(fileMetadata)) {
                         if (isActiveRecording(fileMetadata.getFileName())) {
-                            logger.debug(TAG, "🔄 Skipping active recording: " + fileMetadata.getFileName());
+                            logger.debug(
+                                    TAG,
+                                    "🔄 Skipping active recording: " + fileMetadata.getFileName());
                         }
                         continue;
                     }
 
-                    // Skip and delete AVIF transfer artifacts - these should not be synced to mobile
+                    // Transfer artifacts are hidden, but never physically deleted during a read
+                    // operation. Only an explicit, committed capture acknowledgement may move
+                    // source media out of the live gallery.
                     if (isAvifTransferArtifact(fileMetadata.getFileName())) {
-                        logger.debug(TAG, "🔄 Found AVIF transfer artifact, deleting: " + fileMetadata.getFileName());
-
-                        // Delete the AVIF file to clean up storage
-                        try {
-                            FileOperationResult deleteResult = fileManager.deleteFile(fileManager.getDefaultPackageName(), fileMetadata.getFileName());
-                            if (deleteResult.isSuccess()) {
-                                logger.info(TAG, "🗑️ Successfully deleted AVIF transfer artifact: " + fileMetadata.getFileName() + " (" + fileMetadata.getFileSize() + " bytes)");
-                            } else {
-                                logger.warn(TAG, "⚠️ Failed to delete AVIF transfer artifact: " + fileMetadata.getFileName() + " - " + deleteResult.getMessage());
-                            }
-                        } catch (Exception e) {
-                            logger.error(TAG, "💥 Error deleting AVIF transfer artifact: " + fileMetadata.getFileName(), e);
-                        }
+                        logger.debug(
+                                TAG,
+                                "🔄 Hiding AVIF transfer artifact: " + fileMetadata.getFileName());
                         continue;
                     }
 
@@ -1352,65 +1702,110 @@ public class AsgCameraServer extends AsgServer {
                         if (includeThumbnailsFlag) {
                             // Include base64 thumbnail data for immediate display
                             try {
-                                File videoFile = fileManager.getFile(fileManager.getDefaultPackageName(), fileMetadata.getFileName());
+                                File videoFile =
+                                        fileManager.getFile(
+                                                fileManager.getDefaultPackageName(),
+                                                fileMetadata.getFileName());
                                 if (videoFile != null && videoFile.exists()) {
-                                    File thumbnailFile = fileManager.getThumbnailManager().getOrCreateThumbnail(videoFile);
+                                    File thumbnailFile =
+                                            fileManager
+                                                    .getThumbnailManager()
+                                                    .getOrCreateThumbnail(videoFile);
                                     if (thumbnailFile != null && thumbnailFile.exists()) {
-                                        try (FileInputStream fis = new FileInputStream(thumbnailFile)) {
+                                        try (FileInputStream fis =
+                                                new FileInputStream(thumbnailFile)) {
                                             byte[] thumbnailData;
-                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                            if (Build.VERSION.SDK_INT
+                                                    >= Build.VERSION_CODES.TIRAMISU) {
                                                 thumbnailData = fis.readAllBytes();
                                             } else {
-                                                thumbnailData = new byte[(int) thumbnailFile.length()];
+                                                thumbnailData =
+                                                        new byte[(int) thumbnailFile.length()];
                                                 new DataInputStream(fis).readFully(thumbnailData);
                                             }
-                                            String thumbnailBase64 = android.util.Base64.encodeToString(thumbnailData, android.util.Base64.DEFAULT);
+                                            String thumbnailBase64 =
+                                                    android.util.Base64.encodeToString(
+                                                            thumbnailData,
+                                                            android.util.Base64.DEFAULT);
                                             fileInfo.put("thumbnail_data", thumbnailBase64);
                                         }
                                     }
 
                                     // Extract video duration
                                     try {
-                                        MediaMetadataRetriever retriever = new MediaMetadataRetriever();
+                                        MediaMetadataRetriever retriever =
+                                                new MediaMetadataRetriever();
                                         retriever.setDataSource(videoFile.getAbsolutePath());
-                                        String durationStr = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION);
+                                        String durationStr =
+                                                retriever.extractMetadata(
+                                                        MediaMetadataRetriever
+                                                                .METADATA_KEY_DURATION);
                                         retriever.release();
                                         if (durationStr != null) {
                                             fileInfo.put("duration", Long.parseLong(durationStr));
                                         }
                                     } catch (Exception e) {
-                                        logger.warn(TAG, "Failed to extract duration for " + fileMetadata.getFileName() + ": " + e.getMessage());
+                                        logger.warn(
+                                                TAG,
+                                                "Failed to extract duration for "
+                                                        + fileMetadata.getFileName()
+                                                        + ": "
+                                                        + e.getMessage());
                                     }
                                 }
                             } catch (Exception e) {
-                                logger.warn(TAG, "Failed to include thumbnail for " + fileMetadata.getFileName() + ": " + e.getMessage());
+                                logger.warn(
+                                        TAG,
+                                        "Failed to include thumbnail for "
+                                                + fileMetadata.getFileName()
+                                                + ": "
+                                                + e.getMessage());
                             }
-                            fileInfo.put("thumbnail_url", "/api/photo?file=" + fileMetadata.getFileName());
+                            fileInfo.put(
+                                    "thumbnail_url",
+                                    "/api/photo?file=" + fileMetadata.getFileName());
                         }
                     } else {
                         fileInfo.put("is_video", false);
                         if (includeThumbnailsFlag) {
                             // Include base64 thumbnail data for photos too
                             try {
-                                File imageFile = fileManager.getFile(fileManager.getDefaultPackageName(), fileMetadata.getFileName());
+                                File imageFile =
+                                        fileManager.getFile(
+                                                fileManager.getDefaultPackageName(),
+                                                fileMetadata.getFileName());
                                 if (imageFile != null && imageFile.exists()) {
-                                    File thumbnailFile = fileManager.getThumbnailManager().getOrCreateImageThumbnail(imageFile);
+                                    File thumbnailFile =
+                                            fileManager
+                                                    .getThumbnailManager()
+                                                    .getOrCreateImageThumbnail(imageFile);
                                     if (thumbnailFile != null && thumbnailFile.exists()) {
-                                        try (FileInputStream fis = new FileInputStream(thumbnailFile)) {
+                                        try (FileInputStream fis =
+                                                new FileInputStream(thumbnailFile)) {
                                             byte[] thumbnailData;
-                                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                            if (Build.VERSION.SDK_INT
+                                                    >= Build.VERSION_CODES.TIRAMISU) {
                                                 thumbnailData = fis.readAllBytes();
                                             } else {
-                                                thumbnailData = new byte[(int) thumbnailFile.length()];
+                                                thumbnailData =
+                                                        new byte[(int) thumbnailFile.length()];
                                                 new DataInputStream(fis).readFully(thumbnailData);
                                             }
-                                            String thumbnailBase64 = android.util.Base64.encodeToString(thumbnailData, android.util.Base64.DEFAULT);
+                                            String thumbnailBase64 =
+                                                    android.util.Base64.encodeToString(
+                                                            thumbnailData,
+                                                            android.util.Base64.DEFAULT);
                                             fileInfo.put("thumbnail_data", thumbnailBase64);
                                         }
                                     }
                                 }
                             } catch (Exception e) {
-                                logger.warn(TAG, "Failed to include photo thumbnail for " + fileMetadata.getFileName() + ": " + e.getMessage());
+                                logger.warn(
+                                        TAG,
+                                        "Failed to include photo thumbnail for "
+                                                + fileMetadata.getFileName()
+                                                + ": "
+                                                + e.getMessage());
                             }
                         }
                     }
@@ -1421,13 +1816,14 @@ public class AsgCameraServer extends AsgServer {
 
             // Sort files by modification time (oldest first) for chronological sync
             // This ensures older captures are synced first, building gallery chronologically
-            changedFiles.sort((file1, file2) -> {
-                Long modified1 = (Long) file1.get("modified");
-                Long modified2 = (Long) file2.get("modified");
-                if (modified1 == null) modified1 = 0L;
-                if (modified2 == null) modified2 = 0L;
-                return Long.compare(modified1, modified2);  // Oldest first
-            });
+            changedFiles.sort(
+                    (file1, file2) -> {
+                        Long modified1 = (Long) file1.get("modified");
+                        Long modified2 = (Long) file2.get("modified");
+                        if (modified1 == null) modified1 = 0L;
+                        if (modified2 == null) modified2 = 0L;
+                        return Long.compare(modified1, modified2); // Oldest first
+                    });
 
             // Group files into captures
             Map<String, List<Map<String, Object>>> captureGroups = new LinkedHashMap<>();
@@ -1505,9 +1901,7 @@ public class AsgCameraServer extends AsgServer {
 
             // Calculate sync statistics
             long currentTime = System.currentTimeMillis();
-            long totalSize = changedFiles.stream()
-                    .mapToLong(file -> (Long) file.get("size"))
-                    .sum();
+            long totalSize = changedFiles.stream().mapToLong(file -> (Long) file.get("size")).sum();
 
             Map<String, Object> syncData = new HashMap<>();
             syncData.put("api_version", 2);
@@ -1522,9 +1916,17 @@ public class AsgCameraServer extends AsgServer {
             syncData.put("total_size", totalSize);
             syncData.put("server_time", currentTime);
 
-            logger.debug(TAG, "🔄 ✅ Sync completed: " + captures.size() + " captures, " +
-                           changedFiles.size() + " changed files, " +
-                           deletedFiles.size() + " deleted files, " + totalSize + " bytes");
+            logger.debug(
+                    TAG,
+                    "🔄 ✅ Sync completed: "
+                            + captures.size()
+                            + " captures, "
+                            + changedFiles.size()
+                            + " changed files, "
+                            + deletedFiles.size()
+                            + " deleted files, "
+                            + totalSize
+                            + " bytes");
 
             return createSuccessResponse(syncData);
         } catch (Exception e) {
@@ -1534,8 +1936,8 @@ public class AsgCameraServer extends AsgServer {
     }
 
     /**
-     * Serve batch sync request for downloading multiple files efficiently.
-     * Accepts POST request with JSON body containing file list.
+     * Serve batch sync request for downloading multiple files efficiently. Accepts POST request
+     * with JSON body containing file list.
      */
     private Response serveBatchSync(IHTTPSession session) {
         logger.debug(TAG, "📦 =========================================");
@@ -1544,50 +1946,40 @@ public class AsgCameraServer extends AsgServer {
 
         // Check if it's a POST request
         if (!"POST".equals(session.getMethod().name())) {
-            logger.warn(TAG, "📦 Invalid method: " + session.getMethod().name() + " (expected POST)");
-            return createErrorResponse(Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
+            logger.warn(
+                    TAG, "📦 Invalid method: " + session.getMethod().name() + " (expected POST)");
+            return createErrorResponse(
+                    Response.Status.METHOD_NOT_ALLOWED, "Only POST method is allowed");
         }
 
         try {
-            // Read request body
-            Map<String, String> headers = session.getHeaders();
-            int contentLength = Integer.parseInt(headers.getOrDefault("content-length", "0"));
-
-            if (contentLength <= 0) {
-                logger.warn(TAG, "📦 Empty request body");
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Request body is required");
-            }
-
-            // Read JSON body
-            byte[] body = new byte[contentLength];
-            InputStream inputStream = session.getInputStream();
-            int bytesRead = inputStream.read(body);
-
-            if (bytesRead != contentLength) {
-                logger.warn(TAG, "📦 Incomplete request body: expected " + contentLength + " bytes, got " + bytesRead);
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Incomplete request body");
-            }
-
-            String jsonBody = new String(body, StandardCharsets.UTF_8);
-            logger.debug(TAG, "📦 Request body: " + jsonBody);
-
-            // Parse JSON
-            JSONObject jsonObject = new JSONObject(jsonBody);
+            JSONObject jsonObject = readJsonBody(session);
             JSONArray filesArray = jsonObject.getJSONArray("files");
             String clientId = jsonObject.optString("client_id", "unknown");
             boolean includeThumbnails = jsonObject.optBoolean("include_thumbnails", false);
 
             if (filesArray.length() == 0) {
                 logger.warn(TAG, "📦 Empty files array");
-                return createErrorResponse(Response.Status.BAD_REQUEST, "Files array cannot be empty");
+                return createErrorResponse(
+                        Response.Status.BAD_REQUEST, "Files array cannot be empty");
             }
 
             // OOM protection: limit the number of files in a single batch
             int MAX_BATCH_FILES = 5;
             if (filesArray.length() > MAX_BATCH_FILES) {
-                logger.warn(TAG, "📦 Too many files in batch: " + filesArray.length() + " (max: " + MAX_BATCH_FILES + ")");
-                return newFixedLengthResponse(Response.Status.BAD_REQUEST, "application/json",
-                    "{\"status\":\"error\",\"error\":\"Too many files in batch. Maximum: " + MAX_BATCH_FILES + "\"}");
+                logger.warn(
+                        TAG,
+                        "📦 Too many files in batch: "
+                                + filesArray.length()
+                                + " (max: "
+                                + MAX_BATCH_FILES
+                                + ")");
+                return newFixedLengthResponse(
+                        Response.Status.BAD_REQUEST,
+                        "application/json",
+                        "{\"status\":\"error\",\"error\":\"Too many files in batch. Maximum: "
+                                + MAX_BATCH_FILES
+                                + "\"}");
             }
 
             // Process batch download
@@ -1613,7 +2005,9 @@ public class AsgCameraServer extends AsgServer {
                 logger.debug(TAG, "📦 Processing file: " + fileName);
 
                 if (isActiveRecording(fileName)) {
-                    logger.warn(TAG, "📦 Skipping file pending recording or integrity check: " + fileName);
+                    logger.warn(
+                            TAG,
+                            "📦 Skipping file pending recording or integrity check: " + fileName);
                     Map<String, Object> result = new HashMap<>();
                     result.put("file", fileName);
                     result.put("success", false);
@@ -1625,7 +2019,9 @@ public class AsgCameraServer extends AsgServer {
 
                 try {
                     // Get file metadata
-                    FileMetadata metadata = fileManager.getFileMetadata(fileManager.getDefaultPackageName(), fileName);
+                    FileMetadata metadata =
+                            fileManager.getFileMetadata(
+                                    fileManager.getDefaultPackageName(), fileName);
                     if (metadata == null) {
                         Map<String, Object> result = new HashMap<>();
                         result.put("file", fileName);
@@ -1670,7 +2066,9 @@ public class AsgCameraServer extends AsgServer {
                     }
 
                     // Encode as base64 for JSON transmission
-                    String base64Data = android.util.Base64.encodeToString(fileData, android.util.Base64.DEFAULT);
+                    String base64Data =
+                            android.util.Base64.encodeToString(
+                                    fileData, android.util.Base64.DEFAULT);
 
                     Map<String, Object> result = new HashMap<>();
                     result.put("file", fileName);
@@ -1683,7 +2081,8 @@ public class AsgCameraServer extends AsgServer {
 
                     // Include thumbnail if requested and it's a video
                     if (includeThumbnails && isVideoFile(fileName)) {
-                        File thumbnailFile = fileManager.getThumbnailManager().getOrCreateThumbnail(file);
+                        File thumbnailFile =
+                                fileManager.getThumbnailManager().getOrCreateThumbnail(file);
                         if (thumbnailFile != null && thumbnailFile.exists()) {
                             try (FileInputStream fis = new FileInputStream(thumbnailFile)) {
                                 byte[] thumbnailData;
@@ -1693,7 +2092,9 @@ public class AsgCameraServer extends AsgServer {
                                     thumbnailData = new byte[(int) thumbnailFile.length()];
                                     new DataInputStream(fis).readFully(thumbnailData);
                                 }
-                                String thumbnailBase64 = android.util.Base64.encodeToString(thumbnailData, android.util.Base64.DEFAULT);
+                                String thumbnailBase64 =
+                                        android.util.Base64.encodeToString(
+                                                thumbnailData, android.util.Base64.DEFAULT);
                                 result.put("thumbnail_data", thumbnailBase64);
                             }
                         }
@@ -1703,10 +2104,17 @@ public class AsgCameraServer extends AsgServer {
                     successCount++;
                     totalDownloadedSize += fileData.length;
 
-                    logger.debug(TAG, "📦 Successfully processed: " + fileName + " (" + fileData.length + " bytes)");
+                    logger.debug(
+                            TAG,
+                            "📦 Successfully processed: "
+                                    + fileName
+                                    + " ("
+                                    + fileData.length
+                                    + " bytes)");
 
                 } catch (Exception e) {
-                    logger.error(TAG, "📦 Error processing file " + fileName + ": " + e.getMessage(), e);
+                    logger.error(
+                            TAG, "📦 Error processing file " + fileName + ": " + e.getMessage(), e);
                     Map<String, Object> result = new HashMap<>();
                     result.put("file", fileName);
                     result.put("success", false);
@@ -1726,24 +2134,33 @@ public class AsgCameraServer extends AsgServer {
             responseData.put("total_downloaded_size", totalDownloadedSize);
             responseData.put("results", results);
 
-            logger.info(TAG, "📦 Batch sync completed: " + successCount + " successful, " + failureCount + " failed, " + totalDownloadedSize + " bytes transferred");
+            logger.info(
+                    TAG,
+                    "📦 Batch sync completed: "
+                            + successCount
+                            + " successful, "
+                            + failureCount
+                            + " failed, "
+                            + totalDownloadedSize
+                            + " bytes transferred");
             return createSuccessResponse(responseData);
 
         } catch (JSONException e) {
             logger.error(TAG, "📦 JSON parsing error: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.BAD_REQUEST, "Invalid JSON format: " + e.getMessage());
+            return createErrorResponse(
+                    Response.Status.BAD_REQUEST, "Invalid JSON format: " + e.getMessage());
         } catch (IOException e) {
             logger.error(TAG, "📦 IO error reading request body: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Error reading request body");
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Error reading request body");
         } catch (Exception e) {
             logger.error(TAG, "📦 Unexpected error during batch sync: " + e.getMessage(), e);
-            return createErrorResponse(Response.Status.INTERNAL_ERROR, "Unexpected error: " + e.getMessage());
+            return createErrorResponse(
+                    Response.Status.INTERNAL_ERROR, "Unexpected error: " + e.getMessage());
         }
     }
 
-    /**
-     * Serve sync status for monitoring sync operations.
-     */
+    /** Serve sync status for monitoring sync operations. */
     private Response serveSyncStatus(IHTTPSession session) {
         logger.debug(TAG, "📊 =========================================");
         logger.debug(TAG, "📊 SYNC STATUS REQUEST HANDLER");
@@ -1757,7 +2174,8 @@ public class AsgCameraServer extends AsgServer {
             status.put("server_uptime", System.currentTimeMillis() - getStartTime());
 
             // File statistics (servable media only)
-            List<FileMetadata> allFiles = fileManager.listFiles(fileManager.getDefaultPackageName());
+            List<FileMetadata> allFiles =
+                    fileManager.listFiles(fileManager.getDefaultPackageName());
             List<FileMetadata> servableFiles = new ArrayList<>();
             for (FileMetadata metadata : allFiles) {
                 if (isAvifTransferArtifact(metadata.getFileName())) {
@@ -1771,19 +2189,23 @@ public class AsgCameraServer extends AsgServer {
                 }
             }
             status.put("total_files", servableFiles.size());
-            status.put("total_size", servableFiles.stream().mapToLong(FileMetadata::getFileSize).sum());
+            status.put(
+                    "total_size",
+                    servableFiles.stream().mapToLong(FileMetadata::getFileSize).sum());
 
             // File type breakdown (exclude auxiliary files like HDR brackets and IMU sidecars)
-            long imageCount = servableFiles.stream()
-                .filter(f -> !isVideoFile(f.getFileName()))
-                .count();
-            long videoCount = servableFiles.stream().filter(f -> isVideoFile(f.getFileName())).count();
+            long imageCount =
+                    servableFiles.stream().filter(f -> !isVideoFile(f.getFileName())).count();
+            long videoCount =
+                    servableFiles.stream().filter(f -> isVideoFile(f.getFileName())).count();
             status.put("image_count", imageCount);
             status.put("video_count", videoCount);
 
             // Thumbnail statistics
             status.put("thumbnail_count", fileManager.getThumbnailManager().getThumbnailCount());
-            status.put("thumbnail_size", fileManager.getThumbnailManager().getThumbnailDirectorySize());
+            status.put(
+                    "thumbnail_size",
+                    fileManager.getThumbnailManager().getThumbnailDirectorySize());
 
             // Storage information
             status.put("available_space", fileManager.getAvailableSpace());

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTransferProtocol.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTransferProtocol.java
@@ -1,0 +1,177 @@
+package com.mentra.asg_client.io.server.services;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/** Stateless helpers for reliable, resumable gallery transfers. */
+final class GalleryTransferProtocol {
+
+    private static final int STREAM_BUFFER_BYTES = 64 * 1024;
+
+    private GalleryTransferProtocol() {}
+
+    static final class ByteRange {
+        final long start;
+        final long end;
+
+        ByteRange(long start, long end) {
+            this.start = start;
+            this.end = end;
+        }
+
+        long length() {
+            return end - start + 1;
+        }
+    }
+
+    /**
+     * Parse one RFC 7233 byte range. Multiple ranges are deliberately rejected because gallery
+     * clients download one immutable segment at a time.
+     */
+    static ByteRange parseRange(String header, long fileLength) {
+        if (header == null || header.trim().isEmpty()) {
+            return null;
+        }
+        if (fileLength <= 0 || !header.startsWith("bytes=") || header.indexOf(',') >= 0) {
+            throw new IllegalArgumentException("Unsatisfiable byte range");
+        }
+
+        String value = header.substring("bytes=".length()).trim();
+        int dash = value.indexOf('-');
+        if (dash < 0 || value.indexOf('-', dash + 1) >= 0) {
+            throw new IllegalArgumentException("Invalid byte range");
+        }
+
+        try {
+            String startValue = value.substring(0, dash).trim();
+            String endValue = value.substring(dash + 1).trim();
+            long start;
+            long end;
+
+            if (startValue.isEmpty()) {
+                long suffixLength = Long.parseLong(endValue);
+                if (suffixLength <= 0) {
+                    throw new IllegalArgumentException("Invalid suffix range");
+                }
+                start = Math.max(0, fileLength - suffixLength);
+                end = fileLength - 1;
+            } else {
+                start = Long.parseLong(startValue);
+                end = endValue.isEmpty() ? fileLength - 1 : Long.parseLong(endValue);
+                if (start < 0 || start >= fileLength) {
+                    throw new IllegalArgumentException("Range start is outside file");
+                }
+                end = Math.min(end, fileLength - 1);
+                if (end < start) {
+                    throw new IllegalArgumentException("Range end precedes start");
+                }
+            }
+            return new ByteRange(start, end);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid byte range", e);
+        }
+    }
+
+    /**
+     * A cheap generation validator. It changes whenever the path, size, or modification time
+     * changes; content integrity is checked separately with SHA-256.
+     */
+    static String createEtag(File file) {
+        return createEtag(file.getName(), file.length(), file.lastModified());
+    }
+
+    static String createEtag(String name, long length, long lastModified) {
+        return String.format(
+                "\"%s-%x-%x\"", Integer.toHexString(name.hashCode()), length, lastModified);
+    }
+
+    static InputStream open(File file, long start, long length) throws IOException {
+        FileInputStream stream = new FileInputStream(file);
+        try {
+            skipFully(stream, start);
+            return new BoundedInputStream(
+                    new BufferedInputStream(stream, STREAM_BUFFER_BYTES), length);
+        } catch (IOException e) {
+            stream.close();
+            throw e;
+        }
+    }
+
+    static String sha256(File file) throws IOException {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 is unavailable", e);
+        }
+
+        byte[] buffer = new byte[STREAM_BUFFER_BYTES];
+        try (InputStream input =
+                new BufferedInputStream(new FileInputStream(file), STREAM_BUFFER_BYTES)) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                digest.update(buffer, 0, read);
+            }
+        }
+
+        StringBuilder result = new StringBuilder(64);
+        for (byte value : digest.digest()) {
+            result.append(String.format("%02x", value & 0xff));
+        }
+        return result.toString();
+    }
+
+    private static void skipFully(InputStream stream, long count) throws IOException {
+        long remaining = count;
+        while (remaining > 0) {
+            long skipped = stream.skip(remaining);
+            if (skipped > 0) {
+                remaining -= skipped;
+                continue;
+            }
+            if (stream.read() == -1) {
+                throw new IOException("Unexpected end of file while seeking");
+            }
+            remaining--;
+        }
+    }
+
+    private static final class BoundedInputStream extends FilterInputStream {
+        private long remaining;
+
+        BoundedInputStream(InputStream input, long remaining) {
+            super(input);
+            this.remaining = remaining;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            int value = super.read();
+            if (value != -1) {
+                remaining--;
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            int read = super.read(buffer, offset, (int) Math.min(length, remaining));
+            if (read != -1) {
+                remaining -= read;
+            }
+            return read;
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTrashManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTrashManager.java
@@ -1,0 +1,345 @@
+package com.mentra.asg_client.io.server.services;
+
+import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.utils.GallerySyncFilter;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Implements the gallery source-deletion barrier.
+ *
+ * <p>Acknowledged captures are atomically renamed into a hidden trash directory when possible. They
+ * remain restorable until a later, explicitly requested garbage-collection pass.
+ */
+final class GalleryTrashManager {
+
+    private static final String ACKS_FILE = ".ack_ids";
+    private static final String FLAT_LAYOUT_FILE = ".flat_layout";
+
+    static final class Result {
+        final boolean success;
+        final boolean alreadyTrashed;
+        final String captureId;
+        final int fileCount;
+        final long totalSize;
+        final String message;
+
+        Result(
+                boolean success,
+                boolean alreadyTrashed,
+                String captureId,
+                int fileCount,
+                long totalSize,
+                String message) {
+            this.success = success;
+            this.alreadyTrashed = alreadyTrashed;
+            this.captureId = captureId;
+            this.fileCount = fileCount;
+            this.totalSize = totalSize;
+            this.message = message;
+        }
+    }
+
+    static final class TrashedCapture {
+        final String captureId;
+        final int fileCount;
+        final long totalSize;
+        final long trashedAt;
+
+        TrashedCapture(String captureId, int fileCount, long totalSize, long trashedAt) {
+            this.captureId = captureId;
+            this.fileCount = fileCount;
+            this.totalSize = totalSize;
+            this.trashedAt = trashedAt;
+        }
+    }
+
+    private final File packageDirectory;
+    private final File trashDirectory;
+
+    GalleryTrashManager(File packageDirectory) {
+        this.packageDirectory = packageDirectory;
+        this.trashDirectory = new File(packageDirectory, FileManager.GALLERY_TRASH_DIR_NAME);
+    }
+
+    synchronized Result trashCapture(String requestedId, String ackId) throws IOException {
+        String captureId = validateCaptureId(requestedId);
+        File destination = child(trashDirectory, captureId);
+        if (destination.exists()) {
+            // A process/power loss can interrupt the multi-file legacy layout after some files
+            // have moved. Reconcile every exact capture member before reporting the retry as
+            // acknowledged; otherwise the source could be split between live storage and trash.
+            if (new File(destination, FLAT_LAYOUT_FILE).exists()) {
+                moveFlatFiles(findFlatCaptureFiles(captureId), destination, false);
+            }
+            appendAck(destination, ackId);
+            Counts counts = countMedia(destination);
+            touch(destination);
+            return new Result(
+                    true,
+                    true,
+                    captureId,
+                    counts.files,
+                    counts.bytes,
+                    "Capture was already in recoverable trash");
+        }
+
+        ensureDirectory(trashDirectory);
+        File liveDirectory = child(packageDirectory, captureId);
+        if (liveDirectory.isDirectory()) {
+            Counts counts = countMedia(liveDirectory);
+            if (!liveDirectory.renameTo(destination)) {
+                throw new IOException("Unable to move capture directory to recoverable trash");
+            }
+            appendAck(destination, ackId);
+            touch(destination);
+            return new Result(
+                    true,
+                    false,
+                    captureId,
+                    counts.files,
+                    counts.bytes,
+                    "Capture moved to recoverable trash");
+        }
+
+        List<File> flatFiles = findFlatCaptureFiles(captureId);
+        if (flatFiles.isEmpty()) {
+            return new Result(false, false, captureId, 0, 0, "Capture was not found");
+        }
+
+        ensureDirectory(destination);
+        writeMarker(new File(destination, FLAT_LAYOUT_FILE), "flat");
+        Counts moved = moveFlatFiles(flatFiles, destination, true);
+        appendAck(destination, ackId);
+        touch(destination);
+        return new Result(
+                true,
+                false,
+                captureId,
+                moved.files,
+                moved.bytes,
+                "Capture moved to recoverable trash");
+    }
+
+    synchronized Result restoreCapture(String requestedId) throws IOException {
+        String captureId = validateCaptureId(requestedId);
+        File source = child(trashDirectory, captureId);
+        if (!source.isDirectory()) {
+            return new Result(false, false, captureId, 0, 0, "Capture is not in trash");
+        }
+
+        Counts counts = countMedia(source);
+        if (new File(source, FLAT_LAYOUT_FILE).exists()) {
+            for (File child : listFiles(source)) {
+                if (isMetadata(child)) {
+                    continue;
+                }
+                File target = child(packageDirectory, child.getName());
+                if (target.exists() || !child.renameTo(target)) {
+                    throw new IOException("Unable to restore " + child.getName());
+                }
+            }
+            deleteRecursively(source);
+        } else {
+            deleteMetadata(source);
+            File destination = child(packageDirectory, captureId);
+            if (destination.exists() || !source.renameTo(destination)) {
+                throw new IOException("Unable to restore capture directory");
+            }
+        }
+
+        return new Result(true, false, captureId, counts.files, counts.bytes, "Capture restored");
+    }
+
+    synchronized List<TrashedCapture> listTrashed() throws IOException {
+        if (!trashDirectory.isDirectory()) {
+            return Collections.emptyList();
+        }
+        List<TrashedCapture> results = new ArrayList<>();
+        for (File capture : listFiles(trashDirectory)) {
+            if (!capture.isDirectory()) {
+                continue;
+            }
+            Counts counts = countMedia(capture);
+            results.add(
+                    new TrashedCapture(
+                            capture.getName(), counts.files, counts.bytes, capture.lastModified()));
+        }
+        results.sort(Comparator.comparingLong((TrashedCapture item) -> item.trashedAt).reversed());
+        return results;
+    }
+
+    synchronized int garbageCollect(long minimumAgeMs) throws IOException {
+        if (!trashDirectory.isDirectory()) {
+            return 0;
+        }
+        long cutoff = System.currentTimeMillis() - Math.max(0, minimumAgeMs);
+        int removed = 0;
+        for (File capture : listFiles(trashDirectory)) {
+            File acknowledgements = new File(capture, ACKS_FILE);
+            if (capture.isDirectory()
+                    && acknowledgements.isFile()
+                    && acknowledgements.length() > 0
+                    && capture.lastModified() <= cutoff) {
+                deleteRecursively(capture);
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    private List<File> findFlatCaptureFiles(String captureId) {
+        List<File> matches = new ArrayList<>();
+        for (File file : listFiles(packageDirectory)) {
+            if (file.isFile()
+                    && captureId.equals(GallerySyncFilter.deriveCaptureId(file.getName()))) {
+                matches.add(file);
+            }
+        }
+        matches.sort(Comparator.comparing(File::getName));
+        return matches;
+    }
+
+    private Counts moveFlatFiles(
+            List<File> sources, File destination, boolean removeDestinationOnFailure)
+            throws IOException {
+        List<File> movedTargets = new ArrayList<>();
+        long bytes = 0;
+        try {
+            for (File source : sources) {
+                long sourceSize = source.length();
+                File target = child(destination, source.getName());
+                if (target.exists() || !source.renameTo(target)) {
+                    throw new IOException(
+                            "Unable to move " + source.getName() + " to recoverable trash");
+                }
+                movedTargets.add(target);
+                bytes += sourceSize;
+            }
+            return new Counts(movedTargets.size(), bytes);
+        } catch (IOException e) {
+            for (int i = movedTargets.size() - 1; i >= 0; i--) {
+                File moved = movedTargets.get(i);
+                moved.renameTo(new File(packageDirectory, moved.getName()));
+            }
+            if (removeDestinationOnFailure) {
+                deleteRecursivelyQuietly(destination);
+            }
+            throw e;
+        }
+    }
+
+    private static String validateCaptureId(String captureId) {
+        if (captureId == null || !captureId.matches("[A-Za-z0-9_-]+")) {
+            throw new IllegalArgumentException("Invalid capture ID");
+        }
+        if (captureId.startsWith("_")) {
+            throw new IllegalArgumentException("Reserved capture ID");
+        }
+        return captureId;
+    }
+
+    private static void appendAck(File destination, String ackId) throws IOException {
+        if (ackId == null || ackId.trim().isEmpty()) {
+            return;
+        }
+        File marker = new File(destination, ACKS_FILE);
+        String value = ackId.trim() + "\n";
+        try (FileOutputStream output = new FileOutputStream(marker, true)) {
+            output.write(value.getBytes(StandardCharsets.UTF_8));
+            output.getFD().sync();
+        }
+    }
+
+    private static void deleteMetadata(File directory) throws IOException {
+        for (File file : listFiles(directory)) {
+            if (isMetadata(file) && !file.delete()) {
+                throw new IOException("Unable to remove trash metadata");
+            }
+        }
+    }
+
+    private static boolean isMetadata(File file) {
+        return ACKS_FILE.equals(file.getName()) || FLAT_LAYOUT_FILE.equals(file.getName());
+    }
+
+    private static Counts countMedia(File file) {
+        if (file.isFile()) {
+            return isMetadata(file) ? new Counts(0, 0) : new Counts(1, file.length());
+        }
+        int files = 0;
+        long bytes = 0;
+        for (File child : listFiles(file)) {
+            Counts childCounts = countMedia(child);
+            files += childCounts.files;
+            bytes += childCounts.bytes;
+        }
+        return new Counts(files, bytes);
+    }
+
+    private static void writeMarker(File file, String value) throws IOException {
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            output.write(value.getBytes(StandardCharsets.UTF_8));
+            output.getFD().sync();
+        }
+    }
+
+    private static void ensureDirectory(File directory) throws IOException {
+        if (!directory.isDirectory() && !directory.mkdirs()) {
+            throw new IOException("Unable to create " + directory.getName());
+        }
+    }
+
+    private static File child(File parent, String name) throws IOException {
+        File child = new File(parent, name);
+        String parentPath = parent.getCanonicalPath() + File.separator;
+        if (!child.getCanonicalPath().startsWith(parentPath)) {
+            throw new IllegalArgumentException("Path escapes gallery storage");
+        }
+        return child;
+    }
+
+    private static File[] listFiles(File directory) {
+        File[] files = directory.listFiles();
+        return files != null ? files : new File[0];
+    }
+
+    private static void touch(File file) {
+        file.setLastModified(System.currentTimeMillis());
+    }
+
+    private static void deleteRecursively(File file) throws IOException {
+        if (file.isDirectory()) {
+            for (File child : listFiles(file)) {
+                deleteRecursively(child);
+            }
+        }
+        if (file.exists() && !file.delete()) {
+            throw new IOException("Unable to delete " + file.getName());
+        }
+    }
+
+    private static void deleteRecursivelyQuietly(File file) {
+        try {
+            deleteRecursively(file);
+        } catch (IOException ignored) {
+            // Best effort rollback cleanup; original exception is more useful to the caller.
+        }
+    }
+
+    private static final class Counts {
+        final int files;
+        final long bytes;
+
+        Counts(int files, long bytes) {
+            this.files = files;
+            this.bytes = bytes;
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTrashManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/services/GalleryTrashManager.java
@@ -70,6 +70,7 @@ final class GalleryTrashManager {
 
     synchronized Result trashCapture(String requestedId, String ackId) throws IOException {
         String captureId = validateCaptureId(requestedId);
+        String validatedAckId = validateAckId(ackId);
         File destination = child(trashDirectory, captureId);
         if (destination.exists()) {
             // A process/power loss can interrupt the multi-file legacy layout after some files
@@ -78,7 +79,7 @@ final class GalleryTrashManager {
             if (new File(destination, FLAT_LAYOUT_FILE).exists()) {
                 moveFlatFiles(findFlatCaptureFiles(captureId), destination, false);
             }
-            appendAck(destination, ackId);
+            appendAck(destination, validatedAckId);
             Counts counts = countMedia(destination);
             touch(destination);
             return new Result(
@@ -97,7 +98,7 @@ final class GalleryTrashManager {
             if (!liveDirectory.renameTo(destination)) {
                 throw new IOException("Unable to move capture directory to recoverable trash");
             }
-            appendAck(destination, ackId);
+            appendAck(destination, validatedAckId);
             touch(destination);
             return new Result(
                     true,
@@ -116,7 +117,7 @@ final class GalleryTrashManager {
         ensureDirectory(destination);
         writeMarker(new File(destination, FLAT_LAYOUT_FILE), "flat");
         Counts moved = moveFlatFiles(flatFiles, destination, true);
-        appendAck(destination, ackId);
+        appendAck(destination, validatedAckId);
         touch(destination);
         return new Result(
                 true,
@@ -245,12 +246,20 @@ final class GalleryTrashManager {
         return captureId;
     }
 
-    private static void appendAck(File destination, String ackId) throws IOException {
-        if (ackId == null || ackId.trim().isEmpty()) {
-            return;
+    private static String validateAckId(String ackId) {
+        if (ackId == null) {
+            throw new IllegalArgumentException("Acknowledgement ID is required");
         }
+        String value = ackId.trim();
+        if (value.isEmpty() || value.contains("\n") || value.contains("\r")) {
+            throw new IllegalArgumentException("Invalid acknowledgement ID");
+        }
+        return value;
+    }
+
+    private static void appendAck(File destination, String ackId) throws IOException {
         File marker = new File(destination, ACKS_FILE);
-        String value = ackId.trim() + "\n";
+        String value = validateAckId(ackId) + "\n";
         try (FileOutputStream output = new FileOutputStream(marker, true)) {
             output.write(value.getBytes(StandardCharsets.UTF_8));
             output.getFD().sync();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/BaseMediaCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/BaseMediaCommandHandler.java
@@ -157,8 +157,8 @@ public abstract class BaseMediaCommandHandler implements ICommandHandler {
      * subdirectory. Use this for captures the caller does NOT want saved to the gallery
      * (e.g. SDK photo requests with {@code save=false}): the file is invisible to
      * {@link FileManager#listFiles(String)} so it cannot leak into the gallery count or the
-     * Wi-Fi sync server's listing while the upload is in flight, and the existing periodic
-     * {@code cleanupOldFiles} sweep still age-cleans any orphans left by a crash.
+     * Wi-Fi sync server's listing while the upload is in flight, and the periodic
+     * {@code cleanupOldSdkPendingFiles} sweep still age-cleans any orphans left by a crash.
      */
     protected String generateTransientCaptureFilePath(
             String packageName, String prefix, String extension, String requestId) {
@@ -204,4 +204,4 @@ public abstract class BaseMediaCommandHandler implements ICommandHandler {
             Log.e(TAG, commandType + " command failed: " + errorMessage);
         }
     }
-} 
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/file/core/FileManagerCleanupTest.java
@@ -1,0 +1,100 @@
+package com.mentra.asg_client.io.file.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import com.mentra.asg_client.logging.Logger;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class FileManagerCleanupTest {
+
+    private File baseDirectory;
+    private FileManagerImpl fileManager;
+    private File packageDirectory;
+
+    @Before
+    public void setUp() throws Exception {
+        baseDirectory = Files.createTempDirectory("file-manager-cleanup-test").toFile();
+        fileManager = new FileManagerImpl(baseDirectory, mock(Logger.class));
+        packageDirectory = fileManager.getDefaultMediaDirectory();
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deleteRecursively(baseDirectory);
+    }
+
+    @Test
+    public void sdkPendingCleanupDoesNotTouchLiveOrGalleryManagedFiles() throws Exception {
+        File live = write("IMG_live/base.jpg");
+        File trash = write(FileManager.GALLERY_TRASH_DIR_NAME + "/IMG_trash/base.jpg");
+        File metadata = write(FileManager.GALLERY_METADATA_DIR_NAME + "/ack.json");
+        File pending = write(FileManager.SDK_PENDING_DIR_NAME + "/IMG_pending/base.jpg");
+
+        age(live, trash, metadata, pending);
+
+        assertEquals(
+                1, fileManager.cleanupOldSdkPendingFiles(fileManager.getDefaultPackageName(), 1));
+        assertFalse(pending.exists());
+        assertTrue(live.isFile());
+        assertTrue(trash.isFile());
+        assertTrue(metadata.isFile());
+    }
+
+    @Test
+    public void legacyCleanupNeverDescendsIntoTrashOrMetadata() throws Exception {
+        File live = write("IMG_live/base.jpg");
+        File trash = write(FileManager.GALLERY_TRASH_DIR_NAME + "/IMG_trash/base.jpg");
+        File metadata = write(FileManager.GALLERY_METADATA_DIR_NAME + "/ack.json");
+
+        age(live, trash, metadata);
+
+        assertEquals(1, fileManager.cleanupOldFiles(fileManager.getDefaultPackageName(), 1));
+        assertFalse(live.exists());
+        assertTrue(trash.isFile());
+        assertTrue(metadata.isFile());
+    }
+
+    private File write(String relativePath) throws Exception {
+        File file = new File(packageDirectory, relativePath);
+        assertTrue(file.getParentFile().mkdirs() || file.getParentFile().isDirectory());
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            output.write("data".getBytes(StandardCharsets.UTF_8));
+        }
+        return file;
+    }
+
+    private static void age(File... files) {
+        for (File file : files) {
+            assertTrue(file.setLastModified(1));
+        }
+    }
+
+    private static void deleteRecursively(File file) throws Exception {
+        if (file == null || !file.exists()) {
+            return;
+        }
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        Files.deleteIfExists(file.toPath());
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTransferProtocolTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTransferProtocolTest.java
@@ -1,0 +1,48 @@
+package com.mentra.asg_client.io.server.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+public class GalleryTransferProtocolTest {
+
+    @Test
+    public void parsesClosedAndOpenRanges() {
+        GalleryTransferProtocol.ByteRange closed =
+                GalleryTransferProtocol.parseRange("bytes=10-19", 100);
+        assertEquals(10, closed.start);
+        assertEquals(19, closed.end);
+        assertEquals(10, closed.length());
+
+        GalleryTransferProtocol.ByteRange open =
+                GalleryTransferProtocol.parseRange("bytes=90-", 100);
+        assertEquals(90, open.start);
+        assertEquals(99, open.end);
+    }
+
+    @Test
+    public void parsesSuffixAndClampsEnd() {
+        GalleryTransferProtocol.ByteRange suffix =
+                GalleryTransferProtocol.parseRange("bytes=-5", 100);
+        assertEquals(95, suffix.start);
+        assertEquals(99, suffix.end);
+
+        GalleryTransferProtocol.ByteRange clamped =
+                GalleryTransferProtocol.parseRange("bytes=90-200", 100);
+        assertEquals(90, clamped.start);
+        assertEquals(99, clamped.end);
+    }
+
+    @Test
+    public void rejectsUnsatisfiableAndMultipleRanges() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GalleryTransferProtocol.parseRange("bytes=100-", 100));
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GalleryTransferProtocol.parseRange("bytes=0-1,4-5", 100));
+        assertNull(GalleryTransferProtocol.parseRange(null, 100));
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTrashManagerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTrashManagerTest.java
@@ -82,6 +82,23 @@ public class GalleryTrashManagerTest {
     }
 
     @Test
+    public void rejectsInvalidAcknowledgementBeforeMovingCapture() throws Exception {
+        File capture = new File(packageDirectory, "IMG_invalid_ack");
+        assertTrue(capture.mkdir());
+        write(new File(capture, "base.jpg"), "photo");
+
+        try {
+            manager.trashCapture("IMG_invalid_ack", "  \n  ");
+            throw new AssertionError("Expected invalid acknowledgement to be rejected");
+        } catch (IllegalArgumentException expected) {
+            assertEquals("Invalid acknowledgement ID", expected.getMessage());
+        }
+
+        assertTrue(new File(capture, "base.jpg").isFile());
+        assertFalse(new File(packageDirectory, "_gallery_trash/IMG_invalid_ack").exists());
+    }
+
+    @Test
     public void garbageCollectionOnlyRemovesTrash() throws Exception {
         write(new File(packageDirectory, "IMG_live.jpg"), "live");
         write(new File(packageDirectory, "IMG_old.jpg"), "old");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTrashManagerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/services/GalleryTrashManagerTest.java
@@ -1,0 +1,131 @@
+package com.mentra.asg_client.io.server.services;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class GalleryTrashManagerTest {
+
+    private File packageDirectory;
+    private GalleryTrashManager manager;
+
+    @Before
+    public void setUp() throws Exception {
+        packageDirectory = Files.createTempDirectory("gallery-trash-test").toFile();
+        manager = new GalleryTrashManager(packageDirectory);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        deleteRecursively(packageDirectory);
+    }
+
+    @Test
+    public void trashesAndRestoresDirectoryCaptureIdempotently() throws Exception {
+        File capture = new File(packageDirectory, "VID_100");
+        assertTrue(capture.mkdir());
+        write(new File(capture, "base.mp4"), "video");
+
+        GalleryTrashManager.Result first = manager.trashCapture("VID_100", "ack-1");
+        assertTrue(first.success);
+        assertFalse(first.alreadyTrashed);
+        assertFalse(capture.exists());
+
+        GalleryTrashManager.Result repeated = manager.trashCapture("VID_100", "ack-1");
+        assertTrue(repeated.success);
+        assertTrue(repeated.alreadyTrashed);
+        assertEquals(1, manager.listTrashed().size());
+
+        GalleryTrashManager.Result restored = manager.restoreCapture("VID_100");
+        assertTrue(restored.success);
+        assertTrue(new File(capture, "base.mp4").isFile());
+        assertTrue(manager.listTrashed().isEmpty());
+    }
+
+    @Test
+    public void flatCaptureMatchDoesNotUseUnsafePrefix() throws Exception {
+        write(new File(packageDirectory, "IMG_1.jpg"), "one");
+        write(new File(packageDirectory, "IMG_10.jpg"), "ten");
+
+        GalleryTrashManager.Result result = manager.trashCapture("IMG_1", "ack-1");
+        assertTrue(result.success);
+        assertFalse(new File(packageDirectory, "IMG_1.jpg").exists());
+        assertTrue(new File(packageDirectory, "IMG_10.jpg").exists());
+
+        manager.restoreCapture("IMG_1");
+        assertTrue(new File(packageDirectory, "IMG_1.jpg").isFile());
+    }
+
+    @Test
+    public void retryReconcilesInterruptedFlatCaptureMove() throws Exception {
+        File trashCapture = new File(packageDirectory, "_gallery_trash/IMG_2");
+        assertTrue(trashCapture.mkdirs());
+        write(new File(trashCapture, ".flat_layout"), "flat");
+        write(new File(trashCapture, "IMG_2_ev0.jpg"), "bracket");
+        write(new File(packageDirectory, "IMG_2.jpg"), "primary");
+
+        GalleryTrashManager.Result result = manager.trashCapture("IMG_2", "ack-retry");
+
+        assertTrue(result.success);
+        assertTrue(result.alreadyTrashed);
+        assertEquals(2, result.fileCount);
+        assertFalse(new File(packageDirectory, "IMG_2.jpg").exists());
+        assertTrue(new File(trashCapture, "IMG_2.jpg").isFile());
+    }
+
+    @Test
+    public void garbageCollectionOnlyRemovesTrash() throws Exception {
+        write(new File(packageDirectory, "IMG_live.jpg"), "live");
+        write(new File(packageDirectory, "IMG_old.jpg"), "old");
+        manager.trashCapture("IMG_old", "ack-1");
+
+        File trashed =
+                manager.listTrashed().isEmpty()
+                        ? null
+                        : new File(
+                                new File(packageDirectory, "_gallery_trash"),
+                                manager.listTrashed().get(0).captureId);
+        assertTrue(trashed != null && trashed.setLastModified(1));
+
+        assertEquals(1, manager.garbageCollect(1));
+        assertTrue(new File(packageDirectory, "IMG_live.jpg").isFile());
+        assertTrue(manager.listTrashed().isEmpty());
+    }
+
+    @Test
+    public void garbageCollectionRetainsInterruptedUnacknowledgedTrash() throws Exception {
+        File interrupted = new File(packageDirectory, "_gallery_trash/VID_interrupted");
+        assertTrue(interrupted.mkdirs());
+        write(new File(interrupted, "base.mp4"), "partial-move");
+        assertTrue(interrupted.setLastModified(1));
+
+        assertEquals(0, manager.garbageCollect(1));
+        assertTrue(new File(interrupted, "base.mp4").isFile());
+    }
+
+    private static void write(File file, String value) throws Exception {
+        try (FileOutputStream output = new FileOutputStream(file)) {
+            output.write(value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private static void deleteRecursively(File file) throws Exception {
+        if (file.isDirectory()) {
+            File[] children = file.listFiles();
+            if (children != null) {
+                for (File child : children) {
+                    deleteRecursively(child);
+                }
+            }
+        }
+        Files.deleteIfExists(file.toPath());
+    }
+}

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -589,7 +589,8 @@ class CrustModule : Module() {
                         mediaDisplayName,
                         file.length(),
                         captureTimeMillis,
-        )
+                        relativePath,
+                )
         if (existingUri != null) {
           android.util.Log.d("CrustModule", "Reusing existing gallery asset")
           return@AsyncFunction mapOf(
@@ -900,7 +901,9 @@ class CrustModule : Module() {
   /**
    * Find a completed export from a previous attempt. A crash can happen after MediaStore commits
    * but before JavaScript persists the URI receipt; the stable capture display name, size, and
-   * capture time let the retry return that receipt instead of inserting a duplicate.
+   * capture time, and Mentra album path let the retry return that receipt instead of inserting a
+   * duplicate. Scoping by album is also important before deleting interrupted pending rows: a
+   * same-named asset owned by another album must never be treated as ours.
    */
   private fun findExistingGalleryAsset(
           resolver: android.content.ContentResolver,
@@ -908,6 +911,7 @@ class CrustModule : Module() {
           displayName: String,
           size: Long,
           captureTimeMillis: Long?,
+          relativePath: String?,
   ): android.net.Uri? {
     val dateColumn = android.provider.MediaStore.Images.ImageColumns.DATE_TAKEN
     val selectionParts =
@@ -918,6 +922,20 @@ class CrustModule : Module() {
     if (captureTimeMillis != null) {
       selectionParts.add("$dateColumn = ?")
       selectionArgs.add(captureTimeMillis.toString())
+    }
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q &&
+                    relativePath != null
+    ) {
+      val pathWithoutTrailingSlash = relativePath.trimEnd('/')
+      selectionParts.add(
+              "(${android.provider.MediaStore.MediaColumns.RELATIVE_PATH} = ? OR " +
+                      "${android.provider.MediaStore.MediaColumns.RELATIVE_PATH} = ?)"
+      )
+      // MediaProvider normally canonicalizes RELATIVE_PATH with a trailing slash. Accept the
+      // caller's original representation too so exports created by older Android builds remain
+      // reconcilable, while still requiring an exact Mentra album match.
+      selectionArgs.add(pathWithoutTrailingSlash)
+      selectionArgs.add("$pathWithoutTrailingSlash/")
     }
     val projection =
             mutableListOf(

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -575,6 +575,30 @@ class CrustModule : Module() {
                           }
                         }
 
+        val relativePath =
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                  if (isVideo) "Movies/Mentra" else "Pictures/Mentra"
+                } else {
+                  null
+                }
+        val resolver = context.contentResolver
+        val existingUri =
+                findExistingGalleryAsset(
+                        resolver,
+                        collection,
+                        mediaDisplayName,
+                        file.length(),
+                        captureTimeMillis,
+        )
+        if (existingUri != null) {
+          android.util.Log.d("CrustModule", "Reusing existing gallery asset")
+          return@AsyncFunction mapOf(
+                  "success" to true,
+                  "uri" to existingUri.toString(),
+                  "existing" to true,
+          )
+        }
+
         val values =
                 android.content.ContentValues().apply {
                   put(android.provider.MediaStore.MediaColumns.DISPLAY_NAME, mediaDisplayName)
@@ -593,19 +617,12 @@ class CrustModule : Module() {
                     )
                   }
 
-                  if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
-                    val relativePath =
-                            if (isVideo) {
-                              "Movies/Mentra"
-                            } else {
-                              "Pictures/Mentra"
-                            }
+                  if (relativePath != null) {
                     put(android.provider.MediaStore.MediaColumns.RELATIVE_PATH, relativePath)
                     put(android.provider.MediaStore.MediaColumns.IS_PENDING, 1)
                   }
                 }
 
-        val resolver = context.contentResolver
         val uri =
                 resolver.insert(collection, values)
                         ?: throw IllegalStateException("Failed to create MediaStore entry")
@@ -877,6 +894,80 @@ class CrustModule : Module() {
     AsyncFunction("stopHeading") {
       HeadingManager.stop()
       mapOf("ok" to true)
+    }
+  }
+
+  /**
+   * Find a completed export from a previous attempt. A crash can happen after MediaStore commits
+   * but before JavaScript persists the URI receipt; the stable capture display name, size, and
+   * capture time let the retry return that receipt instead of inserting a duplicate.
+   */
+  private fun findExistingGalleryAsset(
+          resolver: android.content.ContentResolver,
+          collection: android.net.Uri,
+          displayName: String,
+          size: Long,
+          captureTimeMillis: Long?,
+  ): android.net.Uri? {
+    val dateColumn = android.provider.MediaStore.Images.ImageColumns.DATE_TAKEN
+    val selectionParts =
+            mutableListOf(
+                    "${android.provider.MediaStore.MediaColumns.DISPLAY_NAME} = ?",
+            )
+    val selectionArgs = mutableListOf(displayName)
+    if (captureTimeMillis != null) {
+      selectionParts.add("$dateColumn = ?")
+      selectionArgs.add(captureTimeMillis.toString())
+    }
+    val projection =
+            mutableListOf(
+                            android.provider.BaseColumns._ID,
+                            android.provider.MediaStore.MediaColumns.SIZE,
+                    )
+                    .apply {
+              if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                add(android.provider.MediaStore.MediaColumns.IS_PENDING)
+              }
+            }
+
+    return try {
+      resolver
+              .query(
+                      collection,
+                      projection.toTypedArray(),
+                      selectionParts.joinToString(" AND "),
+                      selectionArgs.toTypedArray(),
+                      "${android.provider.BaseColumns._ID} DESC",
+              )
+              ?.use { cursor ->
+                val idColumn = cursor.getColumnIndexOrThrow(android.provider.BaseColumns._ID)
+                val sizeColumn =
+                        cursor.getColumnIndexOrThrow(android.provider.MediaStore.MediaColumns.SIZE)
+                val pendingColumn =
+                        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.Q) {
+                          cursor.getColumnIndex(android.provider.MediaStore.MediaColumns.IS_PENDING)
+                        } else {
+                          -1
+                        }
+                while (cursor.moveToNext()) {
+                  val uri =
+                          android.content.ContentUris.withAppendedId(
+                                  collection,
+                                  cursor.getLong(idColumn),
+                          )
+                  if (pendingColumn >= 0 && cursor.getInt(pendingColumn) != 0) {
+                    // This app owns the row and it was never published. Remove the interrupted
+                    // placeholder before retrying the copy, even if it contains only a prefix.
+                    resolver.delete(uri, null, null)
+                    continue
+                  }
+                  if (cursor.getLong(sizeColumn) == size) return@use uri
+                }
+                null
+              }
+    } catch (error: Exception) {
+      android.util.Log.w("CrustModule", "Unable to reconcile existing gallery asset", error)
+      null
     }
   }
 }

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -418,41 +418,48 @@ public class CrustModule: Module {
                 return ["success": false, "error": "File does not exist"]
             }
 
+            let pathExtension = fileURL.pathExtension.lowercased()
+            let isVideo = ["mp4", "mov", "avi", "m4v"].contains(pathExtension)
+            let assetFileName = displayName?.isEmpty == false
+                ? displayName!
+                : fileURL.lastPathComponent
+            let captureDate = captureTimeMillis.map {
+                Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
+            }
+
+            // The JS ledger normally supplies the previous PhotoKit receipt. If the app was
+            // terminated after Photos committed but before that receipt was persisted, reconcile
+            // by our stable capture filename/date before creating another asset.
+            if let existingIdentifier = self.findExistingGalleryAssetIdentifier(
+                fileName: assetFileName,
+                captureDate: captureDate,
+                isVideo: isVideo
+            ) {
+                NSLog("CrustModule: Reusing existing gallery asset")
+                return [
+                    "success": true,
+                    "identifier": existingIdentifier,
+                    "existing": true,
+                ]
+            }
+
             var assetIdentifier: String?
             let semaphore = DispatchSemaphore(value: 0)
             var resultError: Error?
+            var resultSucceeded = false
             var creationFailed = false
 
             PHPhotoLibrary.shared().performChanges {
-                let pathExtension = fileURL.pathExtension.lowercased()
+                let creationRequest = PHAssetCreationRequest.forAsset()
+                let resourceOptions = PHAssetResourceCreationOptions()
+                resourceOptions.originalFilename = assetFileName
+                creationRequest.addResource(
+                    with: isVideo ? .video : .photo,
+                    fileURL: fileURL,
+                    options: resourceOptions
+                )
 
-                let creationRequest: PHAssetChangeRequest
-                if ["mp4", "mov", "avi", "m4v"].contains(pathExtension) {
-                    guard let req = PHAssetChangeRequest.creationRequestForAssetFromVideo(
-                        atFileURL: fileURL
-                    )
-                    else {
-                        NSLog("CrustModule: Failed to create video asset request for: \(filePath)")
-                        creationFailed = true
-                        return
-                    }
-                    creationRequest = req
-                } else {
-                    guard let req = PHAssetChangeRequest.creationRequestForAssetFromImage(
-                        atFileURL: fileURL
-                    )
-                    else {
-                        NSLog("CrustModule: Failed to create image asset request for: \(filePath)")
-                        creationFailed = true
-                        return
-                    }
-                    creationRequest = req
-                }
-
-                if let captureMillis = captureTimeMillis {
-                    let captureDate = Date(
-                        timeIntervalSince1970: TimeInterval(captureMillis) / 1000.0
-                    )
+                if let captureDate {
                     creationRequest.creationDate = captureDate
                     NSLog("CrustModule: Setting creation date to: \(captureDate)")
                 }
@@ -491,15 +498,21 @@ public class CrustModule: Module {
                         "CrustModule: Mentra album exists but is not writable; asset saved to library only"
                     )
                 }
-            } completionHandler: { _, error in
+            } completionHandler: { success, error in
+                resultSucceeded = success
                 resultError = error
                 semaphore.signal()
             }
 
-            semaphore.wait()
+            if semaphore.wait(timeout: .now() + 120) == .timedOut {
+                return [
+                    "success": false,
+                    "error": "Photo library save timed out; retry will reconcile the result",
+                ]
+            }
 
             if creationFailed {
-                return ["success": false, "error": "Failed to create asset request - file may be corrupted or unsupported"]
+                return ["success": false, "error": "Failed to create PhotoKit asset placeholder"]
             }
 
             if let error = resultError {
@@ -507,10 +520,47 @@ public class CrustModule: Module {
                 return ["success": false, "error": error.localizedDescription]
             }
 
+            guard resultSucceeded else {
+                return ["success": false, "error": "Photo library did not commit the asset"]
+            }
+
             NSLog("CrustModule: Successfully saved to gallery with proper creation date")
             return ["success": true, "identifier": assetIdentifier ?? ""]
         }
+    }
 
+    private func findExistingGalleryAssetIdentifier(
+        fileName: String,
+        captureDate: Date?,
+        isVideo: Bool
+    ) -> String? {
+        let options = PHFetchOptions()
+        let mediaType = isVideo ? PHAssetMediaType.video : PHAssetMediaType.image
+        if let captureDate {
+            options.predicate = NSPredicate(
+                format: "mediaType == %d AND creationDate >= %@ AND creationDate <= %@",
+                mediaType.rawValue,
+                captureDate.addingTimeInterval(-1) as NSDate,
+                captureDate.addingTimeInterval(1) as NSDate
+            )
+        } else {
+            options.predicate = NSPredicate(format: "mediaType == %d", mediaType.rawValue)
+            options.fetchLimit = 200
+        }
+        options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+
+        let assets = PHAsset.fetchAssets(with: options)
+        var identifier: String?
+        assets.enumerateObjects { asset, _, stop in
+            let matches = PHAssetResource.assetResources(for: asset).contains {
+                $0.originalFilename == fileName
+            }
+            if matches {
+                identifier = asset.localIdentifier
+                stop.pointee = true
+            }
+        }
+        return identifier
     }
 }
 

--- a/mobile/modules/crust/src/CrustModule.ts
+++ b/mobile/modules/crust/src/CrustModule.ts
@@ -17,9 +17,7 @@ declare class CrustModule extends NativeModule<CrustModuleEvents> {
    * Pass `[]` to restore default behavior. Android: no-op (Android has no
    * per-app equivalent; system gestures are configured at the OS level).
    */
-  setDeferredSystemGestures(
-    edges: Array<"top" | "bottom" | "left" | "right" | "all">,
-  ): Promise<void>
+  setDeferredSystemGestures(edges: Array<"top" | "bottom" | "left" | "right" | "all">): Promise<void>
 
   // MentraOS Notification Commands
   setNotificationConfig(enabled: boolean, blocklist: string[]): Promise<void>
@@ -82,6 +80,7 @@ declare class CrustModule extends NativeModule<CrustModuleEvents> {
     success: boolean
     uri?: string
     identifier?: string
+    existing?: boolean
     error?: string
   }>
 

--- a/mobile/modules/engine/src/services/asg/asgCameraApi.ts
+++ b/mobile/modules/engine/src/services/asg/asgCameraApi.ts
@@ -11,11 +11,38 @@ import {BgTimer} from "../../utils/timers"
 import {localStorageService} from "./localStorageService"
 import {validateDownloadedMediaFile} from "./galleryMediaValidation"
 import {reportInvalidGalleryMedia} from "./GalleryMediaIntegrityReportService"
+import {galleryTransferLedger} from "./galleryTransferLedger"
+
+export interface GalleryCapabilities {
+  api_version: number
+  range_downloads: boolean
+  fixed_length_downloads: boolean
+  etag: boolean
+  sha256: boolean
+  recoverable_trash: boolean
+  idempotent_ack: boolean
+  selected_capture?: boolean
+  recommended_segment_bytes?: number
+  max_manifest_page_size?: number
+}
+
+type V3ManifestResponse = {
+  status: string
+  data: {
+    api_version: 3
+    captures: CaptureGroup[]
+    has_more: boolean
+    next_cursor?: string | null
+    total_count: number
+    server_time: number
+  }
+}
 
 export class AsgCameraApiClient {
   private baseUrl: string
   private port: number
   private lastRequestTime: number = 0
+  private galleryCapabilities: GalleryCapabilities | null | undefined
 
   constructor(serverUrl?: string, port: number = 8089) {
     this.port = port
@@ -44,6 +71,7 @@ export class AsgCameraApiClient {
     if (this.baseUrl !== newUrl) {
       this.baseUrl = newUrl
       this.port = newPort
+      this.galleryCapabilities = undefined
       // console.log(`[ASG Camera API] Server changed from ${oldUrl} to ${this.baseUrl}`)
     } else {
       // console.log(`[ASG Camera API] Server URL unchanged: ${this.baseUrl}`)
@@ -60,10 +88,9 @@ export class AsgCameraApiClient {
   /**
    * Rate limiting helper - ensures minimum delay between requests
    */
-  private async rateLimit(): Promise<void> {
+  private async rateLimit(minDelay: number = 500): Promise<void> {
     const now = Date.now()
     const timeSinceLastRequest = now - this.lastRequestTime
-    const minDelay = 500 // 500ms minimum delay between requests
 
     if (timeSinceLastRequest < minDelay) {
       const delay = minDelay - timeSinceLastRequest
@@ -77,7 +104,12 @@ export class AsgCameraApiClient {
   /**
    * Make a request to the ASG Camera Server with rate limiting and retry logic
    */
-  private async makeRequest<T>(endpoint: string, options?: RequestInit, retries: number = 5): Promise<T> {
+  private async makeRequest<T>(
+    endpoint: string,
+    options?: RequestInit,
+    retries: number = 5,
+    writeIntervalMs: number = 500,
+  ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`
     const method = options?.method || "GET"
 
@@ -96,8 +128,8 @@ export class AsgCameraApiClient {
 
     try {
       // Apply rate limiting only for non-GET requests
-      if (method !== "GET") {
-        await this.rateLimit()
+      if (method !== "GET" && writeIntervalMs > 0) {
+        await this.rateLimit(writeIntervalMs)
       }
 
       // Prepare headers - don't set Content-Type for GET requests
@@ -140,7 +172,7 @@ export class AsgCameraApiClient {
           const retryDelay = Math.min(Math.pow(2, 6 - retries) * 1000, 10000)
           console.log(`[ASG Camera API] Rate limited, retrying in ${retryDelay}ms (${retries} retries left)`)
           await new Promise<void>((resolve) => BgTimer.setTimeout(() => resolve(), retryDelay))
-          return this.makeRequest<T>(endpoint, options, retries - 1)
+          return this.makeRequest<T>(endpoint, options, retries - 1, writeIntervalMs)
         }
 
         throw new Error(`HTTP ${response.status}: ${response.statusText}`)
@@ -152,7 +184,12 @@ export class AsgCameraApiClient {
 
       if (contentType?.includes("application/json")) {
         const data = await response.json()
-        console.log(`[ASG Camera API] JSON Response received:`, data)
+        console.log(`[ASG Camera API] JSON response received`, {
+          endpoint,
+          status: data?.status,
+          apiVersion: data?.data?.api_version,
+          captureCount: data?.data?.captures?.length,
+        })
         return data
       } else if (contentType?.includes("image/") || contentType?.includes("application/octet-stream")) {
         // For image responses and binary data (including AVIF), return the blob
@@ -602,6 +639,100 @@ export class AsgCameraApiClient {
     }
   }
 
+  /** Probe the additive gallery protocol. A 404 cleanly falls back to legacy v2. */
+  async getGalleryCapabilities(): Promise<GalleryCapabilities | null> {
+    if (this.galleryCapabilities !== undefined) return this.galleryCapabilities
+    try {
+      const response = await fetch(`${this.baseUrl}/api/v3/capabilities`, {
+        headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
+        signal: this.createTimeoutSignal(5000),
+      })
+      if (response.status === 404) {
+        this.galleryCapabilities = null
+        return null
+      }
+      if (!response.ok) throw new Error(`HTTP ${response.status}`)
+      const payload = await response.json()
+      const capabilities = (payload.data || payload) as GalleryCapabilities
+      this.galleryCapabilities = capabilities.api_version >= 3 ? capabilities : null
+      return this.galleryCapabilities
+    } catch (error) {
+      // A failed probe must not break old firmware. Do not permanently cache transient failures.
+      console.warn("[ASG Camera API] v3 capability probe failed; using legacy sync for this attempt", error)
+      return null
+    }
+  }
+
+  /** Fetch all lightweight v3 manifest pages, newest first. */
+  async getV3Manifest(): Promise<V3ManifestResponse["data"] | null> {
+    const capabilities = await this.getGalleryCapabilities()
+    if (!capabilities) return null
+
+    const captures: CaptureGroup[] = []
+    let cursor: string | undefined
+    let serverTime = Date.now()
+    let totalCount = 0
+    do {
+      const params = new URLSearchParams({limit: String(capabilities.max_manifest_page_size || 100)})
+      if (cursor) params.set("cursor", cursor)
+      const response = await this.makeRequest<V3ManifestResponse>(`/api/v3/manifest?${params.toString()}`)
+      const data = response.data || (response as unknown as V3ManifestResponse["data"])
+      captures.push(...(data.captures || []))
+      serverTime = data.server_time || serverTime
+      totalCount = data.total_count || captures.length
+      cursor = data.has_more && data.next_cursor ? data.next_cursor : undefined
+    } while (cursor)
+
+    return {
+      api_version: 3,
+      captures,
+      has_more: false,
+      next_cursor: null,
+      total_count: totalCount,
+      server_time: serverTime,
+    }
+  }
+
+  async getV3FileHash(fileName: string): Promise<{sha256: string; etag: string; size: number}> {
+    const response = await fetch(`${this.baseUrl}/api/v3/hash?file=${encodeURIComponent(fileName)}`, {
+      headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
+      signal: this.createTimeoutSignal(10 * 60 * 1000),
+    })
+    if (!response.ok) throw new Error(`Hash request failed: HTTP ${response.status}`)
+    const payload = await response.json()
+    return (payload.data || payload) as {sha256: string; etag: string; size: number}
+  }
+
+  async acknowledgeCapture(captureId: string, ackId: string): Promise<void> {
+    const response = await this.makeRequest<any>(
+      "/api/v3/ack",
+      {
+        method: "POST",
+        body: JSON.stringify({capture_id: captureId, ack_id: ackId}),
+      },
+      5,
+      0,
+    )
+    const data = response.data || response
+    if (!data.success && !data.already_trashed) {
+      throw new Error(data.message || `Glasses did not acknowledge ${captureId}`)
+    }
+  }
+
+  async restoreCapture(captureId: string): Promise<void> {
+    const response = await this.makeRequest<any>(
+      "/api/v3/restore",
+      {
+        method: "POST",
+        body: JSON.stringify({capture_id: captureId}),
+      },
+      5,
+      0,
+    )
+    const data = response.data || response
+    if (!data.success) throw new Error(data.message || `Glasses did not restore ${captureId}`)
+  }
+
   /**
    * Batch sync files from server with controlled concurrency.
    * Used by the legacy executeDownload path for old asg_client firmware
@@ -637,7 +768,9 @@ export class AsgCameraApiClient {
     for (let i = 0; i < files.length; i += CONCURRENCY_LIMIT) {
       const batch = files.slice(i, i + CONCURRENCY_LIMIT)
       console.log(
-        `[ASG Camera API] Processing batch ${Math.floor(i / CONCURRENCY_LIMIT) + 1}/${Math.ceil(files.length / CONCURRENCY_LIMIT)}: ${batch.length} files`,
+        `[ASG Camera API] Processing batch ${Math.floor(i / CONCURRENCY_LIMIT) + 1}/${Math.ceil(
+          files.length / CONCURRENCY_LIMIT,
+        )}: ${batch.length} files`,
       )
 
       // Process batch in parallel
@@ -706,12 +839,6 @@ export class AsgCameraApiClient {
           results.failed.push(result.error)
         }
       }
-
-      // Small delay between batches to prevent overwhelming the server
-      if (i + CONCURRENCY_LIMIT < files.length) {
-        console.log(`[ASG Camera API] Waiting 300ms between batches`)
-        await new Promise<void>((resolve) => BgTimer.setTimeout(() => resolve(), 300))
-      }
     }
 
     console.log(
@@ -724,7 +851,297 @@ export class AsgCameraApiClient {
    * Download all files in a capture group sequentially.
    * Reports aggregate byte progress across all files in the group.
    */
+  private async downloadResumableCaptureFile(
+    captureId: string,
+    file: CaptureGroup["files"][number],
+    localFilePath: string,
+    onProgress?: (bytesDownloaded: number) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<void> {
+    const segmentBytes = 16 * 1024 * 1024
+    const segmentCount = Math.max(1, Math.ceil(file.size / segmentBytes))
+    const generation = (file.etag || `${file.size}`).replace(/[^A-Za-z0-9_-]/g, "").slice(0, 48) || "legacy"
+    const partPath = (index: number) => `${localFilePath}.partial.${generation}.${index}`
+    const assemblingPath = `${localFilePath}.assembling.${generation}`
+    const transferStartedAt = Date.now()
+    let networkDurationMs = 0
+    let networkBytes = 0
+
+    if (await RNFS.exists(localFilePath)) {
+      const existing = await RNFS.stat(localFilePath)
+      if (existing.size === file.size) {
+        if (file.etag) {
+          const remoteHash = file.sha256 ? {sha256: file.sha256, etag: file.etag} : await this.getV3FileHash(file.name)
+          if (remoteHash.etag && remoteHash.etag !== file.etag) {
+            throw new Error("Source generation changed before existing-file verification")
+          }
+          const localHash = await RNFS.hash(localFilePath, "sha256")
+          if (localHash.toLowerCase() === remoteHash.sha256.toLowerCase()) {
+            galleryTransferLedger.markFileHash(captureId, file.name, localHash.toLowerCase())
+            onProgress?.(file.size)
+            return
+          }
+          console.warn(`[ASG Camera API] Existing file failed SHA-256 verification; replacing ${file.name}`)
+        } else {
+          // Legacy servers have no generation/hash endpoint. Preserve old-client
+          // compatibility and let the media validator below reject corrupt data.
+          onProgress?.(file.size)
+          return
+        }
+      }
+      await RNFS.moveFile(localFilePath, `${localFilePath}.recovery.${Date.now()}`).catch(() => {})
+    }
+
+    let completedBytes = 0
+    let resumedSegmentCount = 0
+    for (let index = 0; index < segmentCount; index++) {
+      const start = index * segmentBytes
+      const expectedLength = Math.min(segmentBytes, file.size - start)
+      if (await RNFS.exists(partPath(index))) {
+        const stat = await RNFS.stat(partPath(index))
+        if (stat.size === expectedLength) {
+          completedBytes += expectedLength
+          resumedSegmentCount++
+          galleryTransferLedger.markSegmentComplete(captureId, file.name, index)
+          continue
+        }
+        await RNFS.unlink(partPath(index)).catch(() => {})
+      }
+
+      let completed = false
+      let lastError: unknown
+      for (let attempt = 0; attempt < 5 && !completed; attempt++) {
+        if (abortSignal?.aborted) throw new Error("Sync cancelled")
+        await RNFS.unlink(partPath(index)).catch(() => {})
+        const end = start + expectedLength - 1
+        let responseHeaders: Record<string, string> = {}
+        const {jobId, promise} = RNFS.downloadFile({
+          fromUrl: `${this.baseUrl}/api/download?file=${encodeURIComponent(file.name)}`,
+          toFile: partPath(index),
+          headers: {
+            "Accept": "*/*",
+            "User-Agent": "MentraOS-Mobile/1.0",
+            "Range": `bytes=${start}-${end}`,
+            ...(file.etag ? {"If-Range": file.etag} : {}),
+          },
+          connectionTimeout: 300000,
+          readTimeout: 300000,
+          backgroundTimeout: 24 * 60 * 60 * 1000,
+          progressDivider: 2,
+          progressInterval: 250,
+          begin: (response) => {
+            responseHeaders = response.headers || {}
+          },
+          progress: (progress) => onProgress?.(completedBytes + (progress.bytesWritten || 0)),
+        })
+
+        let abortPollTimer: number | undefined
+        if (abortSignal) {
+          abortPollTimer = BgTimer.setInterval(() => {
+            if (abortSignal.aborted) RNFS.stopDownload(jobId)
+          }, 500)
+        }
+
+        const attemptStartedAt = Date.now()
+        try {
+          const result = await promise
+          const attemptDurationMs = Math.max(1, Date.now() - attemptStartedAt)
+          networkDurationMs += attemptDurationMs
+          networkBytes += result.bytesWritten || 0
+          if (abortSignal?.aborted) throw new Error("Sync cancelled")
+          const header = (name: string): string | undefined => {
+            const key = Object.keys(responseHeaders).find((candidate) => candidate.toLowerCase() === name.toLowerCase())
+            return key ? responseHeaders[key] : undefined
+          }
+
+          if (result.statusCode === 200 && index === 0 && result.bytesWritten === file.size) {
+            // Older servers ignore Range. A full fixed/chunked response is still compatible;
+            // commit it through the same staging path and skip the remaining segments.
+            await RNFS.unlink(assemblingPath).catch(() => {})
+            await RNFS.moveFile(partPath(index), assemblingPath)
+            completedBytes = file.size
+            completed = true
+            break
+          }
+          if (result.statusCode !== 206) throw new Error(`HTTP ${result.statusCode}; expected 206`)
+          if (result.bytesWritten !== expectedLength) {
+            throw new Error(`Segment ${index} truncated: ${result.bytesWritten}/${expectedLength} bytes`)
+          }
+          const contentRange = header("content-range")
+          if (contentRange !== `bytes ${start}-${end}/${file.size}`) {
+            throw new Error(`Invalid Content-Range: ${contentRange || "missing"}`)
+          }
+          const responseEtag = header("etag")
+          if (file.etag && responseEtag && responseEtag !== file.etag) {
+            throw new Error("Source generation changed during transfer")
+          }
+          galleryTransferLedger.markSegmentComplete(captureId, file.name, index)
+          completedBytes += expectedLength
+          completed = true
+          console.log("[ASG Camera API] Gallery segment complete", {
+            captureId,
+            file: file.name,
+            segment: index,
+            segmentCount,
+            attempt: attempt + 1,
+            status: result.statusCode,
+            bytes: result.bytesWritten,
+            durationMs: attemptDurationMs,
+            throughputMbps: (((result.bytesWritten || 0) * 8) / attemptDurationMs / 1000).toFixed(2),
+            etag: file.etag,
+          })
+        } catch (error) {
+          lastError = error
+          if (error instanceof Error && error.message === "Sync cancelled") throw error
+          console.warn("[ASG Camera API] Gallery segment attempt failed", {
+            captureId,
+            file: file.name,
+            segment: index,
+            segmentCount,
+            attempt: attempt + 1,
+            rangeStart: start,
+            rangeEnd: end,
+            message: error instanceof Error ? error.message : String(error),
+          })
+          await RNFS.unlink(partPath(index)).catch(() => {})
+          if (attempt < 4) {
+            const delay = Math.min(1000 * 2 ** attempt, 10000) + Math.floor(Math.random() * 500)
+            await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, delay))
+          }
+        } finally {
+          if (abortPollTimer !== undefined) BgTimer.clearInterval(abortPollTimer)
+        }
+      }
+      if (!completed) throw lastError || new Error(`Segment ${index} failed`)
+      if (completedBytes === file.size && (await RNFS.exists(assemblingPath))) break
+    }
+
+    if (!(await RNFS.exists(assemblingPath))) {
+      await RNFS.unlink(assemblingPath).catch(() => {})
+      await RNFS.writeFile(assemblingPath, "", "utf8")
+      for (let index = 0; index < segmentCount; index++) {
+        const data = await RNFS.readFile(partPath(index), "base64")
+        await RNFS.appendFile(assemblingPath, data, "base64")
+      }
+    }
+
+    const assembledStat = await RNFS.stat(assemblingPath)
+    if (assembledStat.size !== file.size) {
+      await RNFS.moveFile(assemblingPath, `${assemblingPath}.invalid.${Date.now()}`).catch(() => {})
+      throw new Error(`Assembled file has ${assembledStat.size}/${file.size} bytes`)
+    }
+
+    const verificationStartedAt = Date.now()
+    const capabilities = await this.getGalleryCapabilities()
+    if (capabilities?.sha256) {
+      const remoteHash = file.sha256 ? {sha256: file.sha256, etag: file.etag} : await this.getV3FileHash(file.name)
+      if (file.etag && remoteHash.etag && file.etag !== remoteHash.etag) {
+        throw new Error("Source generation changed before integrity verification")
+      }
+      const localHash = await RNFS.hash(assemblingPath, "sha256")
+      if (localHash.toLowerCase() !== remoteHash.sha256.toLowerCase()) {
+        await RNFS.moveFile(assemblingPath, `${assemblingPath}.invalid.${Date.now()}`).catch(() => {})
+        throw new Error(`SHA-256 mismatch for ${file.name}`)
+      }
+      galleryTransferLedger.markFileHash(captureId, file.name, localHash.toLowerCase())
+    }
+
+    await RNFS.moveFile(assemblingPath, localFilePath)
+    for (let index = 0; index < segmentCount; index++) await RNFS.unlink(partPath(index)).catch(() => {})
+    console.log("[ASG Camera API] Gallery file committed", {
+      captureId,
+      file: file.name,
+      bytes: file.size,
+      segments: segmentCount,
+      networkDurationMs,
+      networkMbps: networkDurationMs > 0 ? ((networkBytes * 8) / networkDurationMs / 1000).toFixed(2) : "0.00",
+      verificationDurationMs: Date.now() - verificationStartedAt,
+      totalDurationMs: Date.now() - transferStartedAt,
+      resumedSegments: resumedSegmentCount,
+    })
+    onProgress?.(file.size)
+  }
+
   async downloadCapture(
+    capture: CaptureGroup,
+    onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
+    abortSignal?: AbortSignal,
+  ): Promise<{captureDir: string; primaryPath: string; bracketPaths: string[]; sidecarPath?: string}> {
+    if (capture.files.some((file) => !file.size || file.size <= 0)) {
+      // Preserve support for malformed manifests from pre-v2 development firmware.
+      return this.downloadCaptureLegacyUnsafe(capture, onProgress, abortSignal)
+    }
+    const captureDir = localStorageService.getPhotoFilePath(capture.capture_id)
+    if (!(await RNFS.exists(captureDir))) await RNFS.mkdir(captureDir)
+    const capabilities = await this.getGalleryCapabilities()
+    galleryTransferLedger.ensureCapture(capture, capabilities?.api_version || 2)
+    galleryTransferLedger.transition(capture.capture_id, "TRANSFERRING")
+
+    const sortedFiles = [...capture.files].sort((a, b) => {
+      const order = {bracket: 0, primary: 1, sidecar: 2}
+      return (order[a.role] ?? 1) - (order[b.role] ?? 1)
+    })
+    let completedCaptureBytes = 0
+    let primaryPath = ""
+    const bracketPaths: string[] = []
+    let sidecarPath: string | undefined
+
+    try {
+      for (const file of sortedFiles) {
+        const leafName = file.name.includes("/") ? file.name.split("/").pop()! : file.name
+        const localFilePath = `${captureDir}/${leafName}`
+        await this.downloadResumableCaptureFile(
+          capture.capture_id,
+          file,
+          localFilePath,
+          (fileBytes) => onProgress?.(completedCaptureBytes + fileBytes, capture.total_size),
+          abortSignal,
+        )
+
+        const isVideo = !!file.name.match(/\.(mp4|mov|avi|webm|mkv)$/i)
+        const mediaKind = file.role === "sidecar" ? "unknown" : isVideo ? "video" : "photo"
+        try {
+          await validateDownloadedMediaFile({
+            path: localFilePath,
+            name: file.name,
+            expectedSize: file.size,
+            mediaKind,
+          })
+        } catch (validationError: any) {
+          reportInvalidGalleryMedia({
+            name: file.name,
+            path: localFilePath,
+            mediaKind,
+            stage: "download_capture_validation",
+            reason: validationError?.message || String(validationError),
+            expectedSize: file.size,
+            captureId: capture.capture_id,
+            duration: capture.duration,
+          })
+          await RNFS.moveFile(localFilePath, `${localFilePath}.invalid.${Date.now()}`).catch(() => {})
+          throw validationError
+        }
+
+        completedCaptureBytes += file.size
+        if (file.role === "primary") primaryPath = localFilePath
+        else if (file.role === "bracket") bracketPaths.push(localFilePath)
+        else if (file.role === "sidecar") sidecarPath = localFilePath
+      }
+      if (!primaryPath && sortedFiles.length > 0) {
+        const leafName = sortedFiles[0].name.includes("/") ? sortedFiles[0].name.split("/").pop()! : sortedFiles[0].name
+        primaryPath = `${captureDir}/${leafName}`
+      }
+      galleryTransferLedger.transition(capture.capture_id, "VERIFIED")
+      onProgress?.(capture.total_size, capture.total_size)
+      return {captureDir, primaryPath, bracketPaths, sidecarPath}
+    } catch (error) {
+      galleryTransferLedger.recordFailure(capture.capture_id, error)
+      throw error
+    }
+  }
+
+  /** Previous direct-to-final implementation kept for binary-source compatibility only. */
+  private async downloadCaptureLegacyUnsafe(
     capture: CaptureGroup,
     onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
     abortSignal?: AbortSignal,
@@ -893,10 +1310,15 @@ export class AsgCameraApiClient {
     }
 
     try {
-      const response = await this.makeRequest("/api/delete-files", {
-        method: "POST",
-        body: JSON.stringify({files: fileNames}),
-      })
+      const response = await this.makeRequest(
+        "/api/delete-files",
+        {
+          method: "POST",
+          body: JSON.stringify({files: fileNames}),
+        },
+        5,
+        0,
+      )
 
       // Parse the response format from the ASG server
       const responseData = response as any
@@ -949,6 +1371,68 @@ export class AsgCameraApiClient {
    * Download a file from the server and save to filesystem
    */
   async downloadFile(
+    filename: string,
+    includeThumbnail: boolean = false,
+    onProgress?: (progress: number) => void,
+    abortSignal?: AbortSignal,
+    expectedSize?: number,
+  ): Promise<{filePath: string; thumbnailPath?: string; mime_type: string}> {
+    // The legacy public shape did not require a size. Keep that rare call compatible while all
+    // sync manifests use the verified resumable path below.
+    if (!expectedSize || expectedSize <= 0) {
+      return this.downloadFileLegacyUnsafe(filename, includeThumbnail, onProgress, abortSignal, expectedSize)
+    }
+
+    const localFilePath = localStorageService.getPhotoFilePath(filename)
+    const parentDir = localFilePath.substring(0, localFilePath.lastIndexOf("/"))
+    if (!(await RNFS.exists(parentDir))) await RNFS.mkdir(parentDir)
+    const lowerName = filename.toLowerCase()
+    const isVideo = /\.(mp4|mov|avi|webm|mkv)$/.test(lowerName)
+    const captureId = filename.includes("/")
+      ? filename.substring(0, filename.indexOf("/"))
+      : filename.replace(/\.imu\.json$/i, "").replace(/\.[^.]+$/, "")
+    const capture: CaptureGroup = {
+      capture_id: captureId,
+      type: isVideo ? "video" : "photo",
+      timestamp: Date.now(),
+      total_size: expectedSize,
+      files: [{name: filename, size: expectedSize, role: "primary"}],
+    }
+    const capabilities = await this.getGalleryCapabilities()
+    galleryTransferLedger.ensureCapture(capture, capabilities?.api_version || 1)
+    galleryTransferLedger.transition(captureId, "TRANSFERRING")
+    try {
+      await this.downloadResumableCaptureFile(
+        captureId,
+        capture.files[0],
+        localFilePath,
+        (bytes) => onProgress?.(Math.min(100, Math.round((bytes / expectedSize) * 100))),
+        abortSignal,
+      )
+      await validateDownloadedMediaFile({
+        path: localFilePath,
+        name: filename,
+        expectedSize,
+        mediaKind: isVideo ? "video" : "photo",
+      })
+      galleryTransferLedger.transition(captureId, "VERIFIED")
+      return {
+        filePath: localFilePath,
+        mime_type: isVideo
+          ? "video/mp4"
+          : lowerName.endsWith(".png")
+            ? "image/png"
+            : lowerName.endsWith(".avif")
+              ? "image/avif"
+              : "image/jpeg",
+      }
+    } catch (error) {
+      galleryTransferLedger.recordFailure(captureId, error)
+      throw error
+    }
+  }
+
+  private async downloadFileLegacyUnsafe(
     filename: string,
     includeThumbnail: boolean = false,
     onProgress?: (progress: number) => void,
@@ -1181,7 +1665,9 @@ export class AsgCameraApiClient {
         }
       } else {
         console.log(
-          `[ASG Camera API] Skipping thumbnail download - includeThumbnail: ${includeThumbnail}, filename: ${filename}, is video extension: ${filename.toLowerCase().match(/\.(mp4|mov|avi|mkv|webm)$/) ? "yes" : "no"}`,
+          `[ASG Camera API] Skipping thumbnail download - includeThumbnail: ${includeThumbnail}, filename: ${filename}, is video extension: ${
+            filename.toLowerCase().match(/\.(mp4|mov|avi|mkv|webm)$/) ? "yes" : "no"
+          }`,
         )
       }
 

--- a/mobile/modules/engine/src/services/asg/galleryPathMigration.ts
+++ b/mobile/modules/engine/src/services/asg/galleryPathMigration.ts
@@ -1,0 +1,22 @@
+/** Convert current or legacy app-container paths into a portable Documents-relative path. */
+export function toPortableGalleryPath(path: string, documentDirectoryPath: string): string | null {
+  if (!path) return null
+  const cleanPath = path.replace(/^file:\/\//, "")
+  const docPath = documentDirectoryPath.replace(/\/$/, "")
+  let candidate: string | null = null
+  if (cleanPath.startsWith(`${docPath}/`)) candidate = cleanPath.substring(docPath.length + 1)
+  else if (!cleanPath.startsWith("/")) candidate = cleanPath.replace(/^\/+/, "")
+
+  if (!candidate) {
+    const documentsMarker = "/Documents/"
+    const documentsIndex = cleanPath.indexOf(documentsMarker)
+    if (documentsIndex >= 0) candidate = cleanPath.substring(documentsIndex + documentsMarker.length)
+  }
+
+  if (!candidate || candidate.includes("\0")) return null
+  const segments = candidate.split("/")
+  if (segments[0] !== "MentraPhotos" || segments.some((segment) => !segment || segment === "." || segment === "..")) {
+    return null
+  }
+  return segments.join("/")
+}

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -30,6 +30,7 @@ import {localStorageService} from "./localStorageService"
 import {mediaProcessingQueue} from "./mediaProcessingQueue"
 import {validateCaptureMetadataForDownload} from "./galleryMediaValidation"
 import {emitGalleryNotice} from "./galleryNotices"
+import {galleryTransferLedger} from "./galleryTransferLedger"
 
 // Timing constants
 const TIMING = {
@@ -960,9 +961,9 @@ class GallerySyncService {
                 lastSeenSSID = currentSSID || "null"
 
                 console.log(
-                  `[GallerySyncService] 🍎 Verify poll ${i + 1}/${maxVerifyAttempts}: Current="${currentSSID}", Target="${
-                    hotspotInfo.ssid
-                  }"`,
+                  `[GallerySyncService] 🍎 Verify poll ${
+                    i + 1
+                  }/${maxVerifyAttempts}: Current="${currentSSID}", Target="${hotspotInfo.ssid}"`,
                 )
 
                 if (currentSSID === hotspotInfo.ssid) {
@@ -1258,8 +1259,30 @@ class GallerySyncService {
   }
 
   private async fetchSyncManifest(clientId: string, lastSyncTime: number): Promise<SyncManifestData> {
-    const syncResponse = await asgCameraApi.syncWithServer(clientId, lastSyncTime, true)
-    return (syncResponse.data || syncResponse) as SyncManifestData
+    const v3 = typeof asgCameraApi.getV3Manifest === "function" ? await asgCameraApi.getV3Manifest() : null
+    if (v3) {
+      return {
+        api_version: 3,
+        client_id: clientId,
+        captures: v3.captures.filter((capture) => !galleryTransferLedger.isLocallyCommitted(capture.capture_id)),
+        changed_files: [],
+        deleted_files: [],
+        server_time: v3.server_time,
+        total_changed: v3.captures.length,
+        total_size: v3.captures.reduce((total, capture) => total + capture.total_size, 0),
+      }
+    }
+    // Old firmware remains on the exact v2 endpoint/schema. Avoid expensive inline thumbnails;
+    // the UI can request them lazily after the primary transfer is safe.
+    const syncResponse = await asgCameraApi.syncWithServer(clientId, lastSyncTime, false)
+    const data = (syncResponse.data || syncResponse) as SyncManifestData
+    if (data.captures) {
+      data.captures = data.captures.filter((capture) => !galleryTransferLedger.isLocallyCommitted(capture.capture_id))
+    }
+    data.changed_files = (data.changed_files || []).filter(
+      (file) => !galleryTransferLedger.isFileLocallyCommitted(file.name),
+    )
+    return data
   }
 
   /**
@@ -1328,6 +1351,13 @@ class GallerySyncService {
       asgCameraApi.setServer(hotspotInfo.ip, 8089)
       console.log("[GallerySyncService]   ✅ API client configured")
 
+      const recovery = await mediaProcessingQueue.retryPending()
+      if (recovery.retried > 0 || recovery.failed > 0) {
+        console.log(
+          `[GallerySyncService]   ♻️ Recovery: ${recovery.retried} completed, ${recovery.failed} still pending`,
+        )
+      }
+
       // Get sync state and files to download
       // IMPORTANT: This creates a SNAPSHOT of files at this moment based on last_sync_time.
       // Any photos taken AFTER this call (during the sync) will NOT be included in this sync.
@@ -1367,18 +1397,24 @@ class GallerySyncService {
 
       if (isSyncManifestEmpty(syncData)) {
         console.log("[GallerySyncService]   ✅ No new files to sync - already up to date!")
-        store.setSyncComplete()
+        if (galleryTransferLedger.hasPendingRecovery()) {
+          store.setSyncError("Gallery export or acknowledgement needs retry")
+        } else {
+          store.setSyncComplete()
+        }
         await this.onSyncComplete(0, 0)
         return
       }
 
       // Detect API version and route to appropriate download path
-      const useCaptures = syncData.api_version === 2 && syncData.captures && syncData.captures.length > 0
+      const useCaptures = (syncData.api_version || 0) >= 2 && syncData.captures && syncData.captures.length > 0
 
       if (useCaptures) {
         // New capture-aware sync path
         const captures: CaptureGroup[] = syncData.captures!
-        console.log(`[GallerySyncService]   📊 Found ${captures.length} captures to download (api_version=2)`)
+        console.log(
+          `[GallerySyncService]   📊 Found ${captures.length} captures to download (api_version=${syncData.api_version})`,
+        )
 
         captures.slice(0, 5).forEach((c: CaptureGroup, idx: number) => {
           console.log(
@@ -1597,6 +1633,7 @@ class GallerySyncService {
                   shouldAutoSave: !!shouldAutoSave,
                   thumbnailPath: downloadedFile.thumbnailPath,
                   deleteFromGlasses: [downloadedFile.name],
+                  protocolVersion: 1,
                 })
               }
             }
@@ -1634,25 +1671,6 @@ class GallerySyncService {
         }
       }
 
-      // Save downloaded files metadata (skip auxiliary files from gallery entries)
-      for (const photoInfo of downloadResult.downloaded) {
-        // Skip HDR brackets and IMU sidecars — they shouldn't appear as separate gallery items
-        const isAuxiliary =
-          photoInfo.name?.match(/_ev-?\d+\.(jpg|jpeg)$/i) ||
-          photoInfo.name?.match(/\.imu\.json$/i) ||
-          photoInfo.name?.match(/\/ev-?\d+\.jpe?g$/i) ||
-          photoInfo.name?.match(/\/imu\.json$/i)
-        if (isAuxiliary) continue
-
-        const downloadedFile = localStorageService.convertToDownloadedFile(
-          photoInfo,
-          photoInfo.filePath || "",
-          photoInfo.thumbnailPath,
-          defaultWearable,
-        )
-        await localStorageService.saveDownloadedFile(downloadedFile)
-      }
-
       // Update queue index to final position
       await localStorageService.updateSyncQueueIndex(files.length)
 
@@ -1666,6 +1684,17 @@ class GallerySyncService {
       console.log("[GallerySyncService]   ⏳ Waiting for processing queue to drain...")
       await mediaProcessingQueue.waitUntilDrained()
       console.log("[GallerySyncService]   ✅ Processing queue drained")
+
+      // Download success is not destination success. Export, validation, metadata, and
+      // acknowledgement failures are reported asynchronously by the processing queue; fold them
+      // back into the legacy result so its timestamp watermark cannot skip the source forever.
+      const processingFailures = new Set(useGallerySyncStore.getState().failedFiles)
+      for (const file of files) {
+        if (processingFailures.has(file.name) && !downloadResult.failed.includes(file.name)) {
+          downloadResult.failed.push(file.name)
+        }
+      }
+      failedCount = downloadResult.failed.length
 
       // Update sync state — only advance watermark if files were downloaded.
       // If any failed, set it before the oldest failure so they get retried.
@@ -1730,8 +1759,11 @@ class GallerySyncService {
         ).toFixed(2)} MB`,
       )
 
-      // Complete
-      store.setSyncComplete()
+      if (failedCount > 0 || galleryTransferLedger.hasPendingRecovery()) {
+        store.setSyncError(`${failedCount || "Some"} gallery items need retry`)
+      } else {
+        store.setSyncComplete()
+      }
       await this.onSyncComplete(downloadedCount, failedCount)
     } catch (error: any) {
       mediaProcessingQueue.abort()
@@ -1795,7 +1827,9 @@ class GallerySyncService {
 
         try {
           console.log(
-            `[GallerySyncService]   📦 Downloading capture ${i + 1}/${captures.length}: ${capture.capture_id} (${capture.files.length} files)`,
+            `[GallerySyncService]   📦 Downloading capture ${i + 1}/${captures.length}: ${capture.capture_id} (${
+              capture.files.length
+            } files)`,
           )
 
           validateCaptureMetadataForDownload(capture)
@@ -1841,6 +1875,7 @@ class GallerySyncService {
             shouldProcess: !!shouldProcessImages,
             shouldAutoSave: !!shouldAutoSave,
             deleteFromGlasses: [capture.capture_id],
+            protocolVersion: capture.files.some((file) => !!file.etag) ? 3 : 2,
           })
         } catch (captureError: any) {
           if (captureError?.message === "Sync cancelled") throw captureError
@@ -1929,7 +1964,11 @@ class GallerySyncService {
         })
       }
 
-      store.setSyncComplete()
+      if (failedCount > 0 || galleryTransferLedger.hasPendingRecovery()) {
+        store.setSyncError(`${failedCount || "Some"} gallery items need retry`)
+      } else {
+        store.setSyncComplete()
+      }
       await this.onSyncComplete(downloadedCount, failedCount)
     } catch (error: any) {
       mediaProcessingQueue.abort()
@@ -1993,13 +2032,25 @@ class GallerySyncService {
     //   console.error(`[GallerySyncService] Failed to get post-sync inventory:`, error)
     // }
 
-    // Clear the queue
-    console.log("[GallerySyncService]   🧹 Clearing sync queue...")
-    await localStorageService.clearSyncQueue()
+    const hasPendingRecovery = galleryTransferLedger.hasPendingRecovery()
+    if (!hasPendingRecovery && failedCount === 0) {
+      console.log("[GallerySyncService]   🧹 Clearing completed sync queue...")
+      await localStorageService.clearSyncQueue()
+    } else {
+      console.log("[GallerySyncService]   ♻️ Keeping recovery state for unfinished export/ack work")
+    }
 
-    // Show completion notification
-    console.log("[GallerySyncService]   📱 Showing completion notification...")
-    await gallerySyncNotifications.showSyncComplete(downloadedCount, failedCount)
+    if (hasPendingRecovery || failedCount > 0) {
+      console.log("[GallerySyncService]   📱 Showing retry-required notification...")
+      await gallerySyncNotifications.showSyncError(
+        failedCount > 0
+          ? `${failedCount} gallery item${failedCount === 1 ? "" : "s"} will be retried`
+          : "Gallery export or acknowledgement will be retried",
+      )
+    } else {
+      console.log("[GallerySyncService]   📱 Showing completion notification...")
+      await gallerySyncNotifications.showSyncComplete(downloadedCount, 0)
+    }
 
     // Close hotspot if we opened it
     const store = useGallerySyncStore.getState()
@@ -2013,8 +2064,10 @@ class GallerySyncService {
     // Clear glasses gallery count immediately after successful sync
     // This ensures UI shows 0 items remaining right away
     // The subsequent query will update this if new photos were taken during sync
-    console.log("[GallerySyncService]   🔄 Clearing glasses gallery count (synced all items)")
-    store.clearGlassesGalleryStatus()
+    if (!hasPendingRecovery && failedCount === 0) {
+      console.log("[GallerySyncService]   🔄 Clearing glasses gallery count (synced all items)")
+      store.clearGlassesGalleryStatus()
+    }
 
     // Auto-reset to idle after 4 seconds to clear "Sync complete!" message,
     // then query glasses for any new content taken during the sync.

--- a/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
+++ b/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
@@ -1,0 +1,310 @@
+import {CaptureGroup} from "../../types/asg"
+import {storage} from "../../utils/storage"
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+export type GalleryTransferState =
+  | "DISCOVERED"
+  | "TRANSFERRING"
+  | "VERIFIED"
+  | "INDEXED"
+  | "EXPORT_PENDING"
+  | "EXPORTED"
+  | "ACK_PENDING"
+  | "TRASHED"
+  | "RESTORE_PENDING"
+  | "GARBAGE_COLLECTED"
+
+export interface GalleryAssetReceipt {
+  platform: "ios" | "android" | "unknown"
+  uri?: string
+  identifier?: string
+  exportedAt: number
+}
+
+export interface GalleryLedgerFile {
+  name: string
+  size: number
+  role: "primary" | "bracket" | "sidecar"
+  etag?: string
+  sha256?: string
+  completedSegments: number[]
+}
+
+export interface GalleryTransferEntry {
+  captureId: string
+  state: GalleryTransferState
+  protocolVersion: number
+  captureType: "photo" | "video"
+  timestamp: number
+  totalSize: number
+  files: GalleryLedgerFile[]
+  deleteFromGlasses: string[]
+  finalPath?: string
+  thumbnailPath?: string
+  shouldAutoSave?: boolean
+  assetReceipt?: GalleryAssetReceipt
+  ackId: string
+  retryCount: number
+  lastError?: string
+  createdAt: number
+  updatedAt: number
+}
+
+type GalleryTransferLedgerData = {
+  version: 1
+  entries: Record<string, GalleryTransferEntry>
+}
+
+const LEDGER_KEY = "asg_gallery_transfer_ledger_v1"
+
+const STATE_ORDER: Record<GalleryTransferState, number> = {
+  DISCOVERED: 0,
+  TRANSFERRING: 1,
+  VERIFIED: 2,
+  INDEXED: 3,
+  EXPORT_PENDING: 4,
+  EXPORTED: 5,
+  ACK_PENDING: 6,
+  TRASHED: 7,
+  RESTORE_PENDING: 0,
+  GARBAGE_COLLECTED: 8,
+}
+
+class GalleryTransferLedger {
+  private load(): GalleryTransferLedgerData {
+    const result = storage.load<GalleryTransferLedgerData>(LEDGER_KEY)
+    if (result.is_error() || result.value?.version !== 1) {
+      return {version: 1, entries: {}}
+    }
+    return {
+      ...result.value,
+      entries: Object.fromEntries(
+        Object.entries(result.value.entries).map(([id, entry]) => [
+          id,
+          {
+            ...entry,
+            finalPath: entry.finalPath ? this.toRuntimePath(entry.finalPath) : undefined,
+            thumbnailPath: entry.thumbnailPath ? this.toRuntimePath(entry.thumbnailPath) : undefined,
+          },
+        ]),
+      ),
+    }
+  }
+
+  private save(data: GalleryTransferLedgerData): void {
+    const portableData: GalleryTransferLedgerData = {
+      ...data,
+      entries: Object.fromEntries(
+        Object.entries(data.entries).map(([id, entry]) => [
+          id,
+          {
+            ...entry,
+            finalPath: entry.finalPath ? this.toStoredPath(entry.finalPath) : undefined,
+            thumbnailPath: entry.thumbnailPath ? this.toStoredPath(entry.thumbnailPath) : undefined,
+          },
+        ]),
+      ),
+    }
+    const result = storage.save(LEDGER_KEY, portableData)
+    if (result.is_error()) {
+      throw result.error
+    }
+  }
+
+  ensureCapture(capture: CaptureGroup, protocolVersion: number): GalleryTransferEntry {
+    const data = this.load()
+    const existing = data.entries[capture.capture_id]
+    const now = Date.now()
+    const incomingFiles = capture.files.map((file) => {
+      const previous = existing?.files.find((candidate) => candidate.name === file.name)
+      const sameGeneration =
+        previous &&
+        previous.size === file.size &&
+        ((!file.etag && !previous.etag) || (!!file.etag && !!previous.etag && previous.etag === file.etag))
+      return {
+        name: file.name,
+        size: file.size,
+        role: file.role,
+        etag: file.etag,
+        sha256: file.sha256,
+        completedSegments: sameGeneration ? previous.completedSegments || [] : [],
+      }
+    })
+
+    const generationChanged =
+      !!existing &&
+      (existing.totalSize !== capture.total_size ||
+        existing.files.length !== incomingFiles.length ||
+        incomingFiles.some((file) => {
+          const previous = existing.files.find((candidate) => candidate.name === file.name)
+          return !previous || file.size !== previous.size || file.role !== previous.role || file.etag !== previous.etag
+        }))
+
+    const entry: GalleryTransferEntry = {
+      ...(existing || {
+        captureId: capture.capture_id,
+        state: "DISCOVERED" as const,
+        ackId: `${capture.capture_id}-${now}-${Math.random().toString(36).slice(2, 10)}`,
+        retryCount: 0,
+        createdAt: now,
+      }),
+      protocolVersion,
+      captureType: capture.type,
+      timestamp: capture.timestamp,
+      totalSize: capture.total_size,
+      files: incomingFiles,
+      deleteFromGlasses: capture.files.map((file) => file.name),
+      state: generationChanged ? "DISCOVERED" : existing?.state || "DISCOVERED",
+      ackId: generationChanged
+        ? `${capture.capture_id}-${now}-${Math.random().toString(36).slice(2, 10)}`
+        : existing?.ackId || `${capture.capture_id}-${now}-${Math.random().toString(36).slice(2, 10)}`,
+      retryCount: generationChanged ? 0 : existing?.retryCount || 0,
+      updatedAt: now,
+    }
+    if (generationChanged) {
+      delete entry.finalPath
+      delete entry.thumbnailPath
+      delete entry.assetReceipt
+      delete entry.lastError
+    }
+    data.entries[capture.capture_id] = entry
+    this.save(data)
+    return entry
+  }
+
+  get(captureId: string): GalleryTransferEntry | undefined {
+    return this.load().entries[captureId]
+  }
+
+  list(): GalleryTransferEntry[] {
+    return Object.values(this.load().entries)
+  }
+
+  update(captureId: string, patch: Partial<GalleryTransferEntry>): GalleryTransferEntry {
+    const data = this.load()
+    const existing = data.entries[captureId]
+    if (!existing) {
+      throw new Error(`Gallery transfer ledger entry missing: ${captureId}`)
+    }
+    const updated = {...existing, ...patch, captureId, updatedAt: Date.now()}
+    data.entries[captureId] = updated
+    this.save(data)
+    return updated
+  }
+
+  transition(
+    captureId: string,
+    state: GalleryTransferState,
+    patch: Partial<GalleryTransferEntry> = {},
+  ): GalleryTransferEntry {
+    return this.update(captureId, {...patch, state})
+  }
+
+  markSegmentComplete(captureId: string, fileName: string, segmentIndex: number): void {
+    const data = this.load()
+    const entry = data.entries[captureId]
+    if (!entry) throw new Error(`Gallery transfer ledger entry missing: ${captureId}`)
+    entry.files = entry.files.map((file) =>
+      file.name === fileName
+        ? {...file, completedSegments: [...new Set([...file.completedSegments, segmentIndex])].sort((a, b) => a - b)}
+        : file,
+    )
+    entry.state = "TRANSFERRING"
+    entry.updatedAt = Date.now()
+    data.entries[captureId] = entry
+    this.save(data)
+  }
+
+  markFileHash(captureId: string, fileName: string, sha256: string): void {
+    const data = this.load()
+    const entry = data.entries[captureId]
+    if (!entry) throw new Error(`Gallery transfer ledger entry missing: ${captureId}`)
+    entry.files = entry.files.map((file) => (file.name === fileName ? {...file, sha256} : file))
+    entry.updatedAt = Date.now()
+    this.save(data)
+  }
+
+  recordFailure(captureId: string, error: unknown): void {
+    const entry = this.get(captureId)
+    if (!entry) return
+    this.update(captureId, {
+      retryCount: entry.retryCount + 1,
+      lastError: error instanceof Error ? error.message : String(error),
+    })
+  }
+
+  isLocallyCommitted(captureId: string): boolean {
+    const entry = this.get(captureId)
+    return !!entry && entry.state !== "RESTORE_PENDING" && STATE_ORDER[entry.state] >= STATE_ORDER.INDEXED
+  }
+
+  isFileLocallyCommitted(fileName: string): boolean {
+    return this.list().some(
+      (entry) => entry.deleteFromGlasses.includes(fileName) && STATE_ORDER[entry.state] >= STATE_ORDER.INDEXED,
+    )
+  }
+
+  pendingRecovery(): GalleryTransferEntry[] {
+    return this.list().filter(
+      (entry) =>
+        entry.state === "INDEXED" ||
+        entry.state === "EXPORT_PENDING" ||
+        entry.state === "EXPORTED" ||
+        entry.state === "ACK_PENDING" ||
+        entry.state === "RESTORE_PENDING",
+    )
+  }
+
+  hasPendingRecovery(): boolean {
+    return this.pendingRecovery().length > 0
+  }
+
+  releaseMissingLocalCommit(captureId: string, recoverAcknowledged: boolean = false): void {
+    const entry = this.get(captureId)
+    if (!entry || entry.state === "GARBAGE_COLLECTED") return
+    if (entry.state === "TRASHED") {
+      if (recoverAcknowledged && entry.protocolVersion >= 3) {
+        this.update(captureId, {
+          state: "RESTORE_PENDING",
+          finalPath: undefined,
+          thumbnailPath: undefined,
+          assetReceipt: undefined,
+          lastError: "Committed local media is missing; source restore is pending",
+          files: entry.files.map((file) => ({...file, completedSegments: []})),
+        })
+      }
+      return
+    }
+    this.update(captureId, {
+      state: "DISCOVERED",
+      finalPath: undefined,
+      thumbnailPath: undefined,
+      assetReceipt: undefined,
+      lastError: "Local media was removed before source acknowledgement",
+      files: entry.files.map((file) => ({...file, completedSegments: []})),
+    })
+  }
+
+  releaseAllMissingLocalCommits(): void {
+    for (const entry of this.list()) this.releaseMissingLocalCommit(entry.captureId)
+  }
+
+  private toStoredPath(path: string): string {
+    const cleanPath = path.replace(/^file:\/\//, "")
+    const documentsPath = RNFS.DocumentDirectoryPath?.replace(/\/$/, "")
+    if (!documentsPath) return cleanPath
+    return cleanPath.startsWith(`${documentsPath}/`) ? cleanPath.substring(documentsPath.length + 1) : cleanPath
+  }
+
+  private toRuntimePath(path: string): string {
+    if (!RNFS.DocumentDirectoryPath) return path
+    if (path.startsWith("/")) {
+      const marker = "/Documents/"
+      const index = path.indexOf(marker)
+      return index >= 0 ? `${RNFS.DocumentDirectoryPath}/${path.substring(index + marker.length)}` : path
+    }
+    return `${RNFS.DocumentDirectoryPath}/${path}`
+  }
+}
+
+export const galleryTransferLedger = new GalleryTransferLedger()

--- a/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
+++ b/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
@@ -263,7 +263,7 @@ class GalleryTransferLedger {
     const entry = this.get(captureId)
     if (!entry || entry.state === "GARBAGE_COLLECTED") return
     if (entry.state === "TRASHED") {
-      if (recoverAcknowledged && entry.protocolVersion >= 3) {
+      if (recoverAcknowledged) {
         this.update(captureId, {
           state: "RESTORE_PENDING",
           finalPath: undefined,

--- a/mobile/modules/engine/src/services/asg/localStorageService.ts
+++ b/mobile/modules/engine/src/services/asg/localStorageService.ts
@@ -8,6 +8,8 @@ import * as RNFS from "@dr.pogodin/react-native-fs"
 import {PhotoInfo} from "../../types/asg"
 import {BgTimer} from "../../utils/timers"
 import {storage, StorageValueNotFoundError} from "../../utils/storage"
+import {galleryTransferLedger, GalleryAssetReceipt} from "./galleryTransferLedger"
+import {toPortableGalleryPath} from "./galleryPathMigration"
 
 export interface DownloadedFile {
   name: string
@@ -21,6 +23,7 @@ export interface DownloadedFile {
   glassesModel?: string // Model of glasses that captured this media
   duration?: number // Video duration in milliseconds
   capture_id?: string // Capture folder name (when synced via capture-aware pipeline)
+  assetReceipt?: GalleryAssetReceipt
 }
 
 interface SyncState {
@@ -47,6 +50,7 @@ export class LocalStorageService {
   private readonly SYNC_STATE_KEY = "asg_sync_state"
   private readonly CLIENT_ID_KEY = "asg_client_id"
   private readonly SYNC_QUEUE_KEY = "asg_sync_queue"
+  private readonly QUARANTINED_FILES_KEY = "asg_quarantined_downloaded_files_v1"
   private readonly ASG_PHOTOS_DIR = `${RNFS.DocumentDirectoryPath}/MentraPhotos`
   private readonly ASG_THUMBNAILS_DIR = `${RNFS.DocumentDirectoryPath}/MentraPhotos/thumbnails`
 
@@ -157,7 +161,22 @@ export class LocalStorageService {
    */
   async saveDownloadedFile(file: DownloadedFile): Promise<void> {
     try {
-      const files = await this.getDownloadedFiles()
+      const rawFiles = this.loadRawDownloadedFiles()
+      const files: Record<string, DownloadedFile> = {}
+      const quarantined = this.loadQuarantinedFiles()
+      const missingCaptureIds: string[] = []
+      for (const [name, existing] of Object.entries(rawFiles)) {
+        const existingPath = this.toPortableRelativePath(existing.filePath)
+        const existingThumbnail = existing.thumbnailPath
+          ? this.toPortableRelativePath(existing.thumbnailPath) || undefined
+          : undefined
+        if (!existingPath) {
+          quarantined[name] = existing
+          missingCaptureIds.push(name)
+          continue
+        }
+        files[name] = {...existing, filePath: existingPath, thumbnailPath: existingThumbnail}
+      }
 
       // 🔍 DIAGNOSTIC: Check if file already exists
       // const existingFile = files[file.name]
@@ -180,15 +199,14 @@ export class LocalStorageService {
 
       // Store relative paths to handle iOS app container changes between launches
       // Convert absolute paths to relative (remove DocumentDirectoryPath prefix)
-      const docPath = RNFS.DocumentDirectoryPath
-      const relativePath = file.filePath.startsWith(docPath)
-        ? file.filePath.substring(docPath.length + 1) // +1 for the slash
-        : file.filePath
+      const relativePath = this.toPortableRelativePath(file.filePath)
       const relativeThumbnailPath = file.thumbnailPath
-        ? file.thumbnailPath.startsWith(docPath)
-          ? file.thumbnailPath.substring(docPath.length + 1)
-          : file.thumbnailPath
+        ? this.toPortableRelativePath(file.thumbnailPath) || undefined
         : undefined
+
+      if (!relativePath) {
+        throw new Error(`Cannot persist non-portable gallery path: ${file.filePath}`)
+      }
 
       files[file.name] = {
         ...file,
@@ -196,7 +214,13 @@ export class LocalStorageService {
         filePath: relativePath,
         thumbnailPath: relativeThumbnailPath,
       }
-      await storage.save(this.DOWNLOADED_FILES_KEY, files)
+      const saveResult = storage.save(this.DOWNLOADED_FILES_KEY, files)
+      if (saveResult.is_error()) throw saveResult.error
+      const quarantineResult = storage.save(this.QUARANTINED_FILES_KEY, quarantined)
+      if (quarantineResult.is_error()) throw quarantineResult.error
+      for (const captureId of missingCaptureIds) {
+        galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
+      }
       // console.log(`[LocalStorage] 💾 Saved metadata for ${file.name} with relative path: ${relativePath}`)
     } catch (error) {
       console.error("Error saving downloaded file metadata:", error)
@@ -218,25 +242,50 @@ export class LocalStorageService {
 
     const files = res.value
     const reconstructedFiles: Record<string, DownloadedFile> = {}
-    const docPath = RNFS.DocumentDirectoryPath
+    const normalizedFiles: Record<string, DownloadedFile> = {}
+    const quarantined = this.loadQuarantinedFiles()
+    const missingCaptureIds: string[] = []
+    let didMigrate = false
 
-    // Reconstruct absolute paths from relative paths
+    // Normalize every record before saving. This fixes the old read-absolute/write-one-relative
+    // bug and migrates stale iOS container UUID paths via their Documents/MentraPhotos suffix.
     for (const [name, file] of Object.entries(files as Record<string, DownloadedFile>)) {
-      // Check if path is already absolute (legacy data) or relative
-      const absolutePath = file.filePath.startsWith("/")
-        ? file.filePath // Already absolute (legacy data)
-        : `${docPath}/${file.filePath}` // Relative path, prepend DocumentDirectoryPath
-
-      const absoluteThumbnailPath = file.thumbnailPath
-        ? file.thumbnailPath.startsWith("/")
-          ? file.thumbnailPath // Already absolute (legacy data)
-          : `${docPath}/${file.thumbnailPath}` // Relative path
+      const relativePath = this.toPortableRelativePath(file.filePath)
+      const relativeThumbnailPath = file.thumbnailPath
+        ? this.toPortableRelativePath(file.thumbnailPath) || undefined
         : undefined
+      if (!relativePath) {
+        quarantined[name] = {...file, downloaded_at: file.downloaded_at || Date.now()}
+        missingCaptureIds.push(name)
+        didMigrate = true
+        continue
+      }
+      const absolutePath = `${RNFS.DocumentDirectoryPath}/${relativePath}`
+      const absoluteThumbnailPath = relativeThumbnailPath
+        ? `${RNFS.DocumentDirectoryPath}/${relativeThumbnailPath}`
+        : undefined
+
+      normalizedFiles[name] = {
+        ...file,
+        filePath: relativePath,
+        thumbnailPath: relativeThumbnailPath,
+      }
 
       reconstructedFiles[name] = {
         ...file,
         filePath: absolutePath,
         thumbnailPath: absoluteThumbnailPath,
+      }
+      if (file.filePath !== relativePath || file.thumbnailPath !== relativeThumbnailPath) didMigrate = true
+    }
+
+    if (didMigrate) {
+      const saveResult = storage.save(this.DOWNLOADED_FILES_KEY, normalizedFiles)
+      if (saveResult.is_error()) throw saveResult.error
+      const quarantineResult = storage.save(this.QUARANTINED_FILES_KEY, quarantined)
+      if (quarantineResult.is_error()) throw quarantineResult.error
+      for (const captureId of missingCaptureIds) {
+        galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
       }
     }
 
@@ -286,6 +335,7 @@ export class LocalStorageService {
         const rawFiles = res.value
         delete rawFiles[fileName]
         await storage.save(this.DOWNLOADED_FILES_KEY, rawFiles)
+        galleryTransferLedger.releaseMissingLocalCommit(fileName)
         return true
       }
       return false
@@ -293,6 +343,25 @@ export class LocalStorageService {
       console.error("Error deleting downloaded file:", error)
       return false
     }
+  }
+
+  /** Preserve unresolved metadata for repair instead of silently deleting it from the gallery. */
+  async quarantineDownloadedFile(fileName: string, reason: string): Promise<void> {
+    const rawFiles = this.loadRawDownloadedFiles()
+    const file = rawFiles[fileName]
+    if (!file) return
+    const quarantined = this.loadQuarantinedFiles()
+    quarantined[fileName] = {...file, quarantineReason: reason} as DownloadedFile
+    delete rawFiles[fileName]
+    const quarantineResult = storage.save(this.QUARANTINED_FILES_KEY, quarantined)
+    if (quarantineResult.is_error()) throw quarantineResult.error
+    const filesResult = storage.save(this.DOWNLOADED_FILES_KEY, rawFiles)
+    if (filesResult.is_error()) throw filesResult.error
+    galleryTransferLedger.releaseMissingLocalCommit(fileName, true)
+  }
+
+  async getQuarantinedDownloadedFiles(): Promise<Record<string, DownloadedFile>> {
+    return this.loadQuarantinedFiles()
   }
 
   /**
@@ -408,6 +477,8 @@ export class LocalStorageService {
       console.error("[LocalStorage] Error clearing downloaded files:", res.error)
       throw res.error
     }
+    storage.remove(this.QUARANTINED_FILES_KEY)
+    galleryTransferLedger.releaseAllMissingLocalCommits()
     console.log("[LocalStorage] Cleared all downloaded files and thumbnails")
   }
 
@@ -491,6 +562,20 @@ export class LocalStorageService {
     if (!queue) return false
     // Has resumable queue if there are still files to process
     return queue.currentIndex < queue.files.length
+  }
+
+  private loadRawDownloadedFiles(): Record<string, DownloadedFile> {
+    const result = storage.load<Record<string, DownloadedFile>>(this.DOWNLOADED_FILES_KEY)
+    return result.is_error() ? {} : result.value
+  }
+
+  private loadQuarantinedFiles(): Record<string, DownloadedFile> {
+    const result = storage.load<Record<string, DownloadedFile>>(this.QUARANTINED_FILES_KEY)
+    return result.is_error() ? {} : result.value
+  }
+
+  private toPortableRelativePath(path: string): string | null {
+    return toPortableGalleryPath(path, RNFS.DocumentDirectoryPath)
   }
 }
 

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -15,6 +15,7 @@ import {reportInvalidGalleryMedia} from "./GalleryMediaIntegrityReportService"
 import {useGallerySyncStore} from "../../stores/gallerySync"
 import {BgTimer} from "../../utils/timers"
 import {MediaLibraryPermissions} from "../../utils/permissions/MediaLibraryPermissions"
+import {galleryTransferLedger, GalleryTransferEntry} from "./galleryTransferLedger"
 
 const TAG = "[MediaProcessingQueue]"
 
@@ -48,6 +49,8 @@ export interface ProcessingItem {
   thumbnailPath?: string
   /** File names to delete from glasses after processing completes */
   deleteFromGlasses?: string[]
+  /** Negotiated gallery protocol; absent entries are inferred from the transfer ledger. */
+  protocolVersion?: number
 }
 
 class MediaProcessingQueue {
@@ -93,7 +96,7 @@ class MediaProcessingQueue {
   }
 
   /** Returns a promise that resolves when the queue is fully drained, or rejects on timeout. */
-  waitUntilDrained(timeoutMs: number = 600000): Promise<void> {
+  waitUntilDrained(timeoutMs: number = 4 * 60 * 60 * 1000): Promise<void> {
     if (!this.hasPending) return Promise.resolve()
     return new Promise((resolve, reject) => {
       const deadline = Date.now() + timeoutMs
@@ -112,6 +115,59 @@ class MediaProcessingQueue {
     })
   }
 
+  /** Retry durable export/ack work after an app restart without downloading media again. */
+  async retryPending(): Promise<{retried: number; failed: number}> {
+    let retried = 0
+    let failed = 0
+    for (let entry of galleryTransferLedger.pendingRecovery()) {
+      try {
+        if (entry.state === "RESTORE_PENDING") {
+          await asgCameraApi.restoreCapture(entry.captureId)
+          galleryTransferLedger.transition(entry.captureId, "DISCOVERED", {lastError: undefined})
+          retried++
+          continue
+        }
+        if (!entry.finalPath || !(await RNFS.exists(entry.finalPath))) {
+          throw new Error(`Recovery file is missing for ${entry.captureId}`)
+        }
+        if (entry.state === "EXPORT_PENDING" || (entry.state === "INDEXED" && entry.shouldAutoSave)) {
+          const receipt = await MediaLibraryPermissions.saveToLibraryWithReceipt(entry.finalPath, entry.timestamp)
+          if (!receipt.success) throw new Error(receipt.error || "camera roll save failed")
+          entry = galleryTransferLedger.transition(entry.captureId, "EXPORTED", {
+            assetReceipt: {
+              platform: receipt.platform,
+              uri: receipt.uri,
+              identifier: receipt.identifier,
+              exportedAt: Date.now(),
+            },
+          })
+        }
+        entry = galleryTransferLedger.transition(entry.captureId, "ACK_PENDING")
+        await this.acknowledgeEntry(entry)
+        galleryTransferLedger.transition(entry.captureId, "TRASHED", {lastError: undefined})
+        retried++
+      } catch (error) {
+        galleryTransferLedger.recordFailure(entry.captureId, error)
+        failed++
+        console.warn(`${TAG} Recovery remains pending for ${entry.captureId}:`, error)
+      }
+    }
+    return {retried, failed}
+  }
+
+  private async acknowledgeEntry(entry: GalleryTransferEntry): Promise<void> {
+    if (entry.protocolVersion >= 3) {
+      await asgCameraApi.acknowledgeCapture(entry.captureId, entry.ackId)
+      return
+    }
+    const result = await asgCameraApi.deleteFilesFromServer(
+      entry.deleteFromGlasses.length > 0 ? entry.deleteFromGlasses : [entry.captureId],
+    )
+    if (result.failed.length > 0 || result.deleted.length === 0) {
+      throw new Error(`Glasses did not acknowledge ${entry.captureId}`)
+    }
+  }
+
   /** Process items one at a time. */
   private async processLoop(): Promise<void> {
     if (this.isRunning) return
@@ -126,6 +182,10 @@ class MediaProcessingQueue {
       } catch (error) {
         console.error(`${TAG} Error processing ${item.id}:`, error)
         processFailed = true
+        const store = useGallerySyncStore.getState()
+        if (!store.failedFiles.includes(item.id)) {
+          store.onFileFailed(item.id, error instanceof Error ? error.message : String(error))
+        }
       }
 
       // Exit if generation changed (reset was called during processing)
@@ -136,9 +196,8 @@ class MediaProcessingQueue {
         // Success: increment processedFiles and remove from processingFiles set.
         store.onFileProcessed(item.id)
       } else {
-        // Failure: processItem already called onFileFailed. Calling onFileProcessed
-        // here would double-count the item (counted as both failed AND processed).
-        // Still clear the processingFiles entry so the UI doesn't show it as in-progress.
+        // Failure is counted exactly once above. Still clear the processingFiles entry so the UI
+        // does not show it as in-progress.
         const current = store.processingFiles
         if (current.has(item.id)) {
           const newSet = new Set(current)
@@ -158,6 +217,23 @@ class MediaProcessingQueue {
   private async processItem(item: ProcessingItem): Promise<void> {
     const startTime = Date.now()
     let filePathToSave = item.primaryPath
+    let ledgerEntry = galleryTransferLedger.get(item.id)
+    if (!ledgerEntry) {
+      ledgerEntry = galleryTransferLedger.ensureCapture(
+        {
+          capture_id: item.id,
+          type: item.type,
+          timestamp: item.timestamp || Date.now(),
+          total_size: item.totalSize,
+          files: (item.deleteFromGlasses?.length ? item.deleteFromGlasses : [item.id]).map((name, index) => ({
+            name,
+            size: index === 0 ? item.totalSize : 0,
+            role: index === 0 ? "primary" : "sidecar",
+          })),
+        },
+        item.protocolVersion || 2,
+      )
+    }
 
     // 1. HDR merge (photos with brackets only)
     if (item.shouldProcess && item.type === "photo" && item.bracketPaths && item.bracketPaths.length >= 3) {
@@ -231,9 +307,8 @@ class MediaProcessingQueue {
         mediaKind: item.type,
       })
     } catch (validationError: any) {
-      const reason =
-        validationError?.message?.includes(INVALID_DOWNLOADED_MEDIA) ?
-          validationError.message
+      const reason = validationError?.message?.includes(INVALID_DOWNLOADED_MEDIA)
+        ? validationError.message
         : `${INVALID_DOWNLOADED_MEDIA}: ${item.id}`
       console.error(`${TAG} Validation failed for ${item.id}: ${reason}`)
       reportInvalidGalleryMedia({
@@ -248,33 +323,11 @@ class MediaProcessingQueue {
       })
       const store = useGallerySyncStore.getState()
       store.onFileFailed(item.id, reason)
-      await RNFS.unlink(filePathToSave).catch(() => {})
-      for (const intermediate of [
-        item.primaryPath + ".hdr.jpg",
-        item.primaryPath + ".processed.jpg",
-        item.primaryPath + ".stabilized.mp4",
-      ]) {
-        if (intermediate !== filePathToSave) {
-          await RNFS.unlink(intermediate).catch(() => {})
-        }
-      }
+      galleryTransferLedger.recordFailure(item.id, validationError)
       throw new Error(reason)
     }
 
-    // 6. Save to camera roll
-    if (item.shouldAutoSave) {
-      const success = await MediaLibraryPermissions.saveToLibrary(filePathToSave, item.timestamp)
-      if (success) {
-        console.log(`${TAG} ✅ Saved to camera roll: ${item.id}`)
-      } else {
-        console.warn(`${TAG} ❌ Failed to save to camera roll: ${item.id}`)
-        // D1: Surface camera roll save failures to the UI
-        const store = useGallerySyncStore.getState()
-        store.onFileFailed(item.id, "camera roll save failed")
-      }
-    }
-
-    // 7. Save metadata
+    // 6. Commit the app-local index before any export or source acknowledgement.
     const isVideo = item.type === "video"
     const downloadedFile = localStorageService.convertToDownloadedFile(
       {
@@ -295,11 +348,38 @@ class MediaProcessingQueue {
     )
     try {
       await localStorageService.saveDownloadedFile(downloadedFile)
+      ledgerEntry = galleryTransferLedger.transition(item.id, "INDEXED", {
+        finalPath: filePathToSave,
+        thumbnailPath: localThumbnailPath,
+        shouldAutoSave: item.shouldAutoSave,
+      })
     } catch (metadataError) {
-      // D2: Clean up orphaned file if metadata save fails, then re-throw
-      console.error(`${TAG} Metadata save failed for ${item.id}, cleaning up file:`, metadataError)
-      await RNFS.unlink(filePathToSave).catch(() => {})
+      console.error(`${TAG} Metadata save failed for ${item.id}; retaining local and glasses copies:`, metadataError)
+      galleryTransferLedger.recordFailure(item.id, metadataError)
       throw metadataError
+    }
+
+    // 7. Export is a durable, receipted step. Failure leaves EXPORT_PENDING and blocks ack.
+    if (item.shouldAutoSave) {
+      galleryTransferLedger.transition(item.id, "EXPORT_PENDING")
+      const receipt = await MediaLibraryPermissions.saveToLibraryWithReceipt(filePathToSave, item.timestamp)
+      if (!receipt.success) {
+        const error = new Error(receipt.error || "camera roll save failed")
+        galleryTransferLedger.recordFailure(item.id, error)
+        useGallerySyncStore.getState().onFileFailed(item.id, error.message)
+        throw error
+      }
+      ledgerEntry = galleryTransferLedger.transition(item.id, "EXPORTED", {
+        assetReceipt: {
+          platform: receipt.platform,
+          uri: receipt.uri,
+          identifier: receipt.identifier,
+          exportedAt: Date.now(),
+        },
+      })
+      downloadedFile.assetReceipt = ledgerEntry.assetReceipt
+      await localStorageService.saveDownloadedFile(downloadedFile)
+      console.log(`${TAG} ✅ Saved to camera roll with receipt: ${item.id}`)
     }
 
     // S4: Clean up intermediate processing files
@@ -336,31 +416,22 @@ class MediaProcessingQueue {
       duration: item.duration,
     })
 
-    // 9. Delete from glasses now that processing is complete — but only if the
-    // local file actually exists and has data. If the download was truncated or
-    // processing failed silently, we must not destroy the only good copy.
-    if (item.deleteFromGlasses && item.deleteFromGlasses.length > 0) {
-      try {
-        const localFileExists = await RNFS.exists(filePathToSave)
-        if (!localFileExists) {
-          console.error(`${TAG} Skipping glasses deletion for ${item.id}: local file missing at ${filePathToSave}`)
-        } else {
-          const localStat = await RNFS.stat(filePathToSave)
-          if (localStat.size === 0) {
-            console.error(`${TAG} Skipping glasses deletion for ${item.id}: local file is 0 bytes`)
-          } else if (item.totalSize > 0 && localStat.size < item.totalSize * 0.5) {
-            // If local file is less than 50% of expected size, something went wrong
-            console.error(
-              `${TAG} Skipping glasses deletion for ${item.id}: local file ${localStat.size} bytes is much smaller than expected ${item.totalSize} bytes`,
-            )
-          } else {
-            await asgCameraApi.deleteFilesFromServer(item.deleteFromGlasses)
-            console.log(`${TAG} 🗑️ Deleted ${item.deleteFromGlasses.join(", ")} from glasses`)
-          }
-        }
-      } catch (deleteError) {
-        console.warn(`${TAG} Delete from glasses failed for ${item.id} (non-fatal):`, deleteError)
-      }
+    // 9. Acknowledge only after VERIFIED -> INDEXED -> (EXPORTED). The server turns this into
+    // recoverable trash; failures remain ACK_PENDING and are retried without re-downloading.
+    const localFileExists = await RNFS.exists(filePathToSave)
+    const localStat = localFileExists ? await RNFS.stat(filePathToSave) : null
+    if (!localStat || localStat.size <= 0) {
+      const error = new Error(`Cannot acknowledge ${item.id}: committed local file is missing or empty`)
+      galleryTransferLedger.recordFailure(item.id, error)
+      throw error
+    }
+    ledgerEntry = galleryTransferLedger.transition(item.id, "ACK_PENDING")
+    try {
+      await this.acknowledgeEntry(ledgerEntry)
+      galleryTransferLedger.transition(item.id, "TRASHED", {lastError: undefined})
+    } catch (ackError) {
+      galleryTransferLedger.recordFailure(item.id, ackError)
+      throw ackError
     }
 
     const elapsed = Date.now() - startTime

--- a/mobile/modules/engine/src/types/asg.ts
+++ b/mobile/modules/engine/src/types/asg.ts
@@ -11,6 +11,12 @@ export interface CaptureFile {
   name: string // "IMG_xxx/base.jpg" or "IMG_xxx.jpg" (legacy)
   size: number
   role: "primary" | "bracket" | "sidecar"
+  modified?: number
+  mime_type?: string
+  etag?: string
+  sha256?: string
+  download_url?: string
+  hash_url?: string
 }
 
 export interface CaptureGroup {
@@ -21,6 +27,7 @@ export interface CaptureGroup {
   total_size: number
   files: CaptureFile[]
   thumbnail_data?: string
+  thumbnail_url?: string
   duration?: number // video only
 }
 

--- a/mobile/modules/engine/src/utils/permissions/MediaLibraryPermissions.ts
+++ b/mobile/modules/engine/src/utils/permissions/MediaLibraryPermissions.ts
@@ -5,6 +5,14 @@ import CrustModule from "@mentra/crust"
 
 import {deriveGalleryDisplayName} from "./galleryDisplayName"
 
+export interface MediaLibrarySaveReceipt {
+  success: boolean
+  platform: "ios" | "android" | "unknown"
+  uri?: string
+  identifier?: string
+  error?: string
+}
+
 /**
  * MediaLibraryPermissions - Handles save-only permissions for camera roll
  *
@@ -85,6 +93,12 @@ export class MediaLibraryPermissions {
    * @param creationTime - Optional creation/capture time in milliseconds (Unix timestamp)
    */
   static async saveToLibrary(filePath: string, creationTime?: number): Promise<boolean> {
+    return (await this.saveToLibraryWithReceipt(filePath, creationTime)).success
+  }
+
+  /** Save and return the durable MediaStore/PhotoKit identifier used as the export receipt. */
+  static async saveToLibraryWithReceipt(filePath: string, creationTime?: number): Promise<MediaLibrarySaveReceipt> {
+    const platform = Platform.OS === "ios" || Platform.OS === "android" ? Platform.OS : "unknown"
     try {
       // On Android 10+, we can save without permission
       // On iOS and older Android, check permission first
@@ -95,7 +109,7 @@ export class MediaLibraryPermissions {
           const granted = await this.requestPermission()
           if (!granted) {
             console.warn("[MediaLibrary] No permission to save to library - photos saved to app storage only")
-            return false
+            return {success: false, platform, error: "permission denied"}
           }
         }
       }
@@ -117,14 +131,19 @@ export class MediaLibraryPermissions {
         } else {
           console.log(`[MediaLibrary] Saved to camera roll: ${cleanPath}`)
         }
-        return true
+        return {
+          success: true,
+          platform,
+          uri: result.uri,
+          identifier: result.identifier,
+        }
       } else {
         console.error(`[MediaLibrary] Failed to save to library: ${result.error}`)
-        return false
+        return {success: false, platform, error: result.error || "native export failed"}
       }
     } catch (error) {
       console.error("[MediaLibrary] Error saving to library:", error)
-      return false
+      return {success: false, platform, error: error instanceof Error ? error.message : String(error)}
     }
   }
 }

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -39,6 +39,7 @@ import {spacing, ThemedStyle} from "@/theme"
 import {PhotoInfo} from "@/types/asg"
 import Share from "react-native-share"
 import showAlert, {showBluetoothAlert} from "@/utils/AlertUtils"
+import {canShareGallerySelection, MAX_GALLERY_SHARE_ITEMS} from "@/utils/galleryShareLimits"
 import {SettingsNavigationUtils} from "@/utils/SettingsNavigationUtils"
 import {ENABLE_TEST_GALLERY_DATA, TEST_GALLERY_ITEMS} from "@/utils/testGalleryData"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
@@ -671,6 +672,14 @@ export function GalleryScreen() {
   // Handle sharing multiple selected photos/videos
   const handleShareSelectedPhotos = async () => {
     if (selectedPhotos.size === 0) return
+    if (!canShareGallerySelection(selectedPhotos.size)) {
+      showAlert(
+        "Share Limit",
+        `You can share up to ${MAX_GALLERY_SHARE_ITEMS} items at a time. You currently have ${selectedPhotos.size} selected.`,
+        [{text: translate("common:ok")}],
+      )
+      return
+    }
 
     try {
       const photosToShare = allPhotos.filter((p) => p.photo && selectedPhotos.has(p.photo.name)).map((p) => p.photo!)

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -308,9 +308,9 @@ export function GalleryScreen() {
         }
       }
 
-      // Clean up stale metadata entries (files that no longer exist on disk)
+      // Preserve stale metadata for path recovery/support instead of deleting the only record.
       for (const fileName of staleFileNames) {
-        await localStorageService.deleteDownloadedFile(fileName)
+        await localStorageService.quarantineDownloadedFile(fileName, "local media missing or empty during gallery load")
       }
 
       // Also unlink zero-byte files from disk so they don't accumulate.

--- a/mobile/src/services/asg/galleryPathMigration.test.ts
+++ b/mobile/src/services/asg/galleryPathMigration.test.ts
@@ -1,0 +1,31 @@
+// This test targets the engine source directly because the helper is intentionally internal.
+import {toPortableGalleryPath} from "../../../modules/engine/src/services/asg/galleryPathMigration"
+
+describe("toPortableGalleryPath", () => {
+  const currentDocuments = "/var/mobile/Containers/Data/Application/NEW/Documents"
+
+  it("stores current container paths relative to Documents", () => {
+    expect(toPortableGalleryPath(`${currentDocuments}/MentraPhotos/IMG_1/base.jpg`, currentDocuments)).toBe(
+      "MentraPhotos/IMG_1/base.jpg",
+    )
+  })
+
+  it("recovers paths from an old iOS container UUID", () => {
+    expect(
+      toPortableGalleryPath(
+        "/var/mobile/Containers/Data/Application/OLD/Documents/MentraPhotos/VID_1/base.mp4",
+        currentDocuments,
+      ),
+    ).toBe("MentraPhotos/VID_1/base.mp4")
+  })
+
+  it("quarantines unrelated absolute paths", () => {
+    expect(toPortableGalleryPath("/private/tmp/unrelated.jpg", currentDocuments)).toBeNull()
+    expect(toPortableGalleryPath("/private/tmp/MentraPhotos/IMG_1/base.jpg", currentDocuments)).toBeNull()
+  })
+
+  it("rejects relative paths that escape gallery storage", () => {
+    expect(toPortableGalleryPath("MentraPhotos/../outside.jpg", currentDocuments)).toBeNull()
+    expect(toPortableGalleryPath("../../outside.jpg", currentDocuments)).toBeNull()
+  })
+})

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -7,6 +7,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 // real island instances the service uses — so store writes here are visible to it.
 import {asgCameraApi} from "../../../modules/engine/src/services/asg/asgCameraApi"
 import {gallerySyncNotifications} from "../../../modules/engine/src/services/asg/gallerySyncNotifications"
+import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
 import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 import {gallerySyncService} from "../../../modules/engine/src/services/asg/gallerySyncService"
@@ -98,12 +99,15 @@ jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => 
     updateSyncState: jest.fn(() => Promise.resolve()),
     saveSyncQueue: jest.fn(() => Promise.resolve()),
     clearSyncQueue: jest.fn(() => Promise.resolve()),
+    convertToDownloadedFile: jest.fn((file: any) => file),
+    saveDownloadedFile: jest.fn(() => Promise.resolve()),
   },
 }))
 
 jest.mock("../../../modules/engine/src/services/asg/mediaProcessingQueue", () => ({
   mediaProcessingQueue: {
     reset: jest.fn(),
+    retryPending: jest.fn(() => Promise.resolve({retried: 0, failed: 0})),
     enqueue: jest.fn(),
     waitUntilDrained: jest.fn(() => Promise.resolve()),
     abort: jest.fn(),
@@ -113,8 +117,10 @@ jest.mock("../../../modules/engine/src/services/asg/mediaProcessingQueue", () =>
 jest.mock("../../../modules/engine/src/services/asg/asgCameraApi", () => ({
   asgCameraApi: {
     setServer: jest.fn(),
+    getV3Manifest: jest.fn(() => Promise.resolve(null)),
     syncWithServer: jest.fn(),
     downloadCapture: jest.fn(),
+    batchSyncFiles: jest.fn(),
   },
 }))
 
@@ -347,6 +353,32 @@ describe("GallerySyncService", () => {
     })
   })
 
+  it("holds back the legacy watermark when processing fails after download", async () => {
+    const serverTime = 1_700_000_000_000
+    const failedTimestamp = serverTime - 20_000
+    const file = {
+      name: "IMG_legacy_failure.jpg",
+      size: 100,
+      modified: failedTimestamp,
+      is_video: false,
+      filePath: "/tmp/IMG_legacy_failure.jpg",
+    }
+    ;(asgCameraApi.batchSyncFiles as jest.Mock).mockResolvedValue({downloaded: [file], failed: [], total_size: 100})
+    ;(mediaProcessingQueue.waitUntilDrained as jest.Mock).mockImplementation(async () => {
+      useGallerySyncStore.getState().onFileFailed(file.name, "PhotoKit unavailable")
+    })
+
+    await (gallerySyncService as any).executeDownload([file], serverTime)
+
+    expect(localStorageService.updateSyncState).toHaveBeenCalledWith({
+      last_sync_time: failedTimestamp - 1,
+      total_downloaded: 1,
+      total_size: 100,
+    })
+    expect(useGallerySyncStore.getState().syncState).toBe("error")
+    expect(localStorageService.clearSyncQueue).not.toHaveBeenCalled()
+  })
+
   describe("startFileDownload /api/sync desync recovery", () => {
     let executeCaptureDownloadSpy: jest.SpyInstance
     let consoleWarnSpy: jest.SpyInstance
@@ -386,8 +418,8 @@ describe("GallerySyncService", () => {
       await startFileDownload()
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(2)
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "test_client", 1500, true)
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "test_client", 0, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "test_client", 1500, false)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "test_client", 0, false)
       expect(executeCaptureDownloadSpy).toHaveBeenCalledWith([FAKE_CAPTURE], 2000)
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining("Empty sync but glasses report content — retrying with last_sync_time=0"),
@@ -407,9 +439,34 @@ describe("GallerySyncService", () => {
       await startFileDownload()
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
-      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 1500, true)
+      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 1500, false)
       expect(executeCaptureDownloadSpy).not.toHaveBeenCalled()
       expect(useGallerySyncStore.getState().syncState).toBe("complete")
+    })
+
+    it("does not report completion when durable recovery is still pending", async () => {
+      useGallerySyncStore.getState().setGlassesGalleryStatus(0, 0, 0, false)
+      mockGetSyncState.mockResolvedValue({
+        last_sync_time: 1500,
+        client_id: "test_client",
+        total_downloaded: 27,
+        total_size: 1000,
+      })
+      mockSyncWithServer.mockResolvedValue(EMPTY_SYNC_RESPONSE)
+      const pendingRecoverySpy = jest.spyOn(galleryTransferLedger, "hasPendingRecovery").mockReturnValue(true)
+
+      try {
+        await startFileDownload()
+      } finally {
+        pendingRecoverySpy.mockRestore()
+      }
+
+      expect(useGallerySyncStore.getState().syncState).toBe("error")
+      expect(gallerySyncNotifications.showSyncComplete).not.toHaveBeenCalled()
+      expect(gallerySyncNotifications.showSyncError).toHaveBeenCalledWith(
+        "Gallery export or acknowledgement will be retried",
+      )
+      expect(localStorageService.clearSyncQueue).not.toHaveBeenCalled()
     })
 
     it("does not retry on first sync when last_sync_time is 0", async () => {
@@ -424,7 +481,7 @@ describe("GallerySyncService", () => {
       await startFileDownload()
 
       expect(mockSyncWithServer).toHaveBeenCalledTimes(1)
-      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 0, true)
+      expect(mockSyncWithServer).toHaveBeenCalledWith("test_client", 0, false)
       expect(consoleWarnSpy).not.toHaveBeenCalledWith(expect.stringContaining("Desync detected"))
     })
 
@@ -525,8 +582,8 @@ describe("GallerySyncService", () => {
       const result = await resultPromise
 
       expect(BluetoothSdk.setSystemTime).toHaveBeenCalledTimes(1)
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "c1", futureWatermark, true)
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(1, "c1", futureWatermark, false)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, false)
       expect(result).not.toBeNull()
       expect(result?.syncData.changed_files).toHaveLength(1)
     })
@@ -561,7 +618,7 @@ describe("GallerySyncService", () => {
       const result = await resolveSyncManifest("c1", now - 5000)
 
       expect(BluetoothSdk.setSystemTime).not.toHaveBeenCalled()
-      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, true)
+      expect(mockSyncWithServer).toHaveBeenNthCalledWith(2, "c1", 0, false)
       expect(result?.syncData.changed_files).toHaveLength(1)
     })
 

--- a/mobile/src/services/asg/galleryTransferLedger.test.ts
+++ b/mobile/src/services/asg/galleryTransferLedger.test.ts
@@ -1,0 +1,69 @@
+// This test targets the engine source directly because the ledger is intentionally internal.
+import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
+
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  DocumentDirectoryPath: "/current/Documents",
+}))
+
+describe("galleryTransferLedger", () => {
+  it("resets a committed entry when v3 introduces a different source generation", () => {
+    const captureId = `IMG_generation_${Date.now()}`
+    const legacyCapture = {
+      capture_id: captureId,
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary" as const}],
+    }
+    const initial = galleryTransferLedger.ensureCapture(legacyCapture, 2)
+    galleryTransferLedger.transition(captureId, "TRASHED")
+
+    const v3 = galleryTransferLedger.ensureCapture(
+      {
+        ...legacyCapture,
+        files: [{...legacyCapture.files[0], etag: '"generation-2"'}],
+      },
+      3,
+    )
+
+    expect(v3.state).toBe("DISCOVERED")
+    expect(v3.ackId).not.toBe(initial.ackId)
+    expect(v3.retryCount).toBe(0)
+    expect(v3.files[0].completedSegments).toEqual([])
+  })
+
+  it("resets a legacy entry when an individual file changes but the capture total does not", () => {
+    const captureId = `IMG_legacy_generation_${Date.now()}`
+    const initial = galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [
+          {name: `${captureId}/base.jpg`, size: 90, role: "primary"},
+          {name: `${captureId}/base.imu.json`, size: 10, role: "sidecar"},
+        ],
+      },
+      2,
+    )
+    galleryTransferLedger.transition(captureId, "INDEXED")
+
+    const changed = galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1001,
+        total_size: 100,
+        files: [
+          {name: `${captureId}/base.jpg`, size: 89, role: "primary"},
+          {name: `${captureId}/base.imu.json`, size: 11, role: "sidecar"},
+        ],
+      },
+      2,
+    )
+
+    expect(changed.state).toBe("DISCOVERED")
+    expect(changed.ackId).not.toBe(initial.ackId)
+  })
+})

--- a/mobile/src/services/asg/galleryTransferLedger.test.ts
+++ b/mobile/src/services/asg/galleryTransferLedger.test.ts
@@ -66,4 +66,38 @@ describe("galleryTransferLedger", () => {
     expect(changed.state).toBe("DISCOVERED")
     expect(changed.ackId).not.toBe(initial.ackId)
   })
+
+  it("queues source restore for a trashed v2 entry when local media is quarantined", () => {
+    const captureId = `IMG_v2_restore_${Date.now()}`
+    galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary"}],
+      },
+      2,
+    )
+    galleryTransferLedger.transition(captureId, "TRASHED", {
+      finalPath: "/current/Documents/MentraPhotos/v2/base.jpg",
+      thumbnailPath: "/current/Documents/MentraPhotos/v2/thumb.jpg",
+      files: [
+        {
+          name: `${captureId}/base.jpg`,
+          size: 100,
+          role: "primary",
+          completedSegments: [0],
+        },
+      ],
+    })
+
+    galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
+
+    const pending = galleryTransferLedger.get(captureId)!
+    expect(pending.state).toBe("RESTORE_PENDING")
+    expect(pending.finalPath).toBeUndefined()
+    expect(pending.thumbnailPath).toBeUndefined()
+    expect(pending.files[0].completedSegments).toEqual([])
+  })
 })

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -3,8 +3,15 @@ import * as RNFS from "@dr.pogodin/react-native-fs"
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
 import {reportInvalidGalleryMedia} from "../../../modules/engine/src/services/asg/GalleryMediaIntegrityReportService"
 import {useGallerySyncStore} from "../../../modules/engine/src/stores/gallerySync"
+import {asgCameraApi} from "../../../modules/engine/src/services/asg/asgCameraApi"
+// The durable ledger is engine-internal; this host test exercises restart recovery directly.
+import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
+import {MediaLibraryPermissions} from "../../../modules/engine/src/utils/permissions/MediaLibraryPermissions"
+
+import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 
 jest.mock("@dr.pogodin/react-native-fs", () => ({
+  DocumentDirectoryPath: "/tmp",
   exists: jest.fn(),
   stat: jest.fn(),
   read: jest.fn(),
@@ -19,7 +26,9 @@ jest.mock("@mentra/crust", () => ({
 
 jest.mock("../../../modules/engine/src/services/asg/asgCameraApi", () => ({
   asgCameraApi: {
-    deleteFilesFromServer: jest.fn(),
+    deleteFilesFromServer: jest.fn((files: string[]) => Promise.resolve({deleted: files, failed: []})),
+    acknowledgeCapture: jest.fn(() => Promise.resolve()),
+    restoreCapture: jest.fn(() => Promise.resolve()),
   },
 }))
 
@@ -37,10 +46,9 @@ jest.mock("../../../modules/engine/src/services/asg/GalleryMediaIntegrityReportS
 jest.mock("../../../modules/engine/src/utils/permissions/MediaLibraryPermissions", () => ({
   MediaLibraryPermissions: {
     saveToLibrary: jest.fn(),
+    saveToLibraryWithReceipt: jest.fn(() => Promise.resolve({success: true, platform: "ios", identifier: "asset"})),
   },
 }))
-
-import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 
 describe("mediaProcessingQueue", () => {
   beforeEach(() => {
@@ -80,7 +88,9 @@ describe("mediaProcessingQueue", () => {
   it("does not compare processed output size against capture total size", async () => {
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
     ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
-    ;(RNFS.read as jest.Mock).mockResolvedValue(Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"))
+    ;(RNFS.read as jest.Mock).mockResolvedValue(
+      Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
+    )
 
     mediaProcessingQueue.reset()
     mediaProcessingQueue.enqueue({
@@ -96,5 +106,113 @@ describe("mediaProcessingQueue", () => {
 
     expect(localStorageService.saveDownloadedFile).toHaveBeenCalled()
     expect(useGallerySyncStore.getState().failedFiles).not.toContain("IMG_with_sidecar")
+  })
+
+  it("never acknowledges the glasses when camera-roll export fails", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(RNFS.read as jest.Mock).mockResolvedValue(
+      Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
+    )
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockResolvedValueOnce({
+      success: false,
+      platform: "ios",
+      error: "PhotoKit unavailable",
+    })
+
+    mediaProcessingQueue.reset()
+    mediaProcessingQueue.enqueue({
+      id: "IMG_export_failure",
+      type: "photo",
+      primaryPath: "/tmp/IMG_export_failure/base.jpg",
+      totalSize: 100,
+      shouldProcess: false,
+      shouldAutoSave: true,
+      deleteFromGlasses: ["IMG_export_failure"],
+      protocolVersion: 3,
+    })
+
+    await expect(mediaProcessingQueue.waitUntilDrained(5000)).resolves.toBeUndefined()
+
+    expect(asgCameraApi.acknowledgeCapture).not.toHaveBeenCalled()
+    expect(asgCameraApi.deleteFilesFromServer).not.toHaveBeenCalled()
+    expect(useGallerySyncStore.getState().failedFiles).toContain("IMG_export_failure")
+  })
+
+  it("retains both copies and reports failure when the local index cannot be saved", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(RNFS.read as jest.Mock).mockResolvedValue(
+      Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
+    )
+    ;(localStorageService.saveDownloadedFile as jest.Mock).mockRejectedValueOnce(new Error("MMKV write failed"))
+
+    mediaProcessingQueue.reset()
+    mediaProcessingQueue.enqueue({
+      id: "IMG_metadata_failure",
+      type: "photo",
+      primaryPath: "/tmp/IMG_metadata_failure/base.jpg",
+      totalSize: 100,
+      shouldProcess: false,
+      shouldAutoSave: false,
+      deleteFromGlasses: ["IMG_metadata_failure"],
+      protocolVersion: 3,
+    })
+
+    await expect(mediaProcessingQueue.waitUntilDrained(5000)).resolves.toBeUndefined()
+
+    expect(asgCameraApi.acknowledgeCapture).not.toHaveBeenCalled()
+    expect(asgCameraApi.deleteFilesFromServer).not.toHaveBeenCalled()
+    expect(useGallerySyncStore.getState().failedFiles).toContain("IMG_metadata_failure")
+  })
+
+  it("retries acknowledgement from an export receipt without inserting another asset", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    const capture = {
+      capture_id: "IMG_exported_before_restart",
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: "IMG_exported_before_restart/base.jpg", size: 100, role: "primary" as const}],
+    }
+    galleryTransferLedger.ensureCapture(capture, 3)
+    const entry = galleryTransferLedger.transition(capture.capture_id, "EXPORTED", {
+      finalPath: "/tmp/IMG_exported_before_restart/base.jpg",
+      shouldAutoSave: true,
+      assetReceipt: {platform: "ios", identifier: "asset-existing", exportedAt: Date.now()},
+    })
+    const recoverySpy = jest.spyOn(galleryTransferLedger, "pendingRecovery").mockReturnValue([entry])
+
+    await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(asgCameraApi.acknowledgeCapture).toHaveBeenCalledWith(capture.capture_id, entry.ackId)
+    expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
+    recoverySpy.mockRestore()
+  })
+
+  it("restores recoverable glasses trash when committed local media unexpectedly disappears", async () => {
+    const capture = {
+      capture_id: "IMG_restore_missing",
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: "IMG_restore_missing/base.jpg", size: 100, role: "primary" as const}],
+    }
+    galleryTransferLedger.ensureCapture(capture, 3)
+    galleryTransferLedger.transition(capture.capture_id, "TRASHED", {
+      finalPath: "/tmp/IMG_restore_missing/base.jpg",
+    })
+    galleryTransferLedger.releaseMissingLocalCommit(capture.capture_id, true)
+    const recoveryEntry = galleryTransferLedger.get(capture.capture_id)!
+    const recoverySpy = jest.spyOn(galleryTransferLedger, "pendingRecovery").mockReturnValue([recoveryEntry])
+
+    await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
+
+    expect(asgCameraApi.restoreCapture).toHaveBeenCalledWith(capture.capture_id)
+    expect(asgCameraApi.acknowledgeCapture).not.toHaveBeenCalled()
+    expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("DISCOVERED")
+    recoverySpy.mockRestore()
   })
 })

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -192,7 +192,7 @@ describe("mediaProcessingQueue", () => {
     recoverySpy.mockRestore()
   })
 
-  it("restores recoverable glasses trash when committed local media unexpectedly disappears", async () => {
+  it("attempts restore for a v2-negotiated capture when committed local media disappears", async () => {
     const capture = {
       capture_id: "IMG_restore_missing",
       type: "photo" as const,
@@ -200,7 +200,9 @@ describe("mediaProcessingQueue", () => {
       total_size: 100,
       files: [{name: "IMG_restore_missing/base.jpg", size: 100, role: "primary" as const}],
     }
-    galleryTransferLedger.ensureCapture(capture, 3)
+    // A transient v3 capability probe failure can negotiate v2 against new glasses firmware.
+    // Recovery must still try the additive restore endpoint instead of silently losing the source.
+    galleryTransferLedger.ensureCapture(capture, 2)
     galleryTransferLedger.transition(capture.capture_id, "TRASHED", {
       finalPath: "/tmp/IMG_restore_missing/base.jpg",
     })

--- a/mobile/src/utils/galleryShareLimits.test.ts
+++ b/mobile/src/utils/galleryShareLimits.test.ts
@@ -1,0 +1,13 @@
+import {canShareGallerySelection, MAX_GALLERY_SHARE_ITEMS} from "./galleryShareLimits"
+
+describe("gallery share limits", () => {
+  it("allows selections up to the 50-item limit", () => {
+    expect(canShareGallerySelection(1)).toBe(true)
+    expect(canShareGallerySelection(MAX_GALLERY_SHARE_ITEMS)).toBe(true)
+  })
+
+  it("rejects empty and oversized selections", () => {
+    expect(canShareGallerySelection(0)).toBe(false)
+    expect(canShareGallerySelection(MAX_GALLERY_SHARE_ITEMS + 1)).toBe(false)
+  })
+})

--- a/mobile/src/utils/galleryShareLimits.ts
+++ b/mobile/src/utils/galleryShareLimits.ts
@@ -1,0 +1,5 @@
+export const MAX_GALLERY_SHARE_ITEMS = 50
+
+export function canShareGallerySelection(itemCount: number): boolean {
+  return itemCount > 0 && itemCount <= MAX_GALLERY_SHARE_ITEMS
+}


### PR DESCRIPTION
## Summary

Makes gallery sync resumable, integrity-checked, recoverable, and safe across app/process failures without breaking released phone or glasses clients.

- Adds an additive v3 gallery protocol with lightweight paginated manifests, fixed-length HTTP range downloads, ETags, lazy SHA-256 verification, idempotent acknowledgement, recoverable trash, and restore.
- Adds a durable phone-side transfer ledger with immutable 16 MiB segments, exponential retry, generation checks, atomic final-file commits, export/ack recovery, and portable iOS paths.
- Enforces the deletion barrier: a source capture is never acknowledged until the app-local index and any required camera-roll export receipt are durably committed.
- Makes Android MediaStore and iOS PhotoKit export retries idempotent so a crash after native commit does not duplicate the asset.
- Replaces destructive server deletion with hidden recoverable trash. Only acknowledged trash can be garbage-collected, after at least seven days; crash-interrupted/unacknowledged trash is retained.
- Removes major transfer overhead: no inline manifest thumbnails, no per-file client delay, no chunked/fixed-length header conflict, and no exhaustion of the control-plane request limiter by range/hash reads.
- Quarantines stale local metadata and requests source restore when a v3-acknowledged local commit unexpectedly disappears.
- Adds transfer timing/throughput telemetry without logging media contents, manifests, or camera-roll identifiers.

## Compatibility

- New phone + new glasses: negotiates v3 and uses resumable, verified transfer plus recoverable acknowledgement.
- New phone + old glasses: a missing capabilities endpoint cleanly falls back to the existing v2/v1 endpoint and response shapes.
- Old phone + new glasses: existing sync/download/delete/cleanup endpoints and response fields remain available; legacy delete now moves the exact capture to hidden recoverable trash.
- Existing storage keys and public `saveToLibrary(): Promise<boolean>` behavior are preserved; new ledger, quarantine, and receipt data use additive schemas.

## Root causes addressed

- Long resources restarted at byte zero and iOS imposed a ten-minute whole-resource timeout.
- Downloads wrote to or deleted the final destination during retries.
- Camera-roll, metadata, validation, and acknowledgement failures were not one durable transaction and could still remove the source or advance the timestamp watermark.
- Server downloads mixed fixed content length with chunked transfer and the global request limiter could reject a long segmented sync.
- Cleanup and delete operations were permanently destructive, and stale absolute iOS container paths were silently discarded.
- Large v2 manifests embedded thumbnails and the legacy client inserted avoidable per-file delays.

## Validation

- `./scripts/check-android-compile.sh asg`
- `./gradlew :app:testDebugUnitTest --tests ...GalleryTransferProtocolTest --tests ...GalleryTrashManagerTest --no-daemon`
- `./gradlew :mentra-crust:compileDebugKotlin --no-daemon`
- `xcodebuild -workspace ios/Mentra.xcworkspace -scheme Crust -sdk iphonesimulator -configuration Debug CODE_SIGNING_ALLOWED=NO -skipPackagePluginValidation build`
- 32 focused Jest tests across sync orchestration, processing recovery, path migration, and ledger generations
- Full engine test suite passed before rebasing; focused gallery tests pass after rebasing
- Targeted ESLint over every changed TypeScript file and test

The post-rebase engine-wide TypeScript build currently encounters pre-existing `origin/dev` errors in untouched speaker-stream files (`AudioPlaybackService.ts` and `LocalMiniappRuntime.ts` reference APIs removed by the latest dev merge). This PR has no diff in those files.

## Scope

Hotspot/routing changes and device fault-injection/throughput benchmarks are intentionally excluded. The ADB-connected Mentra Live was not accessed.

Relates to OS-394, OS-1011, OS-1177, OS-1384, OS-1472, and OS-1679.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core gallery sync, download framing, and deletion semantics on the glasses HTTP server; incorrect trash/GC or range handling could cause data loss or failed transfers for mixed client versions.
> 
> **Overview**
> Adds a **gallery sync reliability plan** document and implements the **glasses-side transfer-correctness** pieces: v3 APIs, safe HTTP downloads, recoverable deletion, and stricter cleanup boundaries.
> 
> On **`AsgCameraServer`**, downloads switch from chunked responses with manual `Content-Length` to **fixed-length** bodies with **`Accept-Ranges`**, **`ETag`**, **`If-Range`**, and **206/416** range handling via new **`GalleryTransferProtocol`**. New routes expose **`/api/v3/capabilities`**, **paginated lightweight manifests** (no inline thumbnails by default), **lazy SHA-256** (`/api/v3/hash`), **idempotent ack** (`/api/v3/ack`), **trash list**, and **restore**. Legacy **`/api/delete`** and **`/api/cleanup`** keep their response shapes but **move captures to hidden `_gallery_trash`** instead of permanent delete; cleanup only **garbage-collects acknowledged trash** (minimum ~7 days) plus scoped SDK-pending and thumbnail maintenance. **Sync no longer deletes AVIF artifacts** during listing. POST bodies are read in a **full loop** with a size cap; **gallery GETs** (download, manifest, hash, etc.) are **exempt from rate limiting** so segmented transfers are not throttled.
> 
> **`GalleryTrashManager`** implements atomic capture moves (folder or legacy flat files), ack recording, restore, and retention-based GC. **`FileManager`** adds **`_gallery_trash`** and **`_gallery_metadata`**, hides them from listings, introduces **`cleanupOldSdkPendingFiles`** so age cleanup does not touch live gallery media, and keeps legacy **`cleanupOldFiles`** from descending into trash/metadata.
> 
> Unit tests cover range parsing, trash behavior, and cleanup scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c69ab90f57799b7ec8715940023d44ebef66d32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes gallery sync resumable, integrity‑checked, and recoverable across crashes or restarts, and validates acknowledgements to prevent bad deletes. Adds a v3 transfer protocol, a durable phone‑side ledger, idempotent camera‑roll export scoped to Mentra albums, and recoverable trash and cleanup, while staying compatible with v1/v2 clients. Addresses OS-394, OS-1011, OS-1177, OS-1384, OS-1472, OS-1679.

- **New Features**
  - v3 protocol with paginated manifests, fixed‑length HTTP range downloads, ETags, SHA‑256, validated idempotent ack that rejects invalid/mismatched acks, and recoverable trash; auto‑negotiates v3 and falls back to v2/v1.
  - Durable transfer ledger on phone: immutable segments, retry/backoff, generation checks, atomic final‑file commits, export/ack recovery, and portable iOS paths.
  - Idempotent camera‑roll export on Android/iOS scoped to Mentra albums; `@mentra/crust` returns durable receipts via `saveToLibraryWithReceipt` with `existing` when reusing an asset; `saveToLibrary(): Promise<boolean>` preserved.
  - Recoverable server‑side deletion and cleanup: hidden `_gallery_trash` with restore; only acknowledged trash is GC‑eligible; internal trash/metadata dirs excluded from listings; new `cleanupOldSdkPendingFiles` limits age cleanup to hidden SDK pending captures; quarantines missing local media and migrates stale iOS absolute paths.
  - Limits gallery share selections to 50 items via `canShareGallerySelection` to prevent oversized shares.

- **Bug Fixes**
  - Resumes long downloads at byte offsets and writes to temp paths; final commit is atomic to avoid corruption/partials and iOS whole‑resource timeouts.
  - Enforces deletion barrier: no source ack until index and (if needed) camera‑roll receipt are durably committed.
  - Exempts gallery transfer segments from the control‑plane rate limiter to prevent throttling.
  - Handles stale iOS container paths via Documents‑relative migration and preserves stale metadata via quarantine instead of deletion.
  - Attempts source restore for legacy (v1/v2) transfers when local media is missing after a crash or restart.

<sup>Written for commit 65d94f01de3b1d050a7110729e03917ccc50f96a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

