### PR TITLE
Prevent mic watchdog resets during app audio

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -28,6 +28,7 @@ import com.mentra.bluetoothsdk.utils.ControllerTypes
 import com.mentra.bluetoothsdk.utils.DeviceTypes
 import com.mentra.bluetoothsdk.utils.MicMap
 import com.mentra.bluetoothsdk.utils.MicTypes
+import com.mentra.bluetoothsdk.utils.PhoneAudioMonitor
 import com.mentra.lc3Lib.Lc3Cpp
 import com.mentra.bluetoothsdk.stt.SherpaOnnxTranscriber
 import kotlinx.coroutines.CoroutineScope
@@ -331,6 +332,11 @@ class DeviceManager {
 
         if (sgc?.isMicSuspendedForAudio == true) {
             Bridge.log("MAN: Glasses mic intentionally suspended for phone audio; skipping mic recovery")
+            return
+        }
+
+        if (PhoneAudioMonitor.getInstance(Bridge.getContext()).isOwnAppAudioPlaying()) {
+            Bridge.log("MAN: Mentra audio is playing; skipping glasses mic recovery")
             return
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
@@ -48,6 +48,10 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
     private var listener: Listener? = null
     private var isMonitoring = false
     private var lastKnownState = false
+    // Set explicitly by AudioPlaybackService. Unlike isPlaying(), this is
+    // limited to Mentra's own playback and is safe for mic-watchdog gating.
+    @Volatile
+    private var ownAppAudioPlaying = false
 
     // Rate limiting: max 1 state change notification per 500ms
     // If state changes rapidly (true/false/true), we wait and send the final state
@@ -78,6 +82,8 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
         return audioManager.isMusicActive
     }
 
+    fun isOwnAppAudioPlaying(): Boolean = ownAppAudioPlaying
+
     /**
      * Notify the monitor that our own app started/stopped playing audio
      * Called from RN AudioPlaybackService via Bridge
@@ -88,6 +94,7 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
      * The hold-off prevents us from reporting STOPPED during this transition.
      */
     fun setOwnAppAudioPlaying(playing: Boolean) {
+        ownAppAudioPlaying = playing
         Bridge.log("$TAG: Own app audio -> ${if (playing) "PLAYING" else "STOPPED"}")
 
         if (playing) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -804,6 +804,11 @@ struct ViewState {
             return
         }
 
+        if PhoneAudioMonitor.getInstance().isOwnAppAudioPlaying() {
+            Bridge.log("MAN: Mentra audio is playing; skipping glasses mic recovery")
+            return
+        }
+
         let timeSinceLastLc3Event = Date().timeIntervalSince(lastLc3Event ?? Date())
         if timeSinceLastLc3Event > 5 {
             Bridge.log("MAN: No audio activity in the last 5 seconds from glasses, reinitializing glasses mic")

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/PhoneAudioMonitor.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/PhoneAudioMonitor.swift
@@ -55,6 +55,10 @@ class PhoneAudioMonitor {
         return session.isOtherAudioPlaying || ownAppAudioPlaying
     }
 
+    func isOwnAppAudioPlaying() -> Bool {
+        ownAppAudioPlaying
+    }
+
     /// Notify the monitor that our own app started/stopped playing audio
     /// Called from RN AudioPlaybackService via Bridge
     func setOwnAppAudioPlaying(_ playing: Bool) {

--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -585,6 +585,10 @@ class AudioPlaybackService {
     // Uses BgTimer to work reliably when app is backgrounded on Android
     this.audioStopDebounceTimer = BgTimer.setTimeout(() => {
       this.audioStopDebounceTimer = null
+      // URL playback and live PCM streams may overlap when stopOtherAudio is false.
+      // A URL that ends must not clear the native playback signal while another
+      // source is still active, or the mic watchdog can interrupt that source.
+      if (this.isPlaying()) return
       BluetoothSdk.setOwnAppAudioPlaying(false).catch((e) => {
         console.warn("AUDIO: Failed to notify native of audio stop:", e)
       })

--- a/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
@@ -10,6 +10,7 @@ import {
   pcmStreamWrite,
   resetAudioTestMocks,
   sendAudioFrame,
+  setOwnAppAudioPlaying,
 } from "./audioTestMocks"
 
 const setAudioModeAsync = mock(async () => {})
@@ -213,6 +214,33 @@ describe("AudioPlaybackService live PCM streams", () => {
 
     expect(firstComplete).toHaveBeenCalledTimes(1)
     expect(firstComplete).toHaveBeenCalledWith("first-url", true, null, expect.any(Number), "interrupted")
+  })
+
+  test("keeps native audio marked active when URL playback finishes beside a live PCM stream", async () => {
+    await audioPlaybackService.openStream({
+      appId: "stream-app",
+      channels: 1,
+      onEnded: () => {},
+      sampleRate: 16_000,
+      stopOtherAudio: false,
+      streamId: "ongoing-stream",
+    })
+    await audioPlaybackService.play(
+      {requestId: "short-url", audioUrl: "file://short.wav", appId: "url-app", stopOtherAudio: false},
+      () => {},
+    )
+    setOwnAppAudioPlaying.mockClear()
+
+    const playbackStatusTarget = audioPlaybackService as unknown as {
+      onPlaybackStatusUpdate(status: {didJustFinish: boolean; duration: number}): void
+    }
+    playbackStatusTarget.onPlaybackStatusUpdate({didJustFinish: true, duration: 1})
+
+    expect(audioPlaybackService.getActiveAppIds()).toEqual(["stream-app"])
+    expect(setOwnAppAudioPlaying).not.toHaveBeenCalledWith(false)
+
+    await audioPlaybackService.closeStream("ongoing-stream")
+    expect(setOwnAppAudioPlaying).toHaveBeenCalledWith(false)
   })
 
   test("only suppresses cloud STT when the caller opts in", async () => {


### PR DESCRIPTION
## Summary
- Skip LC3 mic recovery while Mentra's own audio is playing.
- Keep the existing watchdog active once playback ends, so it can still recover a genuinely stalled glasses mic.
- Apply the guard on Android and iOS.

## Why
Long A2DP TTS can temporarily stop incoming LC3 frames. The watchdog mistook that expected gap for a failed mic and sent the enable_custom_audio_tx command mid-speech, cutting out playback.

## Verification
- Compiled the Android Bluetooth SDK release Kotlin target.
- Built and installed an arm64 release APK.
- Confirmed device logs show the mic watchdog skipping recovery during long TTS instead of reinitializing the mic mid-playback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Bluetooth mic recovery and native audio state on both platforms; wrong gating could delay real mic recovery or leave the watchdog suppressed too long.
> 
> **Overview**
> Stops the glasses **LC3 mic watchdog** from re-enabling the mic while **Mentra’s own audio** is playing. Long TTS over A2DP can pause incoming LC3 frames; without this guard, recovery mid-playback was cutting speech off.
> 
> **Native (Android & iOS):** `checkAndReinitGlassesMic()` now bails when `PhoneAudioMonitor.isOwnAppAudioPlaying()` is true. Android tracks that flag explicitly in `PhoneAudioMonitor` (separate from system-wide `isPlaying()`); iOS exposes the same accessor on the existing `ownAppAudioPlaying` state.
> 
> **JS:** `AudioPlaybackService.notifyAudioStopDebounced()` only calls `setOwnAppAudioPlaying(false)` if nothing is still playing, so a finished URL with `stopOtherAudio: false` does not clear the native “app audio active” signal while a **live PCM stream** is still open.
> 
> A unit test covers URL finish + overlapping PCM stream.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a181f716bbc0752955d712611069a17efe012894. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->