### PR TITLE
Add BetterStack log shipping infra for cloud-v2 (OS-1743)

### DIFF
--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -10,7 +10,7 @@ a worker thread and grows heap without bound under load.
 
 | Env | Source | id | Table | Retention |
 | --- | --- | --- | --- | --- |
-| dev | MentraCloud V2 - Dev | 2616420 | `mentracloud_v2_dev` | 30 days |
+| dev | MentraCloud V2 - Dev | 2616831 | `mentracloud_v2_dev_2` | 30 days |
 
 Staging/prod sources get created when their envs join shipping (deliberate
 edit to the Vector filter + a routed sink per env, never a wildcard).
@@ -34,11 +34,19 @@ first week after any change.
 
 ## Querying
 
+This source lives in the `germany` data region on the `eu-central-1a`
+ClickHouse cluster (the legacy V1 sources are on `eu-nbg-2`). It shares the
+same SQL credentials as the `eu-nbg-2` sources (Doppler `mentra-sre`
+`BETTERSTACK_USERNAME`/`PASSWORD`), but you must query it against its own
+connect endpoint `https://eu-central-1a-connect.betterstackdata.com/`, not
+the `eu-nbg-2-connect` host the `bstack` CLI defaults to. The `remote()`
+table only materializes once the source has received data.
+
 Hot storage (last ~30 min, sub-second):
 
 ```sql
 SELECT dt, level, message, package, module
-FROM remote(t2616420_mentracloud_v2_dev_logs)
+FROM remote(t373499_mentracloud_v2_dev_2_logs)
 WHERE level = 'error' AND dt > now() - INTERVAL 30 MINUTE
 ORDER BY dt DESC LIMIT 100
 ```
@@ -47,7 +55,7 @@ S3 storage (30 days, 3-5s per query, `_row_type = 1` for log rows):
 
 ```sql
 SELECT dt, JSONExtractString(raw, 'message') AS msg
-FROM s3Cluster(primary, t2616420_mentracloud_v2_dev_s3)
+FROM s3Cluster(primary, t373499_mentracloud_v2_dev_2_s3)
 WHERE _row_type = 1
   AND JSONExtractString(raw, 'level') = 'error'
   AND dt > now() - INTERVAL 7 DAY

--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -1,0 +1,75 @@
+# Cloud-v2 logs in BetterStack
+
+Cloud-v2 pods write pino JSON to stdout (`LOG_STDOUT_JSON=true` in deployed
+envs). A Vector DaemonSet on the cluster tails container stdout, filters to
+cloud-v2 app containers, flattens the pino fields, and ships to BetterStack.
+The app never ships logs itself; an in-process HTTP log transport buffers in
+a worker thread and grows heap without bound under load.
+
+## Sources
+
+| Env | Source | id | Table | Retention |
+| --- | --- | --- | --- | --- |
+| dev | MentraCloud V2 - Dev | 2616420 | `mentracloud_v2_dev` | 30 days |
+
+Staging/prod sources get created when their envs join shipping (deliberate
+edit to the Vector filter + a routed sink per env, never a wildcard).
+
+Source tokens live in Doppler: `cloud-v2/<env>` `BETTERSTACK_SOURCE_TOKEN`.
+API credentials for source management live in Doppler `mentra-sre/dev`.
+
+## Install / upgrade
+
+See the header of `cloud-v2/infra/betterstack-logs/values.yaml` for the
+exact `porter helm --cluster 5692` command. Re-run with `upgrade` instead of
+`install` after editing values.
+
+## Cost guard
+
+The Vector filter (`starts_with(container_name, "cloud-dev-")`) is the only
+thing bounding ingest. Renaming a Porter app or adding a service changes
+container names; check the filter whenever that happens. Keep retention at
+30 days unless there is a reason. Watch the source's ingest volume for the
+first week after any change.
+
+## Querying
+
+Hot storage (last ~30 min, sub-second):
+
+```sql
+SELECT dt, level, message, package, module
+FROM remote(t2616420_mentracloud_v2_dev_logs)
+WHERE level = 'error' AND dt > now() - INTERVAL 30 MINUTE
+ORDER BY dt DESC LIMIT 100
+```
+
+S3 storage (30 days, 3-5s per query, `_row_type = 1` for log rows):
+
+```sql
+SELECT dt, JSONExtractString(raw, 'message') AS msg
+FROM s3Cluster(primary, t2616420_mentracloud_v2_dev_s3)
+WHERE _row_type = 1
+  AND JSONExtractString(raw, 'level') = 'error'
+  AND dt > now() - INTERVAL 7 DAY
+ORDER BY dt DESC LIMIT 200
+```
+
+Useful fields (flattened from pino): `level`, `message`, `package`
+(core/runtime), `module` (e.g. audio-worker, soniox), `service`, plus
+whatever structured fields the call site attached. Vector metadata is under
+`_meta` (`kubernetes_pod`, `kubernetes_container`).
+
+Auth investigations: `session created`, `session revoked`, and refresh
+rejections all log from `package=core, service=session.service`; correlate
+with the mobile client's `MENTRA AUTH:` lines by timestamp and session id
+suffix.
+
+## Log hygiene rules
+
+- Everything goes through `createLogger(pkg)` from `@mentra/cloud-shared`
+  (pino). No `console.*` in server code: it bypasses LOG_LEVEL and ships
+  unstructured.
+- Per-message/per-chunk paths must be throttled or at debug. The audio
+  worker's feed heartbeat (1 line per 128 chunks per user) is the ceiling
+  for steady-state chatter.
+- No per-request HTTP access logging. Log outcomes and errors, not traffic.

--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -29,17 +29,26 @@ Doppler config.
 
 ## Install / upgrade
 
-See the header of `cloud-v2/infra/betterstack-logs/values.yaml` for the
-exact `porter helm --cluster 5692` command. Re-run with `upgrade` instead of
-`install` after editing values.
+Cluster 5692 does NOT expose kubeconfig, so `porter helm`/`kubectl` return
+`kubeconfig 400` (architectural, not a permissions gap). Deploy through the
+Porter dashboard: Add-ons -> Helm Chart, chart `betterstack-logs` **pinned to
+v1.1.6** (do not use latest; v2 restructures the metrics pipeline under
+`vector-aggregator` and breaks this `vector.customConfig` layout). Paste the
+contents of `infra/betterstack-logs/values.yaml` with the real per-env tokens
+from Doppler substituted for each `PLACEHOLDER_*_TOKEN`. To change config,
+edit the add-on's Configuration tab and Deploy a new revision. The add-on's
+API calls use the Admin token in Doppler `mentra-sre/dev` `PORTER_TOKEN_ADMIN`.
 
 ## Cost guard
 
-The Vector filter (`starts_with(container_name, "cloud-dev-")`) is the only
-thing bounding ingest. Renaming a Porter app or adding a service changes
-container names; check the filter whenever that happens. Keep retention at
-30 days unless there is a reason. Watch the source's ingest volume for the
-first week after any change.
+`cloudv2_only_filter` (the five `cloud-*` `starts_with` clauses) is the only
+thing bounding ingest; cluster 5692 also runs kube-system, ingress, karaoke,
+etc. which must never be shipped. Renaming a Porter app or adding a service
+changes container names, so re-check the filter and the `route_by_env` prefixes
+whenever that happens. Keep retention at 30 days per source unless there is a
+reason. The metrics pipeline stays disabled (`metrics-server.enabled: false`,
+no metrics-sink override) to avoid the V1 metrics-datapoint cost. Watch each
+source's ingest volume for the first week after any change.
 
 ## Querying
 
@@ -51,12 +60,21 @@ connect endpoint `https://eu-central-1a-connect.betterstackdata.com/`, not
 the `eu-nbg-2-connect` host the `bstack` CLI defaults to. The `remote()`
 table only materializes once the source has received data.
 
