### PR TITLE
Keep Mentra Maps clock on one line

### DIFF
--- a/miniapps/navigation/src/background/managers/DisplayManager.ts
+++ b/miniapps/navigation/src/background/managers/DisplayManager.ts
@@ -24,8 +24,10 @@ export class DisplayManager {
     map: {x: 330, y: 70, w: 150, h: 150},
     arrow: {x: 0, y: 182, w: 38, h: 38},
     // Wall-clock current time, top-LEFT (the phone's clock, sent each refresh).
-    // One firmware text line tall (see stats note below).
-    clock: {x: 0, y: 0, w: 54, h: 26},
+    // The widest 24-hour clock is 52px in the G2 font, and native adds 4px of
+    // padding on each side. Keep a little extra headroom so it never wraps into
+    // a clipped second line.
+    clock: {x: 0, y: 0, w: 64, h: 26},
     // Trip stats (distance remaining + ETA), top-RIGHT — mirrors the clock.
     // No text alignment primitive exists, so the box is positioned right and
     // the (short) text left-aligns within it. One firmware text line tall — the

--- a/miniapps/navigation/src/test/display-manager.test.ts
+++ b/miniapps/navigation/src/test/display-manager.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, test} from "bun:test"
+
+import {DisplayManager} from "../background/managers/DisplayManager"
+
+// Rendered widths from the calibrated G2 font profile. All digits except 1
+// occupy 12px; 1 occupies 8px; the colon occupies 4px.
+const G2_DIGIT_WIDTH_PX = 12
+const G2_COLON_WIDTH_PX = 4
+const G2_NATIVE_HORIZONTAL_PADDING_PX = 8
+
+describe("navigation display layout", () => {
+  test("keeps every 24-hour clock value on one G2 text line", () => {
+    const widestClockWidth = G2_DIGIT_WIDTH_PX * 4 + G2_COLON_WIDTH_PX
+    const availableTextWidth = DisplayManager.HUD.clock.w - G2_NATIVE_HORIZONTAL_PADDING_PX
+
+    expect(availableTextWidth).toBeGreaterThanOrEqual(widestClockWidth)
+  })
+})


### PR DESCRIPTION
## Summary

- widen the Mentra Maps G2 clock slot from 54px to 64px
- account for the G2 text container's native horizontal padding
- add regression coverage for the widest 24-hour clock value

## Root cause

Dev report `rep_01KY5MMR6NH88HD80SXJDBCPQH` showed the top-left clock wrapping into a clipped second line. The widest `HH:mm` value is 52px in the calibrated G2 font, but the 54px container only had 46px available after the firmware's 4px padding on each side.

## User impact

The wall clock in the Mentra Maps HUD remains readable on a single line instead of appearing clipped or malformed.

## Validation

- `bun test` (72 passing)
- `bun run build`
- `bun x tsc --noEmit`
- `bun x prettier --check src/background/managers/DisplayManager.ts src/test/display-manager.test.ts`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Mentra Maps HUD clock from wrapping or clipping by widening the G2 clock container and accounting for native padding. The clock now stays readable on one line for all 24-hour values.

- **Bug Fixes**
  - Accounted for 4px native padding per side and set `clock.w` to 64px.
  - Added a test to ensure the widest `HH:mm` value fits within the available text width.

<sup>Written for commit 8b521cea07ac832b9fb38223209d95e021041968. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

