### PR TITLE
ASG: deliver the approved BES OTA response watchdog (#3478) into dev

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -57,6 +57,16 @@ public class AsgConstants {
      */
     public static final long BES_OTA_SEGMENT_LEASE_WINDOW_MS = 120000;
 
+    /**
+     * Dead-man window for the BES OTA transfer. The transfer is response-driven (every BES
+     * response triggers the next send, there is no wait loop), so one lost response stalls
+     * it silently forever. If no OTA response arrives within this window the transfer is
+     * aborted through the normal failure path - the BES stays on its current firmware and
+     * the phone retries the whole OTA. Kept well below the phone's 120s stall watchdog so
+     * the glasses clean up first; normal inter-response gaps are under a second.
+     */
+    public static final long BES_OTA_RESPONSE_TIMEOUT_MS = 30000;
+
     // RGB LED Control Constants (Glasses BES Chipset - Remote Control via Bluetooth)
     // NOTE: These are different from the local MTK recording LED
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -352,6 +352,17 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
     /** Cleanup and reset state */
     private void cleanup() {
+        // Every terminal path funnels here, gated or not (watchdog and receive dispatch
+        // hold mTransferGate; abortIfInProgress and the auth failure paths do not).
+        // Taking the gate here - reentrant for the former - serializes ALL cleanups with
+        // receive processing and the watchdog re-arm, so no caller can tear the watchdog
+        // state down mid-rearm on another thread.
+        synchronized (mTransferGate) {
+            cleanupLocked();
+        }
+    }
+
+    private void cleanupLocked() {
         // Cancel authorization timeout if pending
         if (authTimeoutHandler != null && authTimeoutRunnable != null) {
             authTimeoutHandler.removeCallbacks(authTimeoutRunnable);
@@ -812,7 +823,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         if (responseWatchdogRunnable != null) {
             responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
         }
-        responseWatchdogRunnable = () -> {
+        Runnable watchdog = () -> {
           synchronized (mTransferGate) {
             if (!isBesOtaInProgress) {
                 return;
@@ -838,8 +849,10 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             cleanup();
           }
         };
-        responseWatchdogHandler.postDelayed(
-                responseWatchdogRunnable, AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS);
+        // Post the local reference: the field is only bookkeeping for removeCallbacks, so
+        // a concurrent teardown nulling it can never turn this into postDelayed(null).
+        responseWatchdogRunnable = watchdog;
+        responseWatchdogHandler.postDelayed(watchdog, AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS);
     }
 
     private void dealOtaRecvCmd(BesOtaMessage msg) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -51,6 +51,12 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     // machine silently forever (2026-07-08 incident: frozen at 80%, no further log line).
     private android.os.Handler responseWatchdogHandler;
     private Runnable responseWatchdogRunnable;
+    // Absolute deadline (elapsedRealtime) of the current watchdog window. The re-arm from
+    // the UART receive thread cannot removeCallbacks() a callback that has ALREADY been
+    // dispatched on the main looper; the dispatched callback re-checks this deadline and
+    // aborts only if no response re-armed it in the meantime, so a response racing the
+    // timeout can never produce a false failure while its handler is mid-flight.
+    private volatile long responseWatchdogDeadlineMs;
 
     private String filePath;
     private boolean bInit = false;
@@ -350,6 +356,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
             responseWatchdogRunnable = null;
         }
+        responseWatchdogDeadlineMs = 0;
 
         operationStartTime = 0;
 
@@ -782,6 +789,11 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
     /** (Re-)arm the response watchdog; called on transfer start and on every OTA response. */
     private void rearmResponseWatchdog() {
+        if (!isBesOtaInProgress && !isWaitingForAuthorization) {
+            return; // no stray timers after cleanup()
+        }
+        responseWatchdogDeadlineMs =
+                android.os.SystemClock.elapsedRealtime() + AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS;
         if (responseWatchdogHandler == null) {
             responseWatchdogHandler = new android.os.Handler(android.os.Looper.getMainLooper());
         }
@@ -791,6 +803,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
         responseWatchdogRunnable = () -> {
             if (!isBesOtaInProgress) {
                 return;
+            }
+            if (android.os.SystemClock.elapsedRealtime() < responseWatchdogDeadlineMs) {
+                return; // a response re-armed the window after this callback was dispatched
             }
             Log.e(TAG, "No BES OTA response for " + AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS
                     + "ms - aborting transfer (sentPos=" + sentPos + "/" + fileLen

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -49,6 +49,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     // on its current firmware and the phone re-runs the whole OTA. Without this, a single
     // lost response (device slept mid-transfer, BES crash, UART drop) stalls the state
     // machine silently forever (2026-07-08 incident: frozen at 80%, no further log line).
+    // Serializes the watchdog's decide+abort with receive processing: both run inside
+    // this monitor, so either the timeout aborts BEFORE a response enters the state
+    // machine (the response then sees the transfer inactive and stops), or the response
+    // wins, re-arms, and the already-dispatched timeout callback re-checks the deadline
+    // under the same monitor and stands down. The interleaving "callback reads expired
+    // deadline, response re-arms and continues, callback still aborts mid-processing"
+    // is structurally impossible.
+    private final Object mTransferGate = new Object();
+
     private android.os.Handler responseWatchdogHandler;
     private Runnable responseWatchdogRunnable;
     // Absolute deadline (elapsedRealtime) of the current watchdog window. The re-arm from
@@ -787,8 +796,11 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
     // ========== Protocol State Machine ==========
 
-    /** (Re-)arm the response watchdog; called on transfer start and on every OTA response. */
-    private void rearmResponseWatchdog() {
+    /**
+     * (Re-)arm the response watchdog; called on transfer start and on every OTA response.
+     * Package-private for the deterministic race tests in BesOtaResponseWatchdogTest.
+     */
+    void rearmResponseWatchdog() {
         if (!isBesOtaInProgress && !isWaitingForAuthorization) {
             return; // no stray timers after cleanup()
         }
@@ -801,6 +813,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
         }
         responseWatchdogRunnable = () -> {
+          synchronized (mTransferGate) {
             if (!isBesOtaInProgress) {
                 return;
             }
@@ -823,13 +836,23 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
                     "No response from BES for "
                             + (AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS / 1000) + "s"));
             cleanup();
+          }
         };
         responseWatchdogHandler.postDelayed(
                 responseWatchdogRunnable, AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS);
     }
 
     private void dealOtaRecvCmd(BesOtaMessage msg) {
+      synchronized (mTransferGate) {
+        if (!isBesOtaInProgress && !isWaitingForAuthorization) {
+            return; // the watchdog (or an abort) won the gate first - this response is stale
+        }
         rearmResponseWatchdog();
+        dealOtaRecvCmdLocked(msg);
+      }
+    }
+
+    private void dealOtaRecvCmdLocked(BesOtaMessage msg) {
         if (msg == null) return;
 
         // Total operation timeout guard

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -3,6 +3,7 @@ package com.mentra.asg_client.io.bes;
 import android.content.Context;
 import android.util.Log;
 import com.mentra.asg_client.io.bes.events.BesOtaProgressEvent;
+import com.mentra.asg_client.logging.BleTraceLogger;
 import com.mentra.asg_client.io.bes.protocol.*;
 import com.mentra.asg_client.io.bes.util.BesOtaUtil;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.SerialPortBridge;
@@ -16,6 +17,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.greenrobot.eventbus.EventBus;
+import org.json.JSONObject;
 
 /**
  * Manages BES2700 firmware OTA updates Handles file loading, packet transmission, state tracking,
@@ -40,6 +42,15 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
     private long operationStartTime = 0;
     private android.os.Handler authTimeoutHandler;
     private Runnable authTimeoutRunnable;
+
+    // Dead-man watchdog for the response-driven transfer: every inbound OTA response
+    // re-arms it. If it fires, the transfer is aborted through the normal failure path
+    // (createFailed + cleanup) - no resume, no retry: an aborted transfer leaves the BES
+    // on its current firmware and the phone re-runs the whole OTA. Without this, a single
+    // lost response (device slept mid-transfer, BES crash, UART drop) stalls the state
+    // machine silently forever (2026-07-08 incident: frozen at 80%, no further log line).
+    private android.os.Handler responseWatchdogHandler;
+    private Runnable responseWatchdogRunnable;
 
     private String filePath;
     private boolean bInit = false;
@@ -333,6 +344,13 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             authTimeoutRunnable = null;
         }
 
+        // Cancel the response watchdog; cleanup is the single funnel for every terminal
+        // path (apply success, CRC failure, watchdog abort), so no timer outlives the run.
+        if (responseWatchdogHandler != null && responseWatchdogRunnable != null) {
+            responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
+            responseWatchdogRunnable = null;
+        }
+
         operationStartTime = 0;
 
         // Flag-clear and lease release are one atomic step against the segment-confirm
@@ -366,6 +384,7 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
         Log.i(TAG, "BES OTA authorization GRANTED - starting protocol");
         isWaitingForAuthorization = false;
+        rearmResponseWatchdog();
 
         // Cancel authorization timeout
         if (authTimeoutHandler != null && authTimeoutRunnable != null) {
@@ -761,7 +780,41 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
 
     // ========== Protocol State Machine ==========
 
+    /** (Re-)arm the response watchdog; called on transfer start and on every OTA response. */
+    private void rearmResponseWatchdog() {
+        if (responseWatchdogHandler == null) {
+            responseWatchdogHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+        }
+        if (responseWatchdogRunnable != null) {
+            responseWatchdogHandler.removeCallbacks(responseWatchdogRunnable);
+        }
+        responseWatchdogRunnable = () -> {
+            if (!isBesOtaInProgress) {
+                return;
+            }
+            Log.e(TAG, "No BES OTA response for " + AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS
+                    + "ms - aborting transfer (sentPos=" + sentPos + "/" + fileLen
+                    + ", confirmedSegments=" + confirmTimes + ")");
+            try {
+                JSONObject extra = new JSONObject();
+                extra.put("sentPos", sentPos);
+                extra.put("fileLen", fileLen);
+                extra.put("confirmedSegments", confirmTimes);
+                BleTraceLogger.logLifecycle(mContext, "BesOtaManager", "bes_ota_response_timeout", extra);
+            } catch (Exception ignored) {
+                // Trace logging must never affect the abort itself.
+            }
+            EventBus.getDefault().post(BesOtaProgressEvent.createFailed(
+                    "No response from BES for "
+                            + (AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS / 1000) + "s"));
+            cleanup();
+        };
+        responseWatchdogHandler.postDelayed(
+                responseWatchdogRunnable, AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS);
+    }
+
     private void dealOtaRecvCmd(BesOtaMessage msg) {
+        rearmResponseWatchdog();
         if (msg == null) return;
 
         // Total operation timeout guard

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaResponseWatchdogTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bes/BesOtaResponseWatchdogTest.java
@@ -1,0 +1,102 @@
+package com.mentra.asg_client.io.bes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.robolectric.Shadows.shadowOf;
+
+import android.app.Application;
+import android.os.Looper;
+import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.io.bes.events.BesOtaProgressEvent;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import org.greenrobot.eventbus.EventBus;
+import org.greenrobot.eventbus.Subscribe;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowSystemClock;
+
+/**
+ * Deterministic interleaving tests for the BES OTA dead-man response watchdog.
+ *
+ * <p>The race under test: the watchdog callback is dispatched on the main looper with an
+ * expired deadline while a response arrives on the UART receive thread. The transfer gate
+ * makes the outcome depend only on ORDER, never on torn state: whichever side wins the
+ * monitor either aborts (and the late response sees the transfer inactive and stops) or
+ * re-arms (and the late callback re-checks the deadline and stands down). These tests pin
+ * that decision table by controlling exactly when the dispatched callback runs relative
+ * to a re-arm.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class BesOtaResponseWatchdogTest {
+
+    private BesOtaManager manager;
+    private final List<BesOtaProgressEvent> events = new ArrayList<>();
+
+    // The test class itself subscribes: EventBus reflection needs a public named class.
+    @Subscribe
+    public void onEvent(BesOtaProgressEvent event) {
+        events.add(event);
+    }
+
+    @Before
+    public void setUp() {
+        manager = new BesOtaManager(null, ApplicationProvider.getApplicationContext(), null);
+        BesOtaManager.isBesOtaInProgress = false;
+        events.clear();
+        EventBus.getDefault().register(this);
+    }
+
+    @After
+    public void tearDown() {
+        EventBus.getDefault().unregister(this);
+        BesOtaManager.isBesOtaInProgress = false;
+        shadowOf(Looper.getMainLooper()).idle();
+    }
+
+    @Test
+    public void timeoutWithNoResponse_abortsAndReportsFailure() {
+        BesOtaManager.isBesOtaInProgress = true;
+        manager.rearmResponseWatchdog();
+
+        // Pass the deadline, then let the dispatched callback run with no response racing it.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(31));
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertThat(BesOtaManager.isBesOtaInProgress).isFalse();
+        assertThat(events).hasSize(1);
+    }
+
+    @Test
+    public void responseRacingTheDispatchedCallback_standsDown() {
+        BesOtaManager.isBesOtaInProgress = true;
+        manager.rearmResponseWatchdog();
+
+        // Deadline passes and the callback becomes due - but a response re-arms BEFORE the
+        // main looper gets to run it (the exact interleaving from review: the callback would
+        // have read the stale expired deadline).
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(31));
+        manager.rearmResponseWatchdog();
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertThat(BesOtaManager.isBesOtaInProgress).isTrue();
+        assertThat(events).isEmpty();
+    }
+
+    @Test
+    public void rearmAfterCleanup_leavesNoTimerBehind() {
+        // Transfer already ended: a stale response must not arm anything.
+        BesOtaManager.isBesOtaInProgress = false;
+        manager.rearmResponseWatchdog();
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(31));
+        shadowOf(Looper.getMainLooper()).idle();
+
+        assertThat(events).isEmpty();
+    }
+}

--- a/asg_client/docs/features/bes-ota.md
+++ b/asg_client/docs/features/bes-ota.md
@@ -139,10 +139,10 @@ Manual procedure:
 ## Troubleshooting
 
 - **Update never starts** — confirm BES OTA path is initialized (`BesOtaManager` log line at startup). Check WiFi, battery (≥ 5%), and that no APK update is currently running.
-- **Silent stall mid-transfer** — UART instability or BES not responding. Look for `BesOtaUartListener` logs. Check the Infinity Cable; loose connections kill UART traffic.
+- **Stall mid-transfer** — UART instability or BES not responding. The transfer is response-driven, so a lost response no longer stalls silently: a dead-man watchdog aborts the transfer after 30 seconds without any BES response (`AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS`), runs the normal cleanup (OTA mode exited, wake leases released), posts a failure the phone surfaces as "Update failed", and emits a `bes_ota_response_timeout` lifecycle trace with the transfer position (`sentPos`, `confirmedSegments`). The BES stays on its current firmware — the recovery is simply retrying the whole OTA from the phone. If aborts recur, look for `BesOtaUartListener` logs and check the Infinity Cable; loose connections kill UART traffic.
 - **`File too big`** — firmware exceeds 2 MB.
 - **`SHA-256 mismatch`** — the downloaded `.bin` doesn't match `version.json`. The file is deleted; verify your hash and re-upload.
-- **Stuck in OTA mode** — if `mbOtaUpdating` doesn't get cleared (rare), normal BLE traffic stays blocked. Restart the app.
+- **Stuck in OTA mode** — if `mbOtaUpdating` doesn't get cleared (rare), normal BLE traffic stays blocked. The response watchdog's cleanup clears it on any stalled transfer; if it somehow persists outside a transfer, restart the app.
 
 ## Logcat tags
 


### PR DESCRIPTION
## Why this PR exists

#3478 (the BES OTA dead-man response watchdog) was **approved and merged — but into its stack base branch, not `dev`**: it was stacked on #3458's branch, and since that branch wasn't deleted when #3458 merged, GitHub never retargeted the stack. The watchdog commits are currently stranded on `claude/asg-wake-window-per-w1-command`.

This PR delivers exactly that already-approved content into `dev` — the diff is precisely #3478's four files (watchdog + gated cleanup in `BesOtaManager`, deterministic Robolectric race tests, docs update). No new changes.

## What it is (recap of #3478)

One dead-man timer for the response-driven BES firmware transfer: armed at authorization, re-armed on every inbound OTA response, cancelled in `cleanup()`. Thirty seconds with no response → clean abort through the existing failure path + `bes_ota_response_timeout` lifecycle trace. Watchdog decide+abort, receive dispatch, and every `cleanup()` caller are serialized under one transfer gate (race findings from codex, aisraelov, and Bugbot all addressed). **No resume, no retry, no recovery smartness** — an aborted transfer leaves the BES on its current bootable firmware and the phone re-runs the whole OTA.

See #3478 for the full review history and approval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BES OTA failure and concurrency behavior on glasses firmware updates; bounded scope with tests and normal cleanup paths, but incorrect watchdog logic could abort healthy transfers or leave OTA mode stuck.
> 
> **Overview**
> Adds a **30s dead-man watchdog** for the response-driven BES firmware UART transfer so a lost BES reply no longer leaves `BesOtaManager` stalled indefinitely (e.g. mid-transfer freeze at ~80%).
> 
> `BesOtaManager` arms the timer when authorization is granted and **re-arms on every inbound OTA response**; if it fires, the transfer aborts through the existing failure path (`BesOtaProgressEvent.createFailed`, `cleanup()`), emits a `bes_ota_response_timeout` lifecycle trace with `sentPos` / `confirmedSegments`, and leaves the BES on its current firmware for a full phone retry. Watchdog abort, UART receive dispatch, and all `cleanup()` paths are serialized under **`mTransferGate`**, with a deadline re-check so a response racing a dispatched timeout callback cannot cause a false abort.
> 
> `AsgConstants.BES_OTA_RESPONSE_TIMEOUT_MS` (30s, under the phone’s 120s stall watchdog) centralizes the window. **Robolectric tests** (`BesOtaResponseWatchdogTest`) cover timeout abort, re-arm vs. dispatched callback, and no timer after cleanup. **bes-ota.md** documents stall recovery and OTA-mode cleanup via the watchdog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caaeede996df547ba419795503741ae24490b52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->