### PR TITLE
Fix direct photo transfer validation gaps

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -10,8 +10,8 @@ import com.mentra.asg_client.io.file.core.FileManager;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.service.core.constants.BatteryConstants;
 import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
-import com.mentra.asg_client.settings.AsgSettings;
 import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.settings.AsgSettings;
 import java.util.Set;
 import org.json.JSONObject;
 
@@ -62,9 +62,9 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
     }
 
     /**
-     * Handle {@code camera_warm_up}: open + configure + preview the camera and hold it warm for a TTL
-     * (default 15000ms) without capturing, so a subsequent {@code take_photo} of the same {@code
-     * size}/{@code exposureTimeNs} reuses the warm session. Routes to {@link
+     * Handle {@code camera_warm_up}: open + configure + preview the camera and hold it warm for a
+     * TTL (default 15000ms) without capturing, so a subsequent {@code take_photo} of the same
+     * {@code size}/{@code exposureTimeNs} reuses the warm session. Routes to {@link
      * MediaCaptureService#warmUpCamera} which emits {@code camera_status} (warming → ready →
      * stopped/error).
      */
@@ -201,17 +201,14 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             String requestId = data.optString("requestId", "");
             String webhookUrl = data.optString("webhookUrl", "");
             String authToken = data.optString("authToken", "");
-            String transferMethod = data.optString("transferMethod", "direct");
+            String transferMethod = resolveTransferMethod(data);
             String bleImgId = data.optString("bleImgId", "");
             boolean save = data.optBoolean("save", false);
             String mode = PhotoMode.normalize(data.optString("mode", PhotoMode.PHOTO));
             String requestedSize = PhotoSizeTier.normalize(data.optString("size", "medium"));
             String size = PhotoMode.captureSize(mode, requestedSize);
             if (!data.has("mode")) {
-                Log.w(
-                        TAG,
-                        "📸 take_photo BLE payload missing mode field; defaulting to "
-                                + mode);
+                Log.w(TAG, "📸 take_photo BLE payload missing mode field; defaulting to " + mode);
             }
             Log.i(TAG, "📸 Mentra Live take_photo mode: " + mode);
             if (!size.equals(requestedSize)) {
@@ -233,8 +230,7 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             PhotoCaptureSettings captureSettings = requestCaptureSettings;
             if (asgSettings != null) {
                 captureSettings =
-                        PhotoCaptureSettings.mergeForSdkRequest(
-                                captureSettings, asgSettings);
+                        PhotoCaptureSettings.mergeForSdkRequest(captureSettings, asgSettings);
             }
             String compress = resolvePhotoCompress(data, asgSettings);
             // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
@@ -254,12 +250,19 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
                                 + " ns");
             }
             if (requestedIso != null && exposureTimeNs == null) {
-                Log.i(TAG, "Mentra Live ignoring ISO for take_photo request "
-                        + requestId + " because exposureTimeNs was not set");
+                Log.i(
+                        TAG,
+                        "Mentra Live ignoring ISO for take_photo request "
+                                + requestId
+                                + " because exposureTimeNs was not set");
             }
             if (iso != null) {
-                Log.i(TAG, "Mentra Live using manual ISO for take_photo request "
-                        + requestId + ": ISO " + iso);
+                Log.i(
+                        TAG,
+                        "Mentra Live using manual ISO for take_photo request "
+                                + requestId
+                                + ": ISO "
+                                + iso);
             }
 
             logResolvedTakePhotoParams(
@@ -282,10 +285,11 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
                 logCommandResult("take_photo", false, "Media capture service not available");
                 return false;
             }
