### PR TITLE
Rewrite iOS BLE relay uploads to loopback for the local photo receiver

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
@@ -3,207 +3,212 @@ import ExpoModulesCore
 import Foundation
 
 public class MentraPhotoReceiverModule: Module {
-  private let receiverLock = NSLock()
-  private var photoUploadServer: LocalPhotoUploadServer?
+    private let receiverLock = NSLock()
+    private var photoUploadServer: LocalPhotoUploadServer?
 
-  public func definition() -> ModuleDefinition {
-    Name("MentraPhotoReceiver")
+    public func definition() -> ModuleDefinition {
+        Name("MentraPhotoReceiver")
 
-    Events("photoUpload", "receiverStatus")
+        Events("photoUpload", "receiverStatus")
 
-    AsyncFunction("isSupported") {
-      true
+        AsyncFunction("isSupported") {
+            true
+        }
+
+        AsyncFunction("startPhotoReceiver") { () -> [String: Any] in
+            try startPhotoReceiver()
+        }
+
+        AsyncFunction("stopPhotoReceiver") {
+            stopPhotoReceiverInternal()
+        }
+
+        OnDestroy {
+            stopPhotoReceiverInternal()
+        }
     }
 
-    AsyncFunction("startPhotoReceiver") { () -> [String: Any] in
-      try startPhotoReceiver()
+    private func startPhotoReceiver() throws -> [String: Any] {
+        receiverLock.lock()
+        defer { receiverLock.unlock() }
+
+        guard let host = bestLocalIPv4Address() else {
+            throw PhotoReceiverError("No Wi-Fi/LAN IPv4 address found for this phone.")
+        }
+
+        let server = photoUploadServer ?? LocalPhotoUploadServer(
+            onLog: { [weak self] message in
+                self?.emitStatus(message: message)
+            },
+            onUpload: { [weak self] upload in
+                self?.handlePhotoUpload(upload)
+            }
+        )
+        photoUploadServer = server
+
+        if let activePort = server.activePort {
+            let uploadUrl = "http://\(host):\(activePort)/upload"
+            LocalPhotoReceiverRegistry.register(uploadUrl)
+            emitStatus(message: "Photo receiver ready at \(uploadUrl)")
+            return receiverResult(uploadUrl: uploadUrl, host: host, port: activePort)
+        }
+
+        var lastError: Error?
+        for port in photoPorts {
+            do {
+                let actualPort = try server.start(port: UInt16(port))
+                let uploadUrl = "http://\(host):\(actualPort)/upload"
+                LocalPhotoReceiverRegistry.register(uploadUrl)
+                emitStatus(message: "Photo receiver ready at \(uploadUrl)")
+                return receiverResult(uploadUrl: uploadUrl, host: host, port: actualPort)
+            } catch {
+                lastError = error
+                emitStatus(message: "Port \(port) unavailable: \(error.localizedDescription)")
+            }
+        }
+
+        throw PhotoReceiverError(
+            "Could not start phone photo receiver: \(lastError?.localizedDescription ?? "all ports unavailable")"
+        )
     }
 
-    AsyncFunction("stopPhotoReceiver") {
-      stopPhotoReceiverInternal()
+    private func stopPhotoReceiverInternal() {
+        receiverLock.lock()
+        defer { receiverLock.unlock() }
+
+        LocalPhotoReceiverRegistry.unregister()
+        photoUploadServer?.stop()
+        emitStatus(message: "Photo receiver stopped")
     }
 
-    OnDestroy {
-      stopPhotoReceiverInternal()
-    }
-  }
-
-  private func startPhotoReceiver() throws -> [String: Any] {
-    receiverLock.lock()
-    defer { receiverLock.unlock() }
-
-    guard let host = bestLocalIPv4Address() else {
-      throw PhotoReceiverError("No Wi-Fi/LAN IPv4 address found for this phone.")
-    }
-
-    let server = photoUploadServer ?? LocalPhotoUploadServer(
-      onLog: { [weak self] message in
-        self?.emitStatus(message: message)
-      },
-      onUpload: { [weak self] upload in
-        self?.handlePhotoUpload(upload)
-      }
-    )
-    photoUploadServer = server
-
-    if let activePort = server.activePort {
-      let uploadUrl = "http://\(host):\(activePort)/upload"
-      emitStatus(message: "Photo receiver ready at \(uploadUrl)")
-      return receiverResult(uploadUrl: uploadUrl, host: host, port: activePort)
+    private func handlePhotoUpload(_ upload: PhotoUpload) {
+        BleTraceLogger.logMap(
+            direction: "phone_to_app",
+            layer: "photo_receiver_event",
+            type: "photo_upload",
+            payload: [
+                "requestId": upload.requestId ?? "",
+                "fileName": upload.photoFile.lastPathComponent,
+                "byteCount": upload.byteCount,
+            ]
+        )
+        sendEvent("photoUpload", [
+            "requestId": upload.requestId as Any,
+            "fileUri": upload.photoFile.absoluteString,
+            "byteCount": upload.byteCount,
+        ])
+        emitStatus(message: "Photo uploaded (\(upload.byteCount) bytes)")
     }
 
-    var lastError: Error?
-    for port in photoPorts {
-      do {
-        let actualPort = try server.start(port: UInt16(port))
-        let uploadUrl = "http://\(host):\(actualPort)/upload"
-        emitStatus(message: "Photo receiver ready at \(uploadUrl)")
-        return receiverResult(uploadUrl: uploadUrl, host: host, port: actualPort)
-      } catch {
-        lastError = error
-        emitStatus(message: "Port \(port) unavailable: \(error.localizedDescription)")
-      }
+    private func emitStatus(message: String) {
+        NSLog("[MentraPhotoReceiver] %@", message)
+        sendEvent("receiverStatus", [
+            "message": message,
+        ])
     }
 
-    throw PhotoReceiverError(
-      "Could not start phone photo receiver: \(lastError?.localizedDescription ?? "all ports unavailable")"
-    )
-  }
+    private func bestLocalIPv4Address() -> String? {
+        var interfaces: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&interfaces) == 0, let first = interfaces else {
+            return nil
+        }
+        defer { freeifaddrs(interfaces) }
 
-  private func stopPhotoReceiverInternal() {
-    receiverLock.lock()
-    defer { receiverLock.unlock() }
+        var preferredPrivate: String?
+        var preferred: String?
+        var privateFallback: String?
+        var fallback: String?
+        var cursor: UnsafeMutablePointer<ifaddrs>? = first
+        while let current = cursor {
+            defer { cursor = current.pointee.ifa_next }
+            let interface = current.pointee
+            guard let addressPointer = interface.ifa_addr,
+                  addressPointer.pointee.sa_family == UInt8(AF_INET)
+            else {
+                continue
+            }
 
-    photoUploadServer?.stop()
-    emitStatus(message: "Photo receiver stopped")
-  }
+            let name = String(cString: interface.ifa_name)
+            let flags = interface.ifa_flags
+            guard (flags & UInt32(IFF_UP)) != 0,
+                  (flags & UInt32(IFF_LOOPBACK)) == 0
+            else {
+                continue
+            }
 
-  private func handlePhotoUpload(_ upload: PhotoUpload) {
-    BleTraceLogger.logMap(
-      direction: "phone_to_app",
-      layer: "photo_receiver_event",
-      type: "photo_upload",
-      payload: [
-        "requestId": upload.requestId ?? "",
-        "fileName": upload.photoFile.lastPathComponent,
-        "byteCount": upload.byteCount,
-      ]
-    )
-    sendEvent("photoUpload", [
-      "requestId": upload.requestId as Any,
-      "fileUri": upload.photoFile.absoluteString,
-      "byteCount": upload.byteCount,
-    ])
-    emitStatus(message: "Photo uploaded (\(upload.byteCount) bytes)")
-  }
+            var address = addressPointer.pointee
+            var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let result = getnameinfo(
+                &address,
+                socklen_t(address.sa_len),
+                &hostname,
+                socklen_t(hostname.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            )
+            guard result == 0 else {
+                continue
+            }
 
-  private func emitStatus(message: String) {
-    NSLog("[MentraPhotoReceiver] %@", message)
-    sendEvent("receiverStatus", [
-      "message": message,
-    ])
-  }
+            let ip = String(cString: hostname)
+            guard ip != "127.0.0.1", !isLinkLocalIPv4(ip) else {
+                continue
+            }
+            if isPreferredLocalInterface(name), isPrivateIPv4(ip) {
+                preferredPrivate = preferredPrivate ?? ip
+            } else if isPreferredLocalInterface(name) {
+                preferred = preferred ?? ip
+            } else if isPrivateIPv4(ip) {
+                privateFallback = privateFallback ?? ip
+            } else {
+                fallback = fallback ?? ip
+            }
+        }
 
-  private func bestLocalIPv4Address() -> String? {
-    var interfaces: UnsafeMutablePointer<ifaddrs>?
-    guard getifaddrs(&interfaces) == 0, let first = interfaces else {
-      return nil
-    }
-    defer { freeifaddrs(interfaces) }
-
-    var preferredPrivate: String?
-    var preferred: String?
-    var privateFallback: String?
-    var fallback: String?
-    var cursor: UnsafeMutablePointer<ifaddrs>? = first
-    while let current = cursor {
-      defer { cursor = current.pointee.ifa_next }
-      let interface = current.pointee
-      guard let addressPointer = interface.ifa_addr,
-            addressPointer.pointee.sa_family == UInt8(AF_INET) else {
-        continue
-      }
-
-      let name = String(cString: interface.ifa_name)
-      let flags = interface.ifa_flags
-      guard (flags & UInt32(IFF_UP)) != 0,
-            (flags & UInt32(IFF_LOOPBACK)) == 0 else {
-        continue
-      }
-
-      var address = addressPointer.pointee
-      var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-      let result = getnameinfo(
-        &address,
-        socklen_t(address.sa_len),
-        &hostname,
-        socklen_t(hostname.count),
-        nil,
-        0,
-        NI_NUMERICHOST
-      )
-      guard result == 0 else {
-        continue
-      }
-
-      let ip = String(cString: hostname)
-      guard ip != "127.0.0.1", !isLinkLocalIPv4(ip) else {
-        continue
-      }
-      if isPreferredLocalInterface(name), isPrivateIPv4(ip) {
-        preferredPrivate = preferredPrivate ?? ip
-      } else if isPreferredLocalInterface(name) {
-        preferred = preferred ?? ip
-      } else if isPrivateIPv4(ip) {
-        privateFallback = privateFallback ?? ip
-      } else {
-        fallback = fallback ?? ip
-      }
+        return preferredPrivate ?? preferred ?? privateFallback ?? fallback
     }
 
-    return preferredPrivate ?? preferred ?? privateFallback ?? fallback
-  }
-
-  private func receiverResult(uploadUrl: String, host: String, port: UInt16) -> [String: Any] {
-    [
-      "uploadUrl": uploadUrl,
-      "host": host,
-      "port": port,
-    ]
-  }
-
-  private func isPreferredLocalInterface(_ name: String) -> Bool {
-    name == "en0" ||
-      name.hasPrefix("bridge") ||
-      name.hasPrefix("ap") ||
-      name.hasPrefix("awdl") ||
-      name.hasPrefix("llw")
-  }
-
-  private func isPrivateIPv4(_ ip: String) -> Bool {
-    if ip.hasPrefix("192.168.") || ip.hasPrefix("10.") {
-      return true
+    private func receiverResult(uploadUrl: String, host: String, port: UInt16) -> [String: Any] {
+        [
+            "uploadUrl": uploadUrl,
+            "host": host,
+            "port": port,
+        ]
     }
-    let parts = ip.split(separator: ".").compactMap { Int($0) }
-    return parts.count == 4 && parts[0] == 172 && (16...31).contains(parts[1])
-  }
 
-  private func isLinkLocalIPv4(_ ip: String) -> Bool {
-    ip.hasPrefix("169.254.")
-  }
+    private func isPreferredLocalInterface(_ name: String) -> Bool {
+        name == "en0" ||
+            name.hasPrefix("bridge") ||
+            name.hasPrefix("ap") ||
+            name.hasPrefix("awdl") ||
+            name.hasPrefix("llw")
+    }
 
-  private let photoPorts = [8787, 8788, 8789, 8790]
+    private func isPrivateIPv4(_ ip: String) -> Bool {
+        if ip.hasPrefix("192.168.") || ip.hasPrefix("10.") {
+            return true
+        }
+        let parts = ip.split(separator: ".").compactMap { Int($0) }
+        return parts.count == 4 && parts[0] == 172 && (16 ... 31).contains(parts[1])
+    }
+
+    private func isLinkLocalIPv4(_ ip: String) -> Bool {
+        ip.hasPrefix("169.254.")
+    }
+
+    private let photoPorts = [8787, 8788, 8789, 8790]
 }
 
 final class PhotoReceiverError: Exception, @unchecked Sendable {
-  private let message: String
+    private let message: String
 
-  init(_ message: String) {
-    self.message = message
-    super.init()
-  }
+    init(_ message: String) {
+        self.message = message
+        super.init()
+    }
 
-  override var reason: String {
-    message
-  }
+    override var reason: String {
+        message
+    }
 }

--- a/mobile/modules/bluetooth-sdk/ios/Source/LocalPhotoReceiverRegistry.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/LocalPhotoReceiverRegistry.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Tracks the SDK photo receiver that is hosted inside the phone app process.
+///
+/// The glasses need a LAN-reachable URL, but the phone-side BLE fallback relay
+/// can upload to the same receiver over loopback. Keeping this tiny registry lets
+/// the relay avoid stale Wi-Fi interface addresses after network changes.
+enum LocalPhotoReceiverRegistry {
+    private static let lock = NSLock()
+    private static var activeUploadUrls: [URLComponents] = []
+
+    static func register(_ uploadUrl: String) {
+        guard let components = URLComponents(string: uploadUrl),
+              isSupportedUploadUri(components)
+        else {
+            return
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        if !activeUploadUrls.contains(where: { matchesRegisteredUploadUri($0, components) }) {
+            activeUploadUrls.append(components)
+        }
+    }
+
+    static func unregister() {
+        lock.lock()
+        defer { lock.unlock() }
+        activeUploadUrls = []
+    }
+
+    static func isActive() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !activeUploadUrls.isEmpty
+    }
+
+    static func loopbackUploadUrl(for webhookUrl: String?) -> String? {
+        guard let webhookUrl, !webhookUrl.isEmpty else {
+            return nil
+        }
+        lock.lock()
+        let registeredUris = activeUploadUrls
+        lock.unlock()
+        guard !registeredUris.isEmpty,
+              let candidate = URLComponents(string: webhookUrl),
+              isSupportedUploadUri(candidate)
+        else {
+            return nil
+        }
+
+        for registered in registeredUris where matchesRegisteredUploadUri(candidate, registered) {
+            var rewritten = URLComponents()
+            rewritten.scheme = candidate.scheme
+            rewritten.host = "127.0.0.1"
+            rewritten.port = effectivePort(candidate)
+            rewritten.percentEncodedPath = normalizedPath(candidate)
+            rewritten.percentEncodedQuery = candidate.percentEncodedQuery
+            rewritten.percentEncodedFragment = candidate.percentEncodedFragment
+            return rewritten.string
+        }
+        return nil
+    }
+
+    private static func matchesRegisteredUploadUri(
+        _ candidate: URLComponents, _ registered: URLComponents
+    ) -> Bool {
+        isSupportedUploadUri(candidate)
+            && equalsIgnoreCase(candidate.scheme, registered.scheme)
+            && equalsIgnoreCase(candidate.host, registered.host)
+            && effectivePort(candidate) == effectivePort(registered)
+            && normalizedPath(candidate) == normalizedPath(registered)
+            && candidate.percentEncodedQuery == registered.percentEncodedQuery
+            && candidate.percentEncodedFragment == registered.percentEncodedFragment
+    }
+
+    private static func isSupportedUploadUri(_ components: URLComponents) -> Bool {
+        guard let scheme = components.scheme,
+              scheme.caseInsensitiveCompare("http") == .orderedSame
+              || scheme.caseInsensitiveCompare("https") == .orderedSame
+        else {
+            return false
+        }
+        guard let host = components.host, !host.isEmpty else {
+            return false
+        }
+        return effectivePort(components) > 0 && normalizedPath(components) == "/upload"
+    }
+
+    private static func effectivePort(_ components: URLComponents) -> Int {
+        if let port = components.port {
+            return port
+        }
+        return components.scheme?.caseInsensitiveCompare("https") == .orderedSame ? 443 : 80
+    }
+
+    private static func normalizedPath(_ components: URLComponents) -> String {
+        let path = components.percentEncodedPath
+        return path.isEmpty ? "/" : path
+    }
+
+    private static func equalsIgnoreCase(_ first: String?, _ second: String?) -> Bool {
+        guard let first, let second else {
+            return first == nil && second == nil
+        }
+        return first.caseInsensitiveCompare(second) == .orderedSame
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -420,8 +420,9 @@ class BlePhotoUploadService {
         webhookUrl: String,
         authToken: String?
     ) async throws -> String {
-        guard let url = URL(string: webhookUrl) else {
-            Bridge.log("LIVE: Invalid webhook URL: \(webhookUrl)")
+        let effectiveWebhookUrl = LocalPhotoReceiverRegistry.loopbackUploadUrl(for: webhookUrl) ?? webhookUrl
+        guard let url = URL(string: effectiveWebhookUrl) else {
+            Bridge.log("LIVE: Invalid webhook URL: \(effectiveWebhookUrl)")
             throw PhotoUploadError.uploadFailed("Invalid webhook URL")
         }
 
@@ -469,7 +470,11 @@ class BlePhotoUploadService {
 
         request.httpBody = body
 
-        print("LIVE: Uploading photo to webhook: \(webhookUrl)")
+        if effectiveWebhookUrl != webhookUrl {
+            print("LIVE: Uploading BLE fallback photo to local receiver via loopback: \(effectiveWebhookUrl)")
+        } else {
+            print("LIVE: Uploading photo to webhook: \(webhookUrl)")
+        }
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)


### PR DESCRIPTION
## Scope

Part 1 of [OS-1796](https://linear.app/mentralabs/issue/OS-1796) (plan: `agents/os-1796-ble-photo-phone-delivery-plan.md` on the follow-up branches). Standalone bug fix: iOS/Android parity for the photo-receiver loopback rewrite.

The Android BLE fallback relay rewrites webhook URLs that target the in-process `LocalPhotoUploadServer` to `127.0.0.1` (`LocalPhotoReceiverRegistry.loopbackUploadUrlFor`), so BLE-relayed photos reach the app's own receiver even when the phone is off Wi-Fi or its LAN address changed after registration. iOS had no equivalent — `BlePhotoUploadService.uploadToWebhook` posted to the literal LAN URL, which fails whenever the phone isn't reachable at that address.

- New `ios/Source/LocalPhotoReceiverRegistry.swift`, a 1:1 port of the Java registry semantics (http/https + `/upload` path match on scheme/host/effective-port/query/fragment, host rewritten to `127.0.0.1`). Placed in `Source/` because `BlePhotoUploadService` compiles in both SDK build shapes, while the receiver module is expo-adapter-only.
- `MentraPhotoReceiverModule` registers the upload URL at both receiver-start return points and unregisters on stop/`OnDestroy`, matching the Android module.
- `uploadToWebhook` resolves the effective URL through the registry and logs when the rewrite fires, mirroring the Android relay.

## Notes

- `MentraPhotoReceiverModule.swift` picked up a whole-file swiftformat pass (repo `.swiftformat` config; the file predated it) — the functional change there is only the three registry calls.
- Test evidence: `swiftc -parse` on the new file; on-device iOS verification (example app photo receiver, phone off Wi-Fi, BLE relay) still to be run and will be posted before merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches photo upload routing in the BLE/SGCS path; wrong URL matching could misroute uploads, but scope is narrow and mirrors proven Android behavior.
> 
> **Overview**
> Brings **iOS in line with Android** for BLE fallback photo delivery to the in-app `LocalPhotoUploadServer`. Glasses still get a LAN URL, but when the phone relays over BLE it can hit the same receiver via `127.0.0.1` instead of a stale Wi‑Fi address.
> 
> Adds **`LocalPhotoReceiverRegistry`** (Swift port of the Java registry): register/unregister active `/upload` URLs, and **`loopbackUploadUrl(for:)`** to rewrite matching webhook URLs to loopback while preserving port/path/query.
> 
> **`MentraPhotoReceiverModule`** registers the upload URL when the receiver starts (both code paths) and unregisters on stop/`OnDestroy`.
> 
> **`MentraLive.uploadToWebhook`** resolves the effective URL through the registry before POSTing and logs when a loopback rewrite is used.
> 
> `MentraPhotoReceiverModule.swift` also picked up a whole-file swiftformat pass; the behavioral change there is only the registry register/unregister calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c82769e2349c88e1a73dda92f7ef3a7ab6830c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->