### PR TITLE
Accumulate streamed WiFi scan results

### DIFF
--- a/mobile/src/__tests__/wifiScanUtils.test.ts
+++ b/mobile/src/__tests__/wifiScanUtils.test.ts
@@ -1,0 +1,24 @@
+import type {WifiSearchResult} from "@mentra/engine"
+
+import {mergeWifiScanResults} from "@/utils/wifi/WifiScanUtils"
+
+const network = (ssid: string, signalStrength: number): WifiSearchResult => ({
+  ssid,
+  requiresPassword: true,
+  signalStrength,
+})
+
+describe("mergeWifiScanResults", () => {
+  it("accumulates networks streamed in separate chunks", () => {
+    const firstChunk = [network("Mentra", -31)]
+    const secondChunk = [network("ATT3hyzFEa", -77)]
+
+    expect(mergeWifiScanResults(firstChunk, secondChunk)).toEqual([...firstChunk, ...secondChunk])
+  })
+
+  it("keeps only the first result for a duplicate SSID", () => {
+    const current = [network("Mentra", -31)]
+
+    expect(mergeWifiScanResults(current, [network("Mentra", -45)])).toBe(current)
+  })
+})

--- a/mobile/src/app/wifi/scan.tsx
+++ b/mobile/src/app/wifi/scan.tsx
@@ -16,6 +16,7 @@ import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {useNavigationStore} from "@/stores/navigation"
 import showAlert from "@/utils/AlertUtils"
 import WifiCredentialsService from "@/utils/wifi/WifiCredentialsService"
+import {mergeWifiScanResults} from "@/utils/wifi/WifiScanUtils"
 import {translate} from "@/i18n"
 
 export default function WifiScanScreen() {
@@ -26,9 +27,7 @@ export default function WifiScanScreen() {
   networksRef.current = networks
   const [savedNetworks, setSavedNetworks] = useState<string[]>([])
   const [isScanning, setIsScanning] = useState(true)
-  const wifiStatus = useEngineSnapshot(engine.glasses.wifi.status, (onChange) =>
-    engine.glasses.wifi.onStatus(onChange),
-  )
+  const wifiStatus = useEngineSnapshot(engine.glasses.wifi.status, (onChange) => engine.glasses.wifi.onStatus(onChange))
   const connectedWifi = wifiStatus.state === "connected" ? wifiStatus : null
   const connectedWifiSsid = connectedWifi?.ssid
   const {push, goBack, getPreviousRoute, incPreventBack, decPreventBack, setAndroidBackFn} =
@@ -77,15 +76,16 @@ export default function WifiScanScreen() {
 
   useEffect(() => {
     refreshSavedNetworks()
-    startScan()
 
     // The glasses stream networks one by one while the scan runs; show them as
     // they arrive instead of waiting for the final requestWifiScan() result.
+    // Each correlated event is one chunk, so merge it into the visible list.
     const unsubscribe = engine.glasses.wifi.onScanResult((scanned) => {
       if (scanned.length > 0) {
-        setNetworks(mapNetworks(scanned))
+        setNetworks((current) => mergeWifiScanResults(current, mapNetworks(scanned)))
       }
     })
+    startScan()
     return unsubscribe
   }, [refreshSavedNetworks])
 

--- a/mobile/src/utils/wifi/WifiScanUtils.ts
+++ b/mobile/src/utils/wifi/WifiScanUtils.ts
@@ -1,0 +1,15 @@
+import type {WifiSearchResult} from "@mentra/engine"
+
+/** Append streamed scan chunks while preserving the first result for each SSID. */
+export function mergeWifiScanResults(current: WifiSearchResult[], incoming: WifiSearchResult[]): WifiSearchResult[] {
+  const seenSsids = new Set(current.map((network) => network.ssid))
+  const newNetworks = incoming.filter((network) => {
+    if (seenSsids.has(network.ssid)) {
+      return false
+    }
+    seenSsids.add(network.ssid)
+    return true
+  })
+
+  return newNetworks.length > 0 ? [...current, ...newNetworks] : current
+}


### PR DESCRIPTION
## Summary

- accumulate streamed Wi-Fi scan chunks in the scan screen instead of replacing the visible list for every chunk
- subscribe before starting the scan so the first streamed result cannot be missed
- deduplicate networks by SSID and cover incremental chunk merging with regression tests

## Root cause

Mentra Live now sends correlated Wi-Fi scan results as one-network chunks followed by an empty completion chunk. The native SDK intentionally forwards those individual chunks while accumulating the final request result. The scan screen treated every streamed chunk as a complete list, so only the most recently received network was visible until the request completed and supplied the full accumulated result.

Fixes bug report `rep_01KY11DHW3KPP02HP3WBQ635HB`.

## User impact

Nearby Wi-Fi networks now remain visible and build up in the list as scan results stream in, rather than showing a single row whose contents keep changing.

## Validation

- `bun run test -- --runInBand src/__tests__/wifiScanUtils.test.ts src/__tests__/glassesWifi.test.ts` (8 tests passed)
- `bun compile`
- scoped ESLint on the three changed files (0 errors; 3 pre-existing warnings in `wifi/scan.tsx`)

Repository-wide lint remains blocked by existing unrelated failures (371 errors across generated, example, and unrelated mobile files).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized Wi‑Fi scan UI/state change with a small pure merge helper and tests; no auth, data, or engine protocol changes.
> 
> **Overview**
> Fixes the Wi‑Fi scan list so **streamed one-network chunks build up** instead of each chunk replacing the whole list (Mentra Live now sends correlated scan events per network).
> 
> Adds **`mergeWifiScanResults`** to append new SSIDs and **keep the first entry** when duplicates arrive; the scan screen uses it in `onScanResult` and **registers that listener before `startScan()`** so the first streamed result isn’t dropped. Unit tests cover chunk accumulation and SSID deduplication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfe34cde98ceb53647bad3b191cd8e067510c469. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accumulates streamed Wi‑Fi scan results so the list grows as networks arrive, fixing the single-row flicker during scans.

- **Bug Fixes**
  - Added `mergeWifiScanResults` to append chunks and keep the first result per SSID.
  - Subscribed to `glasses.wifi.onScanResult` before starting the scan to capture the first chunk.
  - Updated the scan screen to merge incremental results; added unit tests for chunk merging with `@mentra/engine` types.

<sup>Written for commit dfe34cde98ceb53647bad3b191cd8e067510c469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

