### PR TITLE
Fix Mentra AI requests in the Android background

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
   <!-- Other permissions -->
@@ -36,6 +37,6 @@
   <uses-permission android:name="android.permission.VIBRATE"/>
 
   <application>
-    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|location|microphone"/>
+    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|location|mediaPlayback|microphone"/>
   </application>
 </manifest>

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -81,6 +81,14 @@ class ForegroundService : Service() {
 
         var serviceType = 0
 
+        // Audio prompts can be initiated by glasses while the host Activity is
+        // backgrounded. mediaPlayback has no runtime prerequisite, so keep it
+        // active on the existing Mentra service for the entire connected
+        // session rather than trying to launch a second service after a wake
+        // phrase arrives.
+        serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
+        Bridge.log("ForegroundService: Added mediaPlayback (supports background audio)")
+
         // Check Bluetooth permissions
         val hasBluetoothPermission =
                 when {
@@ -174,6 +182,8 @@ class ForegroundService : Service() {
                 (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE) != 0
         val hasMicrophone = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE) != 0
         val hasLocation = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION) != 0
+        val hasMediaPlayback =
+                (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK) != 0
 
         return when {
             hasConnectedDevice && hasMicrophone && hasLocation ->
@@ -184,6 +194,7 @@ class ForegroundService : Service() {
             hasConnectedDevice && hasMicrophone -> "Glasses & microphone active"
             hasConnectedDevice -> "Smart glasses connected"
             hasMicrophone -> "Microphone active"
+            hasMediaPlayback -> "Audio playback active"
             else -> "Syncing data"
         }
     }
@@ -200,6 +211,8 @@ class ForegroundService : Service() {
                 types.add("microphone")
         if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION != 0)
                 types.add("location")
+        if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK != 0)
+                types.add("mediaPlayback")
 
         return types.joinToString("|")
     }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitor.kt
@@ -26,6 +26,14 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
         @Volatile
         private var instance: PhoneAudioMonitor? = null
 
