### PR TITLE
Route audio worker and Soniox logs through pino

### DIFF
--- a/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
@@ -36,6 +36,9 @@ import type {
   TranscriptionProvider,
   TranscriptEvent,
 } from "./provider";
+import { createLogger } from "@mentra/cloud-shared";
+
+const logger = createLogger("runtime").child({ module: "soniox" });
 
 const SONIOX_MODEL = process.env.SONIOX_MODEL ?? "stt-rt-v4";
 function audioGapConfig(): { checkIntervalMs: number; thresholdMs: number } {
@@ -635,9 +638,7 @@ export async function createSonioxProvider(
   // The `disconnected` handler is named so the same function is wired onto every
   // session instance (original + each reconnect) and can be `off`-ed on close.
   const handleDisconnected = (reason: unknown) => {
-    console.log(
-      `[soniox] disconnected scope=${opts.scope} reason=${typeof reason === "string" ? reason : JSON.stringify(reason)}`,
-    );
+    logger.info(`disconnected scope=${opts.scope} reason=${typeof reason === "string" ? reason : JSON.stringify(reason)}`);
     // An UNEXPECTED disconnect (not our own close()) means the upstream session
     // is gone. Self-heal in place so the provider keeps producing transcripts
     // for the audio that is still arriving. An expected disconnect (closed=true)
@@ -646,13 +647,13 @@ export async function createSonioxProvider(
   };
 
   const handleConnected = () => {
-    console.log(
-      `[soniox] connected scope=${opts.scope} lang=${opts.language}${opts.targetLanguage ? ` → ${opts.targetLanguage}` : ""}`,
+    logger.info(
+      `connected scope=${opts.scope} lang=${opts.language}${opts.targetLanguage ? ` → ${opts.targetLanguage}` : ""}`,
     );
   };
 
   const handleFinished = () => {
-    console.log(`[soniox] finished scope=${opts.scope}`);
+    logger.info(`finished scope=${opts.scope}`);
     commitPendingFinal();
     emitFinal();
   };
@@ -707,9 +708,9 @@ export async function createSonioxProvider(
       try {
         session.pause();
         pausedForGap = true;
-        console.log(`[soniox] auto-paused scope=${opts.scope} after audio gap`);
+        logger.info(`auto-paused scope=${opts.scope} after audio gap`);
       } catch (err) {
-        console.warn(`[soniox] auto-pause failed scope=${opts.scope}:`, err);
+        logger.warn({ err }, `auto-pause failed scope=${opts.scope}`);
       }
     }, gapConfig.checkIntervalMs);
   };
@@ -737,9 +738,7 @@ export async function createSonioxProvider(
       while (!closed) {
         reconnectAttempts += 1;
         if (reconnectAttempts > reconnect.maxAttempts) {
-          console.error(
-            `[soniox] self-heal gave up scope=${opts.scope} after ${reconnect.maxAttempts} attempts (trigger=${trigger})`,
-          );
+          logger.error(`self-heal gave up scope=${opts.scope} after ${reconnect.maxAttempts} attempts (trigger=${trigger})`);
           opts.onError?.(
             new Error(`soniox session lost and could not reconnect (scope=${opts.scope})`),
           );
@@ -751,9 +750,7 @@ export async function createSonioxProvider(
           reconnect.maxMs,
           reconnect.baseMs * 2 ** (reconnectAttempts - 1),
         );
-        console.log(
-          `[soniox] self-heal reconnect scope=${opts.scope} attempt=${reconnectAttempts} delayMs=${delay} trigger=${trigger}`,
-        );
+        logger.info(`self-heal reconnect scope=${opts.scope} attempt=${reconnectAttempts} delayMs=${delay} trigger=${trigger}`);
         await new Promise((resolve) => setTimeout(resolve, delay));
         if (closed) break;
 
@@ -769,13 +766,10 @@ export async function createSonioxProvider(
           reconnecting = false;
           reconnectAttempts = 0;
           startGapDetection();
-          console.log(`[soniox] self-heal reconnected scope=${opts.scope}`);
+          logger.info(`self-heal reconnected scope=${opts.scope}`);
           return;
         } catch (err) {
-          console.error(
-            `[soniox] self-heal connect failed scope=${opts.scope} attempt=${reconnectAttempts}:`,
-            err,
-          );
+          logger.error({ err }, `self-heal connect failed scope=${opts.scope} attempt=${reconnectAttempts}`);
           unwireSession(next);
           try {
             await next.close();
@@ -797,7 +791,7 @@ export async function createSonioxProvider(
     await session.connect();
     startGapDetection();
   } catch (err) {
-    console.error(`[soniox] connect failed scope=${opts.scope}:`, err);
+    logger.error({ err }, `connect failed scope=${opts.scope}`);
     opts.onError?.(err as Error);
     throw err;
   }
@@ -817,9 +811,9 @@ export async function createSonioxProvider(
           session.resume();
           pausedForGap = false;
           resetActiveUtterance();
-          console.log(`[soniox] resumed scope=${opts.scope} after audio gap`);
+          logger.info(`resumed scope=${opts.scope} after audio gap`);
         } catch (err) {
-          console.warn(`[soniox] resume failed scope=${opts.scope}:`, err);
+          logger.warn({ err }, `resume failed scope=${opts.scope}`);
         }
       }
       try {

--- a/cloud-v2/packages/runtime/src/services/audio/workers/worker.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/workers/worker.ts
@@ -24,6 +24,7 @@
  */
 
 import {Redis} from "ioredis"
+import {createLogger} from "@mentra/cloud-shared"
 import {AUDIO_STREAM_GROUP, audioStreamKey} from "../../session/stream"
 import {CONTROL_STREAM_GROUP, controlStreamKey} from "../../session/control-stream"
 import type {SubscriptionRecord} from "../../session/subscriptions-store"
@@ -37,6 +38,8 @@ import {
   type LanguageSource,
   type TranscriptionSubscription,
 } from "../../session/subscriptions"
+
+const logger = createLogger("runtime").child({module: "audio-worker"})
 
 // === Worker IPC types ===
 
@@ -258,7 +261,7 @@ async function handleAttach(mentraUserId: string): Promise<void> {
     try {
       decoders.set(mentraUserId, await LC3Decoder.create(userLc3FrameSizes.get(mentraUserId) ?? 20))
     } catch (err) {
-      console.error("[audio-worker] LC3Decoder.create failed:", err)
+      logger.error({err}, "LC3Decoder.create failed")
     }
   }
   const ok = await ensureConsumerGroup(mentraUserId)
@@ -291,7 +294,7 @@ async function reconcileFromKey(mentraUserId: string): Promise<void> {
       subs = record.subscriptions ?? []
     }
   } catch (err) {
-    console.error("[audio-worker] reconcileFromKey read failed:", err)
+    logger.error({err}, "reconcileFromKey read failed")
     return
   }
   await reconcileProviders(mentraUserId, subs)
@@ -328,7 +331,7 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
     if (!desired.has(key)) {
       existing.delete(key)
       provider.close().catch((err) => {
-        console.error("[audio-worker] provider close failed:", err)
+        logger.error({err}, "provider close failed")
       })
     }
   }
@@ -344,11 +347,11 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
           existing.set(key, provider)
         } else if (!existing.has(key)) {
           provider.close().catch((err) => {
-            console.error("[audio-worker] provider close failed:", err)
+            logger.error({err}, "provider close failed")
           })
         }
       } catch (err) {
-        console.error("[audio-worker] provider create failed:", err)
+        logger.error({err}, "provider create failed")
       }
       continue
     }
@@ -361,11 +364,11 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
         existing.set(key, provider)
       } else {
         provider.close().catch((err) => {
-          console.error("[audio-worker] provider close failed:", err)
+          logger.error({err}, "provider close failed")
         })
       }
     } catch (err) {
-      console.error("[audio-worker] provider create failed:", err)
+      logger.error({err}, "provider create failed")
     } finally {
       if (creating.get(key) === creation) creating.delete(key)
       if (creating.size === 0) userProviderCreates.delete(mentraUserId)
@@ -420,7 +423,7 @@ async function createProvider(mentraUserId: string, sub: AudioSubscription): Pro
     self.postMessage(out)
   }
   const onError = (err: Error) => {
-    console.error(`[audio-worker] provider(${PROVIDER_KIND}) error for ${mentraUserId}:`, err)
+    logger.error({err, mentraUserId}, `provider(${PROVIDER_KIND}) error`)
   }
 
   switch (PROVIDER_KIND) {
@@ -464,7 +467,7 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
               decoders.set(msg.mentraUserId, decoder)
             })
             .catch((err) => {
-              console.error("[audio-worker] LC3Decoder.create failed:", err)
+              logger.error({err}, "LC3Decoder.create failed")
             })
         }
       }
