### PR TITLE
BgTimer: native background timers always on; fail loudly when unavailable

### DIFF
--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -83,10 +83,9 @@ EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_STORE_PASSWORD=
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_PASSWORD=
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_ALIAS=
-# Android dev builds default to plain JS timers, which Android PAUSES while
-# the app is backgrounded — engine timers freeze and local miniapps stop
-# working (captions stop, wake words missed) until you foreground the app.
-# Opt in to the native background timer so dev matches production. Requires
-# a dev client built after react-native-nitro-bg-timer landed (bun android);
-# an older client red-boxes at startup — rebuild instead of turning this off.
-EXPO_PUBLIC_USE_NITRO_BG_TIMER=true
+# Background timers (react-native-nitro-bg-timer) are always on for Android —
+# dev and release, no env var. If the native module is missing (dev client
+# older than the module), the app raises a loud error telling you to rebuild
+# with `bun android`; do that rather than looking for a way to disable it,
+# because without it every engine timer and local miniapp freezes whenever
+# the app is backgrounded.

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -83,3 +83,10 @@ EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_STORE_PASSWORD=
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_PASSWORD=
 # ORG_GRADLE_PROJECT_MENTRAOS_UPLOAD_KEY_ALIAS=
+# Android dev builds default to plain JS timers, which Android PAUSES while
+# the app is backgrounded — engine timers freeze and local miniapps stop
+# working (captions stop, wake words missed) until you foreground the app.
+# Opt in to the native background timer so dev matches production. Requires
+# a dev client built after react-native-nitro-bg-timer landed (bun android);
+# an older client red-boxes at startup — rebuild instead of turning this off.
+EXPO_PUBLIC_USE_NITRO_BG_TIMER=true

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -104,14 +104,12 @@ bun ios
 - Backend server required for local testing
 - Port forwarding: `bun adb` (sets up tcp:9090, tcp:3000, tcp:9001, tcp:8081)
 - Bluetooth functionality for glasses pairing
-- **Background behavior on Android dev builds**: set
-  `EXPO_PUBLIC_USE_NITRO_BG_TIMER=true` in `mobile/.env` (see `.env.example`).
-  Without it, dev builds fall back to plain JS timers, which Android pauses
-  in the background — engine timers freeze and local miniapps (captions,
-  wake words) silently stop working whenever the app isn't foregrounded,
-  which does not happen on release builds. Requires a dev client built after
-  `react-native-nitro-bg-timer` landed; if startup red-boxes, rebuild with
-  `bun android` instead of turning the flag off.
+- **Background timers on Android are always native** (no env var, dev and
+  release alike). If startup shows a "Background timers unavailable" alert or
+  red-boxes in the nitro module, your dev client's native binary predates
+  `react-native-nitro-bg-timer` — rebuild with `bun android`. Until then,
+  backgrounded behavior is broken: engine timers freeze and local miniapps
+  (captions, wake words) stop whenever the app isn't foregrounded.
 
 ## Sentry Configuration (iOS)
 

--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -104,6 +104,14 @@ bun ios
 - Backend server required for local testing
 - Port forwarding: `bun adb` (sets up tcp:9090, tcp:3000, tcp:9001, tcp:8081)
 - Bluetooth functionality for glasses pairing
+- **Background behavior on Android dev builds**: set
+  `EXPO_PUBLIC_USE_NITRO_BG_TIMER=true` in `mobile/.env` (see `.env.example`).
+  Without it, dev builds fall back to plain JS timers, which Android pauses
+  in the background — engine timers freeze and local miniapps (captions,
+  wake words) silently stop working whenever the app isn't foregrounded,
+  which does not happen on release builds. Requires a dev client built after
+  `react-native-nitro-bg-timer` landed; if startup red-boxes, rebuild with
+  `bun android` instead of turning the flag off.
 
 ## Sentry Configuration (iOS)
 

--- a/mobile/modules/engine/src/utils/timers/timers.ts
+++ b/mobile/modules/engine/src/utils/timers/timers.ts
@@ -8,22 +8,21 @@
 // is active.
 //
 // Who actually gets native timers:
