### PR TITLE
Ship Miniapp SDK agent guardrails to dev

### DIFF
--- a/mintlify-docs/app-devs/core-concepts/two-layer-architecture.mdx
+++ b/mintlify-docs/app-devs/core-concepts/two-layer-architecture.mdx
@@ -100,6 +100,10 @@ Exchange only serializable data through `mentra.*` / `session.ui.*`.
 If an AI coding agent introduces `performance.now()`, DOM access, or a Node API
 under `src/background/`, move that code to the UI or replace it with a supported
 primitive. For elapsed time in the background, use `Date.now()`.
+
+Projects created with `create-mentra-miniapp` also check background source and
+its imported shared files during `bun run build`. Common unsupported browser or
+Node APIs fail the build with the source location and a supported alternative.
 </Warning>
 
 ## The UI layer

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -260,7 +260,7 @@
     },
     "modules/crust": {
       "name": "@mentra/crust",
-      "version": "0.1.0-dev.0",
+      "version": "0.1.0-dev.1",
       "dependencies": {
         "@mentra/jspolyfill": "^0.1.0-dev.0",
       },
@@ -343,7 +343,7 @@
     },
     "modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0-dev.0",
+      "version": "0.3.0-dev.1",
       "dependencies": {
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
@@ -3210,7 +3210,7 @@
 
     "@livekit/react-native-webrtc/debug": ["debug@4.3.4", "", { "dependencies": { "ms": "2.1.2" } }, "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ=="],
 
-    "@mentra/cli/@mentra/miniapp-cli": ["@mentra/miniapp-cli@file:../sdk/miniapp-cli", { "dependencies": { "@clack/prompts": "^1.2.0", "jszip": "^3.10.1", "qrcode": "^1.5.4" }, "devDependencies": { "@types/qrcode": "^1.5.5", "bun-types": "^1.3.14", "typescript": "^5.0.0" }, "bin": { "mentra-miniapp": "./src/index.ts" } }],
+    "@mentra/cli/@mentra/miniapp-cli": ["@mentra/miniapp-cli@file:../sdk/miniapp-cli", { "dependencies": { "@clack/prompts": "^1.2.0", "jszip": "^3.10.1", "qrcode": "^1.5.4", "typescript": "^5.0.0" }, "devDependencies": { "@types/qrcode": "^1.5.5", "bun-types": "^1.3.14" }, "bin": { "mentra-miniapp": "./src/index.ts" } }],
 
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 

--- a/mobile/modules/crust/package.json
+++ b/mobile/modules/crust/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/crust",
-  "version": "0.1.0-dev.0",
+  "version": "0.1.0-dev.1",
   "description": "Mentra Native Module",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/mobile/modules/miniapp/package.json
+++ b/mobile/modules/miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/miniapp",
-  "version": "0.3.0-dev.0",
+  "version": "0.3.0-dev.1",
   "description": "SDK for building MentraOS local miniapps (browser/WebView)",
   "author": "Mentra Labs",
   "license": "MIT",

--- a/mobile/modules/miniapp/src/background/index.ts
+++ b/mobile/modules/miniapp/src/background/index.ts
@@ -16,7 +16,7 @@
  */
 
 export {MiniappSession, type MiniappSessionOptions} from "../session"
-export {registerMiniapp, type MiniappInitHandler} from "./register"
+export {registerMiniapp, type MiniappInitHandler, type TypedMiniappSession} from "./register"
 
 // Event / data type re-exports — these are payload shapes a miniapp's
 // background-side handlers consume from session.transcription.on, etc.

--- a/mobile/modules/miniapp/src/background/register.ts
+++ b/mobile/modules/miniapp/src/background/register.ts
@@ -22,7 +22,11 @@
 
 import {MiniappSession, type MiniappSessionOptions} from "../session"
 
-export type MiniappInitHandler = (session: MiniappSession) => void | Promise<void>
+export type TypedMiniappSession<TChannels extends object> = MiniappSession<TChannels>
+
+export type MiniappInitHandler<TChannels extends object = Record<string, unknown>> = (
+  session: TypedMiniappSession<TChannels>,
+) => void | Promise<void>
 
 interface InitGlobals {
   __mentraInitCallback?: (sessionId: string) => void
@@ -47,10 +51,13 @@ interface InitGlobals {
  *     })
  *   })
  */
