### PR TITLE
Coalesce phone notification display bursts

### DIFF
--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -309,10 +309,15 @@ describe("MantleManager", () => {
     expect(useGlassesStore.getState().wifi).toEqual({state: "disconnected"})
   })
 
-  it("routes notification events without the retired V1 upload", async () => {
+  it("routes every notification event but coalesces a display burst to the latest card", async () => {
     // The Cloud V1 REST upload is gone; the events still flow through the
     // local-miniapp forward path without a server roundtrip.
     const forwardEvent = jest.spyOn(localMiniappRuntime, "forwardEvent")
+    useAppStatusStore.setState({
+      apps: [{packageName: "cloud.augmentos.notify", type: "background", running: true}] as any,
+    })
+    syncCoreDisplayOwner()
+
     emitCrustEvent("phone_notification", {
       notificationId: "n-1",
       app: "Calendar",
@@ -320,11 +325,6 @@ describe("MantleManager", () => {
       content: "Daily sync",
       priority: 4,
       timestamp: "12345",
-      packageName: "com.calendar",
-    })
-    emitCrustEvent("phone_notification_dismissed", {
-      notificationId: "n-1",
-      notificationKey: "key-1",
       packageName: "com.calendar",
     })
     emitBluetoothSdkEvent("phone_notification", {
@@ -335,6 +335,25 @@ describe("MantleManager", () => {
       priority: "1",
       timestamp: 12345,
       packageName: "com.apple.mobilemail",
+    })
+
+    expect(localDisplayManager.request).not.toHaveBeenCalled()
+    jest.advanceTimersByTime(250)
+
+    expect(localDisplayManager.request).toHaveBeenCalledTimes(1)
+    expect(localDisplayManager.request).toHaveBeenCalledWith("cloud.augmentos.notify", {
+      layout: {
+        layoutType: "reference_card",
+        title: "com.apple.mobilemail: Build complete",
+        text: "The iOS relay is working",
+      },
+      durationMs: 5_000,
+    })
+
+    emitCrustEvent("phone_notification_dismissed", {
+      notificationId: "n-1",
+      notificationKey: "key-1",
+      packageName: "com.calendar",
     })
     emitBluetoothSdkEvent("phone_notification_dismissed", {
       notificationId: "ancs-42",
@@ -358,25 +377,71 @@ describe("MantleManager", () => {
       packageName: "com.apple.mobilemail",
       timestamp: 12346,
     })
-    expect(localDisplayManager.request).toHaveBeenNthCalledWith(1, "cloud.augmentos.notify", {
-      layout: {
-        layoutType: "reference_card",
-        title: "Calendar: Standup",
-        text: "Daily sync",
-      },
-      durationMs: 5_000,
-    })
-    expect(localDisplayManager.request).toHaveBeenNthCalledWith(2, "cloud.augmentos.notify", {
-      layout: {
-        layoutType: "reference_card",
-        title: "com.apple.mobilemail: Build complete",
-        text: "The iOS relay is working",
-      },
-      durationMs: 5_000,
-    })
-    expect(localDisplayManager.dismiss).toHaveBeenCalledTimes(2)
+    expect(localDisplayManager.dismiss).toHaveBeenCalledTimes(1)
     expect(localDisplayManager.dismiss).toHaveBeenLastCalledWith("cloud.augmentos.notify")
     await Promise.resolve()
+  })
+
+  it("does not paint phone notifications while the Notifications miniapp is stopped", () => {
+    const forwardEvent = jest.spyOn(localMiniappRuntime, "forwardEvent")
+    useAppStatusStore.setState({
+      apps: [{packageName: "cloud.augmentos.notify", type: "background", running: false}] as any,
+    })
+    syncCoreDisplayOwner()
+
+    emitCrustEvent("phone_notification", {
+      notificationId: "n-stopped",
+      app: "Messages",
+      title: "New message",
+      content: "Still forwarded to subscribers",
+      priority: "normal",
+      timestamp: 12345,
+      packageName: "com.messages",
+    })
+    jest.advanceTimersByTime(250)
+
+    expect(forwardEvent).toHaveBeenCalledWith(
+      "phone_notification",
+      expect.objectContaining({notificationId: "n-stopped"}),
+    )
+    expect(localDisplayManager.request).not.toHaveBeenCalled()
+  })
+
+  it("cancels notification display work when Notifications stops", () => {
+    useAppStatusStore.setState({
+      apps: [{packageName: "cloud.augmentos.notify", type: "background", running: true}] as any,
+    })
+    syncCoreDisplayOwner()
+    emitCrustEvent("phone_notification", {
+      notificationId: "n-active",
+      app: "Messages",
+      title: "First",
+      content: "Rendered",
+      priority: "normal",
+      timestamp: 12345,
+      packageName: "com.messages",
+    })
+    jest.advanceTimersByTime(250)
+    expect(localDisplayManager.request).toHaveBeenCalledTimes(1)
+
+    emitCrustEvent("phone_notification", {
+      notificationId: "n-pending",
+      app: "Messages",
+      title: "Second",
+      content: "Must not render",
+      priority: "normal",
+      timestamp: 12346,
+      packageName: "com.messages",
+    })
+    useAppStatusStore.setState({
+      apps: [{packageName: "cloud.augmentos.notify", type: "background", running: false}] as any,
+    })
+    syncCoreDisplayOwner()
+    jest.advanceTimersByTime(250)
+
+    expect(localDisplayManager.request).toHaveBeenCalledTimes(1)
+    expect(localDisplayManager.dismiss).toHaveBeenCalledTimes(1)
+    expect(localDisplayManager.dismiss).toHaveBeenCalledWith("cloud.augmentos.notify")
   })
 
   it("tracks OTA status without allowing backward progress or stale terminal update hints", async () => {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -18,7 +18,6 @@ import {
   gallerySyncService,
   localDisplayManager,
   localMiniappRuntime,
-  localSttFallbackCoordinator,
   micStateCoordinator,
   miniappLauncher,
   offlineSpeechModelService,
@@ -64,6 +63,19 @@ function parseBundledMiniappName(name: string): {packageName: string; version: s
   }
 }
 
+interface PendingPhoneNotification {
+  notificationId: string
+  displayTitle: string
+  content: string
+  packageName: string
+}
+
+// Android's native listener already deduplicates repeated copies of the same
+// notification. Different notifications posted together still arrive as a
+// burst, though, and sending every intermediate card to the glasses can queue
+// overlapping display rebuilds. Collapse that burst to the latest card.
+const PHONE_NOTIFICATION_BURST_WINDOW_MS = 250
+
 // The background phone-location task + its tier control moved into island
 // (PhoneLocationService). MantleManager now drives it through the island service
 // (setupSubscriptions / cleanup) instead of defining the task here.
@@ -78,6 +90,8 @@ class MantleManager {
   private subs: Array<any> = []
   private initialized: boolean = false
   private activePhoneNotificationId: string | null = null
+  private pendingPhoneNotification: PendingPhoneNotification | null = null
+  private phoneNotificationDisplayTimer: ReturnType<typeof BgTimer.setTimeout> | null = null
 
   public static getInstance(): MantleManager {
     if (!MantleManager.instance) {
@@ -116,6 +130,59 @@ class MantleManager {
       this.micDataActive = false
       useDebugStore.getState().setDebugInfo({micDataRecvd: false})
     }
+  }
+
+  private isPhoneNotificationDisplayRunning(): boolean {
+    return useAppStatusStore.getState().apps.some((app) => app.packageName === notifyPackageName && app.running)
+  }
+
+  private cancelPendingPhoneNotification(notificationId?: string): void {
+    if (notificationId && this.pendingPhoneNotification?.notificationId !== notificationId) {
+      return
+    }
+    if (this.phoneNotificationDisplayTimer !== null) {
+      BgTimer.clearTimeout(this.phoneNotificationDisplayTimer)
+      this.phoneNotificationDisplayTimer = null
+    }
+    this.pendingPhoneNotification = null
+  }
+
+  private stopPhoneNotificationDisplay(): void {
+    this.cancelPendingPhoneNotification()
+    if (this.activePhoneNotificationId) {
+      localDisplayManager.dismiss(notifyPackageName)
+    }
+    this.activePhoneNotificationId = null
+  }
+
+  private schedulePhoneNotificationDisplay(notification: PendingPhoneNotification): void {
+    if (!this.isPhoneNotificationDisplayRunning()) {
+      return
+    }
+
+    this.cancelPendingPhoneNotification()
+    this.pendingPhoneNotification = notification
+    this.phoneNotificationDisplayTimer = BgTimer.setTimeout(() => {
+      this.phoneNotificationDisplayTimer = null
+      const pending = this.pendingPhoneNotification
+      this.pendingPhoneNotification = null
+      if (!pending || !this.isPhoneNotificationDisplayRunning()) {
+        return
+      }
+
+      console.log(
+        `MANTLE: displaying coalesced phone notification ${pending.notificationId} from ${pending.packageName}`,
+      )
+      this.activePhoneNotificationId = pending.notificationId || null
+      localDisplayManager.request(notifyPackageName, {
+        layout: {
+          layoutType: "reference_card",
+          title: pending.displayTitle || "Notification",
+          text: pending.content,
+        },
+        durationMs: 5_000,
+      })
+    }, PHONE_NOTIFICATION_BURST_WINDOW_MS)
   }
 
   // run at app start on the init.tsx screen:
@@ -239,7 +306,7 @@ class MantleManager {
     // Remove all event subscriptions
     this.subs.forEach((sub) => sub.remove())
     this.subs = []
-    this.activePhoneNotificationId = null
+    this.stopPhoneNotificationDisplay()
 
     phoneLocationService.stopPhoneLocation()
 
@@ -407,10 +474,12 @@ class MantleManager {
     // core owner projected from the app store so a notification can briefly
     // replace Captions and then restore the latest caption frame.
     const syncCoreDisplayOwner = () => {
-      const coreApp = useAppStatusStore
-        .getState()
-        .apps.find((app) => app.running && (app.type === "standard" || !app.type))
+      const apps = useAppStatusStore.getState().apps
+      const coreApp = apps.find((app) => app.running && (app.type === "standard" || !app.type))
       localDisplayManager.onCoreAppChange(coreApp?.packageName ?? null)
+      if (!apps.some((app) => app.packageName === notifyPackageName && app.running)) {
+        this.stopPhoneNotificationDisplay()
+      }
     }
     syncCoreDisplayOwner()
     const unsubscribeCoreDisplayOwner = useAppStatusStore.subscribe(syncCoreDisplayOwner)
@@ -520,14 +589,11 @@ class MantleManager {
         // restores that app's retained frame instead of stopping it.
         const displayTitle = title && title !== app ? [app, title].filter(Boolean).join(": ") : title || app
         if (displayTitle || content) {
-          this.activePhoneNotificationId = notificationId || null
-          localDisplayManager.request(notifyPackageName, {
-            layout: {
-              layoutType: "reference_card",
-              title: displayTitle || "Notification",
-              text: content,
-            },
-            durationMs: 5_000,
+          this.schedulePhoneNotificationDisplay({
+            notificationId,
+            displayTitle,
+            content,
+            packageName: String(event.packageName ?? ""),
           })
         }
       }
@@ -551,6 +617,7 @@ class MantleManager {
         })
 
         const notificationId = String(event.notificationId ?? "")
+        this.cancelPendingPhoneNotification(notificationId)
         if (notificationId && notificationId === this.activePhoneNotificationId) {
           this.activePhoneNotificationId = null
           localDisplayManager.dismiss(notifyPackageName)
@@ -609,7 +676,7 @@ class MantleManager {
       // app end-of-life.
 
       this.subs.push(
-        BluetoothSdk.addListener("mic_lc3", (event) => {
+        BluetoothSdk.addListener("mic_lc3", (_event) => {
           this.noteMicDataReceived()
 
           // console.log("MANTLE: Received mic_lc3 event from Bluetooth SDK", event.lc3.length)


### PR DESCRIPTION
## Summary

- debounce phone-notification glasses cards for 250 ms so a burst paints only its latest card
- require the built-in Notifications miniapp to be running before painting phone notifications
- cancel pending/active notification display work when Notifications stops
- continue forwarding every phone notification and dismissal to subscribed miniapps

## Why

Incident `rep_01KY6EC4W0NWMWHPNF4NECEB5F` captured the Mentra App only after Android restarted it, so the fatal stack was no longer in the report log. The immediately preceding report (`rep_01KY6EAQKE3FS9H5GTZ7DQQQ1S`) preserves the pre-crash timeline and shows repeated notification-shaped G2 scene rebuilds. The reporter also observed intermittent airplane connectivity; a 5G handoff can release several queued phone notifications together.

The restored local notification path sent each card directly to the display manager. Different notifications arriving together therefore queued multiple native display updates/rebuilds in rapid succession. Coalescing the UI side of the burst removes that pressure while preserving the complete event stream for miniapps.

## Validation

- `bun run test -- --runInBand src/services/MantleManager.test.ts` — 10 passed
- `bun test src/services/__tests__/LocalDisplayManager.test.ts` from `mobile/modules/engine` — 28 passed
- `bun compile`
- `bun x eslint src/services/MantleManager.ts`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces phone notification cards with a 250 ms window so only the latest in a burst is rendered, reducing display rebuild churn and crash risk. The UI now renders notifications only when the `cloud.augmentos.notify` miniapp is running and cleans up when it stops.

- **Bug Fixes**
  - Coalesce phone notification display bursts (250 ms); cancel pending display on dismissal.
  - Do not paint notifications while `cloud.augmentos.notify` is stopped; dismiss active card when it stops.
  - Keep forwarding every phone notification and dismissal to subscribed miniapps.

<sup>Written for commit 1517a8eb1078b07e844ca5c3bb5d00202ff4f93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

