### PR TITLE
Fix mobile screenshot, gallery sync, and button incidents

### DIFF
--- a/mobile/jest.setup.js
+++ b/mobile/jest.setup.js
@@ -558,6 +558,8 @@ const mockIslandEntries = () => {
         // one store double.
         list: jest.fn(() => [...appStatusState.apps]),
         onChanged: jest.fn(() => () => {}),
+        buttonPressSubscribers: jest.fn(() => []),
+        onButtonPressSubscribersChanged: jest.fn(() => () => {}),
         refresh: jest.fn((...a) => appStatusState.refresh(...a) ?? Promise.resolve()),
         start: jest.fn((...a) => appStatusState.start(...a) ?? Promise.resolve(true)),
         stop: jest.fn((...a) => appStatusState.stop(...a) ?? Promise.resolve()),

--- a/mobile/modules/engine/src/facades/gallery.ts
+++ b/mobile/modules/engine/src/facades/gallery.ts
@@ -22,7 +22,7 @@ function projectStatus() {
     processingFiles: Array.from(progress.processingFiles),
     processedFiles: s.processedFiles,
     isSyncing: selectIssyncing(s),
-    isStarting: gallerySyncService.isSyncStarting(),
+    isStarting: s.syncStarting,
     glassesGallery: selectGlassesGalleryStatus(s),
     // Copy: the snapshot must not hand callers a mutable reference into the store
     // (each queue item is copied too — callers must not mutate them in place).

--- a/mobile/modules/engine/src/facades/miniapps.ts
+++ b/mobile/modules/engine/src/facades/miniapps.ts
@@ -9,6 +9,7 @@
  * `<WebView>` wired to them. This facade is the lifecycle half.
  */
 import {useAppStatusStore} from "../stores/apps"
+import localMiniappRuntime from "../services/LocalMiniappRuntime"
 import type {ClientApp} from "../types"
 
 type AppsState = ReturnType<typeof useAppStatusStore.getState>
@@ -28,6 +29,12 @@ export const miniapps = {
       cb(apps)
     })
   },
