### PR TITLE
Backfill unsaved gallery media to camera roll

### DIFF
--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -586,10 +586,15 @@ class CrustModule : Module() {
                 findExistingGalleryAsset(
                         resolver,
                         collection,
-                        mediaDisplayName,
+                        listOfNotNull(
+                                        mediaDisplayName,
+                                        file.name.takeIf { it.isNotBlank() },
+                                )
+                                .distinct(),
                         file.length(),
                         captureTimeMillis,
                         relativePath,
+                        context.packageName,
                 )
         if (existingUri != null) {
           android.util.Log.d("CrustModule", "Reusing existing gallery asset")
@@ -908,17 +913,20 @@ class CrustModule : Module() {
   private fun findExistingGalleryAsset(
           resolver: android.content.ContentResolver,
           collection: android.net.Uri,
-          displayName: String,
+          displayNames: List<String>,
           size: Long,
           captureTimeMillis: Long?,
           relativePath: String?,
+          ownerPackageName: String,
   ): android.net.Uri? {
     val dateColumn = android.provider.MediaStore.Images.ImageColumns.DATE_TAKEN
+    if (displayNames.isEmpty()) return null
+    val namePlaceholders = displayNames.joinToString(",") { "?" }
     val selectionParts =
             mutableListOf(
-                    "${android.provider.MediaStore.MediaColumns.DISPLAY_NAME} = ?",
+                    "${android.provider.MediaStore.MediaColumns.DISPLAY_NAME} IN ($namePlaceholders)",
             )
-    val selectionArgs = mutableListOf(displayName)
+    val selectionArgs = displayNames.toMutableList()
     if (captureTimeMillis != null) {
       selectionParts.add("$dateColumn = ?")
       selectionArgs.add(captureTimeMillis.toString())
@@ -936,6 +944,9 @@ class CrustModule : Module() {
       // reconcilable, while still requiring an exact Mentra album match.
       selectionArgs.add(pathWithoutTrailingSlash)
       selectionArgs.add("$pathWithoutTrailingSlash/")
+      // Never reconcile or delete another application's pending MediaStore row.
+      selectionParts.add("${android.provider.MediaStore.MediaColumns.OWNER_PACKAGE_NAME} = ?")
+      selectionArgs.add(ownerPackageName)
     }
     val projection =
             mutableListOf(
@@ -958,6 +969,7 @@ class CrustModule : Module() {
                       "${android.provider.BaseColumns._ID} DESC",
               )
               ?.use { cursor ->
+                val candidates = mutableListOf<android.net.Uri>()
                 val idColumn = cursor.getColumnIndexOrThrow(android.provider.BaseColumns._ID)
                 val sizeColumn =
                         cursor.getColumnIndexOrThrow(android.provider.MediaStore.MediaColumns.SIZE)
@@ -979,9 +991,11 @@ class CrustModule : Module() {
                     resolver.delete(uri, null, null)
                     continue
                   }
-                  if (cursor.getLong(sizeColumn) == size) return@use uri
+                  if (cursor.getLong(sizeColumn) == size) candidates.add(uri)
                 }
-                null
+                // A legacy `base.jpg`/`base.mp4` match is safe only when the complete
+                // name/date/size/path/owner fingerprint identifies exactly one asset.
+                candidates.singleOrNull()
               }
     } catch (error: Exception) {
       android.util.Log.w("CrustModule", "Unable to reconcile existing gallery asset", error)

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -582,20 +582,39 @@ class CrustModule : Module() {
                   null
                 }
         val resolver = context.contentResolver
+        val stableDisplayName =
+                mediaDisplayName.takeIf {
+                  it.startsWith("IMG_") || it.startsWith("VID_")
+                }
         val existingUri =
-                findExistingGalleryAsset(
-                        resolver,
-                        collection,
-                        listOfNotNull(
-                                        mediaDisplayName,
-                                        file.name.takeIf { it.isNotBlank() },
-                                )
-                                .distinct(),
-                        file.length(),
-                        captureTimeMillis,
-                        relativePath,
-                        context.packageName,
-                )
+                stableDisplayName?.let {
+                  findExistingGalleryAsset(
+                          resolver,
+                          collection,
+                          listOf(it),
+                          file.length(),
+                          captureTimeMillis,
+                          relativePath,
+                          context.packageName,
+                          requireUniqueMatch = false,
+                  )
+                }
+                        ?: findExistingGalleryAsset(
+                                resolver,
+                                collection,
+                                listOfNotNull(
+                                                mediaDisplayName.takeIf { stableDisplayName == null },
+                                                file.name.takeIf {
+                                                  it.isNotBlank() && it != stableDisplayName
+                                                },
+                                        )
+                                        .distinct(),
+                                file.length(),
+                                captureTimeMillis,
+                                relativePath,
+                                context.packageName,
+                                requireUniqueMatch = true,
+                        )
         if (existingUri != null) {
           android.util.Log.d("CrustModule", "Reusing existing gallery asset")
           return@AsyncFunction mapOf(
@@ -918,6 +937,7 @@ class CrustModule : Module() {
           captureTimeMillis: Long?,
           relativePath: String?,
           ownerPackageName: String,
+          requireUniqueMatch: Boolean,
   ): android.net.Uri? {
     val dateColumn = android.provider.MediaStore.Images.ImageColumns.DATE_TAKEN
     if (displayNames.isEmpty()) return null
@@ -993,9 +1013,15 @@ class CrustModule : Module() {
                   }
                   if (cursor.getLong(sizeColumn) == size) candidates.add(uri)
                 }
-                // A legacy `base.jpg`/`base.mp4` match is safe only when the complete
-                // name/date/size/path/owner fingerprint identifies exactly one asset.
-                candidates.singleOrNull()
+                if (requireUniqueMatch) {
+                  // A legacy `base.jpg`/`base.mp4` match is safe only when the complete
+                  // name/date/size/path/owner fingerprint identifies exactly one asset.
+                  candidates.singleOrNull()
+                } else {
+                  // Capture-derived display names are stable. If an older retry already made
+                  // duplicates, reuse the newest completed row instead of creating another.
+                  candidates.firstOrNull()
+                }
               }
     } catch (error: Exception) {
       android.util.Log.w("CrustModule", "Unable to reconcile existing gallery asset", error)

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -411,7 +411,11 @@ public class CrustModule: Module {
         // MARK: - Media Library Commands
 
         AsyncFunction("saveToGalleryWithDate") {
-            (filePath: String, captureTimeMillis: Int64?, displayName: String?) -> [String: Any] in
+            (
+                filePath: String,
+                captureTimeMillis: Int64?,
+                displayName: String?
+            ) -> [String: Any] in
             let fileURL = URL(fileURLWithPath: filePath)
 
             guard FileManager.default.fileExists(atPath: filePath) else {
@@ -426,12 +430,26 @@ public class CrustModule: Module {
             let captureDate = captureTimeMillis.map {
                 Date(timeIntervalSince1970: TimeInterval($0) / 1000.0)
             }
+            let candidateFileNames = [assetFileName, fileURL.lastPathComponent]
+                .filter { !$0.isEmpty }
+            let authorizationStatus: PHAuthorizationStatus
+            if #available(iOS 14, *) {
+                authorizationStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+            } else {
+                authorizationStatus = PHPhotoLibrary.authorizationStatus()
+            }
+            let hasLimitedAccess: Bool
+            if #available(iOS 14, *) {
+                hasLimitedAccess = authorizationStatus == .limited
+            } else {
+                hasLimitedAccess = false
+            }
 
             // The JS ledger normally supplies the previous PhotoKit receipt. If the app was
             // terminated after Photos committed but before that receipt was persisted, reconcile
             // by our stable capture filename/date before creating another asset.
             if let existingIdentifier = self.findExistingGalleryAssetIdentifier(
-                fileName: assetFileName,
+                fileNames: candidateFileNames,
                 captureDate: captureDate,
                 isVideo: isVideo
             ) {
@@ -471,6 +489,11 @@ public class CrustModule: Module {
                 }
 
                 assetIdentifier = assetPlaceholder.localIdentifier
+
+                // Limited-library access permits creating an asset, but does not reliably
+                // permit enumerating or mutating arbitrary user albums. Save to the camera
+                // roll and skip Mentra album mutation in that mode.
+                guard !hasLimitedAccess else { return }
 
                 let albumFetch = PHFetchOptions()
                 albumFetch.predicate = NSPredicate(
@@ -530,10 +553,11 @@ public class CrustModule: Module {
     }
 
     private func findExistingGalleryAssetIdentifier(
-        fileName: String,
+        fileNames: [String],
         captureDate: Date?,
         isVideo: Bool
     ) -> String? {
+        guard !fileNames.isEmpty else { return nil }
         let options = PHFetchOptions()
         let mediaType = isVideo ? PHAssetMediaType.video : PHAssetMediaType.image
         if let captureDate {
@@ -550,17 +574,18 @@ public class CrustModule: Module {
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
         let assets = PHAsset.fetchAssets(with: options)
-        var identifier: String?
-        assets.enumerateObjects { asset, _, stop in
+        var identifiers: [String] = []
+        assets.enumerateObjects { asset, _, _ in
             let matches = PHAssetResource.assetResources(for: asset).contains {
-                $0.originalFilename == fileName
+                fileNames.contains($0.originalFilename)
             }
             if matches {
-                identifier = asset.localIdentifier
-                stop.pointee = true
+                identifiers.append(asset.localIdentifier)
             }
         }
-        return identifier
+        // Legacy base filenames were shared by every capture. Only reuse one when
+        // filename + capture time + media type identify a single accessible asset.
+        return identifiers.count == 1 ? identifiers[0] : nil
     }
 }
 

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -453,7 +453,7 @@ public class CrustModule: Module {
             // The JS ledger normally supplies the previous PhotoKit receipt. If the app was
             // terminated after Photos committed but before that receipt was persisted, reconcile
             // by our stable capture filename/date before creating another asset.
-            if let existingIdentifier = self.findExistingGalleryAssetIdentifier(
+            if let existingIdentifier = await self.findExistingGalleryAssetIdentifier(
                 fileNames: candidateFileNames,
                 stableFileName: stableFileName,
                 expectedFileSize: expectedFileSize,
@@ -469,89 +469,71 @@ public class CrustModule: Module {
             }
 
             var assetIdentifier: String?
-            let semaphore = DispatchSemaphore(value: 0)
-            var resultError: Error?
-            var resultSucceeded = false
             var creationFailed = false
 
-            PHPhotoLibrary.shared().performChanges {
-                let creationRequest = PHAssetCreationRequest.forAsset()
-                let resourceOptions = PHAssetResourceCreationOptions()
-                resourceOptions.originalFilename = assetFileName
-                creationRequest.addResource(
-                    with: isVideo ? .video : .photo,
-                    fileURL: fileURL,
-                    options: resourceOptions
-                )
-
-                if let captureDate {
-                    creationRequest.creationDate = captureDate
-                    NSLog("CrustModule: Setting creation date to: \(captureDate)")
-                }
-
-                guard let assetPlaceholder = creationRequest.placeholderForCreatedAsset else {
-                    NSLog("CrustModule: Missing placeholder for created asset")
-                    creationFailed = true
-                    return
-                }
-
-                assetIdentifier = assetPlaceholder.localIdentifier
-
-                // Limited-library access permits creating an asset, but does not reliably
-                // permit enumerating or mutating arbitrary user albums. Save to the camera
-                // roll and skip Mentra album mutation in that mode.
-                guard !hasLimitedAccess else { return }
-
-                let albumFetch = PHFetchOptions()
-                albumFetch.predicate = NSPredicate(
-                    format: "localizedTitle == %@", MentraSyncedMediaAlbum.localizedTitle
-                )
-                albumFetch.fetchLimit = 1
-
-                let existingAlbums = PHAssetCollection.fetchAssetCollections(
-                    with: .album,
-                    subtype: .albumRegular,
-                    options: albumFetch
-                )
-
-                if let album = existingAlbums.firstObject,
-                   let albumChange = PHAssetCollectionChangeRequest(for: album)
-                {
-                    albumChange.addAssets([assetPlaceholder] as NSArray)
-                } else if existingAlbums.firstObject == nil {
-                    let newAlbumChange = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(
-                        withTitle: MentraSyncedMediaAlbum.localizedTitle
+            do {
+                try await PHPhotoLibrary.shared().performChanges {
+                    let creationRequest = PHAssetCreationRequest.forAsset()
+                    let resourceOptions = PHAssetResourceCreationOptions()
+                    resourceOptions.originalFilename = assetFileName
+                    creationRequest.addResource(
+                        with: isVideo ? .video : .photo,
+                        fileURL: fileURL,
+                        options: resourceOptions
                     )
-                    newAlbumChange.addAssets([assetPlaceholder] as NSArray)
-                } else {
-                    NSLog(
-                        "CrustModule: Mentra album exists but is not writable; asset saved to library only"
+
+                    if let captureDate {
+                        creationRequest.creationDate = captureDate
+                        NSLog("CrustModule: Setting creation date to: \(captureDate)")
+                    }
+
+                    guard let assetPlaceholder = creationRequest.placeholderForCreatedAsset else {
+                        NSLog("CrustModule: Missing placeholder for created asset")
+                        creationFailed = true
+                        return
+                    }
+
+                    assetIdentifier = assetPlaceholder.localIdentifier
+
+                    // Limited-library access permits creating an asset, but does not reliably
+                    // permit enumerating or mutating arbitrary user albums. Save to the camera
+                    // roll and skip Mentra album mutation in that mode.
+                    guard !hasLimitedAccess else { return }
+
+                    let albumFetch = PHFetchOptions()
+                    albumFetch.predicate = NSPredicate(
+                        format: "localizedTitle == %@", MentraSyncedMediaAlbum.localizedTitle
                     )
+                    albumFetch.fetchLimit = 1
+
+                    let existingAlbums = PHAssetCollection.fetchAssetCollections(
+                        with: .album,
+                        subtype: .albumRegular,
+                        options: albumFetch
+                    )
+
+                    if let album = existingAlbums.firstObject,
+                       let albumChange = PHAssetCollectionChangeRequest(for: album)
+                    {
+                        albumChange.addAssets([assetPlaceholder] as NSArray)
+                    } else if existingAlbums.firstObject == nil {
+                        let newAlbumChange = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(
+                            withTitle: MentraSyncedMediaAlbum.localizedTitle
+                        )
+                        newAlbumChange.addAssets([assetPlaceholder] as NSArray)
+                    } else {
+                        NSLog(
+                            "CrustModule: Mentra album exists but is not writable; asset saved to library only"
+                        )
+                    }
                 }
-            } completionHandler: { success, error in
-                resultSucceeded = success
-                resultError = error
-                semaphore.signal()
-            }
-
-            if semaphore.wait(timeout: .now() + 120) == .timedOut {
-                return [
-                    "success": false,
-                    "error": "Photo library save timed out; retry will reconcile the result",
-                ]
-            }
-
-            if creationFailed {
-                return ["success": false, "error": "Failed to create PhotoKit asset placeholder"]
-            }
-
-            if let error = resultError {
+            } catch {
                 NSLog("CrustModule: Error saving to gallery: \(error.localizedDescription)")
                 return ["success": false, "error": error.localizedDescription]
             }
 
-            guard resultSucceeded else {
-                return ["success": false, "error": "Photo library did not commit the asset"]
+            if creationFailed {
+                return ["success": false, "error": "Failed to create PhotoKit asset placeholder"]
             }
 
             NSLog("CrustModule: Successfully saved to gallery with proper creation date")
@@ -565,7 +547,7 @@ public class CrustModule: Module {
         expectedFileSize: Int64?,
         captureDate: Date?,
         isVideo: Bool
-    ) -> String? {
+    ) async -> String? {
         guard !fileNames.isEmpty else { return nil }
         let options = PHFetchOptions()
         let mediaType = isVideo ? PHAssetMediaType.video : PHAssetMediaType.image
@@ -584,7 +566,7 @@ public class CrustModule: Module {
 
         let assets = PHAsset.fetchAssets(with: options)
         var stableIdentifiers: [String] = []
-        var legacyIdentifiers: [String] = []
+        var legacyCandidates: [PHAsset] = []
         assets.enumerateObjects { asset, _, _ in
             let resources = PHAssetResource.assetResources(for: asset)
             let stableMatch = stableFileName.map { stableName in
@@ -600,65 +582,61 @@ public class CrustModule: Module {
                 }
                 return true
             }
-            if legacyNameMatch,
-               let expectedFileSize,
-               self.assetOriginalFile(asset, matchesByteCount: expectedFileSize) {
+            if legacyNameMatch { legacyCandidates.append(asset) }
+        }
+        // Capture-derived names are stable. If an older retry already created duplicates,
+        // reuse the newest completed asset instead of inserting another.
+        if let stableIdentifier = stableIdentifiers.first { return stableIdentifier }
+
+        // PhotoKit's original-resource lookups are asynchronous. Resolve legacy candidates
+        // after enumeration so the fetch callback never blocks the Photos framework.
+        guard let expectedFileSize else { return nil }
+        var legacyIdentifiers: [String] = []
+        for asset in legacyCandidates {
+            if await self.assetOriginalFile(asset, matchesByteCount: expectedFileSize) {
                 legacyIdentifiers.append(asset.localIdentifier)
             }
         }
-        // Capture-derived names are stable. If an older retry already created duplicates,
-        // reuse the newest completed asset instead of inserting another. Legacy base names
-        // remain safe only when name + capture time + media type + size identify one asset.
-        return stableIdentifiers.first ?? (legacyIdentifiers.count == 1 ? legacyIdentifiers[0] : nil)
+        // Legacy base names remain safe only when name + capture time + media type + exact
+        // original byte size identify one asset.
+        return legacyIdentifiers.count == 1 ? legacyIdentifiers[0] : nil
     }
 
     /// PhotoKit does not expose resource byte size on the deployment targets we support.
-    /// Request the local original URL and inspect its file metadata instead of streaming a
-    /// potentially large video. Network access stays disabled: if the original is only in
-    /// iCloud, reconciliation fails closed and the caller creates a fresh local-library asset.
+    /// Inspect a video's local original URL or an image's original bytes asynchronously.
+    /// Network access stays disabled: if the original is only in iCloud, reconciliation fails
+    /// closed and the caller creates a fresh local-library asset instead of risking data loss.
     private func assetOriginalFile(
         _ asset: PHAsset,
         matchesByteCount expectedByteCount: Int64
-    ) -> Bool {
-        let semaphore = DispatchSemaphore(value: 0)
-        var matches = false
-
+    ) async -> Bool {
+        let manager = PHImageManager.default()
         if asset.mediaType == .video {
             let options = PHVideoRequestOptions()
             options.isNetworkAccessAllowed = false
             options.version = .original
-            let requestID = PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
-                if let originalURL = (avAsset as? AVURLAsset)?.url,
-                   let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
-                   let byteCount = attributes[.size] as? NSNumber {
-                    matches = byteCount.int64Value == expectedByteCount
+            return await withCheckedContinuation { continuation in
+                manager.requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
+                    guard let originalURL = (avAsset as? AVURLAsset)?.url,
+                          let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
+                          let byteCount = attributes[.size] as? NSNumber else {
+                        continuation.resume(returning: false)
+                        return
+                    }
+                    continuation.resume(returning: byteCount.int64Value == expectedByteCount)
                 }
-                semaphore.signal()
-            }
-
-            if semaphore.wait(timeout: .now() + 30) == .timedOut {
-                PHImageManager.default().cancelImageRequest(requestID)
-                return false
-            }
-        } else {
-            let options = PHContentEditingInputRequestOptions()
-            options.isNetworkAccessAllowed = false
-            let requestID = asset.requestContentEditingInput(with: options) { input, _ in
-                if let originalURL = input?.fullSizeImageURL,
-                   let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
-                   let byteCount = attributes[.size] as? NSNumber {
-                    matches = byteCount.int64Value == expectedByteCount
-                }
-                semaphore.signal()
-            }
-
-            if semaphore.wait(timeout: .now() + 30) == .timedOut {
-                asset.cancelContentEditingInputRequest(requestID)
-                return false
             }
         }
 
-        return matches
+        let options = PHImageRequestOptions()
+        options.isNetworkAccessAllowed = false
+        options.version = .original
+        options.deliveryMode = .highQualityFormat
+        return await withCheckedContinuation { continuation in
+            manager.requestImageDataAndOrientation(for: asset, options: options) { data, _, _, _ in
+                continuation.resume(returning: data.map { Int64($0.count) == expectedByteCount } ?? false)
+            }
+        }
     }
 }
 

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -432,6 +432,11 @@ public class CrustModule: Module {
             }
             let candidateFileNames = [assetFileName, fileURL.lastPathComponent]
                 .filter { !$0.isEmpty }
+            let stableFileName = assetFileName.hasPrefix("IMG_") || assetFileName.hasPrefix("VID_")
+                ? assetFileName
+                : nil
+            let fileAttributes = try? FileManager.default.attributesOfItem(atPath: filePath)
+            let expectedFileSize = (fileAttributes?[.size] as? NSNumber)?.int64Value
             let authorizationStatus: PHAuthorizationStatus
             if #available(iOS 14, *) {
                 authorizationStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
@@ -450,6 +455,8 @@ public class CrustModule: Module {
             // by our stable capture filename/date before creating another asset.
             if let existingIdentifier = self.findExistingGalleryAssetIdentifier(
                 fileNames: candidateFileNames,
+                stableFileName: stableFileName,
+                expectedFileSize: expectedFileSize,
                 captureDate: captureDate,
                 isVideo: isVideo
             ) {
@@ -554,6 +561,8 @@ public class CrustModule: Module {
 
     private func findExistingGalleryAssetIdentifier(
         fileNames: [String],
+        stableFileName: String?,
+        expectedFileSize: Int64?,
         captureDate: Date?,
         isVideo: Bool
     ) -> String? {
@@ -577,7 +586,13 @@ public class CrustModule: Module {
         var identifiers: [String] = []
         assets.enumerateObjects { asset, _, _ in
             let matches = PHAssetResource.assetResources(for: asset).contains {
-                fileNames.contains($0.originalFilename)
+                guard fileNames.contains($0.originalFilename) else { return false }
+                if $0.originalFilename == stableFileName {
+                    // Capture-derived names are stable and unique across Mentra exports.
+                    return true
+                }
+                guard let expectedFileSize else { return false }
+                return self.assetResource($0, matchesByteCount: expectedFileSize)
             }
             if matches {
                 identifiers.append(asset.localIdentifier)
@@ -586,6 +601,42 @@ public class CrustModule: Module {
         // Legacy base filenames were shared by every capture. Only reuse one when
         // filename + capture time + media type identify a single accessible asset.
         return identifiers.count == 1 ? identifiers[0] : nil
+    }
+
+    /// PhotoKit does not expose resource byte size on the deployment targets we support.
+    /// Stream a narrowed legacy candidate locally to verify it before reusing its receipt.
+    /// Network access stays disabled: if the original is only in iCloud, reconciliation fails
+    /// closed and the caller creates a fresh local-library asset instead of risking data loss.
+    private func assetResource(
+        _ resource: PHAssetResource,
+        matchesByteCount expectedByteCount: Int64
+    ) -> Bool {
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = false
+        let manager = PHAssetResourceManager.default()
+        let semaphore = DispatchSemaphore(value: 0)
+        var receivedByteCount: Int64 = 0
+        var resultError: Error?
+
+        let requestID = manager.requestData(
+            for: resource,
+            options: options,
+            dataReceivedHandler: { data in
+                // Once a candidate exceeds the expected size it cannot match. Keep the
+                // counter bounded even though PhotoKit may deliver the remaining chunks.
+                receivedByteCount = min(expectedByteCount + 1, receivedByteCount + Int64(data.count))
+            },
+            completionHandler: { error in
+                resultError = error
+                semaphore.signal()
+            }
+        )
+
+        if semaphore.wait(timeout: .now() + 30) == .timedOut {
+            manager.cancelDataRequest(requestID)
+            return false
+        }
+        return resultError == nil && receivedByteCount == expectedByteCount
     }
 }
 

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -583,24 +583,32 @@ public class CrustModule: Module {
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
         let assets = PHAsset.fetchAssets(with: options)
-        var identifiers: [String] = []
+        var stableIdentifiers: [String] = []
+        var legacyIdentifiers: [String] = []
         assets.enumerateObjects { asset, _, _ in
-            let matches = PHAssetResource.assetResources(for: asset).contains {
-                guard fileNames.contains($0.originalFilename) else { return false }
-                if $0.originalFilename == stableFileName {
-                    // Capture-derived names are stable and unique across Mentra exports.
-                    return true
+            let resources = PHAssetResource.assetResources(for: asset)
+            let stableMatch = stableFileName.map { stableName in
+                resources.contains { $0.originalFilename == stableName }
+            } ?? false
+            if stableMatch {
+                stableIdentifiers.append(asset.localIdentifier)
+                return
+            }
+            let legacyMatch = resources.contains {
+                guard fileNames.contains($0.originalFilename), $0.originalFilename != stableFileName else {
+                    return false
                 }
                 guard let expectedFileSize else { return false }
                 return self.assetResource($0, matchesByteCount: expectedFileSize)
             }
-            if matches {
-                identifiers.append(asset.localIdentifier)
+            if legacyMatch {
+                legacyIdentifiers.append(asset.localIdentifier)
             }
         }
-        // Legacy base filenames were shared by every capture. Only reuse one when
-        // filename + capture time + media type identify a single accessible asset.
-        return identifiers.count == 1 ? identifiers[0] : nil
+        // Capture-derived names are stable. If an older retry already created duplicates,
+        // reuse the newest completed asset instead of inserting another. Legacy base names
+        // remain safe only when name + capture time + media type + size identify one asset.
+        return stableIdentifiers.first ?? (legacyIdentifiers.count == 1 ? legacyIdentifiers[0] : nil)
     }
 
     /// PhotoKit does not expose resource byte size on the deployment targets we support.

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -594,14 +594,15 @@ public class CrustModule: Module {
                 stableIdentifiers.append(asset.localIdentifier)
                 return
             }
-            let legacyMatch = resources.contains {
+            let legacyNameMatch = resources.contains {
                 guard fileNames.contains($0.originalFilename), $0.originalFilename != stableFileName else {
                     return false
                 }
-                guard let expectedFileSize else { return false }
-                return self.assetResource($0, matchesByteCount: expectedFileSize)
+                return true
             }
-            if legacyMatch {
+            if legacyNameMatch,
+               let expectedFileSize,
+               self.assetOriginalFile(asset, matchesByteCount: expectedFileSize) {
                 legacyIdentifiers.append(asset.localIdentifier)
             }
         }
@@ -612,39 +613,52 @@ public class CrustModule: Module {
     }
 
     /// PhotoKit does not expose resource byte size on the deployment targets we support.
-    /// Stream a narrowed legacy candidate locally to verify it before reusing its receipt.
-    /// Network access stays disabled: if the original is only in iCloud, reconciliation fails
-    /// closed and the caller creates a fresh local-library asset instead of risking data loss.
-    private func assetResource(
-        _ resource: PHAssetResource,
+    /// Request the local original URL and inspect its file metadata instead of streaming a
+    /// potentially large video. Network access stays disabled: if the original is only in
+    /// iCloud, reconciliation fails closed and the caller creates a fresh local-library asset.
+    private func assetOriginalFile(
+        _ asset: PHAsset,
         matchesByteCount expectedByteCount: Int64
     ) -> Bool {
-        let options = PHAssetResourceRequestOptions()
-        options.isNetworkAccessAllowed = false
-        let manager = PHAssetResourceManager.default()
         let semaphore = DispatchSemaphore(value: 0)
-        var receivedByteCount: Int64 = 0
-        var resultError: Error?
+        var matches = false
 
-        let requestID = manager.requestData(
-            for: resource,
-            options: options,
-            dataReceivedHandler: { data in
-                // Once a candidate exceeds the expected size it cannot match. Keep the
-                // counter bounded even though PhotoKit may deliver the remaining chunks.
-                receivedByteCount = min(expectedByteCount + 1, receivedByteCount + Int64(data.count))
-            },
-            completionHandler: { error in
-                resultError = error
+        if asset.mediaType == .video {
+            let options = PHVideoRequestOptions()
+            options.isNetworkAccessAllowed = false
+            options.version = .original
+            let requestID = PHImageManager.default().requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
+                if let originalURL = (avAsset as? AVURLAsset)?.url,
+                   let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
+                   let byteCount = attributes[.size] as? NSNumber {
+                    matches = byteCount.int64Value == expectedByteCount
+                }
                 semaphore.signal()
             }
-        )
 
-        if semaphore.wait(timeout: .now() + 30) == .timedOut {
-            manager.cancelDataRequest(requestID)
-            return false
+            if semaphore.wait(timeout: .now() + 30) == .timedOut {
+                PHImageManager.default().cancelImageRequest(requestID)
+                return false
+            }
+        } else {
+            let options = PHContentEditingInputRequestOptions()
+            options.isNetworkAccessAllowed = false
+            let requestID = asset.requestContentEditingInput(with: options) { input, _ in
+                if let originalURL = input?.fullSizeImageURL,
+                   let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
+                   let byteCount = attributes[.size] as? NSNumber {
+                    matches = byteCount.int64Value == expectedByteCount
+                }
+                semaphore.signal()
+            }
+
+            if semaphore.wait(timeout: .now() + 30) == .timedOut {
+                asset.cancelContentEditingInputRequest(requestID)
+                return false
+            }
         }
-        return resultError == nil && receivedByteCount == expectedByteCount
+
+        return matches
     }
 }
 

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -8,6 +8,59 @@ private enum MentraSyncedMediaAlbum {
     static let localizedTitle = "Mentra"
 }
 
+/// Serializes callback and timeout delivery for PhotoKit APIs that may call back more than once.
+private final class CheckedContinuationGate<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Never>?
+
+    init(_ continuation: CheckedContinuation<Value, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume(returning value: Value) {
+        lock.lock()
+        guard let continuation else {
+            lock.unlock()
+            return
+        }
+        self.continuation = nil
+        lock.unlock()
+        continuation.resume(returning: value)
+    }
+}
+
+private final class PhotoLibrarySaveState: @unchecked Sendable {
+    private let lock = NSLock()
+    private var assetIdentifier: String?
+    private var creationFailed = false
+
+    func setAssetIdentifier(_ identifier: String) {
+        lock.lock()
+        assetIdentifier = identifier
+        lock.unlock()
+    }
+
+    func markCreationFailed() {
+        lock.lock()
+        creationFailed = true
+        lock.unlock()
+    }
+
+    func snapshot() -> (assetIdentifier: String?, creationFailed: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (assetIdentifier, creationFailed)
+    }
+}
+
+private struct PhotoLibrarySaveResult {
+    let succeeded: Bool
+    let assetIdentifier: String?
+    let creationFailed: Bool
+    let errorMessage: String?
+    let timedOut: Bool
+}
+
 public class CrustModule: Module {
     public func definition() -> ModuleDefinition {
         Name("Crust")
@@ -468,76 +521,119 @@ public class CrustModule: Module {
                 ]
             }
 
-            var assetIdentifier: String?
-            var creationFailed = false
-
-            do {
-                try await PHPhotoLibrary.shared().performChanges {
-                    let creationRequest = PHAssetCreationRequest.forAsset()
-                    let resourceOptions = PHAssetResourceCreationOptions()
-                    resourceOptions.originalFilename = assetFileName
-                    creationRequest.addResource(
-                        with: isVideo ? .video : .photo,
-                        fileURL: fileURL,
-                        options: resourceOptions
-                    )
-
-                    if let captureDate {
-                        creationRequest.creationDate = captureDate
-                        NSLog("CrustModule: Setting creation date to: \(captureDate)")
-                    }
-
-                    guard let assetPlaceholder = creationRequest.placeholderForCreatedAsset else {
-                        NSLog("CrustModule: Missing placeholder for created asset")
-                        creationFailed = true
-                        return
-                    }
-
-                    assetIdentifier = assetPlaceholder.localIdentifier
-
-                    // Limited-library access permits creating an asset, but does not reliably
-                    // permit enumerating or mutating arbitrary user albums. Save to the camera
-                    // roll and skip Mentra album mutation in that mode.
-                    guard !hasLimitedAccess else { return }
-
-                    let albumFetch = PHFetchOptions()
-                    albumFetch.predicate = NSPredicate(
-                        format: "localizedTitle == %@", MentraSyncedMediaAlbum.localizedTitle
-                    )
-                    albumFetch.fetchLimit = 1
-
-                    let existingAlbums = PHAssetCollection.fetchAssetCollections(
-                        with: .album,
-                        subtype: .albumRegular,
-                        options: albumFetch
-                    )
-
-                    if let album = existingAlbums.firstObject,
-                       let albumChange = PHAssetCollectionChangeRequest(for: album)
-                    {
-                        albumChange.addAssets([assetPlaceholder] as NSArray)
-                    } else if existingAlbums.firstObject == nil {
-                        let newAlbumChange = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(
-                            withTitle: MentraSyncedMediaAlbum.localizedTitle
-                        )
-                        newAlbumChange.addAssets([assetPlaceholder] as NSArray)
-                    } else {
-                        NSLog(
-                            "CrustModule: Mentra album exists but is not writable; asset saved to library only"
-                        )
-                    }
-                }
-            } catch {
-                NSLog("CrustModule: Error saving to gallery: \(error.localizedDescription)")
-                return ["success": false, "error": error.localizedDescription]
+            let saveResult = await self.createGalleryAsset(
+                fileURL: fileURL,
+                assetFileName: assetFileName,
+                captureDate: captureDate,
+                isVideo: isVideo,
+                hasLimitedAccess: hasLimitedAccess
+            )
+            if saveResult.timedOut {
+                return [
+                    "success": false,
+                    "error": "Photo library save timed out; retry will reconcile the result",
+                ]
             }
-
-            if creationFailed {
+            if saveResult.creationFailed {
                 return ["success": false, "error": "Failed to create PhotoKit asset placeholder"]
+            }
+            if let errorMessage = saveResult.errorMessage {
+                NSLog("CrustModule: Error saving to gallery: \(errorMessage)")
+                return ["success": false, "error": errorMessage]
+            }
+            guard saveResult.succeeded else {
+                return ["success": false, "error": "Photo library did not commit the asset"]
             }
 
             NSLog("CrustModule: Successfully saved to gallery with proper creation date")
-            return ["success": true, "identifier": assetIdentifier ?? ""]
+            return ["success": true, "identifier": saveResult.assetIdentifier ?? ""]
+        }
+    }
+
+    private func createGalleryAsset(
+        fileURL: URL,
+        assetFileName: String,
+        captureDate: Date?,
+        isVideo: Bool,
+        hasLimitedAccess: Bool
+    ) async -> PhotoLibrarySaveResult {
+        await withCheckedContinuation { continuation in
+            let gate = CheckedContinuationGate(continuation)
+            let state = PhotoLibrarySaveState()
+
+            PHPhotoLibrary.shared().performChanges {
+                let creationRequest = PHAssetCreationRequest.forAsset()
+                let resourceOptions = PHAssetResourceCreationOptions()
+                resourceOptions.originalFilename = assetFileName
+                creationRequest.addResource(
+                    with: isVideo ? .video : .photo,
+                    fileURL: fileURL,
+                    options: resourceOptions
+                )
+
+                if let captureDate {
+                    creationRequest.creationDate = captureDate
+                    NSLog("CrustModule: Setting creation date to: \(captureDate)")
+                }
+
+                guard let assetPlaceholder = creationRequest.placeholderForCreatedAsset else {
+                    NSLog("CrustModule: Missing placeholder for created asset")
+                    state.markCreationFailed()
+                    return
+                }
+                state.setAssetIdentifier(assetPlaceholder.localIdentifier)
+
+                // Limited-library access permits creating an asset, but does not reliably
+                // permit enumerating or mutating arbitrary user albums. Save to the camera
+                // roll and skip Mentra album mutation in that mode.
+                guard !hasLimitedAccess else { return }
+
+                let albumFetch = PHFetchOptions()
+                albumFetch.predicate = NSPredicate(
+                    format: "localizedTitle == %@", MentraSyncedMediaAlbum.localizedTitle
+                )
+                albumFetch.fetchLimit = 1
+                let existingAlbums = PHAssetCollection.fetchAssetCollections(
+                    with: .album,
+                    subtype: .albumRegular,
+                    options: albumFetch
+                )
+
+                if let album = existingAlbums.firstObject,
+                   let albumChange = PHAssetCollectionChangeRequest(for: album)
+                {
+                    albumChange.addAssets([assetPlaceholder] as NSArray)
+                } else if existingAlbums.firstObject == nil {
+                    let newAlbumChange = PHAssetCollectionChangeRequest.creationRequestForAssetCollection(
+                        withTitle: MentraSyncedMediaAlbum.localizedTitle
+                    )
+                    newAlbumChange.addAssets([assetPlaceholder] as NSArray)
+                } else {
+                    NSLog(
+                        "CrustModule: Mentra album exists but is not writable; asset saved to library only"
+                    )
+                }
+            } completionHandler: { succeeded, error in
+                let snapshot = state.snapshot()
+                gate.resume(returning: PhotoLibrarySaveResult(
+                    succeeded: succeeded,
+                    assetIdentifier: snapshot.assetIdentifier,
+                    creationFailed: snapshot.creationFailed,
+                    errorMessage: error?.localizedDescription,
+                    timedOut: false
+                ))
+            }
+
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 120) {
+                let snapshot = state.snapshot()
+                gate.resume(returning: PhotoLibrarySaveResult(
+                    succeeded: false,
+                    assetIdentifier: snapshot.assetIdentifier,
+                    creationFailed: snapshot.creationFailed,
+                    errorMessage: nil,
+                    timedOut: true
+                ))
+            }
         }
     }
 
@@ -616,14 +712,19 @@ public class CrustModule: Module {
             options.isNetworkAccessAllowed = false
             options.version = .original
             return await withCheckedContinuation { continuation in
-                manager.requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
+                let gate = CheckedContinuationGate(continuation)
+                let requestID = manager.requestAVAsset(forVideo: asset, options: options) { avAsset, _, _ in
                     guard let originalURL = (avAsset as? AVURLAsset)?.url,
                           let attributes = try? FileManager.default.attributesOfItem(atPath: originalURL.path),
                           let byteCount = attributes[.size] as? NSNumber else {
-                        continuation.resume(returning: false)
+                        gate.resume(returning: false)
                         return
                     }
-                    continuation.resume(returning: byteCount.int64Value == expectedByteCount)
+                    gate.resume(returning: byteCount.int64Value == expectedByteCount)
+                }
+                DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 30) {
+                    manager.cancelImageRequest(requestID)
+                    gate.resume(returning: false)
                 }
             }
         }
@@ -633,8 +734,14 @@ public class CrustModule: Module {
         options.version = .original
         options.deliveryMode = .highQualityFormat
         return await withCheckedContinuation { continuation in
-            manager.requestImageDataAndOrientation(for: asset, options: options) { data, _, _, _ in
-                continuation.resume(returning: data.map { Int64($0.count) == expectedByteCount } ?? false)
+            let gate = CheckedContinuationGate(continuation)
+            let requestID = manager.requestImageDataAndOrientation(for: asset, options: options) { data, _, _, info in
+                if info?[PHImageResultIsDegradedKey] as? Bool == true { return }
+                gate.resume(returning: data.map { Int64($0.count) == expectedByteCount } ?? false)
+            }
+            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 30) {
+                manager.cancelImageRequest(requestID)
+                gate.resume(returning: false)
             }
         }
     }

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -661,7 +661,7 @@ public class CrustModule: Module {
         options.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
 
         let assets = PHAsset.fetchAssets(with: options)
-        var stableIdentifiers: [String] = []
+        var stableCandidates: [PHAsset] = []
         var legacyCandidates: [PHAsset] = []
         assets.enumerateObjects { asset, _, _ in
             let resources = PHAssetResource.assetResources(for: asset)
@@ -669,7 +669,7 @@ public class CrustModule: Module {
                 resources.contains { $0.originalFilename == stableName }
             } ?? false
             if stableMatch {
-                stableIdentifiers.append(asset.localIdentifier)
+                stableCandidates.append(asset)
                 return
             }
             let legacyNameMatch = resources.contains {
@@ -680,13 +680,17 @@ public class CrustModule: Module {
             }
             if legacyNameMatch { legacyCandidates.append(asset) }
         }
-        // Capture-derived names are stable. If an older retry already created duplicates,
-        // reuse the newest completed asset instead of inserting another.
-        if let stableIdentifier = stableIdentifiers.first { return stableIdentifier }
-
-        // PhotoKit's original-resource lookups are asynchronous. Resolve legacy candidates
-        // after enumeration so the fetch callback never blocks the Photos framework.
         guard let expectedFileSize else { return nil }
+        // PhotoKit's original-resource lookups are asynchronous. Resolve candidates after
+        // enumeration so the fetch callback never blocks the Photos framework. Stable names
+        // may repeat across a restored/older library; require the generation's exact byte size
+        // and reuse the newest matching completed asset.
+        for asset in stableCandidates {
+            if await self.assetOriginalFile(asset, matchesByteCount: expectedFileSize) {
+                return asset.localIdentifier
+            }
+        }
+
         var legacyIdentifiers: [String] = []
         for asset in legacyCandidates {
             if await self.assetOriginalFile(asset, matchesByteCount: expectedFileSize) {

--- a/mobile/modules/engine/src/internal.ts
+++ b/mobile/modules/engine/src/internal.ts
@@ -115,6 +115,7 @@ export {asgCameraApi} from "./services/asg/asgCameraApi"
 export {localStorageService} from "./services/asg/localStorageService"
 export {mediaProcessingQueue} from "./services/asg/mediaProcessingQueue"
 export {gallerySettingsService} from "./services/asg/gallerySettingsService"
+export {cameraRollExportCoordinator, type CameraRollExportSummary} from "./services/asg/cameraRollExportCoordinator"
 export {
   INVALID_DOWNLOADED_MEDIA,
   validateCaptureMetadataForDownload,

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -162,9 +162,32 @@ class CameraRollExportCoordinator {
     const entry = await this.recordIndexed(file, true, "SOURCE_BARRIER", captureId)
     if (entry.receipt) return entry.receipt
     return new Promise<GalleryAssetReceipt>((resolve, reject) => {
+      const current = cameraRollExportLedger.get(entry.id)
+      if (current?.receipt) {
+        resolve(current.receipt)
+        return
+      }
+      if (!current) {
+        reject(new Error("Camera-roll export was removed before its source barrier registered"))
+        return
+      }
       const waiters = this.sourceWaiters.get(entry.id) || []
       waiters.push({resolve, reject})
       this.sourceWaiters.set(entry.id, waiters)
+      // Re-read after registration so any future refactor that yields while installing a
+      // waiter still cannot miss a receipt committed by the active runner.
+      const registered = cameraRollExportLedger.get(entry.id)
+      if (registered?.receipt) {
+        this.resolveSourceWaiters(entry.id, registered.receipt)
+        return
+      }
+      if (!registered) {
+        this.rejectSourceWaiters(
+          entry.id,
+          new Error("Camera-roll export was removed before its source barrier registered"),
+        )
+        return
+      }
       void this.resume("source barrier")
     })
   }
@@ -220,24 +243,27 @@ class CameraRollExportCoordinator {
       while (this.running) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
       }
+      // The active drain normally consumes rerunRequested before releasing running. Keep
+      // this final durable-work check so a late handoff can never strand an eligible entry.
+      if (this.nextEntry()) await this.resume("work remained after concurrent resume")
       return
     }
     this.running = true
-    this.rerunRequested = false
     this.emitSummary()
     try {
-      let entry = this.nextEntry()
-      while (entry) {
-        await this.processEntry(entry)
-        entry = this.nextEntry()
-      }
+      do {
+        this.rerunRequested = false
+        let entry = this.nextEntry()
+        while (entry) {
+          await this.processEntry(entry)
+          entry = this.nextEntry()
+        }
+      } while (this.rerunRequested)
     } finally {
-      const shouldRerun = this.rerunRequested
       this.rerunRequested = false
       this.running = false
       this.emitSummary()
       this.scheduleRetry()
-      if (shouldRerun) void this.resume("work arrived")
     }
   }
 

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -337,7 +337,18 @@ class CameraRollExportCoordinator {
     }
   }
 
-  retryNow(): void {
+  async retryNow(): Promise<void> {
+    const generation = this.lifecycleGeneration
+    await this.initialize()
+    // A recovered transfer may have rebuilt a missing local-index row since the last lifecycle
+    // reconciliation. Refresh before retrying so the same camera-roll generation becomes
+    // eligible again; never rewrite entry state underneath an active native insert.
+    while (this.running) {
+      await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+    }
+    if (generation !== this.lifecycleGeneration) return
+    await this.reconcileLocalIndex()
+    if (generation !== this.lifecycleGeneration) return
     for (const entry of cameraRollExportLedger.list()) {
       if (
         entry.state === "FAILED_RETRYABLE" ||
@@ -347,7 +358,7 @@ class CameraRollExportCoordinator {
         cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined, lastError: undefined})
       }
     }
-    void this.resume("manual retry")
+    await this.resume("manual retry")
   }
 
   subscribe(listener: SummaryListener): () => void {
@@ -359,7 +370,12 @@ class CameraRollExportCoordinator {
   }
 
   getSummary(): CameraRollExportSummary {
-    const entries = cameraRollExportLedger.list().filter((entry) => entry.localPresent !== false)
+    const entries = cameraRollExportLedger
+      .list()
+      // Exported receipts with no local row are hidden deduplication tombstones. Unexported
+      // missing generations remain user-visible so data that can no longer be backfilled is
+      // never reported as successfully saved.
+      .filter((entry) => entry.localPresent !== false || entry.state === "MISSING_LOCAL")
     const pendingStates = new Set([
       "LEGACY_UNKNOWN",
       "QUEUED",

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -313,7 +313,8 @@ class CameraRollExportCoordinator {
     }
   }
 
-  countNotExported(mediaNames: string[]): number {
+  async countNotExported(mediaNames: string[]): Promise<number> {
+    await this.initialize()
     const entries = cameraRollExportLedger.list()
     return new Set(mediaNames).size === 0
       ? 0

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -202,44 +202,56 @@ class CameraRollExportCoordinator {
     return entry
   }
 
-  /** Source deletion waits on this barrier; historical work never blocks a glasses sync. */
-  async exportForSource(file: DownloadedFile, captureId?: string): Promise<GalleryAssetReceipt> {
+  async isAutoSaveEnabled(): Promise<boolean> {
+    await this.initialize()
+    return this.enabled
+  }
+
+  /** Source deletion waits on this barrier while enabled; disabled exports remain safely app-local. */
+  async exportForSource(file: DownloadedFile, captureId?: string): Promise<GalleryAssetReceipt | undefined> {
     await this.initialize()
     // A durable receipt proves this generation is already safe regardless of the current
     // preference. Return it before enforcing disabled state so recovery can still ack the
     // glasses after a previously-started export committed.
     const entry = await this.recordIndexed(file, this.enabled, "SOURCE_BARRIER", captureId)
     if (entry.receipt) return entry.receipt
-    if (!this.enabled) throw new Error("Automatic camera-roll saving is disabled")
-    return new Promise<GalleryAssetReceipt>((resolve, reject) => {
-      const current = cameraRollExportLedger.get(entry.id)
-      if (current?.receipt) {
-        resolve(current.receipt)
-        return
-      }
-      if (!current) {
-        reject(new Error("Camera-roll export was removed before its source barrier registered"))
-        return
-      }
-      const waiters = this.sourceWaiters.get(entry.id) || []
-      waiters.push({resolve, reject})
-      this.sourceWaiters.set(entry.id, waiters)
-      // Re-read after registration so any future refactor that yields while installing a
-      // waiter still cannot miss a receipt committed by the active runner.
-      const registered = cameraRollExportLedger.get(entry.id)
-      if (registered?.receipt) {
-        this.resolveSourceWaiters(entry.id, registered.receipt)
-        return
-      }
-      if (!registered) {
-        this.rejectSourceWaiters(
-          entry.id,
-          new Error("Camera-roll export was removed before its source barrier registered"),
-        )
-        return
-      }
-      void this.resume("source barrier")
-    })
+    if (!this.enabled) return undefined
+    try {
+      return await new Promise<GalleryAssetReceipt>((resolve, reject) => {
+        const current = cameraRollExportLedger.get(entry.id)
+        if (current?.receipt) {
+          resolve(current.receipt)
+          return
+        }
+        if (!current) {
+          reject(new Error("Camera-roll export was removed before its source barrier registered"))
+          return
+        }
+        const waiters = this.sourceWaiters.get(entry.id) || []
+        waiters.push({resolve, reject})
+        this.sourceWaiters.set(entry.id, waiters)
+        // Re-read after registration so any future refactor that yields while installing a
+        // waiter still cannot miss a receipt committed by the active runner.
+        const registered = cameraRollExportLedger.get(entry.id)
+        if (registered?.receipt) {
+          this.resolveSourceWaiters(entry.id, registered.receipt)
+          return
+        }
+        if (!registered) {
+          this.rejectSourceWaiters(
+            entry.id,
+            new Error("Camera-roll export was removed before its source barrier registered"),
+          )
+          return
+        }
+        void this.resume("source barrier")
+      })
+    } catch (error) {
+      // Turning auto-save off makes the durable app-local commit the source-of-truth. A native
+      // insert already in progress still finishes and returns its receipt; queued work may stop.
+      if (!this.enabled) return undefined
+      throw error
+    }
   }
 
   async setEnabled(enabled: boolean): Promise<void> {

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -97,9 +97,11 @@ class CameraRollExportCoordinator {
   private async reconcileLocalIndex(): Promise<void> {
     const files = await localStorageService.getDownloadedFiles()
     const liveIds = new Set<string>()
+    const liveGenerationByMediaName = new Map<string, string>()
     for (const file of Object.values(files)) {
       const id = cameraRollEntryId(file.name, file.size, file.modified)
       liveIds.add(id)
+      liveGenerationByMediaName.set(file.name, id)
       const current = cameraRollExportLedger.get(id)
       const transfer = file.capture_id
         ? galleryTransferLedger.get(file.capture_id)
@@ -123,6 +125,7 @@ class CameraRollExportCoordinator {
           state: "LEGACY_UNKNOWN" as const,
         }),
         filePath: file.filePath,
+        localPresent: true,
         receipt,
         requiresFullLibraryReconciliation:
           current?.requiresFullLibraryReconciliation ?? (!current && !receipt && !transfer),
@@ -130,9 +133,28 @@ class CameraRollExportCoordinator {
       })
     }
 
-    // Do not let stale generations recreate media after the user replaced/deleted local files.
+    // Explicit app deletion removes receipts through deleteLocalMedia/clearLocalMedia. An index
+    // miss here is not proof of deletion: recovery may not have rebuilt the row yet, and a load
+    // failure is represented as an empty index. Preserve exported receipts as hidden tombstones;
+    // they are the authoritative proof that prevents a duplicate native-library insert.
     for (const entry of cameraRollExportLedger.list()) {
-      if (!liveIds.has(entry.id)) cameraRollExportLedger.remove(entry.id)
+      if (liveIds.has(entry.id)) continue
+      if (entry.receipt) {
+        cameraRollExportLedger.update(entry.id, {state: "EXPORTED", localPresent: false})
+        continue
+      }
+      // A different live generation with the same display name supersedes an unexported stale
+      // row. Never let its old path export the replacement's bytes under the wrong fingerprint.
+      if (liveGenerationByMediaName.has(entry.mediaName)) {
+        cameraRollExportLedger.remove(entry.id)
+        continue
+      }
+      cameraRollExportLedger.update(entry.id, {
+        state: "MISSING_LOCAL",
+        localPresent: false,
+        lastError: "Local media is missing",
+        nextRetryAt: undefined,
+      })
     }
   }
 
@@ -168,6 +190,7 @@ class CameraRollExportCoordinator {
       modified: file.modified,
       isVideo: file.is_video,
       captureId: captureId || file.capture_id || current?.captureId,
+      localPresent: true,
       requiresFullLibraryReconciliation: current?.requiresFullLibraryReconciliation ?? false,
       priority,
       receipt: file.assetReceipt || current?.receipt,
@@ -307,7 +330,7 @@ class CameraRollExportCoordinator {
       if (
         entry.state === "FAILED_RETRYABLE" ||
         entry.state === "BLOCKED_PERMISSION" ||
-        entry.state === "MISSING_LOCAL"
+        (entry.state === "MISSING_LOCAL" && entry.localPresent !== false)
       ) {
         cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined, lastError: undefined})
       }
@@ -324,7 +347,7 @@ class CameraRollExportCoordinator {
   }
 
   getSummary(): CameraRollExportSummary {
-    const entries = cameraRollExportLedger.list()
+    const entries = cameraRollExportLedger.list().filter((entry) => entry.localPresent !== false)
     const pendingStates = new Set([
       "LEGACY_UNKNOWN",
       "QUEUED",
@@ -354,12 +377,15 @@ class CameraRollExportCoordinator {
 
   async countNotExported(mediaNames: string[]): Promise<number> {
     await this.initialize()
-    const entries = cameraRollExportLedger.list()
-    return new Set(mediaNames).size === 0
-      ? 0
-      : [...new Set(mediaNames)].filter(
-          (name) => !entries.some((entry) => entry.mediaName === name && entry.state === "EXPORTED"),
-        ).length
+    const uniqueNames = [...new Set(mediaNames)]
+    if (uniqueNames.length === 0) return 0
+    const files = await localStorageService.getDownloadedFiles()
+    return uniqueNames.filter((name) => {
+      const file = files[name]
+      if (!file) return true
+      const entry = cameraRollExportLedger.get(cameraRollEntryId(file.name, file.size, file.modified))
+      return entry?.state !== "EXPORTED"
+    }).length
   }
 
   /** Serialize local deletion against an in-flight native copy of the same item. */
@@ -414,6 +440,7 @@ class CameraRollExportCoordinator {
     return cameraRollExportLedger
       .list()
       .filter((entry) => {
+        if (entry.localPresent === false) return false
         if (this.clearInProgress || this.deletingMediaNames.has(entry.mediaName)) return false
         if (entry.receipt || entry.state === "EXPORTED" || entry.state === "MISSING_LOCAL") return false
         if (!this.enabled) return false

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -158,9 +158,12 @@ class CameraRollExportCoordinator {
   /** Source deletion waits on this barrier; historical work never blocks a glasses sync. */
   async exportForSource(file: DownloadedFile, captureId?: string): Promise<GalleryAssetReceipt> {
     await this.initialize()
-    if (!this.enabled) throw new Error("Automatic camera-roll saving is disabled")
-    const entry = await this.recordIndexed(file, true, "SOURCE_BARRIER", captureId)
+    // A durable receipt proves this generation is already safe regardless of the current
+    // preference. Return it before enforcing disabled state so recovery can still ack the
+    // glasses after a previously-started export committed.
+    const entry = await this.recordIndexed(file, this.enabled, "SOURCE_BARRIER", captureId)
     if (entry.receipt) return entry.receipt
+    if (!this.enabled) throw new Error("Automatic camera-roll saving is disabled")
     return new Promise<GalleryAssetReceipt>((resolve, reject) => {
       const current = cameraRollExportLedger.get(entry.id)
       if (current?.receipt) {

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -24,6 +24,7 @@ export interface CameraRollExportSummary {
   pending: number
   failed: number
   blockedPermission: number
+  fullAccessRequired: number
   missing: number
   bytesPending: number
   isRunning: boolean
@@ -102,6 +103,7 @@ class CameraRollExportCoordinator {
         }),
         filePath: file.filePath,
         receipt,
+        requiresFullLibraryReconciliation: current?.requiresFullLibraryReconciliation ?? (!current && !receipt),
         state: receipt ? "EXPORTED" : this.nextEligibleState(current?.state),
       })
     }
@@ -142,6 +144,7 @@ class CameraRollExportCoordinator {
       modified: file.modified,
       isVideo: file.is_video,
       captureId: captureId || file.capture_id || current?.captureId,
+      requiresFullLibraryReconciliation: current?.requiresFullLibraryReconciliation ?? false,
       priority,
       receipt: file.assetReceipt || current?.receipt,
       state: file.assetReceipt || current?.receipt ? "EXPORTED" : shouldAutoSave ? "QUEUED" : "NOT_REQUESTED",
@@ -192,9 +195,10 @@ class CameraRollExportCoordinator {
     console.log(`${TAG} Resume requested: ${reason}`)
     if (cameraRollExportLedger.list().some((entry) => entry.state === "BLOCKED_PERMISSION")) {
       const hasPermission = await MediaLibraryPermissions.checkPermission()
+      const hasLimitedAccess = hasPermission && (await MediaLibraryPermissions.hasLimitedAccess())
       if (hasPermission) {
         for (const entry of cameraRollExportLedger.list()) {
-          if (entry.state === "BLOCKED_PERMISSION") {
+          if (entry.state === "BLOCKED_PERMISSION" && !(entry.requiresFullLibraryReconciliation && hasLimitedAccess)) {
             cameraRollExportLedger.update(entry.id, {state: "QUEUED", lastError: undefined})
           }
         }
@@ -263,6 +267,9 @@ class CameraRollExportCoordinator {
       failed: entries.filter((entry) => entry.state === "FAILED_RETRYABLE" || entry.state === "FAILED_PERMANENT")
         .length,
       blockedPermission: entries.filter((entry) => entry.state === "BLOCKED_PERMISSION").length,
+      fullAccessRequired: entries.filter(
+        (entry) => entry.state === "BLOCKED_PERMISSION" && entry.requiresFullLibraryReconciliation,
+      ).length,
       missing: entries.filter((entry) => entry.state === "MISSING_LOCAL").length,
       bytesPending: entries
         .filter((entry) => pendingStates.has(entry.state))
@@ -283,13 +290,14 @@ class CameraRollExportCoordinator {
   /** Serialize local deletion against an in-flight native copy of the same item. */
   async deleteLocalMedia(mediaName: string): Promise<boolean> {
     this.deletingMediaNames.add(mediaName)
-    const entries = cameraRollExportLedger.list().filter((entry) => entry.mediaName === mediaName)
-    for (const entry of entries) {
-      this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
-    }
     try {
       while (this.activeEntryId && cameraRollExportLedger.get(this.activeEntryId)?.mediaName === mediaName) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+      }
+      // An already-running export gets to finish and resolve its source barrier. Queued work
+      // cannot start while the name is in deletingMediaNames, so reject only what remains.
+      for (const entry of cameraRollExportLedger.list().filter((candidate) => candidate.mediaName === mediaName)) {
+        this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
       }
       const deleted = await localStorageService.deleteDownloadedFile(mediaName)
       if (deleted) cameraRollExportLedger.removeForMedia(mediaName)
@@ -304,12 +312,13 @@ class CameraRollExportCoordinator {
   /** Stop scheduling exports, finish the current native copy, then atomically clear app media + receipts. */
   async clearLocalMedia(): Promise<void> {
     this.clearInProgress = true
-    for (const entry of cameraRollExportLedger.list()) {
-      this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
-    }
     try {
       while (this.activeEntryId) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+      }
+      // Let the active native copy deliver its receipt before rejecting queued barriers.
+      for (const entry of cameraRollExportLedger.list()) {
+        this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
       }
       await localStorageService.clearAllFiles()
       cameraRollExportLedger.clear()
@@ -353,6 +362,13 @@ class CameraRollExportCoordinator {
         })
         throw new Error("Camera-roll permission is required")
       }
+      if (entry.requiresFullLibraryReconciliation && (await MediaLibraryPermissions.hasLimitedAccess())) {
+        cameraRollExportLedger.update(entry.id, {
+          state: "BLOCKED_PERMISSION",
+          lastError: "Full photo-library access is required to reconcile this legacy export safely",
+        })
+        throw new Error("Full photo-library access is required to reconcile this legacy export safely")
+      }
       const fsInfo = await RNFS.getFSInfo()
       if (fsInfo.freeSpace < entry.size + MIN_FREE_SPACE_BYTES) {
         throw new Error("Insufficient free space for camera-roll export")
@@ -371,6 +387,7 @@ class CameraRollExportCoordinator {
       entry = cameraRollExportLedger.update(entry.id, {
         state: "EXPORTED",
         receipt,
+        requiresFullLibraryReconciliation: false,
         attempts: entry.attempts + 1,
         nextRetryAt: undefined,
         lastError: undefined,

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -157,6 +157,8 @@ class CameraRollExportCoordinator {
 
   /** Source deletion waits on this barrier; historical work never blocks a glasses sync. */
   async exportForSource(file: DownloadedFile, captureId?: string): Promise<GalleryAssetReceipt> {
+    await this.initialize()
+    if (!this.enabled) throw new Error("Automatic camera-roll saving is disabled")
     const entry = await this.recordIndexed(file, true, "SOURCE_BARRIER", captureId)
     if (entry.receipt) return entry.receipt
     return new Promise<GalleryAssetReceipt>((resolve, reject) => {
@@ -173,10 +175,15 @@ class CameraRollExportCoordinator {
     await gallerySettingsService.setAutoSaveToCameraRoll(enabled)
     try {
       this.enabled = enabled
+      if (!enabled && this.retryTimer != null) {
+        BgTimer.clearTimeout(this.retryTimer)
+        this.retryTimer = null
+      }
       for (const entry of cameraRollExportLedger.list()) {
         if (entry.receipt || entry.state === "EXPORTED" || entry.state === "MISSING_LOCAL") continue
-        if (!enabled && entry.priority === "HISTORICAL_BACKFILL") {
+        if (!enabled && entry.id !== this.activeEntryId) {
           cameraRollExportLedger.update(entry.id, {state: "NOT_REQUESTED", nextRetryAt: undefined})
+          this.rejectSourceWaiters(entry.id, new Error("Automatic camera-roll saving was disabled"))
         } else if (enabled) {
           cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined, lastError: undefined})
         }
@@ -294,13 +301,16 @@ class CameraRollExportCoordinator {
       while (this.activeEntryId && cameraRollExportLedger.get(this.activeEntryId)?.mediaName === mediaName) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
       }
-      // An already-running export gets to finish and resolve its source barrier. Queued work
-      // cannot start while the name is in deletingMediaNames, so reject only what remains.
-      for (const entry of cameraRollExportLedger.list().filter((candidate) => candidate.mediaName === mediaName)) {
-        this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
-      }
       const deleted = await localStorageService.deleteDownloadedFile(mediaName)
-      if (deleted) cameraRollExportLedger.removeForMedia(mediaName)
+      if (deleted) {
+        // An already-running export gets to finish and resolve its source barrier. Queued work
+        // cannot start while the name is in deletingMediaNames, so reject only after deletion
+        // is confirmed. A failed delete leaves the barrier intact and eligible for retry.
+        for (const entry of cameraRollExportLedger.list().filter((candidate) => candidate.mediaName === mediaName)) {
+          this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
+        }
+        cameraRollExportLedger.removeForMedia(mediaName)
+      }
       return deleted
     } finally {
       this.deletingMediaNames.delete(mediaName)
@@ -316,15 +326,18 @@ class CameraRollExportCoordinator {
       while (this.activeEntryId) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
       }
-      // Let the active native copy deliver its receipt before rejecting queued barriers.
+      await localStorageService.clearAllFiles()
+      // Let the active native copy deliver its receipt before rejecting queued barriers, and
+      // reject them only after the app media clear is confirmed. If clear fails, the durable
+      // work and its waiters remain eligible for retry.
       for (const entry of cameraRollExportLedger.list()) {
         this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
       }
-      await localStorageService.clearAllFiles()
       cameraRollExportLedger.clear()
     } finally {
       this.clearInProgress = false
       this.emitSummary()
+      if (this.enabled) void this.resume("local clear finished")
     }
   }
 
@@ -335,10 +348,10 @@ class CameraRollExportCoordinator {
       .filter((entry) => {
         if (this.clearInProgress || this.deletingMediaNames.has(entry.mediaName)) return false
         if (entry.receipt || entry.state === "EXPORTED" || entry.state === "MISSING_LOCAL") return false
-        if (!this.enabled && entry.priority !== "SOURCE_BARRIER") return false
+        if (!this.enabled) return false
         if (entry.state === "BLOCKED_PERMISSION" || entry.state === "FAILED_PERMANENT") return false
         if (entry.state === "FAILED_RETRYABLE" && (entry.nextRetryAt || 0) > now) return false
-        return entry.state !== "NOT_REQUESTED" || entry.priority === "SOURCE_BARRIER"
+        return entry.state !== "NOT_REQUESTED"
       })
       .sort((a, b) => {
         if (a.priority !== b.priority) return a.priority === "SOURCE_BARRIER" ? -1 : 1
@@ -350,6 +363,11 @@ class CameraRollExportCoordinator {
     let entry = original
     this.activeEntryId = entry.id
     try {
+      if (!this.enabled) {
+        cameraRollExportLedger.update(entry.id, {state: "NOT_REQUESTED", nextRetryAt: undefined})
+        this.rejectSourceWaiters(entry.id, new Error("Automatic camera-roll saving was disabled"))
+        return
+      }
       if (!(await RNFS.exists(entry.filePath))) {
         cameraRollExportLedger.update(entry.id, {state: "MISSING_LOCAL", lastError: "Local media is missing"})
         throw new Error("Local media is missing")
@@ -372,6 +390,14 @@ class CameraRollExportCoordinator {
       const fsInfo = await RNFS.getFSInfo()
       if (fsInfo.freeSpace < entry.size + MIN_FREE_SPACE_BYTES) {
         throw new Error("Insufficient free space for camera-roll export")
+      }
+      // A setting change can land while the filesystem and permission checks are in flight.
+      // Once the native save starts it must finish atomically, but do not begin a new save
+      // after the user has disabled automatic camera-roll exports.
+      if (!this.enabled) {
+        cameraRollExportLedger.update(entry.id, {state: "NOT_REQUESTED", nextRetryAt: undefined})
+        this.rejectSourceWaiters(entry.id, new Error("Automatic camera-roll saving was disabled"))
+        return
       }
 
       entry = cameraRollExportLedger.update(entry.id, {state: "RECONCILING", lastError: undefined})

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -1,0 +1,452 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+import {MediaLibraryPermissions} from "../../utils/permissions/MediaLibraryPermissions"
+import {BgTimer} from "../../utils/timers"
+import {
+  cameraRollEntryId,
+  cameraRollExportLedger,
+  cameraRollGeneration,
+  type CameraRollExportEntry,
+  type CameraRollExportPriority,
+} from "./cameraRollExportLedger"
+import {gallerySettingsService} from "./gallerySettingsService"
+import {galleryTransferLedger, type GalleryAssetReceipt} from "./galleryTransferLedger"
+import {localStorageService, type DownloadedFile} from "./localStorageService"
+
+const TAG = "[CameraRollExport]"
+const MIN_FREE_SPACE_BYTES = 100 * 1024 * 1024
+const MAX_RETRY_DELAY_MS = 30 * 60 * 1000
+
+export interface CameraRollExportSummary {
+  enabled: boolean
+  total: number
+  exported: number
+  pending: number
+  failed: number
+  blockedPermission: number
+  missing: number
+  bytesPending: number
+  isRunning: boolean
+}
+
+type SummaryListener = (summary: CameraRollExportSummary) => void
+
+class CameraRollExportCoordinator {
+  private initialized = false
+  private initializing: Promise<void> | null = null
+  private enabled = true
+  private running = false
+  private rerunRequested = false
+  private retryTimer: number | null = null
+  private activeEntryId: string | null = null
+  private clearInProgress = false
+  private deletingMediaNames = new Set<string>()
+  private listeners = new Set<SummaryListener>()
+  private sourceWaiters = new Map<
+    string,
+    Array<{resolve: (receipt: GalleryAssetReceipt) => void; reject: (error: Error) => void}>
+  >()
+
+  initialize(): Promise<void> {
+    if (this.initialized) return Promise.resolve()
+    if (this.initializing) return this.initializing
+    this.initializing = this.initializeInternal().finally(() => {
+      this.initializing = null
+    })
+    return this.initializing
+  }
+
+  cleanup(): void {
+    if (this.retryTimer != null) BgTimer.clearTimeout(this.retryTimer)
+    this.retryTimer = null
+    this.initialized = false
+  }
+
+  private async initializeInternal(): Promise<void> {
+    cameraRollExportLedger.setDocumentDirectory(RNFS.DocumentDirectoryPath)
+    this.enabled = await gallerySettingsService.getAutoSaveToCameraRoll()
+    await this.reconcileLocalIndex()
+    this.initialized = true
+    this.emitSummary()
+    if (this.enabled) void this.resume("startup")
+  }
+
+  /** Rebuild missing per-generation records after upgrading from legacy clients. */
+  private async reconcileLocalIndex(): Promise<void> {
+    const files = await localStorageService.getDownloadedFiles()
+    const liveIds = new Set<string>()
+    for (const file of Object.values(files)) {
+      const id = cameraRollEntryId(file.name, file.size, file.modified)
+      liveIds.add(id)
+      const current = cameraRollExportLedger.get(id)
+      const transfer = file.capture_id
+        ? galleryTransferLedger.get(file.capture_id)
+        : galleryTransferLedger.get(file.name)
+      const receipt = file.assetReceipt || transfer?.assetReceipt || current?.receipt
+      const now = Date.now()
+      cameraRollExportLedger.put({
+        ...(current || {
+          id,
+          mediaName: file.name,
+          generation: cameraRollGeneration(file.name, file.size, file.modified),
+          filePath: file.filePath,
+          size: file.size,
+          modified: file.modified,
+          isVideo: file.is_video,
+          captureId: file.capture_id || transfer?.captureId,
+          priority: "HISTORICAL_BACKFILL" as const,
+          attempts: 0,
+          createdAt: now,
+          updatedAt: now,
+          state: "LEGACY_UNKNOWN" as const,
+        }),
+        filePath: file.filePath,
+        receipt,
+        state: receipt ? "EXPORTED" : this.nextEligibleState(current?.state),
+      })
+    }
+
+    // Do not let stale generations recreate media after the user replaced/deleted local files.
+    for (const entry of cameraRollExportLedger.list()) {
+      if (!liveIds.has(entry.id)) cameraRollExportLedger.remove(entry.id)
+    }
+  }
+
+  private nextEligibleState(current?: CameraRollExportEntry["state"]): CameraRollExportEntry["state"] {
+    if (!this.enabled) return "NOT_REQUESTED"
+    if (current === "FAILED_PERMANENT" || current === "MISSING_LOCAL") return current
+    return "QUEUED"
+  }
+
+  async recordIndexed(
+    file: DownloadedFile,
+    shouldAutoSave: boolean,
+    priority: CameraRollExportPriority = "HISTORICAL_BACKFILL",
+    captureId?: string,
+  ): Promise<CameraRollExportEntry> {
+    await this.initialize()
+    const id = cameraRollEntryId(file.name, file.size, file.modified)
+    const current = cameraRollExportLedger.get(id)
+    const now = Date.now()
+    const entry = cameraRollExportLedger.put({
+      ...(current || {
+        id,
+        mediaName: file.name,
+        generation: cameraRollGeneration(file.name, file.size, file.modified),
+        attempts: 0,
+        createdAt: now,
+        updatedAt: now,
+      }),
+      filePath: file.filePath,
+      size: file.size,
+      modified: file.modified,
+      isVideo: file.is_video,
+      captureId: captureId || file.capture_id || current?.captureId,
+      priority,
+      receipt: file.assetReceipt || current?.receipt,
+      state: file.assetReceipt || current?.receipt ? "EXPORTED" : shouldAutoSave ? "QUEUED" : "NOT_REQUESTED",
+      lastError: undefined,
+      nextRetryAt: undefined,
+    })
+    this.emitSummary()
+    return entry
+  }
+
+  /** Source deletion waits on this barrier; historical work never blocks a glasses sync. */
+  async exportForSource(file: DownloadedFile, captureId?: string): Promise<GalleryAssetReceipt> {
+    const entry = await this.recordIndexed(file, true, "SOURCE_BARRIER", captureId)
+    if (entry.receipt) return entry.receipt
+    return new Promise<GalleryAssetReceipt>((resolve, reject) => {
+      const waiters = this.sourceWaiters.get(entry.id) || []
+      waiters.push({resolve, reject})
+      this.sourceWaiters.set(entry.id, waiters)
+      void this.resume("source barrier")
+    })
+  }
+
+  async setEnabled(enabled: boolean): Promise<void> {
+    await this.initialize()
+    const previous = this.enabled
+    await gallerySettingsService.setAutoSaveToCameraRoll(enabled)
+    try {
+      this.enabled = enabled
+      for (const entry of cameraRollExportLedger.list()) {
+        if (entry.receipt || entry.state === "EXPORTED" || entry.state === "MISSING_LOCAL") continue
+        if (!enabled && entry.priority === "HISTORICAL_BACKFILL") {
+          cameraRollExportLedger.update(entry.id, {state: "NOT_REQUESTED", nextRetryAt: undefined})
+        } else if (enabled) {
+          cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined, lastError: undefined})
+        }
+      }
+    } catch (error) {
+      this.enabled = previous
+      await gallerySettingsService.setAutoSaveToCameraRoll(previous)
+      throw error
+    }
+    this.emitSummary()
+    if (enabled) void this.resume("setting enabled")
+  }
+
+  async resume(reason: string): Promise<void> {
+    await this.initialize()
+    console.log(`${TAG} Resume requested: ${reason}`)
+    if (cameraRollExportLedger.list().some((entry) => entry.state === "BLOCKED_PERMISSION")) {
+      const hasPermission = await MediaLibraryPermissions.checkPermission()
+      if (hasPermission) {
+        for (const entry of cameraRollExportLedger.list()) {
+          if (entry.state === "BLOCKED_PERMISSION") {
+            cameraRollExportLedger.update(entry.id, {state: "QUEUED", lastError: undefined})
+          }
+        }
+      }
+    }
+    if (this.retryTimer != null) {
+      BgTimer.clearTimeout(this.retryTimer)
+      this.retryTimer = null
+    }
+    if (this.running) {
+      this.rerunRequested = true
+      while (this.running) {
+        await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+      }
+      return
+    }
+    this.running = true
+    this.rerunRequested = false
+    this.emitSummary()
+    try {
+      let entry = this.nextEntry()
+      while (entry) {
+        await this.processEntry(entry)
+        entry = this.nextEntry()
+      }
+    } finally {
+      const shouldRerun = this.rerunRequested
+      this.rerunRequested = false
+      this.running = false
+      this.emitSummary()
+      this.scheduleRetry()
+      if (shouldRerun) void this.resume("work arrived")
+    }
+  }
+
+  retryNow(): void {
+    for (const entry of cameraRollExportLedger.list()) {
+      if (entry.state === "FAILED_RETRYABLE" || entry.state === "BLOCKED_PERMISSION") {
+        cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined})
+      }
+    }
+    void this.resume("manual retry")
+  }
+
+  subscribe(listener: SummaryListener): () => void {
+    this.listeners.add(listener)
+    listener(this.getSummary())
+    return () => this.listeners.delete(listener)
+  }
+
+  getSummary(): CameraRollExportSummary {
+    const entries = cameraRollExportLedger.list()
+    const pendingStates = new Set([
+      "LEGACY_UNKNOWN",
+      "QUEUED",
+      "RECONCILING",
+      "EXPORTING",
+      "FAILED_RETRYABLE",
+      "BLOCKED_PERMISSION",
+    ])
+    return {
+      enabled: this.enabled,
+      total: entries.length,
+      exported: entries.filter((entry) => entry.state === "EXPORTED").length,
+      pending: entries.filter((entry) => pendingStates.has(entry.state)).length,
+      failed: entries.filter((entry) => entry.state === "FAILED_RETRYABLE" || entry.state === "FAILED_PERMANENT")
+        .length,
+      blockedPermission: entries.filter((entry) => entry.state === "BLOCKED_PERMISSION").length,
+      missing: entries.filter((entry) => entry.state === "MISSING_LOCAL").length,
+      bytesPending: entries
+        .filter((entry) => pendingStates.has(entry.state))
+        .reduce((sum, entry) => sum + entry.size, 0),
+      isRunning: this.running,
+    }
+  }
+
+  countNotExported(mediaNames: string[]): number {
+    const entries = cameraRollExportLedger.list()
+    return new Set(mediaNames).size === 0
+      ? 0
+      : [...new Set(mediaNames)].filter(
+          (name) => !entries.some((entry) => entry.mediaName === name && entry.state === "EXPORTED"),
+        ).length
+  }
+
+  /** Serialize local deletion against an in-flight native copy of the same item. */
+  async deleteLocalMedia(mediaName: string): Promise<boolean> {
+    this.deletingMediaNames.add(mediaName)
+    const entries = cameraRollExportLedger.list().filter((entry) => entry.mediaName === mediaName)
+    for (const entry of entries) {
+      this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
+    }
+    try {
+      while (this.activeEntryId && cameraRollExportLedger.get(this.activeEntryId)?.mediaName === mediaName) {
+        await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+      }
+      const deleted = await localStorageService.deleteDownloadedFile(mediaName)
+      if (deleted) cameraRollExportLedger.removeForMedia(mediaName)
+      return deleted
+    } finally {
+      this.deletingMediaNames.delete(mediaName)
+      this.emitSummary()
+      if (this.enabled) void this.resume("local deletion finished")
+    }
+  }
+
+  /** Stop scheduling exports, finish the current native copy, then atomically clear app media + receipts. */
+  async clearLocalMedia(): Promise<void> {
+    this.clearInProgress = true
+    for (const entry of cameraRollExportLedger.list()) {
+      this.rejectSourceWaiters(entry.id, new Error("Local media was deleted before camera-roll export"))
+    }
+    try {
+      while (this.activeEntryId) {
+        await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+      }
+      await localStorageService.clearAllFiles()
+      cameraRollExportLedger.clear()
+    } finally {
+      this.clearInProgress = false
+      this.emitSummary()
+    }
+  }
+
+  private nextEntry(): CameraRollExportEntry | undefined {
+    const now = Date.now()
+    return cameraRollExportLedger
+      .list()
+      .filter((entry) => {
+        if (this.clearInProgress || this.deletingMediaNames.has(entry.mediaName)) return false
+        if (entry.receipt || entry.state === "EXPORTED" || entry.state === "MISSING_LOCAL") return false
+        if (!this.enabled && entry.priority !== "SOURCE_BARRIER") return false
+        if (entry.state === "BLOCKED_PERMISSION" || entry.state === "FAILED_PERMANENT") return false
+        if (entry.state === "FAILED_RETRYABLE" && (entry.nextRetryAt || 0) > now) return false
+        return entry.state !== "NOT_REQUESTED" || entry.priority === "SOURCE_BARRIER"
+      })
+      .sort((a, b) => {
+        if (a.priority !== b.priority) return a.priority === "SOURCE_BARRIER" ? -1 : 1
+        return a.modified - b.modified
+      })[0]
+  }
+
+  private async processEntry(original: CameraRollExportEntry): Promise<void> {
+    let entry = original
+    this.activeEntryId = entry.id
+    try {
+      if (!(await RNFS.exists(entry.filePath))) {
+        cameraRollExportLedger.update(entry.id, {state: "MISSING_LOCAL", lastError: "Local media is missing"})
+        throw new Error("Local media is missing")
+      }
+      const permission = await MediaLibraryPermissions.checkPermission()
+      if (!permission) {
+        cameraRollExportLedger.update(entry.id, {
+          state: "BLOCKED_PERMISSION",
+          lastError: "Camera-roll permission is required",
+        })
+        throw new Error("Camera-roll permission is required")
+      }
+      const fsInfo = await RNFS.getFSInfo()
+      if (fsInfo.freeSpace < entry.size + MIN_FREE_SPACE_BYTES) {
+        throw new Error("Insufficient free space for camera-roll export")
+      }
+
+      entry = cameraRollExportLedger.update(entry.id, {state: "RECONCILING", lastError: undefined})
+      entry = cameraRollExportLedger.update(entry.id, {state: "EXPORTING"})
+      const result = await MediaLibraryPermissions.saveToLibraryWithReceipt(entry.filePath, entry.modified)
+      if (!result.success) throw new Error(result.error || "Camera-roll export failed")
+      const receipt: GalleryAssetReceipt = {
+        platform: result.platform,
+        uri: result.uri,
+        identifier: result.identifier,
+        exportedAt: Date.now(),
+      }
+      entry = cameraRollExportLedger.update(entry.id, {
+        state: "EXPORTED",
+        receipt,
+        attempts: entry.attempts + 1,
+        nextRetryAt: undefined,
+        lastError: undefined,
+      })
+      try {
+        await this.mirrorReceipt(entry, receipt)
+      } catch (mirrorError) {
+        // The per-generation ledger is the authoritative durable receipt. A secondary
+        // metadata mirror failure must not cause a duplicate insert or block source ack.
+        console.warn(`${TAG} Export receipt mirror failed for ${entry.mediaName}:`, mirrorError)
+      }
+      this.resolveSourceWaiters(entry.id, receipt)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      const current = cameraRollExportLedger.get(entry.id)
+      if (current && current.state !== "BLOCKED_PERMISSION" && current.state !== "MISSING_LOCAL") {
+        const attempts = current.attempts + 1
+        cameraRollExportLedger.update(entry.id, {
+          state: "FAILED_RETRYABLE",
+          attempts,
+          lastError: message,
+          nextRetryAt: Date.now() + Math.min(2 ** Math.min(attempts, 10) * 1000, MAX_RETRY_DELAY_MS),
+        })
+      }
+      this.rejectSourceWaiters(entry.id, error instanceof Error ? error : new Error(message))
+      console.warn(`${TAG} Export remains pending for ${entry.mediaName}: ${message}`)
+    } finally {
+      if (this.activeEntryId === entry.id) this.activeEntryId = null
+      this.emitSummary()
+    }
+  }
+
+  private async mirrorReceipt(entry: CameraRollExportEntry, receipt: GalleryAssetReceipt): Promise<void> {
+    await localStorageService.updateDownloadedFileAssetReceipt(entry.mediaName, receipt)
+    const transfer = entry.captureId
+      ? galleryTransferLedger.get(entry.captureId)
+      : galleryTransferLedger.get(entry.mediaName)
+    if (transfer) galleryTransferLedger.update(transfer.captureId, {assetReceipt: receipt})
+  }
+
+  private scheduleRetry(): void {
+    if (!this.enabled || this.retryTimer != null) return
+    const next = cameraRollExportLedger
+      .list()
+      .filter((entry) => entry.state === "FAILED_RETRYABLE" && entry.nextRetryAt)
+      .sort((a, b) => (a.nextRetryAt || 0) - (b.nextRetryAt || 0))[0]
+    if (!next?.nextRetryAt) return
+    this.retryTimer = BgTimer.setTimeout(
+      () => {
+        this.retryTimer = null
+        void this.resume("retry timer")
+      },
+      Math.max(0, next.nextRetryAt - Date.now()),
+    )
+  }
+
+  private resolveSourceWaiters(id: string, receipt: GalleryAssetReceipt): void {
+    for (const waiter of this.sourceWaiters.get(id) || []) waiter.resolve(receipt)
+    this.sourceWaiters.delete(id)
+  }
+
+  private rejectSourceWaiters(id: string, error: Error): void {
+    for (const waiter of this.sourceWaiters.get(id) || []) waiter.reject(error)
+    this.sourceWaiters.delete(id)
+  }
+
+  private emitSummary(): void {
+    const summary = this.getSummary()
+    for (const listener of this.listeners) {
+      try {
+        listener(summary)
+      } catch (error) {
+        console.warn(`${TAG} Summary listener failed`, error)
+      }
+    }
+  }
+}
+
+export const cameraRollExportCoordinator = new CameraRollExportCoordinator()

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -35,6 +35,7 @@ type SummaryListener = (summary: CameraRollExportSummary) => void
 class CameraRollExportCoordinator {
   private initialized = false
   private initializing: Promise<void> | null = null
+  private lifecycleGeneration = 0
   private enabled = true
   private running = false
   private rerunRequested = false
@@ -48,25 +49,45 @@ class CameraRollExportCoordinator {
     Array<{resolve: (receipt: GalleryAssetReceipt) => void; reject: (error: Error) => void}>
   >()
 
-  initialize(): Promise<void> {
-    if (this.initialized) return Promise.resolve()
-    if (this.initializing) return this.initializing
-    this.initializing = this.initializeInternal().finally(() => {
-      this.initializing = null
-    })
-    return this.initializing
+  async initialize(): Promise<void> {
+    while (!this.initialized) {
+      if (!this.initializing) {
+        const generation = this.lifecycleGeneration
+        this.initializing = this.initializeInternal(generation)
+      }
+      const initialization = this.initializing
+      try {
+        await initialization
+      } finally {
+        if (this.initializing === initialization) this.initializing = null
+      }
+    }
   }
 
   cleanup(): void {
+    this.lifecycleGeneration += 1
     if (this.retryTimer != null) BgTimer.clearTimeout(this.retryTimer)
     this.retryTimer = null
     this.initialized = false
+    this.rerunRequested = false
+    const error = new Error("Camera-roll export coordinator stopped")
+    for (const id of [...this.sourceWaiters.keys()]) this.rejectSourceWaiters(id, error)
+    if (!this.running) this.activeEntryId = null
   }
 
-  private async initializeInternal(): Promise<void> {
+  private async initializeInternal(generation: number): Promise<void> {
     cameraRollExportLedger.setDocumentDirectory(RNFS.DocumentDirectoryPath)
-    this.enabled = await gallerySettingsService.getAutoSaveToCameraRoll()
+    // A native camera-roll insert is atomic and cannot be cancelled. On a quick engine
+    // stop/start, let the old drain commit its receipt before the new lifecycle reconciles.
+    while (this.running) {
+      await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
+    }
+    if (generation !== this.lifecycleGeneration) return
+    const enabled = await gallerySettingsService.getAutoSaveToCameraRoll()
+    if (generation !== this.lifecycleGeneration) return
+    this.enabled = enabled
     await this.reconcileLocalIndex()
+    if (generation !== this.lifecycleGeneration) return
     this.initialized = true
     this.emitSummary()
     if (this.enabled) void this.resume("startup")
@@ -225,11 +246,14 @@ class CameraRollExportCoordinator {
   }
 
   async resume(reason: string): Promise<void> {
+    const generation = this.lifecycleGeneration
     await this.initialize()
+    if (generation !== this.lifecycleGeneration) return
     console.log(`${TAG} Resume requested: ${reason}`)
     if (cameraRollExportLedger.list().some((entry) => entry.state === "BLOCKED_PERMISSION")) {
       const hasPermission = await MediaLibraryPermissions.checkPermission()
       const hasLimitedAccess = hasPermission && (await MediaLibraryPermissions.hasLimitedAccess())
+      if (generation !== this.lifecycleGeneration) return
       if (hasPermission) {
         for (const entry of cameraRollExportLedger.list()) {
           if (entry.state === "BLOCKED_PERMISSION" && !(entry.requiresFullLibraryReconciliation && hasLimitedAccess)) {
@@ -238,6 +262,7 @@ class CameraRollExportCoordinator {
         }
       }
     }
+    if (generation !== this.lifecycleGeneration) return
     if (this.retryTimer != null) {
       BgTimer.clearTimeout(this.retryTimer)
       this.retryTimer = null
@@ -247,6 +272,7 @@ class CameraRollExportCoordinator {
       while (this.running) {
         await new Promise<void>((resolve) => BgTimer.setTimeout(resolve, 25))
       }
+      if (generation !== this.lifecycleGeneration) return
       // The active drain normally consumes rerunRequested before releasing running. Keep
       // this final durable-work check so a late handoff can never strand an eligible entry.
       if (this.nextEntry()) await this.resume("work remained after concurrent resume")
@@ -258,16 +284,19 @@ class CameraRollExportCoordinator {
       do {
         this.rerunRequested = false
         let entry = this.nextEntry()
-        while (entry) {
-          await this.processEntry(entry)
+        while (entry && generation === this.lifecycleGeneration) {
+          await this.processEntry(entry, generation)
+          if (generation !== this.lifecycleGeneration) break
           entry = this.nextEntry()
         }
-      } while (this.rerunRequested)
+      } while (this.rerunRequested && generation === this.lifecycleGeneration)
     } finally {
       this.rerunRequested = false
       this.running = false
-      this.emitSummary()
-      this.scheduleRetry()
+      if (generation === this.lifecycleGeneration) {
+        this.emitSummary()
+        this.scheduleRetry()
+      }
     }
   }
 
@@ -392,7 +421,7 @@ class CameraRollExportCoordinator {
       })[0]
   }
 
-  private async processEntry(original: CameraRollExportEntry): Promise<void> {
+  private async processEntry(original: CameraRollExportEntry, generation: number): Promise<void> {
     let entry = original
     this.activeEntryId = entry.id
     try {
@@ -401,11 +430,14 @@ class CameraRollExportCoordinator {
         this.rejectSourceWaiters(entry.id, new Error("Automatic camera-roll saving was disabled"))
         return
       }
-      if (!(await RNFS.exists(entry.filePath))) {
+      const exists = await RNFS.exists(entry.filePath)
+      if (generation !== this.lifecycleGeneration) return
+      if (!exists) {
         cameraRollExportLedger.update(entry.id, {state: "MISSING_LOCAL", lastError: "Local media is missing"})
         throw new Error("Local media is missing")
       }
       const permission = await MediaLibraryPermissions.checkPermission()
+      if (generation !== this.lifecycleGeneration) return
       if (!permission) {
         cameraRollExportLedger.update(entry.id, {
           state: "BLOCKED_PERMISSION",
@@ -413,7 +445,10 @@ class CameraRollExportCoordinator {
         })
         throw new Error("Camera-roll permission is required")
       }
-      if (entry.requiresFullLibraryReconciliation && (await MediaLibraryPermissions.hasLimitedAccess())) {
+      const hasLimitedAccess =
+        entry.requiresFullLibraryReconciliation && (await MediaLibraryPermissions.hasLimitedAccess())
+      if (generation !== this.lifecycleGeneration) return
+      if (hasLimitedAccess) {
         cameraRollExportLedger.update(entry.id, {
           state: "BLOCKED_PERMISSION",
           lastError: "Full photo-library access is required to reconcile this legacy export safely",
@@ -421,6 +456,7 @@ class CameraRollExportCoordinator {
         throw new Error("Full photo-library access is required to reconcile this legacy export safely")
       }
       const fsInfo = await RNFS.getFSInfo()
+      if (generation !== this.lifecycleGeneration) return
       if (fsInfo.freeSpace < entry.size + MIN_FREE_SPACE_BYTES) {
         throw new Error("Insufficient free space for camera-roll export")
       }
@@ -475,7 +511,7 @@ class CameraRollExportCoordinator {
       console.warn(`${TAG} Export remains pending for ${entry.mediaName}: ${message}`)
     } finally {
       if (this.activeEntryId === entry.id) this.activeEntryId = null
-      this.emitSummary()
+      if (generation === this.lifecycleGeneration) this.emitSummary()
     }
   }
 
@@ -494,9 +530,11 @@ class CameraRollExportCoordinator {
       .filter((entry) => entry.state === "FAILED_RETRYABLE" && entry.nextRetryAt)
       .sort((a, b) => (a.nextRetryAt || 0) - (b.nextRetryAt || 0))[0]
     if (!next?.nextRetryAt) return
+    const generation = this.lifecycleGeneration
     this.retryTimer = BgTimer.setTimeout(
       () => {
         this.retryTimer = null
+        if (generation !== this.lifecycleGeneration) return
         void this.resume("retry timer")
       },
       Math.max(0, next.nextRetryAt - Date.now()),

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -138,7 +138,9 @@ class CameraRollExportCoordinator {
 
   private nextEligibleState(current?: CameraRollExportEntry["state"]): CameraRollExportEntry["state"] {
     if (!this.enabled) return "NOT_REQUESTED"
-    if (current === "FAILED_PERMANENT" || current === "MISSING_LOCAL") return current
+    // Reconciliation only calls this for files that are present in the durable local index.
+    // A previous filesystem miss was transient if that same generation is visible again.
+    if (current === "FAILED_PERMANENT") return current
     return "QUEUED"
   }
 
@@ -302,8 +304,12 @@ class CameraRollExportCoordinator {
 
   retryNow(): void {
     for (const entry of cameraRollExportLedger.list()) {
-      if (entry.state === "FAILED_RETRYABLE" || entry.state === "BLOCKED_PERMISSION") {
-        cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined})
+      if (
+        entry.state === "FAILED_RETRYABLE" ||
+        entry.state === "BLOCKED_PERMISSION" ||
+        entry.state === "MISSING_LOCAL"
+      ) {
+        cameraRollExportLedger.update(entry.id, {state: "QUEUED", nextRetryAt: undefined, lastError: undefined})
       }
     }
     void this.resume("manual retry")

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -103,7 +103,8 @@ class CameraRollExportCoordinator {
         }),
         filePath: file.filePath,
         receipt,
-        requiresFullLibraryReconciliation: current?.requiresFullLibraryReconciliation ?? (!current && !receipt),
+        requiresFullLibraryReconciliation:
+          current?.requiresFullLibraryReconciliation ?? (!current && !receipt && !transfer),
         state: receipt ? "EXPORTED" : this.nextEligibleState(current?.state),
       })
     }

--- a/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportCoordinator.ts
@@ -278,7 +278,9 @@ class CameraRollExportCoordinator {
 
   subscribe(listener: SummaryListener): () => void {
     this.listeners.add(listener)
-    listener(this.getSummary())
+    // `enabled` is loaded from durable settings during initialize(). Do not emit the
+    // default before that read completes or disabled users briefly see the toggle as on.
+    if (this.initialized) listener(this.getSummary())
     return () => this.listeners.delete(listener)
   }
 

--- a/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
@@ -26,6 +26,8 @@ export interface CameraRollExportEntry {
   modified: number
   isVideo: boolean
   captureId?: string
+  /** True when an older client may already have exported this file without persisting a receipt. */
+  requiresFullLibraryReconciliation?: boolean
   state: CameraRollExportState
   priority: CameraRollExportPriority
   receipt?: GalleryAssetReceipt

--- a/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
@@ -1,0 +1,118 @@
+import {storage} from "../../utils/storage"
+import {toPortableGalleryPath} from "./galleryPathMigration"
+import type {GalleryAssetReceipt} from "./galleryTransferLedger"
+
+export type CameraRollExportState =
+  | "NOT_REQUESTED"
+  | "LEGACY_UNKNOWN"
+  | "QUEUED"
+  | "RECONCILING"
+  | "EXPORTING"
+  | "EXPORTED"
+  | "BLOCKED_PERMISSION"
+  | "FAILED_RETRYABLE"
+  | "FAILED_PERMANENT"
+  | "MISSING_LOCAL"
+
+export type CameraRollExportPriority = "SOURCE_BARRIER" | "HISTORICAL_BACKFILL"
+
+export interface CameraRollExportEntry {
+  /** Stable identity for one local-file generation. */
+  id: string
+  mediaName: string
+  generation: string
+  filePath: string
+  size: number
+  modified: number
+  isVideo: boolean
+  captureId?: string
+  state: CameraRollExportState
+  priority: CameraRollExportPriority
+  receipt?: GalleryAssetReceipt
+  attempts: number
+  nextRetryAt?: number
+  lastError?: string
+  createdAt: number
+  updatedAt: number
+}
+
+const ENTRY_PREFIX = "asg_camera_roll_export_v1:"
+
+export function cameraRollGeneration(mediaName: string, size: number, modified: number): string {
+  return `${mediaName}:${size}:${modified}`
+}
+
+export function cameraRollEntryId(mediaName: string, size: number, modified: number): string {
+  return encodeURIComponent(cameraRollGeneration(mediaName, size, modified))
+}
+
+class CameraRollExportLedger {
+  private runtimeDocumentDirectory = ""
+
+  setDocumentDirectory(path: string): void {
+    this.runtimeDocumentDirectory = path
+  }
+
+  get(id: string): CameraRollExportEntry | undefined {
+    const result = storage.load<CameraRollExportEntry>(`${ENTRY_PREFIX}${id}`)
+    if (result.is_error()) return undefined
+    return this.toRuntimeEntry(result.value)
+  }
+
+  list(): CameraRollExportEntry[] {
+    return storage
+      .getAllKeys()
+      .filter((key) => key.startsWith(ENTRY_PREFIX))
+      .map((key) => {
+        const result = storage.load<CameraRollExportEntry>(key)
+        return result.is_error() ? undefined : this.toRuntimeEntry(result.value)
+      })
+      .filter((entry): entry is CameraRollExportEntry => !!entry)
+  }
+
+  put(entry: CameraRollExportEntry): CameraRollExportEntry {
+    const updated = {...entry, updatedAt: Date.now()}
+    const result = storage.save(`${ENTRY_PREFIX}${entry.id}`, this.toStoredEntry(updated))
+    if (result.is_error()) throw result.error
+    return updated
+  }
+
+  update(id: string, patch: Partial<CameraRollExportEntry>): CameraRollExportEntry {
+    const current = this.get(id)
+    if (!current) throw new Error(`Camera-roll export entry missing: ${id}`)
+    return this.put({...current, ...patch, id})
+  }
+
+  remove(id: string): void {
+    const result = storage.remove(`${ENTRY_PREFIX}${id}`)
+    if (result.is_error()) throw result.error
+  }
+
+  removeForMedia(mediaName: string): void {
+    for (const entry of this.list()) {
+      if (entry.mediaName === mediaName) this.remove(entry.id)
+    }
+  }
+
+  clear(): void {
+    const keys = storage.getAllKeys().filter((key) => key.startsWith(ENTRY_PREFIX))
+    if (keys.length === 0) return
+    const result = storage.removeMultiple(keys)
+    if (result.is_error()) throw result.error
+  }
+
+  private toStoredEntry(entry: CameraRollExportEntry): CameraRollExportEntry {
+    if (!this.runtimeDocumentDirectory) return entry
+    return {
+      ...entry,
+      filePath: toPortableGalleryPath(entry.filePath, this.runtimeDocumentDirectory) || entry.filePath,
+    }
+  }
+
+  private toRuntimeEntry(entry: CameraRollExportEntry): CameraRollExportEntry {
+    if (!this.runtimeDocumentDirectory || entry.filePath.startsWith("/")) return entry
+    return {...entry, filePath: `${this.runtimeDocumentDirectory}/${entry.filePath}`}
+  }
+}
+
+export const cameraRollExportLedger = new CameraRollExportLedger()

--- a/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
+++ b/mobile/modules/engine/src/services/asg/cameraRollExportLedger.ts
@@ -26,6 +26,8 @@ export interface CameraRollExportEntry {
   modified: number
   isVideo: boolean
   captureId?: string
+  /** False while this generation is absent from the local index; exported receipts remain as hidden tombstones. */
+  localPresent?: boolean
   /** True when an older client may already have exported this file without persisting a receipt. */
   requiresFullLibraryReconciliation?: boolean
   state: CameraRollExportState

--- a/mobile/modules/engine/src/services/asg/galleryNotices.ts
+++ b/mobile/modules/engine/src/services/asg/galleryNotices.ts
@@ -12,6 +12,7 @@ export type GalleryNoticeCode =
   | "wifi_initializing"
   | "wifi_off"
   | "location_services_off"
+  | "camera_roll_permission_required"
   | "connect_to_glasses"
 
 export interface GalleryNotice {

--- a/mobile/modules/engine/src/services/asg/gallerySettingsService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySettingsService.ts
@@ -2,6 +2,7 @@ import {storage} from "../../utils/storage/storage"
 
 export interface GallerySettings {
   autoSaveToCameraRoll: boolean
+  autoSaveDisableWarningShown: boolean
   imageProcessingEnabled: boolean
 }
 
@@ -10,6 +11,7 @@ export class GallerySettingsService {
   private readonly SETTINGS_KEY = "gallery_settings"
   private readonly DEFAULT_SETTINGS: GallerySettings = {
     autoSaveToCameraRoll: true, // Default ON
+    autoSaveDisableWarningShown: false,
     imageProcessingEnabled: true, // Lens coefficients calibrated from chessboard photos
   }
 
@@ -39,6 +41,7 @@ export class GallerySettingsService {
     const res = await storage.save(this.SETTINGS_KEY, updated)
     if (res.is_error()) {
       console.error("[GallerySettings] Error saving settings:", res.error)
+      throw res.error
     }
     console.log("[GallerySettings] Settings updated:", updated)
   }

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -31,6 +31,7 @@ import {mediaProcessingQueue} from "./mediaProcessingQueue"
 import {validateCaptureMetadataForDownload} from "./galleryMediaValidation"
 import {emitGalleryNotice} from "./galleryNotices"
 import {galleryTransferLedger} from "./galleryTransferLedger"
+import {cameraRollExportCoordinator} from "./cameraRollExportCoordinator"
 
 // Timing constants
 const TIMING = {
@@ -112,6 +113,8 @@ class GallerySyncService {
     this.hotspotListenerRegistered = true
     this.isInitialized = true
 
+    void cameraRollExportCoordinator.initialize()
+
     // console.log("[GallerySyncService] Initialized")
 
     // Check for resumable sync on startup
@@ -138,6 +141,7 @@ class GallerySyncService {
       this.appStateSubscription.remove()
       this.appStateSubscription = null
     }
+    cameraRollExportCoordinator.cleanup()
 
     if (this.hotspotConnectionTimeout) {
       BgTimer.clearTimeout(this.hotspotConnectionTimeout!)
@@ -202,6 +206,9 @@ class GallerySyncService {
     if (nextAppState !== "active") {
       return
     }
+
+    // Camera-roll backfill is phone-local and must resume independently of glasses/WiFi.
+    void cameraRollExportCoordinator.resume("app foreground")
 
     // Only auto-retry if we were waiting for WiFi
     if (!this.waitingForWifiRetry) {
@@ -537,9 +544,10 @@ class GallerySyncService {
         console.log("[GallerySyncService]   ⚠️ Camera roll permission not granted - requesting...")
         const granted = await MediaLibraryPermissions.requestPermission()
         if (!granted) {
-          console.warn("[GallerySyncService]   ❌ Camera roll permission denied - photos will still sync to app")
-          // Don't block sync - photos will still be downloaded to app storage
-          // They just won't be saved to the camera roll
+          console.warn("[GallerySyncService]   ❌ Camera roll permission denied - auto-save sync cannot continue")
+          store.setSyncError("Camera-roll permission required while automatic saving is enabled")
+          emitGalleryNotice({code: "camera_roll_permission_required"})
+          return
         } else {
           console.log("[GallerySyncService]   ✅ Camera roll permission granted")
         }

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -499,9 +499,6 @@ class GallerySyncService {
       hotspotEnabled: glassesHotspot !== null,
     })
 
-    // Reset processing queue only after pre-flight passes — avoids clobbering an active session
-    mediaProcessingQueue.reset()
-
     // Request all permissions upfront so user isn't interrupted during WiFi/download
     console.log("[GallerySyncService] 🔐 Step 1/6: Requesting permissions...")
 
@@ -747,6 +744,10 @@ class GallerySyncService {
       console.log("[GallerySyncService]   ℹ️ Glasses hotspot not currently enabled")
       console.log("[GallerySyncService]   ➡️ Will request hotspot activation")
     }
+
+    // Every fallible pre-flight gate has passed. It is now safe to replace the previous
+    // in-memory queue; startFileDownload immediately recovers its durable ledger work.
+    mediaProcessingQueue.reset()
 
     if (isAlreadyConnected && currentGlassesHotspot) {
       console.log("[GallerySyncService] 🚀 Skipping hotspot request - already connected!")

--- a/mobile/modules/engine/src/services/asg/localStorageService.ts
+++ b/mobile/modules/engine/src/services/asg/localStorageService.ts
@@ -305,6 +305,14 @@ export class LocalStorageService {
     }
   }
 
+  /** Persist a durable camera-roll receipt without replacing the local-file generation. */
+  async updateDownloadedFileAssetReceipt(fileName: string, assetReceipt: GalleryAssetReceipt): Promise<void> {
+    const files = await this.getDownloadedFiles()
+    const file = files[fileName]
+    if (!file) throw new Error(`Downloaded file is missing: ${fileName}`)
+    await this.saveDownloadedFile({...file, assetReceipt})
+  }
+
   /**
    * Delete downloaded file (both metadata and actual files)
    */

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -466,23 +466,46 @@ class MediaProcessingQueue {
 
   /** Rebuild a missing app-local index row from the durable transfer ledger. */
   private async recoverDownloadedFile(entry: GalleryTransferEntry) {
-    const indexed = await localStorageService.getDownloadedFile(entry.captureId)
-    if (indexed) return indexed
     if (!entry.finalPath) throw new Error(`Recovery file is missing for ${entry.captureId}`)
 
-    const stat = await RNFS.stat(entry.finalPath)
+    // The transfer ledger is the durable source of truth for a committed generation. A local
+    // index row can survive an interrupted replacement and still point at an older/missing path,
+    // or contain the pre-processing size. Only reuse it when its path and identity still match the
+    // ledger's committed file; otherwise rebuild the row before export or source acknowledgement.
+    const finalPath = entry.finalPath.replace(/^file:\/\//, "")
+    const indexed = await localStorageService.getDownloadedFile(entry.captureId)
+    if (indexed) {
+      try {
+        const indexedPath = indexed.filePath?.replace(/^file:\/\//, "")
+        if (indexedPath === finalPath && (await RNFS.exists(indexedPath))) {
+          const indexedStat = await RNFS.stat(indexedPath)
+          const indexedSize = Number(indexedStat.size)
+          if (indexedSize > 0 && indexed.size === indexedSize && indexed.modified === entry.timestamp) {
+            return indexed
+          }
+        }
+      } catch (error) {
+        console.warn(`${TAG} Ignoring stale local index for ${entry.captureId}:`, error)
+      }
+    }
+
+    const stat = await RNFS.stat(finalPath)
+    const finalSize = Number(stat.size)
+    if (!Number.isFinite(finalSize) || finalSize <= 0) {
+      throw new Error(`Recovery file is missing or empty for ${entry.captureId}`)
+    }
     const recovered = localStorageService.convertToDownloadedFile(
       {
         name: entry.captureId,
         url: "",
         download: "",
-        size: Number(stat.size) || entry.totalSize,
+        size: finalSize,
         modified: entry.timestamp,
         mime_type: entry.captureType === "video" ? "video/mp4" : "image/jpeg",
         is_video: entry.captureType === "video",
-        filePath: entry.finalPath,
+        filePath: finalPath,
       },
-      entry.finalPath,
+      finalPath,
       entry.thumbnailPath,
     )
     recovered.capture_id = entry.captureId

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -131,8 +131,7 @@ class MediaProcessingQueue {
           throw new Error(`Recovery file is missing for ${entry.captureId}`)
         }
         if (entry.state === "EXPORT_PENDING" || (entry.state === "INDEXED" && entry.shouldAutoSave)) {
-          const downloadedFile = await localStorageService.getDownloadedFile(entry.captureId)
-          if (!downloadedFile) throw new Error(`Local gallery index is missing for ${entry.captureId}`)
+          const downloadedFile = await this.recoverDownloadedFile(entry)
           const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, entry.captureId)
           entry = galleryTransferLedger.transition(entry.captureId, "EXPORTED", {
             assetReceipt: receipt,
@@ -365,7 +364,13 @@ class MediaProcessingQueue {
     // 7. Export is a durable, receipted step. Failure leaves EXPORT_PENDING and blocks ack.
     if (item.shouldAutoSave) {
       galleryTransferLedger.transition(item.id, "EXPORT_PENDING")
-      const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, item.id)
+      let receipt
+      try {
+        receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, item.id)
+      } catch (error) {
+        galleryTransferLedger.recordFailure(item.id, error)
+        throw error
+      }
       ledgerEntry = galleryTransferLedger.transition(item.id, "EXPORTED", {
         assetReceipt: receipt,
       })
@@ -426,6 +431,33 @@ class MediaProcessingQueue {
 
     const elapsed = Date.now() - startTime
     console.log(`${TAG} ✅ Finished ${item.id} in ${elapsed}ms`)
+  }
+
+  /** Rebuild a missing app-local index row from the durable transfer ledger. */
+  private async recoverDownloadedFile(entry: GalleryTransferEntry) {
+    const indexed = await localStorageService.getDownloadedFile(entry.captureId)
+    if (indexed) return indexed
+    if (!entry.finalPath) throw new Error(`Recovery file is missing for ${entry.captureId}`)
+
+    const stat = await RNFS.stat(entry.finalPath)
+    const recovered = localStorageService.convertToDownloadedFile(
+      {
+        name: entry.captureId,
+        url: "",
+        download: "",
+        size: Number(stat.size) || entry.totalSize,
+        modified: entry.timestamp,
+        mime_type: entry.captureType === "video" ? "video/mp4" : "image/jpeg",
+        is_video: entry.captureType === "video",
+        filePath: entry.finalPath,
+      },
+      entry.finalPath,
+      entry.thumbnailPath,
+    )
+    recovered.capture_id = entry.captureId
+    recovered.assetReceipt = entry.assetReceipt
+    await localStorageService.saveDownloadedFile(recovered)
+    return recovered
   }
 }
 

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -14,8 +14,8 @@ import {INVALID_DOWNLOADED_MEDIA, validateDownloadedMediaFile} from "./galleryMe
 import {reportInvalidGalleryMedia} from "./GalleryMediaIntegrityReportService"
 import {useGallerySyncStore} from "../../stores/gallerySync"
 import {BgTimer} from "../../utils/timers"
-import {MediaLibraryPermissions} from "../../utils/permissions/MediaLibraryPermissions"
 import {galleryTransferLedger, GalleryTransferEntry} from "./galleryTransferLedger"
+import {cameraRollExportCoordinator} from "./cameraRollExportCoordinator"
 
 const TAG = "[MediaProcessingQueue]"
 
@@ -131,15 +131,11 @@ class MediaProcessingQueue {
           throw new Error(`Recovery file is missing for ${entry.captureId}`)
         }
         if (entry.state === "EXPORT_PENDING" || (entry.state === "INDEXED" && entry.shouldAutoSave)) {
-          const receipt = await MediaLibraryPermissions.saveToLibraryWithReceipt(entry.finalPath, entry.timestamp)
-          if (!receipt.success) throw new Error(receipt.error || "camera roll save failed")
+          const downloadedFile = await localStorageService.getDownloadedFile(entry.captureId)
+          if (!downloadedFile) throw new Error(`Local gallery index is missing for ${entry.captureId}`)
+          const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, entry.captureId)
           entry = galleryTransferLedger.transition(entry.captureId, "EXPORTED", {
-            assetReceipt: {
-              platform: receipt.platform,
-              uri: receipt.uri,
-              identifier: receipt.identifier,
-              exportedAt: Date.now(),
-            },
+            assetReceipt: receipt,
           })
         }
         entry = galleryTransferLedger.transition(entry.captureId, "ACK_PENDING")
@@ -346,6 +342,7 @@ class MediaProcessingQueue {
       localThumbnailPath,
       item.glassesModel,
     )
+    downloadedFile.capture_id = item.id
     try {
       await localStorageService.saveDownloadedFile(downloadedFile)
       ledgerEntry = galleryTransferLedger.transition(item.id, "INDEXED", {
@@ -353,6 +350,12 @@ class MediaProcessingQueue {
         thumbnailPath: localThumbnailPath,
         shouldAutoSave: item.shouldAutoSave,
       })
+      await cameraRollExportCoordinator.recordIndexed(
+        downloadedFile,
+        item.shouldAutoSave,
+        item.shouldAutoSave ? "SOURCE_BARRIER" : "HISTORICAL_BACKFILL",
+        item.id,
+      )
     } catch (metadataError) {
       console.error(`${TAG} Metadata save failed for ${item.id}; retaining local and glasses copies:`, metadataError)
       galleryTransferLedger.recordFailure(item.id, metadataError)
@@ -362,23 +365,10 @@ class MediaProcessingQueue {
     // 7. Export is a durable, receipted step. Failure leaves EXPORT_PENDING and blocks ack.
     if (item.shouldAutoSave) {
       galleryTransferLedger.transition(item.id, "EXPORT_PENDING")
-      const receipt = await MediaLibraryPermissions.saveToLibraryWithReceipt(filePathToSave, item.timestamp)
-      if (!receipt.success) {
-        const error = new Error(receipt.error || "camera roll save failed")
-        galleryTransferLedger.recordFailure(item.id, error)
-        useGallerySyncStore.getState().onFileFailed(item.id, error.message)
-        throw error
-      }
+      const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, item.id)
       ledgerEntry = galleryTransferLedger.transition(item.id, "EXPORTED", {
-        assetReceipt: {
-          platform: receipt.platform,
-          uri: receipt.uri,
-          identifier: receipt.identifier,
-          exportedAt: Date.now(),
-        },
+        assetReceipt: receipt,
       })
-      downloadedFile.assetReceipt = ledgerEntry.assetReceipt
-      await localStorageService.saveDownloadedFile(downloadedFile)
       console.log(`${TAG} ✅ Saved to camera roll with receipt: ${item.id}`)
     }
 

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -339,15 +339,19 @@ class MediaProcessingQueue {
       throw new Error(reason)
     }
 
-    // 6. Commit the app-local index before any export or source acknowledgement.
+    // 6. Commit the app-local index before any export or source acknowledgement. Use the final
+    // on-disk output metadata for camera-roll identity: processing can change byte size, while
+    // recovery reconstructs this row from the same file and the transfer ledger timestamp.
     const isVideo = item.type === "video"
+    const finalFileStat = await RNFS.stat(filePathToSave)
+    const finalFileSize = Number(finalFileStat.size)
     const downloadedFile = localStorageService.convertToDownloadedFile(
       {
         name: item.id,
         url: "",
         download: "",
-        size: item.totalSize,
-        modified: item.timestamp || Date.now(),
+        size: finalFileSize,
+        modified: ledgerEntry.timestamp,
         is_video: isVideo,
         thumbnail_data: item.thumbnailData,
         duration: item.duration,
@@ -428,8 +432,8 @@ class MediaProcessingQueue {
       name: item.id,
       url: localFileUrl,
       download: localFileUrl,
-      size: item.totalSize,
-      modified: item.timestamp || Date.now(),
+      size: finalFileSize,
+      modified: ledgerEntry.timestamp,
       is_video: isVideo,
       filePath: filePathToSave,
       mime_type: isVideo ? "video/mp4" : "image/jpeg",

--- a/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
+++ b/mobile/modules/engine/src/services/asg/mediaProcessingQueue.ts
@@ -130,12 +130,29 @@ class MediaProcessingQueue {
         if (!entry.finalPath || !(await RNFS.exists(entry.finalPath))) {
           throw new Error(`Recovery file is missing for ${entry.captureId}`)
         }
-        if (entry.state === "EXPORT_PENDING" || (entry.state === "INDEXED" && entry.shouldAutoSave)) {
-          const downloadedFile = await this.recoverDownloadedFile(entry)
-          const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, entry.captureId)
-          entry = galleryTransferLedger.transition(entry.captureId, "EXPORTED", {
-            assetReceipt: receipt,
-          })
+        // Rebuild a missing app index before any source acknowledgement, even when camera-roll
+        // saving is disabled or an export receipt was already committed before restart.
+        const downloadedFile = await this.recoverDownloadedFile(entry)
+        if (entry.state === "EXPORT_PENDING" || entry.state === "INDEXED") {
+          const shouldAutoSave = await cameraRollExportCoordinator.isAutoSaveEnabled()
+          entry = galleryTransferLedger.update(entry.captureId, {shouldAutoSave, lastError: undefined})
+          if (shouldAutoSave) {
+            if (entry.state !== "EXPORT_PENDING") {
+              entry = galleryTransferLedger.transition(entry.captureId, "EXPORT_PENDING")
+            }
+            const receipt = await cameraRollExportCoordinator.exportForSource(downloadedFile, entry.captureId)
+            entry = receipt
+              ? galleryTransferLedger.transition(entry.captureId, "EXPORTED", {assetReceipt: receipt})
+              : galleryTransferLedger.transition(entry.captureId, "INDEXED", {
+                  shouldAutoSave: false,
+                  lastError: undefined,
+                })
+          } else if (entry.state === "EXPORT_PENDING") {
+            entry = galleryTransferLedger.transition(entry.captureId, "INDEXED", {
+              shouldAutoSave: false,
+              lastError: undefined,
+            })
+          }
         }
         entry = galleryTransferLedger.transition(entry.captureId, "ACK_PENDING")
         await this.acknowledgeEntry(entry)
@@ -342,17 +359,18 @@ class MediaProcessingQueue {
       item.glassesModel,
     )
     downloadedFile.capture_id = item.id
+    const shouldAutoSave = await cameraRollExportCoordinator.isAutoSaveEnabled()
     try {
       await localStorageService.saveDownloadedFile(downloadedFile)
       ledgerEntry = galleryTransferLedger.transition(item.id, "INDEXED", {
         finalPath: filePathToSave,
         thumbnailPath: localThumbnailPath,
-        shouldAutoSave: item.shouldAutoSave,
+        shouldAutoSave,
       })
       await cameraRollExportCoordinator.recordIndexed(
         downloadedFile,
-        item.shouldAutoSave,
-        item.shouldAutoSave ? "SOURCE_BARRIER" : "HISTORICAL_BACKFILL",
+        shouldAutoSave,
+        shouldAutoSave ? "SOURCE_BARRIER" : "HISTORICAL_BACKFILL",
         item.id,
       )
     } catch (metadataError) {
@@ -361,8 +379,9 @@ class MediaProcessingQueue {
       throw metadataError
     }
 
-    // 7. Export is a durable, receipted step. Failure leaves EXPORT_PENDING and blocks ack.
-    if (item.shouldAutoSave) {
+    // 7. While enabled, export is a durable, receipted step whose failures block ack. Turning
+    // auto-save off safely falls back to the already-verified app-local copy and later backfill.
+    if (shouldAutoSave) {
       galleryTransferLedger.transition(item.id, "EXPORT_PENDING")
       let receipt
       try {
@@ -371,10 +390,18 @@ class MediaProcessingQueue {
         galleryTransferLedger.recordFailure(item.id, error)
         throw error
       }
-      ledgerEntry = galleryTransferLedger.transition(item.id, "EXPORTED", {
-        assetReceipt: receipt,
-      })
-      console.log(`${TAG} ✅ Saved to camera roll with receipt: ${item.id}`)
+      if (receipt) {
+        ledgerEntry = galleryTransferLedger.transition(item.id, "EXPORTED", {
+          assetReceipt: receipt,
+        })
+        console.log(`${TAG} ✅ Saved to camera roll with receipt: ${item.id}`)
+      } else {
+        ledgerEntry = galleryTransferLedger.transition(item.id, "INDEXED", {
+          shouldAutoSave: false,
+          lastError: undefined,
+        })
+        console.log(`${TAG} Automatic camera-roll saving was disabled; keeping app-local copy: ${item.id}`)
+      }
     }
 
     // S4: Clean up intermediate processing files

--- a/mobile/modules/engine/src/utils/permissions/MediaLibraryPermissions.ts
+++ b/mobile/modules/engine/src/utils/permissions/MediaLibraryPermissions.ts
@@ -22,6 +22,18 @@ export interface MediaLibrarySaveReceipt {
  * - Android 9-: Uses WRITE_EXTERNAL_STORAGE (legacy)
  */
 export class MediaLibraryPermissions {
+  /** Limited iOS access cannot see historical, unselected assets for duplicate reconciliation. */
+  static async hasLimitedAccess(): Promise<boolean> {
+    if (Platform.OS !== "ios") return false
+    try {
+      return (await check(PERMISSIONS.IOS.PHOTO_LIBRARY)) === RESULTS.LIMITED
+    } catch (error) {
+      console.error("[MediaLibrary] Error checking limited-library access:", error)
+      // Conservatively block legacy reconciliation when the scope cannot be verified.
+      return true
+    }
+  }
+
   /**
    * Check if we have permission to save to the camera roll
    * Note: On Android 10+, this always returns true since no permission is needed

--- a/mobile/src/app/asg/gallery-settings.tsx
+++ b/mobile/src/app/asg/gallery-settings.tsx
@@ -77,7 +77,7 @@ export default function GallerySettingsScreen() {
     }
 
     const itemText = totalLocalMedia === 1 ? "item" : "items"
-    const notExportedCount = cameraRollExportCoordinator.countNotExported(
+    const notExportedCount = await cameraRollExportCoordinator.countNotExported(
       Object.keys(await localStorageService.getDownloadedFiles()),
     )
     const exportWarning =

--- a/mobile/src/app/asg/gallery-settings.tsx
+++ b/mobile/src/app/asg/gallery-settings.tsx
@@ -3,15 +3,14 @@ import {useState, useEffect} from "react"
 import {View, ViewStyle, TextStyle, ScrollView} from "react-native"
 
 import {Header, Screen, Text} from "@/components/ignite"
-import ToggleSetting from "@/components/settings/ToggleSetting"
+import {GalleryCameraRollSetting} from "@/components/glasses/Gallery/GalleryCameraRollSetting"
 import InfoCardSection from "@/components/ui/InfoCard"
 import {RouteButton} from "@/components/ui/RouteButton"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {engine} from "@mentra/engine"
-import {gallerySettingsService, localStorageService} from "@mentra/engine/internal"
-import {SETTINGS, useSetting} from "@mentra/engine"
+import {engine, SETTINGS, useSetting} from "@mentra/engine"
+import {cameraRollExportCoordinator, localStorageService} from "@mentra/engine/internal"
 import {ThemedStyle} from "@/theme"
 import showAlert from "@/utils/AlertUtils"
 
@@ -20,7 +19,6 @@ export default function GallerySettingsScreen() {
   const {theme, themed} = useAppTheme()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
 
-  const [autoSaveToCameraRoll, setAutoSaveToCameraRoll] = useState(true)
   const [localPhotoCount, setLocalPhotoCount] = useState(0)
   const [localVideoCount, setLocalVideoCount] = useState(0)
   const [glassesPhotoCount, setGlassesPhotoCount] = useState(0)
@@ -30,14 +28,8 @@ export default function GallerySettingsScreen() {
 
   // Load settings and stats on mount
   useEffect(() => {
-    loadSettings()
     loadStats()
   }, [])
-
-  const loadSettings = async () => {
-    const settings = await gallerySettingsService.getSettings()
-    setAutoSaveToCameraRoll(settings.autoSaveToCameraRoll)
-  }
 
   const loadStats = async () => {
     try {
@@ -76,11 +68,6 @@ export default function GallerySettingsScreen() {
     }
   }
 
-  const handleToggleAutoSave = async (value: boolean) => {
-    setAutoSaveToCameraRoll(value)
-    await gallerySettingsService.setAutoSaveToCameraRoll(value)
-  }
-
   const handleDeleteAll = async () => {
     const totalLocalMedia = localPhotoCount + localVideoCount
 
@@ -90,7 +77,16 @@ export default function GallerySettingsScreen() {
     }
 
     const itemText = totalLocalMedia === 1 ? "item" : "items"
-    const message = `This will permanently delete all ${totalLocalMedia} ${itemText} from your device. Photos saved to your camera roll will not be affected. This action cannot be undone.`
+    const notExportedCount = cameraRollExportCoordinator.countNotExported(
+      Object.keys(await localStorageService.getDownloadedFiles()),
+    )
+    const exportWarning =
+      notExportedCount > 0
+        ? ` ${notExportedCount} ${
+            notExportedCount === 1 ? "item has" : "items have"
+          } not been confirmed in your camera roll and may be permanently lost.`
+        : " Photos and videos already saved to your camera roll will not be affected."
+    const message = `This will permanently delete all ${totalLocalMedia} ${itemText} from the Mentra App.${exportWarning} This action cannot be undone.`
 
     showAlert("Delete All Photos", message, [
       {text: translate("common:cancel"), style: "cancel"},
@@ -100,7 +96,7 @@ export default function GallerySettingsScreen() {
         onPress: async () => {
           try {
             // console.log("[GallerySettings] 🗑️ Clearing all downloaded files and sync queue")
-            await localStorageService.clearAllFiles()
+            await cameraRollExportCoordinator.clearLocalMedia()
 
             engine.gallery.clearQueue()
             // console.log("[GallerySettings] ✅ Cleared sync queue from store")
@@ -143,12 +139,7 @@ export default function GallerySettingsScreen() {
 
         <View style={themed($sectionCompact)}>
           <Text style={themed($sectionTitle)}>{translate("glasses:automaticSync")}</Text>
-          <ToggleSetting
-            label={translate("glasses:saveToCameraRoll")}
-            subtitle={translate("glasses:saveToLibraryDescription")}
-            value={autoSaveToCameraRoll}
-            onValueChange={handleToggleAutoSave}
-          />
+          <GalleryCameraRollSetting />
         </View>
 
         <Text style={themed($sectionTitle)}>{translate("glasses:storageInfo")}</Text>

--- a/mobile/src/app/miniapps/gallery/gallery-settings.tsx
+++ b/mobile/src/app/miniapps/gallery/gallery-settings.tsx
@@ -3,15 +3,14 @@ import {useState, useEffect} from "react"
 import {View, ViewStyle, TextStyle, ScrollView} from "react-native"
 
 import {Header, Screen, Text} from "@/components/ignite"
-import ToggleSetting from "@/components/settings/ToggleSetting"
+import {GalleryCameraRollSetting} from "@/components/glasses/Gallery/GalleryCameraRollSetting"
 import InfoCardSection from "@/components/ui/InfoCard"
 import {RouteButton} from "@/components/ui/RouteButton"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {engine} from "@mentra/engine"
-import {gallerySettingsService, localStorageService} from "@mentra/engine/internal"
-import {SETTINGS, useSetting} from "@mentra/engine"
+import {engine, SETTINGS, useSetting} from "@mentra/engine"
+import {cameraRollExportCoordinator, localStorageService} from "@mentra/engine/internal"
 import {ThemedStyle} from "@/theme"
 import showAlert from "@/utils/AlertUtils"
 
@@ -20,7 +19,6 @@ export default function GallerySettingsScreen() {
   const {themed} = useAppTheme()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
 
-  const [autoSaveToCameraRoll, setAutoSaveToCameraRoll] = useState(true)
   const [localPhotoCount, setLocalPhotoCount] = useState(0)
   const [localVideoCount, setLocalVideoCount] = useState(0)
   const [glassesPhotoCount, setGlassesPhotoCount] = useState(0)
@@ -30,14 +28,8 @@ export default function GallerySettingsScreen() {
 
   // Load settings and stats on mount
   useEffect(() => {
-    loadSettings()
     loadStats()
   }, [])
-
-  const loadSettings = async () => {
-    const settings = await gallerySettingsService.getSettings()
-    setAutoSaveToCameraRoll(settings.autoSaveToCameraRoll)
-  }
 
   const loadStats = async () => {
     try {
@@ -76,11 +68,6 @@ export default function GallerySettingsScreen() {
     }
   }
 
-  const handleToggleAutoSave = async (value: boolean) => {
-    setAutoSaveToCameraRoll(value)
-    await gallerySettingsService.setAutoSaveToCameraRoll(value)
-  }
-
   const handleDeleteAll = async () => {
     const totalLocalMedia = localPhotoCount + localVideoCount
 
@@ -90,7 +77,16 @@ export default function GallerySettingsScreen() {
     }
 
     const itemText = totalLocalMedia === 1 ? "item" : "items"
-    const message = `This will permanently delete all ${totalLocalMedia} ${itemText} from your device. Photos saved to your camera roll will not be affected. This action cannot be undone.`
+    const notExportedCount = cameraRollExportCoordinator.countNotExported(
+      Object.keys(await localStorageService.getDownloadedFiles()),
+    )
+    const exportWarning =
+      notExportedCount > 0
+        ? ` ${notExportedCount} ${
+            notExportedCount === 1 ? "item has" : "items have"
+          } not been confirmed in your camera roll and may be permanently lost.`
+        : " Photos and videos already saved to your camera roll will not be affected."
+    const message = `This will permanently delete all ${totalLocalMedia} ${itemText} from the Mentra App.${exportWarning} This action cannot be undone.`
 
     showAlert("Delete All Photos", message, [
       {text: translate("common:cancel"), style: "cancel"},
@@ -100,7 +96,7 @@ export default function GallerySettingsScreen() {
         onPress: async () => {
           try {
             // console.log("[GallerySettings] 🗑️ Clearing all downloaded files and sync queue")
-            await localStorageService.clearAllFiles()
+            await cameraRollExportCoordinator.clearLocalMedia()
 
             engine.gallery.clearQueue()
             // console.log("[GallerySettings] ✅ Cleared sync queue from store")
@@ -141,12 +137,7 @@ export default function GallerySettingsScreen() {
 
         <View style={themed($sectionCompact)}>
           <Text style={themed($sectionTitle)}>{translate("glasses:automaticSync")}</Text>
-          <ToggleSetting
-            label={translate("glasses:saveToCameraRoll")}
-            subtitle={translate("glasses:saveToLibraryDescription")}
-            value={autoSaveToCameraRoll}
-            onValueChange={handleToggleAutoSave}
-          />
+          <GalleryCameraRollSetting />
         </View>
 
         <Text style={themed($sectionTitle)}>{translate("glasses:storageInfo")}</Text>

--- a/mobile/src/app/miniapps/gallery/gallery-settings.tsx
+++ b/mobile/src/app/miniapps/gallery/gallery-settings.tsx
@@ -77,7 +77,7 @@ export default function GallerySettingsScreen() {
     }
 
     const itemText = totalLocalMedia === 1 ? "item" : "items"
-    const notExportedCount = cameraRollExportCoordinator.countNotExported(
+    const notExportedCount = await cameraRollExportCoordinator.countNotExported(
       Object.keys(await localStorageService.getDownloadedFiles()),
     )
     const exportWarning =

--- a/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
@@ -137,7 +137,11 @@ export function GalleryCameraRollSetting() {
           <Pressable
             onPress={() => {
               if (summary.blockedPermission > 0) void SettingsNavigationUtils.openAppSettings()
-              else cameraRollExportCoordinator.retryNow()
+              else {
+                void cameraRollExportCoordinator.retryNow().catch((error) => {
+                  console.warn("[GallerySettings] Failed to retry camera-roll exports:", error)
+                })
+              }
             }}>
             <Text text={summary.blockedPermission > 0 ? "Open Settings" : "Retry"} style={themed($actionText)} />
           </Pressable>

--- a/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
@@ -120,7 +120,7 @@ export function GalleryCameraRollSetting() {
   }
 
   const status = getStatusText(summary, enabled)
-  const needsAction = summary.blockedPermission > 0 || summary.failed > 0
+  const needsAction = summary.blockedPermission > 0 || summary.failed > 0 || summary.missing > 0
 
   return (
     <View>

--- a/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
@@ -1,0 +1,188 @@
+import {useEffect, useState} from "react"
+import {Pressable, TextStyle, View, ViewStyle} from "react-native"
+
+import {Text} from "@/components/ignite"
+import ToggleSetting from "@/components/settings/ToggleSetting"
+import {useAppTheme} from "@/contexts/ThemeContext"
+import {translate} from "@/i18n"
+import {ThemedStyle} from "@/theme"
+import showAlert from "@/utils/AlertUtils"
+import {SettingsNavigationUtils} from "@/utils/SettingsNavigationUtils"
+import {MediaLibraryPermissions} from "@mentra/engine"
+import {
+  cameraRollExportCoordinator,
+  gallerySettingsService,
+  type CameraRollExportSummary,
+} from "@mentra/engine/internal"
+
+const EMPTY_SUMMARY: CameraRollExportSummary = {
+  enabled: true,
+  total: 0,
+  exported: 0,
+  pending: 0,
+  failed: 0,
+  blockedPermission: 0,
+  missing: 0,
+  bytesPending: 0,
+  isRunning: false,
+}
+
+export function GalleryCameraRollSetting() {
+  const {themed} = useAppTheme()
+  const [enabled, setEnabled] = useState(true)
+  const [busy, setBusy] = useState(true)
+  const [summary, setSummary] = useState(EMPTY_SUMMARY)
+
+  useEffect(() => {
+    let mounted = true
+    const unsubscribe = cameraRollExportCoordinator.subscribe((next) => {
+      if (!mounted) return
+      setSummary(next)
+      setEnabled(next.enabled)
+    })
+    void (async () => {
+      try {
+        const settings = await gallerySettingsService.getSettings()
+        if (mounted) setEnabled(settings.autoSaveToCameraRoll)
+        await cameraRollExportCoordinator.initialize()
+        if (mounted) setSummary(cameraRollExportCoordinator.getSummary())
+      } finally {
+        if (mounted) setBusy(false)
+      }
+    })()
+    return () => {
+      mounted = false
+      unsubscribe()
+    }
+  }, [])
+
+  const applyToggle = async (value: boolean) => {
+    setBusy(true)
+    try {
+      if (value) {
+        const hasPermission = await MediaLibraryPermissions.checkPermission()
+        const granted = hasPermission || (await MediaLibraryPermissions.requestPermission())
+        if (!granted) {
+          showAlert(
+            "Camera Roll Access Required",
+            "Allow photo-library access in Settings before enabling automatic saving.",
+            [
+              {text: translate("common:cancel"), style: "cancel"},
+              {text: "Open Settings", onPress: () => void SettingsNavigationUtils.openAppSettings()},
+            ],
+          )
+          return
+        }
+      }
+      await cameraRollExportCoordinator.setEnabled(value)
+      setEnabled(value)
+    } catch (error) {
+      console.error("[GallerySettings] Failed to update automatic camera-roll saving:", error)
+      setEnabled(!value)
+      showAlert("Error", "Could not update automatic saving. Please try again.", [{text: translate("common:ok")}])
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleToggle = async (value: boolean) => {
+    if (value) {
+      await applyToggle(true)
+      return
+    }
+    const settings = await gallerySettingsService.getSettings()
+    if (settings.autoSaveDisableWarningShown) {
+      await applyToggle(false)
+      return
+    }
+    showAlert(
+      "Turn Off Automatic Saving?",
+      "New photos and videos will stay only inside the Mentra App. Turning this back on later will automatically save every item that is still missing from your camera roll.",
+      [
+        {text: translate("common:cancel"), style: "cancel"},
+        {
+          text: "Turn Off",
+          style: "destructive",
+          onPress: () => {
+            void (async () => {
+              try {
+                await gallerySettingsService.updateSettings({autoSaveDisableWarningShown: true})
+              } catch (error) {
+                console.warn("[GallerySettings] Failed to persist the automatic-saving warning state:", error)
+              }
+              await applyToggle(false)
+            })()
+          },
+        },
+      ],
+    )
+  }
+
+  const status = getStatusText(summary, enabled)
+  const needsAction = summary.blockedPermission > 0 || summary.failed > 0
+
+  return (
+    <View>
+      <ToggleSetting
+        label={translate("glasses:saveToCameraRoll")}
+        subtitle={translate("glasses:saveToLibraryDescription")}
+        value={enabled}
+        disabled={busy}
+        onValueChange={(value) => void handleToggle(value)}
+      />
+      <View style={themed($statusRow)}>
+        <Text text={status} style={themed($statusText)} />
+        {needsAction && (
+          <Pressable
+            onPress={() => {
+              if (summary.blockedPermission > 0) void SettingsNavigationUtils.openAppSettings()
+              else cameraRollExportCoordinator.retryNow()
+            }}>
+            <Text text={summary.blockedPermission > 0 ? "Open Settings" : "Retry"} style={themed($actionText)} />
+          </Pressable>
+        )}
+      </View>
+    </View>
+  )
+}
+
+function getStatusText(summary: CameraRollExportSummary, enabled: boolean): string {
+  if (!enabled) return "Automatic saving is off. Unsaved items will remain in the Mentra App."
+  if (summary.blockedPermission > 0) {
+    return `${summary.blockedPermission} ${
+      summary.blockedPermission === 1 ? "item needs" : "items need"
+    } photo-library access.`
+  }
+  if (summary.failed > 0) {
+    return `${summary.failed} ${summary.failed === 1 ? "item needs" : "items need"} another export attempt.`
+  }
+  if (summary.pending > 0) {
+    return `${summary.isRunning ? "Saving" : "Waiting to save"} ${summary.pending} ${
+      summary.pending === 1 ? "item" : "items"
+    } to your camera roll.`
+  }
+  if (summary.total > 0) return `All ${summary.exported} items are saved to your camera roll.`
+  return "New photos and videos will also be saved to your camera roll."
+}
+
+const $statusRow: ThemedStyle<ViewStyle> = ({spacing}) => ({
+  flexDirection: "row",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: spacing.s3,
+  marginTop: spacing.s2,
+  paddingHorizontal: spacing.s2,
+})
+
+const $statusText: ThemedStyle<TextStyle> = ({colors}) => ({
+  color: colors.textDim,
+  flex: 1,
+  fontSize: 12,
+  lineHeight: 17,
+})
+
+const $actionText: ThemedStyle<TextStyle> = ({colors}) => ({
+  color: colors.tint,
+  fontSize: 12,
+  fontWeight: "600",
+})

--- a/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
@@ -16,7 +16,7 @@ import {
 } from "@mentra/engine/internal"
 
 const EMPTY_SUMMARY: CameraRollExportSummary = {
-  enabled: true,
+  enabled: false,
   total: 0,
   exported: 0,
   pending: 0,
@@ -30,7 +30,7 @@ const EMPTY_SUMMARY: CameraRollExportSummary = {
 
 export function GalleryCameraRollSetting() {
   const {themed} = useAppTheme()
-  const [enabled, setEnabled] = useState(true)
+  const [enabled, setEnabled] = useState(false)
   const [busy, setBusy] = useState(true)
   const [summary, setSummary] = useState(EMPTY_SUMMARY)
 
@@ -166,6 +166,9 @@ function getStatusText(summary: CameraRollExportSummary, enabled: boolean): stri
     return `${summary.isRunning ? "Saving" : "Waiting to save"} ${summary.pending} ${
       summary.pending === 1 ? "item" : "items"
     } to your camera roll.`
+  }
+  if (summary.missing > 0) {
+    return `${summary.missing} ${summary.missing === 1 ? "item is" : "items are"} no longer available to save.`
   }
   if (summary.total > 0) return `All ${summary.exported} items are saved to your camera roll.`
   return "New photos and videos will also be saved to your camera roll."

--- a/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryCameraRollSetting.tsx
@@ -22,6 +22,7 @@ const EMPTY_SUMMARY: CameraRollExportSummary = {
   pending: 0,
   failed: 0,
   blockedPermission: 0,
+  fullAccessRequired: 0,
   missing: 0,
   bytesPending: 0,
   isRunning: false,
@@ -148,6 +149,11 @@ export function GalleryCameraRollSetting() {
 
 function getStatusText(summary: CameraRollExportSummary, enabled: boolean): string {
   if (!enabled) return "Automatic saving is off. Unsaved items will remain in the Mentra App."
+  if (summary.fullAccessRequired > 0) {
+    return `${summary.fullAccessRequired} legacy ${
+      summary.fullAccessRequired === 1 ? "item needs" : "items need"
+    } Full Photos Access to avoid duplicate copies.`
+  }
   if (summary.blockedPermission > 0) {
     return `${summary.blockedPermission} ${
       summary.blockedPermission === 1 ? "item needs" : "items need"

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -616,7 +616,7 @@ export function GalleryScreen() {
 
     const selectedCount = selectedPhotos.size
     const itemText = selectedCount === 1 ? "item" : "items"
-    const notExportedCount = cameraRollExportCoordinator.countNotExported(Array.from(selectedPhotos))
+    const notExportedCount = await cameraRollExportCoordinator.countNotExported(Array.from(selectedPhotos))
     const exportWarning =
       notExportedCount > 0
         ? ` ${notExportedCount} ${

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -32,9 +32,8 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
 import {translate} from "@/i18n"
-import {MediaLibraryPermissions, engine} from "@mentra/engine"
-import {localStorageService} from "@mentra/engine/internal"
-import {SETTINGS, useSetting} from "@mentra/engine"
+import {engine, MediaLibraryPermissions, SETTINGS, useSetting} from "@mentra/engine"
+import {cameraRollExportCoordinator, localStorageService} from "@mentra/engine/internal"
 import {spacing, ThemedStyle} from "@/theme"
 import {PhotoInfo} from "@/types/asg"
 import Share from "react-native-share"
@@ -70,7 +69,7 @@ interface GalleryItem {
 }
 
 export function GalleryScreen() {
-  const {goBack, push} = useNavigationStore.getState()
+  const {push} = useNavigationStore.getState()
   const {theme, themed} = useAppTheme()
   const insets = useSaferAreaInsets()
 
@@ -180,6 +179,16 @@ export function GalleryScreen() {
               {text: "Enable", onPress: () => void SettingsNavigationUtils.showLocationServicesDialog()},
             ],
             {cancelable: false},
+          )
+          break
+        case "camera_roll_permission_required":
+          showAlert(
+            "Camera Roll Access Required",
+            "Automatic saving is enabled. Allow photo-library access, or turn automatic saving off in Gallery Settings before syncing.",
+            [
+              {text: "Cancel", style: "cancel"},
+              {text: "Open Settings", onPress: () => void SettingsNavigationUtils.openAppSettings()},
+            ],
           )
           break
         case "bluetooth_off":
@@ -607,8 +616,15 @@ export function GalleryScreen() {
 
     const selectedCount = selectedPhotos.size
     const itemText = selectedCount === 1 ? "item" : "items"
+    const notExportedCount = cameraRollExportCoordinator.countNotExported(Array.from(selectedPhotos))
+    const exportWarning =
+      notExportedCount > 0
+        ? ` ${notExportedCount} ${
+            notExportedCount === 1 ? "item has" : "items have"
+          } not been confirmed in your camera roll and may be permanently lost.`
+        : " Copies already saved to your camera roll will not be affected."
 
-    showAlert("Delete Photos", `Are you sure you want to delete ${selectedCount} ${itemText}?`, [
+    showAlert("Delete Photos", `Are you sure you want to delete ${selectedCount} ${itemText}?${exportWarning}`, [
       {text: translate("common:cancel"), style: "cancel"},
       {
         text: translate("common:delete"),
@@ -628,7 +644,7 @@ export function GalleryScreen() {
             if (localPhotos.length > 0) {
               for (const photoName of localPhotos) {
                 try {
-                  const deleted = await localStorageService.deleteDownloadedFile(photoName)
+                  const deleted = await cameraRollExportCoordinator.deleteLocalMedia(photoName)
                   if (deleted) {
                     deletedPhotoNames.push(photoName)
                   } else {
@@ -1054,12 +1070,12 @@ export function GalleryScreen() {
                       ? "item"
                       : "items"
                     : glassesGalleryStatus.photos > 0
-                    ? glassesGalleryStatus.photos === 1
-                      ? "photo"
-                      : "photos"
-                    : glassesGalleryStatus.videos === 1
-                    ? "video"
-                    : "videos"}
+                      ? glassesGalleryStatus.photos === 1
+                        ? "photo"
+                        : "photos"
+                      : glassesGalleryStatus.videos === 1
+                        ? "video"
+                        : "videos"}
                 </Text>
               </View>
             </View>

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -1,0 +1,202 @@
+/* eslint-disable no-restricted-imports */
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+import {cameraRollExportCoordinator} from "../../../modules/engine/src/services/asg/cameraRollExportCoordinator"
+import {cameraRollExportLedger} from "../../../modules/engine/src/services/asg/cameraRollExportLedger"
+import {localStorageService, type DownloadedFile} from "../../../modules/engine/src/services/asg/localStorageService"
+import {MediaLibraryPermissions} from "../../../modules/engine/src/utils/permissions/MediaLibraryPermissions"
+import {storage} from "../../../modules/engine/src/utils/storage"
+
+let mockFiles: Record<string, DownloadedFile> = {}
+let mockAutoSaveEnabled = true
+
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  DocumentDirectoryPath: "/tmp",
+  exists: jest.fn(() => Promise.resolve(true)),
+  getFSInfo: jest.fn(() => Promise.resolve({freeSpace: 10 * 1024 * 1024 * 1024})),
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => ({
+  localStorageService: {
+    getDownloadedFiles: jest.fn(() => Promise.resolve(mockFiles)),
+    updateDownloadedFileAssetReceipt: jest.fn((name: string, receipt: any) => {
+      mockFiles[name] = {...mockFiles[name], assetReceipt: receipt}
+      return Promise.resolve()
+    }),
+    deleteDownloadedFile: jest.fn((name: string) => {
+      const existed = !!mockFiles[name]
+      delete mockFiles[name]
+      return Promise.resolve(existed)
+    }),
+    clearAllFiles: jest.fn(() => {
+      mockFiles = {}
+      return Promise.resolve()
+    }),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/gallerySettingsService", () => ({
+  gallerySettingsService: {
+    getAutoSaveToCameraRoll: jest.fn(() => Promise.resolve(mockAutoSaveEnabled)),
+    setAutoSaveToCameraRoll: jest.fn((enabled: boolean) => {
+      mockAutoSaveEnabled = enabled
+      return Promise.resolve()
+    }),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/galleryTransferLedger", () => ({
+  galleryTransferLedger: {
+    get: jest.fn(),
+    update: jest.fn(),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/utils/permissions/MediaLibraryPermissions", () => ({
+  MediaLibraryPermissions: {
+    checkPermission: jest.fn(() => Promise.resolve(true)),
+    saveToLibraryWithReceipt: jest.fn(() => Promise.resolve({success: true, platform: "ios", identifier: "asset-1"})),
+  },
+}))
+
+function legacyFile(name = "IMG_20260101_120000"): DownloadedFile {
+  return {
+    name,
+    filePath: `/tmp/MentraPhotos/${name}/base.jpg`,
+    size: 1234,
+    modified: 1_767_268_800_000,
+    mime_type: "image/jpeg",
+    is_video: false,
+    downloaded_at: Date.now(),
+  }
+}
+
+describe("cameraRollExportCoordinator", () => {
+  beforeEach(() => {
+    cameraRollExportCoordinator.cleanup()
+    storage.clearAll()
+    mockFiles = {}
+    mockAutoSaveEnabled = true
+    jest.clearAllMocks()
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.getFSInfo as jest.Mock).mockResolvedValue({freeSpace: 10 * 1024 * 1024 * 1024})
+    ;(MediaLibraryPermissions.checkPermission as jest.Mock).mockResolvedValue(true)
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockResolvedValue({
+      success: true,
+      platform: "ios",
+      identifier: "asset-1",
+    })
+  })
+
+  afterEach(() => cameraRollExportCoordinator.cleanup())
+
+  it("backfills a legacy item and reconciles its old basename before inserting", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("test")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
+    expect(localStorageService.updateDownloadedFileAssetReceipt).toHaveBeenCalledWith(
+      file.name,
+      expect.objectContaining({identifier: "asset-1"}),
+    )
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0})
+  })
+
+  it("does not recreate an asset that already has a durable receipt", async () => {
+    const file = legacyFile()
+    file.assetReceipt = {platform: "ios", identifier: "existing", exportedAt: Date.now()}
+    mockFiles[file.name] = file
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("test")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0})
+  })
+
+  it("keeps denied exports durable and blocked instead of dropping them", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+    ;(MediaLibraryPermissions.checkPermission as jest.Mock).mockResolvedValue(false)
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("test")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({blockedPermission: 1, pending: 1})
+    expect(cameraRollExportLedger.list()[0].state).toBe("BLOCKED_PERMISSION")
+  })
+
+  it("queues all still-local unsaved items when automatic saving is re-enabled", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+    mockAutoSaveEnabled = false
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("disabled")
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+
+    await cameraRollExportCoordinator.setEnabled(true)
+    await cameraRollExportCoordinator.resume("enabled")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledTimes(1)
+    expect(cameraRollExportCoordinator.getSummary().exported).toBe(1)
+  })
+
+  it("uses the same durable path for a source-deletion barrier", async () => {
+    const file = legacyFile("IMG_source")
+    mockFiles[file.name] = file
+
+    const receipt = await cameraRollExportCoordinator.exportForSource(file, "IMG_source")
+
+    expect(receipt.identifier).toBe("asset-1")
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      priority: "SOURCE_BARRIER",
+      state: "EXPORTED",
+    })
+  })
+
+  it("clears local media and its export receipts through one serialized operation", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("test")
+
+    await cameraRollExportCoordinator.clearLocalMedia()
+
+    expect(localStorageService.clearAllFiles).toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()).toEqual([])
+    expect(cameraRollExportCoordinator.getSummary().total).toBe(0)
+  })
+
+  it("waits for an in-flight native export before deleting its local source", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+    let finishExport!: (receipt: {success: true; platform: "ios"; identifier: string}) => void
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishExport = resolve
+        }),
+    )
+
+    await cameraRollExportCoordinator.initialize()
+    const drain = cameraRollExportCoordinator.resume("test")
+    for (let i = 0; i < 10 && !finishExport; i += 1) await Promise.resolve()
+    expect(finishExport).toBeDefined()
+
+    const deletion = cameraRollExportCoordinator.deleteLocalMedia(file.name)
+    await Promise.resolve()
+    expect(localStorageService.deleteDownloadedFile).not.toHaveBeenCalled()
+
+    finishExport({success: true, platform: "ios", identifier: "asset-1"})
+    await drain
+    await deletion
+
+    expect(localStorageService.deleteDownloadedFile).toHaveBeenCalledWith(file.name)
+    expect(cameraRollExportLedger.list()).toEqual([])
+  })
+})

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -140,6 +140,18 @@ describe("cameraRollExportCoordinator", () => {
     expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0})
   })
 
+  it("returns a durable source receipt even when automatic saving is disabled", async () => {
+    const file = legacyFile("IMG_exported_before_disable")
+    file.assetReceipt = {platform: "ios", identifier: "existing", exportedAt: Date.now()}
+    mockFiles[file.name] = file
+    mockAutoSaveEnabled = false
+
+    await expect(cameraRollExportCoordinator.exportForSource(file, file.name)).resolves.toMatchObject({
+      identifier: "existing",
+    })
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+  })
+
   it("keeps denied exports durable and blocked instead of dropping them", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -92,6 +92,18 @@ describe("cameraRollExportCoordinator", () => {
 
   afterEach(() => cameraRollExportCoordinator.cleanup())
 
+  it("does not emit a default enabled state before durable settings load", async () => {
+    mockAutoSaveEnabled = false
+    const listener = jest.fn()
+
+    const unsubscribe = cameraRollExportCoordinator.subscribe(listener)
+    expect(listener).not.toHaveBeenCalled()
+
+    await cameraRollExportCoordinator.initialize()
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({enabled: false}))
+    unsubscribe()
+  })
+
   it("backfills a legacy item and reconciles its old basename before inserting", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -299,6 +299,37 @@ describe("cameraRollExportCoordinator", () => {
     }
   })
 
+  it("stops source waiters and serializes restart reconciliation behind an in-flight export", async () => {
+    const file = legacyFile("IMG_engine_restart")
+    let finishExport!: (receipt: {success: true; platform: "ios"; identifier: string}) => void
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishExport = resolve
+        }),
+    )
+
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+    const sourceExport = cameraRollExportCoordinator.exportForSource(file, file.name)
+    for (let i = 0; i < 10 && !finishExport; i += 1) await Promise.resolve()
+    expect(finishExport).toBeDefined()
+
+    cameraRollExportCoordinator.cleanup()
+    await expect(sourceExport).rejects.toThrow("coordinator stopped")
+
+    const reconciliationCalls = (localStorageService.getDownloadedFiles as jest.Mock).mock.calls.length
+    const restart = cameraRollExportCoordinator.initialize()
+    await Promise.resolve()
+    expect(localStorageService.getDownloadedFiles).toHaveBeenCalledTimes(reconciliationCalls)
+
+    finishExport({success: true, platform: "ios", identifier: "asset-after-restart"})
+    await restart
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledTimes(1)
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0, isRunning: false})
+  })
+
   it("drains eligible work after a concurrent resume handoff", async () => {
     const file = legacyFile("IMG_resume_handoff")
     await cameraRollExportCoordinator.initialize()

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -231,6 +231,46 @@ describe("cameraRollExportCoordinator", () => {
     })
   })
 
+  it("returns a receipt committed before its source waiter registers", async () => {
+    const file = legacyFile("IMG_receipt_race")
+    const receipt = {platform: "ios" as const, identifier: "already-exported", exportedAt: Date.now()}
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+    const staleEntry = await cameraRollExportCoordinator.recordIndexed(file, true, "SOURCE_BARRIER", file.name)
+    cameraRollExportLedger.update(staleEntry.id, {state: "EXPORTED", receipt})
+    const recordSpy = jest
+      .spyOn(cameraRollExportCoordinator, "recordIndexed")
+      .mockResolvedValueOnce({...staleEntry, state: "QUEUED", receipt: undefined})
+
+    try {
+      await expect(cameraRollExportCoordinator.exportForSource(file, file.name)).resolves.toEqual(receipt)
+    } finally {
+      recordSpy.mockRestore()
+    }
+  })
+
+  it("drains eligible work after a concurrent resume handoff", async () => {
+    const file = legacyFile("IMG_resume_handoff")
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+    await cameraRollExportCoordinator.recordIndexed(file, true, "HISTORICAL_BACKFILL", file.name)
+
+    const coordinatorState = cameraRollExportCoordinator as unknown as {
+      running: boolean
+      rerunRequested: boolean
+    }
+    coordinatorState.running = true
+    const concurrentResume = cameraRollExportCoordinator.resume("concurrent handoff")
+    for (let i = 0; i < 10 && !coordinatorState.rerunRequested; i += 1) await Promise.resolve()
+    expect(coordinatorState.rerunRequested).toBe(true)
+
+    coordinatorState.running = false
+    await concurrentResume
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
+    expect(cameraRollExportLedger.list()[0].state).toBe("EXPORTED")
+  })
+
   it("clears local media and its export receipts through one serialized operation", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -141,6 +141,53 @@ describe("cameraRollExportCoordinator", () => {
     expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0})
   })
 
+  it("retains a hidden export receipt until its missing local index row is recovered", async () => {
+    const file = legacyFile("IMG_receipt_recovery")
+    file.assetReceipt = {platform: "ios", identifier: "durable-receipt", exportedAt: Date.now()}
+    mockFiles[file.name] = file
+
+    await cameraRollExportCoordinator.initialize()
+    cameraRollExportCoordinator.cleanup()
+    mockFiles = {}
+    await cameraRollExportCoordinator.initialize()
+
+    expect(cameraRollExportLedger.list()).toEqual([
+      expect.objectContaining({state: "EXPORTED", localPresent: false, receipt: file.assetReceipt}),
+    ])
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({total: 0, exported: 0})
+
+    cameraRollExportCoordinator.cleanup()
+    mockFiles[file.name] = {...file, assetReceipt: undefined}
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("recovered index")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      state: "EXPORTED",
+      localPresent: true,
+      receipt: file.assetReceipt,
+    })
+  })
+
+  it("does not let an older receipt confirm a replacement generation with the same name", async () => {
+    const original = legacyFile("IMG_replaced")
+    original.assetReceipt = {platform: "ios", identifier: "old-generation", exportedAt: Date.now()}
+    mockFiles[original.name] = original
+    await cameraRollExportCoordinator.initialize()
+
+    cameraRollExportCoordinator.cleanup()
+    mockAutoSaveEnabled = false
+    mockFiles[original.name] = {
+      ...original,
+      size: original.size + 1,
+      modified: original.modified + 1,
+      assetReceipt: undefined,
+    }
+    await cameraRollExportCoordinator.initialize()
+
+    await expect(cameraRollExportCoordinator.countNotExported([original.name])).resolves.toBe(1)
+  })
+
   it("returns a durable source receipt even when automatic saving is disabled", async () => {
     const file = legacyFile("IMG_exported_before_disable")
     file.assetReceipt = {platform: "ios", identifier: "existing", exportedAt: Date.now()}

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -55,6 +55,7 @@ jest.mock("../../../modules/engine/src/services/asg/galleryTransferLedger", () =
 jest.mock("../../../modules/engine/src/utils/permissions/MediaLibraryPermissions", () => ({
   MediaLibraryPermissions: {
     checkPermission: jest.fn(() => Promise.resolve(true)),
+    hasLimitedAccess: jest.fn(() => Promise.resolve(false)),
     saveToLibraryWithReceipt: jest.fn(() => Promise.resolve({success: true, platform: "ios", identifier: "asset-1"})),
   },
 }))
@@ -81,6 +82,7 @@ describe("cameraRollExportCoordinator", () => {
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
     ;(RNFS.getFSInfo as jest.Mock).mockResolvedValue({freeSpace: 10 * 1024 * 1024 * 1024})
     ;(MediaLibraryPermissions.checkPermission as jest.Mock).mockResolvedValue(true)
+    ;(MediaLibraryPermissions.hasLimitedAccess as jest.Mock).mockResolvedValue(false)
     ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockResolvedValue({
       success: true,
       platform: "ios",
@@ -130,6 +132,36 @@ describe("cameraRollExportCoordinator", () => {
     expect(cameraRollExportLedger.list()[0].state).toBe("BLOCKED_PERMISSION")
   })
 
+  it("does not duplicate an unreceipted legacy export under limited iOS access", async () => {
+    const file = legacyFile()
+    mockFiles[file.name] = file
+    ;(MediaLibraryPermissions.hasLimitedAccess as jest.Mock).mockResolvedValue(true)
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("limited")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      state: "BLOCKED_PERMISSION",
+      requiresFullLibraryReconciliation: true,
+    })
+  })
+
+  it("still exports newly indexed media under limited iOS access", async () => {
+    const file = legacyFile("IMG_new")
+    ;(MediaLibraryPermissions.hasLimitedAccess as jest.Mock).mockResolvedValue(true)
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+
+    const receipt = await cameraRollExportCoordinator.exportForSource(file, file.name)
+
+    expect(receipt.identifier).toBe("asset-1")
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      state: "EXPORTED",
+      requiresFullLibraryReconciliation: false,
+    })
+  })
+
   it("queues all still-local unsaved items when automatic saving is re-enabled", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file
@@ -174,7 +206,6 @@ describe("cameraRollExportCoordinator", () => {
 
   it("waits for an in-flight native export before deleting its local source", async () => {
     const file = legacyFile()
-    mockFiles[file.name] = file
     let finishExport!: (receipt: {success: true; platform: "ios"; identifier: string}) => void
     ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockImplementationOnce(
       () =>
@@ -184,7 +215,8 @@ describe("cameraRollExportCoordinator", () => {
     )
 
     await cameraRollExportCoordinator.initialize()
-    const drain = cameraRollExportCoordinator.resume("test")
+    mockFiles[file.name] = file
+    const exportForSource = cameraRollExportCoordinator.exportForSource(file, file.name)
     for (let i = 0; i < 10 && !finishExport; i += 1) await Promise.resolve()
     expect(finishExport).toBeDefined()
 
@@ -193,7 +225,7 @@ describe("cameraRollExportCoordinator", () => {
     expect(localStorageService.deleteDownloadedFile).not.toHaveBeenCalled()
 
     finishExport({success: true, platform: "ios", identifier: "asset-1"})
-    await drain
+    await expect(exportForSource).resolves.toMatchObject({identifier: "asset-1"})
     await deletion
 
     expect(localStorageService.deleteDownloadedFile).toHaveBeenCalledWith(file.name)

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -3,6 +3,7 @@ import * as RNFS from "@dr.pogodin/react-native-fs"
 
 import {cameraRollExportCoordinator} from "../../../modules/engine/src/services/asg/cameraRollExportCoordinator"
 import {cameraRollExportLedger} from "../../../modules/engine/src/services/asg/cameraRollExportLedger"
+import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
 import {localStorageService, type DownloadedFile} from "../../../modules/engine/src/services/asg/localStorageService"
 import {MediaLibraryPermissions} from "../../../modules/engine/src/utils/permissions/MediaLibraryPermissions"
 import {storage} from "../../../modules/engine/src/utils/storage"
@@ -189,6 +190,22 @@ describe("cameraRollExportCoordinator", () => {
     const receipt = await cameraRollExportCoordinator.exportForSource(file, file.name)
 
     expect(receipt.identifier).toBe("asset-1")
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      state: "EXPORTED",
+      requiresFullLibraryReconciliation: false,
+    })
+  })
+
+  it("does not misclassify a new-pipeline transfer as an ambiguous legacy export", async () => {
+    const file = legacyFile("IMG_new_pipeline_recovery")
+    mockFiles[file.name] = file
+    ;(galleryTransferLedger.get as jest.Mock).mockReturnValue({captureId: file.name})
+    ;(MediaLibraryPermissions.hasLimitedAccess as jest.Mock).mockResolvedValue(true)
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("new pipeline recovery")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
     expect(cameraRollExportLedger.list()[0]).toMatchObject({
       state: "EXPORTED",
       requiresFullLibraryReconciliation: false,

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -200,6 +200,16 @@ describe("cameraRollExportCoordinator", () => {
     expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
   })
 
+  it("keeps an unexported source app-local when automatic saving is disabled", async () => {
+    const file = legacyFile("IMG_disabled_source")
+    mockFiles[file.name] = file
+    mockAutoSaveEnabled = false
+
+    await expect(cameraRollExportCoordinator.exportForSource(file, file.name)).resolves.toBeUndefined()
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({state: "NOT_REQUESTED", localPresent: true})
+  })
+
   it("keeps denied exports durable and blocked instead of dropping them", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file
@@ -270,7 +280,7 @@ describe("cameraRollExportCoordinator", () => {
 
     const receipt = await cameraRollExportCoordinator.exportForSource(file, file.name)
 
-    expect(receipt.identifier).toBe("asset-1")
+    expect(receipt?.identifier).toBe("asset-1")
     expect(cameraRollExportLedger.list()[0]).toMatchObject({
       state: "EXPORTED",
       requiresFullLibraryReconciliation: false,
@@ -344,7 +354,7 @@ describe("cameraRollExportCoordinator", () => {
     await cameraRollExportCoordinator.setEnabled(false)
     finishExists(true)
 
-    await expect(sourceExport).rejects.toThrow("disabled")
+    await expect(sourceExport).resolves.toBeUndefined()
     expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
     expect(cameraRollExportLedger.list()[0].state).toBe("NOT_REQUESTED")
   })
@@ -355,7 +365,7 @@ describe("cameraRollExportCoordinator", () => {
 
     const receipt = await cameraRollExportCoordinator.exportForSource(file, "IMG_source")
 
-    expect(receipt.identifier).toBe("asset-1")
+    expect(receipt?.identifier).toBe("asset-1")
     expect(cameraRollExportLedger.list()[0]).toMatchObject({
       priority: "SOURCE_BARRIER",
       state: "EXPORTED",

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -178,6 +178,46 @@ describe("cameraRollExportCoordinator", () => {
     expect(cameraRollExportCoordinator.getSummary().exported).toBe(1)
   })
 
+  it("pauses queued source barriers when automatic saving is disabled", async () => {
+    const file = legacyFile("IMG_source_paused")
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+    await cameraRollExportCoordinator.recordIndexed(file, true, "SOURCE_BARRIER", file.name)
+
+    await cameraRollExportCoordinator.setEnabled(false)
+    await cameraRollExportCoordinator.resume("disabled foreground")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()[0]).toMatchObject({
+      priority: "SOURCE_BARRIER",
+      state: "NOT_REQUESTED",
+    })
+  })
+
+  it("does not start a native save after an active source barrier is disabled", async () => {
+    const file = legacyFile("IMG_source_disabled_during_checks")
+    let finishExists!: (exists: boolean) => void
+    ;(RNFS.exists as jest.Mock).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishExists = resolve
+        }),
+    )
+
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[file.name] = file
+    const sourceExport = cameraRollExportCoordinator.exportForSource(file, file.name)
+    for (let i = 0; i < 10 && !finishExists; i += 1) await Promise.resolve()
+    expect(finishExists).toBeDefined()
+
+    await cameraRollExportCoordinator.setEnabled(false)
+    finishExists(true)
+
+    await expect(sourceExport).rejects.toThrow("disabled")
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportLedger.list()[0].state).toBe("NOT_REQUESTED")
+  })
+
   it("uses the same durable path for a source-deletion barrier", async () => {
     const file = legacyFile("IMG_source")
     mockFiles[file.name] = file
@@ -230,5 +270,72 @@ describe("cameraRollExportCoordinator", () => {
 
     expect(localStorageService.deleteDownloadedFile).toHaveBeenCalledWith(file.name)
     expect(cameraRollExportLedger.list()).toEqual([])
+  })
+
+  it("keeps a source barrier alive when local deletion fails", async () => {
+    const activeFile = legacyFile("IMG_active")
+    const queuedFile = legacyFile("IMG_delete_failed")
+    let finishActiveExport!: (receipt: {success: true; platform: "ios"; identifier: string}) => void
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishActiveExport = resolve
+          }),
+      )
+      .mockResolvedValueOnce({success: true, platform: "ios", identifier: "asset-2"})
+    ;(localStorageService.deleteDownloadedFile as jest.Mock).mockResolvedValueOnce(false)
+
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[activeFile.name] = activeFile
+    mockFiles[queuedFile.name] = queuedFile
+    const activeExport = cameraRollExportCoordinator.exportForSource(activeFile, activeFile.name)
+    for (let i = 0; i < 10 && !finishActiveExport; i += 1) await Promise.resolve()
+    expect(finishActiveExport).toBeDefined()
+    const queuedExport = cameraRollExportCoordinator.exportForSource(queuedFile, queuedFile.name)
+    for (let i = 0; i < 10 && cameraRollExportLedger.list().length < 2; i += 1) await Promise.resolve()
+
+    await expect(cameraRollExportCoordinator.deleteLocalMedia(queuedFile.name)).resolves.toBe(false)
+    finishActiveExport({success: true, platform: "ios", identifier: "asset-1"})
+
+    await expect(activeExport).resolves.toMatchObject({identifier: "asset-1"})
+    await expect(queuedExport).resolves.toMatchObject({identifier: "asset-2"})
+    expect(cameraRollExportLedger.list().find((entry) => entry.mediaName === queuedFile.name)).toMatchObject({
+      state: "EXPORTED",
+    })
+  })
+
+  it("keeps queued barriers alive when clearing local media fails", async () => {
+    const activeFile = legacyFile("IMG_active_clear")
+    const queuedFile = legacyFile("IMG_clear_failed")
+    let finishActiveExport!: (receipt: {success: true; platform: "ios"; identifier: string}) => void
+    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishActiveExport = resolve
+          }),
+      )
+      .mockResolvedValueOnce({success: true, platform: "ios", identifier: "asset-2"})
+    ;(localStorageService.clearAllFiles as jest.Mock).mockRejectedValueOnce(new Error("clear failed"))
+
+    await cameraRollExportCoordinator.initialize()
+    mockFiles[activeFile.name] = activeFile
+    mockFiles[queuedFile.name] = queuedFile
+    const activeExport = cameraRollExportCoordinator.exportForSource(activeFile, activeFile.name)
+    for (let i = 0; i < 10 && !finishActiveExport; i += 1) await Promise.resolve()
+    expect(finishActiveExport).toBeDefined()
+    const queuedExport = cameraRollExportCoordinator.exportForSource(queuedFile, queuedFile.name)
+    for (let i = 0; i < 10 && cameraRollExportLedger.list().length < 2; i += 1) await Promise.resolve()
+
+    const clearing = cameraRollExportCoordinator.clearLocalMedia()
+    finishActiveExport({success: true, platform: "ios", identifier: "asset-1"})
+
+    await expect(activeExport).resolves.toMatchObject({identifier: "asset-1"})
+    await expect(clearing).rejects.toThrow("clear failed")
+    await expect(queuedExport).resolves.toMatchObject({identifier: "asset-2"})
+    expect(cameraRollExportLedger.list().find((entry) => entry.mediaName === queuedFile.name)).toMatchObject({
+      state: "EXPORTED",
+    })
   })
 })

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -166,6 +166,40 @@ describe("cameraRollExportCoordinator", () => {
     expect(cameraRollExportLedger.list()[0].state).toBe("BLOCKED_PERMISSION")
   })
 
+  it("retries an item after a transient local filesystem miss", async () => {
+    const file = legacyFile("IMG_transient_missing")
+    mockFiles[file.name] = file
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(false)
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("missing")
+    expect(cameraRollExportLedger.list()[0].state).toBe("MISSING_LOCAL")
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    cameraRollExportCoordinator.retryNow()
+    await cameraRollExportCoordinator.resume("file restored")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, missing: 0})
+  })
+
+  it("requeues a previously missing generation when restart reconciliation sees it again", async () => {
+    const file = legacyFile("IMG_missing_at_restart")
+    mockFiles[file.name] = file
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(false)
+
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("missing")
+    expect(cameraRollExportLedger.list()[0].state).toBe("MISSING_LOCAL")
+
+    cameraRollExportCoordinator.cleanup()
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    await cameraRollExportCoordinator.initialize()
+    await cameraRollExportCoordinator.resume("restart")
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, missing: 0})
+  })
+
   it("does not duplicate an unreceipted legacy export under limited iOS access", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -104,6 +104,15 @@ describe("cameraRollExportCoordinator", () => {
     unsubscribe()
   })
 
+  it("reconciles durable receipts before reporting delete-loss warnings", async () => {
+    const file = legacyFile("IMG_already_exported")
+    file.assetReceipt = {platform: "ios", identifier: "existing", exportedAt: Date.now()}
+    mockFiles[file.name] = file
+
+    await expect(cameraRollExportCoordinator.countNotExported([file.name])).resolves.toBe(0)
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, pending: 0})
+  })
+
   it("backfills a legacy item and reconciles its old basename before inserting", async () => {
     const file = legacyFile()
     mockFiles[file.name] = file

--- a/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
+++ b/mobile/src/services/asg/cameraRollExportCoordinator.test.ts
@@ -169,6 +169,27 @@ describe("cameraRollExportCoordinator", () => {
     })
   })
 
+  it("reports an unexported missing row and retries it after the local index is recovered", async () => {
+    const file = legacyFile("IMG_missing_backfill")
+    mockAutoSaveEnabled = false
+    mockFiles[file.name] = file
+    await cameraRollExportCoordinator.initialize()
+
+    cameraRollExportCoordinator.cleanup()
+    mockAutoSaveEnabled = true
+    mockFiles = {}
+    await cameraRollExportCoordinator.initialize()
+
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({total: 1, exported: 0, missing: 1})
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+
+    mockFiles[file.name] = file
+    await cameraRollExportCoordinator.retryNow()
+
+    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
+    expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, missing: 0})
+  })
+
   it("does not let an older receipt confirm a replacement generation with the same name", async () => {
     const original = legacyFile("IMG_replaced")
     original.assetReceipt = {platform: "ios", identifier: "old-generation", exportedAt: Date.now()}
@@ -232,8 +253,7 @@ describe("cameraRollExportCoordinator", () => {
     await cameraRollExportCoordinator.resume("missing")
     expect(cameraRollExportLedger.list()[0].state).toBe("MISSING_LOCAL")
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
-    cameraRollExportCoordinator.retryNow()
-    await cameraRollExportCoordinator.resume("file restored")
+    await cameraRollExportCoordinator.retryNow()
 
     expect(MediaLibraryPermissions.saveToLibraryWithReceipt).toHaveBeenCalledWith(file.filePath, file.modified)
     expect(cameraRollExportCoordinator.getSummary()).toMatchObject({exported: 1, missing: 0})

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 
 // gallerySyncService + its asg cluster moved into @mentra/engine; this CI-gated jest
@@ -8,9 +9,12 @@ import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 import {asgCameraApi} from "../../../modules/engine/src/services/asg/asgCameraApi"
 import {gallerySyncNotifications} from "../../../modules/engine/src/services/asg/gallerySyncNotifications"
 import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
+import {gallerySettingsService} from "../../../modules/engine/src/services/asg/gallerySettingsService"
+import {onGalleryNotice} from "../../../modules/engine/src/services/asg/galleryNotices"
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
 import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 import {gallerySyncService} from "../../../modules/engine/src/services/asg/gallerySyncService"
+import {MediaLibraryPermissions} from "../../../modules/engine/src/utils/permissions/MediaLibraryPermissions"
 import {useGallerySyncStore} from "../../../modules/engine/src/stores/gallerySync"
 import {useGlassesStore} from "../../../modules/engine/src/stores/glasses"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
@@ -101,6 +105,14 @@ jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => 
     clearSyncQueue: jest.fn(() => Promise.resolve()),
     convertToDownloadedFile: jest.fn((file: any) => file),
     saveDownloadedFile: jest.fn(() => Promise.resolve()),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/cameraRollExportCoordinator", () => ({
+  cameraRollExportCoordinator: {
+    initialize: jest.fn(() => Promise.resolve()),
+    cleanup: jest.fn(),
+    resume: jest.fn(() => Promise.resolve()),
   },
 }))
 
@@ -220,6 +232,22 @@ describe("GallerySyncService", () => {
     expect(useGallerySyncStore.getState().syncState).toBe("requesting_hotspot")
     expect(useGallerySyncStore.getState().syncServiceOpenedHotspot).toBe(true)
     expect(BluetoothSdk.setHotspotState).toHaveBeenCalledWith(true)
+  })
+
+  it("does not begin a source-destructive sync when camera-roll intent is on but permission is denied", async () => {
+    ;(gallerySettingsService.getAutoSaveToCameraRoll as jest.Mock).mockResolvedValueOnce(true)
+    ;(MediaLibraryPermissions.checkPermission as jest.Mock).mockResolvedValueOnce(false)
+    ;(MediaLibraryPermissions.requestPermission as jest.Mock).mockResolvedValueOnce(false)
+    const notices: string[] = []
+    const unsubscribe = onGalleryNotice((notice) => notices.push(notice.code))
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+
+    await gallerySyncService.startSync()
+    unsubscribe()
+
+    expect(notices).toContain("camera_roll_permission_required")
+    expect(useGallerySyncStore.getState().syncState).toBe("error")
+    expect(BluetoothSdk.setHotspotState).not.toHaveBeenCalled()
   })
 
   it("aborts pre-flight quietly when glasses disconnect during any pre-flight await", async () => {

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -248,6 +248,7 @@ describe("GallerySyncService", () => {
     expect(notices).toContain("camera_roll_permission_required")
     expect(useGallerySyncStore.getState().syncState).toBe("error")
     expect(BluetoothSdk.setHotspotState).not.toHaveBeenCalled()
+    expect(mediaProcessingQueue.reset).not.toHaveBeenCalled()
   })
 
   it("aborts pre-flight quietly when glasses disconnect during any pre-flight await", async () => {

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import * as RNFS from "@dr.pogodin/react-native-fs"
 
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
@@ -6,7 +7,7 @@ import {useGallerySyncStore} from "../../../modules/engine/src/stores/gallerySyn
 import {asgCameraApi} from "../../../modules/engine/src/services/asg/asgCameraApi"
 // The durable ledger is engine-internal; this host test exercises restart recovery directly.
 import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
-import {MediaLibraryPermissions} from "../../../modules/engine/src/utils/permissions/MediaLibraryPermissions"
+import {cameraRollExportCoordinator} from "../../../modules/engine/src/services/asg/cameraRollExportCoordinator"
 
 import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 
@@ -36,6 +37,14 @@ jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => 
   localStorageService: {
     convertToDownloadedFile: jest.fn((info: any) => info),
     saveDownloadedFile: jest.fn(),
+    getDownloadedFile: jest.fn(),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/cameraRollExportCoordinator", () => ({
+  cameraRollExportCoordinator: {
+    recordIndexed: jest.fn(() => Promise.resolve()),
+    exportForSource: jest.fn(() => Promise.resolve({platform: "ios", identifier: "asset", exportedAt: Date.now()})),
   },
 }))
 
@@ -114,11 +123,7 @@ describe("mediaProcessingQueue", () => {
     ;(RNFS.read as jest.Mock).mockResolvedValue(
       Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
     )
-    ;(MediaLibraryPermissions.saveToLibraryWithReceipt as jest.Mock).mockResolvedValueOnce({
-      success: false,
-      platform: "ios",
-      error: "PhotoKit unavailable",
-    })
+    ;(cameraRollExportCoordinator.exportForSource as jest.Mock).mockRejectedValueOnce(new Error("PhotoKit unavailable"))
 
     mediaProcessingQueue.reset()
     mediaProcessingQueue.enqueue({
@@ -186,7 +191,7 @@ describe("mediaProcessingQueue", () => {
 
     await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
 
-    expect(MediaLibraryPermissions.saveToLibraryWithReceipt).not.toHaveBeenCalled()
+    expect(cameraRollExportCoordinator.exportForSource).not.toHaveBeenCalled()
     expect(asgCameraApi.acknowledgeCapture).toHaveBeenCalledWith(capture.capture_id, entry.ackId)
     expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
     recoverySpy.mockRestore()

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -44,6 +44,7 @@ jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => 
 jest.mock("../../../modules/engine/src/services/asg/cameraRollExportCoordinator", () => ({
   cameraRollExportCoordinator: {
     recordIndexed: jest.fn(() => Promise.resolve()),
+    isAutoSaveEnabled: jest.fn(() => Promise.resolve(false)),
     exportForSource: jest.fn(() => Promise.resolve({platform: "ios", identifier: "asset", exportedAt: Date.now()})),
   },
 }))
@@ -124,6 +125,7 @@ describe("mediaProcessingQueue", () => {
       Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
     )
     ;(cameraRollExportCoordinator.exportForSource as jest.Mock).mockRejectedValueOnce(new Error("PhotoKit unavailable"))
+    ;(cameraRollExportCoordinator.isAutoSaveEnabled as jest.Mock).mockResolvedValueOnce(true)
 
     mediaProcessingQueue.reset()
     mediaProcessingQueue.enqueue({
@@ -146,6 +148,41 @@ describe("mediaProcessingQueue", () => {
       state: "EXPORT_PENDING",
       retryCount: 1,
       lastError: "PhotoKit unavailable",
+    })
+  })
+
+  it("acknowledges an app-local capture when automatic camera-roll saving was turned off", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(RNFS.read as jest.Mock).mockResolvedValue(
+      Buffer.from([0xff, 0xd8, 0x76, 0x61, 0x6c, 0x69, 0x64]).toString("base64"),
+    )
+
+    mediaProcessingQueue.reset()
+    mediaProcessingQueue.enqueue({
+      id: "IMG_disabled_during_sync",
+      type: "photo",
+      primaryPath: "/tmp/IMG_disabled_during_sync/base.jpg",
+      totalSize: 100,
+      shouldProcess: false,
+      shouldAutoSave: true,
+      deleteFromGlasses: ["IMG_disabled_during_sync"],
+      protocolVersion: 3,
+    })
+
+    await expect(mediaProcessingQueue.waitUntilDrained(5000)).resolves.toBeUndefined()
+
+    expect(cameraRollExportCoordinator.exportForSource).not.toHaveBeenCalled()
+    expect(cameraRollExportCoordinator.recordIndexed).toHaveBeenCalledWith(
+      expect.objectContaining({capture_id: "IMG_disabled_during_sync"}),
+      false,
+      "HISTORICAL_BACKFILL",
+      "IMG_disabled_during_sync",
+    )
+    expect(asgCameraApi.acknowledgeCapture).toHaveBeenCalled()
+    expect(galleryTransferLedger.get("IMG_disabled_during_sync")).toMatchObject({
+      state: "TRASHED",
+      shouldAutoSave: false,
     })
   })
 
@@ -206,6 +243,7 @@ describe("mediaProcessingQueue", () => {
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
     ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
     ;(localStorageService.getDownloadedFile as jest.Mock).mockResolvedValueOnce(null)
+    ;(cameraRollExportCoordinator.isAutoSaveEnabled as jest.Mock).mockResolvedValueOnce(true)
     const capture = {
       capture_id: "IMG_recover_index",
       type: "photo" as const,
@@ -235,6 +273,35 @@ describe("mediaProcessingQueue", () => {
       capture.capture_id,
     )
     expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
+    recoverySpy.mockRestore()
+  })
+
+  it("acks recovered EXPORT_PENDING media when automatic saving is now disabled", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(localStorageService.getDownloadedFile as jest.Mock).mockResolvedValueOnce({
+      name: "IMG_recover_disabled",
+      capture_id: "IMG_recover_disabled",
+    })
+    const capture = {
+      capture_id: "IMG_recover_disabled",
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: "IMG_recover_disabled/base.jpg", size: 100, role: "primary" as const}],
+    }
+    galleryTransferLedger.ensureCapture(capture, 3)
+    const entry = galleryTransferLedger.transition(capture.capture_id, "EXPORT_PENDING", {
+      finalPath: "/tmp/IMG_recover_disabled/base.jpg",
+      shouldAutoSave: true,
+    })
+    const recoverySpy = jest.spyOn(galleryTransferLedger, "pendingRecovery").mockReturnValue([entry])
+
+    await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
+
+    expect(cameraRollExportCoordinator.exportForSource).not.toHaveBeenCalled()
+    expect(asgCameraApi.acknowledgeCapture).toHaveBeenCalledWith(capture.capture_id, entry.ackId)
+    expect(galleryTransferLedger.get(capture.capture_id)).toMatchObject({state: "TRASHED", shouldAutoSave: false})
     recoverySpy.mockRestore()
   })
 

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -287,6 +287,50 @@ describe("mediaProcessingQueue", () => {
     recoverySpy.mockRestore()
   })
 
+  it("repairs a stale local index from the durable transfer path before retrying export", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 75})
+    ;(localStorageService.getDownloadedFile as jest.Mock).mockResolvedValueOnce({
+      name: "IMG_recover_stale_index",
+      filePath: "/tmp/old-generation/base.jpg",
+      capture_id: "IMG_recover_stale_index",
+      size: 100,
+      modified: 500,
+    })
+    ;(cameraRollExportCoordinator.isAutoSaveEnabled as jest.Mock).mockResolvedValueOnce(true)
+    const capture = {
+      capture_id: "IMG_recover_stale_index",
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: "IMG_recover_stale_index/base.jpg", size: 100, role: "primary" as const}],
+    }
+    galleryTransferLedger.ensureCapture(capture, 3)
+    const entry = galleryTransferLedger.transition(capture.capture_id, "EXPORT_PENDING", {
+      finalPath: "/tmp/current-generation/base.jpg",
+      thumbnailPath: "/tmp/current-generation/thumb.jpg",
+      shouldAutoSave: true,
+    })
+    const recoverySpy = jest.spyOn(galleryTransferLedger, "pendingRecovery").mockReturnValue([entry])
+
+    await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
+
+    expect(localStorageService.saveDownloadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filePath: entry.finalPath,
+        capture_id: capture.capture_id,
+        size: 75,
+        modified: capture.timestamp,
+      }),
+    )
+    expect(cameraRollExportCoordinator.exportForSource).toHaveBeenCalledWith(
+      expect.objectContaining({filePath: entry.finalPath, size: 75, modified: capture.timestamp}),
+      capture.capture_id,
+    )
+    expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
+    recoverySpy.mockRestore()
+  })
+
   it("acks recovered EXPORT_PENDING media when automatic saving is now disabled", async () => {
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
     ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -108,13 +108,22 @@ describe("mediaProcessingQueue", () => {
       type: "photo",
       primaryPath: "/tmp/IMG_with_sidecar/base.jpg",
       totalSize: 200,
+      timestamp: 1234,
       shouldProcess: false,
       shouldAutoSave: false,
     })
 
     await expect(mediaProcessingQueue.waitUntilDrained(5000)).resolves.toBeUndefined()
 
-    expect(localStorageService.saveDownloadedFile).toHaveBeenCalled()
+    expect(localStorageService.saveDownloadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({size: 100, modified: 1234}),
+    )
+    expect(cameraRollExportCoordinator.recordIndexed).toHaveBeenCalledWith(
+      expect.objectContaining({size: 100, modified: 1234}),
+      false,
+      "HISTORICAL_BACKFILL",
+      "IMG_with_sidecar",
+    )
     expect(useGallerySyncStore.getState().failedFiles).not.toContain("IMG_with_sidecar")
   })
 
@@ -241,7 +250,7 @@ describe("mediaProcessingQueue", () => {
 
   it("rebuilds a missing local index before retrying a durable export", async () => {
     ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
-    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 75})
     ;(localStorageService.getDownloadedFile as jest.Mock).mockResolvedValueOnce(null)
     ;(cameraRollExportCoordinator.isAutoSaveEnabled as jest.Mock).mockResolvedValueOnce(true)
     const capture = {
@@ -266,6 +275,8 @@ describe("mediaProcessingQueue", () => {
         name: capture.capture_id,
         filePath: entry.finalPath,
         capture_id: capture.capture_id,
+        size: 75,
+        modified: capture.timestamp,
       }),
     )
     expect(cameraRollExportCoordinator.exportForSource).toHaveBeenCalledWith(

--- a/mobile/src/services/asg/mediaProcessingQueue.test.ts
+++ b/mobile/src/services/asg/mediaProcessingQueue.test.ts
@@ -142,6 +142,11 @@ describe("mediaProcessingQueue", () => {
     expect(asgCameraApi.acknowledgeCapture).not.toHaveBeenCalled()
     expect(asgCameraApi.deleteFilesFromServer).not.toHaveBeenCalled()
     expect(useGallerySyncStore.getState().failedFiles).toContain("IMG_export_failure")
+    expect(galleryTransferLedger.get("IMG_export_failure")).toMatchObject({
+      state: "EXPORT_PENDING",
+      retryCount: 1,
+      lastError: "PhotoKit unavailable",
+    })
   })
 
   it("retains both copies and reports failure when the local index cannot be saved", async () => {
@@ -193,6 +198,42 @@ describe("mediaProcessingQueue", () => {
 
     expect(cameraRollExportCoordinator.exportForSource).not.toHaveBeenCalled()
     expect(asgCameraApi.acknowledgeCapture).toHaveBeenCalledWith(capture.capture_id, entry.ackId)
+    expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
+    recoverySpy.mockRestore()
+  })
+
+  it("rebuilds a missing local index before retrying a durable export", async () => {
+    ;(RNFS.exists as jest.Mock).mockResolvedValue(true)
+    ;(RNFS.stat as jest.Mock).mockResolvedValue({size: 100})
+    ;(localStorageService.getDownloadedFile as jest.Mock).mockResolvedValueOnce(null)
+    const capture = {
+      capture_id: "IMG_recover_index",
+      type: "photo" as const,
+      timestamp: 1000,
+      total_size: 100,
+      files: [{name: "IMG_recover_index/base.jpg", size: 100, role: "primary" as const}],
+    }
+    galleryTransferLedger.ensureCapture(capture, 3)
+    const entry = galleryTransferLedger.transition(capture.capture_id, "EXPORT_PENDING", {
+      finalPath: "/tmp/IMG_recover_index/base.jpg",
+      thumbnailPath: "/tmp/IMG_recover_index/thumb.jpg",
+      shouldAutoSave: true,
+    })
+    const recoverySpy = jest.spyOn(galleryTransferLedger, "pendingRecovery").mockReturnValue([entry])
+
+    await expect(mediaProcessingQueue.retryPending()).resolves.toEqual({retried: 1, failed: 0})
+
+    expect(localStorageService.saveDownloadedFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: capture.capture_id,
+        filePath: entry.finalPath,
+        capture_id: capture.capture_id,
+      }),
+    )
+    expect(cameraRollExportCoordinator.exportForSource).toHaveBeenCalledWith(
+      expect.objectContaining({capture_id: capture.capture_id}),
+      capture.capture_id,
+    )
     expect(galleryTransferLedger.get(capture.capture_id)?.state).toBe("TRASHED")
     recoverySpy.mockRestore()
   })


### PR DESCRIPTION
## Summary

- add a durable per-file camera-roll export ledger and sequential coordinator
- backfill all still-local, unreceipted gallery media when automatic saving is enabled or re-enabled
- resume interrupted exports on startup/foreground with permission-aware retries and progress reporting
- keep source deletion behind a durable MediaStore/PhotoKit receipt when automatic saving is enabled
- serialize local deletion against in-flight exports and warn when deleting media not confirmed in the camera roll
- reconcile legacy exports by stable name, capture time, size, Mentra album/path, and app ownership to avoid duplicates
- require Full Photos Access only for ambiguous legacy iOS reconciliation; newly indexed media remains exportable under Limited Access
- reconstruct missing local gallery index rows from the durable transfer ledger during recovery

## Compatibility

- no glasses protocol or ASG firmware changes
- preserves the existing three-argument native `saveToGalleryWithDate` bridge contract
- existing mobile clients continue to sync normally
- upgrades rebuild export state from the existing local gallery index and any durable receipts

## Validation

- `bun compile`
- 50 focused Jest tests across camera-roll coordination, gallery sync, media processing, transfer ledger, and path migration
- Android: `:mentra-crust:compileDebugKotlin`
- iOS: `Crust` Debug build for a generic iOS Simulator

Hardware validation was intentionally not run because the attached Mentra Live is in use by another agent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches gallery sync acknowledgment, native MediaStore/PhotoKit save paths, and permission gating—user data and duplicate-export edge cases—but behavior is heavily tested and scoped to camera-roll export.
> 
> **Overview**
> Adds a **durable camera-roll export pipeline** so gallery media can be saved to the system photo library with receipts, retries, and backfill instead of one-off native saves during sync.
> 
> The engine gains a **per-generation export ledger** and **sequential coordinator** that queues work, resumes on startup/foreground, blocks glasses source ack while auto-save is on and export is pending, and backfills still-local items when saving is enabled or re-enabled. **Media processing** and **gallery sync** route through `exportForSource` / `recordIndexed`; sync **aborts pre-flight** if auto-save is on but library permission is denied, and defers **queue reset** until pre-flight passes.
> 
> **Android** reconciliation matches multiple display names, scopes by app owner and Mentra album path, and reuses or uniquely matches by size; **iOS** replaces semaphore-based saves with async continuations, reconciles by filename/size via PhotoKit (no iCloud fetch), skips Mentra album mutation under limited library access, and gates ambiguous legacy reconciliation on full access.
> 
> Gallery UI adds **`GalleryCameraRollSetting`** (status, retry, disable warning) and delete/clear warnings when items are not confirmed exported; deletion goes through the coordinator to serialize against in-flight exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 297f6e56536e8cbd3681c10c5574532b0132b762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


