### PR TITLE
Cap v1 ck chunks at the BLE notification budget

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -126,6 +126,18 @@ public class AsgConstants {
     /** Number of post-APK-restart completion resend attempts (see {@link #OTA_COMPLETION_RESEND_INTERVAL_MS}). */
     public static final int OTA_COMPLETION_RESEND_ATTEMPTS = 15;
 
+    /**
+     * Maximum packed frame size for a v1 K900 STRING ck chunk. The BES relays v1 string
+     * frames to the phone in a single unfragmented BLE notification, and the effective ATT
+     * payload on that link is 253 bytes (ATT MTU 256) regardless of the MTU the phone
+     * requested — a packed chunk over that cap is silently truncated on the wire and the
+     * phone drops it as unparseable (incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA
+     * completion ck chunks packed to 256-263 bytes and none survived). The previous budget
+     * was MTU_TARGET (509), which only holds for v2 binary fragments with phone-side
+     * reassembly. 240 leaves margin for BES re-framing variance.
+     */
+    public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
+
     /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
     public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -1,6 +1,7 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
 import android.util.Log;
+import com.mentra.asg_client.AsgConstants;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +20,16 @@ public class MessageChunker {
     private static final int MESSAGE_SIZE_THRESHOLD_V1 = 200;
     private static final int INITIAL_CHUNK_DATA_SIZE = 80;
     private static final int MIN_CHUNK_DATA_SIZE = 4;
+    /** Budget for v2 binary fragments — these are reassembled phone-side, so MTU_TARGET holds. */
     public static final int MAX_PACKED_CHUNK_SIZE = BesWireFormat.MAX_PACKED_FRAME_SIZE;
+    /**
+     * Budget for v1 STRING ck chunks. Unlike binary fragments, a v1 string frame must
+     * survive the phone leg as ONE BLE notification (the BES relays it unfragmented and
+     * the phone parses per-notification) — so the real ceiling is the ATT payload cap,
+     * not MTU_TARGET. See {@link AsgConstants#K900_STRING_CHUNK_MAX_FRAME_BYTES}.
+     */
+    public static final int MAX_PACKED_STRING_CHUNK_SIZE =
+            AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES;
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
 
     public static boolean needsChunking(String message) {
@@ -79,7 +89,7 @@ public class MessageChunker {
         }
 
         throw new JSONException(
-                "Unable to create K900 chunks within " + MAX_PACKED_CHUNK_SIZE + " bytes");
+                "Unable to create K900 chunks within " + MAX_PACKED_STRING_CHUNK_SIZE + " bytes");
     }
 
     /**
@@ -165,7 +175,7 @@ public class MessageChunker {
     private static boolean allChunksFit(List<JSONObject> chunks) {
         for (int i = 0; i < chunks.size(); i++) {
             byte[] packed = BesWireFormat.formatMessageForTransmission(chunks.get(i).toString());
-            if (packed == null || packed.length > MAX_PACKED_CHUNK_SIZE) {
+            if (packed == null || packed.length > MAX_PACKED_STRING_CHUNK_SIZE) {
                 Log.d(
                         TAG,
                         "Chunk "
@@ -173,7 +183,7 @@ public class MessageChunker {
                                 + " packed to "
                                 + (packed != null ? packed.length : 0)
                                 + " bytes, exceeding "
-                                + MAX_PACKED_CHUNK_SIZE);
+                                + MAX_PACKED_STRING_CHUNK_SIZE);
                 return false;
             }
         }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -1,0 +1,94 @@
+package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mentra.asg_client.service.core.processors.ChunkReassembler;
+import java.util.List;
+import org.json.JSONObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Regression test for incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: v1 ck chunks were sized
+ * against MTU_TARGET (509) but a v1 string frame must survive the phone leg as a single
+ * BLE notification (~253-byte ATT payload). The OTA completion ota_status packed to
+ * 256-263-byte chunk frames, every one was truncated on the wire, and the phone failed a
+ * successful update. Every packed v1 ck chunk must stay within
+ * {@link MessageChunker#MAX_PACKED_STRING_CHUNK_SIZE}.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class StringChunkBudgetTest {
+
+    @Before
+    public void setUp() {
+        // v1 string mode — the post-APK-restart steady state until a BLE reconnect.
+        BesWireFormat.resetBinaryProtocol();
+    }
+
+    @After
+    public void tearDown() {
+        BesWireFormat.resetBinaryProtocol();
+    }
+
+    /** The 251-byte ota_status completion shape from the incident, quote-dense like the real payload. */
+    private static String incidentShapedOtaStatus() {
+        return "{\"sid\":\"d017b9b1\",\"ts\":1,\"cs\":1,\"st\":\"apk\",\"sq\":[\"apk\"],"
+                + "\"phase\":\"install\",\"sp\":100,\"op\":100,\"status\":\"complete\","
+                + "\"type\":\"ota_status\",\"mId\":1828367906865900787,"
+                + "\"glasses_time_ms\":1784772000000,\"extra\":\"padding-to-incident-size-xxxx\"}";
+    }
+
+    private static String largeQuoteDenseJson(int approxBytes) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("type", "ota_status");
+        int i = 0;
+        while (json.toString().length() < approxBytes) {
+            json.put("key_" + i, "value-with-\"quotes\"-" + i);
+            i++;
+        }
+        return json.toString();
+    }
+
+    private static void assertAllPackedChunksFitAndRoundTrip(String message) throws Exception {
+        List<JSONObject> chunks = MessageChunker.createChunks(message, 42L);
+        assertThat(chunks.size()).isGreaterThan(1);
+
+        ChunkReassembler reassembler = new ChunkReassembler();
+        String reassembled = null;
+        for (JSONObject chunk : chunks) {
+            // The wire cost of a chunk includes the C-wrap and its double escaping —
+            // measure the packed frame exactly as the send path produces it.
+            byte[] packed = BesWireFormat.formatMessageForTransmission(chunk.toString());
+            assertThat(packed).isNotNull();
+            assertThat(packed.length).isLessThanOrEqualTo(MessageChunker.MAX_PACKED_STRING_CHUNK_SIZE);
+
+            reassembled =
+                    reassembler.addChunk(
+                            chunk.getString("id"),
+                            chunk.getInt("c"),
+                            chunk.getInt("n"),
+                            chunk.getString("d"));
+        }
+        assertThat(reassembled).isEqualTo(message);
+    }
+
+    @Test
+    public void incidentSizedOtaStatusChunksFitTheNotificationBudget() throws Exception {
+        assertAllPackedChunksFitAndRoundTrip(incidentShapedOtaStatus());
+    }
+
+    @Test
+    public void threeHundredByteMessageChunksFitTheNotificationBudget() throws Exception {
+        assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(300));
+    }
+
+    @Test
+    public void fiveHundredByteMessageChunksFitTheNotificationBudget() throws Exception {
+        assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
+    }
+}


