### PR TITLE
Gate miniapp developer settings

### DIFF
--- a/mobile/src/app/miniapps/settings/debug.tsx
+++ b/mobile/src/app/miniapps/settings/debug.tsx
@@ -38,6 +38,7 @@ export default function DebugSettingsScreen() {
   const [reconnectOnAppForeground, setReconnectOnAppForeground] = useSetting(SETTINGS.reconnect_on_app_foreground.key)
   const [enableSquircles, setEnableSquircles] = useSetting(SETTINGS.enable_squircles.key)
   const [appearanceMenuEnabled, setAppearanceMenuEnabled] = useSetting(SETTINGS.appearance_menu_enabled.key)
+  const [miniappDevMode, setMiniappDevMode] = useSetting(SETTINGS.miniapp_dev_mode.key)
   const [appBootExtraInfo, setAppBootExtraInfo] = useSetting(SETTINGS.app_boot_extra_info.key)
   const [debugConsole, setDebugConsole] = useSetting(SETTINGS.debug_console.key)
   const [_onboardingOsCompleted, setOnboardingOsCompleted] = useSetting(SETTINGS.onboarding_os_completed.key)
@@ -100,6 +101,13 @@ export default function DebugSettingsScreen() {
               subtitle="Show the Appearance settings menu"
               value={appearanceMenuEnabled}
               onValueChange={(value) => setAppearanceMenuEnabled(value)}
+            />
+
+            <ToggleSetting
+              label="Miniapp Developer Settings"
+              subtitle="Show the Miniapp Developer settings menu"
+              value={miniappDevMode}
+              onValueChange={(value) => setMiniappDevMode(value)}
             />
 
             <ToggleSetting
@@ -206,7 +214,6 @@ export default function DebugSettingsScreen() {
                 showAlert("Nav", "T&C cache cleared. Start Test Nav to see the dialog again.")
               }}
             />
-
           </Group>
 
           <Group title="Test Errors">
@@ -254,7 +261,6 @@ export default function DebugSettingsScreen() {
               description="Higher bitrates improve transcription quality but use more bandwidth."
             />
           </Group>
-
 
           <Group title="Cloud V2 (core + runtime)">
             <CloudUrl />

--- a/mobile/src/app/miniapps/settings/main.tsx
+++ b/mobile/src/app/miniapps/settings/main.tsx
@@ -15,11 +15,12 @@ import {useRef} from "react"
 import {useRegisterCapsule} from "@/stores/capsule"
 
 export default function MainSettingsPage() {
-  const {theme, themed} = useAppTheme()
+  const {theme} = useAppTheme()
   const {push} = useNavigationStore.getState()
   const [debugMode] = useSetting(SETTINGS.debug_mode.key)
   const [superMode] = useSetting(SETTINGS.super_mode.key)
   const [appearanceMenuEnabled] = useSetting(SETTINGS.appearance_menu_enabled.key)
+  const [miniappDevMode] = useSetting(SETTINGS.miniapp_dev_mode.key)
   const viewShotRef = useRef<View>(null)
 
   useRegisterCapsule({
@@ -86,11 +87,13 @@ export default function MainSettingsPage() {
                 onLongPress={() => superMode && push("/miniapps/settings/super")}
               />
             )}
-            <RouteButton
-              icon={<Icon name="user-code" size={24} color={theme.colors.secondary_foreground} />}
-              label={translate("settings:miniappDeveloperSettings")}
-              onPress={() => push("/miniapps/settings/miniapp-dev")}
-            />
+            {miniappDevMode && (
+              <RouteButton
+                icon={<Icon name="user-code" size={24} color={theme.colors.secondary_foreground} />}
+                label={translate("settings:miniappDeveloperSettings")}
+                onPress={() => push("/miniapps/settings/miniapp-dev")}
+              />
+            )}
           </Group>
         </View>
 

--- a/mobile/src/utils/miniappDevMode.ts
+++ b/mobile/src/utils/miniappDevMode.ts
@@ -3,11 +3,10 @@ import {SETTINGS, engine} from "@mentra/engine"
 /**
  * Flip the latent per-account "this user is a developer" signal.
  *
- * The miniapp dev tools (Scan QR / Load from URL) no longer hide behind a
- * user-facing toggle — they live openly under the Miniapp Developer settings
- * screen. But `miniapp_dev_mode` is still a useful server-synced signal, so we
- * set it the first time someone actually loads a dev mini app. Idempotent and
- * cheap: once set, it skips the write (and the server push) entirely.
+ * `miniapp_dev_mode` controls whether the Miniapp Developer settings are
+ * visible. Set it the first time someone actually loads a development miniapp
+ * so the tools remain easy to reach afterward. Idempotent and cheap: once set,
+ * it skips the write (and the server push) entirely.
  */
 export function markMiniappDevMode(): void {
   if (engine.settings.get(SETTINGS.miniapp_dev_mode.key)) return


### PR DESCRIPTION
## Summary

- hide the Miniapp Developer Settings entry unless `miniapp_dev_mode` is enabled
- add a Miniapp Developer Settings toggle to Debug Settings
- keep the flag off by default using the existing persisted setting
- update the miniapp developer-mode helper documentation to match the gated behavior

## User impact

Regular users no longer see unfinished miniapp development tools by default. Developers can enable the entry from Debug Settings when they need it.

## Validation

- `cd mobile && bun compile`
- `cd mobile && bunx eslint src/app/miniapps/settings/main.tsx src/app/miniapps/settings/debug.tsx src/utils/miniappDevMode.ts`
- `cd mobile && bunx prettier --check src/app/miniapps/settings/main.tsx src/app/miniapps/settings/debug.tsx src/utils/miniappDevMode.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gated the Miniapp Developer Settings behind the `miniapp_dev_mode` flag and added a toggle in Debug Settings. The menu is hidden by default; developers can enable it as needed and it stays on after loading a dev miniapp.

- **New Features**
  - Added "Miniapp Developer Settings" toggle in Debug Settings.
  - Only show the Developer Settings entry when `miniapp_dev_mode` is true.
  - Updated `markMiniappDevMode` helper docs to reflect the gated, idempotent behavior.

<sup>Written for commit a97d2dd5a365be8f31477c3ab75882ae58c819f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings UI gating only; uses an existing persisted flag with default false and no changes to auth or miniapp loading behavior.
> 
> **Overview**
> **Miniapp Developer Settings** in Advanced Settings are now shown only when the persisted `miniapp_dev_mode` setting is true (default off), so typical users no longer see dev tools in the main settings list.
> 
> A **Miniapp Developer Settings** toggle was added under Debug Settings (alongside Appearance Menu) to turn that menu on manually. Loading a dev miniapp still calls `markMiniappDevMode()`, which sets the same flag so the entry stays available after first use.
> 
> Comments in `miniappDevMode.ts` were updated to describe visibility gating instead of implying the screen is always exposed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a97d2dd5a365be8f31477c3ab75882ae58c819f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->