### PR TITLE
Report glasses device identity in Bluetooth SDK analytics

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/AsgConstants.java
@@ -22,6 +22,9 @@ public class AsgConstants {
     /** Current Mentra Live Android hotspot gateway when interface discovery is unavailable. */
     public static final String DEFAULT_HOTSPOT_GATEWAY_IP = "192.168.43.1";
 
+    /** SharedPreferences key for the manufacturing serial reported by the BES. */
+    public static final String KEY_BES_MANUFACTURING_SERIAL = "bes_manufacturing_serial";
+
     /** Canonical camera crop defaults shared with the phone and Bluetooth SDK. */
     public static final int CAMERA_FOV_DEFAULT = 118;
     public static final int CAMERA_ROI_POSITION_DEFAULT = 0;

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/McuEventParser.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/McuEventParser.java
@@ -163,6 +163,7 @@ public final class McuEventParser {
                 b.optString("ble", "unknown"),
                 b.optString("bt", "unknown"),
                 b.optString("btaddr", "unknown"),
-                b.optString("bleaddr", "unknown"));
+                b.optString("bleaddr", "unknown"),
+                b.optString("serial_number", ""));
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/events/BesVersionEvent.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/peripheral/events/BesVersionEvent.java
@@ -8,18 +8,21 @@ public final class BesVersionEvent extends McuEvent {
     private final String btName;
     private final String btAddress;
     private final String bleAddress;
+    private final String manufacturingSerial;
 
     public BesVersionEvent(
             String firmwareVersion,
             String bleName,
             String btName,
             String btAddress,
-            String bleAddress) {
+            String bleAddress,
+            String manufacturingSerial) {
         this.firmwareVersion = firmwareVersion;
         this.bleName = bleName;
         this.btName = btName;
         this.btAddress = btAddress;
         this.bleAddress = bleAddress;
+        this.manufacturingSerial = manufacturingSerial;
     }
 
     /** BES firmware version from JSON field {@code version}. */
@@ -45,5 +48,10 @@ public final class BesVersionEvent extends McuEvent {
     /** BLE MAC address from JSON field {@code bleaddr}. */
     public String getBleAddress() {
         return bleAddress;
+    }
+
+    /** Manufacturing serial from JSON field {@code serial_number}. */
+    public String getManufacturingSerial() {
+        return manufacturingSerial;
     }
 }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/AsgClientService.java
@@ -1089,9 +1089,9 @@ public class AsgClientService extends Service implements NetworkStateListener, T
     /**
      * Send version information to phone in chunks to work around BLE MTU limitations. Chunk 1
      * (version_info_1): app_version, build_number, device_model, android_version. Chunk 3
-     * (version_info_3): bes_fw_version, mtk_fw_version, bt_mac_address. The phone parses any
-     * version_info* message field-by-field, so chunk numbering gaps are fine (version_info_2
-     * used to carry ota_version_url; the glasses no longer advertise a manifest).
+     * (version_info_3): bes_fw_version, mtk_fw_version, bt_mac_address, serial_number. The phone
+     * parses any version_info* message field-by-field, so chunk numbering gaps are fine
+     * (version_info_2 used to carry ota_version_url; the glasses no longer advertise a manifest).
      */
     public void sendVersionInfo() {
         Log.i(TAG, "📊 Sending version information (chunked for MTU)");
@@ -1138,6 +1138,15 @@ public class AsgClientService extends Service implements NetworkStateListener, T
 
             // Include BES BT MAC address as unique device identifier (stored in system properties)
             String besBtMac = SysProp.getBesBtMac(this);
+            String manufacturingSerial = "";
+            if (serviceInitializer.getServiceManager() != null
+                    && serviceInitializer.getServiceManager().getAsgSettings() != null) {
+                manufacturingSerial =
+                        serviceInitializer
+                                .getServiceManager()
+                                .getAsgSettings()
+                                .getBesManufacturingSerial();
+            }
 
             Log.d(
                     TAG,
@@ -1150,7 +1159,9 @@ public class AsgClientService extends Service implements NetworkStateListener, T
                             + ", MTK Firmware: "
                             + mtkFirmwareVersion
                             + ", BT MAC: "
-                            + besBtMac);
+                            + besBtMac
+                            + ", Manufacturing serial available: "
+                            + !manufacturingSerial.isEmpty());
 
             if (serviceInitializer.getServiceManager().getBluetoothManager() != null
                     && serviceInitializer.getServiceManager().getBluetoothManager().isConnected()) {
@@ -1186,9 +1197,12 @@ public class AsgClientService extends Service implements NetworkStateListener, T
                 chunk3.put("bes_fw_version", besFirmwareVersion);
                 chunk3.put("mtk_fw_version", mtkFirmwareVersion);
                 chunk3.put("bt_mac_address", besBtMac);
+                if (!manufacturingSerial.isEmpty()) {
+                    chunk3.put("serial_number", manufacturingSerial);
+                }
                 addPhoneWireCapsIfSupported(chunk3);
 
-                Log.d(TAG, "📤 Sending version_info_3: " + chunk3.toString());
+                Log.d(TAG, "📤 Sending version_info_3");
                 serviceInitializer
                         .getServiceManager()
                         .getBluetoothManager()

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/BesVersionEventSubscriber.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/subscribers/BesVersionEventSubscriber.java
@@ -45,10 +45,13 @@ public final class BesVersionEventSubscriber implements IPeripheralBus.McuEventL
         String btName = versionEvent.getBtName();
         String btAddr = versionEvent.getBtAddress();
         String bleAddr = versionEvent.getBleAddress();
+        String manufacturingSerial = versionEvent.getManufacturingSerial();
 
         Log.i(TAG, "📋 System Version Report - Firmware: " + version);
         Log.i(TAG, "📋 BLE Name: " + bleName + ", BT Name: " + btName);
         Log.i(TAG, "📋 BT Address: " + btAddr + ", BLE Address: " + bleAddr);
+
+        boolean metadataUpdated = false;
 
         // Cache the MCU firmware version so it can be sent to phone when connected
         if (serviceManager != null
@@ -56,11 +59,18 @@ public final class BesVersionEventSubscriber implements IPeripheralBus.McuEventL
                 && !version.equals("unknown")
                 && !version.isEmpty()) {
             serviceManager.getAsgSettings().setMcuFirmwareVersion(version);
+            metadataUpdated = true;
+        }
 
-            // Re-send version info to phone now that we have fresh BES version
-            // This ensures phone has accurate firmware version for OTA checking
+        if (serviceManager != null && serviceManager.getAsgSettings() != null) {
+            serviceManager.getAsgSettings().setBesManufacturingSerial(manufacturingSerial);
+            metadataUpdated = true;
+        }
+
+        // Re-send version info once all fresh BES metadata has been cached.
+        if (metadataUpdated && serviceManager != null) {
             if (serviceManager.getService() != null) {
-                Log.i(TAG, "📋 BES version cached - re-sending version info to phone");
+                Log.i(TAG, "📋 BES metadata cached - re-sending version info to phone");
                 serviceManager.getService().sendVersionInfo();
             }
         }

--- a/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/settings/AsgSettings.java
@@ -561,6 +561,23 @@ public class AsgSettings {
         setMcuFirmwareVersion(version);
     }
 
+    /** Return the manufacturing serial last reported by the BES. */
+    public String getBesManufacturingSerial() {
+        return prefs.getString(AsgConstants.KEY_BES_MANUFACTURING_SERIAL, "");
+    }
+
+    /** Persist the manufacturing serial reported by the BES, or clear an unprovisioned value. */
+    public void setBesManufacturingSerial(String serialNumber) {
+        String normalized = serialNumber == null ? "" : serialNumber.trim();
+        if (normalized.isEmpty() || normalized.matches("0+")) {
+            prefs.edit().remove(AsgConstants.KEY_BES_MANUFACTURING_SERIAL).commit();
+            return;
+        }
+        prefs.edit()
+                .putString(AsgConstants.KEY_BES_MANUFACTURING_SERIAL, normalized)
+                .commit();
+    }
+
     /** Return the exact BES version field last used to evaluate fast-UART capability. */
     public String getBesBaudSwitchVersion() {
         return prefs.getString(KEY_BES_BAUD_SWITCH_VERSION, "");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/peripheral/McuEventParserTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/peripheral/McuEventParserTest.java
@@ -174,7 +174,8 @@ public class McuEventParserTest {
                         .put("ble", "MyBle")
                         .put("bt", "MyBt")
                         .put("btaddr", "AA:BB")
-                        .put("bleaddr", "CC:DD");
+                        .put("bleaddr", "CC:DD")
+                        .put("serial_number", "ML1234567890ABCD");
         McuEvent event = McuEventParser.parse(cmd("hs_syvr", body));
         assertThat(event).isInstanceOf(BesVersionEvent.class);
         BesVersionEvent version = (BesVersionEvent) event;
@@ -183,6 +184,7 @@ public class McuEventParserTest {
         assertThat(version.getBtName()).isEqualTo("MyBt");
         assertThat(version.getBtAddress()).isEqualTo("AA:BB");
         assertThat(version.getBleAddress()).isEqualTo("CC:DD");
+        assertThat(version.getManufacturingSerial()).isEqualTo("ML1234567890ABCD");
     }
 
     @Test

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -147,6 +147,13 @@ The MTK↔BES UART always starts at 460800 baud. Firmware that supports the nego
 
 ### Diagnostics and reporting
 
+The BES `hs_syvr` system-version response includes the provisioned
+manufacturing serial as `serial_number`. `asg_client` caches a valid value and
+forwards it to the phone in `version_info_3`; the all-zero factory default is
+treated as unprovisioned and omitted. This is the canonical inventory identity
+for Mentra Live. Android's `ro.serialno` and Bluetooth MAC addresses are not
+substitutes for it.
+
 `asg_client` includes logging, crash/error reporting, incident log buffering, and debug receivers for development and OTA testing. Production behavior should prioritize device stability and useful logs for support while avoiding secrets in logs.
 
 ## How Mentra Live works at runtime

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -152,11 +152,13 @@ reordering rows just because RSSI metadata arrives later.
 
 ## Mentra SDK Usage Analytics
 
-The SDK sends two anonymous usage events to Mentra's PostHog project by default
-so Mentra can understand SDK adoption and successful glasses connections:
+The SDK sends three usage events to Mentra's PostHog project by default so
+Mentra can understand SDK adoption, successful glasses connections, and
+enterprise device deployments:
 
 - `bluetooth_sdk_started`: sent once per app runtime after the native SDK starts.
 - `bluetooth_sdk_glasses_connected`: sent when SDK status transitions from not connected to connected.
+- `bluetooth_sdk_glasses_identified`: sent once per connection after the SDK receives a valid manufacturing serial from the glasses. Mentra Live requires compatible BES firmware and `asg_client` software for this event.
 
 Analytics delivery is fire-and-forget: events are submitted asynchronously, do
 not block Bluetooth SDK behavior, and are not retried if delivery fails.
@@ -190,14 +192,20 @@ write token, not a private PostHog personal API key. Apps do not configure the
 analytics destination; these SDK usage events are always sent to Mentra's
 PostHog project unless analytics are disabled.
 
-Captured properties are limited to non-sensitive SDK/app metadata:
-`event_source`, `sdk_platform`, `sdk_surface`, `sdk_version`, the app package or
-bundle identifier, OS platform/version, `event_kind`, and for connection events
-only `fully_booted` plus a glasses model value when the SDK knows it. The SDK
-does not upload BLE MAC addresses, CoreBluetooth identifiers, serial numbers,
-Bluetooth device names, user ids, tokens, Wi-Fi credentials, microphone data,
-photos, or transcripts. PostHog receives a locally generated anonymous SDK
-install id as `distinct_id`, and events include `$process_person_profile: false`.
+Captured properties include `event_source`, `sdk_platform`, `sdk_surface`,
+`sdk_version`, `app_identifier` (the Android package or iOS bundle identifier),
+the platform-specific `app_package` or `app_bundle_identifier`, OS
+platform/version, and `event_kind`. Connection events also include
+`fully_booted` and a glasses model value when known. The identification event
+intentionally includes the provisioned manufacturing serial as
+`glasses_device_id`, with `glasses_device_id_type=manufacturing_serial`, so
+Mentra can correlate enterprise fleet deployments.
+
+The SDK does not upload BLE MAC addresses, CoreBluetooth identifiers, Android
+device serials, Bluetooth device names, user ids, tokens, Wi-Fi credentials,
+microphone data, photos, or transcripts. PostHog receives a locally generated
+anonymous SDK install id as `distinct_id`, and events include
+`$process_person_profile: false`.
 
 ## React Hooks
 

--- a/mobile/modules/bluetooth-sdk/README.md
+++ b/mobile/modules/bluetooth-sdk/README.md
@@ -158,7 +158,7 @@ enterprise device deployments:
 
 - `bluetooth_sdk_started`: sent once per app runtime after the native SDK starts.
 - `bluetooth_sdk_glasses_connected`: sent when SDK status transitions from not connected to connected.
-- `bluetooth_sdk_glasses_identified`: sent once per connection after the SDK receives a valid manufacturing serial from the glasses. Mentra Live requires compatible BES firmware and `asg_client` software for this event.
+- `bluetooth_sdk_glasses_identified`: sent once per connection after the SDK receives a valid manufacturing serial from the glasses. This fires for every supported model that reports a serial. G1 and Ar99 decode the serial from the glasses' BLE advertisement, so they emit this event as soon as this SDK version ships. Mentra Live instead reports the serial provisioned in BES NV storage, which requires compatible BES firmware and `asg_client` software.
 
 Analytics delivery is fire-and-forget: events are submitted asynchronously, do
 not block Bluetooth SDK behavior, and are not retried if delivery fails.
@@ -197,15 +197,18 @@ Captured properties include `event_source`, `sdk_platform`, `sdk_surface`,
 the platform-specific `app_package` or `app_bundle_identifier`, OS
 platform/version, and `event_kind`. Connection events also include
 `fully_booted` and a glasses model value when known. The identification event
-intentionally includes the provisioned manufacturing serial as
-`glasses_device_id`, with `glasses_device_id_type=manufacturing_serial`, so
-Mentra can correlate enterprise fleet deployments.
+intentionally includes the glasses manufacturing serial as `glasses_device_id`,
+with `glasses_device_id_type=manufacturing_serial`, so Mentra can correlate
+fleet deployments across supported models. This serial identifies the glasses
+hardware, not the user or the host phone. Its source depends on the model:
+Mentra Live reports the serial provisioned in BES NV storage, while G1 and Ar99
+decode it from the glasses' BLE advertisement / manufacturer data.
 
-The SDK does not upload BLE MAC addresses, CoreBluetooth identifiers, Android
-device serials, Bluetooth device names, user ids, tokens, Wi-Fi credentials,
-microphone data, photos, or transcripts. PostHog receives a locally generated
-anonymous SDK install id as `distinct_id`, and events include
-`$process_person_profile: false`.
+Apart from that glasses serial, the SDK does not upload BLE MAC addresses,
+CoreBluetooth identifiers, the host phone's Android device serial, Bluetooth
+device names, user ids, tokens, Wi-Fi credentials, microphone data, photos, or
+transcripts. PostHog receives a locally generated anonymous SDK install id as
+`distinct_id`, and events include `$process_person_profile: false`.
 
 ## React Hooks
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkAnalytics.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkAnalytics.kt
@@ -53,7 +53,12 @@ internal class BluetoothSdkAnalytics(
     @Synchronized
     fun initializeGlassesStatus(status: GlassesStatus) {
         lastConnected = status.analyticsConnected
-        identifiedCapturedForConnection = status.analyticsConnected
+        // Only treat identification as already captured when a valid serial is
+        // present at init. If the glasses are connected but the serial has not
+        // arrived yet (Mentra Live fills it via version_info after connect), leave
+        // this false so the identify event still fires once the serial arrives.
+        identifiedCapturedForConnection =
+            status.analyticsConnected && status.serialNumber.validManufacturingSerial() != null
     }
 
     @Synchronized
@@ -83,7 +88,9 @@ internal class BluetoothSdkAnalytics(
                     status.deviceModel.takeIf { it.isNotBlank() }?.let { put("glasses_model", it) }
                 },
             )
-            return
+            // Fall through: a serial already present at connect time (G1/Ar99 report
+            // it in the advertisement) should be identified now rather than waiting
+            // for some later, unrelated glasses-store update to run.
         }
 
         val serialNumber = status.serialNumber.validManufacturingSerial() ?: return

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkAnalytics.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/BluetoothSdkAnalytics.kt
@@ -48,10 +48,12 @@ internal class BluetoothSdkAnalytics(
     private val config = initialConfig.toRuntimeConfig().resolvedForApp(appContext)
     private var startedCaptured = false
     private var lastConnected = false
+    private var identifiedCapturedForConnection = false
 
     @Synchronized
     fun initializeGlassesStatus(status: GlassesStatus) {
         lastConnected = status.analyticsConnected
+        identifiedCapturedForConnection = status.analyticsConnected
     }
 
     @Synchronized
@@ -67,12 +69,33 @@ internal class BluetoothSdkAnalytics(
         val wasConnected = lastConnected
         lastConnected = isConnected
         if (!config.isReady) return
+        if (!isConnected) {
+            identifiedCapturedForConnection = false
+            return
+        }
         if (isConnected && !wasConnected) {
+            identifiedCapturedForConnection = false
             capture(
                 "bluetooth_sdk_glasses_connected",
                 buildMap {
                     put("event_kind", "glasses_connected")
                     put("fully_booted", status.fullyBooted)
+                    status.deviceModel.takeIf { it.isNotBlank() }?.let { put("glasses_model", it) }
+                },
+            )
+            return
+        }
+
+        val serialNumber = status.serialNumber.validManufacturingSerial() ?: return
+        if (!identifiedCapturedForConnection) {
+            identifiedCapturedForConnection = true
+            capture(
+                "bluetooth_sdk_glasses_identified",
+                buildMap {
+                    put("event_kind", "glasses_identified")
+                    put("fully_booted", status.fullyBooted)
+                    put("glasses_device_id", serialNumber)
+                    put("glasses_device_id_type", "manufacturing_serial")
                     status.deviceModel.takeIf { it.isNotBlank() }?.let { put("glasses_model", it) }
                 },
             )
@@ -131,6 +154,7 @@ internal class BluetoothSdkAnalytics(
             put("sdk_platform", "android")
             put("sdk_surface", activeConfig.surface)
             put("sdk_version", BuildConfig.SDK_VERSION)
+            put("app_identifier", appContext.packageName)
             put("app_package", appContext.packageName)
             put("os_platform", "android")
             put("os_version", Build.VERSION.SDK_INT)
@@ -180,3 +204,6 @@ private fun BluetoothSdkAnalyticsRuntimeConfig.resolvedForApp(context: Context):
 
 private val GlassesStatus.analyticsConnected: Boolean
     get() = connectionState.isConnected || connected || fullyBooted
+
+private fun String.validManufacturingSerial(): String? =
+    trim().takeIf { it.isNotEmpty() && !it.matches(Regex("0+")) }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/DeviceManager.kt
@@ -2023,6 +2023,11 @@ class DeviceManager {
         shouldSendBootingMessage = true // Reset for next first connect
         // clear glasses properties:
         DeviceStore.apply("glasses", "deviceModel", "")
+        // A manufacturing serial is session-bound. Clear it on every disconnect so a
+        // previously connected pair's serial can never be reported for the next
+        // connection (e.g. switching from G1/Ar99, which populate it from the
+        // advertisement, to a model that never writes it, like G2).
+        DeviceStore.apply("glasses", "serialNumber", "")
         DeviceStore.apply("glasses", "fullyBooted", false)
         DeviceStore.apply("glasses", "connected", false)
         DeviceStore.apply(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/debug/BleTraceLogger.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/debug/BleTraceLogger.kt
@@ -12,7 +12,7 @@ object BleTraceLogger {
     private const val MAX_PAYLOAD_CHARS = 3000
     private const val K900_TYPE = "k900"
     private val sensitiveKeyParts =
-        listOf("password", "pass", "token", "secret", "authorization", "auth", "email")
+        listOf("password", "pass", "token", "secret", "authorization", "auth", "email", "serial")
 
     @JvmStatic
     fun logJson(direction: String, layer: String, payload: JSONObject?, bytes: Int? = null) {

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -815,9 +815,12 @@ class MentraLive : SGCManager() {
             return
         }
 
-        if (state == ConnTypes.CONNECTED || state == ConnTypes.DISCONNECTED) {
-            // A manufacturing serial is session-bound. Clear it before publishing the state
-            // transition so analytics can never associate a previous pair with this connection.
+        if (state == ConnTypes.DISCONNECTED) {
+            // A manufacturing serial is session-bound. Clear it on disconnect so a previous
+            // pair's serial can never be associated with the next connection. Connect must NOT
+            // clear it: DeviceManager.disconnect already wipes it before any new connection, and
+            // clearing on CONNECTED would wipe a still-valid serial mid-session when a same-link
+            // glasses_ready (e.g. ASG restart) re-publishes CONNECTED.
             DeviceStore.apply("glasses", "serialNumber", "")
         }
 

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -815,6 +815,12 @@ class MentraLive : SGCManager() {
             return
         }
 
+        if (state == ConnTypes.CONNECTED || state == ConnTypes.DISCONNECTED) {
+            // A manufacturing serial is session-bound. Clear it before publishing the state
+            // transition so analytics can never associate a previous pair with this connection.
+            DeviceStore.apply("glasses", "serialNumber", "")
+        }
+
         // Actually update the connection state!
         DeviceStore.apply("glasses", "connectionState", state)
 
@@ -3696,7 +3702,7 @@ class MentraLive : SGCManager() {
 
             "version_info" -> {
                 // Process version information from ASG client (legacy single-message format)
-                Bridge.log("LIVE: Received version info from ASG client: " + json.toString())
+                Bridge.log("LIVE: Received version info from ASG client")
 
                 // Extract version information
                 val appVersionLegacy = json.optString("app_version", "")
@@ -3706,6 +3712,7 @@ class MentraLive : SGCManager() {
                 val otaVersionUrlLegacy: String? = json.optString("ota_version_url", null)
                 val firmwareVersionLegacy = json.optString("firmware_version", "")
                 val btMacAddressLegacy = json.optString("bt_mac_address", "")
+                val serialNumberLegacy = json.optString("serial_number", "")
 
                 // Update parent SGCManager fields
                 DeviceStore.apply("glasses", "appVersion", appVersionLegacy)
@@ -3719,6 +3726,9 @@ class MentraLive : SGCManager() {
                 )
                 DeviceStore.apply("glasses", "firmwareVersion", firmwareVersionLegacy)
                 DeviceStore.apply("glasses", "bluetoothMacAddress", btMacAddressLegacy)
+                if (serialNumberLegacy.isNotBlank()) {
+                    DeviceStore.apply("glasses", "serialNumber", serialNumberLegacy)
+                }
 
                 val versionInfoLegacy = HashMap<String, Any>()
                 versionInfoLegacy["appVersion"] = appVersionLegacy
@@ -3900,7 +3910,7 @@ class MentraLive : SGCManager() {
             else -> {
                 // Flexible version_info parsing - handle any version_info* message
                 if (type.startsWith("version_info")) {
-                    Bridge.log("LIVE: Received " + type + ": " + json.toString())
+                    Bridge.log("LIVE: Received " + type)
 
                     // Extract all fields from JSON (except "type")
                     val fields = HashMap<String, Any>()
@@ -3986,6 +3996,10 @@ class MentraLive : SGCManager() {
                                 "bluetoothMacAddress",
                                 fields["bt_mac_address"] as String
                         )
+                    }
+                    val serialNumber = fields["serial_number"] as? String
+                    if (!serialNumber.isNullOrBlank()) {
+                        DeviceStore.apply("glasses", "serialNumber", serialNumber)
                     }
                     if (fields.containsKey("system_time_ms")) {
                         val v = fields["system_time_ms"]

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1678,6 +1678,11 @@ struct ViewState {
         shouldSendBootingMessage = true // Reset for next first connect
         // clear glasses properties:
         DeviceStore.shared.apply("glasses", "deviceModel", "")
+        // A manufacturing serial is session-bound. Clear it on every disconnect so a
+        // previously connected pair's serial can never be reported for the next
+        // connection (e.g. switching from G1/Ar99, which populate it from the
+        // advertisement, to a model that never writes it, like G2).
+        DeviceStore.shared.apply("glasses", "serialNumber", "")
         DeviceStore.shared.apply("glasses", "fullyBooted", false)
         DeviceStore.shared.apply("glasses", "connected", false)
         DeviceStore.shared.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BleTraceLogger.swift
@@ -6,7 +6,7 @@ enum BleTraceLogger {
     private static let log = OSLog(subsystem: "com.mentra.bluetoothsdk", category: "MentraBleTrace")
     private static let maxPayloadChars = 3000
     private static let k900Type = "k900"
-    private static let sensitiveKeyParts = ["password", "pass", "token", "secret", "authorization", "auth", "email"]
+    private static let sensitiveKeyParts = ["password", "pass", "token", "secret", "authorization", "auth", "email", "serial"]
 
     static func logJson(
         direction: String,

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
@@ -48,7 +48,12 @@ final class BluetoothSdkAnalytics {
     func initializeGlassesStatus(_ status: GlassesStatus) {
         stateQueue.sync {
             lastConnected = status.analyticsConnected
-            identifiedCapturedForConnection = status.analyticsConnected
+            // Only treat identification as already captured when a valid serial is
+            // present at init. If the glasses are connected but the serial has not
+            // arrived yet (Mentra Live fills it via version_info after connect), leave
+            // this false so the identify event still fires once the serial arrives.
+            identifiedCapturedForConnection =
+                status.analyticsConnected && status.serialNumber.validManufacturingSerial != nil
         }
     }
 
@@ -88,7 +93,9 @@ final class BluetoothSdkAnalytics {
                     properties["glasses_model"] = status.deviceModel
                 }
                 capture(event: "bluetooth_sdk_glasses_connected", properties: properties, configuration: configuration)
-                return
+                // Fall through: a serial already present at connect time (G1/Ar99
+                // report it in the advertisement) should be identified now rather than
+                // waiting for some later, unrelated glasses-store update to run.
             }
 
             guard !identifiedCapturedForConnection,

--- a/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/internal/BluetoothSdkAnalytics.swift
@@ -39,6 +39,7 @@ final class BluetoothSdkAnalytics {
     private let configuration: BluetoothSdkAnalyticsConfiguration
     private var startedCaptured = false
     private var lastConnected = false
+    private var identifiedCapturedForConnection = false
 
     init(configuration: BluetoothSdkAnalyticsConfiguration) {
         self.configuration = configuration.resolvedForApp()
@@ -47,6 +48,7 @@ final class BluetoothSdkAnalytics {
     func initializeGlassesStatus(_ status: GlassesStatus) {
         stateQueue.sync {
             lastConnected = status.analyticsConnected
+            identifiedCapturedForConnection = status.analyticsConnected
         }
     }
 
@@ -72,7 +74,12 @@ final class BluetoothSdkAnalytics {
             let wasConnected = lastConnected
             lastConnected = isConnected
             guard configuration.isReady else { return }
+            guard isConnected else {
+                identifiedCapturedForConnection = false
+                return
+            }
             if isConnected, !wasConnected {
+                identifiedCapturedForConnection = false
                 var properties: [String: Any] = [
                     "event_kind": "glasses_connected",
                     "fully_booted": status.fullyBooted,
@@ -81,7 +88,23 @@ final class BluetoothSdkAnalytics {
                     properties["glasses_model"] = status.deviceModel
                 }
                 capture(event: "bluetooth_sdk_glasses_connected", properties: properties, configuration: configuration)
+                return
             }
+
+            guard !identifiedCapturedForConnection,
+                  let serialNumber = status.serialNumber.validManufacturingSerial
+            else { return }
+            identifiedCapturedForConnection = true
+            var properties: [String: Any] = [
+                "event_kind": "glasses_identified",
+                "fully_booted": status.fullyBooted,
+                "glasses_device_id": serialNumber,
+                "glasses_device_id_type": "manufacturing_serial",
+            ]
+            if !status.deviceModel.isEmpty {
+                properties["glasses_model"] = status.deviceModel
+            }
+            capture(event: "bluetooth_sdk_glasses_identified", properties: properties, configuration: configuration)
         }
     }
 
@@ -116,6 +139,7 @@ final class BluetoothSdkAnalytics {
             "event_source": "mentra_bluetooth_sdk",
             "sdk_platform": "ios",
             "sdk_surface": configuration.surface,
+            "app_identifier": Bundle.main.bundleIdentifier ?? "",
             "app_bundle_identifier": Bundle.main.bundleIdentifier ?? "",
             "os_platform": "ios",
             "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
@@ -145,6 +169,14 @@ final class BluetoothSdkAnalytics {
 private extension GlassesStatus {
     var analyticsConnected: Bool {
         connectionState.isConnected || connected || fullyBooted
+    }
+}
+
+private extension String {
+    var validManufacturingSerial: String? {
+        let normalized = trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, normalized.contains(where: { $0 != "0" }) else { return nil }
+        return normalized
     }
 }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1280,9 +1280,13 @@ class MentraLive: NSObject, SGCManager {
 
     /// Mirrors Android `updateConnectionState` — RN home reads `glasses.connectionState` for reconnecting UI.
     private func updateConnectionState(_ state: String) {
-        if state == ConnTypes.CONNECTED || state == ConnTypes.DISCONNECTED {
-            // Clear before publishing the transition so a previous pair's serial cannot be
-            // associated with this connection while fresh version info is still in flight.
+        if state == ConnTypes.DISCONNECTED {
+            // A manufacturing serial is session-bound. Clear it on disconnect so a previous
+            // pair's serial cannot be associated with the next connection. Connect must NOT
+            // clear it: DeviceManager.disconnect already wipes it before any new connection, and
+            // clearing on CONNECTED would wipe a still-valid serial mid-session when a same-link
+            // glasses_ready (e.g. ASG restart) re-publishes CONNECTED (iOS has no equal-state
+            // early return, unlike Android).
             DeviceStore.shared.apply("glasses", "serialNumber", "")
         }
         connectionState = state

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -1280,6 +1280,11 @@ class MentraLive: NSObject, SGCManager {
 
     /// Mirrors Android `updateConnectionState` — RN home reads `glasses.connectionState` for reconnecting UI.
     private func updateConnectionState(_ state: String) {
+        if state == ConnTypes.CONNECTED || state == ConnTypes.DISCONNECTED {
+            // Clear before publishing the transition so a previous pair's serial cannot be
+            // associated with this connection while fresh version info is still in flight.
+            DeviceStore.shared.apply("glasses", "serialNumber", "")
+        }
         connectionState = state
         DeviceStore.shared.apply("glasses", "connectionState", state)
         // Drop OTA caches when fully disconnected — avoids leaking session/step state from
@@ -2709,7 +2714,7 @@ class MentraLive: NSObject, SGCManager {
         default:
             // Flexible version_info parsing - handle any version_info* message
             if type.hasPrefix("version_info") {
-                Bridge.log("LIVE: Received \(type): \(json)")
+                Bridge.log("LIVE: Received \(type)")
 
                 // Extract all fields from JSON (except "type")
                 var fields: [String: Any] = [:]
@@ -2752,6 +2757,9 @@ class MentraLive: NSObject, SGCManager {
                 }
                 if let bluetoothMacAddress = fields["bt_mac_address"] as? String {
                     DeviceStore.shared.apply("glasses", "bluetoothMacAddress", bluetoothMacAddress)
+                }
+                if let serialNumber = fields["serial_number"] as? String, !serialNumber.isEmpty {
+                    DeviceStore.shared.apply("glasses", "serialNumber", serialNumber)
                 }
                 if let systemTimeMs = fields["system_time_ms"] as? NSNumber {
                     DeviceStore.shared.apply("glasses", "systemTimeMs", systemTimeMs.int64Value)
@@ -3429,12 +3437,16 @@ class MentraLive: NSObject, SGCManager {
         let otaVersionUrl = json["ota_version_url"] as? String ?? ""
         let firmwareVersion = json["firmware_version"] as? String ?? ""
         let bluetoothMacAddress = json["bt_mac_address"] as? String ?? ""
+        let serialNumber = json["serial_number"] as? String ?? ""
 
         DeviceStore.shared.apply("glasses", "appVersion", appVersion)
         DeviceStore.shared.apply("glasses", "buildNumber", buildNumber)
         DeviceStore.shared.apply("glasses", "otaVersionUrl", otaVersionUrl)
         DeviceStore.shared.apply("glasses", "firmwareVersion", firmwareVersion)
         DeviceStore.shared.apply("glasses", "bluetoothMacAddress", bluetoothMacAddress)
+        if !serialNumber.isEmpty {
+            DeviceStore.shared.apply("glasses", "serialNumber", serialNumber)
+        }
         isNewVersion = (Int(buildNumber) ?? 0) >= 5
         maybeSendWireHandshake()
         DeviceStore.shared.apply("glasses", "deviceModel", deviceModel)


### PR DESCRIPTION
## Summary

- carry the provisioned Mentra Live manufacturing serial from BES `hs_syvr` through `asg_client` and `version_info_3` into the Android and iOS SDK state
- add `bluetooth_sdk_glasses_identified`, emitted once per successful connection after a valid manufacturing serial arrives
- add a common `app_identifier` property while retaining Android `app_package` and iOS `app_bundle_identifier`
- clear session-bound serial state on connect/disconnect and clear cached all-zero/unprovisioned values
- redact serial fields from BLE diagnostic traces

## Event schema

`bluetooth_sdk_glasses_identified` includes:

- `event_kind=glasses_identified`
- `glasses_device_id=<provisioned manufacturing serial>`
- `glasses_device_id_type=manufacturing_serial`
- `fully_booted`
- `glasses_model` when known
- the existing SDK/platform/app metadata, including `app_identifier`

The raw manufacturing serial is intentionally sent to Mentra PostHog for enterprise fleet correlation. BLE MAC addresses, CoreBluetooth identifiers, Android device serials, Bluetooth names, user ids, credentials, and media are not sent. `$process_person_profile` remains `false`.

The existing `bluetooth_sdk_started` and `bluetooth_sdk_glasses_connected` events are unchanged. Older BES firmware continues to report starts and connections but cannot emit the identification event.

## Configuration and opt-out

Analytics remain enabled by default and continue to target Mentra PostHog. Existing opt-outs are unchanged:

- Expo config plugin: `analytics: false`
- Android: `BluetoothSdkAnalyticsConfig.disabled()` or `com.mentra.bluetoothsdk.analytics.disabled=true`
- iOS: `.disabled` or `MentraBluetoothSdkAnalyticsDisabled=true`

No new secrets or environment variables are required.

## Firmware dependency

Depends on fengyue120/mentra-live-bes#22 for BES firmware to expose the provisioned serial. Roll out the BES firmware plus this `asg_client`/SDK support before expecting identification events.

## Validation

- `git diff --check`
- `./gradlew :app:testDebugUnitTest --tests com.mentra.asg_client.io.peripheral.McuEventParserTest`
- `./scripts/check-android-compile.sh asg`
- `CI=1 bun run build`
- `CI=1 bun test --runInBand` (16 passing)
- `./scripts/check-android-compile.sh bluetooth-sdk`
- `swiftformat --lint` on touched Swift files
- `xcodebuild -scheme MentraBluetoothSDK -destination generic/platform=iOS -sdk iphoneos CODE_SIGNING_ALLOWED=NO build`

No real PostHog events were sent and no firmware or APK was installed on hardware during validation. The repository-wide ASG Spotless check remains blocked in worktrees because ratcheting is disabled and an unrelated existing Java file has non-contiguous imports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new analytics event that uploads manufacturing serials to PostHog and extends the phone↔glasses version protocol; behavior is gated on serial validation and session clearing, but fleet identity reporting is a deliberate product/privacy surface change.
> 
> **Overview**
> **Mentra Live** now treats the BES-provisioned manufacturing serial as canonical device identity: `hs_syvr` parses `serial_number`, caches it in `AsgSettings` (dropping empty/all-zero values), and includes it in BLE `version_info_3` when valid. Docs describe this as the inventory ID, not MAC or `ro.serialno`.
> 
> **Bluetooth SDK (Android/iOS)** ingests `serial_number` from Mentra Live `version_info*` messages into `glasses.serialNumber`, clears that field on disconnect (and on Mentra Live disconnect in `DeviceManager` / `MentraLive`), and adds **`bluetooth_sdk_glasses_identified`**—once per connection after a valid serial is available (including late arrival after connect for Live). Analytics also adds **`app_identifier`** and documents that the manufacturing serial is intentionally sent to PostHog as `glasses_device_id`. BLE trace loggers redact `serial` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e064de1b9f8690c19e5edd99c7ed0ee74900687. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->