### PR TITLE
Bluetooth SDK release: channel promotion with independent prod branch

### DIFF
--- a/.github/scripts/bluetooth-sdk-release-info.mjs
+++ b/.github/scripts/bluetooth-sdk-release-info.mjs
@@ -1,87 +1,100 @@
 #!/usr/bin/env node
+// Release decision for the Bluetooth SDK under the channel-promotion scheme
+// (npm-channel.mjs): git holds one prerelease base version (X.Y.Z-dev.N, only
+// edited on dev) and the branch derives what publishes —
+//   dev                 -> X.Y.Z-dev.N   (npm dev tag,   direct publishes)
+//   staging             -> X.Y.Z-beta.N  (npm beta tag,  staged/approved)
+//   main-bluetooth-sdk  -> X.Y.Z         (npm latest tag, staged/approved)
+// Merging up the chain IS the promotion; no version edits ride the branches.
+// Note the SDK's prod branch is main-bluetooth-sdk, NOT main — SDK prod
+// releases trigger independently of the monorepo's main promotions.
+//
+// The SDK ships to THREE stores, so detection is registry-state across all of
+// them: the release runs when the derived version is missing from ANY of npm
+// (@mentra/bluetooth-sdk), Maven Central (com.mentraglass:bluetooth-sdk +
+// lc3Lib), or the SwiftPM mirror's tags — each publish job still re-checks and
+// skips its own store, so a partially-complete release heals per store.
+// Fail-closed rules match the sibling pipelines: npm absence is E404-only, a
+// partial Maven release (one of the two artifacts) is a hard error, and any
+// network failure fails the run rather than being read as "absent".
+import {readFileSync, appendFileSync} from 'node:fs';
 import {execFileSync} from 'node:child_process';
-import {readFileSync} from 'node:fs';
+import {channelFor, deriveVersion, publishedVersions} from './npm-channel.mjs';
 
 const packagePath = 'mobile/modules/bluetooth-sdk/package.json';
+const SWIFTPM_REPO = 'https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git';
 
 const outputPath = process.env.GITHUB_OUTPUT;
 const eventName = process.env.GITHUB_EVENT_NAME || '';
-const eventPath = process.env.GITHUB_EVENT_PATH;
+const branch = process.env.GITHUB_REF_NAME || '';
 const forceRelease = process.env.FORCE_RELEASE === 'true';
 const dryRun = process.env.DRY_RUN === 'true';
-
-function git(args, options = {}) {
-  return execFileSync('git', args, {
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', options.allowFailure ? 'ignore' : 'pipe'],
-  }).trim();
-}
-
-function readJsonAt(ref, path) {
-  try {
-    return JSON.parse(git(['show', `${ref}:${path}`]));
-  } catch {
-    return null;
-  }
-}
 
 function setOutput(name, value) {
   if (!outputPath) {
     console.log(`${name}=${value}`);
     return;
   }
-  execFileSync('bash', ['-lc', 'cat >> "$GITHUB_OUTPUT"'], {
-    input: `${name}=${value}\n`,
-    env: process.env,
-  });
+  appendFileSync(outputPath, `${name}=${value}\n`);
 }
 
 const currentPackage = JSON.parse(readFileSync(packagePath, 'utf8'));
-const currentVersion = currentPackage.version;
+if (!currentPackage.name) throw new Error(`Missing name in ${packagePath}`);
+if (!currentPackage.version) throw new Error(`Missing version in ${packagePath}`);
 
-if (!currentPackage.name) {
-  throw new Error(`Missing name in ${packagePath}`);
-}
+const {tag} = channelFor(branch); // throws on non-channel branches
+const derived = deriveVersion(currentPackage.version, branch); // validates the base is a prerelease
 
-if (!currentVersion) {
-  throw new Error(`Missing version in ${packagePath}`);
-}
+// npm: E404-strict via the shared helper.
+const npmVersions = publishedVersions(currentPackage.name);
+const npmExists = Boolean(npmVersions?.includes(derived));
 
