### PR TITLE
Reify the ASG-to-BES UART link state into a LinkStateMachine

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -10,6 +10,7 @@ import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesMessag
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.BesWireFormat;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.CsFltsAckPayload;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.K900LengthCodec;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.MessageChunker;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.SerialPortBridge;
 import com.mentra.asg_client.io.bluetooth.utils.DebugNotificationManager;
@@ -45,7 +46,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private static final String TAG = "K900BluetoothManager";
 
     private final SerialPortBridge comManager;
-    private boolean isSerialOpen = false;
+
+    // Single owner of the transport-side link facts (serial open, link proven at current baud,
+    // negotiated BES wire caps). The legacy isSerialOpen/besWireCaps* booleans are derived from it
+    // through thin getters so external call sites keep their existing surface.
+    private final LinkStateMachine linkState = new LinkStateMachine();
     private final DebugNotificationManager notificationManager;
     // Keep normal K900 messages contiguous on the shared ASG-to-BES UART stream.
     private final Object outboundSendLock = new Object();
@@ -61,10 +66,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // interleaves messages. Bounded: abandoned reassemblies would leak entries, so the set
     // is cleared when it exceeds a size no legitimate interleave reaches.
     private final java.util.Set<Integer> pendingBinaryWakeMsgIds = new java.util.LinkedHashSet<>();
-    private volatile boolean besWireCapsK900Le = false;
-    private volatile boolean besWireCapsBinary = false;
-    private volatile boolean besWireCapsFilePayloadV2 = false;
-    private volatile int besWireCapsProto = BesWireFormat.PROTOCOL_VERSION_V1;
     private volatile int gattFilePackSize = BesWireFormat.FILE_PACK_SIZE_DEFAULT;
     private volatile int lastNegotiatedMtu = 0;
     private volatile boolean phoneSupportsFilePayloadV2 = false;
@@ -109,10 +110,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     // first ACK repeatedly overran the BES parser on hardware and triggered 150 ms retries.
     private static final int FILE_PUSH_WINDOW_BIG_PACKS = 8;
     private volatile boolean besSupportsBatchedAcks = false;
