### PR TITLE
Re-run the OTA update check when the manifest changes server-side

### DIFF
--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -50,6 +50,12 @@ export interface OtaCheckResult {
   besVersion: string | null
   /** True when the pending APK step installs an OLDER build than the glasses currently run. */
   isApkDowngrade: boolean
+  /**
+   * Raw manifest JSON (stringified) this check actually fetched, or null when the
+   * fetch failed. Lets change-watchers baseline on exactly what the check saw,
+   * instead of racing it with a second fetch of the same URL.
+   */
+  manifestBody: string | null
 }
 
 export type OtaCheckSkippedReason = "disconnected" | "missing_build"
@@ -81,6 +87,7 @@ function emptyCheckResult(skippedReason?: OtaCheckSkippedReason): OtaCheckCurren
     mtkPatch: null,
     besVersion: null,
     isApkDowngrade: false,
+    manifestBody: null,
     updateInfo: null,
     isRequired: true,
     skippedReason,
@@ -274,6 +281,7 @@ export async function checkForOtaUpdate(
       mtkPatch,
       besVersion: versionJson?.bes_firmware?.version || null,
       isApkDowngrade: apkDirection === "downgrade",
+      manifestBody: versionJson ? JSON.stringify(versionJson) : null,
     }
   } catch (error) {
     console.error("Error checking for OTA update:", error)
@@ -285,6 +293,7 @@ export async function checkForOtaUpdate(
       mtkPatch: null,
       besVersion: null,
       isApkDowngrade: false,
+      manifestBody: null,
     }
   }
 }

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useRef} from "react"
+import {useEffect, useRef, useState} from "react"
 
 import {useNavigationStore} from "@/stores/navigation"
 import {Capabilities, getModelCapabilities} from "@/../../cloud/packages/types/src"
@@ -8,6 +8,7 @@ import showAlert from "@/utils/AlertUtils"
 import {translate} from "@/i18n/translate"
 import {usePathname} from "expo-router"
 import {BgTimer, engine, type VersionInfo} from "@mentra/engine"
