### PR TITLE
Run bug report agent directly from Slack

### DIFF
--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -15,6 +15,8 @@ const savedEnv = {
   CLOUD_ADMIN_CONSOLE_URL: process.env.CLOUD_ADMIN_CONSOLE_URL,
   CLOUD_REPORT_AGENT_URL: process.env.CLOUD_REPORT_AGENT_URL,
   CLOUD_REPORT_AGENT_SIGNING_SECRET: process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET,
+  CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED:
+    process.env.CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED,
 };
 const realFetch = globalThis.fetch;
 
@@ -28,6 +30,7 @@ beforeEach(() => {
   delete process.env.CLOUD_ADMIN_CONSOLE_URL;
   delete process.env.CLOUD_REPORT_AGENT_URL;
   delete process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET;
+  delete process.env.CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED;
   process.env.CLOUD_CORE_ENVIRONMENT = "test-env";
   fetchMock = mock<FetchCall>(async () => new Response("ok", { status: 200 }));
   globalThis.fetch = fetchMock as unknown as typeof fetch;
@@ -44,6 +47,10 @@ afterEach(() => {
   restoreEnv("CLOUD_ADMIN_CONSOLE_URL", savedEnv.CLOUD_ADMIN_CONSOLE_URL);
   restoreEnv("CLOUD_REPORT_AGENT_URL", savedEnv.CLOUD_REPORT_AGENT_URL);
   restoreEnv("CLOUD_REPORT_AGENT_SIGNING_SECRET", savedEnv.CLOUD_REPORT_AGENT_SIGNING_SECRET);
+  restoreEnv(
+    "CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED",
+    savedEnv.CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED,
+  );
 });
 
 describe("notifyReportSlack", () => {
@@ -118,11 +125,33 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain("*Env:*\\ntest-env");
   });
 
-  test("adds a signed one-click fix-agent button to bug reports when configured", async () => {
+  test("keeps the signed confirmation URL until Slack interactivity is enabled", async () => {
     process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
     process.env.CLOUD_CORE_ENVIRONMENT = "dev";
     process.env.CLOUD_REPORT_AGENT_URL = AGENT_URL;
     process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET = AGENT_SIGNING_SECRET;
+
+    await notifyReportSlack(bugNotification());
+
+    const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
+    const payload = JSON.parse(String(init.body)) as {
+      blocks: Array<{
+        type: string;
+        elements?: Array<{ text: { text: string }; url?: string; value?: string }>;
+      }>;
+    };
+    const action = payload.blocks.find((block) => block.type === "actions")?.elements?.[0];
+    expect(action?.text.text).toBe("Run Fix Agent");
+    expect(action?.value).toBeUndefined();
+    expect(new URL(action?.url ?? "").pathname).toBe("/actions/report");
+  });
+
+  test("adds a signed one-click fix-agent button when Slack interactivity is enabled", async () => {
+    process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
+    process.env.CLOUD_CORE_ENVIRONMENT = "dev";
+    process.env.CLOUD_REPORT_AGENT_URL = AGENT_URL;
+    process.env.CLOUD_REPORT_AGENT_SIGNING_SECRET = AGENT_SIGNING_SECRET;
+    process.env.CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED = "true";
 
     await notifyReportSlack(bugNotification());
 

--- a/cloud-v2/packages/core/src/services/report-slack.service.test.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.test.ts
@@ -118,7 +118,7 @@ describe("notifyReportSlack", () => {
     expect(blocksJson).toContain("*Env:*\\ntest-env");
   });
 
-  test("adds a signed fix-agent confirmation button to bug reports when configured", async () => {
+  test("adds a signed one-click fix-agent button to bug reports when configured", async () => {
     process.env.CLOUD_REPORTS_SLACK_WEBHOOK_URL = WEBHOOK_URL;
     process.env.CLOUD_CORE_ENVIRONMENT = "dev";
     process.env.CLOUD_REPORT_AGENT_URL = AGENT_URL;
@@ -128,11 +128,15 @@ describe("notifyReportSlack", () => {
 
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     const payload = JSON.parse(String(init.body)) as {
-      blocks: Array<{ type: string; elements?: Array<{ text: { text: string }; url: string }> }>;
+      blocks: Array<{
+        type: string;
+        elements?: Array<{ text: { text: string }; action_id: string; value: string }>;
+      }>;
     };
     const action = payload.blocks.find((block) => block.type === "actions")?.elements?.[0];
     expect(action?.text.text).toBe("Run Fix Agent");
-    const url = new URL(action?.url ?? "");
+    expect(action?.action_id).toBe("run_fix_agent");
+    const url = new URL(action?.value ?? "");
     expect(`${url.origin}${url.pathname}`).toBe(`${AGENT_URL}/actions/report`);
     expect(url.searchParams.get("reportId")).toBe("rep_TEST123");
     expect(url.searchParams.get("environment")).toBe("dev");

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -77,7 +77,8 @@ interface SlackBlock {
   elements?: Array<{
     type: "button";
     text: { type: "plain_text"; text: string; emoji: boolean };
-    url: string;
+    action_id: string;
+    value: string;
     style?: "primary" | "danger";
   }>;
 }
@@ -221,8 +222,9 @@ function buildSlackMessage(notification: ReportSlackNotification): {
         {
           type: "button",
           text: { type: "plain_text", text: "Run Fix Agent", emoji: true },
+          action_id: "run_fix_agent",
           style: "primary",
-          url: agentActionUrl,
+          value: agentActionUrl,
         },
       ],
     });
@@ -247,10 +249,10 @@ function buildSlackMessage(notification: ReportSlackNotification): {
 }
 
 /**
- * Signed, expiring link to the private agent controller. The link itself is
- * a read-only confirmation page; only its POST form queues work, so Slack's
- * unfurl crawler cannot start an agent. Bug reports are the deliberately
- * narrow MVP scope; feedback and automatic diagnostics never receive it.
+ * Signed, expiring action for the private agent controller. Slack sends the
+ * value only when a human presses the button, so unfurl crawlers cannot start
+ * an agent. Bug reports are the deliberately narrow MVP scope; feedback and
+ * automatic diagnostics never receive it.
  */
 function reportAgentActionUrl(notification: ReportSlackNotification): string | null {
   if (notification.kind !== "bug") return null;

--- a/cloud-v2/packages/core/src/services/report-slack.service.ts
+++ b/cloud-v2/packages/core/src/services/report-slack.service.ts
@@ -74,14 +74,17 @@ interface SlackBlock {
   type: string;
   text?: { type: string; text: string; emoji?: boolean };
   fields?: Array<{ type: string; text: string }>;
-  elements?: Array<{
-    type: "button";
-    text: { type: "plain_text"; text: string; emoji: boolean };
-    action_id: string;
-    value: string;
-    style?: "primary" | "danger";
-  }>;
+  elements?: SlackButton[];
 }
+
+type SlackButton = {
+  type: "button";
+  text: { type: "plain_text"; text: string; emoji: boolean };
+  style?: "primary" | "danger";
+} & (
+  | { url: string; action_id?: never; value?: never }
+  | { action_id: string; value: string; url?: never }
+);
 
 /**
  * Post a report summary to the reports Slack channel. Resolves with
@@ -216,17 +219,24 @@ function buildSlackMessage(notification: ReportSlackNotification): {
 
   const agentActionUrl = reportAgentActionUrl(notification);
   if (agentActionUrl) {
+    const agentButton: SlackButton =
+      process.env.CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED === "true"
+        ? {
+            type: "button",
+            text: { type: "plain_text", text: "Run Fix Agent", emoji: true },
+            action_id: "run_fix_agent",
+            style: "primary",
+            value: agentActionUrl,
+          }
+        : {
+            type: "button",
+            text: { type: "plain_text", text: "Run Fix Agent", emoji: true },
+            style: "primary",
+            url: agentActionUrl,
+          };
     blocks.push({
       type: "actions",
-      elements: [
-        {
-          type: "button",
-          text: { type: "plain_text", text: "Run Fix Agent", emoji: true },
-          action_id: "run_fix_agent",
-          style: "primary",
-          value: agentActionUrl,
-        },
-      ],
+      elements: [agentButton],
     });
   }
 
@@ -249,10 +259,13 @@ function buildSlackMessage(notification: ReportSlackNotification): {
 }
 
 /**
- * Signed, expiring action for the private agent controller. Slack sends the
- * value only when a human presses the button, so unfurl crawlers cannot start
- * an agent. Bug reports are the deliberately narrow MVP scope; feedback and
- * automatic diagnostics never receive it.
+ * Signed, expiring action for the private agent controller. Until Slack's
+ * Interactivity Request URL is configured, the default URL button keeps the
+ * confirmation-page fallback working. Explicitly setting
+ * CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED=true switches to a one-click
+ * action value, which Slack sends only when a human presses the button. Bug
+ * reports are the deliberately narrow MVP scope; feedback and automatic
+ * diagnostics never receive it.
  */
 function reportAgentActionUrl(notification: ReportSlackNotification): string | null {
   if (notification.kind !== "bug") return null;


### PR DESCRIPTION
## Summary

- change **Run Fix Agent** into a true Slack interactive action when explicitly enabled
- keep the signed, expiring payload as the action value
- let the private controller queue the idempotent run directly, without a browser confirmation
- preserve the existing URL/confirmation flow by default for a safe staged rollout

## Behavior

The default remains the existing signed URL button. After the Slack app's Interactivity Request URL is configured, set `CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED=true` to enable one-click actions. One click then queues the report, and repeated delivery or repeated clicks reuse the same run because the controller stores a unique action key. Agent status messages are posted in the original report thread.

## Rollout order

1. Deploy the private controller with `/slack/interactions` support.
2. Configure the reports Slack app's Interactivity Request URL as `https://dev-agent.mentraglass.com/slack/interactions`.
3. Enable `CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED=true` in Cloud V2.

The feature flag defaults off, so merging or deploying this PR before steps 2–3 cannot break the existing action.

## Validation

- `bun test packages/core/src/services/report-slack.service.test.ts` (23 passing)
- `bun run typecheck`
- private controller: `npm run check`, `npm test` (15 passing), `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches how the fix agent is triggered from Slack (signed actions, human-only delivery when interactivity is on); rollout is gated by an env flag with a safe URL-button default.
> 
> **Overview**
> Bug-report Slack messages can now emit **Run Fix Agent** as either a **URL** button (default) or a **Slack interactive** button when `CLOUD_REPORT_AGENT_SLACK_INTERACTIVITY_ENABLED=true`.
> 
> With the flag off, behavior stays on a signed link to `/actions/report` (browser confirmation, unfurl-safe). With it on, the same signed URL moves into the button `value` with `action_id: run_fix_agent` for one-click handling via Slack interactivity. A `SlackButton` union enforces URL vs action shapes, and tests cover both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa0f05110f9638c3d3c68a78faceb5e3c68e307c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->