### PR TITLE
Fix gallery media viewer interactions and performance

### DIFF
--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.test.tsx
@@ -5,6 +5,7 @@ import {PhotoInfo} from "@/types/asg"
 import {AwesomeGalleryViewer, CustomOverlay} from "./AwesomeGalleryViewer"
 
 let mockGalleryProps: Record<string, unknown> = {}
+let mockImageProps: Record<string, unknown> = {}
 
 jest.mock("@gorhom/bottom-sheet", () => ({
   __esModule: true,
@@ -15,8 +16,21 @@ jest.mock("@/components/ignite/Icon", () => {
   const {Text} = require("react-native")
   return {Icon: ({name}: {name: string}) => React.createElement(Text, null, name)}
 })
-jest.mock("expo-image", () => ({Image: () => null}))
+jest.mock("expo-image", () => ({
+  Image: (props: Record<string, unknown>) => {
+    mockImageProps = props
+    return null
+  },
+}))
 jest.mock("./MediaMetadataSheet", () => ({MediaMetadataSheet: () => null}))
+jest.mock("react-native-gesture-handler", () => {
+  const React = require("react")
+  const {View} = require("react-native")
+  return {
+    GestureHandlerRootView: ({children, ...props}: {children: React.ReactNode}) =>
+      React.createElement(View, props, children),
+  }
+})
 jest.mock("react-native-awesome-gallery", () => {
   const React = require("react")
   const MockGallery = React.forwardRef((props: Record<string, unknown>, _ref: unknown) => {
@@ -29,7 +43,13 @@ jest.mock("react-native-awesome-gallery", () => {
     default: MockGallery,
   }
 })
-jest.mock("react-native-vector-icons/MaterialCommunityIcons", () => () => null)
+jest.mock("react-native-vector-icons/MaterialCommunityIcons", () => {
+  const React = require("react")
+  const {Text} = require("react-native")
+  return function MockMaterialCommunityIcon({name}: {name: string}) {
+    return React.createElement(Text, null, name)
+  }
+})
 jest.mock("react-native-video", () => () => null)
 
 describe("CustomOverlay", () => {
@@ -44,7 +64,7 @@ describe("CustomOverlay", () => {
     expect(getByText("3 / 8")).toBeTruthy()
     expect(getByText("chevron-left")).toBeTruthy()
     expect(getByText("info")).toBeTruthy()
-    expect(getByText("share")).toBeTruthy()
+    expect(getByText("share-variant")).toBeTruthy()
     fireEvent.press(getByLabelText("Close media viewer"))
     fireEvent.press(getByLabelText("Show media details"))
     fireEvent.press(getByLabelText("Share media"))
@@ -66,10 +86,38 @@ describe("CustomOverlay", () => {
   it("keeps pinch zoom enabled without observing vertical translation for metadata", () => {
     const photo = {name: "photo.jpg", url: "file:///photo.jpg", is_video: false} as PhotoInfo
 
-    render(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={jest.fn()} />)
+    const onClose = jest.fn()
+    const view = render(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={onClose} />)
+    const firstIndexChange = mockGalleryProps.onIndexChange
+    const firstSwipeToClose = mockGalleryProps.onSwipeToClose
+
+    view.rerender(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={onClose} />)
 
     expect(mockGalleryProps).toMatchObject({pinchEnabled: true, doubleTapEnabled: true})
     expect(mockGalleryProps).not.toHaveProperty("onTranslationYChange")
     expect(mockGalleryProps).not.toHaveProperty("onPanStart")
+    expect(mockGalleryProps.onIndexChange).toBe(firstIndexChange)
+    expect(mockGalleryProps.onSwipeToClose).toBe(firstSwipeToClose)
+    expect(view.getByTestId("media-viewer-gesture-root")).toBeTruthy()
+  })
+
+  it("downscales local images before caching them on Android", () => {
+    const photo = {name: "photo.jpg", filePath: "/gallery/photo.jpg", is_video: false} as PhotoInfo
+
+    render(<AwesomeGalleryViewer visible photos={[photo]} initialIndex={0} onClose={jest.fn()} />)
+    const renderItem = mockGalleryProps.renderItem as (info: {
+      item: PhotoInfo
+      index: number
+      setImageDimensions: jest.Mock
+    }) => React.ReactElement
+
+    render(renderItem({item: photo, index: 0, setImageDimensions: jest.fn()}))
+
+    expect(mockImageProps).toMatchObject({
+      allowDownscaling: true,
+      priority: "high",
+      source: {uri: "file:///gallery/photo.jpg"},
+      transition: 0,
+    })
   })
 })

--- a/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/AwesomeGalleryViewer.tsx
@@ -10,6 +10,7 @@ import {useState, useRef, useEffect, useCallback, useMemo, memo, type ElementRef
 // eslint-disable-next-line no-restricted-imports
 import {View, TouchableOpacity, Modal, StatusBar, Text, useWindowDimensions} from "react-native"
 import Gallery, {GalleryRef} from "react-native-awesome-gallery"
+import {GestureHandlerRootView} from "react-native-gesture-handler"
 import {useSaferAreaInsets} from "@/contexts/SaferAreaContext"
 import MaterialCommunityIcons from "react-native-vector-icons/MaterialCommunityIcons"
 import Video from "react-native-video"
@@ -335,12 +336,7 @@ const VideoPlayerItem = memo(function VideoPlayerItem({
 /**
  * Image component for gallery items
  */
-const ImageItem = memo(function ImageItem({
-  photo,
-  setImageDimensions,
-  isActive: _isActive,
-  onDimensions,
-}: ImageItemProps) {
+const ImageItem = memo(function ImageItem({photo, setImageDimensions, isActive, onDimensions}: ImageItemProps) {
   const {width: screenWidth, height: screenHeight} = useWindowDimensions()
   const hasReportedDimensions = useRef(false)
 
@@ -366,10 +362,10 @@ const ImageItem = memo(function ImageItem({
         source={{uri: imageUri}}
         style={imageStyle}
         contentFit="contain"
-        priority="high"
+        priority={isActive ? "high" : "normal"}
         cachePolicy="memory-disk"
-        transition={100}
-        allowDownscaling={false}
+        transition={0}
+        allowDownscaling
         onLoad={(e) => {
           // Report dimensions back to Gallery for proper scaling - only once
           if (e.source?.width && e.source?.height && !hasReportedDimensions.current) {
@@ -399,7 +395,7 @@ interface CustomOverlayProps {
 
 export function CustomOverlay({onClose, currentIndex, total, onDetails, onShare}: CustomOverlayProps) {
   const insets = useSaferAreaInsets()
-  const {themed} = useAppTheme()
+  const {theme, themed} = useAppTheme()
 
   return (
     <View style={[themed($header), {paddingTop: insets.top}]}>
@@ -408,7 +404,7 @@ export function CustomOverlay({onClose, currentIndex, total, onDetails, onShare}
         accessibilityRole="button"
         onPress={onClose}
         style={themed($actionButton)}>
-        <Icon name="chevron-left" size={28} color="white" />
+        <Icon name="chevron-left" size={28} color={theme.colors.foreground} />
       </TouchableOpacity>
       <Text pointerEvents="none" style={themed($counterText)}>
         {currentIndex + 1} / {total}
@@ -419,7 +415,7 @@ export function CustomOverlay({onClose, currentIndex, total, onDetails, onShare}
           accessibilityRole="button"
           onPress={onDetails}
           style={themed($actionButton)}>
-          <Icon name="info" size={24} color="white" />
+          <Icon name="info" size={24} color={theme.colors.foreground} />
         </TouchableOpacity>
         {onShare && (
           <TouchableOpacity
@@ -427,7 +423,7 @@ export function CustomOverlay({onClose, currentIndex, total, onDetails, onShare}
             accessibilityRole="button"
             onPress={onShare}
             style={themed($actionButton)}>
-            <Icon name="share" size={24} color="white" />
+            <MaterialCommunityIcons name="share-variant" size={24} color={theme.colors.foreground} />
           </TouchableOpacity>
         )}
       </View>
@@ -439,6 +435,7 @@ export function CustomOverlay({onClose, currentIndex, total, onDetails, onShare}
  * Main gallery component using react-native-awesome-gallery
  */
 export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, onShare}: AwesomeGalleryViewerProps) {
+  const {themed} = useAppTheme()
   const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [isVideoSeeking, setIsVideoSeeking] = useState(false)
   const [isMetadataOpen, setIsMetadataOpen] = useState(false)
@@ -446,27 +443,19 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
   const galleryRef = useRef<GalleryRef>(null)
   const metadataSheetRef = useRef<BottomSheet>(null)
 
-  console.log("🎨 [AwesomeGalleryViewer] === RENDER START ===")
-  console.log("🎨 [AwesomeGalleryViewer] visible:", visible)
-  console.log("🎨 [AwesomeGalleryViewer] photos.length:", photos.length)
-  console.log("🎨 [AwesomeGalleryViewer] initialIndex:", initialIndex)
-  console.log(
-    "🎨 [AwesomeGalleryViewer] photos:",
-    photos.map((p) => ({name: p.name, isVideo: p.is_video})),
-  )
-
   // Reset index when modal opens
   useEffect(() => {
     if (visible) {
-      console.log("🎨 [AwesomeGalleryViewer] Modal opened, setting index to:", initialIndex)
       setCurrentIndex(initialIndex)
       setIsMetadataOpen(false)
       metadataSheetRef.current?.close()
       // Reset gallery to initial position
-      setTimeout(() => {
+      const resetTimer = setTimeout(() => {
         galleryRef.current?.setIndex(initialIndex, false)
       }, 50)
+      return () => clearTimeout(resetTimer)
     }
+    return undefined
   }, [visible, initialIndex])
 
   const recordDimensions = useCallback((name: string, dimensions: MediaDimensions) => {
@@ -494,15 +483,6 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
 
       const isActiveItem = index === currentIndex
 
-      console.log(
-        "🎨 [AwesomeGalleryViewer] Rendering item:",
-        item.name,
-        "isVideo:",
-        isVideo,
-        "isActive:",
-        isActiveItem,
-      )
-
       if (isVideo) {
         return (
           <VideoPlayerItem
@@ -528,6 +508,22 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
 
   // Memoized keyExtractor
   const keyExtractor = useCallback((item: PhotoInfo, index: number) => `${item.name}-${index}`, [])
+  const handleIndexChange = useCallback((newIndex: number) => {
+    setCurrentIndex((previousIndex) => (previousIndex === newIndex ? previousIndex : newIndex))
+  }, [])
+  const handleSwipeToClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+  const handleDetails = useCallback(() => {
+    metadataSheetRef.current?.snapToIndex(0)
+  }, [])
+  const handleMetadataChange = useCallback((index: number) => {
+    setIsMetadataOpen(index >= 0)
+  }, [])
+  const handleShare = useCallback(() => {
+    const photo = photos[currentIndex]
+    if (photo) onShare?.(photo)
+  }, [currentIndex, onShare, photos])
 
   if (!visible || photos.length === 0) {
     return null
@@ -535,59 +531,59 @@ export function AwesomeGalleryViewer({visible, photos, initialIndex, onClose, on
 
   return (
     <Modal visible={visible} transparent={false} animationType="fade" onRequestClose={onClose} statusBarTranslucent>
-      <StatusBar hidden />
-      <Gallery
-        ref={galleryRef}
-        data={photos}
-        initialIndex={initialIndex}
-        onIndexChange={(newIndex) => {
-          console.log("🎨 [AwesomeGalleryViewer] Index changed to:", newIndex, photos[newIndex]?.name)
-          setCurrentIndex(newIndex)
-        }}
-        onSwipeToClose={() => {
-          console.log("🎨 [AwesomeGalleryViewer] Swipe to close triggered")
-          onClose()
-        }}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        numToRender={3}
-        emptySpaceWidth={16}
-        maxScale={3}
-        doubleTapScale={2}
-        pinchEnabled={true}
-        swipeEnabled={!isVideoSeeking && !isMetadataOpen}
-        doubleTapEnabled={true}
-        disableVerticalSwipe={isMetadataOpen}
-        disableTransitionOnScaledImage={true}
-        loop={false}
-        onTap={() => {
-          console.log("🎨 [AwesomeGalleryViewer] Gallery tapped")
-        }}
-      />
+      <GestureHandlerRootView testID="media-viewer-gesture-root" style={themed($root)}>
+        <StatusBar hidden />
+        <Gallery
+          ref={galleryRef}
+          data={photos}
+          initialIndex={initialIndex}
+          onIndexChange={handleIndexChange}
+          onSwipeToClose={handleSwipeToClose}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          numToRender={3}
+          emptySpaceWidth={16}
+          maxScale={3}
+          doubleTapScale={2}
+          pinchEnabled
+          swipeEnabled={!isVideoSeeking && !isMetadataOpen}
+          doubleTapEnabled
+          disableVerticalSwipe={isMetadataOpen}
+          disableTransitionOnScaledImage
+          loop={false}
+          style={themed($gallery)}
+        />
 
-      {/* Custom overlay */}
-      <CustomOverlay
-        onClose={onClose}
-        currentIndex={currentIndex}
-        total={photos.length}
-        onDetails={() => metadataSheetRef.current?.snapToIndex(0)}
-        onShare={onShare ? () => onShare(photos[currentIndex]) : undefined}
-      />
+        <CustomOverlay
+          onClose={onClose}
+          currentIndex={currentIndex}
+          total={photos.length}
+          onDetails={handleDetails}
+          onShare={onShare ? handleShare : undefined}
+        />
 
-      <MediaMetadataSheet
-        bottomSheetRef={metadataSheetRef}
-        photo={photos[currentIndex]}
-        dimensions={mediaDimensions[photos[currentIndex].name]}
-        onChange={(index) => {
-          setIsMetadataOpen(index >= 0)
-        }}
-      />
+        <MediaMetadataSheet
+          bottomSheetRef={metadataSheetRef}
+          photo={photos[currentIndex]}
+          dimensions={mediaDimensions[photos[currentIndex].name]}
+          onChange={handleMetadataChange}
+        />
+      </GestureHandlerRootView>
     </Modal>
   )
 }
 
 // Themed styles
-const $header: ThemedStyle<any> = ({spacing}) => ({
+const $root: ThemedStyle<any> = ({colors}) => ({
+  flex: 1,
+  backgroundColor: colors.background,
+})
+
+const $gallery: ThemedStyle<any> = ({colors}) => ({
+  backgroundColor: colors.background,
+})
+
+const $header: ThemedStyle<any> = ({colors, spacing}) => ({
   position: "absolute",
   top: 0,
   left: 0,
@@ -597,7 +593,9 @@ const $header: ThemedStyle<any> = ({spacing}) => ({
   justifyContent: "space-between",
   paddingHorizontal: spacing.s4,
   paddingBottom: spacing.s3,
-  backgroundColor: "rgba(0,0,0,0.5)",
+  backgroundColor: colors.background,
+  borderBottomWidth: 1,
+  borderBottomColor: colors.border,
   zIndex: 100,
 })
 
@@ -614,12 +612,12 @@ const $headerActions: ThemedStyle<any> = () => ({
   alignItems: "center",
 })
 
-const $counterText: ThemedStyle<any> = ({spacing}) => ({
+const $counterText: ThemedStyle<any> = ({colors, spacing}) => ({
   position: "absolute",
   left: 0,
   right: 0,
   bottom: spacing.s6,
-  color: "white",
+  color: colors.foreground,
   fontSize: 16,
   fontWeight: "600",
   textAlign: "center",

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -102,6 +102,9 @@ export function GalleryScreen() {
   // Data state
   const [downloadedPhotos, setDownloadedPhotos] = useState<PhotoInfo[]>([])
   const [selectedPhoto, setSelectedPhoto] = useState<PhotoInfo | null>(null)
+  const [viewerPhotos, setViewerPhotos] = useState<PhotoInfo[]>([])
+  const [viewerInitialIndex, setViewerInitialIndex] = useState(0)
+  const galleryPhotosRef = useRef<GalleryItem[]>([])
 
   // Photo sync states for UI (progress rings on thumbnails)
   const [photoSyncStates, setPhotoSyncStates] = useState<
@@ -525,15 +528,21 @@ export function GalleryScreen() {
       }
 
       // Open MediaViewer directly (no floating transition)
-      // Index will be calculated from photo name when rendering MediaViewer
-      console.log("[GalleryScreen] 🚀 Opening MediaViewer for photo:", item.photo.name)
+      // Snapshot the list so background gallery polling does not continually
+      // rebuild and re-render full-resolution viewer items.
+      const photos = galleryPhotosRef.current
+        .map((galleryItem) => galleryItem.photo)
+        .filter((photo): photo is PhotoInfo => photo !== undefined)
+      const initialIndex = photos.findIndex((photo) => photo.name === item.photo?.name)
+      setViewerPhotos(photos)
+      setViewerInitialIndex(Math.max(initialIndex, 0))
       setSelectedPhoto(item.photo)
     },
     [isSelectionMode, photoSyncStates, togglePhotoSelection],
   )
 
   // Handle photo sharing — copies to cache dir for Android FileProvider compatibility
-  const handleSharePhoto = async (photo: PhotoInfo) => {
+  const handleSharePhoto = useCallback(async (photo: PhotoInfo) => {
     if (!photo) {
       console.error("No photo provided to share")
       return
@@ -589,7 +598,11 @@ export function GalleryScreen() {
       console.error("Error sharing photo:", error)
       showAlert("Error", "Failed to share. Please try again.", [{text: translate("common:ok")}])
     }
-  }
+  }, [])
+
+  const handleCloseMediaViewer = useCallback(() => {
+    setSelectedPhoto(null)
+  }, [])
 
   // Handle sync button press - delegate to the island gallery service.
   const handleSyncPress = async () => {
@@ -954,6 +967,7 @@ export function GalleryScreen() {
 
     return items
   }, [syncState, syncQueue, downloadedPhotos])
+  galleryPhotosRef.current = allPhotos
 
   // Create placeholder items during initial load (only if loading is taking a while)
   const placeholderItems = useMemo(() => {
@@ -1432,35 +1446,16 @@ export function GalleryScreen() {
         {renderStatusBar()}
 
         {/* Gallery viewer - direct open (no floating transition) */}
-        {selectedPhoto &&
-          (() => {
-            // Calculate the actual index in the flattened photos array
-            // GalleryItem.index includes sync queue offsets, so we need to find the real position
-            const flatPhotos = allPhotos.map((item) => item.photo).filter((p): p is PhotoInfo => p !== undefined)
-            const actualIndex = flatPhotos.findIndex((p) => p?.name === selectedPhoto.name)
-
-            if (actualIndex === -1) {
-              console.error("[GalleryScreen] ❌ Selected photo not found in photos array:", selectedPhoto.name)
-              return null
-            }
-
-            console.log("[GalleryScreen] 🎬 Rendering MediaViewer with", flatPhotos.length, "photos")
-            console.log("[GalleryScreen] 🎬 actualIndex for", selectedPhoto.name, ":", actualIndex)
-
-            return (
-              <MediaViewer
-                visible={true}
-                photo={selectedPhoto}
-                photos={flatPhotos}
-                initialIndex={actualIndex}
-                onClose={() => {
-                  console.log("[GalleryScreen] 🎬 MediaViewer closed by user")
-                  setSelectedPhoto(null)
-                }}
-                onShare={handleSharePhoto}
-              />
-            )
-          })()}
+        {selectedPhoto && viewerPhotos.length > 0 && (
+          <MediaViewer
+            visible
+            photo={selectedPhoto}
+            photos={viewerPhotos}
+            initialIndex={viewerInitialIndex}
+            onClose={handleCloseMediaViewer}
+            onShare={handleSharePhoto}
+          />
+        )}
       </View>
     </>
   )

--- a/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
+++ b/mobile/src/components/glasses/Gallery/GalleryScreen.tsx
@@ -24,7 +24,7 @@ import {
 import * as RNFS from "@dr.pogodin/react-native-fs"
 import {createShimmerPlaceholder} from "react-native-shimmer-placeholder"
 
-import {MediaViewer} from "@/components/glasses/Gallery/MediaViewer"
+import {createMediaViewerSnapshot, MediaViewer} from "@/components/glasses/Gallery/MediaViewer"
 import {PhotoImage} from "@/components/glasses/Gallery/PhotoImage"
 import {ProgressRing} from "@/components/glasses/Gallery/ProgressRing"
 import {Header, Icon, Text} from "@/components/ignite"
@@ -530,12 +530,16 @@ export function GalleryScreen() {
       // Open MediaViewer directly (no floating transition)
       // Snapshot the list so background gallery polling does not continually
       // rebuild and re-render full-resolution viewer items.
-      const photos = galleryPhotosRef.current
-        .map((galleryItem) => galleryItem.photo)
-        .filter((photo): photo is PhotoInfo => photo !== undefined)
-      const initialIndex = photos.findIndex((photo) => photo.name === item.photo?.name)
-      setViewerPhotos(photos)
-      setViewerInitialIndex(Math.max(initialIndex, 0))
+      const snapshot = createMediaViewerSnapshot(
+        galleryPhotosRef.current.map((galleryItem) => galleryItem.photo),
+        item.photo.name,
+      )
+      if (!snapshot) {
+        console.warn(`[GalleryScreen] Ignoring stale media selection: ${item.photo.name}`)
+        return
+      }
+      setViewerPhotos(snapshot.photos)
+      setViewerInitialIndex(snapshot.initialIndex)
       setSelectedPhoto(item.photo)
     },
     [isSelectionMode, photoSyncStates, togglePhotoSelection],

--- a/mobile/src/components/glasses/Gallery/MediaMetadataSheet.test.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaMetadataSheet.test.tsx
@@ -1,0 +1,52 @@
+import {render} from "@testing-library/react-native"
+
+import {PhotoInfo} from "@/types/asg"
+
+import {MediaMetadataSheet} from "./MediaMetadataSheet"
+
+let mockBottomSheetProps: Record<string, unknown> = {}
+
+jest.mock("@gorhom/bottom-sheet", () => {
+  const React = require("react")
+  const {View} = require("react-native")
+  const BottomSheet = React.forwardRef((props: Record<string, unknown>, _ref: unknown) => {
+    mockBottomSheetProps = props
+    return React.createElement(View, null, props.children)
+  })
+  BottomSheet.displayName = "BottomSheet"
+  return {
+    __esModule: true,
+    default: BottomSheet,
+    BottomSheetBackdrop: () => null,
+    BottomSheetScrollView: ({children}: {children: React.ReactNode}) => React.createElement(View, null, children),
+  }
+})
+
+jest.mock("./loadMediaMetadata", () => ({
+  loadMediaMetadata: jest.fn(),
+}))
+jest.mock("react-native-vector-icons/MaterialCommunityIcons", () => () => null)
+
+describe("MediaMetadataSheet", () => {
+  it("mounts closed without animation and enables Android pan-to-dismiss gestures", () => {
+    const bottomSheetRef = {current: null}
+    const photo = {name: "photo.jpg", filePath: "/gallery/photo.jpg", is_video: false} as PhotoInfo
+
+    render(
+      <MediaMetadataSheet
+        bottomSheetRef={bottomSheetRef}
+        photo={photo}
+        dimensions={{width: 1920, height: 1080}}
+        onChange={jest.fn()}
+      />,
+    )
+
+    expect(mockBottomSheetProps).toMatchObject({
+      animateOnMount: false,
+      enableContentPanningGesture: true,
+      enableHandlePanningGesture: true,
+      enablePanDownToClose: true,
+      index: -1,
+    })
+  })
+})

--- a/mobile/src/components/glasses/Gallery/MediaMetadataSheet.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaMetadataSheet.tsx
@@ -101,8 +101,11 @@ export function MediaMetadataSheet({bottomSheetRef, photo, dimensions, onChange}
       ref={bottomSheetRef}
       index={-1}
       snapPoints={snapPoints}
+      animateOnMount={false}
       enableDynamicSizing={false}
       enablePanDownToClose
+      enableContentPanningGesture
+      enableHandlePanningGesture
       backdropComponent={renderBackdrop}
       onChange={handleChange}
       style={{zIndex: 200}}

--- a/mobile/src/components/glasses/Gallery/MediaViewer.test.ts
+++ b/mobile/src/components/glasses/Gallery/MediaViewer.test.ts
@@ -1,0 +1,23 @@
+import {PhotoInfo} from "@/types/asg"
+
+import {createMediaViewerSnapshot} from "./MediaViewer"
+
+jest.mock("./AwesomeGalleryViewer", () => ({
+  AwesomeGalleryViewer: () => null,
+}))
+
+describe("createMediaViewerSnapshot", () => {
+  const first = {name: "first.jpg"} as PhotoInfo
+  const selected = {name: "selected.jpg"} as PhotoInfo
+
+  it("returns the selected index in a compact media snapshot", () => {
+    expect(createMediaViewerSnapshot([undefined, first, selected], selected.name)).toEqual({
+      photos: [first, selected],
+      initialIndex: 1,
+    })
+  })
+
+  it("refuses to open a stale selection instead of showing another photo", () => {
+    expect(createMediaViewerSnapshot([first], selected.name)).toBeNull()
+  })
+})

--- a/mobile/src/components/glasses/Gallery/MediaViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaViewer.tsx
@@ -19,6 +19,15 @@ interface MediaViewerProps {
   onDelete?: () => void
 }
 
+export function createMediaViewerSnapshot(
+  photos: readonly (PhotoInfo | undefined)[],
+  selectedPhotoName: string,
+): {photos: PhotoInfo[]; initialIndex: number} | null {
+  const availablePhotos = photos.filter((photo): photo is PhotoInfo => photo !== undefined)
+  const initialIndex = availablePhotos.findIndex((photo) => photo.name === selectedPhotoName)
+  return initialIndex >= 0 ? {photos: availablePhotos, initialIndex} : null
+}
+
 export const MediaViewer = memo(function MediaViewer({
   visible,
   photo,

--- a/mobile/src/components/glasses/Gallery/MediaViewer.tsx
+++ b/mobile/src/components/glasses/Gallery/MediaViewer.tsx
@@ -3,6 +3,8 @@
  * Handles both images and videos with smooth 60fps swiping
  */
 
+import {memo} from "react"
+
 import {PhotoInfo} from "@/types/asg"
 
 import {AwesomeGalleryViewer} from "./AwesomeGalleryViewer"
@@ -17,7 +19,7 @@ interface MediaViewerProps {
   onDelete?: () => void
 }
 
-export function MediaViewer({
+export const MediaViewer = memo(function MediaViewer({
   visible,
   photo,
   photos,
@@ -30,14 +32,7 @@ export function MediaViewer({
   const isGalleryMode = photos && photos.length > 0
   const displayPhotos = isGalleryMode ? photos : photo ? [photo] : []
 
-  console.log("📺 [MediaViewer] === RENDER ===")
-  console.log("📺 [MediaViewer] visible:", visible)
-  console.log("📺 [MediaViewer] isGalleryMode:", isGalleryMode)
-  console.log("📺 [MediaViewer] displayPhotos.length:", displayPhotos.length)
-  console.log("📺 [MediaViewer] initialIndex:", initialIndex)
-
   if (displayPhotos.length === 0) {
-    console.log("📺 [MediaViewer] No photos to display")
     return null
   }
 
@@ -51,4 +46,4 @@ export function MediaViewer({
       onShare={onShare}
     />
   )
-}
+})


### PR DESCRIPTION
## Summary

- stop background gallery polling from rebuilding the open full-resolution media viewer
- use memory-friendly image decoding and stable gallery callbacks for smoother Android swiping and zooming
- add a modal-local gesture root so pinch zoom and the media-details sheet work in Android's modal window
- match gallery surfaces and controls to the active app theme
- use the same share glyph as gallery selection mode

## Root cause

The viewer rebuilt its media array on every gallery status update and passed unstable callbacks into `react-native-awesome-gallery`, causing the same full-resolution images to be rendered repeatedly. Full-size Android bitmap decoding amplified the lag. The metadata sheet also lived outside a gesture-handler root in the native `Modal` window, so Android could not reliably recognize its pan-to-dismiss gesture.

Fixes bug report `rep_01KY8EPQ76NPX4VG48NZMMG9HB`.

## Validation

- `bun run test -- --runInBand src/components/glasses/Gallery src/utils/galleryShareLimits.test.ts` (12 tests)
- `bun run compile`
- scoped ESLint on all changed files (0 errors; existing inline-style/hook warnings only)
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to gallery UI on mobile with behavioral fixes and tests; no auth, sync protocol, or data-model changes.
> 
> **Overview**
> Fixes the Android glasses gallery full-screen viewer by **freezing the photo list at open time** via `createMediaViewerSnapshot`, so ongoing gallery sync/polling no longer rebuilds the viewer or re-decodes full-resolution images on every status tick.
> 
> **AwesomeGalleryViewer** wraps the modal in `GestureHandlerRootView`, passes **stable** gallery callbacks (`onIndexChange`, `onSwipeToClose`, etc.), tunes **expo-image** for Android (`allowDownscaling`, no transition, high priority only for the active slide), and **themes** the header/surfaces (replacing the semi-transparent black bar). Share uses **`share-variant`** to match selection mode. Debug logging is removed.
> 
> **MediaMetadataSheet** mounts closed without mount animation and explicitly enables pan-to-dismiss gestures so metadata works inside the modal on Android.
> 
> Adds unit tests for the snapshot helper, gesture root / image props, stable callbacks, and bottom-sheet config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7528ce2e2d54798a9cbef6834972400e116ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Android gallery media viewer by stopping expensive re-renders, optimizing image decoding, restoring reliable gestures in the modal, and preventing stale selections from opening the wrong item. Also aligns the UI with the app theme and updates the share icon.

- **Bug Fixes**
  - Snapshot photos on open and guard stale selections so an outdated tap won’t open another item.
  - Pass stable `onIndexChange`/`onSwipeToClose` to `react-native-awesome-gallery` to prevent rebuilds.
  - Use `expo-image` with `allowDownscaling`, zero transition, and high priority only when active for smoother Android swiping/zoom.
  - Wrap modal content in `react-native-gesture-handler` `GestureHandlerRootView`; enable pan gestures in `@gorhom/bottom-sheet` and start closed without animation.
  - Match gallery surfaces/controls to the active theme; switch share glyph to `react-native-vector-icons/MaterialCommunityIcons` `share-variant`.
  - Memoize `MediaViewer` and add tests for image downscaling, stable gallery callbacks, gesture root, bottom sheet config, and stale-selection snapshots.

<sup>Written for commit 2a7528ce2e2d54798a9cbef6834972400e116ed6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

