### PR TITLE
Wire AR99 credentials into mobile CI

### DIFF
--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -30,6 +30,9 @@ jobs:
     # staging/release builds. Blacksmith (more vCPU + NVMe) is faster than the
     # free ubuntu-latest tier; same provider we already use for cloud builds.
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
 
     steps:
       - name: Update PR comment - Build started

--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -21,6 +21,9 @@ concurrency:
 jobs:
   build:
     runs-on: [self-hosted, macOS, ARM64]
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
 
     steps:
       - name: Kill stale build processes (this runner's prior job only)

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -74,6 +74,9 @@ jobs:
     # (per-runner git config, Mentra credentials at ~/.mentra/credentials).
     # ASG client below stays unconstrained because it's a clean gradle build.
     runs-on: [self-hosted, macOS, ARM64]
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
 
     # Surface release-status.json fields as job outputs so slack-notify can
     # build a per-platform status section. See mobile/scripts/release-android.mjs.
@@ -287,6 +290,9 @@ jobs:
   build-mobile-ios:
     name: Build Mobile App (iOS)
     runs-on: [self-hosted, macOS, ARM64]
+    env:
+      EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID }}
+      EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: ${{ secrets.EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY }}
 
     outputs:
       ipa_name: ${{ steps.release-status.outputs.ipa_name }}


### PR DESCRIPTION
## Summary

- expose the AR99 release developer ID and client key from GitHub Actions secrets to mobile builds
- cover Android and iOS PR/dev builds
- cover Android and iOS staging release builds

## Why

The AR99 OTA client reads these values from `EXPO_PUBLIC_AR99_RELEASE_*`, but GitHub Actions secrets are not automatically available to build processes. Mapping them at the mobile job level makes the credentials available throughout Expo, Gradle, Xcode, and the release scripts.

## Validation

- confirmed both repository secrets exist with the expected names
- ran `git diff --check`
- parsed all three changed workflow files as YAML

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose AR99 release credentials to mobile CI by wiring GitHub Actions secrets into Android and iOS build jobs. Makes `EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID` and `EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY` available to PR/dev and staging release builds across Expo, Gradle, Xcode, and release scripts.

<sup>Written for commit bc197582b938523aeb3308d1e8a86f138fc53ff2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Injects release OTA client credentials into CI-built binaries (expected for AR99); misconfigured or missing secrets would yield empty creds in shipped PR/staging builds rather than changing unrelated systems.
> 
> **Overview**
> Maps GitHub Actions secrets **`EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID`** and **`EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY`** into **job-level `env`** on every mobile compile path that was missing them, so Expo/Gradle/Xcode and release scripts can bake AR99 OTA client credentials the app already reads from `EXPO_PUBLIC_AR99_*`.
> 
> **Android PR/dev** (`mentra-app-android-build.yml`), **iOS PR/dev** (`mentra-app-ios-build.yml`), and **staging Android + iOS** (`staging-builds.yml` `build-mobile-android` / `build-mobile-ios`) now get the same two variables for the whole job—mirroring how other build-time secrets (e.g. Mapbox) are supplied, without changing build steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc197582b938523aeb3308d1e8a86f138fc53ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->