### PR TITLE
Deliver BLE photos to the phone via a destination union in the Bluetooth SDK

### DIFF
--- a/agents/os-1796-ble-photo-phone-delivery-plan.md
+++ b/agents/os-1796-ble-photo-phone-delivery-plan.md
@@ -1,0 +1,326 @@
+# OS-1796 — BLE photo to phone: deliver/save locally instead of webhook round-trip
+
+Ticket: https://linear.app/mentralabs/issue/OS-1796
+Status: plan (2026-07-28)
+
+## Problem
+
+Every SDK photo today has exactly one delivery mechanism: an HTTP multipart POST to
+`webhookUrl`. The BLE path is a pure relay — the phone reassembles the image from the
+glasses and then re-uploads it to the *same* webhook the glasses would have used
+(`BlePhotoUploadService.uploadToWebhook`, Android `utils/BlePhotoUploadService.java:442`,
+iOS `MentraLive.swift:417`). So a miniapp running on/near the phone gets its photo by
+round-tripping the bytes through the internet back to itself ("webhook to self").
+
+This blocks airgapped Mentra Live deployments and is the wrong default for future
+BT-Classic glasses where bytes always land on the phone first. The miniapp should
+receive the image data directly and decide what to do with it.
+
+## Current state (mapped 2026-07-28)
+
+**Glasses (`asg_client`)** — `PhotoCommandHandler.processPhotoCapture` routes on
+`transferMethod` (`auto|direct|ble`) + `webhookUrl` + `save`:
+
+| condition | destination |
+|---|---|
+| `save && webhookUrl empty` | local gallery only, no upload/BLE |
+| `direct` | glasses HTTP POST → webhookUrl |
+| `ble` | K900 file transfer → phone |
+| `auto` | WiFi present → direct upload; else BLE; upload failure falls back to BLE |
+
+**Phone (bluetooth-sdk)** — BLE reassembly completes in
+`processAndUploadBlePhoto` (Android `MentraLive.kt:8777`, iOS `MentraLive.swift:4015`):
+writes an app-private debug `.avif`, converts AVIF→JPEG preserving IMU EXIF, then
+uploads to `webhookUrl`. The phone already holds the decoded bytes here — this is the
+natural insertion point.
+
+**Existing escape hatch** — `MentraPhotoReceiverModule` + `LocalPhotoUploadServer`
+(ports 8787–8790): a consumer app starts an in-process HTTP server and passes its LAN
+URL as `webhookUrl`. WiFi path: glasses POST over LAN. BLE path: Android rewrites the
+host to `127.0.0.1` via `LocalPhotoReceiverRegistry.loopbackUploadUrlFor()`
+(`BlePhotoUploadService.resolvePhoneRelayWebhookUrl:526`). **iOS has no loopback
+rewrite** — its BLE relay posts to the literal LAN URL, which breaks off-WiFi.
+
+**Mentra App / local miniapps** — `PhonePhotoCoordinator.ts:193` gets a presigned
+cloud upload URL (`startManagedPhoto`), passes it as `webhookUrl`, awaits cloud-v2
+`photo.ready {readUrl}`. So even local miniapps' BLE photos detour through R2.
+cloud-v2 `photoOptionsSchema` accepts `{size, compress, saveToGallery, sound}` but the
+runtime discards them (`camera.service.ts:76` — `void opts;`).
+
+**Cloud miniapps (v1)** — webhook URL minted in `PhotoManager.ts:88-99`
+(`customWebhookUrl` else `${app.publicUrl}/photo-upload`). Known bug found while
+mapping: `saveToGallery` is accepted by the SDK but dropped from the message sent to
+glasses (`PhotoManager.ts:135-149`).
+
+**Camera-roll machinery already exists** (gallery sync only today):
+`cameraRollExportCoordinator` → `CrustModule.saveToGalleryWithDate`
+(Android `CrustModule.kt:534` MediaStore, iOS `CrustModule.swift:466` PHPhotoLibrary),
+date-preserving, with permission/retry state machine.
+
+## Goals
+
+1. A first-class delivery option on `requestPhoto` meaning "give the bytes to the
+   phone; do not upload to a webhook."
+2. Optional save to the phone's camera roll as part of that delivery.
+3. Local-miniapp photos are BLE-only and never touch Cloudflare: no presigned R2
+   upload/read URLs, no cloud round trip anywhere in the request path — which makes
+   airgapped Mentra Live work by construction.
+4. iOS/Android parity, including fixing the existing iOS loopback-rewrite gap.
+
+## Non-goals (follow-ups, not this ticket)
+
+- Changing the *default* path for cloud miniapps (v1 `PhotoManager`). Flipping the
+  default to phone-delivery is a separate, riskier change once the option ships.
+- Raw-bytes-over-websocket delivery to cloud miniapps (only precedent is the
+  deprecated base64 `photo_taken` broadcast).
+- Fixing the dropped `saveToGallery` in v1 `PhotoManager` (file separately; one-line
+  plumb but needs glasses-side confirmation).
+
+## Design
+
+### New API surface (bluetooth-sdk)
+
+A flat `delivery?: "webhook" | "phone"` flag would multiply invalid states
+(`delivery: "phone"` + `webhookUrl` set; `delivery: "webhook"` with no URL;
+`transferMethod: "direct"` with phone delivery). The existing `save` flag has the
+same disease in disguise: it is not orthogonal to destination — on the glasses,
+`save=true` + empty `webhookUrl` is the magic combo that routes to
+*glasses-local-only capture* (`PhotoCommandHandler.java:362`, checked before any
+transfer-method branch), so `save` secretly encodes a third destination. Model all
+of it as one discriminated union so every invalid combination is unrepresentable:
+
+```ts
+type PhotoDestination =
+  | {
+      kind: "webhook";
+      url: string;                       // required — no URL-less webhook state
+      authToken?: string;
+      transferMethod?: PhotoTransferMethod; // auto|direct|ble — only meaningful here
+      keepOnGlasses?: boolean;           // also keep a copy in the glasses gallery
+    }
+  | {
+      kind: "phone";
+      saveToCameraRoll?: boolean;        // only exists on this arm
+      keepOnGlasses?: boolean;           // see wire-mapping note below
+      // no url/authToken/transferMethod: phone delivery always rides BLE
+    }
+  | {
+      kind: "glasses";                   // gallery-only capture; no transfer at all
+      // nothing to configure: this IS "save on glasses", so no keepOnGlasses flag
+    };
+
+interface PhotoRequestParams {
+  destination: PhotoDestination;
+  size?: ...; compress?: ...; sound?: ...; // unchanged capture options
+  // `save` is deleted — its meanings are absorbed by the union
+}
+```
+
+Wire mapping (the `take_photo` JSON keeps its current fields; only the SDK-side
+type changes):
+- `{kind: "webhook", keepOnGlasses}` → `webhookUrl` + `save: keepOnGlasses`.
+  Valid today: with a non-empty webhook the glasses capture into the permanent
+  gallery tree *and* deliver (`PhotoCommandHandler.java:303`).
+- `{kind: "glasses"}` → `save: true`, no `webhookUrl`, no `bleImgId` — exactly
+  today's local-save route, now expressed explicitly instead of via the magic combo.
+- `{kind: "phone"}` → `transferMethod: "ble"` + `bleImgId`, no `webhookUrl`,
+  `save: keepOnGlasses`. **Caveat:** with `keepOnGlasses: true` this trips the
+  `:362` local-save-only check on pre-fix firmware (the BLE transfer would never
+  start). Fix is a one-line asg_client routing change — gate `:362` on `bleImgId`
+  being empty too — shipped as PR 2a ahead of the SDK change. Glasses OTA updates
+  are mandatory now, so no legacy-firmware compat handling is needed in the SDK;
+  the only requirement is release ordering (2a's firmware rolls out before 2b
+  reaches users).
+
+Back-compat: keep the existing top-level `webhookUrl`/`authToken`/`transferMethod`/
+`save` fields as deprecated inputs; when `destination` is absent the SDK normalizes
+them — `webhookUrl` present → `{kind: "webhook", keepOnGlasses: save}`;
+`save: true` + no webhook → `{kind: "glasses"}` — and rejects requests that mix the
+old fields with a `destination`.
+
+### Remaining invalid-state audit of `PhotoRequestParams`
+
+Full sweep of the current type (`BluetoothSdk.types.ts:573`) for other
+incoherent combinations:
+
+- **Killed by the union already:** `webhookUrl`/`authToken` are `string | null`
+  *required-nullable* today, so `authToken` set with `webhookUrl: null` is
+  representable and meaningless. The webhook arm (required `url`, optional
+  `authToken`) removes it. Verified non-issue: `bleImgId` is not in the TS surface —
+  it's generated natively — so no `ble`-without-`bleImgId` state exists at the API
+  layer.
+- **Exposure/capture cluster (in scope for PR 2b, same disease):** the type carries
+  `exposureTimeNs`, `iso` ("only used when exposureTimeNs enables manual exposure"),
+  `aeExposureDivisor`/`isoCap` (AE-metered "scan mode"), and `zsl`/`mfnr` ("forced
+  off for manual/scan stills"). Today `iso` without `exposureTimeNs` is silently
+  ignored, `zsl`/`mfnr` with manual exposure are silently overridden, and
+  `aeExposureDivisor` (metered) with `exposureTimeNs` (fixed) is contradictory.
+  Fold into a second small union while we're breaking the type anyway:
+
+  ```ts
+  exposure?:
+    | { kind: "auto"; zsl?: boolean; mfnr?: boolean }
+    | { kind: "manual"; timeNs: number; iso?: number }
+    | { kind: "scan"; aeExposureDivisor?: number; isoCap?: number };
+  ```
+
+  (`noiseReduction`/`edgeEnhancement`/isp gains stay flat — glasses-side
+  best-effort, no cross-field constraints.)
+- **`compress` vs transport (decide in PR 2b):** the BLE path re-encodes via
+  `BlePhotoEncoders` (AVIF/fast-JPEG) and the phone transcodes to JPEG q90
+  regardless of `compress` — so `compress: "none"` on the phone arm (or any
+  BLE-forced transfer) is a promise the pipeline can't keep, and `size: "max"` over
+  BLE is technically valid but slow. Proposal: the phone arm omits `compress`
+  entirely (transport codec policy governs); on the webhook arm it keeps today's
+  meaning for direct upload and is documented as advisory when the BLE fallback
+  kicks in. Type-level where possible, documented where the fallback makes it
+  runtime-dependent.
+- **Loopback URL + `transferMethod: "direct"` (validation, not types):**
+  `{kind: "webhook", url: "http://127.0.0.1:...", transferMethod: "direct"}` is
+  unreachable by construction — the glasses can't hit the phone's loopback; the
+  `LocalPhotoReceiverRegistry` rewrite only exists on the BLE relay. The URL's
+  loopback-ness isn't expressible in types, so this one is a runtime validation:
+  reject loopback/link-local URLs with `direct`, and keep the existing
+  force-BLE-for-loopback behavior for `auto`.
+
+`kind: "phone"` semantics:
+- Result event carries the photo itself: extend the existing `photo_response`
+  terminal event with `{ requestId, fileUri, mimeType, byteCount, savedToCameraRoll? }`.
+  The file is written to app-private storage (reuse the `MentraLive_Images` dir that
+  already receives the debug copy; write the *converted JPEG*, not the raw AVIF, and
+  stop double-writing the debug `.avif` for this mode).
+
+### Native behavior per route
+
+- **BLE route** (the common no-WiFi case): branch in `processAndUploadBlePhoto`
+  (`MentraLive.kt:8777` / `MentraLive.swift:4015`): convert AVIF→JPEG as today, skip
+  `uploadToWebhook`, persist JPEG, optionally `CrustModule.saveToGalleryWithDate`,
+  emit terminal success with `fileUri`. No HTTP at all — do *not* route through the
+  loopback local-server for this mode; handing bytes straight to the event is simpler
+  and works identically on iOS.
+- **WiFi-direct route**: the glasses need *some* HTTP destination. With the union,
+  `kind: "phone"` simply has no direct route — the SDK builds the `take_photo`
+  command (`MentraLive.kt:5506`) with `transferMethod: "ble"` and no `webhookUrl`.
+  Rationale: no dependency on phone+glasses sharing a LAN, works airgapped by
+  construction, and BLE-photo latency is already acceptable (that's the whole
+  fallback path). Keeps the change surface phone-side only — **no asg_client
+  firmware change required** except the one-line `:362` routing gate needed for
+  `keepOnGlasses` on the phone arm (see wire mapping above). (Rejected for v1: auto-starting
+  `LocalPhotoUploadServer` and passing its LAN URL as the webhook — faster on WiFi
+  but needs LAN co-presence, LAN-IP discovery, and the iOS loopback fix first. Can be
+  layered in later as a transparent optimization without API change.)
+- **Camera roll**: gate on the existing `MediaLibraryPermissions` flow; if permission
+  is denied, still deliver `fileUri` and set `savedToCameraRoll: false` with an error
+  detail rather than failing the photo.
+
+### iOS loopback parity fix (independent, do first)
+
+Port `LocalPhotoReceiverRegistry.loopbackUploadUrlFor()` behavior to iOS
+`BlePhotoUploadService` so a BLE relay targeting the app's own
+`LocalPhotoUploadServer` rewrites to `127.0.0.1`. This fixes the existing
+photo-receiver escape hatch off-WiFi on iOS regardless of the new option.
+
+### Miniapp SDK / engine: BLE path off the Cloudflare relay (default, not opt-in)
+
+Today `PhonePhotoCoordinator.ts:193` always mints a presigned R2 pair via
+`startManagedPhoto` and hands the `uploadUrl` down as `webhookUrl` — so a photo that
+arrives over BLE gets uploaded from the phone to Cloudflare R2 just so the miniapp
+can fetch it back via `readUrl`. That relay is removed for the BLE path:
+
+**Decision (2026-07-28): local-miniapp photos are BLE-only.** No WiFi-direct path,
+no `startManagedPhoto`, no R2 presign — ever — for local miniapps.
+
+- **One transport.** The coordinator always requests
+  `destination: {kind: "phone"}`; the glasses never attempt a WiFi upload for these
+  requests (the union forces `transferMethod: "ble"`). No mint means no cloud round
+  trip in the request path, so airgap works by construction and there is no
+  auto-mode ambiguity, no prediction, no fallback bookkeeping.
+- **One completion path.** When the JPEG lands on the phone, the coordinator
+  completes through the runtime's existing local blob path (`camera.api.ts:161-178`
+  PUT/POST) and the miniapp receives `photo.ready {requestId, readUrl}` with a
+  runtime-served local URL. The miniapp contract ("fetch readUrl") is unchanged;
+  only the URL's origin differs. The storage-webhook completion route
+  (`/api/camera/storage-events`) simply never fires for local miniapps.
+- **Accepted trade-off:** heavy captures (`size: "max"`) ride BLE too — slower
+  transfer, and the BLE encode/transcode pipeline governs final quality. Document
+  this in the miniapp SDK photo options. If a real need for fast full-quality
+  delivery materializes, a WiFi-direct perf path (glasses → presigned URL, lazy
+  local completion as its fallback net) is a well-understood follow-up — deliberately
+  not built now.
+- cloud-v2 dead code this exposes: with no local-miniapp R2 uploads, audit whether
+  `miniapp-sdk-photo-storage.service.ts` / the storage-events route have remaining
+  callers before removing anything (cloud-hosted miniapps are out of scope here).
+- cloud-v2 `photoOptionsSchema` plumbing (`void opts;` at `camera.service.ts:76`)
+  still needs fixing in this PR so `saveToGallery`/size/compress survive, and to add
+  the phone-side `saveToCameraRoll` option — but no `delivery` option is exposed to
+  miniapps: local-vs-R2 is a transport consequence, not an API choice.
+- Airgapped devices follow from the default: no WiFi upload path → BLE transport →
+  local completion. A device-level "force BLE / airgap" setting can pin the transport
+  decision but needs no new delivery API.
+
+## Milestones / PR breakdown
+
+1. **PR 1 — iOS loopback rewrite parity** (bluetooth-sdk/ios). Small, standalone,
+   fixes an existing bug. On-device iOS verification with the example app's photo
+   receiver, phone off WiFi.
+2. **PR 2a — asg_client routing gate** (one line + test): local-save-only route at
+   `PhotoCommandHandler.java:362` additionally requires an empty `bleImgId`, so
+   `save: true` + BLE transfer coexist. Ship ahead of PR 2b via the normal firmware
+   train; no behavior change for any request shape phones send today.
+3. **PR 2b — `destination` union (webhook/phone/glasses) + `saveToCameraRoll` in
+   bluetooth-sdk** (types + Android + iOS + example app toggle, with
+   deprecated-field normalization replacing `save`). Same PR takes the rest of the
+   invalid-state audit: the `exposure` sub-union, `compress` scoped to the webhook
+   arm, and loopback-URL + `direct` runtime rejection. `kind: "phone"` always rides
+   BLE; phone-arm `keepOnGlasses` requires PR 2a's firmware, guaranteed by
+   mandatory OTA — releases only after 2a's firmware is rolled out. Unit tests for
+   the request-builder (union → `take_photo` JSON, old-field normalization incl.
+   `save`, mixed old/new rejection) and the terminal-event shape; hardware
+   verification both platforms (photo lands in `fileUri`, camera roll opt-in works,
+   permission-denied degrades gracefully, phone-arm `keepOnGlasses` leaves a
+   gallery copy). Version-bump the SDK per the usual dev-release flow.
+4. **PR 3 — local-miniapp photos BLE-only, off the R2 relay entirely**
+   (`PhonePhotoCoordinator`, cloud-v2 `photoOptionsSchema`/`camera.service`,
+   cloud-client). Coordinator always uses `{kind: "phone"}`; `startManagedPhoto`
+   and the R2 presign are removed from the local-miniapp flow; completion via the
+   runtime local blob path. Test with a local miniapp with networking disabled
+   (airgap simulation) and confirm `photo.ready` readUrl is local-origin and no
+   cloud request is made at any point in the flow.
+5. **Follow-ups (separate tickets)**: LAN-receiver optimization for WiFi-present
+   phone delivery; flipping the default delivery for BT-Classic glasses; v1
+   `PhotoManager` `saveToGallery` drop; deciding the cloud-miniapp story (presigned
+   URL vs webhook default).
+
+## Test plan
+
+- Unit: `take_photo` command builder (`kind: "phone"` forces `ble`, omits webhook
+  fields; deprecated-field normalization; mixed old/new rejection); BLE completion
+  branch (upload skipped, event payload); camera-roll gating.
+- Maestro/E2E: photo request from example app with `destination: {kind: "phone"}`,
+  assert `photo_response` carries a readable `fileUri`; local miniapp photo asserts
+  no request ever hits an R2/cloud host when transport is BLE.
+- Hardware (Mentra Live, both phone platforms): BLE-only (WiFi off on glasses and
+  phone), WiFi-on (verify forced-BLE still delivers), camera-roll save with
+  permission granted/denied, EXIF UserComment preserved after conversion.
+- Airgap: local miniapp photo round-trip with cloud unreachable.
+
+## Decisions (all resolved 2026-07-28)
+
+1. **Pre-PR-2a firmware compat: moot.** Glasses OTA updates are mandatory now, so
+   the SDK carries no legacy-firmware handling for
+   `{kind: "phone", keepOnGlasses: true}`. The only requirement is release
+   ordering: PR 2a's firmware rolls out before PR 2b reaches users.
+2. **Terminal event payload: `fileUri` only.** Keep bridge/event messages as tiny
+   as possible — no inline base64, no size-threshold behavior. The file must exist
+   anyway (camera-roll export, retention), and consumers that want bytes read the
+   file.
+3. **Local-miniapp photos are BLE-only.** No mint, no WiFi-direct, no prediction;
+   single completion path via the runtime local blob. A WiFi-direct perf path for
+   heavy captures is a possible future follow-up, deliberately not built now.
+4. **Retention: SDK-owned sweep of `MentraLive_Images`.** Phone-delivered JPEGs
+   stay in `MentraLive_Images`; the SDK owns cleanup (age TTL ~24h + total-size
+   cap, swept on session start), documented as "`fileUri` valid for at least N
+   hours; copy it if you need it longer." Legacy debug `.avif` copies fold into
+   the same sweep; camera-roll copies are the user's and are never touched.
+   Runtime local blobs backing `readUrl` get a deliberate short TTL, documented in
+   the miniapp SDK.

