### PR TITLE
Fix G2 onboarding copy

### DIFF
--- a/mobile/src/app/pairing/prep-controller.tsx
+++ b/mobile/src/app/pairing/prep-controller.tsx
@@ -228,10 +228,7 @@ export default function PairingPrepScreen() {
             className="text-lg text-secondary-foreground"
             text="1. Disconnect your G2 from within the Even Realities app, or uninstall the Even Realities app"
           />
-          <Text
-            className="text-lg text-secondary-foreground"
-            text="2. Place your G2 in the charging case with the lid open."
-          />
+          <Text className="text-lg text-secondary-foreground" text="2. Place your G2 in the charging case." />
         </View>
       </View>
     )

--- a/mobile/src/app/pairing/prep.tsx
+++ b/mobile/src/app/pairing/prep.tsx
@@ -379,10 +379,7 @@ export default function PairingPrepScreen() {
             className="text-lg text-secondary-foreground"
             text="1. Disconnect your G2 from within the Even Realities app, or uninstall the Even Realities app"
           />
-          <Text
-            className="text-lg text-secondary-foreground"
-            text="2. Place your G2 in the charging case with the lid open."
-          />
+          <Text className="text-lg text-secondary-foreground" text="2. Place your G2 in the charging case." />
         </View>
       </View>
     )
@@ -394,7 +391,7 @@ export default function PairingPrepScreen() {
       <>
         <View className="gap-4">
           <Button tx="pairing:g1Ready" onPress={advanceToPairing} />
-          <Button tx="pairing:g1NotReady" preset="secondary" onPress={() => setShowTroubleshootingModal(true)} />
+          <Button tx="pairing:g2NotReady" preset="secondary" onPress={() => setShowTroubleshootingModal(true)} />
         </View>
         <GlassesTroubleshootingModal
           isVisible={showTroubleshootingModal}

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -131,6 +131,7 @@ const en = {
     instructions: "Instructions",
     g1Ready: "Continue to pairing",
     g1NotReady: "Orange LED is blinking",
+    g2NotReady: "Need more help?",
     success: "Success",
     glassesConnected: "Your glasses are connected.",
     needHelpPairing: "Need help pairing?",
@@ -151,7 +152,7 @@ const en = {
     },
     G2: {
       step1: "Disconnect your G2 from within the Even Realities app, or uninstall the Even Realities app",
-      step2: "Place your G2 in the charging case with the lid open.",
+      step2: "Place your G2 in the charging case.",
     },
     LIVE: {
       step1: "Make sure your Mentra Live is fully charged and turned on.",


### PR DESCRIPTION
## Summary

- remove the inaccurate instruction that the G2 charging-case lid must remain open
- replace the G1-specific orange LED troubleshooting label with a G2-specific “Need more help?” action
- keep the standard and controller-assisted G2 onboarding instructions consistent

## Why

The G2 does not require the charging-case lid to be open, and it does not use the G1 orange blinking LED state. The onboarding copy was inherited from the G1 flow.

## Validation

- `bun run compile`
- `bunx eslint src/app/pairing/prep.tsx src/app/pairing/prep-controller.tsx` (passes with seven pre-existing warnings)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes G2 onboarding text to remove the incorrect “lid open” step and replaces the G1-specific troubleshooting with a G2 “Need more help?” action. Keeps the standard and controller-assisted G2 flows consistent.

- **Bug Fixes**
  - Removed “with the lid open” from G2 step 2 in `prep.tsx` and `prep-controller.tsx`.
  - Replaced `pairing:g1NotReady` with `pairing:g2NotReady` (“Need more help?”) on the G2 screen.
  - Added `g2NotReady` string and updated `G2.step2` in `mobile/src/i18n/en.ts`.

<sup>Written for commit d95608eb9ac1a15f9b8d7ea4baadc35e95b3cee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and i18n-only changes on pairing screens; no pairing logic or permissions behavior changed.
> 
> **Overview**
> **G2 pairing prep** no longer tells users to keep the charging-case lid open. Step 2 is updated to “Place your G2 in the charging case.” in both `prep.tsx` and `prep-controller.tsx`, and the same wording is applied to `pairingGuides.G2.step2` in English strings.
> 
> On the standard G2 flow, the secondary troubleshooting action now uses **`pairing:g2NotReady`** (“Need more help?”) instead of the G1 **`g1NotReady`** label (“Orange LED is blinking”), which does not apply to G2.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d95608eb9ac1a15f9b8d7ea4baadc35e95b3cee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->