+
+  /** Miniapps actively subscribed to Mentra Live hardware-button events. */
+  buttonPressSubscribers: (): string[] => localMiniappRuntime.getButtonPressSubscribers(),
+  /** Observe the active Mentra Live hardware-button subscriber set. */
+  onButtonPressSubscribersChanged: (cb: (packageNames: string[]) => void): (() => void) =>
+    localMiniappRuntime.onButtonPressSubscribersChanged(cb),
 
   /** Re-fetch the installed-app list from the backend. */
   refresh: () => useAppStatusStore.getState().refresh(),

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -350,6 +350,9 @@ class LocalMiniappRuntime {
   /** Ref-counted stream subscriptions: stream → set of packageNames. */
   private streamSubscribers: Map<string, Set<string>> = new Map()
 
+  /** Host observers for the Mentra Live button-capture policy. */
+  private buttonPressSubscriberListeners = new Set<(packageNames: string[]) => void>()
+
   /** Guards one-time wiring of the cloud transcript/translation fan-out. */
   private cloudResultsWired = false
   private cloudStatusWired = false
@@ -380,6 +383,52 @@ class LocalMiniappRuntime {
   private usedTokens = new Set<string>()
 
   private constructor() {}
+
+  /** Snapshot of miniapps actively subscribed to hardware button events. */
+  public getButtonPressSubscribers(): string[] {
+    return [...(this.streamSubscribers.get(MiniappStreamType.BUTTON_PRESS) ?? [])].sort()
+  }
+
+  /** Observe active hardware-button subscriptions. */
+  public onButtonPressSubscribersChanged(listener: (packageNames: string[]) => void): () => void {
+    this.buttonPressSubscriberListeners.add(listener)
+    return () => this.buttonPressSubscriberListeners.delete(listener)
+  }
+
+  private replaceStreamSubscribers(
+    packageName: string,
+    previousStreams: Iterable<string>,
+    nextStreams: Iterable<string>,
+  ) {
+    const previousButtonSubscribers = this.getButtonPressSubscribers().join("\u0000")
+
+    for (const stream of previousStreams) {
+      const subscribers = this.streamSubscribers.get(stream)
+      if (!subscribers) continue
+      subscribers.delete(packageName)
+      if (subscribers.size === 0) this.streamSubscribers.delete(stream)
+    }
+
+    for (const stream of nextStreams) {
+      let subscribers = this.streamSubscribers.get(stream)
+      if (!subscribers) {
+        subscribers = new Set()
+        this.streamSubscribers.set(stream, subscribers)
+      }
+      subscribers.add(packageName)
+    }
+
+    const nextButtonSubscribers = this.getButtonPressSubscribers()
+    if (previousButtonSubscribers !== nextButtonSubscribers.join("\u0000")) {
+      for (const listener of this.buttonPressSubscriberListeners) {
+        try {
+          listener(nextButtonSubscribers)
+        } catch (error) {
+          console.warn(`${LOG_TAG}: button press subscriber listener threw:`, error)
+        }
+      }
+    }
+  }
 
   /**
    * Generate an HMAC-signed local session token for browser fallback auth.
@@ -606,13 +655,7 @@ class LocalMiniappRuntime {
         BgTimer.clearTimeout(existing.authRetryTimerId)
         existing.authRetryTimerId = null
       }
-      for (const stream of existing.subscriptions) {
-        const subs = this.streamSubscribers.get(stream)
-        if (subs) {
-          subs.delete(packageName)
-          if (subs.size === 0) this.streamSubscribers.delete(stream)
-        }
-      }
+      this.replaceStreamSubscribers(packageName, existing.subscriptions, [])
       this.recomputeMicRequirements()
       this.updateCloudSubscriptions()
     }
@@ -769,15 +812,7 @@ class LocalMiniappRuntime {
     if (!app) return
 
     // Remove from all stream subscriber sets
-    for (const stream of app.subscriptions) {
-      const subs = this.streamSubscribers.get(stream)
-      if (subs) {
-        subs.delete(packageName)
-        if (subs.size === 0) {
-          this.streamSubscribers.delete(stream)
-        }
-      }
-    }
+    this.replaceStreamSubscribers(packageName, app.subscriptions, [])
 
     // Reset per-session warning dedup so a relaunch surfaces issues again.
     resetPermissionWarnings(packageName)
@@ -1450,18 +1485,8 @@ class LocalMiniappRuntime {
       }
     }
 
-    // Remove old subscriptions for this app
-    for (const oldStream of app.subscriptions) {
-      const subs = this.streamSubscribers.get(oldStream)
-      if (subs) {
-        subs.delete(packageName)
-        if (subs.size === 0) {
-          this.streamSubscribers.delete(oldStream)
-        }
-      }
-    }
-
     // Add new subscriptions
+    const previousSubscriptions = app.subscriptions
     app.subscriptions = new Set(streams)
     app.forceLocalTranscriptionStreams = new Set(
       [...forceLocalTranscriptionStreams].filter((stream) => app.subscriptions.has(stream)),
@@ -1469,14 +1494,7 @@ class LocalMiniappRuntime {
     app.cloudTranscriptionStreams = new Set(
       [...cloudTranscriptionStreams].filter((stream) => app.subscriptions.has(stream)),
     )
-    for (const stream of streams) {
-      let subs = this.streamSubscribers.get(stream)
-      if (!subs) {
-        subs = new Set()
-        this.streamSubscribers.set(stream, subs)
-      }
-      subs.add(packageName)
-    }
+    this.replaceStreamSubscribers(packageName, previousSubscriptions, app.subscriptions)
 
     this.recomputeMicRequirements()
     this.updateCloudSubscriptions()
@@ -3140,29 +3158,12 @@ class LocalMiniappRuntime {
       }
     }
 
-    // Remove old subscriptions for this app
-    for (const oldStream of app.subscriptions) {
-      const subs = this.streamSubscribers.get(oldStream)
-      if (subs) {
-        subs.delete(packageName)
-        if (subs.size === 0) {
-          this.streamSubscribers.delete(oldStream)
-        }
-      }
-    }
-
     // Add new subscriptions
+    const previousSubscriptions = app.subscriptions
     app.subscriptions = new Set(streams)
     app.forceLocalTranscriptionStreams.clear()
     app.cloudTranscriptionStreams = new Set(streams.filter((stream) => stream.startsWith("transcription:")))
-    for (const stream of streams) {
-      let subs = this.streamSubscribers.get(stream)
-      if (!subs) {
-        subs = new Set()
-        this.streamSubscribers.set(stream, subs)
-      }
-      subs.add(packageName)
-    }
+    this.replaceStreamSubscribers(packageName, previousSubscriptions, app.subscriptions)
 
     this.recomputeMicRequirements()
     this.updateCloudSubscriptions()
@@ -4205,7 +4206,17 @@ class LocalMiniappRuntime {
 
     // Belt-and-suspenders: clear any remaining state
     this.pendingCloudRequests.clear()
+    const hadButtonPressSubscribers = this.getButtonPressSubscribers().length > 0
     this.streamSubscribers.clear()
+    if (hadButtonPressSubscribers) {
+      for (const listener of this.buttonPressSubscriberListeners) {
+        try {
+          listener([])
+        } catch (error) {
+          console.warn(`${LOG_TAG}: button press subscriber listener threw during cleanup:`, error)
+        }
+      }
+    }
     this.connectedApps.clear()
     for (const timerId of this.foregroundProbeTimers.values()) {
       BgTimer.clearTimeout(timerId)

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -156,6 +156,10 @@ class GallerySyncService {
     }
 
     this.syncStartPromise = null
+    useGallerySyncStore.getState().setSyncStarting(false)
+    this.waitingForWifiRetry = false
+    this.wifiSettingsOpenedAt = null
+    this.startAborted = false
     this.isInitialized = false
     console.log("[GallerySyncService] Cleaned up")
   }
@@ -228,14 +232,23 @@ class GallerySyncService {
     if (!glassesConnected) {
       console.log("[GallerySyncService] Glasses disconnected - not retrying sync")
       this.waitingForWifiRetry = false
+      this.wifiSettingsOpenedAt = null
       return
+    }
+
+    // The user has returned from the WiFi settings prompt, so the previous
+    // "Sync failed" state is no longer actionable. Make the button available
+    // immediately while the native WiFi state catches up; a successful check
+    // below will start the sync automatically.
+    if (store.syncState === "error" && store.lastError?.startsWith("WiFi disabled")) {
+      store.setSyncState("idle")
     }
 
     // Check if WiFi is now enabled (Android only)
     // Use retry logic because WiFi status takes time to propagate after user enables it
     if (Platform.OS === "android") {
       const MAX_RETRIES = 5
-      const RETRY_DELAY_MS = 1000 // Wait 500ms between checks
+      const RETRY_DELAY_MS = 1000
 
       console.log("[GallerySyncService] Waiting for WiFi to initialize (may take a moment after enabling)...")
 
@@ -243,35 +256,28 @@ class GallerySyncService {
         try {
           await new Promise<void>((resolve) => BgTimer.setTimeout(() => resolve(), RETRY_DELAY_MS))
 
-          const netState = await NetInfo.fetch()
-          console.log(
-            `[GallerySyncService] WiFi check attempt ${attempt}/${MAX_RETRIES}: enabled=${netState.isWifiEnabled}`,
-          )
+          // NetInfo can remain stale after Android's WiFi settings close. Use
+          // the same native source as the normal sync preflight.
+          const wifiEnabled = await WifiManager.isEnabled()
+          console.log(`[GallerySyncService] WiFi check attempt ${attempt}/${MAX_RETRIES}: enabled=${wifiEnabled}`)
 
-          if (netState.isWifiEnabled === true) {
+          if (wifiEnabled) {
             console.log("[GallerySyncService] ✅ WiFi is now enabled - auto-retrying sync")
             this.waitingForWifiRetry = false
             this.wifiSettingsOpenedAt = null // Clear cooldown timestamp
-            // Clear previous error state
-            store.setSyncState("idle")
             // Auto-retry sync
             await this.startSync()
             return
-          }
-
-          // If this was the last attempt, log and give up
-          if (attempt === MAX_RETRIES) {
-            console.log(
-              "[GallerySyncService] ❌ WiFi still disabled after all retries - user may need to tap sync manually",
-            )
-            this.waitingForWifiRetry = false
-            this.wifiSettingsOpenedAt = null // Clear cooldown timestamp
           }
         } catch (error) {
           console.warn(`[GallerySyncService] Failed to check WiFi status on attempt ${attempt}:`, error)
           // Continue to next retry
         }
       }
+
+      console.log("[GallerySyncService] WiFi not detected after retries - leaving sync available for manual retry")
+      this.waitingForWifiRetry = false
+      this.wifiSettingsOpenedAt = null
     }
   }
 
@@ -378,8 +384,10 @@ class GallerySyncService {
       return this.syncStartPromise
     }
 
+    useGallerySyncStore.getState().setSyncStarting(true)
     this.syncStartPromise = this.runStartSync().finally(() => {
       this.syncStartPromise = null
+      useGallerySyncStore.getState().setSyncStarting(false)
     })
     return this.syncStartPromise
   }
@@ -2251,7 +2259,7 @@ class GallerySyncService {
 
   /** True while pre-flight startSync work is in flight (before sync state transitions). */
   isSyncStarting(): boolean {
-    return this.syncStartPromise !== null
+    return useGallerySyncStore.getState().syncStarting
   }
 
   /**

--- a/mobile/modules/engine/src/stores/gallerySync.ts
+++ b/mobile/modules/engine/src/stores/gallerySync.ts
@@ -53,6 +53,7 @@ export interface SyncQueue {
 export interface GallerySyncInfo {
   // State machine
   syncState: SyncState
+  syncStarting: boolean
 
   // Progress tracking
   currentFile: string | null
@@ -82,6 +83,7 @@ export interface GallerySyncInfo {
 export interface GallerySyncState extends GallerySyncInfo {
   // State transitions
   setSyncState: (state: SyncState) => void
+  setSyncStarting: (starting: boolean) => void
   setRequestingHotspot: () => void
   setConnectingWifi: () => void
   setSyncing: (files: PhotoInfo[]) => void
@@ -122,6 +124,7 @@ export interface GallerySyncState extends GallerySyncInfo {
 
 const initialState: GallerySyncInfo & {processingFiles: Set<string>; processedFiles: number} = {
   syncState: "idle",
+  syncStarting: false,
   currentFile: null,
   currentFileProgress: 0,
   completedFiles: 0,
@@ -146,6 +149,7 @@ export const useGallerySyncStore = create<GallerySyncState>()(
 
     // State transitions
     setSyncState: (syncState: SyncState) => set({syncState}),
+    setSyncStarting: (syncStarting: boolean) => set({syncStarting}),
 
     setRequestingHotspot: () =>
       set({

--- a/mobile/src/__tests__/galleryFacade.test.ts
+++ b/mobile/src/__tests__/galleryFacade.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {gallery} from "../../modules/engine/src/facades/gallery"
 import {useGallerySyncStore} from "../../modules/engine/src/stores/gallerySync"
 
@@ -42,5 +43,19 @@ describe("gallery facade", () => {
     gallery.clearQueue()
 
     expect(gallery.status()).toEqual(expect.objectContaining({queueLength: 0, queue: []}))
+  })
+
+  it("publishes preflight start completion through the reactive status surface", () => {
+    const statuses: Array<{isStarting: boolean}> = []
+    const unsubscribe = gallery.onStatus((status) => statuses.push(status))
+
+    useGallerySyncStore.getState().setSyncStarting(true)
+    expect(gallery.status().isStarting).toBe(true)
+
+    useGallerySyncStore.getState().setSyncStarting(false)
+    unsubscribe()
+
+    expect(statuses.map(({isStarting}) => isStarting)).toEqual([true, false])
+    expect(gallery.status().isStarting).toBe(false)
   })
 })

--- a/mobile/src/components/miniapp/LocalMiniappView.tsx
+++ b/mobile/src/components/miniapp/LocalMiniappView.tsx
@@ -273,9 +273,7 @@ function LocalMiniappView({
       // dev server returns {uiUri: null} instead. Route those reopens to the
       // offline recovery screen the same way as first-launch resolve failures.
       if (devUrl && !result.uiUri) {
-        console.warn(
-          `LocalMiniappView: ${packageName} already running but UI unresolved, routing to dev-offline`,
-        )
+        console.warn(`LocalMiniappView: ${packageName} already running but UI unresolved, routing to dev-offline`)
         engine.miniapps.clearForeground()
         useNavigationStore.getState().push("/applet/dev-offline", {
           packageName,
@@ -459,7 +457,7 @@ function LocalMiniappView({
 
   if (!uiUri) {
     return (
-      <View className="flex-1">
+      <View ref={viewShotRef} collapsable={false} className="flex-1">
         <MiniappSplash
           name={appName}
           iconUrl={iconUrl}
@@ -499,7 +497,7 @@ function LocalMiniappView({
   }
 
   return (
-    <View className="flex-1 bg-black">
+    <View ref={viewShotRef} collapsable={false} className="flex-1 bg-black">
       <WebView
         ref={handleRef}
         source={{uri: uiUri}}

--- a/mobile/src/effects/ButtonActions.tsx
+++ b/mobile/src/effects/ButtonActions.tsx
@@ -6,6 +6,8 @@ import {useApps, useStart, engine, SETTINGS, useSetting} from "@mentra/engine"
 import {askPermissionsUI} from "@/utils/PermissionsUtils"
 import {ButtonPressEvent} from "@mentra/bluetooth-sdk"
 
+import {shouldUseMentraLiveNativeCapture} from "@/effects/buttonCapturePolicy"
+
 export function ButtonActions() {
   const applets = useApps()
   const startApplet = useStart()
@@ -80,25 +82,19 @@ export function ButtonActions() {
         return
       }
 
-      // Check if any standard or background app is running. A running background app
-      // (e.g. one that listens for hardware button presses) already receives this event
-      // server-side, so it owns the button. Launching the default app here would also
-      // re-enable gallery mode (camera running), recreating the duplicate native-capture +
-      // SDK requestPhoto() race that GalleryModeSync suppresses. Keep this predicate in sync
-      // with GalleryModeSync.
-      const activeButtonHandlingApp = applets.find(
-        (app) => (app.type === "standard" || app.type === "background") && app.running,
-      )
-
-      if (activeButtonHandlingApp) {
+      // A running miniapp only owns Mentra Live's hardware button while it has
+      // an active button_press subscription. This keeps UI-only miniapps such
+      // as Give Feedback from disabling native photo/video capture.
+      const buttonPressSubscribers = engine.miniapps.buttonPressSubscribers()
+      if (!shouldUseMentraLiveNativeCapture(buttonPressSubscribers)) {
         console.log(
-          "BUTTON_ACTION: App is running - button event already sent to server for app:",
-          activeButtonHandlingApp.name,
+          "BUTTON_ACTION: Button event delivered to subscribed miniapp(s):",
+          buttonPressSubscribers.join(", "),
         )
         return
       }
 
-      // No foreground app running - start default app
+      // No miniapp owns this button press - start the default app.
       const defaultAppPackageName = await engine.settings.get(SETTINGS.default_button_action_app.key)
 
       if (!defaultAppPackageName) {

--- a/mobile/src/effects/GalleryModeSync.tsx
+++ b/mobile/src/effects/GalleryModeSync.tsx
@@ -1,53 +1,35 @@
-import {useEffect} from "react"
+import {useEffect, useState} from "react"
 
-import {useApps} from "@mentra/engine"
+import {engine, SETTINGS, useSetting} from "@mentra/engine"
 
-import {cameraPackageName} from "@/constants/miniapps"
-import {SETTINGS, useSetting} from "@mentra/engine"
+import {shouldUseMentraLiveNativeCapture} from "@/effects/buttonCapturePolicy"
 
 /**
- * Syncs gallery mode state to glasses based on app status.
+ * Syncs Mentra Live gallery mode to active hardware-button subscriptions.
  *
  * Gallery mode (capture enabled) is TRUE when:
- * - Camera app is running, OR
- * - No standard/background apps are running
+ * - No miniapp subscribes to button_press
  *
- * This allows button press to capture photos when no apps are active,
- * while preventing capture when other apps are handling button events.
+ * A miniapp being open or running is not enough to block native capture.
  */
 export function GalleryModeSync() {
-  const applets = useApps()
   const [galleryMode, setGalleryMode] = useSetting(SETTINGS.gallery_mode.key)
+  const [buttonPressSubscribers, setButtonPressSubscribers] = useState(() => engine.miniapps.buttonPressSubscribers())
 
   useEffect(() => {
-    // console.log(`📸 [GalleryModeSync] Effect triggered, ${applets.length} applets loaded`)
+    const unsubscribe = engine.miniapps.onButtonPressSubscribersChanged(setButtonPressSubscribers)
+    // Close the snapshot/subscription race by refreshing after registration.
+    setButtonPressSubscribers(engine.miniapps.buttonPressSubscribers())
+    return unsubscribe
+  }, [])
 
-    // Debug: log all running apps
-    // const runningApps = applets.filter((app) => app.running)
-    // console.log(
-    //   `[GalleryModeSync] Running apps (${runningApps.length}):`,
-    //   runningApps.map((app) => `${app.name} (${app.type}, ${app.packageName})`).join(", ") || "NONE",
-    // )
-
-    const cameraApp = applets.find((app) => app.packageName === cameraPackageName && app.running)
-    const otherButtonHandlingApp = applets.find(
-      (app) =>
-        (app.type === "standard" || app.type === "background") &&
-        app.running &&
-        app.packageName !== cameraPackageName,
-    )
-
-    const shouldEnableCapture = !!cameraApp || !otherButtonHandlingApp
-
-    // console.log(
-    //   `[GalleryModeSync] Capture: ${shouldEnableCapture ? "ENABLED" : "DISABLED"} ` +
-    //     `(setting gallery_mode to ${shouldEnableCapture})`,
-    // )
+  useEffect(() => {
+    const shouldEnableCapture = shouldUseMentraLiveNativeCapture(buttonPressSubscribers)
 
     if (galleryMode !== shouldEnableCapture) {
       setGalleryMode(shouldEnableCapture)
     }
-  }, [applets])
+  }, [buttonPressSubscribers, galleryMode, setGalleryMode])
 
   return null
 }

