### PR TITLE
Fix Android gallery preview performance and details controls

### DIFF
--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
@@ -1,10 +1,12 @@
-import {fireEvent, render} from "@testing-library/react-native"
+import {act, fireEvent, render} from "@testing-library/react-native"
+import {Modal, Platform} from "react-native"
 
 import {PhotoInfo} from "@/types/asg"
 
 import {AwesomeGalleryViewer, CustomOverlay} from "./AwesomeGalleryViewer"
 
 let mockGalleryProps: Record<string, unknown> = {}
+let mockImageProps: Record<string, unknown> = {}
 
 jest.mock("@gorhom/bottom-sheet", () => ({
   __esModule: true,
@@ -15,13 +17,40 @@ jest.mock("@/components/ignite/Icon", () => {
   const {Text} = require("react-native")
   return {Icon: ({name}: {name: string}) => React.createElement(Text, null, name)}
 })
-jest.mock("expo-image", () => ({Image: () => null}))
-jest.mock("./MediaMetadataSheet", () => ({MediaMetadataSheet: () => null}))
+jest.mock("expo-image", () => ({
+  Image: (props: Record<string, unknown>) => {
+    mockImageProps = props
+    return null
+  },
+}))
+jest.mock("./MediaMetadataSheet", () => ({
+  MediaMetadataSheet: ({
+    bottomSheetRef,
+    onChange,
+  }: {
+    bottomSheetRef: {current: unknown}
+    onChange: (index: number) => void
+  }) => {
+    const React = require("react")
+    React.useImperativeHandle(
+      bottomSheetRef,
+      () => ({
+        close: () => onChange(-1),
+        snapToIndex: (index: number) => onChange(index),
+      }),
+      [onChange],
+    )
+    return null
+  },
+}))
 jest.mock("react-native-awesome-gallery", () => {
   const React = require("react")
   const MockGallery = React.forwardRef((props: Record<string, unknown>, _ref: unknown) => {
     mockGalleryProps = props
-    return null
+    const data = props.data as unknown[]
+    const index = props.initialIndex as number
+    const renderItem = props.renderItem as jest.Mock
+    return renderItem({item: data[index], index, setImageDimensions: jest.fn()})
   })
   MockGallery.displayName = "MockGallery"
   return {
@@ -33,6 +62,11 @@ jest.mock("react-native-vector-icons/MaterialCommunityIcons", () => () => null)
 jest.mock("react-native-video", () => () => null)
 
 describe("CustomOverlay", () => {
+  beforeEach(() => {
+    mockGalleryProps = {}
+    mockImageProps = {}
+  })
+
   it("exposes visible toolbar actions for closing, details, and sharing", () => {
     const onClose = jest.fn()
     const onDetails = jest.fn()
@@ -71,5 +105,40 @@ describe("CustomOverlay", () => {
     expect(mockGalleryProps).toMatchObject({pinchEnabled: true, doubleTapEnabled: true})
     expect(mockGalleryProps).not.toHaveProperty("onTranslationYChange")
     expect(mockGalleryProps).not.toHaveProperty("onPanStart")
+  })
+
+  it("uses viewport-sized image decoding on Android while preserving iOS full-resolution zoom", () => {
+    const originalPlatform = Platform.OS
+    const photo = {name: "photo.jpg", url: "file:///photo.jpg", is_video: false} as PhotoInfo
+
+    try {
+      Object.defineProperty(Platform, "OS", {configurable: true, value: "android"})
+      render(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={jest.fn()} />)
+      expect(mockImageProps.allowDownscaling).toBe(true)
+
+      Object.defineProperty(Platform, "OS", {configurable: true, value: "ios"})
+      render(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={jest.fn()} />)
+      expect(mockImageProps.allowDownscaling).toBe(false)
+    } finally {
+      Object.defineProperty(Platform, "OS", {configurable: true, value: originalPlatform})
+    }
+  })
+
+  it("removes the overlapping toolbar and closes details before closing the viewer", () => {
+    const onClose = jest.fn()
+    const photo = {name: "photo.jpg", url: "file:///photo.jpg", is_video: false} as PhotoInfo
+    const {getByLabelText, queryByLabelText, UNSAFE_getByType} = render(
+      <AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={onClose} />,
+    )
+
+    fireEvent.press(getByLabelText("Show media details"))
+    expect(queryByLabelText("Close media viewer")).toBeNull()
+
+    act(() => UNSAFE_getByType(Modal).props.onRequestClose())
+    expect(getByLabelText("Close media viewer")).toBeTruthy()
+    expect(onClose).not.toHaveBeenCalled()
+
+    act(() => UNSAFE_getByType(Modal).props.onRequestClose())
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
@@ -8,7 +8,7 @@ import BottomSheet from "@gorhom/bottom-sheet"
 import {Image} from "expo-image"
 import {useState, useRef, useEffect, useCallback, useMemo, memo, type ElementRef} from "react"
 // eslint-disable-next-line no-restricted-imports
-import {View, TouchableOpacity, Modal, StatusBar, Text, useWindowDimensions} from "react-native"
+import {View, TouchableOpacity, Modal, Platform, StatusBar, Text, useWindowDimensions} from "react-native"
 import Gallery, {GalleryRef} from "react-native-awesome-gallery"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons"
@@ -369,7 +369,9 @@ const ImageItem = memo(function ImageItem({
         priority="high"
         cachePolicy="memory-disk"
         transition={100}
-        allowDownscaling={false}
+        // Full-size glasses photos decode into very large Android bitmaps. Let
+        // Expo Image size them for the viewport there; keep iOS zoom fidelity.
+        allowDownscaling={Platform.OS === "android"}
         onLoad={(e) => {
           // Report dimensions back to Gallery for proper scaling - only once
           if (e.source?.width && e.source?.height && !hasReportedDimensions.current) {
@@ -446,27 +448,19 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
   const galleryRef = useRef<GalleryRef>(null)
   const metadataSheetRef = useRef<BottomSheet>(null)
 
-  console.log("🎨 [AwesomeGalleryViewer] === RENDER START ===")
-  console.log("🎨 [AwesomeGalleryViewer] visible:", visible)
-  console.log("🎨 [AwesomeGalleryViewer] photos.length:", photos.length)
-  console.log("🎨 [AwesomeGalleryViewer] initialIndex:", initialIndex)
-  console.log(
-    "🎨 [AwesomeGalleryViewer] photos:",
-    photos.map((p) => ({name: p.name, isVideo: p.is_video})),
-  )
-
   // Reset index when modal opens
   useEffect(() => {
     if (visible) {
-      console.log("🎨 [AwesomeGalleryViewer] Modal opened, setting index to:", initialIndex)
       setCurrentIndex(initialIndex)
       setIsMetadataOpen(false)
       metadataSheetRef.current?.close()
       // Reset gallery to initial position
-      setTimeout(() => {
+      const resetTimer = setTimeout(() => {
         galleryRef.current?.setIndex(initialIndex, false)
       }, 50)
+      return () => clearTimeout(resetTimer)
     }
+    return undefined
   }, [visible, initialIndex])
 
   const recordDimensions = useCallback((name: string, dimensions: MediaDimensions) => {
@@ -494,15 +488,6 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
 
       const isActiveItem = index === currentIndex
 
-      console.log(
-        "🎨 [AwesomeGalleryViewer] Rendering item:",
-        item.name,
-        "isVideo:",
-        isVideo,
-        "isActive:",
-        isActiveItem,
-      )
-
       if (isVideo) {
         return (
           <VideoPlayerItem
@@ -529,25 +514,44 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
   // Memoized keyExtractor
   const keyExtractor = useCallback((item: PhotoInfo, index: number) => `${item.name}-${index}`, [])
 
+  const handleIndexChange = useCallback((newIndex: number) => {
+    setCurrentIndex(newIndex)
+  }, [])
+
+  const handleRequestClose = useCallback(() => {
+    if (isMetadataOpen) {
+      metadataSheetRef.current?.close()
+      return
+    }
+    onClose()
+  }, [isMetadataOpen, onClose])
+
+  const handleShowDetails = useCallback(() => {
+    metadataSheetRef.current?.snapToIndex(0)
+  }, [])
+
+  const handleMetadataChange = useCallback((index: number) => {
+    setIsMetadataOpen(index >= 0)
+  }, [])
+
   if (!visible || photos.length === 0) {
     return null
   }
 
   return (
-    <Modal visible={visible} transparent={false} animationType="fade" onRequestClose={onClose} statusBarTranslucent>
+    <Modal
+      visible={visible}
+      transparent={false}
+      animationType="fade"
+      onRequestClose={handleRequestClose}
+      statusBarTranslucent>
       <StatusBar hidden />
       <Gallery
         ref={galleryRef}
         data={photos}
         initialIndex={initialIndex}
-        onIndexChange={(newIndex) => {
-          console.log("🎨 [AwesomeGalleryViewer] Index changed to:", newIndex, photos[newIndex]?.name)
-          setCurrentIndex(newIndex)
-        }}
-        onSwipeToClose={() => {
-          console.log("🎨 [AwesomeGalleryViewer] Swipe to close triggered")
-          onClose()
-        }}
+        onIndexChange={handleIndexChange}
+        onSwipeToClose={onClose}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
         numToRender={3}
@@ -560,27 +564,24 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
         disableVerticalSwipe={isMetadataOpen}
         disableTransitionOnScaledImage={true}
         loop={false}
-        onTap={() => {
-          console.log("🎨 [AwesomeGalleryViewer] Gallery tapped")
-        }}
       />
 
       {/* Custom overlay */}
-      <CustomOverlay
-        onClose={onClose}
-        currentIndex={currentIndex}
-        total={photos.length}
-        onDetails={() => metadataSheetRef.current?.snapToIndex(0)}
-        onShare={onShare ? () => onShare(photos[currentIndex]) : undefined}
-      />
+      {!isMetadataOpen && (
+        <CustomOverlay
+          onClose={onClose}
+          currentIndex={currentIndex}
+          total={photos.length}
+          onDetails={handleShowDetails}
+          onShare={onShare ? () => onShare(photos[currentIndex]) : undefined}
+        />
+      )}
 
       <MediaMetadataSheet
         bottomSheetRef={metadataSheetRef}
         photo={photos[currentIndex]}
         dimensions={mediaDimensions[photos[currentIndex].name]}
-        onChange={(index) => {
-          setIsMetadataOpen(index >= 0)
-        }}
+        onChange={handleMetadataChange}
       />
     </Modal>
   )

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -533,7 +533,7 @@ export function GalleryScreen() {
   )
 
   // Handle photo sharing — copies to cache dir for Android FileProvider compatibility
-  const handleSharePhoto = async (photo: PhotoInfo) => {
+  const handleSharePhoto = useCallback(async (photo: PhotoInfo) => {
     if (!photo) {
       console.error("No photo provided to share")
       return
@@ -589,7 +589,7 @@ export function GalleryScreen() {
       console.error("Error sharing photo:", error)
       showAlert("Error", "Failed to share. Please try again.", [{text: translate("common:ok")}])
     }
-  }
+  }, [])
 
   // Handle sync button press - delegate to the island gallery service.
   const handleSyncPress = async () => {
@@ -954,6 +954,18 @@ export function GalleryScreen() {
 
     return items
   }, [syncState, syncQueue, downloadedPhotos])
+
+  const viewerPhotos = useMemo(
+    () => allPhotos.map((item) => item.photo).filter((photo): photo is PhotoInfo => photo !== undefined),
+    [allPhotos],
+  )
+  const selectedPhotoIndex = useMemo(
+    () => (selectedPhoto ? viewerPhotos.findIndex((photo) => photo.name === selectedPhoto.name) : -1),
+    [selectedPhoto, viewerPhotos],
+  )
+  const closeMediaViewer = useCallback(() => {
+    setSelectedPhoto(null)
+  }, [])
 
   // Create placeholder items during initial load (only if loading is taking a while)
   const placeholderItems = useMemo(() => {
@@ -1432,35 +1444,16 @@ export function GalleryScreen() {
         {renderStatusBar()}
 
         {/* Gallery viewer - direct open (no floating transition) */}
-        {selectedPhoto &&
-          (() => {
-            // Calculate the actual index in the flattened photos array
-            // GalleryItem.index includes sync queue offsets, so we need to find the real position
-            const flatPhotos = allPhotos.map((item) => item.photo).filter((p): p is PhotoInfo => p !== undefined)
-            const actualIndex = flatPhotos.findIndex((p) => p?.name === selectedPhoto.name)
-
-            if (actualIndex === -1) {
-              console.error("[GalleryScreen] ❌ Selected photo not found in photos array:", selectedPhoto.name)
-              return null
-            }
-
-            console.log("[GalleryScreen] 🎬 Rendering MediaViewer with", flatPhotos.length, "photos")
-            console.log("[GalleryScreen] 🎬 actualIndex for", selectedPhoto.name, ":", actualIndex)
-
-            return (
-              <MediaViewer
-                visible={true}
-                photo={selectedPhoto}
-                photos={flatPhotos}
-                initialIndex={actualIndex}
-                onClose={() => {
-                  console.log("[GalleryScreen] 🎬 MediaViewer closed by user")
-                  setSelectedPhoto(null)
-                }}
-                onShare={handleSharePhoto}
-              />
-            )
-          })()}
+        {selectedPhoto && selectedPhotoIndex >= 0 && (
+          <MediaViewer
+            visible={true}
+            photo={selectedPhoto}
+            photos={viewerPhotos}
+            initialIndex={selectedPhotoIndex}
+            onClose={closeMediaViewer}
+            onShare={handleSharePhoto}
+          />
+        )}
       </View>
     </>
   )

--- a/mobile/src/components/glasses/Gallery/MediaViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaViewer.tsx
@@ -3,6 +3,8 @@
  * Handles both images and videos with smooth 60fps swiping
  */
 
+import {memo} from "react"
+
 import {PhotoInfo} from "@/types/asg"
 
 import {AwesomeGalleryViewer} from "./AwesomeGalleryViewer"
@@ -17,7 +19,7 @@ interface MediaViewerProps {
   onDelete?: () => void
 }
 
-export function MediaViewer({
+export const MediaViewer = memo(function MediaViewer({
   visible,
   photo,
   photos,
@@ -30,14 +32,7 @@ export function MediaViewer({
   const isGalleryMode = photos && photos.length > 0
   const displayPhotos = isGalleryMode ? photos : photo ? [photo] : []
 
-  console.log("📺 [MediaViewer] === RENDER ===")
-  console.log("📺 [MediaViewer] visible:", visible)
-  console.log("📺 [MediaViewer] isGalleryMode:", isGalleryMode)
-  console.log("📺 [MediaViewer] displayPhotos.length:", displayPhotos.length)
-  console.log("📺 [MediaViewer] initialIndex:", initialIndex)
-
   if (displayPhotos.length === 0) {
-    console.log("📺 [MediaViewer] No photos to display")
     return null
   }
 
@@ -51,4 +46,4 @@ export function MediaViewer({
       onShare={onShare}
     />
   )
-}
+})


### PR DESCRIPTION
## Summary

- Decode full-size glasses photos to the viewport on Android while preserving full-resolution zoom behavior on iOS.
- Keep gallery viewer inputs stable across background gallery-status updates and remove render-path diagnostic logging.
- Hide the preview toolbar while media details are open and make Android back close the details sheet before closing the viewer.
- Add regression coverage for Android image decoding and details-sheet back behavior.

## Root cause

Report `rep_01KY62DT5FWKM9APK6NKT0MQK7` showed repeated viewer/item renders while two multi-megabyte glasses photos were open. The preview explicitly disabled Expo Image downscaling on every platform, so Android decoded full-resolution bitmaps for screen-sized previews. Parent gallery updates also rebuilt the viewer photo array and callbacks, causing otherwise unrelated status changes to propagate into the modal.

The details bottom sheet shared the modal with a persistent translucent toolbar. At the expanded snap point the sheet rendered beneath that toolbar, while its backdrop intercepted the toolbar's back control.

## User impact

Android gallery previews use substantially smaller decoded bitmaps and no longer rerender for unrelated parent status changes. Media details no longer overlap the toolbar, and Android back dismisses details before leaving the preview.

## Validation

- `bun run compile`
- Targeted ESLint on the four changed gallery files (zero errors)
- Gallery viewer regression suite: 5 passed
- Full mobile Jest suite: 71 suites passed, 542 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit fe08c8fc6f34233fe07ce33a0b4ce4578d47cf58. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Android gallery preview performance and fixes the details sheet/back behavior in the media viewer. Addresses Linear report 01KY62DT where large photos caused heavy decoding and repeated renders.

- **Bug Fixes**
  - Android: enable viewport-sized decoding by setting `expo-image` `allowDownscaling` on Android; iOS keeps full‑res zoom.
  - Stabilized viewer props/handlers and memoized data to prevent rerenders from parent gallery updates; removed debug logs.
  - Hide the preview toolbar while details are open; Android back now closes details first, then the viewer.
  - Reset initial index safely on open with cleanup; memoized index/change handlers; made `MediaViewer` `memo`.
  - Added regression tests for Android decoding and details-sheet back behavior.

<sup>Written for commit fe08c8fc6f34233fe07ce33a0b4ce4578d47cf58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

