### PR TITLE
Fix G2 scene rendering in Glasses Mirror

### DIFF
--- a/mobile/modules/engine/src/services/SceneRenderer.ts
+++ b/mobile/modules/engine/src/services/SceneRenderer.ts
@@ -13,6 +13,7 @@
 
 import displayProcessor from "./DisplayProcessor"
 import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
+import {useDisplayStore} from "../stores/display"
 import {SETTINGS, useSettingsStore} from "../stores/settings"
 import {useGlassesStore} from "../stores/glasses"
 import {DeviceTypes, getModelCapabilities} from "../types"
@@ -268,6 +269,21 @@ class SceneRenderer {
       // wiring the deleted MantleManager hook provided).
       void Promise.resolve(BluetoothSdk.displayEvent({view: frame.view, scene: frame})).catch((err) => {
         console.error(`${LOG_TAG}: native scene send failed:`, err)
+      })
+
+      // Keep the phone-side glasses mirror on the same frame as native. Legacy
+      // layouts update this store in LocalDisplayManager.sendToNative; scene
+      // frames bypass that method, so without an explicit write every
+      // positioning device (including G2) leaves the mirror blank/stale.
+      const caps = this.currentCapabilities()
+      useDisplayStore.getState().setDisplayEvent({
+        view: frame.view,
+        layout: {
+          layoutType: "scene",
+          width: caps?.width,
+          height: caps?.height,
+          elements: frame.elements,
+        },
       })
     } catch (err) {
       console.error(`${LOG_TAG}: native scene send failed:`, err)

--- a/mobile/src/__tests__/displaySceneWiring.test.ts
+++ b/mobile/src/__tests__/displaySceneWiring.test.ts
@@ -22,6 +22,7 @@ import type {DisplayRequestResult} from "../../modules/engine/src/services/Local
 import {useGlassesStore} from "../../modules/engine/src/stores/glasses"
 import {useSettingsStore, SETTINGS} from "../../modules/engine/src/stores/settings"
 import {bluetoothSdkMock} from "../test-utils/mockBluetoothSdk"
+import {flushDisplayCoalesceForTests, useDisplayStore} from "@mentra/engine/internal"
 
 function setDeviceModel(model: string) {
   useSettingsStore.getState().setSetting(SETTINGS.default_wearable.key, model, false)
@@ -48,6 +49,12 @@ beforeEach(() => {
   setDeviceModel("Even Realities G2")
   setGlassesConnected(true)
   localDisplayManager._resetForTest()
+  useDisplayStore.setState({
+    currentEvent: {},
+    dashboardEvent: {},
+    mainEvent: {},
+    view: "main",
+  })
 })
 
 afterEach(() => {
@@ -67,6 +74,31 @@ describe("scene requests through arbitration", () => {
     const scene = lastScene()
     expect(scene.appId).toBe("com.app.a")
     expect((scene.elements as unknown[]).length).toBe(1)
+  })
+
+  it("publishes the full positioned scene to the glasses mirror store", () => {
+    localDisplayManager.request("com.app.a", {
+      view: "main",
+      scene: [
+        {type: "text", id: "title", box: {x: 12, y: 20, w: 300, h: 50}, text: "mirror me"},
+        {type: "rect", id: "outline", box: {x: 0, y: 0, w: 576, h: 288}, style: {border: 2}},
+      ],
+    })
+    flushDisplayCoalesceForTests()
+
+    const event = useDisplayStore.getState().currentEvent
+    expect(event.view).toBe("main")
+    expect(event.layout).toMatchObject({
+      layoutType: "scene",
+      width: 576,
+      height: 288,
+    })
+    expect(event.layout.elements).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({id: "title", type: "text", text: "mirror me"}),
+        expect.objectContaining({id: "outline", type: "rect"}),
+      ]),
+    )
   })
 
   it("reports degraded + dropped for over-budget scenes", () => {

--- a/mobile/src/components/mirror/GlassesDisplayMirror.tsx
+++ b/mobile/src/components/mirror/GlassesDisplayMirror.tsx
@@ -1,5 +1,5 @@
 import {useState, useEffect, useRef} from "react"
-import {View, ViewStyle, TextStyle} from "react-native"
+import {Image, ImageStyle, View, ViewStyle, TextStyle} from "react-native"
 import Canvas, {Image as CanvasImage} from "react-native-canvas"
 
 import {Text} from "@/components/ignite"
@@ -33,9 +33,7 @@ const GlassesDisplayMirror: React.FC<GlassesDisplayMirrorProps> = ({
   const currentEvent = useEngineSnapshot(engine.display.mirror.current, (onChange) =>
     engine.display.mirror.onMirror(onChange),
   )
-  const batteryLevel = useEngineSnapshot(engine.glasses.status, (onChange) =>
-    engine.glasses.onStatus(onChange),
-  ).battery
+  const batteryLevel = useEngineSnapshot(engine.glasses.status, (onChange) => engine.glasses.onStatus(onChange)).battery
 
   // Use demo layout if in demo mode, otherwise use real layout
   const layout = demoText !== "" ? {layoutType: "text_wall", text: demoText} : currentEvent.layout
@@ -254,6 +252,66 @@ const GlassesDisplayMirror: React.FC<GlassesDisplayMirrorProps> = ({
           </View>
         )
       }
+      case "scene": {
+        const sceneWidth = Number(layout.width) || GLASSES_WIDTH
+        const scale = containerWidth ? containerWidth / sceneWidth : 1
+        const elements = Array.isArray(layout.elements) ? layout.elements : []
+
+        return (
+          <View
+            ref={containerRef}
+            style={{width: "100%", height: "100%", overflow: "hidden"}}
+            onLayout={(event) => {
+              const {width} = event.nativeEvent.layout
+              if (setContainerWidth) {
+                setContainerWidth(width)
+              }
+            }}>
+            {elements.map((element: any, index: number) => {
+              const box = element?.box ?? {}
+              const elementStyle = element?.style ?? {}
+              const frameStyle: ImageStyle = {
+                position: "absolute",
+                left: (Number(box.x) || 0) * scale,
+                top: (Number(box.y) || 0) * scale,
+                width: Math.max(0, Number(box.w) || 0) * scale,
+                height: Math.max(0, Number(box.h) || 0) * scale,
+                overflow: "hidden",
+              }
+              const border = Number(elementStyle.border) || (element?.type === "rect" ? 1 : 0)
+              if (border > 0) {
+                frameStyle.borderWidth = Math.max(1, border * scale)
+                frameStyle.borderColor = (textStyle?.color as string) ?? "#00ff88aa"
+              }
+              const radius = Number(elementStyle.radius) || 0
+              if (radius > 0) {
+                frameStyle.borderRadius = radius * scale
+              }
+
+              const key = typeof element?.id === "string" ? element.id : `scene-${index}`
+              if (element?.type === "image" && typeof element.data === "string" && element.data !== "") {
+                const uri = element.data.startsWith("data:") ? element.data : `data:image/png;base64,${element.data}`
+                return <Image key={key} source={{uri}} style={frameStyle} resizeMode="contain" />
+              }
+
+              if (element?.type === "text") {
+                const text = parseText(typeof element.text === "string" ? element.text : "")
+                return (
+                  <View key={key} style={frameStyle}>
+                    {text.split("\n").map((line: string, lineIndex: number) => (
+                      <Text key={lineIndex} style={[textStyle, styles.cardContent]}>
+                        {line || " "}
+                      </Text>
+                    ))}
+                  </View>
+                )
+              }
+
+              return <View key={key} style={frameStyle} />
+            })}
+          </View>
+        )
+      }
       case "clear_view":
         return null
       default:
@@ -288,10 +346,12 @@ const GlassesDisplayMirror: React.FC<GlassesDisplayMirrorProps> = ({
   // positioned_text places content at absolute native coords from the top-left,
   // so the screen must match the glasses aspect ratio and drop its inner padding
   // for the scaled coordinates to land where they should.
-  const isPositioned = layout.layoutType === "positioned_text"
+  const isPositioned = layout.layoutType === "positioned_text" || layout.layoutType === "scene"
+  const positionedWidth = layout.layoutType === "scene" ? Number(layout.width) || GLASSES_WIDTH : GLASSES_WIDTH
+  const positionedHeight = layout.layoutType === "scene" ? Number(layout.height) || GLASSES_HEIGHT : GLASSES_HEIGHT
   const positionedOverride: ViewStyle = isPositioned
     ? {
-        aspectRatio: GLASSES_WIDTH / GLASSES_HEIGHT,
+        aspectRatio: positionedWidth / positionedHeight,
         minHeight: undefined,
         maxHeight: undefined,
         padding: 0,

--- a/mobile/src/components/mirror/__tests__/GlassesDisplayMirror.test.tsx
+++ b/mobile/src/components/mirror/__tests__/GlassesDisplayMirror.test.tsx
@@ -96,4 +96,40 @@ describe("GlassesDisplayMirror", () => {
 
     expect(getByText("Hello mirror")).toBeTruthy()
   })
+
+  it("renders positioned text from scene frames", () => {
+    useDisplayStore.setState({
+      currentEvent: {
+        view: "main",
+        layout: {
+          layoutType: "scene",
+          width: 576,
+          height: 288,
+          elements: [
+            {
+              id: "title",
+              type: "text",
+              box: {x: 12, y: 20, w: 300, h: 50},
+              text: "Scene mirror text",
+              change: "created",
+              contentHash: "hash",
+            },
+            {
+              id: "outline",
+              type: "rect",
+              box: {x: 0, y: 0, w: 576, h: 288},
+              style: {border: 2, radius: 4},
+              change: "created",
+              contentHash: "rect-hash",
+            },
+          ],
+        },
+      },
+    })
+
+    const {getByText, queryByText} = render(<GlassesDisplayMirror />)
+
+    expect(getByText("Scene mirror text")).toBeTruthy()
+    expect(queryByText(/Unknown layout type/i)).toBeNull()
+  })
 })


### PR DESCRIPTION
## Summary

- publish processed scene frames to the engine display store used by the phone-side Glasses Mirror
- render positioned scene text, borders, rectangles, and PNG images in the mirror
- use the connected device's canvas dimensions so G2 scenes preserve their 576×288 aspect ratio
- cover both scene-to-store wiring and scene rendering in regression tests

## Root cause

Legacy layouts updated the native glasses display and the display-store mirror. Positioning-capable devices such as Even Realities G2 use the newer scene path, which sent frames directly to native and bypassed the mirror store entirely. The phone preview therefore remained blank or stale while scene content was active on the glasses.

## Impact

The Glasses Mirror now follows scene-based display content on G2, including replayed frames after reconnects, while legacy layout behavior remains unchanged.

## Validation

- `bun run test -- --runInBand src/components/mirror/__tests__/GlassesDisplayMirror.test.tsx src/__tests__/displaySceneWiring.test.ts` (12 tests passed)
- `bun test src/services/__tests__/LocalDisplayManager.test.ts` from `mobile/modules/engine` (28 tests passed)
- `bun run compile` from `mobile`
- targeted ESLint on changed implementation/test files completed with no errors (existing warnings only)

Incident: `rep_01KY6EAQKE3FS9H5GTZ7DQQQ1S`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank/stale Glasses Mirror on Even Realities G2 by routing scene frames to the mirror store and adding `scene` rendering so the phone preview matches glasses with the correct 576×288 aspect ratio.

- **Bug Fixes**
  - Publish scene frames to the display store used by the mirror, using device width/height.
  - Render `scene` layouts in the mirror: positioned text, rect borders, and PNG images; scale from `layout.width`/`layout.height`; treat `scene` as positioned for aspect ratio handling.
  - Add regression tests for scene-to-store wiring and mirror rendering.

<sup>Written for commit fe7cd8f0c9919b1a188a119c0eee1843d21d10a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to phone-side mirror state and UI preview; native Bluetooth scene delivery is unchanged aside from the added store write.
> 
> **Overview**
> Fixes a blank or stale **Glasses Mirror** on positioning devices (e.g. Even Realities G2) when apps use the scene display path instead of legacy layouts.
> 
> **SceneRenderer** now writes each native `SceneFrame` into `useDisplayStore` as a `layoutType: "scene"` event (device width/height plus frame elements), matching what legacy layouts already did via `LocalDisplayManager.sendToNative`.
> 
> **GlassesDisplayMirror** adds a `scene` layout branch: absolutely positioned, scaled text, rects (borders/radius), and PNG images, and treats `scene` like `positioned_text` for aspect ratio using `layout.width` / `layout.height` (e.g. 576×288 on G2).
> 
> Regression tests cover store publication after scene requests and mirror rendering of scene elements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe7cd8f0c9919b1a188a119c0eee1843d21d10a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->