+Application fields live inside the `raw` JSON column, not physical columns,
+so extract them with `JSONExtractString` in both `SELECT` and `WHERE` (a bare
+`WHERE level = ...` fails with `UNKNOWN_IDENTIFIER`).
+
 Hot storage (last ~30 min, sub-second):
 
 ```sql
-SELECT dt, level, message, package, module
+SELECT dt,
+       JSONExtractString(raw, 'level')   AS level,
+       JSONExtractString(raw, 'message') AS message,
+       JSONExtractString(raw, 'package') AS package,
+       JSONExtractString(raw, 'module')  AS module
 FROM remote(t373499_mentracloud_v2_dev_2_logs)
-WHERE level = 'error' AND dt > now() - INTERVAL 30 MINUTE
+WHERE JSONExtractString(raw, 'level') = 'error'
+  AND dt > now() - INTERVAL 30 MINUTE
 ORDER BY dt DESC LIMIT 100
 ```
 

--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -59,8 +59,15 @@ thing bounding ingest; cluster 5692 also runs kube-system, ingress, karaoke,
 etc. which must never be shipped. Renaming a Porter app or adding a service
 changes container names, so re-check the filter and the `route_by_env` prefixes
 whenever that happens. Keep retention at 30 days per source unless there is a
-reason. The metrics pipeline stays disabled (`metrics-server.enabled: false`,
-no metrics-sink override) to avoid the V1 metrics-datapoint cost. Watch each
+reason. The metrics pipeline stays disabled (`metrics-server.enabled: false`)
+to avoid the V1 metrics-datapoint cost, but the `better_stack_http_metrics_sink`
+override must remain in the values anyway: the chart default for that sink has
+`token: null`, which is invalid Vector config and crash-loops the whole
+DaemonSet, killing log shipping for every env. Removing the override is what
+caused the 2026-07-20/21 outage (addon revisions 3 and 4, roughly 19 hours of
+lost logs; Vector backfills whatever is still in the node log files on restart,
+rotated logs are gone). The sink receives no events while metrics-server is
+disabled, so it just needs any valid token to pass config validation. Watch each
 source's ingest volume for the first week after any change.
 
 ## Querying

--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -8,15 +8,24 @@ a worker thread and grows heap without bound under load.
 
 ## Sources
 
+One Vector DaemonSet routes each cloud-v2 env to its own source (route transform
+keyed on the container-name prefix). All sources are in the germany /
+eu-central-1a region, 30-day retention.
+
 | Env | Source | id | Table | Retention |
 | --- | --- | --- | --- | --- |
 | dev | MentraCloud V2 - Dev | 2616831 | `mentracloud_v2_dev_2` | 30 days |
+| debug | MentraCloud V2 - Debug | 2616845 | `mentracloud_v2_debug` | 30 days |
+| isaiah | MentraCloud V2 - Isaiah | 2616847 | `mentracloud_v2_isaiah` | 30 days |
+| staging | MentraCloud V2 - Staging | 2616849 | `mentracloud_v2_staging` | 30 days |
+| prod | MentraCloud V2 - Prod | 2616851 | `mentracloud_v2_prod` | 30 days |
 
-Staging/prod sources get created when their envs join shipping (deliberate
-edit to the Vector filter + a routed sink per env, never a wildcard).
-
-Source tokens live in Doppler: `cloud-v2/<env>` `BETTERSTACK_SOURCE_TOKEN`.
-API credentials for source management live in Doppler `mentra-sre/dev`.
+Adding an env = one `starts_with` clause in the filter + a route entry + a sink
+in `infra/betterstack-logs/values.yaml`, never a wildcard. Per-source ingest
+tokens live in Doppler `mentra-sre/dev` as `BETTERSTACK_V2_SOURCE_TOKEN_<ENV>`
+(injected into the addon values; not committed). Source-management + deploy
+credentials (`BETTERSTACK_API_TOKEN`, `PORTER_TOKEN_ADMIN`) are in the same
+Doppler config.
 
 ## Install / upgrade
 

--- a/cloud-v2/docs/runbooks/betterstack-logs.md
+++ b/cloud-v2/docs/runbooks/betterstack-logs.md
@@ -39,6 +39,19 @@ from Doppler substituted for each `PLACEHOLDER_*_TOKEN`. To change config,
 edit the add-on's Configuration tab and Deploy a new revision. The add-on's
 API calls use the Admin token in Doppler `mentra-sre/dev` `PORTER_TOKEN_ADMIN`.
 
+**Landmine (caused a ~19h total shipping outage on 2026-07-20/21):** one bad
+sink token takes down ALL env shipping, not just that env's. Vector runs sink
+healthchecks at startup; if any sink 401s (e.g. a token that is literally the
+string `undefined` from an unset shell var during substitution), the
+DaemonSet pods never go Ready, helm marks the release Failed, and the broken
+config stays live (helm upgrade is not atomic here), so every route stops.
+Before deploying, verify each substituted token with a direct ingest POST
+(`curl -H "Authorization: Bearer $TOKEN" -X POST
+https://s<SOURCE_ID>.eu-central-1a.betterstackdata.com -d '{...}'` must
+return 202) and grep the pasted values for `undefined` and `PLACEHOLDER`.
+After deploying, confirm the add-on shows Deployed (not Failed) AND fresh
+rows arrive in every source's Live Tail.
+
 ## Cost guard
 
 `cloudv2_only_filter` (the five `cloud-*` `starts_with` clauses) is the only
@@ -52,17 +65,49 @@ source's ingest volume for the first week after any change.
 
 ## Querying
 
