### PR TITLE
Fix PR 3496

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -927,6 +927,18 @@ extension MentraLive: CBCentralManagerDelegate {
     }
 
     nonisolated func centralManager(
+        _: CBCentralManager, didUpdateANCSAuthorizationFor peripheral: CBPeripheral
+    ) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self, peripheral === self.connectedPeripheral else { return }
+            Bridge.log(
+                "LIVE: ANCS authorization updated: \(peripheral.ancsAuthorized ? "authorized" : "not authorized")"
+            )
+            self.enableAncsRelayIfAuthorized()
+        }
+    }
+
+    nonisolated func centralManager(
         _: CBCentralManager, didDisconnectPeripheral _: CBPeripheral, error _: Error?
     ) {
         DispatchQueue.main.async { [weak self] in
@@ -1095,6 +1107,10 @@ extension MentraLive: CBPeripheralDelegate {
                     Bridge.log("LIVE: 🎤 Enabled LC3 audio notifications")
                 }
 
+                // Authorization may complete before or after service discovery.
+                // This covers the former; the central-manager callback covers the latter.
+                self.enableAncsRelayIfAuthorized()
+
                 // Start readiness check loop
                 self.startSignalStrengthPolling()
                 self.startReadinessCheckLoop()
@@ -1213,6 +1229,7 @@ extension MentraLive: CBPeripheralDelegate {
 
                 if uuid == self.RX_CHAR_UUID, isNotifying {
                     Bridge.log("LIVE: 🔔 Ready to receive data via notifications")
+                    self.enableAncsRelayIfAuthorized()
                 }
             }
         }
@@ -1268,6 +1285,7 @@ class MentraLive: NSObject, SGCManager {
         // or stale lastBesOtaProgress on the next OTA).
         if state == ConnTypes.DISCONNECTED {
             resetWireNegotiationState()
+            resetAncsRelayState()
             // Queued writes are session-bound: transmitting them into the NEXT session
             // (e.g. a stale handshake whose reply activates v2 before the new session
             // negotiated) is the bug class this clear removes.
@@ -1467,6 +1485,7 @@ class MentraLive: NSObject, SGCManager {
     // v2 binary handshake succeeds, which implies wire-v2 LE).
     private var peerK900Le = false
     private var ancsAppIdentifiers: [UInt32: String] = [:]
+    private var ancsRelayEnableRequested = false
     private var peerWireCapsBinary = false
     private var peerFilePayloadV2 = false
     private var globalMessageId = 0
@@ -2097,6 +2116,29 @@ class MentraLive: NSObject, SGCManager {
             peripheral,
             options: [CBConnectPeripheralOptionRequiresANCS: true]
         )
+    }
+
+    /// Opt the firmware into ANCS only after iOS has authorized this accessory.
+    /// Old firmware safely ignores the command, while new firmware stays inert
+    /// for old mobile clients that never send it.
+    private func enableAncsRelayIfAuthorized() {
+        guard !ancsRelayEnableRequested,
+              let peripheral = connectedPeripheral,
+              txCharacteristic != nil,
+              rxCharacteristic?.isNotifying == true,
+              peripheral.ancsAuthorized
+        else {
+            return
+        }
+
+        let command: [String: Any] = [
+            "C": "cs_ancs",
+            "B": ["enabled": 1],
+        ]
+        if sendRawK900Command(command) {
+            ancsRelayEnableRequested = true
+            Bridge.log("LIVE: Requested ANCS relay from compatible firmware")
+        }
     }
 
     private func handleReconnection() {
@@ -2787,7 +2829,7 @@ class MentraLive: NSObject, SGCManager {
 
         switch command {
         case "sr_ancs":
-            if let body = json["B"] as? [String: Any] {
+            if let body = k900ParseBody(json["B"]) {
                 processAncsRelay(body)
             }
 
@@ -5288,7 +5330,6 @@ extension MentraLive {
     /// phone must treat every glasses_ready as a new wire epoch and renegotiate (bounded by
     /// the per-session handshake attempt cap) instead of trusting stale v2-active state.
     private func resetWireNegotiationState() {
-        ancsAppIdentifiers.removeAll()
         incomingChunkReassembler.clear()
         peerWireProtocolVersion = 0
         useBinaryWireProtocol = false
@@ -5300,6 +5341,14 @@ extension MentraLive {
         peerFilePayloadV2 = false
         BleJsonCompact.resetSession()
         wireHandshakeSentGeneration = -1
+    }
+
+    /// ANCS notification IDs live for the BLE link, not the wire epoch. A
+    /// glasses_ready message may reset wire negotiation without disconnecting,
+    /// so clear this state only when the BLE session itself ends.
+    private func resetAncsRelayState() {
+        ancsAppIdentifiers.removeAll()
+        ancsRelayEnableRequested = false
     }
 
     private func parsePeerWireCaps(_ json: [String: Any]) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when notification relay starts and how ANCS state survives wire renegotiation; guarded one-shot enable and ignored-by-old-firmware command limit blast radius.
> 
> **Overview**
> Fixes iOS Mentra Live ANCS relay so firmware is only opted in **after** iOS has authorized the accessory and the K900 TX/RX path is ready, instead of racing authorization with service setup.
> 
> Adds **`enableAncsRelayIfAuthorized()`**, which sends a one-shot **`cs_ancs`** command when `peripheral.ancsAuthorized`, characteristics are present, and RX notifications are on. It is invoked from service discovery, when RX notify turns on, and from a new **`didUpdateANCSAuthorizationFor`** central-manager callback so authorization can finish before or after discovery.
> 
> **ANCS state is split from wire negotiation:** `ancsAppIdentifiers` and the enable flag are cleared in **`resetAncsRelayState()`** on BLE disconnect only, not when **`resetWireNegotiationState()`** runs on `glasses_ready`, so notification IDs are not dropped on mid-link wire resets.
> 
> Incoming **`sr_ancs`** bodies now use **`k900ParseBody`** so dict or JSON-string `B` payloads parse correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 397d967bca77c7bdc354ae11b6c371bf82ba85a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->