### PR TITLE
Correct BES OTA manifest version

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,7 +44,7 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.23",
+    "version": "17.26.07.22",
     "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.07.23.bin",
     "sha256": "c853166f6fdccb4cc1dd8fe9cb3c8cfebaffbb183aa7197ba3e9300b96b866c2"
   }


### PR DESCRIPTION
## Summary

- Correct the BES firmware version in the source OTA manifest from `17.26.07.23` to `17.26.07.22`.
- Keep the existing firmware URL and SHA-256 unchanged.

## Root cause

The published binary identifies itself over UART as `17.26.7.22`, but the staging manifest advertised the same binary as `17.26.07.23`. The Mentra App therefore continued offering a BES update after successfully installing the advertised bytes.

The local July 23 release artifact and the CDN artifact are byte-for-byte identical and share SHA-256 `c853166f6fdccb4cc1dd8fe9cb3c8cfebaffbb183aa7197ba3e9300b96b866c2`.

## Impact

Once this source manifest is promoted to `staging` and the rolling staging manifest is republished, devices already running this firmware will stop receiving a perpetual BES update prompt.

## Validation

- `git diff --check`
- Parsed `asg_client/ota_manifests/firmware_live.json` with `jq`
- Downloaded the configured CDN artifact and verified its SHA-256 matches the manifest

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the BES firmware version in the OTA manifest to 17.26.07.22 to match the shipped binary and stop repeated update prompts in the Mentra App. The firmware URL and SHA-256 remain unchanged.

<sup>Written for commit d7e4ddf0cb6a1067173a199a71a34a1cbd52999d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3568?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in an OTA manifest; no binary, client logic, or checksum changes.
> 
> **Overview**
> Updates **`bes_firmware.version`** in `firmware_live.json` from **`17.26.07.23`** to **`17.26.07.22`** so the OTA manifest matches the version the glasses report after install. The **CDN URL** and **SHA-256** for the BES image are **unchanged**—only the advertised version string is corrected.
> 
> This should stop the Mentra App from treating an already-updated device as still needing the same BES package once the manifest is promoted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7e4ddf0cb6a1067173a199a71a34a1cbd52999d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->