-This source lives in the `germany` data region on the `eu-central-1a`
-ClickHouse cluster (the legacy V1 sources are on `eu-nbg-2`). It shares the
-same SQL credentials as the `eu-nbg-2` sources (Doppler `mentra-sre`
-`BETTERSTACK_USERNAME`/`PASSWORD`), but you must query it against its own
-connect endpoint `https://eu-central-1a-connect.betterstackdata.com/`, not
-the `eu-nbg-2-connect` host the `bstack` CLI defaults to. The `remote()`
-table only materializes once the source has received data.
+### Via the BetterStack UI (works today)
 
-Application fields live inside the `raw` JSON column, not physical columns,
-so extract them with `JSONExtractString` in both `SELECT` and `WHERE` (a bare
-`WHERE level = ...` fails with `UNKNOWN_IDENTIFIER`).
+Live Tail and Events -> Explore logs query the V2 sources fine: pick the
+`MentraCloud V2 - <env>` source in the source picker. BetterStack's own UI
+federates internally across clusters, so this is the reliable path for
+interactive debugging right now. Live Tail is fixed to the last 10 minutes;
+use Explore logs (Table/Text viz) with a widened time range for history.
+
+### Via the external SQL API (bstack CLI / curl)
+
+Credentials are **cluster-bound**, not team-wide. The V2 sources live in the
+`germany` data region on the `eu-central-1a` ClickHouse cluster; the legacy V1
+sources live on `eu-nbg-2`. A ClickHouse HTTP client (Telemetry ->
+Integrations -> SQL API) is issued against whichever cluster is the team's
+primary at creation time and can only reach sources on that cluster.
+
+- **V2 (eu-central-1a):** Doppler `mentra-sre` `BETTERSTACK_V2_USERNAME` /
+  `BETTERSTACK_V2_PASSWORD`, host `BETTERSTACK_V2_HOST`
+  (`https://eu-central-1a-connect.betterstackdata.com`). Created 2026-07-21;
+  reaches all five V2 sources. Use this for cloud-v2 debugging.
+- **V1 (eu-nbg-2):** the older Doppler `mentra-sre`
+  `BETTERSTACK_USERNAME` / `PASSWORD`, host
+  `https://eu-nbg-2-connect.betterstackdata.com`. Legacy V1 only; it returns
+  `Code 701 CLUSTER_DOESNT_EXIST` for V2 tables and the V2 cred returns
+  `Code 516 AUTHENTICATION_FAILED` on the wrong host, so do not cross them.
+
+Verified 2026-07-21 against the V2 cred: `SELECT 1` -> ok;
+`s3Cluster(primary, t373499_mentracloud_v2_dev_2_s3)` -> 26,013 rows (7d).
+
+Two tables per source: `remote(...)` is the hot buffer (last ~30 min, empty
+when the env is idle) and `s3Cluster(primary, ..._s3)` is the 30-day archive
+(`_row_type = 1` for log rows). Query S3 for anything older than the last few
+minutes. The `remote()` table only materializes once the source has data.
+
+Application fields live inside the `raw` JSON column, not physical columns, so
+extract them with `JSONExtractString` in both `SELECT` and `WHERE` (a bare
+`WHERE level = ...` fails with `UNKNOWN_IDENTIFIER`). **Caveat:** these extract
+to empty strings until the env deploys with `LOG_STDOUT_JSON=true` -- before
+that, pino pretty-prints multi-line text and `raw` is not a JSON object, so
+`level`/`package`/`module` come back blank (observed on cloud-dev 2026-07-21,
+pending a redeploy).
+
+Query the V2 cred against `$BETTERSTACK_V2_HOST`:
 
 Hot storage (last ~30 min, sub-second):
 

--- a/cloud-v2/infra/betterstack-logs/values.yaml
+++ b/cloud-v2/infra/betterstack-logs/values.yaml
@@ -1,5 +1,9 @@
 # BetterStack Logs Helm chart values for the cloud-v2 cluster (Porter 5692).
 #
+# Chart: betterstack-logs PINNED to v1.1.6. Do NOT install unpinned: v2.0.0
+# restructures the metrics pipeline under vector-aggregator, which would invalidate
+# this vector.customConfig layout. The Porter add-on has Chart Version pinned to v1.1.6.
+#
 # ONE Vector DaemonSet (one pod per node) tails every container stdout on the
 # node, filters to the five cloud-v2 Porter apps, flattens the pino JSON, and
 # routes each env to its OWN BetterStack source via a route transform. There is

