### PR TITLE
Fix Mentra App session refresh logouts

### DIFF
--- a/mobile/src/utils/auth/provider/accountClient.test.ts
+++ b/mobile/src/utils/auth/provider/accountClient.test.ts
@@ -1,0 +1,74 @@
+/* eslint-disable import/first -- Jest module mocks must be registered before these imports. */
+jest.mock("@/services/cloudClient", () => ({
+  resolvedEndpoints: () => ({core: "https://core.example.test", runtime: "wss://runtime.example.test"}),
+}))
+
+// accountClient.ts and authClient.ts import each other. The provider overrides
+// the methods used by these focused tests, so an extendable stub is sufficient.
+jest.mock("@/utils/auth/authClient", () => ({AuthClient: class {}}))
+
+import {AccountAuthProvider} from "./accountClient"
+import {storage} from "@/utils/storage"
+
+type TestableProvider = {
+  performRefresh(refresh: string): Promise<{access: string; refresh: string} | null>
+}
+
+describe("AccountAuthProvider refresh requests", () => {
+  const originalFetch = global.fetch
+  const fetchMock = jest.fn()
+  let provider: TestableProvider
+
+  beforeEach(() => {
+    storage.clearAll()
+    fetchMock.mockReset()
+    global.fetch = fetchMock as unknown as typeof fetch
+    provider = new AccountAuthProvider() as unknown as TestableProvider
+  })
+
+  afterAll(() => {
+    global.fetch = originalFetch
+  })
+
+  it("sends the form body as a string for React Native fetch", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({access_token: "new-access", refresh_token: "new-refresh"}),
+    })
+
+    await expect(provider.performRefresh("old-refresh")).resolves.toEqual({
+      access: "new-access",
+      refresh: "new-refresh",
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://core.example.test/api/client/auth/refresh",
+      expect.objectContaining({
+        headers: {"content-type": "application/x-www-form-urlencoded"},
+        body: "grant_type=refresh_token&refresh_token=old-refresh",
+      }),
+    )
+  })
+
+  it("does not treat a malformed refresh request as an expired session", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({error: "unsupported_grant_type"}),
+    })
+
+    await expect(provider.performRefresh("still-live")).rejects.toThrow(
+      "refresh failed without rejecting session: HTTP 400 (unsupported_grant_type)",
+    )
+  })
+
+  it("returns null for an actual invalid_grant", async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({error: "invalid_grant"}),
+    })
+
+    await expect(provider.performRefresh("dead-refresh")).resolves.toBeNull()
+  })
+})

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -102,10 +102,10 @@ export class AccountAuthProvider extends AuthClient {
   private refreshInFlight: Promise<Tokens | null> | null = null
 
   /** Run the V2 refresh grant. Returns the new tokens, or null ONLY when the
-   * server definitively rejected the refresh token (400/401: revoked or
-   * expired session). Throws on network failure AND transient server errors
-   * (5xx, 429) so callers keep the tokens instead of signing the user out
-   * during a brief core outage. */
+   * server definitively rejected the refresh token (`invalid_grant` or 401:
+   * revoked/expired session). Throws on network failure, malformed requests,
+   * and transient server errors (5xx, 429) so callers keep the tokens instead
+   * of signing the user out during a client bug or brief core outage. */
   private async refreshTokens(refresh: string): Promise<Tokens | null> {
     if (this.refreshInFlight) return this.refreshInFlight
     const inFlight = this.performRefresh(refresh).finally(() => {
@@ -119,9 +119,25 @@ export class AccountAuthProvider extends AuthClient {
     const res = await fetch(core("/api/client/auth/refresh"), {
       method: "POST",
       headers: {"content-type": "application/x-www-form-urlencoded"},
-      body: new URLSearchParams({grant_type: "refresh_token", refresh_token: refresh}),
+      // React Native's native request-body converter does not serialize a
+      // URLSearchParams instance. Pass the encoded string explicitly, as the
+      // cloud-client transport does, or Core receives a malformed/empty form
+      // and responds with unsupported_grant_type (HTTP 400).
+      body: new URLSearchParams({grant_type: "refresh_token", refresh_token: refresh}).toString(),
     })
-    if (AccountAuthProvider.tokenRejected(res.status)) {
+    if (!res.ok) {
+      const errorBody = (await res.json().catch(() => ({}))) as {error?: string}
+      const errorCode = errorBody.error ?? "unknown_error"
+
+      // A refresh endpoint can return several RFC-shaped 400 responses. Only
+      // invalid_grant (or an authorization-level 401) proves the stored token
+      // is dead. Treat malformed requests and transient failures as errors so
+      // callers preserve the session instead of logging the user out.
+      const refreshRejected = errorCode === "invalid_grant" || res.status === 401
+      if (!refreshRejected) {
+        throw new Error(`refresh failed without rejecting session: HTTP ${res.status} (${errorCode})`)
+      }
+
       // The in-flight guard above only covers callers that both call
       // refreshTokens() while ONE request is still pending. A caller that
       // snapshotted this exact refresh token earlier (via loadTokens()) but
@@ -134,10 +150,9 @@ export class AccountAuthProvider extends AuthClient {
       // would make the caller clearTokens() out from under it.
       const current = loadTokens()
       if (current && current.refresh !== refresh) return current
-      console.log(`MENTRA AUTH: refresh grant rejected (HTTP ${res.status}), session is dead`)
+      console.log(`MENTRA AUTH: refresh grant rejected (${errorCode}, HTTP ${res.status}), session is dead`)
       return null
     }
-    if (!res.ok) throw new Error(`refresh failed transiently: HTTP ${res.status}`)
     const body = (await res.json()) as {access_token: string; refresh_token: string}
     const t = {access: body.access_token, refresh: body.refresh_token}
     saveTokens(t)


### PR DESCRIPTION
## Summary

- serialize the account refresh form before passing it to React Native `fetch`
- clear credentials only when Core returns an actual `invalid_grant` or HTTP 401
- add regression coverage for successful refresh serialization, malformed-request preservation, and dead sessions

## Root cause

The Mentra App passed a `URLSearchParams` object directly as the React Native request body. React Native's native body converter does not serialize that object, so Core received a malformed form and returned HTTP 400. The client treated every HTTP 400 as an expired refresh token, cleared an otherwise valid session, and sent users to login when the one-hour access token expired.

This matches the cross-platform evidence in:

- `rep_01KY0RMAA326EXGPTEH14H05MN`
- `rep_01KY0TGV63GFP9MZCYZADHD5X5`
- `rep_01KY0WMB50QJ61G0P6XS5KG83P`

Core's session records for the affected users were unexpired and had never rotated, confirming that the refresh form never reached the token lookup successfully.

## User impact

Users on iOS and Android should remain signed in when the short-lived access token expires. Users who were already logged out will need to authenticate once after installing a build containing this fix.

## Validation

- `bun run test -- accountClient --runInBand`
- `bun run compile`
- `bunx eslint src/utils/auth/provider/accountClient.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fd8ac2ee6442432a280067db743ec369994afb5e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile session refresh to prevent accidental logouts by properly serializing the refresh form and tightening error handling. Users stay signed in after the access token expires; only truly dead sessions log out.

- **Bug Fixes**
  - Serialize the refresh form with `.toString()` for React Native `fetch` to avoid malformed 400s.
  - Only treat `invalid_grant` or HTTP 401 as a dead session; keep tokens for other 4xx/5xx.
  - Throw on malformed requests and transient failures to avoid clearing valid sessions.
  - Add tests covering correct serialization, malformed-request preservation, and dead-session behavior.

<sup>Written for commit fd8ac2ee6442432a280067db743ec369994afb5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

