### PR TITLE
Prevent Bluetooth controls from pausing or replaying TTS

### DIFF
--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -370,6 +370,7 @@
     "react-native-mmkv",
   ],
   "patchedDependencies": {
+    "expo-audio@55.0.14": "patches/expo-audio@55.0.14.patch",
     "react-native-draggable-masonry@1.3.0": "patches/react-native-draggable-masonry@1.3.0.patch",
     "react-native-webview@13.16.0": "patches/react-native-webview@13.16.0.patch",
     "react-native-awesome-gallery@0.4.3": "patches/react-native-awesome-gallery@0.4.3.patch",

--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -321,6 +321,25 @@ class AudioPlaybackService {
     }
   }
 
+  private unloadPlaybackSource(playback: PlaybackState, reason: string): void {
+    if (!this.player) return
+    if (this.loadedPlayback !== playback) return
+
+    try {
+      this.player.pause()
+    } catch (e) {
+      console.warn(`AUDIO: Error pausing ${playback.requestId} during ${reason}:`, e)
+    }
+
+    try {
+      this.player.replace(null)
+      this.loadedPlayback = null
+      console.log(`AUDIO: Cleared player for ${playback.requestId} during ${reason}`)
+    } catch (e) {
+      console.warn(`AUDIO: Error clearing ${playback.requestId} during ${reason}:`, e)
+    }
+  }
+
   private clearFinishedPlayerAfterTail(playback: PlaybackState): void {
     if (playback.suppressCloudUplink) {
       this.tailUplinkSuppressions.add(playback.uplinkSuppressionId)
@@ -332,18 +351,7 @@ class AudioPlaybackService {
       if (playback.suppressCloudUplink && this.tailUplinkSuppressions.delete(playback.uplinkSuppressionId)) {
         setAudioCloudUplinkSuppressed(playback.uplinkSuppressionId, false)
       }
-      if (!this.player) return
-      if (this.loadedPlayback !== playback) return
-      try {
-        this.player.pause()
-        this.player.replace(null)
-        this.loadedPlayback = null
-        console.log(
-          `AUDIO: Cleared finished player for ${playback.requestId} after ${AudioPlaybackService.A2DP_TAIL_DRAIN_MS}ms tail drain`,
-        )
-      } catch (e) {
-        console.warn("AUDIO: Error clearing player after tail drain:", e)
-      }
+      this.unloadPlaybackSource(playback, `${AudioPlaybackService.A2DP_TAIL_DRAIN_MS}ms A2DP tail drain`)
     }, AudioPlaybackService.A2DP_TAIL_DRAIN_MS)
   }
 