--- a/cloud-v2/infra/betterstack-logs/values.yaml
+++ b/cloud-v2/infra/betterstack-logs/values.yaml
@@ -1,0 +1,107 @@
+# BetterStack Logs Helm chart values for the cloud-v2 cluster (Porter 5692).
+#
+# Deploys Vector as a DaemonSet that tails container stdout, filters to
+# cloud-v2 app containers, flattens the pino JSON to top-level fields, and
+# ships to the MentraCloud V2 BetterStack source over HTTPS.
+#
+# Never ship logs in-process from the app (a pino HTTP transport buffers in
+# a worker thread and grows heap without bound under load). Pods write JSON
+# to stdout; Vector owns all network shipping.
+#
+# COST GUARD: the filter below is the only thing bounding ingest volume.
+# It matches ONLY the cloud-dev Porter app's containers. Adding an app or
+# env to shipping is a deliberate edit here (new starts_with clause routed
+# to that env's own source), never a wildcard.
+#
+# Install (requires an authenticated porter CLI):
+#   SOURCE_TOKEN=$(doppler secrets get BETTERSTACK_SOURCE_TOKEN --project cloud-v2 --config dev --plain)
+#   porter helm --cluster 5692 -- install betterstack-logs \
+#     betterstack-logs/betterstack-logs \
+#     --namespace betterstack \
+#     --create-namespace \
+#     --values cloud-v2/infra/betterstack-logs/values.yaml \
+#     --set "vector.customConfig.sinks.better_stack_http_sink.auth.token=$SOURCE_TOKEN" \
+#     --set "vector.customConfig.sinks.better_stack_http_sink.uri=https://s2616420.ap-sng-8.betterstackdata.com/" \
+#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.auth.token=$SOURCE_TOKEN" \
+#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.uri=https://s2616420.ap-sng-8.betterstackdata.com/metrics"
+#
+# Source: "MentraCloud V2 - Dev" (id 2616420, table mentracloud_v2_dev,
+# 30-day retention). Token lives in Doppler cloud-v2/dev as
+# BETTERSTACK_SOURCE_TOKEN.
+
+vector:
+  customConfig:
+    transforms:
+      # Filter to cloud-v2 app containers only. Drops kube-system,
+      # ingress, porter-agent, and every other tenant on the node.
+      cloudv2_only_filter:
+        type: "filter"
+        inputs: ["better_stack_kubernetes_parser"]
+        condition: >
+          starts_with(to_string!(.kubernetes.container_name), "cloud-dev-")
+
+      # Flatten the pino JSON so app fields (package, module, level, msg)
+      # are top-level and filterable in Live Tail.
+      flatten_pino:
+        type: "remap"
+        inputs: ["cloudv2_only_filter"]
+        source: |
+          kube_pod = to_string(.kubernetes.pod_name) ?? "unknown"
+          kube_container = to_string(.kubernetes.container_name) ?? "unknown"
+
+          pino_data = .message
+          if is_string(pino_data) {
+            parsed, err = parse_json(string!(pino_data))
+            if err == null {
+              pino_data = parsed
+            }
+          }
+          if is_object(pino_data) {
+            . = object!(pino_data)
+          }
+
+          # msg -> message, time -> dt, numeric level -> string, matching
+          # what BetterStack's UI and saved queries expect.
+          if exists(.msg) {
+            .message = del(.msg)
+          }
+          if exists(.time) {
+            .dt = del(.time)
+          }
+          if is_integer(.level) {
+            numeric_level = to_int!(.level)
+            if numeric_level >= 60 {
+              .level = "fatal"
+            } else if numeric_level >= 50 {
+              .level = "error"
+            } else if numeric_level >= 40 {
+              .level = "warn"
+            } else if numeric_level >= 30 {
+              .level = "info"
+            } else if numeric_level >= 20 {
+              .level = "debug"
+            } else {
+              .level = "trace"
+            }
+          }
+
+          ._meta.kubernetes_pod = kube_pod
+          ._meta.kubernetes_container = kube_container
+          ._meta.log_source = "vector"
+
+    sinks:
+      better_stack_http_sink:
+        inputs: ["flatten_pino"]
+        # Token + uri are injected at install time via --set; never commit them.
+        uri: "https://PLACEHOLDER_INGESTING_HOST/"
+        auth:
+          strategy: "bearer"
+          token: "PLACEHOLDER_SOURCE_TOKEN"
+      better_stack_http_metrics_sink:
+        uri: "https://PLACEHOLDER_INGESTING_HOST/metrics"
+        auth:
+          strategy: "bearer"
+          token: "PLACEHOLDER_SOURCE_TOKEN"
+
+metrics-server:
+  enabled: false

--- a/cloud-v2/infra/betterstack-logs/values.yaml
+++ b/cloud-v2/infra/betterstack-logs/values.yaml
@@ -1,54 +1,54 @@
 # BetterStack Logs Helm chart values for the cloud-v2 cluster (Porter 5692).
 #
-# Deploys Vector as a DaemonSet that tails container stdout, filters to
-# cloud-v2 app containers, flattens the pino JSON to top-level fields, and
-# ships to the MentraCloud V2 BetterStack source over HTTPS.
+# ONE Vector DaemonSet (one pod per node) tails every container stdout on the
+# node, filters to the five cloud-v2 Porter apps, flattens the pino JSON, and
+# routes each env to its OWN BetterStack source via a route transform. There is
+# no compute duplication: adding an env is a routing entry + a sink, not another
+# collector.
 #
-# Never ship logs in-process from the app (a pino HTTP transport buffers in
-# a worker thread and grows heap without bound under load). Pods write JSON
-# to stdout; Vector owns all network shipping.
+# Never ship logs in-process from the app (a pino HTTP transport buffers in a
+# worker thread and grows heap without bound under load). Pods write JSON to
+# stdout; Vector owns all network shipping.
 #
-# COST GUARD: the filter below is the only thing bounding ingest volume.
-# It matches ONLY the cloud-dev Porter app's containers. Adding an app or
-# env to shipping is a deliberate edit here (new starts_with clause routed
-# to that env's own source), never a wildcard.
+# COST GUARD: cloudv2_only_filter is the only thing bounding ingest volume. It
+# matches ONLY the five cloud-* Porter apps; cluster 5692 also hosts kube-system,
+# ingress, karaoke, etc. which must never be ingested. Any new env is a
+# deliberate starts_with clause + a routed sink to its own source, never a
+# wildcard. Retention is 30 days per source (Betterstack API floor).
 #
-# Install (requires an authenticated porter CLI):
-#   SOURCE_TOKEN=$(doppler secrets get BETTERSTACK_SOURCE_TOKEN --project cloud-v2 --config dev --plain)
-#   porter helm --cluster 5692 -- install betterstack-logs \
-#     betterstack-logs/betterstack-logs \
-#     --namespace betterstack \
-#     --create-namespace \
-#     --values cloud-v2/infra/betterstack-logs/values.yaml \
-#     --set "vector.customConfig.sinks.better_stack_http_sink.auth.token=$SOURCE_TOKEN" \
-#     --set "vector.customConfig.sinks.better_stack_http_sink.uri=https://s2616831.eu-central-1a.betterstackdata.com/" \
-#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.auth.token=$SOURCE_TOKEN" \
-#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.uri=https://s2616831.eu-central-1a.betterstackdata.com/metrics"
+# Sources (all germany / eu-central-1a region; tokens are NOT committed, they
+# live in Doppler mentra-sre/dev and are injected into the sinks below):
+#   DEV      src 2616831  host s2616831.eu-central-1a.betterstackdata.com  token Doppler mentra-sre/dev BETTERSTACK_V2_SOURCE_TOKEN_DEV
+#   DEBUG    src 2616845  host s2616845.eu-central-1a.betterstackdata.com  token Doppler mentra-sre/dev BETTERSTACK_V2_SOURCE_TOKEN_DEBUG
+#   ISAIAH   src 2616847  host s2616847.eu-central-1a.betterstackdata.com  token Doppler mentra-sre/dev BETTERSTACK_V2_SOURCE_TOKEN_ISAIAH
+#   STAGING  src 2616849  host s2616849.eu-central-1a.betterstackdata.com  token Doppler mentra-sre/dev BETTERSTACK_V2_SOURCE_TOKEN_STAGING
+#   PROD     src 2616851  host s2616851.eu-central-1a.betterstackdata.com  token Doppler mentra-sre/dev BETTERSTACK_V2_SOURCE_TOKEN_PROD
 #