-            if (!PHOTO_TRANSFER_METHODS.contains(transferMethod)) {
+            if (transferMethod == null || !PHOTO_TRANSFER_METHODS.contains(transferMethod)) {
+                Object invalidTransferMethod = data.opt("transferMethod");
                 String message =
                         "Invalid transferMethod \""
-                                + transferMethod
+                                + invalidTransferMethod
                                 + "\". Expected auto, direct, or ble.";
                 logCommandResult("take_photo", false, message);
                 captureService.sendPhotoErrorResponse(
@@ -296,9 +300,11 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             // Use the permanent gallery path only when the caller wants to save; otherwise use
             // the transient _sdk_pending tree so in-flight SDK photos are invisible to gallery
             // sync and are cleaned up automatically after upload.
-            String photoFilePath = save
-                    ? generateCaptureFilePath(packageName, "IMG_", ".jpg", requestId)
-                    : generateTransientCaptureFilePath(packageName, "IMG_", ".jpg", requestId);
+            String photoFilePath =
+                    save
+                            ? generateCaptureFilePath(packageName, "IMG_", ".jpg", requestId)
+                            : generateTransientCaptureFilePath(
+                                    packageName, "IMG_", ".jpg", requestId);
             if (photoFilePath == null) {
                 logCommandResult("take_photo", false, "Failed to generate file path");
                 captureService.sendPhotoErrorResponse(
@@ -451,6 +457,14 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
         }
     }
 
+    private static String resolveTransferMethod(JSONObject data) {
+        if (!data.has("transferMethod")) {
+            return "auto";
+        }
+        Object value = data.opt("transferMethod");
+        return value instanceof String ? (String) value : null;
+    }
+
     /**
      * Process photo capture based on transfer method.
      *
@@ -488,7 +502,9 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
             PhotoCaptureSettings captureSettings) {
         Log.d(TAG, "Processing photo capture with transfer method: " + transferMethod);
 
-        if (AsgConstants.FORCE_BLE_TRANSFER && !bleImgId.isEmpty() && !"ble".equals(transferMethod)) {
+        if (AsgConstants.FORCE_BLE_TRANSFER
+                && !bleImgId.isEmpty()
+                && !"ble".equals(transferMethod)) {
             Log.i(
                     TAG,
                     "🚫📶 FORCE_BLE_TRANSFER active: overriding requested transferMethod="

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
@@ -1,0 +1,153 @@
+package com.mentra.asg_client.service.core.handlers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.camera.model.PhotoCaptureSettings;
+import com.mentra.asg_client.io.file.core.FileManager;
+import com.mentra.asg_client.io.media.core.MediaCaptureService;
+import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
+import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import org.json.JSONObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class PhotoCommandHandlerTransferMethodTest {
+
+    @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private MediaCaptureService captureService;
+    private PhotoCommandHandler handler;
+
+    @Before
+    public void setUp() {
+        AsgClientServiceManager serviceManager = mock(AsgClientServiceManager.class);
+        FileManager fileManager = mock(FileManager.class);
+        IStateManager stateManager = mock(IStateManager.class);
+        captureService = mock(MediaCaptureService.class);
+
+        when(serviceManager.getMediaCaptureService()).thenReturn(captureService);
+        when(fileManager.getPackageDirectory("com.example.app"))
+                .thenReturn(temporaryFolder.getRoot());
+        when(fileManager.ensurePackageDirectoryExists("com.example.app")).thenReturn(true);
+        when(stateManager.getBatteryLevel()).thenReturn(-1);
+
+        when(captureService.takePhotoAutoTransfer(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyString(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        when(captureService.takePhotoAndUpload(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyString(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+
+        handler = new PhotoCommandHandler(null, serviceManager, fileManager, stateManager);
+    }
+
+    private JSONObject takePhotoData() throws Exception {
+        return new JSONObject()
+                .put("requestId", "req-1")
+                .put("packageName", "com.example.app")
+                .put("webhookUrl", "https://example.com/upload")
+                .put("bleImgId", "ble-1");
+    }
+
+    @Test
+    public void takePhoto_omittedTransferMethod_defaultsToAuto() throws Exception {
+        assertThat(handler.handleCommand("take_photo", takePhotoData())).isTrue();
+
+        verify(captureService)
+                .takePhotoAutoTransfer(
+                        anyString(),
+                        eq("req-1"),
+                        eq("https://example.com/upload"),
+                        eq(""),
+                        eq("ble-1"),
+                        eq(false),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        anyString(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+    }
+
+    @Test
+    public void takePhoto_nullTransferMethod_isRejected() throws Exception {
+        JSONObject data = takePhotoData().put("transferMethod", JSONObject.NULL);
+
+        assertThat(handler.handleCommand("take_photo", data)).isFalse();
+        verify(captureService)
+                .sendPhotoErrorResponse(eq("req-1"), eq("INVALID_TRANSFER_METHOD"), anyString());
+    }
+
+    @Test
+    public void takePhoto_validDirectTransferMethod_isAccepted() throws Exception {
+        JSONObject data = takePhotoData().put("transferMethod", "direct");
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoAndUpload(
+                        anyString(),
+                        eq("req-1"),
+                        eq("https://example.com/upload"),
+                        eq(""),
+                        eq(false),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        anyString(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+    }
+
+    @Test
+    public void takePhoto_invalidTransferMethod_isRejected() throws Exception {
+        JSONObject data = takePhotoData().put("transferMethod", "wifi");
+
+        assertThat(handler.handleCommand("take_photo", data)).isFalse();
+        verify(captureService)
+                .sendPhotoErrorResponse(eq("req-1"), eq("INVALID_TRANSFER_METHOD"), anyString());
+    }
+}

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -214,6 +214,7 @@ export type {
   PhotoFpsRange,
   PhotoMeteredPreview,
   PhotoMode,
+  PhotoTransferMethod,
   PhotoResponseEvent,
   PhotoRequestedCaptureConfig,
   PhotoRequestParams,

--- a/mobile/modules/engine/src/services/__tests__/PhonePhotoCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhonePhotoCoordinator.test.ts
@@ -186,6 +186,30 @@ describe("PhonePhotoCoordinator", () => {
       expect(requestPhotoNative).not.toHaveBeenCalled()
     })
 
+    test("rejects a runtime null transfer method before starting the photo pipeline", async () => {
+      const coord = new PhonePhotoCoordinator()
+      const promise = coord.takePhoto("com.a", {transferMethod: null} as any)
+
+      await expect(promise).rejects.toMatchObject({
+        code: "INVALID_ARGUMENT",
+        message: 'Invalid transferMethod null. Expected "auto", "direct", or "ble".',
+      })
+      expect(startManagedPhoto).not.toHaveBeenCalled()
+      expect(requestPhotoNative).not.toHaveBeenCalled()
+    })
+
+    test("rejects a runtime empty transfer method before starting the photo pipeline", async () => {
+      const coord = new PhonePhotoCoordinator()
+      const promise = coord.takePhoto("com.a", {transferMethod: ""} as any)
+
+      await expect(promise).rejects.toMatchObject({
+        code: "INVALID_ARGUMENT",
+        message: 'Invalid transferMethod "". Expected "auto", "direct", or "ble".',
+      })
+      expect(startManagedPhoto).not.toHaveBeenCalled()
+      expect(requestPhotoNative).not.toHaveBeenCalled()
+    })
+
     test("passes saveToGallery and sound through to the native take_photo command", async () => {
       const coord = new PhonePhotoCoordinator()
       await coord.takePhoto("com.a", {saveToGallery: true, sound: false})

--- a/mobile/modules/miniapp/src/modules/camera.test.ts
+++ b/mobile/modules/miniapp/src/modules/camera.test.ts
@@ -98,6 +98,24 @@ describe("CameraModule", () => {
     expect(requestCalls[0]).toMatchObject({transferMethod: "direct"})
   })
 
+  test("takePhoto preserves a runtime null transfer method for host validation", async () => {
+    const {session, requestCalls} = mockSession({})
+    const camera = new CameraModule(session)
+
+    await camera.takePhoto({transferMethod: null} as any)
+
+    expect(requestCalls[0]).toMatchObject({transferMethod: null})
+  })
+
+  test("takePhoto preserves a runtime empty transfer method for host validation", async () => {
+    const {session, requestCalls} = mockSession({})
+    const camera = new CameraModule(session)
+
+    await camera.takePhoto({transferMethod: ""} as any)
+
+    expect(requestCalls[0]).toMatchObject({transferMethod: ""})
+  })
+
   test("takePhoto forwards zsl and mfnr", async () => {
     const {session, requestCalls} = mockSession({})
     const camera = new CameraModule(session)

--- a/mobile/modules/miniapp/src/modules/camera.ts
+++ b/mobile/modules/miniapp/src/modules/camera.ts
@@ -172,7 +172,7 @@ export class CameraModule {
         type: MiniappRequestType.PHOTO,
         size: options.size ?? "medium",
         mode: options.mode ?? "photo",
-        ...(options.transferMethod ? {transferMethod: options.transferMethod} : {}),
+        ...(options.transferMethod !== undefined ? {transferMethod: options.transferMethod} : {}),
         compress: options.compress ?? "none",
         sound: options.sound ?? true,
         saveToGallery: options.saveToGallery ?? false,


### PR DESCRIPTION
## Summary

Follow-up to #3506 addressing all three findings from the post-merge review:

- default an omitted glasses-side `transferMethod` to `auto`, preserving Wi-Fi upload with BLE fallback
- reject present non-string values, including JSON `null`, with `INVALID_TRANSFER_METHOD` instead of silently coercing them
- preserve every present miniapp runtime value by checking specifically for `undefined`, allowing the existing phone coordinator validation to reject malformed values
- export `PhotoTransferMethod` from the public `@mentra/bluetooth-sdk` package root

## Tests

The new ASG handler suite exercises omitted, explicit `null`, valid `direct`, and invalid string values through `PhotoCommandHandler.handleCommand`. Miniapp tests verify that runtime `null` and empty-string values survive the public camera API boundary, and coordinator tests verify both values are rejected before presigning or sending a native photo request.

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.service.core.handlers.PhotoCommandHandlerTransferMethodTest --no-daemon`
- Spotless IDE-hook formatting check for both changed Java files
- `bun test src/modules/camera.test.ts` in `mobile/modules/miniapp` (13 passing)
- `bun run typecheck` in `mobile/modules/miniapp`
- `bun test src/services/__tests__/PhonePhotoCoordinator.test.ts` in `mobile/modules/engine` (42 passing)
- `bun run build` in `mobile/modules/bluetooth-sdk`; generated declarations include the root `PhotoTransferMethod` export
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted input validation and defaulting for photo transfer routing; behavior change is rejecting malformed values and restoring omitted-default `auto`, with broad test coverage and no auth or data-model changes.
> 
> **Overview**
> Closes post-merge gaps in **photo `transferMethod` validation** across glasses, miniapp, and phone.
> 
> On **ASG**, `take_photo` now uses `resolveTransferMethod`: a missing field defaults to **`auto`** (Wi‑Fi upload with BLE fallback); present **non-string** values (including JSON `null`) return **`INVALID_TRANSFER_METHOD`** instead of being coerced. Invalid strings still fail with the same error, using the raw value in the message.
> 
> **Miniapp** `CameraModule.takePhoto` forwards `transferMethod` whenever it is **not `undefined`** (so `null` and `""` reach the host), and **`PhotoTransferMethod`** is exported from `@mentra/bluetooth-sdk`.
> 
> New **unit tests** cover the ASG handler, miniapp forwarding, and phone coordinator rejection of `null`/empty values before the photo pipeline starts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8f13ff778a62add11ee1d5b70ea89526c0314be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->