### PR TITLE
Deliver already-saved photos across camera device loss (OS-1816 follow-up)

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1718,6 +1718,8 @@ public class CameraNeoService extends LifecycleService {
                 cameraCoordinator.clearDevice();
                 if (forVideo) {
                     notifyVideoError(videoSession.currentVideoId(), "Camera disconnected");
+                } else if (salvageCapturedPhotoAfterDeviceLoss("camera disconnected")) {
+                    return;
                 } else {
                     photoSession.notifyHostPhotoError("Camera disconnected");
                 }
@@ -1744,12 +1746,48 @@ public class CameraNeoService extends LifecycleService {
                 cameraCoordinator.clearDevice();
                 if (forVideo) {
                     notifyVideoError(videoSession.currentVideoId(), cameraError.message());
+                } else if (salvageCapturedPhotoAfterDeviceLoss(
+                        "camera error " + cameraError.code())) {
+                    return;
                 } else {
                     photoSession.notifyHostPhotoError(cameraError);
                 }
                 stopSelf();
             }
         };
+    }
+
+    /**
+     * Device-loss recovery for the observed field failure: the MediaTek camera service
+     * can disconnect the client right after a first-in-session capture completes — the
+     * still image is already saved and waiting only for HAL metadata. Failing it (and
+     * stopping the service, whose onDestroy error could outrun the queued success
+     * callback) threw away a delivered photo. Close local camera state, emit the saved
+     * photo, and stop only after the delivery callback has drained — and only if no new
+     * request took over the service in the meantime.
+     *
+     * @return true when a saved photo was salvaged and the caller must not report an
+     *     error or stop the service itself.
+     */
+    private boolean salvageCapturedPhotoAfterDeviceLoss(String reason) {
+        // Clean local state first: if the flush's completion dispatches a queued
+        // request, it must cold-open against a closed camera, not a dead handle.
+        closeCamera();
+        if (!photoSession.flushPendingCapturedPhotoNow(reason)) {
+            return false;
+        }
+        Log.i(TAG, "Delivered captured photo despite device loss (" + reason + ")");
+        // The success callback is queued on `executor`; routing the stop behind it
+        // guarantees onDestroy's failAllPending cannot error the job first.
+        executor.execute(
+                () -> {
+                    synchronized (SERVICE_LOCK) {
+                        if (!hasPendingCameraWork()) {
+                            stopSelf();
+                        }
+                    }
+                });
+        return true;
     }
 
     private void createCameraSessionInternal(boolean forVideo, long openGeneration) {

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/CameraNeoService.java
@@ -1782,7 +1782,13 @@ public class CameraNeoService extends LifecycleService {
         executor.execute(
                 () -> {
                     synchronized (SERVICE_LOCK) {
-                        if (!hasPendingCameraWork()) {
+                        if (hasPendingCameraWork()) {
+                            // A request enqueued after the salvage sees a live service
+                            // with a closed camera, and that enqueue branch neither
+                            // dispatches nor sends a start intent — without a kick here
+                            // it would sit queued forever (review finding on this PR).
+                            photoSession.dispatchNextPhotoRequest();
+                        } else {
                             stopSelf();
                         }
                     }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/camera/lifecycle/PhotoSession.java
@@ -1543,6 +1543,40 @@ public final class PhotoSession {
         emitPhotoCaptured(filePath, metadataToSend, capturedPhoto, callback, startMs);
     }
 
+    /**
+     * Emits the pending captured photo immediately, without waiting for HAL metadata.
+     * For camera-device loss after the still image was already saved: the photo is on
+     * disk and deliverable, so a disconnect must not fail the request (observed on the
+     * MediaTek stack, which can disconnect the client right after a first-in-session
+     * capture completes). Returns true when a pending photo was flushed; the active
+     * capture is then complete and the disconnect path must not report an error for it.
+     */
+    public boolean flushPendingCapturedPhotoNow(String reason) {
+        String filePath;
+        CameraNeoService.PhotoCaptureCallback callback;
+        CapturedPhoto capturedPhoto;
+        long startMs;
+        synchronized (captureMetadataLock) {
+            if (pendingCapturedFilePath == null || photoCapturedCallbackSent) {
+                return false;
+            }
+            filePath = pendingCapturedFilePath;
+            callback = pendingCapturedCallback;
+            capturedPhoto = pendingCapturedPhoto;
+            startMs = pendingCapturedStartTimeMs;
+            pendingCapturedFilePath = null;
+            pendingCapturedCallback = null;
+            pendingCapturedPhoto = null;
+            pendingCapturedStartTimeMs = 0L;
+            // The delayed timeout no-ops once photoCapturedCallbackSent is set.
+            pendingCaptureMetadataTimeout = null;
+            photoCapturedCallbackSent = true;
+        }
+        Log.w(TAG, "Emitting captured photo without metadata: " + reason);
+        emitPhotoCaptured(filePath, null, capturedPhoto, callback, startMs);
+        return true;
+    }
+
     private void scheduleCaptureMetadataTimeoutLocked(String filePath) {
         if (pendingCaptureMetadataTimeout != null) {
             return;

--- a/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoSessionTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/camera/lifecycle/PhotoSessionTest.java
@@ -450,6 +450,34 @@ public class PhotoSessionTest {
     }
 
     @Test
+    public void flushPendingCapturedPhotoNow_emitsSavedPhotoWithoutMetadata() throws Exception {
+        PhotoSession.Hooks hooks = mockConfiguredCameraHooks();
+        CameraNeoService.PhotoCaptureCallback callback =
+                mock(CameraNeoService.PhotoCaptureCallback.class);
+        QueuedPhotoRequest request =
+                new QueuedPhotoRequest("/tmp/salvage.jpg", "large", false, true, null, callback);
+        PhotoSession session = new PhotoSession(hooks);
+        activateQueuedRequest(session, request);
+
+        // Photo saved, waiting for HAL metadata — then the device disconnects.
+        notifyPhotoCaptured(session, "/tmp/salvage.jpg", null);
+
+        assertThat(session.flushPendingCapturedPhotoNow("camera disconnected")).isTrue();
+        verify(callback)
+                .onPhotoCaptured(
+                        eq("/tmp/salvage.jpg"), (JSONObject) isNull(), (CapturedPhoto) isNull());
+        // Already emitted: a second flush must not double-fire.
+        assertThat(session.flushPendingCapturedPhotoNow("again")).isFalse();
+    }
+
+    @Test
+    public void flushPendingCapturedPhotoNow_withoutPendingPhoto_returnsFalse() {
+        PhotoSession session = new PhotoSession(mockConfiguredCameraHooks());
+
+        assertThat(session.flushPendingCapturedPhotoNow("camera disconnected")).isFalse();
+    }
+
+    @Test
     public void copyJsonPayload_isolatesRamCallbackFromPersistencePayload() throws Exception {
         JSONObject persistencePayload = new JSONObject().put("sampleCount", 2);
         Method copy =


### PR DESCRIPTION
## Scope

Fifth PR of the OS-1816 series, stacked on #3599. Driven by the reporter's adb logcat from the #3596 build: the process crash is gone, but the first capture of a session still fails. The log shows why — **the photo is captured and saved to disk**, then the MediaTek camera service disconnects the client (`checkPidStatus:2264` eviction) 4ms later, while the capture is only waiting for HAL metadata:

```
19:44:18.827 CameraNeo: Photo saved successfully: .../base.jpg
19:44:18.831 CameraCaptureSession: CAMERA_DISCONNECTED (2): checkPidStatus:2264
19:44:18.835 CameraNeo: CameraNeoService service destroying
19:44:19.383 MediaCaptureService: Failed to capture photo: Camera service terminated unexpectedly
```

Our `onDisconnected` handler failed the request and stopped the service; `onDestroy`'s `failAllPending` error is delivered inline and can outrun the success callback queued on the executor — so a photo sitting on disk was reported as `CAMERA_CAPTURE_FAILED` and its files deleted.

## Changes

- `PhotoSession.flushPendingCapturedPhotoNow(reason)`: emits the pending saved photo immediately without metadata, reusing the exact emit path the existing metadata-wait timeout uses. Idempotent via `photoCapturedCallbackSent`.
- `onDisconnected`/`onError` (current-generation, photo path) now salvage instead of fail: close local camera state first (so a queued request dispatched by the completion cold-opens cleanly), flush the saved photo, and route `stopSelf` through the callback executor so the delivery drains before `onDestroy` can run — skipping the stop entirely if a new request took over.
- A disconnect that lands **before** the image reaches the reader still fails the request exactly as before.

This does not address *why* the MTK stack evicts the client after first-in-session captures (still under investigation with the reporter — full unfiltered logcat with `cameraserver` lines requested); it makes the eviction harmless to the user.

## Test evidence

- `./scripts/check-android-compile.sh asg` green
- `./gradlew :app:testDebugUnitTest`: 641 tests, 0 failures
- New `PhotoSessionTest` coverage: flush emits the saved photo without metadata exactly once; flush without a pending photo returns false.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches camera disconnect/error teardown and callback ordering in `CameraNeoService`; behavior change is scoped to photo salvage when a file is already saved, with explicit queue-dispatch handling to avoid stuck requests.
> 
> **Overview**
> When the camera HAL disconnects or errors **after** the JPEG is on disk but **before** HAL metadata arrives (seen on MediaTek after first-in-session capture), photo `onDisconnected` / `onError` no longer fail the shot and tear down the service immediately.
> 
> **`PhotoSession.flushPendingCapturedPhotoNow`** emits the pending saved file through the normal capture callback with `null` metadata, guarded by `photoCapturedCallbackSent` so it only fires once.
> 
> **`CameraNeoService.salvageCapturedPhotoAfterDeviceLoss`** runs on those photo paths: closes local camera state, flushes if a pending save exists, then on the single-thread `executor` either **`stopSelf`** (so success can run before `onDestroy`’s `failAllPending`) or **`dispatchNextPhotoRequest`** if more work is queued. Disconnects with no saved image still error as before; video is unchanged.
> 
> Unit tests cover flush success, idempotency, and the no-pending-photo case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1b708da2f84643d2849cc36ddb6c902890824b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->