-let beforeSha = process.env.BLUETOOTH_SDK_COMPARE_SHA || '';
-if (!beforeSha && eventPath) {
-  try {
-    const event = JSON.parse(readFileSync(eventPath, 'utf8'));
-    beforeSha = event.before || '';
-  } catch {
-    beforeSha = '';
+// Maven Central: HEAD both poms. 200 = exists, 404 = absent, anything else
+// (or exactly one of the two present) fails — never guess registry state.
+async function mavenState(version) {
+  const base = 'https://repo.maven.apache.org/maven2/com/mentraglass';
+  const urls = [
+    `${base}/bluetooth-sdk/${version}/bluetooth-sdk-${version}.pom`,
+    `${base}/lc3Lib/${version}/lc3Lib-${version}.pom`,
+  ];
+  const states = [];
+  for (const url of urls) {
+    const response = await fetch(url, {method: 'HEAD'});
+    if (response.status === 200) states.push(true);
+    else if (response.status === 404) states.push(false);
+    else throw new Error(`Unexpected HTTP ${response.status} checking ${url} — refusing to guess Maven state.`);
   }
+  if (states[0] !== states[1]) {
+    throw new Error(`Maven Central has only one of the two Android artifacts for ${version}; refusing to continue over a partial release.`);
+  }
+  return states[0];
 }
+const mavenExists = await mavenState(derived);
 
-if (/^0+$/.test(beforeSha)) {
-  beforeSha = '';
-}
+// SwiftPM mirror: the derived version IS the tag; ls-remote is anonymous.
+const lsRemote = execFileSync('git', ['ls-remote', SWIFTPM_REPO, `refs/tags/${derived}`], {
+  encoding: 'utf8',
+  stdio: ['ignore', 'pipe', 'pipe'],
+}).trim();
+const swiftpmExists = lsRemote.length > 0;
 
-const previousPackage = beforeSha ? readJsonAt(beforeSha, packagePath) : null;
-const hasPreviousVersion = Boolean(previousPackage?.version);
-const previousVersion = previousPackage?.version || '';
-const versionChanged = hasPreviousVersion && previousVersion !== currentVersion;
-const runRelease = versionChanged || forceRelease || (eventName === 'workflow_dispatch' && dryRun);
+const allExist = npmExists && mavenExists && swiftpmExists;
+const runRelease = !allExist || forceRelease || (eventName === 'workflow_dispatch' && dryRun);
 
 setOutput('package_name', currentPackage.name);
-setOutput('version', currentVersion);
-setOutput('previous_version', previousVersion);
-setOutput('compare_sha', beforeSha);
-setOutput('version_changed', String(versionChanged));
+setOutput('version', derived);
+setOutput('base_version', currentPackage.version);
+setOutput('dist_tag', tag);
+setOutput('swiftpm_tag', derived);
+setOutput('npm_exists', String(npmExists));
+setOutput('maven_exists', String(mavenExists));
+setOutput('swiftpm_exists', String(swiftpmExists));
 setOutput('force_release', String(forceRelease));
 setOutput('dry_run', String(dryRun));
 setOutput('run_release', String(runRelease));
-setOutput('swiftpm_tag', currentVersion);
 
 console.log(`Bluetooth SDK package: ${currentPackage.name}`);
-console.log(`Current version: ${currentVersion}`);
-console.log(`Previous version: ${previousVersion || '(unavailable)'}`);
-console.log(`Compare SHA: ${beforeSha || '(unavailable)'}`);
-console.log(`Version changed: ${versionChanged}`);
-console.log(`Force release: ${forceRelease}`);
-console.log(`Dry run: ${dryRun}`);
-console.log(`Run release jobs: ${runRelease}`);
+console.log(`Base version: ${currentPackage.version}`);
+console.log(`Derived version for ${branch}: ${derived} (npm dist-tag ${tag})`);
+console.log(`Already released — npm: ${npmExists}, maven: ${mavenExists}, swiftpm tag: ${swiftpmExists}`);
+console.log(`Run release jobs: ${runRelease}. Force: ${forceRelease}. Dry run: ${dryRun}.`);

--- a/.github/scripts/bluetooth-sdk-release-info.mjs
+++ b/.github/scripts/bluetooth-sdk-release-info.mjs
@@ -19,7 +19,7 @@
 // network failure fails the run rather than being read as "absent".
 import {readFileSync, appendFileSync} from 'node:fs';
 import {execFileSync} from 'node:child_process';
-import {channelFor, deriveVersion, publishedVersions} from './npm-channel.mjs';
+import {channelFor, deriveVersion, publishedVersions, BLUETOOTH_SDK_CHANNELS} from './npm-channel.mjs';
 
 const packagePath = 'mobile/modules/bluetooth-sdk/package.json';
 const SWIFTPM_REPO = 'https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git';
@@ -42,8 +42,8 @@ const currentPackage = JSON.parse(readFileSync(packagePath, 'utf8'));
 if (!currentPackage.name) throw new Error(`Missing name in ${packagePath}`);
 if (!currentPackage.version) throw new Error(`Missing version in ${packagePath}`);
 
-const {tag} = channelFor(branch); // throws on non-channel branches
-const derived = deriveVersion(currentPackage.version, branch); // validates the base is a prerelease
+const {tag} = channelFor(branch, BLUETOOTH_SDK_CHANNELS); // throws on non-channel branches (including main)
+const derived = deriveVersion(currentPackage.version, branch, BLUETOOTH_SDK_CHANNELS); // validates the base is a prerelease
 
 // npm: E404-strict via the shared helper.
 const npmVersions = publishedVersions(currentPackage.name);

--- a/.github/scripts/npm-channel.mjs
+++ b/.github/scripts/npm-channel.mjs
@@ -19,11 +19,13 @@
 // manifest stamp so version derivation can never drift between them.
 import {execFileSync} from "node:child_process";
 
-// Every npm-published package that follows the channel scheme, name -> manifest
-// path. EXPLICIT list, not a glob: the workspace also holds private packages
-// (cloud-runtime, cloud-shared) and packages on other release models
-// (@mentra/bluetooth-sdk ships plain versions from its own pipeline) that must
-// never be channel-derived.
+// Every package the miniapp/engine pipelines publish under the channel scheme,
+// name -> manifest path. EXPLICIT list, not a glob: the workspace also holds
+// private packages (cloud-runtime, cloud-shared) that must never be
+// channel-derived. @mentra/bluetooth-sdk follows the same channel derivation
+// but through its OWN pipeline (bluetooth-sdk-release.yml, prod branch
+// main-bluetooth-sdk) and nothing here ranges on it (the engine peers it at
+// "*"), so it stays out of this map.
 export const CHANNEL_MANIFESTS = {
   "@mentra/miniapp": "mobile/modules/miniapp/package.json",
   "@mentra/miniapp-cli": "sdk/miniapp-cli/package.json",
@@ -41,6 +43,10 @@ const CHANNELS = {
   dev: {label: "dev", tag: "dev"},
   staging: {label: "beta", tag: "beta"},
   main: {label: null, tag: "latest"},
+  // The Bluetooth SDK's production channel: prod releases of the SDK trigger
+  // independently of the monorepo's main promotions (merge staging into
+  // main-bluetooth-sdk when the SDK should go public).
+  "main-bluetooth-sdk": {label: null, tag: "latest"},
 };
 
 const BASE_RE = /^(\d+\.\d+\.\d+)-[0-9a-z]+\.(\d+)$/i;

--- a/.github/scripts/npm-channel.mjs
+++ b/.github/scripts/npm-channel.mjs
@@ -43,27 +43,33 @@ const CHANNELS = {
   dev: {label: "dev", tag: "dev"},
   staging: {label: "beta", tag: "beta"},
   main: {label: null, tag: "latest"},
-  // The Bluetooth SDK's production channel: prod releases of the SDK trigger
-  // independently of the monorepo's main promotions (merge staging into
-  // main-bluetooth-sdk when the SDK should go public).
+};
+
+// The Bluetooth SDK promotes through its OWN prod branch instead of main, so
+// SDK public releases trigger independently of the monorepo's main promotions.
+// A separate map (not an extra entry in CHANNELS) so the miniapp/engine
+// pipelines keep REJECTING a stray dispatch on main-bluetooth-sdk — and the
+// SDK pipeline rejects one on main.
+export const BLUETOOTH_SDK_CHANNELS = {
+  dev: CHANNELS.dev,
+  staging: CHANNELS.staging,
   "main-bluetooth-sdk": {label: null, tag: "latest"},
 };
 
 const BASE_RE = /^(\d+\.\d+\.\d+)-[0-9a-z]+\.(\d+)$/i;
 
-export function channelFor(branch) {
-  const channel = CHANNELS[branch];
+export function channelFor(branch, channels = CHANNELS) {
+  const channel = channels[branch];
   if (!channel) {
     throw new Error(
-      `No npm release channel for branch "${branch}" — releases ship from dev (dev tag), ` +
-        `staging (beta tag) or main (latest tag).`,
+      `No npm release channel for branch "${branch}" — this pipeline releases from: ${Object.keys(channels).join(", ")}.`,
     );
   }
   return channel;
 }
 
 // 0.1.0-dev.3 on staging -> 0.1.0-beta.3; on main -> 0.1.0.
-export function deriveVersion(baseVersion, branch) {
+export function deriveVersion(baseVersion, branch, channels = CHANNELS) {
   const match = BASE_RE.exec(baseVersion);
   if (!match) {
     throw new Error(
@@ -72,7 +78,7 @@ export function deriveVersion(baseVersion, branch) {
     );
   }
   const [, core, n] = match;
-  const {label} = channelFor(branch);
+  const {label} = channelFor(branch, channels);
   return label ? `${core}-${label}.${n}` : core;
 }
 
@@ -81,8 +87,8 @@ export function deriveVersion(baseVersion, branch) {
 // (^0.1.0); on prerelease channels it pins the exact tuple (prerelease carets
 // only match their own patch tuple), which is what makes the published set
 // self-consistent.
-export function deriveRange(baseVersion, branch) {
-  return `^${deriveVersion(baseVersion, branch)}`;
+export function deriveRange(baseVersion, branch, channels = CHANNELS) {
+  return `^${deriveVersion(baseVersion, branch, channels)}`;
 }
 
 // Registry state, E404-strict: a 404 is the ONLY signal that a package is

--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -459,7 +459,7 @@ jobs:
   npm:
     name: Publish npm package
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.npm_exists != 'true' || needs.detect.outputs.dry_run == 'true')
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.npm_exists != 'true' || needs.detect.outputs.dry_run == 'true' || needs.detect.outputs.force_release == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -611,7 +611,7 @@ jobs:
   maven:
     name: Publish Maven Central artifacts
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.maven_exists != 'true' || needs.detect.outputs.dry_run == 'true')
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.maven_exists != 'true' || needs.detect.outputs.dry_run == 'true' || needs.detect.outputs.force_release == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -762,7 +762,7 @@ jobs:
   ios-swiftpm:
     name: Export iOS SwiftPM mirror
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.swiftpm_exists != 'true' || needs.detect.outputs.dry_run == 'true')
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.swiftpm_exists != 'true' || needs.detect.outputs.dry_run == 'true' || needs.detect.outputs.force_release == 'true')
     runs-on: macos-15
     outputs:
       tag_exists: ${{ steps.swiftpm-tag.outputs.exists }}

--- a/.github/workflows/bluetooth-sdk-release.yml
+++ b/.github/workflows/bluetooth-sdk-release.yml
@@ -1,15 +1,38 @@
 name: Release Bluetooth SDK
 
+# Channel promotion (see .github/scripts/npm-channel.mjs): git holds one
+# prerelease base version (X.Y.Z-dev.N, only edited on dev) and the branch
+# derives what publishes:
+#   dev                -> X.Y.Z-dev.N   (npm dev tag)
+#   staging            -> X.Y.Z-beta.N  (npm beta tag)
+#   main-bluetooth-sdk -> X.Y.Z         (npm latest tag)
+# Merging up the chain IS the promotion; no version edits ride the branches.
+# The SDK's prod branch is main-bluetooth-sdk, NOT main — merge staging into it
+# when the SDK should go public, independently of the monorepo's main.
+#
+# Publish mode per channel, aligned across all three stores: dev releases go
+# straight out; staging/prod releases are STAGED and a human approves each one
+# in the store's own UI —
+#   npm:     `npm stage publish --tag` -> approve in npmjs.com's staging queue
+#   maven:   Sonatype Central upload with publishing_type=user_managed ->
+#            publish at https://central.sonatype.com/publishing/deployments
+#   swiftpm: SPM resolves TAGS only, so the export+commit is invisible until
+#            the tag lands; the tag-push job sits behind the protected
+#            `bluetooth-sdk-release-approval` GitHub environment and waits for
+#            a reviewer's approval in the Actions UI.
+#
+# Detection is registry-state across all three stores (a promotion merge does
+# not change the version field, so the release fires when the derived version
+# is missing from ANY store; each job still re-checks and skips its own store).
+# No paths filter, deliberately: every push to a channel branch reconciles, and
+# the detect job no-ops in seconds when all stores are complete.
+
 on:
   push:
     branches:
       - dev
-    paths:
-      - ".github/scripts/build-bluetooth-sdk-ota-manifest.mjs"
-      - ".github/scripts/bluetooth-sdk-release-info.mjs"
-      - ".github/workflows/bluetooth-sdk-release.yml"
-      - "mobile/modules/bluetooth-sdk/**"
-      - "scripts/export-bluetooth-sdk-ios-spm.sh"
+      - staging
+      - main-bluetooth-sdk
   workflow_dispatch:
     inputs:
       dry_run:
@@ -18,7 +41,7 @@ on:
         default: true
         type: boolean
       force_release:
-        description: "Run release jobs even if the SDK package version did not change"
+        description: "Run release jobs even when every store already has the derived version (immutable stores still skip themselves)."
         required: true
         default: false
         type: boolean
@@ -43,9 +66,11 @@ jobs:
     outputs:
       package_name: ${{ steps.release-info.outputs.package_name }}
       version: ${{ steps.release-info.outputs.version }}
-      previous_version: ${{ steps.release-info.outputs.previous_version }}
-      compare_sha: ${{ steps.release-info.outputs.compare_sha }}
-      version_changed: ${{ steps.release-info.outputs.version_changed }}
+      base_version: ${{ steps.release-info.outputs.base_version }}
+      dist_tag: ${{ steps.release-info.outputs.dist_tag }}
+      npm_exists: ${{ steps.release-info.outputs.npm_exists }}
+      maven_exists: ${{ steps.release-info.outputs.maven_exists }}
+      swiftpm_exists: ${{ steps.release-info.outputs.swiftpm_exists }}
       force_release: ${{ steps.release-info.outputs.force_release }}
       run_release: ${{ steps.release-info.outputs.run_release }}
       dry_run: ${{ steps.release-info.outputs.dry_run }}
@@ -53,10 +78,10 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+        # Depth 1 is fine: the decision reads the working tree + the three
+        # stores' registry state, never git history.
 
-      - name: Detect package version change
+      - name: Decide release for this channel
         id: release-info
         run: node .github/scripts/bluetooth-sdk-release-info.mjs
         env:
@@ -101,9 +126,8 @@ jobs:
             echo "## Bluetooth SDK release decision"
             echo ""
             echo "- Package: \`${{ steps.release-info.outputs.package_name }}\`"
-            echo "- Current version: \`${{ steps.release-info.outputs.version }}\`"
-            echo "- Previous version: \`${{ steps.release-info.outputs.previous_version || 'unavailable' }}\`"
-            echo "- Version changed: \`${{ steps.release-info.outputs.version_changed }}\`"
+            echo "- Base version: \`${{ steps.release-info.outputs.base_version }}\` -> derived \`${{ steps.release-info.outputs.version }}\` (dist-tag \`${{ steps.release-info.outputs.dist_tag }}\`)"
+            echo "- Already released — npm: \`${{ steps.release-info.outputs.npm_exists }}\`, maven: \`${{ steps.release-info.outputs.maven_exists }}\`, swiftpm: \`${{ steps.release-info.outputs.swiftpm_exists }}\`"
             echo "- Dry run: \`${{ steps.release-info.outputs.dry_run }}\`"
             echo "- Run release jobs: \`${{ steps.release-info.outputs.run_release }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -120,12 +144,6 @@ jobs:
       version_code: ${{ steps.existing-sdk-ota.outputs.version_code || steps.asg-build-info.outputs.version_code }}
       version_name: ${{ steps.existing-sdk-ota.outputs.version_name || steps.asg-build-info.outputs.version_name }}
     steps:
-      - name: Refuse non-dev publish
-        if: needs.detect.outputs.dry_run != 'true' && github.ref_name != 'dev'
-        run: |
-          echo "Bluetooth SDK releases must publish from the dev branch while this workflow is being validated." >&2
-          exit 1
-
       - name: Get cache week number
         id: cache-week
         run: echo "week=$(date +%Y-%U)" >> "$GITHUB_OUTPUT"
@@ -439,9 +457,9 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   npm:
-    name: Stage npm package
+    name: Publish npm package
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true'
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.npm_exists != 'true' || needs.detect.outputs.dry_run == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -451,9 +469,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Use npm with staged publishing support
-        run: npm install -g npm@latest
+        # Pinned major: the release-critical path must not pick up whatever npm
+        # shipped this morning. `npm stage publish` needs >=11.15.0.
+        run: |
+          npm install -g npm@11
+          npm stage --help >/dev/null 2>&1 || { echo "::error::this npm ($(npm --version)) lacks 'npm stage' — staged publishing needs >=11.15.0."; exit 1; }
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -472,19 +495,36 @@ jobs:
         working-directory: mobile
         run: bun install --frozen-lockfile
 
+      # After the frozen install (which would reject a changed version field):
+      # stamp the manifest to this channel's derived version — everything
+      # downstream (build, pack, the iOS placeholder substitution) reads it.
+      # Packed checkout only, never committed.
+      - name: Stamp channel version
+        working-directory: ${{ env.SDK_PACKAGE_DIR }}
+        run: npm pkg set version="${{ needs.detect.outputs.version }}"
+
       - name: Build package
         working-directory: ${{ env.SDK_PACKAGE_DIR }}
         run: bun run build
 
       - name: Check npm registry
         id: npm-registry
+        # Belt-and-braces re-check of the detect decision (E404-only absence).
         run: |
           set -euo pipefail
-          if npm view "${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}" version --registry=https://registry.npmjs.org >/dev/null 2>&1; then
+          set +e
+          out=$(npm view "${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}" version --json --registry=https://registry.npmjs.org 2>&1)
+          code=$?
+          set -e
+          if [[ $code -eq 0 ]]; then
             echo "exists=true" >> "$GITHUB_OUTPUT"
             echo "npm already has ${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }}."
-          else
+          elif echo "$out" | grep -q '"code": *"E404"' || echo "$out" | grep -q "code E404"; then
             echo "exists=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::npm view failed with a non-404 error — refusing to guess registry state." >&2
+            echo "$out" >&2
+            exit 1
           fi
 
       - name: Dry-run npm package
@@ -526,19 +566,52 @@ jobs:
             exit 1
           fi
 
-      - name: Stage npm package
-        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.exists != 'true'
+      # Direct publish on the dev channel (fast internal iteration, no
+      # approval). Uses NPM_TOKEN: the package's npm Trusted Publisher is
+      # configured for `npm stage publish` only.
+      - name: Publish to npm (dev channel)
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.exists != 'true' && github.ref_name == 'dev'
         working-directory: ${{ env.SDK_PACKAGE_DIR }}
-        run: npm stage publish
+        run: |
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+            echo "::error::Set the NPM_TOKEN repository secret for dev-channel direct publishes."
+            exit 1
+          fi
+          npm publish --tag "${{ needs.detect.outputs.dist_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Skip npm stage publish
+      - name: Stage npm package for approval (beta/latest channels)
+        if: needs.detect.outputs.dry_run != 'true' && steps.npm-registry.outputs.exists != 'true' && github.ref_name != 'dev'
+        working-directory: ${{ env.SDK_PACKAGE_DIR }}
+        # OIDC trusted publisher; the tag is immutable once staged, so it must
+        # be right here. A staged-but-unapproved version is not live (npm view
+        # won't list it), so a re-merge before approval re-attempts the stage —
+        # tolerate that one error.
+        run: |
+          set +e
+          out=$(npm stage publish --tag "${{ needs.detect.outputs.dist_tag }}" 2>&1)
+          code=$?
+          set -e
+          echo "$out"
+          if [[ $code -ne 0 ]]; then
+            if echo "$out" | grep -qi "already"; then
+              echo "::notice::${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }} is already in the staging queue — approve or reject it in the npm UI."
+            else
+              exit $code
+            fi
+          else
+            echo "::notice::${{ needs.detect.outputs.package_name }}@${{ needs.detect.outputs.version }} staged for '${{ needs.detect.outputs.dist_tag }}' — a maintainer must approve it in the npm UI before it goes live."
+          fi
+
+      - name: Skip npm publish
         if: steps.npm-registry.outputs.exists == 'true'
-        run: echo "Skipping npm stage publish because this version already exists on npm."
+        run: echo "Skipping npm publish because this version already exists on npm."
 
   maven:
     name: Publish Maven Central artifacts
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true'
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.maven_exists != 'true' || needs.detect.outputs.dry_run == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -660,6 +733,10 @@ jobs:
       - name: Publish Maven Central artifacts
         if: needs.detect.outputs.dry_run != 'true' && steps.maven-central.outputs.exists != 'true'
         working-directory: mobile/android
+        # Publish mode mirrors the npm split: the dev channel auto-releases
+        # (publishing_type=automatic), beta/prod uploads stay staged in the
+        # Central Portal (user_managed) until a maintainer publishes them at
+        # https://central.sonatype.com/publishing/deployments.
         run: |
           ./gradlew \
             :lc3Lib:publishReleasePublicationToSonatypeCentralRepository \
@@ -668,22 +745,28 @@ jobs:
             -PmentraPublicSdk=true \
             --no-daemon \
             --stacktrace
+          if [[ "${SONATYPE_PUBLISHING_TYPE}" == "user_managed" ]]; then
+            echo "::notice::Maven deployment for ${{ needs.detect.outputs.version }} is staged in the Central Portal — a maintainer must publish it at https://central.sonatype.com/publishing/deployments."
+          fi
         env:
           MAVEN_CENTRAL_TOKEN_BASE64: ${{ secrets.MAVEN_CENTRAL_TOKEN_BASE64 }}
           MENTRA_MAVEN_VERSION: ${{ needs.detect.outputs.version }}
           SIGNING_KEY: ${{ secrets.MAVEN_SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.MAVEN_SIGNING_PASSWORD }}
-          SONATYPE_PUBLISHING_TYPE: ${{ vars.SONATYPE_PUBLISHING_TYPE || 'user_managed' }}
+          SONATYPE_PUBLISHING_TYPE: ${{ github.ref_name == 'dev' && 'automatic' || 'user_managed' }}
 
       - name: Skip Maven publish
         if: steps.maven-central.outputs.exists == 'true'
         run: echo "Skipping Maven publish because both Android artifacts already exist."
 
   ios-swiftpm:
-    name: Release iOS SwiftPM mirror
+    name: Export iOS SwiftPM mirror
     needs: [detect, sdk-ota]
-    if: needs.detect.outputs.run_release == 'true'
+    if: needs.detect.outputs.run_release == 'true' && (needs.detect.outputs.swiftpm_exists != 'true' || needs.detect.outputs.dry_run == 'true')
     runs-on: macos-15
+    outputs:
+      tag_exists: ${{ steps.swiftpm-tag.outputs.exists }}
+      mirror_sha: ${{ steps.mirror-commit.outputs.mirror_sha }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
@@ -721,6 +804,13 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # The export script reads the SDK package.json version, so stamping the
+      # channel-derived version here flows into Package.swift, the README and
+      # the Swift source placeholder. Export checkout only — never committed.
+      - name: Stamp channel version
+        working-directory: MentraOS/mobile/modules/bluetooth-sdk
+        run: npm pkg set version="${{ needs.detect.outputs.version }}"
+
       - name: Export and verify Swift package
         if: steps.swiftpm-tag.outputs.exists != 'true'
         working-directory: MentraOS
@@ -736,7 +826,12 @@ jobs:
           git status --short
           git diff --stat
 
-      - name: Commit and tag SwiftPM mirror
+      # Commit + push the export, but NOT the tag: SPM resolves tags only, so
+      # an untagged commit is invisible to consumers. The tag push is the
+      # release act and lives in the next job, behind the approval environment
+      # on non-dev channels.
+      - name: Commit SwiftPM mirror (no tag)
+        id: mirror-commit
         if: needs.detect.outputs.dry_run != 'true' && steps.swiftpm-tag.outputs.exists != 'true'
         working-directory: mentra-bluetooth-sdk-ios
         run: |
@@ -746,15 +841,49 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Package.swift README.md LICENSE ios .gitignore
           if git diff --cached --quiet; then
-            echo "SwiftPM export produced no file changes; tagging the current mirror HEAD."
+            echo "SwiftPM export produced no file changes; the tag job will tag the current mirror HEAD."
           else
             git commit -m "Release MentraBluetoothSDK ${{ needs.detect.outputs.version }}" \
               -m "Exported from MentraOS ${source_sha}."
             git push origin HEAD:main
           fi
-          git tag "${{ needs.detect.outputs.swiftpm_tag }}"
-          git push origin "refs/tags/${{ needs.detect.outputs.swiftpm_tag }}"
+          echo "mirror_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Skip SwiftPM release
+      - name: Skip SwiftPM export
         if: steps.swiftpm-tag.outputs.exists == 'true'
-        run: echo "Skipping SwiftPM release because the version tag already exists."
+        run: echo "Skipping SwiftPM export because the version tag already exists."
+
+  ios-swiftpm-tag:
+    name: Tag iOS SwiftPM release
+    needs: [detect, ios-swiftpm]
+    if: needs.detect.outputs.dry_run != 'true' && needs.ios-swiftpm.outputs.tag_exists != 'true' && needs.ios-swiftpm.outputs.mirror_sha != ''
+    runs-on: ubuntu-latest
+    # SPM resolves tags only, so pushing the tag IS the release. On dev the
+    # environment is unprotected and the tag goes straight out; on staging and
+    # main-bluetooth-sdk the approval environment holds this job until a
+    # reviewer approves it in the Actions UI — the SwiftPM equivalent of npm's
+    # staging queue and Sonatype's user_managed deployments. Configure required
+    # reviewers on `bluetooth-sdk-release-approval` (Settings -> Environments);
+    # until that is done the gate is a no-op.
+    environment: ${{ github.ref_name == 'dev' && 'bluetooth-sdk-dev-release' || 'bluetooth-sdk-release-approval' }}
+    steps:
+      - name: Checkout SwiftPM mirror
+        uses: actions/checkout@v4
+        with:
+          repository: Mentra-Community/mentra-bluetooth-sdk-ios
+          token: ${{ secrets.MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN }}
+          fetch-depth: 0
+
+      - name: Tag and push
+        run: |
+          set -euo pipefail
+          mirror_sha="${{ needs.ios-swiftpm.outputs.mirror_sha }}"
+          if ! git cat-file -e "${mirror_sha}^{commit}"; then
+            echo "::error::Exported mirror commit ${mirror_sha} not found — was the mirror force-pushed between export and approval?"
+            exit 1
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ needs.detect.outputs.swiftpm_tag }}" "${mirror_sha}"
+          git push origin "refs/tags/${{ needs.detect.outputs.swiftpm_tag }}"
+          echo "::notice::SwiftPM release ${{ needs.detect.outputs.swiftpm_tag }} is live (tag pushed at ${mirror_sha})."

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -244,7 +244,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.20",
+      "version": "0.1.21-dev.0",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",

--- a/mobile/modules/bluetooth-sdk/RELEASING_CI.md
+++ b/mobile/modules/bluetooth-sdk/RELEASING_CI.md
@@ -1,16 +1,48 @@
 # Bluetooth SDK Release CI
 
 The Bluetooth SDK release workflow lives at
-`.github/workflows/bluetooth-sdk-release.yml`. During initial validation it runs
-on pushes to `dev` that touch the SDK package, the release workflow, or the
-SwiftPM export script. After the workflow has been proven end-to-end, switch the
-trigger and publish guard back to `staging` before using it as the durable SDK
-release path.
-A release is only attempted when the `version` field in
-`mobile/modules/bluetooth-sdk/package.json` changes compared with the previous
-`dev` commit.
+`.github/workflows/bluetooth-sdk-release.yml` and follows the same
+**channel-promotion scheme** as the miniapp/engine pipelines
+(`.github/scripts/npm-channel.mjs`): git holds one prerelease base version
+(`X.Y.Z-dev.N`, only ever edited on `dev`) and the branch derives what
+publishes — merging up the chain IS the promotion, no version edits ride the
+branches:
 
-The same version drives all public artifacts:
+| Branch | Publishes | npm dist-tag | Publish mode |
+| --- | --- | --- | --- |
+| `dev` | `X.Y.Z-dev.N` | `dev` | direct — no approval |
+| `staging` | `X.Y.Z-beta.N` | `beta` | staged — human approves per store |
+| `main-bluetooth-sdk` | `X.Y.Z` | `latest` | staged — human approves per store |
+
+The SDK's prod branch is **`main-bluetooth-sdk`, not `main`** — SDK prod
+releases trigger independently of the monorepo's main promotions. To go public,
+merge `staging` into `main-bluetooth-sdk` (create the branch from `staging` the
+first time). After a plain `X.Y.Z` has shipped, the base is spent: start the
+next cycle by bumping `dev` to `X.Y.(Z+1)-dev.0`.
+
+Detection is **registry-state across all three stores**: a release fires when
+the derived version is missing from any of npm, Maven Central, or the SwiftPM
+mirror's tags, and each store's job re-checks and skips itself when already
+complete — re-runs, re-merges, and partially-failed releases all heal. There is
+no paths filter; every push to a channel branch reconciles in seconds.
+
+The staged ("human approves") mode maps to each store's native mechanism:
+
+- **npm** — `npm stage publish --tag <channel>`: approve in npmjs.com's Staged
+  Packages tab (or `npm stage approve <stage-id>`).
+- **Maven Central** — the Sonatype upload uses `publishing_type=user_managed`:
+  publish the deployment at
+  <https://central.sonatype.com/publishing/deployments>. The `dev` channel
+  uploads with `publishing_type=automatic` instead (no approval).
+- **SwiftPM** — SPM resolves **tags only**, so the export+commit to the mirror
+  is invisible to consumers; the tag push is the release act and lives in a
+  separate job behind the `bluetooth-sdk-release-approval` GitHub environment.
+  Approve it in the workflow run's UI. **Configure required reviewers on that
+  environment once** (Settings → Environments) — until then the gate is a
+  no-op. The `dev` channel tags through the unprotected
+  `bluetooth-sdk-dev-release` environment without waiting.
+
+The same derived version drives all public artifacts:
 
 - ASG OTA manifest:
   `https://github.com/Mentra-Community/MentraOS/releases/download/bluetooth-sdk-ota/bluetooth-sdk-VERSION-version.json`
@@ -53,15 +85,21 @@ workflow for a real release:
 | `MAVEN_SIGNING_KEY` | Secret | ASCII-armored PGP private key used by Gradle in-memory signing. |
 | `MAVEN_SIGNING_PASSWORD` | Secret | Passphrase for `MAVEN_SIGNING_KEY`. |
 | `MENTRA_BLUETOOTH_SDK_IOS_PUSH_TOKEN` | Secret | GitHub token with write access to `Mentra-Community/mentra-bluetooth-sdk-ios` for pushing `main` and version tags. |
-| `SONATYPE_PUBLISHING_TYPE` | Variable | Sonatype Central upload mode; keep `user_managed` unless maintainers intentionally switch to an automatic release mode. |
+| `NPM_TOKEN` | Secret | npm automation token used for dev-channel direct publishes (staged beta/latest publishes use the OIDC Trusted Publisher). |
+
+The Sonatype publishing type is no longer a repository variable: the workflow
+derives it from the channel (`automatic` on `dev`, `user_managed` on
+`staging`/`main-bluetooth-sdk`).
 
 ## Flow
 
-1. The detector job reads `mobile/modules/bluetooth-sdk/package.json` at `HEAD`
-   and at the prior push SHA. If the version did not change, the workflow exits
-   after writing a summary. If GitHub does not provide a usable prior push SHA,
-   the detector fails closed; rerun with `workflow_dispatch` and
-   `force_release=true` after confirming the version should release.
+1. The detector job derives the channel version from the base in
+   `mobile/modules/bluetooth-sdk/package.json` and the branch, then checks all
+   three stores for it (npm E404-strict; both Maven poms — a partial pair is a
+   hard error; the SwiftPM tag via `ls-remote`). If every store already has the
+   derived version, the workflow exits after writing a summary. Publish jobs
+   stamp the derived version into the CI checkout's manifest before
+   building/packing (never committed) — the repo keeps the base version.
 2. The SDK OTA job builds the ASG client APK from the same release commit,
    generates a versioned manifest with ASG APK metadata plus the MTK and BES
    metadata from `asg_client/ota_manifests/firmware_live.json`, then uploads the
@@ -75,20 +113,25 @@ workflow for a real release:
    publishing starts. If the same SDK release is rerun after OTA publishing
    succeeded, existing APK or manifest assets are reused only when their content
    is byte-for-byte identical; mismatched assets fail hard.
-4. The npm job installs mobile workspace dependencies, builds the SDK package,
-   checks whether `@mentra/bluetooth-sdk@VERSION` already exists, runs
-   `npm pack --dry-run`, then submits the package with `npm stage publish` when
-   the workflow is not in dry-run mode. A maintainer must approve the staged
-   package before it becomes available on npm.
+4. The npm job installs mobile workspace dependencies, stamps the derived
+   version, builds the SDK package, re-checks the registry, runs
+   `npm pack --dry-run`, then publishes: **directly with `--tag dev`** on the
+   dev channel (NPM_TOKEN), or via **`npm stage publish --tag <beta|latest>`**
+   on staging/prod — a maintainer must approve the staged package before it
+   goes live.
 5. The Maven job installs the mobile workspace, runs Expo prebuild to create the
    generated `mobile/android` Gradle project, checks Maven Central for both
    Android artifacts, runs a public-mode `publishToMavenLocal`, then uploads the
    signed public-mode `lc3Lib` and `mentra-bluetooth-sdk` publications to
-   Sonatype Central.
-6. The iOS job checks out the SwiftPM mirror repository, refuses to overwrite an
-   existing version tag, exports the package with
-   `scripts/export-bluetooth-sdk-ios-spm.sh --verify`, then pushes `main` and
-   the version tag.
+   Sonatype Central — `publishing_type=automatic` on dev (goes live on its
+   own), `user_managed` on staging/prod (publish it in the Central Portal).
+6. The iOS export job checks out the SwiftPM mirror repository, refuses to
+   overwrite an existing version tag, stamps the derived version, exports the
+   package with `scripts/export-bluetooth-sdk-ios-spm.sh --verify`, and pushes
+   the commit to `main` — **without the tag**. A separate tag job then pushes
+   the version tag at the exported commit: immediately on dev, or after a
+   reviewer approves the `bluetooth-sdk-release-approval` environment gate on
+   staging/prod. The tag going live IS the SwiftPM release.
 
 ## Manual Steps That Remain
 

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.20",
+  "version": "0.1.21-dev.0",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -263,7 +263,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.20",
+      "version": "0.1.21-dev.0",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",


### PR DESCRIPTION
## Why

The Bluetooth SDK released plain versions to prod straight from `dev`. This brings it onto the same channel-promotion scheme as the miniapp/engine pipelines (#3471) — with one deliberate difference: **prod triggers independently via the SDK's own branch `main-bluetooth-sdk`**, so going public never couples to the monorepo's main promotions.

## The scheme

Git holds one prerelease base (`0.1.21-dev.0`, edited only on `dev`); the branch derives what publishes:

| Branch | Publishes | npm tag | Mode |
|---|---|---|---|
| `dev` | `0.1.21-dev.N` | `dev` | direct, no approval |
| `staging` | `0.1.21-beta.N` | `beta` | staged, human approves per store |
| `main-bluetooth-sdk` | `0.1.21` | `latest` | staged, human approves per store |

Merging is the promotion. Detection is **registry-state across all three stores** — the release fires when the derived version is missing from any of npm (E404-strict), Maven Central (both poms; a partial pair hard-fails), or the SwiftPM mirror's tags — and each store's job re-checks and skips itself, so partial releases heal per store. Triggers are pathless on the three channel branches; the detect job no-ops in seconds when the stores are complete.

## Staging mapped to each store's native mechanism

- **npm**: dev publishes directly with `--tag dev` (NPM_TOKEN — the trusted publisher only allows `npm stage publish`); staging/prod use `npm stage publish --tag <beta|latest>` → approve in npmjs.com's staging queue. Already-staged re-merge errors tolerated (staged versions aren't in `npm view`).
- **Maven Central**: `SONATYPE_PUBLISHING_TYPE` is now channel-derived — `automatic` on dev (goes live on its own), `user_managed` on staging/prod → publish the deployment at central.sonatype.com. The repo variable is retired.
- **SwiftPM**: SPM resolves **tags only**, so the export job commits the mirror **without tagging** (invisible to consumers), and a new `ios-swiftpm-tag` job pushes the version tag at the exported SHA — immediately on dev (unprotected `bluetooth-sdk-dev-release` environment), and behind the **`bluetooth-sdk-release-approval` environment's required-reviewer gate** on staging/prod. Approving in the Actions UI IS the SwiftPM release — the exact parity of npm's queue and Sonatype's user_managed deployments, with no machinery needed in the mirror repo.

Publish jobs stamp the derived version into the CI checkout's manifest (after the frozen install; never committed) — the npm pack placeholder substitution and the iOS export script both read it from there, so `Package.swift`, the README pin and the Swift source version all come out channel-correct.

## Verified against the live stores

- dev/staging/prod derive `0.1.21-dev.0` / `0.1.21-beta.0` / `0.1.21`, all three stores report them missing → release runs.
- A spent base (`0.1.20-dev.5` on prod → derives `0.1.20`) finds npm + both Maven poms + the SwiftPM tag all present → clean no-op. This exercised the real Maven HEAD checks and `ls-remote` against production registries.
- Stray branches hard-error in derivation; workflow yaml-lints clean; mobile/sdk lockfiles refreshed for the base bump and pass frozen installs; the range-sync guard passes (engine peers the SDK at `*`, deliberately).

## Setup before first use (documented in RELEASING_CI.md)

1. **Configure required reviewers** on the `bluetooth-sdk-release-approval` environment (Settings → Environments) — until then the SwiftPM gate is a no-op.
2. **Create `main-bluetooth-sdk`** from `staging` when the first public release is wanted.
3. The `SONATYPE_PUBLISHING_TYPE` repo variable is no longer read and can be deleted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release gating and publish paths for npm, Maven, and SwiftPM; misconfiguration of secrets, environments, or registry checks could block or mis-ship artifacts, but behavior is fail-closed and per-store healing limits blast radius.
> 
> **Overview**
> Aligns **Bluetooth SDK** releases with the miniapp/engine **channel-promotion** model: git keeps a single prerelease base (`0.1.21-dev.0`), and **`dev` / `staging` / `main-bluetooth-sdk`** derive the published version and npm dist-tag. Prod uses **`main-bluetooth-sdk`**, not `main`, so public SDK releases stay decoupled from monorepo main.
> 
> **Release detection** no longer compares `package.json` to the previous commit. The detect script derives the channel version via shared **`npm-channel.mjs`** (`BLUETOOTH_SDK_CHANNELS`) and runs the workflow when that version is **missing from any** of npm, Maven Central (both artifacts; partial pair fails), or the SwiftPM mirror tag. Per-store jobs re-check and skip when already published.
> 
> The workflow triggers on all three channel branches **without path filters**; publish jobs **stamp** the derived version in CI only (after frozen install). **npm**: direct `--tag dev` on `dev` (`NPM_TOKEN`); staged publish on beta/latest. **Maven**: `SONATYPE_PUBLISHING_TYPE` is channel-derived (`automatic` vs `user_managed`); the repo variable is dropped. **SwiftPM**: export commits the mirror **without** tagging; a new **`ios-swiftpm-tag`** job pushes the tag behind GitHub environment approval on non-dev channels.
> 
> Docs and locks move the SDK base from `0.1.20` to **`0.1.21-dev.0`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9777861a9f9062206d871beee8043f365c698491. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->