### PR TITLE
Consume BES phone presence and negotiated notify_cap on the glasses

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -127,16 +127,33 @@ public class AsgConstants {
     public static final int OTA_COMPLETION_RESEND_ATTEMPTS = 15;
 
     /**
-     * Maximum packed frame size for a v1 K900 STRING ck chunk. The BES relays v1 string
-     * frames to the phone in a single unfragmented BLE notification, and the effective ATT
-     * payload on that link is 253 bytes (ATT MTU 256) regardless of the MTU the phone
-     * requested — a packed chunk over that cap is silently truncated on the wire and the
-     * phone drops it as unparseable (incident rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA
-     * completion ck chunks packed to 256-263 bytes and none survived). The previous budget
-     * was MTU_TARGET (509), which only holds for v2 binary fragments with phone-side
-     * reassembly. 240 leaves margin for BES re-framing variance.
+     * FALLBACK maximum packed frame size for a v1 K900 STRING ck chunk, used until the BES
+     * advertises its true notification cap. The BES relays v1 string frames to the phone in a
+     * single unfragmented BLE notification, and the worst-case ATT payload on that link is 253
+     * bytes (ATT MTU 256) regardless of the MTU the phone requested — a packed chunk over that
+     * cap is silently truncated on the wire and the phone drops it as unparseable (incident
+     * rep_01KY6BJ0B7A4RBMQ7VN39KAE5E: OTA completion ck chunks packed to 256-263 bytes and none
+     * survived). 240 = 253 - {@link #K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}. BES firmware >=
+     * 17.26.7.23 advertises {@code wire_caps.notify_cap} (the measured single-notification
+     * payload cap) and the budget becomes notify_cap minus the same margin — see
+     * MessageChunker.setStringChunkBudgetFromNotifyCap.
      */
     public static final int K900_STRING_CHUNK_MAX_FRAME_BYTES = 240;
+
+    /**
+     * Safety margin subtracted from the BLE notification payload cap when sizing packed v1
+     * STRING ck chunks, absorbing BES re-framing variance between the UART frame we send and
+     * the notification the BES actually emits (240 = 253 - 13 was the hardware-validated
+     * budget for the worst-case 253-byte cap).
+     */
+    public static final int K900_STRING_CHUNK_BUDGET_MARGIN_BYTES = 13;
+
+    /**
+     * Contract floor of {@code wire_caps.notify_cap} (BES firmware >= 17.26.7.23 computes
+     * max(253, min(ATT MTU - 3, 509))). An advertised value below this is malformed and is
+     * ignored in favor of the fallback budget.
+     */
+    public static final int K900_BLE_NOTIFY_CAP_FLOOR_BYTES = 253;
 
     /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
     public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -155,6 +155,15 @@ public class AsgConstants {
      */
     public static final int K900_BLE_NOTIFY_CAP_FLOOR_BYTES = 253;
 
+    /**
+     * Contract ceiling of {@code wire_caps.notify_cap} (see
+     * {@link #K900_BLE_NOTIFY_CAP_FLOOR_BYTES}: the BES computes max(253, min(ATT MTU - 3,
+     * 509))). An advertised value above this is malformed; it is clamped down so a buggy
+     * advertisement can never size chunks beyond what the transport carries — the exact silent
+     * truncation class the notification budget exists to prevent.
+     */
+    public static final int K900_BLE_NOTIFY_CAP_CEILING_BYTES = 509;
+
     /** Delay before probing the alternate UART baud after ASG starts at the rendezvous rate. */
     public static final long UART_BOOT_RECOVERY_INITIAL_DELAY_MS = 8000;
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -747,7 +747,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                 0,
                 BesWireFormat.getActiveProtocolVersion());
 
-        if (!handleSrSyvrResponse(reassembled) && !handleFileTransportResponse(reassembled)) {
+        if (!handleSrSyvrResponse(reassembled)
+                && !handleSrPhbleResponse(reassembled)
+                && !handleFileTransportResponse(reassembled)) {
             notifyDataReceived(reassembled);
         }
         return true;
@@ -1311,6 +1313,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             }
             cacheBesBaudSwitchVersion(bData);
             cacheBesVersionFromSyvrBField(bData);
+            applyPhonePresenceFromSyvr(bData);
 
             // Runtime UART baud switch: sr_syvr either confirms our post-reopen probe or,
             // if the firmware is new enough, kicks off the cs_baud negotiation.
@@ -1359,7 +1362,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             filePayloadV2,
                             // Big-pack support ships with the file_payload_v2 advertisement.
                             filePayloadV2,
-                            caps.optInt("proto", BesWireFormat.PROTOCOL_VERSION_V2));
+                            caps.optInt("proto", BesWireFormat.PROTOCOL_VERSION_V2),
+                            caps.optInt("notify_cap", 0));
         }
         linkState.srSyvrParsed(advertised);
         if (advertised != null && advertised.k900Le) {
@@ -1373,6 +1377,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
         if (advertised != null && advertised.filePayloadV2) {
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
+        }
+        if (advertised != null && advertised.notifyCap > 0) {
+            Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
     }
 
@@ -1448,6 +1455,62 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         } catch (Exception e) {
             Log.w(TAG, "Failed to parse sr_file_transport", e);
             return false;
+        }
+    }
+
+    /**
+     * Sync phone BLE presence from the {@code phone_ble} field the BES adds to its sr_syvr reply
+     * body (firmware >= 17.26.7.23). This is the boot/wake/recovery sync for the initial value;
+     * live edges arrive as spontaneous {@code sr_phble} commands. Old firmware omits the key, so
+     * presence stays in whatever tri-state it already had (UNKNOWN until a signal ever arrives).
+     */
+    private void applyPhonePresenceFromSyvr(JSONObject bData) {
+        if (bData == null || !bData.has("phone_ble")) {
+            return;
+        }
+        linkState.phonePresenceReported(bData.optInt("phone_ble", 0) == 1);
+    }
+
+    /**
+     * Handle a spontaneous {@code sr_phble} phone-presence edge from the BES (firmware >=
+     * 17.26.7.23): {@code {"C":"sr_phble","S":0,"B":{"on":1}}} on phone BLE connect (first CCC
+     * enable) and {@code {"on":0}} on disconnect. Handled directly here, like sr_syvr, so the
+     * presence fact lands in the link state machine before any CommandProcessor timing concerns.
+     *
+     * @param payload The JSON payload bytes
+     * @return true if this was an sr_phble command and was consumed, false otherwise
+     */
+    private boolean handleSrPhbleResponse(byte[] payload) {
+        try {
+            String jsonStr = new String(payload, java.nio.charset.StandardCharsets.UTF_8);
+            org.json.JSONObject json = new org.json.JSONObject(jsonStr);
+            if (!"sr_phble".equals(json.optString("C", ""))) {
+                return false;
+            }
+
+            org.json.JSONObject bData = json.optJSONObject("B");
+            if (bData == null) {
+                String bFieldStr = json.optString("B", "");
+                if (!bFieldStr.isEmpty()) {
+                    bData = new org.json.JSONObject(bFieldStr);
+                }
+            }
+            if (bData == null || !bData.has("on")) {
+                Log.w(TAG, "📱 sr_phble without an 'on' field - ignoring");
+                return true; // Still consumed: a malformed edge must not reach CommandProcessor.
+            }
+
+            boolean present = bData.optInt("on", 0) == 1;
+            Log.i(
+                    TAG,
+                    "📱 BES reported phone BLE "
+                            + (present ? "connected" : "disconnected")
+                            + " (sr_phble)");
+            linkState.phonePresenceReported(present);
+            return true;
+        } catch (Exception e) {
+            Log.e(TAG, "💥 Error parsing sr_phble", e);
+            return false; // Let it fall through to normal processing
         }
     }
 
