### PR TITLE
Harden Mentra Live UART recovery and direct-boot startup

### DIFF
--- a/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorBenchmarkTest.java
+++ b/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorBenchmarkTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertNotNull;
 import android.util.Log;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -24,7 +25,10 @@ public class MlKitTextRoiDetectorBenchmarkTest {
         assertNotNull(jpeg);
 
         for (int longEdge : new int[] {480, 640, 800, 960, 1280}) {
-            try (MlKitTextRoiDetector detector = new MlKitTextRoiDetector(longEdge)) {
+            try (MlKitTextRoiDetector detector =
+                    new MlKitTextRoiDetector(
+                            InstrumentationRegistry.getInstrumentation().getTargetContext(),
+                            longEdge)) {
                 detector.warmUp();
                 for (int run = 1; run <= 3; run++) {
                     MlKitTextRoiDetector.Detection result = detector.detect(jpeg);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -118,6 +118,9 @@ public class AsgConstants {
     /** Time allowed for BES to reboot at the rendezvous baud after applying an OTA image. */
     public static final long BES_OTA_RECONNECT_DELAY_MS = 2500;
 
+    /** Bounded rendezvous attempts after BES OTA while the controller finishes rebooting. */
+    public static final int BES_OTA_RECONNECT_ATTEMPTS = 6;
+
     // RGB LED Control Constants (Glasses BES Chipset - Remote Control via Bluetooth)
     // NOTE: These are different from the local MTK recording LED
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -100,6 +100,24 @@ public class AsgConstants {
      */
     public static final long BES_OTA_RESPONSE_TIMEOUT_MS = 30000;
 
+    /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
+    public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
+
+    /** Delay before retrying boot recovery when baud negotiation or BES OTA temporarily owns UART. */
+    public static final long UART_BOOT_RECOVERY_RETRY_DELAY_MS = 3000;
+
+    /** Number of spaced system-version probes used to tolerate short BES UART restart windows. */
+    public static final int UART_RECOVERY_PROBES_PER_BURST = 5;
+
+    /** Spacing between UART recovery probes. */
+    public static final long UART_RECOVERY_PROBE_SPACING_MS = 400;
+
+    /** Maximum wait for the old-baud {@code sr_baud} acknowledgement before probing target baud. */
+    public static final long UART_BAUD_ACK_TIMEOUT_MS = 1000;
+
+    /** Time allowed for BES to reboot at the rendezvous baud after applying an OTA image. */
+    public static final long BES_OTA_RECONNECT_DELAY_MS = 2500;
+
     // RGB LED Control Constants (Glasses BES Chipset - Remote Control via Bluetooth)
     // NOTE: These are different from the local MTK recording LED
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bes/BesOtaManager.java
@@ -1122,6 +1122,9 @@ public class BesOtaManager implements IBesOtaController, BesOtaUartListener, Bes
             if (msg.len == 1 && msg.body != null && msg.body[0] == 1) {
                 Log.i(TAG, "BES firmware update SUCCESS! BES will reboot.");
                 EventBus.getDefault().post(BesOtaProgressEvent.createFinished());
+                if (comManager != null) {
+                    comManager.notifyBesOtaApplied();
+                }
             } else {
                 Log.e(TAG, "Apply firmware error");
                 EventBus.getDefault()

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/SerialListener.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/interfaces/SerialListener.java
@@ -32,4 +32,7 @@ public interface SerialListener {
      * @param serialPath The path to the serial port
      */
     void onSerialClose(String serialPath);
-} 
+
+    /** Called after BES accepts an OTA image and begins rebooting at its default UART baud. */
+    default void onBesOtaApplied() {}
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -18,6 +18,7 @@ import com.mentra.asg_client.reporting.domains.BluetoothReporting;
 import com.mentra.asg_client.service.core.AsgClientService;
 import com.mentra.asg_client.service.core.processors.ChunkReassembler;
 import com.mentra.asg_client.service.core.processors.ChunkedMessageProtocolStrategy;
+import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.utils.WakeLockManager;
 
 import org.json.JSONObject;
@@ -33,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BooleanSupplier;
 
 /**
  * Implementation of IBluetoothManager for K900 devices. Uses the K900's serial port to communicate
@@ -163,6 +165,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     /** True between sending cs_baud and receiving sr_baud (guards spurious sr_baud). */
     private boolean baudSwitchWaitingSrBaud = false;
 
+    private ScheduledFuture<?> baudAckTimeoutFuture = null;
+
     // Boot-time baud recovery: if asg restarts after a previous baud switch, the BES
     // is still at the high rate while we reopen at the 460800 default - the link is
     // silent until something hunts for the right rate. The default rate has already
@@ -170,11 +174,10 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // If the firmware does not implement cs_syvr, return to the default instead of
     // rotating rates forever and corrupting otherwise healthy phone traffic.
     private static final int[] BOOT_BAUD_CANDIDATES = {TARGET_UART_BAUD};
-    private static final int BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
-    private static final int BOOT_RECOVERY_STEP_MS = 3000;
     private volatile long lastSrSyvrTime = 0;
     private int bootRecoveryAttempts = 0;
-    private java.util.concurrent.ScheduledFuture<?> bootRecoveryFuture;
+    private ScheduledFuture<?> bootRecoveryFuture;
+    private int recoveryProbeGeneration = 0;
 
     /** True between reopening at TARGET_UART_BAUD and the sr_syvr probe answer. */
     private boolean baudProbePending = false;
@@ -267,16 +270,14 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         notificationManager = new DebugNotificationManager(context);
         notificationManager.showDeviceTypeNotification(true);
 
+        // Initialize every callback dependency before the serial receive thread starts.
+        messageParser = new BesMessageParser();
+        fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
+
         // Create the communication manager
         comManager = new SerialPortBridge(context);
         comManager.registerListener(this);
         comManager.start();
-
-        // Create the message parser to handle fragmented messages
-        messageParser = new BesMessageParser();
-
-        // Initialize file transfer executor
-        fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
 
         // Boot-time baud recovery: if a previous asg run switched the BES to a high
         // baud and asg restarted, we come up at 460800 against a fast BES and the
@@ -285,7 +286,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             bootRecoveryFuture =
                     baudSwitchExecutor.schedule(
                             this::bootBaudRecoveryTick,
-                            BOOT_RECOVERY_INITIAL_DELAY_MS,
+                            AsgConstants.UART_BOOT_RECOVERY_INITIAL_DELAY_MS,
                             TimeUnit.MILLISECONDS);
         }
     }
@@ -298,9 +299,17 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Integer candidate = null;
         boolean settleAtDefault = false;
         synchronized (baudSwitchLock) {
-            if (baudProbePending || comManager.mbOtaUpdating) {
+            if (baudProbePending || baudSwitchWaitingSrBaud || comManager.isOtaUpdating()) {
+                scheduleBootRecoveryLocked(AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS);
+                return; // A switch/OTA is mid-flight; retry after it releases UART.
+            }
+            if (!cachedBesSupportsBaudSwitch()) {
                 bootRecoveryFuture = null;
-                return; // A switch/OTA is mid-flight; stay out of its way.
+                Log.i(
+                        BAUD_TAG,
+                        "Boot recovery: no cached high-baud-capable BES; staying at rendezvous "
+                                + SerialPortBridge.DEFAULT_BAUDRATE);
+                return;
             }
             if (bootRecoveryAttempts >= BOOT_BAUD_CANDIDATES.length) {
                 bootRecoveryFuture = null;
@@ -323,20 +332,56 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + BOOT_BAUD_CANDIDATES.length
                         + ")");
         try {
-            comManager.reopen(candidate);
-            requestBesSystemVersion();
+            messageParser.clear();
+            boolean reopened = comManager.reopen(candidate);
+            if (reopened) {
+                int generation;
+                synchronized (baudSwitchLock) {
+                    generation = ++recoveryProbeGeneration;
+                }
+                scheduleVersionProbeBurst(
+                        candidate,
+                        generation,
+                        () -> lastSrSyvrTime == 0,
+                        "boot_recovery");
+            }
         } catch (Exception e) {
             Log.e(BAUD_TAG, "Boot recovery reopen failed at " + candidate, e);
         }
         synchronized (baudSwitchLock) {
             if (lastSrSyvrTime == 0) {
-                bootRecoveryFuture =
-                        baudSwitchExecutor.schedule(
-                                this::bootBaudRecoveryTick,
-                                BOOT_RECOVERY_STEP_MS,
-                                TimeUnit.MILLISECONDS);
+                scheduleBootRecoveryLocked(AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS);
             }
         }
+    }
+
+    /** The alternate-rate boot probe is safe only after this installation saw capable firmware. */
+    private boolean cachedBesSupportsBaudSwitch() {
+        try {
+            String cachedVersion = new AsgSettings(context).getBesFirmwareVersion();
+            return shouldProbeAlternateBaud(cachedVersion);
+        } catch (Exception e) {
+            Log.w(BAUD_TAG, "Could not read cached BES version; staying at rendezvous baud", e);
+            return false;
+        }
+    }
+
+    /** Pure compatibility gate for the boot-only alternate-baud probe. */
+    static boolean shouldProbeAlternateBaud(String cachedVersion) {
+        return cachedVersion != null
+                && !cachedVersion.trim().isEmpty()
+                && compareDottedVersions(
+                                cachedVersion.trim(), MIN_BES_VERSION_FOR_BAUD_SWITCH)
+                        >= 0;
+    }
+
+    /** Must be called with baudSwitchLock held. */
+    private void scheduleBootRecoveryLocked(long delayMs) {
+        if (bootRecoveryFuture != null) {
+            bootRecoveryFuture.cancel(false);
+        }
+        bootRecoveryFuture =
+                baudSwitchExecutor.schedule(this::bootBaudRecoveryTick, delayMs, TimeUnit.MILLISECONDS);
     }
 
     /** Finish a failed boot probe at the known-safe baud without scheduling another hunt. */
@@ -350,6 +395,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return;
         }
         try {
+            messageParser.clear();
             boolean reopened = comManager.reopen(defaultBaud);
             if (reopened) {
                 Log.w(
@@ -1076,8 +1122,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         // Shutdown the baud switch executor (cancels any pending reopen/probe timers)
         synchronized (baudSwitchLock) {
+            recoveryProbeGeneration++;
+            baudSwitchWaitingSrBaud = false;
             baudProbePending = false;
+            cancelBaudAckTimeoutLocked();
             cancelBaudProbeTimeoutLocked();
+            if (bootRecoveryFuture != null) {
+                bootRecoveryFuture.cancel(false);
+                bootRecoveryFuture = null;
+            }
         }
         baudSwitchExecutor.shutdownNow();
 
@@ -1113,13 +1166,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.i(TAG, "🔧 Requesting BES system version (cs_syvr) via UART");
 
         try {
-            // Build K900 command format: {"C":"cs_syvr","V":1,"B":""}
-            org.json.JSONObject k900Command = new org.json.JSONObject();
-            k900Command.put("C", "cs_syvr");
-            k900Command.put("V", 1);
-            k900Command.put("B", "");
-
-            String commandStr = k900Command.toString();
+            String commandStr = buildBesSystemVersionCommand();
             Log.d(TAG, "📤 Sending cs_syvr request: " + commandStr);
 
             // Send via sendMessage() which handles protocol formatting and isSerialOpen check
@@ -1133,6 +1180,62 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             }
         } catch (org.json.JSONException e) {
             Log.e(TAG, "💥 Failed to build cs_syvr request", e);
+        }
+    }
+
+    /** Build the legacy-compatible system-version request used for discovery and recovery. */
+    private static String buildBesSystemVersionCommand() throws org.json.JSONException {
+        org.json.JSONObject k900Command = new org.json.JSONObject();
+        k900Command.put("C", "cs_syvr");
+        k900Command.put("V", 1);
+        k900Command.put("B", "");
+        return k900Command.toString();
+    }
+
+    /** Queue spaced version probes, dropping stale work immediately before the UART write. */
+    private void scheduleVersionProbeBurst(
+            int expectedBaud,
+            int generation,
+            BooleanSupplier remainsNeeded,
+            String reason) {
+        for (int i = 0; i < AsgConstants.UART_RECOVERY_PROBES_PER_BURST; i++) {
+            baudSwitchExecutor.schedule(
+                    () -> queueGuardedVersionProbe(expectedBaud, generation, remainsNeeded, reason),
+                    i * AsgConstants.UART_RECOVERY_PROBE_SPACING_MS,
+                    TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private void queueGuardedVersionProbe(
+            int expectedBaud,
+            int generation,
+            BooleanSupplier remainsNeeded,
+            String reason) {
+        try {
+            byte[] command = buildBesSystemVersionCommand().getBytes(StandardCharsets.UTF_8);
+            sendMessage(
+                    command,
+                    success -> {
+                        if (!success) {
+                            Log.w(BAUD_TAG, "Version probe did not send (reason=" + reason + ")");
+                        }
+                    },
+                    new SendMessageGate() {
+                        @Override
+                        public boolean shouldSend() {
+                            return generation == recoveryProbeGeneration
+                                    && remainsNeeded.getAsBoolean()
+                                    && !comManager.isOtaUpdating()
+                                    && comManager.getCurrentBaud() == expectedBaud;
+                        }
+
+                        @Override
+                        public Object lock() {
+                            return baudSwitchLock;
+                        }
+                    });
+        } catch (Exception e) {
+            Log.e(BAUD_TAG, "Could not queue version probe (reason=" + reason + ")", e);
         }
     }
 
@@ -1366,7 +1469,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 if (comManager.getCurrentBaud() == TARGET_UART_BAUD) {
                     return; // Already at the target (e.g., boot recovery landed there).
                 }
-                if (comManager.mbOtaUpdating) {
+                if (comManager.isOtaUpdating()) {
                     Log.i(BAUD_TAG, "BES OTA in progress - skipping baud switch");
                     return;
                 }
@@ -1471,19 +1574,56 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(BAUD_TAG, "📤 Sending cs_baud request: " + commandStr);
 
             boolean sent =
-                    sendMessage(commandStr.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                    sendMessage(
+                            commandStr.getBytes(StandardCharsets.UTF_8),
+                            success -> {
+                                synchronized (baudSwitchLock) {
+                                    if (!baudSwitchWaitingSrBaud) {
+                                        return;
+                                    }
+                                    if (!success) {
+                                        baudSwitchWaitingSrBaud = false;
+                                        cancelBaudAckTimeoutLocked();
+                                        Log.e(
+                                                BAUD_TAG,
+                                                "Failed to write cs_baud - staying at rendezvous");
+                                        return;
+                                    }
+                                    cancelBaudAckTimeoutLocked();
+                                    baudAckTimeoutFuture =
+                                            baudSwitchExecutor.schedule(
+                                                    this::onBaudAckTimeout,
+                                                    AsgConstants.UART_BAUD_ACK_TIMEOUT_MS,
+                                                    TimeUnit.MILLISECONDS);
+                                }
+                            });
             if (!sent) {
                 Log.e(BAUD_TAG, "Failed to send cs_baud - staying at 460800");
                 synchronized (baudSwitchLock) {
                     baudSwitchWaitingSrBaud = false;
+                    cancelBaudAckTimeoutLocked();
                 }
             }
         } catch (Exception e) {
             Log.e(BAUD_TAG, "Error building/sending cs_baud - staying at 460800", e);
             synchronized (baudSwitchLock) {
                 baudSwitchWaitingSrBaud = false;
+                cancelBaudAckTimeoutLocked();
             }
         }
+    }
+
+    /** A lost old-baud ack is ambiguous: BES may already have switched, so verify target once. */
+    private void onBaudAckTimeout() {
+        synchronized (baudSwitchLock) {
+            if (!baudSwitchWaitingSrBaud) {
+                return;
+            }
+            baudSwitchWaitingSrBaud = false;
+            baudAckTimeoutFuture = null;
+        }
+        Log.w(BAUD_TAG, "No sr_baud acknowledgement; probing the requested target baud");
+        reopenAtTargetBaudAndProbe();
     }
 
     /**
@@ -1509,6 +1649,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     return true;
                 }
                 baudSwitchWaitingSrBaud = false;
+                cancelBaudAckTimeoutLocked();
             }
 
             String bFieldStr = json.optString("B", "");
@@ -1563,6 +1704,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      */
     private void reopenAtTargetBaudAndProbe() {
         try {
+            messageParser.clear();
             boolean reopened = comManager.reopen(TARGET_UART_BAUD);
             if (!reopened) {
                 Log.e(
@@ -1574,6 +1716,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
             synchronized (baudSwitchLock) {
                 baudProbePending = true;
+                recoveryProbeGeneration++;
                 cancelBaudProbeTimeoutLocked();
                 baudProbeTimeoutFuture =
                         baudSwitchExecutor.schedule(
@@ -1583,7 +1726,15 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             }
 
             Log.i(BAUD_TAG, "UART reopened at " + TARGET_UART_BAUD + " - probing with cs_syvr");
-            requestBesSystemVersion();
+            int generation;
+            synchronized (baudSwitchLock) {
+                generation = recoveryProbeGeneration;
+            }
+            scheduleVersionProbeBurst(
+                    TARGET_UART_BAUD,
+                    generation,
+                    () -> baudProbePending,
+                    "baud_verification");
         } catch (Exception e) {
             Log.e(BAUD_TAG, "‼️ Exception during baud reopen - reverting to 460800", e);
             revertToDefaultBaud("reopen_exception");
@@ -1616,6 +1767,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             cancelBaudProbeTimeoutLocked();
         }
         try {
+            messageParser.clear();
             boolean ok = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
             Log.e(
                     BAUD_TAG,
@@ -1635,6 +1787,14 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (baudProbeTimeoutFuture != null) {
             baudProbeTimeoutFuture.cancel(false);
             baudProbeTimeoutFuture = null;
+        }
+    }
+
+    /** Must be called with baudSwitchLock held. */
+    private void cancelBaudAckTimeoutLocked() {
+        if (baudAckTimeoutFuture != null) {
+            baudAckTimeoutFuture.cancel(false);
+            baudAckTimeoutFuture = null;
         }
     }
 
@@ -1844,6 +2004,58 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         Log.d(TAG, "🔌 📋 Requesting BES system version via UART");
         requestBesSystemVersion();
+    }
+
+    @Override
+    public void onBesOtaApplied() {
+        Log.i(BAUD_TAG, "BES OTA applied; scheduling reconnect at rendezvous baud");
+        synchronized (baudSwitchLock) {
+            recoveryProbeGeneration++;
+            lastSrSyvrTime = 0;
+            baudSwitchAttempted = false;
+            baudSwitchWaitingSrBaud = false;
+            baudProbePending = false;
+            cancelBaudAckTimeoutLocked();
+            cancelBaudProbeTimeoutLocked();
+            if (bootRecoveryFuture != null) {
+                bootRecoveryFuture.cancel(false);
+                bootRecoveryFuture = null;
+            }
+        }
+        baudSwitchExecutor.schedule(
+                this::reconnectAfterBesOta,
+                AsgConstants.BES_OTA_RECONNECT_DELAY_MS,
+                TimeUnit.MILLISECONDS);
+    }
+
+    /** BES reboots at 460800 after OTA; rediscover there and negotiate again if supported. */
+    private void reconnectAfterBesOta() {
+        if (comManager.isOtaUpdating()) {
+            baudSwitchExecutor.schedule(
+                    this::reconnectAfterBesOta,
+                    AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
+                    TimeUnit.MILLISECONDS);
+            return;
+        }
+        try {
+            messageParser.clear();
+            boolean reopened = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
+            if (!reopened) {
+                Log.e(BAUD_TAG, "Could not reopen rendezvous baud after BES OTA");
+                return;
+            }
+            int generation;
+            synchronized (baudSwitchLock) {
+                generation = ++recoveryProbeGeneration;
+            }
+            scheduleVersionProbeBurst(
+                    SerialPortBridge.DEFAULT_BAUDRATE,
+                    generation,
+                    () -> lastSrSyvrTime == 0,
+                    "bes_ota_reconnect");
+        } catch (Exception e) {
+            Log.e(BAUD_TAG, "Failed to reconnect after BES OTA", e);
+        }
     }
 
     @Override

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -359,12 +359,21 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     /** The alternate-rate boot probe is safe only after this installation saw capable firmware. */
     private boolean cachedBesSupportsBaudSwitch() {
         try {
-            String cachedVersion = new AsgSettings(context).getBesFirmwareVersion();
-            return shouldProbeAlternateBaud(cachedVersion);
+            AsgSettings settings = new AsgSettings(context);
+            return shouldProbeAlternateBaud(
+                    settings.getBesBaudSwitchVersion(), settings.getBesFirmwareVersion());
         } catch (Exception e) {
             Log.w(BAUD_TAG, "Could not read cached BES version; staying at rendezvous baud", e);
             return false;
         }
+    }
+
+    /** Prefer the exact capability-gate field; the display version is a migration fallback. */
+    static boolean shouldProbeAlternateBaud(String cachedGateVersion, String cachedDisplayVersion) {
+        if (cachedGateVersion != null && !cachedGateVersion.trim().isEmpty()) {
+            return shouldProbeAlternateBaud(cachedGateVersion);
+        }
+        return shouldProbeAlternateBaud(cachedDisplayVersion);
     }
 
     /** Pure compatibility gate for the boot-only alternate-baud probe. */
@@ -1270,6 +1279,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             } else {
                 bData = new org.json.JSONObject(bFieldStr);
             }
+            cacheBesBaudSwitchVersion(bData);
             cacheBesVersionFromSyvrBField(bData);
 
             // Runtime UART baud switch: sr_syvr either confirms our post-reopen probe or,
@@ -1415,6 +1425,13 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         if (!v.isEmpty()) {
             cacheBesFirmwareVersion(v);
+        }
+    }
+
+    private void cacheBesBaudSwitchVersion(JSONObject bData) {
+        String version = extractBaudSwitchVersion(bData);
+        if (!version.isEmpty()) {
+            new AsgSettings(context).setBesBaudSwitchVersion(version);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -280,14 +280,51 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         comManager.registerListener(this);
         comManager.start();
 
-        // Boot-time baud recovery: if a previous asg run switched the BES to a high
-        // baud and asg restarted, we come up at 460800 against a fast BES and the
-        // link is silent. Hunt candidate rates until sr_syvr answers.
+        // Retry discovery at the rendezvous baud before considering the alternate. This observes
+        // the wire instead of guessing whether Android, BES, or only this process restarted.
+        synchronized (baudSwitchLock) {
+            bootRecoveryFuture =
+                    baudSwitchExecutor.schedule(
+                            this::startupRendezvousProbe,
+                            AsgConstants.UART_BOOT_RECOVERY_INITIAL_DELAY_MS,
+                            TimeUnit.MILLISECONDS);
+        }
+    }
+
+    /** Retry the known-safe baud first, then let alternate recovery run only if still unanswered. */
+    private void startupRendezvousProbe() {
+        if (lastSrSyvrTime > 0) {
+            return;
+        }
+        int generation;
+        synchronized (baudSwitchLock) {
+            bootRecoveryFuture = null;
+            if (baudProbePending || baudSwitchWaitingSrBaud || comManager.isOtaUpdating()) {
+                bootRecoveryFuture =
+                        baudSwitchExecutor.schedule(
+                                this::startupRendezvousProbe,
+                                AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
+                                TimeUnit.MILLISECONDS);
+                return;
+            }
+            generation = ++recoveryProbeGeneration;
+        }
+        Log.i(
+                BAUD_TAG,
+                "Startup recovery: retrying BES discovery at rendezvous baud "
+                        + SerialPortBridge.DEFAULT_BAUDRATE);
+        scheduleVersionProbeBurst(
+                SerialPortBridge.DEFAULT_BAUDRATE,
+                generation,
+                () -> lastSrSyvrTime == 0,
+                "startup_rendezvous");
         synchronized (baudSwitchLock) {
             bootRecoveryFuture =
                     baudSwitchExecutor.schedule(
                             this::bootBaudRecoveryTick,
-                            AsgConstants.UART_BOOT_RECOVERY_INITIAL_DELAY_MS,
+                            AsgConstants.UART_RECOVERY_PROBES_PER_BURST
+                                            * AsgConstants.UART_RECOVERY_PROBE_SPACING_MS
+                                    + AsgConstants.UART_RECOVERY_PROBE_SPACING_MS,
                             TimeUnit.MILLISECONDS);
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2045,6 +2045,24 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 bootRecoveryFuture = null;
             }
         }
+        baudSwitchExecutor.execute(() -> prepareRendezvousAfterBesOta(generation));
+    }
+
+    /** Leave the negotiated fast rate immediately; delay only BES readiness probes. */
+    private void prepareRendezvousAfterBesOta(int generation) {
+        synchronized (baudSwitchLock) {
+            if (generation != recoveryProbeGeneration) {
+                return;
+            }
+        }
+        try {
+            clearMessageParser();
+            if (!comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE)) {
+                Log.e(BAUD_TAG, "Initial rendezvous reopen failed after BES OTA");
+            }
+        } catch (Exception e) {
+            Log.e(BAUD_TAG, "Initial rendezvous reopen threw after BES OTA", e);
+        }
         scheduleBesOtaReconnect(
                 generation,
                 1,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -49,6 +49,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // Keep normal K900 messages contiguous on the shared ASG-to-BES UART stream.
     private final Object outboundSendLock = new Object();
     private BesMessageParser messageParser;
+    private final Object messageParserLock = new Object();
     private final ChunkReassembler inboundBinaryReassembler = new ChunkReassembler();
     private final ChunkedMessageProtocolStrategy inboundBinaryStrategy =
             new ChunkedMessageProtocolStrategy(inboundBinaryReassembler);
@@ -332,7 +333,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + BOOT_BAUD_CANDIDATES.length
                         + ")");
         try {
-            messageParser.clear();
+            clearMessageParser();
             boolean reopened = comManager.reopen(candidate);
             if (reopened) {
                 int generation;
@@ -395,7 +396,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return;
         }
         try {
-            messageParser.clear();
+            clearMessageParser();
             boolean reopened = comManager.reopen(defaultBaud);
             if (reopened) {
                 Log.w(
@@ -1704,7 +1705,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      */
     private void reopenAtTargetBaudAndProbe() {
         try {
-            messageParser.clear();
+            clearMessageParser();
             boolean reopened = comManager.reopen(TARGET_UART_BAUD);
             if (!reopened) {
                 Log.e(
@@ -1767,7 +1768,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             cancelBaudProbeTimeoutLocked();
         }
         try {
-            messageParser.clear();
+            clearMessageParser();
             boolean ok = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
             Log.e(
                     BAUD_TAG,
@@ -1908,72 +1909,76 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             // Hex dump suppressed to prevent logcat overflow
             // Enable only when debugging specific issues
 
-            // Add the data to our message parser
-            if (messageParser != null && messageParser.addData(dataCopy, size)) {
-                // Try to extract complete messages
-                List<byte[]> completeMessages = messageParser.parseMessages();
-                if (completeMessages != null && !completeMessages.isEmpty()) {
-                    Log.d(TAG, "📥 Extracted " + completeMessages.size() + " complete messages");
-                    // Process each complete message
-                    for (byte[] message : completeMessages) {
-                        BleTraceLogger.logK900Frame("bes_to_asg", "asg_uart_input", message);
-
-                        // Check for file transfer acknowledgments first
-                        processReceivedMessage(message);
-
-                        // Extract payload from K900 protocol message for listeners
-                        if (BesWireFormat.isBinaryWireFrame(message)) {
-                            handleInboundBinaryFrame(message);
-                        } else if (BesWireFormat.isK900ProtocolFormat(message)) {
-                            // Auto-detect the length endianness so we parse frames from both legacy
-                            // big-endian and wire-v2 little-endian BES firmware (fixes the
-                            // "Extracted length=9472" misframe against old firmware).
-                            K900LengthCodec.Detected detected =
-                                    K900LengthCodec.detectLength(message);
-                            if (detected != null) {
-                                uartToBesEndian = detected.endian;
-                            }
-                            byte[] payload = BesWireFormat.extractPayloadAuto(message);
-
-                            if (payload != null && payload.length > 0) {
-                                // Notify listeners with the clean payload (JSON data without
-                                // markers)
-                                String payloadPreview =
-                                        new String(payload, 0, Math.min(payload.length, 200));
-                                Log.d(
-                                        TAG,
-                                        "📥 Extracted K900 payload ("
-                                                + payload.length
-                                                + " bytes): "
-                                                + payloadPreview);
-
-                                // Check if this is a sr_syvr response (BES system version)
-                                // or an sr_baud response (UART baud switch ack).
-                                // Handle them directly here to avoid timing issues with
-                                // CommandProcessor initialization
-                                if (!handleSrSyvrResponse(payload)
-                                        && !handleSrBaudResponse(payload)
-                                        && !handleFileTransportResponse(payload)) {
-                                    // Not a sr_syvr/sr_baud response, forward to listeners
-                                    notifyDataReceived(payload);
-                                }
-                            } else {
-                                Log.w(TAG, "📥 Failed to extract payload from K900 message");
-                            }
-                        } else {
-                            // Not a K900 protocol message, pass as-is
-                            Log.d(TAG, "📥 Non-K900 message, passing as-is");
-                            notifyDataReceived(message);
-                        }
+            boolean parserAcceptedData = false;
+            List<byte[]> completeMessages = null;
+            synchronized (messageParserLock) {
+                if (messageParser != null) {
+                    parserAcceptedData = messageParser.addData(dataCopy, size);
+                    if (parserAcceptedData) {
+                        completeMessages = messageParser.parseMessages();
                     }
-                } else {
-                    // No complete messages yet, just accumulating data
-                    Log.d(TAG, "📥 Data added to parser, waiting for complete message");
                 }
-            } else {
+            }
+
+            if (!parserAcceptedData) {
                 // If parser is not available or data couldn't be added, send raw data
                 Log.d(TAG, "📥 📤 Parser unavailable, notifying listeners of raw data...");
                 notifyDataReceived(dataCopy);
+            } else if (completeMessages == null || completeMessages.isEmpty()) {
+                // No complete messages yet, just accumulating data
+                Log.d(TAG, "📥 Data added to parser, waiting for complete message");
+            } else {
+                Log.d(TAG, "📥 Extracted " + completeMessages.size() + " complete messages");
+                // Process each complete message outside the parser lock.
+                for (byte[] message : completeMessages) {
+                    BleTraceLogger.logK900Frame("bes_to_asg", "asg_uart_input", message);
+
+                    // Check for file transfer acknowledgments first
+                    processReceivedMessage(message);
+
+                    // Extract payload from K900 protocol message for listeners
+                    if (BesWireFormat.isBinaryWireFrame(message)) {
+                        handleInboundBinaryFrame(message);
+                    } else if (BesWireFormat.isK900ProtocolFormat(message)) {
+                        // Auto-detect the length endianness so we parse frames from both legacy
+                        // big-endian and wire-v2 little-endian BES firmware (fixes the
+                        // "Extracted length=9472" misframe against old firmware).
+                        K900LengthCodec.Detected detected = K900LengthCodec.detectLength(message);
+                        if (detected != null) {
+                            uartToBesEndian = detected.endian;
+                        }
+                        byte[] payload = BesWireFormat.extractPayloadAuto(message);
+
+                        if (payload != null && payload.length > 0) {
+                            // Notify listeners with the clean payload (JSON data without markers)
+                            String payloadPreview =
+                                    new String(payload, 0, Math.min(payload.length, 200));
+                            Log.d(
+                                    TAG,
+                                    "📥 Extracted K900 payload ("
+                                            + payload.length
+                                            + " bytes): "
+                                            + payloadPreview);
+
+                            // Check if this is a sr_syvr response (BES system version)
+                            // or an sr_baud response (UART baud switch ack).
+                            // Handle them directly here to avoid timing issues with
+                            // CommandProcessor initialization
+                            if (!handleSrSyvrResponse(payload)
+                                    && !handleSrBaudResponse(payload)
+                                    && !handleFileTransportResponse(payload)) {
+                                // Not a sr_syvr/sr_baud response, forward to listeners
+                                notifyDataReceived(payload);
+                            }
+                        } else {
+                            Log.w(TAG, "📥 Failed to extract payload from K900 message");
+                        }
+                    } else {
+                        // Not a K900 protocol message, pass as-is
+                        Log.d(TAG, "📥 Non-K900 message, passing as-is");
+                        notifyDataReceived(message);
+                    }
+                }
             }
             // Data processing complete
         } else {
@@ -2009,8 +2014,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     @Override
     public void onBesOtaApplied() {
         Log.i(BAUD_TAG, "BES OTA applied; scheduling reconnect at rendezvous baud");
+        int generation;
         synchronized (baudSwitchLock) {
-            recoveryProbeGeneration++;
+            generation = ++recoveryProbeGeneration;
             lastSrSyvrTime = 0;
             baudSwitchAttempted = false;
             baudSwitchWaitingSrBaud = false;
@@ -2022,39 +2028,82 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 bootRecoveryFuture = null;
             }
         }
-        baudSwitchExecutor.schedule(
-                this::reconnectAfterBesOta,
+        scheduleBesOtaReconnect(
+                generation,
+                1,
                 AsgConstants.BES_OTA_RECONNECT_DELAY_MS,
+                "initial reboot wait");
+    }
+
+    private void scheduleBesOtaReconnect(
+            int generation, int attempt, long delayMs, String reason) {
+        baudSwitchExecutor.schedule(
+                () -> reconnectAfterBesOta(generation, attempt, reason),
+                delayMs,
                 TimeUnit.MILLISECONDS);
     }
 
     /** BES reboots at 460800 after OTA; rediscover there and negotiate again if supported. */
-    private void reconnectAfterBesOta() {
+    private void reconnectAfterBesOta(int generation, int attempt, String previousReason) {
+        synchronized (baudSwitchLock) {
+            if (generation != recoveryProbeGeneration || lastSrSyvrTime > 0) {
+                return;
+            }
+        }
+        if (attempt > AsgConstants.BES_OTA_RECONNECT_ATTEMPTS) {
+            Log.e(
+                    BAUD_TAG,
+                    "BES OTA reconnect exhausted after "
+                            + AsgConstants.BES_OTA_RECONNECT_ATTEMPTS
+                            + " attempts (last reason="
+                            + previousReason
+                            + ")");
+            return;
+        }
         if (comManager.isOtaUpdating()) {
-            baudSwitchExecutor.schedule(
-                    this::reconnectAfterBesOta,
+            scheduleBesOtaReconnect(
+                    generation,
+                    attempt + 1,
                     AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
-                    TimeUnit.MILLISECONDS);
+                    "OTA still owns UART");
             return;
         }
         try {
-            messageParser.clear();
+            clearMessageParser();
             boolean reopened = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
             if (!reopened) {
-                Log.e(BAUD_TAG, "Could not reopen rendezvous baud after BES OTA");
+                scheduleBesOtaReconnect(
+                        generation,
+                        attempt + 1,
+                        AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
+                        "rendezvous reopen failed");
                 return;
-            }
-            int generation;
-            synchronized (baudSwitchLock) {
-                generation = ++recoveryProbeGeneration;
             }
             scheduleVersionProbeBurst(
                     SerialPortBridge.DEFAULT_BAUDRATE,
                     generation,
                     () -> lastSrSyvrTime == 0,
                     "bes_ota_reconnect");
+            scheduleBesOtaReconnect(
+                    generation,
+                    attempt + 1,
+                    AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
+                    "no version response");
         } catch (Exception e) {
             Log.e(BAUD_TAG, "Failed to reconnect after BES OTA", e);
+            scheduleBesOtaReconnect(
+                    generation,
+                    attempt + 1,
+                    AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
+                    "reconnect exception");
+        }
+    }
+
+    private void clearMessageParser() {
+        synchronized (messageParserLock) {
+            if (messageParser != null) {
+                messageParser.clear();
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
@@ -37,7 +37,7 @@ public class SerialPortBridge {
     protected volatile InputStream mIS;
     private Context mContext = null;
     private boolean mbRequestFast = false;
-    public boolean mbOtaUpdating = false;
+    private volatile boolean mbOtaUpdating = false;
 
     /** Baud rate the port is currently open at (DEFAULT_BAUDRATE until a reopen succeeds). */
     private volatile int mCurrentBaud = DEFAULT_BAUDRATE;
@@ -127,6 +127,19 @@ public class SerialPortBridge {
      */
     public int getCurrentBaud() {
         return mCurrentBaud;
+    }
+
+    /** Whether BES OTA currently owns UART receive routing. */
+    public boolean isOtaUpdating() {
+        return mbOtaUpdating;
+    }
+
+    /** Notify the normal UART owner that BES accepted an OTA image and is rebooting. */
+    public void notifyBesOtaApplied() {
+        SerialListener listener = mListener;
+        if (listener != null) {
+            listener.onBesOtaApplied();
+        }
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -88,7 +88,7 @@ public class MediaCaptureService {
     private MediaCaptureListener mMediaCaptureListener;
     private ServiceCallbackInterface mServiceCallback;
     private final IHardwareManager hardwareManager;
-    private final MlKitTextRoiDetector textRoiDetector = new MlKitTextRoiDetector();
+    private final MlKitTextRoiDetector textRoiDetector;
 
     // Track current video recording
     private boolean isRecordingVideo = false;
@@ -702,6 +702,7 @@ public class MediaCaptureService {
         mMediaQueueManager = mediaQueueManager;
         this.fileManager = fileManager;
         this.mStateManager = stateManager;
+        textRoiDetector = new MlKitTextRoiDetector(mContext);
 
         // Initialize hardware manager
         hardwareManager = HardwareManagerFactory.getInstance(context);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetector.java
@@ -1,16 +1,20 @@
 package com.mentra.asg_client.io.media.core.textdetect;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.SystemClock;
+import android.os.UserManager;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
 
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
+import com.google.mlkit.common.MlKit;
 import com.google.mlkit.vision.common.InputImage;
 import com.google.mlkit.vision.text.Text;
 import com.google.mlkit.vision.text.TextRecognition;
@@ -36,26 +40,29 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
     private static final String TAG = "MlKitTextRoi";
     private static final Executor DIRECT_EXECUTOR = Runnable::run;
 
-    private final TextRecognizer recognizer;
+    @Nullable private final Context context;
     private final int analysisLongEdge;
+    private final Object recognizerLock = new Object();
+
+    @Nullable private TextRecognizer recognizer;
 
     private final AtomicReference<Task<Text>> warmupTask = new AtomicReference<>();
     private final AtomicReference<Task<Text>> activeRecognizerTask = new AtomicReference<>();
     private volatile boolean closed;
 
-    public MlKitTextRoiDetector() {
-        this(AsgConstants.TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE);
+    public MlKitTextRoiDetector(Context context) {
+        this(context, AsgConstants.TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE);
     }
 
     /** Visible for the on-device benchmark harness. */
-    MlKitTextRoiDetector(int analysisLongEdge) {
-        this(
-                analysisLongEdge,
-                TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS));
+    MlKitTextRoiDetector(Context context, int analysisLongEdge) {
+        this.context = context.getApplicationContext();
+        this.analysisLongEdge = analysisLongEdge;
     }
 
     /** Visible for unit tests that exercise recognizer lifecycle failures. */
     MlKitTextRoiDetector(int analysisLongEdge, TextRecognizer recognizer) {
+        this.context = null;
         this.analysisLongEdge = analysisLongEdge;
         this.recognizer = recognizer;
     }
@@ -92,6 +99,10 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
 
     @Nullable
     private Task<Text> tryStartRecognizerProcess(InputImage image) {
+        TextRecognizer availableRecognizer = getOrCreateRecognizer();
+        if (availableRecognizer == null) {
+            return null;
+        }
         synchronized (activeRecognizerTask) {
             Task<Text> activeTask = activeRecognizerTask.get();
             if (activeTask != null && !activeTask.isComplete()) {
@@ -100,13 +111,60 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
             if (activeTask != null) {
                 activeRecognizerTask.compareAndSet(activeTask, null);
             }
-            Task<Text> newTask = recognizer.process(image);
-            activeRecognizerTask.set(newTask);
-            newTask.addOnCompleteListener(
-                    DIRECT_EXECUTOR,
-                    completedTask -> activeRecognizerTask.compareAndSet(completedTask, null));
-            return newTask;
+            try {
+                Task<Text> newTask = availableRecognizer.process(image);
+                activeRecognizerTask.set(newTask);
+                newTask.addOnCompleteListener(
+                        DIRECT_EXECUTOR,
+                        completedTask -> activeRecognizerTask.compareAndSet(completedTask, null));
+                return newTask;
+            } catch (RuntimeException error) {
+                Log.w(TAG, "Unable to start ML Kit recognition; preserving full frame", error);
+                return null;
+            }
         }
+    }
+
+    /**
+     * Initializes ML Kit on first use rather than during direct-boot service construction.
+     *
+     * <p>ML Kit's manifest provider is not direct-boot-aware. Mentra Live starts this process from
+     * {@code LOCKED_BOOT_COMPLETED}, so the provider is skipped and is not rerun when the same
+     * process later unlocks. The public initialization API repairs that state once credential
+     * storage is available.
+     */
+    @Nullable
+    private TextRecognizer getOrCreateRecognizer() {
+        synchronized (recognizerLock) {
+            if (closed) {
+                return null;
+            }
+            if (recognizer != null) {
+                return recognizer;
+            }
+            if (context == null || !isUserUnlocked(context)) {
+                return null;
+            }
+            try {
+                MlKit.initialize(context);
+                recognizer =
+                        TextRecognition.getClient(TextRecognizerOptions.DEFAULT_OPTIONS);
+                return recognizer;
+            } catch (RuntimeException error) {
+                // Do not permanently disable detection: a later capture may run after Android has
+                // finished unlocking or after another transient initialization failure clears.
+                Log.w(TAG, "ML Kit is not ready; preserving full frame", error);
+                return null;
+            }
+        }
+    }
+
+    private static boolean isUserUnlocked(Context context) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+            return true;
+        }
+        UserManager userManager = context.getSystemService(UserManager.class);
+        return userManager == null || userManager.isUserUnlocked();
     }
 
     private void handleWarmupCompletion(Task<Text> completedTask) {
@@ -376,7 +434,12 @@ public final class MlKitTextRoiDetector implements AutoCloseable {
         synchronized (warmupTask) {
             if (!closed) {
                 closed = true;
-                recognizer.close();
+                synchronized (recognizerLock) {
+                    if (recognizer != null) {
+                        recognizer.close();
+                        recognizer = null;
+                    }
+                }
             }
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
@@ -36,6 +36,7 @@ public class AsgSettings {
     private static final String KEY_BUTTON_PHOTO_ZSL = "button_photo_zsl";
     private static final String KEY_HDR_BURST_ENABLED = "hdr_burst_enabled";
     private static final String KEY_MCU_FIRMWARE_VERSION = "mcu_firmware_version";
+    private static final String KEY_BES_BAUD_SWITCH_VERSION = "bes_baud_switch_version";
     private static final String KEY_CAMERA_FOV = "camera_fov";
     private static final String KEY_CAMERA_ROI_POSITION = "camera_roi_position";
     private static final String KEY_CAMERA_ANR_ENABLED = "camera_anr_enabled";
@@ -519,6 +520,19 @@ public class AsgSettings {
      */
     public void setBesFirmwareVersion(String version) {
         setMcuFirmwareVersion(version);
+    }
+
+    /** Return the exact BES version field last used to evaluate fast-UART capability. */
+    public String getBesBaudSwitchVersion() {
+        return prefs.getString(KEY_BES_BAUD_SWITCH_VERSION, "");
+    }
+
+    /** Persist the exact BES version field used to evaluate fast-UART capability. */
+    public void setBesBaudSwitchVersion(String version) {
+        if (version == null || version.isEmpty()) {
+            return;
+        }
+        prefs.edit().putString(KEY_BES_BAUD_SWITCH_VERSION, version).commit();
     }
 
     /**

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManagerBaudPolicyTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManagerBaudPolicyTest.java
@@ -1,0 +1,24 @@
+package com.mentra.asg_client.io.bluetooth.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.app.Application;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class K900BluetoothManagerBaudPolicyTest {
+
+    @Test
+    public void alternateBootProbe_requiresCachedBaudCapableFirmware() {
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud(null)).isFalse();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("")).isFalse();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.4")).isFalse();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.5")).isTrue();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.20")).isTrue();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.5-fix1")).isTrue();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManagerBaudPolicyTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManagerBaudPolicyTest.java
@@ -21,4 +21,13 @@ public class K900BluetoothManagerBaudPolicyTest {
         assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.20")).isTrue();
         assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.5-fix1")).isTrue();
     }
+
+    @Test
+    public void alternateBootProbe_prefersExactGateVersionOverDisplayVersion() {
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.5", "17.26.7.4"))
+                .isTrue();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("17.26.7.4", "17.26.7.5"))
+                .isFalse();
+        assertThat(K900BluetoothManager.shouldProbeAlternateBaud("", "17.26.7.5")).isTrue();
+    }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeOtaCallbackTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeOtaCallbackTest.java
@@ -1,0 +1,29 @@
+package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import android.app.Application;
+import androidx.test.core.app.ApplicationProvider;
+import com.mentra.asg_client.io.bluetooth.interfaces.SerialListener;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(application = Application.class, sdk = 33)
+public class SerialPortBridgeOtaCallbackTest {
+
+    @Test
+    public void otaApplied_notifiesNormalSerialOwner() {
+        SerialPortBridge bridge =
+                new SerialPortBridge(ApplicationProvider.getApplicationContext());
+        SerialListener listener = mock(SerialListener.class);
+        bridge.registerListener(listener);
+
+        bridge.notifyBesOtaApplied();
+
+        verify(listener).onBesOtaApplied();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.when;
 import android.graphics.Bitmap;
 import android.graphics.Rect;
 
+import androidx.test.core.app.ApplicationProvider;
+
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.TaskCompletionSource;
 import com.google.mlkit.vision.text.Text;
@@ -29,6 +31,14 @@ import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(RobolectricTestRunner.class)
 public class MlKitTextRoiDetectorTest {
+
+    @Test
+    public void constructionDoesNotRequireMlKitProviderInitialization() {
+        MlKitTextRoiDetector detector =
+                new MlKitTextRoiDetector(ApplicationProvider.getApplicationContext());
+
+        detector.close();
+    }
 
     @Test
     public void paddedUnionCombinesLinesAndKeepsContext() {

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -141,6 +141,8 @@ Mentra Live has multiple update surfaces:
 
 Update flows must preserve device recoverability, report progress where possible, and avoid interrupting active media operations without cleanup.
 
+The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. If `asg_client` restarts while a previously negotiated BES remains fast, it may probe 1152000 at boot only when a cached compatible BES version makes that safe. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.
+
 ### Diagnostics and reporting
 
 `asg_client` includes logging, crash/error reporting, incident log buffering, and debug receivers for development and OTA testing. Production behavior should prioritize device stability and useful logs for support while avoiding secrets in logs.

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -141,7 +141,7 @@ Mentra Live has multiple update surfaces:
 
 Update flows must preserve device recoverability, report progress where possible, and avoid interrupting active media operations without cleanup.
 
-The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. If `asg_client` restarts while a previously negotiated BES remains fast, it may probe 1152000 at boot only when a cached compatible BES version makes that safe. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.
+The MTK↔BES UART always starts at 460800 baud. Firmware that supports the negotiated fast link may upgrade to 1152000 only after reporting a compatible current firmware version. At startup, `asg_client` retries discovery at 460800 before considering an alternate baud; only if those probes are unanswered and a cached compatible BES version makes it safe may it probe 1152000. This handles full-device, MTK-only, and app-only restarts without assuming which processors rebooted. After a successful BES OTA, BES reboots at 460800, so `asg_client` explicitly reopens the rendezvous baud, rediscovers the new firmware version, and negotiates again when supported. Older firmware on either side remains at 460800.
 
 ### Diagnostics and reporting
 


### PR DESCRIPTION
## Summary

- companion BES firmware change: https://github.com/fengyue120/mentra-live-bes/pull/13
- keep 460800 as the universal MTK↔BES rendezvous baud and negotiate 1152000 only after a current compatible BES version response
- retry the rendezvous baud at startup before probing 1152000, so recovery observes the wire instead of assuming whether Android, BES, or only the app restarted
- recover a previously negotiated fast BES only when the default-baud probes are unanswered and a cached compatible BES version makes the alternate safe
- tolerate a lost `sr_baud` acknowledgement by probing the requested rate once, with stale queued probes guarded at send time
- explicitly return to 460800 after a successful BES OTA reboot using a bounded retry window, rediscover the new version, and renegotiate when supported
- synchronize parser add/parse/clear operations across UART reopens and initialize callback dependencies before the receive thread starts
- persist the exact BES version field used for fast-UART eligibility separately from the display firmware version
- defer ML Kit text-recognizer creation until after direct boot and explicitly initialize it on first use, preventing optional OCR startup from tearing down a healthy UART/media service

## Compatibility

| ASG | BES | Behavior |
| --- | --- | --- |
| old | old | unchanged at 460800 |
| new | old | current BES version fails the capability gate; remains at 460800 |
| old | new | no `cs_baud` request is sent; BES remains at 460800 |
| new | new | negotiates 1152000 and falls back to the shared 460800 rendezvous on failed verification/reboot |

The alternate-baud startup probe is never enabled from an unknown version, and there is no always-on runtime silence hunter. The only non-startup reopen is tied to the explicit successful BES OTA apply event because that operation reboots BES at 460800 while the ASG process remains alive.

## Validation

- `./scripts/check-android-compile.sh asg`
- `./gradlew :app:testDebugUnitTest --tests '*K900BluetoothManagerBaudPolicyTest' --tests '*SerialPortBridgeOtaCallbackTest' --tests '*BesOtaResponseWatchdogTest'`
- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.media.core.textdetect.MlKitTextRoiDetectorTest`
- `git diff --check`

### Mentra Live hardware

- installed the production-signed PR APK (`48821235`) on a Mentra Live
- confirmed process-restart recovery when BES remained at 1152000: ASG retried 460800, probed the cached-capable fast rate, and recovered `sr_syvr`
- transferred the companion BES OTA image; all 68 segment CRC checks and the final Apply response succeeded before the expected whole-device hard reboot
- after replug, BES `17.26.7.20` answered at 460800, acknowledged `cs_baud`, and answered the verification `sr_syvr` after ASG reopened at 1152000
- reproduced a full-boot failure where `LOCKED_BOOT_COMPLETED` skipped ML Kit's non-direct-boot-aware provider and eager recognizer construction caused service cleanup to close the healthy UART
- after the lazy ML Kit fix, performed another full reboot: every service component initialized, UART negotiated and verified at 1152000, the physical camera button delivered `cs_pho`, and the local photo capture completed successfully

Spotless formatted the touched Java files, but the repository-wide Spotless task cannot complete in this worktree because its existing `MediaUploadQueueManager.java` import layout fails google-java-format before the task reaches completion.
