### PR TITLE
Add correlation ids to stream stop statuses and WiFi scans

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/interfaces/StreamingStatusCallback.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/interfaces/StreamingStatusCallback.java
@@ -58,10 +58,22 @@ public interface StreamingStatusCallback {
     void onReconnectFailed(int maxAttempts, String streamId);
 
     /**
-     * Called when a streaming error occurs
+     * Called when a terminal streaming error occurs (no retry scheduled)
      *
      * @param error    Error message
      * @param streamId The stream ID, or null
      */
-    void onStreamError(String error, String streamId);
+    default void onStreamError(String error, String streamId) {
+        onStreamError(error, streamId, false);
+    }
+
+    /**
+     * Called when a streaming error occurs
+     *
+     * @param error     Error message
+     * @param streamId  The stream ID, or null
+     * @param willRetry True when the service has already scheduled a reconnect for
+     *                  this error, so the phone should not treat it as terminal
+     */
+    void onStreamError(String error, String streamId, boolean willRetry);
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -887,7 +887,7 @@ public class RtmpStreamingService extends Service {
                             mIsStreaming = false;
                             EventBus.getDefault().post(new StreamingEvent.Error(errorMsg));
                             if (sStatusCallback != null) {
-                                sStatusCallback.onStreamError(errorMsg, mCurrentStreamId);
+                                sStatusCallback.onStreamError(errorMsg, mCurrentStreamId, true);
                             }
 
                             // Report stream start failure
@@ -949,7 +949,7 @@ public class RtmpStreamingService extends Service {
             }
             EventBus.getDefault().post(new StreamingEvent.Error(errorMsg));
             if (sStatusCallback != null) {
-                sStatusCallback.onStreamError(errorMsg, mCurrentStreamId);
+                sStatusCallback.onStreamError(errorMsg, mCurrentStreamId, true);
             }
 
             // Report stream start failure

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -986,6 +986,14 @@ public class RtmpStreamingService extends Service {
     private void forceStopStreamingInternal(boolean preserveSession) {
         Log.d(TAG, "Force stopping stream and cleaning up resources (preserveSession=" + preserveSession + ")");
 
+        // Capture the id up front - cancelStreamTimeout() and the state reset below
+        // both clear it, and the stopped callback must identify the stream being
+        // stopped.
+        final String stoppedStreamId;
+        synchronized (mStateLock) {
+            stoppedStreamId = mCurrentStreamId;
+        }
+
         // Stop battery monitoring if not preserving session
         if (!preserveSession) {
             stopBatteryMonitoring();
@@ -1134,7 +1142,7 @@ public class RtmpStreamingService extends Service {
             Log.d(TAG, "Stream resources released for reconnection");
         } else {
             if (sStatusCallback != null) {
-                sStatusCallback.onStreamStopped(mCurrentStreamId);
+                sStatusCallback.onStreamStopped(stoppedStreamId);
             }
             EventBus.getDefault().post(new StreamingEvent.Stopped());
             Log.i(TAG, "Streaming stopped and cleaned up");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/RtmpStreamingService.java
@@ -1038,9 +1038,13 @@ public class RtmpStreamingService extends Service {
                     StreamingReporting.reportStreamStopFailure(RtmpStreamingService.this,
                         "stream_stop_error", (Throwable) o);
 
-                    // Notify TPA developer of cleanup failure
+                    // Notify TPA developer of cleanup failure. Use the id captured
+                    // before cleanup: this continuation can resume after the state
+                    // reset cleared mCurrentStreamId or a replacement stream
+                    // overwrote it, and the failure belongs to the stream being
+                    // stopped.
                     if (sStatusCallback != null) {
-                        sStatusCallback.onStreamError("Failed to stop stream: " + ((Throwable) o).getMessage(), mCurrentStreamId);
+                        sStatusCallback.onStreamError("Failed to stop stream: " + ((Throwable) o).getMessage(), stoppedStreamId);
                     }
                 }
                 Log.d(TAG, "Stream stop completed");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -632,6 +632,14 @@ public class SrtStreamingService extends Service {
   private void forceStopStreamingInternal(boolean preserveSession) {
     Log.d(TAG, "Force stopping SRT stream (preserveSession=" + preserveSession + ")");
 
+    // Capture the id up front - cancelStreamTimeout() and the state reset below
+    // both clear it, and the stopped callback must identify the stream being
+    // stopped.
+    final String stoppedStreamId;
+    synchronized (mStateLock) {
+      stoppedStreamId = mCurrentStreamId;
+    }
+
     if (!preserveSession) stopBatteryMonitoring();
 
     mReconnectionSequence++;
@@ -696,7 +704,7 @@ public class SrtStreamingService extends Service {
     }
 
     if (!preserveSession) {
-      if (sStatusCallback != null) sStatusCallback.onStreamStopped(mCurrentStreamId);
+      if (sStatusCallback != null) sStatusCallback.onStreamStopped(stoppedStreamId);
       EventBus.getDefault().post(new StreamingEvent.Stopped());
       Log.i(TAG, "SRT streaming stopped");
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -594,7 +594,7 @@ public class SrtStreamingService extends Service {
               Log.e(TAG, "Error starting SRT stream", (Throwable) o);
               mStreamState = StreamState.IDLE;
               mIsStreaming = false;
-              if (sStatusCallback != null) sStatusCallback.onStreamError(errorMsg, mCurrentStreamId);
+              if (sStatusCallback != null) sStatusCallback.onStreamError(errorMsg, mCurrentStreamId, true);
               StreamingReporting.reportStreamStartFailure(SrtStreamingService.this, mSrtUrl, ((Throwable) o).getMessage(), (Throwable) o);
               scheduleReconnect("start_error");
             } else {
@@ -614,7 +614,7 @@ public class SrtStreamingService extends Service {
       String errorMsg = "Failed to start SRT streaming: " + e.getMessage();
       Log.e(TAG, errorMsg, e);
       synchronized (mStateLock) { mStreamState = StreamState.IDLE; mIsStreaming = false; }
-      if (sStatusCallback != null) sStatusCallback.onStreamError(errorMsg, mCurrentStreamId);
+      if (sStatusCallback != null) sStatusCallback.onStreamError(errorMsg, mCurrentStreamId, true);
       StreamingReporting.reportStreamStartFailure(SrtStreamingService.this, mSrtUrl, e.getMessage(), e);
       scheduleReconnect("start_exception");
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/SrtStreamingService.java
@@ -658,7 +658,10 @@ public class SrtStreamingService extends Service {
         if (o instanceof Throwable) {
           Log.e(TAG, "Error during SRT stream stop", (Throwable) o);
           StreamingReporting.reportStreamStopFailure(SrtStreamingService.this, "stream_stop_error", (Throwable) o);
-          if (sStatusCallback != null) sStatusCallback.onStreamError("Failed to stop SRT stream: " + ((Throwable) o).getMessage(), mCurrentStreamId);
+          // Use the id captured before cleanup: this continuation can resume after
+          // the state reset cleared mCurrentStreamId or a replacement stream
+          // overwrote it, and the failure belongs to the stream being stopped.
+          if (sStatusCallback != null) sStatusCallback.onStreamError("Failed to stop SRT stream: " + ((Throwable) o).getMessage(), stoppedStreamId);
         }
         Log.d(TAG, "SRT stream stop completed");
       }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -897,7 +897,13 @@ public class WhipStreamingService extends Service {
   }
 
   private void notifyStopped() {
-    if (sStatusCallback != null) mMainHandler.post(() -> sStatusCallback.onStreamStopped(mCurrentStreamId));
+    StreamingStatusCallback callback = sStatusCallback;
+    if (callback != null) {
+      // Capture now: by the time the posted runnable runs, a newer start may
+      // already have overwritten mCurrentStreamId.
+      String streamId = mCurrentStreamId;
+      mMainHandler.post(() -> callback.onStreamStopped(streamId));
+    }
   }
 
   private void notifyReconnecting(int attempt, int maxAttempts, String reason) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/interfaces/ICommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/interfaces/ICommunicationManager.java
@@ -33,15 +33,19 @@ public interface ICommunicationManager {
     /**
      * Send WiFi scan results over Bluetooth
      * @param networks List of available networks (legacy format)
+     * @param scanId Correlation id of the scan that produced these results, echoed in
+     *               every chunk; null when the request carried none
      */
-    void sendWifiScanResultsOverBle(java.util.List<String> networks);
-    
+    void sendWifiScanResultsOverBle(java.util.List<String> networks, String scanId);
+
     /**
      * Send enhanced WiFi scan results over Bluetooth with security and signal info
      * @param networks List of NetworkInfo objects with enhanced data
      * @param scanComplete Whether this payload is the terminal scan response
+     * @param scanId Correlation id of the scan that produced these results, echoed in
+     *               every chunk; null when the request carried none
      */
-    void sendWifiScanResultsOverBleEnhanced(java.util.List<NetworkInfo> networks, boolean scanComplete);
+    void sendWifiScanResultsOverBleEnhanced(java.util.List<NetworkInfo> networks, boolean scanComplete, String scanId);
     
     /**
      * Send acknowledgment response

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -158,8 +158,19 @@ public class CommunicationManager
         }
     }
 
+    /** Build a wifi_scan_result envelope echoing the originating scan's correlation id. */
+    private JSONObject newWifiScanResultMessage(String scanId) throws JSONException {
+        JSONObject response = new JSONObject();
+        response.put("type", "wifi_scan_result");
+        response.put("timestamp", System.currentTimeMillis());
+        if (scanId != null && !scanId.isEmpty()) {
+            response.put("scanId", scanId);
+        }
+        return response;
+    }
+
     @Override
-    public void sendWifiScanResultsOverBle(List<String> networks) {
+    public void sendWifiScanResultsOverBle(List<String> networks, String scanId) {
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 SEND WIFI SCAN RESULTS OVER BLE");
         Log.d(TAG, "📡 =========================================");
@@ -180,9 +191,7 @@ public class CommunicationManager
                     List<String> chunk = scanNetworks.subList(i, endIdx);
                     boolean scanComplete = endIdx >= scanNetworks.size();
 
-                    JSONObject response = new JSONObject();
-                    response.put("type", "wifi_scan_result");
-                    response.put("timestamp", System.currentTimeMillis());
+                    JSONObject response = newWifiScanResultMessage(scanId);
 
                     org.json.JSONArray networksArray = new org.json.JSONArray();
                     for (String network : chunk) {
@@ -218,9 +227,7 @@ public class CommunicationManager
                     }
                 }
                 if (scanNetworks.isEmpty()) {
-                    JSONObject response = new JSONObject();
-                    response.put("type", "wifi_scan_result");
-                    response.put("timestamp", System.currentTimeMillis());
+                    JSONObject response = newWifiScanResultMessage(scanId);
                     response.put("networks", new org.json.JSONArray());
                     response.put("scan_complete", true);
 
@@ -247,7 +254,7 @@ public class CommunicationManager
 
     @Override
     public void sendWifiScanResultsOverBleEnhanced(
-            List<NetworkInfo> networks, boolean scanComplete) {
+            List<NetworkInfo> networks, boolean scanComplete, String scanId) {
         Log.d(TAG, "📡 =========================================");
         Log.d(TAG, "📡 SEND ENHANCED WIFI SCAN RESULTS OVER BLE");
         Log.d(TAG, "📡 =========================================");
@@ -262,9 +269,7 @@ public class CommunicationManager
 
                 // Send one network at a time to keep message size minimal
                 for (NetworkInfo network : scanNetworks) {
-                    JSONObject response = new JSONObject();
-                    response.put("type", "wifi_scan_result");
-                    response.put("timestamp", System.currentTimeMillis());
+                    JSONObject response = newWifiScanResultMessage(scanId);
                     response.put("scan_complete", false);
 
                     // Legacy format for backwards compatibility
@@ -312,9 +317,7 @@ public class CommunicationManager
                     }
                 }
                 if (scanComplete) {
-                    JSONObject response = new JSONObject();
-                    response.put("type", "wifi_scan_result");
-                    response.put("timestamp", System.currentTimeMillis());
+                    JSONObject response = newWifiScanResultMessage(scanId);
                     response.put("scan_complete", scanComplete);
                     response.put("networks", new org.json.JSONArray());
                     response.put("networks_neo", new org.json.JSONArray());

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -109,6 +109,7 @@ public class StreamCommandHandler implements ICommandHandler {
     private boolean handleStartCommand(JSONObject data) {
         boolean eisChanged = false;
         boolean streamStarted = false;
+        String streamId = data.optString("streamId", "");
         try {
             // Accept streamUrl first, then legacy rtmpUrl / srtUrl keys
             String streamUrl = data.optString("streamUrl", "");
@@ -118,18 +119,14 @@ public class StreamCommandHandler implements ICommandHandler {
 
             if (streamUrl.isEmpty()) {
                 Log.e(TAG, "Cannot start stream - missing stream URL");
-                streamingManager.sendStreamStatusResponse(
-                        false,
-                        ServiceConstants.STATUS_ERROR,
-                        ServiceConstants.ERROR_MISSING_STREAM_URL);
+                sendStreamErrorStatus(streamId, ServiceConstants.ERROR_MISSING_STREAM_URL);
                 return false;
             }
 
             Protocol protocol = detectProtocol(streamUrl);
             if (protocol == Protocol.UNKNOWN) {
                 Log.e(TAG, "Unknown stream URL protocol: " + streamUrl);
-                streamingManager.sendStreamStatusResponse(
-                        false, ServiceConstants.STATUS_ERROR, "Unknown stream URL protocol");
+                sendStreamErrorStatus(streamId, "Unknown stream URL protocol");
                 return false;
             }
 
@@ -139,9 +136,8 @@ public class StreamCommandHandler implements ICommandHandler {
                 if (batteryLevel >= 0 && batteryLevel < BatteryConstants.MIN_BATTERY_LEVEL) {
                     Log.w(TAG, "🚫 Stream rejected - battery too low (" + batteryLevel + "%)");
                     MediaCaptureService.playBatteryLowSound(context);
-                    streamingManager.sendStreamStatusResponse(
-                            false,
-                            ServiceConstants.STATUS_ERROR,
+                    sendStreamErrorStatus(
+                            streamId,
                             "Battery level too low ("
                                     + batteryLevel
                                     + "%) - minimum "
@@ -156,17 +152,13 @@ public class StreamCommandHandler implements ICommandHandler {
             // WiFi check (WHIP streams may work on mobile data; skip only for WHIP if needed)
             if (stateManager != null && !stateManager.isConnectedToWifi()) {
                 Log.e(TAG, "Cannot start stream - no WiFi connection");
-                streamingManager.sendStreamStatusResponse(
-                        false,
-                        ServiceConstants.STATUS_ERROR,
-                        ServiceConstants.ERROR_NO_WIFI_CONNECTION);
+                sendStreamErrorStatus(streamId, ServiceConstants.ERROR_NO_WIFI_CONNECTION);
                 return false;
             }
 
             // Stop any existing stream
             stopAllServices();
 
-            String streamId = data.optString("streamId", "");
             // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
             boolean flash = true;
             boolean sound = data.optBoolean("sound", true);
@@ -181,7 +173,7 @@ public class StreamCommandHandler implements ICommandHandler {
                 case RTMP:
                     {
                         RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
-                        if (!preflightCameraCaptureForPackStreaming(config)) {
+                        if (!preflightCameraCaptureForPackStreaming(config, streamId)) {
                             return false;
                         }
                         // Toggle EIS for the duration of the stream (see EIS_IN_LIVESTREAMS).
@@ -198,7 +190,7 @@ public class StreamCommandHandler implements ICommandHandler {
                 case SRT:
                     {
                         RtmpStreamConfig config = RtmpStreamConfig.fromJson(videoJson, audioJson);
-                        if (!preflightCameraCaptureForPackStreaming(config)) {
+                        if (!preflightCameraCaptureForPackStreaming(config, streamId)) {
                             return false;
                         }
                         applyEisForStreaming(config.getVideoWidth(), config.getVideoHeight());
@@ -213,7 +205,7 @@ public class StreamCommandHandler implements ICommandHandler {
                 case WHIP:
                     {
                         WhipStreamConfig config = WhipStreamConfig.fromJson(videoJson, audioJson);
-                        if (!preflightCameraCaptureForWhip(config)) {
+                        if (!preflightCameraCaptureForWhip(config, streamId)) {
                             return false;
                         }
                         applyEisForStreaming(config.getVideoWidth(), config.getVideoHeight());
@@ -233,8 +225,7 @@ public class StreamCommandHandler implements ICommandHandler {
                 restoreEisAfterStreaming();
             }
             Log.e(TAG, "Error handling start stream command", e);
-            streamingManager.sendStreamStatusResponse(
-                    false, ServiceConstants.STATUS_ERROR, e.getMessage());
+            sendStreamErrorStatus(streamId, e.getMessage());
             return false;
         }
     }
@@ -270,7 +261,8 @@ public class StreamCommandHandler implements ICommandHandler {
      * RTMP/SRT: reject if no native mode can cover the requested output without upscaling; stamps
      * {@link RtmpStreamConfig#setCaptureSize(int, int)} for StreamPackLite.
      */
-    private boolean preflightCameraCaptureForPackStreaming(RtmpStreamConfig config) {
+    private boolean preflightCameraCaptureForPackStreaming(
+            RtmpStreamConfig config, String streamId) {
         try {
             if (!WhipCameraFormatSelector.stampCaptureSizeOntoConfig(context, config)) {
                 Log.w(
@@ -280,18 +272,14 @@ public class StreamCommandHandler implements ICommandHandler {
                                 + "x"
                                 + config.getVideoHeight());
                 restoreEisAfterStreaming();
-                streamingManager.sendStreamStatusResponse(
-                        false, ServiceConstants.STATUS_ERROR, "Resolution not supported by camera");
+                sendStreamErrorStatus(streamId, "Resolution not supported by camera");
                 return false;
             }
             return true;
         } catch (CameraAccessException e) {
             Log.w(TAG, "Camera access failed during stream preflight", e);
             restoreEisAfterStreaming();
-            streamingManager.sendStreamStatusResponse(
-                    false,
-                    ServiceConstants.STATUS_ERROR,
-                    "Could not access camera for resolution check");
+            sendStreamErrorStatus(streamId, "Could not access camera for resolution check");
             return false;
         }
     }
@@ -299,15 +287,14 @@ public class StreamCommandHandler implements ICommandHandler {
     /**
      * WHIP: reject upscale-only requests. On validation failure, match legacy behavior and allow.
      */
-    private boolean preflightCameraCaptureForWhip(WhipStreamConfig config) {
+    private boolean preflightCameraCaptureForWhip(WhipStreamConfig config, String streamId) {
         try {
             CameraManager cameraManager =
                     (CameraManager) context.getSystemService(Context.CAMERA_SERVICE);
             if (cameraManager == null) {
                 Log.w(TAG, "Rejecting WHIP stream request because camera manager is unavailable");
                 restoreEisAfterStreaming();
-                streamingManager.sendStreamStatusResponse(
-                        false, ServiceConstants.STATUS_ERROR, "Could not access camera");
+                sendStreamErrorStatus(streamId, "Could not access camera");
                 return false;
             }
 
@@ -315,8 +302,7 @@ public class StreamCommandHandler implements ICommandHandler {
             if (cameraId == null) {
                 Log.w(TAG, "Rejecting WHIP stream request because no camera is available");
                 restoreEisAfterStreaming();
-                streamingManager.sendStreamStatusResponse(
-                        false, ServiceConstants.STATUS_ERROR, "Could not access camera");
+                sendStreamErrorStatus(streamId, "Could not access camera");
                 return false;
             }
 
@@ -331,8 +317,7 @@ public class StreamCommandHandler implements ICommandHandler {
                                 + "x"
                                 + config.getVideoHeight());
                 restoreEisAfterStreaming();
-                streamingManager.sendStreamStatusResponse(
-                        false, ServiceConstants.STATUS_ERROR, "Resolution not supported by camera");
+                sendStreamErrorStatus(streamId, "Resolution not supported by camera");
                 return false;
             }
 
@@ -355,21 +340,18 @@ public class StreamCommandHandler implements ICommandHandler {
     public boolean handleStopCommand() {
         try {
             if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
-                streamingManager.sendStreamStatusResponse(
-                        true, ServiceConstants.STATUS_STOPPING, null);
+                sendStreamStoppingStatus(RtmpStreamingService.getCurrentStreamId());
                 RtmpStreamingService.stopStreaming(context);
                 restoreEisAfterStreaming();
                 return true;
             } else if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
-                streamingManager.sendStreamStatusResponse(
-                        true, ServiceConstants.STATUS_STOPPING, null);
+                sendStreamStoppingStatus(SrtStreamingService.getCurrentStreamId());
                 SrtStreamingService.stopStreaming(context);
                 restoreEisAfterStreaming();
                 return true;
             } else if (WhipStreamingService.isStreaming()
                     || WhipStreamingService.isReconnecting()) {
-                streamingManager.sendStreamStatusResponse(
-                        true, ServiceConstants.STATUS_STOPPING, null);
+                sendStreamStoppingStatus(WhipStreamingService.getCurrentStreamId());
                 WhipStreamingService.stopStreaming(context);
                 restoreEisAfterStreaming();
                 return true;
@@ -383,6 +365,43 @@ public class StreamCommandHandler implements ICommandHandler {
             streamingManager.sendStreamStatusResponse(
                     false, ServiceConstants.STATUS_ERROR, e.getMessage());
             return false;
+        }
+    }
+
+    /** Send an error stream status echoing the rejected command's streamId when it carried one. */
+    private void sendStreamErrorStatus(String streamId, String details) {
+        if (streamId == null || streamId.isEmpty()) {
+            streamingManager.sendStreamStatusResponse(
+                    false, ServiceConstants.STATUS_ERROR, details);
+            return;
+        }
+        try {
+            JSONObject status = new JSONObject();
+            status.put("status", ServiceConstants.STATUS_ERROR);
+            if (details != null) {
+                status.put("errorDetails", details);
+            }
+            status.put("streamId", streamId);
+            streamingManager.sendStreamStatusResponse(false, status);
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating stream error status", e);
+        }
+    }
+
+    /** Send a stopping stream status carrying the id of the stream being stopped. */
+    private void sendStreamStoppingStatus(String streamId) {
+        if (streamId == null || streamId.isEmpty()) {
+            streamingManager.sendStreamStatusResponse(
+                    true, ServiceConstants.STATUS_STOPPING, null);
+            return;
+        }
+        try {
+            JSONObject status = new JSONObject();
+            status.put("status", ServiceConstants.STATUS_STOPPING);
+            status.put("streamId", streamId);
+            streamingManager.sendStreamStatusResponse(true, status);
+        } catch (JSONException e) {
+            Log.e(TAG, "Error creating stream stopping status", e);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -44,6 +44,24 @@ public class WifiCommandHandler implements ICommandHandler {
     // auth-failure broadcast can never produce more than one wrong_password verdict.
     private final AtomicReference<ConnectAttempt> activeConnectAttempt = new AtomicReference<>();
 
+    /**
+     * One in-flight WiFi scan run. The scanId it stamps on emissions is mutable:
+     * a request that arrives while a run is active adopts the run by swapping in
+     * its own id (see {@link #handleRequestWifiScan}). Guarded by {@link #scanLock}
+     * because the swap happens on the command thread while the stamping callbacks
+     * fire on the scan thread.
+     */
+    private static final class ScanRun {
+        String scanId;
+
+        ScanRun(String scanId) {
+            this.scanId = scanId;
+        }
+    }
+
+    private final Object scanLock = new Object();
+    private ScanRun activeScanRun; // guarded by scanLock
+
     public WifiCommandHandler(AsgClientServiceManager serviceManager,
                               ICommunicationManager communicationManager,
                               IStateManager stateManager) {
@@ -268,52 +286,92 @@ public class WifiCommandHandler implements ICommandHandler {
     public boolean handleRequestWifiScan(JSONObject data) {
         try {
             // Optional correlation id echoed in every wifi_scan_result chunk so the
-            // phone can tie results to this scan. Captured per request so overlapping
-            // scans each stamp their own chunks.
+            // phone can tie results to this scan.
             String requestedScanId = data.optString("scanId", "");
             String scanId = requestedScanId.isEmpty() ? null : requestedScanId;
             INetworkManager networkManager = serviceManager.getNetworkManager();
-            if (networkManager != null) {
-                new Thread(() -> {
-                    try {
-                        // Use streaming WiFi scan with callback for immediate results
-                        networkManager.scanWifiNetworks(new IWifiScanCallback() {
-                            @Override
-                            public void onNetworksFoundEnhanced(List<NetworkInfo> networks) {
-                                Log.d(TAG, "📡 Streaming " + networks.size() + " enhanced WiFi networks to phone");
-                                // Send each batch of networks immediately as they're found
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(networks, false, scanId);
-                            }
-
-                            @Override
-                            public void onScanComplete(int totalNetworksFound) {
-                                Log.d(TAG, "📡 WiFi scan completed, total networks found: " + totalNetworksFound);
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
-                            }
-
-                            @Override
-                            public void onScanError(String error) {
-                                Log.e(TAG, "📡 WiFi scan error: " + error);
-                                // Send empty list on error to indicate scan failure
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
-                            }
-                        });
-                    } catch (Exception e) {
-                        Log.e(TAG, "Error scanning for WiFi networks", e);
-                        communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
-                    }
-                }).start();
-                return true;
-            } else {
+            if (networkManager == null) {
                 Log.e(TAG, "Network manager not available for WiFi scan");
                 // Terminal empty result so the phone fails fast instead of waiting
                 // out its scan timeout.
                 communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
                 return false;
             }
+            final ScanRun run;
+            synchronized (scanLock) {
+                if (activeScanRun != null) {
+                    // Single-flight: the system scan is global (every run's receiver
+                    // gets the same SCAN_RESULTS_AVAILABLE broadcast), so a second
+                    // concurrent run would stamp the same results with a second id
+                    // and could strand this request. Adopt the running scan instead:
+                    // the phone joins concurrent scan requests under one scanId, so
+                    // a second, DIFFERENT id implies the older phone request was
+                    // abandoned (cancelled/timed out) — swapping the newest id onto
+                    // all subsequent emissions (chunks + terminal) serves the only
+                    // live requester without double-sending chunks.
+                    if (scanId != null) {
+                        activeScanRun.scanId = scanId;
+                    }
+                    return true;
+                }
+                run = new ScanRun(scanId);
+                activeScanRun = run;
+            }
+            new Thread(() -> {
+                try {
+                    // Use streaming WiFi scan with callback for immediate results
+                    networkManager.scanWifiNetworks(new IWifiScanCallback() {
+                        @Override
+                        public void onNetworksFoundEnhanced(List<NetworkInfo> networks) {
+                            Log.d(TAG, "📡 Streaming " + networks.size() + " enhanced WiFi networks to phone");
+                            // Send each batch of networks immediately as they're found
+                            communicationManager.sendWifiScanResultsOverBleEnhanced(networks, false, scanRunId(run));
+                        }
+
+                        @Override
+                        public void onScanComplete(int totalNetworksFound) {
+                            Log.d(TAG, "📡 WiFi scan completed, total networks found: " + totalNetworksFound);
+                            communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, finishScanRun(run));
+                        }
+
+                        @Override
+                        public void onScanError(String error) {
+                            Log.e(TAG, "📡 WiFi scan error: " + error);
+                            // Send empty list on error to indicate scan failure
+                            communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, finishScanRun(run));
+                        }
+                    });
+                } catch (Exception e) {
+                    Log.e(TAG, "Error scanning for WiFi networks", e);
+                    communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, finishScanRun(run));
+                }
+            }).start();
+            return true;
         } catch (Exception e) {
             Log.e(TAG, "Error handling WiFi scan request", e);
             return false;
+        }
+    }
+
+    /** Read the run's current (possibly adopted) id to stamp on an emission. */
+    private String scanRunId(ScanRun run) {
+        synchronized (scanLock) {
+            return run.scanId;
+        }
+    }
+
+    /**
+     * Read the id for the run's terminal emission and release the single-flight
+     * slot, atomically: a request that arrives before the release adopts this run
+     * and its id rides on the terminal; one that arrives after starts a fresh
+     * scan. Idempotent so a late failure path can't clobber a newer run.
+     */
+    private String finishScanRun(ScanRun run) {
+        synchronized (scanLock) {
+            if (activeScanRun == run) {
+                activeScanRun = null;
+            }
+            return run.scanId;
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/WifiCommandHandler.java
@@ -66,7 +66,7 @@ public class WifiCommandHandler implements ICommandHandler {
                 case "request_wifi_status":
                     return handleRequestWifiStatus();
                 case "request_wifi_scan":
-                    return handleRequestWifiScan();
+                    return handleRequestWifiScan(data);
                 case "set_hotspot_state":
                     return handleSetHotspotState(data);
                 case "disconnect_wifi":
@@ -265,8 +265,13 @@ public class WifiCommandHandler implements ICommandHandler {
     /**
      * Handle request WiFi scan command
      */
-    public boolean handleRequestWifiScan() {
+    public boolean handleRequestWifiScan(JSONObject data) {
         try {
+            // Optional correlation id echoed in every wifi_scan_result chunk so the
+            // phone can tie results to this scan. Captured per request so overlapping
+            // scans each stamp their own chunks.
+            String requestedScanId = data.optString("scanId", "");
+            String scanId = requestedScanId.isEmpty() ? null : requestedScanId;
             INetworkManager networkManager = serviceManager.getNetworkManager();
             if (networkManager != null) {
                 new Thread(() -> {
@@ -277,30 +282,33 @@ public class WifiCommandHandler implements ICommandHandler {
                             public void onNetworksFoundEnhanced(List<NetworkInfo> networks) {
                                 Log.d(TAG, "📡 Streaming " + networks.size() + " enhanced WiFi networks to phone");
                                 // Send each batch of networks immediately as they're found
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(networks, false);
+                                communicationManager.sendWifiScanResultsOverBleEnhanced(networks, false, scanId);
                             }
 
                             @Override
                             public void onScanComplete(int totalNetworksFound) {
                                 Log.d(TAG, "📡 WiFi scan completed, total networks found: " + totalNetworksFound);
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true);
+                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
                             }
 
                             @Override
                             public void onScanError(String error) {
                                 Log.e(TAG, "📡 WiFi scan error: " + error);
                                 // Send empty list on error to indicate scan failure
-                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true);
+                                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
                             }
                         });
                     } catch (Exception e) {
                         Log.e(TAG, "Error scanning for WiFi networks", e);
-                        communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true);
+                        communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
                     }
                 }).start();
                 return true;
             } else {
                 Log.e(TAG, "Network manager not available for WiFi scan");
+                // Terminal empty result so the phone fails fast instead of waiting
+                // out its scan timeout.
+                communicationManager.sendWifiScanResultsOverBleEnhanced(new ArrayList<>(), true, scanId);
                 return false;
             }
         } catch (Exception e) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/media/managers/MediaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/media/managers/MediaManager.java
@@ -375,14 +375,17 @@ public class MediaManager implements IMediaManager {
             }
 
             @Override
-            public void onStreamError(String error, String streamId) {
-                Log.e(TAG, "Stream error: " + error);
+            public void onStreamError(String error, String streamId, boolean willRetry) {
+                Log.e(TAG, "Stream error: " + error + (willRetry ? " (will retry)" : ""));
                 try {
                     JSONObject status = new JSONObject();
                     status.put("type", "stream_status");
                     status.put("status", "error");
                     status.put("errorDetails", error);
                     if (streamId != null && !streamId.isEmpty()) status.put("streamId", streamId);
+                    // Additive field: the phone treats an id-carrying error as terminal
+                    // unless the glasses flag that a reconnect is already scheduled.
+                    if (willRetry) status.put("willRetry", true);
                     sendStreamStatusResponse(false, status);
                 } catch (JSONException e) {
                     Log.e(TAG, "Error creating stream error status", e);

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -542,7 +542,11 @@ public class Bridge private constructor() {
 
         /** Send WiFi scan results */
         @JvmStatic
-        fun updateWifiScanResults(networks: List<Map<String, Any>>, scanComplete: Boolean) {
+        fun updateWifiScanResults(
+                networks: List<Map<String, Any>>,
+                scanComplete: Boolean,
+                scanId: String? = null
+        ) {
             var storedNetworks: List<Map<String, Any>> =
                     DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
                             ?: emptyList()
@@ -557,6 +561,9 @@ public class Bridge private constructor() {
             val body = HashMap<String, Any>()
             body["networks"] = updatedNetworks
             body["scanComplete"] = scanComplete
+            if (scanId != null) {
+                body["scanId"] = scanId
+            }
             sendTypedMessage("wifi_scan_result", body)
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -550,6 +550,13 @@ public class Bridge private constructor() {
             var storedNetworks: List<Map<String, Any>> =
                     DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
                             ?: emptyList()
+            val lastScanId = DeviceStore.get("bluetooth", "wifiScanResultsScanId")
+            if (scanId != null && scanId != lastScanId) {
+                // First chunk of a new scan: drop networks accumulated for a previous scan
+                // so stale entries never carry over into this scan's store.
+                storedNetworks = emptyList()
+                DeviceStore.apply("bluetooth", "wifiScanResultsScanId", scanId)
+            }
             // add the networks to the storedNetworks array, removing duplicates by ssid
             val updatedNetworks = storedNetworks.toMutableList()
             for (network in networks) {
@@ -559,7 +566,9 @@ public class Bridge private constructor() {
             }
             DeviceStore.apply("bluetooth", "wifiScanResults", updatedNetworks)
             val body = HashMap<String, Any>()
-            body["networks"] = updatedNetworks
+            // Correlated scans: the SDK accumulates and dedupes chunks per scanId itself,
+            // so forward only this chunk; the merged store list is for UI consumers.
+            body["networks"] = if (scanId != null) networks else updatedNetworks
             body["scanComplete"] = scanComplete
             if (scanId != null) {
                 body["scanId"] = scanId

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/Bridge.kt
@@ -540,6 +540,18 @@ public class Bridge private constructor() {
             sendTypedMessage("wifi_status_change", payload)
         }
 
+        /**
+         * Claim the WiFi scan-results store for a newly requested scan. Called by the
+         * SDK when it generates the scanId, BEFORE the scan command goes out: store
+         * ownership is decided at request time, not by whichever chunk arrives first,
+         * so a delayed chunk from an older, abandoned scan can never reset or clobber
+         * the current scan's accumulator.
+         */
+        @JvmStatic
+        fun claimWifiScanResults(scanId: String) {
+            DeviceStore.apply("bluetooth", "wifiScanActiveScanId", scanId)
+        }
+
         /** Send WiFi scan results */
         @JvmStatic
         fun updateWifiScanResults(
@@ -547,24 +559,34 @@ public class Bridge private constructor() {
                 scanComplete: Boolean,
                 scanId: String? = null
         ) {
-            var storedNetworks: List<Map<String, Any>> =
-                    DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
-                            ?: emptyList()
-            val lastScanId = DeviceStore.get("bluetooth", "wifiScanResultsScanId")
-            if (scanId != null && scanId != lastScanId) {
-                // First chunk of a new scan: drop networks accumulated for a previous scan
-                // so stale entries never carry over into this scan's store.
-                storedNetworks = emptyList()
-                DeviceStore.apply("bluetooth", "wifiScanResultsScanId", scanId)
-            }
-            // add the networks to the storedNetworks array, removing duplicates by ssid
-            val updatedNetworks = storedNetworks.toMutableList()
-            for (network in networks) {
-                if (!updatedNetworks.any { it["ssid"] as? String == network["ssid"] as? String }) {
-                    updatedNetworks.add(network)
+            // Only chunks echoing the active scanId claimed at request time may mutate
+            // the store; foreign chunks are still forwarded to the SDK sink, which
+            // drops stale ids itself. Scan-id-less chunks (old firmware) keep the
+            // legacy accumulate-forever store behavior.
+            val ownsStore =
+                    scanId == null || scanId == DeviceStore.get("bluetooth", "wifiScanActiveScanId")
+            var updatedNetworks: List<Map<String, Any>> = networks
+            if (ownsStore) {
+                var storedNetworks: List<Map<String, Any>> =
+                        DeviceStore.get("bluetooth", "wifiScanResults") as? List<Map<String, Any>>
+                                ?: emptyList()
+                val lastScanId = DeviceStore.get("bluetooth", "wifiScanResultsScanId")
+                if (scanId != null && scanId != lastScanId) {
+                    // First chunk of a new scan: drop networks accumulated for a previous scan
+                    // so stale entries never carry over into this scan's store.
+                    storedNetworks = emptyList()
+                    DeviceStore.apply("bluetooth", "wifiScanResultsScanId", scanId)
                 }
+                // add the networks to the storedNetworks array, removing duplicates by ssid
+                val merged = storedNetworks.toMutableList()
+                for (network in networks) {
+                    if (!merged.any { it["ssid"] as? String == network["ssid"] as? String }) {
+                        merged.add(network)
+                    }
+                }
+                DeviceStore.apply("bluetooth", "wifiScanResults", merged)
+                updatedNetworks = merged
             }
-            DeviceStore.apply("bluetooth", "wifiScanResults", updatedNetworks)
             val body = HashMap<String, Any>()
             // Correlated scans: the SDK accumulates and dedupes chunks per scanId itself,
             // so forward only this chunk; the merged store list is for UI consumers.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -1556,10 +1556,10 @@ class DeviceManager {
         sgc?.sendStreamKeepAlive(message)
     }
 
-    fun requestWifiScan() {
+    fun requestWifiScan(scanId: String? = null) {
         Bridge.log("MAN: Requesting wifi scan")
         DeviceStore.apply("bluetooth", "wifiScanResults", emptyList<Any>())
-        sgc?.requestWifiScan()
+        sgc?.requestWifiScan(scanId)
     }
 
     fun sendIncidentId(incidentId: String, apiBaseUrl: String? = null) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -82,6 +82,18 @@ class MentraBluetoothSdk private constructor(
         private const val DEFAULT_STREAM_KEEP_ALIVE_INTERVAL_SECONDS = 5
         private const val MAX_MISSED_STREAM_KEEP_ALIVE_ACKS = 3
 
+        // Stream states the glasses only reach after start_stream has run past
+        // stopAllServices() — the point where every older start is actually
+        // preempted. ERROR and STOPPED are deliberately absent: an ERROR can be
+        // a command-level preflight rejection emitted before stopAllServices,
+        // and a STOPPED is a stop ack; neither proves older starts were killed.
+        private val PREEMPTION_PROVEN_STATES = setOf(
+            StreamState.INITIALIZING,
+            StreamState.RECONNECTING,
+            StreamState.RECONNECTED,
+            StreamState.STREAMING,
+        )
+
         @JvmStatic
         fun create(
             context: Context,
@@ -1552,7 +1564,16 @@ class MentraBluetoothSdk private constructor(
         val startMatch = matchingStreamStart(event)
         if (startMatch != null) {
             val (streamId, start) = startMatch
-            if (!event.streamId.isNullOrBlank()) {
+            // Preemption may only be inferred from states the glasses emit AFTER
+            // start_stream has run stopAllServices() (see PREEMPTION_PROVEN_STATES).
+            // ERROR must not fire it: a command-level preflight rejection (missing
+            // URL, low battery, no WiFi) carries this start's streamId but is sent
+            // BEFORE stopAllServices, so older starts were not preempted — and
+            // rejecting one that already resolved and started its keep-alive
+            // monitor would strand a live stream without keep-alives. STOPPED
+            // must not fire it either: it is the stop-ack shape and proves
+            // nothing about the start path having run.
+            if (!event.streamId.isNullOrBlank() && event.state in PREEMPTION_PROVEN_STATES) {
                 rejectPreemptedStreamStarts(start.seq)
             }
             when (event.state) {
@@ -1595,11 +1616,11 @@ class MentraBluetoothSdk private constructor(
     }
 
     // The glasses process BLE commands FIFO and every start_stream begins by
-    // stopping whatever runs, so an id-carrying status for start X (any state)
-    // proves every lower-seq start has already been preempted. Their
-    // only verdict on current firmware is a streamId-less stopped, which the
-    // id-less heuristic deliberately ignores — without this they would run out
-    // the 30s timeout instead of failing fast.
+    // stopping whatever runs, so an id-carrying status for start X in one of
+    // these states proves every lower-seq start has already been preempted.
+    // Their only verdict on current firmware is a streamId-less stopped, which
+    // the id-less heuristic deliberately ignores — without this they would run
+    // out the 30s timeout instead of failing fast.
     private fun rejectPreemptedStreamStarts(winnerSeq: Long) {
         for ((streamId, start) in pendingStreamStarts) {
             if (start.seq < winnerSeq && pendingStreamStarts.remove(streamId, start)) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -143,8 +143,12 @@ class MentraBluetoothSdk private constructor(
 
     private data class PendingWifiScan(
         val pending: PendingResponse<List<WifiScanResult>>,
+        val scanId: String,
         var latestResults: List<WifiScanResult> = emptyList(),
         var waiters: Int = 0,
+        // Chunks accumulated from scanId-echoing glasses, deduplicated by SSID;
+        // resolved only when the glasses flag the scan complete.
+        val accumulated: MutableList<WifiScanResult> = mutableListOf(),
     )
 
     private data class PendingWifiStatusRequest(
@@ -665,7 +669,7 @@ class MentraBluetoothSdk private constructor(
 
     suspend fun requestWifiScan(): List<WifiScanResult> {
         val pending = PendingResponse<List<WifiScanResult>>("WiFi scan request")
-        val request = PendingWifiScan(pending, waiters = 1)
+        val request = PendingWifiScan(pending, scanId = "scan-${UUID.randomUUID()}", waiters = 1)
         val existing =
             synchronized(oneShotLock) {
                 pendingWifiScan?.also { it.waiters++ } ?: run {
@@ -683,7 +687,7 @@ class MentraBluetoothSdk private constructor(
             }
         }
         try {
-            deviceManager.requestWifiScan()
+            deviceManager.requestWifiScan(request.scanId)
             // The glasses wait up to 15s for scan-results broadcasts before sending
             // scan_complete, so give them longer than that before falling back.
             return pending.await(WIFI_SCAN_TIMEOUT_MS)
@@ -1395,9 +1399,15 @@ class MentraBluetoothSdk private constructor(
                     data.containsKey("scanComplete") || data.containsKey("scan_complete")
                 val scanComplete =
                     (data["scanComplete"] as? Boolean) ?: (data["scan_complete"] as? Boolean) ?: false
-                updateWifiScanLatestResults(networks)
-                if (scanComplete || !hasCompletionFlag) {
-                    handleWifiScanResultsForRequests(networks)
+                val scanId = (data["scanId"] as? String)?.ifEmpty { null }
+                if (scanId != null) {
+                    handleCorrelatedWifiScanChunk(scanId, networks, scanComplete)
+                } else {
+                    // Old firmware: no correlation id, keep the pre-scanId heuristics.
+                    updateWifiScanLatestResults(networks)
+                    if (scanComplete || !hasCompletionFlag) {
+                        handleWifiScanResultsForRequests(networks)
+                    }
                 }
                 dispatchToListeners { it.onRawEvent(eventName, data) }
             }
@@ -1796,6 +1806,35 @@ class MentraBluetoothSdk private constructor(
             }
         }
         request.pending.resolve(results)
+    }
+
+    // scanId-echoing glasses: results for another scan are ignored instead of
+    // resolving the pending request, and matching chunks accumulate until the
+    // glasses flag the scan complete.
+    private fun handleCorrelatedWifiScanChunk(
+        scanId: String,
+        results: List<WifiScanResult>,
+        scanComplete: Boolean,
+    ) {
+        val request: PendingWifiScan
+        val accumulated: List<WifiScanResult>
+        synchronized(oneShotLock) {
+            request = pendingWifiScan?.takeIf { it.scanId == scanId } ?: return
+            for (network in results) {
+                if (request.accumulated.none { it.ssid == network.ssid }) {
+                    request.accumulated.add(network)
+                }
+            }
+            accumulated = request.accumulated.toList()
+            if (accumulated.isNotEmpty()) {
+                request.latestResults = accumulated
+            }
+            if (!scanComplete) return
+            if (pendingWifiScan === request) {
+                pendingWifiScan = null
+            }
+        }
+        request.pending.resolve(accumulated)
     }
 
     private fun updateWifiScanLatestResults(results: List<WifiScanResult>) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -687,6 +687,10 @@ class MentraBluetoothSdk private constructor(
             }
         }
         try {
+            // Claim the scan-results store for this scan before the command goes
+            // out, so a delayed chunk from an older, abandoned scan can no longer
+            // mutate it.
+            Bridge.claimWifiScanResults(request.scanId)
             deviceManager.requestWifiScan(request.scanId)
             // The glasses wait up to 15s for scan-results broadcasts before sending
             // scan_complete, so give them longer than that before falling back.

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G1.kt
@@ -1773,7 +1773,7 @@ class G1 : SGCManager() {
         return ""
     }
 
-    override fun requestWifiScan() {
+    override fun requestWifiScan(scanId: String?) {
 
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -3782,7 +3782,7 @@ class G2 : SGCManager() {
 
     // ---------- SGCManager: Network (G2 has no WiFi) ----------
 
-    override fun requestWifiScan() {}
+    override fun requestWifiScan(scanId: String?) {}
     override fun sendWifiCredentials(ssid: String, password: String) {}
     override fun forgetWifiNetwork(ssid: String) {}
     override fun sendHotspotState(enabled: Boolean) {}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Mach1.kt
@@ -350,7 +350,7 @@ class Mach1 : SGCManager() {
         destroy()
     }
 
-    override fun requestWifiScan() {
+    override fun requestWifiScan(scanId: String?) {
 
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -3245,7 +3245,8 @@ class MentraLive : SGCManager() {
 
                 val scanComplete =
                         json.optBoolean("scan_complete", json.optBoolean("scanComplete", false))
-                Bridge.updateWifiScanResults(networks, scanComplete)
+                val scanId = json.optString("scanId", "").ifEmpty { null }
+                Bridge.updateWifiScanResults(networks, scanComplete, scanId)
             }
             "token_status" -> {
                 // Process coreToken acknowledgment
@@ -4808,10 +4809,13 @@ class MentraLive : SGCManager() {
     /**
      * Request WiFi scan from the glasses This will ask the glasses to scan for available networks
      */
-    override fun requestWifiScan() {
+    override fun requestWifiScan(scanId: String?) {
         try {
             val json = JSONObject()
             json.put("type", "request_wifi_scan")
+            if (!scanId.isNullOrEmpty()) {
+                json.put("scanId", scanId)
+            }
             sendJson(json, true)
             Bridge.log("LIVE: Sending WiFi scan request to glasses")
         } catch (e: JSONException) {
@@ -7975,7 +7979,7 @@ class MentraLive : SGCManager() {
             val type = json.optString("type", "")
 
             when (type) {
-                "request_wifi_scan" -> requestWifiScan()
+                "request_wifi_scan" -> requestWifiScan(null)
                 "rgb_led_control_on", "rgb_led_control_off" -> {
                     // Forward LED control commands directly to glasses via BLE
                     Log.d(TAG, "💡 Forwarding LED control command to glasses: " + type)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraNex.kt
@@ -334,7 +334,7 @@ class MentraNex : SGCManager() {
     }
 
     // Network Management
-    override fun requestWifiScan () { Bridge.log("Nex: requestWifiScan operation not supported") }
+    override fun requestWifiScan (scanId: String?) { Bridge.log("Nex: requestWifiScan operation not supported") }
     override fun sendWifiCredentials(ssid: String, password: String) { Bridge.log("Nex: sendWifiCredentials operation not supported") }
     override fun forgetWifiNetwork(ssid: String) { }
     override fun sendHotspotState(enabled: Boolean) { Bridge.log("Nex: sendHotspotState operation not supported") }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Nimo.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Nimo.kt
@@ -1427,7 +1427,7 @@ class Nimo : SGCManager() {
 
     // ---------- SGCManager: Network (no WiFi) ----------
 
-    override fun requestWifiScan() {}
+    override fun requestWifiScan(scanId: String?) {}
     override fun sendWifiCredentials(ssid: String, password: String) {}
     override fun forgetWifiNetwork(ssid: String) {}
     override fun sendHotspotState(enabled: Boolean) {}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -296,7 +296,7 @@ abstract class SGCManager {
     abstract fun dbg2()
 
     // Network Management
-    abstract fun requestWifiScan()
+    abstract fun requestWifiScan(scanId: String?)
     abstract fun sendWifiCredentials(ssid: String, password: String)
     abstract fun forgetWifiNetwork(ssid: String)
     abstract fun sendHotspotState(enabled: Boolean)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/Simulated.kt
@@ -188,7 +188,7 @@ class Simulated : SGCManager() {
     override fun dbg2() {}
 
     // Network Management
-    override fun requestWifiScan() {
+    override fun requestWifiScan(scanId: String?) {
         Bridge.log("requestWifiScan")
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -431,6 +431,14 @@ class Bridge {
             MainActor.assumeIsolated {
                 var storedNetworks: [[String: Any]] =
                     DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
+                if let scanId,
+                   scanId != DeviceStore.shared.get("bluetooth", "wifiScanResultsScanId") as? String
+                {
+                    // First chunk of a new scan: drop networks accumulated for a previous scan
+                    // so stale entries never carry over into this scan's store.
+                    storedNetworks = []
+                    DeviceStore.shared.apply("bluetooth", "wifiScanResultsScanId", scanId)
+                }
                 // add the networks to the storedNetworks array, removing duplicates by ssid
                 for network in networks {
                     if !storedNetworks.contains(where: {
@@ -440,7 +448,12 @@ class Bridge {
                     }
                 }
                 DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
-                var body: [String: Any] = ["networks": storedNetworks, "scanComplete": scanComplete]
+                // Correlated scans: the SDK accumulates and dedupes chunks per scanId itself,
+                // so forward only this chunk; the merged store list is for UI consumers.
+                var body: [String: Any] = [
+                    "networks": scanId != nil ? networks : storedNetworks,
+                    "scanComplete": scanComplete,
+                ]
                 if let scanId {
                     body["scanId"] = scanId
                 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -418,6 +418,16 @@ class Bridge {
         Bridge.sendTypedMessage("wifi_status_change", body: body)
     }
 
+    /// Claim the WiFi scan-results store for a newly requested scan. Called by the
+    /// SDK when it generates the scanId, BEFORE the scan command goes out: store
+    /// ownership is decided at request time, not by whichever chunk arrives first,
+    /// so a delayed chunk from an older, abandoned scan can never reset or clobber
+    /// the current scan's accumulator.
+    @MainActor
+    static func claimWifiScanResults(scanId: String) {
+        DeviceStore.shared.apply("bluetooth", "wifiScanActiveScanId", scanId)
+    }
+
     static func updateWifiScanResults(
         _ networks: [[String: Any]],
         scanComplete: Bool,
@@ -429,29 +439,44 @@ class Bridge {
         // order of the serial bluetooth queue that delivers these.
         DispatchQueue.main.async {
             MainActor.assumeIsolated {
-                var storedNetworks: [[String: Any]] =
-                    DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
-                if let scanId,
-                   scanId != DeviceStore.shared.get("bluetooth", "wifiScanResultsScanId") as? String
-                {
-                    // First chunk of a new scan: drop networks accumulated for a previous scan
-                    // so stale entries never carry over into this scan's store.
-                    storedNetworks = []
-                    DeviceStore.shared.apply("bluetooth", "wifiScanResultsScanId", scanId)
+                // Only chunks echoing the active scanId claimed at request time may
+                // mutate the store; foreign chunks are still forwarded to the SDK
+                // sink, which drops stale ids itself. Scan-id-less chunks (old
+                // firmware) keep the legacy accumulate-forever store behavior.
+                let ownsStore: Bool
+                if let scanId {
+                    ownsStore =
+                        scanId == DeviceStore.shared.get("bluetooth", "wifiScanActiveScanId") as? String
+                } else {
+                    ownsStore = true
                 }
-                // add the networks to the storedNetworks array, removing duplicates by ssid
-                for network in networks {
-                    if !storedNetworks.contains(where: {
-                        $0["ssid"] as? String == network["ssid"] as? String
-                    }) {
-                        storedNetworks.append(network)
+                var updatedNetworks: [[String: Any]] = networks
+                if ownsStore {
+                    var storedNetworks: [[String: Any]] =
+                        DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
+                    if let scanId,
+                       scanId != DeviceStore.shared.get("bluetooth", "wifiScanResultsScanId") as? String
+                    {
+                        // First chunk of a new scan: drop networks accumulated for a previous scan
+                        // so stale entries never carry over into this scan's store.
+                        storedNetworks = []
+                        DeviceStore.shared.apply("bluetooth", "wifiScanResultsScanId", scanId)
                     }
+                    // add the networks to the storedNetworks array, removing duplicates by ssid
+                    for network in networks {
+                        if !storedNetworks.contains(where: {
+                            $0["ssid"] as? String == network["ssid"] as? String
+                        }) {
+                            storedNetworks.append(network)
+                        }
+                    }
+                    DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
+                    updatedNetworks = storedNetworks
                 }
-                DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
                 // Correlated scans: the SDK accumulates and dedupes chunks per scanId itself,
                 // so forward only this chunk; the merged store list is for UI consumers.
                 var body: [String: Any] = [
-                    "networks": scanId != nil ? networks : storedNetworks,
+                    "networks": scanId != nil ? networks : updatedNetworks,
                     "scanComplete": scanComplete,
                 ]
                 if let scanId {

--- a/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/Bridge.swift
@@ -418,9 +418,17 @@ class Bridge {
         Bridge.sendTypedMessage("wifi_status_change", body: body)
     }
 
-    static func updateWifiScanResults(_ networks: [[String: Any]], scanComplete: Bool) {
-        Task {
-            await MainActor.run {
+    static func updateWifiScanResults(
+        _ networks: [[String: Any]],
+        scanComplete: Bool,
+        scanId: String? = nil
+    ) {
+        // Correlated scans accumulate chunks until the terminal scan_complete, so
+        // chunks must reach the SDK in receive order. A Task per message can reach
+        // the MainActor out of creation order; DispatchQueue.main keeps the FIFO
+        // order of the serial bluetooth queue that delivers these.
+        DispatchQueue.main.async {
+            MainActor.assumeIsolated {
                 var storedNetworks: [[String: Any]] =
                     DeviceStore.shared.get("bluetooth", "wifiScanResults") as? [[String: Any]] ?? []
                 // add the networks to the storedNetworks array, removing duplicates by ssid
@@ -432,10 +440,11 @@ class Bridge {
                     }
                 }
                 DeviceStore.shared.apply("bluetooth", "wifiScanResults", storedNetworks)
-                Bridge.sendTypedMessage(
-                    "wifi_scan_result",
-                    body: ["networks": storedNetworks, "scanComplete": scanComplete]
-                )
+                var body: [String: Any] = ["networks": storedNetworks, "scanComplete": scanComplete]
+                if let scanId {
+                    body["scanId"] = scanId
+                }
+                Bridge.sendTypedMessage("wifi_scan_result", body: body)
             }
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1276,10 +1276,10 @@ struct ViewState {
         sgc?.sendStreamKeepAlive(message)
     }
 
-    func requestWifiScan() {
+    func requestWifiScan(scanId: String? = nil) {
         Bridge.log("MAN: Requesting wifi scan")
         DeviceStore.shared.apply("bluetooth", "wifiScanResults", [])
-        sgc?.requestWifiScan()
+        sgc?.requestWifiScan(scanId: scanId)
     }
 
     func sendIncidentId(_ incidentId: String, apiBaseUrl: String? = nil) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -686,6 +686,9 @@ public final class MentraBluetoothSDK {
         let pending = PendingResponse<[WifiScanResult]>(operation: "WiFi scan request")
         let request = PendingWifiScan(pending: pending, scanId: "scan-\(UUID().uuidString)")
         pendingWifiScan = request
+        // Claim the scan-results store for this scan before the command goes out,
+        // so a delayed chunk from an older, abandoned scan can no longer mutate it.
+        Bridge.claimWifiScanResults(scanId: request.scanId)
         DeviceManager.shared.requestWifiScan(scanId: request.scanId)
         let task = Task { @MainActor [weak self] () async throws -> [WifiScanResult] in
             defer {

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -201,8 +201,24 @@ public final class MentraBluetoothSDK {
             }
         }
         bridgeEventSinkId = Bridge.addEventSink { [weak self] eventName, data in
-            Task { @MainActor [weak self] in
-                self?.dispatchBridgeEvent(eventName, data)
+            // Bridge.dispatchEvent always invokes sinks on the main thread, in the
+            // FIFO order events were dispatched (correlated WiFi-scan chunks rely
+            // on that order). A fresh Task per event can reach the MainActor out
+            // of creation order and reorder chunks, so consume synchronously
+            // while still on main.
+            if Thread.isMainThread {
+                MainActor.assumeIsolated {
+                    self?.dispatchBridgeEvent(eventName, data)
+                }
+            } else {
+                // Defensive fallback only — Bridge.dispatchEvent should never take
+                // this path. A serial main-queue hop still preserves FIFO order,
+                // unlike an unstructured Task.
+                DispatchQueue.main.async {
+                    MainActor.assumeIsolated {
+                        self?.dispatchBridgeEvent(eventName, data)
+                    }
+                }
             }
         }
         storeListenerId = DeviceStore.shared.store.addListener { [weak self] category, changes in

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -42,10 +42,15 @@ private final class ActiveScanSession {
 @MainActor
 private final class PendingWifiScan {
     let pending: PendingResponse<[WifiScanResult]>
+    let scanId: String
     var latestResults: [WifiScanResult] = []
+    // Chunks accumulated from scanId-echoing glasses, deduplicated by SSID;
+    // resolved only when the glasses flag the scan complete.
+    var accumulated: [WifiScanResult] = []
 
-    init(pending: PendingResponse<[WifiScanResult]>) {
+    init(pending: PendingResponse<[WifiScanResult]>, scanId: String) {
         self.pending = pending
+        self.scanId = scanId
     }
 }
 
@@ -679,9 +684,9 @@ public final class MentraBluetoothSDK {
             return try await existing.value
         }
         let pending = PendingResponse<[WifiScanResult]>(operation: "WiFi scan request")
-        let request = PendingWifiScan(pending: pending)
+        let request = PendingWifiScan(pending: pending, scanId: "scan-\(UUID().uuidString)")
         pendingWifiScan = request
-        DeviceManager.shared.requestWifiScan()
+        DeviceManager.shared.requestWifiScan(scanId: request.scanId)
         let task = Task { @MainActor [weak self] () async throws -> [WifiScanResult] in
             defer {
                 if let self {
@@ -1612,6 +1617,28 @@ public final class MentraBluetoothSDK {
         request.pending.resolve(results)
     }
 
+    // scanId-echoing glasses: results for another scan are ignored instead of
+    // resolving the pending request, and matching chunks accumulate until the
+    // glasses flag the scan complete.
+    private func handleCorrelatedWifiScanChunk(
+        scanId: String,
+        results: [WifiScanResult],
+        scanComplete: Bool
+    ) {
+        guard let request = pendingWifiScan, request.scanId == scanId else { return }
+        for network in results where !request.accumulated.contains(where: { $0.ssid == network.ssid }) {
+            request.accumulated.append(network)
+        }
+        if !request.accumulated.isEmpty {
+            request.latestResults = request.accumulated
+        }
+        guard scanComplete else { return }
+        if pendingWifiScan === request {
+            pendingWifiScan = nil
+        }
+        request.pending.resolve(request.accumulated)
+    }
+
     private func updateWifiScanLatestResults(_ results: [WifiScanResult]) {
         guard !results.isEmpty else { return }
         pendingWifiScan?.latestResults = results
@@ -1823,9 +1850,15 @@ public final class MentraBluetoothSDK {
             let networks = (data["networks"] as? [[String: Any]])?.map(WifiScanResult.init(values:)) ?? []
             let hasCompletionFlag = data.keys.contains("scanComplete") || data.keys.contains("scan_complete")
             let scanComplete = data["scanComplete"] as? Bool ?? data["scan_complete"] as? Bool ?? false
-            updateWifiScanLatestResults(networks)
-            if scanComplete || !hasCompletionFlag {
-                handleWifiScanResultsForRequests(networks)
+            let scanId = (data["scanId"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+            if let scanId {
+                handleCorrelatedWifiScanChunk(scanId: scanId, results: networks, scanComplete: scanComplete)
+            } else {
+                // Old firmware: no correlation id, keep the pre-scanId heuristics.
+                updateWifiScanLatestResults(networks)
+                if scanComplete || !hasCompletionFlag {
+                    handleWifiScanResultsForRequests(networks)
+                }
             }
             delegate?.mentraBluetoothSDK(self, didReceive: .raw(name: "wifi_scan_result", values: data))
         case "hotspot_error":

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G1.swift
@@ -300,7 +300,7 @@ class G1: NSObject, SGCManager {
 
     func setSilentMode(_: Bool) {}
 
-    func requestWifiScan() {}
+    func requestWifiScan(scanId _: String?) {}
 
     func sendWifiCredentials(_: String, _: String) {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -3975,7 +3975,7 @@ class G2: NSObject, SGCManager {
 
     // MARK: - SGCManager: Network (G2 has no WiFi)
 
-    func requestWifiScan() {}
+    func requestWifiScan(scanId _: String?) {}
     func sendWifiCredentials(_: String, _: String) {}
     func forgetWifiNetwork(_: String) {}
     func sendHotspotState(_: Bool) {}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Mach1.swift
@@ -55,7 +55,7 @@ class Mach1: UltraliteBaseViewController, SGCManager {
         )
     }
 
-    func requestWifiScan() {}
+    func requestWifiScan(scanId _: String?) {}
 
     func sendWifiCredentials(_: String, _: String) {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -2947,9 +2947,12 @@ class MentraLive: NSObject, SGCManager {
 
     // commands to send to the glasses:
 
-    func requestWifiScan() {
+    func requestWifiScan(scanId: String?) {
         Bridge.log("LIVE: Requesting WiFi scan from glasses")
-        let json: [String: Any] = ["type": "request_wifi_scan"]
+        var json: [String: Any] = ["type": "request_wifi_scan"]
+        if let scanId, !scanId.isEmpty {
+            json["scanId"] = scanId
+        }
         sendJson(json, wakeUp: true)
     }
 
@@ -3189,7 +3192,8 @@ class MentraLive: NSObject, SGCManager {
         }
 
         let scanComplete = json["scan_complete"] as? Bool ?? json["scanComplete"] as? Bool ?? false
-        Bridge.updateWifiScanResults(networks, scanComplete: scanComplete)
+        let scanId = (json["scanId"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        Bridge.updateWifiScanResults(networks, scanComplete: scanComplete, scanId: scanId)
     }
 
     private func handleButtonPress(_ json: [String: Any]) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraNex.swift
@@ -376,7 +376,7 @@ class MentraNexSGC: NSObject, CBCentralManagerDelegate, CBPeripheralDelegate, SG
     func dbg1() {}
     func dbg2() {}
 
-    func requestWifiScan() {}
+    func requestWifiScan(scanId _: String?) {}
 
     func sendWifiCredentials(_: String, _: String) {}
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Nimo.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Nimo.swift
@@ -1066,7 +1066,7 @@ class Nimo: NSObject, SGCManager {
 
     // MARK: - SGCManager: Network (no WiFi)
 
-    func requestWifiScan() {}
+    func requestWifiScan(scanId _: String?) {}
     func sendWifiCredentials(_: String, _: String) {}
     func forgetWifiNetwork(_: String) {}
     func sendHotspotState(_: Bool) {}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -184,7 +184,7 @@ protocol SGCManager {
 
     // MARK: - Network Management
 
-    func requestWifiScan()
+    func requestWifiScan(scanId: String?)
     func sendWifiCredentials(_ ssid: String, _ password: String)
     func forgetWifiNetwork(_ ssid: String)
     func sendHotspotState(_ enabled: Bool)

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/Simulated.swift
@@ -226,7 +226,7 @@ class Simulated: SGCManager {
 
     // MARK: - Network Management
 
-    func requestWifiScan() {
+    func requestWifiScan(scanId _: String?) {
         Bridge.log("requestWifiScan")
     }
 


### PR DESCRIPTION
Follow-up to #3474 (stacked on `isaiah/os-1714-suspend-bluetooth-asyncfunctions`). Closes the protocol correlation gaps surfaced in that PR's review: stream stop/rejection statuses and WiFi scan results carried no id on the wire, so the phone could only attribute them heuristically. Every new field is additive and optional — old phone + new glasses ignores them, new phone + old glasses falls back to exactly today's heuristics. No firmware version gating.

Hardware background (Mentra Live via the glasses' command intent): a stream started with `streamId:testA` emitted its preemption `stopped` with **no** streamId; command-level start rejections (missing URL, battery low, no WiFi) are id-less too; `wifi_scan_result` chunks carry only `timestamp` + `networks`.

Glasses (`asg_client`):

- **Carry streamId on stream stop and rejection statuses.** `handleStartCommand` hoists the `streamId` parse ahead of every early rejection and echoes it in those error statuses; `handleStopCommand`'s `stopping` carries the active stream's id. Root cause of the id-less `stopped` fixed in all three services: RTMP/SRT cleared `mCurrentStreamId` (timeout-cancel + state reset) before `onStreamStopped` fired — the id is now captured at stop entry; WHIP's `notifyStopped` read the field inside a main-handler runnable that could run after a newer start overwrote it — captured at call time.
- **Echo request scanId in every wifi_scan_result chunk.** `request_wifi_scan` accepts an optional `scanId`, captured as a local and closed over by the scan callback, so each scan's chunks are stamped with the id of the request that started *that* scan (no shared mutable field — overlapping scans can't cross-stamp, which was a review finding against the first cut). The network-manager-unavailable path now sends a terminal empty `scanComplete` message instead of letting the phone wait out its timeout.

Phone (`mobile/modules/bluetooth-sdk`, Android + iOS mirrored):

- **Correlate WiFi scans with a generated scanId.** `requestWifiScan` sends `scan-<uuid>`; results carrying a different scanId are ignored (the stale-association from #3474 discussion r3606439346), matching chunks accumulate (deduped by SSID) and resolve on `scanComplete` — fixing the first-chunk truncation where the phone resolved on the first 4-network chunk. Results with no scanId (old firmware) keep today's behavior unchanged. Other SGC implementations get ignoring stubs for the new parameter.
- **iOS chunk ordering made sound.** Accumulate-until-complete makes ordering load-bearing; the per-message unstructured `Task` hop could reorder chunks onto the MainActor. Replaced with `DispatchQueue.main.async` + `MainActor.assumeIsolated` (chunks originate on the serial bluetooth queue; serial→main dispatch is FIFO; same pattern as `BluetoothSdkModule.readOnMainActor`).

Stream side needs no phone-side changes: the existing exact-match routing plus the preemption rejection landed on #3474 already consume echoed ids. Behavior note: with new firmware, a preempted start fast-fails via its own id-echoed `stopped` (`stream_start_failed`) slightly before the newer start's `initializing` would have rejected it with `stream_preempted`; both are fast and accurate, the code just prefers the earlier signal.

Verification:
- `scripts/check-android-compile.sh asg` — BUILD SUCCESSFUL.
- `scripts/check-android-compile.sh bluetooth-sdk` — BUILD SUCCESSFUL.
- iOS: SPM export + `xcodebuild -scheme MentraBluetoothSDK` — BUILD SUCCEEDED.
- On-device verification of the streamId echo and a correlated scan on real glasses still pending (needs an asg_client build flashed).

Related: OS-1714, PR #3474 discussion threads r3605504628 / r3606439346.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes livestream BLE status semantics and WiFi scan correlation across glasses and mobile SDKs; fields are optional but mis-correlation could affect stream UI and provisioning flows.
> 
> **Overview**
> Adds **additive wire correlation** so the phone can attribute stream and WiFi events to the right request without changing behavior for old firmware or clients.
> 
> **Streaming (glasses):** Start rejections and **stopping** statuses now echo the command’s **`streamId`**. RTMP/SRT capture **`stoppedStreamId`** at stop entry so **`onStreamStopped`** and async stop failures still name the stream after timeout cancel or a newer start overwrites **`mCurrentStreamId`**; WHIP does the same when posting **`onStreamStopped`**. **`StreamingStatusCallback.onStreamError`** gains **`willRetry`** (default overload unchanged); RTMP/SRT pass **`true`** only where **`scheduleReconnect`** runs after start failures. **`MediaManager`** forwards **`willRetry`** on stream error BLE status.
> 
> **WiFi scan (glasses + SDK):** **`request_wifi_scan`** accepts optional **`scanId`**, echoed on every **`wifi_scan_result`** chunk; single-flight scan can **adopt** a newer id for concurrent requests. **`CommunicationManager`** centralizes scan result envelopes; unavailable network manager sends a terminal empty result instead of hanging.
> 
> **Bluetooth SDK (Android/iOS):** Generates **`scan-<uuid>`**, **`claimWifiScanResults`** before sending the command, accumulates/dedupes chunks per id until **`scanComplete`**, ignores stale ids; Bridge only mutates the device store for the active scan and forwards per-chunk payloads when correlated. iOS avoids reordering chunks via main-queue FIFO dispatch instead of per-message **`Task`** hops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4049194d8014a5521213204ed34b02bbc9d555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

---

**Update (review round):**
- WiFi scan chunk forwarding is now scoped to the requesting scan: with a scanId, the Bridge forwards only the incoming chunk (the SDK owns accumulation/dedup) and the DeviceStore UI accumulator resets whenever the scanId changes, so a previous scan's delayed chunks can't leak into the current scan's payload (12f79eb9d7, both platforms).
- New additive protocol field `willRetry` on stream `error` statuses: emitted only at the call sites that schedule a reconnect (RTMP/SRT `start_error`/`start_exception`; all other `onStreamError` sites enumerated and classified terminal — WHIP's reconnect path never emits errors). The phone side consuming it lands in #3487; absent field = terminal, matching old-firmware behavior (1a01e414e5).