-# Source: "MentraCloud V2 - Dev" (id 2616831, table mentracloud_v2_dev_2,
-# 30-day retention). Token lives in Doppler cloud-v2/dev as
-# BETTERSTACK_SOURCE_TOKEN.
+# Deploy path: this cluster does NOT expose kubeconfig, so `porter helm`/`kubectl`
+# 400. Deploy through Porter Add-ons -> Helm Chart (dashboard) or its API with an
+# Admin token (Doppler mentra-sre/dev PORTER_TOKEN_ADMIN). Paste these values with
+# the real per-env tokens substituted for the PLACEHOLDER_*_TOKEN strings below.
+# The metrics sink is intentionally left at the chart default (null token); with
+# metrics-server disabled there is nothing to scrape, so it is inert.
 
 vector:
   customConfig:
     transforms:
-      # Filter to cloud-v2 app containers only. Drops kube-system,
-      # ingress, porter-agent, and every other tenant on the node.
       cloudv2_only_filter:
         type: "filter"
         inputs: ["better_stack_kubernetes_parser"]
         condition: >
-          starts_with(to_string!(.kubernetes.container_name), "cloud-dev-")
-
-      # Flatten the pino JSON so app fields (package, module, level, msg)
-      # are top-level and filterable in Live Tail.
+          starts_with(to_string!(.kubernetes.container_name), "cloud-dev-") ||
+          starts_with(to_string!(.kubernetes.container_name), "cloud-debug-") ||
+          starts_with(to_string!(.kubernetes.container_name), "cloud-isaiah-") ||
+          starts_with(to_string!(.kubernetes.container_name), "cloud-staging-") ||
+          starts_with(to_string!(.kubernetes.container_name), "cloud-prod-")
       flatten_pino:
         type: "remap"
         inputs: ["cloudv2_only_filter"]
         source: |
           kube_pod = to_string(.kubernetes.pod_name) ?? "unknown"
           kube_container = to_string(.kubernetes.container_name) ?? "unknown"
-
           pino_data = .message
           if is_string(pino_data) {
             parsed, err = parse_json(string!(pino_data))
@@ -59,9 +59,6 @@ vector:
           if is_object(pino_data) {
             . = object!(pino_data)
           }
-
-          # msg -> message, time -> dt, numeric level -> string, matching
-          # what BetterStack's UI and saved queries expect.
           if exists(.msg) {
             .message = del(.msg)
           }
@@ -84,24 +81,68 @@ vector:
               .level = "trace"
             }
           }
-
           ._meta.kubernetes_pod = kube_pod
           ._meta.kubernetes_container = kube_container
           ._meta.log_source = "vector"
-
+      route_by_env:
+        type: "route"
+        inputs: ["flatten_pino"]
+        route:
+          dev: 'starts_with(to_string(._meta.kubernetes_container) ?? "", "cloud-dev-")'
+          debug: 'starts_with(to_string(._meta.kubernetes_container) ?? "", "cloud-debug-")'
+          isaiah: 'starts_with(to_string(._meta.kubernetes_container) ?? "", "cloud-isaiah-")'
+          staging: 'starts_with(to_string(._meta.kubernetes_container) ?? "", "cloud-staging-")'
+          prod: 'starts_with(to_string(._meta.kubernetes_container) ?? "", "cloud-prod-")'
     sinks:
       better_stack_http_sink:
-        inputs: ["flatten_pino"]
-        # Token + uri are injected at install time via --set; never commit them.
-        uri: "https://PLACEHOLDER_INGESTING_HOST/"
+        inputs: ["route_by_env.dev"]
+        uri: "https://s2616831.eu-central-1a.betterstackdata.com/"
         auth:
           strategy: "bearer"
-          token: "PLACEHOLDER_SOURCE_TOKEN"
-      better_stack_http_metrics_sink:
-        uri: "https://PLACEHOLDER_INGESTING_HOST/metrics"
+          token: "PLACEHOLDER_DEV_TOKEN"
+      bs_debug:
+        type: http
+        method: post
+        uri: "https://s2616845.eu-central-1a.betterstackdata.com/"
+        encoding:
+          codec: json
+        compression: gzip
         auth:
-          strategy: "bearer"
-          token: "PLACEHOLDER_SOURCE_TOKEN"
-
+          strategy: bearer
+          token: "PLACEHOLDER_DEBUG_TOKEN"
+        inputs: ["route_by_env.debug"]
+      bs_isaiah:
+        type: http
+        method: post
+        uri: "https://s2616847.eu-central-1a.betterstackdata.com/"
+        encoding:
+          codec: json
+        compression: gzip
+        auth:
+          strategy: bearer
+          token: "PLACEHOLDER_ISAIAH_TOKEN"
+        inputs: ["route_by_env.isaiah"]
+      bs_staging:
+        type: http
+        method: post
+        uri: "https://s2616849.eu-central-1a.betterstackdata.com/"
+        encoding:
+          codec: json
+        compression: gzip
+        auth:
+          strategy: bearer
+          token: "PLACEHOLDER_STAGING_TOKEN"
+        inputs: ["route_by_env.staging"]
+      bs_prod:
+        type: http
+        method: post
+        uri: "https://s2616851.eu-central-1a.betterstackdata.com/"
+        encoding:
+          codec: json
+        compression: gzip
+        auth:
+          strategy: bearer
+          token: "PLACEHOLDER_PROD_TOKEN"
+        inputs: ["route_by_env.prod"]
 metrics-server:
   enabled: false

--- a/cloud-v2/infra/betterstack-logs/values.yaml
+++ b/cloud-v2/infra/betterstack-logs/values.yaml
@@ -21,11 +21,11 @@
 #     --create-namespace \
 #     --values cloud-v2/infra/betterstack-logs/values.yaml \
 #     --set "vector.customConfig.sinks.better_stack_http_sink.auth.token=$SOURCE_TOKEN" \
-#     --set "vector.customConfig.sinks.better_stack_http_sink.uri=https://s2616420.ap-sng-8.betterstackdata.com/" \
+#     --set "vector.customConfig.sinks.better_stack_http_sink.uri=https://s2616831.eu-central-1a.betterstackdata.com/" \
 #     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.auth.token=$SOURCE_TOKEN" \
-#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.uri=https://s2616420.ap-sng-8.betterstackdata.com/metrics"
+#     --set "vector.customConfig.sinks.better_stack_http_metrics_sink.uri=https://s2616831.eu-central-1a.betterstackdata.com/metrics"
 #
-# Source: "MentraCloud V2 - Dev" (id 2616420, table mentracloud_v2_dev,
+# Source: "MentraCloud V2 - Dev" (id 2616831, table mentracloud_v2_dev_2,
 # 30-day retention). Token lives in Doppler cloud-v2/dev as
 # BETTERSTACK_SOURCE_TOKEN.
 

--- a/cloud-v2/infra/betterstack-logs/values.yaml
+++ b/cloud-v2/infra/betterstack-logs/values.yaml
@@ -32,8 +32,11 @@
 # 400. Deploy through Porter Add-ons -> Helm Chart (dashboard) or its API with an
 # Admin token (Doppler mentra-sre/dev PORTER_TOKEN_ADMIN). Paste these values with
 # the real per-env tokens substituted for the PLACEHOLDER_*_TOKEN strings below.
