### PR TITLE
Run the camera open path on the camera thread (OS-1816 follow-up)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1176,7 +1176,11 @@ public class CameraNeoService extends LifecycleService {
                     }
                 case ACTION_STOP_VIDEO_RECORDING:
                     String videoIdToStop = intent.getStringExtra(EXTRA_VIDEO_ID);
-                    videoSession.stopRecording(videoIdToStop);
+                    // The recorder is created on the camera thread (its onInfo/onError
+                    // listeners fire there); stopping from main would race them inside
+                    // the lock-free VideoRecordingSession. Stop on the camera thread.
+                    cameraCoordinator.runOnCameraThread(
+                            () -> videoSession.stopRecording(videoIdToStop));
                     SystemControllerFactory.get(this).setEisEnabled(false);
                     break;
                 case ACTION_WARM_UP_CAMERA:
@@ -1390,12 +1394,13 @@ public class CameraNeoService extends LifecycleService {
         if (cameraCoordinator.state() == CameraCoordinator.LifecycleState.OPENING) {
             // An open is already in flight. Its callbacks run on this thread, so
             // blocking on the open/close permit here could only delay them and then
-            // time out anyway — fail fast instead.
+            // time out anyway — fail fast instead. Do NOT stop the service: the
+            // in-flight open still owns it, and its request would be failed by
+            // onDestroy with "Camera service terminated unexpectedly".
             Log.w(TAG, "Camera open requested while another open is in flight");
             if (forVideo)
                 notifyVideoError(videoSession.currentVideoId(), "Camera busy opening");
             else photoSession.notifyHostPhotoError("Camera busy opening");
-            conditionalStopSelf();
             return;
         }
 
@@ -1976,10 +1981,15 @@ public class CameraNeoService extends LifecycleService {
             // Cancel keep-alive timer if it's running
             cancelKeepAliveTimer();
             if (videoSession != null && videoSession.isRecording()) {
-                videoSession.stopRecording(videoSession.currentVideoId());
+                // Stop on the camera thread: the recorder's own listeners fire there,
+                // and VideoRecordingSession has no internal locking. Posted before the
+                // close below, so stop-then-close order is preserved on that thread.
+                String recordingVideoId = videoSession.currentVideoId();
+                cameraCoordinator.runOnCameraThread(
+                        () -> videoSession.stopRecording(recordingVideoId));
             }
             // The close runs on the camera thread; stopBackgroundThread() below drains
-            // the queue before joining, so the close is guaranteed to have completed
+            // the queue before joining, so both are guaranteed to have completed
             // before onDestroy returns.
             cameraCoordinator.runOnCameraThread(this::closeCamera);
             releaseWakeLocks();

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1368,8 +1368,37 @@ public class CameraNeoService extends LifecycleService {
         stopSelf();
     }
 
-    @SuppressLint("MissingPermission")
     private void openCameraInternal(String filePath, boolean forVideo) {
+        // The open belongs on the camera thread with the rest of the lifecycle work;
+        // callers dispatch from the BLE command thread, web-server workers, or main.
+        // The camera-thread body re-takes SERVICE_LOCK to keep the open's session/state
+        // mutations under the same lock the dispatch decision was made under.
+        if (!cameraCoordinator.isOnCameraThread()) {
+            cameraCoordinator.runOnCameraThread(
+                    () -> {
+                        synchronized (SERVICE_LOCK) {
+                            openCameraOnCameraThread(filePath, forVideo);
+                        }
+                    });
+            return;
+        }
+        openCameraOnCameraThread(filePath, forVideo);
+    }
+
+    @SuppressLint("MissingPermission")
+    private void openCameraOnCameraThread(String filePath, boolean forVideo) {
+        if (cameraCoordinator.state() == CameraCoordinator.LifecycleState.OPENING) {
+            // An open is already in flight. Its callbacks run on this thread, so
+            // blocking on the open/close permit here could only delay them and then
+            // time out anyway — fail fast instead.
+            Log.w(TAG, "Camera open requested while another open is in flight");
+            if (forVideo)
+                notifyVideoError(videoSession.currentVideoId(), "Camera busy opening");
+            else photoSession.notifyHostPhotoError("Camera busy opening");
+            conditionalStopSelf();
+            return;
+        }
+
         CameraManager manager = (CameraManager) getSystemService(Context.CAMERA_SERVICE);
         if (manager == null) {
             Log.e(TAG, "Could not get camera manager");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/CameraCoordinatorTest.java
@@ -141,6 +141,26 @@ public class CameraCoordinatorTest {
     }
 
     @Test
+    public void isOnCameraThread_reflectsCallingThread() throws InterruptedException {
+        CameraCoordinator coordinator = new CameraCoordinator();
+        Handler handler = coordinator.startBackgroundThread("CameraCoordinatorTest");
+        assertThat(coordinator.isOnCameraThread()).isFalse();
+
+        CountDownLatch done = new CountDownLatch(1);
+        AtomicBoolean onThread = new AtomicBoolean(false);
+        handler.post(
+                () -> {
+                    onThread.set(coordinator.isOnCameraThread());
+                    done.countDown();
+                });
+
+        assertThat(done.await(1, TimeUnit.SECONDS)).isTrue();
+        assertThat(onThread).isTrue();
+        coordinator.stopBackgroundThread();
+        assertThat(coordinator.isOnCameraThread()).isFalse();
+    }
+
+    @Test
     public void runOnCameraThread_withoutCameraThread_runsInline() {
         CameraCoordinator coordinator = new CameraCoordinator();
         AtomicBoolean ran = new AtomicBoolean(false);


### PR DESCRIPTION
## Scope

Final PR of the OS-1816 series, stacked on #3598. It completes the single-owner-thread model: after #3597 confined teardown and #3598 guarded stale callbacks, the camera **open** machinery (capability queries, ImageReader creation, `openCamera`) was the last lifecycle work still running on arbitrary threads — the BLE command thread, NanoHTTPD web-server workers, or main, depending on who dispatched the photo/video/warm-up.

## Changes

- `openCameraInternal` self-posts to the camera thread. The posted body re-takes `SERVICE_LOCK`, so the open runs under the same lock its dispatch decision was made under — and the video open path, which previously took **no** lock, now behaves like the photo path.
- If an open is already in flight (`LifecycleState.OPENING`), fail fast with a camera-busy error instead of blocking the camera thread on the open/close permit: the in-flight open's callbacks are delivered on this same thread, so waiting could only delay them and then time out anyway.
- `CameraCoordinator.isOnCameraThread()` + test coverage.

With this, every mutation of camera lifecycle state (open, session setup, capture dispatch targets, teardown) happens on the CameraNeoBackground thread; cross-thread entry points only enqueue, evict-and-wait, or read advisory state.

## Scope note

The originally sketched follow-up — extracting the camera controller from the Android `Service` — is deliberately **not** included: its correctness motivation (main-thread teardown racing background setup) is gone after this series, leaving it a large refactor-only diff. Worth scheduling separately if wanted; not needed to close OS-1816.

## Test evidence

- `./scripts/check-android-compile.sh asg` green
- `./gradlew :app:testDebugUnitTest`: 639 tests, 0 failures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core camera open/teardown and video stop threading where OS-1816 races were fixed; behavior changes for overlapping opens (busy error) and off-thread entry points now async-post to the camera thread.
> 
> **Overview**
> Finishes the OS-1816 **single camera-thread owner** model by moving the last lifecycle work that still ran on BLE, HTTP workers, or main onto `CameraNeoBackground`.
> 
> **`openCameraInternal`** now posts to the camera thread and re-takes `SERVICE_LOCK` there so open/session mutations stay under the same lock as dispatch; the real HAL work lives in **`openCameraOnCameraThread`**. If state is already **`OPENING`**, it **fails fast** with a camera-busy error instead of blocking on the open/close permit (and it does **not** stop the service while the in-flight open still owns it). The video open path now follows the same locking pattern as photo.
> 
> **Video stop** (`ACTION_STOP_VIDEO_RECORDING`) and **`onDestroy`** when recording both call **`videoSession.stopRecording`** on the camera thread so MediaRecorder callbacks cannot race the lock-free **`VideoRecordingSession`**; destroy still posts **stop then close** on that thread before the background thread is drained.
> 
> Adds a unit test that **`CameraCoordinator.isOnCameraThread()`** reflects the calling thread.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 197a79429e5ccbfb7069065dd5b53fd1a8b5d3f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->