### PR TITLE
Reduce managed stream startup latency

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/streaming/services/WhipStreamingService.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
+import android.os.SystemClock;
 import android.util.Log;
 
 import androidx.annotation.Nullable;
@@ -150,6 +151,7 @@ public class WhipStreamingService extends Service {
   private volatile boolean mIsReconnecting = false;
 
   private Handler mMainHandler;
+  private long mStartupStartedAtMs;
 
   private static final long STATS_INTERVAL_MS = 2000;
   private long mLastVideoBytesSent = 0;
@@ -230,7 +232,10 @@ public class WhipStreamingService extends Service {
         if (streamId != null && !streamId.isEmpty()) {
           mCurrentStreamId = streamId;
         }
-        mMainHandler.postDelayed(this::startStreaming, 500);
+        mStartupStartedAtMs = SystemClock.elapsedRealtime();
+        logStartupStage("service_command_received");
+        // Defer until onStartCommand returns, without adding a fixed delay.
+        mMainHandler.post(this::startStreaming);
       }
     }
 
@@ -275,6 +280,10 @@ public class WhipStreamingService extends Service {
       }
       mStreamState = StreamState.STARTING;
     }
+    if (!mIsReconnecting && mStartupStartedAtMs == 0) {
+      mStartupStartedAtMs = SystemClock.elapsedRealtime();
+    }
+    logStartupStage("pipeline_started");
 
     // Acquire wake lock to prevent device sleep during streaming
     WakeLockManager.acquireFullWakeLockAndBringToForeground(
@@ -290,9 +299,13 @@ public class WhipStreamingService extends Service {
 
     try {
       initWebRtc();
+      logStartupStage("peer_connection_factory_ready");
       setupCamera();
+      logStartupStage("camera_started");
       setupAudio();
+      logStartupStage("audio_started");
       createPeerConnectionAndOffer();
+      logStartupStage("offer_requested");
     } catch (Exception e) {
       Log.e(TAG, "Failed to start streaming", e);
       handleStartupFailure("Failed to start: " + e.getMessage());
@@ -614,6 +627,7 @@ public class WhipStreamingService extends Service {
   }
 
   private void postOfferToWhip(SessionDescription offer) {
+    logStartupStage("whip_request_started");
     Log.d(TAG, "POSTing SDP offer to WHIP URL: " + mWhipUrl);
     logSdpVideoSection("Offer", offer.description);
 
@@ -691,6 +705,7 @@ public class WhipStreamingService extends Service {
             mMainHandler.postDelayed(mStatsRunnable, STATS_INTERVAL_MS);
             scheduleStreamTimeout(mCurrentStreamId);
             startBatteryMonitoring();
+            logStartupStage("whip_answer_applied");
             Log.i(TAG, "Streaming started via WHIP, negotiated video codec: "
                 + firstVideoCodecFromSdp(answerSdp));
             if (mLedEnabled && mHardwareManager != null && mHardwareManager.supportsRecordingLed()) {
@@ -758,6 +773,7 @@ public class WhipStreamingService extends Service {
     public void onIceGatheringChange(PeerConnection.IceGatheringState newState) {
       Log.d(TAG, "ICE gathering state: " + newState);
       if (newState == PeerConnection.IceGatheringState.COMPLETE) {
+        logStartupStage("ice_gathering_complete");
         synchronized (mStateLock) {
           if (mPeerConnection == null || mStreamState == StreamState.STOPPING || mStreamState == StreamState.IDLE) {
             Log.w(TAG, "ICE gathering complete but stream already stopping/stopped, ignoring");
@@ -966,6 +982,16 @@ public class WhipStreamingService extends Service {
   // Utility
   // -----------------------------------------------------------------------
 
+  private void logStartupStage(String stage) {
+    if (mStartupStartedAtMs == 0) return;
+    Log.i(
+        TAG,
+        "[STREAM_STARTUP] stage="
+            + stage
+            + " elapsedMs="
+            + (SystemClock.elapsedRealtime() - mStartupStartedAtMs));
+  }
+
   private String buildAbsoluteUrl(String base, String location) {
     try {
       java.net.URL baseUrl = new java.net.URL(base);
@@ -1093,6 +1119,8 @@ public class WhipStreamingService extends Service {
       sInstance.mCurrentStreamId = streamId;
       sInstance.mLedEnabled = enableLed;
       sInstance.mSoundEnabled = enableSound;
+      sInstance.mStartupStartedAtMs = SystemClock.elapsedRealtime();
+      sInstance.logStartupStage("service_command_received");
       sInstance.startStreaming();
     } else {
       Intent intent = new Intent(context, WhipStreamingService.class);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/StreamCommandHandler.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.hardware.camera2.CameraAccessException;
 import android.hardware.camera2.CameraCharacteristics;
 import android.hardware.camera2.CameraManager;
+import android.os.SystemClock;
 import android.util.Log;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.io.streaming.config.RtmpStreamConfig;
@@ -107,6 +108,7 @@ public class StreamCommandHandler implements ICommandHandler {
 
     /** Handle start stream command — routes to RTMP, SRT, or WHIP service based on URL. */
     private boolean handleStartCommand(JSONObject data) {
+        long startupStartedAtMs = SystemClock.elapsedRealtime();
         boolean eisChanged = false;
         boolean streamStarted = false;
         String streamId = data.optString("streamId", "");
@@ -157,7 +159,13 @@ public class StreamCommandHandler implements ICommandHandler {
             }
 
             // Stop any existing stream
-            stopAllServices();
+            boolean stoppedExistingStream = stopAllServices();
+            Log.i(
+                    TAG,
+                    "[STREAM_STARTUP] stage=existing_streams_checked elapsedMs="
+                            + (SystemClock.elapsedRealtime() - startupStartedAtMs)
+                            + " stoppedExisting="
+                            + stoppedExistingStream);
 
             // Capture light is mandatory for privacy; ignore any caller-supplied flash value.
             boolean flash = true;
@@ -210,6 +218,10 @@ public class StreamCommandHandler implements ICommandHandler {
                         }
                         applyEisForStreaming(config.getVideoWidth(), config.getVideoHeight());
                         eisChanged = true;
+                        Log.i(
+                                TAG,
+                                "[STREAM_STARTUP] stage=service_start_requested protocol=whip elapsedMs="
+                                        + (SystemClock.elapsedRealtime() - startupStartedAtMs));
                         Log.d(TAG, "Starting WHIP stream to: " + streamUrl);
                         WhipStreamingService.startStreaming(
                                 context, streamUrl, streamId, flash, sound, config);
@@ -512,21 +524,29 @@ public class StreamCommandHandler implements ICommandHandler {
     // Helpers
     // -------------------------------------------------------------------------
 
-    private void stopAllServices() {
+    private boolean stopAllServices() {
+        boolean stoppedExistingStream = false;
         if (RtmpStreamingService.isStreaming() || RtmpStreamingService.isReconnecting()) {
             RtmpStreamingService.stopStreaming(context);
+            stoppedExistingStream = true;
         }
         if (SrtStreamingService.isStreaming() || SrtStreamingService.isReconnecting()) {
             SrtStreamingService.stopStreaming(context);
+            stoppedExistingStream = true;
         }
         if (WhipStreamingService.isStreaming() || WhipStreamingService.isReconnecting()) {
             WhipStreamingService.stopStreaming(context);
+            stoppedExistingStream = true;
         }
-        // Brief pause to let services clean up before starting a new one
-        try {
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+        if (stoppedExistingStream) {
+            // Give an active service time to release camera/encoder resources
+            // before replacing it. Cold starts do not need this delay.
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
         }
+        return stoppedExistingStream;
     }
 }

--- a/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
+++ b/mobile/modules/engine/src/services/PhoneStreamCoordinator.ts
@@ -58,6 +58,9 @@ const DEFAULT_TIMINGS = {
   ackTimeoutMs: 10_000,
   maxMissedAcks: 3,
   cloudflareStatusPollMs: 5_000,
+  // During WHIP startup, probe quickly so readiness is not quantized to the
+  // steady-state 5s monitoring cadence. The delay backs off on each miss.
+  cloudflareStartupPollInitialMs: 500,
   // Cloudflare typically needs ~5-10s after first frame before HLS is live.
   hlsReadinessInitialDelayMs: 5_000,
   hlsReadinessPollMs: 2_000,
@@ -152,11 +155,13 @@ interface ManagedEntry {
   hlsReady: boolean
   hlsReadyResolvers: Array<(result: ManagedStartResult) => void>
   hlsReadyRejecters: Array<(err: Error) => void>
-  cloudflareTimer?: ReturnType<typeof setInterval>
+  cloudflareTimer?: ReturnType<typeof setTimeout>
   hlsTimer?: ReturnType<typeof setInterval>
   hlsAttempts: number
-  /** webrtc mode: CF status polls seen while waiting for first "connected". */
-  connectAttempts: number
+  /** Cloudflare status probes made during this stream session. */
+  cloudflareAttempts: number
+  /** Wall-clock origin for end-to-end managed startup diagnostics. */
+  startupStartedAtMs: number
 }
 
 type Entry = UnmanagedEntry | ManagedEntry
@@ -324,6 +329,7 @@ export class PhoneStreamCoordinator {
     packageName: string,
     opts: StartManagedOptions,
   ): Promise<ManagedStartResult> {
+    const startupStartedAtMs = Date.now()
     // Two-phase: the entry-claim runs under the transition lock; the wait for
     // HLS readiness happens AFTER the lock releases so a long warm-up doesn't
     // block subsequent start/stop transitions on this coordinator.
@@ -382,9 +388,17 @@ export class PhoneStreamCoordinator {
         hlsReadyResolvers: [],
         hlsReadyRejecters: [],
         hlsAttempts: 0,
-        connectAttempts: 0,
+        cloudflareAttempts: 0,
+        startupStartedAtMs,
       }
       this.current = entry
+
+      console.info("[STREAM_STARTUP]", {
+        streamId,
+        stage: "provisioned",
+        mode,
+        elapsedMs: Date.now() - startupStartedAtMs,
+      })
 
       try {
         const event = await BluetoothSdk.startExternallyManagedStream({
@@ -397,6 +411,12 @@ export class PhoneStreamCoordinator {
           ...(opts.audio !== undefined ? {audio: opts.audio} : {}),
         })
         entry.publisherStart = publisherStartResult(streamId, event)
+        console.info("[STREAM_STARTUP]", {
+          streamId,
+          stage: "publisher_ready",
+          mode,
+          elapsedMs: Date.now() - startupStartedAtMs,
+        })
       } catch (err) {
         this.current = null
         await teardownManagedStream(provision.liveInputId).catch(() => undefined)
@@ -416,6 +436,13 @@ export class PhoneStreamCoordinator {
 
     if (decision.kind === "join" && decision.immediate) {
       return decision.immediate
+    }
+
+    // The first Cloudflare probe runs immediately and can complete before the
+    // transition lock releases. Avoid stranding this caller after readiness
+    // resolvers have already been drained.
+    if (decision.entry.hlsReady) {
+      return managedStartResult(decision.entry)
     }
 
     // Wait for playback readiness OUTSIDE the lock — readiness can take ~10s
@@ -550,20 +577,41 @@ export class PhoneStreamCoordinator {
   }
 
   private startCloudflareStatusPoll(entry: ManagedEntry): void {
-    // webrtc mode: how many polls to wait for the first "connected" before
-    // declaring the publisher never reached Cloudflare. Mirrors the HLS
-    // readiness budget (~60s at the default 5s cadence).
-    const maxConnectAttempts = Math.max(
-      1,
-      Math.ceil(
-        (this.timings.hlsReadinessMaxAttempts * this.timings.hlsReadinessPollMs) /
-          this.timings.cloudflareStatusPollMs,
-      ),
-    )
+    // Keep the existing ~60s readiness budget while decoupling it from probe
+    // count. Startup probes begin immediately and back off to the normal 5s
+    // monitoring cadence, so a just-connected publisher is noticed quickly
+    // without increasing steady-state traffic.
+    const connectTimeoutMs = Math.max(1, this.timings.hlsReadinessMaxAttempts * this.timings.hlsReadinessPollMs)
+    const pollingStartedAtMs = Date.now()
+
+    const scheduleNext = () => {
+      if (this.current !== entry) return
+      const waitingForWebRtc = entry.mode === "webrtc" && !entry.hlsReady
+      const elapsedMs = Date.now() - pollingStartedAtMs
+      const remainingMs = Math.max(0, connectTimeoutMs - elapsedMs)
+      const startupDelayMs = Math.min(
+        this.timings.cloudflareStatusPollMs,
+        this.timings.cloudflareStartupPollInitialMs * 2 ** Math.min(Math.max(0, entry.cloudflareAttempts - 1), 10),
+      )
+      const delayMs = waitingForWebRtc ? Math.min(startupDelayMs, remainingMs) : this.timings.cloudflareStatusPollMs
+      entry.cloudflareTimer = setTimeout(() => void poll(), delayMs)
+    }
+
     const poll = async () => {
       if (this.current !== entry) return
+      const requestStartedAtMs = Date.now()
+      let keepPolling = true
+      entry.cloudflareAttempts += 1
       try {
         const status: CloudflareStatus = await getManagedStreamStatus(entry.liveInputId)
+        console.debug("[STREAM_STARTUP]", {
+          streamId: entry.streamId,
+          stage: "cloudflare_probe",
+          connected: status.isConnected,
+          attempt: entry.cloudflareAttempts,
+          requestMs: Date.now() - requestStartedAtMs,
+          elapsedMs: Date.now() - entry.startupStartedAtMs,
+        })
         this.fanout({
           streamId: entry.streamId,
           source: "cloudflare",
@@ -576,6 +624,13 @@ export class PhoneStreamCoordinator {
         if (entry.mode === "webrtc" && !entry.hlsReady) {
           if (status.isConnected) {
             entry.hlsReady = true
+            console.info("[STREAM_STARTUP]", {
+              streamId: entry.streamId,
+              stage: "playback_ready",
+              mode: entry.mode,
+              probes: entry.cloudflareAttempts,
+              elapsedMs: Date.now() - entry.startupStartedAtMs,
+            })
             const result = managedStartResult(entry)
             for (const r of entry.hlsReadyResolvers) r(result)
             entry.hlsReadyResolvers = []
@@ -587,11 +642,8 @@ export class PhoneStreamCoordinator {
               data: result as unknown as Record<string, unknown>,
             })
           } else {
-            entry.connectAttempts += 1
-            if (entry.connectAttempts >= maxConnectAttempts) {
-              const err = new Error(
-                `WebRTC ingest never reached Cloudflare after ${entry.connectAttempts} status polls`,
-              )
+            if (Date.now() - pollingStartedAtMs >= connectTimeoutMs) {
+              const err = new Error(`WebRTC ingest never reached Cloudflare after ${connectTimeoutMs}ms`)
               for (const reject of entry.hlsReadyRejecters) reject(err)
               entry.hlsReadyResolvers = []
               entry.hlsReadyRejecters = []
@@ -606,15 +658,32 @@ export class PhoneStreamCoordinator {
                 if (this.current?.streamId !== targetStreamId) return
                 await this.teardownLocked("webrtc_not_connected")
               })
+              keepPolling = false
             }
           }
         }
       } catch (err) {
         console.warn("[STREAM] cloudflare status poll failed:", err)
+        if (entry.mode === "webrtc" && !entry.hlsReady && Date.now() - pollingStartedAtMs >= connectTimeoutMs) {
+          const timeoutErr = new Error(`WebRTC ingest status could not be confirmed after ${connectTimeoutMs}ms`)
+          for (const reject of entry.hlsReadyRejecters) reject(timeoutErr)
+          entry.hlsReadyResolvers = []
+          entry.hlsReadyRejecters = []
+          const targetStreamId = entry.streamId
+          void this.runExclusive(async () => {
+            if (this.current?.streamId !== targetStreamId) return
+            await this.teardownLocked("webrtc_status_unavailable")
+          })
+          keepPolling = false
+        }
+      } finally {
+        if (keepPolling) scheduleNext()
       }
     }
-    entry.cloudflareTimer = setInterval(poll, this.timings.cloudflareStatusPollMs)
-    // Don't fire immediately — Cloudflare wouldn't have first-frame yet.
+
+    // The glasses publisher has already reported streaming, so the first
+    // status request is useful now. Most starts avoid the old blind 5s wait.
+    void poll()
   }
 
   private startHlsReadinessPoll(entry: ManagedEntry): void {
@@ -630,6 +699,13 @@ export class PhoneStreamCoordinator {
         const res = await fetch(entry.hlsUrl, {method: "HEAD"})
         if (res.status === 200) {
           entry.hlsReady = true
+          console.info("[STREAM_STARTUP]", {
+            streamId: entry.streamId,
+            stage: "playback_ready",
+            mode: entry.mode,
+            probes: entry.hlsAttempts,
+            elapsedMs: Date.now() - entry.startupStartedAtMs,
+          })
           if (entry.hlsTimer) {
             clearInterval(entry.hlsTimer)
             entry.hlsTimer = undefined
@@ -717,7 +793,7 @@ export class PhoneStreamCoordinator {
     this.lifecycle = null
 
     if (entry.kind === "managed") {
-      if (entry.cloudflareTimer) clearInterval(entry.cloudflareTimer)
+      if (entry.cloudflareTimer) clearTimeout(entry.cloudflareTimer)
       if (entry.hlsTimer) clearInterval(entry.hlsTimer)
       // Reject any still-pending HLS readiness waiters.
       const pendingErr = new Error(`Stream torn down: ${reason}`)

--- a/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts
@@ -62,6 +62,10 @@ beforeEach(() => {
   sendExternallyManagedStreamKeepAlive.mockClear()
   provisionManagedStream.mockClear()
   getManagedStreamStatus.mockClear()
+  getManagedStreamStatus.mockImplementation(async (_id: string) => ({
+    isConnected: true,
+    viewerCount: 0,
+  }))
   teardownManagedStream.mockClear()
   hlsHeadResponder = () => new Response(null, {status: 200})
   ;(globalThis as {fetch: typeof fetch}).fetch = (async (url) => {
@@ -165,6 +169,55 @@ describe("PhoneStreamCoordinator", () => {
   })
 
   describe("managed", () => {
+    test("WHIP probes Cloudflare immediately and retries quickly during startup", async () => {
+      getManagedStreamStatus
+        .mockImplementationOnce(async () => ({isConnected: false, viewerCount: 0}))
+        .mockImplementationOnce(async () => ({isConnected: true, viewerCount: 0}))
+
+      const coord = new PhoneStreamCoordinator({
+        cloudflareStartupPollInitialMs: 5,
+        cloudflareStatusPollMs: 1000,
+        hlsReadinessPollMs: 1000,
+        hlsReadinessMaxAttempts: 5,
+        keepAliveIntervalMs: 10_000,
+      })
+      const result = await coord.startManaged("com.a", {ingest: "whip"})
+
+      expect(result.mode).toBe("webrtc")
+      expect(result.webrtcUrl).toBe("https://playback.test/abc/whep")
+      expect(getManagedStreamStatus).toHaveBeenCalledTimes(2)
+      await coord.stop("com.a")
+    })
+
+    test("WHIP startup resolves when the immediate probe is already connected", async () => {
+      const coord = new PhoneStreamCoordinator({
+        cloudflareStartupPollInitialMs: 5,
+        cloudflareStatusPollMs: 1000,
+        keepAliveIntervalMs: 10_000,
+      })
+
+      const result = await coord.startManaged("com.a", {ingest: "whip"})
+
+      expect(result.mode).toBe("webrtc")
+      expect(getManagedStreamStatus).toHaveBeenCalledTimes(1)
+      await coord.stop("com.a")
+    })
+
+    test("WHIP startup rejects when Cloudflare never reports the publisher", async () => {
+      getManagedStreamStatus.mockImplementation(async () => ({isConnected: false, viewerCount: 0}))
+      const coord = new PhoneStreamCoordinator({
+        cloudflareStartupPollInitialMs: 1,
+        cloudflareStatusPollMs: 5,
+        hlsReadinessPollMs: 5,
+        hlsReadinessMaxAttempts: 1,
+        keepAliveIntervalMs: 10_000,
+      })
+
+      await expect(coord.startManaged("com.a", {ingest: "whip"})).rejects.toThrow(
+        "WebRTC ingest never reached Cloudflare",
+      )
+    })
+
     test("startManaged provisions Cloudflare and resolves when HLS is ready", async () => {
       const coord = new PhoneStreamCoordinator({
         hlsReadinessInitialDelayMs: 5,


### PR DESCRIPTION
## Summary

- poll Cloudflare immediately after the glasses publisher reports ready, then back off from 500 ms to the existing 5 s steady-state cadence
- remove two unnecessary 500 ms cold-start waits on Mentra Live while preserving the replacement-stream cleanup delay
- add end-to-end and glasses pipeline `[STREAM_STARTUP]` timing spans
- cover immediate success, adaptive retry, the readiness race, and provider timeout

## Root cause

The managed WHIP path waited for the first 5-second Cloudflare status interval even though the glasses had already reported that its publisher was streaming. That blind gate accounted for roughly half of the reported 9.8-second button-to-preview delay. The glasses path also paid two fixed 500 ms waits on every cold start.

This keeps the existing contract that a managed start resolves only once playback is ready. It does not move retries into Livestreamer, whose current WHEP retry interval could otherwise introduce another 5-second phase delay.

## Impact and profiling

- original incident: about 9.8 s from Start to playback URL
- Mentra Live command-to-publisher median: 2.75 s before, 1.66 s after across three disposable Cloudflare inputs
- Android starter app button-to-Cloudflare-connected median: 4.89 s across three phone → BLE → glasses → provider trials; the generic starter app spent about 2.54 s before sending its BLE command, compared with about 1.05 s for Livestreamer in the incident
- steady-state media latency and the 5-second monitoring cadence are unchanged

## Validation

- `bun test modules/engine/src/services/__tests__/PhoneStreamCoordinator.test.ts` — 20 passed
- `bun run compile` in `mobile`
- `./scripts/check-android-compile.sh asg`
- `:app:assembleDebug` for both ASG and the Mentra App
- three direct Mentra Live → Cloudflare startup trials
- three Android phone → BLE → Mentra Live → Cloudflare startup trials

`spotlessJavaCheck` remains blocked by a pre-existing import-order violation in `MediaUploadQueueManager.java`; neither changed Java file is implicated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts managed WebRTC/WHIP startup time by probing Cloudflare immediately and removing fixed cold-start waits, while keeping the existing steady-state cadence. Adds clear [STREAM_STARTUP] timing logs across the Android pipeline and coordinator.

- **Performance**
  - Probe Cloudflare status immediately after publisher ready; back off from ~500 ms to 5 s using timeouts (keeps ~60 s overall budget).
  - Resolve managed starts as soon as Cloudflare reports connected (WHIP) or HLS is ready; first probe can resolve immediately.
  - Remove two unconditional 500 ms sleeps; only wait 500 ms when replacing an active stream to free camera/encoders.
  - Add granular [STREAM_STARTUP] stages in the Android WHIP service and coordinator for end-to-end timing.
  - Tests cover immediate success, quick retry, readiness race, and timeouts.

<sup>Written for commit 0bfeee015b39d701529e1e778eda7ede97b4de45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes managed-stream readiness timing and Android stream handoff behavior; steady-state monitoring is unchanged but faster WHIP resolution and conditional cleanup could affect edge cases around stream replacement and concurrent starts.
> 
> **Overview**
> **Cuts button-to-preview time** for managed WHIP/WebRTC streams by removing fixed cold-start delays and polling Cloudflare as soon as the glasses publisher is up, instead of waiting on a 5s interval.
> 
> On the phone, `PhoneStreamCoordinator` **probes Cloudflare immediately** after BLE start, uses **exponential backoff** (~500ms → 5s) while waiting for `connected`, keeps the **~60s readiness budget** in wall-clock time, and **returns early** if the first probe already succeeded before the transition lock releases. **`[STREAM_STARTUP]`** logs trace provision → publisher → probes → playback ready.
> 
> On Mentra Live, **`WhipStreamingService`** drops the **500ms** `postDelayed` before `startStreaming` (main-thread `post` only) and logs pipeline stages (ICE, WHIP POST/answer, etc.). **`StreamCommandHandler`** only **sleeps 500ms** when stopping an **existing** stream before starting a new one; cold starts skip that wait.
> 
> Tests cover immediate WHIP success, fast retries, timeout, and the readiness race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bfeee015b39d701529e1e778eda7ede97b4de45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->