@@ -483,7 +486,7 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
         userProviders.delete(msg.mentraUserId)
         for (const provider of providers.values()) {
           provider.close().catch((err) => {
-            console.error("[audio-worker] provider close failed:", err)
+            logger.error({err}, "provider close failed")
           })
         }
       }
@@ -517,7 +520,7 @@ async function ensureConsumerGroup(mentraUserId: string): Promise<boolean> {
     const msg = (err as Error).message ?? ""
     // BUSYGROUP = "already exists" — that's success for our purposes.
     if (msg.includes("BUSYGROUP")) return true
-    console.error("[audio-worker] xgroup create failed:", err)
+    logger.error({err}, "xgroup create failed")
     return false
   }
 }
@@ -538,7 +541,7 @@ async function ensureControlConsumerGroup(mentraUserId: string): Promise<boolean
       controlReadyUsers.add(mentraUserId)
       return true
     }
-    console.error("[audio-worker] control xgroup create failed:", err)
+    logger.error({err}, "control xgroup create failed")
     return false
   }
 }
@@ -592,11 +595,14 @@ async function controlReadLoop(): Promise<void> {
                 shouldReconcile = true
                 break
               case "udp-liveness-ack":
-                console.debug("[audio-worker] udp liveness ack control received", {
-                  mentraUserId,
-                  sessionTag: map.sessionTag,
-                  probeId: map.probeId,
-                })
+                logger.debug(
+                  {
+                    mentraUserId,
+                    sessionTag: map.sessionTag,
+                    probeId: map.probeId,
+                  },
+                  "udp liveness ack control received",
+                )
                 self.postMessage({
                   type: "UDP_LIVENESS_ACK",
                   mentraUserId,
@@ -615,7 +621,7 @@ async function controlReadLoop(): Promise<void> {
             try {
               await controlClient.xack(streamKey, CONTROL_STREAM_GROUP, entryId)
             } catch (err) {
-              console.error("[audio-worker] control xack failed:", err)
+              logger.error({err}, "control xack failed")
             }
           }
         }
@@ -625,7 +631,7 @@ async function controlReadLoop(): Promise<void> {
           await ensureControlConsumerGroup(userId)
           continue
         }
-        console.error("[audio-worker] control xreadgroup failed:", err)
+        logger.error({err}, "control xreadgroup failed")
         await Bun.sleep(500)
       }
     }