-# The metrics sink is intentionally left at the chart default (null token); with
-# metrics-server disabled there is nothing to scrape, so it is inert.
+# The better_stack_http_metrics_sink override below MUST stay. The chart default
+# for that sink has token: null, which is invalid Vector config and crash-loops
+# the entire DaemonSet, stopping log shipping for ALL envs (this caused the
+# 2026-07-20/21 outage, addon revisions 3 and 4). With metrics-server disabled
+# the sink never receives events, so any valid token works; we reuse the dev one.
 
 vector:
   customConfig:
@@ -148,5 +151,10 @@ vector:
           strategy: bearer
           token: "PLACEHOLDER_PROD_TOKEN"
         inputs: ["route_by_env.prod"]
+      better_stack_http_metrics_sink:
+        uri: "https://s2616831.eu-central-1a.betterstackdata.com/metrics"
+        auth:
+          strategy: "bearer"
+          token: "PLACEHOLDER_DEV_TOKEN"
 metrics-server:
   enabled: false

--- a/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/providers/soniox.ts
@@ -36,6 +36,9 @@ import type {
   TranscriptionProvider,
   TranscriptEvent,
 } from "./provider";
+import { createLogger } from "@mentra/cloud-shared";
+
+const logger = createLogger("runtime").child({ module: "soniox" });
 
 const SONIOX_MODEL = process.env.SONIOX_MODEL ?? "stt-rt-v4";
 function audioGapConfig(): { checkIntervalMs: number; thresholdMs: number } {
@@ -635,9 +638,7 @@ export async function createSonioxProvider(
   // The `disconnected` handler is named so the same function is wired onto every
   // session instance (original + each reconnect) and can be `off`-ed on close.
   const handleDisconnected = (reason: unknown) => {
-    console.log(
-      `[soniox] disconnected scope=${opts.scope} reason=${typeof reason === "string" ? reason : JSON.stringify(reason)}`,
-    );
+    logger.info(`disconnected scope=${opts.scope} reason=${typeof reason === "string" ? reason : JSON.stringify(reason)}`);
     // An UNEXPECTED disconnect (not our own close()) means the upstream session
     // is gone. Self-heal in place so the provider keeps producing transcripts
     // for the audio that is still arriving. An expected disconnect (closed=true)
@@ -646,13 +647,13 @@ export async function createSonioxProvider(
   };
 
   const handleConnected = () => {
-    console.log(
-      `[soniox] connected scope=${opts.scope} lang=${opts.language}${opts.targetLanguage ? ` → ${opts.targetLanguage}` : ""}`,
+    logger.info(
+      `connected scope=${opts.scope} lang=${opts.language}${opts.targetLanguage ? ` → ${opts.targetLanguage}` : ""}`,
     );
   };
 
   const handleFinished = () => {
-    console.log(`[soniox] finished scope=${opts.scope}`);
+    logger.info(`finished scope=${opts.scope}`);
     commitPendingFinal();
     emitFinal();
   };
@@ -707,9 +708,9 @@ export async function createSonioxProvider(
       try {
         session.pause();
         pausedForGap = true;
-        console.log(`[soniox] auto-paused scope=${opts.scope} after audio gap`);
+        logger.info(`auto-paused scope=${opts.scope} after audio gap`);
       } catch (err) {
-        console.warn(`[soniox] auto-pause failed scope=${opts.scope}:`, err);
+        logger.warn({ err }, `auto-pause failed scope=${opts.scope}`);
       }
     }, gapConfig.checkIntervalMs);
   };
@@ -737,9 +738,7 @@ export async function createSonioxProvider(
       while (!closed) {
         reconnectAttempts += 1;
         if (reconnectAttempts > reconnect.maxAttempts) {
-          console.error(
-            `[soniox] self-heal gave up scope=${opts.scope} after ${reconnect.maxAttempts} attempts (trigger=${trigger})`,
-          );
+          logger.error(`self-heal gave up scope=${opts.scope} after ${reconnect.maxAttempts} attempts (trigger=${trigger})`);
           opts.onError?.(
             new Error(`soniox session lost and could not reconnect (scope=${opts.scope})`),
           );
@@ -751,9 +750,7 @@ export async function createSonioxProvider(
           reconnect.maxMs,
           reconnect.baseMs * 2 ** (reconnectAttempts - 1),
         );
-        console.log(
-          `[soniox] self-heal reconnect scope=${opts.scope} attempt=${reconnectAttempts} delayMs=${delay} trigger=${trigger}`,
-        );
+        logger.info(`self-heal reconnect scope=${opts.scope} attempt=${reconnectAttempts} delayMs=${delay} trigger=${trigger}`);
         await new Promise((resolve) => setTimeout(resolve, delay));
         if (closed) break;
 
@@ -769,13 +766,10 @@ export async function createSonioxProvider(
           reconnecting = false;
           reconnectAttempts = 0;
           startGapDetection();
-          console.log(`[soniox] self-heal reconnected scope=${opts.scope}`);
+          logger.info(`self-heal reconnected scope=${opts.scope}`);
           return;
         } catch (err) {
-          console.error(
-            `[soniox] self-heal connect failed scope=${opts.scope} attempt=${reconnectAttempts}:`,
-            err,
-          );
+          logger.error({ err }, `self-heal connect failed scope=${opts.scope} attempt=${reconnectAttempts}`);
           unwireSession(next);
           try {
             await next.close();
@@ -797,7 +791,7 @@ export async function createSonioxProvider(
     await session.connect();
     startGapDetection();
   } catch (err) {
-    console.error(`[soniox] connect failed scope=${opts.scope}:`, err);
+    logger.error({ err }, `connect failed scope=${opts.scope}`);
     opts.onError?.(err as Error);
     throw err;
   }
@@ -817,9 +811,9 @@ export async function createSonioxProvider(
           session.resume();
           pausedForGap = false;
           resetActiveUtterance();
-          console.log(`[soniox] resumed scope=${opts.scope} after audio gap`);
+          logger.info(`resumed scope=${opts.scope} after audio gap`);
         } catch (err) {
-          console.warn(`[soniox] resume failed scope=${opts.scope}:`, err);
+          logger.warn({ err }, `resume failed scope=${opts.scope}`);
         }
       }
       try {

--- a/cloud-v2/packages/runtime/src/services/audio/workers/worker.ts
+++ b/cloud-v2/packages/runtime/src/services/audio/workers/worker.ts
@@ -24,6 +24,7 @@
  */
 
 import {Redis} from "ioredis"
+import {createLogger} from "@mentra/cloud-shared"
 import {AUDIO_STREAM_GROUP, audioStreamKey} from "../../session/stream"
 import {CONTROL_STREAM_GROUP, controlStreamKey} from "../../session/control-stream"
 import type {SubscriptionRecord} from "../../session/subscriptions-store"
@@ -37,6 +38,8 @@ import {
   type LanguageSource,
   type TranscriptionSubscription,
 } from "../../session/subscriptions"
+
+const logger = createLogger("runtime").child({module: "audio-worker"})
 
 // === Worker IPC types ===
 
@@ -258,7 +261,7 @@ async function handleAttach(mentraUserId: string): Promise<void> {
     try {
       decoders.set(mentraUserId, await LC3Decoder.create(userLc3FrameSizes.get(mentraUserId) ?? 20))
     } catch (err) {
-      console.error("[audio-worker] LC3Decoder.create failed:", err)
+      logger.error({err}, "LC3Decoder.create failed")
     }
   }
   const ok = await ensureConsumerGroup(mentraUserId)
@@ -291,7 +294,7 @@ async function reconcileFromKey(mentraUserId: string): Promise<void> {
       subs = record.subscriptions ?? []
     }
   } catch (err) {
-    console.error("[audio-worker] reconcileFromKey read failed:", err)
+    logger.error({err}, "reconcileFromKey read failed")
     return
   }
   await reconcileProviders(mentraUserId, subs)
@@ -328,7 +331,7 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
     if (!desired.has(key)) {
       existing.delete(key)
       provider.close().catch((err) => {
-        console.error("[audio-worker] provider close failed:", err)
+        logger.error({err}, "provider close failed")
       })
     }
   }
@@ -344,11 +347,11 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
           existing.set(key, provider)
         } else if (!existing.has(key)) {
           provider.close().catch((err) => {
-            console.error("[audio-worker] provider close failed:", err)
+            logger.error({err}, "provider close failed")
           })
         }
       } catch (err) {
-        console.error("[audio-worker] provider create failed:", err)
+        logger.error({err}, "provider create failed")
       }
       continue
     }
@@ -361,11 +364,11 @@ async function reconcileProviders(mentraUserId: string, subs: AudioSubscription[
         existing.set(key, provider)
       } else {
         provider.close().catch((err) => {
-          console.error("[audio-worker] provider close failed:", err)
+          logger.error({err}, "provider close failed")
         })
       }
     } catch (err) {
-      console.error("[audio-worker] provider create failed:", err)
+      logger.error({err}, "provider create failed")
     } finally {
       if (creating.get(key) === creation) creating.delete(key)
       if (creating.size === 0) userProviderCreates.delete(mentraUserId)
@@ -420,7 +423,7 @@ async function createProvider(mentraUserId: string, sub: AudioSubscription): Pro
     self.postMessage(out)
   }
   const onError = (err: Error) => {
-    console.error(`[audio-worker] provider(${PROVIDER_KIND}) error for ${mentraUserId}:`, err)
+    logger.error({err, mentraUserId}, `provider(${PROVIDER_KIND}) error`)
   }
 
   switch (PROVIDER_KIND) {
@@ -464,7 +467,7 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
               decoders.set(msg.mentraUserId, decoder)
             })
             .catch((err) => {
-              console.error("[audio-worker] LC3Decoder.create failed:", err)
+              logger.error({err}, "LC3Decoder.create failed")
             })
         }
       }
