### PR TITLE
Fix take-photo process crash from abandoned camera surfaces (OS-1816)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -68,6 +68,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class CameraNeoService extends LifecycleService {
     private static final String TAG = "CameraNeo";
@@ -1556,6 +1557,20 @@ public class CameraNeoService extends LifecycleService {
      */
     private CameraDevice.StateCallback newCameraOpenStateCallback(final boolean forVideo) {
         return new CameraDevice.StateCallback() {
+            // The in-flight open owns exactly one open/close permit, surrendered to the
+            // FIRST terminal callback. onDisconnected/onError also fire long after
+            // onOpened (HAL eviction, cable events); an unconditional release there
+            // inflated the Semaphore(1) past one permit, after which the open/close
+            // lock excluded nothing and teardown could interleave with any open — the
+            // cheap way to hit the OS-1816 crash repeatedly.
+            private final AtomicBoolean openPermitReleased = new AtomicBoolean(false);
+
+            private void releaseOpenPermitOnce() {
+                if (openPermitReleased.compareAndSet(false, true)) {
+                    cameraCoordinator.releaseOpenCloseLock();
+                }
+            }
+
             @Override
             public void onOpened(@NonNull CameraDevice camera) {
                 Log.d(TAG, "Camera device opened successfully");
@@ -1568,14 +1583,14 @@ public class CameraNeoService extends LifecycleService {
                 try {
                     createCameraSessionInternal(forVideo);
                 } finally {
-                    cameraCoordinator.releaseOpenCloseLock();
+                    releaseOpenPermitOnce();
                 }
             }
 
             @Override
             public void onDisconnected(@NonNull CameraDevice camera) {
                 Log.d(TAG, "Camera device disconnected");
-                cameraCoordinator.releaseOpenCloseLock();
+                releaseOpenPermitOnce();
                 camera.close();
                 cameraCoordinator.clearDevice();
                 if (forVideo) {
@@ -1597,7 +1612,7 @@ public class CameraNeoService extends LifecycleService {
                                 + " (Android code "
                                 + error
                                 + ")");
-                cameraCoordinator.releaseOpenCloseLock();
+                releaseOpenPermitOnce();
                 camera.close();
                 cameraCoordinator.clearDevice();
                 if (forVideo) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1504,8 +1504,17 @@ public class CameraNeoService extends LifecycleService {
             }
 
             Log.d(TAG, "Opening camera ID: " + this.cameraId);
-            manager.openCamera(
-                    this.cameraId, newCameraOpenStateCallback(forVideo), backgroundHandler);
+            try {
+                manager.openCamera(
+                        this.cameraId, newCameraOpenStateCallback(forVideo), backgroundHandler);
+            } catch (Exception e) {
+                // The state callback owns the permit only once the open is in flight. If
+                // openCamera throws synchronously no callback will ever fire, so release
+                // here or every later open times out and every close falls into the
+                // 5s proceed-anyway teardown.
+                cameraCoordinator.releaseOpenCloseLock();
+                throw e;
+            }
 
         } catch (CameraAccessException e) {
             // Handle camera access exceptions more specifically
@@ -1694,7 +1703,13 @@ public class CameraNeoService extends LifecycleService {
                                 try {
                                     videoSession.startRecording(
                                             cameraCoordinator.session(), previewBuilder);
-                                } catch (CameraAccessException ce) {
+                                } catch (CameraAccessException
+                                        | IllegalArgumentException
+                                        | IllegalStateException ce) {
+                                    // IllegalArgumentException: the recorder surface was
+                                    // released by a racing teardown. IllegalStateException:
+                                    // the session was closed under us. Same crash family as
+                                    // the photo path (OS-1816).
                                     Log.e(TAG, "Failed to start video recording", ce);
                                     notifyVideoError(
                                             videoSession.currentVideoId(),

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1550,10 +1550,17 @@ public class CameraNeoService extends LifecycleService {
             @Override
             public void onOpened(@NonNull CameraDevice camera) {
                 Log.d(TAG, "Camera device opened successfully");
-                cameraCoordinator.releaseOpenCloseLock();
                 cameraCoordinator.setDevice(camera);
 
-                createCameraSessionInternal(forVideo);
+                // Hold the open/close lock until the session surfaces have been handed to
+                // the framework: releasing it first lets closeCamera() close the
+                // ImageReaders on another thread mid-setup, abandoning the surfaces this
+                // session is about to wrap (OS-1816).
+                try {
+                    createCameraSessionInternal(forVideo);
+                } finally {
+                    cameraCoordinator.releaseOpenCloseLock();
+                }
             }
 
             @Override
@@ -1768,6 +1775,16 @@ public class CameraNeoService extends LifecycleService {
             Log.e(TAG, "Illegal state in createCameraSessionInternal", e);
             if (forVideo) notifyVideoError(videoSession.currentVideoId(), "Camera illegal state");
             else photoSession.notifyHostPhotoError("Camera illegal state");
+            conditionalStopSelf();
+        } catch (IllegalArgumentException e) {
+            // A teardown that raced this setup abandons the reader/recorder surfaces;
+            // OutputConfiguration and createCaptureSession then throw
+            // IllegalArgumentException ("Surface was abandoned"). Fail the request
+            // instead of crashing the process (OS-1816).
+            Log.e(TAG, "Camera surface no longer valid in createCameraSessionInternal", e);
+            if (forVideo)
+                notifyVideoError(videoSession.currentVideoId(), "Camera surface no longer valid");
+            else photoSession.notifyHostPhotoError("Camera surface no longer valid");
             conditionalStopSelf();
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1724,11 +1724,16 @@ public class CameraNeoService extends LifecycleService {
                                     // IllegalArgumentException: the recorder surface was
                                     // released by a racing teardown. IllegalStateException:
                                     // the session was closed under us. Same crash family as
-                                    // the photo path (OS-1816).
+                                    // the photo path (OS-1816). Tear down like
+                                    // onConfigureFailed does — reporting the error while
+                                    // leaving device/session/recorder alive would hold the
+                                    // camera hostage for every later open.
                                     Log.e(TAG, "Failed to start video recording", ce);
                                     notifyVideoError(
                                             videoSession.currentVideoId(),
                                             "Failed to start recording: " + ce.getMessage());
+                                    closeCamera();
+                                    conditionalStopSelf();
                                 }
                             } else {
                                 Log.d(TAG, "Camera session configured and ready");

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -1824,7 +1824,10 @@ public final class PhotoSession {
 
             startPrecaptureSequence();
 
-        } catch (CameraAccessException e) {
+        } catch (CameraAccessException | IllegalArgumentException | IllegalStateException e) {
+            // IllegalArgumentException: a teardown racing this call abandoned the preview
+            // surface ("Surface was abandoned", OS-1816). IllegalStateException: the session
+            // was closed under us. Both must fail the request, not crash the process.
             Log.e(TAG, "Error starting preview with AE monitoring", e);
             if (warmUpRequest != null) {
                 failWarmUp(
@@ -2409,7 +2412,9 @@ public final class PhotoSession {
                     // Dedicated thread: ImageReader JPEG work must not delay HAL timing callbacks.
                     stillCaptureCallbackHandler());
 
-        } catch (CameraAccessException e) {
+        } catch (CameraAccessException | IllegalArgumentException | IllegalStateException e) {
+            // IllegalArgumentException: the still surface was abandoned by a racing
+            // teardown (OS-1816). IllegalStateException: the session was closed under us.
             Log.e(TAG, "Error during photo capture", e);
             notifyPhotoError("Error capturing photo: " + e.getMessage());
             hooks.cancelImuRecording();
@@ -2476,7 +2481,9 @@ public final class PhotoSession {
                         }
                     });
 
-        } catch (CameraAccessException e) {
+        } catch (CameraAccessException | IllegalArgumentException | IllegalStateException e) {
+            // Same teardown races as capturePhoto(): abandoned still surface or closed
+            // session must fail the burst, not crash the process (OS-1816).
             Log.e(TAG, "Error during HDR burst capture", e);
             hdrBurstCapture.cancel();
             hooks.cancelImuRecording();


### PR DESCRIPTION
## Scope

Point-fix for OS-1816: `take_photo` intermittently kills the whole `com.mentra.asg_client` process (reported 1-in-3-5 captures on 0.1.21-beta.0) with

```
FATAL EXCEPTION: CameraNeoBackground
java.lang.IllegalArgumentException: Surface was abandoned
    at android.hardware.camera2.params.OutputConfiguration.<init>
    at CameraNeoService.createCameraSessionInternal
    at CameraNeoService$4.onOpened
```

The process death also takes down the BLE bridge, which is why the SDK caller sees requests hang.

## Root cause

`onOpened` released the open/close lock **before** building the capture session, so any of the many cross-thread `closeCamera()` callers (keep-alive expiry, kept-alive eviction from video/stream starts, service destroy) could close the `ImageReader`s in that window. `OutputConfiguration.<init>` then throws `IllegalArgumentException("Surface was abandoned")`, which none of the photo-path call sites caught.

## Changes

- `onOpened` holds the open/close lock through `createCameraSessionInternal` (released in `finally`), so teardown serializes with session setup.
- `createCameraSessionInternal`, `capturePhoto`, `startPreviewWithAeMonitoring`, `captureHdrBurst`, and the video `startRecording` call in `onConfigured` now catch `IllegalArgumentException` (abandoned surface) and `IllegalStateException` (session closed under us) and fail the request through the normal error path instead of crashing.
- Fixed an open/close-semaphore permit leak: a synchronous throw from `CameraManager.openCamera` meant no state callback would ever fire and the permit was never released — every later open then timed out and every close fell into the 5s "proceed anyway" unguarded teardown.

A follow-up PR confines all camera teardown to the camera thread so this race class can't recur; this PR is the minimal crash stop.

## Test evidence

- `./scripts/check-android-compile.sh asg` green
- `./gradlew :app:testDebugUnitTest` green (628 tests, 0 failures)
- Not yet verified on hardware; the race needs the reporter's cadence to reproduce. The defensive catches convert any residual race into a photo error + camera close, which the SDK already handles as a failed request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches critical camera open/close synchronization and error paths on the ASG client; behavior change is intentional (failed capture vs process death) but race timing is hard to reproduce on hardware.
> 
> **Overview**
> Fixes **OS-1816**, where intermittent `take_photo` could crash `com.mentra.asg_client` with `IllegalArgumentException: Surface was abandoned` during capture session setup, taking down the BLE bridge.
> 
> **Locking:** `onOpened` now keeps the open/close lock through `createCameraSessionInternal` (released in `finally`) so `closeCamera()` cannot tear down `ImageReader`s mid-setup. The open callback uses **release-open-permit-once** so `onDisconnected`/`onError` cannot double-release the semaphore after a successful open.
> 
> **Permit leak:** If `CameraManager.openCamera` throws synchronously, the lock is released immediately (no state callback would run).
> 
> **Defensive handling:** Photo and video paths catch `IllegalArgumentException` and `IllegalStateException` at session creation, preview start, still/HDR capture, and video `startRecording`, failing the request and tearing down instead of crashing. Video recording errors also call `closeCamera()` so the HAL is not left wedged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62699ccaeb305b3ee75a4a99eab740be62e9aaec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->