--- a/mobile/src/effects/buttonCapturePolicy.test.ts
+++ b/mobile/src/effects/buttonCapturePolicy.test.ts
@@ -1,0 +1,11 @@
+import {shouldUseMentraLiveNativeCapture} from "./buttonCapturePolicy"
+
+describe("Mentra Live button capture policy", () => {
+  it("uses native photo/video capture when no miniapp subscribes to button presses", () => {
+    expect(shouldUseMentraLiveNativeCapture([])).toBe(true)
+  })
+
+  it("routes button presses to miniapps when at least one active subscriber exists", () => {
+    expect(shouldUseMentraLiveNativeCapture(["com.example.subscriber"])).toBe(false)
+  })
+})

--- a/mobile/src/effects/buttonCapturePolicy.ts
+++ b/mobile/src/effects/buttonCapturePolicy.ts
@@ -1,0 +1,8 @@
+/**
+ * Mentra Live owns its hardware button natively only when no miniapp has an
+ * active button_press subscription. Running a miniapp alone does not transfer
+ * button ownership.
+ */
+export function shouldUseMentraLiveNativeCapture(buttonPressSubscribers: readonly string[]): boolean {
+  return buttonPressSubscribers.length === 0
+}

--- a/mobile/src/services/__tests__/localMiniappButtonSubscriptions.test.ts
+++ b/mobile/src/services/__tests__/localMiniappButtonSubscriptions.test.ts
@@ -1,0 +1,31 @@
+/* eslint-disable no-restricted-imports, import/first */
+import {MiniappStreamType} from "@mentra/miniapp"
+
+jest.mock("react-native-share", () => ({__esModule: true, default: {open: jest.fn()}}))
+jest.unmock("../../../modules/engine/src/services/LocalMiniappRuntime")
+
+import localMiniappRuntime from "../../../modules/engine/src/services/LocalMiniappRuntime"
+
+describe("LocalMiniappRuntime button subscriptions", () => {
+  const packageName = "com.example.button-subscriber"
+
+  afterEach(() => {
+    localMiniappRuntime.unregisterApp(packageName)
+  })
+
+  it("publishes active subscription changes independently of app running state", () => {
+    const changes: string[][] = []
+    localMiniappRuntime.registerApp(packageName, jest.fn())
+    const unsubscribe = localMiniappRuntime.onButtonPressSubscribersChanged((subscribers) => changes.push(subscribers))
+    expect(localMiniappRuntime.getButtonPressSubscribers()).toEqual([])
+
+    expect(localMiniappRuntime.subscribe(packageName, [MiniappStreamType.BUTTON_PRESS])).toEqual({ok: true})
+    expect(localMiniappRuntime.getButtonPressSubscribers()).toEqual([packageName])
+
+    expect(localMiniappRuntime.subscribe(packageName, [])).toEqual({ok: true})
+    expect(localMiniappRuntime.getButtonPressSubscribers()).toEqual([])
+
+    unsubscribe()
+    expect(changes).toEqual([[packageName], []])
+  })
+})

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -20,6 +20,7 @@ import {useGallerySyncStore} from "../../../modules/engine/src/stores/gallerySyn
 import {useGlassesStore} from "../../../modules/engine/src/stores/glasses"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
 import type {CaptureGroup} from "@/types/asg"
