### PR TITLE
Gate archival photo capture on an explicit BLE delivery request

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -351,15 +351,15 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
                 return false;
             }
 
-            // ARCHIVAL CAPTURE: a save-only request (no upload target) has no delivery leg —
+            // ARCHIVAL CAPTURE: a save-only request (no delivery target) has no delivery leg —
             // no webhook upload, no BLE transfer — so there is nothing for the single-flight
             // photo-job gate to protect. Route it down the button-photo path: camera-queue
             // serialized, no CAMERA_BUSY, so SDK callers can burst-save to the gallery and
             // pull the files later over WiFi sync (each stamped with its requestId).
-            // transferMethod is deliberately not consulted: it is always "auto" in practice
-            // and the phone app always supplies a webhookUrl, so this shape is only ever
-            // produced by direct BT-SDK callers that want exactly this behavior.
-            if (save && webhookUrl.isEmpty()) {
+            // A request carrying a bleImgId DOES have a delivery leg (BLE to the phone) and
+            // must go down the normal pipeline even with save=true and no webhookUrl: that
+            // shape is phone-delivery with a kept gallery copy, not an archival capture.
+            if (save && webhookUrl.isEmpty() && bleImgId.isEmpty()) {
                 Log.i(
                         TAG,
                         "PHOTO PIPELINE [ASG 3/3] Local-save capture (no upload target)"

--- a/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandler.java
@@ -352,15 +352,17 @@ public class PhotoCommandHandler extends BaseMediaCommandHandler {
                 return false;
             }
 
-            // ARCHIVAL CAPTURE: a save-only request (no upload target) has no delivery leg —
+            // ARCHIVAL CAPTURE: a save-only request (no delivery target) has no delivery leg —
             // no webhook upload, no BLE transfer — so there is nothing for the single-flight
             // photo-job gate to protect. Route it down the button-photo path: camera-queue
             // serialized, no CAMERA_BUSY, so SDK callers can burst-save to the gallery and
             // pull the files later over WiFi sync (each stamped with its requestId).
-            // transferMethod is deliberately not consulted: it is always "auto" in practice
-            // and the phone app always supplies a webhookUrl, so this shape is only ever
-            // produced by direct BT-SDK callers that want exactly this behavior.
-            if (save && webhookUrl.isEmpty()) {
+            // The one exception is an explicit BLE delivery request: transferMethod "ble"
+            // with save=true and no webhookUrl is phone delivery with a kept gallery copy,
+            // so it must ride the normal pipeline. The gate keys on transferMethod, not on
+            // bleImgId, because the phone SDK mints a bleImgId on every take_photo as a
+            // fallback id, including archival captures; only "ble" expresses delivery intent.
+            if (save && webhookUrl.isEmpty() && !"ble".equals(transferMethod)) {
                 Log.i(
                         TAG,
                         "PHOTO PIPELINE [ASG 3/3] Local-save capture (no upload target)"

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -149,5 +150,83 @@ public class PhotoCommandHandlerTransferMethodTest {
         assertThat(handler.handleCommand("take_photo", data)).isFalse();
         verify(captureService)
                 .sendPhotoErrorResponse(eq("req-1"), eq("INVALID_TRANSFER_METHOD"), anyString());
+    }
+
+    @Test
+    public void takePhoto_saveWithBleImgIdAndNoWebhook_ridesBleTransfer() throws Exception {
+        when(captureService.takePhotoForBleTransfer(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        JSONObject data =
+                takePhotoData()
+                        .put("webhookUrl", "")
+                        .put("save", true)
+                        .put("transferMethod", "ble");
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoForBleTransfer(
+                        anyString(),
+                        eq("req-1"),
+                        eq("ble-1"),
+                        eq(true),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+        verify(captureService, never())
+                .takePhotoForLocalSave(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+    }
+
+    @Test
+    public void takePhoto_saveWithoutBleImgIdOrWebhook_staysLocalSaveCapture() throws Exception {
+        when(captureService.takePhotoForLocalSave(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        JSONObject data =
+                takePhotoData().put("webhookUrl", "").put("bleImgId", "").put("save", true);
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoForLocalSave(
+                        anyString(),
+                        eq("req-1"),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
     }
 }

--- a/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/service/core/handlers/PhotoCommandHandlerTransferMethodTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -149,5 +150,116 @@ public class PhotoCommandHandlerTransferMethodTest {
         assertThat(handler.handleCommand("take_photo", data)).isFalse();
         verify(captureService)
                 .sendPhotoErrorResponse(eq("req-1"), eq("INVALID_TRANSFER_METHOD"), anyString());
+    }
+
+    @Test
+    public void takePhoto_saveWithBleImgIdAndNoWebhook_ridesBleTransfer() throws Exception {
+        when(captureService.takePhotoForBleTransfer(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        JSONObject data =
+                takePhotoData()
+                        .put("webhookUrl", "")
+                        .put("save", true)
+                        .put("transferMethod", "ble");
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoForBleTransfer(
+                        anyString(),
+                        eq("req-1"),
+                        eq("ble-1"),
+                        eq(true),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+        verify(captureService, never())
+                .takePhotoForLocalSave(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+    }
+
+    @Test
+    public void takePhoto_saveWithMintedBleImgIdAndNoWebhook_staysLocalSaveCapture()
+            throws Exception {
+        // Today's SDK mints a bleImgId on every request as a fallback id, so a save-only
+        // archival capture still carries one; only an explicit "ble" method means delivery.
+        when(captureService.takePhotoForLocalSave(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        JSONObject data = takePhotoData().put("webhookUrl", "").put("save", true);
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoForLocalSave(
+                        anyString(),
+                        eq("req-1"),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
+        verify(captureService, never()).markBlePhotoPipelineStart(anyString());
+    }
+
+    @Test
+    public void takePhoto_saveWithoutBleImgIdOrWebhook_staysLocalSaveCapture() throws Exception {
+        when(captureService.takePhotoForLocalSave(
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyString(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class)))
+                .thenReturn(true);
+        JSONObject data =
+                takePhotoData().put("webhookUrl", "").put("bleImgId", "").put("save", true);
+
+        assertThat(handler.handleCommand("take_photo", data)).isTrue();
+        verify(captureService)
+                .takePhotoForLocalSave(
+                        anyString(),
+                        eq("req-1"),
+                        eq("medium"),
+                        eq("photo"),
+                        eq(true),
+                        eq(true),
+                        nullable(Long.class),
+                        nullable(Integer.class),
+                        any(PhotoCaptureSettings.class));
     }
 }


### PR DESCRIPTION
## Scope

Part 2a of [OS-1796](https://linear.app/mentralabs/issue/OS-1796): a one-condition routing change in `PhotoCommandHandler.handleTakePhoto` so `save=true` and a BLE phone delivery can coexist.

Today `save && webhookUrl.isEmpty()` unconditionally routes to the local-save-only (archival) capture path. The upcoming phone-delivery destination in the Bluetooth SDK (#3619) sends `transferMethod: "ble"` + `bleImgId` + `save` (for a kept glasses-gallery copy) with no `webhookUrl`; on current firmware that shape archives on the glasses and never starts the BLE transfer, leaving the phone to time out.

The archival route now additionally requires that the request is **not** an explicit BLE delivery: `save && webhookUrl.isEmpty() && !"ble".equals(transferMethod)`.

### Why `transferMethod`, not `bleImgId`

The first revision of this PR gated on an empty `bleImgId` instead. That was wrong: both Mentra Live serializers mint a `bleImgId` on every `take_photo` as a fallback id ("Always generate BLE ID for potential fallback" in `MentraLive.kt` and `MentraLive.swift`), and the phone only registers the transfer when a `webhookUrl` is present. So a bleImgId-based gate would have pushed today's documented `requestPhoto({save: true, webhookUrl: null})` shape into the auto pipeline with an empty upload URL and an id the phone never tracks. Since this firmware must ship **before** the SDK change, that interim window is guaranteed to exist. `transferMethod: "ble"` is the only field that expresses delivery intent, and it is exactly what the SDK's phone arm forces (see `agents/os-1796-pr2b-contract.md` on #3619).

Request shapes after this change:

| shape | route |
|---|---|
| any `webhookUrl` (phone app today, webhook arm) | unchanged, normal pipeline |
| `save`, no webhook, `transferMethod` auto/direct, minted `bleImgId` (today's SDK archival) | archival, unchanged |
| `save`, no webhook, no `bleImgId` (#3619 glasses arm) | archival |
| `save`, no webhook, `transferMethod: "ble"` (#3619 phone arm with `keepOnGlasses`) | normal pipeline → `takePhotoForBleTransfer` |

Release ordering: this rolls out via the firmware train before #3619 ships. New firmware with today's SDK is fully compatible (the documented archival shape is preserved). The reverse, #3619's phone arm with `keepOnGlasses` on pre-gate firmware, is not: it would archive and never start the BLE transfer. Firmware-first is mandatory.

## Test evidence

`cd asg_client && ./gradlew :app:testDebugUnitTest --tests "*PhotoCommandHandlerTransferMethod*"` on the branch rebased onto `dev`: 7 tests, 0 failures. New cases:

- save + `ble` + no webhook rides `takePhotoForBleTransfer` and never `takePhotoForLocalSave`
- save + minted `bleImgId` + default transferMethod + no webhook stays on `takePhotoForLocalSave` and never marks the BLE pipeline (today's SDK shape)
- save + no `bleImgId` + no webhook stays on `takePhotoForLocalSave` (future glasses arm)

`spotlessApply` run on the ASG app.

The earlier ASG CI failure on this PR was Robolectric `NoClassDefFoundError` in text-detection, media-migrator, and hotspot tests untouched by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
