### PR TITLE
Stage OTA artifacts on the phone for hotspot-served updates

### DIFF
--- a/mobile/modules/engine/src/services/OtaArtifactDownloader.ts
+++ b/mobile/modules/engine/src/services/OtaArtifactDownloader.ts
@@ -1,0 +1,309 @@
+import * as RNFS from "@dr.pogodin/react-native-fs"
+import type {OtaCheckCurrentGlassesResult, VersionJson} from "./OtaUpdateCheckService"
+
+/**
+ * Phone-side artifact staging for hotspot-served OTA (OS-1676).
+ *
+ * When the glasses have no WiFi, the phone downloads the OTA artifacts itself (over
+ * whatever network it is on — the user's tap on "update" is the consent) and serves them
+ * to the glasses via the LocalOtaServer over the glasses' hotspot. This module owns:
+ *
+ * - planning which artifacts the pending update actually needs (from the raw manifest the
+ *   update check fetched, so the glasses re-parse byte-identical version data),
+ * - downloading them with .part staging and sha256 verification, keyed on disk by hash so
+ *   a retry or the post-APK second hotspot window reuses verified files,
+ * - rewriting the manifest's URL fields to point at the phone server, and
+ * - cleanup once the update completes or the manifest moves on.
+ */
+
+export type OtaArtifactKind = "apk" | "mtk" | "bes"
+
+export interface OtaArtifactPlanEntry {
+  kind: OtaArtifactKind
+  /** URL this artifact is fetched from, exactly as it appears in the raw manifest. */
+  url: string
+  /** Expected content hash from the manifest; null when the manifest omits it (MTK). */
+  expectedSha256: string | null
+  /** Size from the manifest when declared (APK); null otherwise. */
+  sizeBytes: number | null
+}
+
+export interface PreparedOtaArtifact extends OtaArtifactPlanEntry {
+  /** Actual content hash — equals expectedSha256 when one was declared. */
+  sha256: string
+  filePath: string
+}
+
+export interface OtaArtifactDownloadProgress {
+  kind: OtaArtifactKind
+  /** 0-based index of the artifact being downloaded. */
+  index: number
+  totalCount: number
+  /** Percent of the current artifact, 0-100 (0 when the server sent no length). */
+  artifactPercent: number
+  bytesWritten: number
+  contentLength: number
+}
+
+export class OtaArtifactError extends Error {
+  constructor(
+    public readonly code: "artifact_download_failed" | "artifact_verify_failed" | "manifest_invalid",
+    message: string,
+  ) {
+    super(message)
+    this.name = "OtaArtifactError"
+  }
+}
+
+const ASG_PACKAGE = "com.mentra.asg_client"
+
+export function otaArtifactsDirectory(): string {
+  return `${RNFS.DocumentDirectoryPath}/ota_artifacts`
+}
+
+/**
+ * Derive the artifact list the pending update needs from a completed check.
+ * Works off the raw manifest body (not the normalized check fields) so the URLs and
+ * hashes match exactly what the glasses will re-parse.
+ */
+export function planArtifacts(result: OtaCheckCurrentGlassesResult): OtaArtifactPlanEntry[] {
+  if (!result.manifestBody) {
+    throw new OtaArtifactError("manifest_invalid", "Check result carries no manifest body")
+  }
+  let manifest: VersionJson
+  try {
+    manifest = JSON.parse(result.manifestBody)
+  } catch {
+    throw new OtaArtifactError("manifest_invalid", "Manifest body is not valid JSON")
+  }
+
+  const entries: OtaArtifactPlanEntry[] = []
+
+  if (result.updates.includes("apk")) {
+    const app = manifest.apps?.[ASG_PACKAGE] as unknown as Record<string, unknown> | undefined
+    const url = typeof app?.apkUrl === "string" ? app.apkUrl : null
+    if (!url) {
+      throw new OtaArtifactError("manifest_invalid", "Manifest has no apkUrl for the pending APK update")
+    }
+    entries.push({
+      kind: "apk",
+      url,
+      expectedSha256: typeof app?.sha256 === "string" ? app.sha256.toLowerCase() : null,
+      sizeBytes: typeof app?.apkSize === "number" ? app.apkSize : null,
+    })
+  }
+
+  if (result.updates.includes("mtk") && result.mtkPatch) {
+    const raw = (manifest.mtk_patches ?? []).find(
+      (patch) => firmwareUrl(patch) === firmwareUrl(result.mtkPatch!),
+    ) as unknown as Record<string, unknown> | undefined
+    const url = firmwareUrl(raw) ?? firmwareUrl(result.mtkPatch)
+    if (!url) {
+      throw new OtaArtifactError("manifest_invalid", "Manifest has no URL for the pending MTK patch")
+    }
+    entries.push({
+      kind: "mtk",
+      url,
+      expectedSha256: typeof raw?.sha256 === "string" ? raw.sha256.toLowerCase() : null,
+      sizeBytes: null,
+    })
+  }
+
+  if (result.updates.includes("bes") && manifest.bes_firmware) {
+    const raw = manifest.bes_firmware as unknown as Record<string, unknown>
+    const url = firmwareUrl(raw)
+    if (!url) {
+      throw new OtaArtifactError("manifest_invalid", "Manifest has no URL for the pending BES firmware")
+    }
+    entries.push({
+      kind: "bes",
+      url,
+      expectedSha256: typeof raw.sha256 === "string" ? raw.sha256.toLowerCase() : null,
+      sizeBytes: null,
+    })
+  }
+
+  return entries
+}
+
+/**
+ * Download every planned artifact into the on-disk hash-keyed store, reusing files that
+ * already verify. Sequential on purpose: progress is legible and the hotspot window that
+ * follows is the slow part, not phone-side parallelism.
+ */
+export async function prepareArtifacts(
+  plan: OtaArtifactPlanEntry[],
+  onProgress?: (progress: OtaArtifactDownloadProgress) => void,
+): Promise<PreparedOtaArtifact[]> {
+  const directory = otaArtifactsDirectory()
+  await RNFS.mkdir(directory, {NSURLIsExcludedFromBackupKey: true})
+
+  const prepared: PreparedOtaArtifact[] = []
+  for (let index = 0; index < plan.length; index++) {
+    const entry = plan[index]
+
+    if (entry.expectedSha256) {
+      const cachedPath = `${directory}/${entry.expectedSha256}`
+      if (await RNFS.exists(cachedPath)) {
+        const cachedHash = (await RNFS.hash(cachedPath, "sha256")).toLowerCase()
+        if (cachedHash === entry.expectedSha256) {
+          prepared.push({...entry, sha256: cachedHash, filePath: cachedPath})
+          continue
+        }
+        await safeUnlink(cachedPath)
+      }
+    }
+
+    const partPath = `${directory}/download-${index}.part`
+    await safeUnlink(partPath)
+    try {
+      const download = RNFS.downloadFile({
+        fromUrl: entry.url,
+        toFile: partPath,
+        connectionTimeout: 30_000,
+        readTimeout: 30_000,
+        progressDivider: 5,
+        progress: (res: RNFS.DownloadProgressCallbackResultT) => {
+          onProgress?.({
+            kind: entry.kind,
+            index,
+            totalCount: plan.length,
+            artifactPercent: res.contentLength > 0 ? Math.round((res.bytesWritten / res.contentLength) * 100) : 0,
+            bytesWritten: res.bytesWritten,
+            contentLength: res.contentLength,
+          })
+        },
+      })
+      const downloadResult = await download.promise
+      if (downloadResult.statusCode !== 200) {
+        throw new OtaArtifactError(
+          "artifact_download_failed",
+          `Download of ${entry.kind} artifact failed with HTTP ${downloadResult.statusCode}`,
+        )
+      }
+
+      const actualSha256 = (await RNFS.hash(partPath, "sha256")).toLowerCase()
+      if (entry.expectedSha256 && actualSha256 !== entry.expectedSha256) {
+        throw new OtaArtifactError(
+          "artifact_verify_failed",
+          `${entry.kind} artifact hash mismatch: expected ${entry.expectedSha256}, got ${actualSha256}`,
+        )
+      }
+
+      const finalPath = `${directory}/${actualSha256}`
+      await safeUnlink(finalPath)
+      await RNFS.moveFile(partPath, finalPath)
+      prepared.push({...entry, sha256: actualSha256, filePath: finalPath})
+    } catch (error) {
+      await safeUnlink(partPath)
+      if (error instanceof OtaArtifactError) {
+        throw error
+      }
+      throw new OtaArtifactError(
+        "artifact_download_failed",
+        `Download of ${entry.kind} artifact failed: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
+  }
+  return prepared
+}
+
+/**
+ * Point the manifest's artifact URLs at the phone server, leaving every other field
+ * byte-compatible with what the update check saw. Entries we host get
+ * `<baseUrl>/artifacts/<sha256>`; entries the update does not need keep their CDN URLs
+ * (the glasses never fetch them). Hosted entries also gain a sha256 when the manifest
+ * omitted one, so the glasses verify the hotspot transfer end to end.
+ */
+export function rewriteManifestForLocalServer(
+  manifestBody: string,
+  artifacts: PreparedOtaArtifact[],
+  baseUrl: string,
+): string {
+  let manifest: VersionJson
+  try {
+    manifest = JSON.parse(manifestBody)
+  } catch {
+    throw new OtaArtifactError("manifest_invalid", "Manifest body is not valid JSON")
+  }
+  const byUrl = new Map(artifacts.map((artifact) => [artifact.url, artifact]))
+  const localUrl = (artifact: PreparedOtaArtifact) => `${baseUrl}/artifacts/${artifact.sha256}`
+
+  for (const app of Object.values(manifest.apps ?? {})) {
+    const record = app as unknown as Record<string, unknown>
+    const artifact = typeof record.apkUrl === "string" ? byUrl.get(record.apkUrl) : undefined
+    if (artifact) {
+      record.apkUrl = localUrl(artifact)
+      record.sha256 = artifact.sha256
+    }
+  }
+
+  for (const patch of manifest.mtk_patches ?? []) {
+    rewriteFirmwareEntry(patch as unknown as Record<string, unknown>, byUrl, localUrl)
+  }
+  if (manifest.bes_firmware) {
+    rewriteFirmwareEntry(manifest.bes_firmware as unknown as Record<string, unknown>, byUrl, localUrl)
+  }
+
+  return JSON.stringify(manifest)
+}
+
+/** Delete every stored artifact whose hash is not in `keepSha256s` (plus stray .part files). */
+export async function cleanupArtifacts(keepSha256s: string[] = []): Promise<void> {
+  const directory = otaArtifactsDirectory()
+  if (!(await RNFS.exists(directory))) {
+    return
+  }
+  const keep = new Set(keepSha256s.map((sha) => sha.toLowerCase()))
+  const items = await RNFS.readDir(directory)
+  for (const item of items) {
+    if (!item.isFile()) continue
+    if (keep.has(item.name.toLowerCase())) continue
+    await safeUnlink(item.path)
+  }
+}
+
+function rewriteFirmwareEntry(
+  entry: Record<string, unknown>,
+  byUrl: Map<string, PreparedOtaArtifact>,
+  localUrl: (artifact: PreparedOtaArtifact) => string,
+): void {
+  const url = firmwareUrl(entry)
+  const artifact = url ? byUrl.get(url) : undefined
+  if (!artifact) {
+    return
+  }
+  entry.url = localUrl(artifact)
+  // Overwrite the legacy key too when present, so no glasses build can prefer a stale
+  // CDN URL over the local one.
+  if (typeof entry.firmwareUrl === "string") {
+    entry.firmwareUrl = localUrl(artifact)
+  }
+  if (typeof entry.sha256 !== "string") {
+    entry.sha256 = artifact.sha256
+  }
+}
+
+function firmwareUrl(entry: unknown): string | null {
+  if (!entry || typeof entry !== "object") {
+    return null
+  }
+  const record = entry as Record<string, unknown>
+  if (typeof record.url === "string" && record.url.length > 0) {
+    return record.url
+  }
+  if (typeof record.firmwareUrl === "string" && record.firmwareUrl.length > 0) {
+    return record.firmwareUrl
+  }
+  return null
+}
+
+async function safeUnlink(path: string): Promise<void> {
+  try {
+    if (await RNFS.exists(path)) {
+      await RNFS.unlink(path)
+    }
+  } catch {
+    // Best-effort: a leftover file only wastes space and is cleaned up next run.
+  }
+}

--- a/mobile/modules/engine/src/services/__tests__/OtaArtifactDownloader.test.ts
+++ b/mobile/modules/engine/src/services/__tests__/OtaArtifactDownloader.test.ts
@@ -1,0 +1,231 @@
+/// <reference types="bun-types" />
+
+import {beforeEach, describe, expect, mock, test} from "bun:test"
+
+// --- In-memory RNFS ---------------------------------------------------------
+// Keyed by absolute path; value is the "content" whose sha256 we fake as
+// `sha:<content>` so hashes are deterministic and human-readable in failures.
+const files = new Map<string, string>()
+const fakeHash = (content: string) => `sha-${content}`
+let downloadImpl: (options: {fromUrl: string; toFile: string}) => Promise<{statusCode: number}> = async () => ({
+  statusCode: 200,
+})
+
+const rnfsMock = {
+  DocumentDirectoryPath: "/docs",
+  mkdir: mock(async () => undefined),
+  exists: mock(async (path: string) => files.has(path) || [...files.keys()].some((key) => key.startsWith(`${path}/`))),
+  hash: mock(async (path: string) => {
+    const content = files.get(path)
+    if (content === undefined) throw new Error(`no such file ${path}`)
+    return fakeHash(content)
+  }),
+  unlink: mock(async (path: string) => {
+    files.delete(path)
+  }),
+  moveFile: mock(async (from: string, to: string) => {
+    const content = files.get(from)
+    if (content === undefined) throw new Error(`no such file ${from}`)
+    files.delete(from)
+    files.set(to, content)
+  }),
+  readDir: mock(async () =>
+    [...files.keys()]
+      .filter((path) => path.startsWith("/docs/ota_artifacts/"))
+      .map((path) => ({
+        path,
+        name: path.split("/").pop()!,
+        isFile: () => true,
+      })),
+  ),
+  downloadFile: mock((options: {fromUrl: string; toFile: string}) => ({
+    jobId: 1,
+    promise: downloadImpl(options),
+  })),
+}
+
+mock.module("@dr.pogodin/react-native-fs", () => ({
+  ...rnfsMock,
+  default: rnfsMock,
+}))
+
+const {OtaArtifactError, cleanupArtifacts, planArtifacts, prepareArtifacts, rewriteManifestForLocalServer} =
+  await import("../OtaArtifactDownloader")
+
+const APK_URL = "https://cdn.example.com/asg.apk"
+const MTK_URL = "https://cdn.example.com/mtk.zip"
+const BES_URL = "https://cdn.example.com/bes.bin"
+
+const manifest = {
+  apps: {
+    "com.mentra.asg_client": {
+      versionCode: 100,
+      versionName: "100",
+      apkUrl: APK_URL,
+      apkSize: 1234,
+      sha256: "sha-apk",
+    },
+  },
+  mtk_patches: [
+    {start_firmware: "A", end_firmware: "B", url: MTK_URL},
+    {start_firmware: "B", end_firmware: "C", url: "https://cdn.example.com/other.zip"},
+  ],
+  bes_firmware: {version: "9.9.9", url: BES_URL, sha256: "sha-bes"},
+}
+
+function checkResult(overrides: Record<string, unknown> = {}) {
+  return {
+    hasCheckCompleted: true,
+    updateAvailable: true,
+    latestVersionInfo: null,
+    updates: ["apk", "mtk", "bes"],
+    mtkPatch: {start_firmware: "A", end_firmware: "B", url: MTK_URL},
+    besVersion: "9.9.9",
+    isApkDowngrade: false,
+    manifestBody: JSON.stringify(manifest),
+    updateInfo: null,
+    isRequired: false,
+    ...overrides,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any
+}
+
+beforeEach(() => {
+  files.clear()
+  downloadImpl = async ({fromUrl, toFile}) => {
+    files.set(toFile, contentFor(fromUrl))
+    return {statusCode: 200}
+  }
+})
+
+function contentFor(url: string): string {
+  if (url === APK_URL) return "apk"
+  if (url === MTK_URL) return "mtk"
+  if (url === BES_URL) return "bes"
+  return "unknown"
+}
+
+describe("planArtifacts", () => {
+  test("plans every pending artifact from the raw manifest", () => {
+    const plan = planArtifacts(checkResult())
+    expect(plan).toEqual([
+      {kind: "apk", url: APK_URL, expectedSha256: "sha-apk", sizeBytes: 1234},
+      {kind: "mtk", url: MTK_URL, expectedSha256: null, sizeBytes: null},
+      {kind: "bes", url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null},
+    ])
+  })
+
+  test("plans only the updates the check reported", () => {
+    const plan = planArtifacts(checkResult({updates: ["bes"], mtkPatch: null}))
+    expect(plan.map((entry) => entry.kind)).toEqual(["bes"])
+  })
+
+  test("throws when the check carries no manifest", () => {
+    expect(() => planArtifacts(checkResult({manifestBody: null}))).toThrow(OtaArtifactError)
+  })
+
+  test("throws when a pending APK update has no URL", () => {
+    const broken = {...manifest, apps: {"com.mentra.asg_client": {versionCode: 100}}}
+    expect(() => planArtifacts(checkResult({manifestBody: JSON.stringify(broken)}))).toThrow("no apkUrl")
+  })
+
+  test("accepts legacy firmwareUrl keys", () => {
+    const legacy = {
+      ...manifest,
+      bes_firmware: {version: "9.9.9", firmwareUrl: BES_URL},
+    }
+    const plan = planArtifacts(checkResult({updates: ["bes"], mtkPatch: null, manifestBody: JSON.stringify(legacy)}))
+    expect(plan).toEqual([{kind: "bes", url: BES_URL, expectedSha256: null, sizeBytes: null}])
+  })
+})
+
+describe("prepareArtifacts", () => {
+  test("downloads, verifies, and stores by hash", async () => {
+    const plan = [{kind: "bes" as const, url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}]
+    const prepared = await prepareArtifacts(plan)
+    expect(prepared).toHaveLength(1)
+    expect(prepared[0].sha256).toBe("sha-bes")
+    expect(prepared[0].filePath).toBe("/docs/ota_artifacts/sha-bes")
+    expect(files.has("/docs/ota_artifacts/sha-bes")).toBe(true)
+  })
+
+  test("reuses a cached artifact that still verifies", async () => {
+    files.set("/docs/ota_artifacts/sha-bes", "bes")
+    downloadImpl = async () => {
+      throw new Error("should not download")
+    }
+    const plan = [{kind: "bes" as const, url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}]
+    const prepared = await prepareArtifacts(plan)
+    expect(prepared[0].filePath).toBe("/docs/ota_artifacts/sha-bes")
+  })
+
+  test("re-downloads when the cached file no longer verifies", async () => {
+    files.set("/docs/ota_artifacts/sha-bes", "corrupted")
+    const plan = [{kind: "bes" as const, url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}]
+    const prepared = await prepareArtifacts(plan)
+    expect(prepared[0].sha256).toBe("sha-bes")
+    expect(files.get("/docs/ota_artifacts/sha-bes")).toBe("bes")
+  })
+
+  test("fails verification on a hash mismatch and cleans the staging file", async () => {
+    downloadImpl = async ({toFile}) => {
+      files.set(toFile, "tampered")
+      return {statusCode: 200}
+    }
+    const plan = [{kind: "bes" as const, url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}]
+    await expect(prepareArtifacts(plan)).rejects.toThrow("hash mismatch")
+    expect([...files.keys()].some((path) => path.endsWith(".part"))).toBe(false)
+  })
+
+  test("keys manifest-less MTK artifacts by their computed hash", async () => {
+    const plan = [{kind: "mtk" as const, url: MTK_URL, expectedSha256: null, sizeBytes: null}]
+    const prepared = await prepareArtifacts(plan)
+    expect(prepared[0].sha256).toBe("sha-mtk")
+    expect(prepared[0].filePath).toBe("/docs/ota_artifacts/sha-mtk")
+  })
+
+  test("surfaces HTTP failures as artifact_download_failed", async () => {
+    downloadImpl = async () => ({statusCode: 503})
+    const plan = [{kind: "bes" as const, url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}]
+    await expect(prepareArtifacts(plan)).rejects.toMatchObject({code: "artifact_download_failed"})
+  })
+})
+
+describe("rewriteManifestForLocalServer", () => {
+  test("points hosted entries at the local server and injects missing hashes", async () => {
+    const prepared = await prepareArtifacts(planArtifacts(checkResult()))
+    const rewritten = JSON.parse(
+      rewriteManifestForLocalServer(JSON.stringify(manifest), prepared, "http://192.168.43.100:8791"),
+    )
+
+    expect(rewritten.apps["com.mentra.asg_client"].apkUrl).toBe("http://192.168.43.100:8791/artifacts/sha-apk")
+    expect(rewritten.apps["com.mentra.asg_client"].versionCode).toBe(100)
+    expect(rewritten.mtk_patches[0].url).toBe("http://192.168.43.100:8791/artifacts/sha-mtk")
+    // The MTK entry had no manifest hash; the rewrite adds the computed one so the
+    // glasses verify the hotspot transfer.
+    expect(rewritten.mtk_patches[0].sha256).toBe("sha-mtk")
+    // Entries the update does not host keep their CDN URLs.
+    expect(rewritten.mtk_patches[1].url).toBe("https://cdn.example.com/other.zip")
+    expect(rewritten.bes_firmware.url).toBe("http://192.168.43.100:8791/artifacts/sha-bes")
+  })
+
+  test("overwrites legacy firmwareUrl keys so no build prefers a stale CDN URL", async () => {
+    const legacy = {
+      bes_firmware: {version: "9.9.9", url: BES_URL, firmwareUrl: BES_URL, sha256: "sha-bes"},
+    }
+    const prepared = await prepareArtifacts([{kind: "bes", url: BES_URL, expectedSha256: "sha-bes", sizeBytes: null}])
+    const rewritten = JSON.parse(rewriteManifestForLocalServer(JSON.stringify(legacy), prepared, "http://host:1"))
+    expect(rewritten.bes_firmware.url).toBe("http://host:1/artifacts/sha-bes")
+    expect(rewritten.bes_firmware.firmwareUrl).toBe("http://host:1/artifacts/sha-bes")
+  })
+})
+
+describe("cleanupArtifacts", () => {
+  test("removes everything not explicitly kept", async () => {
+    files.set("/docs/ota_artifacts/sha-apk", "apk")
+    files.set("/docs/ota_artifacts/sha-bes", "bes")
+    files.set("/docs/ota_artifacts/download-0.part", "partial")
+    await cleanupArtifacts(["sha-apk"])
+    expect([...files.keys()]).toEqual(["/docs/ota_artifacts/sha-apk"])
+  })
+})


### PR DESCRIPTION
## Scope

Third PR for OS-1676, stacked on #3617. Plan: `agents/os-1676-hotspot-ota-plan.md`.

When the glasses have no WiFi, the phone downloads the update artifacts itself — over whatever network it is on, when the user starts the update (the tap is the consent; no background pre-download) — and serves them to the glasses via the local OTA server (#3617) over the glasses' hotspot. This adds the engine-side staging in `OtaArtifactDownloader.ts`:

- `planArtifacts()` derives the artifact list (apk/mtk/bes) from the **raw manifest body** the update check fetched, so URLs and hashes match exactly what the glasses will re-parse; supports the legacy `firmwareUrl` key.
- `prepareArtifacts()` downloads sequentially with `.part` staging into a sha256-keyed store (`DocumentDirectory/ota_artifacts`, excluded from backup), verifies against the manifest hash when one is declared, and reuses already-verified files — a retry or the post-APK second hotspot window skips re-downloading.
- `rewriteManifestForLocalServer()` points hosted entries at `<baseUrl>/artifacts/<sha256>`, overwrites legacy `firmwareUrl` keys so no glasses build can prefer a stale CDN URL, and injects a computed sha256 when the manifest omitted one (MTK) — the glasses then verify the hotspot transfer end to end. Entries the update doesn't need keep their CDN URLs untouched.
- `cleanupArtifacts()` drops everything not explicitly kept.

## Test evidence

- 14 unit tests (bun:test, in-memory RNFS): planning per update-set, legacy-key handling, cache reuse, corrupted-cache re-download, hash-mismatch failure with staging cleanup, hash-keyed MTK storage, HTTP-failure classification, manifest rewriting (URL swap, hash injection, untouched CDN entries, legacy-key overwrite), cleanup.
- Engine suite otherwise unchanged — the 14 pre-existing `PhoneCameraFovCoordinator` failures reproduce identically on the base branch without this change.
- Engine `tsc --noEmit` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches firmware/APK download integrity and manifest rewriting for device updates; mistakes could serve wrong artifacts or break hotspot OTA, though hashing and verification mitigate tampering.
> 
> **Overview**
> Adds **`OtaArtifactDownloader`** so the phone can fetch OTA payloads when glasses have no Wi‑Fi, then serve them over the local OTA server on the hotspot (OS-1676).
> 
> **`planArtifacts`** builds apk/mtk/bes download plans from the check’s **raw `manifestBody`** (matching what glasses re-parse), including legacy **`firmwareUrl`**. **`prepareArtifacts`** downloads sequentially into `DocumentDirectory/ota_artifacts` with `.part` staging, SHA-256 verification, hash-keyed cache reuse for retries/post-APK windows, and progress callbacks. **`rewriteManifestForLocalServer`** swaps hosted URLs to `<baseUrl>/artifacts/<sha256>`, overwrites legacy firmware URL fields, and injects hashes when the manifest omitted them (e.g. MTK). **`cleanupArtifacts`** removes unneeded files and stray `.part` files.
> 
> Ships **14 bun unit tests** with an in-memory RNFS mock covering planning, cache/verify failures, manifest rewrite, and cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68eea40c05129440db5360948f68e98ac2c661b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->