### PR TITLE
Make mongoose model registration idempotent in cloud-v2 core

### DIFF
--- a/cloud-v2/packages/core/src/models/account-code.model.ts
+++ b/cloud-v2/packages/core/src/models/account-code.model.ts
@@ -7,7 +7,8 @@
  * deletion code. `subject` is the thing the code authorizes (email for reset,
  * user id for deletion, the PKCE challenge for oauth).
  */
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const ACCOUNT_CODE_PURPOSES = [
   "password_reset",
@@ -36,4 +37,4 @@ const AccountCodeSchema = new Schema(
 AccountCodeSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 export type AccountCode = InferSchemaType<typeof AccountCodeSchema>;
-export const AccountCodeModel = model("AccountCode", AccountCodeSchema);
+export const AccountCodeModel = registerModel("AccountCode", AccountCodeSchema);

--- a/cloud-v2/packages/core/src/models/admin-action-audit-log.model.ts
+++ b/cloud-v2/packages/core/src/models/admin-action-audit-log.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const AdminActionAuditLogSchema = new Schema(
   {
@@ -15,4 +16,4 @@ const AdminActionAuditLogSchema = new Schema(
 AdminActionAuditLogSchema.index({ createdAt: -1 });
 
 export type AdminActionAuditLog = InferSchemaType<typeof AdminActionAuditLogSchema>;
-export const AdminActionAuditLogModel = model("AdminActionAuditLog", AdminActionAuditLogSchema);
+export const AdminActionAuditLogModel = registerModel("AdminActionAuditLog", AdminActionAuditLogSchema);

--- a/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-api-key.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 /**
  * Org-scoped developer API key, owned entirely in our DB (no WorkOS). The full
@@ -26,4 +27,4 @@ const DeveloperOrgApiKeySchema = new Schema(
 DeveloperOrgApiKeySchema.index({ orgId: 1, revokedAt: 1 });
 
 export type DeveloperOrgApiKey = InferSchemaType<typeof DeveloperOrgApiKeySchema>;
-export const DeveloperOrgApiKeyModel = model("DeveloperOrgApiKey", DeveloperOrgApiKeySchema);
+export const DeveloperOrgApiKeyModel = registerModel("DeveloperOrgApiKey", DeveloperOrgApiKeySchema);

--- a/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-invitation.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const DEVELOPER_ORG_INVITATION_ROLES = ["admin", "member"] as const;
 export const DEVELOPER_ORG_INVITATION_STATUSES = ["pending", "accepted", "revoked"] as const;
@@ -29,7 +30,7 @@ DeveloperOrgInvitationSchema.index(
 );
 
 export type DeveloperOrgInvitation = InferSchemaType<typeof DeveloperOrgInvitationSchema>;
-export const DeveloperOrgInvitationModel = model(
+export const DeveloperOrgInvitationModel = registerModel(
   "DeveloperOrgInvitation",
   DeveloperOrgInvitationSchema,
 );

--- a/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org-membership.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 /**
  * Per-(org, user) role, stored and owned entirely in our DB. Roles are uniform:
@@ -37,7 +38,7 @@ DeveloperOrgMembershipSchema.index(
 );
 
 export type DeveloperOrgMembership = InferSchemaType<typeof DeveloperOrgMembershipSchema>;
-export const DeveloperOrgMembershipModel = model(
+export const DeveloperOrgMembershipModel = registerModel(
   "DeveloperOrgMembership",
   DeveloperOrgMembershipSchema,
 );

--- a/cloud-v2/packages/core/src/models/developer-org.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-org.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const DEVELOPER_ORG_PREFIX_STATUSES = ["unverified", "verified", "rejected"] as const;
 export type DeveloperOrgPrefixStatus = (typeof DEVELOPER_ORG_PREFIX_STATUSES)[number];
@@ -24,4 +25,4 @@ DeveloperOrgSchema.index({ ownerUserId: 1, createdAt: 1 });
 DeveloperOrgSchema.index({ workosOrgId: 1 }, { unique: true, sparse: true });
 
 export type DeveloperOrg = InferSchemaType<typeof DeveloperOrgSchema>;
-export const DeveloperOrgModel = model("DeveloperOrg", DeveloperOrgSchema);
+export const DeveloperOrgModel = registerModel("DeveloperOrg", DeveloperOrgSchema);

--- a/cloud-v2/packages/core/src/models/developer-signing-key.model.ts
+++ b/cloud-v2/packages/core/src/models/developer-signing-key.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const DEVELOPER_SIGNING_KEY_STATUSES = ["active", "revoked"] as const;
 
@@ -16,5 +17,5 @@ const DeveloperSigningKeySchema = new Schema(
 DeveloperSigningKeySchema.index({ orgId: 1, workosUserId: 1, status: 1 });
 
 export type DeveloperSigningKey = InferSchemaType<typeof DeveloperSigningKeySchema>;
-export const DeveloperSigningKeyModel = model("DeveloperSigningKey", DeveloperSigningKeySchema);
+export const DeveloperSigningKeyModel = registerModel("DeveloperSigningKey", DeveloperSigningKeySchema);
 

--- a/cloud-v2/packages/core/src/models/enterprise-org.model.ts
+++ b/cloud-v2/packages/core/src/models/enterprise-org.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const ENTERPRISE_ORG_STATUSES = ["active", "disabled"] as const;
 export type EnterpriseOrgStatus = (typeof ENTERPRISE_ORG_STATUSES)[number];
@@ -26,4 +27,4 @@ EnterpriseOrgSchema.index(
 );
 
 export type EnterpriseOrg = InferSchemaType<typeof EnterpriseOrgSchema>;
-export const EnterpriseOrgModel = model("EnterpriseOrg", EnterpriseOrgSchema);
+export const EnterpriseOrgModel = registerModel("EnterpriseOrg", EnterpriseOrgSchema);

--- a/cloud-v2/packages/core/src/models/miniapp-asset.model.ts
+++ b/cloud-v2/packages/core/src/models/miniapp-asset.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const MINIAPP_ASSET_ROLES = [
   "release_bundle",
@@ -29,4 +30,4 @@ const MiniAppAssetSchema = new Schema(
 );
 
 export type MiniAppAsset = InferSchemaType<typeof MiniAppAssetSchema>;
-export const MiniAppAssetModel = model("MiniAppAsset", MiniAppAssetSchema);
+export const MiniAppAssetModel = registerModel("MiniAppAsset", MiniAppAssetSchema);

--- a/cloud-v2/packages/core/src/models/miniapp-release.model.ts
+++ b/cloud-v2/packages/core/src/models/miniapp-release.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const RELEASE_STATUSES = [
   "draft",
@@ -39,4 +40,4 @@ const MiniAppReleaseSchema = new Schema(
 MiniAppReleaseSchema.index({ miniAppId: 1, version: 1 }, { unique: true });
 
 export type MiniAppRelease = InferSchemaType<typeof MiniAppReleaseSchema>;
-export const MiniAppReleaseModel = model("MiniAppRelease", MiniAppReleaseSchema);
+export const MiniAppReleaseModel = registerModel("MiniAppRelease", MiniAppReleaseSchema);

--- a/cloud-v2/packages/core/src/models/miniapp.model.ts
+++ b/cloud-v2/packages/core/src/models/miniapp.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const MINIAPP_STATUSES = ["active", "archived", "suspended"] as const;
 
@@ -18,4 +19,4 @@ const MiniAppSchema = new Schema(
 MiniAppSchema.index({ orgId: 1, packageName: 1 }, { unique: true });
 
 export type MiniApp = InferSchemaType<typeof MiniAppSchema>;
-export const MiniAppModel = model("MiniApp", MiniAppSchema);
+export const MiniAppModel = registerModel("MiniApp", MiniAppSchema);

--- a/cloud-v2/packages/core/src/models/oem.model.ts
+++ b/cloud-v2/packages/core/src/models/oem.model.ts
@@ -13,7 +13,8 @@
  * Spec: docs/issues/001-oem-auth/design.md ("Data model" / "Collection: oems")
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const OEM_PUBLIC_KEY_MODES = ["static", "jwks-url"] as const;
 export type OemPublicKeyMode = (typeof OEM_PUBLIC_KEY_MODES)[number];
@@ -55,4 +56,4 @@ const OemSchema = new Schema(
 );
 
 export type Oem = InferSchemaType<typeof OemSchema>;
-export const OemModel = model("Oem", OemSchema);
+export const OemModel = registerModel("Oem", OemSchema);

--- a/cloud-v2/packages/core/src/models/preinstalled-registry-revision.model.ts
+++ b/cloud-v2/packages/core/src/models/preinstalled-registry-revision.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const PREINSTALLED_INSTALL_POLICIES = ["install_once", "keep_updated", "mandatory"] as const;
 export const PREINSTALLED_REVISION_STATUSES = ["draft", "active", "archived"] as const;
@@ -38,7 +39,7 @@ PreinstalledRegistryRevisionSchema.index(
 );
 
 export type PreinstalledRegistryRevision = InferSchemaType<typeof PreinstalledRegistryRevisionSchema>;
-export const PreinstalledRegistryRevisionModel = model(
+export const PreinstalledRegistryRevisionModel = registerModel(
   "PreinstalledRegistryRevision",
   PreinstalledRegistryRevisionSchema,
 );

--- a/cloud-v2/packages/core/src/models/preinstalled-registry.model.ts
+++ b/cloud-v2/packages/core/src/models/preinstalled-registry.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 export const PREINSTALLED_REGISTRY_ENVIRONMENTS = ["debug", "dev", "staging", "prod"] as const;
 export const PREINSTALLED_REGISTRY_STATUSES = ["draft", "active", "archived"] as const;
@@ -22,4 +23,4 @@ PreinstalledRegistrySchema.index(
 );
 
 export type PreinstalledRegistry = InferSchemaType<typeof PreinstalledRegistrySchema>;
-export const PreinstalledRegistryModel = model("PreinstalledRegistry", PreinstalledRegistrySchema);
+export const PreinstalledRegistryModel = registerModel("PreinstalledRegistry", PreinstalledRegistrySchema);

--- a/cloud-v2/packages/core/src/models/refresh-token.model.ts
+++ b/cloud-v2/packages/core/src/models/refresh-token.model.ts
@@ -28,7 +28,8 @@
  * Spec: docs/issues/001-oem-auth/design.md ("Data model" / "refreshTokens")
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const RefreshTokenSchema = new Schema(
   {
@@ -91,4 +92,4 @@ RefreshTokenSchema.index({ mentraUserId: 1, tenantId: 1 });
 RefreshTokenSchema.index({ tenantId: 1 });
 
 export type RefreshToken = InferSchemaType<typeof RefreshTokenSchema>;
-export const RefreshTokenModel = model("RefreshToken", RefreshTokenSchema);
+export const RefreshTokenModel = registerModel("RefreshToken", RefreshTokenSchema);

--- a/cloud-v2/packages/core/src/models/register-model.ts
+++ b/cloud-v2/packages/core/src/models/register-model.ts
@@ -1,0 +1,47 @@
+/**
+ * @fileoverview Idempotent mongoose model registration.
+ *
+ * `model("Name", schema)` throws OverwriteModelError when a model file is
+ * evaluated twice in one process — which happens under whole-package
+ * `bun test` runs, where different test files can reach the same model
+ * through different module identities (relative path vs. package entry, or
+ * the package's nested node_modules). Reusing the already-compiled model
+ * makes registration idempotent; the first registration wins, so behavior
+ * in a normal single-identity process is unchanged.
+ */
+
+import {
+  model,
+  models,
+  type HydratedDocument,
+  type InferSchemaType,
+  type Model,
+  type ObtainSchemaGeneric,
+  type Schema,
+} from "mongoose";
+
+// Return type of mongoose's `model(name, schema)` overload for a concrete
+// schema, spelled out because `ReturnType<typeof model<TSchema>>` resolves
+// against the wrong overload (doc type collapses to the Schema itself).
+type CompiledModel<TSchema extends Schema> = Model<
+  InferSchemaType<TSchema>,
+  ObtainSchemaGeneric<TSchema, "TQueryHelpers">,
+  ObtainSchemaGeneric<TSchema, "TInstanceMethods">,
+  ObtainSchemaGeneric<TSchema, "TVirtuals">,
+  HydratedDocument<
+    InferSchemaType<TSchema>,
+    ObtainSchemaGeneric<TSchema, "TVirtuals"> & ObtainSchemaGeneric<TSchema, "TInstanceMethods">,
+    ObtainSchemaGeneric<TSchema, "TQueryHelpers">,
+    ObtainSchemaGeneric<TSchema, "TVirtuals">,
+    ObtainSchemaGeneric<TSchema, "TSchemaOptions">
+  >,
+  TSchema
+> &
+  ObtainSchemaGeneric<TSchema, "TStaticMethods">;
+
+export function registerModel<TSchema extends Schema>(
+  name: string,
+  schema: TSchema,
+): CompiledModel<TSchema> {
+  return (models[name] as CompiledModel<TSchema> | undefined) ?? model(name, schema);
+}

--- a/cloud-v2/packages/core/src/models/report-asset.model.ts
+++ b/cloud-v2/packages/core/src/models/report-asset.model.ts
@@ -9,7 +9,8 @@
  * in the owning report document.
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const ReportAssetSchema = new Schema(
   {
@@ -26,4 +27,4 @@ const ReportAssetSchema = new Schema(
 );
 
 export type ReportAsset = InferSchemaType<typeof ReportAssetSchema>;
-export const ReportAssetModel = model("ReportAsset", ReportAssetSchema);
+export const ReportAssetModel = registerModel("ReportAsset", ReportAssetSchema);

--- a/cloud-v2/packages/core/src/models/report.model.ts
+++ b/cloud-v2/packages/core/src/models/report.model.ts
@@ -14,7 +14,8 @@
  * a deployed environment, so no inline-payload documents exist to migrate.
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const ReportArtifactSchema = new Schema(
   {
@@ -63,4 +64,4 @@ ReportSchema.index({ mentraUserId: 1, createdAt: -1 });
 ReportSchema.index({ createdAt: -1 });
 
 export type Report = InferSchemaType<typeof ReportSchema>;
-export const ReportModel = model("Report", ReportSchema);
+export const ReportModel = registerModel("Report", ReportSchema);

--- a/cloud-v2/packages/core/src/models/revoked-jti.model.ts
+++ b/cloud-v2/packages/core/src/models/revoked-jti.model.ts
@@ -14,7 +14,8 @@
  * Spec: docs/issues/001-oem-auth/design.md ("Data model" / "revokedJtis")
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const RevokedJtiSchema = new Schema(
   {
@@ -33,4 +34,4 @@ const RevokedJtiSchema = new Schema(
 RevokedJtiSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 
 export type RevokedJti = InferSchemaType<typeof RevokedJtiSchema>;
-export const RevokedJtiModel = model("RevokedJti", RevokedJtiSchema);
+export const RevokedJtiModel = registerModel("RevokedJti", RevokedJtiSchema);

--- a/cloud-v2/packages/core/src/models/seen-jti.model.ts
+++ b/cloud-v2/packages/core/src/models/seen-jti.model.ts
@@ -16,7 +16,8 @@
  * Spec: docs/issues/001-oem-auth/design.md ("Data model" / "seenJtis")
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const SeenJtiSchema = new Schema(
   {
@@ -43,4 +44,4 @@ SeenJtiSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
 SeenJtiSchema.index({ jti: 1, tenantId: 1 }, { unique: true });
 
 export type SeenJti = InferSchemaType<typeof SeenJtiSchema>;
-export const SeenJtiModel = model("SeenJti", SeenJtiSchema);
+export const SeenJtiModel = registerModel("SeenJti", SeenJtiSchema);

--- a/cloud-v2/packages/core/src/models/trusted-issuer.model.ts
+++ b/cloud-v2/packages/core/src/models/trusted-issuer.model.ts
@@ -1,4 +1,5 @@
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const TrustedIssuerSchema = new Schema(
   {
@@ -24,4 +25,4 @@ const TrustedIssuerSchema = new Schema(
 TrustedIssuerSchema.index({ enterpriseOrgId: 1, environmentName: 1 }, { unique: true });
 
 export type TrustedIssuer = InferSchemaType<typeof TrustedIssuerSchema>;
-export const TrustedIssuerModel = model("TrustedIssuer", TrustedIssuerSchema);
+export const TrustedIssuerModel = registerModel("TrustedIssuer", TrustedIssuerSchema);

--- a/cloud-v2/packages/core/src/models/user.model.ts
+++ b/cloud-v2/packages/core/src/models/user.model.ts
@@ -12,7 +12,8 @@
  * Spec: docs/issues/001-oem-auth/design.md ("Data model" / "Collection: users")
  */
 
-import { Schema, model, type InferSchemaType } from "mongoose";
+import { Schema, type InferSchemaType } from "mongoose";
+import { registerModel } from "./register-model";
 
 const UserSchema = new Schema(
   {
@@ -36,4 +37,4 @@ const UserSchema = new Schema(
 UserSchema.index({ tenantId: 1, tenantUserId: 1 }, { unique: true });
 
 export type User = InferSchemaType<typeof UserSchema>;
-export const UserModel = model("User", UserSchema);
+export const UserModel = registerModel("User", UserSchema);


### PR DESCRIPTION
## Scope

`bun test packages/core` run from `cloud-v2/` (all core unit tests in one bun process) can fail with `OverwriteModelError: Cannot overwrite \`RefreshToken\` model once compiled` raised from `refresh-token.model.ts` during `session.service.test.ts`. Individual test files pass in isolation: the failure happens when several test files reach the same model file through different module identities in one process (relative path vs package entry, or the package's nested `node_modules` — `packages/core/node_modules` carries its own `mongoose` and `@mentra` entries, so resolution paths can fork), and the second evaluation's bare `model()` call throws.

## Changes

- Add `packages/core/src/models/register-model.ts`: `registerModel(name, schema)` returns `models[name] ?? model(name, schema)`, making registration idempotent. First registration wins, so behavior in a normal single-identity process is unchanged.
- Switch all 21 model files in `packages/core/src/models/` from bare `model("Name", schema)` to `registerModel("Name", schema)`.

Typing note: the naive `ReturnType<typeof model<TSchema>>` resolves against the wrong `model()` overload (the doc type collapses to the Schema itself, breaking every call site), so the helper spells out mongoose's own return type for the schema-generic overload via `InferSchemaType`/`ObtainSchemaGeneric`.

## Test evidence

- `cd cloud-v2 && bun test packages/core`: 29 pass, 0 fail across all 4 test files, including `session.service.test.ts`.
- Direct idempotency check: calling `registerModel("DupCheck", new Schema(...))` twice returns the same compiled model instead of throwing `OverwriteModelError`.
- `tsc --noEmit` output is identical to clean `dev` (remaining errors are the pre-existing `packages/shared/dist` not-built TS6305s and one pre-existing TS18046).

Caveat: the original failure did not reproduce on my checkout (five clean-dev whole-package runs passed), so the trigger is environment-dependent node_modules layout. The fix neutralizes the hazard regardless; a confirming run on a machine where it originally failed would be good.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical registration wrapper only; first registration still wins, so production single-load behavior should be unchanged with no schema or query logic edits.
> 
> **Overview**
> Adds **`registerModel`** in `register-model.ts`, which returns an already-compiled model from `mongoose.models` when the same name was registered earlier, otherwise calls `model(name, schema)`. That avoids **`OverwriteModelError`** when whole-package `bun test packages/core` loads a model file more than once via different module resolution paths.
> 
> All **21** core model modules now export through **`registerModel`** instead of bare **`model()`**; schemas and collection names are unchanged. The helper keeps TypeScript parity with mongoose’s schema-generic **`model()`** return type via an explicit **`CompiledModel`** alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9580914cd7c7e772ff56e7554b523f7f830d15c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->