@@ -681,7 +687,7 @@ async function freshReadLoop(): Promise<void> {
           await ensureConsumerGroup(userId)
           continue
         }
-        console.error("[audio-worker] xreadgroup failed:", err)
+        logger.error({err}, "xreadgroup failed")
         await Bun.sleep(500)
       }
     }
@@ -695,7 +701,7 @@ async function autoclaimLoop(): Promise<void> {
       try {
         await drainAutoclaim(userId)
       } catch (err) {
-        console.error("[audio-worker] autoclaim failed:", err)
+        logger.error({err}, "autoclaim failed")
       }
     }
     await Bun.sleep(XAUTOCLAIM_LOOP_INTERVAL_MS)
@@ -790,7 +796,7 @@ async function processBatch(
             try {
               provider.writeAudio(pcm)
             } catch (err) {
-              console.error("[audio-worker] provider.writeAudio failed:", err)
+              logger.error({err}, "provider.writeAudio failed")
             }
           }
         }
@@ -800,8 +806,17 @@ async function processBatch(
       // observable without flooding: payload size, codec, decode result, and
       // how many providers the PCM actually reached.
       if (seq % 128 === 0) {
-        console.log(
-          `[audio-worker] feed user=${mentraUserId.slice(-6)} seq=${seq} payload=${payloadLen}B codec=${codec} hasDecoder=${decoders.has(mentraUserId)} pcm=${pcmBytesLen}B providers=${userProviders.get(mentraUserId)?.size ?? 0}`,
+        logger.info(
+          {
+            user: mentraUserId.slice(-6),
+            seq,
+            payloadBytes: payloadLen,
+            codec,
+            hasDecoder: decoders.has(mentraUserId),
+            pcmBytes: pcmBytesLen,
+            providers: userProviders.get(mentraUserId)?.size ?? 0,
+          },
+          "feed",
         )
       }
 
@@ -820,7 +835,7 @@ async function processBatch(
       try {
         await streamsClient.xack(streamKey, AUDIO_STREAM_GROUP, entryId)
       } catch (err) {
-        console.error("[audio-worker] xack failed:", err)
+        logger.error({err}, "xack failed")
       }
     }
   }


### PR DESCRIPTION
The audio worker (`packages/runtime/src/services/audio/workers/worker.ts`) and the Soniox provider (`providers/soniox.ts`) were the only cloud-v2 code logging via raw `console.*` (~32 call sites). Those lines bypass `LOG_LEVEL`, carry none of the structured pod/package metadata every other log has, and cannot be filtered or silenced, which matters both for Porter log hygiene and for any future decision to ship v2 logs (the V1 Betterstack bill came from exactly this kind of unfiltered volume).

## Change

- Both files get `createLogger("runtime").child({module: "audio-worker" | "soniox"})`.
- `console.error(..., err)` becomes `logger.error({err}, msg)`; warns keep warn severity; lifecycle events (connect/disconnect/self-heal/auto-pause) log at info.
- The per-user feed heartbeat (already deliberately throttled to one line per 128 chunks, ~1 per 5s of audio) becomes a structured info event with the same fields.
- Message text preserved minus the `[audio-worker]`/`[soniox]` prefixes, which the `module` field now carries.

No behavior change beyond log formatting.

## Verification

- `bun run typecheck` (tsc -b) passes.
- `packages/runtime/src/services/audio/providers/soniox.test.ts`: 14/14 pass.
- `tests/audio.integration.test.ts` (real Redis, exercises the worker end to end): 22 pass / 1 fail, and the same single failure ("ownership claim is set on WS open and released on close") reproduces identically on unmodified dev, so it is pre-existing and unrelated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Logging-only refactor with no changes to audio, Redis, or Soniox session logic.
> 
> **Overview**
> Replaces the remaining **`console.*`** usage in the audio worker and Soniox provider with **`createLogger("runtime")`** child loggers (`module: "audio-worker"` / `"soniox"`), aligning them with the rest of cloud-v2 logging.
> 
> Errors now use structured **`{ err }`** fields; lifecycle and self-heal messages stay at **info**/**warn**/**error** as before. The throttled per-user **feed** heartbeat becomes a structured **info** event (same fields, no `[prefix]` in the message text). **No runtime or transcription behavior changes**—only log shape, **`LOG_LEVEL`** respect, and shared metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f8024b5011398267d161c8012f41063da30d4fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route audio worker and Soniox provider logs through `pino` for structured, filterable output that respects `LOG_LEVEL` and matches the rest of cloud‑v2. Replaces raw console logs with `createLogger` from `@mentra/cloud-shared`.

- **Refactors**
  - Switched to `createLogger("runtime").child({ module: "audio-worker" | "soniox" })`.
  - Preserved severity: errors/warns stay the same; lifecycle events log at info.
  - Converted feed heartbeat to a structured info event (still 1 line per 128 chunks).
  - Message text preserved; `[audio-worker]`/`[soniox]` prefixes now in the `module` field.
  - No behavior changes beyond log formatting.

<sup>Written for commit 0f8024b5011398267d161c8012f41063da30d4fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

