### PR TITLE
Keep Android location available through the Mentra foreground service

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
   <!-- Other permissions -->
@@ -35,6 +36,6 @@
   <uses-permission android:name="android.permission.VIBRATE"/>
 
   <application>
-    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|microphone"/>
+    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|location|microphone"/>
   </application>
 </manifest>

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -2,6 +2,8 @@
 
 package com.mentra.bluetoothsdk
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import com.mentra.bluetoothsdk.utils.DeviceTypes
 import com.mentra.bluetoothsdk.utils.audio.PcmStreamManager
@@ -391,6 +393,21 @@ class BluetoothSdkModule : Module() {
                             sdkListener,
                     )
             deviceManager = DeviceManager.getInstance()
+            val activity = appContext.currentActivity
+            val activityIsResumed =
+                    (activity as? LifecycleOwner)
+                            ?.lifecycle
+                            ?.currentState
+                            ?.isAtLeast(Lifecycle.State.RESUMED) == true
+            if (activityIsResumed) {
+                deviceManager?.refreshForegroundServiceTypes()
+            }
+        }
+
+        OnActivityEntersForeground {
+            // Re-run after runtime permission dialogs and every app resume. This is the safe
+            // point to add Android's while-in-use location foreground-service type.
+            deviceManager?.refreshForegroundServiceTypes()
         }
 
         OnDestroy {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -582,6 +582,36 @@ class DeviceManager {
         }
     }
 
+    /**
+     * Re-evaluate the active foreground-service types while the host Activity is visible.
+     *
+     * Location is a while-in-use permission, so Android 14+ only allows the service to add
+     * the location type from the foreground. Sending a command to the existing service
+     * updates its type mask without tearing down the glasses connection.
+     */
+    fun refreshForegroundServiceTypes() {
+        val context = Bridge.getContext()
+
+        try {
+            Bridge.log("MAN: Refreshing foreground service types")
+            val serviceIntent =
+                Intent(context, ForegroundService::class.java).apply {
+                    action = ForegroundService.ACTION_REFRESH_TYPES
+                }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent)
+            } else {
+                context.startService(serviceIntent)
+            }
+
+            serviceStarted = true
+            Bridge.log("MAN: Foreground service types refreshed")
+        } catch (e: Exception) {
+            Bridge.log("MAN: Failed to refresh foreground service types: ${e.message}")
+        }
+    }
+
     private fun restartForegroundService() {
         val context = Bridge.getContext()
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -6,6 +6,7 @@ import android.app.Service
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.location.LocationManager
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
@@ -17,7 +18,11 @@ class ForegroundService : Service() {
     companion object {
         const val CHANNEL_ID = "MentraServiceChannel"
         const val NOTIFICATION_ID = 1001
+        const val ACTION_REFRESH_TYPES =
+                "com.mentra.bluetoothsdk.services.action.REFRESH_FOREGROUND_SERVICE_TYPES"
     }
+
+    private var locationTypeRequested = false
 
     override fun onCreate() {
         super.onCreate()
@@ -34,6 +39,11 @@ class ForegroundService : Service() {
                 "service_start_command",
                 mapOf("action" to intent?.action, "flags" to flags, "startId" to startId)
         )
+        if (intent?.action == ACTION_REFRESH_TYPES) {
+            // This action is only sent while the host Activity is foregrounded. Android 14+
+            // rejects adding a while-in-use location type from the background.
+            locationTypeRequested = true
+        }
         // Re-check permissions in case they changed
         startForegroundWithAutoDetectedType()
         return START_STICKY
@@ -124,6 +134,28 @@ class ForegroundService : Service() {
             Bridge.log("ForegroundService: No microphone permission")
         }
 
+        val hasLocationPermission =
+                ContextCompat.checkSelfPermission(
+                        this,
+                        android.Manifest.permission.ACCESS_FINE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED ||
+                        ContextCompat.checkSelfPermission(
+                                this,
+                                android.Manifest.permission.ACCESS_COARSE_LOCATION
+                        ) == PackageManager.PERMISSION_GRANTED
+        val locationManager = getSystemService(LocationManager::class.java)
+        val isLocationEnabled = locationManager?.isLocationEnabled == true
+
+        if (locationTypeRequested && hasLocationPermission && isLocationEnabled) {
+            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            Bridge.log("ForegroundService: Added location (has foreground location permission)")
+        } else {
+            Bridge.log(
+                    "ForegroundService: No location type " +
+                            "(requested=$locationTypeRequested, permission=$hasLocationPermission, enabled=$isLocationEnabled)"
+            )
+        }
+
         // Only use dataSync as absolute last resort fallback if no other types were added.
         // WARNING: dataSync has a 6-hour timeout on Android 14+ which will crash the app.
         // This should rarely happen since CHANGE_NETWORK_STATE is a normal permission.
@@ -141,8 +173,14 @@ class ForegroundService : Service() {
         val hasConnectedDevice =
                 (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE) != 0
         val hasMicrophone = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE) != 0
+        val hasLocation = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION) != 0
 
         return when {
+            hasConnectedDevice && hasMicrophone && hasLocation ->
+                    "Glasses, microphone & location active"
+            hasConnectedDevice && hasLocation -> "Smart glasses & location active"
+            hasMicrophone && hasLocation -> "Microphone & location active"
+            hasLocation -> "Location active"
             hasConnectedDevice && hasMicrophone -> "Glasses & microphone active"
             hasConnectedDevice -> "Smart glasses connected"
             hasMicrophone -> "Microphone active"
@@ -160,6 +198,8 @@ class ForegroundService : Service() {
                 types.add("connectedDevice")
         if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE != 0)
                 types.add("microphone")
+        if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION != 0)
+                types.add("location")
 
         return types.joinToString("|")
     }


### PR DESCRIPTION
## Summary

- declare `location` on the existing Mentra Android foreground service
- activate the location service type only while the host Activity is foregrounded and foreground location permission is available
- refresh the existing service after permission dialogs and app resumes without restarting the glasses connection
- keep `ACCESS_BACKGROUND_LOCATION` blocked

## Root cause

Mentra AI's local runtime continued executing after the Android app was backgrounded, but its one-shot Expo location request stalled until the Activity returned to the foreground. The persistent Mentra service was active, but Android only knew it as `connectedDevice`, `microphone`, or `dataSync`; it was not declared or promoted as a `location` foreground service.

The promotion is explicitly initiated from a foreground lifecycle callback so Android 14+ never sees a while-in-use location service being created from the background. Sticky service recreation remains on the non-location types until the next foreground resume.

## User impact

Location-backed Mentra AI questions can finish after the user presses Home, without requesting `ACCESS_BACKGROUND_LOCATION` or introducing a second Expo foreground service.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --no-daemon`
- inspected the generated Bluetooth SDK AAR manifest for `FOREGROUND_SERVICE_LOCATION` and `dataSync|connectedDevice|location|microphone`
- `git diff --check`