### PR TITLE
Enrich incident reports with miniapp runtime context

### DIFF
--- a/mobile/modules/engine/src/internal.ts
+++ b/mobile/modules/engine/src/internal.ts
@@ -30,6 +30,7 @@ export {
   getDevAppAttestation,
   DEV_APP_PACKAGE_NAME,
   type DevAppRecord,
+  type MiniappReleaseIdentity,
 } from "./services/AppRegistry"
 export {default as displayProcessor} from "./services/DisplayProcessor"
 export {default as localDisplayManager, type DisplayPayload} from "./services/LocalDisplayManager"

--- a/mobile/modules/engine/src/services/AppRegistry.ts
+++ b/mobile/modules/engine/src/services/AppRegistry.ts
@@ -159,6 +159,17 @@ interface InstalledLma {
   versions: Record<string, InstalledInfo>
 }
 
+export interface MiniappReleaseIdentity {
+  source: "direct_download" | "bundled_asset" | "preinstalled_registry" | "dev_snapshot"
+  releaseId?: string
+  bundleSha256?: string
+  channel?: string
+}
+
+function releaseIdentityKey(packageName: string, version: string): string {
+  return `miniapp_release_identity:${packageName}:${version}`
+}
+
 /**
  * Download a miniapp zip from `url` into the cache and return its local path.
  *
@@ -451,11 +462,18 @@ class AppRegistry {
    *   of `manifest.version`. The dev caching path uses `dev-<ms>` so multiple
    *   snapshots can coexist alongside semver-installed versions.
    */
