### PR TITLE
Preserve small-text detail in Mentra Live BLE crops

### DIFF
--- a/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/BlePhotoEncoderInstrumentedTest.java
+++ b/asg_client/app/src/androidTest/java/com/mentra/asg_client/io/media/core/BlePhotoEncoderInstrumentedTest.java
@@ -11,6 +11,7 @@ import android.graphics.Paint;
 import android.util.Log;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import com.mentra.asg_client.AsgConstants;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.ArrayList;
@@ -118,9 +119,23 @@ public class BlePhotoEncoderInstrumentedTest {
     }
 
     @Test
-    public void benchmarkCurrentAvifConfig() throws Exception {
-        // Production text-mode AVIF control: 1920px cap at quality 55.
-        runConfig("1920_avif_q55", BleCodec.AVIF, 1920, 55);
+    public void benchmarkCurrentTextModeCropConfig() throws Exception {
+        // A detected text crop preserves more spatial detail for small text.
+        runConfig(
+                "2880_jpeg_q80",
+                BleCodec.JPEG_FAST,
+                AsgConstants.TEXT_MODE_BLE_TARGET_WIDTH,
+                AsgConstants.BLE_PHOTO_JPEG_FAST_QUALITY);
+    }
+
+    @Test
+    public void benchmarkCurrentTextModeFallbackConfig() throws Exception {
+        // A full-frame fallback retains the previous BLE transfer bound.
+        runConfig(
+                "1920_jpeg_q80",
+                BleCodec.JPEG_FAST,
+                AsgConstants.TEXT_MODE_BLE_FALLBACK_TARGET_WIDTH,
+                AsgConstants.BLE_PHOTO_JPEG_FAST_QUALITY);
     }
 
     @Test

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -211,10 +211,15 @@ public class AsgConstants {
      */
     public static final int TEXT_MODE_SENSOR_CAPTURE_HEIGHT = 2160;
 
-    /** Long-edge cap for text-mode BLE downscale after crop (aspect ratio preserved). */
-    public static final int TEXT_MODE_BLE_TARGET_WIDTH = 1920;
+    /** Long-edge cap when text-mode detection produced a usable crop. */
+    public static final int TEXT_MODE_BLE_TARGET_WIDTH = 2880;
 
-    public static final int TEXT_MODE_BLE_TARGET_HEIGHT = 1920;
+    public static final int TEXT_MODE_BLE_TARGET_HEIGHT = 2880;
+
+    /** Long-edge cap when text-mode detection falls back to the full frame. */
+    public static final int TEXT_MODE_BLE_FALLBACK_TARGET_WIDTH = 1920;
+
+    public static final int TEXT_MODE_BLE_FALLBACK_TARGET_HEIGHT = 1920;
 
     /** AVIF quality for the canonical text-mode BLE payload. */
     public static final int TEXT_MODE_AVIF_QUALITY = 55;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -396,6 +396,7 @@ public class MediaCaptureService {
             if (croppedPath != null) {
                 PhotoArtifactFiles.promoteToCanonical(photoFilePath, croppedPath);
                 photoTextCropPrepared.put(requestId, true);
+                photoTextCropApplied.put(requestId, true);
                 return photoFilePath;
             }
         } catch (java.io.IOException e) {
@@ -507,6 +508,7 @@ public class MediaCaptureService {
                 }
             }
             photoTextCropPrepared.put(requestId, true);
+            photoTextCropApplied.put(requestId, wroteCrop);
             Log.i(
                     TAG,
                     wroteCrop
@@ -528,8 +530,10 @@ public class MediaCaptureService {
 
     // Track original photo paths for BLE fallback
     private Map<String, String> photoOriginalPaths = new HashMap<>();
-    // True after text mode has replaced the canonical capture with its final cropped JPEG.
+    // True after text mode has selected either a crop or the full-frame fallback for transfer.
     private Map<String, Boolean> photoTextCropPrepared = new HashMap<>();
+    // True only when the canonical text-mode selection is an actual detected-text crop.
+    private Map<String, Boolean> photoTextCropApplied = new HashMap<>();
     // Track requested photo size per request for proper fallback handling
     private Map<String, String> photoRequestedSizes = new HashMap<>();
     // Track capture mode through asynchronous WiFi-to-BLE fallback.
@@ -561,6 +565,7 @@ public class MediaCaptureService {
         photoBleIds.remove(requestId);
         photoOriginalPaths.remove(requestId);
         photoTextCropPrepared.remove(requestId);
+        photoTextCropApplied.remove(requestId);
         photoRequestedSizes.remove(requestId);
         photoRequestedModes.remove(requestId);
     }
@@ -3201,7 +3206,8 @@ public class MediaCaptureService {
      * Largest power-of-two JPEG subsampling factor that still keeps the decoded region at or above
      * the aspect-fitted BLE output, so the follow-up {@code createScaledBitmap} only ever shrinks.
      * The configured dimensions are caps, not the literal output dimensions. Decoding 4032x3024 at
-     * inSampleSize=2 cuts the ARGB working set 4x with no quality cost at a 1920px output cap.
+     * inSampleSize=2 cuts the ARGB working set 4x while preserving enough detail for the configured
+     * output cap.
      */
     static int computeBleDecodeSampleSize(
             int regionWidth, int regionHeight, int targetWidth, int targetHeight) {
@@ -5250,8 +5256,10 @@ public class MediaCaptureService {
                                     // handoff.
                                     prepareTextModePhotoPath(originalPath, requestId);
                                 }
-                                boolean textCropAlreadyPrepared =
+                                boolean textSelectionAlreadyPrepared =
                                         Boolean.TRUE.equals(photoTextCropPrepared.get(requestId));
+                                boolean textCropAlreadyApplied =
+                                        Boolean.TRUE.equals(photoTextCropApplied.get(requestId));
                                 BleParams bleParams;
                                 BleCodec codec = BlePhotoEncodingPolicy.selectCodec();
                                 logBlePhotoStep(
@@ -5259,8 +5267,10 @@ public class MediaCaptureService {
                                         "text_mode_prepare",
                                         "mode="
                                                 + requestedMode
-                                                + ", canonicalCropPrepared="
-                                                + textCropAlreadyPrepared);
+                                                + ", canonicalSelectionPrepared="
+                                                + textSelectionAlreadyPrepared
+                                                + ", canonicalCropApplied="
+                                                + textCropAlreadyApplied);
                                 boolean shouldCrop =
                                         AsgConstants.ENABLE_TEXT_REGION_CROP || textModeRequested;
                                 Log.i(
@@ -5281,8 +5291,10 @@ public class MediaCaptureService {
                                 // Human-readable verdict for whether ML Kit found a usable text
                                 // region or the transfer is preserving the full frame.
                                 String textCropOutcome =
-                                        textCropAlreadyPrepared
-                                                ? "PREPARED_CANONICAL_CROP"
+                                        textSelectionAlreadyPrepared
+                                                ? textCropAlreadyApplied
+                                                        ? "PREPARED_CANONICAL_CROP"
+                                                        : "PREPARED_FULL_FRAME_FALLBACK"
                                                 : shouldCrop
                                                         ? "NOT_ATTEMPTED (pending detection)"
                                                         : "NOT_ATTEMPTED"
@@ -5296,7 +5308,8 @@ public class MediaCaptureService {
                                 android.graphics.Rect roi = null;
                                 long cropPhaseStartMs = 0L;
                                 long cropPhaseEndMs = 0L;
-                                boolean cropAttempted = shouldCrop && !textCropAlreadyPrepared;
+                                boolean cropAttempted =
+                                        shouldCrop && !textSelectionAlreadyPrepared;
                                 if (cropAttempted) {
                                     stage.start("text-region detection");
                                     cropPhaseStartMs = System.currentTimeMillis();
@@ -5330,7 +5343,7 @@ public class MediaCaptureService {
 
                                 boolean hasUsableTextCrop =
                                         textModeRequested
-                                                && (textCropAlreadyPrepared || roi != null);
+                                                && (textCropAlreadyApplied || roi != null);
                                 bleParams =
                                         textModeRequested
                                                 ? resolveTextModeBleParams(hasUsableTextCrop)
@@ -5491,7 +5504,7 @@ public class MediaCaptureService {
                                     }
 
                                     // Decode subsampled: never materialize the ~46MB full-res
-                                    // ARGB frame when the output is capped at 1920px anyway.
+                                    // ARGB frame when the configured output cap is smaller.
                                     // The ROI (source-pixel coordinates) is mapped onto the
                                     // subsampled space so the crop lands on the same region.
                                     int regionWidth = cropWidth > 0 ? cropWidth : srcWidth;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/media/core/MediaCaptureService.java
@@ -211,10 +211,14 @@ public class MediaCaptureService {
         }
     }
 
-    private BleParams resolveTextModeBleParams() {
+    private BleParams resolveTextModeBleParams(boolean hasUsableTextCrop) {
         return new BleParams(
-                AsgConstants.TEXT_MODE_BLE_TARGET_WIDTH,
-                AsgConstants.TEXT_MODE_BLE_TARGET_HEIGHT,
+                hasUsableTextCrop
+                        ? AsgConstants.TEXT_MODE_BLE_TARGET_WIDTH
+                        : AsgConstants.TEXT_MODE_BLE_FALLBACK_TARGET_WIDTH,
+                hasUsableTextCrop
+                        ? AsgConstants.TEXT_MODE_BLE_TARGET_HEIGHT
+                        : AsgConstants.TEXT_MODE_BLE_FALLBACK_TARGET_HEIGHT,
                 AsgConstants.TEXT_MODE_AVIF_QUALITY);
     }
 
@@ -5248,29 +5252,8 @@ public class MediaCaptureService {
                                 }
                                 boolean textCropAlreadyPrepared =
                                         Boolean.TRUE.equals(photoTextCropPrepared.get(requestId));
-                                BleParams bleParams =
-                                        textModeRequested
-                                                ? resolveTextModeBleParams()
-                                                : tierBleParams;
+                                BleParams bleParams;
                                 BleCodec codec = BlePhotoEncodingPolicy.selectCodec();
-                                logBlePhotoStep(
-                                        requestId,
-                                        "compress_resolve_params",
-                                        "size="
-                                                + requestedSize
-                                                + ", mode="
-                                                + requestedMode
-                                                + ", target="
-                                                + bleParams.targetWidth
-                                                + "x"
-                                                + bleParams.targetHeight
-                                                + ", codec="
-                                                + codec
-                                                + ", quality="
-                                                + (codec == BleCodec.AVIF
-                                                        ? bleParams.avifQuality
-                                                        : AsgConstants
-                                                                .BLE_PHOTO_JPEG_FAST_QUALITY));
                                 logBlePhotoStep(
                                         requestId,
                                         "text_mode_prepare",
@@ -5278,25 +5261,6 @@ public class MediaCaptureService {
                                                 + requestedMode
                                                 + ", canonicalCropPrepared="
                                                 + textCropAlreadyPrepared);
-                                if (textModeRequested && bleParams != tierBleParams) {
-                                    Log.d(
-                                            TAG,
-                                            "Text mode: using dedicated BLE downscale "
-                                                    + bleParams.targetWidth
-                                                    + "x"
-                                                    + bleParams.targetHeight
-                                                    + " (cfg AVIF q"
-                                                    + bleParams.avifQuality
-                                                    + ") (size tier "
-                                                    + requestedSize
-                                                    + " would use "
-                                                    + tierBleParams.targetWidth
-                                                    + "x"
-                                                    + tierBleParams.targetHeight
-                                                    + " (cfg AVIF q"
-                                                    + tierBleParams.avifQuality
-                                                    + "))");
-                                }
                                 boolean shouldCrop =
                                         AsgConstants.ENABLE_TEXT_REGION_CROP || textModeRequested;
                                 Log.i(
@@ -5362,6 +5326,53 @@ public class MediaCaptureService {
                                                     + (roi != null
                                                             ? " roi=" + roi.toShortString()
                                                             : " roi=full-frame"));
+                                }
+
+                                boolean hasUsableTextCrop =
+                                        textModeRequested
+                                                && (textCropAlreadyPrepared || roi != null);
+                                bleParams =
+                                        textModeRequested
+                                                ? resolveTextModeBleParams(hasUsableTextCrop)
+                                                : tierBleParams;
+                                logBlePhotoStep(
+                                        requestId,
+                                        "compress_resolve_params",
+                                        "size="
+                                                + requestedSize
+                                                + ", mode="
+                                                + requestedMode
+                                                + ", textCropAvailable="
+                                                + hasUsableTextCrop
+                                                + ", target="
+                                                + bleParams.targetWidth
+                                                + "x"
+                                                + bleParams.targetHeight
+                                                + ", codec="
+                                                + codec
+                                                + ", quality="
+                                                + (codec == BleCodec.AVIF
+                                                        ? bleParams.avifQuality
+                                                        : AsgConstants
+                                                                .BLE_PHOTO_JPEG_FAST_QUALITY));
+                                if (textModeRequested) {
+                                    Log.d(
+                                            TAG,
+                                            "Text mode: using "
+                                                    + (hasUsableTextCrop
+                                                            ? "detected-crop"
+                                                            : "full-frame fallback")
+                                                    + " BLE downscale "
+                                                    + bleParams.targetWidth
+                                                    + "x"
+                                                    + bleParams.targetHeight
+                                                    + " (size tier "
+                                                    + requestedSize
+                                                    + " would use "
+                                                    + tierBleParams.targetWidth
+                                                    + "x"
+                                                    + tierBleParams.targetHeight
+                                                    + ")");
                                 }
 
                                 int sourceWidth = 0;

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -96,7 +96,7 @@ Capture a still photo. The handler routes through `transferMethod` to one of thr
 - Runs text-region detection and crops to the detected ROI before BLE transfer.
 - Uses a dedicated 2880 px long-edge cap after a successful text crop; the configured BLE codec and quality apply afterward (currently JPEG quality 80).
 - If detection finds no usable text region or fails, the pipeline preserves the full frame and retains the smaller 1920 px fallback cap.
-- Best results on documents, signs, and windshield VIN stickers; plain scenes may look similar to `photo` when the fallback crop is used.
+- Best results on documents, signs, and windshield VIN stickers; plain scenes may look similar to `photo` when the full-frame fallback is used.
 | `compress`           | string  | `"none"`            | Compression preset passed to capture pipeline               |
 | `flash`              | boolean | `true`              | Fire the privacy LED during capture                         |
 | `sound`              | boolean | `true`              | Play shutter sound                                          |
@@ -116,8 +116,9 @@ In `text` mode, Mentra Live captures the source JPEG using ASG text-mode sensor 
 selecting an exact Camera2 JPEG size match when available or the closest supported size otherwise.
 Text mode does not inject an AE exposure divisor; pass `aeExposureDivisor` explicitly when you
 want scan-style shorter shutter. Text-region detection and crop run on both WiFi upload and BLE
-transfer. On BLE, the crop happens before downscale. Text mode always uses the max-tier BLE
-downscale cap (1920 px), regardless of requested {@code size}.
+transfer. On BLE, the crop happens before downscale. A successful text crop uses a 2880 px
+long-edge cap; a full-frame fallback uses a 1920 px cap. Requested {@code size} does not change
+either text-mode cap.
 
 All BLE photo payloads — text mode and ordinary size-tier photos alike — encode with the single
 codec configured in `AsgConstants.BLE_PHOTO_CODEC`. There is no per-mode split: flipping this one

--- a/asg_client/docs/ASG_CLIENT_API.md
+++ b/asg_client/docs/ASG_CLIENT_API.md
@@ -93,10 +93,9 @@ Capture a still photo. The handler routes through `transferMethod` to one of thr
 **Text mode behavior**
 
 - Captures at ASG-owned sensor dimensions (`TEXT_MODE_SENSOR_CAPTURE_*`, currently 3840×2160 — Mentra Live's max 16:9 still) via an internal resolution tier — not the public `max` quality tier. Requested `size` is ignored for sensor resolution.
-- Applies shorter auto-exposure (unless `exposureTimeNs` is set manually).
-- Runs text-region detection and crops to the detected/fallback ROI before BLE transfer.
-- Uses dedicated text BLE downscale/encode targets (1920 px long edge, AVIF q55).
-- If detection is untrustworthy, the pipeline falls back to a generous center crop and logs the outcome (`confidence`, `fallback_reason`) in logcat — the photo still completes.
+- Runs text-region detection and crops to the detected ROI before BLE transfer.
+- Uses a dedicated 2880 px long-edge cap after a successful text crop; the configured BLE codec and quality apply afterward (currently JPEG quality 80).
+- If detection finds no usable text region or fails, the pipeline preserves the full frame and retains the smaller 1920 px fallback cap.
 - Best results on documents, signs, and windshield VIN stickers; plain scenes may look similar to `photo` when the fallback crop is used.
 | `compress`           | string  | `"none"`            | Compression preset passed to capture pipeline               |
 | `flash`              | boolean | `true`              | Fire the privacy LED during capture                         |


### PR DESCRIPTION
Raises successful text-mode crop output from 1920px to 2880px so small label text retains more spatial detail.
Full-frame detection fallbacks remain capped at 1920px to avoid increasing worst-case BLE transfer size, while normal photo tiers remain unchanged.
Updates text-mode logging, on-device encoder benchmark coverage, and API documentation to reflect the split policy and current JPEG path.
Validation: `./scripts/check-android-compile.sh asg` and focused `MlKitTextRoiDetectorTest` pass; the broader Android instrumentation-source compile remains blocked by the pre-existing `ZslFeasibilityProbeTest` wake-lock signature mismatch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes text-mode BLE encode dimensions and payload size on the success path in `MediaCaptureService`, but full-frame fallback stays at 1920px and non-text tiers are unchanged.
> 
> **Overview**
> **Text-mode BLE downscale** no longer uses a single 1920px cap for every transfer. When text-region detection produces a usable crop, the long-edge target moves to **2880px** so small label text keeps more detail; when detection fails or the pipeline keeps the full frame, it stays at **1920px** so worst-case BLE size does not grow.
> 
> `AsgConstants` adds explicit fallback width/height constants and raises the crop target from 1920 to 2880. `MediaCaptureService` tracks whether the canonical selection is an actual crop (`photoTextCropApplied`) versus a prepared full-frame fallback, resolves text-mode `BleParams` from that flag (and inline ROI when detection still runs), and moves compress param logging to **after** crop availability is known. Instrumented encoder benchmarks now cover **2880 JPEG q80** (crop) and **1920 JPEG q80** (fallback) instead of a single AVIF benchmark. `ASG_CLIENT_API.md` documents the split policy and current JPEG path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e19e8ffcd0928cc923b554cdb39f243e6aecc52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase text-mode BLE downscale cap to 2880 px when a detected text-region crop is available to preserve small-text detail. Full-frame fallback stays at 1920 px, so worst-case BLE payload size is unchanged.

- **New Features**
  - Uses 2880 px long edge only with a successful text crop; falls back to 1920 px for full-frame.
  - `MediaCaptureService` defers BLE param resolution until after detection and tracks/logs actual selection with `photoTextCropApplied`.
  - Updates `AsgConstants` with explicit fallback caps; splits instrumented benchmarks into 2880/1920 JPEG; refreshes API docs to reflect crop vs full-frame fallback and current JPEG q80 path.

<sup>Written for commit 4e19e8ffcd0928cc923b554cdb39f243e6aecc52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