@@ -2053,8 +2116,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
                             // CommandProcessor initialization
                             if (!handleSrSyvrResponse(payload)
                                     && !handleSrBaudResponse(payload)
+                                    && !handleSrPhbleResponse(payload)
                                     && !handleFileTransportResponse(payload)) {
-                                // Not a sr_syvr/sr_baud response, forward to listeners
+                                // Not a BES-owned sr_* response, forward to listeners
                                 notifyDataReceived(payload);
                             }
                         } else {
@@ -2446,8 +2510,10 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         // the lastSrSyvrTime reset below instead of waiting for the async rendezvous path, whose
         // clearMessageParser can be skipped entirely by a generation-mismatch early return.
         // Idempotent if that path does run it. Called outside baudSwitchLock so listener
-        // callbacks never execute under it.
+        // callbacks never execute under it. The reboot also drops the BES's phone BLE link, so
+        // the last presence report is stale until the new firmware sends a fresh signal.
         linkState.streamDiscontinuity();
+        linkState.phonePresenceInvalidated();
         int generation;
         synchronized (baudSwitchLock) {
             generation = ++recoveryProbeGeneration;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -572,6 +572,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     public void resetWireProtocolState() {
         resetPhoneWireProtocolState();
         uartToBesEndian = K900LengthCodec.Endian.BE;
+        // The negotiated notify_cap dies with the caps snapshot (serialClosed), so the string
+        // chunk budget must fall back to the conservative default at the same lifecycle point.
+        MessageChunker.resetStringChunkBudget();
     }
 
     /** Send BLE Wire v2 handshake frame (payload "v2"). */
@@ -1379,6 +1382,9 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
         if (advertised != null && advertised.notifyCap > 0) {
+            // Size v1 string ck chunks against the TRUE notification cap the BES measured from
+            // the negotiated ATT MTU, instead of the conservative 253-byte assumption.
+            MessageChunker.setStringChunkBudgetFromNotifyCap(advertised.notifyCap);
             Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1305,9 +1305,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
 
             Log.i(TAG, "📋 Handling sr_syvr response directly in K900BluetoothManager");
 
-            // Negotiate UART length endianness from the BES's advertised wire_caps.
-            applyBesWireCaps(json);
-
             // Parse the B field: prefer "version" (matches factory / hs_syvr) then "dpj"
             String bFieldStr = json.optString("B", "");
             org.json.JSONObject bData;
@@ -1316,9 +1313,18 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             } else {
                 bData = new org.json.JSONObject(bFieldStr);
             }
+
+            // Presence sync MUST run before the wire_caps merge: a presence edge drops the
+            // cached notify_cap (phone session boundary => stale MTU-derived value), while the
+            // notify_cap advertised in THIS reply was measured for the current session and must
+            // survive the merge that follows.
+            applyPhonePresenceFromSyvr(bData);
+
+            // Negotiate UART length endianness from the BES's advertised wire_caps.
+            applyBesWireCaps(json);
+
             cacheBesBaudSwitchVersion(bData);
             cacheBesVersionFromSyvrBField(bData);
-            applyPhonePresenceFromSyvr(bData);
 
             // Runtime UART baud switch: sr_syvr either confirms our post-reopen probe or,
             // if the firmware is new enough, kicks off the cs_baud negotiation.

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -292,6 +292,11 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         messageParser = new BesMessageParser();
         fileTransferExecutor = Executors.newSingleThreadScheduledExecutor();
 
+        // Couple the v1 string chunk budget to the caps lifecycle before any transition can
+        // fire: every path that clears the caps (including reopen failures that never reach the
+        // serial callbacks) then also restores the fallback budget.
+        MessageChunker.followLinkState(linkState);
+
         // Create the communication manager
         comManager = new SerialPortBridge(context);
         comManager.registerListener(this);
@@ -572,9 +577,6 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
     public void resetWireProtocolState() {
         resetPhoneWireProtocolState();
         uartToBesEndian = K900LengthCodec.Endian.BE;
-        // The negotiated notify_cap dies with the caps snapshot (serialClosed), so the string
-        // chunk budget must fall back to the conservative default at the same lifecycle point.
-        MessageChunker.resetStringChunkBudget();
     }
 
     /** Send BLE Wire v2 handshake frame (payload "v2"). */
@@ -1382,9 +1384,8 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             Log.i(TAG, "📦 BES wire_caps advertised negotiated file payloads");
         }
         if (advertised != null && advertised.notifyCap > 0) {
-            // Size v1 string ck chunks against the TRUE notification cap the BES measured from
-            // the negotiated ATT MTU, instead of the conservative 253-byte assumption.
-            MessageChunker.setStringChunkBudgetFromNotifyCap(advertised.notifyCap);
+            // The string chunk budget follows the caps automatically: the MessageChunker
+            // subscription (followLinkState in the constructor) re-derives it on this transition.
             Log.i(TAG, "📏 BES wire_caps advertised notify_cap=" + advertised.notifyCap);
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -108,7 +108,13 @@ public final class LinkStateMachine {
         /**
          * Max single-notification payload the BES delivers to the phone
          * (wire_caps.notify_cap = max(253, min(negotiated ATT MTU - 3, 509))). 0 when the
-         * firmware predates the advertisement.
+         * firmware predates the advertisement or the cached value was invalidated.
+         *
+         * <p>Unlike the other caps, notify_cap derives from the PHONE BLE session's negotiated
+         * ATT MTU, so its validity is the intersection of the UART session, the phone BLE
+         * session, and the BES firmware generation: the machine clears it on serial close, on
+         * every phone-presence edge (a new session renegotiates the MTU), and on BES OTA — it
+         * re-arms only from a fresh wire_caps advertisement.
          */
         public final int notifyCap;
 
@@ -143,6 +149,17 @@ public final class LinkStateMachine {
                     bigPacks || advertised.bigPacks,
                     advertised.binary ? advertised.proto : proto,
                     advertised.notifyCap > 0 ? advertised.notifyCap : notifyCap);
+        }
+
+        /**
+         * Drop the cached notify_cap: a phone BLE session boundary or a BES reboot made the
+         * MTU-derived value stale. Invalidated behaves exactly like never-advertised (the
+         * tri-state degradation rule), until a fresh wire_caps advertisement re-arms it.
+         */
+        BesCaps withoutNotifyCap() {
+            return notifyCap == 0
+                    ? this
+                    : new BesCaps(k900Le, binary, filePayloadV2, bigPacks, proto, 0);
         }
 
         /**
@@ -351,6 +368,13 @@ public final class LinkStateMachine {
      * field of an {@code sr_syvr} reply. Orthogonal to the UART ladder — a baud reopen does not
      * touch the BES-to-phone BLE link, so presence deliberately survives
      * {@link #streamDiscontinuity()}.
+     *
+     * <p>A presence EDGE (the value actually changing, in either direction) is a phone BLE
+     * session boundary, and {@code notify_cap} derives from that session's negotiated ATT MTU:
+     * a new session renegotiates the MTU, so the cached cap is dropped on every edge and only a
+     * fresh wire_caps advertisement re-arms it. Callers syncing presence from an sr_syvr reply
+     * must therefore apply the presence BEFORE merging that reply's own wire_caps, so the
+     * advertisement measured for the current session survives.
      */
     public void phonePresenceReported(boolean present) {
         synchronized (this) {
@@ -359,6 +383,7 @@ public final class LinkStateMachine {
                 return;
             }
             phonePresence = updated;
+            negotiatedCaps = negotiatedCaps.withoutNotifyCap();
             notifyListenersLocked();
         }
     }
@@ -366,15 +391,21 @@ public final class LinkStateMachine {
     /**
      * The last presence report can no longer be trusted (the BES is rebooting after an OTA and
      * drops its phone link on the way down). Presence returns to {@code UNKNOWN} until the
-     * rebooted BES sends a fresh signal.
+     * rebooted BES sends a fresh signal, and the cached {@code notify_cap} is dropped too: the
+     * reboot is a firmware-generation boundary AND kills the phone session whose MTU produced
+     * the value — the new firmware may advertise differently or not at all.
      */
     public void phonePresenceInvalidated() {
         synchronized (this) {
-            if (phonePresence == PhonePresence.UNKNOWN) {
-                return;
-            }
+            BesCaps updatedCaps = negotiatedCaps.withoutNotifyCap();
+            boolean changed =
+                    phonePresence != PhonePresence.UNKNOWN
+                            || !updatedCaps.equals(negotiatedCaps);
             phonePresence = PhonePresence.UNKNOWN;
-            notifyListenersLocked();
+            negotiatedCaps = updatedCaps;
+            if (changed) {
+                notifyListenersLocked();
+            }
         }
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachine.java
@@ -28,6 +28,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * stream, so the link is no longer proven at the current baud) drops back to {@code SERIAL_OPEN},
  * and {@link #serialClosed()} resets everything.
  *
+ * <p>Orthogonal to the ladder, {@link PhonePresence} tracks whether the BES currently holds a
+ * phone BLE connection (see the enum Javadoc for the firmware contract and the tri-state
+ * degradation rule for old firmware).
+ *
  * <p>Caps have two views on purpose:
  *
  * <ul>
@@ -62,13 +66,29 @@ public final class LinkStateMachine {
     }
 
     /**
+     * BES-reported phone BLE presence, orthogonal to the UART ladder. Firmware >= 17.26.7.23
+     * reports edges spontaneously ({@code sr_phble}) and syncs the current value in every
+     * {@code sr_syvr} reply ({@code phone_ble}). Older firmware sends neither, so presence is a
+     * tri-state: it stays {@code UNKNOWN} until a signal arrives and every consumer must degrade
+     * gracefully on {@code UNKNOWN}.
+     */
+    public enum PhonePresence {
+        /** No presence signal since the last reset (old BES firmware, boot, or BES reboot). */
+        UNKNOWN,
+        /** The BES reported a phone BLE connection (first CCC enable). */
+        PRESENT,
+        /** The BES reported the phone BLE link down. */
+        ABSENT
+    }
+
+    /**
      * Immutable snapshot of the wire capabilities negotiated with the BES. Instances are values:
      * mutation happens by replacing the machine's current snapshot, never in place.
      */
     public static final class BesCaps {
         /** No capabilities negotiated: the state before any BES advertisement. */
         public static final BesCaps NONE =
-                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1);
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 0);
 
         /** BES accepts little-endian K900 STRING lengths (wire_caps.k900_le). */
         public final boolean k900Le;
@@ -85,20 +105,35 @@ public final class LinkStateMachine {
         /** Highest wire protocol version the BES advertised. */
         public final int proto;
 
+        /**
+         * Max single-notification payload the BES delivers to the phone
+         * (wire_caps.notify_cap = max(253, min(negotiated ATT MTU - 3, 509))). 0 when the
+         * firmware predates the advertisement.
+         */
+        public final int notifyCap;
+
         public BesCaps(
-                boolean k900Le, boolean binary, boolean filePayloadV2, boolean bigPacks, int proto) {
+                boolean k900Le,
+                boolean binary,
+                boolean filePayloadV2,
+                boolean bigPacks,
+                int proto,
+                int notifyCap) {
             this.k900Le = k900Le;
             this.binary = binary;
             this.filePayloadV2 = filePayloadV2;
             this.bigPacks = bigPacks;
             this.proto = proto;
+            this.notifyCap = notifyCap;
         }
 
         /**
          * Merge an sr_syvr wire_caps advertisement into this snapshot using the legacy accrual
-         * rules: flags only ever turn on, and {@code proto} is overwritten only when the
+         * rules: flags only ever turn on, {@code proto} is overwritten only when the
          * advertisement carries the binary flag (an advertisement without {@code binary} says
-         * nothing about the protocol version).
+         * nothing about the protocol version), and {@code notifyCap} takes the newest advertised
+         * value (it tracks the CURRENT negotiated ATT MTU, which can renegotiate per phone
+         * session) while an absent advertisement keeps the previous one.
          */
         BesCaps mergeAdvertised(BesCaps advertised) {
             return new BesCaps(
@@ -106,7 +141,8 @@ public final class LinkStateMachine {
                     binary || advertised.binary,
                     filePayloadV2 || advertised.filePayloadV2,
                     bigPacks || advertised.bigPacks,
-                    advertised.binary ? advertised.proto : proto);
+                    advertised.binary ? advertised.proto : proto,
+                    advertised.notifyCap > 0 ? advertised.notifyCap : notifyCap);
         }
 
         /**
@@ -119,7 +155,8 @@ public final class LinkStateMachine {
                     true,
                     filePayloadV2,
                     bigPacks,
-                    Math.max(proto, BesWireFormat.PROTOCOL_VERSION_V2));
+                    Math.max(proto, BesWireFormat.PROTOCOL_VERSION_V2),
+                    notifyCap);
         }
 
         @Override
@@ -135,12 +172,13 @@ public final class LinkStateMachine {
                     && binary == other.binary
                     && filePayloadV2 == other.filePayloadV2
                     && bigPacks == other.bigPacks
-                    && proto == other.proto;
+                    && proto == other.proto
+                    && notifyCap == other.notifyCap;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(k900Le, binary, filePayloadV2, bigPacks, proto);
+            return Objects.hash(k900Le, binary, filePayloadV2, bigPacks, proto, notifyCap);
         }
 
         @Override
@@ -155,6 +193,8 @@ public final class LinkStateMachine {
                     + bigPacks
                     + ", proto="
                     + proto
+                    + ", notifyCap="
+                    + notifyCap
                     + "}";
         }
     }
@@ -171,19 +211,26 @@ public final class LinkStateMachine {
          * @param state the link state at the time of the transition being delivered
          * @param provenCaps the trusted caps snapshot; non-null exactly when {@code state} is
          *     {@link LinkState#LINK_PROVEN}
+         * @param phonePresence the BES-reported phone BLE presence at the time of the transition
          */
-        void onLinkStateChanged(LinkState state, BesCaps provenCaps);
+        void onLinkStateChanged(LinkState state, BesCaps provenCaps, PhonePresence phonePresence);
     }
 
-    /** One queued delivery: the state pair at transition time plus its audience. */
+    /** One queued delivery: the state snapshot at transition time plus its audience. */
     private static final class Notification {
         final LinkState state;
         final BesCaps provenCaps;
+        final PhonePresence phonePresence;
         final List<Listener> audience;
 
-        Notification(LinkState state, BesCaps provenCaps, List<Listener> audience) {
+        Notification(
+                LinkState state,
+                BesCaps provenCaps,
+                PhonePresence phonePresence,
+                List<Listener> audience) {
             this.state = state;
             this.provenCaps = provenCaps;
+            this.phonePresence = phonePresence;
             this.audience = audience;
         }
     }
@@ -201,6 +248,7 @@ public final class LinkStateMachine {
 
     private LinkState state = LinkState.SERIAL_CLOSED;
     private BesCaps negotiatedCaps = BesCaps.NONE;
+    private PhonePresence phonePresence = PhonePresence.UNKNOWN;
 
     /**
      * Register a listener and synchronously replay the current state to it. Replay-on-subscribe is
@@ -216,7 +264,7 @@ public final class LinkStateMachine {
         // reflects every transition already performed (only their deliveries can lag), and queued
         // passes snapshot their audience at transition time, so this listener will never also
         // receive an older pass after this newer replay.
-        deliverSafely(listener, state, provenCapsLocked());
+        deliverSafely(listener, state, provenCapsLocked(), phonePresence);
     }
 
     /** Unregister a listener; no-op if it was never added. */
@@ -253,6 +301,15 @@ public final class LinkStateMachine {
     }
 
     /**
+     * BES-reported phone BLE presence. {@code UNKNOWN} until the BES sends a signal (sr_phble
+     * edge or the phone_ble field of an sr_syvr reply) — which old firmware never does, so
+     * consumers must treat {@code UNKNOWN} as "no trustworthy phone link".
+     */
+    public synchronized PhonePresence getPhonePresence() {
+        return phonePresence;
+    }
+
+    /**
      * The serial port opened (onSerialReady / successful onSerialOpen). Promotes
      * {@code SERIAL_CLOSED} to {@code SERIAL_OPEN}; a redundant ready on an already-open link
      * changes nothing.
@@ -269,18 +326,55 @@ public final class LinkStateMachine {
 
     /**
      * The serial port closed (onSerialClose / failed onSerialOpen). Resets everything: state back
-     * to {@code SERIAL_CLOSED} and the negotiated caps to {@link BesCaps#NONE}, matching the
-     * legacy {@code resetWireProtocolState()} reset that ran on serial close.
+     * to {@code SERIAL_CLOSED}, the negotiated caps to {@link BesCaps#NONE} (matching the legacy
+     * {@code resetWireProtocolState()} reset that ran on serial close), and phone presence to
+     * {@code UNKNOWN} — with no UART link there is no way to hear about presence edges, so the
+     * last report cannot be trusted.
      */
     public void serialClosed() {
         synchronized (this) {
-            boolean changed = state != LinkState.SERIAL_CLOSED
-                    || !negotiatedCaps.equals(BesCaps.NONE);
+            boolean changed =
+                    state != LinkState.SERIAL_CLOSED
+                            || !negotiatedCaps.equals(BesCaps.NONE)
+                            || phonePresence != PhonePresence.UNKNOWN;
             state = LinkState.SERIAL_CLOSED;
             negotiatedCaps = BesCaps.NONE;
+            phonePresence = PhonePresence.UNKNOWN;
             if (changed) {
                 notifyListenersLocked();
             }
+        }
+    }
+
+    /**
+     * The BES reported phone BLE presence: an {@code sr_phble} edge or the {@code phone_ble}
+     * field of an {@code sr_syvr} reply. Orthogonal to the UART ladder — a baud reopen does not
+     * touch the BES-to-phone BLE link, so presence deliberately survives
+     * {@link #streamDiscontinuity()}.
+     */
+    public void phonePresenceReported(boolean present) {
+        synchronized (this) {
+            PhonePresence updated = present ? PhonePresence.PRESENT : PhonePresence.ABSENT;
+            if (phonePresence == updated) {
+                return;
+            }
+            phonePresence = updated;
+            notifyListenersLocked();
+        }
+    }
+
+    /**
+     * The last presence report can no longer be trusted (the BES is rebooting after an OTA and
+     * drops its phone link on the way down). Presence returns to {@code UNKNOWN} until the
+     * rebooted BES sends a fresh signal.
+     */
+    public void phonePresenceInvalidated() {
+        synchronized (this) {
+            if (phonePresence == PhonePresence.UNKNOWN) {
+                return;
+            }
+            phonePresence = PhonePresence.UNKNOWN;
+            notifyListenersLocked();
         }
     }
 
@@ -361,7 +455,8 @@ public final class LinkStateMachine {
      */
     private void notifyListenersLocked() {
         pendingNotifications.add(
-                new Notification(state, provenCapsLocked(), List.copyOf(listeners)));
+                new Notification(
+                        state, provenCapsLocked(), phonePresence, List.copyOf(listeners)));
         if (dispatching) {
             return; // The drain below us on the stack will deliver this pass after its own.
         }
@@ -370,7 +465,11 @@ public final class LinkStateMachine {
             Notification notification;
             while ((notification = pendingNotifications.poll()) != null) {
                 for (Listener listener : notification.audience) {
-                    deliverSafely(listener, notification.state, notification.provenCaps);
+                    deliverSafely(
+                            listener,
+                            notification.state,
+                            notification.provenCaps,
+                            notification.phonePresence);
                 }
             }
         } finally {
@@ -383,9 +482,10 @@ public final class LinkStateMachine {
      * into the transport caller (which would misreport a parse failure after the machine already
      * mutated), so exceptions end here.
      */
-    private void deliverSafely(Listener listener, LinkState state, BesCaps provenCaps) {
+    private void deliverSafely(
+            Listener listener, LinkState state, BesCaps provenCaps, PhonePresence phonePresence) {
         try {
-            listener.onLinkStateChanged(state, provenCaps);
+            listener.onLinkStateChanged(state, provenCaps, phonePresence);
         } catch (RuntimeException e) {
             Log.e(TAG, "Link state listener threw for " + state + "; continuing delivery", e);
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -46,9 +46,12 @@ public class MessageChunker {
     /**
      * Adopt the BES-measured notification cap ({@code wire_caps.notify_cap}) as the v1 string
      * chunk ceiling, keeping the same re-framing safety margin the 240-byte fallback encodes
-     * (240 = 253 - {@link AsgConstants#K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}). Values below the
-     * firmware contract floor (253) are malformed and ignored so a buggy advertisement can never
-     * shrink the budget below the hardware-validated fallback.
+     * (240 = 253 - {@link AsgConstants#K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}). The advertised
+     * value is validated against the firmware contract range [253, 509] rather than trusted
+     * blindly: below the floor it is malformed and ignored (the budget must never shrink below
+     * the hardware-validated fallback), above the ceiling it is clamped down (an oversized
+     * advertisement would size chunks beyond what the transport carries — the exact silent
+     * truncation class this budget exists to prevent).
      */
     public static void setStringChunkBudgetFromNotifyCap(int notifyCap) {
         if (notifyCap < AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES) {
@@ -60,8 +63,18 @@ public class MessageChunker {
                             + AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES);
             return;
         }
+        int accepted = notifyCap;
+        if (accepted > AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES) {
+            Log.w(
+                    TAG,
+                    "Clamping notify_cap="
+                            + notifyCap
+                            + " to the contract ceiling "
+                            + AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES);
+            accepted = AsgConstants.K900_BLE_NOTIFY_CAP_CEILING_BYTES;
+        }
         STRING_CHUNK_BUDGET.set(
-                notifyCap - AsgConstants.K900_STRING_CHUNK_BUDGET_MARGIN_BYTES);
+                accepted - AsgConstants.K900_STRING_CHUNK_BUDGET_MARGIN_BYTES);
     }
 
     /** Restore the conservative fallback budget (serial close: the negotiated cap died). */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -22,15 +22,52 @@ public class MessageChunker {
     private static final int MIN_CHUNK_DATA_SIZE = 4;
     /** Budget for v2 binary fragments — these are reassembled phone-side, so MTU_TARGET holds. */
     public static final int MAX_PACKED_CHUNK_SIZE = BesWireFormat.MAX_PACKED_FRAME_SIZE;
+
     /**
-     * Budget for v1 STRING ck chunks. Unlike binary fragments, a v1 string frame must
-     * survive the phone leg as ONE BLE notification (the BES relays it unfragmented and
-     * the phone parses per-notification) — so the real ceiling is the ATT payload cap,
-     * not MTU_TARGET. See {@link AsgConstants#K900_STRING_CHUNK_MAX_FRAME_BYTES}.
+     * Budget for v1 STRING ck chunks. Unlike binary fragments, a v1 string frame must survive
+     * the phone leg as ONE BLE notification (the BES relays it unfragmented and the phone parses
+     * per-notification) — so the real ceiling is the notification payload cap, not MTU_TARGET.
+     * Defaults to the conservative worst-case budget
+     * ({@link AsgConstants#K900_STRING_CHUNK_MAX_FRAME_BYTES}); BES firmware >= 17.26.7.23
+     * advertises the true cap via {@code wire_caps.notify_cap} and
+     * {@link #setStringChunkBudgetFromNotifyCap(int)} raises the budget accordingly.
      */
-    public static final int MAX_PACKED_STRING_CHUNK_SIZE =
-            AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES;
+    private static final java.util.concurrent.atomic.AtomicInteger STRING_CHUNK_BUDGET =
+            new java.util.concurrent.atomic.AtomicInteger(
+                    AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES);
+
     private static final AtomicLong CHUNK_SEQUENCE = new AtomicLong();
+
+    /** Current maximum packed frame size for a v1 STRING ck chunk. */
+    public static int maxPackedStringChunkSize() {
+        return STRING_CHUNK_BUDGET.get();
+    }
+
+    /**
+     * Adopt the BES-measured notification cap ({@code wire_caps.notify_cap}) as the v1 string
+     * chunk ceiling, keeping the same re-framing safety margin the 240-byte fallback encodes
+     * (240 = 253 - {@link AsgConstants#K900_STRING_CHUNK_BUDGET_MARGIN_BYTES}). Values below the
+     * firmware contract floor (253) are malformed and ignored so a buggy advertisement can never
+     * shrink the budget below the hardware-validated fallback.
+     */
+    public static void setStringChunkBudgetFromNotifyCap(int notifyCap) {
+        if (notifyCap < AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES) {
+            Log.w(
+                    TAG,
+                    "Ignoring notify_cap="
+                            + notifyCap
+                            + " below the contract floor "
+                            + AsgConstants.K900_BLE_NOTIFY_CAP_FLOOR_BYTES);
+            return;
+        }
+        STRING_CHUNK_BUDGET.set(
+                notifyCap - AsgConstants.K900_STRING_CHUNK_BUDGET_MARGIN_BYTES);
+    }
+
+    /** Restore the conservative fallback budget (serial close: the negotiated cap died). */
+    public static void resetStringChunkBudget() {
+        STRING_CHUNK_BUDGET.set(AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES);
+    }
 
     public static boolean needsChunking(String message) {
         if (message == null) {
@@ -89,7 +126,7 @@ public class MessageChunker {
         }
 
         throw new JSONException(
-                "Unable to create K900 chunks within " + MAX_PACKED_STRING_CHUNK_SIZE + " bytes");
+                "Unable to create K900 chunks within " + maxPackedStringChunkSize() + " bytes");
     }
 
     /**
@@ -173,9 +210,10 @@ public class MessageChunker {
     }
 
     private static boolean allChunksFit(List<JSONObject> chunks) {
+        int budget = maxPackedStringChunkSize();
         for (int i = 0; i < chunks.size(); i++) {
             byte[] packed = BesWireFormat.formatMessageForTransmission(chunks.get(i).toString());
-            if (packed == null || packed.length > MAX_PACKED_STRING_CHUNK_SIZE) {
+            if (packed == null || packed.length > budget) {
                 Log.d(
                         TAG,
                         "Chunk "
@@ -183,7 +221,7 @@ public class MessageChunker {
                                 + " packed to "
                                 + (packed != null ? packed.length : 0)
                                 + " bytes, exceeding "
-                                + MAX_PACKED_STRING_CHUNK_SIZE);
+                                + budget);
                 return false;
             }
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/MessageChunker.java
@@ -77,9 +77,32 @@ public class MessageChunker {
                 accepted - AsgConstants.K900_STRING_CHUNK_BUDGET_MARGIN_BYTES);
     }
 
-    /** Restore the conservative fallback budget (serial close: the negotiated cap died). */
+    /** Restore the conservative fallback budget (the negotiated cap died with the caps). */
     public static void resetStringChunkBudget() {
         STRING_CHUNK_BUDGET.set(AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES);
+    }
+
+    /**
+     * Couple the string chunk budget to the link state machine's negotiated caps lifecycle: on
+     * every observable transition the budget is re-derived from the current caps snapshot —
+     * notify_cap advertised means the negotiated budget, caps cleared means the fallback. Tying
+     * the budget to the machine (rather than to one serial callback) guarantees it can never go
+     * stale on ANY path that clears the caps: {@code onSerialClose}, a failed
+     * {@code onSerialOpen}, and reopen failures all drive the machine's serialClosed transition
+     * directly, and a subsequent reconnect to firmware that omits notify_cap must not inherit a
+     * previous session's larger budget (that would reintroduce silent notification truncation).
+     * Replay-on-subscribe applies the current caps immediately. Call once per machine.
+     */
+    public static void followLinkState(LinkStateMachine linkState) {
+        linkState.addListener(
+                (state, provenCaps, phonePresence) -> {
+                    int notifyCap = linkState.getNegotiatedCaps().notifyCap;
+                    if (notifyCap > 0) {
+                        setStringChunkBudgetFromNotifyCap(notifyCap);
+                    } else {
+                        resetStringChunkBudget();
+                    }
+                });
     }
 
     public static boolean needsChunking(String message) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/communication/managers/CommunicationManager.java
@@ -3,6 +3,8 @@ package com.mentra.asg_client.service.communication.managers;
 import android.util.Log;
 import com.mentra.asg_client.io.bluetooth.interfaces.IBluetoothManager;
 import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
 import com.mentra.asg_client.io.network.interfaces.INetworkManager;
 import com.mentra.asg_client.io.network.models.NetworkInfo;
 import com.mentra.asg_client.io.ota.helpers.OtaHelper;
@@ -603,9 +605,21 @@ public class CommunicationManager
     /**
      * Check if phone is currently connected via BLE. Part of OtaHelper.PhoneConnectionProvider
      * interface.
+     *
+     * <p>When the BES has reported phone BLE presence (firmware >= 17.26.7.23: sr_phble edges,
+     * phone_ble in sr_syvr), that report is authoritative. When presence is UNKNOWN — the entire
+     * deployed fleet today — this keeps the historical transport-based answer: OTA (and the wifi
+     * scan/set flows that ride the same provider) must keep working against old BES firmware.
      */
     @Override
     public boolean isPhoneConnected() {
+        if (transport instanceof K900BluetoothManager) {
+            LinkStateMachine.PhonePresence presence =
+                    ((K900BluetoothManager) transport).getLinkStateMachine().getPhonePresence();
+            if (presence != LinkStateMachine.PhonePresence.UNKNOWN) {
+                return presence == LinkStateMachine.PhonePresence.PRESENT;
+            }
+        }
         return transport != null && transport.isConnected();
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -129,11 +129,6 @@ public class AsgClientService extends Service implements NetworkStateListener, T
             "com.mentra.recovery.ACTION_INSTALLATION_PROGRESS";
     public static final String ACTION_OTA_HEARTBEAT = "com.mentra.recovery.ACTION_PING";
 
-    // Service health monitoring
-    private static final String ACTION_HEARTBEAT = "com.mentra.asg_client.ACTION_HEARTBEAT";
-    private static final String ACTION_HEARTBEAT_ACK = "com.mentra.asg_client.ACTION_HEARTBEAT_ACK";
-    private static final long HEARTBEAT_TIMEOUT_MS = 35000; // 35 seconds timeout
-
     /** Solid white RGB LED duration while USB UVC streaming (same as video recording). */
     private static final int UVC_STREAMING_LED_DURATION_MS = 1_800_000;
 
@@ -158,7 +153,6 @@ public class AsgClientService extends Service implements NetworkStateListener, T
     private static final AtomicBoolean serviceRunning = new AtomicBoolean(false);
     private boolean lastI2sPlaying = false;
     private boolean lastUvcStreaming = false;
-    private boolean isConnected = false; // Track connection state based on heartbeat
 
     /**
      * Used before {@link ServiceInitializer} exists so FGS promotion is not delayed by heavy init.
@@ -183,12 +177,6 @@ public class AsgClientService extends Service implements NetworkStateListener, T
     private BroadcastReceiver restartReceiver;
     private BroadcastReceiver otaProgressReceiver;
     private BroadcastReceiver mtkUpdateReceiver;
-
-    // ---------------------------------------------
-    // Heartbeat Timeout Management
-    // ---------------------------------------------
-    private Handler heartbeatTimeoutHandler;
-    private Runnable heartbeatTimeoutRunnable;
 
     // ---------------------------------------------
     // Lifecycle Methods
@@ -257,10 +245,6 @@ public class AsgClientService extends Service implements NetworkStateListener, T
             // Send version info
             Log.d(TAG, "📋 Sending initial version information");
             sendVersionInfo();
-
-            // Start heartbeat monitoring
-            Log.d(TAG, "💓 Starting heartbeat monitoring");
-            startHeartbeatMonitoring();
 
             // Clean up orphaned BLE transfer files from previous sessions
             Log.d(TAG, "🗑️ Cleaning up orphaned BLE transfer files");
@@ -847,9 +831,6 @@ public class AsgClientService extends Service implements NetworkStateListener, T
             } else {
                 Log.d(TAG, "⏭️ MTK update receiver is null - skipping");
             }
-
-            // Stop heartbeat monitoring
-            stopHeartbeatMonitoring();
 
             Log.d(TAG, "✅ All receivers unregistered successfully");
         } catch (IllegalArgumentException e) {
@@ -1495,103 +1476,11 @@ public class AsgClientService extends Service implements NetworkStateListener, T
         }
     }
 
-    /** Reset heartbeat timeout - called when heartbeat is received */
-    private void resetHeartbeatTimeout() {
-        Log.d(TAG, "💓 Resetting heartbeat timeout");
-
-        try {
-            // Cancel any existing timeout
-            heartbeatTimeoutHandler.removeCallbacks(heartbeatTimeoutRunnable);
-
-            // Mark as connected
-            isConnected = true;
-            Log.d(TAG, "🔌 Connection state changed to CONNECTED");
-
-            // Schedule new timeout
-            heartbeatTimeoutHandler.postDelayed(heartbeatTimeoutRunnable, HEARTBEAT_TIMEOUT_MS);
-            Log.d(TAG, "⏰ Heartbeat timeout scheduled for " + HEARTBEAT_TIMEOUT_MS + "ms");
-
-        } catch (Exception e) {
-            Log.e(TAG, "💥 Error resetting heartbeat timeout", e);
-        }
-    }
-
-    /** Start heartbeat monitoring - call this when service becomes active */
-    public void startHeartbeatMonitoring() {
-        Log.d(TAG, "💓 Starting heartbeat monitoring");
-
-        try {
-            // Initialize heartbeat timeout handler if not already done
-            if (heartbeatTimeoutHandler == null) {
-                Log.d(TAG, "💓 Initializing heartbeat timeout handler");
-                heartbeatTimeoutHandler = new Handler(Looper.getMainLooper());
-                heartbeatTimeoutRunnable =
-                        () -> {
-                            Log.w(TAG, "⚠️ Heartbeat timeout - marking as disconnected");
-                            isConnected = false;
-                            Log.i(
-                                    TAG,
-                                    "🔌 Connection state changed to DISCONNECTED due to heartbeat"
-                                            + " timeout");
-                        };
-            }
-
-            // Cancel any existing timeout
-            heartbeatTimeoutHandler.removeCallbacks(heartbeatTimeoutRunnable);
-
-            // Don't set connected state - wait for first heartbeat
-            isConnected = false;
-            Log.d(
-                    TAG,
-                    "🔌 Connection state initialized as DISCONNECTED - waiting for first"
-                            + " heartbeat");
-
-            // Schedule initial timeout to detect if no heartbeat comes
-            heartbeatTimeoutHandler.postDelayed(heartbeatTimeoutRunnable, HEARTBEAT_TIMEOUT_MS);
-            Log.d(TAG, "⏰ Initial heartbeat timeout scheduled for " + HEARTBEAT_TIMEOUT_MS + "ms");
-
-        } catch (Exception e) {
-            Log.e(TAG, "💥 Error starting heartbeat monitoring", e);
-        }
-    }
-
-    /** Stop heartbeat monitoring - call this when service becomes inactive */
-    public void stopHeartbeatMonitoring() {
-        Log.d(TAG, "💓 Stopping heartbeat monitoring");
-
-        try {
-            heartbeatTimeoutHandler.removeCallbacks(heartbeatTimeoutRunnable);
-            isConnected = false;
-            Log.d(TAG, "🔌 Connection state changed to DISCONNECTED (monitoring stopped)");
-        } catch (Exception e) {
-            Log.e(TAG, "💥 Error stopping heartbeat monitoring", e);
-        }
-    }
-
-    /** Get current connection state */
-    public boolean isConnected() {
-        return isConnected;
-    }
-
-    /** Handle the phone_ready/glasses_ready handshake completing over Bluetooth. */
-    public void onPhoneReadyHandshakeComplete() {
-        Log.d(TAG, "📱 Phone ready handshake complete - marking phone connection active");
-        resetHeartbeatTimeout();
-    }
-
-    /** Handle any standard command received from the phone over Bluetooth. */
-    public void onPhoneCommandReceived() {
-        Log.d(TAG, "📱 Phone command received - marking phone connection active");
-        resetHeartbeatTimeout();
-    }
-
-    /** Handle service heartbeat received from MentraLiveSGC */
-    public void onServiceHeartbeatReceived() {
-        Log.d(TAG, "💓 Service heartbeat received from MentraLiveSGC");
-
-        // Reset heartbeat timeout and mark as connected
-        resetHeartbeatTimeout();
-    }
+    // The heartbeat-inferred phone "connected" flag (isConnected / resetHeartbeatTimeout /
+    // start/stopHeartbeatMonitoring) was deleted: its only consumer was the button-press local
+    // capture gate, which now reads the BES-reported phone BLE presence from the transport
+    // LinkStateMachine. Ping/heartbeat commands still get their acks; they just no longer feed
+    // an inference.
 
     private void registerRestartReceiver() {
         Log.d(TAG, "🔄 registerRestartReceiver() started");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandler.java
@@ -92,10 +92,6 @@ public class PhoneReadyCommandHandler implements ICommandHandler {
                                     ? "✅ Glasses ready response sent successfully"
                                     : "❌ Failed to send glasses ready response"));
 
-            if (sent && serviceManager != null) {
-                serviceManager.onPhoneReadyHandshakeComplete();
-            }
-
             // Wire v2 activation is RESPONDER-ONLY on the glasses side. glasses_ready
             // advertises wire_caps (a harmless JSON key to old phones); a v2-capable
             // phone then initiates the binary handshake (maybeSendWireHandshake in the

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PingCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PingCommandHandler.java
@@ -62,12 +62,6 @@ public class PingCommandHandler implements ICommandHandler {
         Log.d(TAG, "🏓 Received ping data: " + (data != null ? data.toString() : "null"));
 
         try {
-            // Reset heartbeat timeout - ping proves phone is connected
-            if (serviceManager != null) {
-                serviceManager.onServiceHeartbeatReceived();
-                Log.d(TAG, "🏓 💓 Connection state refreshed via ping");
-            }
-
             Log.d(TAG, "🏓 🔨 Building ping response...");
             JSONObject pingResponse = responseBuilder.buildPingResponse();
             Log.d(TAG, "🏓 📤 Sending ping response: " + pingResponse.toString());

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/ServiceHeartbeatCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/ServiceHeartbeatCommandHandler.java
@@ -53,15 +53,10 @@ public class ServiceHeartbeatCommandHandler implements ICommandHandler {
             int heartbeatCounter = data.optInt("heartbeat_counter", -1);
             
             Log.d(TAG, "💓 Service heartbeat #" + heartbeatCounter + " received at " + timestamp);
-            
-            // Notify AsgClientService about heartbeat to reset timeout
-            if (serviceManager != null) {
-                serviceManager.onServiceHeartbeatReceived();
-                return true;
-            } else {
-                Log.e(TAG, "❌ ServiceManager is null - cannot process heartbeat");
-                return false;
-            }
+
+            // Plain ack path: the heartbeat no longer feeds a connection inference (phone
+            // presence comes from the BES via the transport LinkStateMachine).
+            return true;
         } catch (Exception e) {
             Log.e(TAG, "💥 Error handling service heartbeat command", e);
             return false;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriber.java
@@ -4,6 +4,9 @@ import android.content.Context;
 import android.os.PowerManager;
 import android.util.Log;
 import com.mentra.asg_client.audio.AudioAssets;
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
 import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
 import com.mentra.asg_client.io.media.core.MediaCaptureService;
 import com.mentra.asg_client.io.peripheral.IPeripheralBus;
@@ -90,29 +93,33 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
         // Check if gallery/camera app is active before capturing
         boolean isSaveInGalleryMode = serviceManager.getAsgSettings().isSaveInGalleryMode();
 
-        // Check if glasses are connected to phone
-        boolean isConnected = serviceManager.isConnected();
+        // BES-reported phone BLE presence replaces the old heartbeat-inferred "connected" flag.
+        // UNKNOWN (old BES firmware, or no signal since the link reset) is treated as no phone:
+        // local capture is the safe default — worst case a duplicate photo, never a lost one.
+        LinkStateMachine.PhonePresence presence = phonePresence();
+        boolean phonePresent = presence == LinkStateMachine.PhonePresence.PRESENT;
 
-        // LOG CONNECTION STATE FOR DEBUGGING
         Log.i(
                 TAG,
                 "📸 Photo capture decision - Gallery Mode: "
                         + (isSaveInGalleryMode ? "ACTIVE" : "INACTIVE")
-                        + ", Connection State: "
-                        + (isConnected ? "CONNECTED" : "DISCONNECTED"));
+                        + ", Phone presence: "
+                        + presence);
 
-        // Skip capture only if: camera app NOT running AND phone IS connected
-        if (!isSaveInGalleryMode && isConnected) {
+        // Skip capture only if: camera app NOT running AND the BES reports a phone present
+        if (!isSaveInGalleryMode && phonePresent) {
             Log.d(
                     TAG,
-                    "📸 Camera app not active and connected to phone - skipping local capture (button press already forwarded to apps)");
+                    "📸 Camera app not active and phone present - skipping local capture (button press already forwarded to apps)");
             return;
         }
 
-        if (!isConnected) {
+        if (!phonePresent) {
             Log.d(
                     TAG,
-                    "📸 Disconnected from phone - proceeding with local capture regardless of gallery mode");
+                    "📸 No phone present ("
+                            + presence
+                            + ") - proceeding with local capture regardless of gallery mode");
         } else {
             Log.d(TAG, "📸 Camera app active - proceeding with local capture");
         }
@@ -187,6 +194,22 @@ public final class ButtonEventSubscriber implements IPeripheralBus.McuEventListe
                 captureService.takePhotoLocally(photoSize, ledEnabled, true);
             }
         }
+    }
+
+    /**
+     * BES-reported phone BLE presence from the transport link state machine. {@code UNKNOWN} when
+     * the BES firmware predates sr_phble/phone_ble reporting, when no signal has arrived since
+     * the last link reset, or when the transport is not the K900 UART bridge at all.
+     */
+    private LinkStateMachine.PhonePresence phonePresence() {
+        ICompanionTransport bluetoothManager =
+                serviceManager != null ? serviceManager.getBluetoothManager() : null;
+        if (bluetoothManager instanceof K900BluetoothManager) {
+            return ((K900BluetoothManager) bluetoothManager)
+                    .getLinkStateMachine()
+                    .getPhonePresence();
+        }
+        return LinkStateMachine.PhonePresence.UNKNOWN;
     }
 
     /** Send button press to phone via Bluetooth */

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/processors/CommandProcessor.java
@@ -219,7 +219,6 @@ public class CommandProcessor {
                             + commandData.messageId()
                             + ", Data: "
                             + commandData.data());
-            serviceManager.onPhoneCommandReceived();
 
             // Check for duplicate message ID
             if (isDuplicateMessage(commandData.messageId())) {
@@ -259,7 +258,6 @@ public class CommandProcessor {
 
             if (!result.isValid()) {
                 if ("chunk_in_progress".equals(result.commandType())) {
-                    serviceManager.onPhoneCommandReceived();
                     return null;
                 }
                 Log.w(

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/legacy/managers/AsgClientServiceManager.java
@@ -826,32 +826,8 @@ public class AsgClientServiceManager {
         }
     }
 
-    /**
-     * Get the current connection status from AsgClientService
-     *
-     * @return true if connected to phone, false if disconnected
-     */
-    public boolean isConnected() {
-        boolean connected = service.isConnected();
-        Log.d(TAG, "🔌 Connection status: " + (connected ? "CONNECTED" : "DISCONNECTED"));
-        return connected;
-    }
-
-    /** Mark the phone connection active after the phone_ready/glasses_ready handshake completes. */
-    public void onPhoneReadyHandshakeComplete() {
-        Log.d(TAG, "📱 Phone ready handshake complete");
-        service.onPhoneReadyHandshakeComplete();
-    }
-
-    /** Mark the phone connection active after any standard command arrives from the phone. */
-    public void onPhoneCommandReceived() {
-        Log.d(TAG, "📱 Phone command received");
-        service.onPhoneCommandReceived();
-    }
-
-    /** Handle service heartbeat received from MentraLiveSGC */
-    public void onServiceHeartbeatReceived() {
-        Log.d(TAG, "💓 Service heartbeat received from MentraLiveSGC");
-        service.onServiceHeartbeatReceived();
-    }
+    // The heartbeat-inference pass-throughs (isConnected / onPhoneReadyHandshakeComplete /
+    // onPhoneCommandReceived / onServiceHeartbeatReceived) were deleted with the underlying
+    // machinery in AsgClientService; phone presence now comes from the BES via the transport
+    // LinkStateMachine.
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine.BesCaps;
 import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine.LinkState;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine.PhonePresence;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -24,11 +25,14 @@ public class LinkStateMachineTest {
     private static final class RecordingListener implements LinkStateMachine.Listener {
         final List<LinkState> states = new ArrayList<>();
         final List<BesCaps> caps = new ArrayList<>();
+        final List<PhonePresence> presences = new ArrayList<>();
 
         @Override
-        public void onLinkStateChanged(LinkState state, BesCaps provenCaps) {
+        public void onLinkStateChanged(
+                LinkState state, BesCaps provenCaps, PhonePresence phonePresence) {
             states.add(state);
             caps.add(provenCaps);
+            presences.add(phonePresence);
         }
 
         LinkState lastState() {
@@ -41,7 +45,7 @@ public class LinkStateMachineTest {
     }
 
     private static final BesCaps FULL_CAPS =
-            new BesCaps(true, true, true, true, BesWireFormat.PROTOCOL_VERSION_V2);
+            new BesCaps(true, true, true, true, BesWireFormat.PROTOCOL_VERSION_V2, 509);
 
     private LinkStateMachine machine;
 
@@ -246,9 +250,9 @@ public class LinkStateMachineTest {
     public void srSyvrParsed_mergesFlagsAcrossAdvertisements() {
         machine.serialReady();
         machine.srSyvrParsed(
-                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1));
+                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 0));
         machine.srSyvrParsed(
-                new BesCaps(false, true, false, false, BesWireFormat.PROTOCOL_VERSION_V2));
+                new BesCaps(false, true, false, false, BesWireFormat.PROTOCOL_VERSION_V2, 0));
 
         BesCaps caps = machine.getNegotiatedCaps();
         assertThat(caps.k900Le).isTrue();
@@ -265,7 +269,7 @@ public class LinkStateMachineTest {
 
         // An advertisement without the binary flag says nothing about the protocol version.
         machine.srSyvrParsed(
-                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1));
+                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 0));
 
         assertThat(machine.getNegotiatedCaps().proto)
                 .isEqualTo(BesWireFormat.PROTOCOL_VERSION_V2);
@@ -306,6 +310,120 @@ public class LinkStateMachineTest {
         assertThat(listener.states).hasSize(2);
     }
 
+    // ---- phone presence tri-state ----
+
+    @Test
+    public void phonePresence_defaultsToUnknownAndReplaysOnSubscribe() {
+        RecordingListener listener = new RecordingListener();
+
+        machine.addListener(listener);
+
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.UNKNOWN);
+        assertThat(listener.presences).containsExactly(PhonePresence.UNKNOWN);
+    }
+
+    @Test
+    public void phonePresenceReported_movesThroughPresentAndAbsent() {
+        machine.serialReady();
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.phonePresenceReported(true);
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.PRESENT);
+
+        machine.phonePresenceReported(false);
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.ABSENT);
+
+        assertThat(listener.presences)
+                .containsExactly(
+                        PhonePresence.UNKNOWN, PhonePresence.PRESENT, PhonePresence.ABSENT);
+    }
+
+    @Test
+    public void phonePresenceReported_duplicateReport_doesNotRenotify() {
+        machine.serialReady();
+        machine.phonePresenceReported(true);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.phonePresenceReported(true);
+
+        assertThat(listener.presences).containsExactly(PhonePresence.PRESENT);
+    }
+
+    @Test
+    public void addListener_afterPresenceEdge_replaysPresenceSynchronously() {
+        machine.serialReady();
+        machine.phonePresenceReported(true);
+
+        RecordingListener lateListener = new RecordingListener();
+        machine.addListener(lateListener);
+
+        assertThat(lateListener.presences).containsExactly(PhonePresence.PRESENT);
+    }
+
+    @Test
+    public void serialClosed_resetsPresenceToUnknown() {
+        machine.serialReady();
+        machine.phonePresenceReported(true);
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+
+        machine.serialClosed();
+
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.UNKNOWN);
+        assertThat(listener.presences)
+                .containsExactly(PhonePresence.PRESENT, PhonePresence.UNKNOWN);
+    }
+
+    @Test
+    public void phonePresenceInvalidated_dropsToUnknown() {
+        machine.serialReady();
+        machine.phonePresenceReported(false);
+
+        machine.phonePresenceInvalidated();
+
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.UNKNOWN);
+        // Idempotent: a second invalidation is a no-op.
+        RecordingListener listener = new RecordingListener();
+        machine.addListener(listener);
+        machine.phonePresenceInvalidated();
+        assertThat(listener.presences).containsExactly(PhonePresence.UNKNOWN);
+    }
+
+    @Test
+    public void streamDiscontinuity_keepsPresence() {
+        // A baud reopen invalidates the ASG-to-BES byte stream, not the BES-to-phone BLE link:
+        // presence must survive the discontinuity.
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        machine.phonePresenceReported(true);
+
+        machine.streamDiscontinuity();
+
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.PRESENT);
+    }
+
+    // ---- notify_cap accrual ----
+
+    @Test
+    public void srSyvrParsed_notifyCapTakesNewestAdvertisedValue() {
+        machine.serialReady();
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(509);
+
+        // notify_cap tracks the CURRENT negotiated ATT MTU, so a newer advertisement wins...
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 253));
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(253);
+
+        // ...but an advertisement without notify_cap keeps the previous value.
+        machine.srSyvrParsed(
+                new BesCaps(true, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 0));
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(253);
+    }
+
     // ---- listener ordering / thread safety basics ----
 
     @Test
@@ -338,7 +456,7 @@ public class LinkStateMachineTest {
         RecordingListener b = new RecordingListener();
         machine.serialReady();
         machine.addListener(
-                (state, provenCaps) -> {
+                (state, provenCaps, phonePresence) -> {
                     if (state == LinkState.LINK_PROVEN) {
                         machine.serialClosed();
                     }
@@ -371,7 +489,7 @@ public class LinkStateMachineTest {
     public void throwingListener_doesNotStarveLaterListenersOrPropagateToTheCaller() {
         machine.serialReady();
         machine.addListener(
-                (state, provenCaps) -> {
+                (state, provenCaps, phonePresence) -> {
                     throw new IllegalStateException("listener bug");
                 });
         RecordingListener survivor = new RecordingListener();
@@ -390,7 +508,7 @@ public class LinkStateMachineTest {
         machine.serialReady();
 
         machine.addListener(
-                (state, provenCaps) -> {
+                (state, provenCaps, phonePresence) -> {
                     throw new IllegalStateException("replay bug");
                 });
 
@@ -407,7 +525,8 @@ public class LinkStateMachineTest {
         LinkStateMachine.Listener selfRemoving =
                 new LinkStateMachine.Listener() {
                     @Override
-                    public void onLinkStateChanged(LinkState state, BesCaps provenCaps) {
+                    public void onLinkStateChanged(
+                            LinkState state, BesCaps provenCaps, PhonePresence phonePresence) {
                         calls.incrementAndGet();
                         machine.removeListener(this);
                     }
@@ -426,7 +545,7 @@ public class LinkStateMachineTest {
         // machine from two threads and verify no notification ever violates it.
         AtomicBoolean invariantViolated = new AtomicBoolean(false);
         machine.addListener(
-                (state, provenCaps) -> {
+                (state, provenCaps, phonePresence) -> {
                     if ((provenCaps != null) != (state == LinkState.LINK_PROVEN)) {
                         invariantViolated.set(true);
                     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/LinkStateMachineTest.java
@@ -404,6 +404,62 @@ public class LinkStateMachineTest {
         assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.PRESENT);
     }
 
+    // ---- notify_cap lifecycle: UART session ∩ phone BLE session ∩ firmware generation ----
+
+    @Test
+    public void presenceEdge_dropsNotifyCapButKeepsTheOtherCaps() {
+        machine.serialReady();
+        machine.srSyvrParsed(FULL_CAPS);
+        machine.phonePresenceReported(true);
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(509);
+
+        // The phone disconnected: its session's negotiated ATT MTU (and thus notify_cap) died
+        // with it, but the UART-session caps are still valid.
+        machine.phonePresenceReported(false);
+
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(0);
+        assertThat(machine.getNegotiatedCaps().binary).isTrue();
+        assertThat(machine.getNegotiatedCaps().filePayloadV2).isTrue();
+
+        // A NEW phone session renegotiates the MTU: reconnecting must NOT restore the old cap.
+        machine.phonePresenceReported(true);
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(0);
+
+        // Only a fresh advertisement re-arms it.
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 260));
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(260);
+    }
+
+    @Test
+    public void duplicatePresenceReport_keepsNotifyCap() {
+        machine.serialReady();
+        machine.phonePresenceReported(true);
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+
+        // Same-session syncs (phone_ble repeating the current value) are not session boundaries.
+        machine.phonePresenceReported(true);
+
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(509);
+    }
+
+    @Test
+    public void phonePresenceInvalidated_dropsNotifyCapEvenWhenPresenceAlreadyUnknown() {
+        machine.serialReady();
+        machine.srSyvrParsed(
+                new BesCaps(false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(machine.getPhonePresence()).isEqualTo(PhonePresence.UNKNOWN);
+
+        // BES OTA: firmware-generation boundary — the cached cap must die regardless of what
+        // the presence tri-state happens to be.
+        machine.phonePresenceInvalidated();
+
+        assertThat(machine.getNegotiatedCaps().notifyCap).isEqualTo(0);
+    }
+
     // ---- notify_cap accrual ----
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -181,4 +181,52 @@ public class StringChunkBudgetTest {
         machine.srSyvrParsed(null);
         assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
     }
+
+    @Test
+    public void budgetFollowsThePhoneSessionLifecycle() {
+        // notify_cap derives from the phone BLE session's negotiated ATT MTU, so the budget
+        // must not outlive that session: a reconnecting phone can negotiate a SMALLER MTU, and
+        // the old 496 budget would silently truncate its notifications.
+        LinkStateMachine machine = new LinkStateMachine();
+        MessageChunker.followLinkState(machine);
+        machine.serialReady();
+        machine.phonePresenceReported(true);
+        machine.srSyvrParsed(
+                new LinkStateMachine.BesCaps(
+                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+
+        // Phone disconnects: back to the fallback.
+        machine.phonePresenceReported(false);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+
+        // Phone reconnects WITHOUT a fresh advertisement: the fallback must hold.
+        machine.phonePresenceReported(true);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+
+        // A fresh advertisement (measured for the new session's MTU) re-arms the budget.
+        machine.srSyvrParsed(
+                new LinkStateMachine.BesCaps(
+                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 260));
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(260 - 13);
+    }
+
+    @Test
+    public void budgetFallsBackOnBesOta() {
+        // A BES OTA is a firmware-generation boundary AND kills the phone session: the new
+        // firmware may advertise a different notify_cap or none at all.
+        LinkStateMachine machine = new LinkStateMachine();
+        MessageChunker.followLinkState(machine);
+        machine.serialReady();
+        machine.srSyvrParsed(
+                new LinkStateMachine.BesCaps(
+                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+
+        // onBesOtaApplied drives exactly these two machine transitions.
+        machine.streamDiscontinuity();
+        machine.phonePresenceInvalidated();
+
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+    }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -28,11 +28,13 @@ public class StringChunkBudgetTest {
     public void setUp() {
         // v1 string mode — the post-APK-restart steady state until a BLE reconnect.
         BesWireFormat.resetBinaryProtocol();
+        MessageChunker.resetStringChunkBudget();
     }
 
     @After
     public void tearDown() {
         BesWireFormat.resetBinaryProtocol();
+        MessageChunker.resetStringChunkBudget();
     }
 
     /** The 251-byte ota_status completion shape from the incident, quote-dense like the real payload. */
@@ -65,7 +67,7 @@ public class StringChunkBudgetTest {
             // measure the packed frame exactly as the send path produces it.
             byte[] packed = BesWireFormat.formatMessageForTransmission(chunk.toString());
             assertThat(packed).isNotNull();
-            assertThat(packed.length).isLessThanOrEqualTo(MessageChunker.MAX_PACKED_STRING_CHUNK_SIZE);
+            assertThat(packed.length).isLessThanOrEqualTo(MessageChunker.maxPackedStringChunkSize());
 
             reassembled =
                     reassembler.addChunk(
@@ -89,6 +91,48 @@ public class StringChunkBudgetTest {
 
     @Test
     public void fiveHundredByteMessageChunksFitTheNotificationBudget() throws Exception {
+        assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
+    }
+
+    // ---- negotiated notify_cap budget (BES firmware >= 17.26.7.23) ----
+
+    @Test
+    public void budgetDefaultsToTheConservativeFallback() {
+        assertThat(MessageChunker.maxPackedStringChunkSize())
+                .isEqualTo(com.mentra.asg_client.AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES)
+                .isEqualTo(240);
+    }
+
+    @Test
+    public void advertisedNotifyCapRaisesTheBudgetByTheSameMargin() {
+        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+
+        MessageChunker.setStringChunkBudgetFromNotifyCap(253);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(253 - 13);
+    }
+
+    @Test
+    public void notifyCapBelowTheContractFloorIsIgnored() {
+        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        MessageChunker.setStringChunkBudgetFromNotifyCap(200);
+
+        // The malformed advertisement must not shrink the budget below the validated fallback.
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+    }
+
+    @Test
+    public void resetRestoresTheFallbackBudget() {
+        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+
+        MessageChunker.resetStringChunkBudget();
+
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+    }
+
+    @Test
+    public void chunksStillFitAndRoundTripUnderARaisedBudget() throws Exception {
+        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -153,4 +153,32 @@ public class StringChunkBudgetTest {
         MessageChunker.setStringChunkBudgetFromNotifyCap(509);
         assertAllPackedChunksFitAndRoundTrip(largeQuoteDenseJson(500));
     }
+
+    @Test
+    public void budgetFollowsTheCapsLifecycleThroughTheLinkStateMachine() {
+        LinkStateMachine machine = new LinkStateMachine();
+        MessageChunker.followLinkState(machine);
+
+        machine.serialReady();
+        machine.srSyvrParsed(
+                new LinkStateMachine.BesCaps(
+                        false, false, false, false, BesWireFormat.PROTOCOL_VERSION_V1, 509));
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+
+        // A discontinuity (baud reopen) keeps the negotiated caps — and the budget with them.
+        machine.streamDiscontinuity();
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+
+        // EVERY close path (onSerialClose, failed onSerialOpen, reopen failures) funnels
+        // through the machine's serialClosed transition: caps cleared MUST mean fallback
+        // budget, or a later session against firmware without notify_cap would inherit a
+        // stale oversized budget and silently truncate notifications again.
+        machine.serialClosed();
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+
+        // Reconnect to old firmware (sr_syvr without wire_caps): the fallback must hold.
+        machine.serialReady();
+        machine.srSyvrParsed(null);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(240);
+    }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/managers/mentralive/internal/StringChunkBudgetTest.java
@@ -113,6 +113,24 @@ public class StringChunkBudgetTest {
     }
 
     @Test
+    public void notifyCapAboveTheContractCeilingIsClampedToTheCeiling() {
+        // The BES contract is max(253, min(ATT MTU - 3, 509)); an oversized advertisement must
+        // not size chunks beyond what the transport carries.
+        MessageChunker.setStringChunkBudgetFromNotifyCap(1000);
+
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+    }
+
+    @Test
+    public void notifyCapContractBoundariesAreAcceptedExactly() {
+        MessageChunker.setStringChunkBudgetFromNotifyCap(253);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(253 - 13);
+
+        MessageChunker.setStringChunkBudgetFromNotifyCap(509);
+        assertThat(MessageChunker.maxPackedStringChunkSize()).isEqualTo(509 - 13);
+    }
+
+    @Test
     public void notifyCapBelowTheContractFloorIsIgnored() {
         MessageChunker.setStringChunkBudgetFromNotifyCap(509);
         MessageChunker.setStringChunkBudgetFromNotifyCap(200);

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/communication/managers/CommunicationManagerPresenceTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/communication/managers/CommunicationManagerPresenceTest.java
@@ -1,0 +1,88 @@
+package com.mentra.asg_client.service.communication.managers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
+import com.mentra.asg_client.io.network.interfaces.INetworkManager;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * OtaHelper.PhoneConnectionProvider presence semantics: the BES-reported phone BLE presence is
+ * authoritative when known, and the historical transport-based answer is preserved verbatim when
+ * presence is UNKNOWN — the OTA and wifi flows must keep working against old BES firmware that
+ * never reports presence.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class CommunicationManagerPresenceTest {
+
+    private K900BluetoothManager transport;
+    private LinkStateMachine linkState;
+    private CommunicationManager communicationManager;
+
+    @Before
+    public void setUp() {
+        transport = mock(K900BluetoothManager.class);
+        linkState = new LinkStateMachine();
+        when(transport.getLinkStateMachine()).thenReturn(linkState);
+        communicationManager =
+                new CommunicationManager(transport, mock(INetworkManager.class));
+    }
+
+    @Test
+    public void unknownPresence_fallsBackToTransportState() {
+        // Old BES firmware: no presence signal ever arrives. Behavior must be exactly the
+        // pre-presence transport check, in both directions.
+        when(transport.isConnected()).thenReturn(true);
+        assertThat(communicationManager.isPhoneConnected()).isTrue();
+
+        when(transport.isConnected()).thenReturn(false);
+        assertThat(communicationManager.isPhoneConnected()).isFalse();
+    }
+
+    @Test
+    public void presentPresence_isAuthoritativeOverTransport() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(true);
+        when(transport.isConnected()).thenReturn(false);
+
+        assertThat(communicationManager.isPhoneConnected()).isTrue();
+    }
+
+    @Test
+    public void absentPresence_isAuthoritativeOverTransport() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(false);
+        when(transport.isConnected()).thenReturn(true);
+
+        assertThat(communicationManager.isPhoneConnected()).isFalse();
+    }
+
+    @Test
+    public void presenceInvalidation_restoresTheTransportFallback() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(false);
+        linkState.phonePresenceInvalidated();
+        when(transport.isConnected()).thenReturn(true);
+
+        assertThat(communicationManager.isPhoneConnected()).isTrue();
+    }
+
+    @Test
+    public void nonK900Transport_usesTransportState() {
+        ICompanionTransport plainTransport = mock(ICompanionTransport.class);
+        when(plainTransport.isConnected()).thenReturn(true);
+        CommunicationManager plain =
+                new CommunicationManager(plainTransport, mock(INetworkManager.class));
+
+        assertThat(plain.isPhoneConnected()).isTrue();
+    }
+}

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandlerTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhoneReadyCommandHandlerTest.java
@@ -59,7 +59,6 @@ public class PhoneReadyCommandHandlerTest {
         assertThat(handled).isTrue();
         verify(transport).onTransportReset();
         verify(communicationManager).sendBluetoothResponse(any(JSONObject.class));
-        verify(serviceManager).onPhoneReadyHandshakeComplete();
     }
 
     @Test
@@ -70,7 +69,6 @@ public class PhoneReadyCommandHandlerTest {
 
         assertThat(handled).isTrue();
         verify(communicationManager).sendBluetoothResponse(any(JSONObject.class));
-        verify(serviceManager).onPhoneReadyHandshakeComplete();
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/subscribers/ButtonEventSubscriberTest.java
@@ -1,0 +1,125 @@
+package com.mentra.asg_client.service.core.handlers.subscribers;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.mentra.asg_client.io.bluetooth.interfaces.ICompanionTransport;
+import com.mentra.asg_client.io.bluetooth.managers.K900BluetoothManager;
+import com.mentra.asg_client.io.bluetooth.managers.mentralive.internal.LinkStateMachine;
+import com.mentra.asg_client.io.hardware.interfaces.IHardwareManager;
+import com.mentra.asg_client.io.media.core.MediaCaptureService;
+import com.mentra.asg_client.io.peripheral.events.ButtonEvent;
+import com.mentra.asg_client.service.legacy.managers.AsgClientServiceManager;
+import com.mentra.asg_client.service.system.interfaces.IStateManager;
+import com.mentra.asg_client.settings.AsgSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+/**
+ * Local-capture gating on the BES-reported phone BLE presence tri-state: PRESENT defers to the
+ * phone; ABSENT and UNKNOWN (old BES firmware) fall back to local capture — the safe default is a
+ * possible duplicate photo, never a lost one.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 33)
+public class ButtonEventSubscriberTest {
+
+    private AsgClientServiceManager serviceManager;
+    private MediaCaptureService captureService;
+    private K900BluetoothManager bluetoothManager;
+    private LinkStateMachine linkState;
+    private ButtonEventSubscriber subscriber;
+
+    @Before
+    public void setUp() {
+        serviceManager = mock(AsgClientServiceManager.class);
+        captureService = mock(MediaCaptureService.class);
+        bluetoothManager = mock(K900BluetoothManager.class);
+        AsgSettings asgSettings = mock(AsgSettings.class);
+        linkState = new LinkStateMachine();
+
+        when(serviceManager.getAsgSettings()).thenReturn(asgSettings);
+        when(serviceManager.getMediaCaptureService()).thenReturn(captureService);
+        when(serviceManager.getBluetoothManager()).thenReturn(bluetoothManager);
+        when(bluetoothManager.getLinkStateMachine()).thenReturn(linkState);
+        // Keep the forward-to-phone path inert; this suite only exercises the capture gate.
+        when(bluetoothManager.isConnected()).thenReturn(false);
+        when(asgSettings.isSaveInGalleryMode()).thenReturn(false);
+        when(asgSettings.getButtonPhotoSize()).thenReturn("medium");
+        when(captureService.isRecordingVideo()).thenReturn(false);
+
+        subscriber =
+                new ButtonEventSubscriber(
+                        serviceManager, mock(IHardwareManager.class), mock(IStateManager.class));
+    }
+
+    private void shortPress() {
+        subscriber.onMcuEvent(new ButtonEvent(ButtonEvent.Type.CAMERA_SHORT_PRESS));
+    }
+
+    @Test
+    public void phonePresent_skipsLocalCapture() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(true);
+
+        shortPress();
+
+        verify(captureService, never()).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void phoneAbsent_capturesLocally() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(false);
+
+        shortPress();
+
+        verify(captureService).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void presenceUnknown_capturesLocally() {
+        // Old BES firmware never reports presence — UNKNOWN must behave like "no phone".
+        shortPress();
+
+        verify(captureService).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void presenceUnknownAfterSerialClose_capturesLocally() {
+        linkState.serialReady();
+        linkState.phonePresenceReported(true);
+        linkState.serialClosed();
+
+        shortPress();
+
+        verify(captureService).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void galleryModeActive_capturesLocallyEvenWithPhonePresent() {
+        when(serviceManager.getAsgSettings().isSaveInGalleryMode()).thenReturn(true);
+        linkState.serialReady();
+        linkState.phonePresenceReported(true);
+
+        shortPress();
+
+        verify(captureService).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    public void nonK900Transport_treatedAsUnknown_capturesLocally() {
+        when(serviceManager.getBluetoothManager()).thenReturn(mock(ICompanionTransport.class));
+
+        shortPress();
+
+        verify(captureService).takePhotoLocally(anyString(), anyBoolean(), anyBoolean());
+    }
+}

--- a/asg_client/docs/features/button-press-system.md
+++ b/asg_client/docs/features/button-press-system.md
@@ -37,18 +37,23 @@ Whether the button _also_ captures a photo/video locally is governed by a single
 
 ### Decision rules
 
+The "connected" input is the **BES-reported phone BLE presence** read from the transport `LinkStateMachine` (`ButtonEventSubscriber.phonePresence()`), a tri-state — not the old heartbeat-inferred flag (deleted):
+
 ```
-isSaveInGalleryMode  isConnected       Local capture?
-       true               *                 yes
-       false              true              no — phone app handles it
-       false              false             yes — fallback so disconnected glasses still capture
+isSaveInGalleryMode  phone presence      Local capture?
+       true               *                  yes
+       false              PRESENT            no — phone app handles it
+       false              ABSENT             yes — so the press isn't lost
+       false              UNKNOWN            yes — treated as no phone (safe default)
 ```
 
 In words:
 
 - **Gallery mode active** → always capture locally.
-- **Gallery mode inactive but glasses connected to phone** → skip local capture (the phone routes the press to apps).
-- **Gallery mode inactive and glasses disconnected** → still capture locally so a press isn't lost.
+- **Gallery mode inactive and the BES reports a phone present** → skip local capture (the phone routes the press to apps).
+- **Gallery mode inactive, phone absent or presence unknown** → capture locally so a press isn't lost.
+
+Presence is reported by BES firmware >= 17.26.7.23 (`sr_phble` edges, `phone_ble` sync in `sr_syvr`). **Older BES firmware never reports presence, so on the deployed fleet presence stays `UNKNOWN` and the glasses always capture locally when gallery mode is off** — the accepted trade-off is a possible duplicate capture (glasses and phone app both capture), never a lost photo. Presence resets to `UNKNOWN` on serial close and BES OTA.
 
 ### Persistence
 
@@ -124,7 +129,7 @@ The phone app sets button-related settings via the [API commands](../ASG_CLIENT_
 
 ## Troubleshooting
 
-- **Press doesn't capture locally** — check `📸 Photo capture decision` log line in `K900CommandHandler` for `Gallery Mode` and `Connection State`. If gallery mode is INACTIVE and connection state is CONNECTED, that's expected — the phone will route the press to apps but won't capture locally. Toggle gallery mode on the phone or disconnect to verify.
+- **Press doesn't capture locally** — check the `📸 Photo capture decision` log line in `ButtonEventSubscriber` for `Gallery Mode` and `Phone presence`. If gallery mode is INACTIVE and presence is PRESENT, that's expected — the phone routes the press to apps but the glasses don't capture. Toggle gallery mode on the phone or disconnect to verify. Note: PRESENT requires BES firmware >= 17.26.7.23; on older firmware presence is UNKNOWN and local capture always happens.
 - **Press doesn't reach apps** — verify a `button_press` JSON is being sent over BLE. If not, check that the `cs_pho` / `cs_vdo` / `hs_ntfy` packet is arriving at all (TAG: `K900CommandHandler`, `📦 Received K900 command`).
 - **Long press doesn't start video** — check battery level; recording is rejected below `BatteryConstants.MIN_BATTERY_LEVEL` (10%) with an audio cue.
 - **Recording auto-stops too soon** — check `button_max_recording_time` setting; the default is 10 minutes.

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -87,13 +87,15 @@ Mentra Live supports photo capture and video recording from the glasses camera.
 
 ### Gallery-mode behavior
 
-The phone controls whether a physical button press should capture locally through `save_in_gallery_mode`:
+The phone controls whether a physical button press should capture locally through `save_in_gallery_mode`. The "phone connected" input to that decision is the **BES-reported phone BLE presence** (BES firmware >= 17.26.7.23 reports `sr_phble` connect/disconnect edges and syncs `phone_ble` in every `sr_syvr` reply), which is a tri-state: `PRESENT`, `ABSENT`, or `UNKNOWN` when no signal has arrived — old BES firmware never reports presence, so on the deployed fleet the value stays `UNKNOWN`.
 
-| Gallery mode | Phone connected | Local capture behavior |
+| Gallery mode | Phone presence | Local capture behavior |
 | --- | --- | --- |
-| Enabled | Either | Capture locally. |
-| Disabled | Connected | Do not capture locally; forward the press and let the phone/app flow handle it. |
-| Disabled | Disconnected | Capture locally as a fallback so the user action is not lost. |
+| Enabled | Any | Capture locally. |
+| Disabled | `PRESENT` | Do not capture locally; forward the press and let the phone/app flow handle it. |
+| Disabled | `ABSENT` or `UNKNOWN` | Capture locally so the user action is not lost. |
+
+`UNKNOWN` is deliberately treated as "no phone": the accepted trade-off is a possible duplicate capture (glasses and phone app both capture) rather than a lost photo. In particular, on BES firmware without presence reporting, disabling gallery mode does **not** suppress local capture even while a phone is connected.
 
 Every camera-button press should still be forwarded to the phone as a `button_press` event regardless of the local-capture decision.
 


### PR DESCRIPTION
## What

First consumption PR for the BES phone-presence + negotiated-caps firmware contract (BES PR #20, firmware **17.26.7.23** — not yet on any device; retrocompat against the deployed fleet is designed in throughout). Builds on the reified `LinkStateMachine` (#3591).

## The consumed BES contract (fixed)

| Signal | Shape | Meaning |
|---|---|---|
| `sr_phble` | spontaneous UART C-command `{"C":"sr_phble","S":0,"B":{"on":1}}` / `{"on":0}` | Phone BLE connect/disconnect edge from the BES datapath handlers ("connected" = first CCC enable) |
| `phone_ble` | `0\|1` in the `sr_syvr` reply body, next to `dpj` | Boot/wake/recovery sync of the current presence value |
| `notify_cap` | in `wire_caps`, `max(253, min(negotiated ATT MTU − 3, 509))` | True max single-notification payload the BES delivers to the phone |

Old BES firmware sends **none** of these.

## Changes

1. **`PhonePresence` tri-state in `LinkStateMachine`** (`UNKNOWN`/`PRESENT`/`ABSENT`), orthogonal to the `SERIAL_CLOSED→SERIAL_OPEN→LINK_PROVEN` ladder. Driven by `sr_phble` (handled directly in `K900BluetoothManager` on both the string and binary dispatch chains, same early-handling pattern as `sr_syvr`) and by `phone_ble` in `sr_syvr`. Resets to `UNKNOWN` on serial close and on BES OTA (the reboot drops the BES phone link); deliberately **survives `streamDiscontinuity()`** — a baud reopen invalidates the ASG↔BES byte stream, not the BES↔phone BLE link. Delivered through the existing queued listener dispatch: the listener signature gains the presence value, keeping the FIFO-order and replay-on-subscribe guarantees for all three facts.
2. **Button local-capture gate** (`ButtonEventSubscriber`) reads presence instead of the heartbeat-inferred flag: `PRESENT` → phone handles the press (unless the gallery app is active); `ABSENT` **or `UNKNOWN`** → local capture.
3. **Heartbeat-inference machinery deleted outright** (ledger below).
4. **Negotiated v1 string-chunk budget**: `notify_cap` rides the `BesCaps` snapshot; budget = `notify_cap − 13` (same BES re-framing margin the 240-byte fallback encodes: 240 = 253 − 13), fallback 240 when absent, advertisements clamped to the contract range [253, 509]. The budget follows the machine's caps snapshot via a `MessageChunker.followLinkState()` subscription, and `notify_cap` has its own tighter lifecycle — validity = UART session ∩ phone BLE session ∩ firmware generation: it is dropped on serial close, on every phone-presence edge (a new phone session renegotiates the ATT MTU; only a fresh advertisement re-arms it), and on BES OTA. `AsgConstants.K900_STRING_CHUNK_MAX_FRAME_BYTES` stays as the documented fallback.
5. **`OtaHelper` phone-connection provider** (`CommunicationManager.isPhoneConnected()`): presence is authoritative when known; when `UNKNOWN` the historical transport-based answer is preserved **verbatim**.

## Heartbeat deletion ledger

A consumer audit showed `ButtonEventSubscriber.handlePhotoCapture` was the **only** consumer of the heartbeat-inferred connection flag, so the machinery is deleted rather than kept in parallel:

| Deleted | Where |
|---|---|
| `isConnected` field + `isConnected()` getter | `AsgClientService` |
| `resetHeartbeatTimeout()`, `startHeartbeatMonitoring()`, `stopHeartbeatMonitoring()` + their call sites | `AsgClientService` |
| heartbeat timeout `Handler`/`Runnable`, `HEARTBEAT_TIMEOUT_MS`, unused `ACTION_HEARTBEAT`/`ACTION_HEARTBEAT_ACK` constants | `AsgClientService` |
| `onPhoneReadyHandshakeComplete()`, `onPhoneCommandReceived()`, `onServiceHeartbeatReceived()` pass-throughs + `isConnected()` wrapper | `AsgClientServiceManager` |
| reset-call sites | `CommandProcessor` (×2), `PingCommandHandler`, `ServiceHeartbeatCommandHandler`, `PhoneReadyCommandHandler` |

**Kept**: `ServiceHeartbeatCommandHandler` as a plain ack path, the ping→pong reply, the OTA-updater intent heartbeat (`ServiceHeartbeatReceiver` — a different mechanism), and everything phone-side.

**Scoping rationale (Philippe)**: retrocompat is only *required* for the wifi scan/set and OTA flows; button/gallery logic gets the safe local-capture default (worst case a duplicate photo, never a lost one) and explicitly does not require old-BES retrocompat. Audited the wifi scan/set handlers: they read `stateManager.isConnectedToWifi()` (network state), not the deleted flag.

## Old-BES degradation table (presence stays UNKNOWN forever)

| Consumer | On UNKNOWN | vs. today's behavior |
|---|---|---|
| Button local capture | capture locally (treat as no phone) | Was heartbeat-inferred; now deterministic safe default. Duplicate possible when a phone is actually connected; no photo can be lost |
| `OtaHelper.isPhoneConnected()` | transport-based check, unchanged | Identical (retrocompat-mandatory path) |
| Wifi scan/set | not presence-consumers | Identical |
| v1 chunk budget | 240-byte fallback | Identical |
| `LinkStateMachine` listeners | receive `UNKNOWN` | New surface |

## Tests

- `LinkStateMachineTest`: presence tri-state transitions (edges, duplicate-report no-op, serial-close→UNKNOWN, invalidation, discontinuity-survival, replay-on-subscribe), `notify_cap` accrual rules — 33 tests
- `ButtonEventSubscriberTest`: gating on PRESENT / ABSENT / UNKNOWN / serial-close / gallery-mode / non-K900 transport — 6 tests
- `StringChunkBudgetTest`: 240 fallback, `notify_cap − 13`, contract-floor rejection, reset, round-trip under a raised budget — 8 tests
- `CommunicationManagerPresenceTest`: UNKNOWN falls back to transport verbatim (both directions), PRESENT/ABSENT authoritative, invalidation restores fallback — 5 tests

```
./gradlew :app:testDebugUnitTest compileDebugJavaWithJavac
# BUILD SUCCESSFUL — 611 tests, 0 failures
```

## Pending

**Hardware verification against BES 17.26.7.23 is pending** — the fleet (and bench units) are still on older BES firmware, so the new-firmware halves of these paths (`sr_phble` edges, `phone_ble` sync, `notify_cap` budgets) have unit coverage only. The old-firmware halves are the deployed behavior and are covered by the degradation table above.