### PR DESCRIPTION
## Scope

Fixes the wire-layer failure behind incident `rep_01KY6BJ0B7A4RBMQ7VN39KAE5E` (Jul 23): an APK OTA succeeded on the glasses, but the phone showed "Update failed" — the fixes from #3522 fired correctly (completion resends + install-phase status polls) yet **none of the messages could physically cross the BLE link**.

## Root cause

- v1 K900 STRING ck chunks are sized against `MTU_TARGET` (509), but a v1 string frame must survive the phone leg as **one BLE notification**: the BES relays it unfragmented, the effective ATT payload is **253 bytes**, and the phone parses per-notification with no reassembly.
- The OTA session `ota_status` JSON grew (~158B on Jul 21 → ~251B now). After C-wrapping and double escaping, its ck chunks pack to **256–263 bytes** — every one silently truncated at 253 and dropped as unparseable (`K900 PARSE FAILED dataLen=253` twice a second for minutes in the incident phone log).
- This v1 window is not transient: after an APK-OTA restart the fresh asg process boots in v1 TX and stays there — the phone↔BES BLE link survives the restart, so the phone never re-sends the v2 handshake (confirmed: `version_info` still ck-chunked v1 strings 6 minutes after restart in the incident BES log).

## Change

- New `AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES = 240` (253-byte ATT cap minus margin).
- `MessageChunker` now validates **v1 string ck chunks** against that budget; **v2 binary fragments keep `MTU_TARGET`** (they are reassembled phone-side). The existing shrink-until-fit loop handles the rest — no change to v2 throughput, no threshold changes.
- Regression tests (`StringChunkBudgetTest`): incident-shaped 251B `ota_status` plus 300B/500B quote-dense messages — every packed chunk must fit the budget and round-trip through `ChunkReassembler`.

## Test evidence

- `:app:testDebugUnitTest` full suite green; new suite 3/3, `BinaryMessageChunkerTest` 5/5 and `ChunkReassemblerTest` unaffected.

## Follow-ups (separate)

- Phone-side K900 STRING frame reassembly across notifications (defense-in-depth for deployed glasses).
- Phone re-sends the v2 wire handshake when it observes the asg restart (`K900 SOC ready` / build-number change) — needs old-peer compat care.
- BES: `cmd_pack_cmd_json` writes BLE-bound string-frame lengths with the UART-negotiated endianness (`k900_get_uart_endian()`) instead of `k900_get_ble_endian()` — latent cross-link contamination observed in the incident logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core BLE message chunking for all v1 string traffic (more/smaller chunks) but change is narrowly scoped with regression tests and does not alter v2 binary paths.
> 
> **Overview**
> Fixes **OTA completion and other large v1 JSON** failing to reach the phone after APK restart: v1 `ck` chunks were validated against **509-byte** `MTU_TARGET`, but each v1 string frame must fit in a **single ~253-byte BLE notification** (BES relays unfragmented). Oversized packed frames were truncated and dropped.
> 
> Introduces **`K900_STRING_CHUNK_MAX_FRAME_BYTES` (240)** and **`MessageChunker.MAX_PACKED_STRING_CHUNK_SIZE`** so v1 string chunk packing uses that ceiling in `allChunksFit` / `createChunks`; **v2 binary fragments still use `MAX_PACKED_CHUNK_SIZE`**. Adds **`StringChunkBudgetTest`** (incident-shaped `ota_status` plus larger payloads) asserting packed chunks stay within budget and round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93d4c9d671a5869998fbfec1111f6bb91a03b9c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->