@@ -483,7 +486,7 @@ self.onmessage = (e: MessageEvent<WorkerInMessage>) => {
         userProviders.delete(msg.mentraUserId)
         for (const provider of providers.values()) {
           provider.close().catch((err) => {
-            console.error("[audio-worker] provider close failed:", err)
+            logger.error({err}, "provider close failed")
           })
         }
       }
@@ -517,7 +520,7 @@ async function ensureConsumerGroup(mentraUserId: string): Promise<boolean> {
     const msg = (err as Error).message ?? ""
     // BUSYGROUP = "already exists" — that's success for our purposes.
     if (msg.includes("BUSYGROUP")) return true
-    console.error("[audio-worker] xgroup create failed:", err)
+    logger.error({err}, "xgroup create failed")
     return false
   }
 }
@@ -538,7 +541,7 @@ async function ensureControlConsumerGroup(mentraUserId: string): Promise<boolean
       controlReadyUsers.add(mentraUserId)
       return true
     }
-    console.error("[audio-worker] control xgroup create failed:", err)
+    logger.error({err}, "control xgroup create failed")
     return false
   }
 }
@@ -592,11 +595,14 @@ async function controlReadLoop(): Promise<void> {
                 shouldReconcile = true
                 break
               case "udp-liveness-ack":
-                console.debug("[audio-worker] udp liveness ack control received", {
-                  mentraUserId,
-                  sessionTag: map.sessionTag,
-                  probeId: map.probeId,
-                })
+                logger.debug(
+                  {
+                    mentraUserId,
+                    sessionTag: map.sessionTag,
+                    probeId: map.probeId,
+                  },
+                  "udp liveness ack control received",
+                )
                 self.postMessage({
                   type: "UDP_LIVENESS_ACK",
                   mentraUserId,
@@ -615,7 +621,7 @@ async function controlReadLoop(): Promise<void> {
             try {
               await controlClient.xack(streamKey, CONTROL_STREAM_GROUP, entryId)
             } catch (err) {
-              console.error("[audio-worker] control xack failed:", err)
+              logger.error({err}, "control xack failed")
             }
           }
         }
@@ -625,7 +631,7 @@ async function controlReadLoop(): Promise<void> {
           await ensureControlConsumerGroup(userId)
           continue
         }
-        console.error("[audio-worker] control xreadgroup failed:", err)
+        logger.error({err}, "control xreadgroup failed")
         await Bun.sleep(500)
       }
     }
@@ -681,7 +687,7 @@ async function freshReadLoop(): Promise<void> {
           await ensureConsumerGroup(userId)
           continue
         }
-        console.error("[audio-worker] xreadgroup failed:", err)
+        logger.error({err}, "xreadgroup failed")
         await Bun.sleep(500)
       }
     }
@@ -695,7 +701,7 @@ async function autoclaimLoop(): Promise<void> {
       try {
         await drainAutoclaim(userId)
       } catch (err) {
-        console.error("[audio-worker] autoclaim failed:", err)
+        logger.error({err}, "autoclaim failed")
       }
     }
     await Bun.sleep(XAUTOCLAIM_LOOP_INTERVAL_MS)
@@ -790,7 +796,7 @@ async function processBatch(
             try {
               provider.writeAudio(pcm)
             } catch (err) {
-              console.error("[audio-worker] provider.writeAudio failed:", err)
+              logger.error({err}, "provider.writeAudio failed")
             }
           }
         }
