### PR TITLE
Fix cloud-v2 deploys: copy the protocol workspace manifest into the image

### DIFF
--- a/cloud-v2/docker/Dockerfile
+++ b/cloud-v2/docker/Dockerfile
@@ -23,6 +23,7 @@ COPY cloud-v2/packages/shared/package.json ./packages/shared/
 COPY cloud-v2/packages/auth/package.json ./packages/auth/
 COPY cloud-v2/packages/cli/package.json ./packages/cli/
 COPY cloud-v2/packages/core/package.json ./packages/core/
+COPY cloud-v2/packages/protocol/package.json ./packages/protocol/
 COPY cloud-v2/packages/runtime/package.json ./packages/runtime/
 COPY cloud-v2/packages/proxy/package.json ./packages/proxy/
 COPY cloud-v2/packages/cloud-client/package.json ./packages/cloud-client/


### PR DESCRIPTION
Every cloud-v2-dev deploy has failed since 2026-07-16 19:42Z (four consecutive runs), so core.dev is still running July 15 code. The Docker build dies with:

```
error: lockfile had changes, but lockfile is frozen
```

## Root cause

173ad74f9 extracted `cloud-v2/packages/protocol` (`@mentra/cloud-protocol`) as a new workspace, but the manifest-copy block in `cloud-v2/docker/Dockerfile` was not updated. The image copies `bun.lock` plus each workspace's `package.json` before installing; with `packages/protocol/package.json` missing from that sparse layout, bun sees a workspace that exists in the lockfile but not on disk, recomputes, and the frozen install refuses.

## Verification

Simulated the exact COPY layout locally from current dev: `bun install --frozen-lockfile` reproduces the CI error without `packages/protocol/package.json` and passes with it. A full-tree install on dev also passes, which is why this never showed up outside Docker.

## Impact

Unblocks dev deploys, including #3456 (OS-1703 refresh-rotation grace) which merged yesterday but never reached core.dev. Mobile clients pointed at core.dev are still hitting boot-time logouts from refresh-token races that #3456 fixes. Same Dockerfile serves debug/staging/prod, so this also prevents the same failure on promotion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Dockerfile manifest copy with no runtime or application logic changes.
> 
> **Overview**
> Adds **`packages/protocol/package.json`** to the Dockerfile’s early COPY step so the sparse pre-install layout matches every workspace referenced in **`bun.lock`**.
> 
> Without it, **`bun install --frozen-lockfile`** fails during image build because the new **`@mentra/cloud-protocol`** workspace exists in the lockfile but not on disk in that layer, which has been blocking **cloud-v2** deploys since the protocol package was split out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d352dc1aec4d5d1a610aebc5ab210df7cc4de0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cloud-v2 Docker builds by copying `cloud-v2/packages/protocol/package.json` for the `@mentra/cloud-protocol` workspace into the image, preventing `bun install --frozen-lockfile` failures from the missing manifest. Unblocks dev deploys and avoids the same failure on staging/prod promotion, allowing OS-1703 (refresh-rotation grace) to reach core.dev.

<sup>Written for commit 9d352dc1aec4d5d1a610aebc5ab210df7cc4de0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

