### PR TITLE
Document Mentra Live status LED behavior

### DIFF
--- a/asg_client/docs/README.md
+++ b/asg_client/docs/README.md
@@ -17,7 +17,7 @@ Android application that runs on Mentra Live smart glasses, bridging hardware an
 - [Button press system](features/button-press-system.md) — camera button, gallery-mode gate, video/photo dispatch
 - [Live streaming (RTMP / SRT / WHIP)](features/rtmp-streaming.md) — protocols, lifecycle, keep-alive, reconnect
 - [Camera web server](features/camera-web-server.md) — embedded HTTP server for gallery sync, downloads, deletion
-- [LED control](features/led-control.md) — local MTK recording LED + RGB status LED (BES authority handoff)
+- [LED control](features/led-control.md) — local MTK recording LED, RGB status LED, and charging-case indicator
 - [Command processor](features/command-processor.md) — handler registry, protocol detection, ACK/dedup
 - [File manager integration](features/file-manager-integration.md) — package-namespaced media storage
 - [BES MCU firmware OTA](features/bes-ota.md) — pushing new BES firmware over UART

--- a/asg_client/docs/README.md
+++ b/asg_client/docs/README.md
@@ -17,7 +17,7 @@ Android application that runs on Mentra Live smart glasses, bridging hardware an
 - [Button press system](features/button-press-system.md) — camera button, gallery-mode gate, video/photo dispatch
 - [Live streaming (RTMP / SRT / WHIP)](features/rtmp-streaming.md) — protocols, lifecycle, keep-alive, reconnect
 - [Camera web server](features/camera-web-server.md) — embedded HTTP server for gallery sync, downloads, deletion
-- [LED control](features/led-control.md) — local MTK recording LED + RGB ring (BES authority handoff)
+- [LED control](features/led-control.md) — local MTK recording LED + RGB status LED (BES authority handoff)
 - [Command processor](features/command-processor.md) — handler registry, protocol detection, ACK/dedup
 - [File manager integration](features/file-manager-integration.md) — package-namespaced media storage
 - [BES MCU firmware OTA](features/bes-ota.md) — pushing new BES firmware over UART

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -1,8 +1,10 @@
 # LED control
 
-Mentra Live has **two distinct LED systems** that are easy to confuse. This doc covers both, then explains how the recording pipeline coordinates them.
+Mentra Live has **two distinct on-glasses LED systems**, and the charging case
+has a separate indicator of its own. This doc distinguishes all three, then
+explains how the recording pipeline coordinates the two LEDs on the glasses.
 
-## Two systems
+## On-glasses LED systems
 
 ### 1. Local MTK recording LED (single LED, on the device)
 
@@ -81,7 +83,7 @@ shutting down.
 | Normal shutdown | Red fade | Accompanies the power-off sound. |
 | Mentra miniapp or Mentra App LED request | Requested color and timing | Red, green, blue, orange, and white are supported; this has no universal status meaning. |
 
-### Charging in the case
+### Glasses status LED while charging in the case
 
 Current firmware does **not** show a continuous green "charging" or "fully
 charged" indicator:
@@ -92,6 +94,30 @@ charged" indicator:
   skips the normal green boot indicator and the charger-connected red flashes.
   The status LED normally remains off while charging.
 - Reaching full charge does not turn the status LED green.
