### PR TITLE
Fix stale NavInterceptor swallowing navigation after swipe-exit from offline apps

### DIFF
--- a/mobile/src/effects/Compositor.tsx
+++ b/mobile/src/effects/Compositor.tsx
@@ -38,14 +38,13 @@ import LocalMiniappView from "@/components/miniapp/LocalMiniappView"
 import OfflineAppHost from "@/components/miniapp/OfflineAppHost"
 import {isOfflineHosted} from "@/components/miniapp/offlineHostedPackages"
 import {captureScreenshot} from "@/effects/CapsuleMenu"
-import {engine, useForegroundApp} from "@mentra/engine"
+import {engine, useForegroundApp, SETTINGS, useSetting} from "@mentra/engine"
 import {Screen} from "@/components/ignite/Screen"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
 import {appSwitcherProgress, OPEN_SPRING, SWIPE_DISTANCE_THRESHOLD, SWIPE_PERCENT_THRESHOLD} from "@/stores/appSwitcher"
 import {useNavigationStore} from "@/stores/navigation"
 import {hapticBuzz} from "@/utils/utils"
 import CrustModule from "@mentra/crust"
-import {SETTINGS, useSetting} from "@mentra/engine"
 const EDGE_HIT_WIDTH = 24
 // Distance past which a slow drag commits the back gesture (fraction of screen
 // width). UIKit's interactive pop commits at ~50%; we sit a hair under that.
@@ -154,6 +153,13 @@ export default function Compositor() {
     captureScreenshot(viewShotRef, foregroundApp?.packageName ?? "", insets.top)
   }, [foregroundApp?.packageName, insets.top])
 
+  // Exit for the swipe-commit paths: the screenshot was already captured at
+  // commit time (while the overlay was still mounted — the CLOSE effect
+  // unmounts swipe exits immediately, so capturing here would race teardown).
+  const finishSwipeExit = useCallback(() => {
+    engine.miniapps.clearForeground()
+  }, [])
+
   const swipeTranslateX = useSharedValue(0)
   const swipeTranslateY = useSharedValue(0)
   const fadeOpacity = useSharedValue(0)