+import {fetchVersionInfo} from "@mentra/engine/internal"
 
 export {
   fetchVersionInfo,
@@ -21,6 +22,10 @@ export {
 function areGlassesConnectedNow(): boolean {
   return engine.ota.snapshot().connected
 }
+
+// How often to re-fetch the OTA manifest while glasses stay connected, so a
+// server-side manifest change surfaces the update prompt without a reconnect.
+const MANIFEST_POLL_INTERVAL_MS = 60_000
 
 export function OtaUpdateChecker() {
   const {push} = useNavigationStore.getState()
@@ -57,6 +62,11 @@ export function OtaUpdateChecker() {
     isDowngrade: boolean
   } | null>(null)
   const otaCheckTimeoutRef = useRef<number | null>(null)
+
+  // Bumped when the OTA manifest changes server-side; re-arms the main check
+  // effect the same way a fresh glasses connection does.
+  const [manifestGeneration, setManifestGeneration] = useState(0)
+  const manifestBaselineRef = useRef<{url: string; body: string} | null>(null)
 
   // Reset OTA check flag when glasses disconnect (allows fresh check on reconnect)
   useEffect(() => {
@@ -124,6 +134,51 @@ export function OtaUpdateChecker() {
     if (besFirmwareVersion) last.bes = besFirmwareVersion
   }, [buildNumber, mtkFirmwareVersion, besFirmwareVersion])
 
+  // Watch the OTA manifest for server-side changes while glasses stay connected.
+  // The first successful fetch (per resolved URL) is the baseline; any later
+  // difference in content resets the per-connection check latches and bumps
+  // manifestGeneration so the main check effect runs again and surfaces the
+  // same prompt flow as a fresh connection.
+  useEffect(() => {
+    if (!glassesConnected || !buildNumber || otaSnapshot.inProgress) {
+      manifestBaselineRef.current = null
+      return
+    }
+    const features: Capabilities = getModelCapabilities(defaultWearable)
+    if (!features?.hasOta) {
+      return
+    }
+
+    let cancelled = false
+    const pollManifest = async () => {
+      const url = engine.ota.snapshot().manifestUrl
+      const versionJson = await fetchVersionInfo(url)
+      if (cancelled || !versionJson) return
+      const body = JSON.stringify(versionJson)
+      const baseline = manifestBaselineRef.current
+      if (!baseline) {
+        manifestBaselineRef.current = {url, body}
+        return
+      }
+      if (baseline.url === url && baseline.body === body) return
+
+      console.log("OTA: manifest changed on server - re-arming update check")
+      manifestBaselineRef.current = {url, body}
+      pendingUpdate.current = null
+      hasCheckedOta.current = false
+      hasPromptedOta.current = false
+      hasPromptedOtaWifiSetup.current = false
+      setManifestGeneration((generation) => generation + 1)
+    }
+
+    void pollManifest() // establish the baseline right away
+    const intervalId = BgTimer.setInterval(() => void pollManifest(), MANIFEST_POLL_INTERVAL_MS)
+    return () => {
+      cancelled = true
+      BgTimer.clearInterval(intervalId)
+    }
+  }, [glassesConnected, buildNumber, otaSnapshot.inProgress, defaultWearable])
+
   // Show pending update alert when user navigates back to /home.
   const wasAwayFromHomeRef = useRef(false)
   useEffect(() => {
@@ -158,22 +213,18 @@ export function OtaUpdateChecker() {
     const updateMessage = isDowngrade
       ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${pending.updates.join(", ").toUpperCase()})` : "")
       : superMode
-      ? `Updates available: ${pending.updates.join(", ").toUpperCase()}`
-      : updateCount === 1
-      ? "1 update available"
-      : `${updateCount} updates available`
+        ? `Updates available: ${pending.updates.join(", ").toUpperCase()}`
+        : updateCount === 1
+          ? "1 update available"
+          : `${updateCount} updates available`
     pendingUpdate.current = null
     hasPromptedOta.current = true
     hasPromptedOtaWifiSetup.current = false
 
-    showAlert(
-      translate(isDowngrade ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName}),
-      updateMessage,
-      [
-        {text: translate("ota:updateLater"), style: "cancel"},
-        {text: translate("ota:install"), onPress: () => push("/ota/check-for-updates")},
-      ],
-    )
+    showAlert(translate(isDowngrade ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName}), updateMessage, [
+      {text: translate("ota:updateLater"), style: "cancel"},
+      {text: translate("ota:install"), onPress: () => push("/ota/check-for-updates")},
+    ])
   }, [pathname, glassesConnected, glassesWifiConnected, defaultWearable, superMode, push])
 
   // Main OTA check effect
@@ -211,7 +262,7 @@ export function OtaUpdateChecker() {
 
     // Delay OTA check by 500ms to allow all version_info chunks to arrive
     // (version_info_1, version_info_2, version_info_3 arrive sequentially with ~100ms gaps)
-    console.log("OTA: check scheduled - waiting 500ms for firmware version info...")
+    console.log(`OTA: check scheduled (manifest generation ${manifestGeneration}) - waiting 500ms for version info...`)
     otaCheckTimeoutRef.current = BgTimer.setTimeout(async () => {
       // Re-check conditions after delay (glasses might have disconnected)
       if (!areGlassesConnectedNow()) {
@@ -272,10 +323,10 @@ export function OtaUpdateChecker() {
           const updateMessage = isApkDowngrade
             ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${updateList})` : "")
             : superMode
-            ? `Updates available: ${updateList}`
-            : updateCount === 1
-            ? "1 update available"
-            : `${updateCount} updates available`
+              ? `Updates available: ${updateList}`
+              : updateCount === 1
+                ? "1 update available"
+                : `${updateCount} updates available`
 
           pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
 
@@ -339,6 +390,7 @@ export function OtaUpdateChecker() {
     pathname,
     push,
     superMode,
+    manifestGeneration,
   ])
 
   return null

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -140,8 +140,14 @@ export function OtaUpdateChecker() {
   // manifestGeneration so the main check effect runs again and surfaces the
   // same prompt flow as a fresh connection.
   useEffect(() => {
-    if (!glassesConnected || !buildNumber || otaSnapshot.inProgress) {
+    if (!glassesConnected || !buildNumber) {
       manifestBaselineRef.current = null
+      return
+    }
+    if (otaSnapshot.inProgress) {
+      // Pause polling during an install but keep the baseline: a manifest edit
+      // made during the install window must still re-arm the prompt if the
+      // install ends without a disconnect (failed/abandoned session).
       return
     }
     const features: Capabilities = getModelCapabilities(defaultWearable)

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -135,10 +135,12 @@ export function OtaUpdateChecker() {
   }, [buildNumber, mtkFirmwareVersion, besFirmwareVersion])
 
   // Watch the OTA manifest for server-side changes while glasses stay connected.
-  // The first successful fetch (per resolved URL) is the baseline; any later
-  // difference in content resets the per-connection check latches and bumps
-  // manifestGeneration so the main check effect runs again and surfaces the
-  // same prompt flow as a fresh connection.
+  // The baseline is the manifest body the last completed check actually fetched
+  // (set in the main check effect below), so the watcher can never disagree with
+  // what was prompted on; polls do nothing until the first check completes. A
+  // later difference in content resets the per-connection check latches and
+  // bumps manifestGeneration so the main check effect runs again and surfaces
+  // the same prompt flow as a fresh connection.
   useEffect(() => {
     if (!glassesConnected || !buildNumber) {
       manifestBaselineRef.current = null
@@ -157,15 +159,14 @@ export function OtaUpdateChecker() {
 
     let cancelled = false
     const pollManifest = async () => {
+      if (!manifestBaselineRef.current) return // no completed check yet to compare against
       const url = engine.ota.snapshot().manifestUrl
       const versionJson = await fetchVersionInfo(url)
       if (cancelled || !versionJson) return
-      const body = JSON.stringify(versionJson)
+      // Re-read after the await: a check completing mid-fetch refreshes the baseline.
       const baseline = manifestBaselineRef.current
-      if (!baseline) {
-        manifestBaselineRef.current = {url, body}
-        return
-      }
+      if (!baseline) return
+      const body = JSON.stringify(versionJson)
       if (baseline.url === url && baseline.body === body) return
 
       console.log("OTA: manifest changed on server - re-arming update check")
@@ -177,7 +178,6 @@ export function OtaUpdateChecker() {
       setManifestGeneration((generation) => generation + 1)
     }
 
-    void pollManifest() // establish the baseline right away
     const intervalId = BgTimer.setInterval(() => void pollManifest(), MANIFEST_POLL_INTERVAL_MS)
     return () => {
       cancelled = true
@@ -290,90 +290,97 @@ export function OtaUpdateChecker() {
           waitForMtkVersionMs: 0,
           refreshVersionInfo: false,
         })
-        .then(({updateAvailable, latestVersionInfo, updates, isApkDowngrade, skippedReason}) => {
-          if (skippedReason) {
-            console.log(`OTA: check skipped - ${skippedReason}`)
-            return
-          }
-          console.log(
-            `OTA: check completed - updateAvailable: ${updateAvailable}, updates: ${updates?.join(", ") || "none"}`,
-          )
-
-          if (updates.length === 0 || !latestVersionInfo) {
-            console.log("OTA: check result: No updates available")
-            return
-          }
-
-          // Verify glasses are still connected before showing alert
-          const currentlyConnected = areGlassesConnectedNow()
-          if (!currentlyConnected) {
-            console.log("OTA: update found but glasses disconnected - skipping alert")
-            return
-          }
-          if (hasPromptedOta.current) {
-            console.log("OTA: update found but prompt already shown - skipping duplicate alert")
-            return
-          }
-
-          // Only show update alert on the homepage - user may have navigated away during async check
-          if (pathnameRef.current !== "/home") {
-            console.log(`OTA: update found but not on homepage (${pathnameRef.current}) - caching for later`)
-            pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
-            return
-          }
-
-          const deviceName = defaultWearable || "Glasses"
-          // Super mode shows technical details (APK, MTK, BES), normal mode shows simple count
-          const updateCount = updates.length
-          const updateList = updates.join(", ").toUpperCase() // "APK, MTK, BES"
-          const updateMessage = isApkDowngrade
-            ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${updateList})` : "")
-            : superMode
-              ? `Updates available: ${updateList}`
-              : updateCount === 1
-                ? "1 update available"
-                : `${updateCount} updates available`
-
-          pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
-
-          if (engine.ota.snapshot().wifiConnected) {
-            console.log("OTA: Update available and glasses are on WiFi - prompting install")
-            pendingUpdate.current = null
-            hasPromptedOta.current = true
-            hasPromptedOtaWifiSetup.current = false
-            showAlert(
-              translate(isApkDowngrade ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName}),
-              updateMessage,
-              [
-                {text: translate("ota:updateLater"), style: "cancel"},
-                {text: translate("ota:install"), onPress: () => push("/ota/check-for-updates")},
-              ],
+        .then(
+          ({updateAvailable, latestVersionInfo, updates, isApkDowngrade, skippedReason, manifestUrl, manifestBody}) => {
+            if (skippedReason) {
+              console.log(`OTA: check skipped - ${skippedReason}`)
+              return
+            }
+            // Baseline the manifest watcher on exactly what this check fetched,
+            // so later polls only re-arm for content the check has not seen.
+            if (manifestUrl && manifestBody) {
+              manifestBaselineRef.current = {url: manifestUrl, body: manifestBody}
+            }
+            console.log(
+              `OTA: check completed - updateAvailable: ${updateAvailable}, updates: ${updates?.join(", ") || "none"}`,
             )
-            return
-          }
 
-          // No WiFi path: prompt user to connect/setup WiFi.
-          if (hasPromptedOtaWifiSetup.current) {
-            console.log("OTA: WiFi setup prompt already shown for pending update - skipping duplicate")
-            return
-          }
-          console.log("OTA: Update available and glasses are not on WiFi - prompting WiFi setup")
-          const wifiMessage = superMode
-            ? `Updates available: ${updateList}\n\nConnect your ${deviceName} to WiFi to install.`
-            : `${updateMessage}\n\nConnect your ${deviceName} to WiFi to install.`
-          hasPromptedOtaWifiSetup.current = true
-          showAlert(translate("ota:updateAvailable", {deviceName}), wifiMessage, [
-            {
-              text: translate("ota:updateLater"),
-              style: "cancel",
-              onPress: () => {
-                pendingUpdate.current = null // Clear pending on dismiss
-                hasPromptedOtaWifiSetup.current = false
+            if (updates.length === 0 || !latestVersionInfo) {
+              console.log("OTA: check result: No updates available")
+              return
+            }
+
+            // Verify glasses are still connected before showing alert
+            const currentlyConnected = areGlassesConnectedNow()
+            if (!currentlyConnected) {
+              console.log("OTA: update found but glasses disconnected - skipping alert")
+              return
+            }
+            if (hasPromptedOta.current) {
+              console.log("OTA: update found but prompt already shown - skipping duplicate alert")
+              return
+            }
+
+            // Only show update alert on the homepage - user may have navigated away during async check
+            if (pathnameRef.current !== "/home") {
+              console.log(`OTA: update found but not on homepage (${pathnameRef.current}) - caching for later`)
+              pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
+              return
+            }
+
+            const deviceName = defaultWearable || "Glasses"
+            // Super mode shows technical details (APK, MTK, BES), normal mode shows simple count
+            const updateCount = updates.length
+            const updateList = updates.join(", ").toUpperCase() // "APK, MTK, BES"
+            const updateMessage = isApkDowngrade
+              ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${updateList})` : "")
+              : superMode
+                ? `Updates available: ${updateList}`
+                : updateCount === 1
+                  ? "1 update available"
+                  : `${updateCount} updates available`
+
+            pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
+
+            if (engine.ota.snapshot().wifiConnected) {
+              console.log("OTA: Update available and glasses are on WiFi - prompting install")
+              pendingUpdate.current = null
+              hasPromptedOta.current = true
+              hasPromptedOtaWifiSetup.current = false
+              showAlert(
+                translate(isApkDowngrade ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName}),
+                updateMessage,
+                [
+                  {text: translate("ota:updateLater"), style: "cancel"},
+                  {text: translate("ota:install"), onPress: () => push("/ota/check-for-updates")},
+                ],
+              )
+              return
+            }
+
+            // No WiFi path: prompt user to connect/setup WiFi.
+            if (hasPromptedOtaWifiSetup.current) {
+              console.log("OTA: WiFi setup prompt already shown for pending update - skipping duplicate")
+              return
+            }
+            console.log("OTA: Update available and glasses are not on WiFi - prompting WiFi setup")
+            const wifiMessage = superMode
+              ? `Updates available: ${updateList}\n\nConnect your ${deviceName} to WiFi to install.`
+              : `${updateMessage}\n\nConnect your ${deviceName} to WiFi to install.`
+            hasPromptedOtaWifiSetup.current = true
+            showAlert(translate("ota:updateAvailable", {deviceName}), wifiMessage, [
+              {
+                text: translate("ota:updateLater"),
+                style: "cancel",
+                onPress: () => {
+                  pendingUpdate.current = null // Clear pending on dismiss
+                  hasPromptedOtaWifiSetup.current = false
+                },
               },
-            },
-            {text: translate("ota:setupWifi"), onPress: () => push("/wifi/scan")},
-          ])
-        })
+              {text: translate("ota:setupWifi"), onPress: () => push("/wifi/scan")},
+            ])
+          },
+        )
         .catch((error) => {
           console.log(`OTA: check failed with error: ${error?.message || error}`)
         })


### PR DESCRIPTION
## Scope

Stacked on #3526 (it re-uses the downgrade prompt wording introduced there and cleans up lint in the same file).

The OTA update prompt only ever fired on a fresh glasses connection: `OtaUpdateChecker` latches its check per connection, so a server-side manifest change (new release, or an exact-pin edit like the downgrade pins from #3526) went unnoticed until the glasses reconnected.

This adds a manifest watcher to `OtaUpdateChecker`:

- While glasses are connected with a known build number (and no install in progress, and the device has `hasOta`), the resolved manifest URL is fetched immediately to establish a baseline, then re-polled every 60s via `BgTimer`.
- A change in manifest content — or in the resolved URL itself (e.g. flipping the super-mode dev override) — resets the per-connection check/prompt latches and bumps a `manifestGeneration` state that re-arms the main check effect.
- From there the flow is identical to a fresh connection: `engine.ota.checkForUpdates(...)`, then the install prompt (with downgrade wording where applicable), the WiFi-setup prompt, or pending-update caching when the user is off the home screen.
- The baseline resets on disconnect, so connect-time behavior is unchanged.

Also includes Prettier auto-fixes for pre-existing lint errors in this file (nested ternary indentation, `showAlert` call shape) that came in with the downgrade UI commit on the base branch.

## Test evidence

- `bun compile` (tsc) passes
- `bun run test`: 66 suites / 523 tests pass
- `eslint src/effects/OtaUpdateChecker.tsx` clean (one pre-existing `import/no-named-as-default` warning)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds background manifest polling and re-arms user-facing OTA prompts; logic is gated on connection, `hasOta`, and install state, but duplicate or missed prompts depend on baseline/compare correctness.
> 
> **Overview**
> **OTA prompts no longer require a glasses reconnect** when the manifest is updated on the server. While connected, `OtaUpdateChecker` polls the resolved manifest URL every 60s (paused during install) and compares it to a baseline taken from the last completed `checkForUpdates` fetch.
> 
> The engine now returns **`manifestBody`** (stringified manifest from that check) alongside **`manifestUrl`**, so the watcher does not race a second fetch against what the user was already prompted on. When URL or body changes, per-connection check/prompt latches reset and **`manifestGeneration`** re-triggers the existing home-screen check and install/WiFi/pending-update flow.
> 
> Disconnect still clears the baseline; connect-time behavior is unchanged. Includes minor Prettier fixes in the same effect file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9e22938e89c9158620b38422a5d7dfe16b55997. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->