@@ -800,8 +806,17 @@ async function processBatch(
       // observable without flooding: payload size, codec, decode result, and
       // how many providers the PCM actually reached.
       if (seq % 128 === 0) {
-        console.log(
-          `[audio-worker] feed user=${mentraUserId.slice(-6)} seq=${seq} payload=${payloadLen}B codec=${codec} hasDecoder=${decoders.has(mentraUserId)} pcm=${pcmBytesLen}B providers=${userProviders.get(mentraUserId)?.size ?? 0}`,
+        logger.info(
+          {
+            user: mentraUserId.slice(-6),
+            seq,
+            payloadBytes: payloadLen,
+            codec,
+            hasDecoder: decoders.has(mentraUserId),
+            pcmBytes: pcmBytesLen,
+            providers: userProviders.get(mentraUserId)?.size ?? 0,
+          },
+          "feed",
         )
       }
 
@@ -820,7 +835,7 @@ async function processBatch(
       try {
         await streamsClient.xack(streamKey, AUDIO_STREAM_GROUP, entryId)
       } catch (err) {
-        console.error("[audio-worker] xack failed:", err)
+        logger.error({err}, "xack failed")
       }
     }
   }


### PR DESCRIPTION
Cloud-v2 has never shipped logs anywhere: pods write pino JSON to stdout and only Porter's live viewer can see it, so there is no queryable history. The OS-1691 logout investigation and the frozen-lockfile deploy outage both had to be diagnosed by inference because of this. OS-1743.

## What this adds

- `cloud-v2/infra/betterstack-logs/values.yaml`: BetterStack Helm chart values for a Vector DaemonSet on the cloud-v2 cluster (Porter 5692). Filters container stdout to the `cloud-dev-` Porter app only, flattens pino JSON to top-level fields (msg/message, time/dt, numeric level to string), nests Vector metadata under `_meta`.
- `cloud-v2/docs/runbooks/betterstack-logs.md`: source registry, install command, hot vs S3 query patterns, cost-guard rules, and log hygiene rules.

## Already done outside the diff

- BetterStack source `MentraCloud V2 - Dev` created (id 2616420, table `mentracloud_v2_dev`, platform vector, **30-day retention** from birth).
- Doppler `cloud-v2/dev` `BETTERSTACK_SOURCE_TOKEN` now holds this source's token (it previously pointed at the legacy AugmentOS source and nothing consumed it).
- #3504 (audio worker + Soniox console.* to pino) is the hygiene prerequisite so shipped lines are leveled and structured.

## Deliberate cost design

Everything the V1 bill taught us, applied from day one: tight `starts_with` container filter (each future env is an explicit routed sink to its own source, never a wildcard), 30-day retention, no in-process HTTP log transport (heap-leak class), and cloud-v2's log volume is already lean (~120 pino sites, no per-request access logs, throttled audio heartbeat). Expected dev ingest is tens of MB/month.

## Remaining step to go live

`porter helm --cluster 5692 -- install ...` (exact command in the values header) needs an authenticated porter CLI, then verify lines appear in Live Tail and check ingest volume after a week.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infra is config/docs only until deployed via Porter; runtime changes are log formatting only with no transcription or routing logic changes.
> 
> **Overview**
> Adds **queryable log history** for cloud-v2 by documenting and committing Vector/BetterStack Helm values plus a runbook, and aligns hot-path audio logging with pino so shipped lines are leveled and filterable.
> 
> **Infra & ops:** New `infra/betterstack-logs/values.yaml` configures a single **betterstack-logs v1.1.6** Vector DaemonSet on Porter cluster 5692: filter `cloud-{dev,debug,isaiah,staging,prod}-*` containers only, **flatten_pino** (`msg`→`message`, `time`→`dt`, numeric level→string, `_meta` k8s fields), **route_by_env** to five separate BetterStack sources in eu-central-1a; metrics disabled but **better_stack_http_metrics_sink** kept with a valid token to avoid chart-default crash-loops. `docs/runbooks/betterstack-logs.md` covers source registry, Porter add-on deploy (no kubeconfig), token/outage landmines, cost guards, UI vs V2 SQL API querying (`JSONExtractString` on `raw`), and hygiene rules.
> 
> **Runtime logging (no behavior change):** `soniox.ts` and `audio/workers/worker.ts` replace `console.*` with `createLogger("runtime").child({ module })`; errors use `{ err }`, the throttled feed heartbeat becomes structured `logger.info` fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38f7c509a2abe2c63f8e858e05b9f09d877994cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds BetterStack log shipping for all cloud‑v2 envs on cluster 5692 via a Vector DaemonSet and switches audio worker/Soniox logs to structured `pino`, giving queryable per‑env history with 30‑day retention (Linear OS‑1743).

- **New Features**
  - Vector DaemonSet tails stdout, filters `cloud-{dev,debug,isaiah,staging,prod}-*`, flattens pino JSON (`msg`→`message`, `time`→`dt`, numeric `level`→string), nests `_meta`, and routes per‑env to separate BetterStack sources in eu‑central‑1a; chart pinned to `betterstack-logs` v1.1.6; metrics disabled; keeps the metrics sink override to prevent a Vector crash‑loop when the chart’s default `token: null` is applied.
  - Runbook: corrected ClickHouse queries (`JSONExtractString` in SELECT/WHERE), documented eu‑central‑1a SQL API creds/host (`BETTERSTACK_V2_*`), Porter Add‑ons deploy path, and two landmines — a single bad sink token blocks all shipping and the metrics sink default `token: null` crash‑loops Vector — with a pre‑deploy token check.

- **Refactors**
  - Routed the audio worker and Soniox provider logs through `@mentra/cloud-shared` pino (`createLogger("runtime").child({ module })`) instead of `console.*`; errors/warns keep severity with `{err}`, lifecycle logs at info, and the feed heartbeat stays throttled and now structured. No behavior change beyond log formatting.

<sup>Written for commit 38f7c509a2abe2c63f8e858e05b9f09d877994cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Update 2026-07-21: outage fix + pino logging folded in

- The metrics sink override is restored and now documented as load-bearing. The chart default for `better_stack_http_metrics_sink` has `token: null`, which is invalid Vector config and crash-loops the whole DaemonSet. Removing the override (addon revisions 3 and 4) took down log shipping for all envs for about 19 hours on 2026-07-20/21. Deployed as addon revision 5; verified shipping resumed for all sources.
- Merged #3504 (route audio worker and Soniox `console.*` logs through pino) into this PR, since unparsed multi-line console output was the remaining source of unstructured rows in BetterStack.