--- a/agents/os-1796-ble-photo-phone-delivery-plan.md
+++ b/agents/os-1796-ble-photo-phone-delivery-plan.md
@@ -1,0 +1,343 @@
+# OS-1796 — BLE photo to phone: deliver/save locally instead of webhook round-trip
+
+Ticket: https://linear.app/mentralabs/issue/OS-1796
+Status: plan (2026-07-28); stack consolidated 2026-09-11 — firmware gate #3616
+(keys on `transferMethod`), Bluetooth SDK PRs 1+2b folded into #3619 (rebased on
+dev, `exposure` union deferred), PR 3 (#3622) rewritten to hand the miniapp an
+inline `dataUrl` instead of a runtime-served URL (see the Miniapp SDK section).
+
+## Problem
+
+Every SDK photo today has exactly one delivery mechanism: an HTTP multipart POST to
+`webhookUrl`. The BLE path is a pure relay — the phone reassembles the image from the
+glasses and then re-uploads it to the *same* webhook the glasses would have used
+(`BlePhotoUploadService.uploadToWebhook`, Android `utils/BlePhotoUploadService.java:442`,
+iOS `MentraLive.swift:417`). So a miniapp running on/near the phone gets its photo by
+round-tripping the bytes through the internet back to itself ("webhook to self").
+
+This blocks airgapped Mentra Live deployments and is the wrong default for future
+BT-Classic glasses where bytes always land on the phone first. The miniapp should
+receive the image data directly and decide what to do with it.
+
+## Current state (mapped 2026-07-28)
+
+**Glasses (`asg_client`)** — `PhotoCommandHandler.processPhotoCapture` routes on
+`transferMethod` (`auto|direct|ble`) + `webhookUrl` + `save`:
+
+| condition | destination |
+|---|---|
+| `save && webhookUrl empty` | local gallery only, no upload/BLE |
+| `direct` | glasses HTTP POST → webhookUrl |
+| `ble` | K900 file transfer → phone |
+| `auto` | WiFi present → direct upload; else BLE; upload failure falls back to BLE |
+
+**Phone (bluetooth-sdk)** — BLE reassembly completes in
+`processAndUploadBlePhoto` (Android `MentraLive.kt:8777`, iOS `MentraLive.swift:4015`):
+writes an app-private debug `.avif`, converts AVIF→JPEG preserving IMU EXIF, then
+uploads to `webhookUrl`. The phone already holds the decoded bytes here — this is the
+natural insertion point.
+
+**Existing escape hatch** — `MentraPhotoReceiverModule` + `LocalPhotoUploadServer`
+(ports 8787–8790): a consumer app starts an in-process HTTP server and passes its LAN
+URL as `webhookUrl`. WiFi path: glasses POST over LAN. BLE path: Android rewrites the
+host to `127.0.0.1` via `LocalPhotoReceiverRegistry.loopbackUploadUrlFor()`
+(`BlePhotoUploadService.resolvePhoneRelayWebhookUrl:526`). **iOS has no loopback
+rewrite** — its BLE relay posts to the literal LAN URL, which breaks off-WiFi.
+
+**Mentra App / local miniapps** — `PhonePhotoCoordinator.ts:193` gets a presigned
+cloud upload URL (`startManagedPhoto`), passes it as `webhookUrl`, awaits cloud-v2
+`photo.ready {readUrl}`. So even local miniapps' BLE photos detour through R2.
+cloud-v2 `photoOptionsSchema` accepts `{size, compress, saveToGallery, sound}` but the
+runtime discards them (`camera.service.ts:76` — `void opts;`).
+
+**Cloud miniapps (v1)** — webhook URL minted in `PhotoManager.ts:88-99`
+(`customWebhookUrl` else `${app.publicUrl}/photo-upload`). Known bug found while
+mapping: `saveToGallery` is accepted by the SDK but dropped from the message sent to
+glasses (`PhotoManager.ts:135-149`).
+
+**Camera-roll machinery already exists** (gallery sync only today):
+`cameraRollExportCoordinator` → `CrustModule.saveToGalleryWithDate`
+(Android `CrustModule.kt:534` MediaStore, iOS `CrustModule.swift:466` PHPhotoLibrary),
+date-preserving, with permission/retry state machine.
+
+## Goals
+
+1. A first-class delivery option on `requestPhoto` meaning "give the bytes to the
+   phone; do not upload to a webhook."
+2. Optional save to the phone's camera roll as part of that delivery.
+3. Local-miniapp photos are BLE-only and never touch Cloudflare: no presigned R2
+   upload/read URLs, no cloud round trip anywhere in the request path — which makes
+   airgapped Mentra Live work by construction.
+4. iOS/Android parity, including fixing the existing iOS loopback-rewrite gap.
+
+## Non-goals (follow-ups, not this ticket)
+
+- Changing the *default* path for cloud miniapps (v1 `PhotoManager`). Flipping the
+  default to phone-delivery is a separate, riskier change once the option ships.
+- Raw-bytes-over-websocket delivery to cloud miniapps (only precedent is the
+  deprecated base64 `photo_taken` broadcast).
+- Fixing the dropped `saveToGallery` in v1 `PhotoManager` (file separately; one-line
+  plumb but needs glasses-side confirmation).
+
+## Design
+
+### New API surface (bluetooth-sdk)
+
+A flat `delivery?: "webhook" | "phone"` flag would multiply invalid states
+(`delivery: "phone"` + `webhookUrl` set; `delivery: "webhook"` with no URL;
+`transferMethod: "direct"` with phone delivery). The existing `save` flag has the
+same disease in disguise: it is not orthogonal to destination — on the glasses,
+`save=true` + empty `webhookUrl` is the magic combo that routes to
+*glasses-local-only capture* (`PhotoCommandHandler.java:362`, checked before any
+transfer-method branch), so `save` secretly encodes a third destination. Model all
+of it as one discriminated union so every invalid combination is unrepresentable:
+
+```ts
+type PhotoDestination =
+  | {
+      kind: "webhook";
+      url: string;                       // required — no URL-less webhook state
+      authToken?: string;
+      transferMethod?: PhotoTransferMethod; // auto|direct|ble — only meaningful here
+      keepOnGlasses?: boolean;           // also keep a copy in the glasses gallery
+    }
+  | {
+      kind: "phone";
+      saveToCameraRoll?: boolean;        // only exists on this arm
+      keepOnGlasses?: boolean;           // see wire-mapping note below
+      // no url/authToken/transferMethod: phone delivery always rides BLE
+    }
+  | {
+      kind: "glasses";                   // gallery-only capture; no transfer at all
+      // nothing to configure: this IS "save on glasses", so no keepOnGlasses flag
+    };
+
+interface PhotoRequestParams {
+  destination: PhotoDestination;
+  size?: ...; compress?: ...; sound?: ...; // unchanged capture options
+  // `save` is deleted — its meanings are absorbed by the union
+}
+```
+
+Wire mapping (the `take_photo` JSON keeps its current fields; only the SDK-side
+type changes):
+- `{kind: "webhook", keepOnGlasses}` → `webhookUrl` + `save: keepOnGlasses`.
+  Valid today: with a non-empty webhook the glasses capture into the permanent
+  gallery tree *and* deliver (`PhotoCommandHandler.java:303`).
+- `{kind: "glasses"}` → `save: true`, no `webhookUrl`, no `bleImgId` — exactly
+  today's local-save route, now expressed explicitly instead of via the magic combo.
+- `{kind: "phone"}` → `transferMethod: "ble"` + `bleImgId`, no `webhookUrl`,
+  `save: keepOnGlasses`. **Caveat:** with `keepOnGlasses: true` this trips the
+  `:362` local-save-only check on pre-fix firmware (the BLE transfer would never
+  start). Fix is a one-line asg_client routing change — the `:362` archival route additionally requires `transferMethod` ≠ `ble` (PR 2a, #3616), shipped ahead of the SDK change. It deliberately does not key on `bleImgId`: both Mentra Live serializers mint a `bleImgId` on every `take_photo` as a fallback id, including today's save-only archival captures, so a `bleImgId` gate would misroute those during the firmware-first window. Glasses OTA updates
+  are mandatory now, so no legacy-firmware compat handling is needed in the SDK;
+  the only requirement is release ordering (2a's firmware rolls out before 2b
+  reaches users).
+
+Back-compat: keep the existing top-level `webhookUrl`/`authToken`/`transferMethod`/
+`save` fields as deprecated inputs; when `destination` is absent the SDK normalizes
+them — `webhookUrl` present → `{kind: "webhook", keepOnGlasses: save}`;
+`save: true` + no webhook → `{kind: "glasses"}` — and rejects requests that mix the
+old fields with a `destination`.
+
+### Remaining invalid-state audit of `PhotoRequestParams`
+
+Full sweep of the current type (`BluetoothSdk.types.ts:573`) for other
+incoherent combinations:
+
+- **Killed by the union already:** `webhookUrl`/`authToken` are `string | null`
+  *required-nullable* today, so `authToken` set with `webhookUrl: null` is
+  representable and meaningless. The webhook arm (required `url`, optional
+  `authToken`) removes it. Verified non-issue: `bleImgId` is not in the TS surface —
+  it's generated natively — so no `ble`-without-`bleImgId` state exists at the API
+  layer.
+- **Exposure/capture cluster (same disease; deferred to a follow-up so PR 2b stays a delivery-only API change):** the type carries
+  `exposureTimeNs`, `iso` ("only used when exposureTimeNs enables manual exposure"),
+  `aeExposureDivisor`/`isoCap` (AE-metered "scan mode"), and `zsl`/`mfnr` ("forced
+  off for manual/scan stills"). Today `iso` without `exposureTimeNs` is silently
+  ignored, `zsl`/`mfnr` with manual exposure are silently overridden, and
+  `aeExposureDivisor` (metered) with `exposureTimeNs` (fixed) is contradictory.
+  Candidate follow-up: fold into a second small union:
+
+  ```ts
+  exposure?:
+    | { kind: "auto"; zsl?: boolean; mfnr?: boolean }
+    | { kind: "manual"; timeNs: number; iso?: number }
+    | { kind: "scan"; aeExposureDivisor?: number; isoCap?: number };
+  ```
+
+  (`noiseReduction`/`edgeEnhancement`/isp gains stay flat — glasses-side
+  best-effort, no cross-field constraints.)
+- **`compress` vs transport (decide in PR 2b):** the BLE path re-encodes via
+  `BlePhotoEncoders` (AVIF/fast-JPEG) and the phone transcodes to JPEG q90
+  regardless of `compress` — so `compress: "none"` on the phone arm (or any
+  BLE-forced transfer) is a promise the pipeline can't keep, and `size: "max"` over
+  BLE is technically valid but slow. Proposal: the phone arm omits `compress`
+  entirely (transport codec policy governs); on the webhook arm it keeps today's
+  meaning for direct upload and is documented as advisory when the BLE fallback
+  kicks in. Type-level where possible, documented where the fallback makes it
+  runtime-dependent.
+- **Loopback URL + `transferMethod: "direct"` (validation, not types):**
+  `{kind: "webhook", url: "http://127.0.0.1:...", transferMethod: "direct"}` is
+  unreachable by construction — the glasses can't hit the phone's loopback; the
+  `LocalPhotoReceiverRegistry` rewrite only exists on the BLE relay. The URL's
+  loopback-ness isn't expressible in types, so this one is a runtime validation:
+  reject loopback/link-local URLs with `direct`, and keep the existing
+  force-BLE-for-loopback behavior for `auto`.
+
+`kind: "phone"` semantics:
+- Result event carries the photo itself: extend the existing `photo_response`
+  terminal event with `{ requestId, fileUri, mimeType, byteCount, savedToCameraRoll? }`.
+  The file is written to app-private storage (reuse the `MentraLive_Images` dir that
+  already receives the debug copy; write the *converted JPEG*, not the raw AVIF, and
+  stop double-writing the debug `.avif` for this mode).
+
+### Native behavior per route
+
+- **BLE route** (the common no-WiFi case): branch in `processAndUploadBlePhoto`
+  (`MentraLive.kt:8777` / `MentraLive.swift:4015`): convert AVIF→JPEG as today, skip
+  `uploadToWebhook`, persist JPEG, optionally `CrustModule.saveToGalleryWithDate`,
+  emit terminal success with `fileUri`. No HTTP at all — do *not* route through the
+  loopback local-server for this mode; handing bytes straight to the event is simpler
+  and works identically on iOS.
+- **WiFi-direct route**: the glasses need *some* HTTP destination. With the union,
+  `kind: "phone"` simply has no direct route — the SDK builds the `take_photo`
+  command (`MentraLive.kt:5506`) with `transferMethod: "ble"` and no `webhookUrl`.
+  Rationale: no dependency on phone+glasses sharing a LAN, works airgapped by
+  construction, and BLE-photo latency is already acceptable (that's the whole
+  fallback path). Keeps the change surface phone-side only — **no asg_client
+  firmware change required** except the one-line `:362` routing gate needed for
+  `keepOnGlasses` on the phone arm (see wire mapping above). (Rejected for v1: auto-starting
+  `LocalPhotoUploadServer` and passing its LAN URL as the webhook — faster on WiFi
+  but needs LAN co-presence, LAN-IP discovery, and the iOS loopback fix first. Can be
+  layered in later as a transparent optimization without API change.)
+- **Camera roll**: gate on the existing `MediaLibraryPermissions` flow; if permission
+  is denied, still deliver `fileUri` and set `savedToCameraRoll: false` with an error
+  detail rather than failing the photo.
+
+### iOS loopback parity fix (independent, do first)
+
+Port `LocalPhotoReceiverRegistry.loopbackUploadUrlFor()` behavior to iOS
+`BlePhotoUploadService` so a BLE relay targeting the app's own
+`LocalPhotoUploadServer` rewrites to `127.0.0.1`. This fixes the existing
+photo-receiver escape hatch off-WiFi on iOS regardless of the new option.
+
+### Miniapp SDK / engine: BLE-only, the miniapp gets the bytes (default, not opt-in)
+
+Today `PhonePhotoCoordinator.ts:193` always mints a presigned upload/read pair via
+`startManagedPhoto` and hands the `uploadUrl` down as `webhookUrl` — so a photo that
+arrives over BLE gets re-uploaded from the phone to the cloud runtime just so the
+miniapp can fetch it back via `readUrl`. (Note: every deployed runtime answers the
+blob route with the local provider's response, so in practice this relay lands on
+the runtime's own disk, not R2.) That relay is removed for local miniapps:
+
+**Decision (2026-07-28): local-miniapp photos are BLE-only.** No WiFi-direct path,
+no `startManagedPhoto`, no presign — ever — for local miniapps.
+
+**Decision (2026-08-24, Israel, on the ticket): `takePhoto` hands the miniapp the
+photo itself (bytes/URI/data), not a download URL.** The July draft of PR 3
+published the delivered JPEG through the runtime's local camera-blob route and
+returned that runtime-served URL. That is dropped: the runtime is cloud-hosted, so
+the publish is still a cloud round trip (airgap fails by construction), the local
+blob route is unauthenticated, and the ticket now forbids the download-URL contract.
+
+- **One transport.** The coordinator always requests
+  `destination: {kind: "phone"}`; the glasses never attempt a WiFi upload for these
+  requests (the union forces `transferMethod: "ble"`). No mint means no cloud round
+  trip in the request path, so airgap works by construction and there is no
+  auto-mode ambiguity, no prediction, no fallback bookkeeping.
+- **One completion path.** When the JPEG lands on the phone (`fileUri` on the
+  terminal `photo_response`), the coordinator reads it and resolves the miniapp with
+  `PhotoTaken {requestId, dataUrl, photoUrl, mimeType, size}` where `dataUrl` is the
+  inline `data:image/jpeg;base64,...` image and `photoUrl` carries the same data URL,
+  so code that renders `photoUrl` keeps working (the background runtime's `fetch` is
+  a native HTTP bridge that does not accept data URLs — decode `dataUrl` for bytes).
+  Deadline chain: Bluetooth SDK phone delivery 60 s (vs 30 s for webhook requests) <
+  coordinator watchdog 75 s < miniapp SDK `takePhoto` default 90 s, so every layer
+  reports its typed error before the next one's generic timeout. The SDK never
+  prompts for camera-roll permission inside a capture (the app holds it up front),
+  so nothing user-driven sits inside those deadlines. The bundled
+  Mentra AI miniapp already prefers `dataUrl` and treats `photoUrl` as cloud-only.
+  The delivered file is deleted once read (camera-roll copies are the user's and
+  untouched). No runtime or cloud request anywhere in the flow.
+- **Accepted trade-off:** heavy captures (`size: "max"`) ride BLE too — slower
+  transfer, and the BLE encode/transcode pipeline governs final quality — and the
+  base64 payload crosses the miniapp transport in one message (the blob module
+  already moves 1 MB chunks that way). Document this in the miniapp SDK photo
+  options. If a real need for fast full-quality delivery materializes, a WiFi-direct
+  perf path is a well-understood follow-up — deliberately not built now.
+- cloud-v2 is untouched by PR 3: the local-miniapp path no longer goes through the
+  runtime at all, so `photoOptionsSchema` / `camera.service.ts` (`void opts;`) only
+  matter for cloud-client hosts and stay as they are. `saveToCameraRoll` is a
+  miniapp-SDK option plumbed `camera.ts` → `LocalMiniappRuntime` → coordinator.
+- cloud-v2 dead code this exposes: with no local-miniapp uploads, audit whether
+  `miniapp-sdk-photo-storage.service.ts` / the storage-events route have remaining
+  callers before removing anything (cloud-hosted miniapps are out of scope here).
+- Airgapped devices follow from the default: no WiFi upload path → BLE transport →
+  inline delivery. A device-level "force BLE / airgap" setting can pin the transport
+  decision but needs no new delivery API.
+
+## Milestones / PR breakdown
+
+1. **PR 1 — iOS loopback rewrite parity** (bluetooth-sdk/ios). Small, standalone,
+   fixes an existing bug. On-device iOS verification with the example app's photo
+   receiver, phone off WiFi.
+2. **PR 2a — asg_client routing gate** (one line + test): local-save-only route at `PhotoCommandHandler.java:362` additionally requires `transferMethod` ≠ `ble` (not an empty `bleImgId`, which the SDK mints on every request), so `save: true` + explicit BLE delivery coexist. Ship ahead of PR 2b via the normal firmware
+   train; no behavior change for any request shape phones send today.
+3. **PR 2b — `destination` union (webhook/phone/glasses) + `saveToCameraRoll` in
+   bluetooth-sdk** (types + Android + iOS + example app toggle, with
+   deprecated-field normalization replacing `save`). Same PR takes `compress` scoped to the webhook arm and loopback-URL + `direct` runtime rejection; the `exposure` sub-union is deferred to a follow-up. PR 1 is folded into this PR (#3619) after the July stack went stale against dev. `kind: "phone"` always rides
+   BLE; phone-arm `keepOnGlasses` requires PR 2a's firmware, guaranteed by
+   mandatory OTA — releases only after 2a's firmware is rolled out. Unit tests for
+   the request-builder (union → `take_photo` JSON, old-field normalization incl.
+   `save`, mixed old/new rejection) and the terminal-event shape; hardware
+   verification both platforms (photo lands in `fileUri`, camera roll opt-in works,
+   permission-denied degrades gracefully, phone-arm `keepOnGlasses` leaves a
+   gallery copy). Version-bump the SDK per the usual dev-release flow.
+4. **PR 3 — local-miniapp photos BLE-only, delivered inline** (`PhonePhotoCoordinator`,
+   `LocalMiniappRuntime`, miniapp SDK `camera.ts`). Coordinator always uses
+   `{kind: "phone"}`; `startManagedPhoto` / presign are removed from the
+   local-miniapp flow; completion resolves the miniapp with `dataUrl`. Test with a
+   local miniapp with networking disabled (airgap simulation) and confirm the
+   photo renders from `dataUrl` and no cloud request is made at any point.
+5. **Follow-ups (separate tickets)**: LAN-receiver optimization for WiFi-present
+   phone delivery; flipping the default delivery for BT-Classic glasses; v1
+   `PhotoManager` `saveToGallery` drop; deciding the cloud-miniapp story (presigned
+   URL vs webhook default).
+
+## Test plan
+
+- Unit: `take_photo` command builder (`kind: "phone"` forces `ble`, omits webhook
+  fields; deprecated-field normalization; mixed old/new rejection); BLE completion
+  branch (upload skipped, event payload); camera-roll gating.
+- Maestro/E2E: photo request from example app with `destination: {kind: "phone"}`,
+  assert `photo_response` carries a readable `fileUri`; local miniapp photo asserts
+  no request ever hits an R2/cloud host when transport is BLE.
+- Hardware (Mentra Live, both phone platforms): BLE-only (WiFi off on glasses and
+  phone), WiFi-on (verify forced-BLE still delivers), camera-roll save with
+  permission granted/denied, EXIF UserComment preserved after conversion.
+- Airgap: local miniapp photo round-trip with cloud unreachable.
+
+## Decisions (all resolved 2026-07-28)
+
+1. **Pre-PR-2a firmware compat: moot.** Glasses OTA updates are mandatory now, so
+   the SDK carries no legacy-firmware handling for
+   `{kind: "phone", keepOnGlasses: true}`. The only requirement is release
+   ordering: PR 2a's firmware rolls out before PR 2b reaches users.
+2. **Terminal event payload: `fileUri` only.** Keep bridge/event messages as tiny
+   as possible — no inline base64, no size-threshold behavior. The file must exist
+   anyway (camera-roll export, retention), and consumers that want bytes read the
+   file.
+3. **Local-miniapp photos are BLE-only.** No mint, no WiFi-direct, no prediction;
+   single completion path: the coordinator hands the miniapp an inline `dataUrl`
+   (2026-08-24 ticket note supersedes the July runtime-blob completion). A
+   WiFi-direct perf path for heavy captures is a possible future follow-up,
+   deliberately not built now.
+4. **Retention: SDK-owned sweep of `MentraLive_Images`.** Phone-delivered JPEGs
+   stay in `MentraLive_Images`; the SDK owns cleanup (age TTL ~24h + total-size
+   cap, swept on session start), documented as "`fileUri` valid for at least N
+   hours; copy it if you need it longer." Legacy debug `.avif` copies fold into
+   the same sweep; camera-roll copies are the user's and are never touched. The
+   size cap can evict files younger than 24h after a burst of large captures, and
+   the type documents exactly that. The local-miniapp coordinator deletes its
+   delivered file as soon as it has read it.

--- a/agents/os-1796-pr2b-contract.md
+++ b/agents/os-1796-pr2b-contract.md
@@ -1,0 +1,145 @@
+# OS-1796 PR 2b — implementation contract (destination union)
+
+Parent plan: `agents/os-1796-ble-photo-phone-delivery-plan.md` (Design section).
+This file pins the exact cross-layer contract so the TS, Android, and iOS changes
+compose. Branch: `pferreira/os-1796-photo-destination-union` (stacked on the iOS
+loopback PR).
+
+## Public TS surface (`mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts`)
+
+```ts
+export type PhotoDestination =
+  | {
+      kind: "webhook"
+      url: string
+      authToken?: string
+      /** auto|direct|ble — only meaningful for webhook delivery. */
+      transferMethod?: PhotoTransferMethod
+      /** Also keep a copy in the glasses gallery. */
+      keepOnGlasses?: boolean
+      /** Compression for the webhook upload; advisory when the BLE fallback kicks in. */
+      compress?: PhotoCompression
+    }
+  | {
+      kind: "phone"
+      /** Also export the delivered photo to the OS camera roll. */
+      saveToCameraRoll?: boolean
+      /** Also keep a copy in the glasses gallery (requires the PR-2a firmware gate). */
+      keepOnGlasses?: boolean
+    }
+  | {
+      kind: "glasses"
+    }
+
+export type PhotoExposure =
+  | { kind: "auto"; zsl?: boolean; mfnr?: boolean }
+  | { kind: "manual"; timeNs: number; iso?: number }
+  | { kind: "scan"; aeExposureDivisor?: number; isoCap?: number }
+```
+
+`PhotoRequestParams` gains `destination?: PhotoDestination` and
+`exposure?: PhotoExposure`. The existing flat fields (`webhookUrl`, `authToken`,
+`transferMethod`, `save`, `compress`, `exposureTimeNs`, `iso`,
+`aeExposureDivisor`, `isoCap`, `zsl`, `mfnr`) stay but are `@deprecated`-tagged.
+Flat capture fields with no cross-field constraints (`size`, `mode`, `sound`,
+`noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, `ispAnalogGain`,
+`requestId`, `appId`) are unchanged.
+
+## TS normalization (new pure function, unit-tested)
+
+`normalizePhotoRequestParams(params) -> NativePhotoRequest` in a new
+`src/photoRequest.ts` (exported for tests; called by the `requestPhoto` public
+binding before the native call).
+
+Rules:
+- `destination` present AND any of `webhookUrl`/`authToken`/`transferMethod`/`save`
+  set (non-null/undefined) → **throw** `TypeError` (mixed old/new).
+- Same for `exposure` present AND any of `exposureTimeNs`/`iso`/
+  `aeExposureDivisor`/`isoCap`/`zsl`/`mfnr` set. `destination` + `compress` flat
+  is also mixed (compress now lives on the webhook arm).
+- No `destination` → derive: `webhookUrl` non-empty →
+  `{kind: "webhook", url, authToken, transferMethod, keepOnGlasses: !!save, compress}`;
+  else `save` true → `{kind: "glasses"}`; else → **throw** (today's shape with no
+  webhook and no save was never valid for the public module).
+- No `exposure` → derive: `exposureTimeNs` set → `{kind: "manual", timeNs, iso}`;
+  else `aeExposureDivisor`/`isoCap` set → `{kind: "scan", ...}`; else
+  `{kind: "auto", zsl, mfnr}`.
+- Webhook arm validation: loopback/link-local host (`127.0.0.1`, `localhost`,
+  `169.254.*`) + `transferMethod: "direct"` → throw (glasses can never reach it).
+- `{kind: "manual"}` with `iso` but no `timeNs` cannot be expressed (typed), and
+  scan+manual cannot be mixed (typed) — no runtime checks needed beyond the
+  mixed-field ones.
+
+## Native bridge dict (`NativePhotoRequest`, what the native `requestPhoto` receives)
+
+Existing shape plus:
+- `destinationKind: "webhook" | "phone" | "glasses"` (required, new)
+- `saveToCameraRoll: boolean` (new, only meaningful for `phone`)
+- `webhookUrl`/`authToken`: null unless `webhook`
+- `transferMethod`: `"ble"` for `phone`; caller value (default `"auto"`) for
+  `webhook`; `"auto"` for `glasses` (glasses-side archival route ignores it)
+- `save`: `keepOnGlasses` for webhook/phone arms; `true` for `glasses`
+- exposure flattened back to `exposureTimeNs`/`iso`/`aeExposureDivisor`/`isoCap`/
+  `zsl`/`mfnr` (the wire/native shape is unchanged)
+
+## Native behavior (Android `MentraLive.kt`, iOS `MentraLive.swift`)
+
+Per `destinationKind`:
+- `webhook`: exactly today's behavior (bleImgId minted, BLE fallback relays to
+  webhook, loopback rewrite applies).
+- `glasses`: build `take_photo` with `save: true`, **no** `webhookUrl`, **no**
+  `bleImgId`, do not register a `BlePhotoTransfer`. Resolve the JS promise from
+  the existing ack/terminal path (photo stays on glasses; response carries no
+  fileUri).
+- `phone`: mint `bleImgId` and register the transfer as today, but build
+  `take_photo` with `transferMethod: "ble"`, `save: keepOnGlasses`, **no**
+  `webhookUrl`/`authToken`. On BLE completion (Android
+  `processAndUploadBlePhoto`, iOS call site of
+  `BlePhotoUploadService.processAndUploadPhoto`):
+  - convert to JPEG preserving EXIF exactly as today;
+  - write to `<appFiles>/MentraLive_Images/PHONE_<requestId>_<ts>.jpg` (this IS
+    the deliverable, not a debug copy; skip the raw `.avif` debug write for this
+    mode);
+  - if `saveToCameraRoll`: export to the OS photo library **implemented inside
+    this module** (Android `MediaStore` insert; iOS `PHPhotoLibrary`), no
+    dependency on the crust module. Permission denied → still a success, with
+    `savedToCameraRoll: false` and `cameraRollError: <short reason>`;
+  - emit the terminal success `photo_response` event with
+    `{requestId, fileUri, mimeType: "image/jpeg", byteCount, savedToCameraRoll,
+    cameraRollError?}` — fileUri only, never inline image data;
+  - never call the webhook upload service.
+
+## Retention sweep (both native platforms)
+
+On transport init/connect (once per session): delete files in
+`MentraLive_Images` older than 24h, then oldest-first until the dir is ≤ 256 MB.
+Applies to all files there (including legacy `BLE_*.avif` debug copies).
+Constants live with the other photo constants; document "fileUri valid ≥ 24h,
+copy to keep" on the TS type.
+
+## Terminal event type (TS)
+
+`PhotoSuccessResponseEvent` gains optional `fileUri?: string`,
+`mimeType?: string`, `byteCount?: number`, `savedToCameraRoll?: boolean`,
+`cameraRollError?: string`.
+
+## iOS Photos-permission plist note
+
+Camera-roll export needs `NSPhotoLibraryAddUsageDescription`. The SDK must
+degrade gracefully when absent (treat as permission denied); the example app's
+config gains the key.
+
+## Example app
+
+`modules/bluetooth-sdk/example/App.tsx`: add a "deliver to phone" toggle +
+"save to camera roll" toggle that sends
+`destination: {kind: "phone", saveToCameraRoll}` and renders the returned
+`fileUri` (Image preview) instead of relying on the photo receiver.
+
+## Tests
+
+- TS: jest unit tests for `normalizePhotoRequestParams` (arm mapping, legacy
+  derivation incl. `save`-only → glasses, mixed-field throws, loopback+direct
+  throw, exposure derivation) colocated per module test convention.
+- Native: compile checks (`./scripts/check-android-compile.sh bluetooth-sdk`,
+  `swiftc -parse` at minimum). Hardware verification per plan before merge.

--- a/agents/os-1796-pr2b-contract.md
+++ b/agents/os-1796-pr2b-contract.md
@@ -1,0 +1,142 @@
+# OS-1796 PR 2b — implementation contract (destination union)
+
+Parent plan: `agents/os-1796-ble-photo-phone-delivery-plan.md` (Design section).
+Updated 2026-09-11: the `exposure` union is deferred (flat exposure fields are
+unchanged and not deprecated); the firmware gate (#3616) keys on `transferMethod`.
+This file pins the exact cross-layer contract so the TS, Android, and iOS changes
+compose. Branch: `pferreira/os-1796-photo-destination-union` (stacked on the iOS
+loopback PR).
+
+## Public TS surface (`mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts`)
+
+```ts
+export type PhotoDestination =
+  | {
+      kind: "webhook"
+      url: string
+      authToken?: string
+      /** auto|direct|ble — only meaningful for webhook delivery. */
+      transferMethod?: PhotoTransferMethod
+      /** Also keep a copy in the glasses gallery. */
+      keepOnGlasses?: boolean
+      /** Compression for the webhook upload; advisory when the BLE fallback kicks in. */
+      compress?: PhotoCompression
+    }
+  | {
+      kind: "phone"
+      /** Also export the delivered photo to the OS camera roll. */
+      saveToCameraRoll?: boolean
+      /** Also keep a copy in the glasses gallery (requires the PR-2a firmware gate). */
+      keepOnGlasses?: boolean
+    }
+  | {
+      kind: "glasses"
+    }
+
+```
+
+`PhotoRequestParams` gains `destination?: PhotoDestination`. The existing flat
+delivery fields (`webhookUrl`, `authToken`, `transferMethod`, `save`, `compress`)
+stay but are `@deprecated`-tagged. All other flat fields (`size`, `mode`, `sound`,
+`exposureTimeNs`, `iso`, `aeExposureDivisor`, `isoCap`, `zsl`, `mfnr`,
+`noiseReduction`, `edgeEnhancement`, `ispDigitalGain`, `ispAnalogGain`,
+`requestId`, `appId`) are unchanged.
+
+## TS normalization (new pure function, unit-tested)
+
+`normalizePhotoRequestParams(params) -> NativePhotoRequest` in a new
+`src/photoRequest.ts` (exported for tests; called by the `requestPhoto` public
+binding before the native call).
+
+Rules:
+- `destination` present AND any of `webhookUrl`/`authToken`/`transferMethod`/`save`
+  set (non-null/undefined) → **throw** `TypeError` (mixed old/new).
+- `destination` + flat `compress` is also mixed (compress now lives on the
+  webhook arm).
+- No `destination` → derive: `webhookUrl` non-empty →
+  `{kind: "webhook", url, authToken, transferMethod, keepOnGlasses: !!save, compress}`;
+  else `save` true → `{kind: "glasses"}`; else → **throw** (today's shape with no
+  webhook and no save was never valid for the public module).
+
+- Webhook arm validation: phone-only host (`127.0.0.0/8`, `::1`, `localhost`,
+  `169.254.*`, `fe80::/10`) + `transferMethod: "direct"` → throw (glasses can
+  never reach it).
+
+## Native bridge dict (`NativePhotoRequest`, what the native `requestPhoto` receives)
+
+Existing shape plus:
+- `destinationKind: "webhook" | "phone" | "glasses"` (required, new)
+- `saveToCameraRoll: boolean` (new, only meaningful for `phone`)
+- `webhookUrl`/`authToken`: null unless `webhook`
+- `transferMethod`: `"ble"` for `phone`; caller value (default `"auto"`) for
+  `webhook`; `"auto"` for `glasses` (the glasses archival route consults it: any
+  value but `"ble"` keeps `save`+no-webhook on the archival path, and `"ble"` is
+  the phone arm's explicit delivery signal — PR 2a / #3616)
+- `save`: `keepOnGlasses` for webhook/phone arms; `true` for `glasses`
+- exposure fields pass through flat, unchanged
+
+## Native behavior (Android `MentraLive.kt`, iOS `MentraLive.swift`)
+
+Per `destinationKind`:
+- `webhook`: exactly today's behavior (bleImgId minted, BLE fallback relays to
+  webhook, loopback rewrite applies).
+- `glasses`: build `take_photo` with `save: true`, **no** `webhookUrl`, **no**
+  `bleImgId`, do not register a `BlePhotoTransfer`. Resolve the JS promise from
+  the existing ack/terminal path (photo stays on glasses; response carries no
+  fileUri).
+- `phone`: mint `bleImgId` and register the transfer as today, but build
+  `take_photo` with `transferMethod: "ble"`, `save: keepOnGlasses`, **no**
+  `webhookUrl`/`authToken`. On BLE completion (Android
+  `processAndUploadBlePhoto`, iOS call site of
+  `BlePhotoUploadService.processAndUploadPhoto`):
+  - convert to JPEG preserving EXIF exactly as today;
+  - write to `<appFiles>/MentraLive_Images/PHONE_<requestId>_<ts>.jpg`, with the
+    requestId reduced to `[A-Za-z0-9._-]` (max 64 chars) for the file name (this IS
+    the deliverable, not a debug copy; skip the raw `.avif` debug write for this
+    mode);
+  - if `saveToCameraRoll`: export to the OS photo library **implemented inside
+    this module** (Android `MediaStore` insert; iOS `PHPhotoLibrary`), no
+    dependency on the crust module. The SDK never prompts for permission inside
+    a capture (a dialog would sit inside the photo deadline); the app requests
+    add-only Photos / storage access up front. Undecided or denied → still a
+    success, with `savedToCameraRoll: false` and `cameraRollError: <short reason>`;
+  - emit the terminal success `photo_response` event with
+    `{requestId, fileUri, mimeType: "image/jpeg", byteCount, savedToCameraRoll,
+    cameraRollError?}` — fileUri only, never inline image data;
+  - never call the webhook upload service.
+
+## Retention sweep (both native platforms)
+
+On transport init/connect (once per session): delete files in
+`MentraLive_Images` older than 24h, then oldest-first until the dir is ≤ 256 MB.
+Applies to all files there (including legacy `BLE_*.avif` debug copies).
+Constants live with the other photo constants. The TS type documents exactly
+that: normally kept 24h, but the size cap can evict younger files after a burst
+of large captures — copy to keep.
+
+## Terminal event type (TS)
+
+`PhotoSuccessResponseEvent` gains optional `fileUri?: string`,
+`mimeType?: string`, `byteCount?: number`, `savedToCameraRoll?: boolean`,
+`cameraRollError?: string`.
+
+## iOS Photos-permission plist note
+
+Camera-roll export needs `NSPhotoLibraryAddUsageDescription`. The SDK must
+degrade gracefully when absent (treat as permission denied); the example app's
+config gains the key.
+
+## Example app
+
+`modules/bluetooth-sdk/example/App.tsx`: add a "deliver to phone" toggle +
+"save to camera roll" toggle that sends
+`destination: {kind: "phone", saveToCameraRoll}` and renders the returned
+`fileUri` (Image preview) instead of relying on the photo receiver.
+
+## Tests
+
+- TS: jest unit tests for `normalizePhotoRequestParams` (arm mapping, legacy
+  derivation incl. `save`-only → glasses, mixed-field throws, loopback+direct
+  throw, flat exposure pass-through) colocated per module test convention.
+- Native: compile checks (`./scripts/check-android-compile.sh bluetooth-sdk`,
+  `swiftc -parse` at minimum). Hardware verification per plan before merge.

--- a/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
+++ b/mobile/modules/bluetooth-sdk/android/src/main/AndroidManifest.xml
@@ -36,6 +36,9 @@
   <uses-permission android:name="android.permission.WAKE_LOCK"/>
   <uses-permission android:name="android.permission.VIBRATE"/>
 
+  <!-- Camera-roll export of phone-delivered photos (MediaStore needs this only pre-Q) -->
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
+
   <application>
     <service android:name="com.mentra.bluetoothsdk.services.ForegroundService" android:exported="false" android:foregroundServiceType="dataSync|connectedDevice|location|mediaPlayback|microphone"/>
   </application>

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/MentraBluetoothSdk.kt
@@ -103,6 +103,9 @@ class MentraBluetoothSdk private constructor(
         // A photo response is terminal only after capture, encoding, transport, and upload.
         // Max-quality BLE fallback can legitimately exceed the generic command deadline.
         private const val PHOTO_REQUEST_TIMEOUT_MS = 30_000L
+        // Phone delivery always rides BLE end to end (capture, encode, transfer, JPEG
+        // conversion, optional camera-roll export), so it gets a longer terminal deadline.
+        private const val PHONE_DELIVERY_REQUEST_TIMEOUT_MS = 60_000L
         private const val WIFI_SCAN_TIMEOUT_MS = 20_000L
         private const val VIDEO_UPLOAD_STOP_TIMEOUT_MS = 10 * 60 * 1000L
         private const val STREAM_START_TIMEOUT_MS = 30_000L
@@ -1040,7 +1043,10 @@ class MentraBluetoothSdk private constructor(
         pendingPhotoRequests[routedRequest.requestId] = pending
         try {
             deviceManager.requestPhoto(routedRequest)
-            return pending.await(PHOTO_REQUEST_TIMEOUT_MS)
+            val timeoutMs =
+                if (routedRequest.destinationKind == PhotoDestinationKind.PHONE) PHONE_DELIVERY_REQUEST_TIMEOUT_MS
+                else PHOTO_REQUEST_TIMEOUT_MS
+            return pending.await(timeoutMs)
         } finally {
             pendingPhotoRequests.remove(routedRequest.requestId, pending)
         }

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/camera/CameraModels.kt
@@ -179,6 +179,24 @@ enum class PhotoMode(val value: String) {
     }
 }
 
+enum class PhotoDestinationKind(val value: String) {
+    WEBHOOK("webhook"),
+    PHONE("phone"),
+    GLASSES("glasses");
+
+    companion object {
+        /** Null input = legacy request without a destination union; keep today's routing. */
+        @JvmStatic
+        fun fromValue(value: String?): PhotoDestinationKind? {
+            if (value == null) return null
+            return values().firstOrNull { it.value == value }
+                ?: throw IllegalArgumentException(
+                    "Invalid destinationKind \"$value\". Expected webhook, phone, or glasses."
+                )
+        }
+    }
+}
+
 data class PhotoRequest @JvmOverloads constructor(
     val requestId: String = generatedCameraRequestId("photo"),
     val size: PhotoSize,
@@ -203,6 +221,10 @@ data class PhotoRequest @JvmOverloads constructor(
     val mode: PhotoMode = PhotoMode.PHOTO,
     /** `direct` disables BLE fallback; `ble` skips direct upload; `auto` tries both. */
     val transferMethod: String = "auto",
+    /** Delivery destination; null = legacy request (webhook when webhookUrl is set). */
+    val destinationKind: PhotoDestinationKind? = null,
+    /** Only meaningful for destinationKind PHONE: also export the delivered JPEG to the camera roll. */
+    val saveToCameraRoll: Boolean = false,
 ) {
     companion object {
         private fun transferMethodFromValue(value: Any?): String {
@@ -254,6 +276,8 @@ data class PhotoRequest @JvmOverloads constructor(
                 sound = boolValue(values, "sound") ?: true,
                 mode = PhotoMode.fromValue(stringValue(values, "mode")),
                 transferMethod = transferMethodFromValue(values["transferMethod"]),
+                destinationKind = PhotoDestinationKind.fromValue(stringValue(values, "destinationKind")),
+                saveToCameraRoll = boolValue(values, "saveToCameraRoll") ?: false,
                 exposureTimeNs = exposureTimeNs,
                 iso = iso,
                 aeExposureDivisor = aeDivisor,
@@ -396,6 +420,11 @@ sealed interface PhotoResponse {
         val contentType: String?,
         val fileSizeBytes: Long?,
         override val timestamp: Long,
+        // Phone-delivery (destinationKind "phone") terminal metadata; null for webhook/glasses.
+        val fileUri: String? = null,
+        val byteCount: Long? = null,
+        val savedToCameraRoll: Boolean? = null,
+        val cameraRollError: String? = null,
     ) : PhotoResponse {
         override val state: String = "success"
     }
@@ -428,6 +457,10 @@ sealed interface PhotoResponse {
                             ?: longValue(values, "bytes")
                             ?: longValue(values, "size"),
                     timestamp = timestamp,
+                    fileUri = stringValue(values, "fileUri"),
+                    byteCount = longValue(values, "byteCount"),
+                    savedToCameraRoll = boolValue(values, "savedToCameraRoll"),
+                    cameraRollError = stringValue(values, "cameraRollError"),
                 )
             } else {
                 Error(
@@ -450,6 +483,14 @@ private fun Map<String, Any>.withOptionalPhotoMetadata(
         success.statusUrl?.takeIf { it.isNotBlank() }?.let { this["statusUrl"] = it }
         success.contentType?.takeIf { it.isNotBlank() }?.let { this["contentType"] = it }
         success.fileSizeBytes?.let { this["fileSizeBytes"] = it }
+        success.fileUri?.takeIf { it.isNotBlank() }?.let {
+            this["fileUri"] = it
+            // The phone-delivery contract exposes the delivered type as `mimeType`.
+            success.contentType?.takeIf { ct -> ct.isNotBlank() }?.let { ct -> this["mimeType"] = ct }
+        }
+        success.byteCount?.let { this["byteCount"] = it }
+        success.savedToCameraRoll?.let { this["savedToCameraRoll"] = it }
+        success.cameraRollError?.takeIf { it.isNotBlank() }?.let { this["cameraRollError"] = it }
     }
 
 data class PhotoResponseEvent(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -23,6 +23,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
@@ -32,6 +33,7 @@ import androidx.core.app.ActivityCompat
 import com.mentra.bluetoothsdk.BluetoothSdkDefaults
 import com.mentra.bluetoothsdk.Bridge
 import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.PhotoDestinationKind
 import com.mentra.bluetoothsdk.PhotoRequest
 import com.mentra.bluetoothsdk.PhotoSize
 import com.mentra.bluetoothsdk.PhotoMode
@@ -39,6 +41,7 @@ import com.mentra.bluetoothsdk.DeviceStore
 import com.mentra.bluetoothsdk.ObservableStore
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import com.mentra.bluetoothsdk.utils.BlePhotoUploadService
+import com.mentra.bluetoothsdk.utils.CameraRollExporter
 import com.mentra.bluetoothsdk.utils.ConnTypes
 import com.mentra.bluetoothsdk.utils.DeviceTypes
 import com.mentra.bluetoothsdk.utils.IncidentLogBleRelayNaming
@@ -180,6 +183,10 @@ class MentraLive : SGCManager() {
 
         // File transfer management
         private const val FILE_SAVE_DIR = "MentraLive_Images"
+        // Received-photo retention: delivered fileUris stay valid for at least this long
+        // (documented on the TS type); the sweep runs once per transport session.
+        private const val FILE_SAVE_MAX_AGE_MS = 24L * 60L * 60L * 1000L
+        private const val FILE_SAVE_MAX_TOTAL_BYTES = 256L * 1024L * 1024L
 
         // Glasses media volume (K900 cs_getvol / cs_vol, sr_getvol / sr_vol)
         private const val GLASSES_MEDIA_VOLUME_TIMEOUT_MS = 2000
@@ -389,6 +396,9 @@ class MentraLive : SGCManager() {
             var webhookUrl: String?
     ) {
         var authToken: String? = null
+        // destinationKind "phone": deliver the JPEG to JS as a fileUri, never any webhook upload
+        var deliverToPhone = false
+        var saveToCameraRoll = false
         var session: FileTransferSession? = null
         var phoneStartTime: Long = System.currentTimeMillis() // When phone received the request
         var bleTransferStartTime: Long = 0 // When BLE transfer actually started
@@ -663,6 +673,9 @@ class MentraLive : SGCManager() {
 
         // Initialize connection state
         DeviceStore.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)
+
+        // Retention sweep for received photos (24h TTL, then 256MB cap), once per session
+        fileProcessingHandler.post { sweepSavedImages() }
 
         // Initialize CTKD bonding receiver
         initializeBondingReceiver()
@@ -5463,10 +5476,15 @@ class MentraLive : SGCManager() {
         val requestId = request.requestId
         val size = request.size.value
         val mode = request.mode.value
-        val webhookUrl = request.webhookUrl
-        val authToken = request.authToken
+        val destinationKind = request.destinationKind
+        val deliverToPhone = destinationKind == PhotoDestinationKind.PHONE
+        val glassesOnly = destinationKind == PhotoDestinationKind.GLASSES
+        // Phone and glasses destinations never carry webhook credentials on the wire.
+        val webhookUrl = if (deliverToPhone || glassesOnly) "" else request.webhookUrl
+        val authToken = if (deliverToPhone || glassesOnly) null else request.authToken
         val compress = request.compress.value
-        val save = request.save
+        // A glasses-only capture IS the save; the archival route on the glasses keys off it.
+        val save = if (glassesOnly) true else request.save
         val sound = request.sound
         val exposureTimeNs = request.exposureTimeNs
         val iso = request.iso
@@ -5495,7 +5513,11 @@ class MentraLive : SGCManager() {
                         ", aeDivisor=" +
                         request.aeExposureDivisor +
                         ", isoCap=" +
-                        request.isoCap
+                        request.isoCap +
+                        ", destinationKind=" +
+                        (destinationKind?.value ?: "legacy") +
+                        ", saveToCameraRoll=" +
+                        request.saveToCameraRoll
         )
         Bridge.log(
                 "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry — requestId=" +
@@ -5539,23 +5561,35 @@ class MentraLive : SGCManager() {
             }
             PhotoRequest.appendScanFields(json, request)
 
-            // Always generate BLE ID for potential fallback
-            val bleImgId = "I" + String.format("%09d", System.currentTimeMillis() % 1000000000)
-            json.put("bleImgId", bleImgId)
+            if (glassesOnly) {
+                // Gallery-only capture: no bleImgId and no transfer registration - nothing
+                // ever leaves the glasses; the terminal photo_response resolves the request.
+                Bridge.log("LIVE: Using glasses-only capture (no transfer) for: " + requestId)
+            } else {
+                // Generate BLE ID for the phone delivery / potential webhook fallback
+                val bleImgId = "I" + String.format("%09d", System.currentTimeMillis() % 1000000000)
+                json.put("bleImgId", bleImgId)
 
-            // Miniapps may explicitly skip direct Wi-Fi upload and force the
-            // phone-relayed BLE path. Auto remains the default.
-            json.put("transferMethod", request.transferMethod)
+                // Phone delivery always rides BLE; miniapps may otherwise explicitly skip
+                // direct Wi-Fi upload and force the phone-relayed BLE path. Auto remains
+                // the default.
+                val transferMethod = if (deliverToPhone) "ble" else request.transferMethod
+                json.put("transferMethod", transferMethod)
 
-            // Always prepare for potential BLE transfer
-            if (webhookUrl != null && !webhookUrl.isEmpty()) {
-                // Store the transfer info for BLE route - include authToken
-                val transfer = BlePhotoTransfer(bleImgId, requestId, webhookUrl)
-                transfer.authToken = authToken // Store authToken for BLE transfer
-                blePhotoTransfers[bleImgId] = transfer
+                if (deliverToPhone) {
+                    val transfer = BlePhotoTransfer(bleImgId, requestId, null)
+                    transfer.deliverToPhone = true
+                    transfer.saveToCameraRoll = request.saveToCameraRoll
+                    blePhotoTransfers[bleImgId] = transfer
+                } else if (webhookUrl != null && !webhookUrl.isEmpty()) {
+                    // Store the transfer info for BLE route - include authToken
+                    val transfer = BlePhotoTransfer(bleImgId, requestId, webhookUrl)
+                    transfer.authToken = authToken // Store authToken for BLE transfer
+                    blePhotoTransfers[bleImgId] = transfer
+                }
+
+                Bridge.log("LIVE: Using " + transferMethod + " transfer mode with BLE fallback ID: " + bleImgId)
             }
-
-            Bridge.log("LIVE: Using " + request.transferMethod + " transfer mode with BLE fallback ID: " + bleImgId)
             Bridge.log(
                     "LIVE: PHOTO PIPELINE [5b/6] JSON ready mode=" +
                             mode +
@@ -8776,6 +8810,11 @@ class MentraLive : SGCManager() {
 
     /** Process and upload a BLE photo transfer */
     private fun processAndUploadBlePhoto(transfer: BlePhotoTransfer, imageData: ByteArray) {
+        if (transfer.deliverToPhone) {
+            deliverBlePhotoToPhone(transfer, imageData)
+            return
+        }
+
         Bridge.log("LIVE: Processing BLE photo for upload. RequestId: " + transfer.requestId)
         val uploadStartTime = System.currentTimeMillis()
 
@@ -8840,6 +8879,115 @@ class MentraLive : SGCManager() {
                     }
                 }
         )
+    }
+
+    /**
+     * Deliver a completed BLE photo transfer to the phone itself (destinationKind
+     * "phone"): convert to JPEG exactly as the webhook path does, persist the JPEG
+     * under MentraLive_Images as the deliverable (no raw AVIF debug copy), optionally
+     * export it to the camera roll, and emit the terminal photo_response with the
+     * fileUri. No upload service involved.
+     */
+    private fun deliverBlePhotoToPhone(transfer: BlePhotoTransfer, imageData: ByteArray) {
+        Bridge.log("LIVE: Processing BLE photo for phone delivery. RequestId: " + transfer.requestId)
+        Thread {
+            try {
+                val jpegData = BlePhotoUploadService.convertToJpegPreservingExif(imageData)
+
+                val dir = File(context!!.getExternalFilesDir(null), FILE_SAVE_DIR)
+                if (!dir.exists()) {
+                    dir.mkdirs()
+                }
+                val file =
+                        File(
+                                dir,
+                                "PHONE_" +
+                                        transfer.requestId +
+                                        "_" +
+                                        System.currentTimeMillis() +
+                                        ".jpg"
+                        )
+                FileOutputStream(file).use { fos -> fos.write(jpegData) }
+                Bridge.log("LIVE: 💾 Saved BLE photo for phone delivery: " + file.absolutePath)
+
+                var savedToCameraRoll = false
+                var cameraRollError: String? = null
+                if (transfer.saveToCameraRoll) {
+                    try {
+                        CameraRollExporter.exportJpeg(context!!, jpegData, file.name)
+                        savedToCameraRoll = true
+                    } catch (e: Exception) {
+                        // Camera-roll export is best-effort: report the reason, keep the success.
+                        cameraRollError = e.message ?: e.javaClass.simpleName
+                        Log.w(TAG, "Camera roll export failed for requestId: " + transfer.requestId, e)
+                    }
+                }
+
+                val event = HashMap<String, Any>()
+                event["type"] = "photo_response"
+                event["state"] = "success"
+                event["success"] = true
+                event["requestId"] = transfer.requestId
+                event["timestamp"] = System.currentTimeMillis()
+                event["fileUri"] = Uri.fromFile(file).toString()
+                event["mimeType"] = "image/jpeg"
+                event["byteCount"] = jpegData.size.toLong()
+                event["savedToCameraRoll"] = savedToCameraRoll
+                if (cameraRollError != null) {
+                    event["cameraRollError"] = cameraRollError
+                }
+                Bridge.sendPhotoResponse(event)
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ BLE photo phone delivery failed for requestId: " + transfer.requestId, e)
+                Bridge.sendPhotoError(
+                        transfer.requestId,
+                        "PHONE_DELIVERY_FAILED",
+                        "BLE photo phone delivery failed: " + e.message
+                )
+            }
+        }.start()
+    }
+
+    /**
+     * Enforce the received-photo retention contract on MentraLive_Images: drop files
+     * older than FILE_SAVE_MAX_AGE_MS, then oldest-first until the directory holds at
+     * most FILE_SAVE_MAX_TOTAL_BYTES.
+     */
+    private fun sweepSavedImages() {
+        try {
+            val dir = File(context!!.getExternalFilesDir(null), FILE_SAVE_DIR)
+            val files = dir.listFiles()?.filter { it.isFile } ?: return
+            val cutoffMs = System.currentTimeMillis() - FILE_SAVE_MAX_AGE_MS
+            var removedCount = 0
+            val survivors = ArrayList<File>()
+            for (file in files) {
+                if (file.lastModified() < cutoffMs && file.delete()) {
+                    removedCount++
+                } else {
+                    survivors.add(file)
+                }
+            }
+            survivors.sortBy { it.lastModified() }
+            var totalBytes = survivors.sumOf { it.length() }
+            for (file in survivors) {
+                if (totalBytes <= FILE_SAVE_MAX_TOTAL_BYTES) break
+                val fileBytes = file.length()
+                if (file.delete()) {
+                    totalBytes -= fileBytes
+                    removedCount++
+                }
+            }
+            if (removedCount > 0) {
+                Bridge.log(
+                        "LIVE: 🧹 Retention sweep removed " +
+                                removedCount +
+                                " file(s) from " +
+                                FILE_SAVE_DIR
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sweeping " + FILE_SAVE_DIR, e)
+        }
     }
 
     private fun sendPhotoTerminalSuccessResponse(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/sgcs/MentraLive.kt
@@ -24,6 +24,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.graphics.Bitmap
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
@@ -34,6 +35,7 @@ import androidx.core.app.ActivityCompat
 import com.mentra.bluetoothsdk.BluetoothSdkDefaults
 import com.mentra.bluetoothsdk.Bridge
 import com.mentra.bluetoothsdk.DeviceManager
+import com.mentra.bluetoothsdk.PhotoDestinationKind
 import com.mentra.bluetoothsdk.PhotoRequest
 import com.mentra.bluetoothsdk.PhotoSize
 import com.mentra.bluetoothsdk.PhotoMode
@@ -43,6 +45,7 @@ import com.mentra.bluetoothsdk.incomingGlassesMessageAckId
 import com.mentra.bluetoothsdk.wifiResponseEnvelopeIsValid
 import com.mentra.bluetoothsdk.debug.BleTraceLogger
 import com.mentra.bluetoothsdk.utils.BlePhotoUploadService
+import com.mentra.bluetoothsdk.utils.CameraRollExporter
 import com.mentra.bluetoothsdk.utils.ConnTypes
 import com.mentra.bluetoothsdk.utils.DeviceTypes
 import com.mentra.bluetoothsdk.utils.IncidentLogBleRelayNaming
@@ -476,6 +479,10 @@ class MentraLive : SGCManager() {
 
         // File transfer management
         private const val FILE_SAVE_DIR = "MentraLive_Images"
+        // Received-photo retention: files older than this are swept, then oldest-first down
+        // to the size cap (documented on the TS type); the sweep runs once per transport session.
+        private const val FILE_SAVE_MAX_AGE_MS = 24L * 60L * 60L * 1000L
+        private const val FILE_SAVE_MAX_TOTAL_BYTES = 256L * 1024L * 1024L
 
         // Glasses media volume (K900 cs_getvol / cs_vol, sr_getvol / sr_vol)
         private const val GLASSES_MEDIA_VOLUME_TIMEOUT_MS = 2000
@@ -730,6 +737,9 @@ class MentraLive : SGCManager() {
             var webhookUrl: String?
     ) {
         var authToken: String? = null
+        // destinationKind "phone": deliver the JPEG to JS as a fileUri, never any webhook upload
+        var deliverToPhone = false
+        var saveToCameraRoll = false
         var session: FileTransferSession? = null
         var phoneStartTime: Long = System.currentTimeMillis() // When phone received the request
         var bleTransferStartTime: Long = 0 // When BLE transfer actually started
@@ -1008,6 +1018,9 @@ class MentraLive : SGCManager() {
 
         // Initialize connection state
         DeviceStore.apply("glasses", "connectionState", ConnTypes.DISCONNECTED)
+
+        // Retention sweep for received photos (24h TTL, then 256MB cap), once per session
+        fileProcessingHandler.post { sweepSavedImages() }
 
         // Initialize CTKD bonding receiver
         initializeBondingReceiver()
@@ -6646,10 +6659,15 @@ class MentraLive : SGCManager() {
         val requestId = request.requestId
         val size = request.size.value
         val mode = request.mode.value
-        val webhookUrl = request.webhookUrl
-        val authToken = request.authToken
+        val destinationKind = request.destinationKind
+        val deliverToPhone = destinationKind == PhotoDestinationKind.PHONE
+        val glassesOnly = destinationKind == PhotoDestinationKind.GLASSES
+        // Phone and glasses destinations never carry webhook credentials on the wire.
+        val webhookUrl = if (deliverToPhone || glassesOnly) "" else request.webhookUrl
+        val authToken = if (deliverToPhone || glassesOnly) null else request.authToken
         val compress = request.compress.value
-        val save = request.save
+        // A glasses-only capture IS the save; the archival route on the glasses keys off it.
+        val save = if (glassesOnly) true else request.save
         val sound = request.sound
         val exposureTimeNs = request.exposureTimeNs
         val iso = request.iso
@@ -6678,7 +6696,11 @@ class MentraLive : SGCManager() {
                         ", aeDivisor=" +
                         request.aeExposureDivisor +
                         ", isoCap=" +
-                        request.isoCap
+                        request.isoCap +
+                        ", destinationKind=" +
+                        (destinationKind?.value ?: "legacy") +
+                        ", saveToCameraRoll=" +
+                        request.saveToCameraRoll
         )
         Bridge.log(
                 "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry — requestId=" +
@@ -6722,23 +6744,35 @@ class MentraLive : SGCManager() {
             }
             PhotoRequest.appendScanFields(json, request)
 
-            // Always generate BLE ID for potential fallback
-            val bleImgId = "I" + String.format("%09d", System.currentTimeMillis() % 1000000000)
-            json.put("bleImgId", bleImgId)
+            if (glassesOnly) {
+                // Gallery-only capture: no bleImgId and no transfer registration - nothing
+                // ever leaves the glasses; the terminal photo_response resolves the request.
+                Bridge.log("LIVE: Using glasses-only capture (no transfer) for: " + requestId)
+            } else {
+                // Generate BLE ID for the phone delivery / potential webhook fallback
+                val bleImgId = "I" + String.format("%09d", System.currentTimeMillis() % 1000000000)
+                json.put("bleImgId", bleImgId)
 
-            // Miniapps may explicitly skip direct Wi-Fi upload and force the
-            // phone-relayed BLE path. Auto remains the default.
-            json.put("transferMethod", request.transferMethod)
+                // Phone delivery always rides BLE; miniapps may otherwise explicitly skip
+                // direct Wi-Fi upload and force the phone-relayed BLE path. Auto remains
+                // the default.
+                val transferMethod = if (deliverToPhone) "ble" else request.transferMethod
+                json.put("transferMethod", transferMethod)
 
-            // Always prepare for potential BLE transfer
-            if (webhookUrl != null && !webhookUrl.isEmpty()) {
-                // Store the transfer info for BLE route - include authToken
-                val transfer = BlePhotoTransfer(bleImgId, requestId, webhookUrl)
-                transfer.authToken = authToken // Store authToken for BLE transfer
-                blePhotoTransfers[bleImgId] = transfer
+                if (deliverToPhone) {
+                    val transfer = BlePhotoTransfer(bleImgId, requestId, null)
+                    transfer.deliverToPhone = true
+                    transfer.saveToCameraRoll = request.saveToCameraRoll
+                    blePhotoTransfers[bleImgId] = transfer
+                } else if (webhookUrl != null && !webhookUrl.isEmpty()) {
+                    // Store the transfer info for BLE route - include authToken
+                    val transfer = BlePhotoTransfer(bleImgId, requestId, webhookUrl)
+                    transfer.authToken = authToken // Store authToken for BLE transfer
+                    blePhotoTransfers[bleImgId] = transfer
+                }
+
+                Bridge.log("LIVE: Using " + transferMethod + " transfer mode with BLE fallback ID: " + bleImgId)
             }
-
-            Bridge.log("LIVE: Using " + request.transferMethod + " transfer mode with BLE fallback ID: " + bleImgId)
             Bridge.log(
                     "LIVE: PHOTO PIPELINE [5b/6] JSON ready mode=" +
                             mode +
@@ -10408,6 +10442,11 @@ class MentraLive : SGCManager() {
 
     /** Process and upload a BLE photo transfer */
     private fun processAndUploadBlePhoto(transfer: BlePhotoTransfer, imageData: ByteArray) {
+        if (transfer.deliverToPhone) {
+            deliverBlePhotoToPhone(transfer, imageData)
+            return
+        }
+
         Bridge.log("LIVE: Processing BLE photo for upload. RequestId: " + transfer.requestId)
         val uploadStartTime = System.currentTimeMillis()
 
@@ -10472,6 +10511,124 @@ class MentraLive : SGCManager() {
                     }
                 }
         )
+    }
+
+    /**
+     * Deliver a completed BLE photo transfer to the phone itself (destinationKind
+     * "phone"): convert to JPEG exactly as the webhook path does, persist the JPEG
+     * under MentraLive_Images as the deliverable (no raw AVIF debug copy), optionally
+     * export it to the camera roll, and emit the terminal photo_response with the
+     * fileUri. No upload service involved.
+     */
+    private fun deliverBlePhotoToPhone(transfer: BlePhotoTransfer, imageData: ByteArray) {
+        Bridge.log("LIVE: Processing BLE photo for phone delivery. RequestId: " + transfer.requestId)
+        Thread {
+            try {
+                val jpegData = BlePhotoUploadService.convertToJpegPreservingExif(imageData)
+
+                val dir = File(context!!.getExternalFilesDir(null), FILE_SAVE_DIR)
+                if (!dir.exists()) {
+                    dir.mkdirs()
+                }
+                val file =
+                        File(
+                                dir,
+                                "PHONE_" +
+                                        fileNameComponent(transfer.requestId) +
+                                        "_" +
+                                        System.currentTimeMillis() +
+                                        ".jpg"
+                        )
+                FileOutputStream(file).use { fos -> fos.write(jpegData) }
+                Bridge.log("LIVE: 💾 Saved BLE photo for phone delivery: " + file.absolutePath)
+
+                var savedToCameraRoll = false
+                var cameraRollError: String? = null
+                if (transfer.saveToCameraRoll) {
+                    try {
+                        CameraRollExporter.exportJpeg(context!!, jpegData, file.name)
+                        savedToCameraRoll = true
+                    } catch (e: Exception) {
+                        // Camera-roll export is best-effort: report the reason, keep the success.
+                        cameraRollError = e.message ?: e.javaClass.simpleName
+                        Log.w(TAG, "Camera roll export failed for requestId: " + transfer.requestId, e)
+                    }
+                }
+
+                val event = HashMap<String, Any>()
+                event["type"] = "photo_response"
+                event["state"] = "success"
+                event["success"] = true
+                event["requestId"] = transfer.requestId
+                event["timestamp"] = System.currentTimeMillis()
+                event["fileUri"] = Uri.fromFile(file).toString()
+                event["mimeType"] = "image/jpeg"
+                event["byteCount"] = jpegData.size.toLong()
+                event["savedToCameraRoll"] = savedToCameraRoll
+                if (cameraRollError != null) {
+                    event["cameraRollError"] = cameraRollError
+                }
+                Bridge.sendPhotoResponse(event)
+            } catch (e: Exception) {
+                Log.e(TAG, "❌ BLE photo phone delivery failed for requestId: " + transfer.requestId, e)
+                Bridge.sendPhotoError(
+                        transfer.requestId,
+                        "PHONE_DELIVERY_FAILED",
+                        "BLE photo phone delivery failed: " + e.message
+                )
+            }
+        }.start()
+    }
+
+    /**
+     * Request ids are caller-supplied strings; keep only file-name-safe characters so a
+     * value like "scan/123" cannot turn the delivered path into a missing subdirectory.
+     */
+    private fun fileNameComponent(requestId: String): String {
+        val safe = requestId.replace(Regex("[^A-Za-z0-9._-]"), "_").take(64)
+        return if (safe.isEmpty()) "photo" else safe
+    }
+
+    /**
+     * Enforce the received-photo retention contract on MentraLive_Images: drop files
+     * older than FILE_SAVE_MAX_AGE_MS, then oldest-first until the directory holds at
+     * most FILE_SAVE_MAX_TOTAL_BYTES.
+     */
+    private fun sweepSavedImages() {
+        try {
+            val dir = File(context!!.getExternalFilesDir(null), FILE_SAVE_DIR)
+            val files = dir.listFiles()?.filter { it.isFile } ?: return
+            val cutoffMs = System.currentTimeMillis() - FILE_SAVE_MAX_AGE_MS
+            var removedCount = 0
+            val survivors = ArrayList<File>()
+            for (file in files) {
+                if (file.lastModified() < cutoffMs && file.delete()) {
+                    removedCount++
+                } else {
+                    survivors.add(file)
+                }
+            }
+            survivors.sortBy { it.lastModified() }
+            var totalBytes = survivors.sumOf { it.length() }
+            for (file in survivors) {
+                if (totalBytes <= FILE_SAVE_MAX_TOTAL_BYTES) break
+                val fileBytes = file.length()
+                if (file.delete()) {
+                    totalBytes -= fileBytes
+                    removedCount++
+                }
+            }
+            if (removedCount > 0) {
+                Bridge.log(
+                        "LIVE: 🧹 Retention sweep removed " +
+                                removedCount +
+                                " file(s) from " +
+                                FILE_SAVE_DIR
+                )
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Error sweeping " + FILE_SAVE_DIR, e)
+        }
     }
 
     private fun sendPhotoTerminalSuccessResponse(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
@@ -81,9 +81,9 @@ public class BlePhotoUploadService {
 
     /**
      * Decode incoming AVIF/JPEG, re-encode as JPEG, and re-attach IMU EXIF when present.
+     * Public so phone-delivery (destinationKind "phone") reuses the exact webhook conversion.
      */
-    @VisibleForTesting
-    static byte[] convertToJpegPreservingExif(byte[] imageData) throws Exception {
+    public static byte[] convertToJpegPreservingExif(byte[] imageData) throws Exception {
         long conversionStartMs = System.currentTimeMillis();
         if (isJpeg(imageData)) {
             Log.d(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BlePhotoUploadService.java
@@ -81,9 +81,9 @@ public class BlePhotoUploadService {
 
     /**
      * Decode incoming AVIF/JPEG, re-encode as JPEG, and re-attach IMU EXIF when present.
+     * Public so phone-delivery (destinationKind "phone") reuses the exact webhook conversion.
      */
-    @VisibleForTesting
-    static byte[] convertToJpegPreservingExif(byte[] imageData) throws Exception {
+    public static byte[] convertToJpegPreservingExif(byte[] imageData) throws Exception {
         long conversionStartMs = System.currentTimeMillis();
         if (isJpeg(imageData)) {
             NativeLog.d(

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/CameraRollExporter.kt
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/CameraRollExporter.kt
@@ -1,0 +1,65 @@
+package com.mentra.bluetoothsdk.utils
+
+import android.Manifest
+import android.content.ContentValues
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import androidx.core.app.ActivityCompat
+import java.io.IOException
+
+/**
+ * Exports phone-delivered photos to the OS camera roll via MediaStore, with no
+ * dependency on the host app's media modules. Failures throw with a short reason;
+ * callers report it as `cameraRollError` on an otherwise successful delivery.
+ */
+object CameraRollExporter {
+    private const val ALBUM_DIR = "MentraLive"
+
+    @JvmStatic
+    @Throws(IOException::class)
+    fun exportJpeg(context: Context, jpegData: ByteArray, displayName: String) {
+        // MediaStore inserts owned by the app need no permission from Android 10 (Q) on;
+        // before that WRITE_EXTERNAL_STORAGE is required and may be denied at runtime.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q &&
+            ActivityCompat.checkSelfPermission(context, Manifest.permission.WRITE_EXTERNAL_STORAGE) !=
+                PackageManager.PERMISSION_GRANTED
+        ) {
+            throw IOException("storage permission not granted")
+        }
+
+        val values = ContentValues().apply {
+            put(MediaStore.Images.Media.DISPLAY_NAME, displayName)
+            put(MediaStore.Images.Media.MIME_TYPE, "image/jpeg")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                put(MediaStore.Images.Media.RELATIVE_PATH, Environment.DIRECTORY_DCIM + "/" + ALBUM_DIR)
+                put(MediaStore.Images.Media.IS_PENDING, 1)
+            }
+        }
+
+        val resolver = context.contentResolver
+        val collection =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                MediaStore.Images.Media.getContentUri(MediaStore.VOLUME_EXTERNAL_PRIMARY)
+            } else {
+                MediaStore.Images.Media.EXTERNAL_CONTENT_URI
+            }
+        val uri = resolver.insert(collection, values)
+            ?: throw IOException("MediaStore insert failed")
+        try {
+            resolver.openOutputStream(uri)?.use { it.write(jpegData) }
+                ?: throw IOException("MediaStore stream unavailable")
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                values.clear()
+                values.put(MediaStore.Images.Media.IS_PENDING, 0)
+                resolver.update(uri, values, null, null)
+            }
+        } catch (e: Exception) {
+            // Don't leave a pending/empty MediaStore row behind on a failed write.
+            resolver.delete(uri, null, null)
+            throw if (e is IOException) e else IOException(e.message ?: e.javaClass.simpleName, e)
+        }
+    }
+}

--- a/mobile/modules/bluetooth-sdk/example/App.tsx
+++ b/mobile/modules/bluetooth-sdk/example/App.tsx
@@ -1,27 +1,12 @@
 import BluetoothSdk, {DeviceModels} from "@mentra/bluetooth-sdk"
-import type {
-  PhotoCaptureMetadata,
-  PhotoRequestParams,
-  PhotoSize,
-  PhotoStatusEvent,
-} from "@mentra/bluetooth-sdk"
+import type {PhotoCaptureMetadata, PhotoRequestParams, PhotoSize, PhotoStatusEvent} from "@mentra/bluetooth-sdk"
 import PhotoReceiver from "@mentra/bluetooth-sdk/photo-receiver"
 import * as MediaLibrary from "expo-media-library"
 import type {ReactNode} from "react"
 import {useCallback, useEffect, useRef, useState} from "react"
 // The SDK example intentionally uses plain React Native primitives outside the mobile app shell.
 // eslint-disable-next-line no-restricted-imports
-import {
-  ActivityIndicator,
-  Button,
-  Image,
-  Pressable,
-  SafeAreaView,
-  ScrollView,
-  Switch,
-  Text,
-  View,
-} from "react-native"
+import {ActivityIndicator, Button, Image, Pressable, SafeAreaView, ScrollView, Switch, Text, View} from "react-native"
 
 type TabId = "connection" | "camera"
 
@@ -62,6 +47,8 @@ export default function App() {
   const [mfnr, setMfnr] = useState(true)
   const [aeDivisor, setAeDivisor] = useState<3 | 5>(3)
   const [isoCap, setIsoCap] = useState(800)
+  const [deliverToPhone, setDeliverToPhone] = useState(true)
+  const [saveToCameraRoll, setSaveToCameraRoll] = useState(false)
   const [capturing, setCapturing] = useState(false)
   const [lastCapture, setLastCapture] = useState<CaptureResult | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
@@ -93,7 +80,7 @@ export default function App() {
         }
       }
     })
-    const uploadSub = PhotoReceiver.addListener("photoUpload", event => {
+    const uploadSub = PhotoReceiver.addListener("photoUpload", (event) => {
       if (!pendingRequestId.current) return
       if (event.requestId && event.requestId !== pendingRequestId.current) return
       uploadedUriRef.current = event.fileUri
@@ -166,7 +153,7 @@ export default function App() {
     if (!scanMode) {
       return
     }
-    void pushScanButtonPreset().catch(err => {
+    void pushScanButtonPreset().catch((err) => {
       setStatusMessage(err instanceof Error ? err.message : "failed to sync scan preset")
     })
   }, [aeDivisor, isoCap, pushScanButtonPreset, scanMode])
@@ -179,28 +166,38 @@ export default function App() {
     const requestId = `scan-${Date.now()}`
     pendingRequestId.current = requestId
     try {
-      const webhookUrl = await ensureReceiver()
-      const fields = scanFields()
-      const response = await BluetoothSdk.requestPhoto({
+      // The destination union rejects mixed old/new fields, so keep compress out
+      // of the flat params and put it on the webhook arm.
+      const {compress, ...fields} = scanFields()
+      const capture = {
         requestId,
-        webhookUrl,
-        authToken: null,
         ...fields,
-        size: fields.size ?? "medium",
-        compress: fields.compress ?? "none",
+        size: fields.size ?? ("medium" as const),
         sound: fields.sound ?? true,
         // Always send explicit booleans so the glasses never inherit an ambiguous default.
         zsl: fields.zsl ?? zsl,
         mfnr: fields.mfnr ?? mfnr,
-      })
+      }
+      const response = deliverToPhone
+        ? await BluetoothSdk.requestPhoto({
+            ...capture,
+            destination: {kind: "phone", saveToCameraRoll},
+          })
+        : await BluetoothSdk.requestPhoto({
+            ...capture,
+            destination: {kind: "webhook", url: await ensureReceiver(), compress: compress ?? "none"},
+          })
       setLastCapture({
-        fileUri: uploadedUriRef.current ?? "",
-        byteCount: response.fileSizeBytes ?? 0,
+        fileUri: response.fileUri ?? uploadedUriRef.current ?? "",
+        byteCount: response.byteCount ?? response.fileSizeBytes ?? 0,
         requestId,
         captureMetadata: metadataRef.current,
         photoResponse: response as unknown as Record<string, unknown>,
       })
-      setStatusMessage("complete")
+      let status = "complete"
+      if (response.savedToCameraRoll) status = "complete — saved to camera roll"
+      if (response.cameraRollError) status = `complete — camera roll: ${response.cameraRollError}`
+      setStatusMessage(status)
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "capture failed")
     } finally {
@@ -245,7 +242,7 @@ export default function App() {
           <>
             <Group name={`Button photo quality (${photoSize})`}>
               <Text style={styles.hint}>Hardware button capture size (not used when Scan Mode is on).</Text>
-              {PHOTO_SIZE_OPTIONS.map(option => (
+              {PHOTO_SIZE_OPTIONS.map((option) => (
                 <View key={option.key} style={styles.buttonSpacing}>
                   <Button
                     title={option.key === photoSize ? `${option.label} (selected)` : option.label}
@@ -253,6 +250,25 @@ export default function App() {
                   />
                 </View>
               ))}
+            </Group>
+            <Group name="Delivery">
+              <View style={styles.row}>
+                <View style={styles.labelBlock}>
+                  <Text style={styles.label}>Deliver to phone</Text>
+                  <Text style={styles.hintInline}>
+                    BLE transfer straight to this phone (destination kind &quot;phone&quot;). Off — upload to the local
+                    webhook receiver.
+                  </Text>
+                </View>
+                <Switch value={deliverToPhone} onValueChange={setDeliverToPhone} />
+              </View>
+              <View style={styles.row}>
+                <View style={styles.labelBlock}>
+                  <Text style={styles.label}>Save to camera roll</Text>
+                  <Text style={styles.hintInline}>Also export delivered photos to the OS photo library.</Text>
+                </View>
+                <Switch value={saveToCameraRoll} disabled={!deliverToPhone} onValueChange={setSaveToCameraRoll} />
+              </View>
             </Group>
             <Group name="Scan Mode capture">
               <View style={styles.row}>
@@ -281,8 +297,8 @@ export default function App() {
               {scanMode ? (
                 <>
                   <Text style={styles.hint}>
-                    Preset: max, AE÷{aeDivisor}, ISO cap {isoCap}, compress none, sound off. Sends granular
-                    requestPhoto fields only (never scanMode:true).
+                    Preset: max, AE÷{aeDivisor}, ISO cap {isoCap}, compress none, sound off. Sends granular requestPhoto
+                    fields only (never scanMode:true).
                   </Text>
                   <View style={styles.row}>
                     <Text style={styles.label}>AE divisor</Text>
@@ -306,10 +322,7 @@ export default function App() {
                 {capturing ? (
                   <ActivityIndicator />
                 ) : (
-                  <Button
-                    title={scanMode ? "Take Scan Photo" : "Take Photo"}
-                    onPress={handleTakePhoto}
-                  />
+                  <Button title={scanMode ? "Take Scan Photo" : "Take Photo"} onPress={handleTakePhoto} />
                 )}
               </View>
               {statusMessage ? <Text style={styles.status}>Status: {statusMessage}</Text> : null}
@@ -335,9 +348,7 @@ export default function App() {
 
 function TabButton(props: {label: string; active: boolean; onPress: () => void}) {
   return (
-    <Pressable
-      onPress={props.onPress}
-      style={[styles.tabButton, props.active ? styles.tabButtonActive : null]}>
+    <Pressable onPress={props.onPress} style={[styles.tabButton, props.active ? styles.tabButtonActive : null]}>
       <Text style={[styles.tabLabel, props.active ? styles.tabLabelActive : null]}>{props.label}</Text>
     </Pressable>
   )

--- a/mobile/modules/bluetooth-sdk/example/App.tsx
+++ b/mobile/modules/bluetooth-sdk/example/App.tsx
@@ -1,27 +1,12 @@
 import BluetoothSdk, {DeviceModels} from "@mentra/bluetooth-sdk"
-import type {
-  PhotoCaptureMetadata,
-  PhotoRequestParams,
-  PhotoSize,
-  PhotoStatusEvent,
-} from "@mentra/bluetooth-sdk"
+import type {PhotoCaptureMetadata, PhotoRequestParams, PhotoSize, PhotoStatusEvent} from "@mentra/bluetooth-sdk"
 import PhotoReceiver from "@mentra/bluetooth-sdk/photo-receiver"
 import * as MediaLibrary from "expo-media-library"
 import type {ReactNode} from "react"
 import {useCallback, useEffect, useRef, useState} from "react"
 // The SDK example intentionally uses plain React Native primitives outside the mobile app shell.
 // eslint-disable-next-line no-restricted-imports
-import {
-  ActivityIndicator,
-  Button,
-  Image,
-  Pressable,
-  SafeAreaView,
-  ScrollView,
-  Switch,
-  Text,
-  View,
-} from "react-native"
+import {ActivityIndicator, Button, Image, Pressable, SafeAreaView, ScrollView, Switch, Text, View} from "react-native"
 
 type TabId = "connection" | "camera"
 
@@ -62,6 +47,8 @@ export default function App() {
   const [mfnr, setMfnr] = useState(true)
   const [aeDivisor, setAeDivisor] = useState<3 | 5>(3)
   const [isoCap, setIsoCap] = useState(800)
+  const [deliverToPhone, setDeliverToPhone] = useState(true)
+  const [saveToCameraRoll, setSaveToCameraRoll] = useState(false)
   const [capturing, setCapturing] = useState(false)
   const [lastCapture, setLastCapture] = useState<CaptureResult | null>(null)
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
@@ -93,7 +80,7 @@ export default function App() {
         }
       }
     })
-    const uploadSub = PhotoReceiver.addListener("photoUpload", event => {
+    const uploadSub = PhotoReceiver.addListener("photoUpload", (event) => {
       if (!pendingRequestId.current) return
       if (event.requestId && event.requestId !== pendingRequestId.current) return
       uploadedUriRef.current = event.fileUri
@@ -166,7 +153,7 @@ export default function App() {
     if (!scanMode) {
       return
     }
-    void pushScanButtonPreset().catch(err => {
+    void pushScanButtonPreset().catch((err) => {
       setStatusMessage(err instanceof Error ? err.message : "failed to sync scan preset")
     })
   }, [aeDivisor, isoCap, pushScanButtonPreset, scanMode])
@@ -179,34 +166,56 @@ export default function App() {
     const requestId = `scan-${Date.now()}`
     pendingRequestId.current = requestId
     try {
-      const webhookUrl = await ensureReceiver()
-      const fields = scanFields()
-      const response = await BluetoothSdk.requestPhoto({
+      // The destination union rejects mixed old/new fields, so keep compress out
+      // of the flat params and put it on the webhook arm.
+      const {compress, ...fields} = scanFields()
+      const capture = {
         requestId,
-        webhookUrl,
-        authToken: null,
         ...fields,
-        size: fields.size ?? "medium",
-        compress: fields.compress ?? "none",
+        size: fields.size ?? ("medium" as const),
         sound: fields.sound ?? true,
         // Always send explicit booleans so the glasses never inherit an ambiguous default.
         zsl: fields.zsl ?? zsl,
         mfnr: fields.mfnr ?? mfnr,
-      })
+      }
+      const response = deliverToPhone
+        ? await BluetoothSdk.requestPhoto({
+            ...capture,
+            destination: {kind: "phone", saveToCameraRoll},
+          })
+        : await BluetoothSdk.requestPhoto({
+            ...capture,
+            destination: {kind: "webhook", url: await ensureReceiver(), compress: compress ?? "none"},
+          })
       setLastCapture({
-        fileUri: uploadedUriRef.current ?? "",
-        byteCount: response.fileSizeBytes ?? 0,
+        fileUri: response.fileUri ?? uploadedUriRef.current ?? "",
+        byteCount: response.byteCount ?? response.fileSizeBytes ?? 0,
         requestId,
         captureMetadata: metadataRef.current,
         photoResponse: response as unknown as Record<string, unknown>,
       })
-      setStatusMessage("complete")
+      let status = "complete"
+      if (response.savedToCameraRoll) status = "complete — saved to camera roll"
+      if (response.cameraRollError) status = `complete — camera roll: ${response.cameraRollError}`
+      setStatusMessage(status)
     } catch (err) {
       setStatusMessage(err instanceof Error ? err.message : "capture failed")
     } finally {
       pendingRequestId.current = null
       setCapturing(false)
     }
+  }
+
+  const handleSaveToCameraRollToggle = async (value: boolean) => {
+    if (value) {
+      // The SDK never prompts inside a capture: hold add-only access up front.
+      const permission = await MediaLibrary.requestPermissionsAsync(true)
+      if (!permission.granted) {
+        setStatusMessage("Photo library permission denied")
+        return
+      }
+    }
+    setSaveToCameraRoll(value)
   }
 
   const handleSaveToRoll = async () => {
@@ -245,7 +254,7 @@ export default function App() {
           <>
             <Group name={`Button photo quality (${photoSize})`}>
               <Text style={styles.hint}>Hardware button capture size (not used when Scan Mode is on).</Text>
-              {PHOTO_SIZE_OPTIONS.map(option => (
+              {PHOTO_SIZE_OPTIONS.map((option) => (
                 <View key={option.key} style={styles.buttonSpacing}>
                   <Button
                     title={option.key === photoSize ? `${option.label} (selected)` : option.label}
@@ -253,6 +262,32 @@ export default function App() {
                   />
                 </View>
               ))}
+            </Group>
+            <Group name="Delivery">
+              <View style={styles.row}>
+                <View style={styles.labelBlock}>
+                  <Text style={styles.label}>Deliver to phone</Text>
+                  <Text style={styles.hintInline}>
+                    BLE transfer straight to this phone (destination kind &quot;phone&quot;). Off — upload to the local
+                    webhook receiver.
+                  </Text>
+                </View>
+                <Switch value={deliverToPhone} onValueChange={setDeliverToPhone} />
+              </View>
+              <View style={styles.row}>
+                <View style={styles.labelBlock}>
+                  <Text style={styles.label}>Save to camera roll</Text>
+                  <Text style={styles.hintInline}>
+                    Also export delivered photos to the OS photo library (permission is requested here, never during a
+                    capture).
+                  </Text>
+                </View>
+                <Switch
+                  value={saveToCameraRoll}
+                  disabled={!deliverToPhone}
+                  onValueChange={(value) => void handleSaveToCameraRollToggle(value)}
+                />
+              </View>
             </Group>
             <Group name="Scan Mode capture">
               <View style={styles.row}>
@@ -281,8 +316,8 @@ export default function App() {
               {scanMode ? (
                 <>
                   <Text style={styles.hint}>
-                    Preset: max, AE÷{aeDivisor}, ISO cap {isoCap}, compress none, sound off. Sends granular
-                    requestPhoto fields only (never scanMode:true).
+                    Preset: max, AE÷{aeDivisor}, ISO cap {isoCap}, compress none, sound off. Sends granular requestPhoto
+                    fields only (never scanMode:true).
                   </Text>
                   <View style={styles.row}>
                     <Text style={styles.label}>AE divisor</Text>
@@ -306,10 +341,7 @@ export default function App() {
                 {capturing ? (
                   <ActivityIndicator />
                 ) : (
-                  <Button
-                    title={scanMode ? "Take Scan Photo" : "Take Photo"}
-                    onPress={handleTakePhoto}
-                  />
+                  <Button title={scanMode ? "Take Scan Photo" : "Take Photo"} onPress={handleTakePhoto} />
                 )}
               </View>
               {statusMessage ? <Text style={styles.status}>Status: {statusMessage}</Text> : null}
@@ -335,9 +367,7 @@ export default function App() {
 
 function TabButton(props: {label: string; active: boolean; onPress: () => void}) {
   return (
-    <Pressable
-      onPress={props.onPress}
-      style={[styles.tabButton, props.active ? styles.tabButtonActive : null]}>
+    <Pressable onPress={props.onPress} style={[styles.tabButton, props.active ? styles.tabButtonActive : null]}>
       <Text style={[styles.tabLabel, props.active ? styles.tabLabelActive : null]}>{props.label}</Text>
     </Pressable>
   )

--- a/mobile/modules/bluetooth-sdk/example/app.json
+++ b/mobile/modules/bluetooth-sdk/example/app.json
@@ -14,7 +14,10 @@
     },
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.mentra.bluetoothsdk.example"
+      "bundleIdentifier": "com.mentra.bluetoothsdk.example",
+      "infoPlist": {
+        "NSPhotoLibraryAddUsageDescription": "Saves photos delivered from your glasses to your photo library when you enable camera roll export."
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
+++ b/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
@@ -37,7 +37,7 @@ Pod::Spec.new do |s|
   }
 
   # iOS frameworks required by Bluetooth SDK
-  ios_frameworks = ['AVFoundation', 'CoreBluetooth', 'UIKit', 'CoreGraphics']
+  ios_frameworks = ['AVFoundation', 'CoreBluetooth', 'UIKit', 'CoreGraphics', 'Photos']
   ios_frameworks << 'Network' if include_expo_adapter
   s.frameworks = ios_frameworks
 

--- a/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
+++ b/mobile/modules/bluetooth-sdk/ios/MentraBluetoothSDK.podspec
@@ -38,7 +38,7 @@ Pod::Spec.new do |s|
   }
 
   # iOS frameworks required by Bluetooth SDK
-  ios_frameworks = ['AVFoundation', 'CoreBluetooth', 'UIKit', 'CoreGraphics']
+  ios_frameworks = ['AVFoundation', 'CoreBluetooth', 'UIKit', 'CoreGraphics', 'Photos']
   ios_frameworks << 'Network' if include_expo_adapter
   s.ios.frameworks = ios_frameworks
   s.osx.frameworks = ['AVFoundation', 'CoreBluetooth', 'CoreAudio', 'AudioToolbox', 'ImageIO', 'JavaScriptCore', 'Network']

--- a/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
+++ b/mobile/modules/bluetooth-sdk/ios/MentraPhotoReceiverModule.swift
@@ -48,6 +48,7 @@ public class MentraPhotoReceiverModule: Module {
 
     if let activePort = server.activePort {
       let uploadUrl = "http://\(host):\(activePort)/upload"
+      LocalPhotoReceiverRegistry.register(uploadUrl)
       emitStatus(message: "Photo receiver ready at \(uploadUrl)")
       return receiverResult(uploadUrl: uploadUrl, host: host, port: activePort)
     }
@@ -57,6 +58,7 @@ public class MentraPhotoReceiverModule: Module {
       do {
         let actualPort = try server.start(port: UInt16(port))
         let uploadUrl = "http://\(host):\(actualPort)/upload"
+        LocalPhotoReceiverRegistry.register(uploadUrl)
         emitStatus(message: "Photo receiver ready at \(uploadUrl)")
         return receiverResult(uploadUrl: uploadUrl, host: host, port: actualPort)
       } catch {
@@ -74,6 +76,7 @@ public class MentraPhotoReceiverModule: Module {
     receiverLock.lock()
     defer { receiverLock.unlock() }
 
+    LocalPhotoReceiverRegistry.unregister()
     photoUploadServer?.stop()
     emitStatus(message: "Photo receiver stopped")
   }

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1591,10 +1591,12 @@ struct ViewState {
             ispDigitalGain: request.ispDigitalGain,
             ispAnalogGain: request.ispAnalogGain,
             mode: request.mode,
-            transferMethod: request.transferMethod
+            transferMethod: request.transferMethod,
+            destinationKind: request.destinationKind,
+            saveToCameraRoll: request.saveToCameraRoll
         )
         Bridge.log(
-            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
+            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) destination=\(routed.destinationKind?.rawValue ?? "legacy") webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
         )
         guard let sgc else {
             Bridge.log(

--- a/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/DeviceManager.swift
@@ -1816,10 +1816,12 @@ struct ViewState {
             ispDigitalGain: request.ispDigitalGain,
             ispAnalogGain: request.ispAnalogGain,
             mode: request.mode,
-            transferMethod: request.transferMethod
+            transferMethod: request.transferMethod,
+            destinationKind: request.destinationKind,
+            saveToCameraRoll: request.saveToCameraRoll
         )
         Bridge.log(
-            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
+            "MAN: PHOTO PIPELINE [4/6] DeviceManager.requestPhoto requestId=\(routed.requestId) destination=\(routed.destinationKind?.rawValue ?? "legacy") webhookUrl=\(routed.webhookUrl ?? "nil") size=\(routed.size.rawValue) compress=\(routed.compress?.rawValue ?? "none") save=\(routed.save) sound=\(routed.sound) exposureTimeNs=\(manualExposureNs.map { String($0) } ?? "nil") iso=\(manualIso.map { String($0) } ?? "auto") aeDivisor=\(routed.aeExposureDivisor.map { String($0) } ?? "nil") isoCap=\(routed.isoCap.map { String($0) } ?? "nil") sgc=\(sgc != nil ? String(describing: type(of: sgc!)) : "null")"
         )
         guard let sgc else {
             Bridge.log(

--- a/mobile/modules/bluetooth-sdk/ios/Source/LocalPhotoReceiverRegistry.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/LocalPhotoReceiverRegistry.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// Tracks the SDK photo receiver that is hosted inside the phone app process.
+///
+/// The glasses need a LAN-reachable URL, but the phone-side BLE fallback relay
+/// can upload to the same receiver over loopback. Keeping this tiny registry lets
+/// the relay avoid stale Wi-Fi interface addresses after network changes.
+enum LocalPhotoReceiverRegistry {
+    private static let lock = NSLock()
+    private static var activeUploadUrls: [URLComponents] = []
+
+    static func register(_ uploadUrl: String) {
+        guard let components = URLComponents(string: uploadUrl),
+              isSupportedUploadUri(components)
+        else {
+            return
+        }
+        lock.lock()
+        defer { lock.unlock() }
+        if !activeUploadUrls.contains(where: { matchesRegisteredUploadUri($0, components) }) {
+            activeUploadUrls.append(components)
+        }
+    }
+
+    static func unregister() {
+        lock.lock()
+        defer { lock.unlock() }
+        activeUploadUrls = []
+    }
+
+    static func isActive() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !activeUploadUrls.isEmpty
+    }
+
+    static func loopbackUploadUrl(for webhookUrl: String?) -> String? {
+        guard let webhookUrl, !webhookUrl.isEmpty else {
+            return nil
+        }
+        lock.lock()
+        let registeredUris = activeUploadUrls
+        lock.unlock()
+        guard !registeredUris.isEmpty,
+              let candidate = URLComponents(string: webhookUrl),
+              isSupportedUploadUri(candidate)
+        else {
+            return nil
+        }
+
+        for registered in registeredUris where matchesRegisteredUploadUri(candidate, registered) {
+            var rewritten = URLComponents()
+            rewritten.scheme = candidate.scheme
+            rewritten.host = "127.0.0.1"
+            rewritten.port = effectivePort(candidate)
+            rewritten.percentEncodedPath = normalizedPath(candidate)
+            rewritten.percentEncodedQuery = candidate.percentEncodedQuery
+            rewritten.percentEncodedFragment = candidate.percentEncodedFragment
+            return rewritten.string
+        }
+        return nil
+    }
+
+    private static func matchesRegisteredUploadUri(
+        _ candidate: URLComponents, _ registered: URLComponents
+    ) -> Bool {
+        isSupportedUploadUri(candidate)
+            && equalsIgnoreCase(candidate.scheme, registered.scheme)
+            && equalsIgnoreCase(candidate.host, registered.host)
+            && effectivePort(candidate) == effectivePort(registered)
+            && normalizedPath(candidate) == normalizedPath(registered)
+            && candidate.percentEncodedQuery == registered.percentEncodedQuery
+            && candidate.percentEncodedFragment == registered.percentEncodedFragment
+    }
+
+    private static func isSupportedUploadUri(_ components: URLComponents) -> Bool {
+        guard let scheme = components.scheme,
+              scheme.caseInsensitiveCompare("http") == .orderedSame
+              || scheme.caseInsensitiveCompare("https") == .orderedSame
+        else {
+            return false
+        }
+        guard let host = components.host, !host.isEmpty else {
+            return false
+        }
+        return effectivePort(components) > 0 && normalizedPath(components) == "/upload"
+    }
+
+    private static func effectivePort(_ components: URLComponents) -> Int {
+        if let port = components.port {
+            return port
+        }
+        return components.scheme?.caseInsensitiveCompare("https") == .orderedSame ? 443 : 80
+    }
+
+    private static func normalizedPath(_ components: URLComponents) -> String {
+        let path = components.percentEncodedPath
+        return path.isEmpty ? "/" : path
+    }
+
+    private static func equalsIgnoreCase(_ first: String?, _ second: String?) -> Bool {
+        guard let first, let second else {
+            return first == nil && second == nil
+        }
+        return first.caseInsensitiveCompare(second) == .orderedSame
+    }
+}

--- a/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/MentraBluetoothSDK.swift
@@ -236,6 +236,9 @@ public final class MentraBluetoothSDK {
     // A photo response is terminal only after capture, encoding, transport, and upload.
     // Max-quality BLE fallback can legitimately exceed the generic command deadline.
     private static let photoRequestTimeoutMs = 30000
+    // Phone delivery always rides BLE end to end (capture, encode, transfer, JPEG
+    // conversion, optional camera-roll export), so it gets a longer terminal deadline.
+    private static let phoneDeliveryRequestTimeoutMs = 60000
     private static let otaBesVersionWaitMs = 5000
     private static let otaMtkVersionWaitMs = 2000
     private static let otaVersionPollMs = 100
@@ -1083,11 +1086,15 @@ public final class MentraBluetoothSDK {
         Bridge.log(
             "NATIVE: PHOTO PIPELINE [3b/6] MentraBluetoothSdk.requestPhoto requestId=\(routedRequest.requestId)"
         )
+        let deliverToPhone = routedRequest.destinationKind == .phone
         let pending = PendingResponse<PhotoResponseEvent>(operation: "photo request \(routedRequest.requestId)")
         pendingPhotoRequests[routedRequest.requestId] = pending
         DeviceManager.shared.requestPhoto(routedRequest)
         do {
-            let event = try await pending.wait(timeoutMs: MentraBluetoothSDK.photoRequestTimeoutMs)
+            let timeoutMs = deliverToPhone
+                ? MentraBluetoothSDK.phoneDeliveryRequestTimeoutMs
+                : MentraBluetoothSDK.photoRequestTimeoutMs
+            let event = try await pending.wait(timeoutMs: timeoutMs)
             pendingPhotoRequests.removeValue(forKey: routedRequest.requestId)
             return event
         } catch {

--- a/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/camera/CameraModels.swift
@@ -66,6 +66,12 @@ public enum PhotoCompression: String {
     case heavy
 }
 
+public enum PhotoDestinationKind: String {
+    case webhook
+    case phone
+    case glasses
+}
+
 public struct PhotoCaptureDefaults {
     public let size: PhotoSize?
     public let mfnr: Bool?
@@ -263,6 +269,10 @@ public struct PhotoRequest {
     public let zsl: Bool?
     public let ispDigitalGain: Int?
     public let ispAnalogGain: String?
+    /// nil = legacy request shape (flat webhookUrl/save fields drive the routing).
+    public let destinationKind: PhotoDestinationKind?
+    /// Only meaningful for `destinationKind == .phone`.
+    public let saveToCameraRoll: Bool
 
     public init(
         requestId: String? = nil,
@@ -283,7 +293,9 @@ public struct PhotoRequest {
         ispDigitalGain: Int? = nil,
         ispAnalogGain: String? = nil,
         mode: PhotoMode = .photo,
-        transferMethod: String = "auto"
+        transferMethod: String = "auto",
+        destinationKind: PhotoDestinationKind? = nil,
+        saveToCameraRoll: Bool = false
     ) {
         self.requestId = nonBlankRequestId(requestId) ?? generatedCameraRequestId("photo")
         self.size = size
@@ -304,6 +316,8 @@ public struct PhotoRequest {
         self.ispAnalogGain = ispAnalogGain
         self.mode = mode
         self.transferMethod = transferMethod
+        self.destinationKind = destinationKind
+        self.saveToCameraRoll = saveToCameraRoll
     }
 
     public static func from(params: [String: Any]) throws -> PhotoRequest {
@@ -322,6 +336,20 @@ public struct PhotoRequest {
             transferMethod = rawString
         } else {
             transferMethod = "auto"
+        }
+        let destinationKind: PhotoDestinationKind?
+        if let rawValue = params["destinationKind"] {
+            guard let rawString = rawValue as? String,
+                  let kind = PhotoDestinationKind(rawValue: rawString)
+            else {
+                throw BluetoothSdkError(
+                    code: "invalid_photo_destination",
+                    message: "Invalid destinationKind \(String(describing: rawValue)). Expected webhook, phone, or glasses."
+                )
+            }
+            destinationKind = kind
+        } else {
+            destinationKind = nil
         }
         let exposureTimeNs: Double?
         switch params["exposureTimeNs"] {
@@ -386,7 +414,9 @@ public struct PhotoRequest {
             ispDigitalGain: optionalInt("ispDigitalGain"),
             ispAnalogGain: params["ispAnalogGain"] as? String,
             mode: PhotoMode(normalizedRawValue: params["mode"] as? String),
-            transferMethod: transferMethod
+            transferMethod: transferMethod,
+            destinationKind: destinationKind,
+            saveToCameraRoll: params["saveToCameraRoll"] as? Bool ?? false
         )
     }
 
@@ -437,7 +467,9 @@ public struct PhotoRequest {
             ispDigitalGain: ispDigitalGain,
             ispAnalogGain: ispAnalogGain,
             mode: mode,
-            transferMethod: transferMethod
+            transferMethod: transferMethod,
+            destinationKind: destinationKind,
+            saveToCameraRoll: saveToCameraRoll
         )
     }
 }
@@ -497,7 +529,7 @@ public struct VideoRecordingRequest {
     public let width: Int
     public let height: Int
     public let fps: Int
-    // Optional auto-stop timer in minutes; 0 = record until stopped/interrupted.
+    /// Optional auto-stop timer in minutes; 0 = record until stopped/interrupted.
     public let maxRecordingTimeMinutes: Int
 
     public init(
@@ -609,6 +641,11 @@ public enum PhotoResponse: CustomStringConvertible, Equatable {
         statusUrl: String?,
         contentType: String?,
         fileSizeBytes: Int?,
+        // Phone-delivery (destinationKind "phone") terminal metadata; nil for webhook/glasses.
+        fileUri: String?,
+        byteCount: Int?,
+        savedToCameraRoll: Bool?,
+        cameraRollError: String?,
         timestamp: Int
     )
     case error(requestId: String, errorCode: String?, errorMessage: String, timestamp: Int)
@@ -627,6 +664,10 @@ public enum PhotoResponse: CustomStringConvertible, Equatable {
                 contentType: stringValue(values, "contentType") ?? stringValue(values, "mimeType"),
                 fileSizeBytes: intValue(values["fileSizeBytes"]) ?? intValue(values["bytes"])
                     ?? intValue(values["size"]),
+                fileUri: stringValue(values, "fileUri"),
+                byteCount: intValue(values["byteCount"]),
+                savedToCameraRoll: boolValue(values, "savedToCameraRoll"),
+                cameraRollError: stringValue(values, "cameraRollError"),
                 timestamp: timestamp
             )
         } else {
@@ -651,21 +692,24 @@ public enum PhotoResponse: CustomStringConvertible, Equatable {
 
     public var requestId: String {
         switch self {
-        case let .success(requestId, _, _, _, _, _, _), let .error(requestId, _, _, _):
+        case let .success(requestId, _, _, _, _, _, _, _, _, _, _), let .error(requestId, _, _, _):
             requestId
         }
     }
 
     public var timestamp: Int {
         switch self {
-        case let .success(_, _, _, _, _, _, timestamp), let .error(_, _, _, timestamp):
+        case let .success(_, _, _, _, _, _, _, _, _, _, timestamp), let .error(_, _, _, timestamp):
             timestamp
         }
     }
 
     public var values: [String: Any] {
         switch self {
-        case let .success(requestId, uploadUrl, photoUrl, statusUrl, contentType, fileSizeBytes, timestamp):
+        case let .success(
+            requestId, uploadUrl, photoUrl, statusUrl, contentType, fileSizeBytes,
+            fileUri, byteCount, savedToCameraRoll, cameraRollError, timestamp
+        ):
             var values: [String: Any] = [
                 "state": State.success.rawValue,
                 "requestId": requestId,
@@ -683,6 +727,22 @@ public enum PhotoResponse: CustomStringConvertible, Equatable {
             }
             if let fileSizeBytes {
                 values["fileSizeBytes"] = fileSizeBytes
+            }
+            if let fileUri, !fileUri.isEmpty {
+                values["fileUri"] = fileUri
+                // The phone-delivery contract exposes the delivered type as `mimeType`.
+                if let contentType, !contentType.isEmpty {
+                    values["mimeType"] = contentType
+                }
+            }
+            if let byteCount {
+                values["byteCount"] = byteCount
+            }
+            if let savedToCameraRoll {
+                values["savedToCameraRoll"] = savedToCameraRoll
+            }
+            if let cameraRollError, !cameraRollError.isEmpty {
+                values["cameraRollError"] = cameraRollError
             }
             return values
         case let .error(requestId, errorCode, errorMessage, timestamp):

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -16,6 +16,7 @@ import Combine
 import CoreBluetooth
 import Foundation
 import ImageIO
+import Photos
 import UIKit
 
 // MARK: - Supporting Types
@@ -23,6 +24,84 @@ import UIKit
 struct MentraLiveDevice {
     let name: String
     let address: String
+}
+
+// MARK: - MentraLivePhotoStorage
+
+/// App-private storage for photos received from the glasses (`Documents/MentraLive_Images`).
+/// Phone-delivered files stay valid for at least `MAX_FILE_AGE_SECONDS`; consumers copy
+/// the file to keep it beyond the retention sweep.
+enum MentraLivePhotoStorage {
+    static let TAG = "MentraLivePhotoStorage"
+
+    static let DIRECTORY_NAME = "MentraLive_Images"
+    static let MAX_FILE_AGE_SECONDS: TimeInterval = 24 * 60 * 60
+    static let MAX_TOTAL_BYTES = 256 * 1024 * 1024
+
+    static func directoryUrl(createIfNeeded: Bool = false) throws -> URL {
+        let documentsDirectory = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!
+        let directory = documentsDirectory.appendingPathComponent(DIRECTORY_NAME)
+        if createIfNeeded, !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory
+    }
+
+    static func writePhoneDeliveredPhoto(_ jpegData: Data, requestId: String) throws -> URL {
+        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let fileUrl = try directoryUrl(createIfNeeded: true)
+            .appendingPathComponent("PHONE_\(requestId)_\(timestamp).jpg")
+        try jpegData.write(to: fileUrl)
+        return fileUrl
+    }
+
+    /// Retention sweep, run once per transport session: delete files older than 24h,
+    /// then oldest-first until the directory is within the 256 MB budget.
+    static func sweep() {
+        DispatchQueue.global(qos: .utility).async {
+            let fileManager = FileManager.default
+            guard let directory = try? directoryUrl(),
+                  fileManager.fileExists(atPath: directory.path),
+                  let files = try? fileManager.contentsOfDirectory(
+                      at: directory,
+                      includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
+                  )
+            else { return }
+
+            var entries: [(url: URL, modified: Date, size: Int)] = files.map { url in
+                let values = try? url.resourceValues(
+                    forKeys: [.contentModificationDateKey, .fileSizeKey]
+                )
+                return (url, values?.contentModificationDate ?? .distantPast, values?.fileSize ?? 0)
+            }
+            entries.sort { $0.modified < $1.modified }
+
+            var totalBytes = entries.reduce(0) { $0 + $1.size }
+            let cutoff = Date().addingTimeInterval(-MAX_FILE_AGE_SECONDS)
+            var removedCount = 0
+            var removedBytes = 0
+            for entry in entries {
+                // Entries are oldest-first, so once we reach a fresh file with the
+                // directory inside budget there is nothing left to delete.
+                if entry.modified >= cutoff, totalBytes <= MAX_TOTAL_BYTES { break }
+                do {
+                    try fileManager.removeItem(at: entry.url)
+                    totalBytes -= entry.size
+                    removedCount += 1
+                    removedBytes += entry.size
+                } catch {
+                    Bridge.log("\(TAG): Failed to delete \(entry.url.lastPathComponent): \(error)")
+                }
+            }
+            if removedCount > 0 {
+                Bridge.log(
+                    "\(TAG): Retention sweep removed \(removedCount) file(s) (\(removedBytes) bytes); \(totalBytes) bytes remain"
+                )
+            }
+        }
+    }
 }
 
 // MARK: - BlePhotoUploadService
@@ -99,6 +178,91 @@ class BlePhotoUploadService {
                 )
                 onError?(requestId, error.localizedDescription)
             }
+        }
+    }
+
+    struct PhoneDelivery {
+        let fileUri: String
+        let byteCount: Int
+        let savedToCameraRoll: Bool
+        let cameraRollError: String?
+    }
+
+    /**
+     * Process image data for phone-destination delivery: convert to JPEG preserving
+     * EXIF, persist under MentraLive_Images, and optionally export to the camera roll.
+     * Camera-roll failures never fail the photo; they surface as
+     * `savedToCameraRoll: false` plus `cameraRollError`.
+     */
+    static func processAndStorePhotoOnPhone(
+        imageData: Data,
+        requestId: String,
+        saveToCameraRoll: Bool,
+        onSuccess: @escaping (String, PhoneDelivery) -> Void,
+        onError: @escaping (String, String) -> Void
+    ) {
+        Task {
+            do {
+                Bridge.log(
+                    "\(TAG): Processing BLE photo for phone delivery. Image size: \(imageData.count) bytes"
+                )
+
+                let jpegData = try convertToJpegPreservingExif(imageData: imageData)
+                let fileUrl = try MentraLivePhotoStorage.writePhoneDeliveredPhoto(
+                    jpegData, requestId: requestId
+                )
+
+                var saved = false
+                var cameraRollError: String?
+                if saveToCameraRoll {
+                    (saved, cameraRollError) = await exportToCameraRoll(jpegData: jpegData)
+                    if let cameraRollError {
+                        Bridge.log(
+                            "\(TAG): Camera roll export skipped for requestId: \(requestId): \(cameraRollError)"
+                        )
+                    }
+                }
+
+                Bridge.log(
+                    "\(TAG): Photo delivered to phone for requestId: \(requestId) (\(jpegData.count) bytes)"
+                )
+                onSuccess(
+                    requestId,
+                    PhoneDelivery(
+                        fileUri: fileUrl.absoluteString,
+                        byteCount: jpegData.count,
+                        savedToCameraRoll: saved,
+                        cameraRollError: cameraRollError
+                    )
+                )
+            } catch {
+                Bridge.log(
+                    "\(TAG): Error delivering BLE photo to phone for requestId: \(requestId), error: \(error)"
+                )
+                onError(requestId, error.localizedDescription)
+            }
+        }
+    }
+
+    private static func exportToCameraRoll(jpegData: Data) async -> (saved: Bool, error: String?) {
+        // Requesting Photos access without the plist key crashes the app; degrade to
+        // a delivered-but-not-exported success instead.
+        guard Bundle.main.object(forInfoDictionaryKey: "NSPhotoLibraryAddUsageDescription") != nil
+        else {
+            return (false, "NSPhotoLibraryAddUsageDescription missing from Info.plist")
+        }
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized || status == .limited else {
+            return (false, "Photo library add permission not granted")
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let creationRequest = PHAssetCreationRequest.forAsset()
+                creationRequest.addResource(with: .photo, data: jpegData, options: nil)
+            }
+            return (true, nil)
+        } catch {
+            return (false, error.localizedDescription)
         }
     }
 
@@ -789,14 +953,17 @@ private struct FileTransferSession {
 private struct BlePhotoTransfer {
     let bleImgId: String
     let requestId: String
-    let webhookUrl: String
+    let webhookUrl: String?
     var authToken: String?
+    /// destinationKind "phone": deliver the JPEG to JS as a fileUri, never any webhook upload
+    var deliverToPhone = false
+    var saveToCameraRoll = false
     var session: FileTransferSession?
     let phoneStartTime: Date
     var bleTransferStartTime: Date?
     var glassesCompressionDurationMs: Int64 = 0
 
-    init(bleImgId: String, requestId: String, webhookUrl: String) {
+    init(bleImgId: String, requestId: String, webhookUrl: String?) {
         self.bleImgId = bleImgId
         self.requestId = requestId
         self.webhookUrl = webhookUrl
@@ -1414,7 +1581,7 @@ class MentraLive: NSObject, SGCManager {
     private let LC3_READ_UUID = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
     private let LC3_WRITE_UUID = CBUUID(string: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
 
-    private let FILE_SAVE_DIR = "MentraLive_Images"
+    private let FILE_SAVE_DIR = MentraLivePhotoStorage.DIRECTORY_NAME
 
     // NEW: File transfer properties
     private var fileReadCharacteristic: CBCharacteristic?
@@ -1573,6 +1740,9 @@ class MentraLive: NSObject, SGCManager {
     override init() {
         super.init()
         setupCommandQueue()
+
+        // Retention sweep for received photos (24h TTL, then 256MB cap), once per session
+        MentraLivePhotoStorage.sweep()
 
         // Initialize phone audio monitor for LC3 mic suspend/resume (if enabled)
         // This detects when phone is playing audio and temporarily suspends LC3 mic
@@ -1753,8 +1923,11 @@ class MentraLive: NSObject, SGCManager {
     }
 
     func requestPhoto(_ request: PhotoRequest) {
+        let deliverToPhone = request.destinationKind == .phone
+        let glassesOnly = request.destinationKind == .glasses
+
         Bridge.log(
-            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) mode=\(request.mode.rawValue) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
+            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) destination=\(request.destinationKind?.rawValue ?? "legacy") mode=\(request.mode.rawValue) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
         )
 
         var json: [String: Any] = [
@@ -1762,30 +1935,52 @@ class MentraLive: NSObject, SGCManager {
             "requestId": request.requestId,
         ]
 
-        // Always generate BLE ID for potential fallback
-        let bleImgId =
-            "I" + String(format: "%09d", Int(Date().timeIntervalSince1970 * 1000) % 100_000_000)
-        json["bleImgId"] = bleImgId
-        json["transferMethod"] = request.transferMethod
+        if glassesOnly {
+            // Gallery-only capture: no bleImgId and no transfer registration - nothing
+            // ever leaves the glasses; the terminal photo_response resolves the request.
+            Bridge.log("LIVE: Using glasses-only capture (no transfer) for: \(request.requestId)")
+        } else {
+            // Generate BLE ID for the phone delivery / potential webhook fallback
+            let bleImgId =
+                "I" + String(format: "%09d", Int(Date().timeIntervalSince1970 * 1000) % 100_000_000)
+            json["bleImgId"] = bleImgId
 
-        if let webhookUrl = request.webhookUrl, !webhookUrl.isEmpty {
-            json["webhookUrl"] = webhookUrl
+            // Phone delivery always rides BLE; miniapps may otherwise explicitly skip
+            // direct Wi-Fi upload and force the phone-relayed BLE path. Auto remains
+            // the default.
+            let transferMethod = deliverToPhone ? "ble" : request.transferMethod
+            json["transferMethod"] = transferMethod
 
-            var transfer = BlePhotoTransfer(
-                bleImgId: bleImgId, requestId: request.requestId, webhookUrl: webhookUrl
-            )
+            if deliverToPhone {
+                var transfer = BlePhotoTransfer(
+                    bleImgId: bleImgId, requestId: request.requestId, webhookUrl: nil
+                )
+                transfer.deliverToPhone = true
+                transfer.saveToCameraRoll = request.saveToCameraRoll
+                blePhotoTransfers[bleImgId] = transfer
+            } else if let webhookUrl = request.webhookUrl, !webhookUrl.isEmpty {
+                json["webhookUrl"] = webhookUrl
 
-            // Store authToken for BLE transfer if provided
-            if let authToken = request.authToken, !authToken.isEmpty {
-                transfer.authToken = authToken
+                var transfer = BlePhotoTransfer(
+                    bleImgId: bleImgId, requestId: request.requestId, webhookUrl: webhookUrl
+                )
+
+                // Store authToken for BLE transfer if provided
+                if let authToken = request.authToken, !authToken.isEmpty {
+                    transfer.authToken = authToken
+                }
+
+                blePhotoTransfers[bleImgId] = transfer
             }
 
-            blePhotoTransfers[bleImgId] = transfer
-        }
+            // Phone delivery never carries webhook credentials on the wire.
+            if !deliverToPhone, let authToken = request.authToken, !authToken.isEmpty {
+                json["authToken"] = authToken
+            }
 
-        // Add authToken to JSON if provided
-        if let authToken = request.authToken, !authToken.isEmpty {
-            json["authToken"] = authToken
+            Bridge.log(
+                "LIVE: PHOTO PIPELINE [5b/6] take_photo JSON ready bleImgId=\(bleImgId) transferMethod=\(transferMethod)"
+            )
         }
 
         let allowedSizes = ["low", "medium", "high", "max"]
@@ -1794,7 +1989,8 @@ class MentraLive: NSObject, SGCManager {
         json["mode"] = request.mode.rawValue
 
         json["compress"] = request.compress?.rawValue ?? "none"
-        json["save"] = request.save
+        // A glasses-only capture IS the save; the archival route on the glasses keys off it.
+        json["save"] = glassesOnly ? true : request.save
         json["sound"] = request.sound
 
         if let e = request.exposureTimeNs, e.isFinite, e > 0, e <= Double(Int64.max) {
@@ -1807,9 +2003,6 @@ class MentraLive: NSObject, SGCManager {
         }
         request.appendScanFields(to: &json)
 
-        Bridge.log(
-            "LIVE: PHOTO PIPELINE [5b/6] take_photo JSON ready bleImgId=\(bleImgId) transferMethod=\(request.transferMethod)"
-        )
         Bridge.log("LIVE: PHOTO PIPELINE [6/6] Dispatching take_photo to sendJson()")
 
         sendJson(json, wakeUp: true)
@@ -4016,15 +4209,29 @@ class MentraLive: NSObject, SGCManager {
     }
 
     private func processAndUploadBlePhoto(_ transfer: BlePhotoTransfer, imageData: Data) {
+        if transfer.deliverToPhone {
+            deliverBlePhotoToPhone(transfer, imageData: imageData)
+            return
+        }
+
+        guard let webhookUrl = transfer.webhookUrl, !webhookUrl.isEmpty else {
+            Bridge.sendPhotoError(
+                requestId: transfer.requestId,
+                errorCode: "PHONE_UPLOAD_FAILED",
+                errorMessage: "BLE photo transfer has no webhook destination"
+            )
+            return
+        }
+
         Bridge.log("LIVE: Processing BLE photo for upload. RequestId: \(transfer.requestId)")
 
         BlePhotoUploadService.processAndUploadPhoto(
-            imageData: imageData, requestId: transfer.requestId, webhookUrl: transfer.webhookUrl,
+            imageData: imageData, requestId: transfer.requestId, webhookUrl: webhookUrl,
             authToken: transfer.authToken
         ) { [weak self] requestId, responseBody in
             self?.sendPhotoTerminalSuccessResponse(
                 requestId: requestId,
-                uploadUrl: transfer.webhookUrl,
+                uploadUrl: webhookUrl,
                 responseBody: responseBody
             )
         } onError: { requestId, error in
@@ -4032,6 +4239,43 @@ class MentraLive: NSObject, SGCManager {
                 requestId: requestId,
                 errorCode: "PHONE_UPLOAD_FAILED",
                 errorMessage: "BLE photo upload failed: \(error)"
+            )
+        }
+    }
+
+    /// Deliver a completed BLE photo transfer to the phone itself (destinationKind
+    /// "phone"): convert to JPEG exactly as the webhook path does, persist the JPEG
+    /// under MentraLive_Images as the deliverable, optionally export it to the camera
+    /// roll, and emit the terminal photo_response with the fileUri. No upload service
+    /// involved.
+    private func deliverBlePhotoToPhone(_ transfer: BlePhotoTransfer, imageData: Data) {
+        Bridge.log("LIVE: Processing BLE photo for phone delivery. RequestId: \(transfer.requestId)")
+
+        BlePhotoUploadService.processAndStorePhotoOnPhone(
+            imageData: imageData,
+            requestId: transfer.requestId,
+            saveToCameraRoll: transfer.saveToCameraRoll
+        ) { requestId, delivery in
+            var event: [String: Any] = [
+                "type": "photo_response",
+                "state": "success",
+                "success": true,
+                "requestId": requestId,
+                "timestamp": Int(Date().timeIntervalSince1970 * 1000),
+                "fileUri": delivery.fileUri,
+                "mimeType": "image/jpeg",
+                "byteCount": delivery.byteCount,
+                "savedToCameraRoll": delivery.savedToCameraRoll,
+            ]
+            if let cameraRollError = delivery.cameraRollError {
+                event["cameraRollError"] = cameraRollError
+            }
+            Bridge.sendPhotoResponse(event)
+        } onError: { requestId, error in
+            Bridge.sendPhotoError(
+                requestId: requestId,
+                errorCode: "PHONE_DELIVERY_FAILED",
+                errorMessage: "BLE photo phone delivery failed: \(error)"
             )
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -16,6 +16,7 @@ import Combine
 import CoreBluetooth
 import Foundation
 import ImageIO
+import Photos
 
 // MARK: - Supporting Types
 
@@ -50,6 +51,96 @@ enum MentraLivePendingPairingTarget {
             pendingName: pendingName,
             pendingIdentifier: pendingIdentifier
         )
+    }
+}
+
+// MARK: - MentraLivePhotoStorage
+
+/// App-private storage for photos received from the glasses (`Documents/MentraLive_Images`).
+/// The sweep deletes files older than `MAX_FILE_AGE_SECONDS`, then oldest-first down to
+/// `MAX_TOTAL_BYTES`; consumers copy the file to keep it beyond the retention sweep.
+enum MentraLivePhotoStorage {
+    static let TAG = "MentraLivePhotoStorage"
+
+    static let DIRECTORY_NAME = "MentraLive_Images"
+    static let MAX_FILE_AGE_SECONDS: TimeInterval = 24 * 60 * 60
+    static let MAX_TOTAL_BYTES = 256 * 1024 * 1024
+
+    static func directoryUrl(createIfNeeded: Bool = false) throws -> URL {
+        let documentsDirectory = FileManager.default.urls(
+            for: .documentDirectory, in: .userDomainMask
+        ).first!
+        let directory = documentsDirectory.appendingPathComponent(DIRECTORY_NAME)
+        if createIfNeeded, !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory
+    }
+
+    static func writePhoneDeliveredPhoto(_ jpegData: Data, requestId: String) throws -> URL {
+        let timestamp = Int(Date().timeIntervalSince1970 * 1000)
+        let fileUrl = try directoryUrl(createIfNeeded: true)
+            .appendingPathComponent("PHONE_\(fileNameComponent(requestId))_\(timestamp).jpg")
+        try jpegData.write(to: fileUrl)
+        return fileUrl
+    }
+
+    /// Request ids are caller-supplied strings; keep only file-name-safe characters so a
+    /// value like "scan/123" cannot turn the delivered path into a missing subdirectory.
+    static func fileNameComponent(_ requestId: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "._-"))
+        let safe = String(
+            requestId.unicodeScalars.prefix(64).map { scalar -> Character in
+                scalar.isASCII && allowed.contains(scalar) ? Character(scalar) : "_"
+            }
+        )
+        return safe.isEmpty ? "photo" : safe
+    }
+
+    /// Retention sweep, run once per transport session: delete files older than 24h,
+    /// then oldest-first until the directory is within the 256 MB budget.
+    static func sweep() {
+        DispatchQueue.global(qos: .utility).async {
+            let fileManager = FileManager.default
+            guard let directory = try? directoryUrl(),
+                  fileManager.fileExists(atPath: directory.path),
+                  let files = try? fileManager.contentsOfDirectory(
+                      at: directory,
+                      includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey]
+                  )
+            else { return }
+
+            var entries: [(url: URL, modified: Date, size: Int)] = files.map { url in
+                let values = try? url.resourceValues(
+                    forKeys: [.contentModificationDateKey, .fileSizeKey]
+                )
+                return (url, values?.contentModificationDate ?? .distantPast, values?.fileSize ?? 0)
+            }
+            entries.sort { $0.modified < $1.modified }
+
+            var totalBytes = entries.reduce(0) { $0 + $1.size }
+            let cutoff = Date().addingTimeInterval(-MAX_FILE_AGE_SECONDS)
+            var removedCount = 0
+            var removedBytes = 0
+            for entry in entries {
+                // Entries are oldest-first, so once we reach a fresh file with the
+                // directory inside budget there is nothing left to delete.
+                if entry.modified >= cutoff, totalBytes <= MAX_TOTAL_BYTES { break }
+                do {
+                    try fileManager.removeItem(at: entry.url)
+                    totalBytes -= entry.size
+                    removedCount += 1
+                    removedBytes += entry.size
+                } catch {
+                    Bridge.log("\(TAG): Failed to delete \(entry.url.lastPathComponent): \(error)")
+                }
+            }
+            if removedCount > 0 {
+                Bridge.log(
+                    "\(TAG): Retention sweep removed \(removedCount) file(s) (\(removedBytes) bytes); \(totalBytes) bytes remain"
+                )
+            }
+        }
     }
 }
 
@@ -127,6 +218,96 @@ class BlePhotoUploadService {
                 )
                 onError?(requestId, error.localizedDescription)
             }
+        }
+    }
+
+    struct PhoneDelivery {
+        let fileUri: String
+        let byteCount: Int
+        let savedToCameraRoll: Bool
+        let cameraRollError: String?
+    }
+
+    /**
+     * Process image data for phone-destination delivery: convert to JPEG preserving
+     * EXIF, persist under MentraLive_Images, and optionally export to the camera roll.
+     * Camera-roll failures never fail the photo; they surface as
+     * `savedToCameraRoll: false` plus `cameraRollError`.
+     */
+    static func processAndStorePhotoOnPhone(
+        imageData: Data,
+        requestId: String,
+        saveToCameraRoll: Bool,
+        onSuccess: @escaping (String, PhoneDelivery) -> Void,
+        onError: @escaping (String, String) -> Void
+    ) {
+        Task {
+            do {
+                Bridge.log(
+                    "\(TAG): Processing BLE photo for phone delivery. Image size: \(imageData.count) bytes"
+                )
+
+                let jpegData = try convertToJpegPreservingExif(imageData: imageData)
+                let fileUrl = try MentraLivePhotoStorage.writePhoneDeliveredPhoto(
+                    jpegData, requestId: requestId
+                )
+
+                var saved = false
+                var cameraRollError: String?
+                if saveToCameraRoll {
+                    (saved, cameraRollError) = await exportToCameraRoll(jpegData: jpegData)
+                    if let cameraRollError {
+                        Bridge.log(
+                            "\(TAG): Camera roll export skipped for requestId: \(requestId): \(cameraRollError)"
+                        )
+                    }
+                }
+
+                Bridge.log(
+                    "\(TAG): Photo delivered to phone for requestId: \(requestId) (\(jpegData.count) bytes)"
+                )
+                onSuccess(
+                    requestId,
+                    PhoneDelivery(
+                        fileUri: fileUrl.absoluteString,
+                        byteCount: jpegData.count,
+                        savedToCameraRoll: saved,
+                        cameraRollError: cameraRollError
+                    )
+                )
+            } catch {
+                Bridge.log(
+                    "\(TAG): Error delivering BLE photo to phone for requestId: \(requestId), error: \(error)"
+                )
+                onError(requestId, error.localizedDescription)
+            }
+        }
+    }
+
+    private static var hasPhotoLibraryAddUsageDescription: Bool {
+        Bundle.main.object(forInfoDictionaryKey: "NSPhotoLibraryAddUsageDescription") != nil
+    }
+
+    private static func exportToCameraRoll(jpegData: Data) async -> (saved: Bool, error: String?) {
+        // Never prompt from inside a capture: a permission dialog would sit inside the
+        // photo deadline. The host app requests add-only Photos access up front (the
+        // Mentra App's gallery setting does; SDK consumers use their own flow), and an
+        // undecided or denied status degrades to a delivered-but-not-exported success.
+        guard hasPhotoLibraryAddUsageDescription else {
+            return (false, "NSPhotoLibraryAddUsageDescription missing from Info.plist")
+        }
+        let status = PHPhotoLibrary.authorizationStatus(for: .addOnly)
+        guard status == .authorized || status == .limited else {
+            return (false, "Photo library add permission not granted; request add-only Photos access before capturing")
+        }
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                let creationRequest = PHAssetCreationRequest.forAsset()
+                creationRequest.addResource(with: .photo, data: jpegData, options: nil)
+            }
+            return (true, nil)
+        } catch {
+            return (false, error.localizedDescription)
         }
     }
 
@@ -819,14 +1000,17 @@ private struct FileTransferSession {
 private struct BlePhotoTransfer {
     let bleImgId: String
     let requestId: String
-    let webhookUrl: String
+    let webhookUrl: String?
     var authToken: String?
+    /// destinationKind "phone": deliver the JPEG to JS as a fileUri, never any webhook upload
+    var deliverToPhone = false
+    var saveToCameraRoll = false
     var session: FileTransferSession?
     let phoneStartTime: Date
     var bleTransferStartTime: Date?
     var glassesCompressionDurationMs: Int64 = 0
 
-    init(bleImgId: String, requestId: String, webhookUrl: String) {
+    init(bleImgId: String, requestId: String, webhookUrl: String?) {
         self.bleImgId = bleImgId
         self.requestId = requestId
         self.webhookUrl = webhookUrl
@@ -1597,7 +1781,7 @@ class MentraLive: NSObject, SGCManager {
     private let LC3_READ_UUID = CBUUID(string: "6E400002-B5A3-F393-E0A9-E50E24DCCA9E")
     private let LC3_WRITE_UUID = CBUUID(string: "6E400003-B5A3-F393-E0A9-E50E24DCCA9E")
 
-    private let FILE_SAVE_DIR = "MentraLive_Images"
+    private let FILE_SAVE_DIR = MentraLivePhotoStorage.DIRECTORY_NAME
 
     // NEW: File transfer properties
     private var fileReadCharacteristic: CBCharacteristic?
@@ -1768,6 +1952,9 @@ class MentraLive: NSObject, SGCManager {
     override init() {
         super.init()
         setupCommandQueue()
+
+        // Retention sweep for received photos (24h TTL, then 256MB cap), once per session
+        MentraLivePhotoStorage.sweep()
 
         // Initialize phone audio monitor for LC3 mic suspend/resume (if enabled)
         // This detects when phone is playing audio and temporarily suspends LC3 mic
@@ -2052,8 +2239,11 @@ class MentraLive: NSObject, SGCManager {
     }
 
     func requestPhoto(_ request: PhotoRequest) {
+        let deliverToPhone = request.destinationKind == .phone
+        let glassesOnly = request.destinationKind == .glasses
+
         Bridge.log(
-            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) mode=\(request.mode.rawValue) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
+            "LIVE: PHOTO PIPELINE [5/6] requestPhoto() entry requestId=\(request.requestId) destination=\(request.destinationKind?.rawValue ?? "legacy") mode=\(request.mode.rawValue) save=\(request.save) sound=\(request.sound) iso=\(request.iso.map { String($0) } ?? "auto") aeDivisor=\(request.aeExposureDivisor.map { String($0) } ?? "nil")"
         )
 
         var json: [String: Any] = [
@@ -2061,30 +2251,52 @@ class MentraLive: NSObject, SGCManager {
             "requestId": request.requestId,
         ]
 
-        // Always generate BLE ID for potential fallback
-        let bleImgId =
-            "I" + String(format: "%09d", Int(Date().timeIntervalSince1970 * 1000) % 100_000_000)
-        json["bleImgId"] = bleImgId
-        json["transferMethod"] = request.transferMethod
+        if glassesOnly {
+            // Gallery-only capture: no bleImgId and no transfer registration - nothing
+            // ever leaves the glasses; the terminal photo_response resolves the request.
+            Bridge.log("LIVE: Using glasses-only capture (no transfer) for: \(request.requestId)")
+        } else {
+            // Generate BLE ID for the phone delivery / potential webhook fallback
+            let bleImgId =
+                "I" + String(format: "%09d", Int(Date().timeIntervalSince1970 * 1000) % 100_000_000)
+            json["bleImgId"] = bleImgId
 
-        if let webhookUrl = request.webhookUrl, !webhookUrl.isEmpty {
-            json["webhookUrl"] = webhookUrl
+            // Phone delivery always rides BLE; miniapps may otherwise explicitly skip
+            // direct Wi-Fi upload and force the phone-relayed BLE path. Auto remains
+            // the default.
+            let transferMethod = deliverToPhone ? "ble" : request.transferMethod
+            json["transferMethod"] = transferMethod
 
-            var transfer = BlePhotoTransfer(
-                bleImgId: bleImgId, requestId: request.requestId, webhookUrl: webhookUrl
-            )
+            if deliverToPhone {
+                var transfer = BlePhotoTransfer(
+                    bleImgId: bleImgId, requestId: request.requestId, webhookUrl: nil
+                )
+                transfer.deliverToPhone = true
+                transfer.saveToCameraRoll = request.saveToCameraRoll
+                blePhotoTransfers[bleImgId] = transfer
+            } else if let webhookUrl = request.webhookUrl, !webhookUrl.isEmpty {
+                json["webhookUrl"] = webhookUrl
 
-            // Store authToken for BLE transfer if provided
-            if let authToken = request.authToken, !authToken.isEmpty {
-                transfer.authToken = authToken
+                var transfer = BlePhotoTransfer(
+                    bleImgId: bleImgId, requestId: request.requestId, webhookUrl: webhookUrl
+                )
+
+                // Store authToken for BLE transfer if provided
+                if let authToken = request.authToken, !authToken.isEmpty {
+                    transfer.authToken = authToken
+                }
+
+                blePhotoTransfers[bleImgId] = transfer
             }
 
-            blePhotoTransfers[bleImgId] = transfer
-        }
+            // Phone delivery never carries webhook credentials on the wire.
+            if !deliverToPhone, let authToken = request.authToken, !authToken.isEmpty {
+                json["authToken"] = authToken
+            }
 
-        // Add authToken to JSON if provided
-        if let authToken = request.authToken, !authToken.isEmpty {
-            json["authToken"] = authToken
+            Bridge.log(
+                "LIVE: PHOTO PIPELINE [5b/6] take_photo JSON ready bleImgId=\(bleImgId) transferMethod=\(transferMethod)"
+            )
         }
 
         let allowedSizes = ["low", "medium", "high", "max"]
@@ -2093,7 +2305,8 @@ class MentraLive: NSObject, SGCManager {
         json["mode"] = request.mode.rawValue
 
         json["compress"] = request.compress?.rawValue ?? "none"
-        json["save"] = request.save
+        // A glasses-only capture IS the save; the archival route on the glasses keys off it.
+        json["save"] = glassesOnly ? true : request.save
         json["sound"] = request.sound
 
         if let e = request.exposureTimeNs, e.isFinite, e > 0, e <= Double(Int64.max) {
@@ -2106,9 +2319,6 @@ class MentraLive: NSObject, SGCManager {
         }
         request.appendScanFields(to: &json)
 
-        Bridge.log(
-            "LIVE: PHOTO PIPELINE [5b/6] take_photo JSON ready bleImgId=\(bleImgId) transferMethod=\(request.transferMethod)"
-        )
         Bridge.log("LIVE: PHOTO PIPELINE [6/6] Dispatching take_photo to sendJson()")
 
         sendJson(json, wakeUp: true)
@@ -4487,15 +4697,29 @@ class MentraLive: NSObject, SGCManager {
     }
 
     private func processAndUploadBlePhoto(_ transfer: BlePhotoTransfer, imageData: Data) {
+        if transfer.deliverToPhone {
+            deliverBlePhotoToPhone(transfer, imageData: imageData)
+            return
+        }
+
+        guard let webhookUrl = transfer.webhookUrl, !webhookUrl.isEmpty else {
+            Bridge.sendPhotoError(
+                requestId: transfer.requestId,
+                errorCode: "PHONE_UPLOAD_FAILED",
+                errorMessage: "BLE photo transfer has no webhook destination"
+            )
+            return
+        }
+
         Bridge.log("LIVE: Processing BLE photo for upload. RequestId: \(transfer.requestId)")
 
         BlePhotoUploadService.processAndUploadPhoto(
-            imageData: imageData, requestId: transfer.requestId, webhookUrl: transfer.webhookUrl,
+            imageData: imageData, requestId: transfer.requestId, webhookUrl: webhookUrl,
             authToken: transfer.authToken
         ) { [weak self] requestId, responseBody in
             self?.sendPhotoTerminalSuccessResponse(
                 requestId: requestId,
-                uploadUrl: transfer.webhookUrl,
+                uploadUrl: webhookUrl,
                 responseBody: responseBody
             )
         } onError: { requestId, error in
@@ -4503,6 +4727,43 @@ class MentraLive: NSObject, SGCManager {
                 requestId: requestId,
                 errorCode: "PHONE_UPLOAD_FAILED",
                 errorMessage: "BLE photo upload failed: \(error)"
+            )
+        }
+    }
+
+    /// Deliver a completed BLE photo transfer to the phone itself (destinationKind
+    /// "phone"): convert to JPEG exactly as the webhook path does, persist the JPEG
+    /// under MentraLive_Images as the deliverable, optionally export it to the camera
+    /// roll, and emit the terminal photo_response with the fileUri. No upload service
+    /// involved.
+    private func deliverBlePhotoToPhone(_ transfer: BlePhotoTransfer, imageData: Data) {
+        Bridge.log("LIVE: Processing BLE photo for phone delivery. RequestId: \(transfer.requestId)")
+
+        BlePhotoUploadService.processAndStorePhotoOnPhone(
+            imageData: imageData,
+            requestId: transfer.requestId,
+            saveToCameraRoll: transfer.saveToCameraRoll
+        ) { requestId, delivery in
+            var event: [String: Any] = [
+                "type": "photo_response",
+                "state": "success",
+                "success": true,
+                "requestId": requestId,
+                "timestamp": Int(Date().timeIntervalSince1970 * 1000),
+                "fileUri": delivery.fileUri,
+                "mimeType": "image/jpeg",
+                "byteCount": delivery.byteCount,
+                "savedToCameraRoll": delivery.savedToCameraRoll,
+            ]
+            if let cameraRollError = delivery.cameraRollError {
+                event["cameraRollError"] = cameraRollError
+            }
+            Bridge.sendPhotoResponse(event)
+        } onError: { requestId, error in
+            Bridge.sendPhotoError(
+                requestId: requestId,
+                errorCode: "PHONE_DELIVERY_FAILED",
+                errorMessage: "BLE photo phone delivery failed: \(error)"
             )
         }
     }

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/MentraLive.swift
@@ -448,8 +448,11 @@ class BlePhotoUploadService {
         webhookUrl: String,
         authToken: String?
     ) async throws -> String {
-        guard let url = URL(string: webhookUrl) else {
-            Bridge.log("LIVE: Invalid webhook URL: \(webhookUrl)")
+        // The BLE relay may target the app's own LocalPhotoUploadServer; rewrite it to
+        // loopback (Android parity) so delivery survives Wi-Fi changes after registration.
+        let effectiveWebhookUrl = LocalPhotoReceiverRegistry.loopbackUploadUrl(for: webhookUrl) ?? webhookUrl
+        guard let url = URL(string: effectiveWebhookUrl) else {
+            Bridge.log("LIVE: Invalid webhook URL: \(effectiveWebhookUrl)")
             throw PhotoUploadError.uploadFailed("Invalid webhook URL")
         }
 
@@ -497,7 +500,11 @@ class BlePhotoUploadService {
 
         request.httpBody = body
 
-        Bridge.log("LIVE: Uploading photo to webhook: \(webhookUrl)")
+        if effectiveWebhookUrl != webhookUrl {
+            Bridge.log("LIVE: Uploading BLE fallback photo to local receiver via loopback: \(effectiveWebhookUrl)")
+        } else {
+            Bridge.log("LIVE: Uploading photo to webhook: \(webhookUrl)")
+        }
 
         do {
             let (data, response) = try await URLSession.shared.data(for: request)

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -178,6 +178,20 @@ export type PhotoResponseEvent =
       contentType?: string
       fileSizeBytes?: number
       timestamp: number
+      /**
+       * Local JPEG delivered for `destination: {kind: "phone"}` requests.
+       * The SDK keeps the file for at least 24 hours after delivery (a retention
+       * sweep then reclaims old files) — copy it elsewhere to keep it longer.
+       */
+      fileUri?: string
+      /** MIME type of {@link fileUri} (phone delivery always produces `image/jpeg`). */
+      mimeType?: string
+      /** Size of {@link fileUri} in bytes. */
+      byteCount?: number
+      /** Whether the photo was exported to the OS camera roll (phone delivery with `saveToCameraRoll`). */
+      savedToCameraRoll?: boolean
+      /** Short reason when the camera-roll export failed (e.g. permission denied); delivery still succeeded. */
+      cameraRollError?: string
     }
   | {
       type: "photo_response"
@@ -570,31 +584,94 @@ type NativeCameraFovSetting = {
 export type MicPreference = "auto" | "phone" | "glasses" | "bluetooth"
 export type MicMode = "phone" | "glasses" | "bluetoothClassic" | "bluetooth"
 
+/**
+ * Where a requested photo ends up. Exactly one arm per request; mixing an arm
+ * with the deprecated flat delivery fields throws at request time.
+ */
+export type PhotoDestination =
+  | {
+      kind: "webhook"
+      url: string
+      authToken?: string
+      /** auto|direct|ble — only meaningful for webhook delivery. */
+      transferMethod?: PhotoTransferMethod
+      /** Also keep a copy in the glasses gallery. */
+      keepOnGlasses?: boolean
+      /** Compression for the webhook upload; advisory when the BLE fallback kicks in. */
+      compress?: PhotoCompression
+    }
+  | {
+      kind: "phone"
+      /** Also export the delivered photo to the OS camera roll. */
+      saveToCameraRoll?: boolean
+      /** Also keep a copy in the glasses gallery (requires the PR-2a firmware gate). */
+      keepOnGlasses?: boolean
+    }
+  | {
+      kind: "glasses"
+    }
+
+/**
+ * How the capture is exposed. Exactly one arm per request; mixing an arm with
+ * the deprecated flat exposure fields throws at request time.
+ */
+export type PhotoExposure =
+  | {kind: "auto"; zsl?: boolean; mfnr?: boolean}
+  | {kind: "manual"; timeNs: number; iso?: number}
+  | {kind: "scan"; aeExposureDivisor?: number; isoCap?: number}
+
 export type PhotoRequestParams = {
   requestId?: string
   appId?: string
   size: PhotoSize
   mode?: PhotoMode
-  /** `direct` disables BLE fallback; `ble` skips direct upload and forces phone-relayed transfer. */
+  /** Where the photo ends up. Preferred over the deprecated flat delivery fields. */
+  destination?: PhotoDestination
+  /** How the capture is exposed. Preferred over the deprecated flat exposure fields. */
+  exposure?: PhotoExposure
+  /**
+   * `direct` disables BLE fallback; `ble` skips direct upload and forces phone-relayed transfer.
+   * @deprecated Use `destination: {kind: "webhook", transferMethod}` instead.
+   */
   transferMethod?: PhotoTransferMethod
-  webhookUrl: string | null
-  authToken: string | null
-  compress: PhotoCompression
+  /** @deprecated Use `destination: {kind: "webhook", url}` instead. */
+  webhookUrl?: string | null
+  /** @deprecated Use `destination: {kind: "webhook", authToken}` instead. */
+  authToken?: string | null
+  /** @deprecated Use `destination: {kind: "webhook", compress}` instead. */
+  compress?: PhotoCompression
+  /** @deprecated Use `destination: {kind: "glasses"}` or the `keepOnGlasses` arm fields instead. */
   save?: boolean
   sound: boolean
+  /** @deprecated Use `exposure: {kind: "manual", timeNs}` instead. */
   exposureTimeNs?: number | null
-  /** Sensor ISO for this capture only. Only used when exposureTimeNs enables manual exposure. */
+  /**
+   * Sensor ISO for this capture only. Only used when exposureTimeNs enables manual exposure.
+   * @deprecated Use `exposure: {kind: "manual", iso}` instead.
+   */
   iso?: number | null
-  /** After AE convergence, divide metered exposure by this factor (scan mode). */
+  /**
+   * After AE convergence, divide metered exposure by this factor (scan mode).
+   * @deprecated Use `exposure: {kind: "scan", aeExposureDivisor}` instead.
+   */
   aeExposureDivisor?: number
-  /** Cap ISO after AE metering (scan mode). */
+  /**
+   * Cap ISO after AE metering (scan mode).
+   * @deprecated Use `exposure: {kind: "scan", isoCap}` instead.
+   */
   isoCap?: number
   /** Requested on wire; glasses may log not_implemented. */
   noiseReduction?: boolean
   edgeEnhancement?: boolean
-  /** ZSL buffering. Forced off for manual/scan stills because fixed sensor controls take priority. */
+  /**
+   * ZSL buffering. Forced off for manual/scan stills because fixed sensor controls take priority.
+   * @deprecated Use `exposure: {kind: "auto", zsl}` instead.
+   */
   zsl?: boolean
-  /** MFNR still capture. Forced off for manual/scan stills because fixed sensor controls take priority. */
+  /**
+   * MFNR still capture. Forced off for manual/scan stills because fixed sensor controls take priority.
+   * @deprecated Use `exposure: {kind: "auto", mfnr}` instead.
+   */
   mfnr?: boolean
   ispDigitalGain?: number
   ispAnalogGain?: string
@@ -1138,7 +1215,13 @@ export interface BluetoothSdkPublicModule {
   startAr99OtaFromFile(path: string): Promise<boolean>
   cancelAr99Ota(): Promise<void>
   sendAr99FactoryReset(): Promise<void>
-  buildAr99OtaSignature(secret: string, appName: string, currentVersion: string, serialNumber: string, nonce: string): string
+  buildAr99OtaSignature(
+    secret: string,
+    appName: string,
+    currentVersion: string,
+    serialNumber: string,
+    nonce: string,
+  ): string
 
   // // stt commands (MOVE TO CRUST)
   // setSttModelDetails(path: string, languageCode: string): Promise<void>

--- a/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
+++ b/mobile/modules/bluetooth-sdk/src/BluetoothSdk.types.ts
@@ -260,6 +260,23 @@ export type PhotoResponseEvent =
       contentType?: string
       fileSizeBytes?: number
       timestamp: number
+      /**
+       * Local JPEG delivered for `destination: {kind: "phone"}` requests.
+       * The SDK's retention sweep (run once per transport session) deletes files
+       * older than 24 hours, and if the SDK's photo directory exceeds 256 MB it
+       * also evicts the oldest files first — so the file is normally kept for
+       * 24 hours but a burst of large captures can shorten that. Copy it
+       * elsewhere if you need it beyond the current session.
+       */
+      fileUri?: string
+      /** MIME type of {@link fileUri} (phone delivery always produces `image/jpeg`). */
+      mimeType?: string
+      /** Size of {@link fileUri} in bytes. */
+      byteCount?: number
+      /** Whether the photo was exported to the OS camera roll (phone delivery with `saveToCameraRoll`). */
+      savedToCameraRoll?: boolean
+      /** Short reason when the camera-roll export failed (e.g. permission denied); delivery still succeeded. */
+      cameraRollError?: string
     }
   | {
       type: "photo_response"
@@ -652,16 +669,58 @@ type NativeCameraFovSetting = {
 export type MicPreference = "auto" | "phone" | "glasses" | "bluetooth"
 export type MicMode = "phone" | "glasses" | "bluetoothClassic" | "bluetooth"
 
+/**
+ * Where a requested photo ends up. Exactly one arm per request; mixing an arm
+ * with the deprecated flat delivery fields throws at request time.
+ */
+export type PhotoDestination =
+  | {
+      kind: "webhook"
+      url: string
+      authToken?: string
+      /** auto|direct|ble — only meaningful for webhook delivery. */
+      transferMethod?: PhotoTransferMethod
+      /** Also keep a copy in the glasses gallery. */
+      keepOnGlasses?: boolean
+      /** Compression for the webhook upload; advisory when the BLE fallback kicks in. */
+      compress?: PhotoCompression
+    }
+  | {
+      kind: "phone"
+      /**
+       * Also export the delivered photo to the OS camera roll. The SDK never prompts
+       * for permission inside a capture: the app must already hold add-only Photos
+       * access (iOS, plus `NSPhotoLibraryAddUsageDescription`) or storage access
+       * (Android < 10); otherwise delivery still succeeds with `savedToCameraRoll: false`
+       * and a `cameraRollError`.
+       */
+      saveToCameraRoll?: boolean
+      /** Also keep a copy in the glasses gallery (requires the PR-2a firmware gate). */
+      keepOnGlasses?: boolean
+    }
+  | {
+      kind: "glasses"
+    }
+
 export type PhotoRequestParams = {
   requestId?: string
   appId?: string
   size: PhotoSize
   mode?: PhotoMode
-  /** `direct` disables BLE fallback; `ble` skips direct upload and forces phone-relayed transfer. */
+  /** Where the photo ends up. Preferred over the deprecated flat delivery fields. */
+  destination?: PhotoDestination
+  /**
+   * `direct` disables BLE fallback; `ble` skips direct upload and forces phone-relayed transfer.
+   * @deprecated Use `destination: {kind: "webhook", transferMethod}` instead.
+   */
   transferMethod?: PhotoTransferMethod
-  webhookUrl: string | null
-  authToken: string | null
-  compress: PhotoCompression
+  /** @deprecated Use `destination: {kind: "webhook", url}` instead. */
+  webhookUrl?: string | null
+  /** @deprecated Use `destination: {kind: "webhook", authToken}` instead. */
+  authToken?: string | null
+  /** @deprecated Use `destination: {kind: "webhook", compress}` instead. */
+  compress?: PhotoCompression
+  /** @deprecated Use `destination: {kind: "glasses"}` or the `keepOnGlasses` arm fields instead. */
   save?: boolean
   sound: boolean
   exposureTimeNs?: number | null

--- a/mobile/modules/bluetooth-sdk/src/__tests__/photoRequest.test.ts
+++ b/mobile/modules/bluetooth-sdk/src/__tests__/photoRequest.test.ts
@@ -1,0 +1,304 @@
+const {normalizePhotoRequestParams} = require("../photoRequest")
+
+const baseParams = {
+  requestId: "photo-1",
+  size: "medium",
+  sound: true,
+}
+
+describe("normalizePhotoRequestParams", () => {
+  describe("destination arms", () => {
+    it("maps the webhook arm onto the native dict", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {
+          kind: "webhook",
+          url: "https://example.com/upload",
+          authToken: "token-1",
+          transferMethod: "direct",
+          keepOnGlasses: true,
+          compress: "medium",
+        },
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.webhookUrl).toBe("https://example.com/upload")
+      expect(payload.authToken).toBe("token-1")
+      expect(payload.transferMethod).toBe("direct")
+      expect(payload.save).toBe(true)
+      expect(payload.compress).toBe("medium")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("defaults the webhook arm to auto transfer and no glasses copy", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "webhook", url: "https://example.com/upload"},
+      })
+
+      expect(payload.transferMethod).toBe("auto")
+      expect(payload.save).toBe(false)
+      expect(payload).not.toHaveProperty("authToken")
+    })
+
+    it("maps the phone arm: BLE transfer, no webhook fields", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "phone", saveToCameraRoll: true},
+      })
+
+      expect(payload.destinationKind).toBe("phone")
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.webhookUrl).toBe("")
+      expect(payload).not.toHaveProperty("authToken")
+      expect(payload.save).toBe(false)
+      expect(payload.saveToCameraRoll).toBe(true)
+    })
+
+    it("forces BLE transfer on the phone arm even without options", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination: {kind: "phone"}})
+
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("keeps a glasses copy for the phone arm when keepOnGlasses is set", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "phone", keepOnGlasses: true},
+      })
+
+      expect(payload.save).toBe(true)
+      expect(payload.transferMethod).toBe("ble")
+    })
+
+    it("maps the glasses arm: save true, no webhook fields", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination: {kind: "glasses"}})
+
+      expect(payload.destinationKind).toBe("glasses")
+      expect(payload.save).toBe(true)
+      expect(payload.transferMethod).toBe("auto")
+      expect(payload.webhookUrl).toBe("")
+      expect(payload).not.toHaveProperty("authToken")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+  })
+
+  describe("legacy destination derivation", () => {
+    it("derives a webhook destination from flat webhookUrl fields", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        webhookUrl: "https://example.com/upload",
+        authToken: "token-2",
+        transferMethod: "ble",
+        save: true,
+        compress: "heavy",
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.webhookUrl).toBe("https://example.com/upload")
+      expect(payload.authToken).toBe("token-2")
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.save).toBe(true)
+      expect(payload.compress).toBe("heavy")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("derives keepOnGlasses false when legacy save is unset", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        webhookUrl: "https://example.com/upload",
+        authToken: null,
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.save).toBe(false)
+      expect(payload.transferMethod).toBe("auto")
+    })
+
+    it("derives the glasses arm from save-only requests", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, webhookUrl: null, save: true})
+
+      expect(payload.destinationKind).toBe("glasses")
+      expect(payload.save).toBe(true)
+      expect(payload.webhookUrl).toBe("")
+    })
+
+    it("throws when there is no webhook and no save", () => {
+      expect(() => normalizePhotoRequestParams({...baseParams})).toThrow(TypeError)
+      expect(() => normalizePhotoRequestParams({...baseParams, webhookUrl: "  ", save: false})).toThrow(
+        /no destination/,
+      )
+    })
+  })
+
+  describe("mixed old/new destination fields", () => {
+    const destination = {kind: "phone"} as const
+
+    it.each([
+      ["webhookUrl", {webhookUrl: "https://example.com/upload"}],
+      ["authToken", {authToken: "token"}],
+      ["transferMethod", {transferMethod: "auto"}],
+      ["save", {save: false}],
+      ["compress", {compress: "none"}],
+    ])("throws when destination is combined with flat %s", (field, flat) => {
+      expect(() => normalizePhotoRequestParams({...baseParams, destination, ...flat})).toThrow(
+        new RegExp(`destination cannot be combined .*${field}`),
+      )
+    })
+
+    it("allows explicit null legacy fields alongside destination", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        webhookUrl: null,
+        authToken: null,
+      })
+
+      expect(payload.destinationKind).toBe("phone")
+    })
+  })
+
+  describe("mixed old/new exposure fields", () => {
+    const exposure = {kind: "auto"} as const
+
+    it.each([
+      ["exposureTimeNs", {exposureTimeNs: 8_333_333}],
+      ["iso", {iso: 400}],
+      ["aeExposureDivisor", {aeExposureDivisor: 3}],
+      ["isoCap", {isoCap: 800}],
+      ["zsl", {zsl: true}],
+      ["mfnr", {mfnr: false}],
+    ])("throws when exposure is combined with flat %s", (field, flat) => {
+      expect(() =>
+        normalizePhotoRequestParams({...baseParams, destination: {kind: "glasses"}, exposure, ...flat}),
+      ).toThrow(new RegExp(`exposure cannot be combined .*${field}`))
+    })
+  })
+
+  describe("loopback webhook validation", () => {
+    it.each(["http://127.0.0.1:8080/upload", "http://localhost/upload", "http://169.254.12.34:9090/upload"])(
+      "throws for direct transfer to phone-only host %s",
+      (url) => {
+        expect(() =>
+          normalizePhotoRequestParams({
+            ...baseParams,
+            destination: {kind: "webhook", url, transferMethod: "direct"},
+          }),
+        ).toThrow(/only reachable from this phone/)
+      },
+    )
+
+    it("allows loopback webhooks with auto or ble transfer", () => {
+      for (const transferMethod of ["auto", "ble"] as const) {
+        const payload = normalizePhotoRequestParams({
+          ...baseParams,
+          destination: {kind: "webhook", url: "http://127.0.0.1:8080/upload", transferMethod},
+        })
+        expect(payload.transferMethod).toBe(transferMethod)
+      }
+    })
+
+    it("allows direct transfer to a routable host", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "webhook", url: "http://192.168.1.20:8080/upload", transferMethod: "direct"},
+      })
+      expect(payload.transferMethod).toBe("direct")
+    })
+
+    it("also applies to legacy flat webhook fields", () => {
+      expect(() =>
+        normalizePhotoRequestParams({
+          ...baseParams,
+          webhookUrl: "http://localhost:8080/upload",
+          transferMethod: "direct",
+        }),
+      ).toThrow(/only reachable from this phone/)
+    })
+  })
+
+  describe("exposure arms", () => {
+    const destination = {kind: "glasses"} as const
+
+    it("maps the manual arm onto exposureTimeNs and iso", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        exposure: {kind: "manual", timeNs: 8_333_333, iso: 401.8},
+      })
+
+      expect(payload.exposureTimeNs).toBe(8_333_333)
+      expect(payload.iso).toBe(402)
+    })
+
+    it("maps the scan arm onto aeExposureDivisor and isoCap", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        exposure: {kind: "scan", aeExposureDivisor: 3, isoCap: 800},
+      })
+
+      expect(payload.aeExposureDivisor).toBe(3)
+      expect(payload.isoCap).toBe(800)
+      expect(payload).not.toHaveProperty("exposureTimeNs")
+    })
+
+    it("maps the auto arm onto zsl and mfnr", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        exposure: {kind: "auto", zsl: false, mfnr: true},
+      })
+
+      expect(payload.zsl).toBe(false)
+      expect(payload.mfnr).toBe(true)
+    })
+
+    it("derives the manual arm from legacy exposureTimeNs/iso", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        exposureTimeNs: 8_333_333,
+        iso: 400,
+      })
+
+      expect(payload.exposureTimeNs).toBe(8_333_333)
+      expect(payload.iso).toBe(400)
+    })
+
+    it("derives the scan arm from legacy aeExposureDivisor/isoCap", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination, aeExposureDivisor: 5, isoCap: 400})
+
+      expect(payload.aeExposureDivisor).toBe(5)
+      expect(payload.isoCap).toBe(400)
+    })
+
+    it("derives the auto arm from legacy zsl/mfnr and defaults to omitting them", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination, zsl: true, mfnr: false})
+      expect(payload.zsl).toBe(true)
+      expect(payload.mfnr).toBe(false)
+
+      const defaults = normalizePhotoRequestParams({...baseParams, destination})
+      expect(defaults).not.toHaveProperty("zsl")
+      expect(defaults).not.toHaveProperty("mfnr")
+    })
+  })
+
+  it("keeps flat capture fields and native payload conventions intact", () => {
+    const payload = normalizePhotoRequestParams({
+      ...baseParams,
+      size: "large",
+      mode: "text",
+      noiseReduction: false,
+      ispDigitalGain: 0,
+      destination: {kind: "phone"},
+    })
+
+    expect(payload.size).toBe("high")
+    expect(payload.mode).toBe("text")
+    expect(payload.noiseReduction).toBe(false)
+    expect(payload.ispDigitalGain).toBe(0)
+    expect(payload.requestId).toBe("photo-1")
+  })
+})

--- a/mobile/modules/bluetooth-sdk/src/__tests__/photoRequest.test.ts
+++ b/mobile/modules/bluetooth-sdk/src/__tests__/photoRequest.test.ts
@@ -1,0 +1,260 @@
+const {normalizePhotoRequestParams} = require("../photoRequest")
+
+const baseParams = {
+  requestId: "photo-1",
+  size: "medium",
+  sound: true,
+}
+
+describe("normalizePhotoRequestParams", () => {
+  describe("destination arms", () => {
+    it("maps the webhook arm onto the native dict", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {
+          kind: "webhook",
+          url: "https://example.com/upload",
+          authToken: "token-1",
+          transferMethod: "direct",
+          keepOnGlasses: true,
+          compress: "medium",
+        },
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.webhookUrl).toBe("https://example.com/upload")
+      expect(payload.authToken).toBe("token-1")
+      expect(payload.transferMethod).toBe("direct")
+      expect(payload.save).toBe(true)
+      expect(payload.compress).toBe("medium")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("defaults the webhook arm to auto transfer and no glasses copy", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "webhook", url: "https://example.com/upload"},
+      })
+
+      expect(payload.transferMethod).toBe("auto")
+      expect(payload.save).toBe(false)
+      expect(payload).not.toHaveProperty("authToken")
+    })
+
+    it("maps the phone arm: BLE transfer, no webhook fields", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "phone", saveToCameraRoll: true},
+      })
+
+      expect(payload.destinationKind).toBe("phone")
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.webhookUrl).toBe("")
+      expect(payload).not.toHaveProperty("authToken")
+      expect(payload.save).toBe(false)
+      expect(payload.saveToCameraRoll).toBe(true)
+    })
+
+    it("forces BLE transfer on the phone arm even without options", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination: {kind: "phone"}})
+
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("keeps a glasses copy for the phone arm when keepOnGlasses is set", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "phone", keepOnGlasses: true},
+      })
+
+      expect(payload.save).toBe(true)
+      expect(payload.transferMethod).toBe("ble")
+    })
+
+    it("maps the glasses arm: save true, no webhook fields", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, destination: {kind: "glasses"}})
+
+      expect(payload.destinationKind).toBe("glasses")
+      expect(payload.save).toBe(true)
+      expect(payload.transferMethod).toBe("auto")
+      expect(payload.webhookUrl).toBe("")
+      expect(payload).not.toHaveProperty("authToken")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+  })
+
+  describe("webhook arm validation", () => {
+    it.each(["", "   "])("throws when the webhook url is blank (%j)", (url) => {
+      expect(() =>
+        normalizePhotoRequestParams({...baseParams, destination: {kind: "webhook", url, keepOnGlasses: true}}),
+      ).toThrow(/requires a non-empty url/)
+    })
+  })
+
+  describe("legacy destination derivation", () => {
+    it("derives a webhook destination from flat webhookUrl fields", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        webhookUrl: "https://example.com/upload",
+        authToken: "token-2",
+        transferMethod: "ble",
+        save: true,
+        compress: "heavy",
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.webhookUrl).toBe("https://example.com/upload")
+      expect(payload.authToken).toBe("token-2")
+      expect(payload.transferMethod).toBe("ble")
+      expect(payload.save).toBe(true)
+      expect(payload.compress).toBe("heavy")
+      expect(payload.saveToCameraRoll).toBe(false)
+    })
+
+    it("derives keepOnGlasses false when legacy save is unset", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        webhookUrl: "https://example.com/upload",
+        authToken: null,
+      })
+
+      expect(payload.destinationKind).toBe("webhook")
+      expect(payload.save).toBe(false)
+      expect(payload.transferMethod).toBe("auto")
+    })
+
+    it("derives the glasses arm from save-only requests", () => {
+      const payload = normalizePhotoRequestParams({...baseParams, webhookUrl: null, save: true})
+
+      expect(payload.destinationKind).toBe("glasses")
+      expect(payload.save).toBe(true)
+      expect(payload.webhookUrl).toBe("")
+    })
+
+    it("throws when there is no webhook and no save", () => {
+      expect(() => normalizePhotoRequestParams({...baseParams})).toThrow(TypeError)
+      expect(() => normalizePhotoRequestParams({...baseParams, webhookUrl: "  ", save: false})).toThrow(
+        /no destination/,
+      )
+    })
+  })
+
+  describe("mixed old/new destination fields", () => {
+    const destination = {kind: "phone"} as const
+
+    it.each([
+      ["webhookUrl", {webhookUrl: "https://example.com/upload"}],
+      ["authToken", {authToken: "token"}],
+      ["transferMethod", {transferMethod: "auto"}],
+      ["save", {save: false}],
+      ["compress", {compress: "none"}],
+    ])("throws when destination is combined with flat %s", (field, flat) => {
+      expect(() => normalizePhotoRequestParams({...baseParams, destination, ...flat})).toThrow(
+        new RegExp(`destination cannot be combined .*${field}`),
+      )
+    })
+
+    it("allows explicit null legacy fields alongside destination", () => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination,
+        webhookUrl: null,
+        authToken: null,
+      })
+
+      expect(payload.destinationKind).toBe("phone")
+    })
+  })
+
+  describe("loopback webhook validation", () => {
+    it.each([
+      "http://127.0.0.1:8080/upload",
+      "http://127.0.0.2/upload",
+      "http://127.255.255.254/upload",
+      "http://127.1/upload",
+      "http://127.0.1/upload",
+      "http://2130706433/upload",
+      "http://0x7f.1/upload",
+      "http://0177.0.0.1/upload",
+      "http://169.254.1/upload",
+      "http://[::1]:8080/upload",
+      "http://[0:0::1]/upload",
+      "http://[0:0:0:0:0:0:0:1]/upload",
+      "http://[::ffff:127.0.0.1]/upload",
+      "http://[::FFFF:169.254.1.2]/upload",
+      "http://[fe80::1%25en0]:8080/upload",
+      "http://[FE90::1]/upload",
+      "http://[febf:0:0:0:1:2:3:4]/upload",
+      "http://localhost/upload",
+      "http://169.254.12.34:9090/upload",
+    ])("throws for direct transfer to phone-only host %s", (url) => {
+      expect(() =>
+        normalizePhotoRequestParams({
+          ...baseParams,
+          destination: {kind: "webhook", url, transferMethod: "direct"},
+        }),
+      ).toThrow(/only reachable from this phone/)
+    })
+
+    it("allows loopback webhooks with auto or ble transfer", () => {
+      for (const transferMethod of ["auto", "ble"] as const) {
+        const payload = normalizePhotoRequestParams({
+          ...baseParams,
+          destination: {kind: "webhook", url: "http://127.0.0.1:8080/upload", transferMethod},
+        })
+        expect(payload.transferMethod).toBe(transferMethod)
+      }
+    })
+
+    it.each([
+      "http://192.168.1.20:8080/upload",
+      "http://[2001:db8::1]/upload",
+      "http://[fec0::1]/upload",
+      "http://[::ffff:192.168.1.20]/upload",
+      "http://[::2]/upload",
+      "http://192.168.1/upload",
+      "http://3232235796/upload",
+      "https://uploads.example.com/upload",
+    ])("allows direct transfer to routable host %s", (url) => {
+      const payload = normalizePhotoRequestParams({
+        ...baseParams,
+        destination: {kind: "webhook", url, transferMethod: "direct"},
+      })
+      expect(payload.transferMethod).toBe("direct")
+    })
+
+    it("also applies to legacy flat webhook fields", () => {
+      expect(() =>
+        normalizePhotoRequestParams({
+          ...baseParams,
+          webhookUrl: "http://localhost:8080/upload",
+          transferMethod: "direct",
+        }),
+      ).toThrow(/only reachable from this phone/)
+    })
+  })
+
+  it("keeps flat capture fields and native payload conventions intact", () => {
+    const payload = normalizePhotoRequestParams({
+      ...baseParams,
+      size: "large",
+      mode: "text",
+      noiseReduction: false,
+      ispDigitalGain: 0,
+      exposureTimeNs: 8_333_333,
+      iso: 401.8,
+      zsl: false,
+      destination: {kind: "phone"},
+    })
+
+    expect(payload.size).toBe("high")
+    expect(payload.mode).toBe("text")
+    expect(payload.noiseReduction).toBe(false)
+    expect(payload.ispDigitalGain).toBe(0)
+    expect(payload.exposureTimeNs).toBe(8_333_333)
+    expect(payload.iso).toBe(402)
+    expect(payload.zsl).toBe(false)
+    expect(payload.requestId).toBe("photo-1")
+  })
+})

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -49,8 +49,9 @@ import {
   WifiSearchResult,
   WifiStatusChangeEvent,
 } from "../BluetoothSdk.types"
+// eslint-disable-next-line no-restricted-imports -- standalone npm package; the @/ alias is mobile-app-only
+import {normalizePhotoRequestParams} from "../photoRequest"
 import {warmUpCameraParamsForNative} from "./cameraRequestPayload"
-import {photoRequestParamsForNative} from "./photoRequestPayload"
 
 /**
  * Private React Native native-module facade.
@@ -293,7 +294,7 @@ const CAMERA_ROI_POSITION_VALUES: Record<CameraRoiPosition, CameraFovSetting["ro
 }
 
 // Named presets are a convenience layer over the numeric {fov, roiPosition} API.
-// The default is the full sensor; "standard" preserves the historical 102° crop.
+// The default is the full sensor; "standard" preserves the historical 102ï¿½ crop.
 const CAMERA_FOV_PRESETS: Record<CameraFovPreset, CameraFovSetting> = {
   narrow: {fov: 82, roiPosition: 0},
   standard: {fov: 102, roiPosition: 0},
@@ -639,7 +640,7 @@ NativeBluetoothSdkModule.scan = async function (modelOrOptions: DeviceModel | Sc
 
 const nativeRequestPhoto = NativeBluetoothSdkModule.requestPhoto.bind(NativeBluetoothSdkModule)
 NativeBluetoothSdkModule.requestPhoto = function (params: PhotoRequestParams) {
-  return nativeRequestPhoto(photoRequestParamsForNative(params) as unknown as PhotoRequestParams)
+  return nativeRequestPhoto(normalizePhotoRequestParams(params) as unknown as PhotoRequestParams)
 }
 
 const nativeWarmUpCamera = NativeBluetoothSdkModule.warmUpCamera.bind(NativeBluetoothSdkModule)

--- a/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/BluetoothSdkModule.ts
@@ -59,8 +59,9 @@ import {
   WifiSearchResult,
   WifiStatusChangeEvent,
 } from "../BluetoothSdk.types"
+// eslint-disable-next-line no-restricted-imports -- standalone npm package; the @/ alias is mobile-app-only
+import {normalizePhotoRequestParams} from "../photoRequest"
 import {warmUpCameraParamsForNative} from "./cameraRequestPayload"
-import {photoRequestParamsForNative} from "./photoRequestPayload"
 
 /**
  * Private React Native native-module facade.
@@ -639,7 +640,7 @@ NativeBluetoothSdkModule.scan = async function (modelOrOptions: DeviceModel | Sc
 
 const nativeRequestPhoto = NativeBluetoothSdkModule.requestPhoto.bind(NativeBluetoothSdkModule)
 NativeBluetoothSdkModule.requestPhoto = function (params: PhotoRequestParams) {
-  return nativeRequestPhoto(photoRequestParamsForNative(params) as unknown as PhotoRequestParams)
+  return nativeRequestPhoto(normalizePhotoRequestParams(params) as unknown as PhotoRequestParams)
 }
 
 const nativeWarmUpCamera = NativeBluetoothSdkModule.warmUpCamera.bind(NativeBluetoothSdkModule)

--- a/mobile/modules/bluetooth-sdk/src/_private/photoRequestPayload.ts
+++ b/mobile/modules/bluetooth-sdk/src/_private/photoRequestPayload.ts
@@ -41,8 +41,10 @@ export function photoRequestParamsForNative(params: PhotoRequestParams): Record<
     mode: params.mode ?? "photo",
     transferMethod: photoTransferMethodForNative(params.transferMethod),
     webhookUrl: params.webhookUrl ?? "",
-    compress: params.compress,
     sound: params.sound,
+  }
+  if (params.compress != null) {
+    payload.compress = params.compress
   }
   const requestId = nonBlankString(params.requestId)
   if (requestId != null) {

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -218,6 +218,8 @@ export type {
   PhotoCaptureMetadata,
   PhotoResolvedConfig,
   PhotoCompression,
+  PhotoDestination,
+  PhotoExposure,
   PhotoFpsRange,
   PhotoMeteredPreview,
   PhotoMode,

--- a/mobile/modules/bluetooth-sdk/src/index.ts
+++ b/mobile/modules/bluetooth-sdk/src/index.ts
@@ -265,6 +265,7 @@ export type {
   PhotoCaptureMetadata,
   PhotoResolvedConfig,
   PhotoCompression,
+  PhotoDestination,
   PhotoFpsRange,
   PhotoMeteredPreview,
   PhotoMode,

--- a/mobile/modules/bluetooth-sdk/src/photoRequest.ts
+++ b/mobile/modules/bluetooth-sdk/src/photoRequest.ts
@@ -1,0 +1,168 @@
+import type {PhotoDestination, PhotoExposure, PhotoRequestParams, PhotoTransferMethod} from "./BluetoothSdk.types"
+import {photoRequestParamsForNative} from "./_private/photoRequestPayload"
+
+/**
+ * Flat dict handed to the native `requestPhoto` implementation. Same shape as
+ * the legacy payload plus the destination fields; nullish values are omitted
+ * (Expo Android bridge rejects null in Map<String, Any>), with "no webhook"
+ * encoded as an empty `webhookUrl` and an absent `authToken`.
+ */
+export type NativePhotoRequest = Record<string, string | number | boolean> & {
+  destinationKind: PhotoDestination["kind"]
+  saveToCameraRoll: boolean
+  save: boolean
+  transferMethod: PhotoTransferMethod
+  webhookUrl: string
+}
+
+const DESTINATION_LEGACY_FIELDS = ["webhookUrl", "authToken", "transferMethod", "save", "compress"] as const
+const EXPOSURE_LEGACY_FIELDS = ["exposureTimeNs", "iso", "aeExposureDivisor", "isoCap", "zsl", "mfnr"] as const
+
+function assertNoLegacyFields(
+  params: PhotoRequestParams,
+  fields: readonly (keyof PhotoRequestParams)[],
+  unionName: "destination" | "exposure",
+): void {
+  const mixed = fields.filter((field) => params[field] != null)
+  if (mixed.length > 0) {
+    throw new TypeError(
+      `requestPhoto: ${unionName} cannot be combined with the deprecated flat field(s) ${mixed.join(", ")}. ` +
+        `Move them into the ${unionName} object.`,
+    )
+  }
+}
+
+function resolveDestination(params: PhotoRequestParams): PhotoDestination {
+  if (params.destination != null) {
+    assertNoLegacyFields(params, DESTINATION_LEGACY_FIELDS, "destination")
+    return params.destination
+  }
+  const url = params.webhookUrl?.trim()
+  if (url) {
+    return {
+      kind: "webhook",
+      url,
+      authToken: params.authToken ?? undefined,
+      transferMethod: params.transferMethod,
+      keepOnGlasses: !!params.save,
+      compress: params.compress,
+    }
+  }
+  if (params.save) {
+    return {kind: "glasses"}
+  }
+  throw new TypeError(
+    'requestPhoto: no destination. Pass destination: {kind: "webhook" | "phone" | "glasses"} ' +
+      "(or the deprecated webhookUrl / save fields).",
+  )
+}
+
+function resolveExposure(params: PhotoRequestParams): PhotoExposure {
+  if (params.exposure != null) {
+    assertNoLegacyFields(params, EXPOSURE_LEGACY_FIELDS, "exposure")
+    return params.exposure
+  }
+  if (params.exposureTimeNs != null) {
+    return {kind: "manual", timeNs: params.exposureTimeNs, iso: params.iso ?? undefined}
+  }
+  if (params.aeExposureDivisor != null || params.isoCap != null) {
+    return {kind: "scan", aeExposureDivisor: params.aeExposureDivisor, isoCap: params.isoCap}
+  }
+  return {kind: "auto", zsl: params.zsl, mfnr: params.mfnr}
+}
+
+/** Host part of an absolute URL; avoids the incomplete React Native URL implementation. */
+function webhookHost(url: string): string | undefined {
+  const match = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]+)/.exec(url.trim())
+  if (!match) {
+    return undefined
+  }
+  const hostPort = match[1].slice(match[1].lastIndexOf("@") + 1)
+  if (hostPort.startsWith("[")) {
+    const end = hostPort.indexOf("]")
+    return end === -1 ? undefined : hostPort.slice(1, end).toLowerCase()
+  }
+  const colon = hostPort.indexOf(":")
+  return (colon === -1 ? hostPort : hostPort.slice(0, colon)).toLowerCase()
+}
+
+function isPhoneOnlyHost(host: string): boolean {
+  return host === "127.0.0.1" || host === "localhost" || host.startsWith("169.254.")
+}
+
+/**
+ * Validates a public {@link PhotoRequestParams} shape (union arms XOR the
+ * deprecated flat fields) and flattens it to the {@link NativePhotoRequest}
+ * dict the native bridge understands.
+ */
+export function normalizePhotoRequestParams(params: PhotoRequestParams): NativePhotoRequest {
+  const destination = resolveDestination(params)
+  const exposure = resolveExposure(params)
+
+  if (destination.kind === "webhook" && destination.transferMethod === "direct") {
+    const host = webhookHost(destination.url)
+    if (host != null && isPhoneOnlyHost(host)) {
+      throw new TypeError(
+        `requestPhoto: webhook host "${host}" is only reachable from this phone, so ` +
+          'transferMethod "direct" can never deliver there. Use "auto" or "ble".',
+      )
+    }
+  }
+
+  const {
+    destination: _destination,
+    exposure: _exposure,
+    webhookUrl: _webhookUrl,
+    authToken: _authToken,
+    transferMethod: _transferMethod,
+    save: _save,
+    compress: _compress,
+    exposureTimeNs: _exposureTimeNs,
+    iso: _iso,
+    aeExposureDivisor: _aeExposureDivisor,
+    isoCap: _isoCap,
+    zsl: _zsl,
+    mfnr: _mfnr,
+    ...captureFields
+  } = params
+  const flat: PhotoRequestParams = {...captureFields}
+
+  switch (destination.kind) {
+    case "webhook":
+      flat.webhookUrl = destination.url
+      flat.authToken = destination.authToken ?? null
+      flat.transferMethod = destination.transferMethod
+      flat.save = destination.keepOnGlasses ?? false
+      flat.compress = destination.compress
+      break
+    case "phone":
+      flat.transferMethod = "ble"
+      flat.save = destination.keepOnGlasses ?? false
+      break
+    case "glasses":
+      flat.transferMethod = "auto"
+      flat.save = true
+      break
+  }
+
+  switch (exposure.kind) {
+    case "manual":
+      flat.exposureTimeNs = exposure.timeNs
+      flat.iso = exposure.iso
+      break
+    case "scan":
+      flat.aeExposureDivisor = exposure.aeExposureDivisor
+      flat.isoCap = exposure.isoCap
+      break
+    case "auto":
+      flat.zsl = exposure.zsl
+      flat.mfnr = exposure.mfnr
+      break
+  }
+
+  return {
+    ...photoRequestParamsForNative(flat),
+    destinationKind: destination.kind,
+    saveToCameraRoll: destination.kind === "phone" && destination.saveToCameraRoll === true,
+  } as NativePhotoRequest
+}

--- a/mobile/modules/bluetooth-sdk/src/photoRequest.ts
+++ b/mobile/modules/bluetooth-sdk/src/photoRequest.ts
@@ -1,0 +1,202 @@
+import type {PhotoDestination, PhotoRequestParams, PhotoTransferMethod} from "./BluetoothSdk.types"
+import {photoRequestParamsForNative} from "./_private/photoRequestPayload"
+
+/**
+ * Flat dict handed to the native `requestPhoto` implementation. Same shape as
+ * the legacy payload plus the destination fields; nullish values are omitted
+ * (Expo Android bridge rejects null in Map<String, Any>), with "no webhook"
+ * encoded as an empty `webhookUrl` and an absent `authToken`.
+ */
+export type NativePhotoRequest = Record<string, string | number | boolean> & {
+  destinationKind: PhotoDestination["kind"]
+  saveToCameraRoll: boolean
+  save: boolean
+  transferMethod: PhotoTransferMethod
+  webhookUrl: string
+}
+
+const DESTINATION_LEGACY_FIELDS = ["webhookUrl", "authToken", "transferMethod", "save", "compress"] as const
+
+function resolveDestination(params: PhotoRequestParams): PhotoDestination {
+  if (params.destination != null) {
+    const mixed = DESTINATION_LEGACY_FIELDS.filter((field) => params[field] != null)
+    if (mixed.length > 0) {
+      throw new TypeError(
+        `requestPhoto: destination cannot be combined with the deprecated flat field(s) ${mixed.join(", ")}. ` +
+          "Move them into the destination object.",
+      )
+    }
+    if (params.destination.kind === "webhook" && !params.destination.url?.trim()) {
+      // An empty webhook would reach the glasses as "no delivery target" and silently
+      // turn into an archival (glasses-only) capture.
+      throw new TypeError('requestPhoto: destination {kind: "webhook"} requires a non-empty url.')
+    }
+    return params.destination
+  }
+  const url = params.webhookUrl?.trim()
+  if (url) {
+    return {
+      kind: "webhook",
+      url,
+      authToken: params.authToken ?? undefined,
+      transferMethod: params.transferMethod,
+      keepOnGlasses: !!params.save,
+      compress: params.compress,
+    }
+  }
+  if (params.save) {
+    return {kind: "glasses"}
+  }
+  throw new TypeError(
+    'requestPhoto: no destination. Pass destination: {kind: "webhook" | "phone" | "glasses"} ' +
+      "(or the deprecated webhookUrl / save fields).",
+  )
+}
+
+/** Host part of an absolute URL; avoids the incomplete React Native URL implementation. */
+function webhookHost(url: string): string | undefined {
+  const match = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/([^/?#]+)/.exec(url.trim())
+  if (!match) {
+    return undefined
+  }
+  const hostPort = match[1].slice(match[1].lastIndexOf("@") + 1)
+  if (hostPort.startsWith("[")) {
+    const end = hostPort.indexOf("]")
+    return end === -1 ? undefined : hostPort.slice(1, end).toLowerCase()
+  }
+  const colon = hostPort.indexOf(":")
+  return (colon === -1 ? hostPort : hostPort.slice(0, colon)).toLowerCase()
+}
+
+/**
+ * Four octets of a numeric IPv4 host, accepting every form the platform network
+ * stacks (inet_aton) accept — not just dotted quads: 1 to 4 components, each
+ * decimal, `0x` hex or leading-zero octal, with the last component filling the
+ * remaining bytes (`127.1` → 127.0.0.1, `2130706433` → 127.0.0.1,
+ * `169.254.1` → 169.254.0.1). Undefined for anything that is not numeric.
+ */
+function parseIPv4(host: string): number[] | undefined {
+  const parts = host.split(".")
+  if (parts.length < 1 || parts.length > 4) return undefined
+  const values: number[] = []
+  for (const part of parts) {
+    let value: number
+    if (/^0x[0-9a-f]+$/i.test(part)) value = parseInt(part.slice(2), 16)
+    else if (/^0[0-7]+$/.test(part)) value = parseInt(part, 8)
+    else if (/^\d+$/.test(part)) value = Number(part)
+    else return undefined
+    values.push(value)
+  }
+  const last = values[values.length - 1]
+  const lastBytes = 5 - values.length // the final component spans the remaining bytes
+  if (values.slice(0, -1).some((value) => value > 255) || last >= 2 ** (8 * lastBytes)) return undefined
+  const octets = values.slice(0, -1)
+  for (let shift = lastBytes - 1; shift >= 0; shift--) octets.push((last >>> (8 * shift)) & 0xff)
+  return octets
+}
+
+/** Eight 16-bit groups of an IPv6 literal (zone id and embedded IPv4 handled), or undefined. */
+function parseIPv6(host: string): number[] | undefined {
+  let text = host.toLowerCase()
+  const zone = text.indexOf("%")
+  if (zone !== -1) text = text.slice(0, zone)
+  if (text.includes(".")) {
+    const lastColon = text.lastIndexOf(":")
+    const embedded = parseIPv4(text.slice(lastColon + 1))
+    if (!embedded) return undefined
+    text = `${text.slice(0, lastColon + 1)}${((embedded[0] << 8) | embedded[1]).toString(16)}:${(
+      (embedded[2] << 8) |
+      embedded[3]
+    ).toString(16)}`
+  }
+  const halves = text.split("::")
+  if (halves.length > 2) return undefined
+  const toGroups = (part: string): number[] | undefined => {
+    if (part === "") return []
+    const groups = part.split(":").map((group) => (/^[0-9a-f]{1,4}$/.test(group) ? parseInt(group, 16) : NaN))
+    return groups.some((group) => Number.isNaN(group)) ? undefined : groups
+  }
+  const head = toGroups(halves[0])
+  const tail = halves.length === 2 ? toGroups(halves[1]) : []
+  if (!head || !tail) return undefined
+  const missing = 8 - head.length - tail.length
+  if (halves.length === 2 ? missing < 1 : missing !== 0) return undefined
+  return [...head, ...new Array<number>(missing).fill(0), ...tail]
+}
+
+/**
+ * Hosts only the phone itself can reach: `localhost`, IPv4 loopback (127/8) and
+ * link-local (169.254/16), IPv6 loopback (::1) and link-local (fe80::/10), and
+ * IPv4-mapped forms of the IPv4 ranges. Compared as addresses, not spellings.
+ * The glasses can never deliver directly to any of these; only the phone-side
+ * BLE relay can.
+ */
+function isPhoneOnlyHost(host: string): boolean {
+  if (host === "localhost") return true
+  const isPhoneOnlyIPv4 = (octets: number[]): boolean => octets[0] === 127 || (octets[0] === 169 && octets[1] === 254)
+  const v4 = parseIPv4(host)
+  if (v4) return isPhoneOnlyIPv4(v4)
+  const v6 = parseIPv6(host)
+  if (!v6) return false
+  if (v6.slice(0, 7).every((group) => group === 0) && v6[7] === 1) return true // ::1
+  if ((v6[0] & 0xffc0) === 0xfe80) return true // fe80::/10
+  if (v6.slice(0, 5).every((group) => group === 0) && v6[5] === 0xffff) {
+    // ::ffff:a.b.c.d
+    return isPhoneOnlyIPv4([v6[6] >> 8, v6[6] & 0xff, v6[7] >> 8, v6[7] & 0xff])
+  }
+  return false
+}
+
+/**
+ * Validates a public {@link PhotoRequestParams} shape (a destination arm XOR
+ * the deprecated flat delivery fields) and flattens it to the
+ * {@link NativePhotoRequest} dict the native bridge understands.
+ */
+export function normalizePhotoRequestParams(params: PhotoRequestParams): NativePhotoRequest {
+  const destination = resolveDestination(params)
+
+  if (destination.kind === "webhook" && destination.transferMethod === "direct") {
+    const host = webhookHost(destination.url)
+    if (host != null && isPhoneOnlyHost(host)) {
+      throw new TypeError(
+        `requestPhoto: webhook host "${host}" is only reachable from this phone, so ` +
+          'transferMethod "direct" can never deliver there. Use "auto" or "ble".',
+      )
+    }
+  }
+
+  const {
+    destination: _destination,
+    webhookUrl: _webhookUrl,
+    authToken: _authToken,
+    transferMethod: _transferMethod,
+    save: _save,
+    compress: _compress,
+    ...captureFields
+  } = params
+  const flat: PhotoRequestParams = {...captureFields}
+
+  switch (destination.kind) {
+    case "webhook":
+      flat.webhookUrl = destination.url
+      flat.authToken = destination.authToken ?? null
+      flat.transferMethod = destination.transferMethod
+      flat.save = destination.keepOnGlasses ?? false
+      flat.compress = destination.compress
+      break
+    case "phone":
+      flat.transferMethod = "ble"
+      flat.save = destination.keepOnGlasses ?? false
+      break
+    case "glasses":
+      flat.transferMethod = "auto"
+      flat.save = true
+      break
+  }
+
+  return {
+    ...photoRequestParamsForNative(flat),
+    destinationKind: destination.kind,
+    saveToCameraRoll: destination.kind === "phone" && destination.saveToCameraRoll === true,
+  } as NativePhotoRequest
+}


### PR DESCRIPTION
## Scope

Bluetooth SDK half of [OS-1796](https://linear.app/mentralabs/issue/OS-1796): BLE photos can be delivered to the phone instead of relayed to a webhook. This PR now carries what used to be #3615 (iOS loopback parity, folded in — the July stack went stale against dev) plus the destination union, rebased on current `dev` and targeting `dev` directly. Design: `agents/os-1796-ble-photo-phone-delivery-plan.md`; exact cross-layer contract: `agents/os-1796-pr2b-contract.md` (both updated in this PR).

**Firmware gate:** `keepOnGlasses` on the phone arm depends on #3616 (the archival route on the glasses now keys on `transferMethod !== "ble"`). #3616 must roll out via the firmware train before this reaches users. The `exposure` union sketched in the plan is deferred to a follow-up so this stays a delivery-only API change.

### Commit 1 — iOS loopback parity (was #3615)
Android's BLE fallback relay rewrites webhook URLs that target the in-process `LocalPhotoUploadServer` to `127.0.0.1`; iOS posted to the literal LAN URL and failed off Wi-Fi. `ios/Source/LocalPhotoReceiverRegistry.swift` is a 1:1 port of the Java registry semantics; `MentraPhotoReceiverModule` registers/unregisters; `uploadToWebhook` resolves through it. (Re-applied by hand on dev: the original commit also reformatted the whole module file, which dev never adopted.)

### Commit 2 — `destination` union
`PhotoRequestParams` gains `destination`:

```ts
| {kind: "webhook", url, authToken?, transferMethod?, keepOnGlasses?, compress?}
| {kind: "phone", saveToCameraRoll?, keepOnGlasses?}
| {kind: "glasses"}
```

- Deprecated flat fields (`webhookUrl`/`authToken`/`transferMethod`/`save`/`compress`) stay functional and are normalized onto the union; mixing them with a `destination` throws `TypeError`, and so does a webhook arm with a blank `url`. A webhook on a phone-only host with `transferMethod: "direct"` is rejected at request time — compared as an address, not a spelling (127/8 and 169.254/16 in every numeric form the network stacks accept — dotted quad, `127.1`, `2130706433`, hex/octal components — `::1` in any form, fe80::/10, IPv4-mapped forms, `localhost`).
- `{kind: "phone"}` rides BLE with no webhook on the wire. On completion the SDK converts to JPEG preserving IMU EXIF (same conversion as the relay), writes `MentraLive_Images/PHONE_<requestId>_<ts>.jpg` (requestId reduced to `[A-Za-z0-9._-]`, max 64), optionally exports to the OS camera roll (in-module MediaStore / PHPhotoLibrary; denial degrades to `savedToCameraRoll: false` + `cameraRollError`), and resolves with `{fileUri, mimeType, byteCount, savedToCameraRoll}` — fileUri only, no inline bytes on the native bridge.
- `{kind: "glasses"}` reifies today's save-without-webhook archival capture: no `bleImgId`, no transfer registration.
- Phone delivery gets a 60 s terminal deadline in the SDK entry points (webhook requests keep 30 s): it always rides BLE end to end, so a max-size transfer must not be cut off by the generic deadline. The SDK never prompts for camera-roll permission inside a capture (a dialog would sit inside that deadline): the app holds add-only Photos / storage access up front, and an undecided or denied status degrades to `savedToCameraRoll: false` + `cameraRollError`. The example app requests the permission when the toggle is switched on.
- `MentraLive_Images` is swept once per transport session: 24h TTL, then oldest-first down to 256 MB (legacy `BLE_*.avif` debug copies included). The type documents that the size cap can shorten the 24h window.
- Example app: "deliver to phone" / "save to camera roll" toggles, renders the returned `fileUri`.

### Review findings addressed
July Codex connector: loopback check covers the full loopback/link-local ranges; requestId is sanitized before building the file name (both platforms); retention wording no longer promises a 24h floor the size cap cannot keep. Local Codex (gpt-6-astra) rounds 1–2: no permission prompt inside a capture; blank webhook `url` rejected; loopback/link-local compared as parsed addresses including abbreviated/numeric IPv4 forms.

## Test evidence
- TS: `bun run compile` (mobile tsc) clean; jest `photoRequest.test.ts` + `photoRequestParamsForNative.test.ts` 64 pass; changed files eslint-clean (remaining errors on `App.tsx`/`LocalMiniappRuntime.ts` are pre-existing on dev).
- Android: `./scripts/check-android-compile.sh bluetooth-sdk` BUILD SUCCESSFUL.
- iOS: `xcrun swiftc -parse` clean on all changed Swift files; `swiftformat --lint` clean on the new/edited regions (the pre-existing drift in `CameraModels.swift`/`DeviceManager.swift`/`MentraPhotoReceiverModule.swift` is untouched).
- Hardware verification (both platforms: `fileUri` delivery, camera-roll opt-in + denial, `keepOnGlasses` gallery copy on #3616 firmware) still to run before merge.

## Notes
- SDK version bump intentionally left to the usual dev-release flow.
- Native event emits `mimeType` alongside the pre-existing `contentType`; Android adds pre-Q `WRITE_EXTERNAL_STORAGE` (maxSdkVersion 28) for camera-roll export on API 28; the podspec links `Photos`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