+        internal fun shouldKeepOwnAppAudioSignal(
+            signalledPlaying: Boolean,
+            systemAudioPlaying: Boolean,
+            nowMs: Long,
+            holdoffUntilMs: Long,
+        ): Boolean =
+            signalledPlaying && (systemAudioPlaying || nowMs < holdoffUntilMs)
+
         @JvmStatic
         fun getInstance(context: Context): PhoneAudioMonitor {
             return instance ?: synchronized(this) {
@@ -82,7 +90,36 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
         return audioManager.isMusicActive
     }
 
-    fun isOwnAppAudioPlaying(): Boolean = ownAppAudioPlaying
+    /**
+     * Return the explicit React Native playback hint, reconciling it with
+     * Android's actual media state.
+     *
+     * Expo can miss a completion callback while its Activity is backgrounded,
+     * leaving the explicit hint stuck at PLAYING. The hint only protects the
+     * short A2DP codec transition; after that hold-off, Android's
+     * isMusicActive is authoritative. Clearing a stale hint lets the glasses
+     * mic watchdog recover instead of suppressing recovery forever.
+     */
+    @Synchronized
+    fun isOwnAppAudioPlaying(): Boolean {
+        val systemAudioPlaying = isPlaying()
+        if (
+            shouldKeepOwnAppAudioSignal(
+                ownAppAudioPlaying,
+                systemAudioPlaying,
+                System.currentTimeMillis(),
+                audioStartHoldoffUntil,
+            )
+        ) {
+            return true
+        }
+
+        if (ownAppAudioPlaying) {
+            ownAppAudioPlaying = false
+            Bridge.log("$TAG: Cleared stale own-app audio flag (system audio is inactive)")
+        }
+        return false
+    }
 
     /**
      * Notify the monitor that our own app started/stopped playing audio
@@ -93,6 +130,7 @@ class PhoneAudioMonitor private constructor(private val context: Context) {
      * there's a brief gap where the system reports 0 active configs (codec is switching).
      * The hold-off prevents us from reporting STOPPED during this transition.
      */
+    @Synchronized
     fun setOwnAppAudioPlaying(playing: Boolean) {
         ownAppAudioPlaying = playing
         Bridge.log("$TAG: Own app audio -> ${if (playing) "PLAYING" else "STOPPED"}")

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitorTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/PhoneAudioMonitorTest.kt
@@ -1,0 +1,45 @@
+package com.mentra.bluetoothsdk.utils
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PhoneAudioMonitorTest {
+    @Test
+    fun `keeps explicit playback hint while Android reports active media`() {
+        assertThat(
+                PhoneAudioMonitor.shouldKeepOwnAppAudioSignal(
+                        signalledPlaying = true,
+                        systemAudioPlaying = true,
+                        nowMs = 10_000,
+                        holdoffUntilMs = 1_000,
+                )
+            )
+            .isTrue()
+    }
+
+    @Test
+    fun `keeps explicit playback hint during codec transition holdoff`() {
+        assertThat(
+                PhoneAudioMonitor.shouldKeepOwnAppAudioSignal(
+                        signalledPlaying = true,
+                        systemAudioPlaying = false,
+                        nowMs = 500,
+                        holdoffUntilMs = 1_000,
+                )
+            )
+            .isTrue()
+    }
+
+    @Test
+    fun `expires stale playback hint when Android media is inactive`() {
+        assertThat(
+                PhoneAudioMonitor.shouldKeepOwnAppAudioSignal(
+                        signalledPlaying = true,
+                        systemAudioPlaying = false,
+                        nowMs = 1_000,
+                        holdoffUntilMs = 1_000,
+                )
+            )
+            .isFalse()
+    }
+}

--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -1,6 +1,6 @@
 import {createAudioPlayer, AudioPlayer, AudioStatus, setAudioModeAsync} from "expo-audio"
 import BluetoothSdk from "@mentra/bluetooth-sdk/internal"
-import {Platform} from "react-native"
+import {AppState, Platform} from "react-native"
 import {BgTimer} from "../utils/timers"
 import {setAudioCloudUplinkSuppressed} from "./AudioCloudUplink"
 
@@ -189,6 +189,14 @@ class AudioPlaybackService {
    */
   private async prewarmAudioRouteIfCold(): Promise<void> {
     if (Platform.OS !== "android" || this.isAudioRouteWarm()) return
+    // This silent PCM pre-roll is only an anti-clipping optimization. Some
+    // Android devices defer opening its AudioTrack until the host Activity
+    // resumes even though the real URL player supports background playback.
+    // Never let that optional pre-roll block a glasses-initiated prompt.
+    if (AppState.currentState !== "active") {
+      console.log(`AUDIO: Skipping cold-route prewarm while app is ${AppState.currentState}`)
+      return
+    }
     if (this.audioRouteWarmupPromise) return this.audioRouteWarmupPromise
 
     const streamId = `audio-route-prewarm-${Date.now()}-${Math.random().toString(36).slice(2)}`

--- a/mobile/modules/engine/src/services/ForegroundLocationPermission.ts
+++ b/mobile/modules/engine/src/services/ForegroundLocationPermission.ts
@@ -13,10 +13,10 @@ export interface ForegroundLocationPermissionClient {
  */
 export async function resolveForegroundLocationPermission(
   client: ForegroundLocationPermissionClient,
-  appState: string,
+  getAppState: () => string,
 ): Promise<ForegroundLocationPermissionResponse> {
   const current = await client.getForegroundPermissionsAsync()
-  if (current.status === "granted" || appState !== "active") {
+  if (current.status === "granted" || getAppState() !== "active") {
     return current
   }
 

--- a/mobile/modules/engine/src/services/ForegroundLocationPermission.ts
+++ b/mobile/modules/engine/src/services/ForegroundLocationPermission.ts
@@ -1,0 +1,24 @@
+export interface ForegroundLocationPermissionResponse {
+  status: string
+}
+
+export interface ForegroundLocationPermissionClient {
+  getForegroundPermissionsAsync(): Promise<ForegroundLocationPermissionResponse>
+  requestForegroundPermissionsAsync(): Promise<ForegroundLocationPermissionResponse>
+}
+
+/**
+ * Resolve foreground location permission without invoking an Activity-bound
+ * Android permission request while the app is backgrounded.
+ */
+export async function resolveForegroundLocationPermission(
+  client: ForegroundLocationPermissionClient,
+  appState: string,
+): Promise<ForegroundLocationPermissionResponse> {
+  const current = await client.getForegroundPermissionsAsync()
+  if (current.status === "granted" || appState !== "active") {
+    return current
+  }
+
+  return client.requestForegroundPermissionsAsync()
+}

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -75,6 +75,7 @@ import type {ClientApp} from "../types/applet"
 import {useAppStatusStore} from "../stores/apps"
 import {getDevAppAttestation, getDevAppSourcePackage} from "./AppRegistry"
 import {resolveForegroundLocationPermission} from "./ForegroundLocationPermission"
+import {advanceMiniappPingLiveness} from "./MiniappLiveness"
 import {listPhoneCalendarEvents, PhoneCalendarError} from "./PhoneCalendarService"
 
 // =============================================================================
@@ -106,6 +107,7 @@ interface ConnectedMiniapp {
   cloudTranscriptionStreams: Set<string>
   sendMessage: (raw: string) => void
   lastPongAt: number
+  unansweredPingRounds: number
   installedManifest?: InstalledMiniappManifest
   authRefreshTimerId: number | null
   /**
@@ -741,6 +743,7 @@ class LocalMiniappRuntime {
       cloudTranscriptionStreams: new Set(),
       sendMessage: sendFn,
       lastPongAt: Date.now(),
+      unansweredPingRounds: 0,
       installedManifest,
       authRefreshTimerId: null,
       authRetryTimerId: null,
@@ -1296,6 +1299,7 @@ class LocalMiniappRuntime {
 
     // Update lastPongAt so it doesn't time out right away
     existing.lastPongAt = Date.now()
+    existing.unansweredPingRounds = 0
 
     // Read current glasses capabilities from the settings store
     const defaultWearable = useSettingsStore.getState().getSetting(ISLAND_SETTINGS_KEYS.defaultWearable) as
@@ -4307,17 +4311,16 @@ class LocalMiniappRuntime {
   }
 
   private doPingRound(): void {
-    const now = Date.now()
-    const staleThreshold = PING_INTERVAL_MS * PING_TIMEOUT_THRESHOLD
-
     const toRemove: string[] = []
 
     for (const [packageName, app] of this.connectedApps) {
-      if (now - app.lastPongAt > staleThreshold) {
+      const liveness = advanceMiniappPingLiveness(app.unansweredPingRounds, PING_TIMEOUT_THRESHOLD)
+      if (liveness.shouldUnregister) {
         console.warn(`${LOG_TAG}: ${packageName} missed ${PING_TIMEOUT_THRESHOLD} pings, unregistering`)
         toRemove.push(packageName)
         continue
       }
+      app.unansweredPingRounds = liveness.unansweredPingRounds
 
       // Send PING — SDK auto-replies with PONG
       this.sendToMiniapp(packageName, {
@@ -4341,6 +4344,7 @@ class LocalMiniappRuntime {
     const app = this.connectedApps.get(packageName)
     if (app) {
       app.lastPongAt = Date.now()
+      app.unansweredPingRounds = 0
       this.clearForegroundProbe(packageName)
     }
   }

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -9,7 +9,7 @@
  * management (connect/disconnect/ping).
  */
 
-import {Linking} from "react-native"
+import {AppState, Linking} from "react-native"
 import Share from "react-native-share"
 import * as Battery from "expo-battery"
 import * as Clipboard from "expo-clipboard"
@@ -74,6 +74,7 @@ import {NavigationHandlers} from "./NavigationHandlers"
 import type {ClientApp} from "../types/applet"
 import {useAppStatusStore} from "../stores/apps"
 import {getDevAppAttestation, getDevAppSourcePackage} from "./AppRegistry"
+import {resolveForegroundLocationPermission} from "./ForegroundLocationPermission"
 import {listPhoneCalendarEvents, PhoneCalendarError} from "./PhoneCalendarService"
 
 // =============================================================================
@@ -2450,7 +2451,18 @@ class LocalMiniappRuntime {
 
   private async handleLocationPoll(packageName: string, requestId?: string): Promise<void> {
     try {
-      const {status} = await Location.requestForegroundPermissionsAsync()
+      // Expo's Android requestForegroundPermissionsAsync always delegates to
+      // Activity.requestPermissions(), even when permission is already granted.
+      // Calling it after the user presses Home therefore waits until the Activity
+      // resumes. Read the current grant first, and only enter the prompt flow
+      // while the Activity is actually foregrounded.
+      const permissionStartedAt = Date.now()
+      const appState = AppState.currentState
+      const permission = await resolveForegroundLocationPermission(Location, appState)
+      const {status} = permission
+      console.log(
+        `${LOG_TAG}: location poll permission status=${status} appState=${appState} elapsed=${Date.now() - permissionStartedAt}ms`,
+      )
       if (status !== "granted") {
         this.sendResult(packageName, requestId, false, undefined, {
           code: MiniappErrorCode.PERMISSION_NOT_DECLARED,
@@ -2463,8 +2475,13 @@ class LocalMiniappRuntime {
       // a fresh fix if the cache is empty. Use Low accuracy on the fresh
       // path so we get a cell/wifi-tower fix in ~1s instead of waiting
       // for full GPS warm-up.
+      const locationStartedAt = Date.now()
       const cached = await Location.getLastKnownPositionAsync({maxAge: 60_000})
+      console.log(
+        `${LOG_TAG}: location poll cache hit=${cached !== null} elapsed=${Date.now() - locationStartedAt}ms`,
+      )
       const location = cached ?? (await Location.getCurrentPositionAsync({accuracy: Location.Accuracy.Low}))
+      console.log(`${LOG_TAG}: location poll resolved elapsed=${Date.now() - locationStartedAt}ms`)
 
       this.sendResult(packageName, requestId, true, {
         lat: location.coords.latitude,

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -2457,11 +2457,10 @@ class LocalMiniappRuntime {
       // resumes. Read the current grant first, and only enter the prompt flow
       // while the Activity is actually foregrounded.
       const permissionStartedAt = Date.now()
-      const appState = AppState.currentState
-      const permission = await resolveForegroundLocationPermission(Location, appState)
+      const permission = await resolveForegroundLocationPermission(Location, () => AppState.currentState)
       const {status} = permission
       console.log(
-        `${LOG_TAG}: location poll permission status=${status} appState=${appState} elapsed=${Date.now() - permissionStartedAt}ms`,
+        `${LOG_TAG}: location poll permission status=${status} appState=${AppState.currentState} elapsed=${Date.now() - permissionStartedAt}ms`,
       )
       if (status !== "granted") {
         this.sendResult(packageName, requestId, false, undefined, {

--- a/mobile/modules/engine/src/services/MiniappLiveness.ts
+++ b/mobile/modules/engine/src/services/MiniappLiveness.ts
@@ -1,0 +1,24 @@
+export interface MiniappPingLivenessDecision {
+  shouldUnregister: boolean
+  unansweredPingRounds: number
+}
+
+/**
+ * Advance liveness by one scheduled ping round.
+ *
+ * Counting actual rounds avoids treating time while React Native's scheduler
+ * was paused in the background as pings the miniapp failed to answer.
+ */
+export function advanceMiniappPingLiveness(
+  unansweredPingRounds: number,
+  timeoutThreshold: number,
+): MiniappPingLivenessDecision {
+  if (unansweredPingRounds >= timeoutThreshold) {
+    return {shouldUnregister: true, unansweredPingRounds}
+  }
+
+  return {
+    shouldUnregister: false,
+    unansweredPingRounds: unansweredPingRounds + 1,
+  }
+}

--- a/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/AudioPlaybackService.test.ts
@@ -15,6 +15,7 @@ import {
 
 const setAudioModeAsync = mock(async () => {})
 const tailTimerCallbacks: Array<() => void> = []
+const appState = {currentState: "active"}
 
 const audioPlayer = {
   addListener: mock(() => ({remove: () => {}})),
@@ -31,6 +32,7 @@ mock.module("expo-audio", () => ({
 }))
 
 mock.module("react-native", () => ({
+  AppState: appState,
   Platform: {OS: "android"},
 }))
 
@@ -56,6 +58,8 @@ describe("AudioPlaybackService live PCM streams", () => {
     await audioPlaybackService.stopAll()
     stopAudioCloudUplink()
     resetAudioTestMocks()
+    appState.currentState = "active"
+    Object.assign(audioPlaybackService, {audioRouteWarmUntil: 0})
     tailTimerCallbacks.length = 0
     startAudioCloudUplink()
     setAudioModeAsync.mockClear()
@@ -77,6 +81,20 @@ describe("AudioPlaybackService live PCM streams", () => {
     expect(pcmStreamWrite).toHaveBeenCalledTimes(1)
     expect(pcmStreamAbort).toHaveBeenCalledTimes(1)
     expect(pcmStreamClose).not.toHaveBeenCalled()
+    expect(audioPlayer.play).toHaveBeenCalledTimes(1)
+  })
+
+  test("skips optional route prewarm so background URL playback cannot stall", async () => {
+    appState.currentState = "background"
+    await audioPlaybackService.play(
+      {audioUrl: "https://example.test/background.wav", requestId: "background"},
+      () => {},
+    )
+    audioPlaybackService.cancelPlayback("background")
+
+    expect(pcmStreamOpen).not.toHaveBeenCalled()
+    expect(pcmStreamWrite).not.toHaveBeenCalled()
+    expect(pcmStreamAbort).not.toHaveBeenCalled()
     expect(audioPlayer.play).toHaveBeenCalledTimes(1)
   })
 

--- a/mobile/modules/engine/src/services/__tests__/ForegroundLocationPermission.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/ForegroundLocationPermission.test.ts
@@ -22,7 +22,7 @@ describe("resolveForegroundLocationPermission", () => {
   test("does not invoke the Activity-bound request when permission is already granted in the background", async () => {
     const mocks = buildClient("granted")
 
-    const result = await resolveForegroundLocationPermission(mocks.client, "background")
+    const result = await resolveForegroundLocationPermission(mocks.client, () => "background")
 
     expect(result.status).toBe("granted")
     expect(mocks.getForegroundPermissionsAsync).toHaveBeenCalledTimes(1)
@@ -32,7 +32,7 @@ describe("resolveForegroundLocationPermission", () => {
   test("requests missing permission while the app is active", async () => {
     const mocks = buildClient("undetermined", "granted")
 
-    const result = await resolveForegroundLocationPermission(mocks.client, "active")
+    const result = await resolveForegroundLocationPermission(mocks.client, () => "active")
 
     expect(result.status).toBe("granted")
     expect(mocks.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1)
@@ -41,9 +41,26 @@ describe("resolveForegroundLocationPermission", () => {
   test("returns missing permission without requesting it from the background", async () => {
     const mocks = buildClient("denied", "granted")
 
-    const result = await resolveForegroundLocationPermission(mocks.client, "background")
+    const result = await resolveForegroundLocationPermission(mocks.client, () => "background")
 
     expect(result.status).toBe("denied")
     expect(mocks.requestForegroundPermissionsAsync).not.toHaveBeenCalled()
+  })
+
+  test("rechecks app state after the permission read before requesting", async () => {
+    let appState = "active"
+    const requestForegroundPermissionsAsync = jest.fn(async () => ({status: "granted"}))
+    const client: ForegroundLocationPermissionClient = {
+      getForegroundPermissionsAsync: jest.fn(async () => {
+        appState = "background"
+        return {status: "undetermined"}
+      }),
+      requestForegroundPermissionsAsync,
+    }
+
+    const result = await resolveForegroundLocationPermission(client, () => appState)
+
+    expect(result.status).toBe("undetermined")
+    expect(requestForegroundPermissionsAsync).not.toHaveBeenCalled()
   })
 })

--- a/mobile/modules/engine/src/services/__tests__/ForegroundLocationPermission.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/ForegroundLocationPermission.test.ts
@@ -1,0 +1,49 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, jest, test} from "bun:test"
+
+import {
+  resolveForegroundLocationPermission,
+  type ForegroundLocationPermissionClient,
+} from "../ForegroundLocationPermission"
+
+function buildClient(currentStatus: string, requestedStatus = currentStatus) {
+  const getForegroundPermissionsAsync = jest.fn(async () => ({status: currentStatus}))
+  const requestForegroundPermissionsAsync = jest.fn(async () => ({status: requestedStatus}))
+  const client: ForegroundLocationPermissionClient = {
+    getForegroundPermissionsAsync,
+    requestForegroundPermissionsAsync,
+  }
+
+  return {client, getForegroundPermissionsAsync, requestForegroundPermissionsAsync}
+}
+
+describe("resolveForegroundLocationPermission", () => {
+  test("does not invoke the Activity-bound request when permission is already granted in the background", async () => {
+    const mocks = buildClient("granted")
+
+    const result = await resolveForegroundLocationPermission(mocks.client, "background")
+
+    expect(result.status).toBe("granted")
+    expect(mocks.getForegroundPermissionsAsync).toHaveBeenCalledTimes(1)
+    expect(mocks.requestForegroundPermissionsAsync).not.toHaveBeenCalled()
+  })
+
+  test("requests missing permission while the app is active", async () => {
+    const mocks = buildClient("undetermined", "granted")
+
+    const result = await resolveForegroundLocationPermission(mocks.client, "active")
+
+    expect(result.status).toBe("granted")
+    expect(mocks.requestForegroundPermissionsAsync).toHaveBeenCalledTimes(1)
+  })
+
+  test("returns missing permission without requesting it from the background", async () => {
+    const mocks = buildClient("denied", "granted")
+
+    const result = await resolveForegroundLocationPermission(mocks.client, "background")
+
+    expect(result.status).toBe("denied")
+    expect(mocks.requestForegroundPermissionsAsync).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/modules/engine/src/services/__tests__/MiniappLiveness.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/MiniappLiveness.test.ts
@@ -1,0 +1,28 @@
+/// <reference types="bun-types" />
+
+import {describe, expect, test} from "bun:test"
+
+import {advanceMiniappPingLiveness} from "../MiniappLiveness"
+
+describe("advanceMiniappPingLiveness", () => {
+  test("counts a ping round that has not answered yet", () => {
+    expect(advanceMiniappPingLiveness(0, 6)).toEqual({
+      shouldUnregister: false,
+      unansweredPingRounds: 1,
+    })
+  })
+
+  test("allows the configured number of actual ping attempts", () => {
+    expect(advanceMiniappPingLiveness(5, 6)).toEqual({
+      shouldUnregister: false,
+      unansweredPingRounds: 6,
+    })
+  })
+
+  test("unregisters only after the configured attempts went unanswered", () => {
+    expect(advanceMiniappPingLiveness(6, 6)).toEqual({
+      shouldUnregister: true,
+      unansweredPingRounds: 6,
+    })
+  })
+})

--- a/mobile/plugins/android.ts
+++ b/mobile/plugins/android.ts
@@ -259,6 +259,7 @@ function withAndroidManifestModifications(config: any) {
       {name: "android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"},
       {name: "android.permission.FOREGROUND_SERVICE_DATA_SYNC"},
       {name: "android.permission.FOREGROUND_SERVICE_LOCATION"},
+      {name: "android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"},
       {name: "android.permission.FOREGROUND_SERVICE_MICROPHONE"},
       {name: "android.permission.NEARBY_DEVICES"},
       {name: "android.permission.POST_NOTIFICATIONS"},


### PR DESCRIPTION
## Summary

- avoid Activity-bound Expo location permission prompts while the Mentra App is backgrounded
- add `mediaPlayback` to the existing Mentra Android foreground service and its manifest permissions
- skip the optional silent PCM route prewarm while backgrounded so it cannot block real URL/TTS playback
- reconcile a stale native “Mentra audio is playing” hint with Android's actual media state so the glasses mic watchdog can recover
- count miniapp liveness from ping rounds actually sent, preventing a paused React Native timer from unregistering Mentra AI immediately on resume
- add regression coverage for background playback, audio-state recovery, permission handling, and miniapp liveness

## Root cause

The incident logs identify three independent background/resume failure modes.

First, incident `rep_01KY6V1N08HW4PMVJJ19MQBWM0` showed that the Mentra foreground service was already running as `connectedDevice|microphone|location`, but `Location.requestForegroundPermissionsAsync()` still blocked. Expo's Android implementation delegates that call to `Activity.requestPermissions(...)` even when foreground location is already granted, so the callback waited for Activity resume. The host now reads `getForegroundPermissionsAsync()` first. Existing grants proceed immediately, while a missing grant only opens Expo's prompt path if the app is still active.

Second, `AudioPlaybackService` started its optional cold-A2DP silent PCM prewarm in the background; that prewarm completed only when the Activity became active, releasing queued sound at once. Background URL playback now bypasses that optional optimization and starts the real player directly. The persistent Mentra foreground service also declares and activates Android's `mediaPlayback` type.

Finally, incident `rep_01KY6WTT74Z49QY0G5JEWSV1CT` showed TTS completion without the debounced native `STOPPED` notification. The stale `PLAYING` hint then blocked the native glasses-mic recovery watchdog every ten seconds even though Android reported no active media. `PhoneAudioMonitor` now expires that hint after its short codec-transition holdoff when Android media is inactive, allowing mic recovery on the next watchdog pass.

The same incident also showed the React Native ping interval being paused for roughly two minutes in the background. On resume, elapsed wall time was incorrectly interpreted as six missed pings, so Mentra AI was unregistered and its transcription subscription—and home-screen mic icon—disappeared. Liveness now counts actual unanswered ping rounds instead of wall time, so resume sends a fresh ping rather than killing a context that was never probed.

## Validation

- `bun test src/services/__tests__/MiniappLiveness.test.ts src/services/__tests__/AudioPlaybackService.test.ts` (21 pass)
- `./gradlew :mentra-bluetooth-sdk:testDebugUnitTest --tests com.mentra.bluetoothsdk.utils.PhoneAudioMonitorTest --no-daemon`
- `bun compile`
- `./scripts/check-android-compile.sh bluetooth-sdk`
- forced `:app:processDebugMainManifest` merge; packaged service includes `dataSync|connectedDevice|location|mediaPlayback|microphone`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches foreground service types, background audio/location paths, and miniapp unregister logic—important for glasses connectivity and Mentra AI, but changes are targeted with unit tests.
> 
> **Overview**
> **Fixes Mentra AI and glasses-initiated flows when the Android app is backgrounded or resumes**, addressing several independent failure modes seen in production.
> 
> The **Mentra Bluetooth foreground service** now always includes **`mediaPlayback`** (manifest + Expo plugin + runtime type detection) so background TTS/prompts are allowed without spinning up a second service. **`AudioPlaybackService`** skips the optional silent PCM cold-route prewarm when **`AppState` is not active**, so glasses prompts are not held until the Activity resumes.
> 
> **`PhoneAudioMonitor`** reconciles the RN “own app playing” hint with **`isMusicActive`**: it still honors the short codec-transition holdoff, but clears a stuck **PLAYING** flag when Android reports no media so the glasses mic watchdog can recover.
> 
> **Miniapp location polls** use **`resolveForegroundLocationPermission`**: read grant first and only call Expo’s Activity-bound **`requestForegroundPermissionsAsync`** while foreground. **Miniapp liveness** counts **unanswered ping rounds** instead of wall-clock time since last pong, so a paused RN timer in background no longer unregisters Mentra AI immediately on resume.
> 
> Regression tests cover audio prewarm skip, location permission resolution, ping liveness, and **`shouldKeepOwnAppAudioSignal`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae39297d6de7e1c7012ef6c5356c49c781f0d543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->