### PR TITLE
Pin expo-calendar in example-oem-app to fix startup crash

### DIFF
--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -412,6 +412,7 @@
         "expo-audio": "~55.0.14",
         "expo-battery": "^55.0.13",
         "expo-build-properties": "~55.0.14",
+        "expo-calendar": "~55.0.14",
         "expo-clipboard": "~55.0.13",
         "expo-constants": "~55.0.16",
         "expo-file-system": "~55.0.20",
@@ -3174,6 +3175,8 @@
     "example-oem-app/@react-native-community/netinfo": ["@react-native-community/netinfo@11.5.2", "", { "peerDependencies": { "react": "*", "react-native": ">=0.59" } }, "sha512-/g0m65BtX9HU+bPiCH2517bOHpEIUsGrWFXDzi1a5nNKn5KujQgm04WhL7/OSXWKHyrT8VVtUoJA0XKRxueBpQ=="],
 
     "example-oem-app/expo-audio": ["expo-audio@55.0.15", "", { "peerDependencies": { "expo": "*", "expo-asset": "*", "react": "*", "react-native": "*" } }, "sha512-VS5112dO7sUivJpqLjAJLsP4Cv1c4o92wrMqkUCPA/879f8hy6RUQI7t2NVTnK5qkVzp1MtzkWhArwAtjVuVHg=="],
+
+    "example-oem-app/expo-calendar": ["expo-calendar@55.0.17", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-+SixsYR4jrSvPsEEUpwGbpsMuui+g+GO5OdoWwv/SRtmmQ/n+klK8dOvgB7Tc5WzzvV3Io8sjfy5gc6SRVhSuw=="],
 
     "example-oem-app/expo-constants": ["expo-constants@55.0.16", "", { "dependencies": { "@expo/env": "~2.1.2" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-Z15/No94UHoogD+pulxjudGAeOHTEIWZgb/vnX48Wx5D+apWTeCbnKxQZZtGQlosvduYL5kaic2/W8U+NHfBQQ=="],
 

--- a/sdk/example-oem-app/app.json
+++ b/sdk/example-oem-app/app.json
@@ -20,7 +20,9 @@
         "NSBluetoothAlwaysUsageDescription": "This app connects to your smart glasses over Bluetooth.",
         "NSMicrophoneUsageDescription": "This app uses the microphone when you enable audio features.",
         "NSLocalNetworkUsageDescription": "This app connects to local photo and streaming helpers during development.",
-        "NSLocationWhenInUseUsageDescription": "Location is used while scanning for nearby glasses over Bluetooth."
+        "NSLocationWhenInUseUsageDescription": "Location is used while scanning for nearby glasses over Bluetooth.",
+        "NSCalendarsUsageDescription": "This app accesses your calendar so miniapps can display upcoming events on your smart glasses.",
+        "NSCalendarsFullAccessUsageDescription": "This app accesses your calendar so miniapps can display upcoming events on your smart glasses."
       },
       "appleTeamId": "T5XXXL6N36"
     },
@@ -39,7 +41,9 @@
         "android.permission.ACCESS_FINE_LOCATION",
         "android.permission.RECORD_AUDIO",
         "android.permission.INTERNET",
-        "android.permission.POST_NOTIFICATIONS"
+        "android.permission.POST_NOTIFICATIONS",
+        "android.permission.READ_CALENDAR",
+        "android.permission.WRITE_CALENDAR"
       ]
     },
     "plugins": [

--- a/sdk/example-oem-app/package.json
+++ b/sdk/example-oem-app/package.json
@@ -26,6 +26,7 @@
     "expo-audio": "~55.0.14",
     "expo-battery": "^55.0.13",
     "expo-build-properties": "~55.0.14",
+    "expo-calendar": "~55.0.14",
     "expo-clipboard": "~55.0.13",
     "expo-constants": "~55.0.16",
     "expo-file-system": "~55.0.20",


### PR DESCRIPTION
## Summary
- `sdk/example-oem-app` crashed on every launch with `NoClassDefFoundError: Lexpo/modules/kotlin/types/AnyTypeCache` thrown from `CalendarModule.definition()` during Expo's native module registration.
- `@mentra/engine` depends on `expo-calendar` (used by `PhoneCalendarService.ts`) but only declares it as an unpinned peer dependency (`"expo-calendar": "*"`). `example-oem-app` never declared `expo-calendar` itself, so bun resolved the wildcard peer to the latest published version (`57.0.1`) instead of the `55.x` line the rest of the app is pinned to — an ABI mismatch between the compiled `CalendarModule` and the actually-bundled `expo-modules-core` classes.
- Pin `expo-calendar` to `~55.0.14` in `sdk/example-oem-app/package.json`, matching the version already used by `mobile/package.json` and the rest of the `expo-*` `55.x` dependencies in this package.
- Follow-up caught in review: with `expo-calendar` now correctly resolved, it's reachable at runtime whenever a hosted miniapp requests calendar access through the engine. `app.json` had no iOS calendar usage descriptions or Android calendar permissions, which would crash/reject that access. Added `NSCalendarsUsageDescription` / `NSCalendarsFullAccessUsageDescription` to `ios.infoPlist` and `READ_CALENDAR` / `WRITE_CALENDAR` to `android.permissions`, matching the existing pattern for Bluetooth/mic/location in this file.

## Test plan
- [x] Reproduced the crash on a physical Z Fold via `adb logcat` (`FATAL EXCEPTION: pool-4-thread-1`, `NoClassDefFoundError` in `CalendarModule.kt` → `ClassNotFoundException: expo.modules.kotlin.types.AnyTypeCache`).
- [x] Confirmed `bun install` now resolves `expo-calendar@55.0.17` (matching the SDK 55 line) instead of `57.0.1`.
- [x] Clean `expo prebuild` + `expo run:android`, reinstalled on the same device — app launches with no crash, process stays alive, no `FATAL EXCEPTION` in logcat.
- [x] After adding the permission strings, confirmed `READ_CALENDAR`/`WRITE_CALENDAR` land in the generated `AndroidManifest.xml`, rebuilt and reinstalled again — still launches clean on-device.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pinning and manifest permission strings for the example OEM app only; no changes to engine or production app logic beyond fixing version alignment and declaring calendar access.
> 
> **Overview**
> Fixes a **launch crash** in `example-oem-app` caused by resolving `@mentra/engine`’s `expo-calendar` peer to **57.x** while the app is on **Expo 55**, which broke native module registration (`CalendarModule` / `AnyTypeCache`).
> 
> The app now **declares `expo-calendar` at `~55.0.14`** (lockfile resolves **55.0.17** for that package) so it aligns with the rest of the pinned `expo-*` stack. **`app.json`** also adds **iOS calendar usage strings** and **Android `READ_CALENDAR` / `WRITE_CALENDAR`** so calendar access matches what engine miniapps expect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56ef105dce66103dce76e1f88dd844bb5f5b00ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->