@@ -165,6 +171,12 @@ export default function Compositor() {
 
   const markSwipedToExit = () => {
     didSwipeToExit.current = true
+    // Swipe exits bypass OfflineAppHost's beginExit(), so the host never gets
+    // to stand its NavInterceptor down itself. Clear it here so pushes landing
+    // during the exit spring reach the real router instead of the dying host's
+    // internal stack. (Identity-guarded cleanups make this safe: the host's
+    // unmount cleanup only clears an interceptor that is still its own.)
+    useNavigationStore.getState().setInterceptor(null)
   }
 
   const swipeGesture = Gesture.Pan()
@@ -197,11 +209,15 @@ export default function Compositor() {
         // is seamless. Clamp the seed so a violent flick doesn't overshoot.
         const velocity = Math.min(Math.max(e.velocityX, 0), MAX_COMMIT_VELOCITY)
         runOnJS(markSwipedToExit)()
+        // Capture the app-switcher card now, while the overlay is guaranteed
+        // mounted for the whole spring (the swipe exit unmounts right after
+        // clearForeground, unlike the button close's slide-out grace period).
+        runOnJS(handleShouldCapture)()
         swipeTranslateX.value = withSpring(
           screenWidth,
           {damping: 50, stiffness: 800, velocity, overshootClamping: true},
           (finished) => {
-            if (finished) runOnJS(handleBack)()
+            if (finished) runOnJS(finishSwipeExit)()
           },
         )
 
@@ -354,7 +370,17 @@ export default function Compositor() {
   useEffect(() => {
     if (isForeground) return
     openedPackageRef.current = null // allow the next open to re-trigger the slide
-    if (didSwipeToExit.current) return
+    if (didSwipeToExit.current) {
+      // The swipe gesture already drove the overlay off-screen (edge swipe) or
+      // faded it out (switcher swipe-up) before clearing foreground — unmount
+      // immediately. Skipping the unmount here left renderedApp set forever:
+      // the host stayed mounted invisibly, and for offline-hosted apps its
+      // still-registered NavInterceptor silently swallowed every later push()
+      // to a route it owns (e.g. home's glasses card → /miniapps/settings/main
+      // after swiping out of Settings).
+      setRenderedApp(null)
+      return
+    }
     fadeOpacity.value = 1
     fadeScale.value = 1
     swipeTranslateX.value = withTiming(

--- a/mobile/src/stores/navigation.ts
+++ b/mobile/src/stores/navigation.ts
@@ -70,7 +70,10 @@ export const useNavigationStore = create<NavigationState>((set, get) => ({
   interceptor: null,
 
   push: (path, params) => {
-    if (get().interceptor?.push(path, params)) return
+    if (get().interceptor?.push(path, params)) {
+      console.info("NAV: push() intercepted", path)
+      return
+    }
     console.info("NAV: push()", path)
     const {history, historyParams, _resetAnimationDelayed} = get()
     if (history[history.length - 1] === path) return
@@ -87,7 +90,10 @@ export const useNavigationStore = create<NavigationState>((set, get) => ({
   },
 
   replace: (path, params) => {
-    if (get().interceptor?.replace(path, params)) return
+    if (get().interceptor?.replace(path, params)) {
+      console.info("NAV: replace() intercepted", path)
+      return
+    }
     console.info("NAV: replace()", path)
     const {history, historyParams, _resetAnimationDelayed} = get()
     set({
@@ -107,7 +113,10 @@ export const useNavigationStore = create<NavigationState>((set, get) => ({
   },
 
   goBack: () => {
-    if (get().interceptor?.goBack()) return
+    if (get().interceptor?.goBack()) {
+      console.info("NAV: goBack() intercepted")
+      return
+    }
     console.log("NAV: goBack()")
     const {history, historyParams, _resetAnimationDelayed} = get()
     const currentPath = history[history.length - 1]


### PR DESCRIPTION
## Scope

Fixes a navigation dead-end: after swiping out of an offline-hosted app (Settings, Gallery, Mirror, Feedback), tapping the home screen's glasses card — or anything else pushing a route the offline app owns, e.g. `/miniapps/settings/main` — silently did nothing. No error, no log, no navigation. Reproduced on-device via idevicesyslog.

## Root cause

Swipe-to-exit was the one exit path that never tore the offline-app host down:

- The edge-swipe / swipe-up-to-switcher commit paths set `didSwipeToExit` and call `clearForeground()` directly, bypassing `OfflineAppHost.beginExit()` — so the host's `activeRef` stayed `true`.
- The Compositor's CLOSE effect early-returns when `didSwipeToExit` is set, so `setRenderedApp(null)` never ran. The host stayed mounted invisibly forever, its unmount cleanup never fired, and its `NavInterceptor` stayed registered in the navigation store.
- Every later `push()` to a route in the app's route table hit the stale interceptor, which "handled" it on the orphaned internal stack (top of stack was already `/miniapps/settings/main`, so not even a re-render) and returned `true` — the real router never saw the call, and nothing was logged.

Non-swipe exits (capsule house/X, hardware back) go through `beginExit()` + the animated close, which unmounts and cleans up correctly. Regular miniapps (`LocalMiniappView`) never register an interceptor, which is why they were unaffected.

## Fix

- **Compositor CLOSE effect**: unmount the overlay immediately on swipe exits instead of early-returning — the gesture already drove it off-screen (edge swipe) or faded it out (switcher swipe-up). Unmount runs the host's existing identity-guarded cleanup, clearing the interceptor.
- **Swipe commit** (`markSwipedToExit`): stand the interceptor down right away, so a push landing during the ~200 ms exit spring can't be swallowed either.
- **Edge-swipe screenshot**: capture the app-switcher card at commit time, while the overlay is still guaranteed mounted, instead of after the spring — `captureRef` is async and would otherwise race the now-immediate unmount. (The swipe-up path already captured at gesture begin.)
- **Navigation store**: log `NAV: push()/replace()/goBack() intercepted` so a swallowed navigation is never silent again.

Deliberately untouched: interceptor registration and internal-route handling while an offline app is genuinely foregrounded, and the `activeRef` mechanism (the transient-`foregrounded`-flag protection it exists for — this change never reads that flag).

## Test evidence

- `bun compile`: exactly 55 errors both with and without this change (all pre-existing, e.g. `@mentra/crust` module resolution).
- `bun lint`: no findings on any changed line (repo baseline is not lint-clean; formatter churn on unrelated files was reverted, keeping only a duplicate-import merge in Compositor.tsx).
- No existing unit tests cover Compositor or the navigation store.

### On-device checklist (open)

- [ ] Swipe out of Settings → glasses card navigates (`NAV: push()` in syslog)
- [ ] Internal navigation while Settings is open still lands on the host's stack (main → appearance, back-swipe pops)
- [ ] Capsule X and hardware-back exits unaffected
- [ ] App-switcher card shows a fresh Settings screenshot after an edge-swipe exit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches foreground miniapp lifecycle and global navigation interception—high user impact if wrong, but changes are narrowly scoped to swipe-exit teardown and logging.
> 
> **Overview**
> Fixes a **silent navigation dead-end** after swiping out of offline-hosted apps (Settings, etc.): later `push()` calls to routes those apps own were swallowed by a stale `NavInterceptor` because the Compositor overlay never unmounted on swipe exits.
> 
> **Compositor:** On swipe-to-exit, the CLOSE effect now calls `setRenderedApp(null)` immediately (gesture already hid the overlay) so `OfflineAppHost` tears down and clears its interceptor. `markSwipedToExit` also calls `setInterceptor(null)` so navigation during the exit spring isn’t intercepted. Edge-swipe commit captures the app-switcher screenshot at commit time and uses `finishSwipeExit` (clear foreground only) after the spring—avoiding a race with immediate unmount and duplicate capture from `handleBack`.
> 
> **Navigation store:** When `push` / `replace` / `goBack` are handled by an interceptor, logs `NAV: … intercepted` so swallowed navigation isn’t silent.
> 
> Minor import consolidation in `Compositor.tsx` (`SETTINGS`, `useSetting` merged into the main `@mentra/engine` import).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8726b34bf64177e06e8405ab1c6525cdc14fc051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->