### PR TITLE
Log why boot-time auth clears tokens; fix settings LOAD log (OS-1724)

### DIFF
--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -908,8 +908,12 @@ export const useSettingsStore = create<SettingsState>()(
           let value = res.value
           // res.value IS the stored value; logging value.value printed
           // "undefined" for every loaded setting and disguised present
-          // values as missing. Redact token-bearing keys.
-          const printable = setting.key.includes("token") ? "<redacted>" : JSON.stringify(value)
+          // values as missing. Redact token- and email-bearing keys: console
+          // logs are uploaded in bug-report artifacts (same keys
+          // diagnosticContext's SENSITIVE_SETTINGS_KEYS strips, minus an
+          // import that would cycle stores <-> utils).
+          const printable =
+            setting.key.includes("token") || setting.key.includes("email") ? "<redacted>" : JSON.stringify(value)
           console.log(`SETTINGS: LOAD: ${setting.key} = ${printable}`)
           loadedSettings[setting.key] = value
         }

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -906,7 +906,11 @@ export const useSettingsStore = create<SettingsState>()(
           }
           // normal key:value pair:
           let value = res.value
-          console.log(`SETTINGS: LOAD: ${setting.key} = ${value.value}`)
+          // res.value IS the stored value; logging value.value printed
+          // "undefined" for every loaded setting and disguised present
+          // values as missing. Redact token-bearing keys.
+          const printable = setting.key.includes("token") ? "<redacted>" : JSON.stringify(value)
+          console.log(`SETTINGS: LOAD: ${setting.key} = ${printable}`)
           loadedSettings[setting.key] = value
         }
 

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -194,8 +194,10 @@ export class AccountAuthProvider extends AuthClient {
             headers: {authorization: `Bearer ${access}`},
           }).catch(() => null)
         } else if (!offline) {
+          // getSession() runs on cold boot but also from deeplink auth checks
+          // and reset-password, so don't claim "boot" here.
           console.log(
-            `MENTRA AUTH: clearing tokens on boot, /me rejected (HTTP ${meRes?.status}) and refresh grant rejected`,
+            `MENTRA AUTH: getSession clearing tokens, /me rejected (HTTP ${meRes?.status}) and refresh grant rejected`,
           )
           clearTokens()
           return {token: undefined}

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -134,6 +134,7 @@ export class AccountAuthProvider extends AuthClient {
       // would make the caller clearTokens() out from under it.
       const current = loadTokens()
       if (current && current.refresh !== refresh) return current
+      console.log(`MENTRA AUTH: refresh grant rejected (HTTP ${res.status}), session is dead`)
       return null
     }
     if (!res.ok) throw new Error(`refresh failed transiently: HTTP ${res.status}`)
@@ -161,6 +162,7 @@ export class AccountAuthProvider extends AuthClient {
     if (!AccountAuthProvider.tokenRejected(probe.status)) return tokens.access
     const refreshed = await this.refreshTokens(tokens.refresh)
     if (!refreshed) {
+      console.log(`MENTRA AUTH: clearing tokens, refresh rejected after /me probe (HTTP ${probe.status})`)
       clearTokens()
       throw new Error("session expired")
     }
@@ -192,6 +194,9 @@ export class AccountAuthProvider extends AuthClient {
             headers: {authorization: `Bearer ${access}`},
           }).catch(() => null)
         } else if (!offline) {
+          console.log(
+            `MENTRA AUTH: clearing tokens on boot, /me rejected (HTTP ${meRes?.status}) and refresh grant rejected`,
+          )
           clearTokens()
           return {token: undefined}
         }


### PR DESCRIPTION
Log-only changes, no behavior change. OS-1724.

## Problem

Diagnosing why a device bounced to /auth/start on boot (2026-07-17) took a multi-hour forensic dig, for two reasons:

1. `accountClient.ts` clears tokens silently. `getSession()` and `ensureFreshAccess()` call `clearTokens()` when the refresh grant is rejected, with zero logging: no record of which call failed (the /me probe vs the refresh grant) or what HTTP status came back.
2. The settings loader log prints the wrong field. `settings.ts` logged `value.value` of the already-unwrapped stored value, so every successfully loaded setting printed `= undefined`. A present `auth_email` masqueraded as a missing auth session and pointed the investigation the wrong way.

## Change

- One log line at each `clearTokens()` reject site and at the definitive refresh rejection in `performRefresh`: failing step plus HTTP status. Tokens are never logged.
- Settings loader logs the actual loaded value, with token-bearing keys redacted.

## Verification

`bun compile` (tsc) passes. Log-only; the auth flow and settings hydration are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Console-only changes with no auth, storage, or settings logic modifications.
> 
> **Overview**
> **Log-only** observability for boot-time auth and settings hydration—no flow or storage behavior changes.
> 
> In **`accountClient.ts`**, adds `MENTRA AUTH:` console lines when a refresh grant is definitively rejected and immediately before **`clearTokens()`** in **`ensureFreshAccess`** and boot **`getSession`**, including HTTP status and which step failed. Tokens are never logged.
> 
> In **`settings.ts`**, fixes **`loadAllSettings`** debug output to log the real stored value (`res.value`) instead of **`value.value`** (which always printed `undefined`). Keys whose name includes **`token`** log as **`<redacted>`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1f5780ad3590a6c3d481ea7d8a0f189b9e30314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add targeted auth logs to explain why tokens are cleared and fix the settings LOAD log to show the real value (with token and email keys redacted). No behavior change; supports OS-1724 investigation into /auth/start bounces.

- **Bug Fixes**
  - Auth: log the failing step and HTTP status at each token-clear path (refresh reject, /me+refresh); drop "on boot" wording in the getSession log. Never logs tokens.
  - Settings: print the actual loaded value instead of `value.value`; redact keys containing "token" or "email".

<sup>Written for commit ee8f6feaff3f0d7561e2836a7ca5dce6da5df7f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

