### PR TITLE
Stop auto-muting the mic while TTS is speaking

### DIFF
--- a/mobile/modules/engine/src/services/AudioCloudUplink.ts
+++ b/mobile/modules/engine/src/services/AudioCloudUplink.ts
@@ -21,9 +21,15 @@ let sub: {remove: () => void} | null = null
 const suppressionSources = new Set<string>()
 
 /**
- * Keep the glasses LC3 transport alive while preventing spoken TTS from being
- * ingested by cloud STT. Sources are reference-counted by id so overlapping
- * speech playback cannot reopen the uplink until every active prompt has ended.
+ * Keep the glasses LC3 transport alive while dropping mic audio before cloud
+ * STT. Sources are reference-counted by id so overlapping playback cannot
+ * reopen the uplink until every active source has released.
+ *
+ * Suppression is global to the uplink: one source silences STT for every app.
+ * That is why no platform path arms it any more (spoken TTS used to, which made
+ * every assistant reply punch a hole in Live Translation and Captions). The
+ * mechanism stays because it is the right primitive for an explicit,
+ * caller-scoped mute; see OS-1741 for the per-app opt-in that will use it.
  */
 export function setAudioCloudUplinkSuppressed(sourceId: string, suppressed: boolean): void {
   if (suppressed) suppressionSources.add(sourceId)

--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -12,7 +12,12 @@ interface AudioPlayRequest {
   appId?: string
   volume?: number
   stopOtherAudio?: boolean
-  /** Suppress microphone audio sent to cloud STT while this audio is audible. */
+  /**
+   * Suppress microphone audio sent to cloud STT while this audio is audible.
+   * Opt-in and off by default: the suppression is global to the uplink, so a
+   * caller that sets this silences STT for every running app, not just itself.
+   * No platform path sets it today (see AudioCloudUplink and OS-1741).
+   */
   suppressCloudUplink?: boolean
 }
 
@@ -91,9 +96,9 @@ class AudioPlaybackService {
   // window after actual audio so we only pre-roll the first sound after idle.
   private audioRouteWarmUntil = 0
   private audioRouteWarmupPromise: Promise<void> | null = null
-  // Spoken playback remains suppressed briefly while its A2DP tail drains.
-  // Track those completed sources so a new non-spoken sound can resume
-  // listening immediately instead of inheriting the previous TTS gate.
+  // Playback that opted into suppression stays suppressed briefly while its
+  // A2DP tail drains. Track those completed sources so a later unsuppressed
+  // sound can resume listening immediately instead of inheriting that gate.
   private tailUplinkSuppressions = new Set<string>()
   // Original glasses media volume captured before we bump it for A2DP playback.
   private glassesVolumeRestoreLevel: number | null = null

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -2306,7 +2306,6 @@ class LocalMiniappRuntime {
                     appId: packageName,
                     volume,
                     stopOtherAudio,
-                    suppressCloudUplink: true,
                   },
                   (_responseId, success, error, duration, completionReason) => {
                     if (run.playbackRequestId === sentenceRequestId) run.playbackRequestId = undefined
@@ -2355,7 +2354,6 @@ class LocalMiniappRuntime {
             appId: packageName,
             volume,
             stopOtherAudio,
-            suppressCloudUplink: true,
           },
           (_respId, success, error, duration, completionReason) => {
             if (run.playbackRequestId === audioRequestId) run.playbackRequestId = undefined
@@ -2408,7 +2406,6 @@ class LocalMiniappRuntime {
               appId: packageName,
               volume,
               stopOtherAudio,
-              suppressCloudUplink: true,
             },
             (_respId, success, error, duration, completionReason) => {
               if (run.playbackRequestId === audioRequestId) run.playbackRequestId = undefined


### PR DESCRIPTION
Closes part of OS-1741 (the default flip). The SDK surface in that ticket (`mic.mute()`, `mic.status`, `speaker.speak({muteMicWhileSpeaking})`) is a separate PR.

## What

Spoken TTS armed the cloud-uplink suppression on every playback. That suppression is **global to the uplink**, not scoped to the app that is speaking, so while any app was talking, mic audio was dropped before cloud STT for every app.

Concretely, on `dev` today:

- **Live Translation** speaks translated audio while the other person is still talking, so every translated sentence punches a hole in the speech it is translating.
- **Captions** stop during any app's TTS.
- **No barge-in.** "Hey Mentra stop" while it is talking is never transcribed, because the audio that would carry it is discarded.

This removes the three hardcoded `suppressCloudUplink: true` call sites in `LocalMiniappRuntime` so nothing arms it automatically.

## What this does not do

The mechanism stays. `suppressCloudUplink` remains on `AudioPlayRequest`, defaults to `false`, and is still reference-counted per source with the 700ms A2DP tail drain. It simply has no callers now. OS-1741's per-app opt-in will set it explicitly, so deleting it would only mean rebuilding it. Comments on both the flag and `setAudioCloudUplinkSuppressed` now say that plainly, including why arming it is a heavier decision than it looks.

`speaker.play()` and PCM streams already never suppressed (that was `1a0a161a2a`); this brings spoken TTS in line with them.

## Echo

The suppression existed for a real reason: on 2026-07-17 Merge's spoken insight was re-transcribed as a phantom speaker and fanned out to every app. Trading that for a platform-wide STT blackout was the wrong split, and the echo case now has better answers coming (per-app opt-in, and AEC in BES firmware, OS-1799). Worth watching for on `dev`: assistant replies re-entering transcripts.

Note the offline path was never suppressed at all. `DeviceManager.handlePcm` feeds Sherpa with no playback gate, so on-device STT has always heard TTS. That is OS-1786 and is unchanged here.

## Test

- `bun test src/` in `mobile/modules/engine`: 320 pass, 14 fail, identical to a clean `dev` checkout (the 14 are pre-existing `PhoneCameraFovCoordinator` failures on `dev`).
- Audio suites specifically: 21 pass, 0 fail.
- `tsc --noEmit` clean for all three changed files.
- The existing `only suppresses cloud STT when the caller opts in` test already pins the contract this PR relies on.

Not yet verified on device.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default real-time mic→cloud STT behavior for all apps during TTS playback; low code risk but user-visible (echo vs barge-in/translation) until per-app opt-in lands.
> 
> **Overview**
> **Spoken TTS no longer mutes the mic for cloud STT.** The three `LocalMiniappRuntime` paths that played sentence, offline, and cloud TTS used to pass `suppressCloudUplink: true`, which dropped glasses mic audio on the **global** cloud uplink—so any app’s speech could blank Live Translation, Captions, and voice barge-in for everyone.
> 
> That flag is removed from those call sites only. **`suppressCloudUplink` stays on `AudioPlayRequest`** (default `false`), with the same ref-count + A2DP tail behavior in `AudioPlaybackService`; comments in `AudioCloudUplink` and `AudioPlaybackService` now spell out that suppression is uplink-wide and that nothing in the platform arms it today (OS-1741 will add explicit opt-in).
> 
> **Trade-off:** assistant TTS may re-enter transcripts (echo) more often; continuous STT during playback is the intended default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7244f9238b822d0a2e16bd64743e27a0444a30b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop auto-muting the mic during spoken TTS by removing automatic cloud-uplink suppression. This restores continuous cloud STT so Live Translation, Captions, and barge-in keep working during playback.

- **Bug Fixes**
  - Removed `suppressCloudUplink: true` from 3 spoken TTS paths in `LocalMiniappRuntime` so mic audio isn’t dropped platform-wide during playback.
  - Kept `AudioPlayRequest.suppressCloudUplink` as an explicit opt-in (default `false`), still ref-counted with a brief A2DP tail; clarified its global effect in `AudioCloudUplink.ts` and `AudioPlaybackService.ts` and noted no platform path sets it today.
  - Aligned spoken TTS with `speaker.play()` and PCM streams (which never suppressed). Connects to OS-1741; per-app opt-in will be handled in a separate PR.

<sup>Written for commit 7244f9238b822d0a2e16bd64743e27a0444a30b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3586?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

