### PR TITLE
Add npm READMEs and registry metadata for published packages

### DIFF
--- a/cloud-v2/packages/auth/package.json
+++ b/cloud-v2/packages/auth/package.json
@@ -11,7 +11,10 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist", "README.md"],
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "publishConfig": {
     "access": "public",
     "tag": "dev"
@@ -22,5 +25,20 @@
   },
   "dependencies": {
     "jose": "^5.9.6"
+  },
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "auth",
+    "jwks"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "cloud-v2/packages/auth"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/cloud-v2/packages/auth#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
   }
 }

--- a/cloud-v2/packages/cli/README.md
+++ b/cloud-v2/packages/cli/README.md
@@ -13,14 +13,14 @@ It wraps [`@mentra/miniapp-cli`](https://www.npmjs.com/package/@mentra/miniapp-c
 ## Install
 
 ```bash
-bun add -g @mentra/cli@alpha
+bun add -g @mentra/cli@dev
 mentra --help
 ```
 
 Or run without installing:
 
 ```bash
-bunx @mentra/cli@alpha --help
+bunx @mentra/cli@dev --help
 ```
 
 ## Common commands

--- a/cloud-v2/packages/cli/package.json
+++ b/cloud-v2/packages/cli/package.json
@@ -1,12 +1,14 @@
 {
   "name": "@mentra/cli",
   "version": "2.0.0-dev.0",
-  "description": "Mentra developer CLI — build, publish, and manage Mentra miniapps (Cloud V2). Bun-only.",
+  "description": "Mentra developer CLI \u2014 build, publish, and manage Mentra miniapps (Cloud V2). Bun-only.",
   "type": "module",
   "bin": {
     "mentra": "./src/index.ts"
   },
-  "files": ["src"],
+  "files": [
+    "src"
+  ],
   "engines": {
     "bun": ">=1.0.0"
   },
@@ -26,5 +28,20 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@types/qrcode": "^1.5.5"
+  },
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "cli",
+    "miniapp"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "cloud-v2/packages/cli"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/cloud-v2/packages/cli#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
   }
 }

--- a/cloud-v2/packages/cloud-client/README.md
+++ b/cloud-v2/packages/cloud-client/README.md
@@ -22,7 +22,7 @@ npm install @mentra/cloud-client@dev
 
 | Import | Use |
 | --- | --- |
