### PR TITLE
Fix example-oem-app scan hang and Metro bundling in the sdk workspace

### DIFF
--- a/sdk/example-oem-app/App.tsx
+++ b/sdk/example-oem-app/App.tsx
@@ -61,12 +61,20 @@ export default function App() {
 
   // --- Pairing ---
   const scanForGlasses = useCallback(async () => {
+    // Without BLUETOOTH_SCAN/CONNECT (Android 12+) the OS silently withholds
+    // scan results — the native scan "starts" but never reports a device, so
+    // the button spins on "Scanning…" forever with no error. Request first.
+    const granted = await run("permissions.request(bluetooth)", () => engine.permissions.request("bluetooth"))
+    if (!granted) {
+      logger.logError("Bluetooth permission denied — can't scan for glasses.")
+      return
+    }
     // Mark the model as the pending selection (the scan-entry write of the
     // two-phase identity contract), then start scanning. Results stream into
     // `devices` via onFound.
     engine.pairing.markPendingSelection(GLASSES_MODEL)
     await run(`scan(${GLASSES_MODEL})`, () => engine.pairing.scan(GLASSES_MODEL))
-  }, [run])
+  }, [run, logger])
 
   const pairDevice = useCallback(
     async (device: ScanResult) => {

--- a/sdk/example-oem-app/metro.config.js
+++ b/sdk/example-oem-app/metro.config.js
@@ -6,6 +6,13 @@ const projectRoot = __dirname
 const sdkRoot = path.resolve(projectRoot, "..") // the `sdk` workspace root
 const repoRoot = path.resolve(projectRoot, "..", "..") // monorepo root
 const modulesRoot = path.resolve(repoRoot, "mobile", "modules")
+// The `mobile` bun workspace's own node_modules — where @mentra/engine's
+// transitive deps (typesafe-ts, buffer, events, semver, ...) actually live on
+// disk, since engine is a member of that workspace, not sdk's. Metro's Node
+// resolution walk finds these fine, but Metro also requires the resolved path
+// to be inside a watched folder (its Haste/file index) or it 404s as if the
+// file didn't exist — so this has to be watched explicitly, not just modulesRoot.
+const mobileNodeModulesRoot = path.resolve(repoRoot, "mobile", "node_modules")
 
 const config = getDefaultConfig(projectRoot)
 
@@ -14,8 +21,12 @@ const config = getDefaultConfig(projectRoot)
 // (sdk/node_modules/.bun/*) and the modules folder so every symlinked package —
 // including transitive deps of `expo` — resolves.
 const cloudPackagesRoot = path.resolve(repoRoot, "cloud-v2", "packages")
+// Same isolated-linker gap as mobileNodeModulesRoot above, one workspace over:
+// cloud-v2/packages/*/node_modules/<pkg> symlinks resolve into
+// cloud-v2/node_modules/.bun/*, not anywhere under cloudPackagesRoot.
+const cloudNodeModulesRoot = path.resolve(repoRoot, "cloud-v2", "node_modules")
 
-config.watchFolders = [sdkRoot, modulesRoot, cloudPackagesRoot]
+config.watchFolders = [sdkRoot, modulesRoot, mobileNodeModulesRoot, cloudPackagesRoot, cloudNodeModulesRoot]
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),


### PR DESCRIPTION
## Summary
Follow-up to #3511. After fixing the calendar-crash startup issue, tapping "Scan for glasses" in `example-oem-app` on a physical device (Z Fold) got stuck permanently on "Scanning…" with a disabled button and no error. Root-caused two independent bugs:

- **`App.tsx`**: `scanForGlasses()` called `engine.pairing.scan(...)` without first requesting `BLUETOOTH_SCAN`/`BLUETOOTH_CONNECT` (Android 12+). Without those, Android silently withholds scan callbacks — the native scan registers successfully (`onScannerRegistered status=0`) but never delivers a single result, so the UI just spins forever with nothing to show for it. Confirmed via `dumpsys package` that these permissions were `granted=false`. Fixed by requesting `engine.permissions.request("bluetooth")` before scanning and surfacing a clear error on denial — matching the pattern the main Mentra app already uses (`requestFeaturePermissions(PermissionFeatures.BLUETOOTH)` in `mobile/src/app/pairing/prep.tsx`).
- **`metro.config.js`**: separately, Metro couldn't even bundle the app (500 error / "Unable to load script") once the permission fix pulled `engine.permissions` into the graph. `@mentra/engine` (lives at `mobile/modules/engine`) and `@mentra/cloud-client` (lives at `cloud-v2/packages/cloud-client`) both have transitive deps (`typesafe-ts`, `tweetnacl`, etc.) that only resolve on disk via their *own* workspace's bun store (`mobile/node_modules`, `cloud-v2/node_modules`) rather than being hoisted into `sdk/`. Metro's Node resolution walk finds these paths fine, but Metro also requires the resolved file to be inside a watched folder (its Haste index) or it 404s as if the file doesn't exist. `watchFolders` was missing both of those directories. Added them.

Neither of these is specific to the calendar-crash fix — both would block first-run pairing for anyone standing up `example-oem-app` fresh in this sdk workspace.

## Test plan
- [x] Reproduced the hang on a physical Galaxy Z Fold: `BLUETOOTH_SCAN`/`BLUETOOTH_CONNECT` confirmed `granted=false` via `dumpsys package com.mentra.exampleoemapp`; native scan registered (`scannerId=10, status=0`) but zero `onScanResult` callbacks ever arrived.
- [x] Reproduced the Metro 500 independently (`Unable to resolve module ./index` due to serverRoot autodetection, then `Unable to resolve module 'typesafe-ts'` / `'tweetnacl'` once pointed at the right bundle URL) and fixed by watching the two missing node_modules roots — verified `curl .../index.bundle` returns `HTTP 200` with all modules bundled.
- [x] After both fixes: relaunched on-device, tapped Scan, got the system Bluetooth permission dialog, granted it, `BLUETOOTH_SCAN`/`BLUETOOTH_CONNECT` now `granted=true` and the native scan proceeds.
- [ ] Full pair-to-connected confirmation is blocked on unrelated hardware state on the test glasses (not advertising — confirmed independently via the phone's own native Bluetooth pairing screen, which also can't see them). Permission + bundling are the two software bugs in scope here; glasses discovery once they're advertising again is expected to work off the existing `G2.kt` scan/connect path, unchanged by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to the example OEM app and its Metro config; no changes to production pairing or engine runtime behavior.
> 
> **Overview**
> Fixes two first-run blockers in **`example-oem-app`**: pairing scan that never finishes on Android 12+, and Metro failing to bundle once the engine permission path is in the graph.
> 
> **Pairing:** `scanForGlasses` now calls `engine.permissions.request("bluetooth")` before `engine.pairing.scan`, logs a clear error if denied, and adds `logger` to the callback deps. Without runtime `BLUETOOTH_SCAN`/`CONNECT`, scans can appear to start but deliver no devices, leaving the UI stuck on "Scanning…".
> 
> **Metro:** `watchFolders` now includes `mobile/node_modules` and `cloud-v2/node_modules` so transitive deps of `@mentra/engine` and `@mentra/cloud-client` resolve inside Metro’s watched Haste roots instead of 404ing during bundle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d52f7a92f8ea5a852bc8fddac754ab4b165cce0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->