### PR TITLE
dev2staging

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_LOCATION"/>
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE"/>
 
   <!-- Other permissions -->
@@ -35,6 +36,6 @@
   <uses-permission android:name="android.permission.VIBRATE"/>
 
   <application>
-    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|microphone"/>
+    <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|location|microphone"/>
   </application>
 </manifest>

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkModule.kt
@@ -2,6 +2,8 @@
 
 package com.mentra.bluetoothsdk
 
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import com.mentra.bluetoothsdk.utils.DeviceTypes
 import com.mentra.bluetoothsdk.utils.audio.PcmStreamManager
@@ -391,6 +393,21 @@ class BluetoothSdkModule : Module() {
                             sdkListener,
                     )
             deviceManager = DeviceManager.getInstance()
+            val activity = appContext.currentActivity
+            val activityIsResumed =
+                    (activity as? LifecycleOwner)
+                            ?.lifecycle
+                            ?.currentState
+                            ?.isAtLeast(Lifecycle.State.RESUMED) == true
+            if (activityIsResumed) {
+                deviceManager?.refreshForegroundServiceTypes()
+            }
+        }
+
+        OnActivityEntersForeground {
+            // Re-run after runtime permission dialogs and every app resume. This is the safe
+            // point to add Android's while-in-use location foreground-service type.
+            deviceManager?.refreshForegroundServiceTypes()
         }
 
         OnDestroy {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -582,6 +582,36 @@ class DeviceManager {
         }
     }
 
