### PR TITLE
Disable Android notification listener by default

### DIFF
--- a/mobile/modules/crust/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/crust/android/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     <service
       android:name="com.mentra.crust.services.NotificationListenerServiceImpl"
       android:label="@string/mentra_crust_notification_listener_label"
+      android:enabled="false"
       android:exported="false"
       android:permission="android.permission.BIND_NOTIFICATION_LISTENER_SERVICE">
       <intent-filter>

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -152,12 +152,18 @@ class CrustModule : Module() {
 
     // MARK: - MentraOS Notification Commands
 
-    AsyncFunction("setNotificationConfig") { enabled: Boolean, blocklist: List<String> ->
+    AsyncFunction("setNotificationConfig") {
+      listenerEnabled: Boolean, notificationsEnabled: Boolean, blocklist: List<String> ->
       val context =
               appContext.reactContext
                       ?: appContext.currentActivity
                               ?: throw IllegalStateException("No context available")
-      NotificationListener.getInstance(context).setNotificationConfig(enabled, blocklist)
+      NotificationListener.setNotificationConfig(
+        context,
+        listenerEnabled,
+        notificationsEnabled,
+        blocklist,
+      )
     }
 
     AsyncFunction("getInstalledApps") {

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
@@ -19,6 +19,7 @@ class NotificationListener private constructor(private val context: Context) {
   companion object {
     private const val TAG = "CrustNotificationListener"
     private const val PREFS_NAME = "mentra_crust_notification_prefs"
+    private const val PREF_LISTENER_ENABLED = "notification_listener_enabled"
     private const val PREF_NOTIFICATIONS_ENABLED = "notifications_enabled"
     private const val PREF_NOTIFICATIONS_BLOCKLIST = "notifications_blocklist"
 
@@ -32,6 +33,57 @@ class NotificationListener private constructor(private val context: Context) {
               instance = it
             }
         }
+    }
+
+    /**
+     * Persist the developer gate without constructing the listener singleton.
+     * When the gate is off (the default), app startup must not create the
+     * notification HandlerThread merely to disable it.
+     */
+    fun setNotificationConfig(
+      context: Context,
+      listenerEnabled: Boolean,
+      notificationsEnabled: Boolean,
+      blocklist: List<String>,
+    ) {
+      val applicationContext = context.applicationContext
+      val blocklistSet = blocklist.toSet()
+      applicationContext
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .edit()
+        .putBoolean(PREF_LISTENER_ENABLED, listenerEnabled)
+        .putBoolean(PREF_NOTIFICATIONS_ENABLED, notificationsEnabled)
+        .putStringSet(PREF_NOTIFICATIONS_BLOCKLIST, blocklistSet)
+        .apply()
+
+      synchronized(this) {
+        instance?.applyConfig(listenerEnabled, notificationsEnabled, blocklistSet)
+      }
+
+      val component = ComponentName(applicationContext, NotificationListenerServiceImpl::class.java)
+      val newState =
+        if (listenerEnabled) {
+          PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+        } else {
+          PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+        }
+      val packageManager = applicationContext.packageManager
+      if (packageManager.getComponentEnabledSetting(component) != newState) {
+        packageManager.setComponentEnabledSetting(
+          component,
+          newState,
+          PackageManager.DONT_KILL_APP,
+        )
+        if (listenerEnabled) {
+          NotificationListenerService.requestRebind(component)
+        }
+      }
+    }
+
+    fun isListenerEnabled(context: Context): Boolean {
+      return context
+        .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        .getBoolean(PREF_LISTENER_ENABLED, false)
     }
 
     /** Dispose the process singleton so a service rebind gets a live HandlerThread. */
@@ -54,21 +106,20 @@ class NotificationListener private constructor(private val context: Context) {
 
   private val preferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
 
+  @Volatile private var listenerEnabled = preferences.getBoolean(PREF_LISTENER_ENABLED, false)
   @Volatile private var notificationsEnabled = preferences.getBoolean(PREF_NOTIFICATIONS_ENABLED, false)
   @Volatile
   private var notificationsBlocklist =
     preferences.getStringSet(PREF_NOTIFICATIONS_BLOCKLIST, emptySet())?.toSet() ?: emptySet()
 
-  /** Keep MentraOS notification settings in Crust instead of Bluetooth SDK state. */
-  fun setNotificationConfig(enabled: Boolean, blocklist: List<String>) {
-    val blocklistSet = blocklist.toSet()
-    notificationsEnabled = enabled
-    notificationsBlocklist = blocklistSet
-    preferences
-      .edit()
-      .putBoolean(PREF_NOTIFICATIONS_ENABLED, enabled)
-      .putStringSet(PREF_NOTIFICATIONS_BLOCKLIST, blocklistSet)
-      .apply()
+  private fun applyConfig(
+    listenerEnabled: Boolean,
+    notificationsEnabled: Boolean,
+    blocklist: Set<String>,
+  ) {
+    this.listenerEnabled = listenerEnabled
+    this.notificationsEnabled = notificationsEnabled
+    notificationsBlocklist = blocklist
   }
 
   /** Check if notification listener permission is granted. */
@@ -129,6 +180,11 @@ class NotificationListener private constructor(private val context: Context) {
 
   /** Called internally by the service when a notification is posted. */
   internal fun onNotificationPosted(sbn: StatusBarNotification) {
+    if (!listenerEnabled || !notificationsEnabled) {
+      Log.d(TAG, "Notification listener disabled")
+      return
+    }
+
     val packageName = sbn.packageName
     Log.d(TAG, "Received notification from $packageName (key: ${sbn.key})")
 
@@ -139,11 +195,6 @@ class NotificationListener private constructor(private val context: Context) {
 
     if (notificationsBlocklist.contains(packageName)) {
       Log.d(TAG, "Notification in blocklist, returning")
-      return
-    }
-
-    if (!notificationsEnabled) {
-      Log.d(TAG, "Notifications disabled globally")
       return
     }
 
@@ -221,6 +272,10 @@ class NotificationListener private constructor(private val context: Context) {
 
   /** Called internally by the service when a notification is removed. */
   internal fun onNotificationRemoved(sbn: StatusBarNotification) {
+    if (!listenerEnabled || !notificationsEnabled) {
+      return
+    }
+
     val packageName = sbn.packageName
     val notificationKey = sbn.key
 
@@ -315,8 +370,10 @@ class NotificationListenerServiceImpl : NotificationListenerService() {
 
   override fun onListenerDisconnected() {
     super.onListenerDisconnected()
-    Log.d("CrustNotificationListener", "NotificationListenerService disconnected, requesting rebind")
-    requestRebind(ComponentName(this, NotificationListenerServiceImpl::class.java))
+    Log.d("CrustNotificationListener", "NotificationListenerService disconnected")
+    if (NotificationListener.isListenerEnabled(applicationContext)) {
+      requestRebind(ComponentName(this, NotificationListenerServiceImpl::class.java))
+    }
   }
 
   override fun onDestroy() {

--- a/mobile/modules/crust/ios/CrustModule.swift
+++ b/mobile/modules/crust/ios/CrustModule.swift
@@ -243,7 +243,7 @@ public class CrustModule: Module {
 
         // MARK: - MentraOS Notification Commands
 
-        AsyncFunction("setNotificationConfig") { (_: Bool, _: [String]) in
+        AsyncFunction("setNotificationConfig") { (_: Bool, _: Bool, _: [String]) in
             // No-op on iOS
         }
 

--- a/mobile/modules/crust/src/CrustModule.ts
+++ b/mobile/modules/crust/src/CrustModule.ts
@@ -26,7 +26,7 @@ declare class CrustModule extends NativeModule<CrustModuleEvents> {
   setDeferredSystemGestures(edges: Array<"top" | "bottom" | "left" | "right" | "all">): Promise<void>
 
   // MentraOS Notification Commands
-  setNotificationConfig(enabled: boolean, blocklist: string[]): Promise<void>
+  setNotificationConfig(listenerEnabled: boolean, notificationsEnabled: boolean, blocklist: string[]): Promise<void>
   getInstalledApps(): Promise<InstalledApp[]>
   getInstalledAppsForNotifications(): Promise<InstalledApp[]>
   hasNotificationListenerPermission(): Promise<boolean>

--- a/mobile/modules/crust/src/CrustModule.web.ts
+++ b/mobile/modules/crust/src/CrustModule.web.ts
@@ -21,7 +21,11 @@ class CrustModule extends NativeModule<CrustModuleEvents> {
   }
   showAVRoutePicker(_tintColor?: string | null) {}
   async setDeferredSystemGestures(_edges: string[]): Promise<void> {}
-  async setNotificationConfig(_enabled: boolean, _blocklist: string[]): Promise<void> {}
+  async setNotificationConfig(
+    _listenerEnabled: boolean,
+    _notificationsEnabled: boolean,
+    _blocklist: string[],
+  ): Promise<void> {}
   async getInstalledApps() {
     return []
   }

--- a/mobile/modules/engine/src/facades/phoneNotifications.ts
+++ b/mobile/modules/engine/src/facades/phoneNotifications.ts
@@ -14,7 +14,11 @@ export const phoneNotifications = {
   /** Is phone-notification forwarding enabled? (false on iOS) */
   enabled: (): boolean => {
     if (Platform.OS !== "android") return false
-    return useSettingsStore.getState().getSetting(SETTINGS.notifications_enabled.key) ?? true
+    const settings = useSettingsStore.getState()
+    return (
+      Boolean(settings.getSetting(SETTINGS.android_notification_listener_enabled.key)) &&
+      Boolean(settings.getSetting(SETTINGS.notifications_enabled.key))
+    )
   },
   /** Enable/disable phone-notification forwarding. (no-op on iOS) */
   setEnabled: (enabled: boolean) => {

--- a/mobile/modules/engine/src/services/PhoneNotificationsSync.ts
+++ b/mobile/modules/engine/src/services/PhoneNotificationsSync.ts
@@ -1,10 +1,13 @@
 /**
  * Phone-notifications sync — engine-owned. Pushes the notification-forwarding
- * config (`notifications_enabled` + `notifications_blocklist`) to the native
+ * developer gate + config (`android_notification_listener_enabled`,
+ * `notifications_enabled`, and `notifications_blocklist`) to the native
  * NotificationListener via `CrustModule.setNotificationConfig`, so
  * `engine.phoneNotifications.setEnabled()/setBlocklist()` actually reach the
  * listener for ANY host — not just the Mentra app, where this used to live in
- * MantleManager. Android-only; a no-op elsewhere. Started by `engine.start()`.
+ * MantleManager. The Android service component is disabled unless the developer
+ * gate is explicitly enabled. Android-only; a no-op elsewhere. Started by
+ * `engine.start()`.
  */
 import {shallow} from "zustand/shallow"
 import CrustModule from "@mentra/crust"
@@ -15,12 +18,14 @@ let unsubscribe: (() => void) | null = null
 
 function pushConfig(): void {
   const s = useSettingsStore.getState()
-  const enabled = Boolean(s.getSetting(SETTINGS.notifications_enabled.key))
+  const listenerEnabled = Boolean(s.getSetting(SETTINGS.android_notification_listener_enabled.key))
+  const notificationsEnabled = Boolean(s.getSetting(SETTINGS.notifications_enabled.key))
   const blocklist = s.getSetting(SETTINGS.notifications_blocklist.key)
-  // Unconditional (matches the prior MantleManager sync) — the listener is
-  // Android-only, but CrustModule.setNotificationConfig is a safe no-op elsewhere;
-  // the Android-only gating lives on the facade's setEnabled/setBlocklist.
-  CrustModule.setNotificationConfig(enabled, Array.isArray(blocklist) ? blocklist : []).catch((err: unknown) =>
+  CrustModule.setNotificationConfig(
+    listenerEnabled,
+    notificationsEnabled,
+    Array.isArray(blocklist) ? blocklist : [],
+  ).catch((err: unknown) =>
     console.warn(`PhoneNotificationsSync: setNotificationConfig failed: ${(err as Error)?.message ?? err}`),
   )
 }
@@ -30,6 +35,7 @@ export function startPhoneNotificationsSync(): void {
   pushConfig() // initial sync so the listener has the current config
   unsubscribe = useSettingsStore.subscribe(
     (state) => ({
+      listenerEnabled: state.getSetting(SETTINGS.android_notification_listener_enabled.key),
       enabled: state.getSetting(SETTINGS.notifications_enabled.key),
       blocklist: state.getSetting(SETTINGS.notifications_blocklist.key),
     }),

--- a/mobile/modules/engine/src/services/__tests__/PhoneNotificationsSync.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/PhoneNotificationsSync.test.ts
@@ -1,0 +1,74 @@
+/// <reference types="bun-types" />
+
+import {beforeEach, describe, expect, mock, test} from "bun:test"
+
+const mockSetNotificationConfig = mock(() => Promise.resolve())
+mock.module("@mentra/crust", () => ({
+  __esModule: true,
+  default: {
+    setNotificationConfig: mockSetNotificationConfig,
+  },
+}))
+
+const values: Record<string, unknown> = {}
+let onSettingsChanged: (() => void) | null = null
+const mockUnsubscribe = mock(() => {})
+
+mock.module("../../stores/settings", () => ({
+  SETTINGS: {
+    android_notification_listener_enabled: {key: "android_notification_listener_enabled"},
+    notifications_enabled: {key: "notifications_enabled"},
+    notifications_blocklist: {key: "notifications_blocklist"},
+  },
+  useSettingsStore: {
+    getState: () => ({
+      getSetting: (key: string) => values[key],
+    }),
+    subscribe: (_selector: unknown, listener: () => void) => {
+      onSettingsChanged = listener
+      return mockUnsubscribe
+    },
+  },
+}))
+
+const {startPhoneNotificationsSync, stopPhoneNotificationsSync} = require("../PhoneNotificationsSync")
+
+describe("PhoneNotificationsSync", () => {
+  beforeEach(() => {
+    stopPhoneNotificationsSync()
+    mockSetNotificationConfig.mockClear()
+    mockUnsubscribe.mockClear()
+    onSettingsChanged = null
+    Object.assign(values, {
+      android_notification_listener_enabled: false,
+      notifications_enabled: true,
+      notifications_blocklist: [],
+    })
+  })
+
+  test("keeps the Android listener disabled by default", () => {
+    startPhoneNotificationsSync()
+
+    expect(mockSetNotificationConfig).toHaveBeenCalledWith(false, true, [])
+  })
+
+  test("enables the listener only through the developer flag", () => {
+    startPhoneNotificationsSync()
+    values.android_notification_listener_enabled = true
+    onSettingsChanged?.()
+
+    expect(mockSetNotificationConfig).toHaveBeenLastCalledWith(true, true, [])
+  })
+
+  test("keeps the user notification toggle subordinate to the developer flag", () => {
+    Object.assign(values, {
+      android_notification_listener_enabled: true,
+      notifications_enabled: false,
+      notifications_blocklist: ["com.example.noisy"],
+    })
+
+    startPhoneNotificationsSync()
+
+    expect(mockSetNotificationConfig).toHaveBeenCalledWith(true, false, ["com.example.noisy"])
+  })
+})

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -35,6 +35,13 @@ export const SETTINGS: Record<string, Setting> = {
   // feature flags / mantle settings:
   dev_mode: {key: "dev_mode", defaultValue: () => __DEV__, writable: true, saveOnServer: true, persist: true}, // deprecated
   debug_mode: {key: "debug_mode", defaultValue: () => __DEV__, writable: true, saveOnServer: true, persist: true},
+  android_notification_listener_enabled: {
+    key: "android_notification_listener_enabled",
+    defaultValue: () => false,
+    writable: true,
+    saveOnServer: true,
+    persist: true,
+  },
   super_mode: {key: "super_mode", defaultValue: () => false, writable: true, saveOnServer: true, persist: true},
   appearance_menu_enabled: {
     key: "appearance_menu_enabled",

--- a/mobile/src/app/miniapps/settings/debug.tsx
+++ b/mobile/src/app/miniapps/settings/debug.tsx
@@ -1,6 +1,6 @@
 import {DeviceTypes} from "@/../../cloud/packages/types/src"
 import {useEffect, useRef, useState} from "react"
-import {ScrollView, View} from "react-native"
+import {Platform, ScrollView, View} from "react-native"
 
 import CloudUrl from "@/components/dev/CloudUrl"
 import OtaVersionUrl from "@/components/dev/OtaVersionUrl"
@@ -33,6 +33,9 @@ export default function DebugSettingsScreen() {
   const {goBack, push, replaceAll, clearHistoryAndGoHome} = useNavigationStore.getState()
   const [defaultWearable] = useSetting(SETTINGS.default_wearable.key)
   const [debugMode, setDebugMode] = useSetting(SETTINGS.debug_mode.key)
+  const [androidNotificationListenerEnabled, setAndroidNotificationListenerEnabled] = useSetting(
+    SETTINGS.android_notification_listener_enabled.key,
+  )
   const [superMode] = useSetting(SETTINGS.super_mode.key)
   const [powerSavingMode, setPowerSavingMode] = useSetting(SETTINGS.power_saving_mode.key)
   const [reconnectOnAppForeground, setReconnectOnAppForeground] = useSetting(SETTINGS.reconnect_on_app_foreground.key)
@@ -75,6 +78,14 @@ export default function DebugSettingsScreen() {
               value={debugMode}
               onValueChange={(value) => setDebugMode(value)}
             />
+            {Platform.OS === "android" && (
+              <ToggleSetting
+                label="Android Notification Listener"
+                subtitle="Allow Android notifications to be read and forwarded (experimental)"
+                value={androidNotificationListenerEnabled}
+                onValueChange={(value) => setAndroidNotificationListenerEnabled(value)}
+              />
+            )}
             <ToggleSetting
               label={translate("settings:reconnectOnAppForeground")}
               subtitle={translate("settings:reconnectOnAppForegroundSubtitle")}

--- a/mobile/src/services/MantleManager.test.ts
+++ b/mobile/src/services/MantleManager.test.ts
@@ -167,7 +167,7 @@ describe("MantleManager", () => {
         twelve_hour_time: true,
       }),
     )
-    expect(crustModuleMock.setNotificationConfig).toHaveBeenCalledWith(true, [])
+    expect(crustModuleMock.setNotificationConfig).toHaveBeenCalledWith(false, true, [])
     expect(getBluetoothSdkListenerCount("local_transcription")).toBe(1)
 
     emitBluetoothSdkEvent("bluetooth_status", {searching: true, otherBtConnected: true})
@@ -221,7 +221,7 @@ describe("MantleManager", () => {
     await useSettingsStore.getState().setSetting(SETTINGS.notifications_blocklist.key, ["com.blocked"], false)
 
     await waitFor(() => {
-      expect(crustModuleMock.setNotificationConfig).toHaveBeenLastCalledWith(false, ["com.blocked"])
+      expect(crustModuleMock.setNotificationConfig).toHaveBeenLastCalledWith(false, false, ["com.blocked"])
     })
     expect(bluetoothSdkMock.updateBluetoothSettings).not.toHaveBeenCalledWith(
       expect.objectContaining({


### PR DESCRIPTION
## Summary

- disable the Android `NotificationListenerService` component by default
- add a persisted `android_notification_listener_enabled` developer flag, defaulting to off
- expose the flag as an Android-only toggle in Debug Settings
- gate both posted and dismissed notification events behind the developer flag and the existing user notification setting
- avoid constructing the listener background thread while the developer flag is off

## Why

An Android Mentra App process terminated while handling G2/notification activity, but the staging build had no runtime Sentry DSN and the uploaded logs ended before the failure. This emergency kill switch removes Android notification listening from normal builds while retaining an explicit developer-only path for controlled testing. It does not claim that notifications were the proven crash cause.

## Validation

- `bun test modules/engine/src/services/__tests__/PhoneNotificationsSync.test.ts` — 3 passed
- Jest: `MantleManager.test.ts` and `NotificationServiceUtils.test.tsx` — 11 passed
- `bun compile`
- targeted ESLint — no errors
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `./gradlew :mentra-crust:compileDebugKotlin --no-daemon --console=plain`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 36b69afa6827644531001aa1e9385415f568ae72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable the Android notification listener by default and add a developer-only toggle to re-enable it for testing. Gates post/dismiss events and avoids starting the listener thread unless explicitly enabled.

- **New Features**
  - Android service component is disabled by default; toggled at runtime via `android_notification_listener_enabled`.
  - New persisted setting `android_notification_listener_enabled` (default false) with an Android-only toggle in Debug Settings.
  - Engine pushes gate + config via `@mentra/crust` `CrustModule.setNotificationConfig(listenerEnabled, notificationsEnabled, blocklist)`; Android implemented, iOS/web no-op.
  - Listener checks both the developer gate and user notification setting; rebinds only when enabled; avoids creating the background thread when off.
  - `phoneNotifications.enabled()` now returns true only when both flags are true.
  - Added focused tests for sync logic and updated existing tests.

- **Migration**
  - Update any calls to `CrustModule.setNotificationConfig` to pass `(listenerEnabled, notificationsEnabled, blocklist)`.

<sup>Written for commit 36b69afa6827644531001aa1e9385415f568ae72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

