### PR TITLE
Bring iOS stream-start semantics to parity with Android

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -114,6 +114,11 @@ class MentraBluetoothSdk private constructor(
     private data class PendingStreamStart(
         val seq: Long,
         val pending: PendingResponse<StreamStatusEvent>,
+        // Set when an id-carrying error arrives: a fatal publisher error never
+        // reaches the reconnect machinery and winds down with a streamId-less
+        // stopped, so the stash both attributes that stopped to this start and
+        // preserves the real error details for the rejection.
+        var lastError: StreamStatusEvent? = null,
     )
 
     private data class PendingStreamStop(
@@ -1560,11 +1565,27 @@ class MentraBluetoothSdk private constructor(
                     pendingStreamStarts.remove(streamId, start)
                     start.pending.resolve(event)
                 }
-                StreamState.ERROR,
                 StreamState.RECONNECT_FAILED,
                 StreamState.STOPPED -> {
                     pendingStreamStarts.remove(streamId, start)
-                    start.pending.reject(streamStatusException(event, "stream_start_failed"))
+                    start.pending.reject(
+                        streamStatusException(start.lastError ?: event, "stream_start_failed")
+                    )
+                }
+                StreamState.ERROR -> {
+                    if (event.streamId.isNullOrBlank()) {
+                        // An id-less error is the glasses' command-level rejection
+                        // (missing URL, low battery, no WiFi), emitted before any
+                        // publisher starts; nothing further follows for this start.
+                        pendingStreamStarts.remove(streamId, start)
+                        start.pending.reject(streamStatusException(event, "stream_start_failed"))
+                    } else {
+                        // The glasses publisher automatically retries transient transport
+                        // errors, so keep the start pending for a later `streaming`.
+                        // Stash the details for the streamId-less `stopped` that a fatal
+                        // publisher error winds down with instead.
+                        start.lastError = event
+                    }
                 }
                 else -> Unit
             }
@@ -1621,15 +1642,19 @@ class MentraBluetoothSdk private constructor(
             return streamId to start
         }
         if (pendingStreamStarts.size == 1) {
+            val entry = pendingStreamStarts.entries.first()
             // A streamId-less STOPPED is the glasses' stop-ack for a PREVIOUS
             // stream (their stop ack carries no streamId), not a verdict on the
             // pending start — a start_stream that replaces a running publisher
             // emits exactly this sequence (stopped -> initializing -> streaming).
             // Attributing it here would reject a start that is about to succeed.
-            if (event.state == StreamState.STOPPED) {
+            // After an id-carrying error for the pending start, though, the
+            // stopped is a fatal publisher's wind-down (the stop-ack always
+            // precedes any status for the new start), so it is that start's
+            // verdict.
+            if (event.state == StreamState.STOPPED && entry.value.lastError == null) {
                 return null
             }
-            val entry = pendingStreamStarts.entries.first()
             return entry.key to entry.value
         }
         return null

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1680,6 +1680,18 @@ class MentraBluetoothSdk private constructor(
             val start = pendingStreamStarts[streamId] ?: return null
             return streamId to start
         }
+        if (event.state == StreamState.ERROR) {
+            // An id-less error is a command-level preflight rejection (missing
+            // URL, low battery, no WiFi) emitted synchronously, while lifecycle
+            // statuses arrive async — so with overlapping starts the wire is
+            // genuinely ambiguous about which start it answers. Attribute it to
+            // the newest pending start: the common case is a later start
+            // failing preflight while an earlier one is already emitting
+            // lifecycle statuses, and at worst this swaps which start carries
+            // the error instead of letting both time out.
+            val entry = pendingStreamStarts.entries.maxByOrNull { it.value.seq } ?: return null
+            return entry.key to entry.value
+        }
         if (pendingStreamStarts.size == 1) {
             val entry = pendingStreamStarts.entries.first()
             // A streamId-less STOPPED is the glasses' stop-ack for a PREVIOUS

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1561,7 +1561,11 @@ class MentraBluetoothSdk private constructor(
                 rejectPreemptedStreamStarts(start.seq)
             }
             when (event.state) {
-                StreamState.STREAMING -> {
+                // `reconnected` also proves the stream is live: when an async start
+                // failure triggers the glasses' publisher retry, a successful retry
+                // reports `reconnected` instead of `streaming`.
+                StreamState.STREAMING,
+                StreamState.RECONNECTED -> {
                     pendingStreamStarts.remove(streamId, start)
                     start.pending.resolve(event)
                 }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -123,6 +123,10 @@ class MentraBluetoothSdk private constructor(
 
     private data class PendingStreamStop(
         val streamId: String?,
+        // The stop's slot in the shared streamStartSeq order (drawn inside
+        // streamStartOrderLock at send time): every pending start with a
+        // lower seq reached the glasses' FIFO before this stop.
+        val seq: Long,
         val pending: PendingResponse<StreamStatusEvent>,
     )
 
@@ -919,18 +923,25 @@ class MentraBluetoothSdk private constructor(
         val targetStreamId = synchronized(streamKeepAliveLock) {
             activeStreamKeepAlive?.streamId
         }
-        synchronized(oneShotLock) {
-            if (pendingStreamStop != null) {
-                throw BluetoothSdkException(
-                    "request_in_flight",
-                    "A stream stop command is already waiting for a glasses response.",
-                )
-            }
-            pendingStreamStop = PendingStreamStop(targetStreamId, pending)
-        }
-        stopStreamKeepAliveMonitor()
         try {
-            deviceManager.stopStream()
+            // The seq draw and the BLE hand-off share startStream's ordering
+            // critical section: the stop takes its own slot in the send order,
+            // so its ack can separate the pending starts the glasses consumed
+            // before it (lower seq) from starts sent after it (higher seq).
+            synchronized(streamStartOrderLock) {
+                synchronized(oneShotLock) {
+                    if (pendingStreamStop != null) {
+                        throw BluetoothSdkException(
+                            "request_in_flight",
+                            "A stream stop command is already waiting for a glasses response.",
+                        )
+                    }
+                    pendingStreamStop =
+                        PendingStreamStop(targetStreamId, streamStartSeq.incrementAndGet(), pending)
+                }
+                stopStreamKeepAliveMonitor()
+                deviceManager.stopStream()
+            }
             return pending.await(STREAM_STOP_TIMEOUT_MS)
         } finally {
             synchronized(oneShotLock) {
@@ -1609,6 +1620,7 @@ class MentraBluetoothSdk private constructor(
                             pendingStreamStop = null
                         }
                     }
+                    rejectStreamStartsSupersededByStop(stop.seq)
                     stop.pending.resolve(stoppedStreamEvent(event, stop.streamId))
                 }
                 event.state == StreamState.ERROR || event.state == StreamState.RECONNECT_FAILED -> {
@@ -1638,6 +1650,24 @@ class MentraBluetoothSdk private constructor(
                         "stream_preempted",
                         "start stream $streamId was preempted by a newer start_stream; " +
                             "the glasses run a single stream and the last request wins.",
+                    )
+                )
+            }
+        }
+    }
+
+    // The glasses process BLE commands FIFO, so this stop's ack also settles
+    // every start sent before it: whatever those starts brought up (or would
+    // have brought up) has been stopped, and no further status will arrive
+    // for them. Without this they would run out the 30s start timeout.
+    // Starts sent after the stop keep waiting for their own statuses.
+    private fun rejectStreamStartsSupersededByStop(stopSeq: Long) {
+        for ((streamId, start) in pendingStreamStarts) {
+            if (start.seq < stopSeq && pendingStreamStarts.remove(streamId, start)) {
+                start.pending.reject(
+                    BluetoothSdkException(
+                        "stream_stopped",
+                        "start stream $streamId was superseded by a stop_stream issued after it.",
                     )
                 )
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1577,9 +1577,7 @@ class MentraBluetoothSdk private constructor(
                     )
                 }
                 StreamState.ERROR -> {
-                    if (!event.streamId.isNullOrBlank() &&
-                        (event.status as? StreamStatus.Error)?.willRetry == true
-                    ) {
+                    if (!event.streamId.isNullOrBlank() && event.willRetry == true) {
                         // The glasses flag errors their publisher will retry with
                         // `willRetry` (emitting side lands in PR #3488), so keep the
                         // start pending for the retry's verdict — `reconnected` or

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1693,7 +1693,10 @@ class MentraBluetoothSdk private constructor(
             return entry.key to entry.value
         }
         if (pendingStreamStarts.size == 1) {
-            val entry = pendingStreamStarts.entries.first()
+            // firstOrNull: timeouts and other handler threads mutate the
+            // ConcurrentHashMap concurrently, so the map can empty between the
+            // size check and this read; bail out instead of throwing.
+            val entry = pendingStreamStarts.entries.firstOrNull() ?: return null
             // A streamId-less STOPPED is the glasses' stop-ack for a PREVIOUS
             // stream (their stop ack carries no streamId), not a verdict on the
             // pending start — a start_stream that replaces a running publisher

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -1577,18 +1577,25 @@ class MentraBluetoothSdk private constructor(
                     )
                 }
                 StreamState.ERROR -> {
-                    if (event.streamId.isNullOrBlank()) {
+                    if (!event.streamId.isNullOrBlank() &&
+                        (event.status as? StreamStatus.Error)?.willRetry == true
+                    ) {
+                        // The glasses flag errors their publisher will retry with
+                        // `willRetry` (emitting side lands in PR #3488), so keep the
+                        // start pending for the retry's verdict — `reconnected` or
+                        // `streaming` on success, `reconnect_failed` or the
+                        // streamId-less `stopped` wind-down (which reports these
+                        // stashed details) on failure.
+                        start.lastError = event
+                    } else {
                         // An id-less error is the glasses' command-level rejection
-                        // (missing URL, low battery, no WiFi), emitted before any
-                        // publisher starts; nothing further follows for this start.
+                        // (missing URL, low battery, no WiFi) emitted before any
+                        // publisher starts; an id-carrying error without `willRetry`
+                        // is terminal (`camera_busy` emits an error and nothing else).
+                        // Old firmware never sends `willRetry`, so its errors always
+                        // fail fast here — the shipped pre-#3487 Android behavior.
                         pendingStreamStarts.remove(streamId, start)
                         start.pending.reject(streamStatusException(event, "stream_start_failed"))
-                    } else {
-                        // The glasses publisher automatically retries transient transport
-                        // errors, so keep the start pending for a later `streaming`.
-                        // Stash the details for the streamId-less `stopped` that a fatal
-                        // publisher error winds down with instead.
-                        start.lastError = event
                     }
                 }
                 else -> Unit
@@ -1652,10 +1659,10 @@ class MentraBluetoothSdk private constructor(
             // pending start — a start_stream that replaces a running publisher
             // emits exactly this sequence (stopped -> initializing -> streaming).
             // Attributing it here would reject a start that is about to succeed.
-            // After an id-carrying error for the pending start, though, the
-            // stopped is a fatal publisher's wind-down (the stop-ack always
-            // precedes any status for the new start), so it is that start's
-            // verdict.
+            // After a stashed `willRetry` error for the pending start, though,
+            // the stopped is the retrying publisher's wind-down (the stop-ack
+            // always precedes any status for the new start), so it is that
+            // start's verdict.
             if (event.state == StreamState.STOPPED && entry.value.lastError == null) {
                 return null
             }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
@@ -280,7 +280,10 @@ sealed interface StreamStatus {
             }
             is Reconnected -> values["attempt"] = attempt
             is ReconnectFailed -> values["maxAttempts"] = maxAttempts
-            is Error -> values["errorDetails"] = errorDetails
+            is Error -> {
+                values["errorDetails"] = errorDetails
+                willRetry?.let { values["willRetry"] = it }
+            }
             is Snapshot -> {
                 values["streaming"] = streaming
                 values["reconnecting"] = reconnecting
@@ -337,6 +340,9 @@ sealed interface StreamStatus {
     data class Error(
         override val streamId: String?,
         val errorDetails: String,
+        // True when the glasses will retry the failed publisher themselves
+        // (emitting side lands in PR #3488); absent on older firmware.
+        val willRetry: Boolean? = null,
         override val timestamp: Long?,
         override val resolvedConfig: StreamResolvedConfig?,
     ) : StreamStatus {
@@ -419,6 +425,7 @@ sealed interface StreamStatus {
                     streamId = streamId,
                     errorDetails = stringValue(values, "errorDetails")
                         ?: if (rawState == "error_not_streaming") "not_streaming" else "Unknown stream error",
+                    willRetry = boolValue(values, "willRetry"),
                     timestamp = timestamp,
                     resolvedConfig = resolvedConfig,
                 )

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/streaming/StreamModels.kt
@@ -280,10 +280,7 @@ sealed interface StreamStatus {
             }
             is Reconnected -> values["attempt"] = attempt
             is ReconnectFailed -> values["maxAttempts"] = maxAttempts
-            is Error -> {
-                values["errorDetails"] = errorDetails
-                willRetry?.let { values["willRetry"] = it }
-            }
+            is Error -> values["errorDetails"] = errorDetails
             is Snapshot -> {
                 values["streaming"] = streaming
                 values["reconnecting"] = reconnecting
@@ -340,9 +337,6 @@ sealed interface StreamStatus {
     data class Error(
         override val streamId: String?,
         val errorDetails: String,
-        // True when the glasses will retry the failed publisher themselves
-        // (emitting side lands in PR #3488); absent on older firmware.
-        val willRetry: Boolean? = null,
         override val timestamp: Long?,
         override val resolvedConfig: StreamResolvedConfig?,
     ) : StreamStatus {
@@ -425,7 +419,6 @@ sealed interface StreamStatus {
                     streamId = streamId,
                     errorDetails = stringValue(values, "errorDetails")
                         ?: if (rawState == "error_not_streaming") "not_streaming" else "Unknown stream error",
-                    willRetry = boolValue(values, "willRetry"),
                     timestamp = timestamp,
                     resolvedConfig = resolvedConfig,
                 )
@@ -443,12 +436,25 @@ sealed interface StreamStatus {
 data class StreamStatusEvent(
     val status: StreamStatus,
 ) {
-    constructor(values: Map<String, Any>) : this(StreamStatus.fromMap(values))
+    // True when the glasses will retry the failed publisher themselves
+    // (emitting side lands in PR #3488); absent on older firmware and on
+    // events not parsed from a glasses status map. Carried here instead of
+    // on StreamStatus.Error so the public Error shape stays unchanged.
+    var willRetry: Boolean? = null
+        private set
+
+    constructor(values: Map<String, Any>) : this(StreamStatus.fromMap(values)) {
+        willRetry = boolValue(values, "willRetry")
+    }
 
     val state: StreamState get() = status.state
     val streamId: String? get() = status.streamId
     val resolvedConfig: StreamResolvedConfig? get() = status.resolvedConfig
-    val values: Map<String, Any> get() = status.toEventMap()
+    val values: Map<String, Any>
+        get() = buildMap {
+            putAll(status.toEventMap())
+            willRetry?.let { put("willRetry", it) }
+        }
 }
 
 data class KeepAliveAckEvent(

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -94,6 +94,20 @@ private final class PendingVideoRecordingRequest {
 }
 
 @MainActor
+private final class PendingStreamStart {
+    let pending: PendingResponse<StreamStatusEvent>
+    // Set when an id-carrying error arrives: a fatal publisher error never
+    // reaches the reconnect machinery and winds down with a streamId-less
+    // stopped, so the stash both attributes that stopped to this start and
+    // preserves the real error details for the rejection.
+    var lastError: StreamStatusEvent?
+
+    init(pending: PendingResponse<StreamStatusEvent>) {
+        self.pending = pending
+    }
+}
+
+@MainActor
 private final class PendingResponse<T> {
     private let operation: String
     private var continuation: CheckedContinuation<T, Error>?
@@ -175,7 +189,7 @@ public final class MentraBluetoothSDK {
     private var pendingVideoRecordingRequests: [String: PendingVideoRecordingRequest] = [:]
     private var pendingRgbLedRequests: [String: PendingResponse<RgbLedControlResponseEvent>] = [:]
     private var pendingSettingsRequests: [String: PendingResponse<SettingsAckEvent>] = [:]
-    private var pendingStreamStarts: [String: PendingResponse<StreamStatusEvent>] = [:]
+    private var pendingStreamStarts: [String: PendingStreamStart] = [:]
     private var pendingStreamStop: (streamId: String?, pending: PendingResponse<StreamStatusEvent>)?
     private var pendingGalleryStatus: PendingResponse<GalleryStatusEvent>?
     private var pendingOtaQuery: PendingResponse<OtaQueryResult>?
@@ -869,7 +883,7 @@ public final class MentraBluetoothSDK {
         let streamId = stringValue(values, "streamId").flatMap { $0.isEmpty ? nil : $0 } ?? "sdk-\(UUID().uuidString)"
         values["streamId"] = streamId
         let pending = PendingResponse<StreamStatusEvent>(operation: "start stream \(streamId)")
-        pendingStreamStarts[streamId] = pending
+        pendingStreamStarts[streamId] = PendingStreamStart(pending: pending)
         stopStreamKeepAliveMonitor()
         DeviceManager.shared.startStream(values)
         do {
@@ -1413,20 +1427,28 @@ public final class MentraBluetoothSDK {
     }
 
     private func handleStreamStatusForRequests(_ event: StreamStatusEvent) {
-        if let (streamId, pending) = matchingStreamStart(for: event) {
+        if let (streamId, start) = matchingStreamStart(for: event) {
             switch event.state {
             case .streaming:
                 pendingStreamStarts.removeValue(forKey: streamId)
-                pending.resolve(event)
+                start.pending.resolve(event)
             case .reconnectFailed, .stopped:
                 pendingStreamStarts.removeValue(forKey: streamId)
-                pending.reject(streamStatusError(event, code: "stream_start_failed"))
+                start.pending.reject(streamStatusError(start.lastError ?? event, code: "stream_start_failed"))
             case .error:
-                // The glasses publisher automatically retries transient transport
-                // errors. Keep the start pending so a subsequent `streaming`
-                // status can resolve it; `reconnectFailed` or the request timeout
-                // still terminates a publisher that cannot recover.
-                break
+                if let eventStreamId = event.streamId, !eventStreamId.isEmpty {
+                    // The glasses publisher automatically retries transient transport
+                    // errors, so keep the start pending for a later `streaming`.
+                    // Stash the details for the streamId-less `stopped` that a fatal
+                    // publisher error winds down with instead.
+                    start.lastError = event
+                } else {
+                    // An id-less error is the glasses' command-level rejection
+                    // (missing URL, low battery, no WiFi), emitted before any
+                    // publisher starts; nothing further follows for this start.
+                    pendingStreamStarts.removeValue(forKey: streamId)
+                    start.pending.reject(streamStatusError(event, code: "stream_start_failed"))
+                }
             default:
                 break
             }
@@ -1447,12 +1469,24 @@ public final class MentraBluetoothSDK {
         }
     }
 
-    private func matchingStreamStart(for event: StreamStatusEvent) -> (String, PendingResponse<StreamStatusEvent>)? {
+    private func matchingStreamStart(for event: StreamStatusEvent) -> (String, PendingStreamStart)? {
         if let streamId = event.streamId, !streamId.isEmpty {
-            guard let pending = pendingStreamStarts[streamId] else { return nil }
-            return (streamId, pending)
+            guard let start = pendingStreamStarts[streamId] else { return nil }
+            return (streamId, start)
         }
         if pendingStreamStarts.count == 1, let entry = pendingStreamStarts.first {
+            // A streamId-less STOPPED is the glasses' stop-ack for a PREVIOUS
+            // stream (their stop ack carries no streamId), not a verdict on the
+            // pending start — a start_stream that replaces a running publisher
+            // emits exactly this sequence (stopped -> initializing -> streaming).
+            // Attributing it here would reject a start that is about to succeed.
+            // After an id-carrying error for the pending start, though, the
+            // stopped is a fatal publisher's wind-down (the stop-ack always
+            // precedes any status for the new start), so it is that start's
+            // verdict.
+            if event.state == .stopped, entry.value.lastError == nil {
+                return nil
+            }
             return (entry.key, entry.value)
         }
         return nil

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1448,8 +1448,20 @@ public final class MentraBluetoothSDK {
 
     private func handleStreamStatusForRequests(_ event: StreamStatusEvent) {
         if let (streamId, start) = matchingStreamStart(for: event) {
+            // Preemption is only proven by statuses the start path emits after
+            // the glasses' stopAllServices has run: initializing, reconnecting,
+            // reconnected, streaming. An id-stamped `error` can be a
+            // command-level preflight rejection (#3488 firmware) emitted
+            // synchronously before stopAllServices, and `stopped` is a
+            // stop-ack for a previous stream — treating either as a winner
+            // could reject an older start that is still healthy.
             if let eventStreamId = event.streamId, !eventStreamId.isEmpty {
-                rejectPreemptedStreamStarts(winnerSeq: start.seq)
+                switch event.state {
+                case .initializing, .reconnecting, .reconnected, .streaming:
+                    rejectPreemptedStreamStarts(winnerSeq: start.seq)
+                default:
+                    break
+                }
             }
             switch event.state {
             // `reconnected` also proves the stream is live: when an async start
@@ -1502,11 +1514,12 @@ public final class MentraBluetoothSDK {
     }
 
     // The glasses process BLE commands FIFO and every start_stream begins by
-    // stopping whatever runs, so an id-carrying status for start X (any state)
-    // proves every lower-seq start has already been preempted. Their
-    // only verdict on current firmware is a streamId-less stopped, which the
-    // id-less heuristic deliberately ignores — without this they would run out
-    // the 30s timeout instead of failing fast.
+    // stopping whatever runs, so an id-carrying status proving start X's
+    // start path ran on the glasses also proves every lower-seq start has
+    // already been preempted. Their only verdict on current firmware is a
+    // streamId-less stopped, which the id-less heuristic deliberately
+    // ignores — without this they would run out the 30s timeout instead of
+    // failing fast.
     private func rejectPreemptedStreamStarts(winnerSeq: Int) {
         for (streamId, start) in pendingStreamStarts where start.seq < winnerSeq {
             pendingStreamStarts.removeValue(forKey: streamId)

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1377,6 +1377,7 @@ public final class MentraBluetoothSDK {
                     status: .error(
                         streamId: tracker.streamId,
                         errorDetails: "Stream keep-alive timed out after \(tracker.missedAckCount) missed ACKs",
+                        willRetry: nil,
                         timestamp: Int(Date().timeIntervalSince1970 * 1000),
                         resolvedConfig: nil
                     )
@@ -1453,16 +1454,22 @@ public final class MentraBluetoothSDK {
                 pendingStreamStarts.removeValue(forKey: streamId)
                 start.pending.reject(streamStatusError(start.lastError ?? event, code: "stream_start_failed"))
             case .error:
-                if let eventStreamId = event.streamId, !eventStreamId.isEmpty {
-                    // The glasses publisher automatically retries transient transport
-                    // errors, so keep the start pending for a later `streaming`.
-                    // Stash the details for the streamId-less `stopped` that a fatal
-                    // publisher error winds down with instead.
+                if let eventStreamId = event.streamId, !eventStreamId.isEmpty,
+                   case let .error(_, _, willRetry, _, _) = event.status, willRetry == true {
+                    // The glasses flag errors their publisher will retry with
+                    // `willRetry` (emitting side lands in PR #3488), so keep the
+                    // start pending for the retry's verdict — `reconnected` or
+                    // `streaming` on success, `reconnect_failed` or the
+                    // streamId-less `stopped` wind-down (which reports these
+                    // stashed details) on failure.
                     start.lastError = event
                 } else {
                     // An id-less error is the glasses' command-level rejection
-                    // (missing URL, low battery, no WiFi), emitted before any
-                    // publisher starts; nothing further follows for this start.
+                    // (missing URL, low battery, no WiFi) emitted before any
+                    // publisher starts; an id-carrying error without `willRetry`
+                    // is terminal (`camera_busy` emits an error and nothing else).
+                    // Old firmware never sends `willRetry`, so its errors always
+                    // fail fast here — the shipped pre-#3487 Android behavior.
                     pendingStreamStarts.removeValue(forKey: streamId)
                     start.pending.reject(streamStatusError(event, code: "stream_start_failed"))
                 }
@@ -1516,10 +1523,10 @@ public final class MentraBluetoothSDK {
             // pending start — a start_stream that replaces a running publisher
             // emits exactly this sequence (stopped -> initializing -> streaming).
             // Attributing it here would reject a start that is about to succeed.
-            // After an id-carrying error for the pending start, though, the
-            // stopped is a fatal publisher's wind-down (the stop-ack always
-            // precedes any status for the new start), so it is that start's
-            // verdict.
+            // After a stashed `willRetry` error for the pending start, though,
+            // the stopped is the retrying publisher's wind-down (the stop-ack
+            // always precedes any status for the new start), so it is that
+            // start's verdict.
             if event.state == .stopped, entry.value.lastError == nil {
                 return nil
             }
@@ -1538,7 +1545,7 @@ public final class MentraBluetoothSDK {
         if event.state == .stopped {
             return true
         }
-        guard case let .error(_, errorDetails, _, _) = event.status else {
+        guard case let .error(_, errorDetails, _, _, _) = event.status else {
             return false
         }
         return ["not_streaming", "already_stopped", "not streaming"].contains(errorDetails.lowercased())
@@ -1557,7 +1564,7 @@ public final class MentraBluetoothSDK {
 
     private func streamStatusError(_ event: StreamStatusEvent, code: String) -> BluetoothSdkError {
         let message: String
-        if case let .error(_, errorDetails, _, _) = event.status {
+        if case let .error(_, errorDetails, _, _, _) = event.status {
             message = errorDetails
         } else {
             message = "Stream status \(event.state.rawValue)"

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1443,7 +1443,10 @@ public final class MentraBluetoothSDK {
                 rejectPreemptedStreamStarts(winnerSeq: start.seq)
             }
             switch event.state {
-            case .streaming:
+            // `reconnected` also proves the stream is live: when an async start
+            // failure triggers the glasses' publisher retry, a successful retry
+            // reports `reconnected` instead of `streaming`.
+            case .streaming, .reconnected:
                 pendingStreamStarts.removeValue(forKey: streamId)
                 start.pending.resolve(event)
             case .reconnectFailed, .stopped:

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -196,7 +196,10 @@ public final class MentraBluetoothSDK {
     private var pendingSettingsRequests: [String: PendingResponse<SettingsAckEvent>] = [:]
     private var pendingStreamStarts: [String: PendingStreamStart] = [:]
     private var streamStartSeq = 0
-    private var pendingStreamStop: (streamId: String?, pending: PendingResponse<StreamStatusEvent>)?
+    // seq is the stop's slot in the shared streamStartSeq order (drawn in the
+    // same await-free MainActor turn that sends the command): every pending
+    // start with a lower seq reached the glasses' FIFO before this stop.
+    private var pendingStreamStop: (streamId: String?, seq: Int, pending: PendingResponse<StreamStatusEvent>)?
     private var pendingGalleryStatus: PendingResponse<GalleryStatusEvent>?
     private var pendingOtaQuery: PendingResponse<OtaQueryResult>?
     private var pendingOtaStart: PendingResponse<OtaStartAckEvent>?
@@ -947,7 +950,13 @@ public final class MentraBluetoothSDK {
             )
         }
         let pending = PendingResponse<StreamStatusEvent>(operation: "stop stream")
-        pendingStreamStop = (streamId: activeStreamKeepAlive?.streamId, pending: pending)
+        // The seq draw and the BLE hand-off stay in this single await-free
+        // MainActor turn, sharing startStream's ordering critical section:
+        // the stop takes its own slot in the send order, so its ack can
+        // separate the pending starts the glasses consumed before it (lower
+        // seq) from starts sent after it (higher seq).
+        streamStartSeq += 1
+        pendingStreamStop = (streamId: activeStreamKeepAlive?.streamId, seq: streamStartSeq, pending: pending)
         stopStreamKeepAliveMonitor()
         DeviceManager.shared.stopStream()
         do {
@@ -1481,6 +1490,7 @@ public final class MentraBluetoothSDK {
                 if pendingStreamStop?.pending === stop.pending {
                     pendingStreamStop = nil
                 }
+                rejectStreamStartsSuperseded(byStopSeq: stop.seq)
                 stop.pending.resolve(stoppedStreamEvent(from: event, fallbackStreamId: stop.streamId))
             } else if event.state == .error || event.state == .reconnectFailed {
                 if pendingStreamStop?.pending === stop.pending {
@@ -1505,6 +1515,23 @@ public final class MentraBluetoothSDK {
                     code: "stream_preempted",
                     message: "start stream \(streamId) was preempted by a newer start_stream; "
                         + "the glasses run a single stream and the last request wins."
+                )
+            )
+        }
+    }
+
+    // The glasses process BLE commands FIFO, so this stop's ack also settles
+    // every start sent before it: whatever those starts brought up (or would
+    // have brought up) has been stopped, and no further status will arrive
+    // for them. Without this they would run out the 30s start timeout.
+    // Starts sent after the stop keep waiting for their own statuses.
+    private func rejectStreamStartsSuperseded(byStopSeq stopSeq: Int) {
+        for (streamId, start) in pendingStreamStarts where start.seq < stopSeq {
+            pendingStreamStarts.removeValue(forKey: streamId)
+            start.pending.reject(
+                BluetoothSdkError(
+                    code: "stream_stopped",
+                    message: "start stream \(streamId) was superseded by a stop_stream issued after it."
                 )
             )
         }

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1377,7 +1377,6 @@ public final class MentraBluetoothSDK {
                     status: .error(
                         streamId: tracker.streamId,
                         errorDetails: "Stream keep-alive timed out after \(tracker.missedAckCount) missed ACKs",
-                        willRetry: nil,
                         timestamp: Int(Date().timeIntervalSince1970 * 1000),
                         resolvedConfig: nil
                     )
@@ -1454,8 +1453,7 @@ public final class MentraBluetoothSDK {
                 pendingStreamStarts.removeValue(forKey: streamId)
                 start.pending.reject(streamStatusError(start.lastError ?? event, code: "stream_start_failed"))
             case .error:
-                if let eventStreamId = event.streamId, !eventStreamId.isEmpty,
-                   case let .error(_, _, willRetry, _, _) = event.status, willRetry == true {
+                if let eventStreamId = event.streamId, !eventStreamId.isEmpty, event.willRetry == true {
                     // The glasses flag errors their publisher will retry with
                     // `willRetry` (emitting side lands in PR #3488), so keep the
                     // start pending for the retry's verdict — `reconnected` or
@@ -1545,7 +1543,7 @@ public final class MentraBluetoothSDK {
         if event.state == .stopped {
             return true
         }
-        guard case let .error(_, errorDetails, _, _, _) = event.status else {
+        guard case let .error(_, errorDetails, _, _) = event.status else {
             return false
         }
         return ["not_streaming", "already_stopped", "not streaming"].contains(errorDetails.lowercased())
@@ -1564,7 +1562,7 @@ public final class MentraBluetoothSDK {
 
     private func streamStatusError(_ event: StreamStatusEvent, code: String) -> BluetoothSdkError {
         let message: String
-        if case let .error(_, errorDetails, _, _, _) = event.status {
+        if case let .error(_, errorDetails, _, _) = event.status {
             message = errorDetails
         } else {
             message = "Stream status \(event.state.rawValue)"

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -93,8 +93,12 @@ private final class PendingVideoRecordingRequest {
     }
 }
 
+// seq records send order (assigned and handed to the BLE queue in a single
+// MainActor turn) so that an id-carrying status for a newer start can
+// identify which older in-flight starts it preempted.
 @MainActor
 private final class PendingStreamStart {
+    let seq: Int
     let pending: PendingResponse<StreamStatusEvent>
     // Set when an id-carrying error arrives: a fatal publisher error never
     // reaches the reconnect machinery and winds down with a streamId-less
@@ -102,7 +106,8 @@ private final class PendingStreamStart {
     // preserves the real error details for the rejection.
     var lastError: StreamStatusEvent?
 
-    init(pending: PendingResponse<StreamStatusEvent>) {
+    init(seq: Int, pending: PendingResponse<StreamStatusEvent>) {
+        self.seq = seq
         self.pending = pending
     }
 }
@@ -190,6 +195,7 @@ public final class MentraBluetoothSDK {
     private var pendingRgbLedRequests: [String: PendingResponse<RgbLedControlResponseEvent>] = [:]
     private var pendingSettingsRequests: [String: PendingResponse<SettingsAckEvent>] = [:]
     private var pendingStreamStarts: [String: PendingStreamStart] = [:]
+    private var streamStartSeq = 0
     private var pendingStreamStop: (streamId: String?, pending: PendingResponse<StreamStatusEvent>)?
     private var pendingGalleryStatus: PendingResponse<GalleryStatusEvent>?
     private var pendingOtaQuery: PendingResponse<OtaQueryResult>?
@@ -883,7 +889,12 @@ public final class MentraBluetoothSDK {
         let streamId = stringValue(values, "streamId").flatMap { $0.isEmpty ? nil : $0 } ?? "sdk-\(UUID().uuidString)"
         values["streamId"] = streamId
         let pending = PendingResponse<StreamStatusEvent>(operation: "start stream \(streamId)")
-        pendingStreamStarts[streamId] = PendingStreamStart(pending: pending)
+        // seq assignment through the BLE hand-off must stay await-free so this
+        // MainActor turn is one critical section: rejectPreemptedStreamStarts
+        // only works if seq order equals the order the commands reach the
+        // glasses' FIFO.
+        streamStartSeq += 1
+        pendingStreamStarts[streamId] = PendingStreamStart(seq: streamStartSeq, pending: pending)
         stopStreamKeepAliveMonitor()
         DeviceManager.shared.startStream(values)
         do {
@@ -1428,6 +1439,9 @@ public final class MentraBluetoothSDK {
 
     private func handleStreamStatusForRequests(_ event: StreamStatusEvent) {
         if let (streamId, start) = matchingStreamStart(for: event) {
+            if let eventStreamId = event.streamId, !eventStreamId.isEmpty {
+                rejectPreemptedStreamStarts(winnerSeq: start.seq)
+            }
             switch event.state {
             case .streaming:
                 pendingStreamStarts.removeValue(forKey: streamId)
@@ -1466,6 +1480,25 @@ public final class MentraBluetoothSDK {
                 }
                 stop.pending.reject(streamStatusError(event, code: "stream_stop_failed"))
             }
+        }
+    }
+
+    // The glasses process BLE commands FIFO and every start_stream begins by
+    // stopping whatever runs, so an id-carrying status for start X (any state)
+    // proves every lower-seq start has already been preempted. Their
+    // only verdict on current firmware is a streamId-less stopped, which the
+    // id-less heuristic deliberately ignores — without this they would run out
+    // the 30s timeout instead of failing fast.
+    private func rejectPreemptedStreamStarts(winnerSeq: Int) {
+        for (streamId, start) in pendingStreamStarts where start.seq < winnerSeq {
+            pendingStreamStarts.removeValue(forKey: streamId)
+            start.pending.reject(
+                BluetoothSdkError(
+                    code: "stream_preempted",
+                    message: "start stream \(streamId) was preempted by a newer start_stream; "
+                        + "the glasses run a single stream and the last request wins."
+                )
+            )
         }
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -1542,6 +1542,18 @@ public final class MentraBluetoothSDK {
             guard let start = pendingStreamStarts[streamId] else { return nil }
             return (streamId, start)
         }
+        if event.state == .error {
+            // An id-less error is a command-level preflight rejection (missing
+            // URL, low battery, no WiFi) emitted synchronously, while lifecycle
+            // statuses arrive async — so with overlapping starts the wire is
+            // genuinely ambiguous about which start it answers. Attribute it to
+            // the newest pending start: the common case is a later start
+            // failing preflight while an earlier one is already emitting
+            // lifecycle statuses, and at worst this swaps which start carries
+            // the error instead of letting both time out.
+            guard let entry = pendingStreamStarts.max(by: { $0.value.seq < $1.value.seq }) else { return nil }
+            return (entry.key, entry.value)
+        }
         if pendingStreamStarts.count == 1, let entry = pendingStreamStarts.first {
             // A streamId-less STOPPED is the glasses' stop-ack for a PREVIOUS
             // stream (their stop ack carries no streamId), not a verdict on the

--- a/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
@@ -346,7 +346,15 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
     )
     case reconnected(streamId: String?, attempt: Int, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
     case reconnectFailed(streamId: String?, maxAttempts: Int, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
-    case error(streamId: String?, errorDetails: String, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
+    // `willRetry` is true when the glasses will retry the failed publisher
+    // themselves (emitting side lands in PR #3488); absent on older firmware.
+    case error(
+        streamId: String?,
+        errorDetails: String,
+        willRetry: Bool?,
+        timestamp: Int?,
+        resolvedConfig: StreamResolvedConfig?
+    )
     case snapshot(
         state: StreamState,
         streaming: Bool,
@@ -393,6 +401,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
             self = .error(
                 streamId: streamId,
                 errorDetails: rawState.map { "Unknown stream status: \($0)" } ?? "Missing stream status",
+                willRetry: nil,
                 timestamp: timestamp,
                 resolvedConfig: resolvedConfig
             )
@@ -428,6 +437,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
                 streamId: streamId,
                 errorDetails: stringValue(values, "errorDetails")
                     ?? (rawState == "error_not_streaming" ? "not_streaming" : "Unknown stream error"),
+                willRetry: boolValue(values, "willRetry"),
                 timestamp: timestamp,
                 resolvedConfig: resolvedConfig
             )
@@ -477,7 +487,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(streamId, _, _, _, _, _),
              let .reconnected(streamId, _, _, _),
              let .reconnectFailed(streamId, _, _, _),
-             let .error(streamId, _, _, _),
+             let .error(streamId, _, _, _, _),
              let .snapshot(_, _, _, streamId, _, _, _):
             streamId
         }
@@ -489,7 +499,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(_, _, _, _, timestamp, _),
              let .reconnected(_, _, timestamp, _),
              let .reconnectFailed(_, _, timestamp, _),
-             let .error(_, _, timestamp, _),
+             let .error(_, _, _, timestamp, _),
              let .snapshot(_, _, _, _, _, timestamp, _):
             timestamp
         }
@@ -501,7 +511,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(_, _, _, _, _, resolvedConfig),
              let .reconnected(_, _, _, resolvedConfig),
              let .reconnectFailed(_, _, _, resolvedConfig),
-             let .error(_, _, _, resolvedConfig),
+             let .error(_, _, _, _, resolvedConfig),
              let .snapshot(_, _, _, _, _, _, resolvedConfig):
             resolvedConfig
         }
@@ -533,8 +543,11 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
             values["attempt"] = attempt
         case let .reconnectFailed(_, maxAttempts, _, _):
             values["maxAttempts"] = maxAttempts
-        case let .error(_, errorDetails, _, _):
+        case let .error(_, errorDetails, willRetry, _, _):
             values["errorDetails"] = errorDetails
+            if let willRetry {
+                values["willRetry"] = willRetry
+            }
         case let .snapshot(_, streaming, reconnecting, _, attempt, _, _):
             values["streaming"] = streaming
             values["reconnecting"] = reconnecting

--- a/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/streaming/StreamModels.swift
@@ -346,15 +346,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
     )
     case reconnected(streamId: String?, attempt: Int, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
     case reconnectFailed(streamId: String?, maxAttempts: Int, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
-    // `willRetry` is true when the glasses will retry the failed publisher
-    // themselves (emitting side lands in PR #3488); absent on older firmware.
-    case error(
-        streamId: String?,
-        errorDetails: String,
-        willRetry: Bool?,
-        timestamp: Int?,
-        resolvedConfig: StreamResolvedConfig?
-    )
+    case error(streamId: String?, errorDetails: String, timestamp: Int?, resolvedConfig: StreamResolvedConfig?)
     case snapshot(
         state: StreamState,
         streaming: Bool,
@@ -401,7 +393,6 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
             self = .error(
                 streamId: streamId,
                 errorDetails: rawState.map { "Unknown stream status: \($0)" } ?? "Missing stream status",
-                willRetry: nil,
                 timestamp: timestamp,
                 resolvedConfig: resolvedConfig
             )
@@ -437,7 +428,6 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
                 streamId: streamId,
                 errorDetails: stringValue(values, "errorDetails")
                     ?? (rawState == "error_not_streaming" ? "not_streaming" : "Unknown stream error"),
-                willRetry: boolValue(values, "willRetry"),
                 timestamp: timestamp,
                 resolvedConfig: resolvedConfig
             )
@@ -487,7 +477,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(streamId, _, _, _, _, _),
              let .reconnected(streamId, _, _, _),
              let .reconnectFailed(streamId, _, _, _),
-             let .error(streamId, _, _, _, _),
+             let .error(streamId, _, _, _),
              let .snapshot(_, _, _, streamId, _, _, _):
             streamId
         }
@@ -499,7 +489,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(_, _, _, _, timestamp, _),
              let .reconnected(_, _, timestamp, _),
              let .reconnectFailed(_, _, timestamp, _),
-             let .error(_, _, _, timestamp, _),
+             let .error(_, _, timestamp, _),
              let .snapshot(_, _, _, _, _, timestamp, _):
             timestamp
         }
@@ -511,7 +501,7 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
              let .reconnecting(_, _, _, _, _, resolvedConfig),
              let .reconnected(_, _, _, resolvedConfig),
              let .reconnectFailed(_, _, _, resolvedConfig),
-             let .error(_, _, _, _, resolvedConfig),
+             let .error(_, _, _, resolvedConfig),
              let .snapshot(_, _, _, _, _, _, resolvedConfig):
             resolvedConfig
         }
@@ -543,11 +533,8 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
             values["attempt"] = attempt
         case let .reconnectFailed(_, maxAttempts, _, _):
             values["maxAttempts"] = maxAttempts
-        case let .error(_, errorDetails, willRetry, _, _):
+        case let .error(_, errorDetails, _, _):
             values["errorDetails"] = errorDetails
-            if let willRetry {
-                values["willRetry"] = willRetry
-            }
         case let .snapshot(_, streaming, reconnecting, _, attempt, _, _):
             values["streaming"] = streaming
             values["reconnecting"] = reconnecting
@@ -566,6 +553,11 @@ public enum StreamStatus: CustomStringConvertible, Equatable {
 
 public struct StreamStatusEvent: CustomStringConvertible {
     public let status: StreamStatus
+    // True when the glasses will retry the failed publisher themselves
+    // (emitting side lands in PR #3488); absent on older firmware and on
+    // events not parsed from a glasses status map. Carried here instead of
+    // as an `.error` associated value so the public case stays unchanged.
+    public private(set) var willRetry: Bool?
 
     public init(status: StreamStatus) {
         self.status = status
@@ -573,6 +565,7 @@ public struct StreamStatusEvent: CustomStringConvertible {
 
     public init(values: [String: Any]) {
         status = StreamStatus(values: values)
+        willRetry = boolValue(values, "willRetry")
     }
 
     public var state: StreamState {
@@ -590,6 +583,9 @@ public struct StreamStatusEvent: CustomStringConvertible {
     public var values: [String: Any] {
         var values = status.values
         values["type"] = "stream_status"
+        if let willRetry {
+            values["willRetry"] = willRetry
+        }
         return values
     }
 


### PR DESCRIPTION
Follow-up to #3474 (stacked on `isaiah/os-1714-suspend-bluetooth-asyncfunctions`). Brings iOS and Android stream-start semantics to parity in both directions, prompted by the overlapping-start review threads on that PR.

Background (hardware-verified on a Mentra Live via the glasses' command intent): the glasses preempt on `start_stream` — `stopAllServices()` runs before every start, last request wins, no queue. Lifecycle statuses echo `streamId`; `stopping`/`stopped` and command-level rejections (missing URL, battery low, no WiFi) arrive with no `streamId` on current firmware. A start that replaces a running publisher emits exactly `stopped` (id-less) → `initializing{new}` → `streaming{new}`.

Changes:

- **Ignore streamId-less stopped for a pending iOS stream start.** iOS `matchingStreamStart` was missing the guard Android already has, so the id-less stop-ack of the *previous* stream was attributed to the single pending start and rejected it with `stream_start_failed` even though the new stream goes live moments later. Real shipped-iOS bug; the hardware test emits the exact sequence. The guard has one deliberate exception (below).
- **Reject preempted iOS stream starts instead of timing them out.** Mirror of the Android preemption rejection from #3474: per-start sequence numbers assigned in the same await-free MainActor turn as the BLE hand-off; any id-matched status for start X rejects all lower-seq pending starts with `stream_preempted`.
- **Keep Android stream starts pending through transient stream errors.** Android rejected on the first `error` status; iOS deliberately tolerates them because the glasses publisher auto-retries transient transport errors. Android now matches iOS — with a discriminator both platforms need (found in review): an **id-less** `error` is the glasses' command-level rejection (missing URL, low battery, no WiFi), emitted before any publisher exists and never followed by another status, so it still rejects immediately with the glasses' `errorDetails`. Only **id-carrying** errors stay pending.
- **Fatal-error fast-fail preserved (both platforms).** A fatal (non-retryable) publisher error emits `error{streamId}` then winds down with an id-less `stopped`, bypassing the reconnect machinery. The error event is stashed on the pending start; the subsequent id-less `stopped` is then attributed to that start and rejects with the stashed error details. Without this, tolerating errors would have converted fatal start failures into 30s timeouts. The replace-running-publisher stop-ack is unaffected (its stopped arrives before any status for the pending id, so no stash exists).

Verification:
- Android: `scripts/check-android-compile.sh bluetooth-sdk` — BUILD SUCCESSFUL.
- iOS: SPM export + `xcodebuild -scheme MentraBluetoothSDK` — BUILD SUCCEEDED (intermediate and final states).
- On-device: the preemption/parity paths follow the status sequences captured on hardware for #3474; a live two-start run on iOS is still worth doing before release.

Related: OS-1714, PR #3474 discussion threads r3605423618 / r3605370232.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core async stream start/stop completion logic on both mobile SDKs; wrong attribution of ambiguous statuses could still mis-resolve overlapping calls, but behavior is scoped to concurrent stream commands and is intended to fix known timeout/false-failure bugs.
> 
> **Overview**
> Aligns **Android and iOS** Bluetooth SDK stream **start/stop** promise handling with glasses FIFO behavior (last `start_stream` wins, overlapping commands) and upcoming firmware status shapes.
> 
> Both platforms track **send-order sequence numbers** on pending starts (and stops), reject older starts with **`stream_preempted`** or **`stream_stopped`** when a newer start or a stop settles them, and route **`stop_stream`** through the same ordering critical section as starts so stop acks can clear superseded starts instead of 30s timeouts.
> 
> **Status matching** is tightened: ignore **streamId-less `stopped`** as a verdict on a lone pending start unless a **`willRetry` error** was stashed; attribute ambiguous **id-less errors** to the newest pending start; treat **`reconnected`** as success; on **`stopped`/`reconnect_failed`**, reject using stashed **`lastError`** when a fatal publisher error preceded an id-less wind-down.
> 
> **`StreamStatusEvent`** gains optional **`willRetry`** (parsed from glasses maps, forwarded in `values`). Stream errors with **`willRetry: true`** keep the start pending; terminal or legacy errors fail fast (preserving pre-#3487 behavior when the flag is absent).
> 
> iOS adds **`PendingStreamStart`** and mirrors Android’s preemption/supersede helpers; preemption on iOS is triggered only for id-matched **post-`stopAllServices`** lifecycle states (`initializing`, `reconnecting`, `reconnected`, `streaming`), avoiding false preemption from preflight errors or previous-stream stop-acks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85ac3f05b447ee9c636617bbedd8a78185d9e40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

**Update (review round):** two refinements from the Codex findings, both verified in the service code:
- A matched pending start now also resolves on `reconnected` — the async start-failure path schedules a reconnect and reports success via `onReconnected`, never `onStreamStarted` (bf2c6a9b62).
- The error-tolerance rule is now discriminated on the wire instead of by id-presence alone: an id-carrying `error` rejects immediately with the glasses' `errorDetails` unless it carries the new optional `willRetry: true` (parsed here, emitted by #3488 exactly where the glasses schedule a reconnect). Terminal id-carrying errors like `camera_busy` — which emit nothing further — fast-fail again instead of hanging 30s. Old firmware never sends the flag, so its errors always fast-fail: the shipped pre-#3487 Android behavior, which also fixes the same latent camera_busy hang iOS had at base (5f6859a62d).
