### PR TITLE
Fix offline Mapbox route fallback

### DIFF
--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/navigation/NavigationManager.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/navigation/NavigationManager.kt
@@ -436,6 +436,8 @@ object NavigationManager {
       .alternatives(false)
       .steps(true)
       .bannerInstructions(true)
+      // The onboard router rejects voice units when voice instructions are disabled.
+      .voiceUnits(null)
       .voiceInstructions(false)
       .exclude(buildExclude(options))
       .build()


### PR DESCRIPTION
## Summary

- clear `voiceUnits` when native Mapbox voice instructions are disabled
- keep device-language setup for localized banner instructions and road names
- allow Mapbox's onboard router to parse fallback route requests

## Root cause

`applyLanguageAndVoiceUnitOptions` adds `voice_units`, but this integration then sets `voice_instructions=false` because the miniapp owns TTS. Mapbox's online API tolerated that combination; the onboard router rejects it as an input error.

## Validation

- `./scripts/check-android-compile.sh bluetooth-sdk`
- `cd mobile/android && ./gradlew :mentra-crust:compileDebugKotlin --no-daemon --console=plain`
- `git diff --check`

Linear: [OS-1791](https://linear.app/mentralabs/issue/OS-1791/maps-offline-routing-fallback-always-fails-voice-units-sent-without)

Review: @isaiahb

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes offline `Mapbox` routing fallback by clearing voice units when voice instructions are disabled so the onboard router accepts route requests. Addresses Linear OS-1791.

- **Bug Fixes**
  - Set `.voiceUnits(null)` when `.voiceInstructions(false)` to prevent onboard router input errors while keeping localized banner instructions and road names.

<sup>Written for commit 33d8d7bd4e69557e147736a4ff7b84ae8b563001. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter tweak on route option building; no auth or data changes, with localized banner behavior preserved.
> 
> **Overview**
> Fixes **offline Mapbox route fallback** failing when the online router is unavailable.
> 
> In `requestAndStartRoute`, route options still call `applyLanguageAndVoiceUnitOptions` for localized banners and road names, but now **clear `voiceUnits`** (`.voiceUnits(null)`) before `voiceInstructions(false)`. Mapbox’s onboard router rejects requests that include voice units without voice instructions; the online API allowed that mismatch because TTS is handled in the miniapp, not native Mapbox voice.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33d8d7bd4e69557e147736a4ff7b84ae8b563001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->