### PR TITLE
Fix app-switcher card thrash and splash layout jump when opening an app

### DIFF
--- a/mobile/src/components/home/AppSwitcher.tsx
+++ b/mobile/src/components/home/AppSwitcher.tsx
@@ -301,12 +301,23 @@ export default function AppSwitcher({swipeProgress, blurTargetRef: _blurTargetRe
   //   return useAppletStatusStore.getState().apps.filter((a) => activePackageNames.includes(a.packageName))
   // }, [activePackageNames])
 
+  // While a card tap is mid-flight (selection → app opens under the drawer →
+  // drawer closes ~750ms later), the store updates several times
+  // (last-open-time save, foregrounded flip) and each poll would re-sort the
+  // VISIBLE card stack — the tapped card jumps to the end of the list and the
+  // whole strip thrashes left/right ("seizure" during open,
+  // rep_01KY6D2EMFXC8JQKZH9EGMZ5G3). Freeze the rendered order for the whole
+  // selection window and apply the final order once, after the close finishes.
+  const selectionInFlight = useRef(false)
+  const directAppsRef = useRef(directApps)
+  directAppsRef.current = directApps
+
   useEffect(() => {
+    if (selectionInFlight.current) return
     let cancelled = false
     sortAppsByLastOpenTime(directApps).then((sorted) => {
-      if (!cancelled) setApps(sorted)
+      if (!cancelled && !selectionInFlight.current) setApps(sorted)
     })
-    // console.log("apps screenshot", apps.map((a) => a.screenshot))
     return () => {
       cancelled = true
     }
@@ -637,6 +648,10 @@ export default function AppSwitcher({swipeProgress, blurTargetRef: _blurTargetRe
       return
     }
 
+    // Freeze the visible card order until the drawer has fully closed (see
+    // the sort effect above). Released in handleClose's settle timeout.
+    selectionInFlight.current = true
+
     // Handle apps with custom routes (offline or online with offlineRoute override)
     if (applet.offlineRoute && isOfflineHosted(applet.packageName)) {
       // Registry-hosted offline apps render in the Compositor overlay like
@@ -672,6 +687,14 @@ export default function AppSwitcher({swipeProgress, blurTargetRef: _blurTargetRe
     setTimeout(() => {
       swipeProgress.value = 0
       // goToIndex(apps.length - 1, true)
+      // Selection window over (drawer is fully hidden): unfreeze the card
+      // order and apply the sort that was suppressed during the open/close.
+      if (selectionInFlight.current) {
+        selectionInFlight.current = false
+        sortAppsByLastOpenTime(directAppsRef.current).then((sorted) => {
+          if (!selectionInFlight.current) setApps(sorted)
+        })
+      }
     }, 250)
   }, [apps.length])
 

--- a/mobile/src/components/miniapp/MiniappSplash.tsx
+++ b/mobile/src/components/miniapp/MiniappSplash.tsx
@@ -81,34 +81,36 @@ export default function MiniappSplash({
         {backgroundColor: bgColor, justifyContent: "center", alignItems: "center"},
         animatedStyle,
       ]}>
-      {(iconUrl || devApp) && (
-        <View style={{position: "relative"}}>
-          <SquircleView
-            cornerSmoothing={100}
-            preserveSmoothing={true}
-            style={{
-              width: size,
-              height: size,
-              borderRadius,
-              overflow: "hidden",
-              alignItems: "center",
-              justifyContent: "center",
-            }}>
-            {iconUrl ? (
-              <Image
-                source={iconUrl}
-                style={{width: "100%", height: "100%"}}
-                contentFit="cover"
-                transition={200}
-                cachePolicy="memory-disk"
-              />
-            ) : (
-              <DevIcon size={size} />
-            )}
-          </SquircleView>
-          {devApp && <DevMiniappBadge size={18} />}
-        </View>
-      )}
+      {/* Always mounted: iconUrl can resolve a beat after the splash appears
+          (lazy icon resolution), and conditionally mounting this block made
+          the name text jump down when the icon landed. An empty squircle is
+          invisible, so reserving the space costs nothing. */}
+      <View style={{position: "relative"}}>
+        <SquircleView
+          cornerSmoothing={100}
+          preserveSmoothing={true}
+          style={{
+            width: size,
+            height: size,
+            borderRadius,
+            overflow: "hidden",
+            alignItems: "center",
+            justifyContent: "center",
+          }}>
+          {iconUrl ? (
+            <Image
+              source={iconUrl}
+              style={{width: "100%", height: "100%"}}
+              contentFit="cover"
+              transition={200}
+              cachePolicy="memory-disk"
+            />
+          ) : devApp ? (
+            <DevIcon size={size} />
+          ) : null}
+        </SquircleView>
+        {devApp && <DevMiniappBadge size={18} />}
+      </View>
 
       <View className="h-16 items-center justify-center w-full mt-4">
         {name && <Text className="text-lg h-10 font-semibold text-center" text={name} />}


### PR DESCRIPTION
## Problem

rep_01KY6D2EMFXC8JQKZH9EGMZ5G3: "Opening an app from the running task drawer has a seizure animation."

Reproduced on a Pixel 8 and characterized frame-by-frame from 30fps screen recordings. Two distinct artifacts:

1. **Card thrash**: tapping a card saves last-open-time and flips the foregrounded flag; each resulting apps-store poll re-sorted the *still-visible* card stack by recency. The tapped card jumps to the end of the list, the strip re-indexes, and `translateX` visibly thrashes left/right several times during the 500ms window before the drawer closes — the "seizure."
2. **Splash layout jump**: the miniapp splash mounts its icon block conditionally on `iconUrl`, which can resolve a beat after the splash appears; when the icon lands the app-name text jumps down.

## Fix

- `AppSwitcher`: freeze the rendered card order while a selection is in flight (`selectionInFlight` ref, armed in `handleSelect`, released in `handleClose`'s settle timeout), then apply the suppressed sort once the drawer is fully hidden. Card dismissal paths are untouched — the freeze only arms on select.
- `MiniappSplash`: always mount the icon container (an empty squircle is invisible), so a late-resolving icon fades into reserved space instead of shifting the label.

## Verification

- `bun compile` clean.
- Before/after 30fps screen recordings of the identical repro (4 running apps → open switcher → tap the Mentra AI card): before shows the card oscillating left/center for ~400ms plus the name-text jump; after shows the card stack perfectly still through the tap and the icon fading into place with no layout shift. Recordings available on request (captured via adb screenrecord).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 3cc56de78c422b68dbb0def3ffd8c2f0f1234e72. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the app-switcher card thrash and the splash text jump when opening an app. Fixes rep_01KY6D2EMFXC8JQKZH9EGMZ5G3.

- **Bug Fixes - Bug fixes implemented**
  - App switcher: freeze rendered card order during selection; suppress resorting until the drawer fully closes, then apply one final sort. Dismissal behavior unchanged.
  - Miniapp splash: always render the icon container so late icons fade into reserved space without shifting the app name.

<sup>Written for commit 3cc56de78c422b68dbb0def3ffd8c2f0f1234e72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