-  public installFromUrl(url: string, opts?: {versionOverride?: string}): AsyncResult<void, Error> {
+  public installFromUrl(
+    url: string,
+    opts?: {versionOverride?: string; releaseIdentity?: MiniappReleaseIdentity},
+  ): AsyncResult<void, Error> {
     return Res.try_async(async () => {
       const {packageName, version} = await downloadAndInstallMiniApp(url, opts?.versionOverride)
       console.log("APP_REGISTRY: Downloaded and installed mini app")
-      this.finalizeInstall(packageName, version)
+      this.finalizeInstall(
+        packageName,
+        version,
+        opts?.releaseIdentity ?? {source: version.startsWith("dev-") ? "dev_snapshot" : "direct_download"},
+      )
     })
   }
 
@@ -468,12 +486,12 @@ class AppRegistry {
    */
   public installFromLocalZip(
     zipPath: string,
-    opts?: {versionOverride?: string},
+    opts?: {versionOverride?: string; releaseIdentity?: MiniappReleaseIdentity},
   ): AsyncResult<{packageName: string; version: string}, Error> {
     return Res.try_async(async () => {
       const {packageName, version} = await unpackMiniApp(zipPath, opts?.versionOverride)
       console.log("APP_REGISTRY: Installed mini app from local zip")
-      this.finalizeInstall(packageName, version)
+      this.finalizeInstall(packageName, version, opts?.releaseIdentity ?? {source: "bundled_asset"})
       return {packageName, version}
     })
   }
@@ -483,7 +501,7 @@ class AppRegistry {
    * artifacts on release installs, point the active-version at the just-
    * installed bundle, and notify subscribers to refresh.
    */
-  private finalizeInstall(packageName: string, version: string): void {
+  private finalizeInstall(packageName: string, version: string, releaseIdentity: MiniappReleaseIdentity): void {
     // If this is a release install (semver, not dev-*) of a package that
     // currently has dev-* snapshots, clear the dev state so the swap to
     // "released" is clean. Otherwise the dev version would keep winning
@@ -495,8 +513,14 @@ class AppRegistry {
     }
 
     this.setActiveVersion(packageName, version)
+    storage.save(releaseIdentityKey(packageName, version), releaseIdentity)
     this.refreshNeeded = true
     this.notify()
+  }
+
+  public getReleaseIdentity(packageName: string, version: string): MiniappReleaseIdentity | null {
+    const result = storage.load<MiniappReleaseIdentity>(releaseIdentityKey(packageName, version))
+    return result.is_ok() ? result.value : null
   }
 
   public installFromJsonUrl(baseUrl: string): AsyncResult<{packageName: string; version: string; name: string}, Error> {
@@ -534,6 +558,7 @@ class AppRegistry {
         for (const item of pkgDir.list()) {
           if (item instanceof Directory && item.name.startsWith("dev-")) {
             try {
+              storage.remove(releaseIdentityKey(packageName, item.name))
               item.delete()
             } catch (e) {
               console.warn(`APP_REGISTRY: failed to delete ${item.name}:`, e)
@@ -588,12 +613,16 @@ class AppRegistry {
         // Guard exists: a dev miniapp loads over HTTP and has no on-disk dir,
         // so an unconditional delete() would throw and abort the cleanup below.
         if (lmaDir.exists) lmaDir.delete()
+        storage.remove(releaseIdentityKey(packageName, version))
         console.log("APP_REGISTRY: Uninstalled mini app version", version)
         const packageDir = new Directory(Paths.document, "lmas", packageName)
         if (packageDir.exists && packageDir.list().length === 0) {
           packageDir.delete()
         }
       } else {
+        for (const installedVersion of this.getInstalledVersions(packageName)) {
+          storage.remove(releaseIdentityKey(packageName, installedVersion))
+        }
         const packageDir = new Directory(Paths.document, "lmas", packageName)
         if (packageDir.exists) {
           packageDir.delete()

--- a/mobile/modules/engine/src/services/LocalDisplayManager.ts
+++ b/mobile/modules/engine/src/services/LocalDisplayManager.ts
@@ -195,6 +195,16 @@ class LocalDisplayManager {
     }
   }
 
+  /** Report-safe ownership snapshot for incident diagnostics. */
+  public getDiagnosticSnapshot(): Record<string, unknown> {
+    return {
+      coreAppPackageName: this.coreApp,
+      currentDisplayPackageName: this.currentDisplay?.packageName ?? null,
+      backgroundLockPackageName: this.backgroundLock?.packageName ?? null,
+      bootingPackageName: this.bootingApp?.packageName ?? null,
+    }
+  }
+
   /**
    * A local miniapp is going away. Clean up all state associated with it.
    */

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -66,6 +66,7 @@ import {
 import {getAnalytics, getUiSeams} from "../runtime/bootstrap"
 import {normalizeStreamAudioConfig, normalizeStreamVideoConfig} from "../runtime/streamConfig"
 import type {AudioSubscription, LanguageSource, TranscriptionData, TranslationData} from "@mentra/cloud-protocol"
+import {buildMiniappManifestSnapshot, type MiniappRuntimeDiagnosticSnapshot} from "../utils/miniappDiagnostics"
 import ttsModelManager from "./TTSModelManager"
 import {NavigationHandlers} from "./NavigationHandlers"
 import type {ClientApp} from "../types/applet"
@@ -78,11 +79,18 @@ import {listPhoneCalendarEvents, PhoneCalendarError} from "./PhoneCalendarServic
 // =============================================================================
 
 export interface InstalledMiniappManifest {
+  packageName?: string
   /** Human-facing app name (from miniapp.json `name`). Shown in the "Starting
    * <name>…" boot message; falls back to the package name when absent. */
   name?: string
+  version?: string
+  sdkVersion?: string
+  minHostVersion?: string
+  type?: string
+  entry?: {background?: string; ui?: string}
   permissions?: Array<{type: string; required?: boolean; description?: string}>
   hardwareRequirements?: Array<{type: string; level: string; description?: string}>
+  actions?: Array<{id?: unknown; description?: unknown; parameters?: unknown}>
 }
 
 type SpeakerStateValue = "idle" | "loading" | "playing" | "stopped" | "error"
@@ -168,6 +176,16 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | nul
 }
 
 const LOG_TAG = "LOCAL_MINIAPP"
+const DIAGNOSTIC_MAX_LIST_ITEMS = 100
+const DIAGNOSTIC_MAX_STRING_LENGTH = 512
+
+function diagnosticStringList(values: Iterable<string>): string[] {
+  return [...values]
+    .map((value) => value.slice(0, DIAGNOSTIC_MAX_STRING_LENGTH))
+    .sort()
+    .slice(0, DIAGNOSTIC_MAX_LIST_ITEMS)
+}
+
 const SYSTEM_MINIAPP_PACKAGES = new Set([
   "com.mentra.camera",
   "com.mentra.gallery",
@@ -393,6 +411,53 @@ class LocalMiniappRuntime {
   public onButtonPressSubscribersChanged(listener: (packageNames: string[]) => void): () => void {
     this.buttonPressSubscriberListeners.add(listener)
     return () => this.buttonPressSubscriberListeners.delete(listener)
+  }
+
+  /** Report-safe live miniapp/subscription/resource snapshot. */
+  public getDiagnosticSnapshot(nowMs = Date.now()): MiniappRuntimeDiagnosticSnapshot {
+    const connectedApps = [...this.connectedApps.entries()]
+      .sort(([a], [b]) => a.localeCompare(b))
+      .slice(0, DIAGNOSTIC_MAX_LIST_ITEMS)
+      .map(([packageName, app]) => ({
+        packageName: packageName.slice(0, DIAGNOSTIC_MAX_STRING_LENGTH),
+        handshakeComplete: this.handshookApps.has(packageName),
+        subscriptions: diagnosticStringList(app.subscriptions),
+        lastMessageAgeMs: Math.max(0, nowMs - app.lastPongAt),
+        requestedLocationRate: app.requestedLocationRate,
+        hasActiveSpeakerStream: app.activeSpeakerStreamId !== undefined,
+        ...(app.installedManifest
+          ? {
+              manifest: buildMiniappManifestSnapshot(app.installedManifest, {
+                packageName,
+                name: app.installedManifest.name,
+                version: app.installedManifest.version,
+                type: app.installedManifest.type,
+              }),
+            }
+          : {}),
+      }))
+    const subscriptionsByStream = Object.fromEntries(
+      [...this.streamSubscribers.entries()]
+        .filter(([, packageNames]) => packageNames.size > 0)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .slice(0, DIAGNOSTIC_MAX_LIST_ITEMS)
+        .map(([stream, packageNames]) => [
+          stream.slice(0, DIAGNOSTIC_MAX_STRING_LENGTH),
+          diagnosticStringList(packageNames),
+        ]),
+    )
+
+    return {
+      connectedApps,
+      subscriptionsByStream,
+      resources: {
+        display: localDisplayManager.getDiagnosticSnapshot(),
+        camera: phonePhotoCoordinator.getDiagnosticSnapshot(),
+        video: phoneVideoCoordinator.getDiagnosticSnapshot(),
+        stream: phoneStreamCoordinator.getDiagnosticSnapshot(),
+        cameraFov: phoneCameraFovCoordinator.getDiagnosticSnapshot(),
+      },
+    }
   }
 
   private replaceStreamSubscribers(

--- a/mobile/modules/engine/src/services/MiniappLauncher.ts
+++ b/mobile/modules/engine/src/services/MiniappLauncher.ts
@@ -120,9 +120,16 @@ class MiniappLauncher {
         .map((p) => (typeof p === "string" ? p : p?.type))
         .filter((t): t is string => typeof t === "string")
       const installedManifest: InstalledMiniappManifest = {
+        packageName: typeof manifest.packageName === "string" ? manifest.packageName : packageName,
         name: manifest.name,
+        version: typeof manifest.version === "string" ? manifest.version : undefined,
+        sdkVersion: typeof manifest.sdkVersion === "string" ? manifest.sdkVersion : undefined,
+        minHostVersion: typeof manifest.minHostVersion === "string" ? manifest.minHostVersion : undefined,
+        type: typeof manifest.type === "string" ? manifest.type : undefined,
+        entry: manifest.entry as InstalledMiniappManifest["entry"],
         permissions: manifest.permissions as InstalledMiniappManifest["permissions"],
         hardwareRequirements: manifest.hardwareRequirements as InstalledMiniappManifest["hardwareRequirements"],
+        actions: manifest.actions as InstalledMiniappManifest["actions"],
       }
 
       let bgSource: string
@@ -152,15 +159,33 @@ class MiniappLauncher {
     if (!entryPaths?.background) return null
 
     const manifest = appRegistry.getMiniappManifest(packageName, version) as {
+      packageName?: string
       name?: string
+      version?: string
+      sdkVersion?: string
+      minHostVersion?: string
+      type?: string
+      entry?: {background?: string; ui?: string}
       permissions?: Array<{type: string; required?: boolean; description?: string}>
       hardwareRequirements?: Array<{type: string; level: string; description?: string}>
+      actions?: Array<{id?: unknown; description?: unknown; parameters?: unknown}>
     } | null
     const declaredPermissions = (manifest?.permissions ?? [])
       .map((p) => p.type)
       .filter((t): t is string => typeof t === "string")
     const installedManifest: InstalledMiniappManifest | undefined = manifest
-      ? {name: manifest.name, permissions: manifest.permissions, hardwareRequirements: manifest.hardwareRequirements}
+      ? {
+          packageName: manifest.packageName ?? packageName,
+          name: manifest.name,
+          version: manifest.version ?? version,
+          sdkVersion: manifest.sdkVersion,
+          minHostVersion: manifest.minHostVersion,
+          type: manifest.type,
+          entry: manifest.entry,
+          permissions: manifest.permissions,
+          hardwareRequirements: manifest.hardwareRequirements,
+          actions: manifest.actions,
+        }
       : undefined
 
     let bgSource: string

--- a/mobile/modules/engine/src/services/PhoneCameraFovCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneCameraFovCoordinator.ts
@@ -41,6 +41,21 @@ export class PhoneCameraFovCoordinator {
 
   constructor(private readonly legacyRestartSettleMs = LEGACY_CAMERA_RESTART_SETTLE_MS) {}
 
+  /** Report-safe FOV ownership snapshot for incident diagnostics. */
+  getDiagnosticSnapshot(): Record<string, unknown> {
+    return {
+      owners: [...this.overrides.entries()]
+        .sort(([, a], [, b]) => b.order - a.order)
+        .map(([packageName, entry]) => ({
+          packageName,
+          effective: entry.leaseId === this.effectiveLeaseId,
+          fov: entry.fov,
+          roiPosition: entry.roiPosition,
+        })),
+      legacyMode: this.legacyMode,
+    }
+  }
+
   setOverride(packageName: string, request: CameraFovRequest): Promise<CameraFovResult> {
     return this.enqueue(async () => {
       const previous = this.overrides.get(packageName)

--- a/mobile/modules/engine/src/services/PhonePhotoCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhonePhotoCoordinator.ts
@@ -140,6 +140,15 @@ export class PhonePhotoCoordinator {
     {requestId: string; durationMs: number; expiryTimer?: ReturnType<typeof setTimeout>}
   >()
 
+  /** Report-safe camera ownership snapshot for incident diagnostics. */
+  getDiagnosticSnapshot(): Record<string, unknown> {
+    return {
+      captureOwners: [...new Set([...this.activeRequests.values()].map((request) => request.packageName))].sort(),
+      warmUpOwners: [...this.activeWarmUps.keys()].sort(),
+      activeCaptureCount: this.activeRequests.size,
+    }
+  }
+
   async takePhoto(packageName: string, opts: PhotoOpts): Promise<PhotoTaken> {
     // Pre-check: if glasses aren't even connected, the BLE photo command
     // would be sent into the void and we'd wait 30s for the cloud long-poll

--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -250,6 +250,26 @@ export class PhoneStreamCoordinator {
     return this.current !== null && this.current.streamId === streamId
   }
 
+  /** Report-safe stream ownership snapshot for incident diagnostics. */
+  getDiagnosticSnapshot(): Record<string, unknown> {
+    if (!this.current) return {active: false}
+    return this.current.kind === "managed"
+      ? {
+          active: true,
+          kind: this.current.kind,
+          streamId: this.current.streamId,
+          subscribers: [...this.current.subscribers].sort(),
+          mode: this.current.mode,
+          playbackReady: this.current.hlsReady,
+        }
+      : {
+          active: true,
+          kind: this.current.kind,
+          streamId: this.current.streamId,
+          ownerPackageName: this.current.packageName,
+        }
+  }
+
   async startUnmanaged(
     packageName: string,
     opts: StartUnmanagedOptions,

--- a/mobile/modules/engine/src/services/PhoneVideoCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneVideoCoordinator.ts
@@ -55,6 +55,17 @@ export class PhoneVideoCoordinator {
   // second start that races the first is still rejected.
   private starting = false
 
+  /** Report-safe recording ownership snapshot for incident diagnostics. */
+  getDiagnosticSnapshot(): Record<string, unknown> {
+    return {
+      recordingOwners: [
+        ...new Set([...this.activeRecordings.values()].map((recording) => recording.packageName)),
+      ].sort(),
+      activeRecordingCount: this.activeRecordings.size,
+      startInProgress: this.starting,
+    }
+  }
+
   async startRecording(packageName: string, opts: VideoRecordingOpts): Promise<VideoRecordingStarted> {
     // Fail fast if glasses aren't connected — the BLE command would otherwise
     // be sent into the void.

--- a/mobile/modules/engine/src/utils/__tests__/miniappDiagnostics.test.ts
+++ b/mobile/modules/engine/src/utils/__tests__/miniappDiagnostics.test.ts
@@ -1,0 +1,184 @@
+import {describe, expect, test} from "bun:test"
+
+import type {ClientApp} from "../../types/applet"
+import {
+  buildMiniappDiagnosticContext,
+  buildMiniappManifestSnapshot,
+  type MiniappRuntimeDiagnosticSnapshot,
+} from "../miniappDiagnostics"
+
+function app(overrides: Partial<ClientApp>): ClientApp {
+  return {
+    packageName: "com.example.miniapp",
+    name: "Example",
+    webviewUrl: "",
+    logoUrl: "",
+    type: "standard",
+    permissions: [],
+    running: true,
+    foregrounded: false,
+    healthy: true,
+    hardwareRequirements: [],
+    offline: false,
+    offlineRoute: "",
+    loading: false,
+    local: true,
+    hidden: false,
+    ...overrides,
+  }
+}
+
+const runtime = (overrides?: Partial<MiniappRuntimeDiagnosticSnapshot>): MiniappRuntimeDiagnosticSnapshot => ({
+  connectedApps: [],
+  subscriptionsByStream: {},
+  resources: {
+    display: {},
+    camera: {},
+    video: {},
+    stream: {},
+    cameraFov: {},
+  },
+  ...overrides,
+})
+
+describe("miniapp diagnostics", () => {
+  test("keeps routing/build manifest fields and excludes arbitrary content", () => {
+    const manifest = buildMiniappManifestSnapshot(
+      {
+        packageName: "com.mentra.ai",
+        name: "Mentra AI",
+        version: "1.4.9",
+        sdkVersion: "0.3.0",
+        minHostVersion: "2.12.0",
+        type: "standard",
+        entry: {background: "background/index.js", ui: "ui/index.html"},
+        permissions: [{type: "MICROPHONE", required: true, description: "free-form"}],
+        hardwareRequirements: [{type: "MICROPHONE", level: "REQUIRED", description: "free-form"}],
+        actions: [{id: "summarize", description: "free-form", parameters: {secret: "nope"}}],
+        backendUrl: "https://private.example",
+        apiKey: "must-not-leak",
+      },
+      {packageName: "fallback"},
+    )
+
+    expect(manifest).toEqual({
+      packageName: "com.mentra.ai",
+      name: "Mentra AI",
+      version: "1.4.9",
+      sdkVersion: "0.3.0",
+      minHostVersion: "2.12.0",
+      type: "standard",
+      entry: {background: "background/index.js", ui: "ui/index.html"},
+      permissions: [{type: "MICROPHONE", required: true}],
+      hardwareRequirements: [{type: "MICROPHONE", level: "REQUIRED"}],
+      actionIds: ["summarize"],
+    })
+    expect(JSON.stringify(manifest)).not.toContain("must-not-leak")
+    expect(JSON.stringify(manifest)).not.toContain("private.example")
+    expect(JSON.stringify(manifest)).not.toContain("free-form")
+  })
+
+  test("includes every running manifest, live subscriptions, release identity, and interaction order", () => {
+    const apps = [
+      app({packageName: "com.mentra.ai", name: "Mentra AI", version: "1.4.9", foregrounded: true}),
+      app({
+        packageName: "com.mentra.notes",
+        name: "Mentra Notes",
+        version: "1.0.11",
+        running: false,
+      }),
+      app({
+        packageName: "com.example.dev",
+        name: "Dev Miniapp",
+        version: undefined,
+        isMiniappDev: true,
+        devUrl: "http://192.168.1.2:3140",
+      }),
+    ]
+    const runtimeSnapshot = runtime({
+      connectedApps: [
+        {
+          packageName: "com.mentra.ai",
+          handshakeComplete: true,
+          subscriptions: ["button_press", "transcription:auto"],
+          lastMessageAgeMs: 25,
+          requestedLocationRate: null,
+          hasActiveSpeakerStream: false,
+        },
+        {
+          packageName: "com.example.dev",
+          handshakeComplete: true,
+          subscriptions: ["location_stream"],
+          lastMessageAgeMs: 50,
+          requestedLocationRate: "high",
+          hasActiveSpeakerStream: false,
+          manifest: buildMiniappManifestSnapshot(
+            {
+              packageName: "com.example.dev",
+              version: "0.4.0",
+              sdkVersion: "0.3.0",
+              actions: [{id: "dev_action"}],
+            },
+            {packageName: "com.example.dev"},
+          ),
+        },
+      ],
+      subscriptionsByStream: {
+        "button_press": ["com.mentra.ai"],
+        "transcription:auto": ["com.mentra.ai"],
+        "location_stream": ["com.example.dev"],
+      },
+    })
+
+    const context = buildMiniappDiagnosticContext({
+      apps,
+      foregroundedPackage: "com.mentra.ai",
+      runtime: runtimeSnapshot,
+      getLastOpenedAtMs: (candidate) =>
+        candidate.packageName === "com.mentra.notes" ? 300 : candidate.packageName === "com.mentra.ai" ? 200 : 100,
+      getManifest: (candidate) =>
+        candidate.packageName === "com.mentra.ai"
+          ? {packageName: candidate.packageName, version: candidate.version, sdkVersion: "0.3.0"}
+          : undefined,
+      getReleaseIdentity: (candidate) =>
+        candidate.packageName === "com.mentra.ai"
+          ? {source: "preinstalled_registry", bundleSha256: "abc123", channel: "stable", ignored: "no"}
+          : undefined,
+    }) as {
+      running: string[]
+      foregroundedPackage: string
+      mostRecentlyInteractedPackage: string
+      recentlyInteracted: Array<{packageName: string}>
+      runningMiniapps: Array<Record<string, unknown>>
+    }
+
+    expect(context.running).toEqual(["com.mentra.ai", "com.example.dev"])
+    expect(context.foregroundedPackage).toBe("com.mentra.ai")
+    expect(context.mostRecentlyInteractedPackage).toBe("com.mentra.notes")
+    expect(context.recentlyInteracted.map((recent) => recent.packageName)).toEqual([
+      "com.mentra.notes",
+      "com.mentra.ai",
+      "com.example.dev",
+    ])
+    expect(context.runningMiniapps[0]).toMatchObject({
+      packageName: "com.mentra.ai",
+      version: "1.4.9",
+      executionMode: "installed_bundle",
+      foregrounded: true,
+      manifest: {packageName: "com.mentra.ai", version: "1.4.9", sdkVersion: "0.3.0"},
+      releaseIdentity: {source: "preinstalled_registry", bundleSha256: "abc123", channel: "stable"},
+      runtime: {handshakeComplete: true, subscriptions: ["button_press", "transcription:auto"]},
+    })
+    expect(context.runningMiniapps[1]).toMatchObject({
+      packageName: "com.example.dev",
+      version: "0.4.0",
+      executionMode: "dev_server",
+      manifest: {
+        packageName: "com.example.dev",
+        version: "0.4.0",
+        sdkVersion: "0.3.0",
+        actionIds: ["dev_action"],
+      },
+    })
+  })
+})

--- a/mobile/modules/engine/src/utils/diagnosticContext.ts
+++ b/mobile/modules/engine/src/utils/diagnosticContext.ts
@@ -4,11 +4,14 @@ import * as Location from "expo-location"
 import {Platform} from "react-native"
 import type {ReportContext} from "@mentra/cloud-client"
 
-import {useAppStatusStore} from "../stores/apps"
+import appRegistry from "../services/AppRegistry"
+import localMiniappRuntime from "../services/LocalMiniappRuntime"
+import {getLastOpenTime, useAppStatusStore} from "../stores/apps"
 import {useConnectionStore} from "../stores/connection"
 import {useCoreStore} from "../stores/core"
 import {useGlassesStore} from "../stores/glasses"
 import {SETTINGS, useSettingsStore} from "../stores/settings"
+import {buildMiniappDiagnosticContext} from "./miniappDiagnostics"
 
 const SENSITIVE_SETTINGS_KEYS = ["core_token", "auth_token", "auth_email"] as const
 const SENSITIVE_GLASSES_KEYS = ["hotspotPassword"] as const
@@ -108,17 +111,17 @@ export async function collectDiagnosticContext(extra?: Partial<ReportContext>): 
 
   const offlineMode = await useSettingsStore.getState().getSetting(SETTINGS.offline_mode.key)
   const defaultWearable = await useSettingsStore.getState().getSetting(SETTINGS.default_wearable.key)
-  const apps = appletState.apps.map((app) => ({
-    packageName: app.packageName,
-    name: app.name,
-    running: app.running,
-    loading: app.loading,
-    healthy: app.healthy,
-    hidden: app.hidden,
-    type: app.type,
-    offline: app.offline,
-    local: app.local,
-  }))
+  const miniappRuntime = localMiniappRuntime.getDiagnosticSnapshot()
+  const miniapps = buildMiniappDiagnosticContext({
+    apps: appletState.apps,
+    foregroundedPackage: appletState.foregroundedPackage,
+    runtime: miniappRuntime,
+    getLastOpenedAtMs: (app) => getLastOpenTime(app.packageName),
+    getManifest: (app) =>
+      app.local && app.version ? appRegistry.getMiniappManifest(app.packageName, app.version) : undefined,
+    getReleaseIdentity: (app) =>
+      app.local && app.version ? appRegistry.getReleaseIdentity(app.packageName, app.version) : undefined,
+  })
 
   return {
     app: {
@@ -139,12 +142,9 @@ export async function collectDiagnosticContext(extra?: Partial<ReportContext>): 
     runtime: {
       core: coreState,
       connection: connectionState,
+      miniapps: miniappRuntime,
     },
-    apps: {
-      apps,
-      installed: apps.map((app) => app.packageName),
-      running: apps.filter((app) => app.running).map((app) => app.packageName),
-    },
+    apps: miniapps,
     settings: {
       ...filteredSettings,
       offlineMode: !!offlineMode,

--- a/mobile/modules/engine/src/utils/miniappDiagnostics.ts
+++ b/mobile/modules/engine/src/utils/miniappDiagnostics.ts
@@ -1,0 +1,226 @@
+import type {ClientApp} from "../types/applet"
+
+const MAX_DIAGNOSTIC_STRING_LENGTH = 512
+const MAX_DIAGNOSTIC_LIST_ITEMS = 100
+const MAX_RECENT_MINIAPPS = 20
+
+export interface MiniappManifestSnapshot {
+  packageName: string
+  name?: string
+  version?: string
+  sdkVersion?: string
+  minHostVersion?: string
+  type?: string
+  entry?: {
+    background?: string
+    ui?: string
+  }
+  permissions: Array<{type: string; required?: boolean}>
+  hardwareRequirements: Array<{type: string; level: string}>
+  actionIds: string[]
+}
+
+export interface MiniappRuntimeAppSnapshot {
+  packageName: string
+  handshakeComplete: boolean
+  subscriptions: string[]
+  lastMessageAgeMs: number
+  requestedLocationRate: string | null
+  hasActiveSpeakerStream: boolean
+  manifest?: MiniappManifestSnapshot
+}
+
+export interface MiniappRuntimeDiagnosticSnapshot {
+  connectedApps: MiniappRuntimeAppSnapshot[]
+  subscriptionsByStream: Record<string, string[]>
+  resources: {
+    display: Record<string, unknown>
+    camera: Record<string, unknown>
+    video: Record<string, unknown>
+    stream: Record<string, unknown>
+    cameraFov: Record<string, unknown>
+  }
+}
+
+type ManifestFallback = {
+  packageName: string
+  name?: string
+  version?: string
+  type?: string
+}
+
+function boundedString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  if (!trimmed) return undefined
+  return trimmed.slice(0, MAX_DIAGNOSTIC_STRING_LENGTH)
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : null
+}
+
+function diagnosticPermissions(value: unknown): Array<{type: string; required?: boolean}> {
+  if (!Array.isArray(value)) return []
+  const permissions: Array<{type: string; required?: boolean}> = []
+  for (const raw of value) {
+    if (typeof raw === "string") {
+      const type = boundedString(raw)
+      if (type) permissions.push({type})
+      continue
+    }
+    const permission = recordValue(raw)
+    const type = boundedString(permission?.type)
+    if (!type) continue
+    permissions.push({
+      type,
+      ...(typeof permission?.required === "boolean" ? {required: permission.required} : {}),
+    })
+  }
+  return permissions.slice(0, MAX_DIAGNOSTIC_LIST_ITEMS)
+}
+
+function diagnosticHardwareRequirements(value: unknown): Array<{type: string; level: string}> {
+  if (!Array.isArray(value)) return []
+  const requirements: Array<{type: string; level: string}> = []
+  for (const raw of value) {
+    const requirement = recordValue(raw)
+    const type = boundedString(requirement?.type)
+    const level = boundedString(requirement?.level)
+    if (type && level) requirements.push({type, level})
+  }
+  return requirements.slice(0, MAX_DIAGNOSTIC_LIST_ITEMS)
+}
+
+function diagnosticActionIds(value: unknown): string[] {
+  if (!Array.isArray(value)) return []
+  return value
+    .map((raw) => boundedString(typeof raw === "string" ? raw : recordValue(raw)?.id))
+    .filter((id): id is string => id !== undefined)
+    .sort()
+    .slice(0, MAX_DIAGNOSTIC_LIST_ITEMS)
+}
+
+/**
+ * Keep the routing/build fields from miniapp.json while excluding arbitrary
+ * free-form manifest content from reports. Descriptions, URLs, and unknown
+ * extension fields are intentionally omitted.
+ */
+export function buildMiniappManifestSnapshot(raw: unknown, fallback: ManifestFallback): MiniappManifestSnapshot {
+  const manifest = recordValue(raw)
+  const entry = recordValue(manifest?.entry)
+  const packageName = boundedString(manifest?.packageName) ?? boundedString(fallback.packageName) ?? "unknown"
+  const name = boundedString(manifest?.name) ?? boundedString(fallback.name)
+  const version = boundedString(manifest?.version) ?? boundedString(fallback.version)
+  const type = boundedString(manifest?.type) ?? boundedString(fallback.type)
+  const background = boundedString(entry?.background)
+  const ui = boundedString(entry?.ui)
+
+  return {
+    packageName,
+    ...(name ? {name} : {}),
+    ...(version ? {version} : {}),
+    ...(boundedString(manifest?.sdkVersion) ? {sdkVersion: boundedString(manifest?.sdkVersion)} : {}),
+    ...(boundedString(manifest?.minHostVersion) ? {minHostVersion: boundedString(manifest?.minHostVersion)} : {}),
+    ...(type ? {type} : {}),
+    ...(background || ui ? {entry: {...(background ? {background} : {}), ...(ui ? {ui} : {})}} : {}),
+    permissions: diagnosticPermissions(manifest?.permissions),
+    hardwareRequirements: diagnosticHardwareRequirements(manifest?.hardwareRequirements),
+    actionIds: diagnosticActionIds(manifest?.actions ?? manifest?.actionIds),
+  }
+}
+
+function executionMode(app: ClientApp): "built_in" | "dev_server" | "dev_snapshot" | "installed_bundle" {
+  if (app.offline) return "built_in"
+  if (app.isMiniappDev && app.devUrl && !app.version) return "dev_server"
+  if (app.isMiniappDev) return "dev_snapshot"
+  return "installed_bundle"
+}
+
+function safeReleaseIdentity(value: unknown): Record<string, string> | undefined {
+  const identity = recordValue(value)
+  if (!identity) return undefined
+  const out: Record<string, string> = {}
+  for (const key of ["source", "releaseId", "bundleSha256", "channel"] as const) {
+    const field = boundedString(identity[key])
+    if (field) out[key] = field
+  }
+  return Object.keys(out).length > 0 ? out : undefined
+}
+
+export function buildMiniappDiagnosticContext(input: {
+  apps: ClientApp[]
+  foregroundedPackage: string | null
+  runtime: MiniappRuntimeDiagnosticSnapshot
+  getLastOpenedAtMs: (app: ClientApp) => number
+  getManifest: (app: ClientApp) => unknown
+  getReleaseIdentity: (app: ClientApp) => unknown
+}): Record<string, unknown> {
+  const runtimeByPackage = new Map(input.runtime.connectedApps.map((app) => [app.packageName, app]))
+  const appSnapshots = input.apps.map((app) => {
+    const lastOpenedAtMs = input.getLastOpenedAtMs(app)
+    const packageName = boundedString(app.packageName) ?? "unknown"
+    return {
+      packageName,
+      name: boundedString(app.name) ?? packageName,
+      version: boundedString(app.version) ?? null,
+      executionMode: executionMode(app),
+      running: app.running,
+      foregrounded: app.packageName === input.foregroundedPackage,
+      loading: app.loading,
+      healthy: app.healthy,
+      hidden: app.hidden,
+      type: app.type,
+      offline: app.offline,
+      local: app.local,
+      lastOpenedAtMs: Number.isFinite(lastOpenedAtMs) ? lastOpenedAtMs : 0,
+    }
+  })
+
+  const recentlyInteracted = [...appSnapshots]
+    .filter((app) => app.lastOpenedAtMs > 0)
+    .sort((a, b) => b.lastOpenedAtMs - a.lastOpenedAtMs)
+    .slice(0, MAX_RECENT_MINIAPPS)
+    .map((app) => ({packageName: app.packageName, lastOpenedAtMs: app.lastOpenedAtMs}))
+
+  const runningMiniapps = input.apps
+    .filter((app) => app.running)
+    .map((app) => {
+      const runtime = runtimeByPackage.get(app.packageName)
+      const releaseIdentity = safeReleaseIdentity(input.getReleaseIdentity(app))
+      const packageName = boundedString(app.packageName) ?? "unknown"
+      const manifest = buildMiniappManifestSnapshot(input.getManifest(app) ?? runtime?.manifest, {
+        packageName,
+        name: app.name,
+        version: app.version,
+        type: app.type,
+      })
+      return {
+        packageName,
+        version: boundedString(app.version) ?? manifest.version ?? null,
+        executionMode: executionMode(app),
+        foregrounded: app.packageName === input.foregroundedPackage,
+        manifest,
+        ...(releaseIdentity ? {releaseIdentity} : {}),
+        runtime: runtime
+          ? {
+              handshakeComplete: runtime.handshakeComplete,
+              subscriptions: runtime.subscriptions,
+              lastMessageAgeMs: runtime.lastMessageAgeMs,
+              requestedLocationRate: runtime.requestedLocationRate,
+              hasActiveSpeakerStream: runtime.hasActiveSpeakerStream,
+            }
+          : null,
+      }
+    })
+
+  return {
+    apps: appSnapshots,
+    installed: appSnapshots.map((app) => app.packageName),
+    running: runningMiniapps.map((app) => app.packageName),
+    foregroundedPackage: boundedString(input.foregroundedPackage) ?? null,
+    mostRecentlyInteractedPackage: recentlyInteracted[0]?.packageName ?? null,
+    recentlyInteracted,
+    runningMiniapps,
+  }
+}

--- a/mobile/src/app/miniapps/settings/feedback.tsx
+++ b/mobile/src/app/miniapps/settings/feedback.tsx
@@ -8,19 +8,19 @@ import {Button, Icon, Screen, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
 import {RadioGroup, RatingButtons, StarRating} from "@/components/ui"
-import {buildReportDetails, submitBugReport} from "@/services/bugReport/bugReportSubmission"
+import {buildReportDetails, buildReportSurfaceContext, submitBugReport} from "@/services/bugReport/bugReportSubmission"
 import {buildReportTrigger} from "@/services/bugReport/bugReportCategorization"
 import {useNavigationStore} from "@/stores/navigation"
-import {SETTINGS, useSetting} from "@mentra/engine"
+import {engine, SETTINGS, useSetting} from "@mentra/engine"
 import showAlert from "@/utils/AlertUtils"
 import mentraAuth from "@/utils/auth/authClient"
 import {useRegisterCapsule} from "@/stores/capsule"
-import {engine} from "@mentra/engine"
 
 export default function FeedbackPage() {
   const params = useLocalSearchParams<{
     triggerSource?: string
     triggerReason?: string
+    sourceRoute?: string
     sourceAppletPackageName?: string
     sourceAppletName?: string
   }>()
@@ -39,7 +39,7 @@ export default function FeedbackPage() {
 
   const {theme} = useAppTheme()
   const viewShotRef = useRef<View>(null)
-  const {goBack} = useNavigationStore.getState()
+  const {goBack, getPreviousRoute} = useNavigationStore.getState()
 
   useRegisterCapsule({
     packageName: "com.mentra.settings",
@@ -104,15 +104,34 @@ export default function FeedbackPage() {
 
     // Check if user rated 4-5 stars on feature request
     const shouldPromptAppRating = feedbackType === "feature" && experienceRating !== null && experienceRating >= 4
+    const triggerSource = typeof params.triggerSource === "string" ? params.triggerSource : "feedback_screen"
+    const triggerReason =
+      typeof params.triggerReason === "string"
+        ? params.triggerReason
+        : feedbackType === "bug"
+          ? "manual_bug_report"
+          : "manual_feedback"
+    const sourceAppletPackageName =
+      typeof params.sourceAppletPackageName === "string" ? params.sourceAppletPackageName.trim() : ""
+    const sourceAppletName = typeof params.sourceAppletName === "string" ? params.sourceAppletName.trim() : ""
+    const sourceRoute = typeof params.sourceRoute === "string" ? params.sourceRoute : getPreviousRoute()
+    const reportContext = buildReportSurfaceContext({
+      surface: "feedback_form",
+      route: "/miniapps/settings/feedback",
+      source: triggerSource,
+      sourceRoute,
+      reason: triggerReason,
+      sourceAppletPackageName,
+      sourceAppletName,
+    })
 
     // Bug reports and feature requests both go through the engine reports surface.
     if (feedbackType === "bug") {
       const trigger = buildReportTrigger({
-        triggerSource: typeof params.triggerSource === "string" ? params.triggerSource : "feedback_screen",
-        triggerReason: typeof params.triggerReason === "string" ? params.triggerReason : "manual_bug_report",
-        sourceAppletPackageName:
-          typeof params.sourceAppletPackageName === "string" ? params.sourceAppletPackageName : undefined,
-        sourceAppletName: typeof params.sourceAppletName === "string" ? params.sourceAppletName : undefined,
+        triggerSource,
+        triggerReason,
+        sourceAppletPackageName: sourceAppletPackageName || undefined,
+        sourceAppletName: sourceAppletName || undefined,
       })
       const report = buildReportDetails({
         expectedBehavior,
@@ -123,7 +142,7 @@ export default function FeedbackPage() {
 
       console.log("Bug report submitted:", JSON.stringify({trigger, report}, null, 2))
 
-      const submitRes = await submitBugReport({trigger, report}, {screenshots})
+      const submitRes = await submitBugReport({trigger, report, context: reportContext}, {screenshots})
 
       if (!submitRes.ok) {
         setIsSubmitting(false)
@@ -151,6 +170,7 @@ export default function FeedbackPage() {
         const submitRes = await engine.reports.submit({
           kind: "feedback",
           feedback: feedbackPayload,
+          context: reportContext,
         })
         if (submitRes.status !== "submitted") {
           setIsSubmitting(false)

--- a/mobile/src/app/miniapps/settings/feedback.tsx
+++ b/mobile/src/app/miniapps/settings/feedback.tsx
@@ -8,7 +8,12 @@ import {Button, Icon, Screen, Text} from "@/components/ignite"
 import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
 import {RadioGroup, RatingButtons, StarRating} from "@/components/ui"
-import {buildReportDetails, buildReportSurfaceContext, submitBugReport} from "@/services/bugReport/bugReportSubmission"
+import {
+  buildReportDetails,
+  buildReportSurfaceContext,
+  resolveFeedbackTriggerReason,
+  submitBugReport,
+} from "@/services/bugReport/bugReportSubmission"
 import {buildReportTrigger} from "@/services/bugReport/bugReportCategorization"
 import {useNavigationStore} from "@/stores/navigation"
 import {engine, SETTINGS, useSetting} from "@mentra/engine"
@@ -105,12 +110,7 @@ export default function FeedbackPage() {
     // Check if user rated 4-5 stars on feature request
     const shouldPromptAppRating = feedbackType === "feature" && experienceRating !== null && experienceRating >= 4
     const triggerSource = typeof params.triggerSource === "string" ? params.triggerSource : "feedback_screen"
-    const triggerReason =
-      typeof params.triggerReason === "string"
-        ? params.triggerReason
-        : feedbackType === "bug"
-          ? "manual_bug_report"
-          : "manual_feedback"
+    const triggerReason = resolveFeedbackTriggerReason(params.triggerReason, feedbackType)
     const sourceAppletPackageName =
       typeof params.sourceAppletPackageName === "string" ? params.sourceAppletPackageName.trim() : ""
     const sourceAppletName = typeof params.sourceAppletName === "string" ? params.sourceAppletName.trim() : ""

--- a/mobile/src/app/miniapps/settings/main.tsx
+++ b/mobile/src/app/miniapps/settings/main.tsx
@@ -43,7 +43,13 @@ export default function MainSettingsPage() {
             <RouteButton
               icon={<Icon name="message-2-star" size={24} color={theme.colors.secondary_foreground} />}
               label={translate("settings:feedback")}
-              onPress={() => push("/miniapps/settings/feedback")}
+              onPress={() =>
+                push("/miniapps/settings/feedback", {
+                  triggerSource: "settings",
+                  triggerReason: "manual_feedback",
+                  sourceRoute: "/miniapps/settings/",
+                })
+              }
             />
           </Group>
 

--- a/mobile/src/app/miniapps/settings/main.tsx
+++ b/mobile/src/app/miniapps/settings/main.tsx
@@ -46,7 +46,6 @@ export default function MainSettingsPage() {
               onPress={() =>
                 push("/miniapps/settings/feedback", {
                   triggerSource: "settings",
-                  triggerReason: "manual_feedback",
                   sourceRoute: "/miniapps/settings/",
                 })
               }

--- a/mobile/src/effects/ScreenshotFeedbackPrompt.tsx
+++ b/mobile/src/effects/ScreenshotFeedbackPrompt.tsx
@@ -8,7 +8,7 @@ import {showAlert} from "@/contexts/ModalContext"
 import {translate} from "@/i18n"
 
 export function ScreenshotFeedbackPrompt() {
-  const {push} = useNavigationStore.getState()
+  const {getCurrentRoute, push} = useNavigationStore.getState()
   useEffect(() => {
     if (Platform.OS !== "ios") return
 
@@ -28,7 +28,11 @@ export function ScreenshotFeedbackPrompt() {
         })
 
         if (result === 1) {
-          push("/miniapps/settings/feedback")
+          push("/miniapps/settings/feedback", {
+            triggerSource: "screenshot_feedback_prompt",
+            triggerReason: "screenshot_detected",
+            sourceRoute: getCurrentRoute() ?? undefined,
+          })
         }
       })
     })
@@ -36,7 +40,7 @@ export function ScreenshotFeedbackPrompt() {
     return () => {
       subscription?.remove()
     }
-  }, [])
+  }, [getCurrentRoute, push])
 
   return null
 }

--- a/mobile/src/services/__tests__/localMiniappButtonSubscriptions.test.ts
+++ b/mobile/src/services/__tests__/localMiniappButtonSubscriptions.test.ts
@@ -21,6 +21,9 @@ describe("LocalMiniappRuntime button subscriptions", () => {
 
     expect(localMiniappRuntime.subscribe(packageName, [MiniappStreamType.BUTTON_PRESS])).toEqual({ok: true})
     expect(localMiniappRuntime.getButtonPressSubscribers()).toEqual([packageName])
+    expect(localMiniappRuntime.getDiagnosticSnapshot().subscriptionsByStream).toEqual({
+      [MiniappStreamType.BUTTON_PRESS]: [packageName],
+    })
 
     expect(localMiniappRuntime.subscribe(packageName, [])).toEqual({ok: true})
     expect(localMiniappRuntime.getButtonPressSubscribers()).toEqual([])

--- a/mobile/src/services/bugReport/bugReportSubmission.test.ts
+++ b/mobile/src/services/bugReport/bugReportSubmission.test.ts
@@ -1,4 +1,15 @@
-import {buildReportSurfaceContext} from "./bugReportSubmission"
+import {buildReportSurfaceContext, resolveFeedbackTriggerReason} from "./bugReportSubmission"
+
+describe("resolveFeedbackTriggerReason", () => {
+  it("derives the generic feedback form reason from the submitted type", () => {
+    expect(resolveFeedbackTriggerReason(undefined, "bug")).toBe("manual_bug_report")
+    expect(resolveFeedbackTriggerReason(undefined, "feature")).toBe("manual_feedback")
+  })
+
+  it("preserves a specific launch reason", () => {
+    expect(resolveFeedbackTriggerReason(" screenshot_detected ", "bug")).toBe("screenshot_detected")
+  })
+})
 
 describe("buildReportSurfaceContext", () => {
   it("records launch attribution without claiming the user selected a subject", () => {

--- a/mobile/src/services/bugReport/bugReportSubmission.test.ts
+++ b/mobile/src/services/bugReport/bugReportSubmission.test.ts
@@ -1,0 +1,51 @@
+import {buildReportSurfaceContext} from "./bugReportSubmission"
+
+describe("buildReportSurfaceContext", () => {
+  it("records launch attribution without claiming the user selected a subject", () => {
+    expect(
+      buildReportSurfaceContext({
+        surface: "feedback_form",
+        route: "/miniapps/settings/feedback",
+        source: "applet_capsule_menu",
+        sourceRoute: "/applet/local",
+        reason: "manual_bug_report",
+        sourceAppletPackageName: " com.mentra.ai ",
+        sourceAppletName: " Mentra AI ",
+      }),
+    ).toEqual({
+      reporting: {
+        surface: "feedback_form",
+        route: "/miniapps/settings/feedback",
+        openedFrom: {
+          source: "applet_capsule_menu",
+          reason: "manual_bug_report",
+          route: "/applet/local",
+        },
+        subject: {
+          packageName: "com.mentra.ai",
+          name: "Mentra AI",
+          attribution: "launch_context",
+        },
+        userSelectedSubject: false,
+      },
+    })
+  })
+
+  it("distinguishes an explicit subject selection", () => {
+    expect(
+      buildReportSurfaceContext({
+        surface: "feedback_form",
+        route: "/miniapps/settings/feedback",
+        source: "feedback_screen",
+        reason: "manual_bug_report",
+        sourceAppletPackageName: "com.mentra.notes",
+        userSelectedSubject: true,
+      }),
+    ).toMatchObject({
+      reporting: {
+        subject: {packageName: "com.mentra.notes", attribution: "user_selection"},
+        userSelectedSubject: true,
+      },
+    })
+  })
+})

--- a/mobile/src/services/bugReport/bugReportSubmission.ts
+++ b/mobile/src/services/bugReport/bugReportSubmission.ts
@@ -1,14 +1,50 @@
 import type * as ImagePicker from "expo-image-picker"
 
-import {engine, type ReportDetails, type ReportTrigger} from "@mentra/engine"
+import {engine, type ReportContext, type ReportDetails, type ReportTrigger} from "@mentra/engine"
 
 export interface SubmitBugReportInput {
   trigger: ReportTrigger
   report: ReportDetails
+  context?: Partial<ReportContext>
 }
 
 export interface SubmitBugReportOptions {
   screenshots?: ImagePicker.ImagePickerAsset[]
+}
+
+export function buildReportSurfaceContext(input: {
+  surface: string
+  route: string
+  source: string
+  sourceRoute?: string | null
+  reason: string
+  sourceAppletPackageName?: string
+  sourceAppletName?: string
+  userSelectedSubject?: boolean
+}): Partial<ReportContext> {
+  const packageName = input.sourceAppletPackageName?.trim()
+  const name = input.sourceAppletName?.trim()
+  const userSelectedSubject = input.userSelectedSubject === true
+
+  return {
+    reporting: {
+      surface: input.surface,
+      route: input.route,
+      openedFrom: {
+        source: input.source,
+        reason: input.reason,
+        ...(input.sourceRoute ? {route: input.sourceRoute} : {}),
+      },
+      subject: packageName
+        ? {
+            packageName,
+            ...(name ? {name} : {}),
+            attribution: userSelectedSubject ? "user_selection" : "launch_context",
+          }
+        : null,
+      userSelectedSubject,
+    },
+  }
 }
 
 export function buildReportDetails(input: {
@@ -43,6 +79,7 @@ export async function submitBugReport(
     kind: "bug",
     trigger: input.trigger,
     report: input.report,
+    context: input.context,
     screenshots: options?.screenshots,
   })
   if (res.status === "failed") {

--- a/mobile/src/services/bugReport/bugReportSubmission.ts
+++ b/mobile/src/services/bugReport/bugReportSubmission.ts
@@ -12,6 +12,14 @@ export interface SubmitBugReportOptions {
   screenshots?: ImagePicker.ImagePickerAsset[]
 }
 
+export function resolveFeedbackTriggerReason(
+  providedReason: string | string[] | undefined,
+  feedbackType: "bug" | "feature",
+): string {
+  if (typeof providedReason === "string" && providedReason.trim()) return providedReason.trim()
+  return feedbackType === "bug" ? "manual_bug_report" : "manual_feedback"
+}
+
 export function buildReportSurfaceContext(input: {
   surface: string
   route: string

--- a/mobile/src/services/miniapps/preinstalledMiniappSync.ts
+++ b/mobile/src/services/miniapps/preinstalledMiniappSync.ts
@@ -60,7 +60,13 @@ async function installEntry(entry: PreinstalledMiniappRegistryEntry): Promise<vo
 
   console.log(`${LOG_TAG}: installing ${entry.packageName}@${entry.version} (${entry.installPolicy})`)
   const zipPath = await downloadVerifiedBundle(entry)
-  const result = await appRegistry.installFromLocalZip(zipPath)
+  const result = await appRegistry.installFromLocalZip(zipPath, {
+    releaseIdentity: {
+      source: "preinstalled_registry",
+      bundleSha256: entry.bundleSha256.toLowerCase(),
+      channel: entry.channel,
+    },
+  })
   if (result.is_error()) {
     throw result.error
   }


### PR DESCRIPTION
## Summary

- add foreground and recent-interaction attribution to report context
- attach sanitized manifests for every running miniapp, including package/version, SDK/host compatibility, entrypoints, declared permissions, hardware requirements, and action IDs
- capture live subscriptions plus display, camera, video, stream, speaker, location-tier, and camera-FOV ownership
- preserve install/release identity, including verified preinstalled bundle SHA-256 values and release channels
- record the feedback surface, destination route, source route, trigger, and whether miniapp subject attribution came from launch context or an explicit user selection
- bound and sanitize miniapp-controlled diagnostic values so arbitrary manifest content, URLs, descriptions, and unknown fields are not uploaded

## Why

Incident reports currently list installed/running package names but omit the state needed to route a report to MentraOS versus a first-party miniapp and to understand which miniapp owned a resource when the failure occurred. This adds that diagnostic evidence without changing the Cloud V2 report schema, which already accepts structured context.

## Impact

Reports submitted from the Mentra App now contain enough miniapp identity and live runtime context for automated or human triage to identify the likely owning repository and reproduce ownership/subscription conflicts. There is no user-visible UI change.

## Validation

- `cd mobile && bun run compile`
- `cd mobile && bun run test -- --runInBand` — 516 passed, 2 skipped
- `cd mobile/modules/engine && bun test src`
- `cd mobile/modules/engine && bun run build`
- focused manifest redaction, routing attribution, report facade, and live-subscription tests
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches install/uninstall storage and broad diagnostic payloads sent on reports; values are bounded/redacted but more operational data leaves the device on submit.
> 
> **Overview**
> Incident reports now carry **sanitized miniapp diagnostics** instead of a thin list of package names. `diagnosticContext` builds a richer `apps` block via `buildMiniappDiagnosticContext` and adds `runtime.miniapps` from live engine snapshots.
> 
> **Release identity** is persisted on install (`MiniappReleaseIdentity` in `AppRegistry`, including preinstall SHA/channel) and surfaced for running bundles. **Running miniapps** get redacted manifest snapshots (version, SDK, entry, permissions, hardware, action IDs only), live subscriptions/handshake timing, foreground and recent-interaction ordering, plus **resource ownership** from new `getDiagnosticSnapshot()` hooks on display, camera, video, stream, and camera-FOV coordinators.
> 
> **Feedback submissions** attach `reporting` context (surface, routes, trigger, launch vs user-selected subject) from settings, screenshot prompt, and the feedback form; bug/feedback paths pass optional `context` into `engine.reports.submit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2401e2e930a1708573d91b525bb43a2f20274851. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rich miniapp runtime and release context to incident reports so triage can identify the owning miniapp and reproduce resource/subscription conflicts without changing the Cloud V2 schema. Also preserves bug report trigger reasons and attributes feedback launches. No UI changes.

- **New Features**
  - Attach sanitized manifest snapshots for each running miniapp (package/version, SDK/host, entry, permissions, hardware, action IDs).
  - Include a live runtime snapshot: per-app subscriptions/handshake/message age, stream subscriber map, and ownership of display, camera, video, streams, and camera FOV.
  - Record foreground app, recent interaction order, and reporting surface details (surface, route, source route, reason). Attribute subject via launch context or explicit user selection.
  - Persist and report release identity for installed bundles (`source`, `bundleSha256`, `channel`, `releaseId`) via `AppRegistry` and preinstall sync.
  - Bound and sanitize all diagnostic strings/lists to prevent arbitrary manifest/URL/description data from being uploaded, with unit tests covering redaction and context shaping.

- **Bug Fixes**
  - Preserve explicit bug report trigger reasons (e.g., screenshot prompt), include launch route/source route in context, and derive a sensible default reason when none is provided.

<sup>Written for commit 2401e2e930a1708573d91b525bb43a2f20274851. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