+    /**
+     * Re-evaluate the active foreground-service types while the host Activity is visible.
+     *
+     * Location is a while-in-use permission, so Android 14+ only allows the service to add
+     * the location type from the foreground. Sending a command to the existing service
+     * updates its type mask without tearing down the glasses connection.
+     */
+    fun refreshForegroundServiceTypes() {
+        val context = Bridge.getContext()
+
+        try {
+            Bridge.log("MAN: Refreshing foreground service types")
+            val serviceIntent =
+                Intent(context, ForegroundService::class.java).apply {
+                    action = ForegroundService.ACTION_REFRESH_TYPES
+                }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent)
+            } else {
+                context.startService(serviceIntent)
+            }
+
+            serviceStarted = true
+            Bridge.log("MAN: Foreground service types refreshed")
+        } catch (e: Exception) {
+            Bridge.log("MAN: Failed to refresh foreground service types: ${e.message}")
+        }
+    }
+
     private fun restartForegroundService() {
         val context = Bridge.getContext()
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/services/Foreground.kt
@@ -6,6 +6,7 @@ import android.app.Service
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
+import android.location.LocationManager
 import android.os.Build
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
@@ -17,7 +18,11 @@ class ForegroundService : Service() {
     companion object {
         const val CHANNEL_ID = "MentraServiceChannel"
         const val NOTIFICATION_ID = 1001
+        const val ACTION_REFRESH_TYPES =
+                "com.mentra.bluetoothsdk.services.action.REFRESH_FOREGROUND_SERVICE_TYPES"
     }
+
+    private var locationTypeRequested = false
 
     override fun onCreate() {
         super.onCreate()
@@ -34,6 +39,11 @@ class ForegroundService : Service() {
                 "service_start_command",
                 mapOf("action" to intent?.action, "flags" to flags, "startId" to startId)
         )
+        if (intent?.action == ACTION_REFRESH_TYPES) {
+            // This action is only sent while the host Activity is foregrounded. Android 14+
+            // rejects adding a while-in-use location type from the background.
+            locationTypeRequested = true
+        }
         // Re-check permissions in case they changed
         startForegroundWithAutoDetectedType()
         return START_STICKY
@@ -124,6 +134,28 @@ class ForegroundService : Service() {
             Bridge.log("ForegroundService: No microphone permission")
         }
 
+        val hasLocationPermission =
+                ContextCompat.checkSelfPermission(
+                        this,
+                        android.Manifest.permission.ACCESS_FINE_LOCATION
+                ) == PackageManager.PERMISSION_GRANTED ||
+                        ContextCompat.checkSelfPermission(
+                                this,
+                                android.Manifest.permission.ACCESS_COARSE_LOCATION
+                        ) == PackageManager.PERMISSION_GRANTED
+        val locationManager = getSystemService(LocationManager::class.java)
+        val isLocationEnabled = locationManager?.isLocationEnabled == true
+
+        if (locationTypeRequested && hasLocationPermission && isLocationEnabled) {
+            serviceType = serviceType or ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION
+            Bridge.log("ForegroundService: Added location (has foreground location permission)")
+        } else {
+            Bridge.log(
+                    "ForegroundService: No location type " +
+                            "(requested=$locationTypeRequested, permission=$hasLocationPermission, enabled=$isLocationEnabled)"
+            )
+        }
+
         // Only use dataSync as absolute last resort fallback if no other types were added.
         // WARNING: dataSync has a 6-hour timeout on Android 14+ which will crash the app.
         // This should rarely happen since CHANGE_NETWORK_STATE is a normal permission.
@@ -141,8 +173,14 @@ class ForegroundService : Service() {
         val hasConnectedDevice =
                 (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE) != 0
         val hasMicrophone = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE) != 0
+        val hasLocation = (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION) != 0
 
         return when {
+            hasConnectedDevice && hasMicrophone && hasLocation ->
+                    "Glasses, microphone & location active"
+            hasConnectedDevice && hasLocation -> "Smart glasses & location active"
+            hasMicrophone && hasLocation -> "Microphone & location active"
+            hasLocation -> "Location active"
             hasConnectedDevice && hasMicrophone -> "Glasses & microphone active"
             hasConnectedDevice -> "Smart glasses connected"
             hasMicrophone -> "Microphone active"
@@ -160,6 +198,8 @@ class ForegroundService : Service() {
                 types.add("connectedDevice")
         if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE != 0)
                 types.add("microphone")
+        if (serviceType and ServiceInfo.FOREGROUND_SERVICE_TYPE_LOCATION != 0)
+                types.add("location")
 
         return types.joinToString("|")
     }

--- a/sdk/example-oem-app/App.tsx
+++ b/sdk/example-oem-app/App.tsx
@@ -61,12 +61,20 @@ export default function App() {
 
   // --- Pairing ---
   const scanForGlasses = useCallback(async () => {
+    // Without BLUETOOTH_SCAN/CONNECT (Android 12+) the OS silently withholds
+    // scan results — the native scan "starts" but never reports a device, so
+    // the button spins on "Scanning…" forever with no error. Request first.
+    const granted = await run("permissions.request(bluetooth)", () => engine.permissions.request("bluetooth"))
+    if (!granted) {
+      logger.logError("Bluetooth permission denied — can't scan for glasses.")
+      return
+    }
     // Mark the model as the pending selection (the scan-entry write of the
     // two-phase identity contract), then start scanning. Results stream into
     // `devices` via onFound.
     engine.pairing.markPendingSelection(GLASSES_MODEL)
     await run(`scan(${GLASSES_MODEL})`, () => engine.pairing.scan(GLASSES_MODEL))
-  }, [run])
+  }, [run, logger])
 
   const pairDevice = useCallback(
     async (device: ScanResult) => {

--- a/sdk/example-oem-app/metro.config.js
+++ b/sdk/example-oem-app/metro.config.js
@@ -6,6 +6,13 @@ const projectRoot = __dirname
 const sdkRoot = path.resolve(projectRoot, "..") // the `sdk` workspace root
 const repoRoot = path.resolve(projectRoot, "..", "..") // monorepo root
 const modulesRoot = path.resolve(repoRoot, "mobile", "modules")
+// The `mobile` bun workspace's own node_modules — where @mentra/engine's
+// transitive deps (typesafe-ts, buffer, events, semver, ...) actually live on
+// disk, since engine is a member of that workspace, not sdk's. Metro's Node
+// resolution walk finds these fine, but Metro also requires the resolved path
+// to be inside a watched folder (its Haste/file index) or it 404s as if the
+// file didn't exist — so this has to be watched explicitly, not just modulesRoot.
+const mobileNodeModulesRoot = path.resolve(repoRoot, "mobile", "node_modules")
 
 const config = getDefaultConfig(projectRoot)
 
@@ -14,8 +21,12 @@ const config = getDefaultConfig(projectRoot)
 // (sdk/node_modules/.bun/*) and the modules folder so every symlinked package —
 // including transitive deps of `expo` — resolves.
 const cloudPackagesRoot = path.resolve(repoRoot, "cloud-v2", "packages")
+// Same isolated-linker gap as mobileNodeModulesRoot above, one workspace over:
+// cloud-v2/packages/*/node_modules/<pkg> symlinks resolve into
+// cloud-v2/node_modules/.bun/*, not anywhere under cloudPackagesRoot.
+const cloudNodeModulesRoot = path.resolve(repoRoot, "cloud-v2", "node_modules")
 
-config.watchFolders = [sdkRoot, modulesRoot, cloudPackagesRoot]
+config.watchFolders = [sdkRoot, modulesRoot, mobileNodeModulesRoot, cloudPackagesRoot, cloudNodeModulesRoot]
 
 config.resolver.extraNodeModules = {
   ...(config.resolver.extraNodeModules ?? {}),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keep Android location available in the Mentra foreground service and fix the SDK example app’s scan hang and Metro bundling issues.

- **New Features**
  - Added `FOREGROUND_SERVICE_LOCATION` permission and service type; foreground service now includes location when allowed.
  - Added `DeviceManager.refreshForegroundServiceTypes()` and lifecycle hooks to re-apply service types on resume without dropping the glasses connection.
  - Updated notification text and logs to reflect active location state.

- **Bug Fixes**
  - Example OEM app: request Bluetooth permissions before scanning to prevent silent scan hangs on Android 12+; log clear error on denial.
  - Metro config: added watch folders for `mobile/node_modules` and `cloud-v2/node_modules` so transitive deps of `@mentra/engine` and `@mentra/cloud-client` resolve during bundling.

<sup>Written for commit 24db0b0fc79cff6093b9304b66e7500f2dc84056. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches foreground-service type and location permission behavior on Android 14+; incorrect timing could cause FGS violations, but changes are gated on foreground and explicit refresh actions.
> 
> **Overview**
> **Android Bluetooth SDK** now adds the **location** foreground-service type only while the host activity is visible—required on Android 14+ for while-in-use location. Manifest declares `FOREGROUND_SERVICE_LOCATION` and the service type mask includes `location`; `ForegroundService` applies that bit when it receives `ACTION_REFRESH_TYPES` and location permission plus system location are satisfied. `BluetoothSdkModule` triggers `DeviceManager.refreshForegroundServiceTypes()` on module create (if resumed) and on every foreground entry so permission dialogs and resumes can update the mask without restarting the glasses connection.
> 
> **Example OEM app:** scanning requests Bluetooth runtime permission before `pairing.scan` so Android 12+ does not hang silently. **Metro** watches `mobile/node_modules` and `cloud-v2/node_modules` so monorepo isolated-linker deps resolve during bundling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24db0b0fc79cff6093b9304b66e7500f2dc84056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->