### PR TITLE
Offer the hotspot-served install when glasses have no WiFi

### DIFF
--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -10,9 +10,12 @@ import {useAppTheme} from "@/contexts/ThemeContext"
 import {useEngineSnapshot} from "@/hooks/useEngineSnapshot"
 import {translate} from "@/i18n/translate"
 import {useNavigationStore} from "@/stores/navigation"
+import {showAlert} from "@/utils/AlertUtils"
 import {getNextOnboardingRoute} from "@/utils/onboarding/getNextOnboardingRoute"
 
-type CheckState = "checking" | "update_available" | "no_update" | "dev_build" | "error"
+type CheckState = "checking" | "update_available" | "preparing" | "no_update" | "dev_build" | "error"
+
+type CheckResult = Awaited<ReturnType<typeof engine.ota.checkForUpdates>>
 
 export default function OtaCheckForUpdatesScreen() {
   const {theme} = useAppTheme()
@@ -34,6 +37,11 @@ export default function OtaCheckForUpdatesScreen() {
   /** Distinguishes retryable network trouble from a dead pin (remedy: update the app). */
   const [errorKind, setErrorKind] = useState<"network" | "pin_unavailable">("network")
   const [checkKey, setCheckKey] = useState(0)
+  /** Hotspot-served path (no glasses WiFi): phone-download percent + link phase. */
+  const [preparingPercent, setPreparingPercent] = useState<number | null>(null)
+  const [preparingPhase, setPreparingPhase] = useState<"downloading" | "connecting">("downloading")
+  /** Full check result of the update currently offered — the hotspot path serves its manifest. */
+  const lastCheckResultRef = useRef<CheckResult | null>(null)
   /** Incremented each effect run so stale async performCheck exits before mutating state. */
   const performCheckGenerationRef = useRef(0)
   const activeCheckKeyRef = useRef<number | null>(null)
@@ -142,6 +150,7 @@ export default function OtaCheckForUpdatesScreen() {
         if (result.updateAvailable && result.updateInfo) {
           console.log("📱 Updates available - setting update_available state")
           checkCompletedRef.current = true
+          lastCheckResultRef.current = result
           setIsUpdateRequired(result.isRequired)
           setIsDowngradeUpdate(result.updateInfo.isDowngrade === true)
           setCheckState("update_available")
@@ -205,9 +214,47 @@ export default function OtaCheckForUpdatesScreen() {
     setCheckKey((k) => k + 1)
   }
 
+  /**
+   * Hotspot-served install (OS-1676): glasses have no WiFi, so the phone downloads the
+   * artifacts over its own connection (the user's tap here is the consent), brings the
+   * glasses hotspot up, and serves the update locally. Once the session is active the
+   * progress screen's install coordinator drives ota_start through it automatically.
+   */
+  const startHotspotUpdate = async (result: CheckResult) => {
+    setPreparingPercent(null)
+    setPreparingPhase("downloading")
+    setCheckState("preparing")
+    const offPhase = engine.ota.hotspotSession.onPhase((phase) => {
+      if (phase === "connecting" || phase === "serving") setPreparingPhase("connecting")
+    })
+    try {
+      await engine.ota.hotspotSession.begin(result, (progress) => {
+        setPreparingPercent(progress.artifactPercent)
+      })
+      engine.ota.clearProgress()
+      replace("/ota/progress")
+    } catch (error) {
+      console.error("OTA: hotspot session bring-up failed:", error)
+      await engine.ota.hotspotSession.end().catch(() => {})
+      setCheckState("update_available")
+      showAlert(translate("ota:hotspotPrepareFailedTitle"), translate("ota:hotspotPrepareFailedMessage"), [
+        {text: translate("common:ok")},
+        {text: translate("ota:setupWifi"), onPress: () => push("/wifi/scan")},
+      ])
+    } finally {
+      offPhase()
+    }
+  }
+
   const handleUpdateNow = () => {
     if (!engine.ota.snapshot().wifiConnected) {
-      console.log("OTA: Update Now pressed but glasses not on WiFi - pushing /wifi/scan")
+      const result = lastCheckResultRef.current
+      if (result?.manifestBody) {
+        console.log("OTA: Update Now without glasses WiFi - starting hotspot-served update")
+        void startHotspotUpdate(result)
+        return
+      }
+      console.log("OTA: Update Now pressed but glasses not on WiFi and no manifest - pushing /wifi/scan")
       push("/wifi/scan")
       return
     }
@@ -253,6 +300,35 @@ export default function OtaCheckForUpdatesScreen() {
       )
     }
 
+    // Hotspot-served install bring-up: phone-side download, then the hotspot join
+    // (the OS shows its own connection dialog during the "connecting" phase).
+    if (checkState === "preparing") {
+      return (
+        <>
+          <View className="flex-1 items-center justify-center px-6">
+            <Icon name="world-download" size={64} color={theme.colors.primary} />
+            <View className="h-6" />
+            <Text
+              tx={preparingPhase === "downloading" ? "ota:preparingDownloadTitle" : "ota:preparingConnectTitle"}
+              className="font-semibold text-xl text-center"
+            />
+            <View className="h-2" />
+            {preparingPhase === "downloading" ? (
+              <Text className="text-sm text-center">
+                {translate("ota:preparingDownloadMessage")}
+                {preparingPercent != null ? ` (${preparingPercent}%)` : ""}
+              </Text>
+            ) : (
+              <Text tx="ota:preparingConnectMessage" className="text-sm text-center" />
+            )}
+            <View className="h-6" />
+            <ActivityIndicator size="large" color={theme.colors.foreground} />
+          </View>
+          <View className="h-12" />
+        </>
+      )
+    }
+
     // Update available state
     if (checkState === "update_available") {
       return (
@@ -269,6 +345,8 @@ export default function OtaCheckForUpdatesScreen() {
               text={
                 glassesWifiConnected
                   ? translate(isDowngradeUpdate ? "ota:downgradeDescription" : "ota:updateDescription")
+                  : lastCheckResultRef.current?.manifestBody
+                  ? translate("ota:updateViaHotspot", {deviceName})
                   : translate("ota:updateConnectWifi", {deviceName})
               }
               className="text-sm text-center"
@@ -279,7 +357,7 @@ export default function OtaCheckForUpdatesScreen() {
           <View className="gap-3">
             <Button
               preset="primary"
-              tx={glassesWifiConnected ? "ota:updateNow" : "ota:setupWifi"}
+              tx={glassesWifiConnected || lastCheckResultRef.current?.manifestBody ? "ota:updateNow" : "ota:setupWifi"}
               onPress={handleUpdateNow}
             />
             {!isUpdateRequired && <Button preset="secondary" tx="ota:updateLater" onPress={handleContinue} />}

--- a/mobile/src/effects/OtaUpdateChecker.tsx
+++ b/mobile/src/effects/OtaUpdateChecker.tsx
@@ -207,10 +207,8 @@ export function OtaUpdateChecker() {
     // Last-moment imperative check: reactive glassesConnected can be stale if
     // disconnect and navigation happen in the same render cycle.
     if (!areGlassesConnectedNow()) return
-    if (!engine.ota.snapshot().wifiConnected) {
-      console.log("OTA: Pending update is waiting for glasses WiFi before showing install prompt")
-      return
-    }
+    // No glasses-WiFi gate: without WiFi the update runs over the glasses hotspot
+    // (OS-1676), served from this phone. The check screen picks the transport.
 
     console.log("OTA: User returned to home with pending update - showing alert")
     const deviceName = defaultWearable || "Glasses"
@@ -219,10 +217,10 @@ export function OtaUpdateChecker() {
     const updateMessage = isDowngrade
       ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${pending.updates.join(", ").toUpperCase()})` : "")
       : superMode
-        ? `Updates available: ${pending.updates.join(", ").toUpperCase()}`
-        : updateCount === 1
-          ? "1 update available"
-          : `${updateCount} updates available`
+      ? `Updates available: ${pending.updates.join(", ").toUpperCase()}`
+      : updateCount === 1
+      ? "1 update available"
+      : `${updateCount} updates available`
     pendingUpdate.current = null
     hasPromptedOta.current = true
     hasPromptedOtaWifiSetup.current = false
@@ -335,10 +333,10 @@ export function OtaUpdateChecker() {
             const updateMessage = isApkDowngrade
               ? translate("ota:downgradeDescriptionShort") + (superMode ? ` (${updateList})` : "")
               : superMode
-                ? `Updates available: ${updateList}`
-                : updateCount === 1
-                  ? "1 update available"
-                  : `${updateCount} updates available`
+              ? `Updates available: ${updateList}`
+              : updateCount === 1
+              ? "1 update available"
+              : `${updateCount} updates available`
 
             pendingUpdate.current = {latestVersionInfo, updates, isDowngrade: isApkDowngrade}
 
@@ -358,30 +356,19 @@ export function OtaUpdateChecker() {
               return
             }
 
-            // No WiFi path: prompt user to connect/setup WiFi.
-            if (hasPromptedOtaWifiSetup.current) {
-              console.log("OTA: WiFi setup prompt already shown for pending update - skipping duplicate")
-              return
-            }
-            console.log("OTA: Update available and glasses are not on WiFi - prompting WiFi setup")
-            const wifiMessage =
-              superMode && !isApkDowngrade
-                ? `Updates available: ${updateList}\n\nConnect your ${deviceName} to WiFi to install.`
-                : `${updateMessage}\n\nConnect your ${deviceName} to WiFi to install.`
-            hasPromptedOtaWifiSetup.current = true
+            // No glasses-WiFi path: the update still installs — served from this phone
+            // over the glasses hotspot (OS-1676). Same install prompt; the check screen
+            // picks the transport.
+            console.log("OTA: Update available without glasses WiFi - prompting hotspot-served install")
+            pendingUpdate.current = null
+            hasPromptedOta.current = true
+            hasPromptedOtaWifiSetup.current = false
             showAlert(
               translate(isApkDowngrade ? "ota:downgradeAvailable" : "ota:updateAvailable", {deviceName}),
-              wifiMessage,
+              updateMessage,
               [
-              {
-                text: translate("ota:updateLater"),
-                style: "cancel",
-                onPress: () => {
-                  pendingUpdate.current = null // Clear pending on dismiss
-                  hasPromptedOtaWifiSetup.current = false
-                },
-              },
-              {text: translate("ota:setupWifi"), onPress: () => push("/wifi/scan")},
+                {text: translate("ota:updateLater"), style: "cancel"},
+                {text: translate("ota:install"), onPress: () => push("/ota/check-for-updates")},
               ],
             )
           },

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -395,10 +395,21 @@ const en = {
     updateNow: "Update Now",
     install: "Install",
     setupWifi: "Setup WiFi",
+    updateViaHotspot:
+      "Your {{deviceName}} isn't on WiFi, so the update will be downloaded to your phone first and transferred directly.",
+    preparingDownloadTitle: "Downloading update",
+    preparingDownloadMessage: "Downloading the update to your phone using its internet connection",
+    preparingConnectTitle: "Connecting to your glasses",
+    preparingConnectMessage:
+      "Transferring over your glasses' hotspot. If your phone asks to join a network, approve it.",
+    hotspotPrepareFailedTitle: "Could not start the update",
+    hotspotPrepareFailedMessage:
+      "The update could not be transferred to your glasses. Try again, or connect your glasses to WiFi instead.",
     updateLater: "Later",
     upToDate: "Up to Date",
     devBuild: "Development Build",
-    devBuildNoOta: "These glasses run a development build, so automatic updates are disabled. Use the developer settings manifest override to update them manually.",
+    devBuildNoOta:
+      "These glasses run a development build, so automatic updates are disabled. Use the developer settings manifest override to update them manually.",
     noUpdatesAvailable: "Your glasses are running the latest version.",
     checkFailed: "Check Failed",
     checkFailedMessage: "Couldn't check for updates. Please check your connection and try again.",
@@ -416,9 +427,11 @@ const en = {
     versionChangeVerifying: "Verifying your glasses\u2026",
     versionChangeKeepNearby: "Keep your glasses nearby and connected. They will restart on their own.",
     versionChangeComplete: "Version Change Complete",
-    versionChangeCompleteMessage: "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
+    versionChangeCompleteMessage:
+      "Your glasses are now on the required version. Their settings were reset and are being restored automatically.",
     versionChangeFirmwarePassComplete: "Firmware updated",
-    versionChangeFirmwarePassCompleteMessage: "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
+    versionChangeFirmwarePassCompleteMessage:
+      "Your glasses restarted with new firmware. One more step: they'll now continue to the required version.",
     updateComplete: "Update Complete",
     updateCompleteMessage: "Your glasses have been updated successfully.",
     updateFailed: "Update Failed",


### PR DESCRIPTION
## Scope

Fifth and final PR of the OS-1676 stack (on #3620), completing the user flow from the ticket: *"There is an update ready for your Mentra Live. Please press Join."*

When the glasses are not on WiFi, **Update Now no longer dead-ends into WiFi setup**. The check screen starts a hotspot-served session instead: it downloads the update to the phone over the phone's own connection (the tap is the consent — no background pre-download, per the plan decision), then brings up the glasses hotspot (`engine.ota.hotspotSession.begin`, #3620) and hands off to the existing `/ota/progress` screen, whose install coordinator drives `ota_start` through the session automatically — including the post-APK-restart re-join.

- `check-for-updates`: new `preparing` state — phone-download percent, then the hotspot-join phase with a heads-up that the OS may show a join/connect dialog. Failure returns to the update prompt (staged artifacts kept, so retrying skips the re-download) and offers WiFi setup as the alternative.
- Update-available copy explains the phone-transfer path; **Setup WiFi remains only as the fallback** when there is no manifest to serve.
- `OtaUpdateChecker`: both background prompts (return-home and main-check) now offer Install without the glasses-WiFi gate; the WiFi-setup-only alert is gone. The glasses-WiFi path itself is untouched and remains primary.

## Test evidence

- Mobile `tsc --noEmit` clean; full mobile jest suite green (including the 25 `OtaUpdateChecker` tests).
- End-to-end on-device verification of the full stack (apk+mtk+bes over hotspot, two hotspot windows) is the next step now that the flow is drivable from the UI — tracked as the stack's hardware gate before any of it merges.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core OTA user flows and transport selection when glasses lack WiFi; regressions could block updates or mis-route users, though WiFi path is preserved and manifest gating limits the new path.
> 
> **Overview**
> **When glasses are not on WiFi, OTA no longer forces WiFi setup as the only path.** Users with a servable manifest can install via the phone hotspot flow (OS-1676).
> 
> On **`check-for-updates`**, **Update Now** starts `engine.ota.hotspotSession.begin` when there is no glasses WiFi but `manifestBody` exists: a new **`preparing`** state shows phone download progress, then hotspot join messaging, then navigation to `/ota/progress`. Failures return to the update prompt with an alert and optional WiFi setup. Copy and the primary button switch to **Update Now** / hotspot explanation when a manifest is available; **Setup WiFi** remains only without a manifest.
> 
> **`OtaUpdateChecker`** removes the glasses-WiFi requirement for background and return-home update prompts—both now show **Install** (same as on WiFi) instead of a WiFi-setup-only alert. WiFi-connected behavior is unchanged.
> 
> New **`ota:*`** strings cover hotspot transfer, preparing phases, and prepare-failure messaging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac50ca1840a03f8606db48fa233810fd94576c1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->