+
+## Charging case indicator
+
+The charging case has its own external power indicator. It is separate from
+both LEDs on Mentra Live and is not controlled by the BES-to-MTK authority
+handoff described above.
+
+**The charging case indicator always reports the battery level of the case
+itself, not the battery level of the Mentra Live glasses.**
+
+Newer charging cases use only orange and green for this indication:
+
+| Charging case battery level | Indicator color |
+| --- | --- |
+| Below approximately 70% | Orange |
+| Above approximately 70% | Green |
+
+Opening the lid, inserting or removing the glasses, connecting or disconnecting
+external power, or pressing the case button can trigger the case indicator. The
+light may be steady, blinking, or breathing depending on the event and whether
+power is flowing, but its orange/green battery meaning remains the same: it
+reports the charging case, not the glasses.
+
+Source: [Mentra Live Charge Case Function List](https://drive.google.com/file/d/1_qjmxCxpRhGhQDbEIyRgkb3XMM_XvhgQ/view).
 
 ### Interaction with MentraOS control
 

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -27,7 +27,10 @@ UART.
 
 ## RGB LED control authority
 
-By default, BES owns the RGB status LED and uses it to indicate battery state, Bluetooth connection, and firmware-upgrade progress. For ASG client to drive the status LED programmatically, MTK must **claim** authority from BES. When the app shuts down, it **releases** authority and BES resumes its default behavior.
+At startup, BES owns the RGB status LED. Once the MTK-to-BES UART transport is
+ready, ASG client **claims** authority so BES suppresses its ordinary
+ownership-sensitive LED output. When the app shuts down, it **releases**
+authority.
 
 The handoff command (sent over UART):
 
@@ -39,39 +42,44 @@ The handoff command (sent over UART):
 
 Lifecycle in `AsgClientService` and `PhoneReadyCommandHandler`:
 
-- **Claim** — `phone_ready` is received, ~500 ms after `glasses_ready`. Also re-sent on Bluetooth reconnection.
+- **Claim** — immediately when the UART transport reports that it is connected.
+  It is also re-sent approximately 500 ms after `phone_ready` is handled and on
+  later transport reconnections.
 - **Release** — `AsgClientService.onDestroy()`.
 
-If the claim isn't sent, RGB LED commands appear to "succeed" at the API surface but BES ignores them in favor of its own LED logic.
+The authority flag is not a permission check around `cs_ledon` or `cs_ledoff`;
+those commands drive the LED directly. Its purpose is to keep ordinary BES
+status helpers from interfering with MTK output. Forced charger patterns and
+direct BES firmware-update or shutdown output can still change the LED while
+MTK owns it.
 
-## Default right-eye status patterns
+## Status patterns reachable in normal operation
 
 The RGB status LED is the internal indicator visible near the right eye. It is
-not the front-facing MTK recording/privacy LED. The patterns below describe the
-defaults in BES firmware `17.26.07.22`.
+not the front-facing MTK recording/privacy LED. The patterns below are the
+current user-visible paths after accounting for the normal BES-to-MTK ownership
+handoff. The BES behavior was checked against firmware `17.26.07.22`.
 
 Interpret the complete pattern rather than the color alone. For example, red can
-mean that charging started, Bluetooth audio disconnected, an operation failed,
-the battery is critically low, or the glasses are shutting down.
+mean that charging started, a BES firmware update failed, or the glasses are
+shutting down.
 
 | Event | RGB status LED pattern | Notes |
 | --- | --- | --- |
 | Normal power-on | Green fade, then solid green | Remains green while BES waits for the MTK Android side to respond. |
-| MTK Android ready | Three green flashes | Each flash is approximately 200 ms, with a 100 ms gap. |
-| Bluetooth audio/AVRCP connected | Blue for approximately 3 seconds | This reports the classic Bluetooth audio profile, not the Mentra App BLE session. |
-| Bluetooth audio/AVRCP disconnected | Two quick red flashes | Approximately 100 ms on and 100 ms off per flash. |
-| Touch gesture | Brief green flash | Approximately 80 ms; suppressed while MTK owns the status LED. |
-| Wear-state change | Green for approximately 1 second | Used for both wear-on and wear-off; suppressed while MTK owns the status LED. |
-| Recording or continuous-photo progress | Brief blue flash | Approximately 80 ms; suppressed while MTK owns the status LED. |
-| Operation failed or MTK unavailable | Brief red flash | Approximately 100 ms; suppressed while MTK owns the status LED. |
+| First MTK UART contact | Three green flashes | BES shows this before processing the first MTK command. Each flash is approximately 200 ms, with a 100 ms gap; ASG client then claims LED authority. |
+| Photo capture | White for approximately 2.2 seconds | Driven by `MediaCaptureService` for button and SDK photo paths. |
+| Video recording | Solid white | The command has a 30-minute duration and is explicitly stopped on recording stop or error. |
+| USB UVC streaming | Solid white | Uses the same 30-minute command and is explicitly stopped when UVC streaming stops. |
 | Charger connected while the glasses are already on | Five quick red flashes | Forced by BES even when MTK has claimed LED authority. |
 | Charger disconnected at 0–25% | Three quick orange flashes | Forced by BES. |
 | Charger disconnected at 26–65% | Three quick yellow flashes | Forced by BES. |
 | Charger disconnected above 65% | Three quick green flashes | Forced by BES. |
-| Battery at 4–10% | Brief orange flash every 2 minutes | Suppressed while MTK owns the status LED. |
-| Critically low battery | Five red flashes, then shutdown | Also used when starting below 20% and during automatic shutdown at 3% or lower. |
+| BES firmware update in progress | Brief blue flash every 3 seconds | Each flash is approximately 100 ms. The update path writes the LED directly. |
+| BES firmware update succeeded | Three quick green flashes | Approximately 100 ms on and 100 ms off per flash. |
+| BES firmware update failed verification | Solid red | Written directly by the BES update path. |
 | Normal shutdown | Red fade | Accompanies the power-off sound. |
-| Internal voice/VAD firmware update | Alternating green and blue | A failed update shows red for approximately 5 seconds. |
+| Mentra miniapp or Mentra App LED request | Requested color and timing | Red, green, blue, orange, and white are supported; this has no universal status meaning. |
 
 ### Charging in the case
 
@@ -85,24 +93,19 @@ charged" indicator:
   The status LED normally remains off while charging.
 - Reaching full charge does not turn the status LED green.
 
-The firmware contains an unused charging timer that would pulse red while
-charging and show solid green near full charge. Nothing starts that timer, so it
-is not part of the current user-visible behavior.
-
 ### Interaction with MentraOS control
 
-These are firmware defaults, not guaranteed meanings for every light a user
-sees. `asg_client` claims the status LED when the MTK-to-BES UART connection
-becomes ready and claims it again after the phone-ready handshake. While MTK
-owns the status LED, BES suppresses most non-forced status patterns. Charger
-connection and disconnection patterns are explicitly forced and can still
-appear.
+`asg_client` claims the status LED when the MTK-to-BES UART connection becomes
+ready and claims it again after the phone-ready handshake. While MTK owns the
+status LED, BES suppresses its ordinary ownership-sensitive patterns. Charger
+transitions are explicitly forced, and BES firmware-update and shutdown paths
+write the hardware directly, so those patterns can still appear.
 
-MentraOS also uses the status LED for camera and streaming feedback, commonly as
-a white flash or solid white light, and Mentra miniapps can request arbitrary
-supported colors and patterns. A sustained color should therefore be
-correlated with the active camera, stream, or miniapp rather than treated as a
-universal device status.
+MentraOS uses the status LED for photo, video-recording, and USB UVC feedback.
+RTMP, SRT, and WHIP livestreaming currently drive only the separate MTK
+recording/privacy LED and do not set the status LED. Mentra miniapps can request
+any supported status LED color and timing, so an app-requested pattern has no
+universal device meaning.
 
 ## Wire format for `cs_ledon` / `cs_ledoff`
 
@@ -144,22 +147,22 @@ These commands are documented in detail in [ASG_CLIENT_API.md#rgb-led-control](.
 
 Each command responds with `<command>_response` on success or `rgb_led_control_error` on failure / unsupported hardware.
 
-## Recording-LED behavior (orchestration of both systems)
+## Camera LED behavior
 
-`MediaCaptureService` and the streaming services drive both LEDs together so the user gets a consistent privacy indicator:
+The current camera paths use the two LED systems as follows:
 
-| Event                     | Local MTK LED               | RGB status LED                        |
-| ------------------------- | --------------------------- | ------------------------------------- |
-| Photo capture (flash on)  | brief flash                 | white flash via `rgb_led_photo_flash` |
-| Video recording start     | solid on                    | white solid via `rgb_led_video_solid` |
-| Video recording stop      | off                         | off via `rgb_led_control_off`         |
-| Stream start              | solid on                    | (handled by stream service)           |
-| Stream stop               | off                         | off                                   |
-| Buffer recording active   | blinking (1 s on / 2 s off) | (BES default)                         |
-| Buffer recording stopped  | off                         | (BES default)                         |
-| Recording error           | off                         | off                                   |
+| Event | Local MTK recording/privacy LED | RGB status LED |
+| --- | --- | --- |
+| Photo capture | Brief flash | White for approximately 2.2 seconds |
+| Video recording start | Solid on | Solid white, with a 30-minute command duration |
+| Video recording stop or error | Off | Off |
+| RTMP, SRT, or WHIP stream start | Solid on | Unchanged |
+| RTMP, SRT, or WHIP stream stop | Off | Unchanged |
+| USB UVC stream start | Solid on | Solid white, with a 30-minute command duration |
+| USB UVC stream stop | Off | Off |
 
-The local MTK capture LED is always enabled for photo, video, and stream capture.
+Current phone-command handlers require the local MTK capture LED for photo,
+video, and network stream capture.
 
 ## Direct manipulation (Java only — not generally needed)
 
@@ -189,7 +192,9 @@ In application code, prefer routing through the BLE command surface (so the phon
 ## Failure modes
 
 - **`libxydev.so` doesn't load** — `K900LedController` logs the error and becomes a no-op. The local MTK LED simply doesn't light. App keeps running.
-- **MTK never claimed RGB authority** — RGB commands appear to succeed but the status LED continues showing BES's defaults. Check that `phone_ready` was received and `🚨 Sending RGB LED authority command:` appears in logcat.
+- **MTK never claimed RGB authority** — RGB commands can still drive the LED,
+  but ownership-sensitive BES output is no longer suppressed and can interfere.
+  Check for `🚨 Sending RGB LED authority command:` in logcat.
 - **Hardware doesn't support RGB LEDs** — `RgbLedCommandHandler` returns an error response (`{"type": "rgb_led_control_error", "error": "RGB LED not supported on this device"}`) and short-circuits.
 
 ## Logcat tags

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -42,6 +42,65 @@ Lifecycle in `AsgClientService` and `PhoneReadyCommandHandler`:
 
 If the claim isn't sent, RGB LED commands appear to "succeed" at the API surface but BES ignores them in favor of its own LED logic.
 
+## Default right-eye status patterns
+
+The RGB ring is the internal indicator visible near the right eye. It is not the
+front-facing MTK recording/privacy LED. The patterns below describe the defaults
+in BES firmware `17.26.07.22`.
+
+Interpret the complete pattern rather than the color alone. For example, red can
+mean that charging started, Bluetooth audio disconnected, an operation failed,
+the battery is critically low, or the glasses are shutting down.
+
+| Event | RGB ring pattern | Notes |
+| --- | --- | --- |
+| Normal power-on | Green fade, then solid green | Remains green while BES waits for the MTK Android side to respond. |
+| MTK Android ready | Three green flashes | Each flash is approximately 200 ms, with a 100 ms gap. |
+| Bluetooth audio/AVRCP connected | Blue for approximately 3 seconds | This reports the classic Bluetooth audio profile, not the Mentra App BLE session. |
+| Bluetooth audio/AVRCP disconnected | Two quick red flashes | Approximately 100 ms on and 100 ms off per flash. |
+| Touch gesture | Brief green flash | Approximately 80 ms; suppressed while MTK owns the ring. |
+| Wear-state change | Green for approximately 1 second | Used for both wear-on and wear-off; suppressed while MTK owns the ring. |
+| Recording or continuous-photo progress | Brief blue flash | Approximately 80 ms; suppressed while MTK owns the ring. |
+| Operation failed or MTK unavailable | Brief red flash | Approximately 100 ms; suppressed while MTK owns the ring. |
+| Charger connected while the glasses are already on | Five quick red flashes | Forced by BES even when MTK has claimed LED authority. |
+| Charger disconnected at 0–25% | Three quick orange flashes | Forced by BES. |
+| Charger disconnected at 26–65% | Three quick yellow flashes | Forced by BES. |
+| Charger disconnected above 65% | Three quick green flashes | Forced by BES. |
+| Battery at 4–10% | Brief orange flash every 2 minutes | Suppressed while MTK owns the ring. |
+| Critically low battery | Five red flashes, then shutdown | Also used when starting below 20% and during automatic shutdown at 3% or lower. |
+| Normal shutdown | Red fade | Accompanies the power-off sound. |
+| Internal voice/VAD firmware update | Alternating green and blue | A failed update shows red for approximately 5 seconds. |
+
+### Charging in the case
+
+Current firmware does **not** show a continuous green "charging" or "fully
+charged" indicator:
+
+- If the glasses are already powered on when charging begins, BES shows five
+  quick red flashes.
+- If inserting powered-off glasses into the case causes a charge-only boot, BES
+  skips the normal green boot indicator and the charger-connected red flashes.
+  The ring normally remains off while charging.
+- Reaching full charge does not turn the ring green.
+
+The firmware contains an unused charging timer that would pulse red while
+charging and show solid green near full charge. Nothing starts that timer, so it
+is not part of the current user-visible behavior.
+
+### Interaction with MentraOS control
+
+These are firmware defaults, not guaranteed meanings for every light a user
+sees. `asg_client` claims the ring when the MTK-to-BES UART connection becomes
+ready and claims it again after the phone-ready handshake. While MTK owns the
+ring, BES suppresses most non-forced status patterns. Charger connection and
+disconnection patterns are explicitly forced and can still appear.
+
+MentraOS also uses the ring for camera and streaming feedback, commonly as a
+white flash or solid white light, and Mentra miniapps can request arbitrary
+supported colors and patterns. A sustained color should therefore be correlated
+with the active camera, stream, or miniapp rather than treated as a universal
+device status.
+
 ## Wire format for `cs_ledon` / `cs_ledoff`
 
 `K900RgbLedController.setLedOn(led, ontime, offtime, count, brightness)` produces:

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -117,8 +117,6 @@ light may be steady, blinking, or breathing depending on the event and whether
 power is flowing, but its orange/green battery meaning remains the same: it
 reports the charging case, not the glasses.
 
-Source: [Mentra Live Charge Case Function List](https://drive.google.com/file/d/1_qjmxCxpRhGhQDbEIyRgkb3XMM_XvhgQ/view).
-
 ### Interaction with MentraOS control
 
 `asg_client` claims the status LED when the MTK-to-BES UART connection becomes

--- a/asg_client/docs/features/led-control.md
+++ b/asg_client/docs/features/led-control.md
@@ -14,9 +14,11 @@ A single privacy LED on the glasses, controlled directly by the Android (MTK) So
 - Convenience wrappers: `SysControl.setRecordingLedOn(context, on)`, `SysControl.setRecordingLedBlinking(context, blink)`, `SysControl.flashRecordingLed(context, durationMs)`
 - Native libs ship in `app/src/main/jniLibs/{armeabi-v7a,arm64-v8a}/libxydev.so`
 
-### 2. RGB LED ring (multi-color, on the BES chipset)
+### 2. RGB status LED (multi-color, on the BES chipset)
 
-The colored LEDs visible on the glasses themselves. Controlled by the BES microcontroller, addressed from MTK by sending K900 protocol commands over UART.
+The internal multicolor status LED visible near the right eye. Controlled by the
+BES microcontroller, addressed from MTK by sending K900 protocol commands over
+UART.
 
 - Owned by: `K900RgbLedController` (`hardware/K900RgbLedController.java`)
 - K900 commands: `cs_ledon`, `cs_ledoff`, `cs_ledsetlevel`
@@ -25,7 +27,7 @@ The colored LEDs visible on the glasses themselves. Controlled by the BES microc
 
 ## RGB LED control authority
 
-By default, BES owns the RGB ring and uses it to indicate battery state, Bluetooth connection, and firmware-upgrade progress. For ASG client to drive the ring programmatically, MTK must **claim** authority from BES. When the app shuts down, it **releases** authority and BES resumes its default behavior.
+By default, BES owns the RGB status LED and uses it to indicate battery state, Bluetooth connection, and firmware-upgrade progress. For ASG client to drive the status LED programmatically, MTK must **claim** authority from BES. When the app shuts down, it **releases** authority and BES resumes its default behavior.
 
 The handoff command (sent over UART):
 
@@ -44,29 +46,29 @@ If the claim isn't sent, RGB LED commands appear to "succeed" at the API surface
 
 ## Default right-eye status patterns
 
-The RGB ring is the internal indicator visible near the right eye. It is not the
-front-facing MTK recording/privacy LED. The patterns below describe the defaults
-in BES firmware `17.26.07.22`.
+The RGB status LED is the internal indicator visible near the right eye. It is
+not the front-facing MTK recording/privacy LED. The patterns below describe the
+defaults in BES firmware `17.26.07.22`.
 
 Interpret the complete pattern rather than the color alone. For example, red can
 mean that charging started, Bluetooth audio disconnected, an operation failed,
 the battery is critically low, or the glasses are shutting down.
 
-| Event | RGB ring pattern | Notes |
+| Event | RGB status LED pattern | Notes |
 | --- | --- | --- |
 | Normal power-on | Green fade, then solid green | Remains green while BES waits for the MTK Android side to respond. |
 | MTK Android ready | Three green flashes | Each flash is approximately 200 ms, with a 100 ms gap. |
 | Bluetooth audio/AVRCP connected | Blue for approximately 3 seconds | This reports the classic Bluetooth audio profile, not the Mentra App BLE session. |
 | Bluetooth audio/AVRCP disconnected | Two quick red flashes | Approximately 100 ms on and 100 ms off per flash. |
-| Touch gesture | Brief green flash | Approximately 80 ms; suppressed while MTK owns the ring. |
-| Wear-state change | Green for approximately 1 second | Used for both wear-on and wear-off; suppressed while MTK owns the ring. |
-| Recording or continuous-photo progress | Brief blue flash | Approximately 80 ms; suppressed while MTK owns the ring. |
-| Operation failed or MTK unavailable | Brief red flash | Approximately 100 ms; suppressed while MTK owns the ring. |
+| Touch gesture | Brief green flash | Approximately 80 ms; suppressed while MTK owns the status LED. |
+| Wear-state change | Green for approximately 1 second | Used for both wear-on and wear-off; suppressed while MTK owns the status LED. |
+| Recording or continuous-photo progress | Brief blue flash | Approximately 80 ms; suppressed while MTK owns the status LED. |
+| Operation failed or MTK unavailable | Brief red flash | Approximately 100 ms; suppressed while MTK owns the status LED. |
 | Charger connected while the glasses are already on | Five quick red flashes | Forced by BES even when MTK has claimed LED authority. |
 | Charger disconnected at 0–25% | Three quick orange flashes | Forced by BES. |
 | Charger disconnected at 26–65% | Three quick yellow flashes | Forced by BES. |
 | Charger disconnected above 65% | Three quick green flashes | Forced by BES. |
-| Battery at 4–10% | Brief orange flash every 2 minutes | Suppressed while MTK owns the ring. |
+| Battery at 4–10% | Brief orange flash every 2 minutes | Suppressed while MTK owns the status LED. |
 | Critically low battery | Five red flashes, then shutdown | Also used when starting below 20% and during automatic shutdown at 3% or lower. |
 | Normal shutdown | Red fade | Accompanies the power-off sound. |
 | Internal voice/VAD firmware update | Alternating green and blue | A failed update shows red for approximately 5 seconds. |
@@ -80,8 +82,8 @@ charged" indicator:
   quick red flashes.
 - If inserting powered-off glasses into the case causes a charge-only boot, BES
   skips the normal green boot indicator and the charger-connected red flashes.
-  The ring normally remains off while charging.
-- Reaching full charge does not turn the ring green.
+  The status LED normally remains off while charging.
+- Reaching full charge does not turn the status LED green.
 
 The firmware contains an unused charging timer that would pulse red while
 charging and show solid green near full charge. Nothing starts that timer, so it
@@ -90,16 +92,17 @@ is not part of the current user-visible behavior.
 ### Interaction with MentraOS control
 
 These are firmware defaults, not guaranteed meanings for every light a user
-sees. `asg_client` claims the ring when the MTK-to-BES UART connection becomes
-ready and claims it again after the phone-ready handshake. While MTK owns the
-ring, BES suppresses most non-forced status patterns. Charger connection and
-disconnection patterns are explicitly forced and can still appear.
+sees. `asg_client` claims the status LED when the MTK-to-BES UART connection
+becomes ready and claims it again after the phone-ready handshake. While MTK
+owns the status LED, BES suppresses most non-forced status patterns. Charger
+connection and disconnection patterns are explicitly forced and can still
+appear.
 
-MentraOS also uses the ring for camera and streaming feedback, commonly as a
-white flash or solid white light, and Mentra miniapps can request arbitrary
-supported colors and patterns. A sustained color should therefore be correlated
-with the active camera, stream, or miniapp rather than treated as a universal
-device status.
+MentraOS also uses the status LED for camera and streaming feedback, commonly as
+a white flash or solid white light, and Mentra miniapps can request arbitrary
+supported colors and patterns. A sustained color should therefore be
+correlated with the active camera, stream, or miniapp rather than treated as a
+universal device status.
 
 ## Wire format for `cs_ledon` / `cs_ledoff`
 
@@ -135,7 +138,7 @@ These commands are documented in detail in [ASG_CLIENT_API.md#rgb-led-control](.
 | Command               | Purpose                                                                                                 |
 | --------------------- | ------------------------------------------------------------------------------------------------------- |
 | `rgb_led_control_on`  | Generic on/blink. Pick `led`, `ontime`, `offtime`, `count`, optional `brightness`.                      |
-| `rgb_led_control_off` | Turn the ring off.                                                                                      |
+| `rgb_led_control_off` | Turn the status LED off.                                                                                |
 | `rgb_led_photo_flash` | White flash for photo capture (default 5 s).                                                            |
 | `rgb_led_video_solid` | Solid white for video recording (30 min internal duration; turned off explicitly when recording stops). |
 
@@ -145,7 +148,7 @@ Each command responds with `<command>_response` on success or `rgb_led_control_e
 
 `MediaCaptureService` and the streaming services drive both LEDs together so the user gets a consistent privacy indicator:
 
-| Event                     | Local MTK LED               | RGB ring                              |
+| Event                     | Local MTK LED               | RGB status LED                        |
 | ------------------------- | --------------------------- | ------------------------------------- |
 | Photo capture (flash on)  | brief flash                 | white flash via `rgb_led_photo_flash` |
 | Video recording start     | solid on                    | white solid via `rgb_led_video_solid` |
@@ -186,7 +189,7 @@ In application code, prefer routing through the BLE command surface (so the phon
 ## Failure modes
 
 - **`libxydev.so` doesn't load** — `K900LedController` logs the error and becomes a no-op. The local MTK LED simply doesn't light. App keeps running.
-- **MTK never claimed RGB authority** — RGB commands appear to succeed but the ring continues showing BES's defaults. Check that `phone_ready` was received and `🚨 Sending RGB LED authority command:` appears in logcat.
+- **MTK never claimed RGB authority** — RGB commands appear to succeed but the status LED continues showing BES's defaults. Check that `phone_ready` was received and `🚨 Sending RGB LED authority command:` appears in logcat.
 - **Hardware doesn't support RGB LEDs** — `RgbLedCommandHandler` returns an error response (`{"type": "rgb_led_control_error", "error": "RGB LED not supported on this device"}`) and short-circuits.
 
 ## Logcat tags
@@ -194,7 +197,7 @@ In application code, prefer routing through the BLE command surface (so the phon
 | Tag                    | Component                            |
 | ---------------------- | ------------------------------------ |
 | `K900LedController`    | Local MTK LED                        |
-| `K900RgbLedController` | RGB ring driver                      |
+| `K900RgbLedController` | RGB status LED driver                |
 | `RgbLedCommandHandler` | Phone-facing RGB LED command handler |
 | `K900CommandHandler`   | RGB authority claim/release          |
 | `MediaCaptureService`  | Recording-LED orchestration          |

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -17,7 +17,7 @@ Mentra Live consists of:
 
 - Smart glasses hardware with camera, microphone/audio path, physical camera button, temple touch/swipe input, battery, sensors, WiFi/Bluetooth connectivity, privacy/status LEDs, and firmware-updatable components.
 - An Android runtime on the glasses, powered by a Mediatek (**MTK**) SoC.
-- A dedicated Bluetooth/audio microcontroller (**BES**) that handles low-level Bluetooth/audio behavior, button/touch events, battery-related signaling, RGB LED defaults, and BES firmware OTA.
+- A dedicated Bluetooth/audio microcontroller (**BES**) that handles low-level Bluetooth/audio behavior, button/touch events, battery reporting, pre-handoff and forced RGB status LED signaling, and BES firmware OTA.
 - The `com.mentra.asg_client` Android app, shipped as a system app on production devices, which exposes the device to MentraOS.
 - The MentraOS phone app, which pairs with the glasses over BLE, configures device behavior, syncs media, routes app events, and connects the user session to MentraOS Cloud.
 
@@ -62,7 +62,7 @@ For some outbound commands, `B` is a JSON object serialized as a string inside t
 
 - Detecting and classifying camera-button presses.
 - Reporting touch/swipe/power-button events.
-- Battery and default LED signaling.
+- Battery reporting and forced charger status LED signaling.
 - RGB status LED ownership when MTK has not claimed control.
 - BES firmware OTA.
 - Bluetooth/audio responsibilities specific to the glasses firmware.
@@ -114,7 +114,7 @@ Mentra Live exposes microphone/audio paths used for recording, streaming, and de
 Mentra Live has two LED systems:
 
 1. **Local MTK recording/privacy LED** — controlled directly by MTK through native APIs; used for camera-in-use feedback.
-2. **BES RGB status LED** — controlled by BES by default for battery, Bluetooth, and firmware status; MTK can claim authority and send RGB commands over UART.
+2. **BES RGB status LED** — controlled by BES during early boot and by forced/direct BES paths for charger transitions, firmware updates, and shutdown; MTK claims authority once UART is ready and sends camera or app-requested RGB commands.
 
 Camera and streaming features must leave LEDs in a safe state on stop, error, service shutdown, or command cancellation. User-visible privacy indication should not be bypassed accidentally.
 
@@ -161,7 +161,7 @@ The MTK↔BES UART always starts at 460800 baud. Firmware that supports the nego
 
 1. Phone connects over BLE and sends readiness/configuration commands.
 2. `asg_client` responds with device status and applies persisted or received settings.
-3. For Mentra Live, after phone readiness, MTK claims RGB LED authority from BES when it needs programmatic LED control.
+3. For Mentra Live, MTK claims RGB status LED authority as soon as the BES UART transport is ready, then reasserts it after phone readiness.
 4. Ongoing commands are dispatched through command handlers and responses are sent back over BLE.
 
 ### Camera button photo flow

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -63,7 +63,7 @@ For some outbound commands, `B` is a JSON object serialized as a string inside t
 - Detecting and classifying camera-button presses.
 - Reporting touch/swipe/power-button events.
 - Battery and default LED signaling.
-- RGB LED ring ownership when MTK has not claimed control.
+- RGB status LED ownership when MTK has not claimed control.
 - BES firmware OTA.
 - Bluetooth/audio responsibilities specific to the glasses firmware.
 
@@ -114,7 +114,7 @@ Mentra Live exposes microphone/audio paths used for recording, streaming, and de
 Mentra Live has two LED systems:
 
 1. **Local MTK recording/privacy LED** — controlled directly by MTK through native APIs; used for camera-in-use feedback.
-2. **BES RGB LED ring** — controlled by BES by default for battery, Bluetooth, and firmware status; MTK can claim authority and send RGB commands over UART.
+2. **BES RGB status LED** — controlled by BES by default for battery, Bluetooth, and firmware status; MTK can claim authority and send RGB commands over UART.
 
 Camera and streaming features must leave LEDs in a safe state on stop, error, service shutdown, or command cancellation. User-visible privacy indication should not be bypassed accidentally.
 
@@ -216,7 +216,7 @@ When changing Mentra Live behavior:
 - [`overview.md`](overview.md) — `asg_client` architecture and K900 naming notes.
 - [`ASG_CLIENT_API.md`](ASG_CLIENT_API.md) — phone/glasses command protocol.
 - [`features/button-press-system.md`](features/button-press-system.md) — camera button and gallery-mode behavior.
-- [`features/led-control.md`](features/led-control.md) — local privacy LED and BES RGB LED ring behavior.
+- [`features/led-control.md`](features/led-control.md) — local privacy LED and BES RGB status LED behavior.
 - [`features/rtmp-streaming.md`](features/rtmp-streaming.md) — live streaming lifecycle.
 - [`features/camera-web-server.md`](features/camera-web-server.md) — local media sync server.
 - [`features/bes-ota.md`](features/bes-ota.md) — BES firmware update flow.

--- a/asg_client/docs/overview.md
+++ b/asg_client/docs/overview.md
@@ -10,14 +10,14 @@ Throughout the codebase you will see `K900` everywhere — class names (`K900Blu
 
 **K900 is the internal codename for Mentra Live**, used during development. There is no separate "K900" device — the codename was kept in the code to avoid a sweeping rename. When you see `K900` in code or in the rest of these docs, read it as "the Mentra Live hardware platform."
 
-The two chips on Mentra Live: **MTK** is the Mediatek SoC running Android (and ASG Client itself). **BES** is the dedicated Bluetooth/audio microcontroller it talks to over UART. You'll see both names in feature docs, especially around LED control where the two chips share a single LED ring.
+The two chips on Mentra Live: **MTK** is the Mediatek SoC running Android (and ASG Client itself). **BES** is the dedicated Bluetooth/audio microcontroller it talks to over UART. You'll see both names in feature docs, especially around control of the shared RGB status LED.
 
 ## Architecture
 
 `AsgClientService` is the main foreground Android service. It owns lifecycle and routes messages between four subsystems:
 
 1. **Bluetooth communication** — receives JSON commands from the phone over BLE, sends status updates and media back. The wire-level command surface is documented in [ASG Client Command API](ASG_CLIENT_API.md).
-2. **Hardware integration** — talks to the BES microcontroller over UART for button presses, touch/swipe events, battery voltage, BES OTA, and the LED ring. See [features/button-press-system.md](features/button-press-system.md) and [features/led-control.md](features/led-control.md).
+2. **Hardware integration** — talks to the BES microcontroller over UART for button presses, touch/swipe events, battery voltage, BES OTA, and the RGB status LED. See [features/button-press-system.md](features/button-press-system.md) and [features/led-control.md](features/led-control.md).
 3. **Media** — photo capture, video recording, RTMP/SRT/WHIP streaming, and the local HTTP server for sync. See [features/rtmp-streaming.md](features/rtmp-streaming.md) and [features/camera-web-server.md](features/camera-web-server.md).
 4. **Network** — WiFi connect/scan/forget, hotspot, and the heuristics that decide which network manager to use on a given platform.
 
@@ -51,7 +51,7 @@ Physical hardware → BES MCU (UART) → AsgClientService → BLE → Phone app 
 
 ### Hardware managers (`io/hardware/managers/`)
 
-- `K900HardwareManager` — Mentra Live (LED ring, battery, audio assets)
+- `K900HardwareManager` — Mentra Live (RGB status LED, battery, audio assets)
 - `StandardHardwareManager` — generic Android fallback
 
 Selected at runtime by `HardwareManagerFactory`.


### PR DESCRIPTION
## Summary

- document only status LED patterns reachable in current normal operation after the BES-to-MTK authority handoff
- cover boot, photo/video/UVC capture, charging transitions, BES OTA, shutdown, and explicit app or miniapp requests
- explain that the authority flag suppresses ordinary BES helpers but does not gate direct MTK LED commands
- add a separate charging-case indicator section for newer cases and clarify that it always reports the case battery, not the glasses battery
- standardize the hardware name as RGB status LED across ASG Client documentation

## Why

The internal right-eye status LED and the separate charging-case indicator were undocumented at the pattern level. Support teams and partners need a source-backed reference for the behavior users can actually observe without confusing the case battery indication with the Mentra Live battery.

## Reachability audit

- traced normal BES boot through the first MTK UART command and the immediate ASG Client authority claim
- checked every BES LED writer for authority checks, forced output, direct hardware writes, and active trigger paths
- traced ASG Client photo, video, UVC, RTMP, SRT, and WHIP LED calls
- traced Mentra App and miniapp status LED requests through the mobile bridge
- documented the newer two-color orange/green case indicator separately using current hardware clarification

## Impact

Documentation only. The camera matrix clarifies which capture and streaming paths currently drive the RGB status LED versus the separate privacy LED. The charging-case section explicitly states that its approximately 70% orange/green threshold represents the case itself.

## Validation

- compared BES behavior against firmware 17.26.07.22
- verified each glasses pattern has a reachable pre-handoff, forced/direct BES, or active MTK call path
- cross-checked the charging-case section against current hardware clarification
- ran git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation with no application or firmware changes.
> 
> **Overview**
> **Documentation-only** update to ASG Client docs for Mentra Live LED behavior—no runtime code changes.
> 
> **`features/led-control.md`** is the main expansion: renames the BES multicolor path from “RGB LED ring” to **RGB status LED**, adds a **third** feedback surface (charging-case indicator), and documents user-visible **status patterns** (boot, UART handoff, photo/video/UVC, charger transitions, BES OTA, shutdown, app/miniapp requests) against firmware `17.26.07.22`. It clarifies that **`android_control_led` authority** is claimed when UART is ready (plus reassert after `phone_ready`), suppresses ordinary BES helpers rather than gating `cs_ledon`/`cs_ledoff`, and that **forced BES paths** can still override MTK. The **camera LED matrix** now states RTMP/SRT/WHIP affect only the MTK privacy LED, not the RGB status LED, and drops buffer-recording blink rows. A new section explains **newer charging cases** report **case battery** (~70% orange/green threshold), not glasses battery.
> 
> **`mentra-live-spec.md`**, **`overview.md`**, and **`README.md`** align cross-references and BES responsibility wording with the same terminology and UART-ready authority timing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e58ba981d3b4b969e5299709ce97c8d9252fe11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->