### PR TITLE
Docs: refresh Mentra Live Wi-Fi and OTA reference for the provisioning-error and watchdog changes

### DIFF
--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -400,7 +400,7 @@ React Native exposes the narrowest return types for clear branching after `await
 | API | Resolves With | Rejection / Throw Criteria |
 | --- | --- | --- |
 | `requestWifiScan()` | Final `WifiSearchResult[]` from `wifi_scan_result` where `scanComplete: true`, including `[]` when no networks are found. | Scan response timeout, send failure, or another Wi-Fi scan already in flight. |
-| `sendWifiCredentials(ssid, password)` | `WifiStatusChangeEvent` whose state is `connected` for the requested SSID. | Wi-Fi disconnect/error state, timeout, send failure, or another Wi-Fi status command in flight. |
+| `sendWifiCredentials(ssid, password)` | `WifiStatusChangeEvent` whose state is `connected` for the requested SSID. Success typically resolves within a few seconds. | Glasses-reported provisioning failure, with the reason as the error code: `wrong_password` (typically ~7s), `connect_timeout` (~12s, network unreachable or join never completed), or `connected_to_other_network` (the glasses ended up on a different SSID than requested). Also request timeout, send failure, or another Wi-Fi status command in flight. Routine `disconnected` events during association do **not** reject — the glasses briefly report disconnected while switching networks. Glasses running older software never send failure reasons; failed attempts there surface as request timeouts. |
 | `forgetWifiNetwork(ssid)` | `WifiStatusChangeEvent` once the requested SSID is no longer connected. | Timeout, send failure, or another Wi-Fi status command in flight. |
 | `setHotspotState(enabled)` | `HotspotStatusChangeEvent` matching the requested enabled/disabled state. | `hotspot_error`, timeout, send failure, or another hotspot command in flight. |
 | `requestVersionInfo()` | `VersionInfoResult` from the ASG `version_info` response. | Timeout, send failure, or another version query in flight. |
@@ -465,6 +465,8 @@ Mentra Live OTA installation is glasses-owned. The SDK checks its release-specif
 Use the boolean check result for update prompts and keep `ota_status` listeners/delegates for install progress and terminal `complete` / `failed` state. Availability is exposed through `checkForOtaUpdate()` rather than a public event; React Native receives `ota_start_ack` and `ota_status` events during the install flow. Android listeners receive `onOtaStartAck` and `onOtaStatus`; iOS delegates receive `.otaStartAck` and `.otaStatus` through `BluetoothEvent`.
 
 OTA requires Mentra Live glasses firmware that supports the ASG OTA protocol and network access from the glasses. During install, normal BLE traffic can be interrupted and the glasses may restart; keep the app connected and avoid sending unrelated commands until `ota_status.status` is `complete` or `failed`.
+
+Treat `complete` as terminal even though the connection may drop immediately after it: when the final step of an update is the BES firmware, the glasses power-cycle right after emitting `complete`, so no further `ota_status` follows. A transfer that stalls on the glasses side aborts itself after about 30 seconds and surfaces as `failed`; the glasses stay on their current software, and retrying the whole update from the app is the intended recovery.
 
 ## Events
 
@@ -559,7 +561,7 @@ The React Native event surface is typed through `BluetoothSdkEventMap`. These ar
 | `speaking_status` | `SpeakingStatusEvent` | Glasses-side Voice Activity Detection reports speaking or not speaking. |
 | `battery_status` | `BatteryStatusEvent` | Battery update from glasses. |
 | `local_transcription` | `LocalTranscriptionEvent` | SDK local transcription text update. |
-| `wifi_status_change` | `WifiStatusChangeEvent` | Glasses Wi-Fi connection state changes. |
+| `wifi_status_change` | `WifiStatusChangeEvent` | Glasses Wi-Fi connection state changes. When the event is the verdict of a failed `sendWifiCredentials` attempt it carries an `error` reason (`wrong_password`, `connect_timeout`, `connected_to_other_network`); the reason describes the attempt, not the link, so `connected_to_other_network` arrives on a `connected` state. Routine link updates carry no `error`. |
 | `wifi_scan_result` | `WifiScanResultEvent` | Wi-Fi scan results. Intermediate events can have `scanComplete: false`; the final event has `scanComplete: true` and is what `requestWifiScan()` awaits. |
 | `version_info` | `VersionInfoEvent` | Glasses version metadata response. Also returned by `requestVersionInfo()`. |
 | `hotspot_status_change` | `HotspotStatusChangeEvent` | Glasses hotspot state changes. |

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -466,7 +466,7 @@ Use the boolean check result for update prompts and keep `ota_status` listeners/
 
 OTA requires Mentra Live glasses firmware that supports the ASG OTA protocol and network access from the glasses. During install, normal BLE traffic can be interrupted and the glasses may restart; keep the app connected and avoid sending unrelated commands until `ota_status.status` is `complete` or `failed`.
 
-Treat `complete` as terminal even though the connection may drop immediately after it: when the final step of an update is the BES firmware, the glasses power-cycle right after emitting `complete`, so no further `ota_status` follows. A transfer that stalls on the glasses side aborts itself after about 30 seconds and surfaces as `failed`; the glasses stay on their current software, and retrying the whole update from the app is the intended recovery.
+Treat `complete` as terminal even though the connection may drop immediately after it: when the final step of an update is the BES firmware, the glasses power-cycle right after emitting `complete`, so no further `ota_status` follows. If the BES firmware transfer step stalls on the glasses side, it aborts itself after about 30 seconds and surfaces as `failed`; the APK and MTK steps use their own timeout paths. On such an abort the BES stays on its current firmware — earlier APK or MTK steps of the same update may already have completed — and retrying the whole update from the app is the intended recovery.
 
 ## Events
 


### PR DESCRIPTION
## Scope

Doc-freshness pass over `mintlify-docs/mentra-live/` against the just-merged Wi-Fi/OTA changes (#3458, #3459, #3460, #3461, #3462, #3478/#3484). All stale content was concentrated in `api-reference.mdx`; three updates:

1. **`sendWifiCredentials` rejection contract** — the old row said "Wi-Fi disconnect/error state, timeout…", which was both vague and wrong on one point: the SDK deliberately does **not** reject on bare `disconnected` (the glasses briefly report disconnected during every network switch). Now documents the actual contract from #3459/#3460: the glasses-reported reason is the error code — `wrong_password` (~7s), `connect_timeout` (~12s), `connected_to_other_network` — with the older-glasses fallback (request timeout only) called out, plus the expected success latency.
2. **`wifi_status_change` event** — documents the `error` field as an *attempt verdict riding on a truthful link state* (so `connected_to_other_network` arrives on a `connected` state), absent on routine updates.
3. **OTA section** — two consumer-critical behaviors from #3461/#3478: `complete` is terminal even though the connection may drop immediately after (BES-final passes power-cycle the glasses right after emitting it), and a glasses-side stalled transfer now self-aborts after ~30s into `failed` with whole-update retry as the intended recovery.

## Verified current (no changes needed)

- `software-update.mdx` — describes the flow at manifest/step level; step 5 ("progress until `complete` or `failed`") is now accurate *because of* #3461.
- `troubleshooting.mdx`, per-platform pages, `examples.mdx`, `quickstart.mdx` — no Wi-Fi/OTA behavioral claims affected by the merged PRs.
- Wire-v2 negotiation hardening (#3462) is internal to the SDK and intentionally undocumented at this level.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits to public API reference; no runtime or SDK behavior changes.
> 
> **Overview**
> Updates **`api-reference.mdx`** so Mentra Live docs match recently shipped Wi-Fi provisioning and OTA behavior—no SDK code changes.
> 
> The **`sendWifiCredentials`** promise table row now documents glasses-reported failure codes (`wrong_password`, `connect_timeout`, `connected_to_other_network`), typical timings, success latency, and that routine **`disconnected`** during association does **not** reject the promise. Older glasses without failure reasons are called out as timing out instead.
> 
> The **`wifi_status_change`** event row explains when the optional **`error`** field appears (failed credential attempts) and that **`connected_to_other_network`** can arrive with a **`connected`** state.
> 
> The **OTA Updates** section adds guidance that **`complete`** is terminal even if BLE drops right after (BES-final updates power-cycle), that a stalled BES transfer self-aborts to **`failed`** after ~30s with whole-update retry as recovery, and partial-step completion implications.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 590072d5d5f7d80a32d1639dbe7cfd590697bd18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->