+import {Platform} from "react-native"
 import WifiManager from "react-native-wifi-reborn"
 
 jest.mock("@mentra/bluetooth-sdk", () => {
@@ -147,6 +148,7 @@ const mockGetV3Manifest = asgCameraApi.getV3Manifest as jest.Mock
 const mockSyncWithServer = asgCameraApi.syncWithServer as jest.Mock
 const mockSetServer = asgCameraApi.setServer as jest.Mock
 const mockGetCurrentWifiSSID = WifiManager.getCurrentWifiSSID as jest.Mock
+const mockIsWifiEnabled = WifiManager.isEnabled as jest.Mock
 
 const EMPTY_SYNC_RESPONSE = {
   data: {
@@ -183,12 +185,15 @@ async function startFileDownload(): Promise<void> {
 }
 
 describe("GallerySyncService", () => {
+  const originalPlatformOS = Platform.OS
+
   beforeEach(() => {
     // Pin Date.now() to match EMPTY_SYNC_RESPONSE.server_time so detectClockSkew stays quiet
     // in tests that don't explicitly want to trigger clock-skew recovery.
     jest.useFakeTimers({now: 2000})
     jest.clearAllMocks()
     mockGetCurrentWifiSSID.mockResolvedValue("")
+    mockIsWifiEnabled.mockResolvedValue(true)
     useGallerySyncStore.getState().reset()
     useGlassesStore.getState().reset()
     gallerySyncService.cleanup()
@@ -197,6 +202,7 @@ describe("GallerySyncService", () => {
   afterEach(() => {
     jest.restoreAllMocks()
     gallerySyncService.cleanup()
+    Object.defineProperty(Platform, "OS", {value: originalPlatformOS, configurable: true, writable: true})
     jest.clearAllTimers()
     jest.useRealTimers()
   })
@@ -352,6 +358,45 @@ describe("GallerySyncService", () => {
     await Promise.all([first, second])
 
     expect(useGallerySyncStore.getState().syncState).toBe("requesting_hotspot")
+  })
+
+  it("makes sync tappable and uses native WiFi state after returning from settings", async () => {
+    Object.defineProperty(Platform, "OS", {value: "android", configurable: true, writable: true})
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    useGallerySyncStore.getState().setSyncError("WiFi disabled - enable WiFi and try again")
+    ;(gallerySyncService as any).waitingForWifiRetry = true
+    ;(gallerySyncService as any).wifiSettingsOpenedAt = Date.now()
+    mockIsWifiEnabled.mockResolvedValueOnce(true)
+    const startSpy = jest.spyOn(gallerySyncService, "startSync").mockResolvedValue(undefined)
+
+    const foregroundPromise = (gallerySyncService as any).handleAppStateChange("active")
+    expect(useGallerySyncStore.getState().syncState).toBe("idle")
+    await jest.advanceTimersByTimeAsync(1000)
+    await foregroundPromise
+
+    expect(mockIsWifiEnabled).toHaveBeenCalledTimes(1)
+    expect(startSpy).toHaveBeenCalledTimes(1)
+    expect((gallerySyncService as any).waitingForWifiRetry).toBe(false)
+    expect((gallerySyncService as any).wifiSettingsOpenedAt).toBeNull()
+  })
+
+  it("releases the WiFi retry guard after native checks fail", async () => {
+    Object.defineProperty(Platform, "OS", {value: "android", configurable: true, writable: true})
+    useGlassesStore.getState().setGlassesInfo({connection: {state: "connected", fullyBooted: true}})
+    useGallerySyncStore.getState().setSyncError("WiFi disabled - enable WiFi and try again")
+    ;(gallerySyncService as any).waitingForWifiRetry = true
+    ;(gallerySyncService as any).wifiSettingsOpenedAt = Date.now()
+    mockIsWifiEnabled.mockResolvedValue(false)
+    const startSpy = jest.spyOn(gallerySyncService, "startSync").mockResolvedValue(undefined)
+
+    const foregroundPromise = (gallerySyncService as any).handleAppStateChange("active")
+    await jest.advanceTimersByTimeAsync(5000)
+    await foregroundPromise
+
+    expect(useGallerySyncStore.getState().syncState).toBe("idle")
+    expect(startSpy).not.toHaveBeenCalled()
+    expect((gallerySyncService as any).waitingForWifiRetry).toBe(false)
+    expect((gallerySyncService as any).wifiSettingsOpenedAt).toBeNull()
   })
 
   it("keeps sync watermark before zero-byte video captures", async () => {

--- a/mobile/src/stores/gallerySync.test.ts
+++ b/mobile/src/stores/gallerySync.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-restricted-imports */
 import {PhotoInfo} from "@/types/asg"
 import {useGallerySyncStore} from "../../modules/engine/src/stores/gallerySync"
 
@@ -12,6 +13,14 @@ const createPhoto = (name: string): PhotoInfo => ({
 describe("gallerySync store", () => {
   beforeEach(() => {
     useGallerySyncStore.getState().reset()
+  })
+
+  it("resets the reactive sync-start latch", () => {
+    useGallerySyncStore.getState().setSyncStarting(true)
+
+    useGallerySyncStore.getState().reset()
+
+    expect(useGallerySyncStore.getState().syncStarting).toBe(false)
   })
 
   it("removes deleted items from the retained queue", () => {


### PR DESCRIPTION
## Summary

- attach local miniapp roots to the switcher screenshot ref so Android minimize captures the visible app card
- recover gallery sync after returning from Wi-Fi settings using the authoritative native Wi-Fi state, clear the stale error immediately, and make preflight completion reactive so retry taps are never latched out
- drive Mentra Live native capture and default camera launch from active button_press subscriptions: subscribers receive button events; with no subscriber, the button remains in photo/video mode

## Incidents

- rep_01KY182W422NA82012WD5Q0X1G
- rep_01KY2P1NDV8H18EV13E0XF17D6
- rep_01KY2P41JSBSXSJNQ2Q99X4SS8

## Validation

- bun run compile
- bun run test -- --runInBand --silent (65 suites passed, 514 tests passed, 1 suite skipped)
- ESLint on every changed file (0 errors; pre-existing warnings only)
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Android miniapp screenshots, restores gallery sync after returning from Wi‑Fi settings, and routes hardware button presses to subscribed miniapps while keeping native capture when none subscribe. Addresses incidents rep_01KY182W422NA82012WD5Q0X1G, rep_01KY2P1NDV8H18EV13E0XF17D6, and rep_01KY2P41JSBSXSJNQ2Q99X4SS8.

- **Bug Fixes**
  - Android screenshot: attach the switcher screenshot ref to local miniapp roots so minimizing captures the visible app card.
  - Gallery sync: clear stale “Wi‑Fi disabled” error on return from settings; check Wi‑Fi via `react-native-wifi-reborn`’s `WifiManager.isEnabled()`; auto‑retry `startSync()` when enabled; release the retry guard if Wi‑Fi stays off; add a reactive `syncStarting` flag in the store/facade to prevent latched‑out retries.
  - Hardware button: track active `button_press` subscribers in the runtime and notify hosts; expose `engine.miniapps.buttonPressSubscribers()` and `onButtonPressSubscribersChanged()`; `GalleryModeSync` enables native capture only when no subscribers exist; `ButtonActions` sends events to subscribers, otherwise launches the default app.

<sup>Written for commit 7b302c056181da266c3ef6cb4fafec04f18a3444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible hardware-button routing, glasses gallery-mode sync, and gallery sync preflight/retry; behavior is covered by new tests but affects capture and sync flows.
> 
> **Overview**
> Fixes three mobile incidents: **switcher screenshots**, **gallery sync after Wi‑Fi settings**, and **Mentra Live hardware button ownership**.
> 
> **Screenshots:** `LocalMiniappView` roots (splash and loaded WebView) now use `ref={viewShotRef}` with `collapsable={false}` so the capsule/switcher capture targets the visible miniapp card on Android.
> 
> **Gallery sync:** Preflight “starting” is tracked in `gallerySync` as `syncStarting` and exposed via `gallery.status().isStarting` / `onStatus`, so UI isn’t stuck behind a non-reactive latch. After returning from Wi‑Fi settings on Android, a stale “WiFi disabled” error clears to `idle` immediately, retries use native `WifiManager.isEnabled()` (not NetInfo), and cleanup resets retry guards.
> 
> **Button / gallery mode:** Native photo/video capture and the default button action run only when **no** miniapp has an active `button_press` subscription (`shouldUseMentraLiveNativeCapture`). `LocalMiniappRuntime` publishes subscriber changes; `GalleryModeSync` and `ButtonActions` subscribe via `engine.miniapps` instead of treating any running standard/background app as owning the button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b302c056181da266c3ef6cb4fafec04f18a3444. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->