### PR TITLE
Fix false 'Update failed' after successful Mentra Live APK OTA

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -100,6 +100,19 @@ public class AsgConstants {
      */
     public static final long BES_OTA_RESPONSE_TIMEOUT_MS = 30000;
 
+    /**
+     * Resend schedule for the post-APK-restart OTA completion push
+     * (OtaHelper#sendCompletionToPhone). The freshly installed process races its own UART
+     * transport startup, and a one-shot send can be silently lost — the phone then fails a
+     * successful update via its 120s stall watchdog (incident rep_01KY31HEMTSBSMK8DVMNXJ5XGG).
+     * 15 attempts x 3s = 45s of coverage, well past transport settle and below the phone's
+     * watchdog. Duplicate terminal statuses are idempotent on the phone.
+     */
+    public static final long OTA_COMPLETION_RESEND_INTERVAL_MS = 3_000L;
+
+    /** Number of post-APK-restart completion resend attempts (see {@link #OTA_COMPLETION_RESEND_INTERVAL_MS}). */
+    public static final int OTA_COMPLETION_RESEND_ATTEMPTS = 15;
+
     /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
     public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -16,6 +16,7 @@ import org.json.JSONObject;
 import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
+import com.mentra.asg_client.AsgConstants;
 import com.mentra.asg_client.events.BatteryStatusEvent;
 import com.mentra.asg_client.di.hilt.AsgClientEntryPoint;
 import com.mentra.asg_client.io.ota.events.DownloadProgressEvent;
@@ -86,10 +87,6 @@ public class OtaHelper {
     private Handler handler;
     private Context context;
 
-
-    /** Resend schedule for the post-APK-restart completion push (see {@link #sendCompletionToPhone}). */
-    private static final long COMPLETION_RESEND_INTERVAL_MS = 3_000L;
-    private static final int COMPLETION_RESEND_ATTEMPTS = 15;
 
     // Update order configuration - can be easily modified to change update sequence
     // Order: APK updates → MTK firmware → BES firmware
@@ -2503,7 +2500,7 @@ public class OtaHelper {
     public void sendCompletionToPhone(OtaSessionManager sm) {
         if (sm == null) return;
         this.sessionManager = sm;
-        for (int attempt = 1; attempt <= COMPLETION_RESEND_ATTEMPTS; attempt++) {
+        for (int attempt = 1; attempt <= AsgConstants.OTA_COMPLETION_RESEND_ATTEMPTS; attempt++) {
             final int attemptNumber = attempt;
             handler.postDelayed(
                     () -> {
@@ -2512,13 +2509,13 @@ public class OtaHelper {
                                 "APK completion push attempt "
                                         + attemptNumber
                                         + "/"
-                                        + COMPLETION_RESEND_ATTEMPTS
+                                        + AsgConstants.OTA_COMPLETION_RESEND_ATTEMPTS
                                         + " (phoneConnected="
                                         + isPhoneConnected()
                                         + ")");
                         sendOtaStatus();
                     },
-                    (attempt - 1) * COMPLETION_RESEND_INTERVAL_MS);
+                    (attempt - 1) * AsgConstants.OTA_COMPLETION_RESEND_INTERVAL_MS);
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/helpers/OtaHelper.java
@@ -87,6 +87,10 @@ public class OtaHelper {
     private Context context;
 
 
+    /** Resend schedule for the post-APK-restart completion push (see {@link #sendCompletionToPhone}). */
+    private static final long COMPLETION_RESEND_INTERVAL_MS = 3_000L;
+    private static final int COMPLETION_RESEND_ATTEMPTS = 15;
+
     // Update order configuration - can be easily modified to change update sequence
     // Order: APK updates → MTK firmware → BES firmware
     private static final String UPDATE_TYPE_APK = "apk";
@@ -2478,17 +2482,44 @@ public class OtaHelper {
     }
 
     /**
-     * Attach a session manager and immediately push its current state to the phone.
+     * Attach a session manager and push its current state to the phone, resending on a
+     * fixed schedule instead of firing once.
      *
      * Used by {@link OtaService#resumeFromSession(OtaSessionManager)} after an APK-only
      * OTA completes across a process restart. The original {@code installApk()} call
      * deliberately skips the FINISHED send because the process is about to die, so the
      * phone needs an explicit completion signal once the new process comes up.
+     *
+     * This runs during early startup of the freshly installed process, usually before the
+     * UART transport is open ({@link #sendOtaStatus()} silently no-ops while the phone is
+     * unreachable) — and a single send at the serial-ready instant can still be dropped
+     * downstream while the wire protocol settles. A one-shot push losing that race leaves
+     * the phone staring at a stale "install in_progress 0%" until its stall watchdog fails
+     * a successful update (incident rep_01KY31HEMTSBSMK8DVMNXJ5XGG). Resending is safe:
+     * each attempt re-reads the persisted session state, duplicate terminal statuses are
+     * idempotent on the phone, and any phone-initiated ota_start/ota_query_status
+     * supersedes these pushes.
      */
     public void sendCompletionToPhone(OtaSessionManager sm) {
         if (sm == null) return;
         this.sessionManager = sm;
-        sendOtaStatus();
+        for (int attempt = 1; attempt <= COMPLETION_RESEND_ATTEMPTS; attempt++) {
+            final int attemptNumber = attempt;
+            handler.postDelayed(
+                    () -> {
+                        Log.i(
+                                TAG,
+                                "APK completion push attempt "
+                                        + attemptNumber
+                                        + "/"
+                                        + COMPLETION_RESEND_ATTEMPTS
+                                        + " (phoneConnected="
+                                        + isPhoneConnected()
+                                        + ")");
+                        sendOtaStatus();
+                    },
+                    (attempt - 1) * COMPLETION_RESEND_INTERVAL_MS);
+        }
     }
 
     /**

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/ota/services/OtaService.java
@@ -442,9 +442,10 @@ public class OtaService extends Service {
                 // can still read the correct session fields (total_steps, step_sequence, etc.).
                 sessionManager.setPendingApkStatus("complete");
                 sessionManager.setComplete();
-                // onPhoneConnected() is the primary delivery path for the APK done signal.
-                // sendCompletionToPhone() here is a fallback for the case where the phone
-                // is already connected when this code runs (unlikely but possible).
+                // sendCompletionToPhone() resends the completion on a fixed schedule, so
+                // delivery no longer depends on winning the startup race against the UART
+                // transport. onPhoneConnected() remains a complementary path for a real
+                // BLE drop/reconnect mid-session.
                 if (otaHelper != null) {
                     otaHelper.sendCompletionToPhone(sessionManager);
                 }

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -640,6 +640,7 @@ class OtaInstallCoordinator {
         const pingIntervalMs = legacySession ? LEGACY_PING_INTERVAL_MS : PING_INTERVAL_MS
         this.pingInterval = setInterval(() => {
           void BluetoothSdk.ping().catch(() => {})
+          this.maybePollApkInstallStatus()
         }, pingIntervalMs)
       }
     }
@@ -936,6 +937,25 @@ class OtaInstallCoordinator {
       legacyApkSettleHold: this.legacyApkSettleHold,
       apkCompletedViaBuildIncrease: this.apkCompletedViaBuildIncrease,
     })
+  }
+
+  /**
+   * During an APK install the package installer kills and restarts the glasses
+   * process, and the new process's completion push can lose its startup race
+   * against the UART transport (incident rep_01KY31HEMTSBSMK8DVMNXJ5XGG: the
+   * phone sat on a stale "install in_progress 0%" until the stall watchdog
+   * failed a successful update). The persisted session on the glasses always
+   * knows the truth, so poll ota_query_status on the keepalive tick while an
+   * apk step sits in its install phase — the reply either confirms progress or
+   * delivers the missed completion. Gated to the apk install phase so a stray
+   * idle reply can't disturb an active download; legacy (< 37) builds ignore
+   * the query, which is harmless.
+   */
+  private maybePollApkInstallStatus(): void {
+    const s = useGlassesStore.getState().otaStatus
+    if (s?.stepType === "apk" && s.phase === "install" && s.status === "in_progress") {
+      void BluetoothSdk.sendOtaQueryStatus()
+    }
   }
 
   /**

--- a/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
+++ b/mobile/modules/engine/src/services/OtaInstallCoordinator.ts
@@ -178,6 +178,8 @@ class OtaInstallCoordinator {
   private mtkSimTickTimer: ReturnType<typeof setInterval> | null = null
 
   // Retry / ack bookkeeping (no glasses source)
+  // At most one apk-install status poll in flight (native rejects concurrent queries).
+  private apkInstallPollInFlight = false
   private hasReceivedAck = false
   private hasFirstActivity = false
   // Stuck-at-zero watchdog clears only on first NON-ZERO progress; "first activity"
@@ -370,6 +372,7 @@ class OtaInstallCoordinator {
     this.legacyApkSettleHold = false
     this.mtkSimulatedPercent = null
     this.lastRealMtkProgress = 0
+    this.apkInstallPollInFlight = false
     this.hasReceivedAck = false
     this.hasFirstActivity = false
     this.hasFirstNonZeroProgress = false
@@ -950,11 +953,22 @@ class OtaInstallCoordinator {
    * delivers the missed completion. Gated to the apk install phase so a stray
    * idle reply can't disturb an active download; legacy (< 37) builds ignore
    * the query, which is harmless.
+   *
+   * The native query pends up to 15s and rejects a concurrent call with
+   * request_in_flight — longer than the 10s tick — so exactly one poll is kept
+   * in flight (the glasses being slow to answer IS the silent-restart window
+   * this poll exists for) and rejections are swallowed: the next tick retries.
    */
   private maybePollApkInstallStatus(): void {
+    if (this.apkInstallPollInFlight) return
     const s = useGlassesStore.getState().otaStatus
     if (s?.stepType === "apk" && s.phase === "install" && s.status === "in_progress") {
+      this.apkInstallPollInFlight = true
       void BluetoothSdk.sendOtaQueryStatus()
+        .catch(() => {})
+        .finally(() => {
+          this.apkInstallPollInFlight = false
+        })
     }
   }
 

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -742,6 +742,36 @@ describe("OtaInstallCoordinator apk install-phase status poll", () => {
     expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(2)
   })
 
+  it("keeps one poll in flight and swallows its rejection", async () => {
+    // The native query pends up to 15s (longer than the 10s tick) and rejects a
+    // concurrent call with request_in_flight; a slow glasses restart must not
+    // stack queries or surface an unhandled rejection.
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 0, overallPercent: 100}))
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+    let rejectPending!: (err: Error) => void
+    bluetoothSdkMock.sendOtaQueryStatus.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectPending = reject
+        }),
+    )
+
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+
+    // First query still pending: the next tick must not fire a concurrent one.
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+
+    // Rejection (e.g. request_timeout) is swallowed and polling resumes.
+    rejectPending(new Error("request_timeout"))
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(2)
+  })
+
   it("does not poll during the download phase", async () => {
     setGlassesConnected()
     otaInstallCoordinator.attach()

--- a/mobile/src/__tests__/otaInstallCoordinator.test.ts
+++ b/mobile/src/__tests__/otaInstallCoordinator.test.ts
@@ -728,6 +728,55 @@ describe("OtaInstallCoordinator legacy padded watchdogs (WP 8C-g)", () => {
   })
 })
 
