### PR TITLE
Relay Mentra Live iOS notifications

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1466,6 +1466,7 @@ class MentraLive: NSObject, SGCManager {
     // big-endian; upgraded to little-endian only when the glasses advertise wire_caps.k900_le (or a
     // v2 binary handshake succeeds, which implies wire-v2 LE).
     private var peerK900Le = false
+    private var ancsAppIdentifiers: [UInt32: String] = [:]
     private var peerWireCapsBinary = false
     private var peerFilePayloadV2 = false
     private var globalMessageId = 0
@@ -2089,7 +2090,13 @@ class MentraLive: NSObject, SGCManager {
         // Set connection timeout
         startConnectionTimeout()
 
-        centralManager?.connect(peripheral, options: nil)
+        // ANCS is hosted by iOS and is only exposed to authorized accessories.
+        // Requiring it at connect time lets the system complete that authorization
+        // flow before the glasses subscribe to the ANCS characteristics.
+        centralManager?.connect(
+            peripheral,
+            options: [CBConnectPeripheralOptionRequiresANCS: true]
+        )
     }
 
     private func handleReconnection() {
@@ -2779,6 +2786,11 @@ class MentraLive: NSObject, SGCManager {
         }
 
         switch command {
+        case "sr_ancs":
+            if let body = json["B"] as? [String: Any] {
+                processAncsRelay(body)
+            }
+
         case "sr_hrt":
             if let bodyObj = json["B"] as? [String: Any] {
                 let readyResponse = bodyObj["ready"] as? Int ?? 0
@@ -2991,6 +3003,79 @@ class MentraLive: NSObject, SGCManager {
             // Bridge.log("Unknown K900 command: \(command)")
             break
         }
+    }
+
+    /// Convert a Mentra Live firmware ANCS relay packet into the same native
+    /// events used by Android's NotificationListenerService.
+    private func processAncsRelay(_ body: [String: Any]) {
+        guard let event = body["event"] as? String,
+              let uid = (body["uid"] as? NSNumber)?.uint32Value
+        else {
+            Bridge.log("LIVE: Ignoring malformed ANCS relay packet")
+            return
+        }
+
+        let notificationId = "ancs-\(uid)"
+        let appIdentifier = body["appIdentifier"] as? String ?? ""
+
+        if event == "removed" {
+            let removedAppIdentifier = ancsAppIdentifiers.removeValue(forKey: uid) ?? appIdentifier
+            Bridge.sendTypedMessage(
+                "phone_notification_dismissed",
+                body: [
+                    "notificationId": notificationId,
+                    "notificationKey": notificationId,
+                    "packageName": removedAppIdentifier,
+                    "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
+                ]
+            )
+            return
+        }
+
+        guard event == "added" || event == "modified" else {
+            Bridge.log("LIVE: Ignoring unknown ANCS event: \(event)")
+            return
+        }
+
+        let title = body["title"] as? String ?? ""
+        let subtitle = body["subtitle"] as? String ?? ""
+        let message = body["message"] as? String ?? ""
+        let content = [subtitle, message]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let flags = (body["flags"] as? NSNumber)?.uint8Value ?? 0
+        if !appIdentifier.isEmpty {
+            ancsAppIdentifiers[uid] = appIdentifier
+        }
+
+        Bridge.sendTypedMessage(
+            "phone_notification",
+            body: [
+                "notificationId": notificationId,
+                "app": appIdentifier,
+                "title": title,
+                "content": content,
+                "priority": (flags & 0x02) != 0 ? "1" : "0",
+                "timestamp": ancsTimestamp(body["date"] as? String),
+                "packageName": appIdentifier,
+            ]
+        )
+    }
+
+    private func ancsTimestamp(_ value: String?) -> Int64 {
+        guard let value, !value.isEmpty else {
+            return Int64(Date().timeIntervalSince1970 * 1000)
+        }
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss"
+        guard let date = formatter.date(from: value) else {
+            return Int64(Date().timeIntervalSince1970 * 1000)
+        }
+        return Int64(date.timeIntervalSince1970 * 1000)
     }
 
     // commands to send to the glasses:
@@ -5203,6 +5288,7 @@ extension MentraLive {
     /// phone must treat every glasses_ready as a new wire epoch and renegotiate (bounded by
     /// the per-session handshake attempt cap) instead of trusting stale v2-active state.
     private func resetWireNegotiationState() {
+        ancsAppIdentifiers.removeAll()
         incomingChunkReassembler.clear()
         peerWireProtocolVersion = 0
         useBinaryWireProtocol = false

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -860,6 +860,8 @@ export type BluetoothSdkModuleEvents = {
   speaking_status: (event: SpeakingStatusEvent) => void
   battery_status: (event: BatteryStatusEvent) => void
   local_transcription: (event: LocalTranscriptionEvent) => void
+  phone_notification: (event: PhoneNotificationEvent) => void
+  phone_notification_dismissed: (event: PhoneNotificationDismissedEvent) => void
   wifi_status_change: (event: WifiStatusChangeEvent) => void
   wifi_scan_result: (event: WifiScanResultEvent) => void
   hotspot_status_change: (event: HotspotStatusChangeEvent) => void
@@ -904,6 +906,23 @@ export interface ExtractionProgressEvent {
   percentage: number
   bytesRead: number
   totalBytes: number
+}
+
+export interface PhoneNotificationEvent {
+  notificationId: string
+  app: string
+  title: string
+  content: string
+  priority: string
+  timestamp: number
+  packageName: string
+}
+
+export interface PhoneNotificationDismissedEvent {
+  notificationId: string
+  notificationKey: string
+  packageName: string
+  timestamp: number
 }
 
 export type PublicGlassesStatus = Omit<

--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -1,11 +1,9 @@
 import {waitFor} from "@testing-library/react-native"
 
 import mantle from "@/services/MantleManager"
-import {useCoreStore} from "@mentra/engine/internal"
-import {useDisplayStore} from "@mentra/engine/internal"
+import {localMiniappRuntime, useCoreStore, useDisplayStore, useSettingsStore} from "@mentra/engine/internal"
 import {isGlassesConnected, useGlassesStore} from "../../modules/engine/src/stores/glasses"
 import {engine, SETTINGS} from "@mentra/engine"
-import {useSettingsStore} from "@mentra/engine/internal"
 import {crustModuleMock, emitCrustEvent, resetCrustModuleMock} from "@/test-utils/mockCrustModule"
 import {
   bluetoothSdkMock,
@@ -287,7 +285,8 @@ describe("MantleManager", () => {
 
   it("routes notification events without the retired V1 upload", async () => {
     // The Cloud V1 REST upload is gone; the events still flow through the
-    // local-miniapp forward path without throwing.
+    // local-miniapp forward path without a server roundtrip.
+    const forwardEvent = jest.spyOn(localMiniappRuntime, "forwardEvent")
     emitCrustEvent("phone_notification", {
       notificationId: "n-1",
       app: "Calendar",
@@ -301,6 +300,37 @@ describe("MantleManager", () => {
       notificationId: "n-1",
       notificationKey: "key-1",
       packageName: "com.calendar",
+    })
+    emitBluetoothSdkEvent("phone_notification", {
+      notificationId: "ancs-42",
+      app: "com.apple.mobilemail",
+      title: "Build complete",
+      content: "The iOS relay is working",
+      priority: "1",
+      timestamp: 12345,
+      packageName: "com.apple.mobilemail",
+    })
+    emitBluetoothSdkEvent("phone_notification_dismissed", {
+      notificationId: "ancs-42",
+      notificationKey: "ancs-42",
+      packageName: "com.apple.mobilemail",
+      timestamp: 12346,
+    })
+
+    expect(forwardEvent).toHaveBeenCalledWith("phone_notification", {
+      notificationId: "ancs-42",
+      app: "com.apple.mobilemail",
+      title: "Build complete",
+      content: "The iOS relay is working",
+      priority: "1",
+      timestamp: 12345,
+      packageName: "com.apple.mobilemail",
+    })
+    expect(forwardEvent).toHaveBeenCalledWith("phone_notification_dismissed", {
+      notificationId: "ancs-42",
+      notificationKey: "ancs-42",
+      packageName: "com.apple.mobilemail",
+      timestamp: 12346,
     })
     await Promise.resolve()
   })

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -495,25 +495,26 @@ class MantleManager {
       // Android: Crust's NotificationListenerService reads notifications.
       this.subs.push((CrustModule.addListener as any)("phone_notification", forwardPhoneNotification))
 
-      // iOS: the phone can't read other apps' notifications, but connected
-      // glasses can (ANCS) — the G2 SGC reports the source app on its
-      // notification service and pipes it up as the SAME event (empty
-      // title/content; app identity only). Feeds the identical path.
-      this.subs.push(BluetoothSdk.addListener("phone_notification" as any, forwardPhoneNotification))
+      // iOS: connected glasses consume ANCS and relay notifications through
+      // the Bluetooth SDK, which feeds the identical local event path.
+      this.subs.push(BluetoothSdk.addListener("phone_notification", forwardPhoneNotification))
+
+      const forwardPhoneNotificationDismissed = async (event: any) => {
+        // Direct forward to local miniapps subscribed to
+        // phone_notification_dismissed. Gated by READ_NOTIFICATIONS at
+        // subscribe time.
+        localMiniappRuntime.forwardEvent("phone_notification_dismissed", {
+          notificationId: event.notificationId,
+          notificationKey: event.notificationKey,
+          packageName: event.packageName,
+          timestamp: event.timestamp ?? Date.now(),
+        })
+      }
 
       this.subs.push(
-        (CrustModule.addListener as any)("phone_notification_dismissed", async (event: any) => {
-          // Direct forward to local miniapps subscribed to
-          // phone_notification_dismissed (Android only — iOS never emits this).
-          // Gated by READ_NOTIFICATIONS at subscribe time.
-          localMiniappRuntime.forwardEvent("phone_notification_dismissed", {
-            notificationId: event.notificationId,
-            notificationKey: event.notificationKey,
-            packageName: event.packageName,
-            timestamp: Date.now(),
-          })
-        }),
+        (CrustModule.addListener as any)("phone_notification_dismissed", forwardPhoneNotificationDismissed),
       )
+      this.subs.push(BluetoothSdk.addListener("phone_notification_dismissed", forwardPhoneNotificationDismissed))
 
       this.subs.push(
         BluetoothSdk.addListener("audio_pairing_needed", (event) => {


### PR DESCRIPTION
## Summary

- require ANCS authorization when iOS connects to Mentra Live
- decode the BES `sr_ancs` relay into stable notification add/modify/remove events
- preserve the source app identifier for later dismissal events
- type the internal Bluetooth SDK notification events
- forward both notification and dismissal events through the same local runtime path used by Android
- add focused coverage for the Bluetooth relay path

This is the Mentra App half of [OS-958](https://linear.app/mentralabs/issue/OS-958/notify-works-on-mentra-live-with-ios-phones). It is intentionally limited to relay/data flow; it does not add or change the Notify miniapp, notification summarization, or speech behavior.

## Firmware dependency

- [fengyue120/mentra-live-bes#16](https://github.com/fengyue120/mentra-live-bes/pull/16)

## Validation

- `xcrun swiftc -frontend -parse modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift`
- `bun run test -- --runInBand src/services/MantleManager.test.ts` — 7 tests passed
- `bun run compile`

## Hardware validation

The complete iPhone → ANCS → Mentra Live BES → K900 → Mentra App flow still needs verification on a physical iPhone and glasses running the paired firmware PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iOS ANCS notification relay to Mentra Live. Requires ANCS authorization at connect and forwards add, update, and dismiss events through the same local path as Android (meets OS-958).

- New Features
  - Require ANCS authorization on iOS connect.
  - Decode `sr_ancs` into `phone_notification` and `phone_notification_dismissed`, preserving the source app for later dismissals.
  - Add types for these events in `BluetoothSdk.types.ts` and forward via `localMiniappRuntime`.
  - Add focused tests for the Bluetooth relay path.

- Dependencies
  - Requires Mentra Live BES firmware with ANCS relay support (`sr_ancs`).

<sup>Written for commit 8839b5d97e4f45e61dc885f560bde2a5ab1dfe8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches BLE connect options and notification relay semantics; depends on paired firmware but changes are localized to the relay path with tests.
> 
> **Overview**
> **iOS Mentra Live** now participates in the same phone-notification pipeline as Android by relaying glasses-side ANCS through the Bluetooth SDK.
> 
> On connect, BLE uses **`CBConnectPeripheralOptionRequiresANCS`** so iOS can authorize ANCS before the glasses subscribe. Firmware **`sr_ancs`** packets are decoded into **`phone_notification`** and **`phone_notification_dismissed`** events (added/modified/removed), aligned with Android’s Crust events. A per-UID **`ancsAppIdentifiers`** map keeps the source app for dismissals; it is cleared on wire-session reset.
> 
> **`BluetoothSdk.types.ts`** adds typed handlers for those events. **`MantleManager`** forwards both from **`BluetoothSdk`** into **`localMiniappRuntime`** (shared with Crust on Android), including dismissals that were previously Android-only. Tests assert the Bluetooth relay forwarding path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8839b5d97e4f45e61dc885f560bde2a5ab1dfe8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->