-export function registerMiniapp(handler: MiniappInitHandler, options: MiniappSessionOptions = {}): void {
+export function registerMiniapp<TChannels extends object = Record<string, unknown>>(
+  handler: MiniappInitHandler<TChannels>,
+  options: MiniappSessionOptions = {},
+): void {
   const g = globalThis as unknown as InitGlobals
   g.__mentraInitCallback = (_sessionId: string) => {
-    const session = new MiniappSession(options)
+    const session = new MiniappSession<TChannels>(options)
     // Fire the user handler first so any session.* subscriptions get
     // registered before the CONNECT_ACK fan-out lands.
     try {

--- a/mobile/modules/miniapp/src/session.ts
+++ b/mobile/modules/miniapp/src/session.ts
@@ -194,7 +194,11 @@ type SessionEmitterEvents = {
   auth: (auth: MiniappAuthState) => void
 }
 
-export class MiniappSession {
+// The default preserves the pre-channel-registry behavior for code that creates
+// or accepts a bare MiniappSession. `registerMiniapp<Channels>` supplies the
+// concrete mapping for scaffolded miniapps.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export class MiniappSession<TChannels extends object = any> {
   public readonly auth: AuthModule
   public readonly display: DisplayManager
   /**
@@ -238,7 +242,7 @@ export class MiniappSession {
    * with inverted buffering policy (background drops when no WebView is
    * bound; the WebView buffers until ready).
    */
-  public readonly ui: UIModule
+  public readonly ui: UIModule<TChannels>
   /**
    * Inter-miniapp lifecycle + discovery (list / start / stop). SYSTEM-only —
    * calls reject with NOT_PERMITTED unless this miniapp is a system app.
@@ -324,7 +328,7 @@ export class MiniappSession {
     this.system = new SystemModule(this)
     this.transcription = new TranscriptionModule(this)
     this.translation = new TranslationModule(this)
-    this.ui = new UIModuleImpl(this)
+    this.ui = new UIModuleImpl<TChannels>(this)
     this.miniapps = new MiniappsModule(this)
     this.actions = new ActionsModule(this)
   }

--- a/mobile/modules/miniapp/src/sub-path-types.test-d.ts
+++ b/mobile/modules/miniapp/src/sub-path-types.test-d.ts
@@ -23,11 +23,22 @@
  */
 
 // ----- @mentra/miniapp/background ---------------------------------------
-import type {MiniappSession} from "./background/index"
+import {registerMiniapp} from "./background/index"
+import type {MiniappSession, UIModule} from "./background/index"
 
 // ✅ MiniappSession is reachable from the background entry.
 const _bg: MiniappSession | undefined = undefined
 void _bg
+
+// ✅ registerMiniapp<Channels> carries the shared channel registry into
+//    session.ui on the background side.
+interface _TestChannels {
+  ping: {at: number}
+}
+type _RegisteredHandler = Parameters<typeof registerMiniapp<_TestChannels>>[0]
+type _RegisteredSession = Parameters<_RegisteredHandler>[0]
+type _Assert<T extends true> = T
+export type _TypedBackground = _Assert<_RegisteredSession["ui"] extends UIModule<_TestChannels> ? true : false>
 
 // ----- @mentra/miniapp/ui -----------------------------------------------
 import type {MentraUiGlobal, MentraTyped} from "./ui/index"

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -279,7 +279,7 @@
     },
     "../mobile/modules/crust": {
       "name": "@mentra/crust",
-      "version": "0.1.0-dev.0",
+      "version": "0.1.0-dev.1",
       "dependencies": {
         "@mentra/jspolyfill": "^0.1.0-dev.0",
       },
@@ -362,7 +362,7 @@
     },
     "../mobile/modules/miniapp": {
       "name": "@mentra/miniapp",
-      "version": "0.3.0-dev.0",
+      "version": "0.3.0-dev.1",
       "dependencies": {
         "@mentra/types": "1.0.0-beta.2",
         "eventemitter3": "^5.0.1",
@@ -381,7 +381,7 @@
     },
     "create-mentra-miniapp": {
       "name": "create-mentra-miniapp",
-      "version": "0.1.0-dev.0",
+      "version": "0.1.0-dev.1",
       "bin": {
         "create-mentra-miniapp": "./bin/index.ts",
       },
@@ -447,7 +447,7 @@
     },
     "miniapp-cli": {
       "name": "@mentra/miniapp-cli",
-      "version": "0.1.0-dev.0",
+      "version": "0.1.0-dev.1",
       "bin": {
         "mentra-miniapp": "./src/index.ts",
       },
@@ -455,11 +455,11 @@
         "@clack/prompts": "^1.2.0",
         "jszip": "^3.10.1",
         "qrcode": "^1.5.4",
+        "typescript": "^5.0.0",
       },
       "devDependencies": {
         "@types/qrcode": "^1.5.5",
         "bun-types": "^1.3.14",
-        "typescript": "^5.0.0",
       },
     },
   },

--- a/sdk/create-mentra-miniapp/package.json
+++ b/sdk/create-mentra-miniapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-mentra-miniapp",
-  "version": "0.1.0-dev.0",
+  "version": "0.1.0-dev.1",
   "description": "Scaffold a new MentraOS miniapp project",
   "type": "module",
   "publishConfig": {

--- a/sdk/create-mentra-miniapp/template/README.md
+++ b/sdk/create-mentra-miniapp/template/README.md
@@ -16,6 +16,10 @@ support `window`, `document`, DOM elements, `performance`, `XMLHttpRequest`,
 `crypto.subtle`, Node built-ins, `process`, or runtime module resolution. Use
 `Date.now()` instead of `performance.now()`.
 
+`bun run build` checks background source (including imported shared files) and
+reports common unsupported browser or Node APIs with a file, line, and supported
+alternative before it emits a bundle.
+
 The layers do not share memory. Exchange serializable data through the typed
 `mentra.*` / `session.ui.*` message bus declared in `src/shared/channels.ts`.
 

--- a/sdk/create-mentra-miniapp/template/build.ts
+++ b/sdk/create-mentra-miniapp/template/build.ts
@@ -29,7 +29,7 @@
  */
 
 import {rm} from "fs/promises"
-import {reactSingletonPlugin} from "@mentra/miniapp-cli/build-helpers"
+import {backgroundRuntimeGuardPlugin, reactSingletonPlugin} from "@mentra/miniapp-cli/build-helpers"
 
 const distDir = "./dist"
 
@@ -50,6 +50,7 @@ const backgroundResult = await Bun.build({
   outdir: `${distDir}/background`,
   target: "browser",
   format: "iife",
+  plugins: [backgroundRuntimeGuardPlugin(import.meta.url)],
   minify: false,
   define,
 })

--- a/sdk/create-mentra-miniapp/template/src/background/index.ts
+++ b/sdk/create-mentra-miniapp/template/src/background/index.ts
@@ -11,9 +11,9 @@
  */
 
 import {registerMiniapp} from "@mentra/miniapp/background"
-import "../shared/channels"
+import type {Channels} from "../shared/channels"
 
-registerMiniapp(async (session) => {
+registerMiniapp<Channels>(async (session) => {
   // Hydrate any persisted state from session.storage (string KV — JSON-encode
   // structured data yourself).
   // const stored = await session.storage.get("notes")

--- a/sdk/create-mentra-miniapp/template/src/ui/App.tsx
+++ b/sdk/create-mentra-miniapp/template/src/ui/App.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useState} from "react"
 
-export function App(): JSX.Element {
+export function App() {
   const [roundtripMs, setRoundtripMs] = useState<number | null>(null)
 
   useEffect(() => {

--- a/sdk/miniapp-cli/package.json
+++ b/sdk/miniapp-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/miniapp-cli",
-  "version": "0.1.0-dev.0",
+  "version": "0.1.0-dev.1",
   "description": "Dev tools for MentraOS miniapps",
   "type": "module",
   "bin": {
@@ -22,12 +22,12 @@
   "dependencies": {
     "@clack/prompts": "^1.2.0",
     "jszip": "^3.10.1",
-    "qrcode": "^1.5.4"
+    "qrcode": "^1.5.4",
+    "typescript": "^5.0.0"
   },
   "devDependencies": {
     "@types/qrcode": "^1.5.5",
-    "bun-types": "^1.3.14",
-    "typescript": "^5.0.0"
+    "bun-types": "^1.3.14"
   },
   "files": [
     "src",

--- a/sdk/miniapp-cli/src/build-helpers.test.ts
+++ b/sdk/miniapp-cli/src/build-helpers.test.ts
@@ -23,6 +23,8 @@ describe("background runtime guard", () => {
       interface Metrics { performance: number }
       import type {Stats} from "node:fs"
       import {type BufferEncoding} from "node:buffer"
+      export type {PathLike} from "node:fs"
+      export {type PathLike as FilePath} from "node:fs"
       const metrics = {performance: Date.now()}
       const bytes = new TextEncoder().encode("hello")
       const id = crypto.randomUUID()
@@ -31,6 +33,15 @@ describe("background runtime guard", () => {
     `)
 
     expect(findings).toEqual([])
+  })
+
+  test("reports value re-exports from Node built-ins", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      export {readFile} from "node:fs/promises"
+      export * from "fs"
+    `)
+
+    expect(findings.map(({api}) => api)).toEqual(["node:fs/promises", "fs"])
   })
 
   test("allows public env values that the scaffold build inlines", () => {

--- a/sdk/miniapp-cli/src/build-helpers.test.ts
+++ b/sdk/miniapp-cli/src/build-helpers.test.ts
@@ -65,4 +65,29 @@ describe("background runtime guard", () => {
 
     expect(findings).toEqual([])
   })
+
+  test("reports unsupported APIs accessed through global objects", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      globalThis.performance.now()
+      self.document.querySelector("main")
+      void globalThis.crypto.subtle
+    `)
+
+    expect(findings.map(({api}) => api)).toEqual([
+      "globalThis.performance",
+      "self.document",
+      "globalThis.crypto.subtle",
+    ])
+  })
+
+  test("allows shadowed global-object names", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      function read(globalThis: {performance: number}, self: {document: string}) {
+        return [globalThis.performance, self.document]
+      }
+      void read
+    `)
+
+    expect(findings).toEqual([])
+  })
 })

--- a/sdk/miniapp-cli/src/build-helpers.test.ts
+++ b/sdk/miniapp-cli/src/build-helpers.test.ts
@@ -32,4 +32,37 @@ describe("background runtime guard", () => {
 
     expect(findings).toEqual([])
   })
+
+  test("allows public env values that the scaffold build inlines", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      const apiUrl = process.env.MENTRA_PUBLIC_API_URL
+      void fetch(apiUrl)
+    `)
+
+    expect(findings).toEqual([])
+  })
+
+  test("rejects process access that the scaffold cannot inline", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      const secret = process.env.API_SECRET
+      const env = process.env
+      void secret
+      void env
+    `)
+
+    expect(findings.map(({api}) => api)).toEqual(["process", "process"])
+  })
+
+  test("does not mistake local bindings for runtime globals", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      const location = {latitude: 1, longitude: 2}
+      const crypto = {subtle: "local"}
+      function report(performance: number) {
+        return {location, performance, subtle: crypto.subtle}
+      }
+      void report(1)
+    `)
+
+    expect(findings).toEqual([])
+  })
 })

--- a/sdk/miniapp-cli/src/build-helpers.test.ts
+++ b/sdk/miniapp-cli/src/build-helpers.test.ts
@@ -1,0 +1,35 @@
+import {describe, expect, test} from "bun:test"
+
+import {findUnsupportedBackgroundApis} from "./build-helpers"
+
+describe("background runtime guard", () => {
+  test("reports browser and Node globals with actionable replacements", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      import {readFile} from "node:fs/promises"
+      const started = performance.now()
+      document.querySelector("main")
+      const digest = crypto.subtle.digest("SHA-256", new Uint8Array())
+      void readFile
+      void started
+      void digest
+    `)
+
+    expect(findings.map(({api}) => api)).toEqual(["node:fs/promises", "performance", "document", "crypto.subtle"])
+    expect(findings.find(({api}) => api === "performance")?.replacement).toContain("Date.now()")
+  })
+
+  test("allows the documented background runtime and ordinary property names", () => {
+    const findings = findUnsupportedBackgroundApis(`
+      interface Metrics { performance: number }
+      import type {Stats} from "node:fs"
+      import {type BufferEncoding} from "node:buffer"
+      const metrics = {performance: Date.now()}
+      const bytes = new TextEncoder().encode("hello")
+      const id = crypto.randomUUID()
+      setTimeout(() => console.log(id, metrics.performance, bytes), 10)
+      void fetch("https://example.com", {headers: {"Content-Type": "application/json"}})
+    `)
+
+    expect(findings).toEqual([])
+  })
+})

--- a/sdk/miniapp-cli/src/build-helpers.ts
+++ b/sdk/miniapp-cli/src/build-helpers.ts
@@ -111,6 +111,12 @@ function importHasRuntimeBindings(node: ts.ImportDeclaration): boolean {
   return clause.namedBindings?.elements.some((element) => !element.isTypeOnly) ?? false
 }
 
+function exportHasRuntimeBindings(node: ts.ExportDeclaration): boolean {
+  if (node.isTypeOnly) return false
+  if (!node.exportClause || ts.isNamespaceExport(node.exportClause)) return true
+  return node.exportClause.elements.some((element) => !element.isTypeOnly)
+}
+
 function isDeclarationOrPropertyName(node: ts.Identifier): boolean {
   const parent = node.parent
   if (!parent) return false
@@ -210,7 +216,23 @@ export function findUnsupportedBackgroundApis(
   }
 
   const visit = (node: ts.Node): void => {
-    if (ts.isImportDeclaration(node) && importHasRuntimeBindings(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+    if (
+      ts.isImportDeclaration(node) &&
+      importHasRuntimeBindings(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const builtin = nodeBuiltinName(node.moduleSpecifier.text)
+      if (builtin) {
+        add(node.moduleSpecifier, builtin, "remove the Node built-in; it is unavailable in background")
+      }
+    }
+
+    if (
+      ts.isExportDeclaration(node) &&
+      exportHasRuntimeBindings(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
       const builtin = nodeBuiltinName(node.moduleSpecifier.text)
       if (builtin) {
         add(node.moduleSpecifier, builtin, "remove the Node built-in; it is unavailable in background")

--- a/sdk/miniapp-cli/src/build-helpers.ts
+++ b/sdk/miniapp-cli/src/build-helpers.ts
@@ -135,6 +135,26 @@ function isDeclarationOrPropertyName(node: ts.Identifier): boolean {
   return false
 }
 
+function isPublicEnvAccess(node: ts.Identifier): boolean {
+  const envAccess = node.parent
+  if (
+    node.text !== "process" ||
+    !envAccess ||
+    !ts.isPropertyAccessExpression(envAccess) ||
+    envAccess.expression !== node ||
+    envAccess.name.text !== "env"
+  ) {
+    return false
+  }
+
+  const valueAccess = envAccess.parent
+  return (
+    ts.isPropertyAccessExpression(valueAccess) &&
+    valueAccess.expression === envAccess &&
+    valueAccess.name.text.startsWith("MENTRA_PUBLIC_")
+  )
+}
+
 /** Analyze one background source file against the documented bare-runtime contract. */
 export function findUnsupportedBackgroundApis(
   sourceText: string,
@@ -142,8 +162,26 @@ export function findUnsupportedBackgroundApis(
 ): BackgroundRuntimeFinding[] {
   const kind = fileName.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
   const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, kind)
+  const compilerOptions: ts.CompilerOptions = {
+    allowJs: true,
+    jsx: ts.JsxEmit.Preserve,
+    noLib: true,
+    noResolve: true,
+    target: ts.ScriptTarget.Latest,
+  }
+  const host = ts.createCompilerHost(compilerOptions)
+  host.fileExists = (candidate) => candidate === fileName
+  host.getSourceFile = (candidate) => (candidate === fileName ? source : undefined)
+  host.readFile = (candidate) => (candidate === fileName ? sourceText : undefined)
+  host.writeFile = () => {}
+  const checker = ts.createProgram([fileName], compilerOptions, host).getTypeChecker()
   const findings: BackgroundRuntimeFinding[] = []
   const seen = new Set<string>()
+
+  const isLocallyBound = (node: ts.Identifier): boolean =>
+    checker
+      .getSymbolAtLocation(node)
+      ?.declarations?.some((declaration) => declaration.getSourceFile() === source) ?? false
 
   const add = (node: ts.Node, api: string, replacement: string): void => {
     const start = node.getStart(source)
@@ -178,12 +216,18 @@ export function findUnsupportedBackgroundApis(
       ts.isPropertyAccessExpression(node) &&
       ts.isIdentifier(node.expression) &&
       node.expression.text === "crypto" &&
+      !isLocallyBound(node.expression) &&
       node.name.text === "subtle"
     ) {
       add(node, "crypto.subtle", "use crypto.getRandomValues/randomUUID or move cryptography behind your backend")
     }
 
-    if (ts.isIdentifier(node) && !isDeclarationOrPropertyName(node)) {
+    if (
+      ts.isIdentifier(node) &&
+      !isDeclarationOrPropertyName(node) &&
+      !isLocallyBound(node) &&
+      !isPublicEnvAccess(node)
+    ) {
       const replacement = UNSUPPORTED_BACKGROUND_GLOBALS.get(node.text)
       if (replacement) add(node, node.text, replacement)
     }

--- a/sdk/miniapp-cli/src/build-helpers.ts
+++ b/sdk/miniapp-cli/src/build-helpers.ts
@@ -1,10 +1,232 @@
+import {readFile} from "fs/promises"
 import {createRequire} from "module"
-import {dirname, join} from "path"
+import {dirname, isAbsolute, join, relative, resolve} from "path"
+import {fileURLToPath} from "url"
+import ts from "typescript"
 
 type ResolveArgs = {path: string}
 type ResolveResult = {path: string}
+type LoadArgs = {path: string}
+type LoadResult = {contents: string; loader: "js" | "jsx" | "ts" | "tsx"}
 type BunBuild = {
   onResolve(args: {filter: RegExp}, callback: (args: ResolveArgs) => ResolveResult): void
+  onLoad(args: {filter: RegExp}, callback: (args: LoadArgs) => Promise<LoadResult | undefined>): void
+}
+
+export interface BackgroundRuntimeFinding {
+  api: string
+  line: number
+  column: number
+  replacement: string
+}
+
+const UNSUPPORTED_BACKGROUND_GLOBALS = new Map<string, string>([
+  ["window", "move browser/UI work to src/ui/"],
+  ["document", "move DOM work to src/ui/"],
+  ["navigator", "move browser capability checks to src/ui/"],
+  ["location", "use session.location for glasses/phone location, or move browser URL work to src/ui/"],
+  ["performance", "use Date.now() for elapsed time"],
+  ["XMLHttpRequest", "use fetch()"],
+  ["EventSource", "use fetch() or WebSocket"],
+  ["FormData", "send a supported string request body"],
+  ["File", "move browser file handling to src/ui/ or use session.blob"],
+  ["FileReader", "move browser file handling to src/ui/ or use session.blob"],
+  ["Blob", "use session.blob for binary storage"],
+  ["URL", "pass URL strings directly"],
+  ["URLSearchParams", "build the query string explicitly"],
+  ["Request", "call fetch() with a URL string and options"],
+  ["Response", "consume the object returned by fetch()"],
+  ["Headers", "pass a plain header record to fetch()"],
+  ["Worker", "keep durable work in the background entry itself"],
+  ["MessageChannel", "use session.ui channels"],
+  ["MutationObserver", "move DOM work to src/ui/"],
+  ["HTMLElement", "move DOM work to src/ui/"],
+  ["customElements", "move DOM work to src/ui/"],
+  ["indexedDB", "use session.storage, session.blob, or localStorage"],
+  ["caches", "use session.storage, session.blob, or localStorage"],
+  ["process", "remove the Node API; build.ts only inlines MENTRA_PUBLIC_* values"],
+  ["Buffer", "use Uint8Array plus TextEncoder/TextDecoder or the SDK base64 helpers"],
+  ["require", "use a static import that Bun can bundle"],
+  ["module", "use ES modules"],
+  ["exports", "use ES module exports"],
+  ["__dirname", "do not read the filesystem at runtime"],
+  ["__filename", "do not read the filesystem at runtime"],
+])
+
+const NODE_BUILTINS = new Set([
+  "assert",
+  "async_hooks",
+  "buffer",
+  "child_process",
+  "cluster",
+  "console",
+  "crypto",
+  "dgram",
+  "diagnostics_channel",
+  "dns",
+  "domain",
+  "events",
+  "fs",
+  "http",
+  "http2",
+  "https",
+  "module",
+  "net",
+  "os",
+  "path",
+  "perf_hooks",
+  "process",
+  "punycode",
+  "querystring",
+  "readline",
+  "repl",
+  "stream",
+  "string_decoder",
+  "sys",
+  "timers",
+  "tls",
+  "trace_events",
+  "tty",
+  "url",
+  "util",
+  "v8",
+  "vm",
+  "wasi",
+  "worker_threads",
+  "zlib",
+])
+
+function nodeBuiltinName(specifier: string): string | null {
+  const bare = specifier.startsWith("node:") ? specifier.slice(5) : specifier
+  const root = bare.split("/")[0]!
+  return NODE_BUILTINS.has(root) ? specifier : null
+}
+
+function importHasRuntimeBindings(node: ts.ImportDeclaration): boolean {
+  const clause = node.importClause
+  if (!clause) return true
+  if (clause.isTypeOnly) return false
+  if (clause.name) return true
+  if (clause.namedBindings && ts.isNamespaceImport(clause.namedBindings)) return true
+  return clause.namedBindings?.elements.some((element) => !element.isTypeOnly) ?? false
+}
+
+function isDeclarationOrPropertyName(node: ts.Identifier): boolean {
+  const parent = node.parent
+  if (!parent) return false
+  if (ts.isPropertyAccessExpression(parent) && parent.name === node) return true
+  if (ts.isPropertyAssignment(parent) && parent.name === node) return true
+  if (ts.isMethodDeclaration(parent) && parent.name === node) return true
+  if (ts.isPropertyDeclaration(parent) && parent.name === node) return true
+  if (ts.isPropertySignature(parent) && parent.name === node) return true
+  if (ts.isBindingElement(parent) && parent.name === node) return true
+  if (ts.isVariableDeclaration(parent) && parent.name === node) return true
+  if (ts.isParameter(parent) && parent.name === node) return true
+  if (ts.isFunctionDeclaration(parent) && parent.name === node) return true
+  if (ts.isFunctionExpression(parent) && parent.name === node) return true
+  if (ts.isClassDeclaration(parent) && parent.name === node) return true
+  if (ts.isClassExpression(parent) && parent.name === node) return true
+  if (ts.isInterfaceDeclaration(parent) && parent.name === node) return true
+  if (ts.isTypeAliasDeclaration(parent) && parent.name === node) return true
+  if (ts.isEnumDeclaration(parent) && parent.name === node) return true
+  if (ts.isImportClause(parent) || ts.isImportSpecifier(parent) || ts.isNamespaceImport(parent)) return true
+  if (ts.isExportSpecifier(parent)) return true
+  if (ts.isQualifiedName(parent) || ts.isTypeReferenceNode(parent) || ts.isTypeQueryNode(parent)) return true
+  return false
+}
+
+/** Analyze one background source file against the documented bare-runtime contract. */
+export function findUnsupportedBackgroundApis(
+  sourceText: string,
+  fileName = "background.ts",
+): BackgroundRuntimeFinding[] {
+  const kind = fileName.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  const source = ts.createSourceFile(fileName, sourceText, ts.ScriptTarget.Latest, true, kind)
+  const findings: BackgroundRuntimeFinding[] = []
+  const seen = new Set<string>()
+
+  const add = (node: ts.Node, api: string, replacement: string): void => {
+    const start = node.getStart(source)
+    const {line, character} = source.getLineAndCharacterOfPosition(start)
+    const key = `${api}:${line}:${character}`
+    if (seen.has(key)) return
+    seen.add(key)
+    findings.push({api, line: line + 1, column: character + 1, replacement})
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isImportDeclaration(node) && importHasRuntimeBindings(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      const builtin = nodeBuiltinName(node.moduleSpecifier.text)
+      if (builtin) {
+        add(node.moduleSpecifier, builtin, "remove the Node built-in; it is unavailable in background")
+      }
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1
+    ) {
+      const specifier = node.arguments[0]
+      if (specifier && ts.isStringLiteral(specifier)) {
+        const builtin = nodeBuiltinName(specifier.text)
+        if (builtin) add(specifier, builtin, "remove the Node built-in; it is unavailable in background")
+      }
+    }
+
+    if (
+      ts.isPropertyAccessExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "crypto" &&
+      node.name.text === "subtle"
+    ) {
+      add(node, "crypto.subtle", "use crypto.getRandomValues/randomUUID or move cryptography behind your backend")
+    }
+
+    if (ts.isIdentifier(node) && !isDeclarationOrPropertyName(node)) {
+      const replacement = UNSUPPORTED_BACKGROUND_GLOBALS.get(node.text)
+      if (replacement) add(node, node.text, replacement)
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(source)
+  return findings.sort((a, b) => a.line - b.line || a.column - b.column)
+}
+
+/**
+ * Fail the background bundle when source code relies on browser or Node APIs
+ * that do not exist in MentraOS's JavaScriptCore/QuickJS runtime.
+ */
+export function backgroundRuntimeGuardPlugin(importMetaUrl: string) {
+  const sourceRoot = resolve(dirname(fileURLToPath(importMetaUrl)), "src")
+  return {
+    name: "mentra-background-runtime-guard",
+    setup(build: BunBuild) {
+      build.onLoad({filter: /\.[cm]?[jt]sx?$/}, async ({path}) => {
+        const rel = relative(sourceRoot, path)
+        if (rel.startsWith("..") || isAbsolute(rel)) return undefined
+
+        const contents = await readFile(path, "utf8")
+        const findings = findUnsupportedBackgroundApis(contents, path)
+        if (findings.length > 0) {
+          const details = findings
+            .map(({api, line, column, replacement}) => `  ${rel}:${line}:${column} ${api}: ${replacement}`)
+            .join("\n")
+          throw new Error(
+            `Unsupported API in Mentra miniapp background runtime:\n${details}\n` +
+              "Background is not a browser or Node. Put browser UI code in src/ui/.",
+          )
+        }
+
+        const ext = path.split(".").pop()
+        const loader =
+          ext === "tsx" ? "tsx" : ext === "jsx" ? "jsx" : ext === "ts" || ext === "mts" || ext === "cts" ? "ts" : "js"
+        return {contents, loader}
+      })
+    },
+  }
 }
 
 /**

--- a/sdk/miniapp-cli/src/build-helpers.ts
+++ b/sdk/miniapp-cli/src/build-helpers.ts
@@ -183,6 +183,23 @@ export function findUnsupportedBackgroundApis(
       .getSymbolAtLocation(node)
       ?.declarations?.some((declaration) => declaration.getSourceFile() === source) ?? false
 
+  const globalObjectPath = (node: ts.PropertyAccessExpression): string[] | null => {
+    const properties: string[] = []
+    let expression: ts.Expression = node
+    while (ts.isPropertyAccessExpression(expression)) {
+      properties.unshift(expression.name.text)
+      expression = expression.expression
+    }
+    if (
+      !ts.isIdentifier(expression) ||
+      (expression.text !== "globalThis" && expression.text !== "self") ||
+      isLocallyBound(expression)
+    ) {
+      return null
+    }
+    return [expression.text, ...properties]
+  }
+
   const add = (node: ts.Node, api: string, replacement: string): void => {
     const start = node.getStart(source)
     const {line, character} = source.getLineAndCharacterOfPosition(start)
@@ -209,6 +226,18 @@ export function findUnsupportedBackgroundApis(
       if (specifier && ts.isStringLiteral(specifier)) {
         const builtin = nodeBuiltinName(specifier.text)
         if (builtin) add(specifier, builtin, "remove the Node built-in; it is unavailable in background")
+      }
+    }
+
+    if (
+      ts.isPropertyAccessExpression(node)
+    ) {
+      const path = globalObjectPath(node)
+      if (path?.[1] === "crypto" && path[2] === "subtle") {
+        add(node, `${path[0]}.crypto.subtle`, "use crypto.getRandomValues/randomUUID or move cryptography behind your backend")
+      } else if (path?.[1]) {
+        const replacement = UNSUPPORTED_BACKGROUND_GLOBALS.get(path[1])
+        if (replacement) add(node, `${path[0]}.${path[1]}`, replacement)
       }
     }
 


### PR DESCRIPTION
## Summary

- fail background builds on common browser and Node APIs that MentraOS does not provide, with source locations and supported alternatives
- type `registerMiniapp<Channels>` through to `session.ui`, and fix the generated React 19 return type so a fresh scaffold passes its own typecheck
- publish new dev-channel versions of `@mentra/miniapp`, `@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/crust`

## Audit findings

The runtime and documentation fixes were already merged in #3490 and #3503:

- background/UI ownership is documented in the scaffold README, generated `AGENTS.md`, and public two-layer guide
- the supported background global list explicitly excludes `performance` and recommends `Date.now()`
- Android HTTP now resolves `Content-Type` case-insensitively instead of replacing `Content-Type` with `application/octet-stream`

Two delivery gaps remained:

1. The affected npm `dev` packages were still the July 17 `*-dev.0` artifacts, predating both fixes. The registry-state release workflow therefore skipped every later push because the version had not changed.
2. A fresh published scaffold failed `bun run typecheck`, while `build.ts` accepted unsupported background globals and deferred the failure to the phone runtime.

This PR closes both gaps. The build guard parses only project source reachable from the background entry; type-only Node imports and ordinary object property names are not treated as runtime usage.

## Validation

- `cd sdk && bun test miniapp-cli` (72 pass)
- `cd sdk && bun x tsc -p miniapp-cli/tsconfig.json --noEmit`
- `cd mobile && bun test modules/miniapp/src` (239 pass)
- `cd mobile && bun run compile`
- `cd mobile/modules/jspolyfill && bun test` (36 pass)
- fresh scaffold with local candidate packages: `bun run typecheck` and `bun run build`
- injected `performance.now()` into a fresh scaffold and confirmed the build fails with file/line plus `Date.now()` guidance
- npm dry-run packs for all four bumped packages
- miniapp SDK release detection selects exactly the four intended `dev.1` packages
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the miniapp SDK build path and public typing surface for all scaffolded apps; behavior is covered by new unit tests but could surprise authors who relied on previously accepted invalid background APIs.
> 
> **Overview**
> Adds **build-time enforcement** of the documented bare background runtime: `@mentra/miniapp-cli` exposes `backgroundRuntimeGuardPlugin` and `findUnsupportedBackgroundApis`, which scan background entry and `src/` imports during `bun run build` and fail with file/line plus replacement hints (e.g. `performance` → `Date.now()`, Node built-ins, DOM globals). The scaffold template wires this plugin into its background bundle; docs and template README describe the check.
> 
> **Typing:** `registerMiniapp<Channels>` is now generic end-to-end—`MiniappSession` and `session.ui` carry the shared channel registry (`TypedMiniappSession` exported). The template uses `registerMiniapp<Channels>` and drops an explicit `JSX.Element` return on `App` for React 19 typecheck.
> 
> **Release:** Bumps `-dev.0` → `-dev.1` for `@mentra/miniapp`, `@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/crust`; moves `typescript` to a runtime dependency of `miniapp-cli` for the analyzer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc0fdba05693f5f92b313a9da1ff02bbc4efd8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds build-time guardrails for the Miniapp background runtime and updates dev-channel packages. Builds now fail on unsupported browser/Node APIs (including `globalThis`/`self` access and Node builtin re-exports), and `registerMiniapp<Channels>` types `session.ui` so new scaffolds pass with React 19.

- **New Features**
  - Added `backgroundRuntimeGuardPlugin` in `@mentra/miniapp-cli/build-helpers` and wired it into the scaffold build. It scans the background entry and shared imports, then fails the build with file/line and replacement hints for DOM globals (e.g., `document`), `performance`, Node built-ins (imports and value re-exports like `"fs"`/`"node:fs"`), and `crypto.subtle`. Allows `process.env.MENTRA_PUBLIC_*`, rejects other `process` access, and catches unsupported APIs via `globalThis`/`self`. Docs and the template README describe the check.
  - Made `registerMiniapp` generic and exported `TypedMiniappSession`, carrying the shared channel registry into `session.ui`. Template uses `registerMiniapp<Channels>`; React 19 return type fixed.

- **Dependencies**
  - Published `-dev.1` for `@mentra/miniapp`, `@mentra/miniapp-cli`, `create-mentra-miniapp`, and `@mentra/crust`. Moved `typescript` to a runtime dependency of `@mentra/miniapp-cli`.

<sup>Written for commit 73f7a9e5b294a73d824b00119dafa3ddbc8cf299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

