### PR TITLE
Add the phone-side OTA file server to the Bluetooth SDK

### DIFF
--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/net/LocalIpv4.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/net/LocalIpv4.kt
@@ -1,0 +1,57 @@
+package com.mentra.bluetoothsdk.net
+
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/**
+ * Best-effort local IPv4 discovery for phone-hosted servers the glasses reach over WiFi
+ * (photo upload receiver, hotspot-served OTA). Prefers WiFi-ish interfaces carrying RFC1918
+ * addresses — under a glasses-hotspot session wlan0 holds the 192.168.43.x client address.
+ */
+object LocalIpv4 {
+  fun bestLocalIpv4Address(): String? {
+    val wifiPrivateCandidates = mutableListOf<Inet4Address>()
+    val wifiCandidates = mutableListOf<Inet4Address>()
+    val privateCandidates = mutableListOf<Inet4Address>()
+    val otherCandidates = mutableListOf<Inet4Address>()
+    val interfaces = NetworkInterface.getNetworkInterfaces()?.toList().orEmpty()
+    for (networkInterface in interfaces) {
+      if (!networkInterface.isUp || networkInterface.isLoopback) {
+        continue
+      }
+      val addresses = networkInterface.inetAddresses.toList()
+        .filterIsInstance<Inet4Address>()
+        .filter { address ->
+          !address.isLoopbackAddress &&
+            !address.isLinkLocalAddress
+        }
+      if (isWifiInterface(networkInterface.name)) {
+        wifiPrivateCandidates += addresses.filter { isPrivateIpv4(it.hostAddress.orEmpty()) }
+        wifiCandidates += addresses
+      } else {
+        privateCandidates += addresses.filter { isPrivateIpv4(it.hostAddress.orEmpty()) }
+        otherCandidates += addresses
+      }
+    }
+
+    return (
+      wifiPrivateCandidates.firstOrNull() ?:
+        wifiCandidates.firstOrNull() ?:
+        privateCandidates.firstOrNull() ?:
+        otherCandidates.firstOrNull()
+      )?.hostAddress
+  }
+
+  private fun isWifiInterface(name: String): Boolean {
+    return name.startsWith("wlan") ||
+      name.startsWith("p2p") ||
+      name.startsWith("ap") ||
+      name.startsWith("swlan")
+  }
+
+  private fun isPrivateIpv4(host: String): Boolean {
+    return host.startsWith("192.168.") ||
+      host.startsWith("10.") ||
+      host.matches(Regex("^172\\.(1[6-9]|2[0-9]|3[0-1])\\..*"))
+  }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/otaserver/LocalOtaServer.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/otaserver/LocalOtaServer.kt
@@ -1,0 +1,371 @@
+package com.mentra.bluetoothsdk.otaserver
+
+import com.mentra.bluetoothsdk.debug.BleTraceLogger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import java.io.EOFException
+import java.io.File
+import java.io.InputStream
+import java.io.OutputStream
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.SocketException
+import java.nio.charset.StandardCharsets
+import java.util.Locale
+import java.util.concurrent.Semaphore
+import org.json.JSONObject
+
+/**
+ * Static HTTP server for hotspot-served glasses OTA (OS-1676).
+ *
+ * Serves the rewritten OTA manifest at /version.json and pre-downloaded artifacts at
+ * /artifacts/<sha256> to the glasses over the glasses-hotspot link. GET and HEAD only
+ * (the glasses' post-restart resume probes the manifest with HEAD), with single-range
+ * support on artifacts. Same hand-rolled socket structure as [LocalPhotoUploadServer] —
+ * no third-party HTTP dependency in the SDK.
+ */
+class LocalOtaServer(
+    private val onLog: (String) -> Unit,
+) : AutoCloseable {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private var serverSocket: ServerSocket? = null
+    private var serverJob: Job? = null
+    private val clientSlots = Semaphore(MAX_ACTIVE_CLIENTS)
+
+    @Volatile
+    private var manifestJson: String = "{}"
+
+    @Volatile
+    private var artifacts: Map<String, File> = emptyMap()
+
+    @Volatile
+    var running: Boolean = false
+        private set
+
+    val activePort: Int?
+        get() = serverSocket
+            ?.takeIf { running && !it.isClosed }
+            ?.localPort
+
+    /** Swap the served manifest and artifact set. Safe while the server is running. */
+    fun configure(manifestJson: String, artifacts: Map<String, File>) {
+        this.manifestJson = manifestJson
+        this.artifacts = artifacts
+    }
+
+    fun start(port: Int): Int {
+        val activeSocket = serverSocket
+        if (running && activeSocket != null && !activeSocket.isClosed && activeSocket.localPort == port) {
+            onLog("Already listening on 0.0.0.0:${activeSocket.localPort}")
+            return activeSocket.localPort
+        }
+        stop()
+        val socket = ServerSocket()
+        try {
+            socket.reuseAddress = true
+            socket.bind(InetSocketAddress("0.0.0.0", port))
+            serverSocket = socket
+            running = true
+            serverJob = scope.launch {
+                acceptLoop(socket)
+            }
+        } catch (error: Throwable) {
+            try {
+                socket.close()
+            } catch (_: Throwable) {
+            }
+            throw error
+        }
+        onLog("OTA server listening on 0.0.0.0:${socket.localPort}")
+        return socket.localPort
+    }
+
+    fun stop() {
+        running = false
+        serverJob?.cancel()
+        serverJob = null
+        try {
+            serverSocket?.close()
+        } catch (_: Throwable) {
+        }
+        serverSocket = null
+    }
+
+    override fun close() {
+        stop()
+        scope.cancel()
+    }
+
+    private fun acceptLoop(socket: ServerSocket) {
+        while (scope.isActive && !socket.isClosed) {
+            try {
+                val client = socket.accept()
+                if (!clientSlots.tryAcquire()) {
+                    rejectClient(client)
+                    continue
+                }
+                scope.launch {
+                    try {
+                        handleClient(client)
+                    } finally {
+                        clientSlots.release()
+                    }
+                }
+            } catch (error: SocketException) {
+                if (running) onLog("Accept failed: ${error.message}")
+            } catch (error: Throwable) {
+                if (running) onLog("Accept failed: ${error.message ?: error::class.java.simpleName}")
+            }
+        }
+    }
+
+    private fun handleClient(socket: Socket) {
+        socket.use { client ->
+            val requestStartMs = System.currentTimeMillis()
+            client.soTimeout = SOCKET_TIMEOUT_MS
+            val input = BufferedInputStream(client.getInputStream())
+            val output = client.getOutputStream()
+            var request: HttpRequest? = null
+            var status = 0
+            var responseBytes = 0L
+
+            try {
+                val headerText = readHeaders(input).toString(StandardCharsets.ISO_8859_1)
+                request = HttpRequest.parse(headerText)
+                onLog("${request.method} ${request.path} from ${client.inetAddress.hostAddress}")
+
+                if (request.method != "GET" && request.method != "HEAD") {
+                    status = 405
+                    writeJson(output, status, """{"ok":false,"error":"method_not_allowed"}""")
+                    return
+                }
+                val headOnly = request.method == "HEAD"
+
+                when {
+                    request.path == "/" || request.path == "/health" -> {
+                        status = 200
+                        writeJson(output, status, """{"ok":true,"service":"mentra-ota-server"}""", headOnly)
+                    }
+                    request.path == "/version.json" -> {
+                        val body = manifestJson.toByteArray(StandardCharsets.UTF_8)
+                        status = 200
+                        responseBytes = body.size.toLong()
+                        writeBody(output, status, "application/json", body, headOnly)
+                    }
+                    request.path.startsWith("/artifacts/") -> {
+                        val key = request.path.removePrefix("/artifacts/")
+                        val file = artifacts[key]
+                        if (file == null || !file.isFile) {
+                            status = 404
+                            writeJson(output, status, """{"ok":false,"error":"artifact_not_found"}""", headOnly)
+                        } else {
+                            val range = parseRange(request.headers["range"], file.length())
+                            if (range == INVALID_RANGE) {
+                                status = 416
+                                writeJson(output, status, """{"ok":false,"error":"range_not_satisfiable"}""", headOnly)
+                            } else {
+                                status = if (range == null) 200 else 206
+                                responseBytes = (range?.let { it.last - it.first + 1 }) ?: file.length()
+                                writeFile(output, file, range, headOnly)
+                            }
+                        }
+                    }
+                    else -> {
+                        status = 404
+                        writeJson(output, status, """{"ok":false,"error":"not_found"}""", headOnly)
+                    }
+                }
+            } catch (error: Throwable) {
+                onLog("request failed: ${error.message ?: error::class.java.simpleName}")
+                if (status == 0) {
+                    status = 500
+                    try {
+                        writeJson(output, status, """{"ok":false,"error":"server_error"}""")
+                    } catch (_: Throwable) {
+                    }
+                }
+            } finally {
+                trace(client, request, status, responseBytes, requestStartMs)
+            }
+        }
+    }
+
+    /** Returns null for no range, [INVALID_RANGE] for an unsatisfiable/malformed one. */
+    private fun parseRange(header: String?, fileLength: Long): LongRange? {
+        if (header == null) return null
+        val match = Regex("""^bytes=(\d*)-(\d*)$""").find(header.trim()) ?: return INVALID_RANGE
+        val (startText, endText) = match.destructured
+        if (startText.isEmpty() && endText.isEmpty()) return INVALID_RANGE
+        if (startText.isEmpty()) {
+            // Suffix range: last N bytes.
+            val suffix = endText.toLongOrNull() ?: return INVALID_RANGE
+            if (suffix <= 0) return INVALID_RANGE
+            val start = maxOf(0, fileLength - suffix)
+            return if (fileLength == 0L) INVALID_RANGE else start..(fileLength - 1)
+        }
+        val start = startText.toLongOrNull() ?: return INVALID_RANGE
+        val end = if (endText.isEmpty()) fileLength - 1 else (endText.toLongOrNull() ?: return INVALID_RANGE)
+        if (start > end || start >= fileLength) return INVALID_RANGE
+        return start..minOf(end, fileLength - 1)
+    }
+
+    private fun writeFile(output: OutputStream, file: File, range: LongRange?, headOnly: Boolean) {
+        val fileLength = file.length()
+        val byteCount = range?.let { it.last - it.first + 1 } ?: fileLength
+        val status = if (range == null) "200 OK" else "206 Partial Content"
+        output.write("HTTP/1.1 $status\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Content-Type: application/octet-stream\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Content-Length: $byteCount\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Accept-Ranges: bytes\r\n".toByteArray(StandardCharsets.US_ASCII))
+        if (range != null) {
+            output.write(
+                "Content-Range: bytes ${range.first}-${range.last}/$fileLength\r\n"
+                    .toByteArray(StandardCharsets.US_ASCII),
+            )
+        }
+        output.write("Connection: close\r\n\r\n".toByteArray(StandardCharsets.US_ASCII))
+        if (headOnly) {
+            output.flush()
+            return
+        }
+        file.inputStream().use { fileInput ->
+            if (range != null) {
+                skipFully(fileInput, range.first)
+            }
+            val buffer = ByteArray(STREAM_CHUNK_BYTES)
+            var remaining = byteCount
+            while (remaining > 0) {
+                val read = fileInput.read(buffer, 0, minOf(buffer.size.toLong(), remaining).toInt())
+                if (read <= 0) throw EOFException("artifact truncated while streaming")
+                output.write(buffer, 0, read)
+                remaining -= read
+            }
+        }
+        output.flush()
+    }
+
+    private fun skipFully(input: InputStream, byteCount: Long) {
+        var remaining = byteCount
+        while (remaining > 0) {
+            val skipped = input.skip(remaining)
+            if (skipped <= 0) throw EOFException("artifact truncated while seeking")
+            remaining -= skipped
+        }
+    }
+
+    private fun rejectClient(socket: Socket) {
+        socket.use { client ->
+            try {
+                writeJson(client.getOutputStream(), 503, """{"ok":false,"error":"too_many_connections"}""")
+            } catch (_: Throwable) {
+            }
+        }
+    }
+
+    private fun readHeaders(input: InputStream): ByteArray {
+        val out = ByteArrayOutputStream()
+        val delimiter = byteArrayOf(13, 10, 13, 10)
+        var matched = 0
+        while (true) {
+            val byte = input.read()
+            if (byte == -1) throw EOFException("Socket closed before HTTP headers completed")
+            out.write(byte)
+            matched = if (byte.toByte() == delimiter[matched]) {
+                matched + 1
+            } else if (byte.toByte() == delimiter[0]) {
+                1
+            } else {
+                0
+            }
+            if (matched == delimiter.size) return out.toByteArray()
+            if (out.size() > MAX_HEADER_BYTES) throw IllegalArgumentException("HTTP headers too large")
+        }
+    }
+
+    private fun writeJson(output: OutputStream, status: Int, body: String, headOnly: Boolean = false) {
+        writeBody(output, status, "application/json", body.toByteArray(StandardCharsets.UTF_8), headOnly)
+    }
+
+    private fun writeBody(
+        output: OutputStream,
+        status: Int,
+        contentType: String,
+        body: ByteArray,
+        headOnly: Boolean,
+    ) {
+        val reason = when (status) {
+            200 -> "OK"
+            404 -> "Not Found"
+            405 -> "Method Not Allowed"
+            416 -> "Range Not Satisfiable"
+            503 -> "Service Unavailable"
+            else -> "Internal Server Error"
+        }
+        output.write("HTTP/1.1 $status $reason\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Content-Type: $contentType\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Content-Length: ${body.size}\r\n".toByteArray(StandardCharsets.US_ASCII))
+        output.write("Connection: close\r\n\r\n".toByteArray(StandardCharsets.US_ASCII))
+        if (!headOnly) {
+            output.write(body)
+        }
+        output.flush()
+    }
+
+    private fun trace(
+        client: Socket,
+        request: HttpRequest?,
+        status: Int,
+        responseBytes: Long,
+        startMs: Long,
+    ) {
+        val payload = JSONObject()
+        try {
+            payload.put("type", "ota_server_request")
+            payload.put("remoteHost", client.inetAddress?.hostAddress ?: "")
+            payload.put("method", request?.method ?: "")
+            payload.put("path", request?.path ?: "")
+            payload.put("statusCode", status)
+            payload.put("responseBytes", responseBytes)
+            payload.put("durationMs", System.currentTimeMillis() - startMs)
+            BleTraceLogger.logJson("phone_to_wifi", "wifi_http_output", payload, null)
+        } catch (_: Throwable) {
+        }
+    }
+
+    private data class HttpRequest(
+        val method: String,
+        val path: String,
+        val headers: Map<String, String>,
+    ) {
+        companion object {
+            fun parse(headerText: String): HttpRequest {
+                val lines = headerText.split("\r\n").filter { it.isNotBlank() }
+                val requestParts = lines.firstOrNull()?.split(" ").orEmpty()
+                val method = requestParts.getOrNull(0)?.uppercase(Locale.US).orEmpty()
+                val path = requestParts.getOrNull(1)?.substringBefore("?").orEmpty()
+                val headers = lines.drop(1).mapNotNull { line ->
+                    val separator = line.indexOf(':')
+                    if (separator <= 0) return@mapNotNull null
+                    line.substring(0, separator).lowercase(Locale.US) to line.substring(separator + 1).trim()
+                }.toMap()
+                return HttpRequest(method, path, headers)
+            }
+        }
+    }
+
+    companion object {
+        private const val MAX_HEADER_BYTES = 64 * 1024
+        private const val MAX_ACTIVE_CLIENTS = 2
+        private const val SOCKET_TIMEOUT_MS = 20_000
+        private const val STREAM_CHUNK_BYTES = 64 * 1024
+        private val INVALID_RANGE = 1L..0L
+    }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/otaserver/MentraOtaServerModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/otaserver/MentraOtaServerModule.kt
@@ -1,0 +1,123 @@
+package com.mentra.bluetoothsdk.otaserver
+
+import android.util.Log
+import com.mentra.bluetoothsdk.net.LocalIpv4
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import java.io.File
+
+/**
+ * Expo surface for the hotspot-served OTA file server (OS-1676).
+ *
+ * JS hands over the rewritten manifest body and a map of sha256 -> local file path, and gets
+ * back the base URL the glasses should be pointed at via ota_start. The optional host
+ * argument lets the caller pass the authoritative scoped-network address (from
+ * MentraLocalNetwork's LinkProperties); otherwise interface scanning is used.
+ */
+class MentraOtaServerModule : Module() {
+  private var otaServer: LocalOtaServer? = null
+
+  override fun definition() = ModuleDefinition {
+    Name("MentraOtaServer")
+
+    Events("serverStatus")
+
+    AsyncFunction("isSupported") {
+      true
+    }
+
+    AsyncFunction("startOtaServer") { manifestJson: String, artifactPaths: Map<String, String>, host: String? ->
+      startOtaServer(manifestJson, artifactPaths, host)
+    }
+
+    AsyncFunction("stopOtaServer") {
+      stopOtaServerInternal()
+    }
+
+    OnDestroy {
+      closeOtaServerInternal()
+    }
+  }
+
+  @Synchronized
+  private fun startOtaServer(
+    manifestJson: String,
+    artifactPaths: Map<String, String>,
+    hostOverride: String?,
+  ): Map<String, Any> {
+    val artifacts = artifactPaths.mapValues { (_, path) ->
+      File(path.removePrefix("file://"))
+    }
+    artifacts.forEach { (key, file) ->
+      if (!file.isFile) {
+        throw IllegalArgumentException("Artifact $key not found at ${file.absolutePath}")
+      }
+    }
+
+    val server = otaServer ?: LocalOtaServer(
+      onLog = { message -> emitStatus(message) },
+    ).also {
+      otaServer = it
+    }
+    server.configure(manifestJson, artifacts)
+
+    val host = hostOverride?.takeIf { it.isNotBlank() }
+      ?: LocalIpv4.bestLocalIpv4Address()
+      ?: throw IllegalStateException("No Wi-Fi/LAN IPv4 address found for this phone.")
+
+    server.activePort?.let { activePort ->
+      emitStatus("OTA server ready at http://$host:$activePort/version.json")
+      return serverResult(host, activePort)
+    }
+
+    var lastError: Throwable? = null
+    for (port in OTA_PORTS) {
+      try {
+        val actualPort = server.start(port)
+        emitStatus("OTA server ready at http://$host:$actualPort/version.json")
+        return serverResult(host, actualPort)
+      } catch (error: Throwable) {
+        lastError = error
+        emitStatus("Port $port unavailable: ${error.message ?: error::class.java.simpleName}")
+      }
+    }
+
+    throw IllegalStateException(
+      "Could not start OTA server: ${lastError?.message ?: "all ports unavailable"}",
+    )
+  }
+
+  @Synchronized
+  private fun stopOtaServerInternal() {
+    otaServer?.stop()
+    emitStatus("OTA server stopped")
+  }
+
+  @Synchronized
+  private fun closeOtaServerInternal() {
+    otaServer?.close()
+    otaServer = null
+  }
+
+  private fun emitStatus(message: String) {
+    Log.d(TAG, message)
+    sendEvent(
+      "serverStatus",
+      mapOf("message" to message),
+    )
+  }
+
+  private fun serverResult(host: String, port: Int): Map<String, Any> {
+    return mapOf(
+      "baseUrl" to "http://$host:$port",
+      "manifestUrl" to "http://$host:$port/version.json",
+      "host" to host,
+      "port" to port,
+    )
+  }
+
+  private companion object {
+    const val TAG = "MentraOtaServer"
+    val OTA_PORTS = listOf(8791, 8792, 8793, 8794)
+  }
+}

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/photoreceiver/MentraPhotoReceiverModule.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/photoreceiver/MentraPhotoReceiverModule.kt
@@ -4,11 +4,10 @@ import android.content.Context
 import android.net.Uri
 import android.util.Log
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
+import com.mentra.bluetoothsdk.net.LocalIpv4
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
-import java.net.Inet4Address
-import java.net.NetworkInterface
 
 class MentraPhotoReceiverModule : Module() {
   private var photoUploadServer: LocalPhotoUploadServer? = null
@@ -45,7 +44,7 @@ class MentraPhotoReceiverModule : Module() {
       photoUploadServer = it
     }
 
-    val host = bestLocalIpv4Address()
+    val host = LocalIpv4.bestLocalIpv4Address()
       ?: throw IllegalStateException("No Wi-Fi/LAN IPv4 address found for this phone.")
 
     server.activePort?.let { activePort ->
@@ -128,39 +127,6 @@ class MentraPhotoReceiverModule : Module() {
       ?: throw Exceptions.ReactContextLost()
   }
 
-  private fun bestLocalIpv4Address(): String? {
-    val wifiPrivateCandidates = mutableListOf<Inet4Address>()
-    val wifiCandidates = mutableListOf<Inet4Address>()
-    val privateCandidates = mutableListOf<Inet4Address>()
-    val otherCandidates = mutableListOf<Inet4Address>()
-    val interfaces = NetworkInterface.getNetworkInterfaces()?.toList().orEmpty()
-    for (networkInterface in interfaces) {
-      if (!networkInterface.isUp || networkInterface.isLoopback) {
-        continue
-      }
-      val addresses = networkInterface.inetAddresses.toList()
-        .filterIsInstance<Inet4Address>()
-        .filter { address ->
-          !address.isLoopbackAddress &&
-            !address.isLinkLocalAddress
-        }
-      if (isWifiInterface(networkInterface.name)) {
-        wifiPrivateCandidates += addresses.filter { isPrivateIpv4(it.hostAddress.orEmpty()) }
-        wifiCandidates += addresses
-      } else {
-        privateCandidates += addresses.filter { isPrivateIpv4(it.hostAddress.orEmpty()) }
-        otherCandidates += addresses
-      }
-    }
-
-    return (
-      wifiPrivateCandidates.firstOrNull() ?:
-        wifiCandidates.firstOrNull() ?:
-        privateCandidates.firstOrNull() ?:
-        otherCandidates.firstOrNull()
-      )?.hostAddress
-  }
-
   private fun receiverEndpoint(host: String, port: Int): ReceiverEndpoint {
     return ReceiverEndpoint(
       uploadUrl = "http://$host:$port/upload",
@@ -175,19 +141,6 @@ class MentraPhotoReceiverModule : Module() {
       "host" to endpoint.host,
       "port" to endpoint.port,
     )
-  }
-
-  private fun isWifiInterface(name: String): Boolean {
-    return name.startsWith("wlan") ||
-      name.startsWith("p2p") ||
-      name.startsWith("ap") ||
-      name.startsWith("swlan")
-  }
-
-  private fun isPrivateIpv4(host: String): Boolean {
-    return host.startsWith("192.168.") ||
-      host.startsWith("10.") ||
-      host.matches(Regex("^172\\.(1[6-9]|2[0-9]|3[0-1])\\..*"))
   }
 
   private companion object {

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/otaserver/LocalOtaServerTest.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/otaserver/LocalOtaServerTest.kt
@@ -1,0 +1,136 @@
+package com.mentra.bluetoothsdk.otaserver
+
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class LocalOtaServerTest {
+    private lateinit var server: LocalOtaServer
+    private lateinit var artifactFile: File
+    private var port = 0
+
+    private val manifest = """{"apps":{"com.mentra.asg_client":{"versionCode":1}}}"""
+    private val artifactBytes = ByteArray(1024) { (it % 251).toByte() }
+    private val sha = "a".repeat(64)
+
+    @Before
+    fun startServer() {
+        artifactFile = File.createTempFile("ota-artifact", ".bin").apply {
+            writeBytes(artifactBytes)
+        }
+        server = LocalOtaServer(onLog = {})
+        server.configure(manifest, mapOf(sha to artifactFile))
+        port = server.start(0)
+    }
+
+    @After
+    fun stopServer() {
+        server.close()
+        artifactFile.delete()
+    }
+
+    @Test
+    fun `serves the configured manifest`() {
+        val connection = open("/version.json")
+        assertThat(connection.responseCode).isEqualTo(200)
+        assertThat(connection.contentType).isEqualTo("application/json")
+        assertThat(connection.inputStream.readBytes().decodeToString()).isEqualTo(manifest)
+    }
+
+    @Test
+    fun `answers manifest HEAD probes`() {
+        val connection = open("/version.json")
+        connection.requestMethod = "HEAD"
+        assertThat(connection.responseCode).isEqualTo(200)
+        assertThat(connection.contentLengthLong)
+            .isEqualTo(manifest.toByteArray().size.toLong())
+        assertThat(connection.inputStream.readBytes()).isEmpty()
+    }
+
+    @Test
+    fun `streams a full artifact`() {
+        val connection = open("/artifacts/$sha")
+        assertThat(connection.responseCode).isEqualTo(200)
+        assertThat(connection.getHeaderField("Accept-Ranges")).isEqualTo("bytes")
+        assertThat(connection.inputStream.readBytes()).isEqualTo(artifactBytes)
+    }
+
+    @Test
+    fun `serves a byte range`() {
+        val connection = open("/artifacts/$sha")
+        connection.setRequestProperty("Range", "bytes=100-199")
+        assertThat(connection.responseCode).isEqualTo(206)
+        assertThat(connection.getHeaderField("Content-Range"))
+            .isEqualTo("bytes 100-199/${artifactBytes.size}")
+        assertThat(connection.inputStream.readBytes())
+            .isEqualTo(artifactBytes.copyOfRange(100, 200))
+    }
+
+    @Test
+    fun `serves a suffix range`() {
+        val connection = open("/artifacts/$sha")
+        connection.setRequestProperty("Range", "bytes=-16")
+        assertThat(connection.responseCode).isEqualTo(206)
+        assertThat(connection.inputStream.readBytes())
+            .isEqualTo(artifactBytes.copyOfRange(artifactBytes.size - 16, artifactBytes.size))
+    }
+
+    @Test
+    fun `serves an open-ended range`() {
+        val connection = open("/artifacts/$sha")
+        connection.setRequestProperty("Range", "bytes=1000-")
+        assertThat(connection.responseCode).isEqualTo(206)
+        assertThat(connection.inputStream.readBytes())
+            .isEqualTo(artifactBytes.copyOfRange(1000, artifactBytes.size))
+    }
+
+    @Test
+    fun `rejects an unsatisfiable range`() {
+        val connection = open("/artifacts/$sha")
+        connection.setRequestProperty("Range", "bytes=${artifactBytes.size}-")
+        assertThat(connection.responseCode).isEqualTo(416)
+    }
+
+    @Test
+    fun `returns 404 for unknown artifacts`() {
+        val connection = open("/artifacts/${"b".repeat(64)}")
+        assertThat(connection.responseCode).isEqualTo(404)
+    }
+
+    @Test
+    fun `rejects non-GET methods`() {
+        val connection = open("/version.json")
+        connection.requestMethod = "POST"
+        connection.doOutput = true
+        connection.outputStream.use { it.write("{}".toByteArray()) }
+        assertThat(connection.responseCode).isEqualTo(405)
+    }
+
+    @Test
+    fun `reports health`() {
+        val connection = open("/health")
+        assertThat(connection.responseCode).isEqualTo(200)
+        assertThat(connection.inputStream.readBytes().decodeToString()).contains("mentra-ota-server")
+    }
+
+    @Test
+    fun `reconfigures while running`() {
+        server.configure("""{"updated":true}""", emptyMap())
+        val manifestConnection = open("/version.json")
+        assertThat(manifestConnection.inputStream.readBytes().decodeToString())
+            .isEqualTo("""{"updated":true}""")
+        val artifactConnection = open("/artifacts/$sha")
+        assertThat(artifactConnection.responseCode).isEqualTo(404)
+    }
+
+    private fun open(path: String): HttpURLConnection {
+        val connection = URL("http://127.0.0.1:$port$path").openConnection() as HttpURLConnection
+        connection.connectTimeout = 5_000
+        connection.readTimeout = 5_000
+        return connection
+    }
+}

--- a/mobile/modules/bluetooth-sdk/expo-module.config.json
+++ b/mobile/modules/bluetooth-sdk/expo-module.config.json
@@ -1,13 +1,14 @@
 {
   "platforms": ["apple", "android"],
   "apple": {
-    "modules": ["BluetoothSdkModule", "MentraPhotoReceiverModule"]
+    "modules": ["BluetoothSdkModule", "MentraPhotoReceiverModule", "MentraOtaServerModule"]
   },
   "android": {
     "modules": [
       "com.mentra.bluetoothsdk.BluetoothSdkModule",
       "com.mentra.bluetoothsdk.MentraLocalNetworkModule",
-      "com.mentra.bluetoothsdk.photoreceiver.MentraPhotoReceiverModule"
+      "com.mentra.bluetoothsdk.photoreceiver.MentraPhotoReceiverModule",
+      "com.mentra.bluetoothsdk.otaserver.MentraOtaServerModule"
     ]
   }
 }

--- a/mobile/modules/bluetooth-sdk/ios/LocalIPv4.swift
+++ b/mobile/modules/bluetooth-sdk/ios/LocalIPv4.swift
@@ -1,0 +1,87 @@
+import Darwin
+import Foundation
+
+/// Best-effort local IPv4 discovery for phone-hosted servers the glasses reach over WiFi
+/// (photo upload receiver, hotspot-served OTA). Prefers WiFi-ish interfaces carrying RFC1918
+/// addresses — under a glasses-hotspot session en0 holds the 192.168.43.x client address.
+enum LocalIPv4 {
+  static func bestLocalIPv4Address() -> String? {
+    var interfaces: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&interfaces) == 0, let first = interfaces else {
+      return nil
+    }
+    defer { freeifaddrs(interfaces) }
+
+    var preferredPrivate: String?
+    var preferred: String?
+    var privateFallback: String?
+    var fallback: String?
+    var cursor: UnsafeMutablePointer<ifaddrs>? = first
+    while let current = cursor {
+      defer { cursor = current.pointee.ifa_next }
+      let interface = current.pointee
+      guard let addressPointer = interface.ifa_addr,
+            addressPointer.pointee.sa_family == UInt8(AF_INET) else {
+        continue
+      }
+
+      let name = String(cString: interface.ifa_name)
+      let flags = interface.ifa_flags
+      guard (flags & UInt32(IFF_UP)) != 0,
+            (flags & UInt32(IFF_LOOPBACK)) == 0 else {
+        continue
+      }
+
+      var address = addressPointer.pointee
+      var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+      let result = getnameinfo(
+        &address,
+        socklen_t(address.sa_len),
+        &hostname,
+        socklen_t(hostname.count),
+        nil,
+        0,
+        NI_NUMERICHOST
+      )
+      guard result == 0 else {
+        continue
+      }
+
+      let ip = String(cString: hostname)
+      guard ip != "127.0.0.1", !isLinkLocalIPv4(ip) else {
+        continue
+      }
+      if isPreferredLocalInterface(name), isPrivateIPv4(ip) {
+        preferredPrivate = preferredPrivate ?? ip
+      } else if isPreferredLocalInterface(name) {
+        preferred = preferred ?? ip
+      } else if isPrivateIPv4(ip) {
+        privateFallback = privateFallback ?? ip
+      } else {
+        fallback = fallback ?? ip
+      }
+    }
+
+    return preferredPrivate ?? preferred ?? privateFallback ?? fallback
+  }
+
+  private static func isPreferredLocalInterface(_ name: String) -> Bool {
+    name == "en0" ||
+      name.hasPrefix("bridge") ||
+      name.hasPrefix("ap") ||
+      name.hasPrefix("awdl") ||
+      name.hasPrefix("llw")
+  }
+
+  private static func isPrivateIPv4(_ ip: String) -> Bool {
+    if ip.hasPrefix("192.168.") || ip.hasPrefix("10.") {
+      return true
+    }
+    let parts = ip.split(separator: ".").compactMap { Int($0) }
+    return parts.count == 4 && parts[0] == 172 && (16...31).contains(parts[1])
+  }
+
+  private static func isLinkLocalIPv4(_ ip: String) -> Bool {
+    ip.hasPrefix("169.254.")
+  }
+}

--- a/mobile/modules/bluetooth-sdk/ios/LocalOtaServer.swift
+++ b/mobile/modules/bluetooth-sdk/ios/LocalOtaServer.swift
@@ -1,0 +1,406 @@
+import Foundation
+import Network
+
+struct OtaServerError: LocalizedError {
+  let message: String
+
+  init(_ message: String) {
+    self.message = message
+  }
+
+  var errorDescription: String? { message }
+}
+
+/// Static HTTP server for hotspot-served glasses OTA (OS-1676).
+///
+/// Serves the rewritten OTA manifest at /version.json and pre-downloaded artifacts at
+/// /artifacts/<sha256> to the glasses over the glasses-hotspot link. GET and HEAD only
+/// (the glasses' post-restart resume probes the manifest with HEAD), with single-range
+/// support on artifacts. Mirrors LocalPhotoUploadServer's NWListener structure.
+final class LocalOtaServer {
+  private let queue = DispatchQueue(label: "com.mentra.ota-server")
+  private let onLog: (String) -> Void
+  private var listener: NWListener?
+  private var listenerGeneration = 0
+  private(set) var activePort: UInt16?
+
+  private var manifestJson = "{}"
+  private var artifacts: [String: URL] = [:]
+
+  private static let maxHeaderBytes = 64 * 1024
+  private static let streamChunkBytes = 256 * 1024
+
+  init(onLog: @escaping (String) -> Void) {
+    self.onLog = onLog
+  }
+
+  /// Swap the served manifest and artifact set. Safe while the server is running.
+  func configure(manifestJson: String, artifacts: [String: URL]) {
+    queue.async {
+      self.manifestJson = manifestJson
+      self.artifacts = artifacts
+    }
+  }
+
+  func start(port: UInt16) throws -> UInt16 {
+    if listener != nil, activePort == port {
+      onLog("Already listening on 0.0.0.0:\(port)")
+      return port
+    }
+    stop()
+
+    let parameters = NWParameters.tcp
+    parameters.allowLocalEndpointReuse = true
+    guard let endpointPort = NWEndpoint.Port(rawValue: port) else {
+      throw OtaServerError("Invalid port \(port)")
+    }
+
+    let listener = try NWListener(using: parameters, on: endpointPort)
+    listenerGeneration += 1
+    let generation = listenerGeneration
+    let started = DispatchSemaphore(value: 0)
+    var startError: Error?
+    var isReady = false
+
+    listener.stateUpdateHandler = { [weak self] state in
+      guard let self, self.listenerGeneration == generation else {
+        return
+      }
+      switch state {
+      case .ready:
+        isReady = true
+        self.activePort = port
+        self.onLog("OTA server listening on 0.0.0.0:\(port)")
+        started.signal()
+      case .failed(let error):
+        startError = error
+        self.activePort = nil
+        self.listener = nil
+        self.onLog("OTA server failed on \(port): \(error)")
+        started.signal()
+      case .cancelled:
+        self.activePort = nil
+        if !isReady {
+          startError = OtaServerError("Listener cancelled")
+          started.signal()
+        }
+      default:
+        break
+      }
+    }
+
+    listener.newConnectionHandler = { [weak self] connection in
+      self?.handle(connection)
+    }
+
+    self.listener = listener
+    listener.start(queue: queue)
+
+    if started.wait(timeout: .now() + 2) == .timedOut {
+      self.listener = nil
+      listener.cancel()
+      throw OtaServerError("Timed out starting listener")
+    }
+    if let startError {
+      self.listener = nil
+      listener.cancel()
+      throw startError
+    }
+
+    return port
+  }
+
+  func stop() {
+    listenerGeneration += 1
+    listener?.cancel()
+    listener = nil
+    activePort = nil
+  }
+
+  private final class RequestReadState {
+    var buffer = Data()
+  }
+
+  private func handle(_ connection: NWConnection) {
+    connection.start(queue: queue)
+    receive(connection, state: RequestReadState())
+  }
+
+  private func receive(_ connection: NWConnection, state: RequestReadState) {
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+      [weak self] data, _, isComplete, error in
+      guard let self else {
+        connection.cancel()
+        return
+      }
+      if let error {
+        self.onLog("request failed: \(error.localizedDescription)")
+        connection.cancel()
+        return
+      }
+      if let data, !data.isEmpty {
+        state.buffer.append(data)
+      }
+
+      if let headerRange = state.buffer.range(of: Data([13, 10, 13, 10])) {
+        let headerData = state.buffer.subdata(in: state.buffer.startIndex..<headerRange.lowerBound)
+        let headerText = String(data: headerData, encoding: .isoLatin1) ?? ""
+        self.route(connection, headerText: headerText)
+        return
+      }
+      if state.buffer.count > Self.maxHeaderBytes {
+        self.writeJson(connection, status: 400, body: #"{"ok":false,"error":"headers_too_large"}"#)
+        return
+      }
+      if isComplete {
+        connection.cancel()
+        return
+      }
+      self.receive(connection, state: state)
+    }
+  }
+
+  private func route(_ connection: NWConnection, headerText: String) {
+    let lines = headerText.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+    let requestParts = lines.first?.components(separatedBy: " ") ?? []
+    let method = requestParts.count > 0 ? requestParts[0].uppercased() : ""
+    let rawPath = requestParts.count > 1 ? requestParts[1] : ""
+    let path = rawPath.components(separatedBy: "?")[0]
+    var headers: [String: String] = [:]
+    for line in lines.dropFirst() {
+      guard let separator = line.firstIndex(of: ":") else { continue }
+      let name = String(line[line.startIndex..<separator]).lowercased()
+      let value = String(line[line.index(after: separator)...])
+        .trimmingCharacters(in: .whitespaces)
+      headers[name] = value
+    }
+
+    onLog("\(method) \(path)")
+
+    guard method == "GET" || method == "HEAD" else {
+      writeJson(connection, status: 405, body: #"{"ok":false,"error":"method_not_allowed"}"#)
+      return
+    }
+    let headOnly = method == "HEAD"
+
+    if path == "/" || path == "/health" {
+      writeJson(
+        connection,
+        status: 200,
+        body: #"{"ok":true,"service":"mentra-ota-server"}"#,
+        headOnly: headOnly
+      )
+      return
+    }
+
+    if path == "/version.json" {
+      writeBody(
+        connection,
+        status: 200,
+        contentType: "application/json",
+        body: Data(manifestJson.utf8),
+        headOnly: headOnly
+      )
+      return
+    }
+
+    if path.hasPrefix("/artifacts/") {
+      let key = String(path.dropFirst("/artifacts/".count))
+      guard let fileUrl = artifacts[key],
+            let fileSize = try? fileUrl.resourceValues(forKeys: [.fileSizeKey]).fileSize
+      else {
+        writeJson(connection, status: 404, body: #"{"ok":false,"error":"artifact_not_found"}"#, headOnly: headOnly)
+        return
+      }
+      switch parseRange(headers["range"], fileLength: Int64(fileSize)) {
+      case .invalid:
+        writeJson(connection, status: 416, body: #"{"ok":false,"error":"range_not_satisfiable"}"#, headOnly: headOnly)
+      case .none:
+        sendFile(connection, fileUrl: fileUrl, fileLength: Int64(fileSize), range: nil, headOnly: headOnly)
+      case .range(let start, let end):
+        sendFile(
+          connection,
+          fileUrl: fileUrl,
+          fileLength: Int64(fileSize),
+          range: (start, end),
+          headOnly: headOnly
+        )
+      }
+      return
+    }
+
+    writeJson(connection, status: 404, body: #"{"ok":false,"error":"not_found"}"#, headOnly: headOnly)
+  }
+
+  private enum ParsedRange {
+    case none
+    case invalid
+    case range(Int64, Int64)
+  }
+
+  private func parseRange(_ header: String?, fileLength: Int64) -> ParsedRange {
+    guard let header else { return .none }
+    let trimmed = header.trimmingCharacters(in: .whitespaces)
+    guard trimmed.hasPrefix("bytes=") else { return .invalid }
+    let spec = String(trimmed.dropFirst("bytes=".count))
+    let parts = spec.components(separatedBy: "-")
+    guard parts.count == 2 else { return .invalid }
+    let startText = parts[0]
+    let endText = parts[1]
+    if startText.isEmpty && endText.isEmpty { return .invalid }
+    if startText.isEmpty {
+      guard let suffix = Int64(endText), suffix > 0, fileLength > 0 else { return .invalid }
+      return .range(max(0, fileLength - suffix), fileLength - 1)
+    }
+    guard let start = Int64(startText) else { return .invalid }
+    let end: Int64
+    if endText.isEmpty {
+      end = fileLength - 1
+    } else {
+      guard let parsedEnd = Int64(endText) else { return .invalid }
+      end = min(parsedEnd, fileLength - 1)
+    }
+    if start > end || start >= fileLength { return .invalid }
+    return .range(start, end)
+  }
+
+  private func sendFile(
+    _ connection: NWConnection,
+    fileUrl: URL,
+    fileLength: Int64,
+    range: (Int64, Int64)?,
+    headOnly: Bool
+  ) {
+    let byteCount = range.map { $0.1 - $0.0 + 1 } ?? fileLength
+    let statusLine = range == nil ? "200 OK" : "206 Partial Content"
+    var header =
+      "HTTP/1.1 \(statusLine)\r\n" +
+      "Content-Type: application/octet-stream\r\n" +
+      "Content-Length: \(byteCount)\r\n" +
+      "Accept-Ranges: bytes\r\n"
+    if let range {
+      header += "Content-Range: bytes \(range.0)-\(range.1)/\(fileLength)\r\n"
+    }
+    header += "Connection: close\r\n\r\n"
+
+    if headOnly {
+      connection.send(content: Data(header.utf8), completion: .contentProcessed { _ in
+        connection.cancel()
+      })
+      return
+    }
+
+    guard let fileHandle = try? FileHandle(forReadingFrom: fileUrl) else {
+      writeJson(connection, status: 500, body: #"{"ok":false,"error":"artifact_unreadable"}"#)
+      return
+    }
+    if let range {
+      do {
+        try fileHandle.seek(toOffset: UInt64(range.0))
+      } catch {
+        try? fileHandle.close()
+        writeJson(connection, status: 500, body: #"{"ok":false,"error":"artifact_unreadable"}"#)
+        return
+      }
+    }
+
+    connection.send(content: Data(header.utf8), completion: .contentProcessed { [weak self] error in
+      guard let self, error == nil else {
+        try? fileHandle.close()
+        connection.cancel()
+        return
+      }
+      self.streamChunks(connection, fileHandle: fileHandle, remaining: byteCount)
+    })
+  }
+
+  private func streamChunks(_ connection: NWConnection, fileHandle: FileHandle, remaining: Int64) {
+    if remaining <= 0 {
+      try? fileHandle.close()
+      connection.send(content: nil, contentContext: .finalMessage, isComplete: true, completion: .contentProcessed { _ in
+        connection.cancel()
+      })
+      return
+    }
+    let chunkSize = Int(min(Int64(Self.streamChunkBytes), remaining))
+    let chunk: Data
+    do {
+      guard let data = try fileHandle.read(upToCount: chunkSize), !data.isEmpty else {
+        throw OtaServerError("artifact truncated while streaming")
+      }
+      chunk = data
+    } catch {
+      onLog("stream failed: \(error.localizedDescription)")
+      try? fileHandle.close()
+      connection.cancel()
+      return
+    }
+    connection.send(content: chunk, completion: .contentProcessed { [weak self] error in
+      guard let self else {
+        try? fileHandle.close()
+        connection.cancel()
+        return
+      }
+      if let error {
+        self.onLog("stream failed: \(error.localizedDescription)")
+        try? fileHandle.close()
+        connection.cancel()
+        return
+      }
+      self.streamChunks(connection, fileHandle: fileHandle, remaining: remaining - Int64(chunk.count))
+    })
+  }
+
+  private func writeJson(
+    _ connection: NWConnection,
+    status: Int,
+    body: String,
+    headOnly: Bool = false
+  ) {
+    writeBody(
+      connection,
+      status: status,
+      contentType: "application/json",
+      body: Data(body.utf8),
+      headOnly: headOnly
+    )
+  }
+
+  private func writeBody(
+    _ connection: NWConnection,
+    status: Int,
+    contentType: String,
+    body: Data,
+    headOnly: Bool
+  ) {
+    let reason: String
+    switch status {
+    case 200:
+      reason = "OK"
+    case 400:
+      reason = "Bad Request"
+    case 404:
+      reason = "Not Found"
+    case 405:
+      reason = "Method Not Allowed"
+    case 416:
+      reason = "Range Not Satisfiable"
+    default:
+      reason = "Internal Server Error"
+    }
+
+    let header =
+      "HTTP/1.1 \(status) \(reason)\r\n" +
+      "Content-Type: \(contentType)\r\n" +
+      "Content-Length: \(body.count)\r\n" +
+      "Connection: close\r\n" +
+      "\r\n"
+    var response = Data(header.utf8)
+    if !headOnly {
+      response.append(body)
+    }
+    connection.send(content: response, completion: .contentProcessed { _ in
+      connection.cancel()
+    })
+  }
+}

--- a/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
+++ b/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
@@ -63,7 +63,10 @@ Pod::Spec.new do |s|
   native_source_files.concat([
     "BluetoothSdkModule.swift",
     "LocalPhotoUploadServer.swift",
-    "MentraPhotoReceiverModule.swift"
+    "MentraPhotoReceiverModule.swift",
+    "LocalIPv4.swift",
+    "LocalOtaServer.swift",
+    "MentraOtaServerModule.swift"
   ]) if include_expo_adapter
   s.source_files = native_source_files
 

--- a/mobile/modules/bluetooth-sdk/ios/MentraOtaServerModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/MentraOtaServerModule.swift
@@ -1,0 +1,127 @@
+import ExpoModulesCore
+import Foundation
+
+/// Expo surface for the hotspot-served OTA file server (OS-1676).
+///
+/// JS hands over the rewritten manifest body and a map of sha256 -> local file path, and gets
+/// back the base URL the glasses should be pointed at via ota_start. The optional host
+/// argument lets the caller pass an authoritative address; otherwise interface scanning is
+/// used (under a glasses-hotspot session en0 holds the hotspot client address).
+public class MentraOtaServerModule: Module {
+  private let serverLock = NSLock()
+  private var otaServer: LocalOtaServer?
+
+  public func definition() -> ModuleDefinition {
+    Name("MentraOtaServer")
+
+    Events("serverStatus")
+
+    AsyncFunction("isSupported") {
+      true
+    }
+
+    AsyncFunction("startOtaServer") { (manifestJson: String, artifactPaths: [String: String], host: String?) -> [String: Any] in
+      try self.startOtaServer(manifestJson: manifestJson, artifactPaths: artifactPaths, hostOverride: host)
+    }
+
+    AsyncFunction("stopOtaServer") {
+      self.stopOtaServerInternal()
+    }
+
+    OnDestroy {
+      self.stopOtaServerInternal()
+    }
+  }
+
+  private func startOtaServer(
+    manifestJson: String,
+    artifactPaths: [String: String],
+    hostOverride: String?
+  ) throws -> [String: Any] {
+    serverLock.lock()
+    defer { serverLock.unlock() }
+
+    var artifacts: [String: URL] = [:]
+    for (key, path) in artifactPaths {
+      let url = path.hasPrefix("file://")
+        ? (URL(string: path) ?? URL(fileURLWithPath: String(path.dropFirst("file://".count))))
+        : URL(fileURLWithPath: path)
+      guard FileManager.default.fileExists(atPath: url.path) else {
+        throw OtaServerModuleError("Artifact \(key) not found at \(url.path)")
+      }
+      artifacts[key] = url
+    }
+
+    guard let host = hostOverride?.isEmpty == false ? hostOverride : LocalIPv4.bestLocalIPv4Address() else {
+      throw OtaServerModuleError("No Wi-Fi/LAN IPv4 address found for this phone.")
+    }
+
+    let server = otaServer ?? LocalOtaServer(
+      onLog: { [weak self] message in
+        self?.emitStatus(message: message)
+      }
+    )
+    otaServer = server
+    server.configure(manifestJson: manifestJson, artifacts: artifacts)
+
+    if let activePort = server.activePort {
+      emitStatus(message: "OTA server ready at http://\(host):\(activePort)/version.json")
+      return serverResult(host: host, port: activePort)
+    }
+
+    var lastError: Error?
+    for port in otaPorts {
+      do {
+        let actualPort = try server.start(port: UInt16(port))
+        emitStatus(message: "OTA server ready at http://\(host):\(actualPort)/version.json")
+        return serverResult(host: host, port: actualPort)
+      } catch {
+        lastError = error
+        emitStatus(message: "Port \(port) unavailable: \(error.localizedDescription)")
+      }
+    }
+
+    throw OtaServerModuleError(
+      "Could not start OTA server: \(lastError?.localizedDescription ?? "all ports unavailable")"
+    )
+  }
+
+  private func stopOtaServerInternal() {
+    serverLock.lock()
+    defer { serverLock.unlock() }
+
+    otaServer?.stop()
+    emitStatus(message: "OTA server stopped")
+  }
+
+  private func emitStatus(message: String) {
+    NSLog("[MentraOtaServer] %@", message)
+    sendEvent("serverStatus", [
+      "message": message,
+    ])
+  }
+
+  private func serverResult(host: String, port: UInt16) -> [String: Any] {
+    [
+      "baseUrl": "http://\(host):\(port)",
+      "manifestUrl": "http://\(host):\(port)/version.json",
+      "host": host,
+      "port": port,
+    ]
+  }
+
+  private let otaPorts = [8791, 8792, 8793, 8794]
+}
+
+final class OtaServerModuleError: Exception, @unchecked Sendable {
+  private let message: String
+
+  init(_ message: String) {
+    self.message = message
+    super.init()
+  }
+
+  override var reason: String {
+    message
+  }
+}

--- a/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
@@ -32,7 +32,7 @@ public class MentraPhotoReceiverModule: Module {
     receiverLock.lock()
     defer { receiverLock.unlock() }
 
-    guard let host = bestLocalIPv4Address() else {
+    guard let host = LocalIPv4.bestLocalIPv4Address() else {
       throw PhotoReceiverError("No Wi-Fi/LAN IPv4 address found for this phone.")
     }
 
@@ -104,92 +104,12 @@ public class MentraPhotoReceiverModule: Module {
     ])
   }
 
-  private func bestLocalIPv4Address() -> String? {
-    var interfaces: UnsafeMutablePointer<ifaddrs>?
-    guard getifaddrs(&interfaces) == 0, let first = interfaces else {
-      return nil
-    }
-    defer { freeifaddrs(interfaces) }
-
-    var preferredPrivate: String?
-    var preferred: String?
-    var privateFallback: String?
-    var fallback: String?
-    var cursor: UnsafeMutablePointer<ifaddrs>? = first
-    while let current = cursor {
-      defer { cursor = current.pointee.ifa_next }
-      let interface = current.pointee
-      guard let addressPointer = interface.ifa_addr,
-            addressPointer.pointee.sa_family == UInt8(AF_INET) else {
-        continue
-      }
-
-      let name = String(cString: interface.ifa_name)
-      let flags = interface.ifa_flags
-      guard (flags & UInt32(IFF_UP)) != 0,
-            (flags & UInt32(IFF_LOOPBACK)) == 0 else {
-        continue
-      }
-
-      var address = addressPointer.pointee
-      var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
-      let result = getnameinfo(
-        &address,
-        socklen_t(address.sa_len),
-        &hostname,
-        socklen_t(hostname.count),
-        nil,
-        0,
-        NI_NUMERICHOST
-      )
-      guard result == 0 else {
-        continue
-      }
-
-      let ip = String(cString: hostname)
-      guard ip != "127.0.0.1", !isLinkLocalIPv4(ip) else {
-        continue
-      }
-      if isPreferredLocalInterface(name), isPrivateIPv4(ip) {
-        preferredPrivate = preferredPrivate ?? ip
-      } else if isPreferredLocalInterface(name) {
-        preferred = preferred ?? ip
-      } else if isPrivateIPv4(ip) {
-        privateFallback = privateFallback ?? ip
-      } else {
-        fallback = fallback ?? ip
-      }
-    }
-
-    return preferredPrivate ?? preferred ?? privateFallback ?? fallback
-  }
-
   private func receiverResult(uploadUrl: String, host: String, port: UInt16) -> [String: Any] {
     [
       "uploadUrl": uploadUrl,
       "host": host,
       "port": port,
     ]
-  }
-
-  private func isPreferredLocalInterface(_ name: String) -> Bool {
-    name == "en0" ||
-      name.hasPrefix("bridge") ||
-      name.hasPrefix("ap") ||
-      name.hasPrefix("awdl") ||
-      name.hasPrefix("llw")
-  }
-
-  private func isPrivateIPv4(_ ip: String) -> Bool {
-    if ip.hasPrefix("192.168.") || ip.hasPrefix("10.") {
-      return true
-    }
-    let parts = ip.split(separator: ".").compactMap { Int($0) }
-    return parts.count == 4 && parts[0] == 172 && (16...31).contains(parts[1])
-  }
-
-  private func isLinkLocalIPv4(_ ip: String) -> Bool {
-    ip.hasPrefix("169.254.")
   }
 
   private let photoPorts = [8787, 8788, 8789, 8790]

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -32,6 +32,11 @@
       "types": "./build/photo-receiver/index.d.ts",
       "default": "./build/photo-receiver/index.js"
     },
+    "./ota-server": {
+      "react-native": "./src/ota-server/index.ts",
+      "types": "./build/ota-server/index.d.ts",
+      "default": "./build/ota-server/index.js"
+    },
     "./debug": {
       "react-native": "./src/debug.ts",
       "types": "./build/debug.d.ts",

--- a/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServer.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServer.types.ts
@@ -1,0 +1,14 @@
+export type OtaServerStatusEvent = {
+  message: string
+}
+
+export type OtaServerResult = {
+  baseUrl: string
+  host: string
+  manifestUrl: string
+  port: number
+}
+
+export type MentraOtaServerModuleEvents = {
+  serverStatus: (event: OtaServerStatusEvent) => void
+}

--- a/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServerModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServerModule.ts
@@ -1,0 +1,21 @@
+import {NativeModule, requireNativeModule} from "expo"
+
+import type {MentraOtaServerModuleEvents, OtaServerResult} from "./MentraOtaServer.types"
+
+declare class MentraOtaServerModule extends NativeModule<MentraOtaServerModuleEvents> {
+  isSupported(): Promise<boolean>
+  /**
+   * Serve `manifestJson` at /version.json and `artifactPaths` (sha256 -> local file path)
+   * at /artifacts/<sha256>. Pass `host` when the caller knows the authoritative local
+   * address (e.g. from the scoped hotspot network); omit to fall back to interface
+   * scanning. Returns the URLs to hand to the glasses via ota_start.
+   */
+  startOtaServer(
+    manifestJson: string,
+    artifactPaths: Record<string, string>,
+    host?: string | null,
+  ): Promise<OtaServerResult>
+  stopOtaServer(): Promise<void>
+}
+
+export default requireNativeModule<MentraOtaServerModule>("MentraOtaServer")

--- a/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServerModule.web.ts
+++ b/mobile/modules/bluetooth-sdk/src/ota-server/MentraOtaServerModule.web.ts
@@ -1,0 +1,17 @@
+import {NativeModule, registerWebModule} from "expo"
+
+import type {MentraOtaServerModuleEvents, OtaServerResult} from "./MentraOtaServer.types"
+
+class MentraOtaServerModule extends NativeModule<MentraOtaServerModuleEvents> {
+  async isSupported(): Promise<boolean> {
+    return false
+  }
+
+  async startOtaServer(): Promise<OtaServerResult> {
+    throw new Error("The OTA server is only available in native apps.")
+  }
+
+  async stopOtaServer(): Promise<void> {}
+}
+
+export default registerWebModule(MentraOtaServerModule, "MentraOtaServer")

--- a/mobile/modules/bluetooth-sdk/src/ota-server/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/ota-server/index.ts
@@ -1,0 +1,2 @@
+export {default} from "./MentraOtaServerModule"
+export * from "./MentraOtaServer.types"


### PR DESCRIPTION
## Scope

Second PR for OS-1676 (hotspot-served glasses OTA), stacked on #3614. Plan: `agents/os-1676-hotspot-ota-plan.md`.

The phone needs to serve the rewritten OTA manifest and pre-downloaded artifacts to the glasses over the glasses-hotspot link — `ota_start` already accepts any http URL, so a local static file server is the entire transport.

**`LocalOtaServer`** (Kotlin `ServerSocket` / Swift `NWListener`, mirroring `LocalPhotoUploadServer`'s hand-rolled structure — no third-party HTTP dependency in the SDK):

- `GET`/`HEAD /version.json` — manifest body handed over from JS. HEAD matters: the glasses' post-APK-restart resume (#3614) probes the manifest URL with HEAD before re-fetching.
- `GET`/`HEAD /artifacts/<sha256>` — streams artifacts with `Content-Length` and single-range support (`Accept-Ranges`/`Content-Range`), future-proofing glasses-side resumable downloads.
- `configure()` swaps manifest/artifacts while running; port ladder 8791–8794 (distinct from the photo receiver's 8787–8790); `Semaphore(2)` client cap; 64KB header cap.

**`MentraOtaServer` Expo module** (both platforms): `startOtaServer(manifestJson, artifactPaths, host?) → {baseUrl, manifestUrl, host, port}` / `stopOtaServer()`, `serverStatus` events. The optional `host` lets the orchestrator (PR4) pass the authoritative scoped-network address from `MentraLocalNetwork`'s `LinkProperties`; the fallback is interface scanning. JS surface at `@mentra/bluetooth-sdk/ota-server`.

Refactor: the best-local-IPv4 heuristics move out of the photo receiver modules into shared `LocalIpv4` (Kotlin) / `LocalIPv4` (Swift) helpers used by both — no behavior change.

## Test evidence

- 11 new JVM unit tests (manifest, HEAD, full/range/suffix/open-ended reads, 416, 404, 405, health, live reconfigure) — green via `:mentra-bluetooth-sdk:testDebugUnitTest`
- `./scripts/check-android-compile.sh bluetooth-sdk` green (public-SDK dependency shape)
- `swiftc -parse` green on the new Swift files; `expo-module build` green
- End-to-end bench verification (glasses downloading a real APK from this server over the hotspot) lands with the PR4 orchestrator; the equivalent path was already proven in the Phase 0 spike with a python server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New local HTTP server on device and OTA artifact serving are operationally sensitive, but scope is read-only GET/HEAD on caller-supplied files with solid unit coverage; full e2e lands in a follow-up orchestrator PR.
> 
> **Overview**
> Adds a **phone-hosted static HTTP server** so glasses can pull a rewritten OTA manifest and pre-downloaded APK artifacts over the glasses-hotspot link (OS-1676), wired for `ota_start` URLs.
> 
> **`LocalOtaServer`** on Android (hand-rolled `ServerSocket`) and iOS (`NWListener`), parallel to the photo upload server: **GET/HEAD** `/version.json`, **GET/HEAD** `/artifacts/<sha256>` with **byte-range** support, live **`configure()`**, ports **8791–8794**, and a small client cap.
> 
> **`MentraOtaServer`** Expo module on both platforms exposes **`startOtaServer(manifestJson, artifactPaths, host?)`** → `{ baseUrl, manifestUrl, host, port }`, **`stopOtaServer`**, and **`serverStatus`** events. JS imports **`@mentra/bluetooth-sdk/ota-server`**; web stub reports unsupported.
> 
> **Refactor:** local IPv4 discovery moves into shared **`LocalIpv4`** / **`LocalIPv4`** helpers; photo receiver modules call those instead of inlined heuristics (intended behavior unchanged).
> 
> **Tests:** 11 JVM unit tests cover manifest, HEAD, ranges, errors, health, and reconfigure while running.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b37352f824aa48918997b221e2a2abc44a54f33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->