-    private volatile boolean besSupportsBigPacks = false;
 
     private int effectivePushWindow() {
-        if (besSupportsBigPacks) {
+        if (linkState.getNegotiatedCaps().bigPacks) {
             return FILE_PUSH_WINDOW_BIG_PACKS;
         }
         return besSupportsBatchedAcks ? FILE_PUSH_WINDOW_BATCHED : FILE_PUSH_WINDOW;
@@ -458,7 +458,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             return false;
         }
 
-        if (!isSerialOpen) {
+        if (!linkState.isSerialOpen()) {
             Log.w(TAG, "📡 ❌ Cannot send data - serial port not open");
             notificationManager.showDebugNotification(
                     "Bluetooth Error", "Cannot send data - serial port not open");
@@ -564,23 +564,22 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         wireV2HandshakeSent = false;
     }
 
-    /** Reset all negotiated wire protocol state when the BES UART link is closed. */
+    /**
+     * Reset the remaining wire protocol state when the BES UART link is closed. The negotiated BES
+     * caps are cleared by {@code linkState.serialClosed()}; this covers the phone-facing state and
+     * the UART length endianness, which live outside the link state machine.
+     */
     public void resetWireProtocolState() {
         resetPhoneWireProtocolState();
-        besWireCapsK900Le = false;
-        besWireCapsBinary = false;
-        besWireCapsFilePayloadV2 = false;
-        besSupportsBigPacks = false;
-        besWireCapsProto = BesWireFormat.PROTOCOL_VERSION_V1;
         uartToBesEndian = K900LengthCodec.Endian.BE;
     }
 
     /** Send BLE Wire v2 handshake frame (payload "v2"). */
     public boolean sendWireV2Handshake() {
-        if (!isSerialOpen) {
+        if (!linkState.isSerialOpen()) {
             return false;
         }
-        if (!besWireCapsBinary) {
+        if (!linkState.getNegotiatedCaps().binary) {
             Log.i(TAG, "📡 Skipping BLE wire v2 handshake; BES has not advertised binary relay");
             return false;
         }
@@ -684,10 +683,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         if (!header.valid) {
             return false;
         }
-        besWireCapsBinary = true;
-        if (besWireCapsProto < BesWireFormat.PROTOCOL_VERSION_V2) {
-            besWireCapsProto = BesWireFormat.PROTOCOL_VERSION_V2;
-        }
+        // A valid binary frame proves binary relay support even without a wire_caps advert.
+        linkState.binaryRelayObserved();
 
         if ((header.flags & BesWireFormat.FLAG_HANDSHAKE) != 0) {
             if (BesWireFormat.isV2HandshakePayload(header.payload)) {
@@ -762,20 +759,20 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      * reachable.
      */
     public void addPhoneWireCapsIfSupported(JSONObject response) {
-        if (response == null
-                || (!besWireCapsK900Le && !besWireCapsBinary && !besWireCapsFilePayloadV2)) {
+        LinkStateMachine.BesCaps besCaps = linkState.getNegotiatedCaps();
+        if (response == null || (!besCaps.k900Le && !besCaps.binary && !besCaps.filePayloadV2)) {
             return;
         }
         try {
             JSONObject caps = new JSONObject();
-            if (besWireCapsK900Le) {
+            if (besCaps.k900Le) {
                 caps.put("k900_le", true);
             }
-            if (besWireCapsBinary) {
+            if (besCaps.binary) {
                 caps.put("binary", true);
-                caps.put("proto", Math.max(besWireCapsProto, BesWireFormat.PROTOCOL_VERSION_V2));
+                caps.put("proto", Math.max(besCaps.proto, BesWireFormat.PROTOCOL_VERSION_V2));
             }
-            if (besWireCapsFilePayloadV2) {
+            if (besCaps.filePayloadV2) {
                 caps.put("file_payload_v2", true);
                 caps.put("file_payload_gatt_max", BesWireFormat.FILE_PACK_SIZE_GATT_MAX);
                 caps.put("file_payload_coc_max", BesWireFormat.FILE_PACK_SIZE_COC_MAX);
@@ -786,8 +783,18 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
+    /** Whether the BES has proven binary relay support (wire_caps advert or an observed frame). */
     public boolean isBesBinaryRelaySupported() {
-        return besWireCapsBinary;
+        return linkState.getNegotiatedCaps().binary;
+    }
+
+    /**
+     * Observable transport link state (serial open, link proven, negotiated BES caps). New
+     * consumers should subscribe here: {@code addListener} replays the current state
+     * synchronously, so subscribing late cannot miss the only edge.
+     */
+    public LinkStateMachine getLinkStateMachine() {
+        return linkState;
     }
 
     /** Queues an internal command without broadcasting it as a phone-facing command response. */
@@ -1317,9 +1324,10 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     /**
-     * Inspect a message from the BES for a {@code wire_caps} object and upgrade the UART link to
-     * little-endian K900 STRING lengths when the firmware advertises it. {@code wire_caps} may sit
-     * at the top level or inside the {@code B} body.
+     * Inspect an sr_syvr message from the BES for a {@code wire_caps} object, record the
+     * advertisement in the link state machine (any sr_syvr also proves the link at the current
+     * baud), and upgrade the UART link to little-endian K900 STRING lengths when the firmware
+     * advertises it. {@code wire_caps} may sit at the top level or inside the {@code B} body.
      */
     private void applyBesWireCaps(JSONObject json) {
         if (json == null) {
@@ -1341,21 +1349,29 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 }
             }
         }
-        if (caps != null && caps.optBoolean("k900_le", false)) {
-            besWireCapsK900Le = true;
+        LinkStateMachine.BesCaps advertised = null;
+        if (caps != null) {
+            boolean filePayloadV2 = caps.optBoolean("file_payload_v2", false);
+            advertised =
+                    new LinkStateMachine.BesCaps(
+                            caps.optBoolean("k900_le", false),
+                            caps.optBoolean("binary", false),
+                            filePayloadV2,
+                            // Big-pack support ships with the file_payload_v2 advertisement.
+                            filePayloadV2,
+                            caps.optInt("proto", BesWireFormat.PROTOCOL_VERSION_V2));
+        }
+        linkState.srSyvrParsed(advertised);
+        if (advertised != null && advertised.k900Le) {
             if (uartToBesEndian != K900LengthCodec.Endian.LE) {
                 uartToBesEndian = K900LengthCodec.Endian.LE;
                 Log.i(TAG, "🔤 UART K900 endian negotiated to LE via wire_caps");
             }
         }
-        if (caps != null && caps.optBoolean("binary", false)) {
-            besWireCapsBinary = true;
-            besWireCapsProto = caps.optInt("proto", BesWireFormat.PROTOCOL_VERSION_V2);
-            Log.i(TAG, "📡 BES wire_caps advertised binary relay proto=" + besWireCapsProto);
+        if (advertised != null && advertised.binary) {
+            Log.i(TAG, "📡 BES wire_caps advertised binary relay proto=" + advertised.proto);
         }
-        if (caps != null && caps.optBoolean("file_payload_v2", false)) {
-            besWireCapsFilePayloadV2 = true;
-            besSupportsBigPacks = true;
+        if (advertised != null && advertised.filePayloadV2) {
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
     }
@@ -1379,7 +1395,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 phoneSupportsFilePayloadV2 = true;
             }
             if ("coc".equals(transport)
-                    && besWireCapsFilePayloadV2
+                    && linkState.getNegotiatedCaps().filePayloadV2
                     && phoneSupportsFilePayloadV2) {
                 if (fileTransportCoc
                         && currentFileTransfer != null
@@ -1397,7 +1413,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 if (lastNegotiatedMtu > 0) {
                     BesWireFormat.setFilePackSizeFromMtu(
                             lastNegotiatedMtu,
-                            besWireCapsFilePayloadV2 && phoneSupportsFilePayloadV2);
+                            linkState.getNegotiatedCaps().filePayloadV2
+                                    && phoneSupportsFilePayloadV2);
                     gattFilePackSize = BesWireFormat.getFilePackSize();
                 } else {
                     BesWireFormat.setFilePackSize(gattFilePackSize);
@@ -1866,7 +1883,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     "📦 Batched-ack push mode "
                             + (besSupportsBatchedAcks ? "ENABLED" : "disabled")
                             + ", big packs "
-                            + (besSupportsBigPacks ? "ENABLED" : "disabled")
+                            + (linkState.getNegotiatedCaps().bigPacks ? "ENABLED" : "disabled")
                             + " (fw " + version + ", window " + effectivePushWindow()
                             + ", packSize " + effectiveUartPackSize() + ")");
         } catch (Exception e) {
@@ -1908,7 +1925,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     @Override
     public boolean isConnected() {
         // For K900, we consider the device connected if the serial port is open
-        return isSerialOpen && super.isConnected();
+        return linkState.isSerialOpen() && super.isConnected();
     }
 
     @Override
@@ -1926,7 +1943,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.d(TAG, "🔌 =========================================");
         Log.d(TAG, "🔌 Serial path: " + serialPath);
 
-        isSerialOpen = false;
+        // serialClosed() also clears the negotiated BES caps (the legacy resetWireProtocolState
+        // caps reset); resetWireProtocolState() covers the phone-facing state and UART endianness.
+        linkState.serialClosed();
         resetWireProtocolState();
         Log.d(TAG, "🔌 ✅ Serial port marked as closed");
 
@@ -2390,7 +2409,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.d(TAG, "🔌 =========================================");
         Log.d(TAG, "🔌 Serial path: " + serialPath);
 
-        isSerialOpen = true;
+        linkState.serialReady();
         Log.d(TAG, "🔌 ✅ Serial port marked as open");
 
         // For K900, when the serial port is ready, we consider ourselves "connected"
@@ -2520,7 +2539,14 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
+    /**
+     * Shared prelude of every reopen/baud-switch path: the byte stream is about to be
+     * discontinuous, so drop any partially parsed frame and tell the link state machine the link
+     * is no longer proven at the current baud ({@code SerialPortBridge.reopen()} fires no serial
+     * close/ready callbacks, so this is the only signal those paths emit).
+     */
     private void clearMessageParser() {
+        linkState.streamDiscontinuity();
         synchronized (messageParserLock) {
             if (messageParser != null) {
                 messageParser.clear();
@@ -2538,7 +2564,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         Log.d(TAG, "🔌 Serial path: " + serialPath);
         Log.d(TAG, "🔌 Message: " + msg);
 
-        isSerialOpen = bSucc;
+        if (bSucc) {
+            linkState.serialReady();
+        } else {
+            linkState.serialClosed();
+        }
         Log.d(TAG, "🔌 Serial port open state set to: " + bSucc);
 
         if (bSucc) {
@@ -2569,7 +2599,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      */
     @Override
     protected boolean sendFileInternal(String filePath) {
-        if (!isSerialOpen) {
+        if (!linkState.isSerialOpen()) {
             Log.e(TAG, "Cannot send file - serial port not open");
 
             // Report file transfer failure
@@ -2633,7 +2663,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
      */
     @Override
     protected boolean sendFileInternal(byte[] data, String fileName) {
-        if (!isSerialOpen) {
+        if (!linkState.isSerialOpen()) {
             Log.e(TAG, "Cannot send in-memory file - serial port not open");
             BluetoothReporting.reportFileTransferFailure(
                     context, memoryReportPath(fileName), "send_file", "serial_port_not_open", null);
@@ -2679,7 +2709,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             fileName,
                             fileData,
                             effectiveUartPackSize(),
-                            besWireCapsFilePayloadV2);
+                            linkState.getNegotiatedCaps().filePayloadV2);
         }
         pendingPackets.clear();
         consecutiveFailures = 0; // Reset failure counter for new transfer
@@ -2812,7 +2842,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // Advertise push-mode/batched-ack support to firmware that understands it
         // (bit 0 of the flags field; older firmware never reads flags).
         int flags = besSupportsBatchedAcks ? BesWireFormat.FILE_FLAG_PUSH_BATCH_ACK : 0;
-        if (besWireCapsFilePayloadV2) {
+        if (linkState.getNegotiatedCaps().filePayloadV2) {
             flags |= BesWireFormat.FILE_FLAG_DYNAMIC_PAYLOAD;
         }
         byte[] packet =
@@ -2954,7 +2984,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         lastNegotiatedMtu = mtu;
         int cocFilePackSize = fileTransportCoc ? BesWireFormat.getFilePackSize() : 0;
         BesWireFormat.setFilePackSizeFromMtu(
-                mtu, besWireCapsFilePayloadV2 && phoneSupportsFilePayloadV2);
+                mtu, linkState.getNegotiatedCaps().filePayloadV2 && phoneSupportsFilePayloadV2);
         gattFilePackSize = BesWireFormat.getFilePackSize();
         if (fileTransportCoc) {
             BesWireFormat.setFilePackSize(cocFilePackSize);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -380,7 +380,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                         + ")");
         try {
             clearMessageParser();
-            boolean reopened = comManager.reopen(candidate);
+            boolean reopened = reopenSerial(candidate);
             if (reopened) {
                 int generation;
                 synchronized (baudSwitchLock) {
@@ -423,7 +423,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         try {
             clearMessageParser();
-            boolean reopened = comManager.reopen(defaultBaud);
+            boolean reopened = reopenSerial(defaultBaud);
             if (reopened) {
                 Log.w(
                         BAUD_TAG,
@@ -1767,7 +1767,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     private void reopenAtTargetBaudAndProbe() {
         try {
             clearMessageParser();
-            boolean reopened = comManager.reopen(TARGET_UART_BAUD);
+            boolean reopened = reopenSerial(TARGET_UART_BAUD);
             if (!reopened) {
                 Log.e(
                         BAUD_TAG,
@@ -1831,7 +1831,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         try {
             clearMessageParser();
-            boolean ok = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
+            boolean ok = reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE);
             Log.e(
                     BAUD_TAG,
                     "Revert to "
@@ -2263,7 +2263,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
         try {
             clearMessageParser();
-            if (comManager.getCurrentBaud() != candidate && !comManager.reopen(candidate)) {
+            if (comManager.getCurrentBaud() != candidate && !reopenSerial(candidate)) {
                 Log.e(BAUD_TAG, "Runtime recovery could not reopen " + candidate + " baud");
             } else {
                 Log.i(
@@ -2301,7 +2301,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             baudSwitchAttempted = false;
             if (comManager.getCurrentBaud() != SerialPortBridge.DEFAULT_BAUDRATE) {
                 try {
-                    reopened = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
+                    reopened = reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE);
                 } catch (Exception e) {
                     reopened = false;
                     Log.e(BAUD_TAG, "Runtime recovery rendezvous reopen failed", e);
@@ -2468,7 +2468,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         try {
             clearMessageParser();
-            if (!comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE)) {
+            if (!reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE)) {
                 Log.e(BAUD_TAG, "Initial rendezvous reopen failed after BES OTA");
             }
         } catch (Exception e) {
@@ -2516,7 +2516,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         try {
             clearMessageParser();
-            boolean reopened = comManager.reopen(SerialPortBridge.DEFAULT_BAUDRATE);
+            boolean reopened = reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE);
             if (!reopened) {
                 scheduleBesOtaReconnect(
                         generation,
@@ -2542,6 +2542,24 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                     attempt + 1,
                     AsgConstants.UART_BOOT_RECOVERY_RETRY_DELAY_MS,
                     "reconnect exception");
+        }
+    }
+
+    /**
+     * Reopen the UART through the bridge and propagate the ACTUAL post-reopen port state into the
+     * link state machine. {@code SerialPortBridge.reopen()} falls back to the default baud
+     * internally, but when both opens fail it leaves the port closed WITHOUT firing any serial
+     * callback — the machine (now the source of truth for serial-open) must not keep reporting an
+     * open link while every send fails. The bridge refuses further reopens once closed, so the
+     * only way back to open is a fresh {@code start()}, which fires the normal serial callbacks.
+     */
+    private boolean reopenSerial(int baud) {
+        try {
+            return comManager.reopen(baud);
+        } finally {
+            if (!comManager.isOpen()) {
+                linkState.serialClosed();
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2430,6 +2430,12 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     @Override
     public void onBesOtaApplied() {
         Log.i(BAUD_TAG, "BES OTA applied; scheduling reconnect at rendezvous baud");
+        // The BES is rebooting, so the sr_syvr proof is invalid NOW: demote synchronously with
+        // the lastSrSyvrTime reset below instead of waiting for the async rendezvous path, whose
+        // clearMessageParser can be skipped entirely by a generation-mismatch early return.
+        // Idempotent if that path does run it. Called outside baudSwitchLock so listener
+        // callbacks never execute under it.
+        linkState.streamDiscontinuity();
         int generation;
         synchronized (baudSwitchLock) {
             generation = ++recoveryProbeGeneration;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -2290,24 +2290,36 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     }
 
     private void parkRuntimeRecoveryAtRendezvous(int generation, long retryDelayMs) {
-        clearMessageParser();
-        boolean reopened = true;
         synchronized (baudSwitchLock) {
             if (!runtimeBaudRecoveryInProgress
                     || generation != runtimeBaudRecoveryGeneration
                     || generation != recoveryProbeGeneration) {
+                // Stale park: a newer recovery (or a valid frame that ended this one) owns the
+                // link now — touch nothing, especially not the proven link state.
                 return;
             }
             baudSwitchAttempted = false;
-            if (comManager.getCurrentBaud() != SerialPortBridge.DEFAULT_BAUDRATE) {
-                try {
-                    reopened = reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE);
-                } catch (Exception e) {
-                    reopened = false;
-                    Log.e(BAUD_TAG, "Runtime recovery rendezvous reopen failed", e);
-                }
+        }
+        // Outside baudSwitchLock: both clearMessageParser() and reopenSerial() can notify link
+        // state listeners under the machine's monitor and must never do so while holding the
+        // baud lock. All reopen paths run on the single-threaded baud executor, so no other
+        // reopen can interleave here.
+        clearMessageParser();
+        boolean reopened = true;
+        if (comManager.getCurrentBaud() != SerialPortBridge.DEFAULT_BAUDRATE) {
+            try {
+                reopened = reopenSerial(SerialPortBridge.DEFAULT_BAUDRATE);
+            } catch (Exception e) {
+                reopened = false;
+                Log.e(BAUD_TAG, "Runtime recovery rendezvous reopen failed", e);
             }
-            scheduleRuntimeBaudRecoveryLocked(generation, retryDelayMs);
+        }
+        synchronized (baudSwitchLock) {
+            if (runtimeBaudRecoveryInProgress
+                    && generation == runtimeBaudRecoveryGeneration
+                    && generation == recoveryProbeGeneration) {
+                scheduleRuntimeBaudRecoveryLocked(generation, retryDelayMs);
+            }
         }
         Log.w(
                 BAUD_TAG,

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -317,11 +317,19 @@ public final class LinkStateMachine {
         return state == LinkState.LINK_PROVEN ? negotiatedCaps : null;
     }
 
-    /** Must hold the monitor. */
+    /**
+     * Must hold the monitor. Snapshots BOTH state and caps before the loop: the monitor is
+     * reentrant, so a listener may perform a transition from inside its callback, and reading the
+     * {@code state} field live per iteration would then hand later listeners in this pass a torn
+     * pair (e.g. {@code SERIAL_CLOSED} with non-null caps). With the snapshot, every listener in
+     * one pass sees the consistent pair of the transition that triggered it; the reentrant
+     * transition delivers its own pass.
+     */
     private void notifyListenersLocked() {
-        BesCaps provenCaps = provenCapsLocked();
+        LinkState snapshotState = state;
+        BesCaps snapshotProvenCaps = provenCapsLocked();
         for (Listener listener : listeners) {
-            listener.onLinkStateChanged(state, provenCaps);
+            listener.onLinkStateChanged(snapshotState, snapshotProvenCaps);
         }
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -1,5 +1,8 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
+import android.util.Log;
+
+import java.util.ArrayDeque;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -40,9 +43,11 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * <p>Thread safety: transitions arrive from the serial RX thread, the baud-switch executor, and
  * binder threads. All state mutation and listener notification happen under the internal monitor,
- * so every listener observes transitions in a single global order and replay-on-subscribe cannot
- * interleave with a concurrent transition. Listeners must therefore be fast and must not block on
- * locks that transition callers might hold.
+ * and deliveries go through a FIFO dispatch queue (reentrant transitions from inside a callback
+ * are queued behind the pass in flight), so every listener observes transitions in a single global
+ * order — always ending on the machine's final state — and replay-on-subscribe cannot interleave
+ * with a concurrent transition. Listeners must therefore be fast and must not block on locks that
+ * transition callers might hold.
  */
 public final class LinkStateMachine {
 
@@ -158,18 +163,41 @@ public final class LinkStateMachine {
     public interface Listener {
         /**
          * Called under the machine's monitor on every observable change, and synchronously from
-         * {@link #addListener} with the current state.
+         * {@link #addListener} with the current state. Transitions are delivered in one global
+         * FIFO order: a transition performed from inside a callback is queued behind the pass in
+         * flight, so every listener's LAST observation always matches the machine's final state.
+         * A thrown exception is logged and does not affect other listeners or the caller.
          *
-         * @param state the current link state
+         * @param state the link state at the time of the transition being delivered
          * @param provenCaps the trusted caps snapshot; non-null exactly when {@code state} is
          *     {@link LinkState#LINK_PROVEN}
          */
         void onLinkStateChanged(LinkState state, BesCaps provenCaps);
     }
 
+    /** One queued delivery: the state pair at transition time plus its audience. */
+    private static final class Notification {
+        final LinkState state;
+        final BesCaps provenCaps;
+        final List<Listener> audience;
+
+        Notification(LinkState state, BesCaps provenCaps, List<Listener> audience) {
+            this.state = state;
+            this.provenCaps = provenCaps;
+            this.audience = audience;
+        }
+    }
+
+    private static final String TAG = "LinkStateMachine";
+
     // Copy-on-write so a listener may add/remove listeners from inside a callback without
     // corrupting the iteration that is notifying it.
     private final List<Listener> listeners = new CopyOnWriteArrayList<>();
+
+    // FIFO dispatch queue (guarded by the monitor): transitions performed from inside a listener
+    // callback are enqueued behind the pass currently being delivered instead of nesting.
+    private final ArrayDeque<Notification> pendingNotifications = new ArrayDeque<>();
+    private boolean dispatching = false;
 
     private LinkState state = LinkState.SERIAL_CLOSED;
     private BesCaps negotiatedCaps = BesCaps.NONE;
@@ -184,7 +212,11 @@ public final class LinkStateMachine {
             return;
         }
         listeners.add(listener);
-        listener.onLinkStateChanged(state, provenCapsLocked());
+        // Replay the CURRENT state directly, not through the queue: the state field always
+        // reflects every transition already performed (only their deliveries can lag), and queued
+        // passes snapshot their audience at transition time, so this listener will never also
+        // receive an older pass after this newer replay.
+        deliverSafely(listener, state, provenCapsLocked());
     }
 
     /** Unregister a listener; no-op if it was never added. */
@@ -318,18 +350,44 @@ public final class LinkStateMachine {
     }
 
     /**
-     * Must hold the monitor. Snapshots BOTH state and caps before the loop: the monitor is
-     * reentrant, so a listener may perform a transition from inside its callback, and reading the
-     * {@code state} field live per iteration would then hand later listeners in this pass a torn
-     * pair (e.g. {@code SERIAL_CLOSED} with non-null caps). With the snapshot, every listener in
-     * one pass sees the consistent pair of the transition that triggered it; the reentrant
-     * transition delivers its own pass.
+     * Must hold the monitor. Enqueues the current (state, provenCaps) pair and drains the queue
+     * in FIFO order. The monitor is reentrant, so a listener may perform a transition from inside
+     * its callback; delivering that nested transition inline would either tear the pair for later
+     * listeners in the outer pass or hand them the passes out of order (a stale pair delivered
+     * last). Queueing instead means every listener observes transitions in the same global order
+     * and its LAST observation always matches the machine's final state. The audience is
+     * snapshotted at transition time: a listener added mid-dispatch replays the (already final)
+     * current state on subscribe and must not also receive older queued passes afterwards.
      */
     private void notifyListenersLocked() {
-        LinkState snapshotState = state;
-        BesCaps snapshotProvenCaps = provenCapsLocked();
-        for (Listener listener : listeners) {
-            listener.onLinkStateChanged(snapshotState, snapshotProvenCaps);
+        pendingNotifications.add(
+                new Notification(state, provenCapsLocked(), List.copyOf(listeners)));
+        if (dispatching) {
+            return; // The drain below us on the stack will deliver this pass after its own.
+        }
+        dispatching = true;
+        try {
+            Notification notification;
+            while ((notification = pendingNotifications.poll()) != null) {
+                for (Listener listener : notification.audience) {
+                    deliverSafely(listener, notification.state, notification.provenCaps);
+                }
+            }
+        } finally {
+            dispatching = false;
+        }
+    }
+
+    /**
+     * Must hold the monitor. A throwing listener must not starve later listeners or propagate
+     * into the transport caller (which would misreport a parse failure after the machine already
+     * mutated), so exceptions end here.
+     */
+    private void deliverSafely(Listener listener, LinkState state, BesCaps provenCaps) {
+        try {
+            listener.onLinkStateChanged(state, provenCaps);
+        } catch (RuntimeException e) {
+            Log.e(TAG, "Link state listener threw for " + state + "; continuing delivery", e);
         }
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -1,0 +1,327 @@
+package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Single owner of the ASG-to-BES UART transport link state.
+ *
+ * <p>Historically "connected" was five separate implicit facts spread across volatile booleans in
+ * {@code K900BluetoothManager} ({@code isSerialOpen}, the {@code lastSrSyvrTime} liveness aspect,
+ * and the negotiated {@code besWireCaps*} flags), each with its own ad-hoc reset sites. Listeners
+ * that registered after the only edge of one of those facts never learned about it, which is the
+ * bug class this class exists to remove. All transport-side facts now live here, transitions are
+ * driven from the exact call sites that used to flip the booleans, and {@link #addListener}
+ * synchronously replays the current state so late subscribers can never miss an edge.
+ *
+ * <p>The link is modeled as a three-step ladder:
+ *
+ * <pre>
+ *   SERIAL_CLOSED  --serialReady()-->  SERIAL_OPEN  --srSyvrParsed()-->  LINK_PROVEN
+ * </pre>
+ *
+ * with two demotions: {@link #streamDiscontinuity()} (a reopen/baud switch invalidated the byte
+ * stream, so the link is no longer proven at the current baud) drops back to {@code SERIAL_OPEN},
+ * and {@link #serialClosed()} resets everything.
+ *
+ * <p>Caps have two views on purpose:
+ *
+ * <ul>
+ *   <li>{@link #getProvenCaps()} (also the listener payload) is non-null only in
+ *       {@code LINK_PROVEN}: it is the snapshot a consumer may trust because an sr_syvr proved the
+ *       link at the current baud.
+ *   <li>{@link #getNegotiatedCaps()} is the sticky negotiation result, cleared only by
+ *       {@link #serialClosed()}. This mirrors the legacy reset rules exactly: a mid-session baud
+ *       reopen never cleared {@code besWireCaps*}, and outbound capability decisions (binary relay,
+ *       file payload v2, push window) must not silently downgrade for a whole phone session just
+ *       because a reopen window was in flight. The legacy delegating getters read this view.
+ * </ul>
+ *
+ * <p>Thread safety: transitions arrive from the serial RX thread, the baud-switch executor, and
+ * binder threads. All state mutation and listener notification happen under the internal monitor,
+ * so every listener observes transitions in a single global order and replay-on-subscribe cannot
+ * interleave with a concurrent transition. Listeners must therefore be fast and must not block on
+ * locks that transition callers might hold.
+ */
+public final class LinkStateMachine {
+
+    /** Transport-side link states, ordered from least to most established. */
+    public enum LinkState {
+        /** The UART serial port is not open (boot, failed open, or after close). */
+        SERIAL_CLOSED,
+        /** The serial port is open but the BES has not answered at the current baud. */
+        SERIAL_OPEN,
+        /** An sr_syvr reply was parsed at the current baud: the link is proven alive. */
+        LINK_PROVEN
+    }
+
+    /**
+     * Immutable snapshot of the wire capabilities negotiated with the BES. Instances are values:
+     * mutation happens by replacing the machine's current snapshot, never in place.
+     */
+    public static final class BesCaps {
+        /** No capabilities negotiated: the state before any BES advertisement. */
+        public static final BesCaps NONE =
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1);
+
+        /** BES accepts little-endian K900 STRING lengths (wire_caps.k900_le). */
+        public final boolean k900Le;
+
+        /** BES relays the binary wire protocol (wire_caps.binary or an observed binary frame). */
+        public final boolean binary;
+
+        /** BES supports negotiated file payload sizes (wire_caps.file_payload_v2). */
+        public final boolean filePayloadV2;
+
+        /** BES accepts large file packs (advertised together with file_payload_v2). */
+        public final boolean bigPacks;
+
+        /** Highest wire protocol version the BES advertised. */
+        public final int proto;
+
+        public BesCaps(
+                boolean k900Le, boolean binary, boolean filePayloadV2, boolean bigPacks, int proto) {
+            this.k900Le = k900Le;
+            this.binary = binary;
+            this.filePayloadV2 = filePayloadV2;
+            this.bigPacks = bigPacks;
+            this.proto = proto;
+        }
+
+        /**
+         * Merge an sr_syvr wire_caps advertisement into this snapshot using the legacy accrual
+         * rules: flags only ever turn on, and {@code proto} is overwritten only when the
+         * advertisement carries the binary flag (an advertisement without {@code binary} says
+         * nothing about the protocol version).
+         */
+        BesCaps mergeAdvertised(BesCaps advertised) {
+            return new BesCaps(
+                    k900Le || advertised.k900Le,
+                    binary || advertised.binary,
+                    filePayloadV2 || advertised.filePayloadV2,
+                    bigPacks || advertised.bigPacks,
+                    advertised.binary ? advertised.proto : proto);
+        }
+
+        /**
+         * Record that a valid binary wire frame arrived: proof of binary relay support even when
+         * the BES never advertised it, with the protocol floored at v2.
+         */
+        BesCaps withBinaryRelayObserved() {
+            return new BesCaps(
+                    k900Le,
+                    true,
+                    filePayloadV2,
+                    bigPacks,
+                    Math.max(proto, BesWireFormat.PROTOCOL_VERSION_V2));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof BesCaps)) {
+                return false;
+            }
+            BesCaps other = (BesCaps) o;
+            return k900Le == other.k900Le
+                    && binary == other.binary
+                    && filePayloadV2 == other.filePayloadV2
+                    && bigPacks == other.bigPacks
+                    && proto == other.proto;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(k900Le, binary, filePayloadV2, bigPacks, proto);
+        }
+
+        @Override
+        public String toString() {
+            return "BesCaps{k900Le="
+                    + k900Le
+                    + ", binary="
+                    + binary
+                    + ", filePayloadV2="
+                    + filePayloadV2
+                    + ", bigPacks="
+                    + bigPacks
+                    + ", proto="
+                    + proto
+                    + "}";
+        }
+    }
+
+    /** Observer of link state transitions. */
+    public interface Listener {
+        /**
+         * Called under the machine's monitor on every observable change, and synchronously from
+         * {@link #addListener} with the current state.
+         *
+         * @param state the current link state
+         * @param provenCaps the trusted caps snapshot; non-null exactly when {@code state} is
+         *     {@link LinkState#LINK_PROVEN}
+         */
+        void onLinkStateChanged(LinkState state, BesCaps provenCaps);
+    }
+
+    // Copy-on-write so a listener may add/remove listeners from inside a callback without
+    // corrupting the iteration that is notifying it.
+    private final List<Listener> listeners = new CopyOnWriteArrayList<>();
+
+    private LinkState state = LinkState.SERIAL_CLOSED;
+    private BesCaps negotiatedCaps = BesCaps.NONE;
+
+    /**
+     * Register a listener and synchronously replay the current state to it. Replay-on-subscribe is
+     * the core contract: a subscriber that arrives after the only serialReady/srSyvr edge still
+     * observes the state it missed, instead of waiting forever for an edge that already happened.
+     */
+    public synchronized void addListener(Listener listener) {
+        if (listener == null || listeners.contains(listener)) {
+            return;
+        }
+        listeners.add(listener);
+        listener.onLinkStateChanged(state, provenCapsLocked());
+    }
+
+    /** Unregister a listener; no-op if it was never added. */
+    public synchronized void removeListener(Listener listener) {
+        listeners.remove(listener);
+    }
+
+    /** Current link state. */
+    public synchronized LinkState getState() {
+        return state;
+    }
+
+    /** Whether the serial port is open (i.e. the state is past {@code SERIAL_CLOSED}). */
+    public synchronized boolean isSerialOpen() {
+        return state != LinkState.SERIAL_CLOSED;
+    }
+
+    /**
+     * The trusted caps snapshot: non-null exactly in {@code LINK_PROVEN}. Consumers that must not
+     * act on unproven capabilities read this view.
+     */
+    public synchronized BesCaps getProvenCaps() {
+        return provenCapsLocked();
+    }
+
+    /**
+     * The sticky negotiation result, cleared only when the serial port closes. Never null. This
+     * intentionally survives {@link #streamDiscontinuity()}: reopen windows are byte-stream
+     * discontinuities, not renegotiations, and the legacy {@code besWireCaps*} booleans survived
+     * them too — outbound capability decisions must not flip mid-session (see class Javadoc).
+     */
+    public synchronized BesCaps getNegotiatedCaps() {
+        return negotiatedCaps;
+    }
+
+    /**
+     * The serial port opened (onSerialReady / successful onSerialOpen). Promotes
+     * {@code SERIAL_CLOSED} to {@code SERIAL_OPEN}; a redundant ready on an already-open link
+     * changes nothing.
+     */
+    public void serialReady() {
+        synchronized (this) {
+            if (state != LinkState.SERIAL_CLOSED) {
+                return;
+            }
+            state = LinkState.SERIAL_OPEN;
+            notifyListenersLocked();
+        }
+    }
+
+    /**
+     * The serial port closed (onSerialClose / failed onSerialOpen). Resets everything: state back
+     * to {@code SERIAL_CLOSED} and the negotiated caps to {@link BesCaps#NONE}, matching the
+     * legacy {@code resetWireProtocolState()} reset that ran on serial close.
+     */
+    public void serialClosed() {
+        synchronized (this) {
+            boolean changed = state != LinkState.SERIAL_CLOSED
+                    || !negotiatedCaps.equals(BesCaps.NONE);
+            state = LinkState.SERIAL_CLOSED;
+            negotiatedCaps = BesCaps.NONE;
+            if (changed) {
+                notifyListenersLocked();
+            }
+        }
+    }
+
+    /**
+     * The receive byte stream was invalidated without a serial close/ready cycle: every reopen and
+     * baud switch clears the message parser, and {@code SerialPortBridge.reopen()} fires no serial
+     * callbacks. The link is no longer proven at the current baud, so {@code LINK_PROVEN} drops to
+     * {@code SERIAL_OPEN} and the proven caps view goes null until the next sr_syvr. The
+     * negotiated caps stay (see {@link #getNegotiatedCaps()}).
+     */
+    public void streamDiscontinuity() {
+        synchronized (this) {
+            if (state != LinkState.LINK_PROVEN) {
+                return;
+            }
+            state = LinkState.SERIAL_OPEN;
+            notifyListenersLocked();
+        }
+    }
+
+    /**
+     * An sr_syvr reply was parsed: the UART link is proven alive at the current baud, optionally
+     * with a wire_caps advertisement.
+     *
+     * @param advertised the caps the BES advertised in this sr_syvr, or null when the reply
+     *     carried no wire_caps (legacy firmware); merged with the legacy accrual rules
+     */
+    public void srSyvrParsed(BesCaps advertised) {
+        synchronized (this) {
+            LinkState previousState = state;
+            BesCaps previousProven = provenCapsLocked();
+            if (advertised != null) {
+                negotiatedCaps = negotiatedCaps.mergeAdvertised(advertised);
+            }
+            // A reply cannot arrive through a closed port; if it somehow does (races around
+            // shutdown) record the caps but do not fabricate an open link.
+            if (state != LinkState.SERIAL_CLOSED) {
+                state = LinkState.LINK_PROVEN;
+            }
+            if (previousState != state || !Objects.equals(previousProven, provenCapsLocked())) {
+                notifyListenersLocked();
+            }
+        }
+    }
+
+    /**
+     * A valid binary wire frame arrived from the BES: proof of binary relay support. Accrues into
+     * the negotiated caps without touching the link state, because a relayed frame does not prove
+     * the sr_syvr round trip at the current baud.
+     */
+    public void binaryRelayObserved() {
+        synchronized (this) {
+            BesCaps updated = negotiatedCaps.withBinaryRelayObserved();
+            if (updated.equals(negotiatedCaps)) {
+                return;
+            }
+            negotiatedCaps = updated;
+            if (state == LinkState.LINK_PROVEN) {
+                notifyListenersLocked();
+            }
+        }
+    }
+
+    /** Must hold the monitor. */
+    private BesCaps provenCapsLocked() {
+        return state == LinkState.LINK_PROVEN ? negotiatedCaps : null;
+    }
+
+    /** Must hold the monitor. */
+    private void notifyListenersLocked() {
+        BesCaps provenCaps = provenCapsLocked();
+        for (Listener listener : listeners) {
+            listener.onLinkStateChanged(state, provenCaps);
+        }
+    }
+}

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridge.java
@@ -129,6 +129,16 @@ public class SerialPortBridge {
         return mCurrentBaud;
     }
 
+    /**
+     * Whether the serial port is currently open. Normally tracked through the serial callbacks,
+     * but {@link #reopen(int)} can fail both the requested baud AND the default fallback, leaving
+     * the port closed WITHOUT firing any callback — callers that own link state must consult this
+     * after a reopen instead of assuming the port survived.
+     */
+    public boolean isOpen() {
+        return mbStart;
+    }
+
     /** Whether BES OTA currently owns UART receive routing. */
     public boolean isOtaUpdating() {
         return mbOtaUpdating;

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
@@ -1,0 +1,405 @@
+package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine.BesCaps;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine.LinkState;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class LinkStateMachineTest {
+
+    /** Records every notification so tests can assert on ordering and payloads. */
+    private static final class RecordingListener implements LinkStateMachine.Listener {
+        final List<LinkState> states = new ArrayList<>();
+        final List<BesCaps> caps = new ArrayList<>();
+
+        @Override
+        public void onLinkStateChanged(LinkState state, BesCaps provenCaps) {
+            states.add(state);
+            caps.add(provenCaps);
+        }
+
+        LinkState lastState() {
+            return states.get(states.size() - 1);
+        }
+
+        BesCaps lastCaps() {
+            return caps.get(caps.size() - 1);
+        }
+    }
+
+    private static final BesCaps FULL_CAPS =
+            new BesCaps(true, true, true, true, BesWireFormat.PROTOCOL_VERSION_V2);
+
+    private LinkStateMachine machine;
+
+    @Before
+    public void setUp() {
+        machine = new LinkStateMachine();
+    }
+
+    // ---- replay-on-subscribe ----
+
+    @Test
+    public void addListener_replaysInitialClosedStateSynchronously() {
+        RecordingListener listener = new RecordingListener();
+
+        machine.addListener(listener);
+
+        assertThat(listener.states).containsExactly(LinkState.SERIAL_CLOSED);
+        assertThat(listener.caps).containsExactly((BesCaps) null);
+    }
+
+    @Test
+    public void addListener_afterProvenEdge_replaysProvenStateAndCapsSynchronously() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+
+        // The bug class this machine exists to fix: a listener registering after the only
+        // edge must still observe it.
+        RecordingListener lateListener = new RecordingListener();
+        machine.addListener(lateListener);
+
+        assertThat(lateListener.states).containsExactly(LinkState.LINK_PROVEN);
+        assertThat(lateListener.lastCaps()).isEqualTo(FULL_CAPS);
+    }
+
+    @Test
+    public void addListener_sameListenerTwice_replaysOnlyOnce() {
+        RecordingListener listener = new RecordingListener();
+
+        machine.addListener(listener);
+        machine.addListener(listener);
+        machine.serialReady();
+
+        assertThat(listener.states)
+                .containsExactly(LinkState.SERIAL_CLOSED, LinkState.SERIAL_OPEN);
+    }
+
+    @Test
+    public void removeListener_stopsNotifications() {
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.removeListener(listener);
+        machine.serialReady();
+
+        assertThat(listener.states).containsExactly(LinkState.SERIAL_CLOSED);
+    }
+
+    // ---- ladder transitions ----
+
+    @Test
+    public void serialReady_promotesClosedToOpen() {
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialReady();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_OPEN);
+        assertThat(machine.isSerialOpen()).isTrue();
+        assertThat(listener.lastState()).isEqualTo(LinkState.SERIAL_OPEN);
+    }
+
+    @Test
+    public void serialReady_whenAlreadyProven_isANoOp() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialReady();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.LINK_PROVEN);
+        assertThat(listener.states).containsExactly(LinkState.LINK_PROVEN);
+    }
+
+    @Test
+    public void srSyvrParsed_withCaps_provesLinkAndExposesCaps() {
+        machine.serialReady();
+
+        machine.srSyvrParsed(FULL_CAPS);
+
+        assertThat(machine.getState()).isEqualTo(LinkState.LINK_PROVEN);
+        assertThat(machine.getProvenCaps()).isEqualTo(FULL_CAPS);
+        assertThat(machine.getNegotiatedCaps()).isEqualTo(FULL_CAPS);
+    }
+
+    @Test
+    public void srSyvrParsed_withoutCaps_provesLinkWithEmptyCapsSnapshot() {
+        machine.serialReady();
+
+        // Legacy firmware answers sr_syvr without a wire_caps object.
+        machine.srSyvrParsed(null);
+
+        assertThat(machine.getState()).isEqualTo(LinkState.LINK_PROVEN);
+        assertThat(machine.getProvenCaps()).isEqualTo(BesCaps.NONE);
+        assertThat(machine.getProvenCaps().binary).isFalse();
+    }
+
+    @Test
+    public void srSyvrParsed_whileSerialClosed_recordsCapsWithoutFabricatingAnOpenLink() {
+        machine.srSyvrParsed(FULL_CAPS);
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_CLOSED);
+        assertThat(machine.getProvenCaps()).isNull();
+        assertThat(machine.getNegotiatedCaps()).isEqualTo(FULL_CAPS);
+    }
+
+    // ---- discontinuity ----
+
+    @Test
+    public void streamDiscontinuity_dropsProvenAndHidesCaps() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.streamDiscontinuity();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_OPEN);
+        assertThat(machine.getProvenCaps()).isNull();
+        assertThat(listener.lastState()).isEqualTo(LinkState.SERIAL_OPEN);
+        assertThat(listener.lastCaps()).isNull();
+    }
+
+    @Test
+    public void streamDiscontinuity_keepsNegotiatedCapsForLegacyGetters() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+
+        machine.streamDiscontinuity();
+
+        // Parity with the legacy besWireCaps* booleans: a reopen never cleared them, and
+        // outbound capability decisions must not downgrade mid-session.
+        assertThat(machine.getNegotiatedCaps()).isEqualTo(FULL_CAPS);
+    }
+
+    @Test
+    public void streamDiscontinuity_whenNotProven_isANoOp() {
+        machine.serialReady();
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.streamDiscontinuity();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_OPEN);
+        assertThat(listener.states).containsExactly(LinkState.SERIAL_OPEN);
+    }
+
+    @Test
+    public void reprovingAfterDiscontinuity_restoresProvenCaps() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        machine.streamDiscontinuity();
+
+        machine.srSyvrParsed(null);
+
+        assertThat(machine.getState()).isEqualTo(LinkState.LINK_PROVEN);
+        assertThat(machine.getProvenCaps()).isEqualTo(FULL_CAPS);
+    }
+
+    // ---- serial close ----
+
+    @Test
+    public void serialClosed_resetsStateAndCaps() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialClosed();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_CLOSED);
+        assertThat(machine.isSerialOpen()).isFalse();
+        assertThat(machine.getProvenCaps()).isNull();
+        assertThat(machine.getNegotiatedCaps()).isEqualTo(BesCaps.NONE);
+        assertThat(listener.lastState()).isEqualTo(LinkState.SERIAL_CLOSED);
+        assertThat(listener.lastCaps()).isNull();
+    }
+
+    @Test
+    public void serialClosed_whenAlreadyClosedWithNoCaps_doesNotNotify() {
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialClosed();
+
+        assertThat(listener.states).containsExactly(LinkState.SERIAL_CLOSED);
+    }
+
+    // ---- caps accrual rules ----
+
+    @Test
+    public void srSyvrParsed_mergesFlagsAcrossAdvertisements() {
+        machine.serialReady();
+        machine.srSyvrParsed(
+                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1));
+        machine.srSyvrParsed(
+                new BesCaps(false, true, false, false, BesWireFormat.PROTOCOL_VERSION_V2));
+
+        BesCaps caps = machine.getNegotiatedCaps();
+        assertThat(caps.k900Le).isTrue();
+        assertThat(caps.binary).isTrue();
+        assertThat(caps.proto).isEqualTo(BesWireFormat.PROTOCOL_VERSION_V2);
+    }
+
+    @Test
+    public void srSyvrParsed_withoutBinaryFlag_doesNotTouchProto() {
+        machine.serialReady();
+        machine.binaryRelayObserved();
+        assertThat(machine.getNegotiatedCaps().proto)
+                .isEqualTo(BesWireFormat.PROTOCOL_VERSION_V2);
+
+        // An advertisement without the binary flag says nothing about the protocol version.
+        machine.srSyvrParsed(
+                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1));
+
+        assertThat(machine.getNegotiatedCaps().proto)
+                .isEqualTo(BesWireFormat.PROTOCOL_VERSION_V2);
+        assertThat(machine.getNegotiatedCaps().binary).isTrue();
+    }
+
+    @Test
+    public void binaryRelayObserved_accruesBinaryWithoutChangingState() {
+        machine.serialReady();
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.binaryRelayObserved();
+
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_OPEN);
+        assertThat(machine.getNegotiatedCaps().binary).isTrue();
+        assertThat(machine.getNegotiatedCaps().proto)
+                .isEqualTo(BesWireFormat.PROTOCOL_VERSION_V2);
+        // Not proven, so the observable (state, provenCaps) pair did not change.
+        assertThat(listener.states).containsExactly(LinkState.SERIAL_OPEN);
+    }
+
+    @Test
+    public void binaryRelayObserved_whileProven_updatesProvenCapsAndNotifies() {
+        machine.serialReady();
+        machine.srSyvrParsed(null);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.binaryRelayObserved();
+
+        assertThat(listener.states)
+                .containsExactly(LinkState.LINK_PROVEN, LinkState.LINK_PROVEN);
+        assertThat(listener.lastCaps().binary).isTrue();
+
+        // A repeated observation changes nothing and must not re-notify.
+        machine.binaryRelayObserved();
+        assertThat(listener.states).hasSize(2);
+    }
+
+    // ---- listener ordering / thread safety basics ----
+
+    @Test
+    public void listeners_observeTransitionsInOrder() {
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        machine.streamDiscontinuity();
+        machine.serialClosed();
+
+        assertThat(listener.states)
+                .containsExactly(
+                        LinkState.SERIAL_CLOSED,
+                        LinkState.SERIAL_OPEN,
+                        LinkState.LINK_PROVEN,
+                        LinkState.SERIAL_OPEN,
+                        LinkState.SERIAL_CLOSED);
+        assertThat(listener.caps.get(2)).isEqualTo(FULL_CAPS);
+        assertThat(listener.caps.get(3)).isNull();
+    }
+
+    @Test
+    public void listener_mayRemoveItselfDuringNotification() {
+        AtomicInteger calls = new AtomicInteger();
+        LinkStateMachine.Listener selfRemoving =
+                new LinkStateMachine.Listener() {
+                    @Override
+                    public void onLinkStateChanged(LinkState state, BesCaps provenCaps) {
+                        calls.incrementAndGet();
+                        machine.removeListener(this);
+                    }
+                };
+
+        machine.addListener(selfRemoving);
+        machine.serialReady();
+
+        // One call from replay-on-subscribe; the removal inside it must stick.
+        assertThat(calls.get()).isEqualTo(1);
+    }
+
+    @Test
+    public void concurrentTransitions_neverTearStateAndCapsApart() throws Exception {
+        // The listener contract: provenCaps is non-null exactly in LINK_PROVEN. Hammer the
+        // machine from two threads and verify no notification ever violates it.
+        AtomicBoolean invariantViolated = new AtomicBoolean(false);
+        machine.addListener(
+                (state, provenCaps) -> {
+                    if ((provenCaps != null) != (state == LinkState.LINK_PROVEN)) {
+                        invariantViolated.set(true);
+                    }
+                });
+
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        Runnable prover =
+                () -> {
+                    awaitQuietly(start);
+                    for (int i = 0; i < 500; i++) {
+                        machine.serialReady();
+                        machine.srSyvrParsed(FULL_CAPS);
+                    }
+                    done.countDown();
+                };
+        Runnable dropper =
+                () -> {
+                    awaitQuietly(start);
+                    for (int i = 0; i < 500; i++) {
+                        machine.streamDiscontinuity();
+                        machine.serialClosed();
+                    }
+                    done.countDown();
+                };
+        new Thread(prover).start();
+        new Thread(dropper).start();
+        start.countDown();
+
+        assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(invariantViolated.get()).isFalse();
+        // The machine must land in one of the coherent end states, not somewhere torn.
+        LinkState finalState = machine.getState();
+        if (finalState == LinkState.LINK_PROVEN) {
+            assertThat(machine.getProvenCaps()).isNotNull();
+        } else {
+            assertThat(machine.getProvenCaps()).isNull();
+        }
+    }
+
+    private static void awaitQuietly(CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
@@ -330,11 +330,11 @@ public class LinkStateMachineTest {
     }
 
     @Test
-    public void reentrantTransitionInListener_neverTearsThePairForLaterListeners() {
-        // Listener A closes the serial port from inside its LINK_PROVEN callback. The monitor is
-        // reentrant, so without snapshotting BOTH state and caps before the loop, listener B
-        // would receive the mutated SERIAL_CLOSED state paired with the pre-transition non-null
-        // caps — a torn pair violating the non-null-exactly-in-LINK_PROVEN contract.
+    public void reentrantTransitionInListener_deliversInGlobalOrderEndingOnFinalState() {
+        // Listener A closes the serial port from inside its LINK_PROVEN callback. The reentrant
+        // transition must be QUEUED behind the pass in flight, so B observes the transitions in
+        // global FIFO order (proven, then closed) with consistent pairs throughout — never a torn
+        // pair, and never a stale proven pair delivered after the close.
         RecordingListener b = new RecordingListener();
         machine.serialReady();
         machine.addListener(
@@ -354,16 +354,51 @@ public class LinkStateMachineTest {
                     .as("pair %d: state=%s caps=%s", i, b.states.get(i), b.caps.get(i))
                     .isEqualTo(proven);
         }
-        // B sees A's reentrant close pass first (delivered from inside A's callback), then the
-        // outer pass with the original consistent proven pair.
+        // Global FIFO order: replay, the outer proven pass, then A's queued reentrant close.
         assertThat(b.states)
                 .containsExactly(
-                        LinkState.SERIAL_OPEN, LinkState.SERIAL_CLOSED, LinkState.LINK_PROVEN);
-        assertThat(b.caps.get(1)).isNull();
-        assertThat(b.caps.get(2)).isEqualTo(FULL_CAPS);
-        // The machine itself ends in the state A's reentrant transition left it in.
+                        LinkState.SERIAL_OPEN, LinkState.LINK_PROVEN, LinkState.SERIAL_CLOSED);
+        assertThat(b.caps.get(1)).isEqualTo(FULL_CAPS);
+        assertThat(b.caps.get(2)).isNull();
+        // B's LAST observation matches the machine's final state, so a consumer keyed off the
+        // latest callback can never re-enable work after the close.
         assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_CLOSED);
-        assertThat(machine.getProvenCaps()).isNull();
+        assertThat(b.lastState()).isEqualTo(machine.getState());
+        assertThat(b.lastCaps()).isEqualTo(machine.getProvenCaps());
+    }
+
+    @Test
+    public void throwingListener_doesNotStarveLaterListenersOrPropagateToTheCaller() {
+        machine.serialReady();
+        machine.addListener(
+                (state, provenCaps) -> {
+                    throw new IllegalStateException("listener bug");
+                });
+        RecordingListener survivor = new RecordingListener();
+        machine.addListener(survivor);
+
+        // Must not throw into the transport caller (which would misreport a parse failure).
+        machine.srSyvrParsed(FULL_CAPS);
+
+        assertThat(survivor.lastState()).isEqualTo(LinkState.LINK_PROVEN);
+        assertThat(survivor.lastCaps()).isEqualTo(FULL_CAPS);
+        assertThat(machine.getState()).isEqualTo(LinkState.LINK_PROVEN);
+    }
+
+    @Test
+    public void throwingListener_duringReplayOnSubscribe_doesNotPropagate() {
+        machine.serialReady();
+
+        machine.addListener(
+                (state, provenCaps) -> {
+                    throw new IllegalStateException("replay bug");
+                });
+
+        // The add itself survives and later transitions still reach healthy listeners.
+        RecordingListener survivor = new RecordingListener();
+        machine.addListener(survivor);
+        machine.srSyvrParsed(FULL_CAPS);
+        assertThat(survivor.lastState()).isEqualTo(LinkState.LINK_PROVEN);
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
@@ -330,6 +330,43 @@ public class LinkStateMachineTest {
     }
 
     @Test
+    public void reentrantTransitionInListener_neverTearsThePairForLaterListeners() {
+        // Listener A closes the serial port from inside its LINK_PROVEN callback. The monitor is
+        // reentrant, so without snapshotting BOTH state and caps before the loop, listener B
+        // would receive the mutated SERIAL_CLOSED state paired with the pre-transition non-null
+        // caps — a torn pair violating the non-null-exactly-in-LINK_PROVEN contract.
+        RecordingListener b = new RecordingListener();
+        machine.serialReady();
+        machine.addListener(
+                (state, provenCaps) -> {
+                    if (state == LinkState.LINK_PROVEN) {
+                        machine.serialClosed();
+                    }
+                });
+        machine.addListener(b);
+
+        machine.srSyvrParsed(FULL_CAPS);
+
+        // Every pair B ever observed must be internally consistent.
+        for (int i = 0; i < b.states.size(); i++) {
+            boolean proven = b.states.get(i) == LinkState.LINK_PROVEN;
+            assertThat(b.caps.get(i) != null)
+                    .as("pair %d: state=%s caps=%s", i, b.states.get(i), b.caps.get(i))
+                    .isEqualTo(proven);
+        }
+        // B sees A's reentrant close pass first (delivered from inside A's callback), then the
+        // outer pass with the original consistent proven pair.
+        assertThat(b.states)
+                .containsExactly(
+                        LinkState.SERIAL_OPEN, LinkState.SERIAL_CLOSED, LinkState.LINK_PROVEN);
+        assertThat(b.caps.get(1)).isNull();
+        assertThat(b.caps.get(2)).isEqualTo(FULL_CAPS);
+        // The machine itself ends in the state A's reentrant transition left it in.
+        assertThat(machine.getState()).isEqualTo(LinkState.SERIAL_CLOSED);
+        assertThat(machine.getProvenCaps()).isNull();
+    }
+
+    @Test
     public void listener_mayRemoveItselfDuringNotification() {
         AtomicInteger calls = new AtomicInteger();
         LinkStateMachine.Listener selfRemoving =

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeOtaCallbackTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/SerialPortBridgeOtaCallbackTest.java
@@ -1,5 +1,6 @@
 package com.mentra.asg_client.io.bluetooth.managers.mentralive.internal;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -25,5 +26,17 @@ public class SerialPortBridgeOtaCallbackTest {
         bridge.notifyBesOtaApplied();
 
         verify(listener).onBesOtaApplied();
+    }
+
+    @Test
+    public void reopenOnClosedPort_failsAndReportsClosed() {
+        SerialPortBridge bridge =
+                new SerialPortBridge(ApplicationProvider.getApplicationContext());
+
+        // A closed port refuses reopen and stays closed — and fires NO serial callback, which is
+        // why link-state owners must consult isOpen() after every reopen instead of assuming.
+        assertThat(bridge.isOpen()).isFalse();
+        assertThat(bridge.reopen(SerialPortBridge.DEFAULT_BAUDRATE)).isFalse();
+        assertThat(bridge.isOpen()).isFalse();
     }
 }


### PR DESCRIPTION
## Why

"Connected" on the glasses side of the BES UART link was five different implicit facts, each a volatile boolean (or a boolean aspect of a timestamp) in `K900BluetoothManager`, each with its own ad-hoc reset sites:

1. `isSerialOpen` — serial port open (set in `onSerialReady`/`onSerialClose`/`onSerialOpen`)
2. the boolean aspect of `lastSrSyvrTime` — link proven alive at the current baud (any parsed `sr_syvr`)
3. the negotiated BES caps: `besWireCapsK900Le`, `besWireCapsBinary`, `besWireCapsFilePayloadV2`, `besSupportsBigPacks`, `besWireCapsProto` — reset only in `resetWireProtocolState()` on serial close
4. phone-facing wire state (`wireV2HandshakeSent`, BesWireFormat binary-active, reassembler) — reset on serial close and `onTransportReset`
5. the byte-stream discontinuity fact — implicit in `clearMessageParser()`, the shared prelude of all eight reopen/baud-switch call sites (`SerialPortBridge.reopen()` fires no serial callbacks)

Because these facts had no single owner and no observability, components that registered after the only edge of one of them simply never learned about it — the bug class behind the recent week of production link bugs.

## What

New `LinkStateMachine` (in `io/bluetooth/managers/mentralive/internal/`, next to `SerialPortBridge`/`BesWireFormat`) that owns the transport-side facts:

- **States:** `SERIAL_CLOSED → SERIAL_OPEN → LINK_PROVEN` (proven = `sr_syvr` parsed at the current baud).
- **Transitions** driven from the exact existing edges in `K900BluetoothManager`:
  - `serialReady()` / `serialClosed()` from the serial callbacks (`onSerialOpen(false)` maps to `serialClosed()`);
  - `streamDiscontinuity()` from `clearMessageParser()` — covers all eight reopen/baud-switch paths (boot probes, target-baud probe, revert-to-default, runtime recovery, rendezvous park, post-BES-OTA reconnects); drops `LINK_PROVEN → SERIAL_OPEN`;
  - `srSyvrParsed(caps)` from the `sr_syvr` handler (merges the wire_caps advertisement with the legacy accrual rules: flags only turn on, `proto` overwritten only when `binary` is advertised);
  - `binaryRelayObserved()` from valid inbound binary frames (binary=true, proto floored at v2, no state change — a relayed frame does not prove the sr_syvr round trip).
- **Observable with replay-on-subscribe:** `addListener()` synchronously replays the current state under the machine's monitor, so a late subscriber cannot miss an edge. All mutation + notification happen under one monitor → listeners see one global transition order.
- **Two caps views, on purpose:**
  - `getProvenCaps()` (also the listener payload) is non-null **exactly** in `LINK_PROVEN` — the snapshot new consumers may trust.
  - `getNegotiatedCaps()` is the sticky negotiation result, cleared only on serial close. This mirrors the legacy `besWireCaps*` reset rules bit-for-bit: a mid-session baud reopen never cleared them, and letting a reopen window flip `isBesBinaryRelaySupported()`/`file_payload_v2` to false could downgrade a whole phone session (e.g. a `glasses_ready` response built during the window would advertise no binary support). The legacy delegating getters read this view, which is what keeps this PR a strict-parity refactor.
- `K900BluetoothManager` keeps thin delegating getters (`isBesBinaryRelaySupported()`, `addPhoneWireCapsIfSupported()`, the file-transfer capability checks) so no external call site changes. The old booleans are deleted; `isConnected()` is still `serialOpen && super.isConnected()` — semantics unchanged.
- `lastSrSyvrTime` is kept as the baud-recovery **timing** input (last-proof wall clock); only its boolean "link proven" role moved into the machine.
- New consumers subscribe via `K900BluetoothManager.getLinkStateMachine()`.

## Deliberately out of scope

- **`PHONE_SESSION` state** — needs BES phone-presence reporting; separate PR.
- **Phone-facing wire state** (`wireV2HandshakeSent`, BesWireFormat binary-active, inbound reassembler) stays in `resetPhoneWireProtocolState()` — it belongs to the phone session, not the UART transport.
- **`OtaHelper.setPhoneConnectionProvider` replay workaround** stays: its "connected" is the phone BLE session (`onPhoneConnected` consumes `pendingApkStatus`), which this transport machine does not model. It becomes deletable once `PHONE_SESSION` lands.
- Non-transport consumers are untouched; only the internal owner changed.

## Behavior notes (parity)

- No timing changes, no new sends, no change to when any existing method returns true/false.
- One deliberate deviation from a spec-literal reading: `streamDiscontinuity()` hides the *proven* caps view but keeps the *negotiated* caps, because clearing them at every reopen would be a behavior change with session-long consequences (see above). The machine documents both views.
- Edge preserved: today `applyBesWireCaps` runs before the `B`-field parse that can throw in `handleSrSyvrResponse`, so caps could be recorded even when `lastSrSyvrTime` was not updated; the machine's `srSyvrParsed` sits at the same point, so caps accrual is unchanged (machine-proven can lead `lastSrSyvrTime` in that rare edge — new observable surface only, nothing existing reads it).

## Tests

New `LinkStateMachineTest` (22 tests) covering: replay-on-subscribe (late listener gets the current state synchronously), discontinuity dropping proven + hiding caps while negotiated caps survive, `srSyvrParsed` with/without caps, serial close resetting everything, caps accrual/merge rules (proto overwrite only with binary advert; binary-frame observation floors proto at v2), listener ordering, self-removal during notification, and a two-thread hammer verifying the (state, provenCaps) invariant never tears.

```
./gradlew :app:testDebugUnitTest compileDebugJavaWithJavac
# BUILD SUCCESSFUL — 583 tests, 0 failures (22 new)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical K900 UART recovery, baud switching, and wire-cap gating for file transfer and phone SDK behavior; intended as parity refactor but regressions could affect production link stability.
> 
> **Overview**
> Introduces **`LinkStateMachine`** as the single owner of ASG-to-BES UART transport facts (serial open, link proven via `sr_syvr`, negotiated BES wire caps), with **replay-on-subscribe** listeners so late subscribers cannot miss edges that previously lived in scattered volatile booleans.
> 
> **`K900BluetoothManager`** wires serial callbacks, `sr_syvr` / binary-frame handling, and every reopen/baud path into the machine; removes `isSerialOpen` and `besWireCaps*` fields in favor of thin getters and **`getLinkStateMachine()`**. Adds **`reopenSerial()`** (syncs closed port when `reopen` fails without callbacks), **`streamDiscontinuity()`** on parser clear and BES OTA reboot, and fixes runtime recovery **park** to avoid link updates under `baudSwitchLock` and to ignore stale generations.
> 
> **`SerialPortBridge.isOpen()`** exposes post-reopen port state. Unit tests cover the state machine and closed-port reopen behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcde96c55314686a1aa9e495f4b6f45f1d011e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->