### PR TITLE
Align MentraOS onboarding with Mentra Live styling

### DIFF
--- a/mobile/src/__tests__/app/onboarding/os.test.tsx
+++ b/mobile/src/__tests__/app/onboarding/os.test.tsx
@@ -87,8 +87,9 @@ describe("MentraOS onboarding", () => {
     )
 
     const {steps} = mockOnboardingGuide.mock.calls[0][0]
-    expect(steps).toHaveLength(5)
+    expect(steps).toHaveLength(6)
     expect(steps.map((step: {title: string}) => step.title)).toEqual([
+      "onboarding:osWelcomeTitle",
       "onboarding:osStartMiniappTitle",
       "onboarding:osMinimizeCloseTitle",
       "onboarding:osSwitchMiniappsTitle",
@@ -96,6 +97,16 @@ describe("MentraOS onboarding", () => {
       "onboarding:osMovedMiniappsTitle",
     ])
     expect(steps[0]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        transition: true,
+        title: "onboarding:osWelcomeTitle",
+        subtitle: "onboarding:osWelcomeSubtitle",
+        titleCentered: true,
+        subtitleCentered: true,
+      }),
+    )
+    expect(steps[1]).toEqual(
       expect.objectContaining({
         type: "image",
         testID: "mentraos-onboarding-hero-1",
@@ -107,7 +118,7 @@ describe("MentraOS onboarding", () => {
         ],
       }),
     )
-    expect(steps[4]).toEqual(
+    expect(steps[5]).toEqual(
       expect.objectContaining({
         type: "image",
         testID: "mentraos-onboarding-hero-5",
@@ -150,9 +161,9 @@ describe("MentraOS onboarding", () => {
     render(<MentraOSOnboarding />)
 
     const {steps} = mockOnboardingGuide.mock.calls[0][0]
-    act(() => steps[4].action.onPress())
+    act(() => steps[5].action.onPress())
 
-    expect(steps[4].action.testID).toBe("mentraos-onboarding-open-legacy")
+    expect(steps[5].action.testID).toBe("mentraos-onboarding-open-legacy")
     expect(openUrl).toHaveBeenCalledWith("https://mentraglass.com/legacy")
   })
 })

--- a/mobile/src/__tests__/app/onboarding/os.test.tsx
+++ b/mobile/src/__tests__/app/onboarding/os.test.tsx
@@ -1,20 +1,15 @@
-import {fireEvent, render} from "@testing-library/react-native"
+import {SETTINGS} from "@mentra/engine"
+import {useSettingsStore} from "@mentra/engine/internal"
+import {act, fireEvent, render} from "@testing-library/react-native"
 import type {ReactNode} from "react"
 import {Linking} from "react-native"
 
 import MentraOSOnboarding from "@/app/onboarding/os"
-import {SETTINGS} from "@mentra/engine"
-import {useSettingsStore} from "@mentra/engine/internal"
+import showAlertMock from "@/utils/AlertUtils"
 
 const mockPushPrevious = jest.fn()
 const mockScreen = jest.fn()
-
-jest.mock("expo-image", () => {
-  const {View} = require("react-native")
-  return {
-    Image: ({testID}: {testID?: string}) => <View testID={testID} />,
-  }
-})
+const mockOnboardingGuide = jest.fn()
 
 jest.mock("@/components/ignite", () => {
   const {Text: RNText, View} = require("react-native")
@@ -31,13 +26,39 @@ jest.mock("@/components/ignite", () => {
   return {Icon: MockIcon, Screen: MockScreen, Text: MockText}
 })
 
+jest.mock("@/components/onboarding/OnboardingGuide", () => {
+  const {Text, TouchableOpacity, View} = require("react-native")
+  function MockOnboardingGuide(props: {endButtonFn: () => void; skipFn: () => void}) {
+    mockOnboardingGuide(props)
+    return (
+      <View>
+        <TouchableOpacity testID="skip-os-onboarding" onPress={props.skipFn}>
+          <Text>Skip</Text>
+        </TouchableOpacity>
+        <TouchableOpacity testID="finish-os-onboarding" onPress={props.endButtonFn}>
+          <Text>Finish</Text>
+        </TouchableOpacity>
+      </View>
+    )
+  }
+  return {OnboardingGuide: MockOnboardingGuide}
+})
+
 jest.mock("@/contexts/NavigationHistoryContext", () => ({
-  focusEffectPreventBack: jest.fn(),
   usePushPrevious: () => mockPushPrevious,
+}))
+
+jest.mock("@/contexts/ThemeContext", () => ({
+  useAppTheme: () => ({theme: {colors: {primary: "#00b869"}}}),
 }))
 
 jest.mock("@/i18n", () => ({
   translate: (key: string) => key,
+}))
+
+jest.mock("@/utils/AlertUtils", () => ({
+  __esModule: true,
+  default: jest.fn(),
 }))
 
 describe("MentraOS onboarding", () => {
@@ -46,32 +67,70 @@ describe("MentraOS onboarding", () => {
     useSettingsStore.getState().resetAllSettingsLocally()
   })
 
-  it("renders the full-screen Figma flow and supports back navigation", () => {
-    const {getByText, getByTestId, queryByTestId} = render(<MentraOSOnboarding />)
+  it("uses the shared Mentra Live onboarding preset for the full tutorial", () => {
+    render(<MentraOSOnboarding />)
 
-    expect(getByText("onboarding:osStartMiniappTitle")).toBeTruthy()
-    expect(getByTestId("mentraos-onboarding-hero-1")).toBeTruthy()
-    expect(queryByTestId("mentraos-onboarding-back")).toBeNull()
     expect(mockScreen).toHaveBeenCalledWith(
       expect.objectContaining({
         extraAndroidInsets: true,
-        safeAreaEdges: ["top", "bottom"],
-        StatusBarProps: {hidden: true},
+        safeAreaEdges: ["bottom"],
+      }),
+    )
+    expect(mockOnboardingGuide).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoStart: false,
+        endButtonText: "common:continue",
+        preventBack: true,
+        showCloseButton: true,
+        startButtonText: "onboarding:continueOnboarding",
       }),
     )
 
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    expect(getByText("onboarding:osMinimizeCloseTitle")).toBeTruthy()
-    expect(getByTestId("mentraos-onboarding-back")).toBeTruthy()
-
-    fireEvent.press(getByTestId("mentraos-onboarding-back"))
-    expect(getByText("onboarding:osStartMiniappTitle")).toBeTruthy()
+    const {steps} = mockOnboardingGuide.mock.calls[0][0]
+    expect(steps).toHaveLength(5)
+    expect(steps.map((step: {title: string}) => step.title)).toEqual([
+      "onboarding:osStartMiniappTitle",
+      "onboarding:osMinimizeCloseTitle",
+      "onboarding:osSwitchMiniappsTitle",
+      "onboarding:osMiniappDrawerTitle",
+      "onboarding:osMovedMiniappsTitle",
+    ])
+    expect(steps[0]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        testID: "mentraos-onboarding-hero-1",
+        details: [
+          {
+            title: "onboarding:osTapToLaunchTitle",
+            description: "onboarding:osTapToLaunchDescription",
+          },
+        ],
+      }),
+    )
+    expect(steps[4]).toEqual(
+      expect.objectContaining({
+        type: "image",
+        testID: "mentraos-onboarding-hero-5",
+        details: expect.arrayContaining([
+          expect.objectContaining({title: "onboarding:osMissingMiniappTitle"}),
+          expect.objectContaining({title: "onboarding:osMentraOsLegacyTitle"}),
+        ]),
+      }),
+    )
   })
 
-  it("persists completion when the user skips", () => {
+  it("confirms before persisting completion when the user skips", () => {
     const {getByTestId} = render(<MentraOSOnboarding />)
 
-    fireEvent.press(getByTestId("mentraos-onboarding-skip"))
+    fireEvent.press(getByTestId("skip-os-onboarding"))
+    expect(showAlertMock).toHaveBeenCalledWith(
+      "onboarding:osEndOnboardingTitle",
+      "onboarding:osEndOnboardingMessage",
+      expect.any(Array),
+    )
+
+    const confirmSkip = (showAlertMock as jest.Mock).mock.calls[0][2][1]
+    act(() => confirmSkip.onPress())
 
     expect(useSettingsStore.getState().getSetting(SETTINGS.onboarding_os_completed.key)).toBe(true)
     expect(mockPushPrevious).toHaveBeenCalledTimes(1)
@@ -80,30 +139,20 @@ describe("MentraOS onboarding", () => {
   it("persists completion after the final page", () => {
     const {getByTestId} = render(<MentraOSOnboarding />)
 
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-done"))
+    fireEvent.press(getByTestId("finish-os-onboarding"))
 
     expect(useSettingsStore.getState().getSetting(SETTINGS.onboarding_os_completed.key)).toBe(true)
     expect(mockPushPrevious).toHaveBeenCalledTimes(1)
   })
 
-  it("opens the MentraOS Legacy page from the moved miniapps page", () => {
+  it("opens the MentraOS Legacy page from the moved miniapps step", () => {
     const openUrl = jest.spyOn(Linking, "openURL").mockResolvedValueOnce(undefined)
-    const {getByTestId, getByText} = render(<MentraOSOnboarding />)
+    render(<MentraOSOnboarding />)
 
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
-    fireEvent.press(getByTestId("mentraos-onboarding-next"))
+    const {steps} = mockOnboardingGuide.mock.calls[0][0]
+    act(() => steps[4].action.onPress())
 
-    expect(getByText("onboarding:osMovedMiniappsTitle")).toBeTruthy()
-    expect(getByText("onboarding:osMissingMiniappTitle")).toBeTruthy()
-    expect(getByTestId("mentraos-onboarding-hero-5")).toBeTruthy()
-    fireEvent.press(getByTestId("mentraos-onboarding-open-legacy"))
-
+    expect(steps[4].action.testID).toBe("mentraos-onboarding-open-legacy")
     expect(openUrl).toHaveBeenCalledWith("https://mentraglass.com/legacy")
   })
 })

--- a/mobile/src/__tests__/app/onboarding/os.test.tsx
+++ b/mobile/src/__tests__/app/onboarding/os.test.tsx
@@ -104,8 +104,10 @@ describe("MentraOS onboarding", () => {
         subtitle: "onboarding:osWelcomeSubtitle",
         titleCentered: true,
         subtitleCentered: true,
+        content: expect.anything(),
       }),
     )
+    expect(steps[0].source).toBeUndefined()
     expect(steps[1]).toEqual(
       expect.objectContaining({
         type: "image",

--- a/mobile/src/app/onboarding/os.tsx
+++ b/mobile/src/app/onboarding/os.tsx
@@ -27,6 +27,18 @@ export default function MentraOSOnboarding() {
       {
         type: "image",
         source: require("@assets/onboarding/os/figma/start-miniapp.png"),
+        name: "Welcome to Mentra",
+        transition: true,
+        fadeOut: true,
+        duration: 500,
+        title: translate("onboarding:osWelcomeTitle"),
+        subtitle: translate("onboarding:osWelcomeSubtitle"),
+        titleCentered: true,
+        subtitleCentered: true,
+      },
+      {
+        type: "image",
+        source: require("@assets/onboarding/os/figma/start-miniapp.png"),
         name: "Start using a miniapp",
         transition: false,
         fadeOut: true,

--- a/mobile/src/app/onboarding/os.tsx
+++ b/mobile/src/app/onboarding/os.tsx
@@ -1,430 +1,170 @@
 import {SETTINGS, useSetting} from "@mentra/engine"
-import {Image, type ImageSource} from "expo-image"
-import {useState} from "react"
-import {Linking, Pressable, View, type ImageStyle, type TextStyle, type ViewStyle} from "react-native"
+import {useCallback, useMemo} from "react"
+import {Linking, View} from "react-native"
 
 import {Icon, Screen, Text} from "@/components/ignite"
-import {focusEffectPreventBack, usePushPrevious} from "@/contexts/NavigationHistoryContext"
+import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
+import {usePushPrevious} from "@/contexts/NavigationHistoryContext"
+import {useAppTheme} from "@/contexts/ThemeContext"
 import {translate} from "@/i18n"
-import {typography} from "@/theme"
+import showAlert from "@/utils/AlertUtils"
 
-interface OnboardingDetail {
-  title: string
-  description: string
-}
-
-interface OnboardingPage {
-  title: string
-  hero?: ImageSource
-  details: OnboardingDetail[]
-  actionLabel?: string
-}
-
-const HERO_SHADOW_INSET = -6
 const LEGACY_MENTRAOS_URL = "https://mentraglass.com/legacy"
 
 export default function MentraOSOnboarding() {
   const pushPrevious = usePushPrevious()
+  const {theme} = useAppTheme()
   const [, setOnboardingOsCompleted] = useSetting<boolean>(SETTINGS.onboarding_os_completed.key)
-  const [currentIndex, setCurrentIndex] = useState(0)
 
-  focusEffectPreventBack()
+  const openLegacyPage = useCallback(() => {
+    void Linking.openURL(LEGACY_MENTRAOS_URL).catch((error) => {
+      console.error("Failed to open the MentraOS Legacy page", error)
+    })
+  }, [])
 
-  const pages: OnboardingPage[] = [
-    {
-      title: translate("onboarding:osStartMiniappTitle"),
-      hero: require("@assets/onboarding/os/figma/start-miniapp.png"),
-      details: [
-        {
-          title: translate("onboarding:osTapToLaunchTitle"),
-          description: translate("onboarding:osTapToLaunchDescription"),
+  const steps = useMemo<OnboardingStep[]>(
+    () => [
+      {
+        type: "image",
+        source: require("@assets/onboarding/os/figma/start-miniapp.png"),
+        name: "Start using a miniapp",
+        transition: false,
+        fadeOut: true,
+        testID: "mentraos-onboarding-hero-1",
+        title: translate("onboarding:osStartMiniappTitle"),
+        details: [
+          {
+            title: translate("onboarding:osTapToLaunchTitle"),
+            description: translate("onboarding:osTapToLaunchDescription"),
+          },
+        ],
+      },
+      {
+        type: "image",
+        source: require("@assets/onboarding/os/figma/minimize-close.png"),
+        name: "Minimize or close",
+        transition: false,
+        fadeOut: true,
+        testID: "mentraos-onboarding-hero-2",
+        title: translate("onboarding:osMinimizeCloseTitle"),
+        details: [
+          {
+            title: translate("onboarding:osMinimizeTitle"),
+            description: translate("onboarding:osMinimizeDescription"),
+          },
+          {
+            title: translate("onboarding:osExitTitle"),
+            description: translate("onboarding:osExitDescription"),
+          },
+        ],
+      },
+      {
+        type: "image",
+        source: require("@assets/onboarding/os/figma/running-miniapps.png"),
+        name: "Switch between miniapps",
+        transition: false,
+        fadeOut: true,
+        testID: "mentraos-onboarding-hero-3",
+        title: translate("onboarding:osSwitchMiniappsTitle"),
+        details: [
+          {
+            title: translate("onboarding:osRunningMiniappsTitle"),
+            description: translate("onboarding:osRunningMiniappsDescription"),
+          },
+          {
+            title: translate("onboarding:osExpandTrayTitle"),
+            description: translate("onboarding:osExpandTrayDescription"),
+          },
+        ],
+      },
+      {
+        type: "image",
+        source: require("@assets/onboarding/os/figma/miniapp-drawer.png"),
+        name: "The miniapp drawer",
+        transition: false,
+        fadeOut: true,
+        testID: "mentraos-onboarding-hero-4",
+        title: translate("onboarding:osMiniappDrawerTitle"),
+        details: [
+          {
+            title: translate("onboarding:osTapGridTitle"),
+            description: translate("onboarding:osTapGridDescription"),
+          },
+          {
+            title: translate("onboarding:osSearchTitle"),
+            description: translate("onboarding:osSearchDescription"),
+          },
+        ],
+      },
+      {
+        type: "image",
+        name: "MentraOS Legacy",
+        transition: false,
+        testID: "mentraos-onboarding-hero-5",
+        title: translate("onboarding:osMovedMiniappsTitle"),
+        content: (
+          <View
+            className="m-6 flex-1 items-center justify-center rounded-3xl bg-secondary px-7"
+            testID="mentraos-onboarding-hero-5">
+            <View className="mb-6 h-22 w-22 items-center justify-center rounded-full bg-background">
+              <Icon color={theme.colors.primary} name="world-download" size={48} />
+            </View>
+            <View className="w-full flex-row items-center rounded-2xl border border-border bg-card px-4 py-4">
+              <View className="flex-1">
+                <Text className="text-base font-semibold text-card-foreground" text="MentraOS Legacy" />
+                <Text className="text-sm text-muted-foreground" text="mentraglass.com/legacy" />
+              </View>
+              <Icon color={theme.colors.primary} name="external-link" size={24} />
+            </View>
+          </View>
+        ),
+        details: [
+          {
+            title: translate("onboarding:osMissingMiniappTitle"),
+            description: translate("onboarding:osMissingMiniappDescription"),
+          },
+          {
+            title: translate("onboarding:osMentraOsLegacyTitle"),
+            description: translate("onboarding:osMentraOsLegacyDescription"),
+          },
+        ],
+        action: {
+          label: translate("onboarding:osOpenLegacyPage"),
+          onPress: openLegacyPage,
+          testID: "mentraos-onboarding-open-legacy",
         },
-      ],
-    },
-    {
-      title: translate("onboarding:osMinimizeCloseTitle"),
-      hero: require("@assets/onboarding/os/figma/minimize-close.png"),
-      details: [
-        {
-          title: translate("onboarding:osMinimizeTitle"),
-          description: translate("onboarding:osMinimizeDescription"),
-        },
-        {
-          title: translate("onboarding:osExitTitle"),
-          description: translate("onboarding:osExitDescription"),
-        },
-      ],
-    },
-    {
-      title: translate("onboarding:osSwitchMiniappsTitle"),
-      hero: require("@assets/onboarding/os/figma/running-miniapps.png"),
-      details: [
-        {
-          title: translate("onboarding:osRunningMiniappsTitle"),
-          description: translate("onboarding:osRunningMiniappsDescription"),
-        },
-        {
-          title: translate("onboarding:osExpandTrayTitle"),
-          description: translate("onboarding:osExpandTrayDescription"),
-        },
-      ],
-    },
-    {
-      title: translate("onboarding:osMiniappDrawerTitle"),
-      hero: require("@assets/onboarding/os/figma/miniapp-drawer.png"),
-      details: [
-        {
-          title: translate("onboarding:osTapGridTitle"),
-          description: translate("onboarding:osTapGridDescription"),
-        },
-        {
-          title: translate("onboarding:osSearchTitle"),
-          description: translate("onboarding:osSearchDescription"),
-        },
-      ],
-    },
-    {
-      title: translate("onboarding:osMovedMiniappsTitle"),
-      actionLabel: translate("onboarding:osOpenLegacyPage"),
-      details: [
-        {
-          title: translate("onboarding:osMissingMiniappTitle"),
-          description: translate("onboarding:osMissingMiniappDescription"),
-        },
-        {
-          title: translate("onboarding:osMentraOsLegacyTitle"),
-          description: translate("onboarding:osMentraOsLegacyDescription"),
-        },
-      ],
-    },
-  ]
-
-  const page = pages[currentIndex]
-  const isFirstPage = currentIndex === 0
-  const isLastPage = currentIndex === pages.length - 1
+      },
+    ],
+    [openLegacyPage, theme.colors.primary],
+  )
 
   const finishOnboarding = () => {
     setOnboardingOsCompleted(true)
     pushPrevious()
   }
 
-  const openLegacyPage = () => {
-    void Linking.openURL(LEGACY_MENTRAOS_URL).catch((error) => {
-      console.error("Failed to open the MentraOS Legacy page", error)
-    })
+  const handleCloseButton = () => {
+    showAlert(translate("onboarding:osEndOnboardingTitle"), translate("onboarding:osEndOnboardingMessage"), [
+      {text: translate("common:no"), onPress: () => {}},
+      {
+        text: translate("onboarding:confirmSkip"),
+        onPress: finishOnboarding,
+      },
+    ])
   }
 
   return (
-    <Screen
-      preset="fixed"
-      className="px-0"
-      backgroundColor="#ffffff"
-      extraAndroidInsets
-      safeAreaEdges={["top", "bottom"]}
-      StatusBarProps={{hidden: true}}
-      statusBarStyle="dark">
-      <View style={styles.screen}>
-        <View style={styles.page}>
-          <Pressable
-            accessibilityRole="button"
-            onPress={finishOnboarding}
-            style={({pressed}) => [styles.skipButton, pressed && styles.pressed]}
-            testID="mentraos-onboarding-skip">
-            <Text text={translate("common:skip")} style={styles.skipText} />
-          </Pressable>
-
-          <View style={styles.titleContainer}>
-            <View style={styles.titleSpacer} />
-            <Text text={page.title} style={styles.title} />
-          </View>
-
-          <View style={styles.heroSpacer} />
-          <View style={styles.heroColumn}>
-            <View style={styles.hero}>
-              {page.hero ? (
-                <Image
-                  accessibilityLabel={page.title}
-                  contentFit="fill"
-                  source={page.hero}
-                  style={styles.heroImage}
-                  testID={`mentraos-onboarding-hero-${currentIndex + 1}`}
-                />
-              ) : (
-                <View
-                  accessibilityLabel={page.title}
-                  style={styles.legacyHero}
-                  testID={`mentraos-onboarding-hero-${currentIndex + 1}`}>
-                  <View style={styles.legacyIconBadge}>
-                    <Icon color="#356b53" name="world-download" size={48} />
-                  </View>
-                  <View style={styles.legacyPageCard}>
-                    <View style={styles.legacyPageCopy}>
-                      <Text text="MentraOS Legacy" style={styles.legacyPageTitle} />
-                      <Text text="mentraglass.com/legacy" style={styles.legacyPageUrl} />
-                    </View>
-                    <Icon color="#356b53" name="external-link" size={24} />
-                  </View>
-                </View>
-              )}
-            </View>
-          </View>
-
-          <View style={styles.detailsSpacer} />
-          <View style={styles.details}>
-            {page.details.map((detail, index) => (
-              <View key={detail.title} style={[styles.detail, index > 0 && styles.additionalDetail]}>
-                <Text text={detail.title} style={styles.detailTitle} />
-                <View style={styles.detailTextSpacer} />
-                <Text text={detail.description} style={styles.detailDescription} />
-              </View>
-            ))}
-            {page.actionLabel && (
-              <Pressable
-                accessibilityRole="link"
-                onPress={openLegacyPage}
-                style={({pressed}) => [styles.legacyLink, pressed && styles.pressed]}
-                testID="mentraos-onboarding-open-legacy">
-                <Text text={page.actionLabel} style={styles.legacyLinkText} />
-                <Icon color="#356b53" name="external-link" size={18} />
-              </Pressable>
-            )}
-          </View>
-
-          <View style={styles.flexSpacer} />
-          <View style={[styles.controls, isFirstPage && styles.firstPageControls]}>
-            {!isFirstPage && (
-              <Pressable
-                accessibilityRole="button"
-                onPress={() => setCurrentIndex((index) => index - 1)}
-                style={({pressed}) => [styles.backButton, pressed && styles.pressed]}
-                testID="mentraos-onboarding-back">
-                <Text text={translate("common:back")} style={styles.backButtonText} />
-              </Pressable>
-            )}
-
-            <Pressable
-              accessibilityRole="button"
-              onPress={isLastPage ? finishOnboarding : () => setCurrentIndex((index) => index + 1)}
-              style={({pressed}) => [styles.nextButton, pressed && styles.pressed]}
-              testID={isLastPage ? "mentraos-onboarding-done" : "mentraos-onboarding-next"}>
-              <Text text={translate(isLastPage ? "common:done" : "common:next")} style={styles.nextButtonText} />
-            </Pressable>
-          </View>
-        </View>
-      </View>
+    <Screen preset="fixed" safeAreaEdges={["bottom"]} extraAndroidInsets>
+      <OnboardingGuide
+        steps={steps}
+        autoStart={false}
+        showCloseButton={true}
+        preventBack={true}
+        skipFn={handleCloseButton}
+        endButtonFn={finishOnboarding}
+        startButtonText={translate("onboarding:continueOnboarding")}
+        endButtonText={translate("common:continue")}
+      />
     </Screen>
   )
 }
-
-const styles = {
-  screen: {
-    alignItems: "center",
-    backgroundColor: "#ffffff",
-    flex: 1,
-  },
-  page: {
-    flex: 1,
-    maxWidth: 390,
-    paddingBottom: 28,
-    paddingHorizontal: 14,
-    paddingTop: 32,
-    position: "relative",
-    width: "100%",
-  },
-  skipButton: {
-    alignItems: "center",
-    justifyContent: "center",
-    paddingHorizontal: 4,
-    paddingVertical: 6,
-    position: "absolute",
-    right: 22,
-    top: 18,
-    zIndex: 1,
-  },
-  skipText: {
-    color: "rgba(0, 0, 0, 0.55)",
-    fontFamily: typography.fonts.redHatDisplay.medium,
-    fontSize: 15,
-    letterSpacing: -0.075,
-    lineHeight: 20,
-  },
-  titleContainer: {
-    paddingHorizontal: 10,
-    paddingTop: 20,
-  },
-  titleSpacer: {
-    height: 10,
-  },
-  title: {
-    color: "#0e0e0e",
-    fontFamily: typography.fonts.redHatDisplay.bold,
-    fontSize: 26,
-    letterSpacing: -0.572,
-    lineHeight: 30,
-  },
-  heroSpacer: {
-    height: 24,
-  },
-  heroColumn: {
-    marginRight: 8,
-  },
-  hero: {
-    aspectRatio: 354 / 330,
-    position: "relative",
-  },
-  heroImage: {
-    bottom: HERO_SHADOW_INSET,
-    left: HERO_SHADOW_INSET,
-    position: "absolute",
-    right: HERO_SHADOW_INSET,
-    top: HERO_SHADOW_INSET,
-  },
-  legacyHero: {
-    alignItems: "center",
-    backgroundColor: "#e6f0e9",
-    borderRadius: 20,
-    flex: 1,
-    justifyContent: "center",
-    paddingHorizontal: 28,
-  },
-  legacyIconBadge: {
-    alignItems: "center",
-    backgroundColor: "rgba(255, 255, 255, 0.82)",
-    borderRadius: 999,
-    height: 88,
-    justifyContent: "center",
-    marginBottom: 24,
-    width: 88,
-  },
-  legacyPageCard: {
-    alignItems: "center",
-    backgroundColor: "#ffffff",
-    borderColor: "rgba(53, 107, 83, 0.12)",
-    borderRadius: 16,
-    borderWidth: 1,
-    elevation: 2,
-    flexDirection: "row",
-    paddingHorizontal: 18,
-    paddingVertical: 16,
-    shadowColor: "#214332",
-    shadowOffset: {width: 0, height: 2},
-    shadowOpacity: 0.12,
-    shadowRadius: 4,
-    width: "100%",
-  },
-  legacyPageCopy: {
-    flex: 1,
-  },
-  legacyPageTitle: {
-    color: "#0e0e0e",
-    fontFamily: typography.fonts.redHatDisplay.semibold,
-    fontSize: 16,
-    lineHeight: 21,
-  },
-  legacyPageUrl: {
-    color: "rgba(0, 0, 0, 0.55)",
-    fontFamily: typography.fonts.redHatDisplay.normal,
-    fontSize: 13,
-    lineHeight: 18,
-    marginTop: 2,
-  },
-  detailsSpacer: {
-    height: 16,
-  },
-  details: {
-    paddingHorizontal: 24,
-    paddingTop: 8,
-  },
-  detail: {
-    width: "100%",
-  },
-  additionalDetail: {
-    marginTop: 18,
-    paddingTop: 4,
-  },
-  detailTitle: {
-    color: "#0e0e0e",
-    fontFamily: typography.fonts.redHatDisplay.semibold,
-    fontSize: 15,
-    letterSpacing: -0.12,
-    lineHeight: 20,
-  },
-  detailTextSpacer: {
-    height: 2,
-  },
-  detailDescription: {
-    color: "rgba(0, 0, 0, 0.55)",
-    fontFamily: typography.fonts.redHatDisplay.normal,
-    fontSize: 14,
-    lineHeight: 19,
-  },
-  legacyLink: {
-    alignItems: "center",
-    alignSelf: "flex-start",
-    flexDirection: "row",
-    gap: 6,
-    marginTop: 16,
-    minHeight: 32,
-  },
-  legacyLinkText: {
-    color: "#356b53",
-    fontFamily: typography.fonts.redHatDisplay.semibold,
-    fontSize: 14,
-    lineHeight: 19,
-  },
-  flexSpacer: {
-    flex: 1,
-    minHeight: 8,
-  },
-  controls: {
-    flexDirection: "row",
-    gap: 10,
-    minHeight: 48,
-    width: "100%",
-  },
-  firstPageControls: {
-    paddingLeft: 10,
-  },
-  backButton: {
-    alignItems: "center",
-    backgroundColor: "#f2f2f2",
-    borderColor: "rgba(0, 0, 0, 0.12)",
-    borderRadius: 999,
-    borderWidth: 1,
-    flex: 1,
-    justifyContent: "center",
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-  },
-  backButtonText: {
-    color: "#1a1a1a",
-    fontFamily: typography.fonts.redHatDisplay.semibold,
-    fontSize: 16,
-    letterSpacing: -0.16,
-    lineHeight: 20,
-  },
-  nextButton: {
-    alignItems: "center",
-    backgroundColor: "#1a1a1a",
-    borderRadius: 999,
-    elevation: 3,
-    flex: 1,
-    justifyContent: "center",
-    paddingHorizontal: 20,
-    paddingVertical: 12,
-    shadowColor: "#000000",
-    shadowOffset: {width: 0, height: 2},
-    shadowOpacity: 0.22,
-    shadowRadius: 3,
-  },
-  nextButtonText: {
-    color: "#ffffff",
-    fontFamily: typography.fonts.redHatDisplay.semibold,
-    fontSize: 16,
-    letterSpacing: -0.16,
-    lineHeight: 20,
-  },
-  pressed: {
-    opacity: 0.72,
-  },
-} satisfies Record<string, ImageStyle | TextStyle | ViewStyle>

--- a/mobile/src/app/onboarding/os.tsx
+++ b/mobile/src/app/onboarding/os.tsx
@@ -2,6 +2,7 @@ import {SETTINGS, useSetting} from "@mentra/engine"
 import {useCallback, useMemo} from "react"
 import {Linking, View} from "react-native"
 
+import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
 import {Icon, Screen, Text} from "@/components/ignite"
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
 import {usePushPrevious} from "@/contexts/NavigationHistoryContext"
@@ -26,7 +27,6 @@ export default function MentraOSOnboarding() {
     () => [
       {
         type: "image",
-        source: require("@assets/onboarding/os/figma/start-miniapp.png"),
         name: "Welcome to Mentra",
         transition: true,
         fadeOut: true,
@@ -35,6 +35,13 @@ export default function MentraOSOnboarding() {
         subtitle: translate("onboarding:osWelcomeSubtitle"),
         titleCentered: true,
         subtitleCentered: true,
+        content: (
+          <View className="m-6 flex-1 items-center justify-center rounded-3xl bg-secondary">
+            <View className="h-32 w-32 items-center justify-center rounded-full bg-background">
+              <MentraLogoStandalone width={92} height={50} />
+            </View>
+          </View>
+        ),
       },
       {
         type: "image",

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -374,8 +374,9 @@ export function OnboardingGuide({
 
     fadeOpacity.setValue(1)
 
-    // The start is a special case
-    if (currentIndex === 0 || currentIndex === 1) {
+    // Transition intros act as a welcome gate, so backing into them returns to
+    // the unstarted state. Peer instructional steps should navigate normally.
+    if (currentIndex === 0 || (currentIndex === 1 && steps[0].transition)) {
       resettingRef.current = true
       setHasStarted(autoStart) // if autoStart is true, we don't want to reset the hasStarted state (because it's already started)
       setCurrentIndex(0)

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -1,6 +1,6 @@
 import {Image, ImageSource} from "expo-image"
 import {useVideoPlayer, VideoView, VideoSource, VideoPlayer} from "expo-video"
-import {useState, useCallback, useEffect, useMemo, useRef} from "react"
+import {ReactNode, useState, useCallback, useEffect, useMemo, useRef} from "react"
 import {View, ViewStyle, ActivityIndicator, Platform, Animated, ScrollView} from "react-native"
 
 import {MentraLogoStandalone} from "@/components/brands/MentraLogoStandalone"
@@ -15,6 +15,7 @@ import {BgTimer} from "@mentra/engine"
 interface BaseStep {
   name: string
   transition: boolean
+  testID?: string
   title?: string
   titleCentered?: boolean
   subtitle?: string
@@ -24,6 +25,15 @@ interface BaseStep {
   info?: string
   bullets?: string[]
   numberedBullets?: string[]
+  details?: {
+    title: string
+    description: string
+  }[]
+  action?: {
+    label: string
+    onPress: () => void
+    testID?: string
+  }
   fadeOut?: boolean // if true, the step will fade out after the duration
   // Resolves when the step's required user action is detected. Receives an
   // AbortSignal that fires when the step is left or the component re-renders;
@@ -46,7 +56,8 @@ interface VideoStep extends BaseStep {
 
 interface ImageStep extends BaseStep {
   type: "image"
-  source: ImageSource
+  source?: ImageSource
+  content?: ReactNode
   containerStyle?: ViewStyle
   containerClassName?: string
   duration?: number // ms before showing next button, undefined = immediate
@@ -72,8 +83,9 @@ interface OnboardingGuideProps {
 // Find next video step's source for preloading
 const findNextVideoSource = (steps: OnboardingStep[], fromIndex: number): VideoSource | null => {
   for (let i = fromIndex; i < steps.length; i++) {
-    if (steps[i].type === "video") {
-      return steps[i].source
+    const candidate = steps[i]
+    if (candidate.type === "video") {
+      return candidate.source
     }
   }
   return null
@@ -737,14 +749,18 @@ export function OnboardingGuide({
     if (isCurrentStepImage) {
       return (
         <View style={step.containerStyle} className={step.containerClassName}>
-          <Image
-            source={step.source}
-            style={{
-              width: "100%",
-              height: "100%",
-            }}
-            contentFit="contain"
-          />
+          {step.content ??
+            (step.source && (
+              <Image
+                source={step.source}
+                style={{
+                  width: "100%",
+                  height: "100%",
+                }}
+                contentFit="contain"
+                testID={step.testID}
+              />
+            ))}
         </View>
       )
     }
@@ -964,6 +980,31 @@ export function OnboardingGuide({
     )
   }
 
+  const renderDetails = () => {
+    if (!step.details && !step.action) {
+      return null
+    }
+
+    return (
+      <View className="gap-5 px-2 pb-5">
+        {step.details?.map((detail) => (
+          <View key={detail.title} className="gap-1">
+            <Text className="text-lg font-semibold text-foreground" text={detail.title} />
+            <Text className="text-[15px] text-muted-foreground" text={detail.description} />
+          </View>
+        ))}
+        {step.action && (
+          <Button
+            preset="secondary"
+            text={step.action.label}
+            onPress={step.action.onPress}
+            testID={step.action.testID}
+          />
+        )}
+      </View>
+    )
+  }
+
   // don't show the counter on the last step:
   const showCounter = hasStarted && steps.length > 1 && uiIndex != nonTransitionVideoFiles.length
   const showContent = step.title || step.subtitle || step.info
@@ -1009,6 +1050,7 @@ export function OnboardingGuide({
             )}
           </View>
           <View className="flex-shrink">{renderStepCheck()}</View>
+          {renderDetails()}
           {renderBullets()}
           {renderNumberedBullets()}
         </ScrollView>

--- a/mobile/src/components/onboarding/OnboardingGuide.tsx
+++ b/mobile/src/components/onboarding/OnboardingGuide.tsx
@@ -748,7 +748,7 @@ export function OnboardingGuide({
   const renderContent = () => {
     if (isCurrentStepImage) {
       return (
-        <View style={step.containerStyle} className={step.containerClassName}>
+        <View style={step.containerStyle} className={`h-full w-full ${step.containerClassName ?? ""}`}>
           {step.content ??
             (step.source && (
               <Image

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -4,6 +4,8 @@ import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/Onboardin
 import {getBluetoothSdkListenerCount, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
 import BluetoothSdk from "@mentra/bluetooth-sdk"
 
+const mockFocusEffectPreventBack = jest.fn()
+
 // --- Heavy / native deps that OnboardingGuide pulls in ---
 
 jest.mock("expo-video", () => {
@@ -40,7 +42,7 @@ jest.mock("@/contexts/ThemeContext", () => ({
 }))
 
 jest.mock("@/contexts/NavigationHistoryContext", () => ({
-  focusEffectPreventBack: jest.fn(),
+  focusEffectPreventBack: (callback: () => void) => mockFocusEffectPreventBack(callback),
 }))
 
 jest.mock("@/stores/navigation", () => ({
@@ -52,8 +54,8 @@ jest.mock("@/components/ignite", () => {
   const React = require("react")
   return {
     Text: ({text, children}: any) => React.createElement(RNText, null, text ?? children),
-    Button: ({text, onPress}: any) =>
-      React.createElement(TouchableOpacity, {onPress}, React.createElement(RNText, null, text)),
+    Button: ({text, tx, onPress}: any) =>
+      React.createElement(TouchableOpacity, {onPress}, React.createElement(RNText, null, text ?? tx)),
     Header: () => null,
     Icon: () => null,
   }
@@ -107,6 +109,7 @@ const buildSteps = (): OnboardingStep[] => [
 describe("OnboardingGuide waitFn lifecycle", () => {
   beforeEach(() => {
     resetBluetoothSdkMock()
+    mockFocusEffectPreventBack.mockClear()
     jest.useFakeTimers()
   })
 
@@ -173,5 +176,41 @@ describe("OnboardingGuide waitFn lifecycle", () => {
     expect(getByText("Tap any miniapp to have it launch instantly.")).toBeTruthy()
     fireEvent.press(getByText("Open MentraOS Legacy"))
     expect(handleAction).toHaveBeenCalledTimes(1)
+  })
+
+  it("navigates back to a peer first step without reopening the start gate", () => {
+    const {getByText, queryByText} = render(
+      <OnboardingGuide
+        autoStart={false}
+        preventBack={true}
+        startButtonText="Start onboarding"
+        steps={[
+          {
+            type: "image",
+            source: {uri: "first.png"},
+            name: "First",
+            transition: false,
+            title: "First step",
+          },
+          {
+            type: "image",
+            source: {uri: "second.png"},
+            name: "Second",
+            transition: false,
+            title: "Second step",
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.press(getByText("Start onboarding"))
+    fireEvent.press(getByText("common:continue"))
+    expect(getByText("Second step")).toBeTruthy()
+
+    const backHandler = mockFocusEffectPreventBack.mock.calls.at(-1)?.[0]
+    act(() => backHandler())
+
+    expect(getByText("First step")).toBeTruthy()
+    expect(queryByText("Start onboarding")).toBeNull()
   })
 })

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -1,4 +1,4 @@
-import {render, act} from "@testing-library/react-native"
+import {act, fireEvent, render} from "@testing-library/react-native"
 
 import {OnboardingGuide, OnboardingStep} from "@/components/onboarding/OnboardingGuide"
 import {getBluetoothSdkListenerCount, resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
@@ -139,5 +139,39 @@ describe("OnboardingGuide waitFn lifecycle", () => {
     // the previous one, so the count grows unbounded. There should be at most
     // one active listener for the current step.
     expect(getBluetoothSdkListenerCount("button_press")).toBeLessThanOrEqual(1)
+  })
+
+  it("renders structured image-step details and actions", () => {
+    const handleAction = jest.fn()
+    const {getByText} = render(
+      <OnboardingGuide
+        autoStart={true}
+        requiresGlassesConnection={false}
+        steps={[
+          {
+            type: "image",
+            source: {uri: "step.png"},
+            name: "MentraOS step",
+            transition: false,
+            title: "Start using a miniapp",
+            details: [
+              {
+                title: "Tap to launch",
+                description: "Tap any miniapp to have it launch instantly.",
+              },
+            ],
+            action: {
+              label: "Open MentraOS Legacy",
+              onPress: handleAction,
+            },
+          },
+        ]}
+      />,
+    )
+
+    expect(getByText("Tap to launch")).toBeTruthy()
+    expect(getByText("Tap any miniapp to have it launch instantly.")).toBeTruthy()
+    fireEvent.press(getByText("Open MentraOS Legacy"))
+    expect(handleAction).toHaveBeenCalledTimes(1)
   })
 })

--- a/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
+++ b/mobile/src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx
@@ -178,6 +178,40 @@ describe("OnboardingGuide waitFn lifecycle", () => {
     expect(handleAction).toHaveBeenCalledTimes(1)
   })
 
+  it("advances from a transition welcome after the start gate", () => {
+    const {getByText, queryByText} = render(
+      <OnboardingGuide
+        autoStart={false}
+        startButtonText="Start onboarding"
+        steps={[
+          {
+            type: "image",
+            source: {uri: "welcome.png"},
+            name: "Welcome",
+            transition: true,
+            duration: 500,
+            title: "Welcome to Mentra",
+          },
+          {
+            type: "image",
+            source: {uri: "first.png"},
+            name: "First",
+            transition: false,
+            title: "First lesson",
+          },
+        ]}
+      />,
+    )
+
+    fireEvent.press(getByText("Start onboarding"))
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    expect(getByText("First lesson")).toBeTruthy()
+    expect(queryByText("Welcome to Mentra")).toBeNull()
+  })
+
   it("navigates back to a peer first step without reopening the start gate", () => {
     const {getByText, queryByText} = render(
       <OnboardingGuide


### PR DESCRIPTION
## Summary

- move the MentraOS tutorial onto the shared `OnboardingGuide` used by Mentra Live
- preserve the current MentraOS artwork, instructional copy, completion state, and Legacy link
- extend the shared guide with reusable detail blocks and secondary step actions
- match Mentra Live's header, logo, step counter, themed typography, transitions, start/skip treatment, and navigation controls

## Why

The newer MentraOS onboarding was implemented as a one-off screen with hard-coded layout, colors, typography, and controls, so it no longer matched the deliberately styled Mentra Live onboarding experience. Reusing the existing guide keeps both flows visually consistent and prevents future drift.

## User impact

MentraOS onboarding now feels like a continuation of Mentra Live onboarding, including the same opening treatment, progress chrome, button styles, themed colors, and skip confirmation. The tutorial content and MentraOS Legacy link remain intact.

## Validation

- `bun run compile`
- `bun run test --runInBand src/__tests__/app/onboarding/os.test.tsx src/__tests__/app/onboarding/live.test.tsx src/components/onboarding/__tests__/OnboardingGuide.waitFn.test.tsx`
- targeted ESLint on the four changed files (no errors; existing warnings remain in `OnboardingGuide`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding-only UI refactor with broad test coverage; shared guide back-navigation logic changed slightly but scoped to transition intros.
> 
> **Overview**
> **MentraOS onboarding** drops its custom pager, styles, and inline navigation in favor of the shared `OnboardingGuide`, with a six-step preset (welcome transition plus five instructional screens), Mentra Live–style start/close/skip confirmation, and the same completion flag and Legacy URL behavior. The final step uses custom hero `content` instead of a static image.
> 
> **`OnboardingGuide`** gains reusable image-step **`details`**, optional **`action`** buttons, per-step **`testID`**, and optional **`content`** when there is no `source`. Back handling only returns to the unstarted gate when step 0 is a **transition** intro, so peer steps can move back normally.
> 
> Tests now assert guide wiring, step shape, skip alert flow, and the new guide behaviors (details/actions, welcome auto-advance, back without reopening the start gate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1feda76b684eadac990b81a1ce67d9bd08b3394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns MentraOS onboarding with Mentra Live using the shared `OnboardingGuide`, adds a MentraOS‑branded welcome transition, and supports reusable details/actions with hero content sized to the guide frame. Existing artwork/copy, completion state, and the MentraOS Legacy link are preserved.

- **New Features**
  - `OnboardingGuide` now supports image-step `details`, an optional `action` (label/onPress/testID), per-step `testID`, and custom `content` that fills the hero frame.
  - MentraOS onboarding is a six-step preset with a MentraOS‑specific welcome transition, a close/skip flow with confirmation, and a final action that opens https://mentraglass.com/legacy.

- **Refactors**
  - Replaced the bespoke MentraOS screen with `OnboardingGuide`; aligned `Screen` to bottom edges and moved back-prevention into the guide.
  - Back behavior: transition intros reset to the unstarted gate; peer instructional steps navigate back normally.
  - Updated tests to cover the welcome transition, details/action rendering, skip confirmation and completion persistence, and the legacy action.

<sup>Written for commit a9bf48867703f4f1644945c5d5a726957e51f377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

