### PR TITLE
Show account email and absolute console links in report Slack posts

### DIFF
--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -135,6 +135,48 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain("<https://admin.example.test/?report=rep_TEST123|Open incident>");
   });
 
+  test("shows the resolved account email as the user, mentraUserId only as fallback", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+
+    await notifyReportSlack(bugNotification({ userEmail: "reporter@example.test" }));
+    await notifyReportSlack(bugNotification({ userEmail: null }));
+
+    const bodies = fetchMock.mock.calls.map((call) => {
+      const [, init] = call as unknown as [string, RequestInit];
+      return JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    });
+    expect(JSON.stringify(bodies[0].blocks)).toContain("*User:*\\nreporter@example.test");
+    expect(JSON.stringify(bodies[0].blocks)).not.toContain("user-1");
+    expect(bodies[0].text).toContain("from reporter@example.test");
+    expect(JSON.stringify(bodies[1].blocks)).toContain("*User:*\\nuser-1");
+  });
+
+  test("adds https to a schemeless CLOUD_ADMIN_CONSOLE_URL so Slack links leave Slack", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_ADMIN_CONSOLE_URL = "admin.dev.mentraglass.com";
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as { text: string; blocks: unknown[] };
+    const blocksJson = JSON.stringify(payload.blocks);
+    expect(blocksJson).toContain(
+      "<https://admin.dev.mentraglass.com/?report=rep_TEST123|Open incident>",
+    );
+    expect(payload.text).toContain("Console: https://admin.dev.mentraglass.com/?report=rep_TEST123");
+  });
+
+  test("keeps an explicit http scheme on CLOUD_ADMIN_CONSOLE_URL", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_ADMIN_CONSOLE_URL = "http://localhost:5173";
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const blocksJson = JSON.stringify(JSON.parse(String(init.body)).blocks);
+    expect(blocksJson).toContain("<http://localhost:5173/?report=rep_TEST123|Open incident>");
+  });
+
   test("omits the console link and System line when environment and context are unknown", async () => {
     process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
 

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -35,6 +35,10 @@ const SLACK_FIELD_TEXT_MAX = 1900;
 export interface ReportSlackNotification {
   reportId: string;
   mentraUserId: string;
+  /** Account email resolved by the caller (best-effort); the message falls
+   * back to the opaque mentraUserId when null so a GoTrue outage or an OEM
+   * tenant never blocks the notification. */
+  userEmail?: string | null;
   kind: "bug" | "feedback" | "automatic";
   /** Trigger/report/feedback are snapshots of the stored (Mixed) report
    * fields, so every property is read defensively. */
@@ -135,6 +139,7 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   blocks: SlackBlock[];
 } {
   const { reportId, mentraUserId, kind, trigger, artifactCount } = notification;
+  const userLabel = notification.userEmail || mentraUserId;
   const env = environmentLabel();
   const header =
     kind === "bug"
@@ -150,7 +155,7 @@ function buildSlackMessage(notification: ReportSlackNotification): {
 
   const consoleUrl = adminConsoleReportUrl(reportId);
   const identityFields = [
-    { type: "mrkdwn", text: `*User:*\n${slackText(mentraUserId, SHORT_TEXT_MAX)}` },
+    { type: "mrkdwn", text: `*User:*\n${slackText(userLabel, SHORT_TEXT_MAX)}` },
     { type: "mrkdwn", text: `*Report ID:*\n\`${slackText(reportId, SHORT_TEXT_MAX)}\`` },
     { type: "mrkdwn", text: `*Env:*\n${slackText(env, SHORT_TEXT_MAX)}` },
   ];
@@ -206,7 +211,7 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   });
 
   const fallbackParts = [
-    `New ${kind} report from ${mentraUserId} (${env})`,
+    `New ${kind} report from ${truncate(userLabel, SHORT_TEXT_MAX)} (${env})`,
     `Report ID: ${reportId}`,
     ...(consoleUrl ? [`Console: ${consoleUrl}`] : []),
     ...(typeof trigger?.reason === "string"
@@ -328,15 +333,26 @@ function environmentLabel(): string {
  */
 function adminConsoleReportUrl(reportId: string): string | null {
   const env = process.env.CLOUD_CORE_ENVIRONMENT;
-  const base =
-    process.env.CLOUD_ADMIN_CONSOLE_URL ||
-    (env === "prod" || env === "production"
+  const configured = process.env.CLOUD_ADMIN_CONSOLE_URL;
+  const base = configured
+    ? withHttpsScheme(configured)
+    : env === "prod" || env === "production"
       ? "https://admin.mentraglass.com"
       : env === "dev" || env === "staging"
         ? `https://admin.${env}.mentraglass.com`
-        : null);
+        : null;
   if (!base) return null;
   return `${base.replace(/\/+$/, "")}/?report=${encodeURIComponent(reportId)}`;
+}
+
+/**
+ * Slack treats a schemeless link target as an in-app relative path and
+ * renders it as app.slack.com/client/<team>/admin.dev.mentraglass.com/...,
+ * so a configured console base must carry a scheme before it goes into the
+ * message.
+ */
+function withHttpsScheme(url: string): string {
+  return /^https?:\/\//i.test(url) ? url : `https://${url}`;
 }
 
 /**

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -13,6 +13,8 @@ import { createLogger } from "@mentra/cloud-shared";
 import { ReportModel } from "../models/report.model";
 import { ReportAssetModel } from "../models/report-asset.model";
 import { notifyReportSlack } from "./report-slack.service";
+import { UserModel } from "../models/user.model";
+import { getUserById } from "./account/gotrue.client";
 import { createStorageService } from "./storage/storage.service";
 
 const logger = createLogger("core").child({ service: "report.service" });
@@ -94,6 +96,25 @@ export interface AddReportArtifactsResult {
   stored: number;
 }
 
+/**
+ * Best-effort account email for a report's Slack post: V1 showed the
+ * submitter's email, and an opaque mu_ id is useless to a human triaging the
+ * channel. First-party users' tenantUserId is their GoTrue id, so it resolves
+ * through the admin API; anything that can't resolve (OEM tenants, missing
+ * service-role key, GoTrue outage) yields null and the message falls back to
+ * the mentraUserId. Never throws — this runs on the fire-and-forget path.
+ */
+async function reportUserEmail(mentraUserId: string): Promise<string | null> {
+  try {
+    const user = await UserModel.findOne({ mentraUserId }).lean();
+    if (!user) return null;
+    const identity = await getUserById(user.tenantUserId);
+    return identity?.email || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function submitReport(input: SubmitReportInput): Promise<SubmitReportResult> {
   const reportId = `rep_${ulid()}`;
   const status: ReportStatus = input.kind === "feedback" ? "ready" : "collecting";
@@ -116,15 +137,21 @@ export async function submitReport(input: SubmitReportInput): Promise<SubmitRepo
 
   // Feedback reports are complete as submitted, so they notify here;
   // bug/automatic reports notify from markReportReady once artifact
-  // collection finishes. Fire-and-forget: the response never waits on Slack.
+  // collection finishes. Fire-and-forget: the response never waits on Slack
+  // or the email lookup.
   if (status === "ready") {
-    notifyReportSlack({
-      reportId,
-      mentraUserId: input.mentraUserId,
-      kind: input.kind,
-      feedback,
-      context: input.context,
-    }).catch(() => {});
+    reportUserEmail(input.mentraUserId)
+      .then((userEmail) =>
+        notifyReportSlack({
+          reportId,
+          mentraUserId: input.mentraUserId,
+          userEmail,
+          kind: input.kind,
+          feedback,
+          context: input.context,
+        }),
+      )
+      .catch(() => {});
   }
 
   return { reportId, status };
@@ -183,16 +210,21 @@ export async function markReportReady(input: {
   ).lean();
   if (!before) return null;
   if (before.status === "collecting") {
-    notifyReportSlack({
-      reportId: input.reportId,
-      mentraUserId: input.mentraUserId,
-      kind: before.kind,
-      trigger: before.trigger,
-      report: before.report,
-      feedback: before.feedback,
-      context: before.context,
-      artifactCount: before.artifacts?.length ?? 0,
-    }).catch(() => {});
+    reportUserEmail(input.mentraUserId)
+      .then((userEmail) =>
+        notifyReportSlack({
+          reportId: input.reportId,
+          mentraUserId: input.mentraUserId,
+          userEmail,
+          kind: before.kind,
+          trigger: before.trigger,
+          report: before.report,
+          feedback: before.feedback,
+          context: before.context,
+          artifactCount: before.artifacts?.length ?? 0,
+        }),
+      )
+      .catch(() => {});
   }
   return "ready";
 }

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -126,7 +126,11 @@ const EMAIL_LOOKUP_TIMEOUT_MS = 5_000;
 
 async function lookupUserEmail(mentraUserId: string): Promise<string | null> {
   const user = await UserModel.findOne({ mentraUserId }).lean();
-  if (!user) return null;
+  // Only first-party rows store a GoTrue id in tenantUserId (same gate as
+  // account.api's tenantUserIdFor); an OEM sub is a different identifier
+  // space, and a stray collision would resolve some unrelated account's
+  // email.
+  if (!user || user.tenantId !== "mentra") return null;
   const identity = await getUserById(user.tenantUserId);
   return identity?.email || null;
 }

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -106,13 +106,29 @@ export interface AddReportArtifactsResult {
  */
 async function reportUserEmail(mentraUserId: string): Promise<string | null> {
   try {
-    const user = await UserModel.findOne({ mentraUserId }).lean();
-    if (!user) return null;
-    const identity = await getUserById(user.tenantUserId);
-    return identity?.email || null;
+    return await Promise.race([
+      lookupUserEmail(mentraUserId),
+      // The email is a nicety: neither Mongo nor the GoTrue fetch carries a
+      // timeout, and a hung lookup would stall the Slack post itself (the
+      // API response is already decoupled). Give up and post the mu_ id
+      // instead of waiting.
+      new Promise<null>((resolve) => {
+        const timer = setTimeout(() => resolve(null), EMAIL_LOOKUP_TIMEOUT_MS);
+        timer.unref?.();
+      }),
+    ]);
   } catch {
     return null;
   }
+}
+
+const EMAIL_LOOKUP_TIMEOUT_MS = 5_000;
+
+async function lookupUserEmail(mentraUserId: string): Promise<string | null> {
+  const user = await UserModel.findOne({ mentraUserId }).lean();
+  if (!user) return null;
+  const identity = await getUserById(user.tenantUserId);
+  return identity?.email || null;
 }
 
 export async function submitReport(input: SubmitReportInput): Promise<SubmitReportResult> {

--- a/cloud-v2/packages/core/src/services/report.service.ts
+++ b/cloud-v2/packages/core/src/services/report.service.ts
@@ -105,21 +105,21 @@ export interface AddReportArtifactsResult {
  * the mentraUserId. Never throws — this runs on the fire-and-forget path.
  */
 async function reportUserEmail(mentraUserId: string): Promise<string | null> {
-  try {
-    return await Promise.race([
-      lookupUserEmail(mentraUserId),
-      // The email is a nicety: neither Mongo nor the GoTrue fetch carries a
-      // timeout, and a hung lookup would stall the Slack post itself (the
-      // API response is already decoupled). Give up and post the mu_ id
-      // instead of waiting.
-      new Promise<null>((resolve) => {
-        const timer = setTimeout(() => resolve(null), EMAIL_LOOKUP_TIMEOUT_MS);
-        timer.unref?.();
-      }),
-    ]);
-  } catch {
-    return null;
-  }
+  // The catch is attached to the lookup itself, not around the race: once
+  // the timer wins, a later rejection of the still-running lookup would
+  // otherwise be unhandled.
+  const lookup = lookupUserEmail(mentraUserId).catch(() => null);
+  return await Promise.race([
+    lookup,
+    // The email is a nicety: neither Mongo nor the GoTrue fetch carries a
+    // timeout, and a hung lookup would stall the Slack post itself (the
+    // API response is already decoupled). Give up and post the mu_ id
+    // instead of waiting.
+    new Promise<null>((resolve) => {
+      const timer = setTimeout(() => resolve(null), EMAIL_LOOKUP_TIMEOUT_MS);
+      timer.unref?.();
+    }),
+  ]);
 }
 
 const EMAIL_LOOKUP_TIMEOUT_MS = 5_000;


### PR DESCRIPTION
## What this does

Fixes the two issues found in ticket verification of the report Slack notifications (#3377 / #3390):

**1. Console links pointed into Slack instead of the admin panel.** A schemeless `CLOUD_ADMIN_CONSOLE_URL` (e.g. `admin.dev.mentraglass.com`) flowed verbatim into the mrkdwn link target, and the Slack client resolves schemeless targets as in-app relative paths — rendering `https://app.slack.com/client/<team>/admin.dev.mentraglass.com/?report=...`. The configured base now gets `https://` prepended when it lacks a scheme (an explicit `http://` for local consoles is preserved). The env-derived URLs already carried `https://` and are unchanged.

**2. Posts showed `mu_…` instead of the user's email.** V1 identified the submitter by email; V2 showed the opaque `mentraUserId`. The notify path now resolves the account email best-effort — `users` collection (`mentraUserId → tenantUserId`) then the GoTrue admin API (`getUserById`) — and shows it as `*User:*`, falling back to the `mentraUserId` when resolution fails (OEM tenants, missing `SUPABASE_SERVICE_ROLE_KEY`, GoTrue outage). The lookup runs inside the existing fire-and-forget block, so the reports API response never waits on it and resolution failure can never fail a request.

## Configuration

No Doppler changes required: the scheme fix makes the current schemeless `CLOUD_ADMIN_CONSOLE_URL` value work as-is, and the email lookup reuses `SUPABASE_URL` / `SUPABASE_SERVICE_ROLE_KEY` already present for the account service.

## Tests

Three new unit cases in `report-slack.service.test.ts`: schemeless console base gets `https://` (blocks + fallback text), explicit `http://` preserved, and email-vs-mentraUserId user labeling. Full runs: 20/20 notifier unit tests, `tsc -b` clean. The whole-package `bun test packages/core` run has a pre-existing mongoose `OverwriteModelError` failure on `dev` unrelated to this change (verified against a clean checkout; flagged separately).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to Slack message formatting and a best-effort, timeout-bounded email lookup on an already fire-and-forget path; report submission behavior and API responses are not gated on lookup success.
> 
> **Overview**
> Report Slack notifications now show the **submitter’s account email** in `*User:*` and fallback text when it can be resolved, instead of only the opaque `mentraUserId`. Resolution is **best-effort** on the existing fire-and-forget notify path: Mongo `users` → GoTrue admin `getUserById` for **first-party (`tenantId === "mentra"`)** users only, with a **5s cap** and silent fallback to `mentraUserId` on timeout, OEM tenants, or lookup failure so report APIs are unchanged.
> 
> **Admin console links** from `CLOUD_ADMIN_CONSOLE_URL` are normalized with **`https://`** when the value has no scheme (fixing Slack treating schemeless targets as in-app paths); explicit **`http://`** (e.g. local dev) is left as-is. Env-derived admin URLs are unchanged.
> 
> Unit tests cover email vs fallback labeling and scheme handling for console URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19dd996c4dbb340870671b188238a13a0e7ff016. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->