### PR TITLE
OS-1709: Route gallery traffic over local-only hotspot

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -1,6 +1,24 @@
 package com.mentra.asg_client;
 
 public class AsgConstants {
+    /** Mentra Live hotspot idle timeout after the last local HTTP activity. */
+    public static final long HOTSPOT_INACTIVITY_TIMEOUT_MS = 120_000L;
+
+    /** Frequency for checking whether an active hotspot has become idle. */
+    public static final long HOTSPOT_INACTIVITY_CHECK_INTERVAL_MS = 10_000L;
+
+    /** Maximum interval between activity updates while a response body is streaming. */
+    public static final long HTTP_ACTIVITY_STREAM_UPDATE_INTERVAL_MS = 5_000L;
+
+    /** How often Mentra Live checks for the LocalOnlyHotspot gateway interface. */
+    public static final long LOCAL_HOTSPOT_READINESS_POLL_MS = 200L;
+
+    /** Maximum wait for the LocalOnlyHotspot gateway interface to become ready. */
+    public static final long LOCAL_HOTSPOT_READINESS_TIMEOUT_MS = 12_000L;
+
+    /** Current Mentra Live Android hotspot gateway when interface discovery is unavailable. */
+    public static final String DEFAULT_HOTSPOT_GATEWAY_IP = "192.168.43.1";
+
     public static String appName = "AugmentOS ASG Client";
     public static int augmentOsSdkVerion = 1;
     public static int asgServiceNotificationId = 3540;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -16,6 +16,9 @@ public class AsgConstants {
     /** Maximum wait for the LocalOnlyHotspot gateway interface to become ready. */
     public static final long LOCAL_HOTSPOT_READINESS_TIMEOUT_MS = 12_000L;
 
+    /** Delay after enabling the WiFi radio before requesting a LocalOnlyHotspot. */
+    public static final long LOCAL_HOTSPOT_WIFI_ENABLE_DELAY_MS = 500L;
+
     /** Current Mentra Live Android hotspot gateway when interface discovery is unavailable. */
     public static final String DEFAULT_HOTSPOT_GATEWAY_IP = "192.168.43.1";
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -165,15 +165,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
     // Boot-time baud recovery: if asg restarts after a previous baud switch, the BES
     // is still at the high rate while we reopen at the 460800 default - the link is
-    // silent until something hunts for the right rate. Cycle candidates until an
-    // sr_syvr answers.
-    private static final int[] BOOT_BAUD_CANDIDATES = {
-        SerialPortBridge.DEFAULT_BAUDRATE, TARGET_UART_BAUD, 1152000
-    };
+    // silent until something hunts for the right rate. The default rate has already
+    // had the initial-delay window to answer, so probe the only alternate rate once.
+    // If the firmware does not implement cs_syvr, return to the default instead of
+    // rotating rates forever and corrupting otherwise healthy phone traffic.
+    private static final int[] BOOT_BAUD_CANDIDATES = {TARGET_UART_BAUD};
     private static final int BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
     private static final int BOOT_RECOVERY_STEP_MS = 3000;
     private volatile long lastSrSyvrTime = 0;
-    private int bootRecoveryIdx = 0;
+    private int bootRecoveryAttempts = 0;
     private java.util.concurrent.ScheduledFuture<?> bootRecoveryFuture;
 
     /** True between reopening at TARGET_UART_BAUD and the sr_syvr probe answer. */
@@ -290,24 +290,35 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
-    /** No sr_syvr since boot: cycle through candidate bauds until the BES answers. */
+    /** No sr_syvr since boot: probe alternate bauds once, then settle at the default. */
     private void bootBaudRecoveryTick() {
         if (lastSrSyvrTime > 0) {
             return; // Link is alive; nothing to recover.
         }
+        Integer candidate = null;
+        boolean settleAtDefault = false;
         synchronized (baudSwitchLock) {
             if (baudProbePending || comManager.mbOtaUpdating) {
+                bootRecoveryFuture = null;
                 return; // A switch/OTA is mid-flight; stay out of its way.
             }
+            if (bootRecoveryAttempts >= BOOT_BAUD_CANDIDATES.length) {
+                bootRecoveryFuture = null;
+                settleAtDefault = true;
+            } else {
+                candidate = BOOT_BAUD_CANDIDATES[bootRecoveryAttempts++];
+            }
         }
-        bootRecoveryIdx = (bootRecoveryIdx + 1) % BOOT_BAUD_CANDIDATES.length;
-        int candidate = BOOT_BAUD_CANDIDATES[bootRecoveryIdx];
+        if (settleAtDefault) {
+            settleBootRecoveryAtDefaultBaud();
+            return;
+        }
         Log.w(
                 BAUD_TAG,
                 "Boot recovery: no sr_syvr yet - trying "
                         + candidate
                         + " baud (candidate "
-                        + (bootRecoveryIdx + 1)
+                        + bootRecoveryAttempts
                         + "/"
                         + BOOT_BAUD_CANDIDATES.length
                         + ")");
@@ -325,6 +336,34 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                                 BOOT_RECOVERY_STEP_MS,
                                 TimeUnit.MILLISECONDS);
             }
+        }
+    }
+
+    /** Finish a failed boot probe at the known-safe baud without scheduling another hunt. */
+    private void settleBootRecoveryAtDefaultBaud() {
+        if (lastSrSyvrTime > 0) {
+            return;
+        }
+        int defaultBaud = SerialPortBridge.DEFAULT_BAUDRATE;
+        if (comManager.getCurrentBaud() == defaultBaud) {
+            Log.w(BAUD_TAG, "Boot recovery exhausted; remaining at " + defaultBaud + " baud");
+            return;
+        }
+        try {
+            boolean reopened = comManager.reopen(defaultBaud);
+            if (reopened) {
+                Log.w(
+                        BAUD_TAG,
+                        "Boot recovery exhausted without sr_syvr; settled at "
+                                + defaultBaud
+                                + " baud and stopped probing");
+            } else {
+                Log.e(
+                        BAUD_TAG,
+                        "Boot recovery could not reopen the default " + defaultBaud + " baud");
+            }
+        } catch (Exception e) {
+            Log.e(BAUD_TAG, "Boot recovery failed to restore default " + defaultBaud + " baud", e);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/core/BaseNetworkManager.java
@@ -12,7 +12,9 @@ import android.net.wifi.ScanResult;
 import android.net.wifi.WifiManager;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.NetworkUtils;
 import com.mentra.asg_client.io.network.interfaces.INetworkController;
 import com.mentra.asg_client.io.network.interfaces.IWifiScanCallback;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Base implementation of the INetworkManager interface. Provides common functionality for all
@@ -44,6 +47,7 @@ public abstract class BaseNetworkManager implements INetworkController {
     protected boolean isHotspotEnabled = false;
     protected String currentHotspotSsid = "";
     protected String currentHotspotPassword = "";
+    protected String currentHotspotGatewayIp = AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP;
 
     // Device-persistent hotspot credentials
     private String deviceHotspotSsid = null;
@@ -53,9 +57,7 @@ public abstract class BaseNetworkManager implements INetworkController {
     private BroadcastReceiver tetheringStateReceiver;
 
     // HTTP activity tracking for auto-disconnect
-    private long lastHttpActivityTime = 0;
-    private static final long HOTSPOT_INACTIVITY_TIMEOUT_MS =
-            120000; // 120 seconds - increased from 40s to allow time for iOS WiFi connection
+    private final AtomicLong lastHttpActivityTime = new AtomicLong(0L);
     private Handler inactivityCheckHandler;
     private Runnable inactivityCheckRunnable;
 
@@ -287,8 +289,14 @@ public abstract class BaseNetworkManager implements INetworkController {
         Log.d(TAG, "Initializing BaseNetworkManager");
         Log.d(TAG, "Device hotspot SSID: " + deviceHotspotSsid);
 
-        // Register tethering state broadcast receiver
-        registerTetheringStateReceiver();
+        if (shouldMonitorTetheringBroadcasts()) {
+            registerTetheringStateReceiver();
+        }
+    }
+
+    /** Whether this manager uses Android's tethering broadcasts for hotspot lifecycle state. */
+    protected boolean shouldMonitorTetheringBroadcasts() {
+        return true;
     }
 
     @Override
@@ -791,22 +799,51 @@ public abstract class BaseNetworkManager implements INetworkController {
      */
     @Override
     public String getHotspotGatewayIp() {
-        // Standard Android hotspot gateway IP
-        return "192.168.43.1";
+        return currentHotspotGatewayIp;
     }
 
     /** Update hotspot state - to be called by subclasses when hotspot state changes */
     protected void updateHotspotState(boolean enabled, String ssid, String password) {
+        updateHotspotState(enabled, ssid, password, AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP);
+    }
+
+    /** Update hotspot state including the gateway advertised to the paired phone. */
+    protected void updateHotspotState(
+            boolean enabled, String ssid, String password, String gatewayIp) {
         this.isHotspotEnabled = enabled;
         this.currentHotspotSsid = ssid != null ? ssid : "";
         this.currentHotspotPassword = password != null ? password : "";
+        this.currentHotspotGatewayIp =
+                gatewayIp != null && !gatewayIp.isEmpty()
+                        ? gatewayIp
+                        : AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP;
 
         Log.d(TAG, "Hotspot state updated: enabled=" + enabled + ", ssid=" + ssid);
     }
 
     /** Clear hotspot state - to be called by subclasses on shutdown or error */
     protected void clearHotspotState() {
-        updateHotspotState(false, "", "");
+        updateHotspotState(false, "", "", AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP);
+    }
+
+    /** Mark a hotspot ready and begin the shared idle policy. */
+    protected final void onHotspotStarted(String ssid, String password, String gatewayIp) {
+        boolean wasEnabled = isHotspotEnabled;
+        updateHotspotState(true, ssid, password, gatewayIp);
+        startInactivityMonitoring();
+        if (!wasEnabled) {
+            notifyHotspotStateChanged(true);
+        }
+    }
+
+    /** Mark a hotspot stopped and cancel the shared idle policy. */
+    protected final void onHotspotStopped() {
+        boolean wasEnabled = isHotspotEnabled;
+        stopInactivityMonitoring();
+        clearHotspotState();
+        if (wasEnabled) {
+            notifyHotspotStateChanged(false);
+        }
     }
 
     /** Register broadcast receiver for tethering state changes */
@@ -893,10 +930,7 @@ public abstract class BaseNetworkManager implements INetworkController {
         }
     }
 
-    /**
-     * Refresh hotspot credentials - to be overridden by subclasses K900 will read from
-     * Settings.Global, others use device credentials
-     */
+    /** Refresh tethered-hotspot credentials for managers that use the base broadcast path. */
     protected void refreshHotspotCredentials() {
         // Default implementation for non-K900 devices
         String ssid = getDeviceHotspotSsid();
@@ -907,12 +941,12 @@ public abstract class BaseNetworkManager implements INetworkController {
 
     /** Update HTTP activity timestamp */
     public void updateHttpActivity() {
-        lastHttpActivityTime = System.currentTimeMillis();
+        lastHttpActivityTime.set(SystemClock.elapsedRealtime());
         Log.d(TAG, "📡 HTTP activity detected, updating timestamp");
     }
 
     /** Start monitoring for hotspot inactivity */
-    private void startInactivityMonitoring() {
+    protected final void startInactivityMonitoring() {
         stopInactivityMonitoring(); // Clear any existing monitoring
 
         inactivityCheckRunnable =
@@ -923,11 +957,12 @@ public abstract class BaseNetworkManager implements INetworkController {
                             return; // Hotspot already disabled
                         }
 
-                        long currentTime = System.currentTimeMillis();
-                        long timeSinceLastActivity = currentTime - lastHttpActivityTime;
+                        long currentTime = SystemClock.elapsedRealtime();
+                        long lastActivity = lastHttpActivityTime.get();
+                        long timeSinceLastActivity = currentTime - lastActivity;
 
-                        if (lastHttpActivityTime > 0
-                                && timeSinceLastActivity > HOTSPOT_INACTIVITY_TIMEOUT_MS) {
+                        if (timeSinceLastActivity
+                                > AsgConstants.HOTSPOT_INACTIVITY_TIMEOUT_MS) {
                             Log.i(
                                     TAG,
                                     "🔥 Hotspot inactive for "
@@ -936,25 +971,27 @@ public abstract class BaseNetworkManager implements INetworkController {
                             stopHotspot();
                         } else {
                             // Schedule next check in 10 seconds
-                            inactivityCheckHandler.postDelayed(this, 10000);
+                            inactivityCheckHandler.postDelayed(
+                                    this, AsgConstants.HOTSPOT_INACTIVITY_CHECK_INTERVAL_MS);
                         }
                     }
                 };
 
         // Reset activity time when starting
-        lastHttpActivityTime = System.currentTimeMillis();
+        lastHttpActivityTime.set(SystemClock.elapsedRealtime());
 
         // Start checking after initial timeout period
-        inactivityCheckHandler.postDelayed(inactivityCheckRunnable, HOTSPOT_INACTIVITY_TIMEOUT_MS);
+        inactivityCheckHandler.postDelayed(
+                inactivityCheckRunnable, AsgConstants.HOTSPOT_INACTIVITY_TIMEOUT_MS);
         Log.d(TAG, "📡 Started hotspot inactivity monitoring");
     }
 
     /** Stop monitoring for hotspot inactivity */
-    private void stopInactivityMonitoring() {
+    protected final void stopInactivityMonitoring() {
         if (inactivityCheckRunnable != null) {
             inactivityCheckHandler.removeCallbacks(inactivityCheckRunnable);
             inactivityCheckRunnable = null;
-            lastHttpActivityTime = 0;
+            lastHttpActivityTime.set(0L);
             Log.d(TAG, "📡 Stopped hotspot inactivity monitoring");
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/interfaces/INetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/interfaces/INetworkManager.java
@@ -23,11 +23,7 @@ public interface INetworkManager {
      */
     void disableWifi();
     
-    /**
-     * Start a hotspot with device-generated persistent credentials
-     * SSID format: MentraOS_XXXXX where XXXXX is a persistent device ID
-     * Password: 12345678 (fixed)
-     */
+    /** Start a hotspot. Credentials may be generated dynamically by the platform. */
     void startHotspot();
     
     /**
@@ -134,4 +130,4 @@ public interface INetworkManager {
      * Cleanup resources when the manager is no longer needed
      */
     void shutdown();
-} 
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -204,9 +204,38 @@ public class K900NetworkManager extends BaseNetworkManager {
             generation = ++localHotspotGeneration;
         }
 
+        requestLocalOnlyHotspot(generation);
+    }
+
+    private void requestLocalOnlyHotspot(int generation) {
+        synchronized (localHotspotLock) {
+            if (generation != localHotspotGeneration || !localHotspotStarting) {
+                Log.d(TAG, "🔥 Ignoring hotspot request from a stale generation");
+                return;
+            }
+        }
+
         try {
             if (wifiManager == null) {
                 failLocalHotspotStartup(generation, "WifiManager is unavailable");
+                return;
+            }
+            if (!wifiManager.isWifiEnabled()) {
+                Log.i(TAG, "🔥 WiFi radio is off; enabling it before LocalOnlyHotspot startup");
+                if (!wifiManager.setWifiEnabled(true)) {
+                    failLocalHotspotStartup(generation, "Failed to enable WiFi for local hotspot");
+                    return;
+                }
+                localHotspotHandler.postDelayed(
+                        () -> {
+                            if (!wifiManager.isWifiEnabled()) {
+                                failLocalHotspotStartup(
+                                        generation, "WiFi did not become ready for local hotspot");
+                                return;
+                            }
+                            requestLocalOnlyHotspot(generation);
+                        },
+                        AsgConstants.LOCAL_HOTSPOT_WIFI_ENABLE_DELAY_MS);
                 return;
             }
             wifiManager.startLocalOnlyHotspot(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -333,19 +333,53 @@ public class K900NetworkManager extends BaseNetworkManager {
     private String findLocalHotspotGatewayIp() {
         try {
             NetworkInterface interfaceInfo = NetworkInterface.getByName("ap0");
-            if (interfaceInfo != null && interfaceInfo.isUp()) {
-                Enumeration<InetAddress> addrs = interfaceInfo.getInetAddresses();
-                while (addrs.hasMoreElements()) {
-                    InetAddress address = addrs.nextElement();
-                    if (address instanceof Inet4Address && !address.isLoopbackAddress()) {
-                        return address.getHostAddress();
-                    }
+            String gatewayIp = findLocalHotspotGatewayIp(interfaceInfo, true);
+            if (!gatewayIp.isEmpty()) {
+                return gatewayIp;
+            }
+
+            Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces != null && interfaces.hasMoreElements()) {
+                NetworkInterface candidate = interfaces.nextElement();
+                if ("ap0".equals(candidate.getName())) {
+                    continue;
+                }
+                gatewayIp = findLocalHotspotGatewayIp(candidate, false);
+                if (!gatewayIp.isEmpty()) {
+                    Log.i(TAG, "🔥 Local hotspot gateway found on " + candidate.getName());
+                    return gatewayIp;
                 }
             }
         } catch (Exception e) {
             Log.w(TAG, "🔥 Error reading local hotspot gateway", e);
         }
         return "";
+    }
+
+    private String findLocalHotspotGatewayIp(
+            NetworkInterface interfaceInfo, boolean knownHotspotInterface) throws Exception {
+        if (interfaceInfo == null || !interfaceInfo.isUp()) {
+            return "";
+        }
+        Enumeration<InetAddress> addrs = interfaceInfo.getInetAddresses();
+        while (addrs.hasMoreElements()) {
+            InetAddress address = addrs.nextElement();
+            if (address instanceof Inet4Address
+                    && !address.isLoopbackAddress()
+                    && (knownHotspotInterface
+                            || isLocalHotspotAddress(
+                                    interfaceInfo.getName(), address.getHostAddress()))) {
+                return address.getHostAddress();
+            }
+        }
+        return "";
+    }
+
+    static boolean isLocalHotspotAddress(String interfaceName, String address) {
+        // Never mistake wlan0's station address for the hotspot. Alternate AP interface names
+        // remain eligible, as does the gateway address used by current K900 firmware.
+        return (interfaceName != null && interfaceName.startsWith("ap"))
+                || AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP.equals(address);
     }
 
     private void failLocalHotspotStartup(int generation, String errorMessage) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/network/managers/K900NetworkManager.java
@@ -4,17 +4,23 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.net.wifi.WifiConfiguration;
 import android.net.wifi.WifiManager;
 import android.os.Handler;
 import android.os.Looper;
-import android.provider.Settings;
+import android.os.SystemClock;
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.network.core.BaseNetworkManager;
 import com.mentra.asg_client.io.network.utils.WifiSecurityChooser;
 import com.mentra.asg_client.io.network.interfaces.IWifiScanCallback;
 import com.mentra.asg_client.io.network.utils.DebugNotificationManager;
 import com.mentra.asg_client.service.system.core.SystemControllerFactory;
 import java.util.ArrayList;
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
+import java.util.Enumeration;
 import java.util.List;
 
 /**
@@ -28,32 +34,20 @@ public class K900NetworkManager extends BaseNetworkManager {
     private static final String K900_BROADCAST_ACTION = "com.xy.xsetting.action";
     private static final String K900_SYSTEM_UI_PACKAGE = "com.android.systemui";
 
-    // K900 hotspot constants
-    private static final String K900_HOTSPOT_PREFIX = "XySmart_";
-    private static final String K900_HOTSPOT_PASSWORD = "00001111";
-
     private final WifiManager wifiManager;
     private final DebugNotificationManager notificationManager;
     private BroadcastReceiver wifiStateReceiver;
     private final boolean isSystemApp;
 
-    // Hotspot readiness watch. The ap_start intent returns immediately and the SSID in
-    // Settings.Global persists across sessions, so neither proves the AP is up. The watch
-    // polls the real signals (framework AP state + gateway IP on the AP interface + SSID)
-    // and only then reports the hotspot as enabled — the phone treats that message as
-    // "safe to join", so sending it early causes iOS "Unable to Join" failures.
-    private static final int HOTSPOT_READINESS_POLL_MS = 200;
-    private static final int HOTSPOT_READINESS_TIMEOUT_MS = 12000;
-    private final Handler hotspotReadinessHandler = new Handler(Looper.getMainLooper());
-    private Runnable pendingHotspotReadinessRunnable = null;
-    private long hotspotReadinessStartMs = 0;
-    private long hotspotReadinessDeadlineMs = 0;
-
-    // Watch ticks run on the main looper but stopHotspot can run on a command-processing
-    // thread. The lock + stop flag prevent a mid-flight tick from reporting "enabled"
-    // after the user disabled the AP (removeCallbacks alone can't cancel a running tick).
-    private final Object hotspotWatchLock = new Object();
-    private boolean hotspotStopRequested = false;
+    private final Handler localHotspotHandler = new Handler(Looper.getMainLooper());
+    private final Object localHotspotLock = new Object();
+    private WifiManager.LocalOnlyHotspotReservation localHotspotReservation;
+    private Runnable pendingLocalHotspotReadiness;
+    private boolean localHotspotStarting;
+    private int localHotspotGeneration;
+    private long localHotspotReadinessDeadlineMs;
+    private String pendingLocalHotspotSsid = "";
+    private String pendingLocalHotspotPassword = "";
 
     /**
      * Create a new K900NetworkManager
@@ -115,6 +109,13 @@ public class K900NetworkManager extends BaseNetworkManager {
         }
 
         Log.d(TAG, "🌐 ✅ K900 Network Manager initialization complete");
+    }
+
+    @Override
+    protected boolean shouldMonitorTetheringBroadcasts() {
+        // LocalOnlyHotspot owns its lifecycle through LocalOnlyHotspotCallback. Treating its
+        // interface as a tethered AP can publish static credentials before the LOHS callback.
+        return false;
     }
 
     @Override
@@ -190,274 +191,206 @@ public class K900NetworkManager extends BaseNetworkManager {
     @Override
     public void startHotspot() {
         Log.d(TAG, "🔥 =========================================");
-        Log.d(TAG, "🔥 START K900 HOTSPOT (INTENT MODE)");
+        Log.d(TAG, "🔥 START K900 LOCAL-ONLY HOTSPOT");
         Log.d(TAG, "🔥 =========================================");
 
-        try {
-            // IMPORTANT: Hotspot requires WiFi radio to be enabled (even if not connected)
-            // Check and enable WiFi if needed before starting hotspot
-            if (!wifiManager.isWifiEnabled()) {
-                Log.d(TAG, "🔥 ⚠️ WiFi radio is OFF - enabling WiFi radio for hotspot...");
-                boolean enabled = wifiManager.setWifiEnabled(true);
-                if (enabled) {
-                    Log.d(TAG, "🔥 ✅ WiFi radio enabled successfully");
-                    // Give WiFi a moment to initialize
-                    try {
-                        Thread.sleep(500);
-                    } catch (InterruptedException e) {
-                        Log.w(TAG, "Sleep interrupted while waiting for WiFi radio", e);
-                    }
-                } else {
-                    Log.e(TAG, "🔥 ❌ Failed to enable WiFi radio - hotspot may not start");
-                }
-            } else {
-                Log.d(TAG, "🔥 ✅ WiFi radio already enabled");
-            }
-
-            // Send K900 hotspot enable intent
-            Log.d(TAG, "🔥 📡 Sending K900 hotspot enable intent...");
-            Intent intent = new Intent();
-            intent.setAction("com.xy.xsetting.action");
-            intent.setPackage("com.android.systemui");
-            intent.putExtra("cmd", "ap_start");
-            intent.putExtra("enable", true);
-
-            context.sendBroadcast(intent);
-            Log.d(TAG, "🔥 ✅ K900 hotspot enable intent sent");
-
-            // Do NOT report the hotspot as enabled yet — wait until the AP is actually
-            // accepting clients. The watch notifies listeners (and thus the phone) only
-            // once AP state, gateway IP, and SSID are all confirmed.
-            beginHotspotReadinessWatch();
-
-            Log.i(TAG, "🔥 ✅ K900 hotspot start initiated (awaiting readiness)");
-        } catch (Exception e) {
-            Log.e(TAG, "🔥 💥 Error starting K900 hotspot", e);
-            clearHotspotState();
-            notificationManager.showDebugNotification(
-                    "Hotspot Error", "Failed to start: " + e.getMessage());
-        }
-    }
-
-    /**
-     * Starts (or restarts nothing if already running) the hotspot readiness watch. The watch
-     * polls until the framework reports the AP enabled, the AP interface holds the gateway IP,
-     * and the SSID is readable — only then are listeners told the hotspot is enabled. Measured
-     * on-device, readiness lands ~0.4-1.0s after the ap_start intent; the timeout is a
-     * generous multiple of that.
-     */
-    private void beginHotspotReadinessWatch() {
-        synchronized (hotspotWatchLock) {
-            hotspotStopRequested = false;
-            if (pendingHotspotReadinessRunnable != null) {
-                Log.d(TAG, "🔥 ⏳ Hotspot readiness watch already running");
+        final int generation;
+        synchronized (localHotspotLock) {
+            if (isHotspotEnabled || localHotspotStarting || localHotspotReservation != null) {
+                Log.d(TAG, "🔥 Local-only hotspot is already active or starting");
                 return;
             }
-            hotspotReadinessStartMs = System.currentTimeMillis();
-            hotspotReadinessDeadlineMs = hotspotReadinessStartMs + HOTSPOT_READINESS_TIMEOUT_MS;
+            localHotspotStarting = true;
+            generation = ++localHotspotGeneration;
         }
-        Log.d(TAG, "🔥 ⏳ Watching for hotspot readiness (AP state + gateway IP + SSID)...");
-        checkHotspotReadiness();
-    }
 
-    /** One tick of the readiness watch; reschedules itself until ready, timeout, or cancel. */
-    private void checkHotspotReadiness() {
-        synchronized (hotspotWatchLock) {
-            pendingHotspotReadinessRunnable = null;
-            if (hotspotStopRequested) {
-                Log.d(TAG, "🔥 ⛔ Hotspot stopped - abandoning readiness check");
+        try {
+            if (wifiManager == null) {
+                failLocalHotspotStartup(generation, "WifiManager is unavailable");
                 return;
             }
-            checkHotspotReadinessLocked();
+            wifiManager.startLocalOnlyHotspot(
+                    new WifiManager.LocalOnlyHotspotCallback() {
+                        @Override
+                        public void onStarted(
+                                WifiManager.LocalOnlyHotspotReservation reservation) {
+                            handleLocalHotspotStarted(generation, reservation);
+                        }
+
+                        @Override
+                        public void onStopped() {
+                            handleLocalHotspotStopped(generation);
+                        }
+
+                        @Override
+                        public void onFailed(int reason) {
+                            failLocalHotspotStartup(
+                                    generation,
+                                    "Local-only hotspot failed with reason " + reason);
+                        }
+                    },
+                    localHotspotHandler);
+            Log.i(TAG, "🔥 Local-only hotspot start requested");
+        } catch (Exception e) {
+            Log.e(TAG, "🔥 Error requesting local-only hotspot", e);
+            failLocalHotspotStartup(generation, "Failed to start: " + e.getMessage());
         }
     }
 
-    private void checkHotspotReadinessLocked() {
-        // Gate on the direct signal: the tethering state machine assigns the gateway IP to
-        // the AP interface only after hostapd reports AP-ENABLED, so gatewayUp implies the
-        // AP accepts clients. The framework AP state (reflection, hidden API) is logged as
-        // corroboration but not required — it is unavailable to non-system dev builds.
-        boolean apEnabled = isWifiTetheringActive();
-        boolean gatewayUp = hasHotspotGatewayIp();
-        String ssid = null;
-        try {
-            ssid = Settings.Global.getString(context.getContentResolver(), "xy_ssid");
-        } catch (Exception e) {
-            Log.w(TAG, "🔥 ⚠️ Error reading xy_ssid during readiness check", e);
+    private void handleLocalHotspotStarted(
+            int generation, WifiManager.LocalOnlyHotspotReservation reservation) {
+        synchronized (localHotspotLock) {
+            if (generation != localHotspotGeneration || !localHotspotStarting) {
+                Log.d(TAG, "🔥 Closing hotspot that completed after a stop request");
+                reservation.close();
+                return;
+            }
+            localHotspotStarting = false;
+            localHotspotReservation = reservation;
         }
-        boolean ssidReady = ssid != null && !ssid.isEmpty();
 
-        if (gatewayUp && ssidReady) {
-            long elapsedMs = System.currentTimeMillis() - hotspotReadinessStartMs;
-            Log.i(
-                    TAG,
-                    "🔥 ✅ K900 hotspot READY after "
-                            + elapsedMs
-                            + "ms (apEnabled="
-                            + apEnabled
-                            + "): "
-                            + ssid);
-
-            updateHotspotState(true, ssid, K900_HOTSPOT_PASSWORD);
-            notifyHotspotStateChanged(true);
-
-            notificationManager.showHotspotStateNotification(true);
-            notificationManager.showDebugNotification(
-                    "K900 Hotspot Active", ssid + " | " + K900_HOTSPOT_PASSWORD);
+        WifiConfiguration configuration = reservation.getWifiConfiguration();
+        String ssid = configuration != null ? unquote(configuration.SSID) : "";
+        String password = configuration != null ? unquote(configuration.preSharedKey) : "";
+        if (ssid.isEmpty() || password.isEmpty()) {
+            failLocalHotspotStartup(
+                    generation, "Local-only hotspot returned invalid credentials");
             return;
         }
 
-        if (System.currentTimeMillis() >= hotspotReadinessDeadlineMs) {
-            failHotspotStartup(
-                    "Hotspot did not become ready within "
-                            + HOTSPOT_READINESS_TIMEOUT_MS
-                            + "ms (apEnabled="
-                            + apEnabled
-                            + ", gatewayUp="
-                            + gatewayUp
-                            + ", ssidReady="
-                            + ssidReady
-                            + ")");
-            return;
+        synchronized (localHotspotLock) {
+            pendingLocalHotspotSsid = ssid;
+            pendingLocalHotspotPassword = password;
+            localHotspotReadinessDeadlineMs =
+                    SystemClock.elapsedRealtime()
+                            + AsgConstants.LOCAL_HOTSPOT_READINESS_TIMEOUT_MS;
         }
-
-        Log.d(
-                TAG,
-                "🔥 ⏳ Hotspot not ready yet (apEnabled="
-                        + apEnabled
-                        + ", gatewayUp="
-                        + gatewayUp
-                        + ", ssidReady="
-                        + ssidReady
-                        + "), rechecking in "
-                        + HOTSPOT_READINESS_POLL_MS
-                        + "ms");
-        pendingHotspotReadinessRunnable = this::checkHotspotReadiness;
-        hotspotReadinessHandler.postDelayed(
-                pendingHotspotReadinessRunnable, HOTSPOT_READINESS_POLL_MS);
+        checkLocalHotspotReadiness(generation);
     }
 
-    /** True when any up interface holds the hotspot gateway IP (192.168.43.1). */
-    private boolean hasHotspotGatewayIp() {
+    private void checkLocalHotspotReadiness(int generation) {
+        String gatewayIp = findLocalHotspotGatewayIp();
+        synchronized (localHotspotLock) {
+            pendingLocalHotspotReadiness = null;
+            if (generation != localHotspotGeneration || localHotspotReservation == null) {
+                return;
+            }
+            if (!gatewayIp.isEmpty()) {
+                onHotspotStarted(
+                        pendingLocalHotspotSsid, pendingLocalHotspotPassword, gatewayIp);
+                notificationManager.showHotspotStateNotification(true);
+                notificationManager.showDebugNotification(
+                        "Mentra Live Hotspot Active", pendingLocalHotspotSsid);
+                Log.i(
+                        TAG,
+                        "🔥 Local-only hotspot ready: "
+                                + pendingLocalHotspotSsid
+                                + " gateway="
+                                + gatewayIp);
+                return;
+            }
+            if (SystemClock.elapsedRealtime() >= localHotspotReadinessDeadlineMs) {
+                failLocalHotspotStartup(
+                        generation, "Local-only hotspot gateway did not become ready");
+                return;
+            }
+            pendingLocalHotspotReadiness = () -> checkLocalHotspotReadiness(generation);
+            localHotspotHandler.postDelayed(
+                    pendingLocalHotspotReadiness,
+                    AsgConstants.LOCAL_HOTSPOT_READINESS_POLL_MS);
+        }
+    }
+
+    private String findLocalHotspotGatewayIp() {
         try {
-            String gatewayIp = getHotspotGatewayIp();
-            java.util.Enumeration<java.net.NetworkInterface> ifaces =
-                    java.net.NetworkInterface.getNetworkInterfaces();
-            while (ifaces != null && ifaces.hasMoreElements()) {
-                java.net.NetworkInterface iface = ifaces.nextElement();
-                if (!iface.isUp()) {
-                    continue;
-                }
-                java.util.Enumeration<java.net.InetAddress> addrs = iface.getInetAddresses();
+            NetworkInterface interfaceInfo = NetworkInterface.getByName("ap0");
+            if (interfaceInfo != null && interfaceInfo.isUp()) {
+                Enumeration<InetAddress> addrs = interfaceInfo.getInetAddresses();
                 while (addrs.hasMoreElements()) {
-                    if (gatewayIp.equals(addrs.nextElement().getHostAddress())) {
-                        return true;
+                    InetAddress address = addrs.nextElement();
+                    if (address instanceof Inet4Address && !address.isLoopbackAddress()) {
+                        return address.getHostAddress();
                     }
                 }
             }
         } catch (Exception e) {
-            Log.w(TAG, "🔥 ⚠️ Error checking hotspot gateway interface", e);
+            Log.w(TAG, "🔥 Error reading local hotspot gateway", e);
         }
-        return false;
+        return "";
     }
 
-    /** Cleans up a hotspot start that never became ready: disable AP, clear state, notify. */
-    private void failHotspotStartup(String errorMessage) {
-        Log.e(TAG, "🔥 ❌ " + errorMessage + " - disabling hotspot");
-
-        // This is a stop: the disable intent below produces its own teardown echo on the
-        // tethering broadcast, which must not restart the watch off lingering ssid/gateway.
-        // Runs under hotspotWatchLock (called from the watch tick).
-        hotspotStopRequested = true;
-
-        try {
-            Intent disableIntent = new Intent();
-            disableIntent.setAction("com.xy.xsetting.action");
-            disableIntent.setPackage("com.android.systemui");
-            disableIntent.putExtra("cmd", "ap_start");
-            disableIntent.putExtra("enable", false);
-            context.sendBroadcast(disableIntent);
-            Log.d(TAG, "🔥 📡 Sent disable intent to clean up failed hotspot");
-        } catch (Exception ex) {
-            Log.e(TAG, "🔥 💥 Error sending disable intent", ex);
+    private void failLocalHotspotStartup(int generation, String errorMessage) {
+        Log.e(TAG, "🔥 " + errorMessage);
+        WifiManager.LocalOnlyHotspotReservation reservation;
+        synchronized (localHotspotLock) {
+            if (generation != localHotspotGeneration) {
+                Log.d(TAG, "🔥 Ignoring failure from a stale hotspot generation");
+                return;
+            }
+            localHotspotStarting = false;
+            cancelLocalHotspotReadinessLocked();
+            reservation = localHotspotReservation;
+            localHotspotReservation = null;
         }
-
-        clearHotspotState();
-        notifyHotspotStateChanged(false);
+        if (reservation != null) {
+            reservation.close();
+        }
+        onHotspotStopped();
         notifyHotspotError(errorMessage);
         notificationManager.showDebugNotification("Hotspot Failed", errorMessage);
     }
 
-    @Override
-    protected void refreshHotspotCredentials() {
-        // Called from the tethering-state broadcast when the framework starts bringing the
-        // AP up (including hotspots enabled outside asg_client). That broadcast can precede
-        // the AP interface holding its gateway IP, so route through the readiness watch —
-        // listeners only hear "enabled" once clients can actually join.
-        synchronized (hotspotWatchLock) {
-            if (hotspotStopRequested) {
-                // Teardown echo: after a deliberate stop the framework AP can still look
-                // active for a beat, and this broadcast fires while xy_ssid and the gateway
-                // IP may linger. Restarting the watch here would clear the stop flag and
-                // re-announce "enabled" right after the user disabled the AP. Only a real
-                // startHotspot() re-arms the watch.
-                Log.d(TAG, "🔥 ⛔ Ignoring tethering-active echo after hotspot stop");
+    private void handleLocalHotspotStopped(int generation) {
+        synchronized (localHotspotLock) {
+            if (generation != localHotspotGeneration) {
+                Log.d(TAG, "🔥 Ignoring stop callback from a stale hotspot generation");
                 return;
             }
+            localHotspotStarting = false;
+            localHotspotReservation = null;
+            cancelLocalHotspotReadinessLocked();
         }
-        beginHotspotReadinessWatch();
+        onHotspotStopped();
+        notificationManager.showHotspotStateNotification(false);
+        Log.i(TAG, "🔥 Local-only hotspot stopped");
     }
 
-    /**
-     * Cancels any pending hotspot readiness checks. Called when the hotspot is stopped to
-     * prevent stale callbacks from firing.
-     */
-    private void cancelHotspotReadinessWatch() {
-        if (pendingHotspotReadinessRunnable != null) {
-            Log.d(TAG, "🔥 ⛔ Cancelling hotspot readiness watch");
-            hotspotReadinessHandler.removeCallbacks(pendingHotspotReadinessRunnable);
-            pendingHotspotReadinessRunnable = null;
+    private void cancelLocalHotspotReadinessLocked() {
+        if (pendingLocalHotspotReadiness != null) {
+            localHotspotHandler.removeCallbacks(pendingLocalHotspotReadiness);
+            pendingLocalHotspotReadiness = null;
         }
+    }
+
+    private String unquote(String value) {
+        if (value == null) {
+            return "";
+        }
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
     @Override
     public void stopHotspot() {
         Log.d(TAG, "🔥 =========================================");
-        Log.d(TAG, "🔥 STOP K900 HOTSPOT (INTENT MODE)");
+        Log.d(TAG, "🔥 STOP K900 LOCAL-ONLY HOTSPOT");
         Log.d(TAG, "🔥 =========================================");
 
-        try {
-            // Send K900 hotspot disable intent
-            Log.d(TAG, "🔥 📡 Sending K900 hotspot disable intent...");
-            Intent intent = new Intent();
-            intent.setAction("com.xy.xsetting.action");
-            intent.setPackage("com.android.systemui");
-            intent.putExtra("cmd", "ap_start");
-            intent.putExtra("enable", false);
-
-            context.sendBroadcast(intent);
-
-            // Clear hotspot state immediately
-            clearHotspotState();
-
-            // Cancel any pending readiness checks. The flag also stops a tick that is
-            // already executing on the main looper from reporting a late "enabled".
-            synchronized (hotspotWatchLock) {
-                hotspotStopRequested = true;
-                cancelHotspotReadinessWatch();
-            }
-
-            Log.d(TAG, "🔥 ✅ K900 hotspot disable intent sent");
-            notificationManager.showHotspotStateNotification(false);
-            notifyHotspotStateChanged(false);
-
-            Log.i(TAG, "🔥 ✅ K900 hotspot disabled");
-        } catch (Exception e) {
-            Log.e(TAG, "🔥 💥 Error stopping K900 hotspot", e);
-            clearHotspotState();
-            notificationManager.showDebugNotification(
-                    "Hotspot Error", "Failed to stop: " + e.getMessage());
+        WifiManager.LocalOnlyHotspotReservation reservation;
+        synchronized (localHotspotLock) {
+            localHotspotStarting = false;
+            localHotspotGeneration++;
+            cancelLocalHotspotReadinessLocked();
+            reservation = localHotspotReservation;
+            localHotspotReservation = null;
         }
+        if (reservation != null) {
+            reservation.close();
+        }
+        onHotspotStopped();
+        notificationManager.showHotspotStateNotification(false);
     }
 
     @Override
@@ -698,11 +631,6 @@ public class K900NetworkManager extends BaseNetworkManager {
                     notificationManager.showWifiStateNotification(isConnected);
                     notifyWifiStateChanged(isConnected);
                     break;
-                case "hotspot_state":
-                    boolean isEnabled = intent.getBooleanExtra("enabled", false);
-                    notificationManager.showHotspotStateNotification(isEnabled);
-                    notifyHotspotStateChanged(isEnabled);
-                    break;
             }
         }
     }
@@ -773,6 +701,7 @@ public class K900NetworkManager extends BaseNetworkManager {
     @Override
     public void shutdown() {
         Log.d(TAG, "Shutting down K900NetworkManager");
+        stopHotspot();
         unregisterWifiStateReceiver();
         super.shutdown();
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/server/core/AsgServer.java
@@ -1,10 +1,13 @@
 package com.mentra.asg_client.io.server.core;
 
+import android.os.SystemClock;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.io.server.interfaces.*;
 import com.mentra.asg_client.logging.Logger;
 import fi.iki.elonen.NanoHTTPD;
 
 import java.io.IOException;
+import java.io.FilterInputStream;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,6 +31,12 @@ public abstract class AsgServer extends NanoHTTPD {
     protected final CacheManager cacheManager;
     protected final RateLimiter rateLimiter;
     protected final Logger logger;
+    private HttpActivityListener httpActivityListener;
+
+    /** Receives local HTTP activity used by the hotspot idle policy. */
+    public interface HttpActivityListener {
+        void onHttpActivity();
+    }
 
     /**
      * Constructor for ASG server with dependency injection.
@@ -68,6 +77,11 @@ public abstract class AsgServer extends NanoHTTPD {
             logger.error(getTag(), "Error getting server URL: " + e.getMessage(), e);
             return "http://localhost:" + getListeningPort();
         }
+    }
+
+    /** Set the listener notified for requests and active response streaming. */
+    public void setHttpActivityListener(HttpActivityListener listener) {
+        this.httpActivityListener = listener;
     }
 
     /**
@@ -127,6 +141,7 @@ public abstract class AsgServer extends NanoHTTPD {
      */
     @Override
     public Response serve(IHTTPSession session) {
+        recordHttpActivity();
         String uri = session.getUri();
         Method method = session.getMethod();
         String clientIp = session.getRemoteIpAddress();
@@ -143,11 +158,11 @@ public abstract class AsgServer extends NanoHTTPD {
         boolean rateLimitedRequest = shouldRateLimit(session);
         if (rateLimitedRequest && !rateLimiter.isAllowed(clientIp)) {
             logger.warn(getTag(), "🚫 Rate limit exceeded for IP: " + clientIp);
-            return newFixedLengthResponse(
+            return trackResponse(newFixedLengthResponse(
                 Response.Status.TOO_MANY_REQUESTS, 
                 "text/plain", 
                 "Rate limit exceeded. Please wait before making more requests."
-            );
+            ));
         }
         
         // Record the request for rate limiting
@@ -166,20 +181,69 @@ public abstract class AsgServer extends NanoHTTPD {
         // Handle preflight OPTIONS requests
         if (method == Method.OPTIONS) {
             logger.debug(getTag(), "🔄 Handling CORS preflight request");
-            return newFixedLengthResponse(Response.Status.OK, "text/plain", "");
+            return trackResponse(newFixedLengthResponse(Response.Status.OK, "text/plain", ""));
         }
 
         try {
             // Route requests using the abstract method
             logger.debug(getTag(), "🛣️ Routing request to appropriate handler...");
-            return handleRequest(session);
+            return trackResponse(handleRequest(session));
         } catch (Exception e) {
             logger.error(getTag(), "💥 Error handling request " + uri + ": " + e.getMessage(), e);
-            return newFixedLengthResponse(
+            return trackResponse(newFixedLengthResponse(
                 Response.Status.INTERNAL_ERROR, 
                 "text/plain", 
                 "Internal server error: " + e.getMessage()
-            );
+            ));
+        }
+    }
+
+    private void recordHttpActivity() {
+        HttpActivityListener listener = httpActivityListener;
+        if (listener != null) {
+            listener.onHttpActivity();
+        }
+    }
+
+    private Response trackResponse(Response response) {
+        if (response == null || response.getData() == null || httpActivityListener == null) {
+            return response;
+        }
+        response.setData(new ActivityTrackingInputStream(response.getData()));
+        return response;
+    }
+
+    private final class ActivityTrackingInputStream extends FilterInputStream {
+        private long lastUpdateMs = SystemClock.elapsedRealtime();
+
+        ActivityTrackingInputStream(InputStream inputStream) {
+            super(inputStream);
+        }
+
+        @Override
+        public int read() throws IOException {
+            int value = super.read();
+            if (value >= 0) {
+                maybeRecordActivity();
+            }
+            return value;
+        }
+
+        @Override
+        public int read(byte[] buffer, int offset, int length) throws IOException {
+            int count = super.read(buffer, offset, length);
+            if (count > 0) {
+                maybeRecordActivity();
+            }
+            return count;
+        }
+
+        private void maybeRecordActivity() {
+            long now = SystemClock.elapsedRealtime();
+            if (now - lastUpdateMs >= AsgConstants.HTTP_ACTIVITY_STREAM_UPDATE_INTERVAL_MS) {
+                lastUpdateMs = now;
+                recordHttpActivity();
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -618,6 +618,9 @@ public class AsgClientServiceManager {
                         });
                 Log.d(TAG, "📡 Picture request listener set");
 
+                cameraServer.setHttpActivityListener(networkManager::updateHttpActivity);
+                Log.d(TAG, "📡 HTTP activity listener set");
+
                 // Wire active recording provider so sync/download skip in-progress and
                 // not-yet-validated videos
                 if (mediaCaptureService != null) {

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/core/BaseNetworkManagerHotspotActivityTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/core/BaseNetworkManagerHotspotActivityTest.java
@@ -1,0 +1,97 @@
+package com.mentra.asg_client.io.network.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.content.Context;
+import android.os.Looper;
+import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.io.network.interfaces.NetworkStateListener;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+@RunWith(RobolectricTestRunner.class)
+public class BaseNetworkManagerHotspotActivityTest {
+    private TestNetworkManager manager;
+
+    @Before
+    public void setUp() {
+        manager = new TestNetworkManager(ApplicationProvider.getApplicationContext());
+    }
+
+    @Test
+    public void activeHttpTrafficPostponesIdleShutdown() {
+        manager.markStarted();
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(100));
+
+        manager.updateHttpActivity();
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(30));
+
+        assertThat(manager.stopCount).isZero();
+
+        shadowOf(Looper.getMainLooper()).idleFor(Duration.ofSeconds(100));
+
+        assertThat(manager.stopCount).isEqualTo(1);
+    }
+
+    @Test
+    public void duplicateLifecycleTransitionsDoNotPublishStaleStates() {
+        NetworkStateListener listener = mock(NetworkStateListener.class);
+        manager.addWifiListener(listener);
+
+        manager.markStarted();
+        manager.markStarted();
+        manager.markStopped();
+        manager.markStopped();
+
+        verify(listener, times(1)).onHotspotStateChanged(true);
+        verify(listener, times(1)).onHotspotStateChanged(false);
+        assertThat(manager.isHotspotEnabled()).isFalse();
+    }
+
+    private static final class TestNetworkManager extends BaseNetworkManager {
+        int stopCount;
+
+        TestNetworkManager(Context context) {
+            super(context);
+        }
+
+        void markStarted() {
+            onHotspotStarted("test", "x", "192.168.43.1");
+        }
+
+        void markStopped() {
+            onHotspotStopped();
+        }
+
+        @Override
+        public void startHotspot() {}
+
+        @Override
+        public void stopHotspot() {
+            stopCount++;
+            onHotspotStopped();
+        }
+
+        @Override
+        public void enableWifi() {}
+
+        @Override
+        public void disableWifi() {}
+
+        @Override
+        public void connectToWifi(String ssid, String password) {}
+
+        @Override
+        public void disconnectFromWifi() {}
+
+        @Override
+        public void forgetWifiNetwork(String ssid) {}
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/network/managers/K900NetworkManagerGatewayTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/network/managers/K900NetworkManagerGatewayTest.java
@@ -1,0 +1,24 @@
+package com.mentra.asg_client.io.network.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mentra.asg_client.AsgConstants;
+import org.junit.Test;
+
+public class K900NetworkManagerGatewayTest {
+
+    @Test
+    public void acceptsRenamedApInterfacesAndTheKnownK900Gateway() {
+        assertThat(K900NetworkManager.isLocalHotspotAddress("ap1", "192.168.44.1")).isTrue();
+        assertThat(
+                        K900NetworkManager.isLocalHotspotAddress(
+                                "wlan1", AsgConstants.DEFAULT_HOTSPOT_GATEWAY_IP))
+                .isTrue();
+    }
+
+    @Test
+    public void rejectsTheStationInterfaceAtAnUnrelatedAddress() {
+        assertThat(K900NetworkManager.isLocalHotspotAddress("wlan0", "192.168.1.24"))
+                .isFalse();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/server/core/AsgServerHttpActivityTest.java
@@ -1,0 +1,77 @@
+package com.mentra.asg_client.io.server.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.io.server.interfaces.CacheManager;
+import com.mentra.asg_client.io.server.interfaces.NetworkProvider;
+import com.mentra.asg_client.io.server.interfaces.RateLimiter;
+import com.mentra.asg_client.io.server.interfaces.ServerConfig;
+import com.mentra.asg_client.logging.Logger;
+import fi.iki.elonen.NanoHTTPD;
+import java.io.ByteArrayInputStream;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.shadows.ShadowSystemClock;
+
+@RunWith(RobolectricTestRunner.class)
+public class AsgServerHttpActivityTest {
+    @Test
+    public void requestAndLongResponseStreamNotifyHttpActivityListener() throws Exception {
+        ServerConfig config = mock(ServerConfig.class);
+        NetworkProvider networkProvider = mock(NetworkProvider.class);
+        CacheManager cacheManager = mock(CacheManager.class);
+        RateLimiter rateLimiter = mock(RateLimiter.class);
+        Logger logger = mock(Logger.class);
+        when(config.getPort()).thenReturn(8089);
+        when(rateLimiter.isAllowed("phone")).thenReturn(true);
+
+        TestServer server = new TestServer(config, networkProvider, cacheManager, rateLimiter, logger);
+        AtomicInteger activityCount = new AtomicInteger();
+        server.setHttpActivityListener(activityCount::incrementAndGet);
+
+        NanoHTTPD.IHTTPSession session = mock(NanoHTTPD.IHTTPSession.class);
+        when(session.getUri()).thenReturn("/api/health");
+        when(session.getMethod()).thenReturn(NanoHTTPD.Method.GET);
+        when(session.getRemoteIpAddress()).thenReturn("phone");
+        when(session.getHeaders()).thenReturn(java.util.Collections.emptyMap());
+
+        NanoHTTPD.Response response = server.serve(session);
+
+        assertThat(response.getData()).isNotNull();
+        assertThat(activityCount.get()).isEqualTo(1);
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6));
+        assertThat(response.getData().read(new byte[3])).isEqualTo(3);
+        assertThat(activityCount.get()).isEqualTo(2);
+    }
+
+    private static final class TestServer extends AsgServer {
+        TestServer(
+                ServerConfig config,
+                NetworkProvider networkProvider,
+                CacheManager cacheManager,
+                RateLimiter rateLimiter,
+                Logger logger) {
+            super(config, networkProvider, cacheManager, rateLimiter, logger);
+        }
+
+        @Override
+        protected String getTag() {
+            return "TestServer";
+        }
+
+        @Override
+        protected Response handleRequest(IHTTPSession session) {
+            return newFixedLengthResponse(
+                    Response.Status.OK,
+                    "application/octet-stream",
+                    new ByteArrayInputStream(new byte[] {1, 2, 3}),
+                    3);
+        }
+    }
+}

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -129,6 +129,8 @@ Camera and streaming features must leave LEDs in a safe state on stop, error, se
 
 The phone can configure WiFi behavior through `asg_client`. Mentra Live-specific network managers should be used when platform APIs are required; generic Android fallbacks exist for non-K900 paths.
 
+When the phone requests the Mentra Live hotspot, `asg_client` creates an Android local-only hotspot rather than an internet-sharing tethered hotspot. Android generates the session SSID and password, which are returned to the phone over BLE. Credentials are scoped to the current reservation (and can change on every start), so clients must use the latest BLE status rather than save a fixed network. On current K900 builds the platform selects 2.4 GHz for this local-only AP. This keeps the glasses' `wlan0` station connection intact and lets a phone route glasses-local media traffic over WiFi while continuing to use cellular data for internet traffic. The hotspot remains active while the local HTTP server is receiving requests or streaming response data and automatically stops after 120 seconds of genuine HTTP inactivity.
+
 ### OTA and updates
 
 Mentra Live has multiple update surfaces:

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -114,6 +114,7 @@ module.exports = ({config}: ConfigContext): Partial<ExpoConfig> => {
       allowBackup: false,
       permissions: [
         "ACCESS_FINE_LOCATION",
+        "NEARBY_WIFI_DEVICES",
         "ACCESS_WIFI_STATE",
         "ACCESS_NETWORK_STATE",
         "CHANGE_WIFI_STATE",

--- a/mobile/jest.config.js
+++ b/mobile/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     "^@/(.*)$": "<rootDir>/src/$1",
     "^@assets/(.*)$": "<rootDir>/assets/$1",
     "^@mentra/bluetooth-sdk-internal$": "<rootDir>/modules/bluetooth-sdk/src/_internal.ts",
+    "^@mentra/bluetooth-sdk/internal$": "<rootDir>/modules/bluetooth-sdk/src/_internal.ts",
     // Mirror metro: the @mentra/engine entry points resolve to SOURCE, not the
     // (stale) build/ output — tests must exercise the same code the app
     // bundles. jest.setup.js mocks all three entries.

--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -28,6 +28,16 @@ jest.mock("@mentra/bluetooth-sdk-internal", () => {
   }
 })
 
+jest.mock("@mentra/bluetooth-sdk/internal", () => {
+  const {bluetoothSdkMock, mentraLocalNetworkMock} = require("./src/test-utils/mockBluetoothSdk")
+  return {
+    __esModule: true,
+    default: bluetoothSdkMock,
+    ...bluetoothSdkMock,
+    MentraLocalNetwork: mentraLocalNetworkMock,
+  }
+})
+
 jest.mock("@/utils/auth/authClient", () => ({
   __esModule: true,
   default: {
@@ -933,7 +943,6 @@ const mockIslandEntries = () => {
 jest.mock("@mentra/engine", () => mockIslandEntries().main)
 jest.mock("@mentra/engine/internal", () => mockIslandEntries().internal)
 jest.mock("@mentra/engine/devtools", () => mockIslandEntries().devtools)
-
 
 // Mock crust native module to avoid native bridge errors
 jest.mock("@mentra/crust", () => ({

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraLocalNetworkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraLocalNetworkModule.kt
@@ -1,0 +1,318 @@
+package com.mentra.bluetoothsdk
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.net.wifi.WifiNetworkSpecifier
+import android.os.Build
+import android.util.Base64
+import android.util.Log
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.File
+import java.io.FileOutputStream
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+
+/** MentraOS-internal transport for glasses-local traffic without process network binding. */
+class MentraLocalNetworkModule : Module() {
+    private companion object {
+        const val TAG = "MentraLocalNetwork"
+    }
+
+    private val lock = Any()
+    private val executor = Executors.newCachedThreadPool()
+    private val activeConnections = ConcurrentHashMap<String, HttpURLConnection>()
+    private var localNetwork: Network? = null
+    private var networkCallback: ConnectivityManager.NetworkCallback? = null
+    private var pendingConnectPromise: Promise? = null
+
+    override fun definition() = ModuleDefinition {
+        Name("MentraLocalNetwork")
+        Events("downloadProgress", "networkLost")
+
+        AsyncFunction("connect") { ssid: String, password: String, promise: Promise ->
+            connect(ssid, password, promise)
+        }
+
+        AsyncFunction("request") {
+            requestId: String,
+            url: String,
+            method: String,
+            headers: Map<String, String>,
+            body: String?,
+            timeoutMs: Int,
+            promise: Promise ->
+            executor.execute { performRequest(requestId, url, method, headers, body, timeoutMs, promise) }
+        }
+
+        AsyncFunction("download") {
+            requestId: String,
+            url: String,
+            destination: String,
+            headers: Map<String, String>,
+            connectionTimeoutMs: Int,
+            readTimeoutMs: Int,
+            promise: Promise ->
+            executor.execute {
+                performDownload(
+                    requestId,
+                    url,
+                    destination,
+                    headers,
+                    connectionTimeoutMs,
+                    readTimeoutMs,
+                    promise,
+                )
+            }
+        }
+
+        AsyncFunction("cancel") { requestId: String -> cancel(requestId) }
+        AsyncFunction("disconnect") { disconnect() }
+
+        OnDestroy { disconnect() }
+    }
+
+    private fun connectivityManager(): ConnectivityManager =
+        requireNotNull(appContext.reactContext?.getSystemService(ConnectivityManager::class.java)) {
+            "ConnectivityManager is unavailable"
+        }
+
+    private fun connect(ssid: String, password: String, promise: Promise) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            promise.reject("ERR_UNSUPPORTED_ANDROID", "Scoped local WiFi requires Android 10 or newer", null)
+            return
+        }
+
+        disconnect()
+        val manager = connectivityManager()
+        val specifier =
+            WifiNetworkSpecifier.Builder()
+                .setSsid(ssid)
+                .setWpa2Passphrase(password)
+                .build()
+        val request =
+            NetworkRequest.Builder()
+                .addTransportType(NetworkCapabilities.TRANSPORT_WIFI)
+                .removeCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+                .setNetworkSpecifier(specifier)
+                .build()
+
+        val callback =
+            object : ConnectivityManager.NetworkCallback() {
+                override fun onAvailable(network: Network) {
+                    val connectPromise: Promise?
+                    synchronized(lock) {
+                        if (networkCallback !== this) {
+                            Log.d(TAG, "Ignoring onAvailable from a stale network request")
+                            return
+                        }
+                        localNetwork = network
+                        connectPromise = pendingConnectPromise
+                        pendingConnectPromise = null
+                    }
+                    Log.i(
+                        TAG,
+                        "Captured glasses WiFi network=$network processBoundNetwork=${manager.boundNetworkForProcess}",
+                    )
+                    connectPromise?.resolve(mapOf("connected" to true, "ssid" to ssid))
+                }
+
+                override fun onUnavailable() {
+                    synchronized(lock) {
+                        if (networkCallback !== this) {
+                            Log.d(TAG, "Ignoring onUnavailable from a stale network request")
+                            return
+                        }
+                    }
+                    rejectPendingConnect("ERR_LOCAL_WIFI_UNAVAILABLE", "Could not connect to $ssid")
+                    clearNetworkCallback(this)
+                }
+
+                override fun onLost(network: Network) {
+                    synchronized(lock) {
+                        if (networkCallback !== this || localNetwork != network) {
+                            Log.d(TAG, "Ignoring onLost from a stale network request")
+                            return
+                        }
+                        localNetwork = null
+                    }
+                    cancelAll()
+                    clearNetworkCallback(this)
+                    sendEvent("networkLost", mapOf("ssid" to ssid))
+                }
+            }
+
+        synchronized(lock) {
+            pendingConnectPromise = promise
+            networkCallback = callback
+        }
+        try {
+            manager.requestNetwork(request, callback, 30_000)
+        } catch (error: Exception) {
+            clearNetworkCallback(callback)
+            rejectPendingConnect("ERR_LOCAL_WIFI_REQUEST", error.message ?: "Local WiFi request failed", error)
+        }
+    }
+
+    private fun performRequest(
+        requestId: String,
+        url: String,
+        method: String,
+        headers: Map<String, String>,
+        body: String?,
+        timeoutMs: Int,
+        promise: Promise,
+    ) {
+        var connection: HttpURLConnection? = null
+        try {
+            connection = openConnection(requestId, url)
+            connection.requestMethod = method
+            connection.connectTimeout = timeoutMs
+            connection.readTimeout = timeoutMs
+            headers.forEach(connection::setRequestProperty)
+            if (body != null) {
+                connection.doOutput = true
+                connection.outputStream.use { it.write(body.toByteArray(Charsets.UTF_8)) }
+            }
+            val status = connection.responseCode
+            val stream = if (status >= 400) connection.errorStream else connection.inputStream
+            val bytes = stream?.use { it.readBytes() } ?: ByteArray(0)
+            promise.resolve(
+                mapOf(
+                    "status" to status,
+                    "headers" to responseHeaders(connection),
+                    "bodyBase64" to Base64.encodeToString(bytes, Base64.NO_WRAP),
+                ),
+            )
+        } catch (error: Exception) {
+            promise.reject("ERR_LOCAL_HTTP", error.message ?: "Local HTTP request failed", error)
+        } finally {
+            activeConnections.remove(requestId)
+            connection?.disconnect()
+        }
+    }
+
+    private fun performDownload(
+        requestId: String,
+        url: String,
+        destination: String,
+        headers: Map<String, String>,
+        connectionTimeoutMs: Int,
+        readTimeoutMs: Int,
+        promise: Promise,
+    ) {
+        var connection: HttpURLConnection? = null
+        try {
+            connection = openConnection(requestId, url)
+            connection.requestMethod = "GET"
+            connection.connectTimeout = connectionTimeoutMs
+            connection.readTimeout = readTimeoutMs
+            headers.forEach(connection::setRequestProperty)
+            val status = connection.responseCode
+            if (status !in 200..299) throw IllegalStateException("HTTP $status")
+
+            val destinationFile = File(destination)
+            destinationFile.parentFile?.mkdirs()
+            var bytesWritten = 0L
+            connection.inputStream.use { input ->
+                FileOutputStream(destinationFile, false).use { output ->
+                    val buffer = ByteArray(64 * 1024)
+                    while (true) {
+                        val count = input.read(buffer)
+                        if (count < 0) break
+                        output.write(buffer, 0, count)
+                        bytesWritten += count
+                        sendEvent(
+                            "downloadProgress",
+                            mapOf(
+                                "requestId" to requestId,
+                                "bytesWritten" to bytesWritten,
+                                "contentLength" to connection.contentLengthLong,
+                            ),
+                        )
+                    }
+                }
+            }
+            promise.resolve(
+                mapOf(
+                    "statusCode" to status,
+                    "bytesWritten" to bytesWritten,
+                    "headers" to responseHeaders(connection),
+                ),
+            )
+        } catch (error: Exception) {
+            promise.reject("ERR_LOCAL_DOWNLOAD", error.message ?: "Local download failed", error)
+        } finally {
+            activeConnections.remove(requestId)
+            connection?.disconnect()
+        }
+    }
+
+    private fun openConnection(requestId: String, url: String): HttpURLConnection {
+        val network = synchronized(lock) { localNetwork }
+            ?: throw IllegalStateException("Local WiFi is not connected")
+        val connection = network.openConnection(URL(url)) as HttpURLConnection
+        activeConnections[requestId] = connection
+        return connection
+    }
+
+    private fun responseHeaders(connection: HttpURLConnection): Map<String, String> =
+        connection.headerFields
+            .filterKeys { it != null }
+            .mapValues { (_, values) -> values.joinToString(", ") }
+
+    private fun cancel(requestId: String) {
+        activeConnections.remove(requestId)?.disconnect()
+    }
+
+    private fun cancelAll() {
+        activeConnections.keys.toList().forEach(::cancel)
+    }
+
+    private fun disconnect() {
+        cancelAll()
+        val manager = appContext.reactContext?.getSystemService(ConnectivityManager::class.java)
+        val callback: ConnectivityManager.NetworkCallback?
+        synchronized(lock) {
+            callback = networkCallback
+            networkCallback = null
+            localNetwork = null
+        }
+        if (callback != null && manager != null) {
+            try {
+                manager.unregisterNetworkCallback(callback)
+            } catch (_: IllegalArgumentException) {
+                // Already unregistered by the platform.
+            }
+        }
+        rejectPendingConnect("ERR_LOCAL_WIFI_CANCELLED", "Local WiFi connection cancelled")
+    }
+
+    private fun clearNetworkCallback(callback: ConnectivityManager.NetworkCallback) {
+        val manager = appContext.reactContext?.getSystemService(ConnectivityManager::class.java)
+        synchronized(lock) {
+            if (networkCallback == callback) networkCallback = null
+        }
+        if (manager != null) {
+            try {
+                manager.unregisterNetworkCallback(callback)
+            } catch (_: IllegalArgumentException) {
+                // Callback was not registered or has already been removed.
+            }
+        }
+    }
+
+    private fun rejectPendingConnect(code: String, message: String, cause: Throwable? = null) {
+        val promise: Promise?
+        synchronized(lock) {
+            promise = pendingConnectPromise
+            pendingConnectPromise = null
+        }
+        promise?.reject(code, message, cause)
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraLocalNetworkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraLocalNetworkModule.kt
@@ -215,6 +215,21 @@ class MentraLocalNetworkModule : Module() {
             headers.forEach(connection::setRequestProperty)
             val status = connection.responseCode
             if (status !in 200..299) throw IllegalStateException("HTTP $status")
+            val contentLength = connection.contentLengthLong
+            val responseHeaders = responseHeaders(connection)
+
+            // Match RNFS's begin callback contract before the first response byte. Gallery
+            // resumable downloads need the real status and Content-Range to validate segments.
+            sendEvent(
+                "downloadProgress",
+                mapOf(
+                    "requestId" to requestId,
+                    "bytesWritten" to 0L,
+                    "contentLength" to contentLength,
+                    "statusCode" to status,
+                    "headers" to responseHeaders,
+                ),
+            )
 
             val destinationFile = File(destination)
             destinationFile.parentFile?.mkdirs()
@@ -232,7 +247,7 @@ class MentraLocalNetworkModule : Module() {
                             mapOf(
                                 "requestId" to requestId,
                                 "bytesWritten" to bytesWritten,
-                                "contentLength" to connection.contentLengthLong,
+                                "contentLength" to contentLength,
                             ),
                         )
                     }
@@ -242,7 +257,7 @@ class MentraLocalNetworkModule : Module() {
                 mapOf(
                     "statusCode" to status,
                     "bytesWritten" to bytesWritten,
-                    "headers" to responseHeaders(connection),
+                    "headers" to responseHeaders,
                 ),
             )
         } catch (error: Exception) {

--- a/mobile/modules/bluetooth-sdk/expo-module.config.json
+++ b/mobile/modules/bluetooth-sdk/expo-module.config.json
@@ -6,6 +6,7 @@
   "android": {
     "modules": [
       "com.mentra.bluetoothsdk.BluetoothSdkModule",
+      "com.mentra.bluetoothsdk.MentraLocalNetworkModule",
       "com.mentra.bluetoothsdk.photoreceiver.MentraPhotoReceiverModule"
     ]
   }

--- a/mobile/modules/bluetooth-sdk/src/_internal.ts
+++ b/mobile/modules/bluetooth-sdk/src/_internal.ts
@@ -9,3 +9,5 @@
 export {default} from "./_private/BluetoothSdkModule"
 export type {BluetoothSdkInternalModule} from "./_private/BluetoothSdkModule"
 export * from "./BluetoothSdk.types"
+export {default as MentraLocalNetwork} from "./_private/MentraLocalNetworkModule"
+export * from "./_private/MentraLocalNetworkModule"

--- a/mobile/modules/bluetooth-sdk/src/_private/MentraLocalNetworkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/MentraLocalNetworkModule.ts
@@ -1,0 +1,48 @@
+import {NativeModule, requireOptionalNativeModule} from "expo"
+
+export type LocalNetworkResponse = {
+  status: number
+  headers: Record<string, string>
+  bodyBase64: string
+}
+
+export type LocalNetworkDownloadResult = {
+  statusCode: number
+  bytesWritten: number
+  headers: Record<string, string>
+}
+
+export type LocalNetworkDownloadProgress = {
+  requestId: string
+  bytesWritten: number
+  contentLength: number
+}
+
+type LocalNetworkEvents = {
+  downloadProgress: (event: LocalNetworkDownloadProgress) => void
+  networkLost: (event: {ssid: string}) => void
+}
+
+declare class MentraLocalNetworkNativeModule extends NativeModule<LocalNetworkEvents> {
+  connect(ssid: string, password: string): Promise<{connected: boolean; ssid: string}>
+  request(
+    requestId: string,
+    url: string,
+    method: string,
+    headers: Record<string, string>,
+    body: string | null,
+    timeoutMs: number,
+  ): Promise<LocalNetworkResponse>
+  download(
+    requestId: string,
+    url: string,
+    destination: string,
+    headers: Record<string, string>,
+    connectionTimeoutMs: number,
+    readTimeoutMs: number,
+  ): Promise<LocalNetworkDownloadResult>
+  cancel(requestId: string): Promise<void>
+  disconnect(): Promise<void>
+}
+
+export default requireOptionalNativeModule<MentraLocalNetworkNativeModule>("MentraLocalNetwork")

--- a/mobile/modules/bluetooth-sdk/src/_private/MentraLocalNetworkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/MentraLocalNetworkModule.ts
@@ -16,6 +16,8 @@ export type LocalNetworkDownloadProgress = {
   requestId: string
   bytesWritten: number
   contentLength: number
+  statusCode?: number
+  headers?: Record<string, string>
 }
 
 type LocalNetworkEvents = {

--- a/mobile/modules/engine/src/facades/__tests__/permissions.test.ts
+++ b/mobile/modules/engine/src/facades/__tests__/permissions.test.ts
@@ -4,6 +4,7 @@ import {beforeEach, describe, expect, mock, test} from "bun:test"
 
 const FINE_LOCATION = "android.permission.ACCESS_FINE_LOCATION"
 const BACKGROUND_LOCATION = "android.permission.ACCESS_BACKGROUND_LOCATION"
+const NEARBY_WIFI_DEVICES = "android.permission.NEARBY_WIFI_DEVICES"
 
 const permissionChecks = new Map<string, boolean>()
 const permissionRequestResults = new Map<string, string>()
@@ -26,6 +27,7 @@ mock.module("react-native", () => ({
       BLUETOOTH_CONNECT: "android.permission.BLUETOOTH_CONNECT",
       BLUETOOTH_SCAN: "android.permission.BLUETOOTH_SCAN",
       CAMERA: "android.permission.CAMERA",
+      NEARBY_WIFI_DEVICES,
       POST_NOTIFICATIONS: "android.permission.POST_NOTIFICATIONS",
       READ_CALENDAR: "android.permission.READ_CALENDAR",
       READ_PHONE_STATE: "android.permission.READ_PHONE_STATE",
@@ -73,7 +75,7 @@ mock.module("../../services/AppRegistry", () => ({
   saveLocalAppRunningState: () => {},
 }))
 
-const {PermissionFeatures, permissions} = await import("../permissions")
+const {PermissionFeatures, localWifiPermissionForAndroid, permissions} = await import("../permissions")
 
 describe("permissions facade", () => {
   beforeEach(() => {
@@ -132,5 +134,22 @@ describe("permissions facade", () => {
       "android.permission.READ_CALENDAR",
       "android.permission.WRITE_CALENDAR",
     ])
+  })
+
+  test("uses location permission for local WiFi on Android 12 and earlier", async () => {
+    permissionRequestResults.set(FINE_LOCATION, "granted")
+
+    await expect(permissions.request(PermissionFeatures.LOCAL_WIFI)).resolves.toBe(true)
+
+    expect(androidRequestMultiple).toHaveBeenCalledWith([FINE_LOCATION])
+  })
+
+  test("uses nearby WiFi permission for local WiFi on Android 13 and newer", () => {
+    expect(
+      localWifiPermissionForAndroid(33, {
+        ACCESS_FINE_LOCATION: FINE_LOCATION,
+        NEARBY_WIFI_DEVICES,
+      } as any),
+    ).toBe(NEARBY_WIFI_DEVICES)
   })
 })

--- a/mobile/modules/engine/src/facades/permissions.ts
+++ b/mobile/modules/engine/src/facades/permissions.ts
@@ -17,6 +17,7 @@ export const PermissionFeatures = {
   CAMERA: "camera",
   CALENDAR: "calendar",
   LOCATION: "location",
+  LOCAL_WIFI: "local_wifi",
   BACKGROUND_LOCATION: "background_location",
   BLUETOOTH: "bluetooth",
   PHONE_STATE: "phone_state",
@@ -26,6 +27,13 @@ export const PermissionFeatures = {
 const ANDROID = PermissionsAndroid.PERMISSIONS
 const apiLevel = typeof Platform.Version === "number" ? Platform.Version : parseInt(String(Platform.Version), 10)
 const requiresSeparateAndroidBackgroundLocation = apiLevel >= 29
+
+export function localWifiPermissionForAndroid(
+  androidApiLevel: number,
+  androidPermissions: typeof PermissionsAndroid.PERMISSIONS = ANDROID,
+): AndroidPermission {
+  return androidApiLevel >= 33 ? androidPermissions.NEARBY_WIFI_DEVICES : androidPermissions.ACCESS_FINE_LOCATION
+}
 
 async function areAndroidPermissionsGranted(perms: AndroidPermission[]): Promise<boolean> {
   for (const p of perms) {
@@ -66,6 +74,8 @@ function iosPerms(feature: string): Permission[] {
       return [PERMISSIONS.IOS.CALENDARS]
     case PermissionFeatures.LOCATION:
       return [PERMISSIONS.IOS.LOCATION_WHEN_IN_USE]
+    case PermissionFeatures.LOCAL_WIFI:
+      return []
     case PermissionFeatures.BACKGROUND_LOCATION:
       // iOS won't grant ALWAYS without WHEN_IN_USE first — request both (matches
       // the host PermissionsUtils mapping), else a cold request can't escalate.
@@ -90,6 +100,8 @@ function androidPerms(feature: string): AndroidPermission[] {
     case PermissionFeatures.LOCATION:
     case PermissionFeatures.BACKGROUND_LOCATION:
       return [ANDROID.ACCESS_FINE_LOCATION]
+    case PermissionFeatures.LOCAL_WIFI:
+      return [localWifiPermissionForAndroid(apiLevel)]
     case PermissionFeatures.PHONE_STATE:
       return [ANDROID.READ_PHONE_STATE]
     case PermissionFeatures.BLUETOOTH:

--- a/mobile/modules/engine/src/services/asg/asgCameraApi.ts
+++ b/mobile/modules/engine/src/services/asg/asgCameraApi.ts
@@ -701,6 +701,7 @@ export class AsgCameraApiClient {
         headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
         signal: this.createTimeoutSignal(10 * 60 * 1000),
       },
+      10 * 60 * 1000,
     )
     if (!response.ok) throw new Error(`Hash request failed: HTTP ${response.status}`)
     const payload = await response.json()

--- a/mobile/modules/engine/src/services/asg/asgCameraApi.ts
+++ b/mobile/modules/engine/src/services/asg/asgCameraApi.ts
@@ -12,6 +12,7 @@ import {localStorageService} from "./localStorageService"
 import {validateDownloadedMediaFile} from "./galleryMediaValidation"
 import {reportInvalidGalleryMedia} from "./GalleryMediaIntegrityReportService"
 import {galleryTransferLedger} from "./galleryTransferLedger"
+import {localNetworkTransport} from "./localNetworkTransport"
 
 export interface GalleryCapabilities {
   api_version: number
@@ -148,7 +149,7 @@ export class AsgCameraApiClient {
       console.log(`[ASG Camera API] Headers being sent:`, headers)
 
       // N4: Add 30s timeout to all fetch calls in makeRequest
-      const response = await fetch(url, {
+      const response = await localNetworkTransport.fetch(url, {
         headers,
         ...options,
         signal: options?.signal || this.createTimeoutSignal(30000),
@@ -287,7 +288,7 @@ export class AsgCameraApiClient {
     // Use browser-like headers since we know the browser works
     try {
       console.log(`[ASG Camera API] Making direct fetch to gallery endpoint`)
-      const response = await fetch(galleryUrl, {
+      const response = await localNetworkTransport.fetch(galleryUrl, {
         method: "GET",
         headers: {
           "Accept": "application/json",
@@ -427,7 +428,7 @@ export class AsgCameraApiClient {
     for (const endpoint of testEndpoints) {
       try {
         console.log(`[ASG Camera API] Testing endpoint: ${endpoint}`)
-        const response = await fetch(`${this.baseUrl}${endpoint}`, {
+        const response = await localNetworkTransport.fetch(`${this.baseUrl}${endpoint}`, {
           method: "HEAD",
           headers: {
             "Accept": "*/*",
@@ -448,7 +449,7 @@ export class AsgCameraApiClient {
         if (endpoint === "/api/gallery") {
           try {
             console.log(`[ASG Camera API] Trying GET request for /api/gallery...`)
-            const getResponse = await fetch(`${this.baseUrl}${endpoint}`, {
+            const getResponse = await localNetworkTransport.fetch(`${this.baseUrl}${endpoint}`, {
               method: "GET",
               headers: {
                 "Accept": "application/json",
@@ -552,7 +553,7 @@ export class AsgCameraApiClient {
       const controller = new AbortController()
       const timeoutId = BgTimer.setTimeout(() => controller.abort(), 3000) // 3 second timeout
 
-      const response = await fetch(`${this.baseUrl}/api/health`, {
+      const response = await localNetworkTransport.fetch(`${this.baseUrl}/api/health`, {
         method: "HEAD",
         signal: controller.signal,
       })
@@ -643,7 +644,7 @@ export class AsgCameraApiClient {
   async getGalleryCapabilities(): Promise<GalleryCapabilities | null> {
     if (this.galleryCapabilities !== undefined) return this.galleryCapabilities
     try {
-      const response = await fetch(`${this.baseUrl}/api/v3/capabilities`, {
+      const response = await localNetworkTransport.fetch(`${this.baseUrl}/api/v3/capabilities`, {
         headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
         signal: this.createTimeoutSignal(5000),
       })
@@ -694,10 +695,13 @@ export class AsgCameraApiClient {
   }
 
   async getV3FileHash(fileName: string): Promise<{sha256: string; etag: string; size: number}> {
-    const response = await fetch(`${this.baseUrl}/api/v3/hash?file=${encodeURIComponent(fileName)}`, {
-      headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
-      signal: this.createTimeoutSignal(10 * 60 * 1000),
-    })
+    const response = await localNetworkTransport.fetch(
+      `${this.baseUrl}/api/v3/hash?file=${encodeURIComponent(fileName)}`,
+      {
+        headers: {"Accept": "application/json", "User-Agent": "MentraOS-Mobile/1.0"},
+        signal: this.createTimeoutSignal(10 * 60 * 1000),
+      },
+    )
     if (!response.ok) throw new Error(`Hash request failed: HTTP ${response.status}`)
     const payload = await response.json()
     return (payload.data || payload) as {sha256: string; etag: string; size: number}
@@ -915,7 +919,7 @@ export class AsgCameraApiClient {
         await RNFS.unlink(partPath(index)).catch(() => {})
         const end = start + expectedLength - 1
         let responseHeaders: Record<string, string> = {}
-        const {jobId, promise} = RNFS.downloadFile({
+        const {jobId, promise} = localNetworkTransport.downloadFile({
           fromUrl: `${this.baseUrl}/api/download?file=${encodeURIComponent(file.name)}`,
           toFile: partPath(index),
           headers: {
@@ -938,7 +942,7 @@ export class AsgCameraApiClient {
         let abortPollTimer: number | undefined
         if (abortSignal) {
           abortPollTimer = BgTimer.setInterval(() => {
-            if (abortSignal.aborted) RNFS.stopDownload(jobId)
+            if (abortSignal.aborted) localNetworkTransport.stopDownload(jobId)
           }, 500)
         }
 
@@ -1186,7 +1190,7 @@ export class AsgCameraApiClient {
       try {
         // Throttle progress: only fire when bytesWritten changes meaningfully
         let lastReportedBytes = -1
-        const {jobId, promise: dlPromise} = RNFS.downloadFile({
+        const {jobId, promise: dlPromise} = localNetworkTransport.downloadFile({
           fromUrl: downloadUrl,
           toFile: localFilePath,
           headers: {
@@ -1211,12 +1215,12 @@ export class AsgCameraApiClient {
         let abortPollTimer: number | undefined
         if (abortSignal) {
           if (abortSignal.aborted) {
-            RNFS.stopDownload(jobId)
+            localNetworkTransport.stopDownload(jobId)
             throw new Error("Sync cancelled")
           }
           abortPollTimer = BgTimer.setInterval(() => {
             if (abortSignal.aborted) {
-              RNFS.stopDownload(jobId)
+              localNetworkTransport.stopDownload(jobId)
             }
           }, 500)
         }
@@ -1421,10 +1425,10 @@ export class AsgCameraApiClient {
         mime_type: isVideo
           ? "video/mp4"
           : lowerName.endsWith(".png")
-            ? "image/png"
-            : lowerName.endsWith(".avif")
-              ? "image/avif"
-              : "image/jpeg",
+          ? "image/png"
+          : lowerName.endsWith(".avif")
+          ? "image/avif"
+          : "image/jpeg",
       }
     } catch (error) {
       galleryTransferLedger.recordFailure(captureId, error)
@@ -1475,7 +1479,7 @@ export class AsgCameraApiClient {
       // Throttle progress: only call onProgress when percentage actually changes
       let lastReportedProgress = -1
 
-      const {jobId, promise: downloadPromise} = RNFS.downloadFile({
+      const {jobId, promise: downloadPromise} = localNetworkTransport.downloadFile({
         fromUrl: downloadUrl,
         toFile: localFilePath,
         headers: {
@@ -1520,12 +1524,12 @@ export class AsgCameraApiClient {
       let abortPollTimer: number | undefined
       if (abortSignal) {
         if (abortSignal.aborted) {
-          RNFS.stopDownload(jobId)
+          localNetworkTransport.stopDownload(jobId)
           throw new Error("Sync cancelled")
         }
         abortPollTimer = BgTimer.setInterval(() => {
           if (abortSignal.aborted) {
-            RNFS.stopDownload(jobId)
+            localNetworkTransport.stopDownload(jobId)
           }
         }, 500)
       }
@@ -1625,7 +1629,7 @@ export class AsgCameraApiClient {
 
           // The server's /api/photo endpoint serves thumbnails for video files
           // It detects video files and automatically generates/serves thumbnails instead of the full video
-          const thumbResult = await RNFS.downloadFile({
+          const thumbResult = await localNetworkTransport.downloadFile({
             fromUrl: `${this.baseUrl}/api/photo?file=${encodeURIComponent(filename)}`,
             toFile: localThumbnailPath as string,
             headers: {

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -26,6 +26,7 @@ import {permissions, PermissionFeatures} from "../../facades/permissions"
 import {asgCameraApi} from "./asgCameraApi"
 import {gallerySettingsService} from "./gallerySettingsService"
 import {gallerySyncNotifications} from "./gallerySyncNotifications"
+import {localNetworkTransport} from "./localNetworkTransport"
 import {localStorageService} from "./localStorageService"
 import {mediaProcessingQueue} from "./mediaProcessingQueue"
 import {validateCaptureMetadataForDownload} from "./galleryMediaValidation"
@@ -122,6 +123,7 @@ class GallerySyncService {
    * Cleanup - remove event listeners
    */
   cleanup(): void {
+    void localNetworkTransport.disconnect()
     if (this.hotspotListenerRegistered) {
       GlobalEventEmitter.removeListener("hotspot_status_change", this.handleHotspotStatusChange)
       GlobalEventEmitter.removeListener("hotspot_error", this.handleHotspotError)
@@ -192,6 +194,7 @@ class GallerySyncService {
     }
 
     gallerySyncNotifications.showSyncError("Glasses disconnected")
+    void localNetworkTransport.disconnect()
   }
 
   /**
@@ -525,6 +528,23 @@ class GallerySyncService {
     if (this.shouldAbortPreFlight()) {
       console.log("[GallerySyncService] Pre-flight aborted after location permission")
       return
+    }
+
+    if (Platform.OS === "android") {
+      console.log("[GallerySyncService]   📡 Checking local WiFi permission...")
+      const hasLocalWifiPermission = await permissions.check(PermissionFeatures.LOCAL_WIFI)
+      if (!hasLocalWifiPermission) {
+        const granted = await permissions.request(PermissionFeatures.LOCAL_WIFI)
+        if (!granted) {
+          store.setSyncError("Local WiFi permission is required for gallery sync")
+          await gallerySyncNotifications.showSyncError("Allow WiFi access to connect to your glasses")
+          return
+        }
+      }
+      if (this.shouldAbortPreFlight()) {
+        console.log("[GallerySyncService] Pre-flight aborted after local WiFi permission")
+        return
+      }
     }
 
     // 3. Camera roll permission (if auto-save is enabled)
@@ -901,7 +921,7 @@ class GallerySyncService {
             console.log(`[GallerySyncService] 📡 Current WiFi SSID: "${preConnectSSID}"`)
 
             // Check if already connected (shouldn't happen, but good to verify)
-            if (preConnectSSID === hotspotInfo.ssid) {
+            if (!localNetworkTransport.supportsScopedConnection() && preConnectSSID === hotspotInfo.ssid) {
               console.log("[GallerySyncService] ✅ Already connected to target SSID! Proceeding to download.")
               appStateSubscription.remove()
 
@@ -920,8 +940,7 @@ class GallerySyncService {
             console.warn("[GallerySyncService] ⚠️ Error code:", preError?.code)
           }
 
-          // Use connectToProtectedSSID with joinOnce=false for persistent connection
-          console.log(`[GallerySyncService] 🔌 Calling WifiManager.connectToProtectedSSID...`)
+          console.log(`[GallerySyncService] 🔌 Connecting the glasses-local transport...`)
           console.log(`[GallerySyncService] 🔌 Parameters:`)
           console.log(`[GallerySyncService]    - SSID: "${hotspotInfo.ssid}"`)
           console.log(`[GallerySyncService]    - Password: ${"*".repeat(hotspotInfo.password.length)}`)
@@ -932,10 +951,10 @@ class GallerySyncService {
           appBackgrounded = false // Reset flag for this attempt
           appBackgroundTime = null
 
-          await WifiManager.connectToProtectedSSID(hotspotInfo.ssid, hotspotInfo.password, false, false)
+          await localNetworkTransport.connect(hotspotInfo.ssid, hotspotInfo.password)
 
           const connectCallDuration = Date.now() - connectCallStartTime
-          console.log(`[GallerySyncService] ✅ WifiManager.connectToProtectedSSID returned successfully`)
+          console.log(`[GallerySyncService] ✅ Glasses-local transport connected successfully`)
           console.log(`[GallerySyncService] ⏱️ Library call duration: ${connectCallDuration}ms`)
           console.log(`[GallerySyncService] 📱 App was backgrounded during call: ${appBackgrounded}`)
           if (appBackgrounded && appBackgroundTime) {
@@ -1015,7 +1034,9 @@ class GallerySyncService {
 
           // Final verification: Check SSID one more time before starting download
           try {
-            const finalSSID = await WifiManager.getCurrentWifiSSID()
+            const finalSSID = localNetworkTransport.isScopedConnectionActive()
+              ? hotspotInfo.ssid
+              : await WifiManager.getCurrentWifiSSID()
             console.log(`[GallerySyncService] 📶 Final SSID check before download: "${finalSSID}"`)
             if (Platform.OS === "android") {
               // Some local builds can have stale generated typings for the Bluetooth SDK module.
@@ -1051,7 +1072,7 @@ class GallerySyncService {
                 const probeTimeout = BgTimer.setTimeout(() => probeController.abort(), 1000) // 1 second timeout per probe
 
                 const probeStartTime = Date.now()
-                const probeResponse = await fetch(`http://${hotspotInfo.ip}:8089/api/health`, {
+                const probeResponse = await localNetworkTransport.fetch(`http://${hotspotInfo.ip}:8089/api/health`, {
                   method: "GET",
                   signal: probeController.signal,
                 })
@@ -1253,6 +1274,9 @@ class GallerySyncService {
         await this.closeHotspot()
       }
     } finally {
+      // Release the scoped Android Network on every terminal path. This is idempotent with
+      // closeHotspot(), and intentionally leaves Android 9/iOS legacy routing unchanged.
+      await localNetworkTransport.disconnect()
       // L2: Guarantee listener cleanup on all exit paths (cancel, success, error, exhaustion)
       appStateSubscription.remove()
     }
@@ -1261,10 +1285,20 @@ class GallerySyncService {
   private async fetchSyncManifest(clientId: string, lastSyncTime: number): Promise<SyncManifestData> {
     const v3 = typeof asgCameraApi.getV3Manifest === "function" ? await asgCameraApi.getV3Manifest() : null
     if (v3) {
+      const downloadedFiles = await localStorageService.getDownloadedFiles()
+      await localStorageService.reconcileRemoteCaptures(
+        v3.captures.map((capture) => capture.capture_id),
+        downloadedFiles,
+      )
       return {
         api_version: 3,
         client_id: clientId,
-        captures: v3.captures.filter((capture) => !galleryTransferLedger.isLocallyCommitted(capture.capture_id)),
+        // The ledger is a crash-recovery journal, not proof that app-private media survived an
+        // Android restore or reinstall. Suppress a remote capture only when both records agree.
+        captures: v3.captures.filter(
+          (capture) =>
+            !downloadedFiles[capture.capture_id] || !galleryTransferLedger.isLocallyCommitted(capture.capture_id),
+        ),
         changed_files: [],
         deleted_files: [],
         server_time: v3.server_time,
@@ -1536,7 +1570,7 @@ class GallerySyncService {
         (current, total, fileName, fileProgress, downloadedFile) => {
           // CRITICAL: This callback MUST NOT throw!
           // RNFS progress callbacks run inside native bridge — throwing here causes
-          // EXC_BAD_ACCESS. Cancellation is handled via AbortSignal → RNFS.stopDownload.
+          // EXC_BAD_ACCESS. Cancellation is handled via AbortSignal → the active transport.
 
           // Check if cancelled — just return, abort signal will stop the download
           if (this.abortController?.signal.aborted) {
@@ -2135,6 +2169,7 @@ class GallerySyncService {
 
     try {
       console.log("[GallerySyncService] Closing hotspot...")
+      await localNetworkTransport.disconnect()
       await BluetoothSdk.setHotspotState(false)
       store.setSyncServiceOpenedHotspot(false)
       store.setHotspotInfo(null)

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -761,11 +761,16 @@ class GallerySyncService {
     }
 
     if (isAlreadyConnected && currentGlassesHotspot) {
-      console.log("[GallerySyncService] 🚀 Skipping hotspot request - already connected!")
       const hotspotInfo: HotspotInfo = currentGlassesHotspot
       store.setHotspotInfo(hotspotInfo)
       store.setSyncState("connecting_wifi")
-      await this.startFileDownload(hotspotInfo)
+      if (localNetworkTransport.supportsScopedConnection() && !localNetworkTransport.isScopedConnectionActive()) {
+        console.log("[GallerySyncService] 📡 System SSID matches; establishing scoped glasses transport")
+        await this.connectToHotspotWifi(hotspotInfo)
+      } else {
+        console.log("[GallerySyncService] 🚀 Skipping hotspot request - already connected!")
+        await this.startFileDownload(hotspotInfo)
+      }
       return
     }
 

--- a/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
+++ b/mobile/modules/engine/src/services/asg/galleryTransferLedger.ts
@@ -261,8 +261,8 @@ class GalleryTransferLedger {
 
   releaseMissingLocalCommit(captureId: string, recoverAcknowledged: boolean = false): void {
     const entry = this.get(captureId)
-    if (!entry || entry.state === "GARBAGE_COLLECTED") return
-    if (entry.state === "TRASHED") {
+    if (!entry) return
+    if (entry.state === "TRASHED" || entry.state === "GARBAGE_COLLECTED") {
       if (recoverAcknowledged) {
         this.update(captureId, {
           state: "RESTORE_PENDING",
@@ -285,8 +285,10 @@ class GalleryTransferLedger {
     })
   }
 
-  releaseAllMissingLocalCommits(): void {
-    for (const entry of this.list()) this.releaseMissingLocalCommit(entry.captureId)
+  releaseAllMissingLocalCommits(recoverAcknowledged: boolean = false): void {
+    for (const entry of this.list()) {
+      this.releaseMissingLocalCommit(entry.captureId, recoverAcknowledged)
+    }
   }
 
   private toStoredPath(path: string): string {

--- a/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
+++ b/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
@@ -1,0 +1,173 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+import {MentraLocalNetwork, type LocalNetworkDownloadProgress} from "@mentra/bluetooth-sdk/internal"
+import {Buffer} from "buffer"
+import {Platform} from "react-native"
+import WifiManager from "react-native-wifi-reborn"
+
+type DownloadOptions = Parameters<typeof RNFS.downloadFile>[0]
+type DownloadHandle = ReturnType<typeof RNFS.downloadFile>
+
+let scopedConnectionActive = false
+let nextJobId = 1_000_000
+const nativeJobs = new Map<number, string>()
+const cancelledNativeJobs = new Set<number>()
+
+export function shouldUseScopedLocalNetwork(
+  os: string,
+  platformVersion: number | string,
+  moduleAvailable: boolean,
+): boolean {
+  const level = typeof platformVersion === "number" ? platformVersion : Number.parseInt(platformVersion, 10)
+  return os === "android" && level >= 29 && moduleAvailable
+}
+
+function supportsScopedConnection(): boolean {
+  return shouldUseScopedLocalNetwork(Platform.OS, Platform.Version, MentraLocalNetwork != null)
+}
+
+function normalizeHeaders(headers?: HeadersInit): Record<string, string> {
+  if (!headers) return {}
+  if (headers instanceof Headers) {
+    const result: Record<string, string> = {}
+    headers.forEach((value, key) => {
+      result[key] = value
+    })
+    return result
+  }
+  if (Array.isArray(headers)) return Object.fromEntries(headers)
+  return {...headers}
+}
+
+function requestId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2)}`
+}
+
+export const localNetworkTransport = {
+  supportsScopedConnection: (): boolean => supportsScopedConnection(),
+  isScopedConnectionActive: (): boolean => scopedConnectionActive,
+
+  async connect(ssid: string, password: string): Promise<void> {
+    scopedConnectionActive = false
+    nativeJobs.clear()
+    if (!supportsScopedConnection()) {
+      await WifiManager.connectToProtectedSSID(ssid, password, false, false)
+      return
+    }
+    await MentraLocalNetwork!.connect(ssid, password)
+    scopedConnectionActive = true
+  },
+
+  async disconnect(): Promise<void> {
+    if (supportsScopedConnection()) {
+      await MentraLocalNetwork!.disconnect().catch(() => {})
+    }
+    scopedConnectionActive = false
+    nativeJobs.clear()
+  },
+
+  async fetch(url: string | URL | Request, init?: RequestInit): Promise<Response> {
+    if (!scopedConnectionActive || !MentraLocalNetwork || typeof url !== "string") {
+      return globalThis.fetch(url, init)
+    }
+
+    const nativeModule = MentraLocalNetwork
+    const id = requestId("request")
+    const signal = init?.signal
+    const cancel = () => void nativeModule.cancel(id)
+    if (signal?.aborted) throw new Error("Request aborted")
+    signal?.addEventListener("abort", cancel, {once: true})
+    try {
+      const result = await nativeModule.request(
+        id,
+        url,
+        init?.method || "GET",
+        normalizeHeaders(init?.headers),
+        typeof init?.body === "string" ? init.body : null,
+        30_000,
+      )
+      const bytes = Buffer.from(result.bodyBase64, "base64")
+      return new Response(bytes as unknown as BodyInit, {
+        status: result.status,
+        headers: result.headers,
+      })
+    } finally {
+      signal?.removeEventListener("abort", cancel)
+    }
+  },
+
+  downloadFile(options: DownloadOptions): DownloadHandle {
+    if (!scopedConnectionActive || !MentraLocalNetwork) return RNFS.downloadFile(options)
+
+    const jobId = nextJobId++
+    const id = requestId("download")
+    let began = false
+    nativeJobs.set(jobId, id)
+    const subscription = MentraLocalNetwork.addListener("downloadProgress", (event: LocalNetworkDownloadProgress) => {
+      if (event.requestId !== id) return
+      if (!began) {
+        began = true
+        options.begin?.({
+          jobId,
+          statusCode: 200,
+          contentLength: event.contentLength,
+          headers: {},
+        })
+      }
+      options.progress?.({
+        jobId,
+        contentLength: event.contentLength,
+        bytesWritten: event.bytesWritten,
+      })
+    })
+
+    const promise = MentraLocalNetwork.download(
+      id,
+      options.fromUrl,
+      options.toFile,
+      options.headers || {},
+      options.connectionTimeout || 30_000,
+      options.readTimeout || 30_000,
+    )
+      .then((result) => {
+        if (!began) {
+          options.begin?.({
+            jobId,
+            statusCode: result.statusCode,
+            contentLength: result.bytesWritten,
+            headers: result.headers,
+          })
+        }
+        return {
+          jobId,
+          statusCode: result.statusCode,
+          bytesWritten: result.bytesWritten,
+        }
+      })
+      .catch((error) => {
+        if (cancelledNativeJobs.has(jobId)) throw new Error("Sync cancelled")
+        throw error
+      })
+      .finally(() => {
+        nativeJobs.delete(jobId)
+        cancelledNativeJobs.delete(jobId)
+        subscription.remove()
+      })
+
+    return {jobId, promise} as DownloadHandle
+  },
+
+  stopDownload(jobId: number): void {
+    const nativeId = nativeJobs.get(jobId)
+    if (nativeId && MentraLocalNetwork) {
+      cancelledNativeJobs.add(jobId)
+      void MentraLocalNetwork.cancel(nativeId)
+      return
+    }
+    RNFS.stopDownload(jobId)
+  },
+}
+
+MentraLocalNetwork?.addListener("networkLost", () => {
+  scopedConnectionActive = false
+  nativeJobs.clear()
+})

--- a/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
+++ b/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
@@ -65,7 +65,7 @@ export const localNetworkTransport = {
     nativeJobs.clear()
   },
 
-  async fetch(url: string | URL | Request, init?: RequestInit): Promise<Response> {
+  async fetch(url: string | URL | Request, init?: RequestInit, timeoutMs = 30_000): Promise<Response> {
     if (!scopedConnectionActive || !MentraLocalNetwork || typeof url !== "string") {
       return globalThis.fetch(url, init)
     }
@@ -83,7 +83,7 @@ export const localNetworkTransport = {
         init?.method || "GET",
         normalizeHeaders(init?.headers),
         typeof init?.body === "string" ? init.body : null,
-        30_000,
+        timeoutMs,
       )
       const bytes = Buffer.from(result.bodyBase64, "base64")
       return new Response(bytes as unknown as BodyInit, {

--- a/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
+++ b/mobile/modules/engine/src/services/asg/localNetworkTransport.ts
@@ -108,9 +108,9 @@ export const localNetworkTransport = {
         began = true
         options.begin?.({
           jobId,
-          statusCode: 200,
+          statusCode: event.statusCode || 200,
           contentLength: event.contentLength,
-          headers: {},
+          headers: event.headers || {},
         })
       }
       options.progress?.({

--- a/mobile/modules/engine/src/services/asg/localStorageService.ts
+++ b/mobile/modules/engine/src/services/asg/localStorageService.ts
@@ -293,6 +293,31 @@ export class LocalStorageService {
   }
 
   /**
+   * Reconcile the remote manifest against the app-local gallery index before ledger filtering.
+   * Android backup/restore and data-preserving reinstalls can restore MMKV ledger rows without
+   * restoring app-private media. Only captures currently advertised by the glasses are released,
+   * so acknowledged captures that remain in glasses trash are not resurrected unnecessarily.
+   */
+  async reconcileRemoteCaptures(
+    captureIds: string[],
+    downloadedFiles?: Record<string, DownloadedFile>,
+  ): Promise<number> {
+    const localFiles = downloadedFiles || (await this.getDownloadedFiles())
+    let released = 0
+    for (const captureId of captureIds) {
+      if (localFiles[captureId]) continue
+      const entry = galleryTransferLedger.get(captureId)
+      if (!entry || !galleryTransferLedger.isLocallyCommitted(captureId)) continue
+      galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
+      released++
+    }
+    if (released > 0) {
+      console.warn(`[LocalStorage] Released ${released} stale gallery ledger commit(s) missing local media`)
+    }
+    return released
+  }
+
+  /**
    * Get downloaded file by name
    */
   async getDownloadedFile(fileName: string): Promise<DownloadedFile | null> {

--- a/mobile/modules/engine/src/services/asg/localStorageService.ts
+++ b/mobile/modules/engine/src/services/asg/localStorageService.ts
@@ -305,9 +305,11 @@ export class LocalStorageService {
     const localFiles = downloadedFiles || (await this.getDownloadedFiles())
     let released = 0
     for (const captureId of captureIds) {
-      if (localFiles[captureId]) continue
       const entry = galleryTransferLedger.get(captureId)
       if (!entry || !galleryTransferLedger.isLocallyCommitted(captureId)) continue
+      const localFile = localFiles[captureId]
+      const localFileExists = localFile?.filePath ? await RNFS.exists(localFile.filePath).catch(() => false) : false
+      if (localFileExists) continue
       galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
       released++
     }

--- a/mobile/modules/engine/src/services/asg/localStorageService.ts
+++ b/mobile/modules/engine/src/services/asg/localStorageService.ts
@@ -310,6 +310,41 @@ export class LocalStorageService {
       const localFile = localFiles[captureId]
       const localFileExists = localFile?.filePath ? await RNFS.exists(localFile.filePath).catch(() => false) : false
       if (localFileExists) continue
+
+      // The transfer ledger and gallery index are persisted independently. A crash can leave the
+      // committed media in place after its index write was lost, so repair the index from the
+      // ledger before deciding that the capture needs to be restored from the glasses.
+      const committedPath = entry.finalPath?.replace(/^file:\/\//, "")
+      const committedFileExists = committedPath ? await RNFS.exists(committedPath).catch(() => false) : false
+      if (committedPath && committedFileExists) {
+        try {
+          const stat = await RNFS.stat(committedPath)
+          const size = Number(stat.size)
+          if (Number.isFinite(size) && size > 0) {
+            const recovered = this.convertToDownloadedFile(
+              {
+                name: captureId,
+                url: "",
+                download: "",
+                size,
+                modified: entry.timestamp,
+                mime_type: entry.captureType === "video" ? "video/mp4" : "image/jpeg",
+                is_video: entry.captureType === "video",
+                filePath: committedPath,
+              },
+              committedPath,
+              entry.thumbnailPath,
+            )
+            recovered.capture_id = captureId
+            recovered.assetReceipt = entry.assetReceipt
+            await this.saveDownloadedFile(recovered)
+            localFiles[captureId] = recovered
+            continue
+          }
+        } catch (error) {
+          console.warn(`[LocalStorage] Could not recover gallery index for ${captureId}:`, error)
+        }
+      }
       galleryTransferLedger.releaseMissingLocalCommit(captureId, true)
       released++
     }
@@ -431,15 +466,15 @@ export class LocalStorageService {
     const fileUrl = downloadedFile.filePath.startsWith("file://")
       ? downloadedFile.filePath
       : downloadedFile.filePath.startsWith("/")
-        ? `file://${downloadedFile.filePath}` // Path already has leading slash
-        : `file:///${downloadedFile.filePath}` // Path needs leading slash
+      ? `file://${downloadedFile.filePath}` // Path already has leading slash
+      : `file:///${downloadedFile.filePath}` // Path needs leading slash
 
     const thumbnailUrl = downloadedFile.thumbnailPath
       ? downloadedFile.thumbnailPath.startsWith("file://")
         ? downloadedFile.thumbnailPath
         : downloadedFile.thumbnailPath.startsWith("/")
-          ? `file://${downloadedFile.thumbnailPath}` // Path already has leading slash
-          : `file:///${downloadedFile.thumbnailPath}` // Path needs leading slash
+        ? `file://${downloadedFile.thumbnailPath}` // Path already has leading slash
+        : `file:///${downloadedFile.thumbnailPath}` // Path needs leading slash
       : undefined
 
     return {

--- a/mobile/modules/engine/src/services/gallerySyncClock.ts
+++ b/mobile/modules/engine/src/services/gallerySyncClock.ts
@@ -32,7 +32,7 @@ export function isSyncManifestEmpty(syncData: {
   captures?: unknown[]
   changed_files?: unknown[]
 }): boolean {
-  if (syncData.api_version === 2 && syncData.captures && syncData.captures.length > 0) {
+  if ((syncData.api_version || 0) >= 2 && syncData.captures && syncData.captures.length > 0) {
     return false
   }
   return !syncData.changed_files || syncData.changed_files.length === 0

--- a/mobile/src/services/asg/gallerySyncClock.test.ts
+++ b/mobile/src/services/asg/gallerySyncClock.test.ts
@@ -48,5 +48,15 @@ describe("gallerySyncClock", () => {
         }),
       ).toBe(false)
     })
+
+    it("returns false when captures are present in a newer manifest version", () => {
+      expect(
+        isSyncManifestEmpty({
+          api_version: 3,
+          captures: [{capture_id: "IMG_1"}],
+          changed_files: [],
+        }),
+      ).toBe(false)
+    })
   })
 })

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -8,6 +8,7 @@ import BluetoothSdk from "@mentra/bluetooth-sdk-internal"
 import {asgCameraApi} from "../../../modules/engine/src/services/asg/asgCameraApi"
 import {gallerySyncNotifications} from "../../../modules/engine/src/services/asg/gallerySyncNotifications"
 import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
+import {localNetworkTransport} from "../../../modules/engine/src/services/asg/localNetworkTransport"
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
 import {mediaProcessingQueue} from "../../../modules/engine/src/services/asg/mediaProcessingQueue"
 import {gallerySyncService} from "../../../modules/engine/src/services/asg/gallerySyncService"
@@ -15,6 +16,7 @@ import {useGallerySyncStore} from "../../../modules/engine/src/stores/gallerySyn
 import {useGlassesStore} from "../../../modules/engine/src/stores/glasses"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import type {CaptureGroup} from "@/types/asg"
+import WifiManager from "react-native-wifi-reborn"
 
 jest.mock("@mentra/bluetooth-sdk", () => {
   const {bluetoothSdkMock} = require("@/test-utils/mockBluetoothSdk")
@@ -42,6 +44,7 @@ jest.mock("@react-native-community/netinfo", () => ({
 }))
 
 jest.mock("react-native-wifi-reborn", () => ({
+  getCurrentWifiSSID: jest.fn(() => Promise.resolve("")),
   isEnabled: jest.fn(() => Promise.resolve(true)),
 }))
 
@@ -131,6 +134,7 @@ const mockGetDownloadedFiles = localStorageService.getDownloadedFiles as jest.Mo
 const mockGetV3Manifest = asgCameraApi.getV3Manifest as jest.Mock
 const mockSyncWithServer = asgCameraApi.syncWithServer as jest.Mock
 const mockSetServer = asgCameraApi.setServer as jest.Mock
+const mockGetCurrentWifiSSID = WifiManager.getCurrentWifiSSID as jest.Mock
 
 const EMPTY_SYNC_RESPONSE = {
   data: {
@@ -172,12 +176,14 @@ describe("GallerySyncService", () => {
     // in tests that don't explicitly want to trigger clock-skew recovery.
     jest.useFakeTimers({now: 2000})
     jest.clearAllMocks()
+    mockGetCurrentWifiSSID.mockResolvedValue("")
     useGallerySyncStore.getState().reset()
     useGlassesStore.getState().reset()
     gallerySyncService.cleanup()
   })
 
   afterEach(() => {
+    jest.restoreAllMocks()
     gallerySyncService.cleanup()
     jest.clearAllTimers()
     jest.useRealTimers()
@@ -224,6 +230,27 @@ describe("GallerySyncService", () => {
     expect(useGallerySyncStore.getState().syncState).toBe("requesting_hotspot")
     expect(useGallerySyncStore.getState().syncServiceOpenedHotspot).toBe(true)
     expect(BluetoothSdk.setHotspotState).toHaveBeenCalledWith(true)
+  })
+
+  it("establishes scoped routing when the system SSID already matches the hotspot", async () => {
+    useGlassesStore.getState().setGlassesInfo({
+      connection: {state: "connected", fullyBooted: true},
+      hotspotEnabled: true,
+      hotspotSsid: HOTSPOT_INFO.ssid,
+      hotspotPassword: HOTSPOT_INFO.password,
+      hotspotGatewayIp: HOTSPOT_INFO.ip,
+    })
+    mockGetCurrentWifiSSID.mockResolvedValue(HOTSPOT_INFO.ssid)
+    jest.spyOn(localNetworkTransport, "supportsScopedConnection").mockReturnValue(true)
+    jest.spyOn(localNetworkTransport, "isScopedConnectionActive").mockReturnValue(false)
+    const connectSpy = jest.spyOn(gallerySyncService as any, "connectToHotspotWifi").mockResolvedValue(undefined)
+    const downloadSpy = jest.spyOn(gallerySyncService as any, "startFileDownload").mockResolvedValue(undefined)
+
+    await gallerySyncService.startSync()
+
+    expect(connectSpy).toHaveBeenCalledWith(HOTSPOT_INFO)
+    expect(downloadSpy).not.toHaveBeenCalled()
+    expect(BluetoothSdk.setHotspotState).not.toHaveBeenCalled()
   })
 
   it("aborts pre-flight quietly when glasses disconnect during any pre-flight await", async () => {

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -65,7 +65,7 @@ jest.mock("../../../modules/engine/src/facades/permissions", () => ({
     request: jest.fn(() => Promise.resolve(true)),
     openSettings: jest.fn(() => Promise.resolve()),
   },
-  PermissionFeatures: {LOCATION: "location"},
+  PermissionFeatures: {LOCATION: "location", LOCAL_WIFI: "local_wifi"},
 }))
 
 jest.mock("../../../modules/engine/src/utils/permissions/MediaLibraryPermissions", () => ({
@@ -101,6 +101,8 @@ jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => 
     clearSyncQueue: jest.fn(() => Promise.resolve()),
     convertToDownloadedFile: jest.fn((file: any) => file),
     saveDownloadedFile: jest.fn(() => Promise.resolve()),
+    getDownloadedFiles: jest.fn(() => Promise.resolve({})),
+    reconcileRemoteCaptures: jest.fn(() => Promise.resolve(0)),
   },
 }))
 
@@ -125,6 +127,8 @@ jest.mock("../../../modules/engine/src/services/asg/asgCameraApi", () => ({
 }))
 
 const mockGetSyncState = localStorageService.getSyncState as jest.Mock
+const mockGetDownloadedFiles = localStorageService.getDownloadedFiles as jest.Mock
+const mockGetV3Manifest = asgCameraApi.getV3Manifest as jest.Mock
 const mockSyncWithServer = asgCameraApi.syncWithServer as jest.Mock
 const mockSetServer = asgCameraApi.setServer as jest.Mock
 
@@ -557,6 +561,7 @@ describe("GallerySyncService", () => {
       (gallerySyncService as any).resolveSyncManifest(clientId, lastSyncTime)
 
     beforeEach(() => {
+      mockGetV3Manifest.mockResolvedValue(null)
       mockSyncWithServer.mockReset()
     })
 
@@ -647,6 +652,27 @@ describe("GallerySyncService", () => {
 
       expect(result).not.toBeNull()
       expect(result?.syncData.changed_files).toHaveLength(0)
+    })
+  })
+
+  describe("v3 manifest reconciliation", () => {
+    it("does not suppress a remote capture when its committed ledger row has no local gallery record", async () => {
+      mockGetV3Manifest.mockResolvedValue({
+        api_version: 3,
+        captures: [FAKE_CAPTURE],
+        has_more: false,
+        next_cursor: null,
+        total_count: 1,
+        server_time: Date.now(),
+      })
+      mockGetDownloadedFiles.mockResolvedValue({})
+      const committedSpy = jest.spyOn(galleryTransferLedger, "isLocallyCommitted").mockReturnValue(true)
+
+      const result = await (gallerySyncService as any).fetchSyncManifest("c1", 0)
+
+      expect(result.captures).toEqual([FAKE_CAPTURE])
+      expect(localStorageService.reconcileRemoteCaptures).toHaveBeenCalledWith([FAKE_CAPTURE.capture_id], {})
+      committedSpy.mockRestore()
     })
   })
 })

--- a/mobile/src/services/asg/galleryTransferLedger.test.ts
+++ b/mobile/src/services/asg/galleryTransferLedger.test.ts
@@ -1,7 +1,11 @@
 // This test targets the engine source directly because the ledger is intentionally internal.
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
 import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
 import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
 import {storage} from "../../../modules/engine/src/utils/storage"
+
+const mockExists = RNFS.exists as jest.Mock
 
 jest.mock("@dr.pogodin/react-native-fs", () => ({
   DocumentDirectoryPath: "/current/Documents",
@@ -10,6 +14,10 @@ jest.mock("@dr.pogodin/react-native-fs", () => ({
 }))
 
 describe("galleryTransferLedger", () => {
+  beforeEach(() => {
+    mockExists.mockResolvedValue(true)
+  })
+
   it("resets a committed entry when v3 introduces a different source generation", () => {
     const captureId = `IMG_generation_${Date.now()}`
     const legacyCapture = {
@@ -148,6 +156,41 @@ describe("galleryTransferLedger", () => {
 
     const released = await localStorageService.reconcileRemoteCaptures([captureId])
 
+    expect(released).toBe(1)
+    expect(galleryTransferLedger.get(captureId)?.state).toBe("RESTORE_PENDING")
+  })
+
+  it("releases a restored local record when its media file is missing", async () => {
+    const captureId = `IMG_missing_restored_file_${Date.now()}`
+    const filePath = `/current/Documents/MentraPhotos/${captureId}/base.jpg`
+    galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary"}],
+      },
+      3,
+    )
+    galleryTransferLedger.transition(captureId, "TRASHED", {finalPath: filePath})
+    storage.save("asg_downloaded_files", {
+      [captureId]: {
+        name: captureId,
+        filePath: `MentraPhotos/${captureId}/base.jpg`,
+        size: 100,
+        modified: 1000,
+        mime_type: "image/jpeg",
+        is_video: false,
+        downloaded_at: 1000,
+        capture_id: captureId,
+      },
+    })
+    mockExists.mockResolvedValue(false)
+
+    const released = await localStorageService.reconcileRemoteCaptures([captureId])
+
+    expect(mockExists).toHaveBeenCalledWith(filePath)
     expect(released).toBe(1)
     expect(galleryTransferLedger.get(captureId)?.state).toBe("RESTORE_PENDING")
   })

--- a/mobile/src/services/asg/galleryTransferLedger.test.ts
+++ b/mobile/src/services/asg/galleryTransferLedger.test.ts
@@ -6,16 +6,19 @@ import {localStorageService} from "../../../modules/engine/src/services/asg/loca
 import {storage} from "../../../modules/engine/src/utils/storage"
 
 const mockExists = RNFS.exists as jest.Mock
+const mockStat = RNFS.stat as jest.Mock
 
 jest.mock("@dr.pogodin/react-native-fs", () => ({
   DocumentDirectoryPath: "/current/Documents",
   exists: jest.fn().mockResolvedValue(true),
+  stat: jest.fn().mockResolvedValue({size: 100}),
   mkdir: jest.fn().mockResolvedValue(undefined),
 }))
 
 describe("galleryTransferLedger", () => {
   beforeEach(() => {
     mockExists.mockResolvedValue(true)
+    mockStat.mockResolvedValue({size: 100})
   })
 
   it("resets a committed entry when v3 introduces a different source generation", () => {
@@ -153,11 +156,44 @@ describe("galleryTransferLedger", () => {
       finalPath: `/current/Documents/MentraPhotos/${captureId}/base.jpg`,
     })
     storage.save("asg_downloaded_files", {})
+    mockExists.mockResolvedValue(false)
 
     const released = await localStorageService.reconcileRemoteCaptures([captureId])
 
     expect(released).toBe(1)
     expect(galleryTransferLedger.get(captureId)?.state).toBe("RESTORE_PENDING")
+  })
+
+  it("rebuilds a missing local index from committed media on disk", async () => {
+    const captureId = `IMG_missing_index_${Date.now()}`
+    const filePath = `/current/Documents/MentraPhotos/${captureId}/base.jpg`
+    galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary"}],
+      },
+      3,
+    )
+    galleryTransferLedger.transition(captureId, "TRASHED", {finalPath: filePath})
+    storage.save("asg_downloaded_files", {})
+
+    const downloadedFiles = {}
+    const released = await localStorageService.reconcileRemoteCaptures([captureId], downloadedFiles)
+
+    expect(mockStat).toHaveBeenCalledWith(filePath)
+    expect(released).toBe(0)
+    expect(downloadedFiles).toEqual(
+      expect.objectContaining({
+        [captureId]: expect.objectContaining({capture_id: captureId, filePath}),
+      }),
+    )
+    expect(await localStorageService.getDownloadedFile(captureId)).toEqual(
+      expect.objectContaining({capture_id: captureId, filePath}),
+    )
+    expect(galleryTransferLedger.get(captureId)?.state).toBe("TRASHED")
   })
 
   it("releases a restored local record when its media file is missing", async () => {

--- a/mobile/src/services/asg/galleryTransferLedger.test.ts
+++ b/mobile/src/services/asg/galleryTransferLedger.test.ts
@@ -1,8 +1,12 @@
 // This test targets the engine source directly because the ledger is intentionally internal.
 import {galleryTransferLedger} from "../../../modules/engine/src/services/asg/galleryTransferLedger"
+import {localStorageService} from "../../../modules/engine/src/services/asg/localStorageService"
+import {storage} from "../../../modules/engine/src/utils/storage"
 
 jest.mock("@dr.pogodin/react-native-fs", () => ({
   DocumentDirectoryPath: "/current/Documents",
+  exists: jest.fn().mockResolvedValue(true),
+  mkdir: jest.fn().mockResolvedValue(undefined),
 }))
 
 describe("galleryTransferLedger", () => {
@@ -99,5 +103,52 @@ describe("galleryTransferLedger", () => {
     expect(pending.finalPath).toBeUndefined()
     expect(pending.thumbnailPath).toBeUndefined()
     expect(pending.files[0].completedSegments).toEqual([])
+  })
+
+  it("releases every committed entry when local gallery metadata was not restored", () => {
+    const captureId = `IMG_missing_local_metadata_${Date.now()}`
+    galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary"}],
+      },
+      3,
+    )
+    galleryTransferLedger.transition(captureId, "TRASHED", {
+      finalPath: `/current/Documents/MentraPhotos/${captureId}/base.jpg`,
+    })
+
+    galleryTransferLedger.releaseAllMissingLocalCommits(true)
+
+    const released = galleryTransferLedger.get(captureId)!
+    expect(released.state).toBe("RESTORE_PENDING")
+    expect(released.finalPath).toBeUndefined()
+    expect(released.files[0].completedSegments).toEqual([])
+  })
+
+  it("releases a stale committed ledger when a remote capture is missing from the local index", async () => {
+    const captureId = `IMG_empty_restored_index_${Date.now()}`
+    galleryTransferLedger.ensureCapture(
+      {
+        capture_id: captureId,
+        type: "photo",
+        timestamp: 1000,
+        total_size: 100,
+        files: [{name: `${captureId}/base.jpg`, size: 100, role: "primary"}],
+      },
+      3,
+    )
+    galleryTransferLedger.transition(captureId, "TRASHED", {
+      finalPath: `/current/Documents/MentraPhotos/${captureId}/base.jpg`,
+    })
+    storage.save("asg_downloaded_files", {})
+
+    const released = await localStorageService.reconcileRemoteCaptures([captureId])
+
+    expect(released).toBe(1)
+    expect(galleryTransferLedger.get(captureId)?.state).toBe("RESTORE_PENDING")
   })
 })

--- a/mobile/src/services/asg/localNetworkTransport.test.ts
+++ b/mobile/src/services/asg/localNetworkTransport.test.ts
@@ -14,7 +14,10 @@ import {
   localNetworkTransport,
   shouldUseScopedLocalNetwork,
 } from "../../../modules/engine/src/services/asg/localNetworkTransport"
-import {mentraLocalNetworkMock as mockNativeModule} from "../../test-utils/mockBluetoothSdk"
+import {
+  emitLocalNetworkEvent,
+  mentraLocalNetworkMock as mockNativeModule,
+} from "../../test-utils/mockBluetoothSdk"
 
 describe("localNetworkTransport", () => {
   beforeEach(async () => {
@@ -78,6 +81,42 @@ describe("localNetworkTransport", () => {
 
     await expect(handle.promise).rejects.toThrow("Sync cancelled")
     expect(mockNativeModule.cancel).toHaveBeenCalledWith(expect.stringMatching(/^download_/))
+  })
+
+  it("forwards native response metadata before download progress", async () => {
+    let resolveDownload: (result: {statusCode: number; bytesWritten: number; headers: Record<string, string>}) => void =
+      () => {}
+    mockNativeModule.download.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveDownload = resolve
+        }),
+    )
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+    const begin = jest.fn()
+
+    const handle = localNetworkTransport.downloadFile({
+      fromUrl: "http://192.168.43.1:8089/api/download?file=photo.jpg",
+      toFile: "/tmp/photo.jpg",
+      begin,
+    })
+    const requestId = (mockNativeModule.download as jest.Mock).mock.calls[0][0]
+    emitLocalNetworkEvent("downloadProgress", {
+      requestId,
+      bytesWritten: 0,
+      contentLength: 4,
+      statusCode: 206,
+      headers: {"Content-Range": "bytes 0-3/4"},
+    })
+
+    expect(begin).toHaveBeenCalledWith({
+      jobId: handle.jobId,
+      statusCode: 206,
+      contentLength: 4,
+      headers: {"Content-Range": "bytes 0-3/4"},
+    })
+    resolveDownload({statusCode: 206, bytesWritten: 4, headers: {"Content-Range": "bytes 0-3/4"}})
+    await expect(handle.promise).resolves.toMatchObject({statusCode: 206, bytesWritten: 4})
   })
 
   it("keeps Android 9 on the legacy transport", () => {

--- a/mobile/src/services/asg/localNetworkTransport.test.ts
+++ b/mobile/src/services/asg/localNetworkTransport.test.ts
@@ -42,6 +42,21 @@ describe("localNetworkTransport", () => {
     await expect(response.json()).resolves.toEqual({ok: true})
   })
 
+  it("forwards caller-specific timeouts to scoped HTTP requests", async () => {
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+
+    await localNetworkTransport.fetch("http://192.168.43.1:8089/api/v3/hash", undefined, 10 * 60 * 1000)
+
+    expect(mockNativeModule.request).toHaveBeenCalledWith(
+      expect.stringMatching(/^request_/),
+      "http://192.168.43.1:8089/api/v3/hash",
+      "GET",
+      {},
+      null,
+      10 * 60 * 1000,
+    )
+  })
+
   it("releases the scoped connection during cleanup", async () => {
     await localNetworkTransport.connect("AndroidShare_test", "password")
     await localNetworkTransport.disconnect()

--- a/mobile/src/services/asg/localNetworkTransport.test.ts
+++ b/mobile/src/services/asg/localNetworkTransport.test.ts
@@ -1,0 +1,88 @@
+jest.mock("react-native", () => ({Platform: {OS: "android", Version: 33}}))
+
+const mockLegacyConnect = jest.fn(() => Promise.resolve())
+jest.mock("react-native-wifi-reborn", () => ({
+  __esModule: true,
+  default: {connectToProtectedSSID: mockLegacyConnect},
+}))
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  downloadFile: jest.fn(),
+  stopDownload: jest.fn(),
+}))
+
+import {
+  localNetworkTransport,
+  shouldUseScopedLocalNetwork,
+} from "../../../modules/engine/src/services/asg/localNetworkTransport"
+import {mentraLocalNetworkMock as mockNativeModule} from "../../test-utils/mockBluetoothSdk"
+
+describe("localNetworkTransport", () => {
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    await localNetworkTransport.disconnect()
+  })
+
+  it("uses the scoped native connection on Android 10+", async () => {
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+
+    expect(mockNativeModule.connect).toHaveBeenCalledWith("AndroidShare_test", "password")
+    expect(mockLegacyConnect).not.toHaveBeenCalled()
+    expect(localNetworkTransport.isScopedConnectionActive()).toBe(true)
+  })
+
+  it("routes glasses HTTP through the captured WiFi network", async () => {
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+
+    const response = await localNetworkTransport.fetch("http://192.168.43.1:8089/api/health")
+
+    expect(mockNativeModule.request).toHaveBeenCalled()
+    await expect(response.json()).resolves.toEqual({ok: true})
+  })
+
+  it("releases the scoped connection during cleanup", async () => {
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+    await localNetworkTransport.disconnect()
+
+    expect(mockNativeModule.disconnect).toHaveBeenCalled()
+    expect(localNetworkTransport.isScopedConnectionActive()).toBe(false)
+  })
+
+  it("cancels a native request when its AbortSignal fires", async () => {
+    mockNativeModule.request.mockImplementationOnce(() => new Promise(() => {}))
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+    const controller = new AbortController()
+
+    void localNetworkTransport.fetch("http://192.168.43.1:8089/api/sync", {signal: controller.signal})
+    controller.abort()
+    await Promise.resolve()
+
+    expect(mockNativeModule.cancel).toHaveBeenCalledWith(expect.stringMatching(/^request_/))
+  })
+
+  it("cancels native downloads and preserves sync cancellation semantics", async () => {
+    let rejectDownload: (error: Error) => void = () => {}
+    mockNativeModule.download.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectDownload = reject
+        }),
+    )
+    await localNetworkTransport.connect("AndroidShare_test", "password")
+
+    const handle = localNetworkTransport.downloadFile({
+      fromUrl: "http://192.168.43.1:8089/api/download?file=video.mp4",
+      toFile: "/tmp/video.mp4",
+    })
+    localNetworkTransport.stopDownload(handle.jobId)
+    rejectDownload(new Error("socket closed"))
+
+    await expect(handle.promise).rejects.toThrow("Sync cancelled")
+    expect(mockNativeModule.cancel).toHaveBeenCalledWith(expect.stringMatching(/^download_/))
+  })
+
+  it("keeps Android 9 on the legacy transport", () => {
+    expect(shouldUseScopedLocalNetwork("android", 28, true)).toBe(false)
+    expect(shouldUseScopedLocalNetwork("android", 29, true)).toBe(true)
+    expect(shouldUseScopedLocalNetwork("ios", 18, true)).toBe(false)
+  })
+})

--- a/mobile/src/test-utils/mockBluetoothSdk.ts
+++ b/mobile/src/test-utils/mockBluetoothSdk.ts
@@ -25,6 +25,10 @@ const addListener = jest.fn((eventName: string, listener: Listener) => {
 
 const localNetworkListeners = new Map<string, Set<Listener>>()
 
+export const emitLocalNetworkEvent = (eventName: string, payload: any) => {
+  localNetworkListeners.get(eventName)?.forEach((listener) => listener(payload))
+}
+
 export const mentraLocalNetworkMock = {
   addListener: jest.fn((eventName: string, listener: Listener) => {
     if (!localNetworkListeners.has(eventName)) localNetworkListeners.set(eventName, new Set())

--- a/mobile/src/test-utils/mockBluetoothSdk.ts
+++ b/mobile/src/test-utils/mockBluetoothSdk.ts
@@ -23,6 +23,27 @@ const addListener = jest.fn((eventName: string, listener: Listener) => {
   }
 })
 
+const localNetworkListeners = new Map<string, Set<Listener>>()
+
+export const mentraLocalNetworkMock = {
+  addListener: jest.fn((eventName: string, listener: Listener) => {
+    if (!localNetworkListeners.has(eventName)) localNetworkListeners.set(eventName, new Set())
+    localNetworkListeners.get(eventName)!.add(listener)
+    return {remove: () => localNetworkListeners.get(eventName)?.delete(listener)}
+  }),
+  cancel: jest.fn(() => Promise.resolve()),
+  connect: jest.fn((ssid: string) => Promise.resolve({connected: true, ssid})),
+  disconnect: jest.fn(() => Promise.resolve()),
+  download: jest.fn(() => Promise.resolve({statusCode: 200, bytesWritten: 3, headers: {}})),
+  request: jest.fn(() =>
+    Promise.resolve({
+      status: 200,
+      headers: {"content-type": "application/json"},
+      bodyBase64: Buffer.from('{"ok":true}').toString("base64"),
+    }),
+  ),
+}
+
 export const bluetoothSdkMock = {
   addListener,
   isConnectedGlassesConnectionStatus,
@@ -102,7 +123,9 @@ export const bluetoothSdkMock = {
   ping: jest.fn(() => Promise.resolve()),
   sendIncidentId: jest.fn(() => Promise.resolve()),
   requestWifiScan: jest.fn(() => Promise.resolve([])),
-  sendWifiCredentials: jest.fn((ssid: string) => Promise.resolve({type: "wifi_status_change", state: "connected", ssid})),
+  sendWifiCredentials: jest.fn((ssid: string) =>
+    Promise.resolve({type: "wifi_status_change", state: "connected", ssid}),
+  ),
   forgetWifiNetwork: jest.fn(() => Promise.resolve({type: "wifi_status_change", state: "disconnected"})),
   setHotspotState: jest.fn((enabled: boolean) =>
     Promise.resolve(


### PR DESCRIPTION
## Summary

- replace the K900 vendor tethered-AP startup path with Android `LocalOnlyHotspot`, retaining the reservation and reporting generated credentials/gateway through the existing BLE status
- keep the 120-second idle policy while counting camera-server requests and active response-stream reads
- add the MentraOS-internal Android `MentraLocalNetwork` module and route Gallery traffic through `Network.openConnection()` without process binding
- fix two Gallery v3 issues found on hardware: newer manifests being treated as empty and ranged downloads losing their real `206 Content-Range` metadata
- bound Mentra Live boot baud recovery so unsupported BES probing cannot rotate UART rates forever

## Root cause

`BaseNetworkManager`'s inactivity timer was intended to be refreshed by `updateHttpActivity()`, but the camera server had no caller. The nominal idle timeout therefore behaved as an unconditional 120-second hotspot cap even during active transfers.

The previous Android gallery flow joined the glasses AP through the normal Wi-Fi/RNFS path, which could displace internet routing. `WifiNetworkSpecifier` can retain a local-only glasses `Network`; opening local connections through that exact `Network` leaves the process/default internet route on cellular.

Hardware testing also found:

- Gallery v3 manifests with captures were considered empty because the predicate only recognized exactly API v2.
- The scoped native downloader fabricated HTTP 200/empty headers for the RNFS-style `begin` callback. Resumable v3 downloads require the actual HTTP 206 and `Content-Range` before progress.
- Current BES firmware did not answer the existing boot baud probe, causing the recovery task to rotate UART rates indefinitely after an ASG restart.

## Behavior and boundaries

- K900 hotspot startup has one path: `WifiManager.startLocalOnlyHotspot()`. Startup errors are reported over BLE; there is no tethering fallback.
- Reservation-scoped credentials may change on every start. The phone consumes the current BLE status. The test run selected 5805 MHz, so callers must not assume a fixed 2.4/5 GHz band.
- Lifecycle callbacks are generation-gated so duplicate start/stop calls and delayed callbacks cannot publish stale states.
- Request arrival refreshes activity immediately; active response streams refresh at most every five seconds. Idle shutdown remains the next 10-second monitor tick after 120 seconds without request/response bytes.
- Android 10+ gallery HTTP is network-scoped and never calls `bindProcessToNetwork` or `setProcessDefaultNetwork`.
- Android 9 keeps the existing `react-native-wifi-reborn`/RNFS behavior and does not claim cellular coexistence.
- iOS is unchanged. A persistent iOS hotspot configuration is expected to preserve cellular for non-local traffic, but this PR does not claim iOS hardware proof.
- Cancellation, errors, completion, connection loss, and cleanup unregister the network callback and cancel native transfers.

## Validation

- `./scripts/check-android-compile.sh` (ASG and Bluetooth SDK): pass
- targeted ASG hotspot lifecycle/request/stream/idle tests: pass
- Bluetooth SDK module build and Mentra engine module build: pass
- Mentra App TypeScript compile: pass
- 36 targeted mobile gallery/local-network tests: pass
- 7 engine permission tests: pass

Hardware evidence on Mentra Live `0123456789ABCDEF` and Pixel 6a `26151JEGR02309`:

- `dumpsys wifi` recorded `mSoftApLocalOnlyEvents` and no tethered events
- glasses held `ap0` at `192.168.43.1` while `wlan0` remained at `192.168.1.192`
- Pixel active default remained validated LTE network `124` on `rmnet1`
- the Mentra App captured Wi-Fi network `146` with `processBoundNetwork=null`
- real Gallery v3 sync completed five captures with `Downloaded: 5, Failed: 0`
- a separate 13-minute-16-second active HTTP session remained up; after traffic stopped, ASG auto-disabled at 125 seconds idle

Raw logs and command output are retained under `.context/` in the validation workspace. No firmware/OTA write was performed.

Linear: OS-1709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches hotspot lifecycle, gallery transfer paths, and UART recovery on device-critical networking; misbehavior could break gallery sync, cellular coexistence, or BES serial stability, though hardware validation and broad tests are included.
> 
> **Overview**
> Routes Mentra Live gallery sync over a **local-only hotspot** and **network-scoped HTTP** on Android, while fixing idle shutdown, v3 sync edge cases, and UART boot recovery.
> 
> **Glasses (K900):** Hotspot startup moves from vendor `ap_start` / tethering readiness to **`WifiManager.startLocalOnlyHotspot()`**, with generation-gated callbacks, gateway discovery on `ap*`, and BLE-reported session SSID/password/IP. Shared hotspot lifecycle uses **`onHotspotStarted` / `onHotspotStopped`**; idle policy now uses **`SystemClock.elapsedRealtime`**, counts activity without requiring a prior timestamp, and **`AsgServer`** notifies **`updateHttpActivity`** on each request and during response streaming (throttled). **K900** skips tethering broadcasts so LOHS is not confused with tethered AP state.
> 
> **Phone:** New **`MentraLocalNetwork`** Expo module captures a glasses WiFi **`Network`** via **`WifiNetworkSpecifier`** (no process bind) and serves fetch/download/cancel. Gallery traffic goes through **`localNetworkTransport`** (scoped on Android 10+, legacy WiFi/RNFS otherwise), with **`LOCAL_WIFI`** / **`NEARBY_WIFI_DEVICES`** permission handling. v3 fixes: manifests with captures no longer treated as empty; ranged downloads get real **206 / `Content-Range`** in the native `begin` callback; **`reconcileRemoteCaptures`** re-downloads when ledger says committed but local media/index is missing after restore.
> 
> **Other:** Boot baud recovery probes one alternate rate then **settles at default** instead of cycling forever. Docs and tests updated across ASG, Bluetooth SDK, and engine.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 136d00abfcd9fa41d29b88e35ce9befdcf8a3201. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->