### PR TITLE
Revive Fixes 56 PR

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/G2.kt
@@ -575,16 +575,18 @@ private object DevSettingsProto {
     /// TimeSync submessage: f1 = (Unix seconds + TZ offset seconds) as Int32, no TZ field.
     /// Firmware appears to ignore the TZ field, so we pre-shift the timestamp itself
     /// to make UTC interpretation read as local. Empirically confirmed via probe variants in dbg1().
-    fun timeSync(magicRandom: Int): ByteArray {
+    fun timeSync(
+        magicRandom: Int,
+        timestampMs: Long = System.currentTimeMillis()
+    ): ByteArray {
         val w = ProtobufWriter()
         w.writeInt32Field(1, DevCfgCommandId.TIME_SYNC.value)
         w.writeInt32Field(2, magicRandom)
 
         val tsW = ProtobufWriter()
-        val nowMs = System.currentTimeMillis()
-        val nowSec = nowMs / 1000
-        val tzSec = (TimeZone.getDefault().getOffset(nowMs) / 1000).toLong()
-        tsW.writeInt32Field(1, (nowSec + tzSec).toInt())
+        val timestampSec = timestampMs / 1000
+        val tzSec = (TimeZone.getDefault().getOffset(timestampMs) / 1000).toLong()
+        tsW.writeInt32Field(1, (timestampSec + tzSec).toInt())
         w.writeMessageField(128, tsW.toByteArray())
         return w.toByteArray()
     }
@@ -1707,7 +1709,7 @@ class G2 : SGCManager() {
                 payload = payload,
                 reserveFlag = true
             )
-        sendToGlasses(packets)
+        sendToGlasses(packets, left = true, right = true)
     }
 
     // ---------- Authentication Sequence ----------
@@ -1732,7 +1734,7 @@ class G2 : SGCManager() {
 
         delay(200)
         val timeSync = DevSettingsProto.timeSync(sendManager.nextMagicRandom())
-        sendDevSettingsCommand(timeSync)
+        sendDevSettingsCommand(timeSync, left = true, right = true)
 
         // Skip onboarding on connect
         delay(200)
@@ -3763,7 +3765,12 @@ class G2 : SGCManager() {
     /// time-zone travel, or a long sleep where the glasses' clock has drifted.
     fun syncTime() {
         Bridge.log("G2: syncTime()")
-        val msg = DevSettingsProto.timeSync(sendManager.nextMagicRandom())
+        sendSetSystemTime(System.currentTimeMillis())
+    }
+
+    override fun sendSetSystemTime(timestampMs: Long) {
+        Bridge.log("G2: sendSetSystemTime()")
+        val msg = DevSettingsProto.timeSync(sendManager.nextMagicRandom(), timestampMs)
         sendDevSettingsCommand(msg, left = true, right = true)
     }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/SGCManager.kt
@@ -301,7 +301,7 @@ abstract class SGCManager {
     abstract fun forgetWifiNetwork(ssid: String)
     abstract fun sendHotspotState(enabled: Boolean)
 
-    /** Set glasses system clock (Mentra Live only; no-op on other devices). */
+    /** Set glasses system clock (Mentra Live and G2; no-op on other devices). */
     open fun sendSetSystemTime(timestampMs: Long) {
         Bridge.log("SGC: sendSetSystemTime not supported on $type")
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -587,15 +587,19 @@ private enum DevSettingsProto {
     /// TimeSync submessage: f1 = (Unix seconds + TZ offset seconds) as Int32, no TZ field.
     /// Firmware appears to ignore the TZ field, so we pre-shift the timestamp itself
     /// to make UTC interpretation read as local. Empirically confirmed via probe variants in dbg1().
-    static func timeSync(magicRandom: Int32) -> Data {
+    static func timeSync(
+        magicRandom: Int32,
+        timestampMs: Int64 = Int64(Date().timeIntervalSince1970 * 1000)
+    ) -> Data {
         var w = ProtobufWriter()
         w.writeInt32Field(1, DevCfgCommandId.timeSync.rawValue)
         w.writeInt32Field(2, magicRandom)
 
         var tsW = ProtobufWriter()
-        let nowSec = Int64(Date().timeIntervalSince1970)
-        let tzSec = Int64(TimeZone.current.secondsFromGMT())
-        tsW.writeInt32Field(1, Int32(truncatingIfNeeded: nowSec + tzSec))
+        let timestamp = Date(timeIntervalSince1970: Double(timestampMs) / 1000)
+        let timestampSec = timestampMs / 1000
+        let tzSec = Int64(TimeZone.current.secondsFromGMT(for: timestamp))
+        tsW.writeInt32Field(1, Int32(truncatingIfNeeded: timestampSec + tzSec))
         w.writeMessageField(128, tsW.data)  // timeSync (field 128 in DevCfgDataPackage)
         return w.data
     }
@@ -1908,7 +1912,7 @@ class G2: NSObject, SGCManager {
         let timeSync = DevSettingsProto.timeSync(
             magicRandom: self.sendManager.nextMagicRandom()
         )
-        self.sendDevSettingsCommand(timeSync)
+        self.sendDevSettingsCommand(timeSync, left: true, right: true)
 
         // Skip onboarding on connect
         try? await Task.sleep(nanoseconds: 200_000_000)
@@ -3941,7 +3945,15 @@ class G2: NSObject, SGCManager {
     /// time-zone travel, or a long sleep where the glasses' clock has drifted.
     func syncTime() {
         Bridge.log("G2: syncTime()")
-        let msg = DevSettingsProto.timeSync(magicRandom: sendManager.nextMagicRandom())
+        sendSetSystemTime(Int64(Date().timeIntervalSince1970 * 1000))
+    }
+
+    func sendSetSystemTime(_ timestampMs: Int64) {
+        Bridge.log("G2: sendSetSystemTime()")
+        let msg = DevSettingsProto.timeSync(
+            magicRandom: sendManager.nextMagicRandom(),
+            timestampMs: timestampMs
+        )
         sendDevSettingsCommand(msg, left: true, right: true)
     }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/SGCManager.swift
@@ -362,7 +362,7 @@ extension SGCManager {
 
     func sendVoiceActivityDetectionSetting() {}
 
-    /// Default no-op; Mentra Live overrides when phone detects clock skew during gallery sync.
+    /// Default no-op; Mentra Live and G2 override to handle phone-detected clock skew.
     func sendSetSystemTime(_: Int64) {
         Bridge.log("SGC: sendSetSystemTime not supported")
     }

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -117,7 +117,7 @@ declare class BluetoothSdkNativeModule extends NativeModule<BluetoothSdkModuleEv
   sendWifiCredentials(ssid: string, password: string): Promise<WifiStatusChangeEvent>
   forgetWifiNetwork(ssid: string): Promise<WifiStatusChangeEvent>
   setHotspotState(enabled: boolean): Promise<HotspotStatusChangeEvent>
-  /** Set glasses system clock (Mentra Live only) when phone detects clock skew. */
+  /** Set the glasses system clock when phone detects clock skew (Mentra Live and G2). */
   setSystemTime(timestampMs: number): Promise<void>
   /** Logs current WiFi frequency (MHz) and 5 GHz band to Android logcat. */
   logCurrentWifiFrequency(): Promise<void>


### PR DESCRIPTION
## Summary

- send the G2 authentication-time clock sync command to both buds on Android and iOS
- support runtime `setSystemTime(timestampMs)` correction for G2 on both platforms, preserving the caller-provided timestamp and applying the timezone offset for that instant
- route Android G2 dashboard commands to both buds, matching the existing iOS behavior and covering Schedule/calendar updates

## Why

PR #3234 contained a useful dual-bud clock-sync fix, but the rest of that PR has been superseded. Current clock-skew correction already calls the shared native `setSystemTime` path, but G2 did not implement it. Android dashboard commands also remained right-bud-only while iOS sent them to both buds.

This extracts the still-relevant behavior into one focused cross-platform change without reviving the obsolete calendar-store or calendar-contract changes from #3234.

## Impact

G2 receives consistent clock synchronization during connection and runtime correction, and Android dashboard/Schedule payload routing now matches iOS.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `xcodebuild -workspace ios/Mentra.xcworkspace -scheme MentraBluetoothSDK -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`

Hardware validation on a physical G2 is still recommended for dual-bud clock display and Android Schedule/calendar behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves G2 clock sync and aligns Android routing with iOS. Time sync and dashboard commands now go to both buds, and G2 supports runtime `setSystemTime(timestampMs)` with proper timezone handling.

- **New Features**
  - Add cross-platform runtime `setSystemTime(timestampMs)` for G2; preserves the provided timestamp and applies the timezone offset for that moment.

- **Bug Fixes**
  - Send G2 auth-time TimeSync to both buds on Android and iOS.
  - Route Android G2 dashboard/Schedule updates to both buds to match iOS.

<sup>Written for commit 224352b83f06b52c0c8949c76c614a42e670e033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dual-bud BLE routing and device clock sync at connect and runtime; scope is G2-specific with no auth changes, but incorrect time or one-sided routing could affect dashboard/schedule display until validated on hardware.
> 
> **Overview**
> **G2 clock sync** now hits **both buds** during auth and whenever the shared `setSystemTime(timestampMs)` path runs. `DevSettingsProto.timeSync` accepts an optional timestamp and applies the **timezone offset for that instant** (not only “now”), so skew correction from the phone can pass through unchanged.
> 
> On **Android**, **dashboard** commands (including Schedule/calendar pushes) are sent **left + right**, matching iOS instead of defaulting to the right bud only. `syncTime()` delegates to `sendSetSystemTime`; docs note G2 implements the same API as Mentra Live for runtime clock correction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224352b83f06b52c0c8949c76c614a42e670e033. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->