### PR TITLE
Document Miniapp dashboard before docs cutover

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/display/dashboard.mdx
+++ b/mintlify-docs/app-devs/core-concepts/display/dashboard.mdx
@@ -1,0 +1,81 @@
+---
+title: "Dashboard"
+description: "Show persistent, glanceable status text in the glasses dashboard."
+icon: "gauge"
+---
+
+`session.dashboard` writes text to the glasses dashboard: the status view the
+user opens with a glasses-specific gesture. Use it for short-lived state that
+should remain available while the miniapp is running, such as a recording
+timer, connection state, or unread count.
+
+```typescript src/background/index.ts
+import {registerMiniapp} from "@mentra/miniapp/background"
+
+registerMiniapp((session) => {
+  session.dashboard.showText("Connected")
+})
+```
+
+Dashboard commands are fire-and-forget. They send immediately and do not wait
+for a delivery acknowledgement.
+
+## Methods
+
+| Method                        | Returns | Behavior                                                        |
+| ----------------------------- | ------- | --------------------------------------------------------------- |
+| `showText(text)`              | `void`  | Replace this miniapp's dashboard text.                           |
+| `clear()`                     | `void`  | Remove this miniapp's dashboard text.                            |
+
+`showText` accepts either one string or an array of pre-wrapped lines. Arrays
+are joined with newline characters before they are sent:
+
+```typescript
+session.dashboard.showText([
+  "Recording",
+  "Elapsed: 01:23",
+])
+```
+
+Call `clear()` when the status is no longer useful:
+
+```typescript
+session.dashboard.clear()
+```
+
+## Dashboard text or a rendered scene?
+
+Use `session.dashboard` for brief text-only status. Use
+[`session.display.render()`](/app-devs/core-concepts/display/layouts#dashboard-view)
+with `{view: "dashboard"}` when the dashboard needs positioned text, images,
+shapes, or an auto-clear duration.
+
+```typescript
+session.display.render(
+  [
+    {
+      type: "text",
+      id: "status",
+      box: {x: 12, y: 12, w: 300, h: 40},
+      text: "3 unread messages",
+    },
+  ],
+  {view: "dashboard"},
+)
+```
+
+Unlike `session.dashboard.showText()`, `session.display.render()` returns a
+promise whose result reports whether the scene was displayed, blocked, or
+degraded for the connected glasses.
+
+## Guidelines
+
+- Keep dashboard text brief and glanceable.
+- Update only when the displayed state changes.
+- Clear stale status when an operation finishes.
+- Use the main display view for content that needs the user's immediate
+  attention.
+
+Declare a `DISPLAY` hardware requirement in the
+[miniapp manifest](/app-devs/core-concepts/miniapp-manifest) when the dashboard
+is essential to the miniapp.

--- a/mintlify-docs/app-devs/core-concepts/session.mdx
+++ b/mintlify-docs/app-devs/core-concepts/session.mdx
@@ -40,6 +40,7 @@ covered in its own page.
 | Module | What it does |
 |---|---|
 | [`session.display`](/app-devs/core-concepts/display/layouts) | Scenes of positioned text, images, and shapes on the glasses HUD. |
+| [`session.dashboard`](/app-devs/core-concepts/display/dashboard) | Persistent, glanceable status text in the glasses dashboard. |
 | [`session.speaker`](/app-devs/core-concepts/speakers/text-to-speech) | Play audio and text-to-speech. |
 | [`session.led`](/app-devs/core-concepts/led/overview) | The LED on supported glasses. |
 

--- a/mintlify-docs/docs.json
+++ b/mintlify-docs/docs.json
@@ -55,7 +55,11 @@
           {
             "group": "Display",
             "icon": "display",
-            "pages": ["app-devs/core-concepts/display/layouts", "app-devs/core-concepts/led/overview"]
+            "pages": [
+              "app-devs/core-concepts/display/layouts",
+              "app-devs/core-concepts/display/dashboard",
+              "app-devs/core-concepts/led/overview"
+            ]
           },
           {
             "group": "Audio & Speech",
@@ -273,7 +277,7 @@
     {"source": "/app-devs/reference/index", "destination": "/app-devs/core-concepts/session"},
     {"source": "/app-devs/reference/app-server", "destination": "/app-devs/core-concepts/session"},
     {"source": "/app-devs/reference/app-session", "destination": "/app-devs/core-concepts/session"},
-    {"source": "/app-devs/reference/dashboard-api", "destination": "/app-devs/core-concepts/display/layouts"},
+    {"source": "/app-devs/reference/dashboard-api", "destination": "/app-devs/core-concepts/display/dashboard"},
     {"source": "/app-devs/reference/enums", "destination": "/app-devs/core-concepts/session"},
     {"source": "/app-devs/reference/token-utils", "destination": "/app-devs/core-concepts/auth"},
     {"source": "/app-devs/reference/utilities", "destination": "/app-devs/core-concepts/session"},
@@ -295,6 +299,7 @@
     {"source": "/app-devs/reference/interfaces/setting-types", "destination": "/app-devs/core-concepts/session"},
     {"source": "/app-devs/reference/interfaces/tool-types", "destination": "/app-devs/core-concepts/miniapp-interop"},
     {"source": "/app-devs/reference/interfaces/webhook-types", "destination": "/app-devs/core-concepts/session"},
+    {"source": "/app-devs/core-concepts/speakers/playing-audio-files", "destination": "/app-devs/core-concepts/speakers/text-to-speech"},
     {"source": "/cookbook/dashboard-note-app", "destination": "/app-devs/getting-started/overview"},
     {"source": "/os-devs/contributing/overview", "destination": "/contributing"},
     {"source": "/os-devs/contributing/mentraos-manager-guidelines", "destination": "/contributing"},


### PR DESCRIPTION
Adds current `session.dashboard` documentation and links it from the Miniapp navigation and session reference.
Redirects the legacy dashboard API and playing-audio-files URLs to maintained pages, closing the only uncovered public routes found while comparing `frozen-docs` with `dev`.
This keeps `dev:mintlify-docs` ready to become the canonical Mintlify source without restoring obsolete cloud SDK pages.
Validation: the Mintlify export generated 57 pages successfully, `docs.json` parsed cleanly, and the frozen-navigation coverage audit found zero uncovered pages.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds docs for `session.dashboard` and links it from the navigation and session reference. Adds redirects for legacy pages to close the last uncovered routes and keep `dev:mintlify-docs` ready as the canonical source.

- **New Features**
  - New `Dashboard` page documenting `session.dashboard` with usage, methods, and guidelines.
  - Linked `session.dashboard` from `session.mdx` and added to the Display group in `docs.json`.
  - Redirects: `/app-devs/reference/dashboard-api` → `/app-devs/core-concepts/display/dashboard`, and `/app-devs/core-concepts/speakers/playing-audio-files` → `/app-devs/core-concepts/speakers/text-to-speech`.

<sup>Written for commit 97f4a68fafc60f92e2b4ebdc2815ddecf7a75afd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

