### PR TITLE
Ship BES 17.26.07.23 in the live firmware manifest

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.22",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.07.23.bin",
-    "sha256": "c853166f6fdccb4cc1dd8fe9cb3c8cfebaffbb183aa7197ba3e9300b96b866c2"
+    "version": "17.26.07.23",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.07.24.bin",
+    "sha256": "e1e5ecc67a5cf3ad0092a6a044c5aecaaaee8ab19ed1b61c3b47e3c0efcd4f6f"
   }
 }


### PR DESCRIPTION
Bumps the live firmware manifest to BES **17.26.07.23**, carrying BES PR fengyue120/mentra-live-bes#20: `sr_phble`/`phone_ble` phone presence, the UART→BLE relay endianness fix, `notify_cap` in `wire_caps`, and the wire proxy contract doc. Pairs with consumption PR #3593.

**Artifact verified end-to-end:** `best1502x_ibrt_bpone_lzma_crc32.bin` (1,138,312 bytes) from release [`main-20260724-80eb1496`](https://github.com/fengyue120/mentra-live-bes/releases/tag/main-20260724-80eb1496), deployed to the CDN as [`bes_firmware_26.07.24.bin`](https://firmwarecdn.mentraglass.com/bes_firmware_26.07.24.bin); sha256 `e1e5ecc67a5cf3ad0092a6a044c5aecaaaee8ab19ed1b61c3b47e3c0efcd4f6f` matches both the release asset (computed locally) and the CDN's `latest.json`.

This is the gate flagged at program start: the manifest must reference the new BES **before merging dev → staging** so the prod train ships app + ASG + BES coherently. Note: if the raw-v2-relay BES PR (in progress) lands before the train, this bump should advance to `.24` instead — flagged for that decision point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong URL or hash in the live manifest would push incorrect BES bits to field devices via OTA; scope is limited to manifest metadata with no application code changes.
> 
> **Overview**
> Updates the **live** OTA manifest’s `bes_firmware` entry from **17.26.07.22** to **17.26.07.23**, pointing devices at the new CDN artifact `bes_firmware_26.07.24.bin` with an updated **sha256**. **MTK patch list is unchanged.**
> 
> This is the production gate so the release train can ship ASG/app and BES firmware together; SDK OTA manifest generation reads this file’s `bes_firmware` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efb2e0839f125f568652ae67c2a903c79d0b6a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->