### PR TITLE
Improve text mode small-text crops

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -277,9 +277,9 @@ public class AsgConstants {
     public static final int TEXT_MODE_BLE_JPEG_QUALITY = 80;
 
     /** Long-edge size used for on-glasses ML Kit text localization. */
-    // 1280 is the smallest tested size that consistently retained stylized/low-contrast label
-    // text on real 4032x3024 Mentra Live captures while remaining below the 1s detector budget.
-    public static final int TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE = 1280;
+    // 1600 reliably retained small label/instruction text on real 4032x3024 Mentra Live captures
+    // while remaining comfortably below the detector timeout.
+    public static final int TEXT_MODE_MLKIT_ANALYSIS_LONG_EDGE = 1600;
 
     /** Minimum source-pixel padding around the union of ML Kit text lines. */
     public static final int TEXT_MODE_MLKIT_MIN_PADDING_PX = 32;
@@ -288,7 +288,7 @@ public class AsgConstants {
     public static final float TEXT_MODE_MLKIT_PADDING_X_FRACTION = 0.12f;
 
     /** Vertical padding relative to the detected text-union height. */
-    public static final float TEXT_MODE_MLKIT_PADDING_Y_FRACTION = 0.25f;
+    public static final float TEXT_MODE_MLKIT_PADDING_Y_FRACTION = 0.35f;
 
     // A lone OCR line is weak evidence for the complete text-bearing object. Keep generous
     // surrounding context so a small conventional label can pull in nearby stylized text that

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/media/core/textdetect/MlKitTextRoiDetectorTest.java
@@ -69,8 +69,8 @@ public class MlKitTextRoiDetectorTest {
                         1000,
                         800);
 
-        // Union is [100,200]-[420,300]. Padding is max(32px, 12%/25% of union size).
-        assertThat(roi).isEqualTo(new Rect(62, 168, 458, 332));
+        // Union is [100,200]-[420,300]. Padding is max(32px, 12%/35% of union size).
+        assertThat(roi).isEqualTo(new Rect(62, 165, 458, 335));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- increase the on-glasses ML Kit analysis long edge from 1280 to 1600 pixels
- increase multi-line vertical crop padding from 25% to 35%
- update the ROI geometry test for the new padding

## Why

The current 1280-pixel analysis image drops small but human-readable label and instruction text before it reaches ML Kit. In a physical-device evaluation of ten 4032x3024 Mentra Live captures, 1600 detected text in 10/10 images versus 7/10 at 1280, including the previously missed `Quickstart` examples. Average detector-pipeline time increased from 368 ms to 454 ms, remaining well under the existing 5-second timeout.

The additional vertical padding preserves a little more context around multi-line detections and reduces the chance that adjacent lower text is clipped.

## User impact

Text mode should more reliably localize small text and produce slightly less aggressive vertical crops, with an observed average latency increase of about 86 ms on the evaluated corpus.

## Validation

- `./scripts/check-android-compile.sh asg` — passed
- focused `MlKitTextRoiDetectorTest` assertions — 11 passed, 0 failures, 0 errors in the generated JUnit report
- note: the Gradle unit-test worker still exits nonzero after completing the tests because Robolectric fails to delete active Sentry/font temporary directories (`DirectoryNotEmptyException`); this occurs during test-environment cleanup, not in an assertion

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase ML Kit text localization long edge from 1280 to 1600 and vertical padding from 25% to 35% to better retain small text and surrounding context in Text mode. Updated ROI geometry test; improves small-text hits (10/10 vs 7/10 in sample) with ~86 ms average latency increase, still well under the 5 s timeout.

<sup>Written for commit 04efa2375fcbd632cc04ebed9645f86c7c518c8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant-only tuning for text-mode ML Kit scaling and crop padding with an updated unit test; no auth, data, or pipeline control-flow changes.
> 
> **Overview**
> **Text mode** on-glasses ML Kit localization now uses a **1600px** long-edge analysis image (up from **1280px**) so small label and instruction text is less likely to be missed before detection runs.
> 
> Multi-line ROI padding increases **vertical** margin from **25%** to **35%** of the detected text-union height (horizontal padding unchanged), so crops keep more context above and below clustered lines.
> 
> `MlKitTextRoiDetectorTest` expected padded union geometry is updated for the new vertical padding; comments in `AsgConstants` reflect the new tuning rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04efa2375fcbd632cc04ebed9645f86c7c518c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->