-//   - Android release builds: always (silent fallback to JS timers only if
-//     the require() fails — which also silently breaks background behavior,
-//     so treat that warning seriously if it ever shows in prod logs).
-//   - Android dev builds: OPT-IN via EXPO_PUBLIC_USE_NITRO_BG_TIMER=true.
-//     Without it, a backgrounded dev build freezes every engine timer AND
-//     local miniapps stop working (captions stop rendering, wake words are
-//     missed, the watchdog respawns contexts on foreground) — dev behavior
-//     silently diverges from production in exactly the backgrounded
-//     scenarios that matter on glasses. Set the var in mobile/.env after a
-//     native rebuild (bun android); see .env.example.
+//   - Android, dev AND release: always attempted — dev must match production
+//     background behavior. There is no opt-in/opt-out env var. If the native
+//     module is unavailable (a dev client whose binary predates it, or a
+//     broken release binary), the failure is LOUD: a console.error with the
+//     remediation, plus a blocking dev alert. The JS-timer fallback still
+//     engages so foreground behavior keeps working, but backgrounded
+//     behavior is broken until the native rebuild — the error says exactly
+//     that. (A silent dev fallback previously cost a full debugging day of
+//     phantom "zombie miniapp" bugs; see OS-1790.)
 //   - iOS: never, dev or prod — the package is disabled pending
 //     https://github.com/tconns/react-native-nitro-bg-timer/issues/2. iOS
 //     suspends the whole process in background anyway, so background timing
 //     there is handled by native per-device queues, not JS timers.
 
