### PR TITLE
dev to staging

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,7 +44,7 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.23",
+    "version": "17.26.07.22",
     "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.07.23.bin",
     "sha256": "c853166f6fdccb4cc1dd8fe9cb3c8cfebaffbb183aa7197ba3e9300b96b866c2"
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Corrected the BES OTA manifest version for live firmware updates so devices report the right release.

- **Bug Fixes**
  - Set bes_firmware.version to 17.26.07.22 in asg_client/ota_manifests/firmware_live.json.

<sup>Written for commit 4d5f9ee045c229d814bce4cbd6aa70e28c543661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Manifest-only but affects live BES OTA eligibility; the version string no longer matches the `26.07.23` artifact name, which can confuse rollout or skip updates for devices already on `.07.23`.
> 
> **Overview**
> Updates the **live** OTA manifest (`firmware_live.json`) so `bes_firmware.version` is **`17.26.07.22`** instead of **`17.26.07.23`**. MTK patch entries are unchanged.
> 
> The BES **download URL** and **sha256** still reference `bes_firmware_26.07.23.bin`; only the advertised version string in the manifest changes. Clients use that field in `checkBesUpdate` to decide whether to offer a BES OTA step, so lowering it changes which devices see an update as “newer” than the manifest.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5f9ee045c229d814bce4cbd6aa70e28c543661. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->