### PR TITLE
Restore thumbnails for synced videos

### DIFF
--- a/mobile/modules/engine/src/services/asg/asgCameraApi.ts
+++ b/mobile/modules/engine/src/services/asg/asgCameraApi.ts
@@ -1333,8 +1333,12 @@ export class AsgCameraApiClient {
     abortSignal?: AbortSignal,
   ): Promise<string | undefined> {
     const partialPath = `${thumbnailPath}.partial`
+    const parentDir = thumbnailPath.substring(0, thumbnailPath.lastIndexOf("/"))
 
     try {
+      if (parentDir && !(await RNFS.exists(parentDir))) {
+        await RNFS.mkdir(parentDir)
+      }
       await RNFS.unlink(partialPath).catch(() => {})
       const {jobId, promise} = localNetworkTransport.downloadFile({
         fromUrl: `${this.baseUrl}/api/photo?file=${encodeURIComponent(sourceFileName)}`,

--- a/mobile/modules/engine/src/services/asg/asgCameraApi.ts
+++ b/mobile/modules/engine/src/services/asg/asgCameraApi.ts
@@ -1071,7 +1071,13 @@ export class AsgCameraApiClient {
     capture: CaptureGroup,
     onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
     abortSignal?: AbortSignal,
-  ): Promise<{captureDir: string; primaryPath: string; bracketPaths: string[]; sidecarPath?: string}> {
+  ): Promise<{
+    captureDir: string
+    primaryPath: string
+    bracketPaths: string[]
+    sidecarPath?: string
+    thumbnailPath?: string
+  }> {
     if (capture.files.some((file) => !file.size || file.size <= 0)) {
       // Preserve support for malformed manifests from pre-v2 development firmware.
       return this.downloadCaptureLegacyUnsafe(capture, onProgress, abortSignal)
@@ -1136,9 +1142,14 @@ export class AsgCameraApiClient {
         const leafName = sortedFiles[0].name.includes("/") ? sortedFiles[0].name.split("/").pop()! : sortedFiles[0].name
         primaryPath = `${captureDir}/${leafName}`
       }
+      const primaryFile = sortedFiles.find((file) => file.role === "primary") || sortedFiles[0]
+      const thumbnailPath =
+        capture.type === "video" && primaryFile
+          ? await this.downloadVideoThumbnail(primaryFile.name, `${captureDir}/.thumb.jpg`, abortSignal)
+          : undefined
       galleryTransferLedger.transition(capture.capture_id, "VERIFIED")
       onProgress?.(capture.total_size, capture.total_size)
-      return {captureDir, primaryPath, bracketPaths, sidecarPath}
+      return {captureDir, primaryPath, bracketPaths, sidecarPath, thumbnailPath}
     } catch (error) {
       galleryTransferLedger.recordFailure(capture.capture_id, error)
       throw error
@@ -1150,7 +1161,13 @@ export class AsgCameraApiClient {
     capture: CaptureGroup,
     onProgress?: (bytesDownloaded: number, totalBytes: number) => void,
     abortSignal?: AbortSignal,
-  ): Promise<{captureDir: string; primaryPath: string; bracketPaths: string[]; sidecarPath?: string}> {
+  ): Promise<{
+    captureDir: string
+    primaryPath: string
+    bracketPaths: string[]
+    sidecarPath?: string
+    thumbnailPath?: string
+  }> {
     const captureDir = localStorageService.getPhotoFilePath(capture.capture_id)
     console.log(
       `[ASG Camera API] downloadCapture: ${capture.capture_id} (${capture.files.length} files) -> ${captureDir}`,
@@ -1300,7 +1317,72 @@ export class AsgCameraApiClient {
       onProgress(totalBytes, totalBytes)
     }
 
-    return {captureDir, primaryPath, bracketPaths, sidecarPath}
+    const primaryFile = sortedFiles.find((file) => file.role === "primary") || sortedFiles[0]
+    const thumbnailPath =
+      capture.type === "video" && primaryFile
+        ? await this.downloadVideoThumbnail(primaryFile.name, `${captureDir}/.thumb.jpg`, abortSignal)
+        : undefined
+
+    return {captureDir, primaryPath, bracketPaths, sidecarPath, thumbnailPath}
+  }
+
+  /** Download an on-demand video thumbnail while the source capture is still on the glasses. */
+  private async downloadVideoThumbnail(
+    sourceFileName: string,
+    thumbnailPath: string,
+    abortSignal?: AbortSignal,
+  ): Promise<string | undefined> {
+    const partialPath = `${thumbnailPath}.partial`
+
+    try {
+      await RNFS.unlink(partialPath).catch(() => {})
+      const {jobId, promise} = localNetworkTransport.downloadFile({
+        fromUrl: `${this.baseUrl}/api/photo?file=${encodeURIComponent(sourceFileName)}`,
+        toFile: partialPath,
+        headers: {
+          "Accept": "image/jpeg",
+          "User-Agent": "MentraOS-Mobile/1.0",
+        },
+        connectionTimeout: 60000,
+        readTimeout: 60000,
+        progressDivider: 10,
+      })
+
+      let abortPollTimer: number | undefined
+      if (abortSignal) {
+        if (abortSignal.aborted) {
+          localNetworkTransport.stopDownload(jobId)
+          throw new Error("Sync cancelled")
+        }
+        abortPollTimer = BgTimer.setInterval(() => {
+          if (abortSignal.aborted) localNetworkTransport.stopDownload(jobId)
+        }, 500)
+      }
+
+      let result
+      try {
+        result = await promise
+      } finally {
+        if (abortPollTimer !== undefined) BgTimer.clearInterval(abortPollTimer)
+      }
+
+      if (abortSignal?.aborted) throw new Error("Sync cancelled")
+      if (result.statusCode !== 200 || result.bytesWritten <= 0) {
+        throw new Error(`HTTP ${result.statusCode}, ${result.bytesWritten} bytes`)
+      }
+
+      await RNFS.unlink(thumbnailPath).catch(() => {})
+      await RNFS.moveFile(partialPath, thumbnailPath)
+      console.log(`[ASG Camera API] Downloaded video thumbnail for ${sourceFileName}`)
+      return thumbnailPath
+    } catch (error) {
+      await RNFS.unlink(partialPath).catch(() => {})
+      if (abortSignal?.aborted || (error instanceof Error && error.message === "Sync cancelled")) {
+        throw new Error("Sync cancelled")
+      }
+      console.warn(`[ASG Camera API] Failed to download video thumbnail for ${sourceFileName}:`, error)
+      return undefined
+    }
   }
 
   /**
@@ -1421,15 +1503,20 @@ export class AsgCameraApiClient {
         mediaKind: isVideo ? "video" : "photo",
       })
       galleryTransferLedger.transition(captureId, "VERIFIED")
+      const thumbnailPath =
+        includeThumbnail && isVideo
+          ? await this.downloadVideoThumbnail(filename, localStorageService.getThumbnailFilePath(filename), abortSignal)
+          : undefined
       return {
         filePath: localFilePath,
+        thumbnailPath,
         mime_type: isVideo
           ? "video/mp4"
           : lowerName.endsWith(".png")
-          ? "image/png"
-          : lowerName.endsWith(".avif")
-          ? "image/avif"
-          : "image/jpeg",
+            ? "image/png"
+            : lowerName.endsWith(".avif")
+              ? "image/avif"
+              : "image/jpeg",
       }
     } catch (error) {
       galleryTransferLedger.recordFailure(captureId, error)

--- a/mobile/modules/engine/src/services/asg/gallerySyncService.ts
+++ b/mobile/modules/engine/src/services/asg/gallerySyncService.ts
@@ -1329,7 +1329,7 @@ class GallerySyncService {
       }
     }
     // Old firmware remains on the exact v2 endpoint/schema. Avoid expensive inline thumbnails;
-    // the UI can request them lazily after the primary transfer is safe.
+    // video thumbnails are fetched as small side downloads with their primary media.
     const syncResponse = await asgCameraApi.syncWithServer(clientId, lastSyncTime, false)
     const data = (syncResponse.data || syncResponse) as SyncManifestData
     if (data.captures) {
@@ -1923,6 +1923,7 @@ class GallerySyncService {
             bracketPaths: result.bracketPaths,
             sidecarPath: result.sidecarPath,
             thumbnailData: capture.thumbnail_data,
+            thumbnailPath: result.thumbnailPath,
             captureDir: result.captureDir,
             timestamp: capture.timestamp,
             totalSize: capture.total_size,

--- a/mobile/src/services/asg/asgCameraApi.test.ts
+++ b/mobile/src/services/asg/asgCameraApi.test.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-restricted-imports */
+import * as RNFS from "@dr.pogodin/react-native-fs"
+
+import {AsgCameraApiClient} from "../../../modules/engine/src/services/asg/asgCameraApi"
+import {localNetworkTransport} from "../../../modules/engine/src/services/asg/localNetworkTransport"
+
+jest.mock("@dr.pogodin/react-native-fs", () => ({
+  unlink: jest.fn(() => Promise.resolve()),
+  moveFile: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/localNetworkTransport", () => ({
+  localNetworkTransport: {
+    downloadFile: jest.fn(),
+    stopDownload: jest.fn(),
+  },
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/localStorageService", () => ({
+  localStorageService: {},
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/galleryMediaValidation", () => ({
+  validateDownloadedMediaFile: jest.fn(),
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/GalleryMediaIntegrityReportService", () => ({
+  reportInvalidGalleryMedia: jest.fn(),
+}))
+
+jest.mock("../../../modules/engine/src/services/asg/galleryTransferLedger", () => ({
+  galleryTransferLedger: {},
+}))
+
+describe("AsgCameraApiClient video thumbnails", () => {
+  const downloadFile = localNetworkTransport.downloadFile as jest.Mock
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("commits a non-empty server-generated thumbnail", async () => {
+    downloadFile.mockReturnValue({
+      jobId: 1,
+      promise: Promise.resolve({statusCode: 200, bytesWritten: 512}),
+    })
+    const client = new AsgCameraApiClient()
+    client.setServer("192.168.43.1")
+
+    const result = await (client as any).downloadVideoThumbnail(
+      "VID_20260723_021413_958_665/base.mp4",
+      "/tmp/VID_20260723_021413_958_665/.thumb.jpg",
+    )
+
+    expect(downloadFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fromUrl: "http://192.168.43.1:8089/api/photo?file=VID_20260723_021413_958_665%2Fbase.mp4",
+        toFile: "/tmp/VID_20260723_021413_958_665/.thumb.jpg.partial",
+      }),
+    )
+    expect(RNFS.moveFile).toHaveBeenCalledWith(
+      "/tmp/VID_20260723_021413_958_665/.thumb.jpg.partial",
+      "/tmp/VID_20260723_021413_958_665/.thumb.jpg",
+    )
+    expect(result).toBe("/tmp/VID_20260723_021413_958_665/.thumb.jpg")
+  })
+
+  it("keeps a thumbnail failure non-fatal for the downloaded video", async () => {
+    downloadFile.mockReturnValue({
+      jobId: 1,
+      promise: Promise.resolve({statusCode: 500, bytesWritten: 0}),
+    })
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+    const client = new AsgCameraApiClient()
+    client.setServer("192.168.43.1")
+
+    await expect(
+      (client as any).downloadVideoThumbnail("VID_failed/base.mp4", "/tmp/VID_failed/.thumb.jpg"),
+    ).resolves.toBeUndefined()
+    expect(RNFS.moveFile).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[ASG Camera API] Failed to download video thumbnail for VID_failed/base.mp4:",
+      expect.any(Error),
+    )
+  })
+
+  it("propagates cancellation instead of acknowledging a thumbnail-less capture", async () => {
+    downloadFile.mockReturnValue({
+      jobId: 7,
+      promise: new Promise(() => {}),
+    })
+    const controller = new AbortController()
+    controller.abort()
+    const client = new AsgCameraApiClient()
+    client.setServer("192.168.43.1")
+
+    await expect(
+      (client as any).downloadVideoThumbnail(
+        "VID_cancelled/base.mp4",
+        "/tmp/VID_cancelled/.thumb.jpg",
+        controller.signal,
+      ),
+    ).rejects.toThrow("Sync cancelled")
+    expect(localNetworkTransport.stopDownload).toHaveBeenCalledWith(7)
+  })
+})

--- a/mobile/src/services/asg/asgCameraApi.test.ts
+++ b/mobile/src/services/asg/asgCameraApi.test.ts
@@ -5,6 +5,8 @@ import {AsgCameraApiClient} from "../../../modules/engine/src/services/asg/asgCa
 import {localNetworkTransport} from "../../../modules/engine/src/services/asg/localNetworkTransport"
 
 jest.mock("@dr.pogodin/react-native-fs", () => ({
+  exists: jest.fn(() => Promise.resolve(false)),
+  mkdir: jest.fn(() => Promise.resolve()),
   unlink: jest.fn(() => Promise.resolve()),
   moveFile: jest.fn(() => Promise.resolve()),
 }))
@@ -58,6 +60,7 @@ describe("AsgCameraApiClient video thumbnails", () => {
         toFile: "/tmp/VID_20260723_021413_958_665/.thumb.jpg.partial",
       }),
     )
+    expect(RNFS.mkdir).toHaveBeenCalledWith("/tmp/VID_20260723_021413_958_665")
     expect(RNFS.moveFile).toHaveBeenCalledWith(
       "/tmp/VID_20260723_021413_958_665/.thumb.jpg.partial",
       "/tmp/VID_20260723_021413_958_665/.thumb.jpg",

--- a/mobile/src/services/asg/gallerySyncService.test.ts
+++ b/mobile/src/services/asg/gallerySyncService.test.ts
@@ -458,6 +458,32 @@ describe("GallerySyncService", () => {
     })
   })
 
+  it("passes the downloaded thumbnail to capture-aware media processing", async () => {
+    const capture = {
+      capture_id: "VID_with_thumbnail",
+      type: "video" as const,
+      timestamp: 1_000,
+      total_size: 100,
+      files: [{name: "VID_with_thumbnail/base.mp4", size: 100, role: "primary" as const}],
+    }
+    ;(asgCameraApi.downloadCapture as jest.Mock).mockResolvedValue({
+      primaryPath: "/tmp/VID_with_thumbnail/base.mp4",
+      bracketPaths: [],
+      sidecarPath: undefined,
+      captureDir: "/tmp/VID_with_thumbnail",
+      thumbnailPath: "/tmp/VID_with_thumbnail/.thumb.jpg",
+    })
+
+    await (gallerySyncService as any).executeCaptureDownload([capture], 2_000)
+
+    expect(mediaProcessingQueue.enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: capture.capture_id,
+        thumbnailPath: "/tmp/VID_with_thumbnail/.thumb.jpg",
+      }),
+    )
+  })
+
   it("holds back the legacy watermark when processing fails after download", async () => {
     const serverTime = 1_700_000_000_000
     const failedTimestamp = serverTime - 20_000


### PR DESCRIPTION
## Summary

Synced videos could appear with the clapperboard fallback because capture-aware and resumable sync downloaded the primary media without requesting the glasses-generated thumbnail.
This restores the small `/api/photo` side download, commits it through a partial file, and persists its path while preserving cancellation behavior.
The fix covers capture-aware v2/v3 sync and the size-verified legacy path.
Validation: 39 targeted tests, TypeScript compilation, and ESLint all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore video thumbnails during gallery sync by fetching a small JPEG from `/api/photo` alongside each video and creating the thumbnail directory when missing. This removes the clapperboard placeholder and passes the saved `thumbnailPath` through capture‑aware v2/v3 and legacy flows.

- **Bug Fixes**
  - Download on-demand video thumbnails as side requests; write to `.partial`, then move to `.thumb.jpg`; ensure parent dir exists; respects cancellation.
  - Add `thumbnailPath` to `downloadCapture` and legacy download results and propagate via `GallerySyncService` to media processing.
  - Keep thumbnail failures non-fatal; log and continue the video transfer.
  - Tests added for thumbnail success, directory creation, failure, and cancel; plus pass-through to the processing queue.

<sup>Written for commit caad781c9422523469d0760afa9da58566eaa5e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3557?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive gallery download behavior with graceful thumbnail fallback; touches sync/media pipeline but not auth or security-sensitive paths.
> 
> **Overview**
> **Restores video preview images** that were missing after capture-aware and resumable sync (clapperboard fallback).
> 
> After the primary video files finish downloading, the client requests a small JPEG from **`/api/photo`** (same endpoint the glasses use for generated thumbnails). Writes go through a **`.partial` → final** path (e.g. `.thumb.jpg` under the capture dir). **`downloadCapture`**, legacy capture download, and the size-verified **`downloadFile`** path all expose optional **`thumbnailPath`** on the result.
> 
> **`GallerySyncService`** forwards that path into **`mediaProcessingQueue.enqueue`** alongside existing manifest thumbnail data. Thumbnail errors are **logged and ignored** so the video transfer still completes; **sync cancellation** still aborts the thumbnail download and surfaces **`Sync cancelled`**.
> 
> Tests cover successful commit, HTTP failure, cancel/stopDownload, and enqueue pass-through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0994943a671539be1f753f477c2bd30fe68d799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->