### PR TITLE
Add opt-in muteMicWhileSpeaking to speaker.speak()

### DIFF
--- a/mobile/modules/engine/src/services/AudioCloudUplink.ts
+++ b/mobile/modules/engine/src/services/AudioCloudUplink.ts
@@ -26,10 +26,13 @@ const suppressionSources = new Set<string>()
  * reopen the uplink until every active source has released.
  *
  * Suppression is global to the uplink: one source silences STT for every app.
- * That is why no platform path arms it any more (spoken TTS used to, which made
- * every assistant reply punch a hole in Live Translation and Captions). The
- * mechanism stays because it is the right primitive for an explicit,
- * caller-scoped mute; see OS-1741 for the per-app opt-in that will use it.
+ * That is why nothing arms it by default. Spoken TTS used to, unconditionally,
+ * which made every assistant reply punch a hole in Live Translation and
+ * Captions. The only way in now is a miniapp explicitly passing
+ * `speaker.speak(text, {muteMicWhileSpeaking: true})`, which LocalMiniappRuntime
+ * logs on every arming because the blast radius reaches apps that never asked
+ * for it. See OS-1741 for the mic.status work that would make it visible to
+ * the apps being muted rather than only in the logs.
  */
 export function setAudioCloudUplinkSuppressed(sourceId: string, suppressed: boolean): void {
   if (suppressed) suppressionSources.add(sourceId)

--- a/mobile/modules/engine/src/services/AudioPlaybackService.ts
+++ b/mobile/modules/engine/src/services/AudioPlaybackService.ts
@@ -16,7 +16,8 @@ interface AudioPlayRequest {
    * Suppress microphone audio sent to cloud STT while this audio is audible.
    * Opt-in and off by default: the suppression is global to the uplink, so a
    * caller that sets this silences STT for every running app, not just itself.
-   * No platform path sets it today (see AudioCloudUplink and OS-1741).
+   * Reaches here only from a miniapp's explicit
+   * `speaker.speak(text, {muteMicWhileSpeaking: true})`.
    */
   suppressCloudUplink?: boolean
 }

--- a/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
+++ b/mobile/modules/engine/src/services/LocalMiniappRuntime.ts
@@ -2196,6 +2196,17 @@ class LocalMiniappRuntime {
     const audioRequestId = requestId || `tts_${Date.now()}`
     const volume = typeof payload.volume === "number" ? payload.volume : 1.0
     const stopOtherAudio = payload.stopOtherAudio !== false
+    // Opt-in only, and deliberately opt-in: the uplink suppression is
+    // device-wide, so honouring this silences cloud STT for every running
+    // miniapp, not just this one. Log every arming so a support case that
+    // starts "captions stopped for no reason" is traceable to the caller.
+    const muteMicWhileSpeaking = payload.muteMicWhileSpeaking === true
+    if (muteMicWhileSpeaking) {
+      console.warn(
+        `${LOG_TAG}: ${packageName} requested muteMicWhileSpeaking; cloud STT is suppressed ` +
+          `device-wide for the duration of this playback`,
+      )
+    }
     const voiceSettings =
       payload.voice_settings && typeof payload.voice_settings === "object"
         ? (payload.voice_settings as Record<string, unknown>)
@@ -2306,6 +2317,7 @@ class LocalMiniappRuntime {
                     appId: packageName,
                     volume,
                     stopOtherAudio,
+                    suppressCloudUplink: muteMicWhileSpeaking,
                   },
                   (_responseId, success, error, duration, completionReason) => {
                     if (run.playbackRequestId === sentenceRequestId) run.playbackRequestId = undefined
@@ -2354,6 +2366,7 @@ class LocalMiniappRuntime {
             appId: packageName,
             volume,
             stopOtherAudio,
+            suppressCloudUplink: muteMicWhileSpeaking,
           },
           (_respId, success, error, duration, completionReason) => {
             if (run.playbackRequestId === audioRequestId) run.playbackRequestId = undefined
@@ -2406,6 +2419,7 @@ class LocalMiniappRuntime {
               appId: packageName,
               volume,
               stopOtherAudio,
+              suppressCloudUplink: muteMicWhileSpeaking,
             },
             (_respId, success, error, duration, completionReason) => {
               if (run.playbackRequestId === audioRequestId) run.playbackRequestId = undefined

--- a/mobile/modules/miniapp/src/modules/speaker.test.ts
+++ b/mobile/modules/miniapp/src/modules/speaker.test.ts
@@ -47,9 +47,34 @@ describe("SpeakerModule.speak", () => {
         stopOtherAudio: false,
         enableSanitization: true,
         forceLocal: true,
+        muteMicWhileSpeaking: false,
       },
     ])
     expect(requestOptions).toEqual([{timeoutMs: 0}])
+  })
+
+  test("does not mute the microphone unless the caller asks", async () => {
+    const {session, requestCalls} = mockSession([{completed: true}])
+    const speaker = new SpeakerModule(session)
+
+    await speaker.speak("An ordinary spoken reply.")
+
+    // The suppression is device-wide, so silence has to be the default no
+    // matter which overload or option set a miniapp uses.
+    expect(requestCalls[0]).toMatchObject({muteMicWhileSpeaking: false})
+  })
+
+  test("forwards an explicit microphone mute opt-in", async () => {
+    const {session, requestCalls} = mockSession([{completed: true}])
+    const speaker = new SpeakerModule(session)
+
+    await speaker.speak(["Answering now.", "Here is the result."], {muteMicWhileSpeaking: true})
+
+    expect(requestCalls[0]).toMatchObject({
+      type: MiniappRequestType.SPEAK,
+      text: ["Answering now.", "Here is the result."],
+      muteMicWhileSpeaking: true,
+    })
   })
 
   test("sends an explicit sentence list through the normal SPEAK request", async () => {

--- a/mobile/modules/miniapp/src/modules/speaker.ts
+++ b/mobile/modules/miniapp/src/modules/speaker.ts
@@ -61,6 +61,23 @@ export interface SpeakOptions {
    * if the offline model isn't ready instead of falling back to cloud.
    */
   forceLocal?: boolean
+  /**
+   * Drop microphone audio before cloud speech-to-text for as long as this
+   * playback is audible, so the TTS is not transcribed as if the user had
+   * said it. Defaults to false.
+   *
+   * READ THIS BEFORE SETTING IT. The suppression is device-wide, not scoped
+   * to the calling miniapp. There is one microphone uplink and one cloud STT
+   * stream shared by every running miniapp, so setting this silences
+   * transcription for all of them: Captions stops, Live Translation stops,
+   * and nothing can be barged in on until the playback plus its audio tail
+   * has finished. The user is given no indication that this happened.
+   *
+   * Only reach for this when self-transcription would actively break your
+   * miniapp (an assistant re-hearing its own answer and replying to it), and
+   * prefer keeping spoken replies short so the blackout window stays small.
+   */
+  muteMicWhileSpeaking?: boolean
 }
 
 export interface SpeakResult {
@@ -276,6 +293,7 @@ export class SpeakerModule {
           stopOtherAudio: options.stopOtherAudio ?? false,
           enableSanitization: options.enableSanitization ?? true,
           forceLocal: options.forceLocal ?? false,
+          muteMicWhileSpeaking: options.muteMicWhileSpeaking ?? false,
         },
         {timeoutMs: 0},
       )


### PR DESCRIPTION
**Draft on purpose. Do not merge without a decision on the blast radius below.**

Stacked on #3586 (base is that branch, so the diff here is only the new work; GitHub retargets to `dev` once #3586 merges).

## What

#3586 removed the platform's automatic mic mute during TTS. That left the mechanism plumbed but unreachable: a miniapp had no way to ask for it. This adds the way in.

```ts
await session.speaker.speak("Here is your answer.", {muteMicWhileSpeaking: true})
```

Off by default. `LocalMiniappRuntime` reads it as `payload.muteMicWhileSpeaking === true` and threads it into all three playback paths (cloud TTS, offline single-shot, offline sentence pipeline).

## Why this is draft and not just merged

The suppression is device-wide. There is one microphone uplink and one cloud STT stream shared by every running miniapp, so a miniapp setting this does not mute its own transcription. It mutes Captions, Live Translation, and everything else running, for the duration of the playback plus the 700ms A2DP tail, with no indication to the user or to the apps being silenced.

So this hands any miniapp, including third-party ones, a device-wide kill switch over everyone else's transcription behind a one-line option. That is a real product decision, not a mechanical follow-up, and it should be made deliberately.

Two things partially blunt it, neither of which is a fix:

- The option's doc comment states the blast radius in the API surface itself, where an author will actually read it.
- `LocalMiniappRuntime` logs a warning naming the requesting package on every arming, so a support case that starts "captions stopped for no reason" is traceable to a caller instead of being a mystery.

The actual fix is OS-1741's `mic.status` / `mic.onStatusChange`, which would let a muted app see that it has been muted and by whom. Until that exists, this is observable in logs only.

## Options if the blast radius is not acceptable

1. Merge as is, accept it, and prioritise `mic.status` right after.
2. Restrict the option to first-party packages (Mentra AI, Merge) until scoping exists.
3. Scope the suppression per-subscriber rather than per-uplink, so an app only mutes its own transcript delivery. Bigger change, and the right end state.
4. Leave this branch parked and do nothing, since AEC in firmware may remove the need entirely (OS-1799).

I lean 1 or 4 depending on how the firmware test goes.

## Test

- `mobile/modules/miniapp`: 253 pass, 0 fail. Added two cases pinning that the default is off across both `speak()` overloads and that an explicit opt-in is forwarded.
- `mobile/modules/engine`: 320 pass, 14 fail, identical to a clean `dev` checkout (pre-existing `PhoneCameraFovCoordinator` failures).
- `tsc --noEmit` clean for every changed file.
- Not exercised on device. #3586 has the device traces showing the underlying mechanism does what the counters say when it is armed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `muteMicWhileSpeaking` to `session.speaker.speak()` to suppress mic audio to cloud STT while TTS plays. Off by default; suppression is device-wide and will mute Captions/Live Translation for all apps during playback.

- New Features
  - Threads `muteMicWhileSpeaking` through `LocalMiniappRuntime` to `AudioPlaybackService`/`AudioCloudUplink` across all playback paths, and logs the requesting package when suppression is armed.
  - Tests cover default-off behavior and forwarding of an explicit opt-in; future `mic.status` (OS-1741) will let muted apps detect and attribute the suppression.

<sup>Written for commit 01d9da527fcef0e28f2a296f1f597e7b8ad91b82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