@@ -450,9 +458,11 @@ class AudioPlaybackService {
       if (suppressCloudUplink) {
         setAudioCloudUplinkSuppressed(`url:${requestId}`, false)
       }
-      if (this.currentPlayback?.requestId === requestId) {
-        this.currentPlayback.completed = true
+      const failedPlayback = this.currentPlayback?.requestId === requestId ? this.currentPlayback : null
+      if (failedPlayback) {
+        failedPlayback.completed = true
         this.currentPlayback = null
+        this.unloadPlaybackSource(failedPlayback, "playback start failure")
       }
       if (pending.cancelled) {
         onComplete(requestId, true, null, 0, "interrupted")
@@ -497,14 +507,9 @@ class AudioPlaybackService {
     }
     this.markAudioRouteWarm()
 
-    // Stop the player
-    if (this.player) {
-      try {
-        this.player.pause()
-      } catch (error) {
-        console.error("AUDIO: Error pausing player:", error)
-      }
-    }
+    // Pausing alone leaves the URI available to OS/Bluetooth media Play.
+    // Unload it unless a newer request has already replaced this source.
+    this.unloadPlaybackSource(playback, "interruption")
 
     // Notify native that our app stopped playing audio (debounced)
     this.notifyAudioStopDebounced()
@@ -563,6 +568,7 @@ class AudioPlaybackService {
         if (playback.suppressCloudUplink) {
           setAudioCloudUplinkSuppressed(playback.uplinkSuppressionId, false)
         }
+        this.unloadPlaybackSource(playback, "playback failure")
         playback.onComplete(playback.requestId, false, "Playback failed (player went idle)", null, "error")
         this.markAudioRouteWarm()
         this.notifyAudioStopDebounced()

--- a/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
@@ -214,6 +214,7 @@ describe("AudioPlaybackService live PCM streams", () => {
 
     expect(firstComplete).toHaveBeenCalledTimes(1)
     expect(firstComplete).toHaveBeenCalledWith("first-url", true, null, expect.any(Number), "interrupted")
+    expect(audioPlayer.replace.mock.calls).toEqual([[{uri: "file://first.wav"}], [null], [{uri: "file://second.wav"}]])
   })
 
   test("keeps native audio marked active when URL playback finishes beside a live PCM stream", async () => {
@@ -350,7 +351,70 @@ describe("AudioPlaybackService live PCM streams", () => {
     audioPlaybackService.cancelPlayback("active-tts")
 
     expect(audioPlayer.pause).toHaveBeenCalledTimes(1)
+    expect(audioPlayer.replace).toHaveBeenLastCalledWith(null)
     expect(onComplete).toHaveBeenCalledWith("active-tts", true, null, expect.any(Number), "interrupted")
+    expect(audioPlaybackService.isPlaying()).toBe(false)
+  })
+
+  test("unloads URL playback when its owning miniapp stops", async () => {
+    await audioPlaybackService.play(
+      {requestId: "stopped-tts", audioUrl: "file://speech.wav", appId: "app-one"},
+      () => {},
+    )
+
+    await audioPlaybackService.stopForApp("app-one")
+
+    expect(audioPlayer.replace).toHaveBeenLastCalledWith(null)
+    expect(audioPlaybackService.isPlaying()).toBe(false)
+  })
+
+  test("unloads a source when native playback start fails", async () => {
+    const onComplete = mock(() => {})
+    audioPlayer.play.mockImplementationOnce(() => {
+      throw new Error("native start failed")
+    })
+
+    await audioPlaybackService.play(
+      {requestId: "failed-tts", audioUrl: "file://speech.wav", appId: "app-one"},
+      onComplete,
+    )
+
+    expect(audioPlayer.replace).toHaveBeenLastCalledWith(null)
+    expect(onComplete).toHaveBeenCalledWith("failed-tts", false, "native start failed", null, "error")
+    expect(audioPlaybackService.isPlaying()).toBe(false)
+  })
+
+  test("unloads a source when the native player falls idle with an error", async () => {
+    const onComplete = mock(() => {})
+    await audioPlaybackService.play(
+      {requestId: "idle-tts", audioUrl: "file://speech.wav", appId: "app-one"},
+      onComplete,
+    )
+
+    const dateNow = spyOn(Date, "now").mockReturnValue(Date.now() + 2_000)
+    try {
+      const playbackStatusTarget = audioPlaybackService as unknown as {
+        onPlaybackStatusUpdate(status: {
+          didJustFinish: boolean
+          duration: number
+          isBuffering: boolean
+          isLoaded: boolean
+          playbackState: string
+        }): void
+      }
+      playbackStatusTarget.onPlaybackStatusUpdate({
+        didJustFinish: false,
+        duration: 0,
+        isBuffering: false,
+        isLoaded: false,
+        playbackState: "idle",
+      })
+    } finally {
+      dateNow.mockRestore()
+    }
+
+    expect(audioPlayer.replace).toHaveBeenLastCalledWith(null)
+    expect(onComplete).toHaveBeenCalledWith("idle-tts", false, "Playback failed (player went idle)", null, "error")
     expect(audioPlaybackService.isPlaying()).toBe(false)
   })
 

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -209,7 +209,8 @@
     "react-native-executorch@0.7.2": "patches/react-native-executorch@0.7.2.patch",
     "expo-speech-transcriber@0.1.9": "patches/expo-speech-transcriber@0.1.9.patch",
     "react-native-inner-shadow@2.4.0": "patches/react-native-inner-shadow@2.4.0.patch",
-    "react-native-webview@13.16.0": "patches/react-native-webview@13.16.0.patch"
+    "react-native-webview@13.16.0": "patches/react-native-webview@13.16.0.patch",
+    "expo-audio@55.0.14": "patches/expo-audio@55.0.14.patch"
   },
   "trustedDependencies": [
     "@sentry/cli",

--- a/mobile/patches/expo-audio@55.0.14.patch
+++ b/mobile/patches/expo-audio@55.0.14.patch
@@ -1,0 +1,34 @@
+diff --git a/android/src/main/java/expo/modules/audio/AudioUtils.kt b/android/src/main/java/expo/modules/audio/AudioUtils.kt
+index dca91c32a2787a7bc3ecba26f0f3f2ad9cc40d3d..4bf95c84dcf076e5e330bdaf1f1fcd49132c6bb3 100644
+--- a/android/src/main/java/expo/modules/audio/AudioUtils.kt
++++ b/android/src/main/java/expo/modules/audio/AudioUtils.kt
+@@ -3,6 +3,7 @@ package expo.modules.audio
+ import android.content.Context
+ import android.media.AudioDeviceInfo
+ import android.os.Bundle
++import androidx.media3.common.Player
+ import androidx.media3.exoplayer.ExoPlayer
+ import androidx.media3.session.MediaSession
+ import java.io.File
+@@ -34,5 +35,21 @@ fun getMapFromDeviceInfo(deviceInfo: AudioDeviceInfo): Bundle {
+ fun buildBasicMediaSession(context: Context, player: ExoPlayer): MediaSession {
+   return MediaSession.Builder(context, player)
+     .setId("ExpoAudioBasicMediaSession_${player.hashCode()}")
++    .setCallback(object : MediaSession.Callback {
++      override fun onConnect(
++        session: MediaSession,
++        controller: MediaSession.ControllerInfo
++      ): MediaSession.ConnectionResult {
++        // Mentra owns the lifecycle of short-form TTS. Hardware media keys
++        // must not pause or later resume a transient utterance.
++        return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
++          .setAvailablePlayerCommands(
++            MediaSession.ConnectionResult.DEFAULT_PLAYER_COMMANDS.buildUpon()
++              .remove(Player.COMMAND_PLAY_PAUSE)
++              .build()
++          )
++          .build()
++      }
++    })
+     .build()
+ }

--- a/mobile/src/services/AudioPlaybackService.test.ts
+++ b/mobile/src/services/AudioPlaybackService.test.ts
@@ -110,6 +110,11 @@ describe("AudioPlaybackService", () => {
     await flushAsyncVolumeGuard()
 
     expect(firstComplete).toHaveBeenCalledWith("first", true, null, expect.any(Number), "interrupted")
+    expect(mockPlayer.replace.mock.calls.slice(0, 3)).toEqual([
+      [{uri: "https://example.com/one.mp3"}],
+      [null],
+      [{uri: "https://example.com/two.mp3"}],
+    ])
     expect(BluetoothSdk.setGlassesMediaVolume).toHaveBeenCalledTimes(1)
     expect(createAudioPlayer).toHaveBeenCalledTimes(1)
 
@@ -135,6 +140,20 @@ describe("AudioPlaybackService", () => {
 
     jest.advanceTimersByTime(300)
     expect(mockPlayer.replace).toHaveBeenLastCalledWith(null)
+  })
+
+  it("unloads cancelled playback so Bluetooth media play cannot resume it", async () => {
+    const onComplete = jest.fn()
+    await audioPlaybackService.play(
+      {requestId: "cancelled", audioUrl: "https://example.com/speech.mp3", appId: "com.mentra.merge"},
+      onComplete,
+    )
+
+    audioPlaybackService.cancelPlayback("cancelled")
+
+    expect(mockPlayer.pause).toHaveBeenCalled()
+    expect(mockPlayer.replace).toHaveBeenLastCalledWith(null)
+    expect(onComplete).toHaveBeenCalledWith("cancelled", true, null, expect.any(Number), "interrupted")
   })
 
   it("starts playback without waiting for a slow glasses volume response", async () => {


### PR DESCRIPTION
## Summary

- unload reusable URL/TTS player sources when playback is interrupted, cancelled, stopped with its miniapp, or fails
- keep source cleanup guarded by playback identity so stale callbacks cannot unload newer audio
- extend engine and mobile regression coverage for cancellation, superseding playback, miniapp shutdown, native start failure, and idle failure

## Root cause

The earlier completed-playback fix only called `replace(null)` after a normal `didJustFinish` event. Interruption and error paths called `pause()` but left the URI loaded in the reusable ExoPlayer. Mentra Live double tap emits an AVRCP media Play command, which could therefore resume Merge's last interrupted TTS.

Observed in dev report `rep_01KY3FGNGVEM9EXXSS5SS4PYNQ` on Mentra App 2.12.0.

## User impact

Completed and interrupted miniapp speech can no longer be restarted by a later Bluetooth/OS media Play command. Back-to-back playback still preserves the newer source.

## Validation

- `cd mobile && bun test modules/engine/src/services/__tests__/AudioPlaybackService.test.ts` — 17 pass
- `cd mobile && bun run test -- --runInBand src/services/AudioPlaybackService.test.ts` — 5 pass
- `cd mobile && CI=true bun run test -- --runInBand` — 70 suites, 537 pass, 2 skipped
- `cd mobile && bun run compile`
- `git diff --check`

## Device validation requested

- let Merge finish or interrupt a TTS response on Mentra Live
- double tap the touchpad after speech stops
- confirm the prior TTS does not replay

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Bluetooth/OS media Play from restarting interrupted TTS by unloading sources and ignoring transport play/pause for TTS sessions.

- **Bug Fixes**
  - Added `unloadPlaybackSource` and invoke it on interruption, cancellation, miniapp stop, native start failure, idle failure, and after A2DP tail drain; cleanup is guarded by playback identity so stale callbacks can’t clear newer audio.
  - Patched `expo-audio@55.0.14` to remove `Player.COMMAND_PLAY_PAUSE` from the `MediaSession`, so AVRCP media keys can’t pause/resume short-form TTS.
  - Expanded engine and mobile tests to assert `replace(null)` on all interrupt and error paths, including miniapp stop, start failure, and idle failure.

<sup>Written for commit f945544aba1b76b760cc49230929ebcb2b72368d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Bluetooth/TTS playback lifecycle and a native expo-audio MediaSession patch; identity guards limit cross-talk between concurrent requests, but glasses behavior should be validated on device.
> 
> **Overview**
> Fixes Mentra Live double-tap (AVRCP **Play**) replaying the last interrupted or finished miniapp TTS because the shared ExoPlayer still held the URI after paths that only called `pause()`.
> 
> **`AudioPlaybackService`** adds **`unloadPlaybackSource`**, which pauses and `replace(null)` only when the playback identity still matches `loadedPlayback`, and routes interruption, cancellation, miniapp **`stopForApp`**, native start failure, idle failure, and post-tail cleanup through it. Tests assert `replace(null)` on those paths.
> 
> **`expo-audio@55.0.14`** is registered as a patched dependency; the Android patch strips **`COMMAND_PLAY_PAUSE`** from the basic MediaSession so hardware media keys cannot pause or later resume transient TTS while Mentra owns the lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f945544aba1b76b760cc49230929ebcb2b72368d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->