+describe("OtaInstallCoordinator apk install-phase status poll", () => {
+  it("polls ota_query_status on each keepalive tick while an apk step is installing", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 0, overallPercent: 100}))
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(1)
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not poll during the download phase", async () => {
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({stepPercent: 40, overallPercent: 40}))
+    bluetoothSdkMock.sendOtaQueryStatus.mockClear()
+
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS * 3)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).not.toHaveBeenCalled()
+  })
+
+  it("a polled complete reply lands the session on complete instead of the stall failure", async () => {
+    // The incident shape (rep_01KY31HEMTSBSMK8DVMNXJ5XGG): the apk install starts,
+    // the glasses process restarts, and no further push arrives. The poll's reply
+    // must complete the session before the PROGRESS_TIMEOUT_MS stall watchdog fails it.
+    setGlassesConnected()
+    otaInstallCoordinator.attach()
+    GlobalEventEmitter.emit("ota_start_ack", {timestamp: Date.now()})
+    useGlassesStore.getState().setOtaStatus(inProgressStatus({phase: "install", stepPercent: 0, overallPercent: 100}))
+
+    await jest.advanceTimersByTimeAsync(PING_INTERVAL_MS)
+    expect(bluetoothSdkMock.sendOtaQueryStatus).toHaveBeenCalled()
+
+    // Glasses answer the query from their persisted session: install complete.
+    useGlassesStore
+      .getState()
+      .setOtaStatus(inProgressStatus({phase: "install", status: "complete", stepPercent: 100, overallPercent: 100}))
+
+    await jest.advanceTimersByTimeAsync(PROGRESS_TIMEOUT_MS)
+    const snap = otaInstallCoordinator.snapshot()
+    expect(snap.errorMsg).toBe("")
+    expect(snap.displayState).toBe("complete")
+  })
+})
+
 describe("OtaInstallCoordinator legacy APK completion settle hold (WP 8C-g)", () => {
   it("holds the complete state for the 32s settle window after an in-flight apk install FINISHED", async () => {
     setLegacyGlassesConnected("33")


### PR DESCRIPTION
## Problem

A successful Mentra Live APK OTA can end with the phone showing **"Update failed. Update may have failed. Ensure glasses have internet access and try again."** even though the glasses installed the update fine (incident `rep_01KY31HEMTSBSMK8DVMNXJ5XGG`, reported by Alex; also reproduced on my own pair).

Incident timeline (phone log):

- 19:07:28 — last `ota_status`: `install in_progress 0%` (install starts, glasses process is killed by the package installer)
- 19:07:53 — the phone's version-check path already sees the **new** build number via `version_info_2` — the install had succeeded
- 19:09:28 — the coordinator's 120s progress-stall watchdog fires → false "Update failed"
- 19:12:19 — user taps retry → glasses instantly reply `install complete 100%` from their persisted session

Root cause: the new process's completion push was a fragile one-shot racing its own transport startup. `OtaService.resumeFromSession()` usually runs before the UART serial is open (`sendOtaStatus()` silently no-ops while the phone is unreachable), and the complementary `onPhoneConnected()` edge fires exactly once at the serial-ready instant — the earliest moment in the transport's life, where a send can still be dropped while the wire protocol settles, and the one-shot `pendingApkStatus` flag is consumed whether or not the message survived.

## Fix

**Glasses (`asg_client`)** — `OtaHelper.sendCompletionToPhone()` resends the completed session status every 3s for 45s instead of firing once. Each attempt re-reads the persisted session state; duplicate terminal statuses are idempotent on the phone; phone-initiated `ota_start` / `ota_query_status` supersede the pushes. Since the completion is always sent by the freshly-installed APK, every update **to** a build carrying this fix gets reliable delivery regardless of the build being updated from.

**Phone (`engine`)** — safety net for targets that predate the glasses fix (and any other silent drop): while `otaStatus` sits in the apk install phase, the coordinator piggybacks `sendOtaQueryStatus()` on the existing 10s ping keepalive tick. The glasses answer from their persisted session (proven by the incident's instant reply on retry), so the phone learns the truth well before the stall watchdog fires. Gated to the apk install phase so a stray idle reply cannot disturb an active download; legacy (< 37) builds ignore the query.

## Test evidence

- **Hardware (Mentra Live, end-to-end via `asg_client/scripts/test-apk-ota.sh`)**: real download → install → process restart on device. Install commit 20:37:09 → new process 20:37:19 → session resumed and **first completion push 20:37:25** (`APK completion push attempt 1/15 (phoneConnected=true)`), with `ota_status … status=complete` visible in the BLE trace on every 3s retry. Previously the phone would have waited out 120s and failed.
- **Jest** (`mobile`): 3 new cases in `otaInstallCoordinator.test.ts` — polls on each keepalive tick during apk install, does not poll during download, and the incident shape (silent install + polled `complete` reply finishes the session instead of failing). Full mobile suite: 66 suites / 522 tests green.
- `asg_client` compiles clean (`compileDebugJavaWithJavac`); release build installs over the staging build (signature verified identical).
- Lint: the 8 pre-existing errors on these files are unchanged; no new ones.

## Notes

- The old process cannot announce completion before dying (it can't know the install will succeed), so the fix makes the new process's report reliable rather than moving the report earlier.
- My test glasses now run a locally-built release-signed APK (versionCode 49076573); the next published staging build will OTA over it normally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OTA completion signaling and install watchdog behavior on both glasses and phone; changes are bounded (idempotent resends, phase-gated polls) but affect a critical user-facing update path.
> 
> **Overview**
> Fixes **false "Update failed"** when a Mentra Live APK OTA actually succeeded but the phone never saw completion after the glasses process restarts.
> 
> **Glasses:** After APK-only session resume, `sendCompletionToPhone()` **re-sends** persisted `ota_status` every **3s for up to 15 attempts** (~45s) instead of a single push that can no-op before UART is ready or drop on the wire. New tuning lives in `AsgConstants`; `OtaService` comments reflect that scheduled push as the main delivery path (with `onPhoneConnected()` still complementary).
> 
> **Phone:** While `otaStatus` is **apk / install / in_progress**, the install coordinator issues **`ota_query_status` on each ping keepalive tick**, with **at most one query in flight** so native `request_in_flight` rejections are swallowed and retried—covering glasses builds that predate the resend fix. Jest cases cover polling, concurrency, download-phase gating, and stall-watchdog avoidance when a polled `complete` arrives.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c696d4acb1779f69f118f6754434c486705bbbf6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->