### PR TITLE
Add fix agent action to bug reports

### DIFF
--- a/cloud-v2/packages/core/src/api/admin/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/admin/reports.api.ts
@@ -6,9 +6,8 @@
  *   GET /:reportId   — full report document plus its asset rows
  *   GET /:reportId/artifacts/:artifactId — raw artifact payload bytes
  *
- * Mounted behind either the admin console auth gate or the dedicated,
- * read-only report-agent auth gate. Keep authentication in the parent routers
- * so this shared handler surface stays identical for both trusted callers.
+ * Mounted behind the admin console auth gate. The private report-agent router
+ * reuses only the exported detail and artifact handlers, never the list route.
  */
 
 import { Hono } from "hono";
@@ -47,13 +46,13 @@ async function getReportsList(c: AppContext) {
   return c.json({ reports: await listReports(parsed.data) });
 }
 
-async function getReportDetail(c: AppContext) {
+export async function getReportDetail(c: AppContext) {
   const detail = await getReport(requiredParam(c, "reportId"));
   if (!detail) return c.json({ error: "not_found", error_description: "report not found" }, 404);
   return c.json(detail);
 }
 
-async function getReportArtifact(c: AppContext) {
+export async function getReportArtifact(c: AppContext) {
   const reportId = requiredParam(c, "reportId");
   const artifactId = requiredParam(c, "artifactId");
 

--- a/cloud-v2/packages/core/src/api/admin/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/admin/reports.api.ts
@@ -6,9 +6,9 @@
  *   GET /:reportId   — full report document plus its asset rows
  *   GET /:reportId/artifacts/:artifactId — raw artifact payload bytes
  *
- * Mounted at `/reports` inside the admin router (preinstalled.api.ts) AFTER
- * its `adminAuth` gate, so every route here is admin-only without running the
- * auth middleware a second time. Do not mount this router anywhere else.
+ * Mounted behind either the admin console auth gate or the dedicated,
+ * read-only report-agent auth gate. Keep authentication in the parent routers
+ * so this shared handler surface stays identical for both trusted callers.
  */
 
 import { Hono } from "hono";

--- a/cloud-v2/packages/core/src/api/agent/reports.api.test.ts
+++ b/cloud-v2/packages/core/src/api/agent/reports.api.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import reports from "./reports.api";
+
+const TOKEN = "a".repeat(64);
+let previousToken: string | undefined;
+
+beforeEach(() => {
+  previousToken = process.env.CLOUD_REPORT_AGENT_API_TOKEN;
+  process.env.CLOUD_REPORT_AGENT_API_TOKEN = TOKEN;
+});
+
+afterEach(() => {
+  if (previousToken === undefined) delete process.env.CLOUD_REPORT_AGENT_API_TOKEN;
+  else process.env.CLOUD_REPORT_AGENT_API_TOKEN = previousToken;
+});
+
+describe("report agent routes", () => {
+  test("provides an authenticated health probe without exposing report enumeration", async () => {
+    const headers = { authorization: `Bearer ${TOKEN}` };
+    expect((await reports.request("/health", { headers })).status).toBe(200);
+    expect((await reports.request("/", { headers })).status).toBe(404);
+  });
+});

--- a/cloud-v2/packages/core/src/api/agent/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/agent/reports.api.ts
@@ -6,13 +6,15 @@
  */
 
 import { Hono } from "hono";
-import reports from "../admin/reports.api";
+import { getReportArtifact, getReportDetail } from "../admin/reports.api";
 import { reportAgentAuth } from "../middleware/report-agent-auth.middleware";
 import type { AppEnv } from "../../types/hono.types";
 
 const app = new Hono<AppEnv>();
 
 app.use("*", reportAgentAuth);
-app.route("/", reports);
+app.get("/health", c => c.json({ ok: true }));
+app.get("/:reportId", getReportDetail);
+app.get("/:reportId/artifacts/:artifactId", getReportArtifact);
 
 export default app;

--- a/cloud-v2/packages/core/src/api/agent/reports.api.ts
+++ b/cloud-v2/packages/core/src/api/agent/reports.api.ts
@@ -1,0 +1,18 @@
+/**
+ * Read-only report access for the private Mentra Dev Agent.
+ *
+ * This route intentionally exposes only report detail and artifact reads. It
+ * does not share the broader admin router or accept human session credentials.
+ */
+
+import { Hono } from "hono";
+import reports from "../admin/reports.api";
+import { reportAgentAuth } from "../middleware/report-agent-auth.middleware";
+import type { AppEnv } from "../../types/hono.types";
+
+const app = new Hono<AppEnv>();
+
+app.use("*", reportAgentAuth);
+app.route("/", reports);
+
+export default app;

--- a/cloud-v2/packages/core/src/api/app.ts
+++ b/cloud-v2/packages/core/src/api/app.ts
@@ -8,6 +8,7 @@
  *   /api/client/auth/*          — device-called auth: exchange, refresh,
  *                                 miniapp-token
  *   /api/client/reports/*       — device-filed reports
+ *   /api/agent/reports/*        — read-only private dev-agent access
  *
  * Caller convention (auth/spec.md): /api/client/* is device-called and
  * /api/oem/* is reserved for the OEM's backend. The token exchange + refresh
@@ -26,6 +27,7 @@ import { OauthError } from "../types/oauth.types";
 import { AccountError } from "../services/account/account-error";
 import { requestContext } from "./middleware/context.middleware";
 import adminPreinstalled from "./admin/preinstalled.api";
+import reportAgent from "./agent/reports.api";
 import clientAuth from "./client/auth.api";
 import clientReports from "./client/reports.api";
 import clientMiniapps from "./client/miniapps.api";
@@ -79,6 +81,7 @@ export function createApp(opts: CreateAppOptions): Hono<AppEnv> {
   // Audience mounts. Device-called auth lives under /api/client/*.
   app.route("/api/client/auth", clientAuth);
   app.route("/api/client/reports", clientReports);
+  app.route("/api/agent/reports", reportAgent);
   app.route("/api/client/miniapps", clientMiniapps);
   app.route("/api/account", accountApi);
   app.route("/api/account/oauth", accountOauth);

--- a/cloud-v2/packages/core/src/api/middleware/report-agent-auth.middleware.test.ts
+++ b/cloud-v2/packages/core/src/api/middleware/report-agent-auth.middleware.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Hono } from "hono";
+import type { AppEnv } from "../../types/hono.types";
+import { reportAgentAuth } from "./report-agent-auth.middleware";
+
+const TOKEN = "a".repeat(64);
+let previousToken: string | undefined;
+
+beforeEach(() => {
+  previousToken = process.env.CLOUD_REPORT_AGENT_API_TOKEN;
+  process.env.CLOUD_REPORT_AGENT_API_TOKEN = TOKEN;
+});
+
+afterEach(() => {
+  if (previousToken === undefined) delete process.env.CLOUD_REPORT_AGENT_API_TOKEN;
+  else process.env.CLOUD_REPORT_AGENT_API_TOKEN = previousToken;
+});
+
+async function request(authorization?: string): Promise<Response> {
+  const app = new Hono<AppEnv>();
+  app.use("*", reportAgentAuth);
+  app.get("/reports", c => c.json({ ok: true }));
+  return app.request("http://localhost/reports", {
+    headers: authorization ? { authorization } : undefined,
+  });
+}
+
+describe("reportAgentAuth", () => {
+  test("accepts the configured bearer credential", async () => {
+    const response = await request(`Bearer ${TOKEN}`);
+    expect(response.status).toBe(200);
+  });
+
+  test("rejects missing and incorrect credentials", async () => {
+    expect((await request()).status).toBe(401);
+    expect((await request(`Bearer ${"b".repeat(64)}`)).status).toBe(401);
+  });
+
+  test("fails closed when the service credential is not configured", async () => {
+    delete process.env.CLOUD_REPORT_AGENT_API_TOKEN;
+    expect((await request(`Bearer ${TOKEN}`)).status).toBe(401);
+  });
+});

--- a/cloud-v2/packages/core/src/api/middleware/report-agent-auth.middleware.ts
+++ b/cloud-v2/packages/core/src/api/middleware/report-agent-auth.middleware.ts
@@ -1,0 +1,35 @@
+import { timingSafeEqual } from "node:crypto";
+import { createMiddleware } from "hono/factory";
+import type { AppEnv } from "../../types/hono.types";
+
+const BEARER_PREFIX = "Bearer ";
+const MIN_TOKEN_LENGTH = 32;
+
+/** Authenticate the private agent without granting access to other admin APIs. */
+export const reportAgentAuth = createMiddleware<AppEnv>(async (c, next) => {
+  const expected = process.env.CLOUD_REPORT_AGENT_API_TOKEN?.trim() ?? "";
+  const header = c.req.header("authorization") ?? "";
+  const actual = header.startsWith(BEARER_PREFIX)
+    ? header.slice(BEARER_PREFIX.length).trim()
+    : "";
+
+  if (
+    expected.length < MIN_TOKEN_LENGTH ||
+    actual.length < MIN_TOKEN_LENGTH ||
+    !safeEqual(actual, expected)
+  ) {
+    return c.json(
+      { error: "unauthorized", error_description: "report agent credential required" },
+      401,
+      { "WWW-Authenticate": "Bearer" },
+    );
+  }
+
+  return next();
+});
+
+function safeEqual(actual: string, expected: string): boolean {
+  const actualBuffer = Buffer.from(actual, "utf8");
+  const expectedBuffer = Buffer.from(expected, "utf8");
+  return actualBuffer.length === expectedBuffer.length && timingSafeEqual(actualBuffer, expectedBuffer);
+}

--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -1,15 +1,20 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { createHmac } from "node:crypto";
 
 import { notifyReportSlack, type ReportSlackNotification } from "./report-slack.service";
 
 const WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/reports";
 const AUTOMATIC_WEBHOOK_URL = "https://hooks.slack.test/services/T000/B000/automatic";
+const AGENT_URL = "https://dev-agent.mentraglass.com";
+const AGENT_SIGNING_SECRET = "test-agent-signing-secret-with-at-least-32-bytes";
 
 const savedEnv = {
   CLOUD_REPORTS_SLACK_WEBHOOK_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL,
   CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL: process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL,
   CLOUD_CORE_ENVIRONMENT: process.env.CLOUD_CORE_ENVIRONMENT,
   CLOUD_ADMIN_CONSOLE_URL: process.env.CLOUD_ADMIN_CONSOLE_URL,
+  CLOUD_REPORT_AGENT_URL: process.env.CLOUD_REPORT_AGENT_URL,
+  CLOUD_REPORT_AGENT_SIGNING_SECRET: process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET,
 };
 const realFetch = globalThis.fetch;
 
@@ -21,6 +26,8 @@ beforeEach(() => {
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL;
   delete process.env.CLOUD_REPORTS_SLACK_WEBHOOK_AUTOMATIC_URL;
   delete process.env.CLOUD_ADMIN_CONSOLE_URL;
+  delete process.env.CLOUD_REPORT_AGENT_URL;
+  delete process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET;
   process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
   fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -35,6 +42,8 @@ afterEach(() => {
   );
   restoreEnv("CLOUD_CORE_ENVIRONMENT", savedEnv.CLOUD_CORE_ENVIRONMENT);
   restoreEnv("CLOUD_ADMIN_CONSOLE_URL", savedEnv.CLOUD_ADMIN_CONSOLE_URL);
+  restoreEnv("CLOUD_REPORT_AGENT_URL", savedEnv.CLOUD_REPORT_AGENT_URL);
+  restoreEnv("CLOUD_REPORT_AGENT_SIGNING_SECRET", savedEnv.CLOUD_REPORT_AGENT_SIGNING_SECRET);
 });
 
 describe("notifyReportSlack", () => {
@@ -107,6 +116,47 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain("glasses stuck on boot screen");
     expect(blocksJson).toContain("*Artifacts:*\\n3");
     expect(blocksJson).toContain("*Env:*\\ntest-env");
+  });
+
+  test("adds a signed fix-agent confirmation button to bug reports when configured", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_CORE_ENVIRONMENT = "dev";
+    process.env.CLOUD_REPORT_AGENT_URL = AGENT_URL;
+    process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET = AGENT_SIGNING_SECRET;
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as {
+      blocks: Array<{ type: string; elements?: Array<{ text: { text: string }; url: string }> }>;
+    };
+    const action = payload.blocks.find((block) => block.type === "actions")?.elements?.[0];
+    expect(action?.text.text).toBe("Run Fix Agent");
+    const url = new URL(action?.url ?? "");
+    expect(`${url.origin}${url.pathname}`).toBe(`${AGENT_URL}/actions/report`);
+    expect(url.searchParams.get("reportId")).toBe("rep_TEST123");
+    expect(url.searchParams.get("environment")).toBe("dev");
+    const expires = url.searchParams.get("expires");
+    const expectedSignature = createHmac("sha256", AGENT_SIGNING_SECRET)
+      .update(`rep_TEST123|dev|${expires}`)
+      .digest("hex");
+    expect(url.searchParams.get("signature")).toBe(expectedSignature);
+  });
+
+  test("does not add the fix-agent action to feedback or automatic reports", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_CORE_ENVIRONMENT = "prod";
+    process.env.CLOUD_REPORT_AGENT_URL = AGENT_URL;
+    process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET = AGENT_SIGNING_SECRET;
+
+    await notifyReportSlack(bugNotification({ kind: "feedback", feedback: { message: "hi" } }));
+    await notifyReportSlack(bugNotification({ kind: "automatic" }));
+
+    for (const call of fetchMock.mock.calls) {
+      const [, init] = call as unknown as [string, RequestInit];
+      const payload = JSON.parse(String(init.body)) as { blocks: Array<{ type: string }> };
+      expect(payload.blocks.some((block) => block.type === "actions")).toBe(false);
+    }
   });
 
   test("links the report to the admin console for known environments", async () => {

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -15,10 +15,12 @@
  */
 
 import { createLogger } from "@mentra/cloud-shared";
+import { createHmac } from "node:crypto";
 
 const logger = createLogger("core").child({ service: "report-slack.service" });
 
 const SLACK_TIMEOUT_MS = 10_000;
+const REPORT_AGENT_ACTION_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 /** How much user-authored text a Slack field keeps, mirroring V1 limits. */
 const BEHAVIOR_TEXT_MAX = 500;
@@ -72,6 +74,12 @@ interface SlackBlock {
   type: string;
   text?: { type: string; text: string; emoji?: boolean };
   fields?: Array<{ type: string; text: string }>;
+  elements?: Array<{
+    type: "button";
+    text: { type: "plain_text"; text: string; emoji: boolean };
+    url: string;
+    style?: "primary" | "danger";
+  }>;
 }
 
 /**
@@ -205,6 +213,21 @@ function buildSlackMessage(notification: ReportSlackNotification): {
     });
   }
 
+  const agentActionUrl = reportAgentActionUrl(notification);
+  if (agentActionUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          text: { type: "plain_text", text: "Run Fix Agent", emoji: true },
+          style: "primary",
+          url: agentActionUrl,
+        },
+      ],
+    });
+  }
+
   blocks.push({
     type: "section",
     text: { type: "mrkdwn", text: `_Submitted: ${timestamp}_` },
@@ -221,6 +244,45 @@ function buildSlackMessage(notification: ReportSlackNotification): {
   ];
 
   return { text: fallbackParts.join("\n"), blocks };
+}
+
+/**
+ * Signed, expiring link to the private agent controller. The link itself is
+ * a read-only confirmation page; only its POST form queues work, so Slack's
+ * unfurl crawler cannot start an agent. Bug reports are the deliberately
+ * narrow MVP scope; feedback and automatic diagnostics never receive it.
+ */
+function reportAgentActionUrl(notification: ReportSlackNotification): string | null {
+  if (notification.kind !== "bug") return null;
+  const configuredBase = process.env.CLOUD_REPORT_AGENT_URL?.trim();
+  const signingSecret = process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET;
+  const environment = reportAgentEnvironment();
+  if (!configuredBase || !signingSecret || signingSecret.length < 32 || !environment) return null;
+
+  try {
+    const expires = Math.floor(Date.now() / 1000) + REPORT_AGENT_ACTION_TTL_SECONDS;
+    const payload = `${notification.reportId}|${environment}|${expires}`;
+    const signature = createHmac("sha256", signingSecret).update(payload).digest("hex");
+    const url = new URL("/actions/report", withHttpsScheme(configuredBase));
+    url.searchParams.set("reportId", notification.reportId);
+    url.searchParams.set("environment", environment);
+    url.searchParams.set("expires", String(expires));
+    url.searchParams.set("signature", signature);
+    return url.toString();
+  } catch (error) {
+    logger.warn(
+      { error: (error as Error)?.message },
+      "invalid CLOUD_REPORT_AGENT_URL; omitting report agent action",
+    );
+    return null;
+  }
+}
+
+function reportAgentEnvironment(): "prod" | "staging" | "dev" | null {
+  const environment = process.env.CLOUD_CORE_ENVIRONMENT;
+  if (environment === "prod" || environment === "production") return "prod";
+  if (environment === "staging" || environment === "dev") return environment;
+  return null;
 }
 
 /** Kind-specific body: bug/automatic report details, or the feedback text. */


### PR DESCRIPTION
## Summary
- add a signed, seven-day `Run Fix Agent` button to Cloud V2 bug report Slack notifications
- keep feedback and automatic reports outside the MVP scope
- use a read-only confirmation URL so Slack unfurls cannot queue agent work

## Validation
- `bun test packages/core/src/services/report-slack.service.test.ts` (22 passed)
- `bun run typecheck`

## Configuration
- `CLOUD_REPORT_AGENT_URL`
- `CLOUD_REPORT_AGENT_SIGNING_SECRET`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a signed “Run Fix Agent” button to Slack bug reports and a token‑protected, read‑only reports API for the private agent. The agent can read single reports and artifacts only; the Slack link is a 7‑day, read‑only confirmation page so unfurls can’t start work.

- **New Features**
  - Show “Run Fix Agent” on bug reports only; signed URL (HMAC-SHA256) with `reportId`, `environment`, `expires` (7‑day TTL).
  - Add private read-only `\`/api/agent/reports\`` guarded by `CLOUD_REPORT_AGENT_API_TOKEN`; exposes only `GET /:reportId` and `GET /:reportId/artifacts/:artifactId` plus `GET /health` (no list/index). Reuses admin detail/artifact handlers; list remains admin-only.

- **Migration**
  - Set `CLOUD_REPORT_AGENT_URL` and `CLOUD_REPORT_AGENT_SIGNING_SECRET` (>= 32 bytes).
  - Set `CLOUD_REPORT_AGENT_API_TOKEN` (>= 32 bytes).
  - Ensure `CLOUD_CORE_ENVIRONMENT` resolves to `prod`, `staging`, or `dev`.

<sup>Written for commit 657febb6d26797487b15a444e594460fa866f502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New authenticated API surface for report/artifact reads and signed Slack links that gate agent actions; scope is intentionally narrow (no enumeration, bug-only button) but touches incident data access and operational secrets.
> 
> **Overview**
> Adds a **Run Fix Agent** primary button to Slack notifications for **bug** reports when `CLOUD_REPORT_AGENT_URL` and `CLOUD_REPORT_AGENT_SIGNING_SECRET` (≥32 bytes) are set and `CLOUD_CORE_ENVIRONMENT` maps to `dev`, `staging`, or `prod`. The URL points at the agent’s read-only `/actions/report` confirmation page with HMAC-SHA256 over `reportId|environment|expires` and a 7-day TTL so Slack unfurls cannot queue work; feedback and automatic reports are unchanged.
> 
> Introduces **`/api/agent/reports`** with bearer auth via `CLOUD_REPORT_AGENT_API_TOKEN` (timing-safe compare, fails closed if unset/short). It exposes health, report detail, and artifact reads by re-exporting admin handlers—**no report list**—so the private dev agent can read incidents without admin session credentials. Admin `getReportDetail` / `getReportArtifact` are exported for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657febb6d26797487b15a444e594460fa866f502. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->