-import {Platform} from "react-native"
+import {Alert, Platform} from "react-native"
 
 type NitroTimerApi = {
   setInterval: (callback: () => void, delay: number) => number
@@ -34,34 +33,40 @@ type NitroTimerApi = {
 
 let nitroTimer: NitroTimerApi | null | undefined
 let nitroDisabled = false
-let warnedUnavailable = false
+let failedLoud = false
 
-function warnUnavailable(reason: string) {
-  if (warnedUnavailable) {
+/**
+ * The native background timer is unavailable — say so ONCE, loudly, with the
+ * remediation. The JS-timer fallback keeps foreground behavior working, but
+ * everything timing-driven freezes while the app is backgrounded, which
+ * presents as phantom miniapp bugs (frozen captions, missed wake words,
+ * watchdog kills on resume). A quiet warning here has already cost a full
+ * debugging day; never downgrade this to console.warn.
+ */
+function failUnavailable(reason: string) {
+  if (failedLoud) {
     return
   }
-  warnedUnavailable = true
-  console.warn(`BgTimer: ${reason}, using JS timers`)
+  failedLoud = true
+  const message =
+    `BgTimer: native background timer unavailable (${reason}). ` +
+    "Backgrounded behavior IS BROKEN until you rebuild the Android app: run `bun android`. " +
+    "Engine timers and local miniapps (captions, wake words) freeze whenever the app is not foregrounded."
+  console.error(message)
+  if (__DEV__) {
+    // A stale dev client may ALSO show the library's own require-time red box
+    // (bridgeless LogBox surfaces it even though we catch below) — this alert
+    // is the actionable one: it names the fix.
+    try {
+      Alert.alert("Background timers unavailable", message)
+    } catch {
+      /* Alert not available (tests / headless) — the console.error stands. */
+    }
+  }
 }
 
 function getNitroTimer(): NitroTimerApi | null {
   if (nitroDisabled || Platform.OS !== "android") {
-    return null
-  }
-
-  // Dev default is OFF because react-native-nitro-bg-timer calls
-  // createHybridObject() at require() time, and on a dev client whose native
-  // binary predates the module that throws an NPE which LogBox red-boxes even
-  // when caught (bridgeless RN). The cost of this guard is severe though:
-  // with it active, a BACKGROUNDED dev build loses all engine timers and
-  // local miniapps freeze (see header). If your dev client was built after
-  // the module landed, opt in via EXPO_PUBLIC_USE_NITRO_BG_TIMER=true in
-  // mobile/.env so dev matches production background behavior.
-  if (__DEV__ && process.env.EXPO_PUBLIC_USE_NITRO_BG_TIMER !== "true") {
-    warnUnavailable(
-      "nitro bg-timer disabled in dev — BACKGROUNDED apps will freeze engine timers and miniapps. " +
-        "Set EXPO_PUBLIC_USE_NITRO_BG_TIMER=true in mobile/.env (after a native rebuild: bun android)",
-    )
     return null
   }
 
@@ -73,7 +78,7 @@ function getNitroTimer(): NitroTimerApi | null {
     const {isRuntimeAlive} = require("react-native-nitro-modules") as {isRuntimeAlive?: () => boolean}
     if (typeof isRuntimeAlive === "function" && !isRuntimeAlive()) {
       nitroTimer = null
-      warnUnavailable("nitro runtime is not alive")
+      failUnavailable("nitro runtime is not alive")
       return nitroTimer
     }
 
@@ -92,7 +97,7 @@ function getNitroTimer(): NitroTimerApi | null {
   }
 
   if (!nitroTimer) {
-    warnUnavailable("react-native-nitro-bg-timer unavailable")
+    failUnavailable("react-native-nitro-bg-timer failed to load")
   }
   return nitroTimer
 }
@@ -107,7 +112,8 @@ function withNitro<T>(run: (api: NitroTimerApi) => T, fallback: () => T): T {
   } catch (error) {
     nitroDisabled = true
     nitroTimer = null
-    console.warn("BgTimer: nitro timer failed, using JS timers", error)
+    failedLoud = false // a mid-session failure is new information — re-announce
+    failUnavailable(`nitro timer call threw: ${String(error)}`)
     return fallback()
   }
 }

--- a/mobile/modules/engine/src/utils/timers/timers.ts
+++ b/mobile/modules/engine/src/utils/timers/timers.ts
@@ -1,4 +1,27 @@
-// until https://github.com/tconns/react-native-nitro-bg-timer/issues/2 is resolved, we need to use this class to disable this package on iOS:
+// BgTimer — background-safe timers for the engine.
+//
+// Everything timing-critical in the engine runs through this class: the
+// miniapp liveness watchdog, display durationMs expiries, boot windows,
+// auth-token refresh. On Android, React Native PAUSES plain JS timers while
+// the app is backgrounded, so those features only keep working in the
+// background when the native implementation (react-native-nitro-bg-timer)
+// is active.
+//
+// Who actually gets native timers:
+//   - Android release builds: always (silent fallback to JS timers only if
+//     the require() fails — which also silently breaks background behavior,
+//     so treat that warning seriously if it ever shows in prod logs).
+//   - Android dev builds: OPT-IN via EXPO_PUBLIC_USE_NITRO_BG_TIMER=true.
+//     Without it, a backgrounded dev build freezes every engine timer AND
+//     local miniapps stop working (captions stop rendering, wake words are
+//     missed, the watchdog respawns contexts on foreground) — dev behavior
+//     silently diverges from production in exactly the backgrounded
+//     scenarios that matter on glasses. Set the var in mobile/.env after a
+//     native rebuild (bun android); see .env.example.
+//   - iOS: never, dev or prod — the package is disabled pending
+//     https://github.com/tconns/react-native-nitro-bg-timer/issues/2. iOS
+//     suspends the whole process in background anyway, so background timing
+//     there is handled by native per-device queues, not JS timers.
 
 import {Platform} from "react-native"
 
@@ -26,12 +49,19 @@ function getNitroTimer(): NitroTimerApi | null {
     return null
   }
 
-  // react-native-nitro-bg-timer calls createHybridObject() at require() time. On dev
-  // builds with a stale native binary that throws NPE, React Native still surfaces a
-  // red LogBox error even when the exception is caught. Skip nitro in __DEV__ unless
-  // explicitly enabled after a native rebuild (bun android).
+  // Dev default is OFF because react-native-nitro-bg-timer calls
+  // createHybridObject() at require() time, and on a dev client whose native
+  // binary predates the module that throws an NPE which LogBox red-boxes even
+  // when caught (bridgeless RN). The cost of this guard is severe though:
+  // with it active, a BACKGROUNDED dev build loses all engine timers and
+  // local miniapps freeze (see header). If your dev client was built after
+  // the module landed, opt in via EXPO_PUBLIC_USE_NITRO_BG_TIMER=true in
+  // mobile/.env so dev matches production background behavior.
   if (__DEV__ && process.env.EXPO_PUBLIC_USE_NITRO_BG_TIMER !== "true") {
-    warnUnavailable("nitro bg-timer disabled in dev (set EXPO_PUBLIC_USE_NITRO_BG_TIMER=true after native rebuild)")
+    warnUnavailable(
+      "nitro bg-timer disabled in dev — BACKGROUNDED apps will freeze engine timers and miniapps. " +
+        "Set EXPO_PUBLIC_USE_NITRO_BG_TIMER=true in mobile/.env (after a native rebuild: bun android)",
+    )
     return null
   }
 


### PR DESCRIPTION
## What

Was docs-only; now implements the behavior change it documented (per OS-1790's direction).

**Removes `EXPO_PUBLIC_USE_NITRO_BG_TIMER` entirely.** Android dev builds now attempt the native background timer unconditionally, exactly like release builds — dev/prod background behavior parity, no env var to know about.

**When the native module is unavailable, the failure is loud and actionable** instead of a one-line `console.warn`:

- `console.error` naming the consequence ("backgrounded behavior IS BROKEN") and the fix (rebuild with `bun android`) — this also lands in bug-report log artifacts, making the previously-invisible release-build fallback visible for the first time.
- A blocking dev alert with the same message. A stale dev client may additionally show the nitro library's own require-time red box (bridgeless LogBox surfaces it despite our catch); the alert is the actionable one.
- A mid-session nitro failure re-announces rather than staying silent.

The JS-timer fallback still engages after the announcement, so foreground behavior keeps working either way.

## Why

The opt-in guard (added to avoid red-boxing stale dev clients) silently forked dev behavior from production: backgrounded dev builds froze every engine timer — miniapp liveness watchdog, display expiries, boot windows — and stranded local miniapps (captions stop, wake words ignored, contexts respawned on foreground). This cost a full live-debugging day of phantom "zombie miniapp" bugs (see OS-1790), and produced misleading bug reports that mimicked real background failures (`rep_01KY6WTT74…`).

A red box on a stale dev client that says "rebuild" is a far cheaper failure than a silent behavioral fork.

## Release-build impact

None mechanically — release always attempted nitro (the guard was `__DEV__`-only). The change there is observability: the silent `require()`-failure fallback now errors loudly. Follow-up (OS-1790): surface that path to Sentry, and evaluate a registry-based existence probe to avoid the library's red box entirely.

## Verification

- `bun compile` clean.
- Happy path exercised on a Pixel 8 dev client with the module present (nitro active, no warnings; background captions/wake-word behavior survives backgrounding — the original repro for this whole saga).
- The stale-client failure path is not exercisable here (requires an APK predating the module); the fallback + messaging code path is identical in shape to the previous warn path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Android dev timer behavior for all engine timing paths; misbuilt or stale dev clients get louder failures but avoid silent background regressions.
> 
> **Overview**
> **Android dev builds now match release for engine timing:** `BgTimer` no longer skips `react-native-nitro-bg-timer` in `__DEV__` unless `EXPO_PUBLIC_USE_NITRO_BG_TIMER=true`. The native module is **always** attempted on Android (dev and release); there is no env toggle.
> 
> When native timers are unavailable (stale dev client, failed load, dead nitro runtime, or a thrown call), the old one-time `console.warn` is replaced by **`failUnavailable`**: a **`console.error`**, a **`__DEV__` blocking `Alert`**, and explicit text that **backgrounded engine/miniapp behavior is broken** until `bun android`. Foreground still uses the JS-timer fallback.
> 
> **Docs** in `timers.ts`, `.env.example`, and `AGENTS.md` explain that background timers are always on for Android, what breaks without them (watchdog, display expiry, captions, wake words), and point at OS-1790.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bf5710871dac7fedb4c7b42f407cc036c06cdb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->