### PR TITLE
Guard live UART recovery during file transfer

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2196,6 +2196,17 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     || generation != recoveryProbeGeneration) {
                 return;
             }
+            if (isFileTransferInProgress()) {
+                runtimeBaudRecoveryInProgress = false;
+                runtimeBaudRecoveryGeneration++;
+                uartDiscardedBytesSinceValidFrame = 0;
+                uartDiscardEventsSinceValidFrame = 0;
+                cancelRuntimeBaudRecoveryLocked();
+                scheduleHighBaudHealthCheckLocked(
+                        AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS);
+                Log.i(BAUD_TAG, "Stopping UART recovery because a file transfer is active");
+                return;
+            }
             if (comManager.isOtaUpdating() || baudSwitchWaitingSrBaud || baudProbePending) {
                 scheduleRuntimeBaudRecoveryLocked(
                         generation, AsgConstants.UART_RUNTIME_RECOVERY_RETRY_DELAY_MS);
@@ -2207,7 +2218,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 uartDiscardedBytesSinceValidFrame = 0;
                 uartDiscardEventsSinceValidFrame = 0;
                 cancelRuntimeBaudRecoveryLocked();
-                scheduleHighBaudHealthCheckLocked(AsgConstants.UART_HIGH_BAUD_IDLE_PROBE_MS);
                 Log.e(
                         BAUD_TAG,
                         "Runtime recovery scan found no valid UART frame; remaining at preferred "
@@ -2604,13 +2614,19 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             fileName = fileName.substring(0, 16); // Truncate to 16 chars max
         }
 
-        currentFileTransfer =
-                new FileTransferSession(
-                        filePath,
-                        fileName,
-                        fileData,
-                        effectiveUartPackSize(),
-                        besWireCapsFilePayloadV2);
+        synchronized (baudSwitchLock) {
+            if (runtimeBaudRecoveryInProgress) {
+                Log.w(TAG, "Cannot start file transfer while UART recovery is active");
+                return false;
+            }
+            currentFileTransfer =
+                    new FileTransferSession(
+                            filePath,
+                            fileName,
+                            fileData,
+                            effectiveUartPackSize(),
+                            besWireCapsFilePayloadV2);
+        }
         pendingPackets.clear();
         consecutiveFailures = 0; // Reset failure counter for new transfer
         pendingFailureRetryIndex = -1;


### PR DESCRIPTION
## Summary

- reject a file transfer that races with an active UART recovery scan
- stop a queued recovery step if a transfer has already become active
- do not restart a fully exhausted high/default/high scan until new UART evidence arrives

## Context

This addresses the two actionable automated review findings that arrived immediately after #3542 auto-merged. The file-transfer session and recovery state are now coordinated under the same lock, so a baud reopen cannot begin in the middle of an active transfer. A silent BES gets one bounded scan; later valid or corrupt UART input can trigger fresh recovery, but silence alone no longer loops indefinitely.

## Validation

- focused UART policy, parser, and wire-format unit tests
- `./gradlew assembleDebug`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 07daffc9e1f27c672b5b5067f545972eff34f77d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarded runtime UART recovery during file transfers to prevent conflicts and stalls. Transfers won't start while recovery runs, and recovery pauses when a transfer is active; scans no longer loop on silence.

- **Bug Fixes**
  - Coordinate file transfers and UART recovery under `baudSwitchLock`; reject starting a transfer when `runtimeBaudRecoveryInProgress` is true.
  - If a transfer is active, stop the recovery step, cancel it, and schedule a deferred health check to avoid baud reopen mid-transfer.
  - Do not restart a fully exhausted high/default/high scan; wait for new UART evidence before retrying.

<sup>Written for commit 07daffc9e1f27c672b5b5067f545972eff34f77d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3543?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

