### PR TITLE
Confine camera teardown to the camera thread (OS-1816 follow-up)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -47,6 +47,13 @@ public class AsgConstants {
     public static final long CAMERA_FOV_OVERRIDE_DEFAULT_TTL_MS = 300_000L;
     public static final long CAMERA_FOV_OVERRIDE_MAX_TTL_MS = 600_000L;
 
+    /**
+     * How long a caller evicting the kept-alive camera waits for the camera-thread close
+     * to finish before proceeding. Slightly above closeCamera's own 5s open/close-lock
+     * timeout so the wait can only expire after the close itself gave up.
+     */
+    public static final long CAMERA_TEARDOWN_AWAIT_MS = 6_000L;
+
     public static String appName = "AugmentOS ASG Client";
     public static int augmentOsSdkVerion = 1;
     public static int asgServiceNotificationId = 3540;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1492,6 +1492,10 @@ public class CameraNeoService extends LifecycleService {
                     notifyVideoError(
                             videoSession.currentVideoId(),
                             "Failed to set up video recorder: " + ioe.getMessage());
+                    // Without the recorder surface the open can only fail again later
+                    // with a second, more confusing error — stop here.
+                    conditionalStopSelf();
+                    return;
                 }
             } else {
                 // For photos, find the closest available JPEG size to our target
@@ -1588,11 +1592,16 @@ public class CameraNeoService extends LifecycleService {
             stopSelf();
         } catch (InterruptedException e) {
             Log.e(TAG, "Interrupted while trying to lock camera", e);
-            photoSession.notifyHostPhotoError("Camera operation interrupted");
+            if (forVideo) notifyVideoError(videoSession.currentVideoId(), "Camera operation interrupted");
+            else photoSession.notifyHostPhotoError("Camera operation interrupted");
             stopSelf();
         } catch (Exception e) {
             Log.e(TAG, "Error setting up camera", e);
-            photoSession.notifyHostPhotoError("Error setting up camera: " + e.getMessage());
+            if (forVideo)
+                notifyVideoError(
+                        videoSession.currentVideoId(),
+                        "Error setting up camera: " + e.getMessage());
+            else photoSession.notifyHostPhotoError("Error setting up camera: " + e.getMessage());
             stopSelf();
         }
     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1338,10 +1338,6 @@ public class CameraNeoService extends LifecycleService {
         warmLeaseDeadlineMs = latest;
     }
 
-    private void setupCameraForQueuedRequest(QueuedPhotoRequest request) {
-        photoSession.setupCameraForQueuedRequest(request);
-    }
-
     private void setupCameraAndStartRecording(
             String videoId, String filePath, VideoSettings settings) {
         videoSession.setCallback(videoSessionCallback);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -504,15 +504,36 @@ public class CameraNeoService extends LifecycleService {
      * @return true if camera was closed, false if camera was busy or not open
      */
     public static boolean closeKeptAliveCamera() {
-        if (sInstance != null
-                && sInstance.cameraCoordinator.isCameraKeptAlive()
-                && sInstance.photoSession.shotState() == AeStateMachine.ShotState.IDLE) {
-            Log.d(TAG, "Force closing kept-alive camera for other operation");
-            sInstance.cameraCoordinator.closeIfKeptAlive(sInstance::closeCamera);
-            sInstance.stopSelf();
-            return true;
+        // Snapshot: onDestroy nulls sInstance concurrently with this caller-thread check.
+        CameraNeoService instance = sInstance;
+        if (instance == null
+                || !instance.cameraCoordinator.isCameraKeptAlive()
+                || instance.photoSession.shotState() != AeStateMachine.ShotState.IDLE) {
+            return false;
         }
-        return false;
+        Log.d(TAG, "Force closing kept-alive camera for other operation");
+        // The close runs on the camera thread so it cannot interleave with an in-flight
+        // open/session setup there. Callers (video/stream starts) rely on the eviction
+        // having completed before they open their own camera, so wait for it. The
+        // SERVICE_LOCK re-check drops the eviction if a photo raced in since the
+        // advisory check above — previously that race tore the camera down mid-dispatch.
+        boolean[] closed = {false};
+        instance.cameraCoordinator.awaitOnCameraThread(
+                () -> {
+                    synchronized (SERVICE_LOCK) {
+                        if (instance.photoSession.shotState() != AeStateMachine.ShotState.IDLE) {
+                            Log.d(TAG, "Kept-alive eviction dropped; a capture started");
+                            return;
+                        }
+                        closed[0] =
+                                instance.cameraCoordinator.closeIfKeptAlive(instance::closeCamera);
+                        if (closed[0]) {
+                            instance.stopSelf();
+                        }
+                    }
+                },
+                AsgConstants.CAMERA_TEARDOWN_AWAIT_MS);
+        return closed[0];
     }
 
     @Override
@@ -565,8 +586,14 @@ public class CameraNeoService extends LifecycleService {
 
                 @Override
                 public void onSessionTerminated() {
-                    closeCamera();
-                    conditionalStopSelf();
+                    // Video stop paths land here on the main thread (stop intent,
+                    // MediaRecorder info listener, onDestroy); the close itself must run
+                    // on the camera thread so it cannot race session setup there.
+                    cameraCoordinator.runOnCameraThread(
+                            () -> {
+                                closeCamera();
+                                conditionalStopSelf();
+                            });
                 }
             };
 
@@ -971,14 +998,12 @@ public class CameraNeoService extends LifecycleService {
                     sInstance.openingWarmMode = null;
                     sInstance.photoSession.cancelWarmUp();
                     sInstance.cancelKeepAliveTimer();
-                    sInstance.closeCamera();
-                    sInstance.stopSelf();
+                    sInstance.closeCameraFromWarmTeardown();
                 } else if (lease != null) {
                     if (sInstance.warmLeases.isEmpty()) {
                         sInstance.warmLeaseMode = null;
                         sInstance.cancelKeepAliveTimer();
-                        sInstance.closeCamera();
-                        sInstance.stopSelf();
+                        sInstance.closeCameraFromWarmTeardown();
                     } else {
                         sInstance.armWarmLeaseTimer();
                     }
@@ -992,6 +1017,27 @@ public class CameraNeoService extends LifecycleService {
         if (stopped != null) {
             stopped.onCameraStopped();
         }
+    }
+
+    /**
+     * Warm-up teardown: the bookkeeping that decided to close ran under SERVICE_LOCK on
+     * the caller's thread, but the close itself belongs on the camera thread. Re-check
+     * there — a warm-up or photo that raced in after the decision must keep its camera.
+     */
+    private void closeCameraFromWarmTeardown() {
+        cameraCoordinator.runOnCameraThread(
+                () -> {
+                    synchronized (SERVICE_LOCK) {
+                        if (!warmCallbacks.isEmpty()
+                                || !warmLeases.isEmpty()
+                                || photoSession.shotState() != AeStateMachine.ShotState.IDLE) {
+                            Log.d(TAG, "Warm teardown superseded; leaving camera open");
+                            return;
+                        }
+                        closeCamera();
+                        stopSelf();
+                    }
+                });
     }
 
     private static long clampWarmUpDuration(long durationMs) {
@@ -1848,7 +1894,10 @@ public class CameraNeoService extends LifecycleService {
             if (videoSession != null && videoSession.isRecording()) {
                 videoSession.stopRecording(videoSession.currentVideoId());
             }
-            closeCamera();
+            // The close runs on the camera thread; stopBackgroundThread() below drains
+            // the queue before joining, so the close is guaranteed to have completed
+            // before onDestroy returns.
+            cameraCoordinator.runOnCameraThread(this::closeCamera);
             releaseWakeLocks();
 
             sInstance = null;
@@ -1989,8 +2038,10 @@ public class CameraNeoService extends LifecycleService {
             if (close) {
                 warmLeaseMode = null;
                 if (closeWhenEmpty) {
-                    closeCamera();
-                    stopSelf();
+                    // Post-capture completion paths reach here on the StillCaptureCb or
+                    // dispatch threads; the confined close also re-checks that no new
+                    // capture/warm-up raced in before actually closing.
+                    closeCameraFromWarmTeardown();
                 }
             } else {
                 armWarmLeaseTimer();
@@ -2049,19 +2100,28 @@ public class CameraNeoService extends LifecycleService {
 
     /** Attempt to restart the camera service with different parameters if needed */
     private void restartCameraServiceIfNeeded() {
+        // The helper's delayed retry runs on the main looper; route the device/session
+        // close it performs onto the camera thread — a bare main-thread close here was
+        // one of the unguarded teardowns that raced session setup (OS-1816 family).
         CameraRecoveryHelper.restartCameraServiceIfNeeded(
                 this::releaseCameraResources,
                 this,
                 () -> cameraId,
                 id -> cameraId = id,
                 this::wakeUpScreen,
-                () -> cameraCoordinator.closeDeviceAndSession());
+                () ->
+                        cameraCoordinator.runOnCameraThread(
+                                () -> cameraCoordinator.closeDeviceAndSession()));
     }
 
     /** Release all camera system resources */
     private void releaseCameraResources() {
         CameraRecoveryHelper.releaseCameraResources(
-                this::closeCamera, () -> cameraCoordinator.closeDeviceAndSession(), this);
+                () -> cameraCoordinator.runOnCameraThread(this::closeCamera),
+                () ->
+                        cameraCoordinator.runOnCameraThread(
+                                () -> cameraCoordinator.closeDeviceAndSession()),
+                this);
     }
 
     // -----------------------------------------------------------------------------------

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BooleanSupplier;
@@ -17,11 +18,14 @@ public final class CameraCoordinator {
 
     private static final String TAG = "CameraCoordinator";
 
-    private HandlerThread backgroundThread;
-    private Handler backgroundHandler;
-    private CameraDevice device;
-    private CameraCaptureSession session;
-    private Timer keepAliveTimer;
+    // Volatile: mutated on the camera thread but still read from caller threads
+    // (advisory state checks, keep-alive TimerTask) — plain fields gave those
+    // readers no visibility guarantee at all.
+    private volatile HandlerThread backgroundThread;
+    private volatile Handler backgroundHandler;
+    private volatile CameraDevice device;
+    private volatile CameraCaptureSession session;
+    private volatile Timer keepAliveTimer;
     private volatile boolean cameraKeptAlive;
     private final Semaphore openCloseLock = new Semaphore(1);
 
@@ -34,6 +38,60 @@ public final class CameraCoordinator {
 
     public Handler backgroundHandler() {
         return backgroundHandler;
+    }
+
+    /**
+     * Runs {@code action} on the camera background thread, where all camera lifecycle
+     * mutations (device, session, readers, recorder) belong — Camera2 already delivers
+     * the open/session callbacks there, so posting serializes teardown against setup
+     * without locks. Runs inline when already on the camera thread, and also when the
+     * thread is gone (service teardown) so a close is never dropped.
+     */
+    public void runOnCameraThread(Runnable action) {
+        Handler handler = backgroundHandler;
+        if (handler == null || handler.getLooper().isCurrentThread()) {
+            action.run();
+            return;
+        }
+        if (!handler.post(action)) {
+            // Looper is quitting; teardown work must still happen.
+            action.run();
+        }
+    }
+
+    /**
+     * Like {@link #runOnCameraThread} but waits up to {@code timeoutMs} for the action
+     * to finish. For callers that need the camera actually released before proceeding
+     * (e.g. evicting a kept-alive camera before starting video). Returns false when the
+     * wait timed out or was interrupted; the action still runs in that case, just later.
+     * Never call while holding a lock the action also takes.
+     */
+    public boolean awaitOnCameraThread(Runnable action, long timeoutMs) {
+        Handler handler = backgroundHandler;
+        if (handler == null || handler.getLooper().isCurrentThread()) {
+            action.run();
+            return true;
+        }
+        CountDownLatch done = new CountDownLatch(1);
+        boolean posted =
+                handler.post(
+                        () -> {
+                            try {
+                                action.run();
+                            } finally {
+                                done.countDown();
+                            }
+                        });
+        if (!posted) {
+            action.run();
+            return true;
+        }
+        try {
+            return done.await(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
     }
 
     public void stopBackgroundThread() {
@@ -120,7 +178,11 @@ public final class CameraCoordinator {
                 if (handler != null) {
                     handler.post(expiry);
                 } else {
-                    expiry.run();
+                    // A null handler means the camera thread was already stopped, which
+                    // only happens on service teardown — the camera is closed (or being
+                    // closed) by that path. Running the teardown here would mutate camera
+                    // state on a raw Timer thread.
+                    Log.w(TAG, "Keep-alive expired after camera thread stopped; skipping");
                 }
             }
         }, delayMs);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -2401,7 +2401,16 @@ public final class PhotoSession {
 
                                 @Override
                                 public void closeCamera() {
-                                    hooks.closeCamera();
+                                    // These hooks run on the dedicated StillCaptureCb
+                                    // thread; the close itself belongs on the camera
+                                    // thread where the rest of teardown is serialized.
+                                    Handler cameraHandler = hooks.backgroundHandler();
+                                    if (cameraHandler == null
+                                            || cameraHandler.getLooper().isCurrentThread()) {
+                                        hooks.closeCamera();
+                                    } else {
+                                        cameraHandler.post(hooks::closeCamera);
+                                    }
                                 }
 
                                 @Override

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
@@ -15,6 +15,7 @@ import org.robolectric.annotation.Config;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 33)
@@ -68,14 +69,119 @@ public class CameraCoordinatorTest {
     }
 
     @Test
-    public void keepAliveExpiry_runsExpireAction() throws InterruptedException {
+    public void keepAliveExpiry_runsExpireActionOnCameraThread() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        coordinator.startBackgroundThread("CameraCoordinatorTest");
+        CountDownLatch expired = new CountDownLatch(1);
+        AtomicReference<String> expiredOn = new AtomicReference<>();
+
+        coordinator.startKeepAlive(
+                1,
+                () -> false,
+                () -> {
+                    expiredOn.set(Thread.currentThread().getName());
+                    expired.countDown();
+                });
+
+        assertThat(expired.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(coordinator.isCameraKeptAlive()).isFalse();
+        assertThat(expiredOn.get()).isEqualTo("CameraCoordinatorTest");
+        coordinator.stopBackgroundThread();
+    }
+
+    @Test
+    public void keepAliveExpiry_withoutCameraThread_skipsTeardown() throws InterruptedException {
         CameraCoordinator coordinator = new CameraCoordinator();
         CountDownLatch expired = new CountDownLatch(1);
 
         coordinator.startKeepAlive(1, () -> false, expired::countDown);
 
-        assertThat(expired.await(1, TimeUnit.SECONDS)).isTrue();
-        assertThat(coordinator.isCameraKeptAlive()).isFalse();
+        // No camera thread means service teardown already owns the close; the raw
+        // Timer thread must never run camera teardown itself.
+        assertThat(expired.await(300, TimeUnit.MILLISECONDS)).isFalse();
+    }
+
+    @Test
+    public void runOnCameraThread_offThread_postsToCameraThread() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        coordinator.startBackgroundThread("CameraCoordinatorTest");
+        CountDownLatch ran = new CountDownLatch(1);
+        AtomicReference<String> ranOn = new AtomicReference<>();
+
+        coordinator.runOnCameraThread(
+                () -> {
+                    ranOn.set(Thread.currentThread().getName());
+                    ran.countDown();
+                });
+
+        assertThat(ran.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(ranOn.get()).isEqualTo("CameraCoordinatorTest");
+        coordinator.stopBackgroundThread();
+    }
+
+    @Test
+    public void runOnCameraThread_onCameraThread_runsInline() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        Handler handler = coordinator.startBackgroundThread("CameraCoordinatorTest");
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicBoolean ranInline = new AtomicBoolean(false);
+
+        handler.post(
+                () -> {
+                    AtomicBoolean ran = new AtomicBoolean(false);
+                    coordinator.runOnCameraThread(() -> ran.set(true));
+                    // Inline execution means the action completed before this returns.
+                    ranInline.set(ran.get());
+                    done.countDown();
+                });
+
+        assertThat(done.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(ranInline).isTrue();
+        coordinator.stopBackgroundThread();
+    }
+
+    @Test
+    public void runOnCameraThread_withoutCameraThread_runsInline() {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        coordinator.runOnCameraThread(() -> ran.set(true));
+
+        assertThat(ran).isTrue();
+    }
+
+    @Test
+    public void awaitOnCameraThread_waitsForCompletion() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        coordinator.startBackgroundThread("CameraCoordinatorTest");
+        AtomicBoolean ran = new AtomicBoolean(false);
+
+        boolean completed = coordinator.awaitOnCameraThread(() -> ran.set(true), 1_000);
+
+        assertThat(completed).isTrue();
+        assertThat(ran).isTrue();
+        coordinator.stopBackgroundThread();
+    }
+
+    @Test
+    public void awaitOnCameraThread_timesOutOnBusyThread() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        Handler handler = coordinator.startBackgroundThread("CameraCoordinatorTest");
+        CountDownLatch release = new CountDownLatch(1);
+        handler.post(
+                () -> {
+                    try {
+                        release.await(5, TimeUnit.SECONDS);
+                    } catch (InterruptedException ignored) {
+                        Thread.currentThread().interrupt();
+                    }
+                });
+
+        boolean completed = coordinator.awaitOnCameraThread(() -> {}, 100);
+
+        assertThat(completed).isFalse();
+        release.countDown();
+        coordinator.stopBackgroundThread();
     }
 
     @Test


### PR DESCRIPTION
## Scope

Second PR of the OS-1816 series, stacked on #3596. The point-fix stops the crash; this PR removes the structural cause: camera teardown ran on six different thread classes (main, BLE RecvThread, NanoHTTPD workers, streaming-service threads, the StillCaptureCb handler thread, raw Timer threads), racing the open/session work that Camera2 delivers on the CameraNeoBackground thread — coordinated only by a best-effort semaphore that tears down unguarded after a 5s timeout, and bypassed entirely by two recovery paths.

## Changes

**Commit 1 — thread confinement.** `CameraCoordinator` gains `runOnCameraThread` (post; inline when already on the camera thread or when it's gone, so a close is never dropped) and `awaitOnCameraThread` (bounded wait for callers that need the eviction finished before proceeding). All fire-and-forget teardowns now route through it:

- `closeKeptAliveCamera` (video/stream starts evicting the kept-alive camera) — waits for the close, snapshots `sInstance` against a racing `onDestroy`, and re-checks shot state under `SERVICE_LOCK` on the camera thread so a photo that raced in keeps its camera.
- video `onSessionTerminated`, warm-up teardown (`stopCameraWarmUp`, `expireWarmLeases`), `onDestroy`, both `CameraRecoveryHelper` paths (which previously closed device/session with **no** lock at all), and `StillCaptureCallback`'s close hook.
- keep-alive expiry no longer runs teardown inline on the raw Timer thread when the camera thread is gone.
- `CameraCoordinator`'s device/session/handler/timer fields become volatile for the remaining cross-thread advisory reads.

`onDestroy` still guarantees the close completes before returning: `stopBackgroundThread`'s `quitSafely` + `join` drains the posted close first.

**Commit 2 — video open-failure routing.** `openCameraInternal`'s `InterruptedException`/generic handlers notified the *photo* error path even for video opens; and a MediaRecorder setup failure continued into the open only to fail again later with a second confusing error.

**Commit 3 — dead code.** Remove the caller-less `setupCameraForQueuedRequest` wrapper.

Deliberately *not* in this PR: the synchronous close+reopen inside photo dispatch (`PhotoSession.setupCameraForQueuedRequest`/`setupWarmUp`) stays on the dispatch thread — it is serialized by the open/close semaphore held through session creation since #3596, and confining it changes dispatch semantics (follow-up PR).

## Test evidence

- `./scripts/check-android-compile.sh asg` green after each commit
- `./gradlew :app:testDebugUnitTest`: 634 tests, 0 failures
- New `CameraCoordinatorTest` coverage: `runOnCameraThread` on/off-thread/no-thread, `awaitOnCameraThread` completion + timeout, keep-alive expiry now runs on the camera thread, and the raw-Timer-thread fallback skip (the old test encoding the removed fallback was updated to start the camera thread).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Camera2 lifecycle and multi-threaded teardown ordering; behavior changes are intentional hardening but affect video eviction, warm-up, and service destroy paths where races were previously possible.
> 
> **Overview**
> Follow-up to OS-1816: **camera teardown is serialized on the CameraNeo background thread** instead of running from main, timer, capture, and recovery threads that could race Camera2 open/session setup.
> 
> `CameraCoordinator` adds **`runOnCameraThread`** and **`awaitOnCameraThread`** (with **`CAMERA_TEARDOWN_AWAIT_MS`** for eviction). **`closeKeptAliveCamera`** now waits for that close and re-checks shot state under `SERVICE_LOCK` so a racing photo is not torn down mid-capture. Warm-up expiry, video session end, `onDestroy`, recovery helpers, and still-capture close hooks route through the same path; **`closeCameraFromWarmTeardown`** re-validates warm leases and shot state before closing. Keep-alive expiry no longer runs teardown on a raw timer thread when the camera handler is gone; coordinator device/session fields are **volatile**.
> 
> **Video open failures** now report via the video error path (including MediaRecorder setup failure, which stops instead of continuing into a doomed open). Removes an unused `setupCameraForQueuedRequest` wrapper. Unit tests cover thread posting, await timeout, and keep-alive behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c25a4ca35baee4fa3150748c866242721ca8558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->