### PR TITLE
Add camera lifecycle generation guard for stale Camera2 callbacks (OS-1816 follow-up)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1551,14 +1551,19 @@ public class CameraNeoService extends LifecycleService {
             }
 
             Log.d(TAG, "Opening camera ID: " + this.cameraId);
+            final long openGeneration = cameraCoordinator.beginOpen();
             try {
                 manager.openCamera(
-                        this.cameraId, newCameraOpenStateCallback(forVideo), backgroundHandler);
+                        this.cameraId,
+                        newCameraOpenStateCallback(forVideo, openGeneration),
+                        backgroundHandler);
             } catch (Exception e) {
                 // The state callback owns the permit only once the open is in flight. If
                 // openCamera throws synchronously no callback will ever fire, so release
                 // here or every later open times out and every close falls into the
-                // 5s proceed-anyway teardown.
+                // 5s proceed-anyway teardown. closeDeviceAndSession() retires the failed
+                // generation (no handles exist yet, so it only bumps the guard).
+                cameraCoordinator.closeDeviceAndSession();
                 cameraCoordinator.releaseOpenCloseLock();
                 throw e;
             }
@@ -1605,8 +1610,14 @@ public class CameraNeoService extends LifecycleService {
     /**
      * Single camera-open callback for both photo and video; behavior matches the former {@code
      * photoStateCallback} / {@code videoStateCallback} pair (Phase 2f prep).
+     *
+     * <p>{@code openGeneration} is the generation returned by {@link
+     * CameraCoordinator#beginOpen()} for this open attempt. Every callback checks it before
+     * touching shared camera state: after a close (or close+reopen) these callbacks still
+     * fire for the old device, and a null-check cannot tell a reopened camera from its own.
      */
-    private CameraDevice.StateCallback newCameraOpenStateCallback(final boolean forVideo) {
+    private CameraDevice.StateCallback newCameraOpenStateCallback(
+            final boolean forVideo, final long openGeneration) {
         return new CameraDevice.StateCallback() {
             // The in-flight open owns exactly one open/close permit, surrendered to the
             // FIRST terminal callback. onDisconnected/onError also fire long after
@@ -1624,15 +1635,22 @@ public class CameraNeoService extends LifecycleService {
 
             @Override
             public void onOpened(@NonNull CameraDevice camera) {
-                Log.d(TAG, "Camera device opened successfully");
-                cameraCoordinator.setDevice(camera);
-
-                // Hold the open/close lock until the session surfaces have been handed to
-                // the framework: releasing it first lets closeCamera() close the
-                // ImageReaders on another thread mid-setup, abandoning the surfaces this
-                // session is about to wrap (OS-1816).
                 try {
-                    createCameraSessionInternal(forVideo);
+                    if (!cameraCoordinator.isCurrentGeneration(openGeneration)) {
+                        // A proceed-anyway teardown retired this open while the HAL was
+                        // still working on it. The device is real but unwanted.
+                        Log.w(TAG, "Stale onOpened (generation " + openGeneration + "); closing");
+                        camera.close();
+                        return;
+                    }
+                    Log.d(TAG, "Camera device opened successfully");
+                    cameraCoordinator.setDevice(camera);
+
+                    // Hold the open/close lock until the session surfaces have been
+                    // handed to the framework: releasing it first lets closeCamera()
+                    // close the ImageReaders on another thread mid-setup, abandoning the
+                    // surfaces this session is about to wrap (OS-1816).
+                    createCameraSessionInternal(forVideo, openGeneration);
                 } finally {
                     releaseOpenPermitOnce();
                 }
@@ -1643,6 +1661,12 @@ public class CameraNeoService extends LifecycleService {
                 Log.d(TAG, "Camera device disconnected");
                 releaseOpenPermitOnce();
                 camera.close();
+                if (!cameraCoordinator.isCurrentGeneration(openGeneration)) {
+                    // The disconnect belongs to a camera that was already closed or
+                    // replaced; wiping current state would hit the successor.
+                    Log.d(TAG, "Stale onDisconnected (generation " + openGeneration + ")");
+                    return;
+                }
                 cameraCoordinator.clearDevice();
                 if (forVideo) {
                     notifyVideoError(videoSession.currentVideoId(), "Camera disconnected");
@@ -1665,6 +1689,10 @@ public class CameraNeoService extends LifecycleService {
                                 + ")");
                 releaseOpenPermitOnce();
                 camera.close();
+                if (!cameraCoordinator.isCurrentGeneration(openGeneration)) {
+                    Log.d(TAG, "Stale onError (generation " + openGeneration + ")");
+                    return;
+                }
                 cameraCoordinator.clearDevice();
                 if (forVideo) {
                     notifyVideoError(videoSession.currentVideoId(), cameraError.message());
@@ -1676,7 +1704,7 @@ public class CameraNeoService extends LifecycleService {
         };
     }
 
-    private void createCameraSessionInternal(boolean forVideo) {
+    private void createCameraSessionInternal(boolean forVideo, long openGeneration) {
         try {
             CameraDevice activeCameraDevice = cameraCoordinator.device();
             if (activeCameraDevice == null) {
@@ -1755,7 +1783,13 @@ public class CameraNeoService extends LifecycleService {
                             synchronized (SERVICE_LOCK) {
                                 handler = backgroundHandler;
                                 device = cameraCoordinator.device();
-                                if (handler == null || device == null) {
+                                // The generation check is the authoritative staleness
+                                // test: after a close+reopen the null-checks pass again
+                                // but device/session belong to the successor camera.
+                                if (handler == null
+                                        || device == null
+                                        || !cameraCoordinator.isCurrentGeneration(
+                                                openGeneration)) {
                                     Log.w(
                                             TAG,
                                             "onConfigured after camera teardown; closing session");
@@ -1808,11 +1842,13 @@ public class CameraNeoService extends LifecycleService {
                         public void onConfigureFailed(@NonNull CameraCaptureSession session) {
                             Handler handler;
                             CameraDevice device;
+                            boolean stale;
                             synchronized (SERVICE_LOCK) {
                                 handler = backgroundHandler;
                                 device = cameraCoordinator.device();
+                                stale = !cameraCoordinator.isCurrentGeneration(openGeneration);
                             }
-                            if (handler == null || device == null) {
+                            if (handler == null || device == null || stale) {
                                 Log.w(TAG, "onConfigureFailed after camera teardown; ignoring");
                                 session.close();
                                 return;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1030,8 +1030,22 @@ public class CameraNeoService extends LifecycleService {
                     synchronized (SERVICE_LOCK) {
                         if (!warmCallbacks.isEmpty()
                                 || !warmLeases.isEmpty()
-                                || photoSession.shotState() != AeStateMachine.ShotState.IDLE) {
+                                || hasPendingCameraWork()
+                                || (videoSession != null && videoSession.isRecording())) {
+                            // A queued photo or live video owns the camera lifecycle now;
+                            // closing + stopSelf here would fail it with "Camera service
+                            // terminated unexpectedly" — the first-shot failure reported
+                            // against the OS-1816 point-fix build.
                             Log.d(TAG, "Warm teardown superseded; leaving camera open");
+                            // A request queued during the cancelled warm-up may have no
+                            // other dispatcher once the camera is parked (the stale
+                            // AE-ready callback drops itself); kick it here. Mid-open
+                            // cases are dispatched by onConfigured instead.
+                            if (photoSession.shotState() == AeStateMachine.ShotState.IDLE
+                                    && cameraCoordinator.hasConfiguredCamera()
+                                    && !QueuedPhotoRequestQueue.getInstance().isEmpty()) {
+                                photoSession.dispatchNextPhotoRequest();
+                            }
                             return;
                         }
                         closeCamera();
@@ -1976,6 +1990,17 @@ public class CameraNeoService extends LifecycleService {
     /** Close camera resources */
     private void closeCamera() {
         warmLeaseDeadlineMs = 0;
+        if (cameraCoordinator.isOnCameraThread()
+                && cameraCoordinator.state() == CameraCoordinator.LifecycleState.OPENING) {
+            // The open/close permit is held by the in-flight open, and its releasing
+            // callback is queued behind this very message on the camera looper —
+            // waiting would deterministically burn the full 5s and then proceed
+            // anyway. Retire the generation instead: the stale onOpened closes its
+            // own device and releases the permit.
+            Log.w(TAG, "closeCamera during in-flight open; retiring generation without permit");
+            closeCameraResources();
+            return;
+        }
         boolean lockAcquired = false;
         try {
             lockAcquired = cameraCoordinator.tryAcquireOpenCloseLock(5000);
@@ -1985,16 +2010,7 @@ public class CameraNeoService extends LifecycleService {
                         "closeCamera: Failed to acquire lock within 5 seconds, proceeding with"
                                 + " cleanup anyway");
             }
-            cameraCoordinator.closeDeviceAndSession();
-            photoSession.closeImageReadersIfPresent();
-            photoSession.onCameraClosed();
-            if (videoSession != null) {
-                videoSession.release();
-            }
-            // Reset keep-alive flag when camera is actually closed
-            cameraCoordinator.markCameraClosed();
-
-            releaseWakeLocks();
+            closeCameraResources();
         } catch (InterruptedException e) {
             Log.e(TAG, "Interrupted while closing camera", e);
         } finally {
@@ -2004,11 +2020,35 @@ public class CameraNeoService extends LifecycleService {
         }
     }
 
+    private void closeCameraResources() {
+        cameraCoordinator.closeDeviceAndSession();
+        photoSession.closeImageReadersIfPresent();
+        photoSession.onCameraClosed();
+        if (videoSession != null) {
+            videoSession.release();
+        }
+        // Reset keep-alive flag when camera is actually closed
+        cameraCoordinator.markCameraClosed();
+
+        releaseWakeLocks();
+    }
+
+    /**
+     * Keep-alive extension predicate: never tear down under an in-flight capture OR
+     * while photo requests are still queued — a queued request whose service gets
+     * stopped is failed with "Camera service terminated unexpectedly" in onDestroy,
+     * which callers see as a first-shot failure (OS-1816 follow-up report).
+     */
+    private boolean hasPendingCameraWork() {
+        return photoSession.shotState() != AeStateMachine.ShotState.IDLE
+                || !QueuedPhotoRequestQueue.getInstance().isEmpty();
+    }
+
     /** Start the keep-alive timer to keep camera open for rapid successive shots */
     private void startKeepAliveTimer() {
         cameraCoordinator.startKeepAlive(
                 CAMERA_KEEP_ALIVE_MS,
-                () -> photoSession.shotState() != AeStateMachine.ShotState.IDLE,
+                this::hasPendingCameraWork,
                 () -> {
                     // Tear down under SERVICE_LOCK so this background-thread close is atomic with
                     // respect to isCameraWarm() and enqueuePhotoRequest(), which both take the same
@@ -2032,10 +2072,7 @@ public class CameraNeoService extends LifecycleService {
      */
     private void startWarmKeepAliveTimer(long durationMs) {
         long ttl = clampWarmUpDuration(durationMs);
-        cameraCoordinator.startKeepAlive(
-                ttl,
-                () -> photoSession.shotState() != AeStateMachine.ShotState.IDLE,
-                this::expireWarmLeases);
+        cameraCoordinator.startKeepAlive(ttl, this::hasPendingCameraWork, this::expireWarmLeases);
     }
 
     /** Arm the next per-owner lease deadline while leaving later compatible leases intact. */
@@ -2049,10 +2086,7 @@ public class CameraNeoService extends LifecycleService {
             earliest = Math.min(earliest, lease.deadlineMs);
         }
         long delay = Math.max(1L, earliest - now);
-        cameraCoordinator.startKeepAlive(
-                delay,
-                () -> photoSession.shotState() != AeStateMachine.ShotState.IDLE,
-                this::expireWarmLeases);
+        cameraCoordinator.startKeepAlive(delay, this::hasPendingCameraWork, this::expireWarmLeases);
     }
 
     private void expireWarmLeases() {
@@ -2150,18 +2184,27 @@ public class CameraNeoService extends LifecycleService {
                 () -> cameraId,
                 id -> cameraId = id,
                 this::wakeUpScreen,
-                () ->
-                        cameraCoordinator.runOnCameraThread(
-                                () -> cameraCoordinator.closeDeviceAndSession()));
+                () -> cameraCoordinator.runOnCameraThread(this::nudgeCloseIfStillClosed));
+    }
+
+    /**
+     * The 1s-delayed recovery nudge fires regardless of what happened since the open
+     * failure; closing when a fresh open is already in flight (or succeeded) would
+     * retire a healthy generation. Only nudge a camera that is still down.
+     */
+    private void nudgeCloseIfStillClosed() {
+        if (cameraCoordinator.state() == CameraCoordinator.LifecycleState.CLOSED) {
+            cameraCoordinator.closeDeviceAndSession();
+        } else {
+            Log.d(TAG, "Skipping recovery close nudge; camera no longer closed");
+        }
     }
 
     /** Release all camera system resources */
     private void releaseCameraResources() {
         CameraRecoveryHelper.releaseCameraResources(
                 () -> cameraCoordinator.runOnCameraThread(this::closeCamera),
-                () ->
-                        cameraCoordinator.runOnCameraThread(
-                                () -> cameraCoordinator.closeDeviceAndSession()),
+                () -> cameraCoordinator.runOnCameraThread(this::nudgeCloseIfStillClosed),
                 this);
     }
 

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
@@ -11,12 +11,27 @@ import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 
 /** Coordinates camera-adjacent lifecycle resources that outlive a single capture. */
 public final class CameraCoordinator {
 
     private static final String TAG = "CameraCoordinator";
+
+    /**
+     * Coarse camera lifecycle, tracked for logging and stale-callback detection. The
+     * authoritative guard is {@link #generation()}: every open attempt and every
+     * device/session close bump it, and async work captures the generation it was
+     * issued under so late callbacks can detect that the camera they belong to is gone
+     * (or worse, replaced — a null-check cannot tell a reopened camera from its own).
+     */
+    public enum LifecycleState {
+        CLOSED,
+        OPENING,
+        OPENED,
+        CONFIGURED
+    }
 
     // Volatile: mutated on the camera thread but still read from caller threads
     // (advisory state checks, keep-alive TimerTask) — plain fields gave those
@@ -28,6 +43,34 @@ public final class CameraCoordinator {
     private volatile Timer keepAliveTimer;
     private volatile boolean cameraKeptAlive;
     private final Semaphore openCloseLock = new Semaphore(1);
+    private volatile LifecycleState state = LifecycleState.CLOSED;
+    private final AtomicLong generation = new AtomicLong();
+
+    public LifecycleState state() {
+        return state;
+    }
+
+    /** The current camera generation; see {@link LifecycleState}. */
+    public long generation() {
+        return generation.get();
+    }
+
+    /** Whether async work issued under {@code observedGeneration} still owns the camera. */
+    public boolean isCurrentGeneration(long observedGeneration) {
+        return generation.get() == observedGeneration;
+    }
+
+    /**
+     * Marks the start of a new open attempt and returns its generation. Callbacks of
+     * this open must capture the returned value and drop themselves via
+     * {@link #isCurrentGeneration} once a newer open or a close has superseded them.
+     */
+    public long beginOpen() {
+        state = LifecycleState.OPENING;
+        long next = generation.incrementAndGet();
+        Log.d(TAG, "Camera open attempt, generation " + next);
+        return next;
+    }
 
     public Handler startBackgroundThread(String name) {
         backgroundThread = new HandlerThread(name);
@@ -123,10 +166,12 @@ public final class CameraCoordinator {
 
     public void setDevice(CameraDevice device) {
         this.device = device;
+        state = LifecycleState.OPENED;
     }
 
     public void clearDevice() {
         device = null;
+        state = LifecycleState.CLOSED;
     }
 
     public CameraCaptureSession session() {
@@ -135,6 +180,7 @@ public final class CameraCoordinator {
 
     public void setSession(CameraCaptureSession session) {
         this.session = session;
+        state = LifecycleState.CONFIGURED;
     }
 
     public void clearSession() {
@@ -146,6 +192,10 @@ public final class CameraCoordinator {
     }
 
     public void closeDeviceAndSession() {
+        // Bump first: anything still in flight for the old camera must see itself
+        // stale before the device handles start closing.
+        generation.incrementAndGet();
+        state = LifecycleState.CLOSED;
         if (session != null) {
             session.close();
             session = null;
@@ -160,11 +210,21 @@ public final class CameraCoordinator {
         Log.d(TAG, "Starting camera keep-alive timer for " + delayMs + "ms");
         cancelKeepAlive();
         cameraKeptAlive = true;
+        // The expiry closes the camera this keep-alive was armed for — not whatever
+        // camera exists when it finally runs. Timer.cancel() cannot dequeue an expiry
+        // already posted to the camera thread, so a close+reopen (or a capture that
+        // cancelled this timer) otherwise gets its fresh camera torn down by a stale
+        // expiry.
+        long armedGeneration = generation.get();
         keepAliveTimer = new Timer();
         keepAliveTimer.schedule(new TimerTask() {
             @Override
             public void run() {
                 Runnable expiry = () -> {
+                    if (!isCurrentGeneration(armedGeneration)) {
+                        Log.d(TAG, "Keep-alive expiry is stale (camera reopened); skipping");
+                        return;
+                    }
                     if (shouldExtend.getAsBoolean()) {
                         Log.w(TAG, "Keep-alive expired but capture in progress - extending timer");
                         startKeepAlive(delayMs, shouldExtend, onExpire);

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinator.java
@@ -46,6 +46,7 @@ public final class CameraCoordinator {
     private volatile LifecycleState state = LifecycleState.CLOSED;
     private final AtomicLong generation = new AtomicLong();
 
+    /** Coarse lifecycle position; see {@link LifecycleState}. Advisory for off-thread readers. */
     public LifecycleState state() {
         return state;
     }
@@ -81,6 +82,12 @@ public final class CameraCoordinator {
 
     public Handler backgroundHandler() {
         return backgroundHandler;
+    }
+
+    /** Whether the calling thread is the camera background thread. */
+    public boolean isOnCameraThread() {
+        Handler handler = backgroundHandler;
+        return handler != null && handler.getLooper().isCurrentThread();
     }
 
     /**
@@ -249,9 +256,12 @@ public final class CameraCoordinator {
     }
 
     public void cancelKeepAlive() {
-        if (keepAliveTimer != null) {
+        // Snapshot: cancel is called from several threads and the field is cleared
+        // concurrently; a check-then-cancel on the field itself can NPE.
+        Timer timer = keepAliveTimer;
+        if (timer != null) {
             Log.d(TAG, "Cancelling camera keep-alive timer");
-            keepAliveTimer.cancel();
+            timer.cancel();
             keepAliveTimer = null;
         }
     }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
@@ -177,11 +177,13 @@ public class CameraCoordinatorTest {
                     }
                 });
 
-        boolean completed = coordinator.awaitOnCameraThread(() -> {}, 100);
-
-        assertThat(completed).isFalse();
-        release.countDown();
-        coordinator.stopBackgroundThread();
+        try {
+            boolean completed = coordinator.awaitOnCameraThread(() -> {}, 100);
+            assertThat(completed).isFalse();
+        } finally {
+            release.countDown();
+            coordinator.stopBackgroundThread();
+        }
     }
 
     @Test
@@ -259,13 +261,17 @@ public class CameraCoordinatorTest {
         coordinator.startBackgroundThread("CameraCoordinatorTest");
         CountDownLatch expired = new CountDownLatch(1);
 
-        coordinator.startKeepAlive(50, () -> false, expired::countDown);
-        // Reopen before the timer fires: the expiry was armed for the old camera and
-        // must not tear down its successor.
-        coordinator.closeDeviceAndSession();
+        try {
+            coordinator.startKeepAlive(250, () -> false, expired::countDown);
+            // Reopen before the timer fires: the expiry was armed for the old camera
+            // and must not tear down its successor. The 250ms arm gives the bump a
+            // wide margin over Timer scheduling jitter.
+            coordinator.closeDeviceAndSession();
 
-        assertThat(expired.await(400, TimeUnit.MILLISECONDS)).isFalse();
-        coordinator.stopBackgroundThread();
+            assertThat(expired.await(800, TimeUnit.MILLISECONDS)).isFalse();
+        } finally {
+            coordinator.stopBackgroundThread();
+        }
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
@@ -213,6 +213,62 @@ public class CameraCoordinatorTest {
     }
 
     @Test
+    public void beginOpen_bumpsGenerationAndMarksOpening() {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        long before = coordinator.generation();
+
+        long gen = coordinator.beginOpen();
+
+        assertThat(gen).isEqualTo(before + 1);
+        assertThat(coordinator.isCurrentGeneration(gen)).isTrue();
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.OPENING);
+    }
+
+    @Test
+    public void closeDeviceAndSession_retiresTheOpenGeneration() {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        long gen = coordinator.beginOpen();
+
+        coordinator.closeDeviceAndSession();
+
+        assertThat(coordinator.isCurrentGeneration(gen)).isFalse();
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.CLOSED);
+    }
+
+    @Test
+    public void lifecycleState_tracksOpenConfigureClose() {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.CLOSED);
+
+        coordinator.beginOpen();
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.OPENING);
+
+        coordinator.setDevice(Mockito.mock(CameraDevice.class));
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.OPENED);
+
+        coordinator.setSession(Mockito.mock(CameraCaptureSession.class));
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.CONFIGURED);
+
+        coordinator.closeDeviceAndSession();
+        assertThat(coordinator.state()).isEqualTo(CameraCoordinator.LifecycleState.CLOSED);
+    }
+
+    @Test
+    public void keepAliveExpiry_staleGeneration_skipsTeardown() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        coordinator.startBackgroundThread("CameraCoordinatorTest");
+        CountDownLatch expired = new CountDownLatch(1);
+
+        coordinator.startKeepAlive(50, () -> false, expired::countDown);
+        // Reopen before the timer fires: the expiry was armed for the old camera and
+        // must not tear down its successor.
+        coordinator.closeDeviceAndSession();
+
+        assertThat(expired.await(400, TimeUnit.MILLISECONDS)).isFalse();
+        coordinator.stopBackgroundThread();
+    }
+
+    @Test
     public void closeDeviceAndSession_closesAndClearsBoth() {
         CameraCoordinator coordinator = new CameraCoordinator();
         CameraDevice device = Mockito.mock(CameraDevice.class);


### PR DESCRIPTION
## Scope

Third PR of the OS-1816 series, stacked on #3597. The teardown-detection in the camera's async callbacks was a set of null checks — and a null check cannot tell a reopened camera from its own. After a close+reopen, `device`/`session` are non-null again, so a late callback for the OLD camera would mutate the successor's state: `onConfigured` installing a dead session, `onDisconnected` wiping the live device, a stale keep-alive expiry closing a camera it never owned (`Timer.cancel()` cannot dequeue an expiry already posted to the camera thread).

## Changes

`CameraCoordinator` now tracks:

- a coarse **lifecycle state** (`CLOSED → OPENING → OPENED → CONFIGURED`), for logging/diagnostics and as scaffolding for further confinement work;
- an authoritative **generation counter**: `beginOpen()` bumps it for every open attempt, `closeDeviceAndSession()` for every teardown.

Async work captures the generation it was issued under and drops itself when superseded:

- `onOpened` closes the surplus device instead of installing it — this also recovers cleanly when a 5s proceed-anyway teardown retired the open while the HAL was still working on it (previously that path re-leaked into exactly the abandoned-surface crash).
- `onDisconnected` / `onError` skip `clearDevice`/notify/`stopSelf` when stale.
- `onConfigured` / `onConfigureFailed` close the session and return when stale.
- keep-alive expiry skips when the camera it was armed for is gone — this closes the audit finding that an expiry posted before `Timer.cancel()` could tear down the camera of a capture that had just cancelled it.

The pattern follows the existing `captureMetadataGeneration` precedent in `PhotoSession` (`recordStillCaptureMetadata_staleGenerationIgnored`).

## Test evidence

- `./scripts/check-android-compile.sh asg` green
- `./gradlew :app:testDebugUnitTest`: 638 tests, 0 failures
- New `CameraCoordinatorTest` coverage: `beginOpen` bumps generation + `OPENING`; `closeDeviceAndSession` retires the open generation; full state walk `CLOSED→OPENING→OPENED→CONFIGURED→CLOSED`; stale-generation keep-alive expiry is skipped after a reopen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core Camera2 open/close/teardown and async callback ordering; mistakes could regress first-shot failures, leaks, or races already tracked under OS-1816.
> 
> **Overview**
> **OS-1816 follow-up:** Replaces null-only staleness checks with a **camera generation** so late Camera2 callbacks after close/reopen cannot corrupt the live session (stale `onConfigured`, `onDisconnected`, keep-alive expiry, etc.).
> 
> `CameraCoordinator` adds lifecycle state and a generation counter (`beginOpen()` / bump on `closeDeviceAndSession()`). Open and session callbacks capture their generation and no-op or close surplus devices when superseded; keep-alive expiry is tied to the generation it was armed with. `CameraNeoService` wires this through open/configure paths, handles synchronous `openCamera` failures, and avoids blocking `closeCamera` on an in-flight open by retiring the generation on the camera thread.
> 
> **Pending-work teardown:** `hasPendingCameraWork()` (in-flight shot + queued photos) and active video recording block warm teardown / keep-alive shutdown that would stop the service and surface “Camera service terminated unexpectedly”; warm teardown can re-dispatch queued photos when the camera stays open. Recovery closes use `nudgeCloseIfStillClosed()` so a delayed nudge does not tear down a healthy reopen.
> 
> Unit tests cover generation, lifecycle transitions, and stale keep-alive expiry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bff3ca75532141847b58edf6440a256b28944cad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->