-| `@mentra/cloud-client` | platform-neutral core (client, modules, protocol re-exports) |
+| `@mentra/cloud-client` | platform-neutral core: `CloudClient` plus the public config, transport, and error types (wire-protocol types are deliberately *not* re-exported — import those from `@mentra/cloud-protocol`) |
 | `@mentra/cloud-client/react-native` | React Native transport bindings (used by the engine) |
 | `@mentra/cloud-client/node` | Node transport bindings — requires the optional [`ws`](https://www.npmjs.com/package/ws) peer (`npm i ws`) |
 

--- a/cloud-v2/packages/cloud-client/README.md
+++ b/cloud-v2/packages/cloud-client/README.md
@@ -1,0 +1,35 @@
+# @mentra/cloud-client
+
+The MentraOS cloud client: connects a device (or a test harness) to the
+MentraOS cloud over the wire protocol defined in
+[`@mentra/cloud-protocol`](https://www.npmjs.com/package/@mentra/cloud-protocol),
+handling the handshake, message envelopes, and per-module message flows
+(camera, audio, maps, reports, …).
+
+Its main consumer is [`@mentra/engine`](https://www.npmjs.com/package/@mentra/engine),
+which lists it as a peer dependency — an app embedding the engine installs
+this package alongside it.
+
+## Install
+
+```sh
+npm install @mentra/cloud-client@dev
+```
+
+> Currently published on the `dev` dist-tag (prerelease channel).
+
+## Entry points
+
+| Import | Use |
+| --- | --- |
+| `@mentra/cloud-client` | platform-neutral core (client, modules, protocol re-exports) |
+| `@mentra/cloud-client/react-native` | React Native transport bindings (used by the engine) |
+| `@mentra/cloud-client/node` | Node transport bindings — requires the optional [`ws`](https://www.npmjs.com/package/ws) peer (`npm i ws`) |
+
+The package ships TypeScript source and targets consumers that compile TS
+themselves (Metro / bundlers / tsc).
+
+## Part of MentraOS
+
+Source lives in the [MentraOS monorepo](https://github.com/Mentra-Community/MentraOS)
+under `cloud-v2/packages/cloud-client`. Issues and contributions welcome there.

--- a/cloud-v2/packages/cloud-client/package.json
+++ b/cloud-v2/packages/cloud-client/package.json
@@ -42,5 +42,17 @@
     "type": "git",
     "url": "git+https://github.com/Mentra-Community/MentraOS.git",
     "directory": "cloud-v2/packages/cloud-client"
+  },
+  "description": "MentraOS cloud client — handshake, envelopes and module message flows over the cloud wire protocol",
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "cloud",
+    "client",
+    "websocket"
+  ],
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/cloud-v2/packages/cloud-client#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
   }
 }

--- a/cloud-v2/packages/protocol/README.md
+++ b/cloud-v2/packages/protocol/README.md
@@ -1,0 +1,42 @@
+# @mentra/cloud-protocol
+
+The MentraOS phone ↔ cloud wire protocol: message schemas, envelopes, and
+error types shared by everything that speaks to the MentraOS cloud. Pure
+TypeScript + [zod](https://github.com/colinhacks/zod) — no server or native
+dependencies.
+
+This is a **leaf package**: [`@mentra/cloud-client`](https://www.npmjs.com/package/@mentra/cloud-client)
+and [`@mentra/engine`](https://www.npmjs.com/package/@mentra/engine) depend on
+it, and the MentraOS cloud runtime consumes the same schemas server-side, so
+both ends of the wire validate against one definition.
+
+## Install
+
+You normally get this package automatically as a dependency of
+`@mentra/cloud-client` or a peer of `@mentra/engine`. For direct use:
+
+```sh
+npm install @mentra/cloud-protocol@dev
+```
+
+> Currently published on the `dev` dist-tag (prerelease channel).
+
+## Usage
+
+```ts
+import {parseEnvelope} from "@mentra/cloud-protocol";
+// or per-module subpaths:
+import {normalizePhotoSizeTier} from "@mentra/cloud-protocol/camera";
+```
+
+Modules: `envelope`, `messages`, `handshake`, `control`, `camera`, `audio`,
+`maps`, `errors` — each importable as `@mentra/cloud-protocol/<module>`.
+
+The package ships TypeScript source (`main: ./src/index.ts`) and targets
+consumers that compile TS themselves (Metro / bundlers / tsc); it is not
+precompiled for plain Node `require`.
+
+## Part of MentraOS
+
+Source lives in the [MentraOS monorepo](https://github.com/Mentra-Community/MentraOS)
+under `cloud-v2/packages/protocol`. Issues and contributions welcome there.

--- a/cloud-v2/packages/protocol/README.md
+++ b/cloud-v2/packages/protocol/README.md
@@ -24,7 +24,10 @@ npm install @mentra/cloud-protocol@dev
 ## Usage
 
 ```ts
-import {parseEnvelope} from "@mentra/cloud-protocol";
+import {envelopeSchema, PROTOCOL_MAJOR, type Envelope} from "@mentra/cloud-protocol";
+
+const message: Envelope = envelopeSchema.parse(JSON.parse(raw));
+
 // or per-module subpaths:
 import {normalizePhotoSizeTier} from "@mentra/cloud-protocol/camera";
 ```

--- a/cloud-v2/packages/protocol/package.json
+++ b/cloud-v2/packages/protocol/package.json
@@ -24,5 +24,17 @@
     "type": "git",
     "url": "git+https://github.com/Mentra-Community/MentraOS.git",
     "directory": "cloud-v2/packages/protocol"
+  },
+  "description": "MentraOS phone-cloud wire protocol — message schemas, envelopes and error types (zod)",
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "protocol",
+    "schemas",
+    "zod"
+  ],
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/cloud-v2/packages/protocol#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
   }
 }

--- a/mobile/modules/crust/README.md
+++ b/mobile/modules/crust/README.md
@@ -1,35 +1,41 @@
-# crust
+# @mentra/crust
 
-Mentra Native Module
+The MentraOS native runtime layer: an [Expo module](https://docs.expo.dev/modules/overview/)
+providing the native capabilities the Mentra Engine's miniapp runtime sits on —
+per-miniapp JS contexts (QuickJS on Android, JavaScriptCore on iOS), the
+native side of the MentraJS bridge, navigation, and device utilities.
 
-# API documentation
+You don't call crust directly from app code: it's a **peer dependency of
+[`@mentra/engine`](https://www.npmjs.com/package/@mentra/engine)**. A host app
+embedding the engine installs crust alongside it and Expo autolinking picks it
+up.
 
-- [Documentation for the latest stable release](https://docs.expo.dev/versions/latest/sdk/crust/)
-- [Documentation for the main branch](https://docs.expo.dev/versions/unversioned/sdk/crust/)
+## Install
 
-# Installation in managed Expo projects
-
-For [managed](https://docs.expo.dev/archive/managed-vs-bare/) Expo projects, please follow the installation instructions in the [API documentation for the latest stable release](#api-documentation). If you follow the link and there is no documentation available then this library is not yet usable within managed projects &mdash; it is likely to be included in an upcoming Expo SDK release.
-
-# Installation in bare React Native projects
-
-For bare React Native projects, you must ensure that you have [installed and configured the `expo` package](https://docs.expo.dev/bare/installing-expo-modules/) before continuing.
-
-### Add the package to your npm dependencies
-
-```
-npm install crust
+```sh
+npm install @mentra/crust@dev
 ```
 
-### Configure for Android
+> Currently published on the `dev` dist-tag (prerelease channel).
 
+## Config plugin
 
+The package ships an Expo config plugin (`app.plugin.js`) that carries its
+Android build contract — Mapbox's maven repository, protobuf exclusions, and
+core-library desugaring. Add it to the host app's Expo config:
 
+```json
+{"expo": {"plugins": ["@mentra/crust"]}}
+```
 
-### Configure for iOS
+Building with the navigation feature requires a `MAPBOX_DOWNLOADS_TOKEN` in
+the Android build environment (Mapbox's SDK repository is authenticated).
 
-Run `npx pod-install` after installing the npm package.
+At build time the Android side also reads the MentraJS polyfill bundle from
+its [`@mentra/jspolyfill`](https://www.npmjs.com/package/@mentra/jspolyfill)
+sibling, which is declared as a dependency.
 
-# Contributing
+## Part of MentraOS
 
-Contributions are very welcome! Please refer to guidelines described in the [contributing guide]( https://github.com/expo/expo#contributing).
+Source lives in the [MentraOS monorepo](https://github.com/Mentra-Community/MentraOS)
+under `mobile/modules/crust`. Issues and contributions welcome there.

--- a/mobile/modules/jspolyfill/README.md
+++ b/mobile/modules/jspolyfill/README.md
@@ -1,0 +1,30 @@
+# @mentra/jspolyfill
+
+The MentraJS polyfill bundle. MentraOS runs each miniapp in its own bare JS
+context (JavaScriptCore on iOS, QuickJS on Android); this package provides the
+browser-like standard library those contexts lack — `console`, timers,
+`fetch`, `WebSocket`, `localStorage`, `crypto.subtle` — implemented over a
+single `__dispatch` native bridge, plus the `__deliver` / `signalReady`
+plumbing the host runtime relies on.
+
+You don't import this package from app code: it's a **peer of the runtime
+stack**. [`@mentra/crust`](https://www.npmjs.com/package/@mentra/crust)'s
+Android build reads the bundle from this package's `assets/` at build time,
+and the engine injects it into each miniapp context at spawn.
+
+## Install
+
+Installed automatically alongside
+[`@mentra/engine`](https://www.npmjs.com/package/@mentra/engine) /
+`@mentra/crust`. For direct use:
+
+```sh
+npm install @mentra/jspolyfill@dev
+```
+
+> Currently published on the `dev` dist-tag (prerelease channel).
+
+## Part of MentraOS
+
+Source lives in the [MentraOS monorepo](https://github.com/Mentra-Community/MentraOS)
+under `mobile/modules/jspolyfill`. Issues and contributions welcome there.

--- a/mobile/modules/jspolyfill/package.json
+++ b/mobile/modules/jspolyfill/package.json
@@ -32,5 +32,9 @@
     "type": "git",
     "url": "git+https://github.com/Mentra-Community/MentraOS.git",
     "directory": "mobile/modules/jspolyfill"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/mobile/modules/jspolyfill#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
   }
 }

--- a/mobile/modules/miniapp/package.json
+++ b/mobile/modules/miniapp/package.json
@@ -71,5 +71,14 @@
     "mentraos",
     "miniapp",
     "smart-glasses"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "mobile/modules/miniapp"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/mobile/modules/miniapp#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
+  }
 }

--- a/sdk/create-mentra-miniapp/README.md
+++ b/sdk/create-mentra-miniapp/README.md
@@ -1,0 +1,34 @@
+# create-mentra-miniapp
+
+Scaffold a new [MentraOS](https://github.com/Mentra-Community/MentraOS)
+miniapp project — the `bun create` starter for apps that run on MentraOS
+smart glasses.
+
+## Usage
+
+```sh
+bun create mentra-miniapp my-app
+cd my-app
+bun install
+bun run dev
+```
+
+> **Bun-only.** The scaffolder and the generated project's tooling run under
+> [Bun](https://bun.sh) — use `bun` / `bunx`, not `npx`.
+
+The generated project comes wired with
+[`@mentra/miniapp`](https://www.npmjs.com/package/@mentra/miniapp) (the SDK
+runtime) and [`@mentra/miniapp-cli`](https://www.npmjs.com/package/@mentra/miniapp-cli)
+(the `dev` / `build` / `pack` author flow), a `miniapp.json` manifest, and a
+TypeScript setup. Dependency pins are stamped at publish time to the exact
+SDK versions this scaffolder shipped with, so a generated project installs
+on any release channel.
+
+To publish a finished miniapp to the Mentra store, see
+[`@mentra/cli`](https://www.npmjs.com/package/@mentra/cli) (`mentra login` /
+`mentra publish`).
+
+## Part of MentraOS
+
+Source lives in the [MentraOS monorepo](https://github.com/Mentra-Community/MentraOS)
+under `sdk/create-mentra-miniapp`. Issues and contributions welcome there.

--- a/sdk/create-mentra-miniapp/README.md
+++ b/sdk/create-mentra-miniapp/README.md
@@ -24,7 +24,7 @@ TypeScript setup. Dependency pins are stamped at publish time to the exact
 SDK versions this scaffolder shipped with, so a generated project installs
 on any release channel.
 
-To publish a finished miniapp to the Mentra store, see
+To publish a finished miniapp to the Mentra Miniapp Store, see
 [`@mentra/cli`](https://www.npmjs.com/package/@mentra/cli) (`mentra login` /
 `mentra publish`).
 

--- a/sdk/create-mentra-miniapp/package.json
+++ b/sdk/create-mentra-miniapp/package.json
@@ -11,7 +11,7 @@
     "create-mentra-miniapp": "./bin/index.ts"
   },
   "scripts": {
-    "build": "echo 'No build needed — runs via bun'"
+    "build": "echo 'No build needed \u2014 runs via bun'"
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0"
@@ -19,5 +19,24 @@
   "devDependencies": {
     "typescript": "^5.0.0"
   },
-  "files": ["bin", "template"]
+  "files": [
+    "bin",
+    "template"
+  ],
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "miniapp",
+    "create",
+    "scaffold"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "sdk/create-mentra-miniapp"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/sdk/create-mentra-miniapp#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
+  }
 }

--- a/sdk/miniapp-cli/package.json
+++ b/sdk/miniapp-cli/package.json
@@ -29,5 +29,23 @@
     "bun-types": "^1.3.14",
     "typescript": "^5.0.0"
   },
-  "files": ["src", "schema"]
+  "files": [
+    "src",
+    "schema"
+  ],
+  "keywords": [
+    "mentra",
+    "mentraos",
+    "miniapp",
+    "cli"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mentra-Community/MentraOS.git",
+    "directory": "sdk/miniapp-cli"
+  },
+  "homepage": "https://github.com/Mentra-Community/MentraOS/tree/dev/sdk/miniapp-cli#readme",
+  "bugs": {
+    "url": "https://github.com/Mentra-Community/MentraOS/issues"
+  }
 }


### PR DESCRIPTION
## Why

Several of the ten packages published in the npm bootstrap render badly on npmjs.com: four ship **no README at all** (`create-mentra-miniapp`, `@mentra/jspolyfill`, `@mentra/cloud-protocol`, `@mentra/cloud-client`), and `@mentra/crust` ships the untouched expo-module template — dead `docs.expo.dev/sdk/crust` links, `npm install crust` (a different, unscoped name), and an `expo/expo` contributing pointer.

## What

- **Five READMEs** (four new + crust replaced), one consistent shape: what the package is, where it sits (engine peer closure / miniapp SDK), how it's *actually* installed (most arrive via `@mentra/engine`'s peer ranges, not directly), the `dev` dist-tag note, and a monorepo backlink. Package-specific substance: crust documents its config plugin + `MAPBOX_DOWNLOADS_TOKEN`; cloud-client documents its three entry points incl. the optional `ws` peer for `./node`; create-mentra-miniapp documents `bun create mentra-miniapp` and the publish-time pin stamping.
- **`@mentra/cli` README**: install examples move off the stale `@alpha` tag to `@dev`.
- **Registry metadata sweep**: `description` for cloud-protocol/cloud-client (the npm-search subtitle), `repository`/`homepage`/`bugs` wherever missing (npm sidebar links; `repository` is also a prerequisite for provenance), `keywords` where empty. All nine touched manifests now carry the full set.

## Deliberately NOT included

No version bumps — nothing republishes on merge (registry-state detection: all derived versions already exist). The content reaches npmjs.com with the next natural version bump of each package, since npm renders the tarball README of the version `latest` points to.

## Verified

`npm pack --dry-run` confirms each new README ships in its tarball (npm auto-includes README.md regardless of `files`); all manifests are valid JSON with the complete metadata set; frozen installs pass on all three workspaces (metadata doesn't touch lockfiles); the range-sync guard passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and npm manifest metadata only; no application, auth, or runtime code changes.
> 
> **Overview**
> Improves how MentraOS packages look on npmjs.com ahead of the next publish: **four new READMEs** (`create-mentra-miniapp`, `@mentra/jspolyfill`, `@mentra/cloud-protocol`, `@mentra/cloud-client`) plus a **full rewrite** of `@mentra/crust`’s Expo template README. The docs follow a shared pattern (role in the stack, `@dev` install, monorepo link), with package-specific notes such as crust’s config plugin / `MAPBOX_DOWNLOADS_TOKEN`, cloud-client’s three entry points and optional `ws` peer, and `bun create mentra-miniapp` usage.
> 
> **`@mentra/cli` README** install examples switch from `@alpha` to **`@dev`**. A **metadata sweep** across touched `package.json` files adds `description`, `keywords`, `repository`, `homepage`, and `bugs` where missing (including `@mentra/auth`, `@mentra/miniapp`, `@mentra/miniapp-cli`, and others in the diff). No version bumps—runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce01b393fd65f6344021add315c1b92e37579c0a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->