### PR TITLE
[Android] Restore end-to-end notifications on Mentra Live (OS-1821)

### DIFF
--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/CrustModule.kt
@@ -25,6 +25,7 @@ class CrustModule : Module() {
             title: String,
             text: String,
             timestamp: Long,
+            priority: Int,
     ) {
       val data =
               mapOf(
@@ -32,7 +33,13 @@ class CrustModule : Module() {
                       "app" to appName,
                       "title" to title.ifEmpty { appName },
                       "content" to text,
-                      "priority" to "normal",
+                      // The real Notification.priority, not a placeholder. This
+                      // was hardcoded to "normal", which made every consumer's
+                      // priority handling dead code — notably the spoken-
+                      // notification path, which is supposed to stay quiet for
+                      // PRIORITY_LOW/MIN because those are exactly the ones an
+                      // app asked not to interrupt with (OS-1821).
+                      "priority" to priority,
                       "timestamp" to timestamp,
                       "packageName" to packageName,
               )

--- a/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
+++ b/mobile/modules/crust/android/src/main/java/com/mentra/crust/services/NotificationListener.kt
@@ -179,7 +179,12 @@ class NotificationListener private constructor(private val context: Context) {
   }
 
   /** Called internally by the service when a notification is posted. */
-  internal fun onNotificationPosted(sbn: StatusBarNotification) {
+  /**
+   * @param importance NotificationManager.IMPORTANCE_* from the ranking, or null
+   *   when unavailable. Preferred over the deprecated Notification.priority,
+   *   which reads 0 for channel-based notifications.
+   */
+  internal fun onNotificationPosted(sbn: StatusBarNotification, importance: Int? = null) {
     if (!listenerEnabled || !notificationsEnabled) {
       Log.d(TAG, "Notification listener disabled")
       return
@@ -241,6 +246,10 @@ class NotificationListener private constructor(private val context: Context) {
               title = title,
               text = text,
               timestamp = sbn.postTime,
+              // Map channel importance onto the priority scale consumers
+              // already understand (LOW/MIN are negative). Fall back to the
+              // deprecated field only when no ranking was available.
+              priority = importance?.let { it - 3 } ?: notification.priority,
             )
 
             val notificationData =
@@ -355,7 +364,22 @@ class NotificationListener private constructor(private val context: Context) {
 class NotificationListenerServiceImpl : NotificationListenerService() {
   override fun onNotificationPosted(sbn: StatusBarNotification) {
     super.onNotificationPosted(sbn)
-    NotificationListener.getInstance(applicationContext).onNotificationPosted(sbn)
+    // Channel importance, not Notification.priority: the latter was deprecated
+    // at API 26 and reads 0 for apps that express intent through a channel
+    // instead, which would make every consumer treat them as ordinary. Only the
+    // service can see the ranking, so it is resolved here and passed down.
+    NotificationListener.getInstance(applicationContext).onNotificationPosted(sbn, importanceOf(sbn))
+  }
+
+  /** IMPORTANCE_* for this notification, or null when the ranking is unavailable. */
+  private fun importanceOf(sbn: StatusBarNotification): Int? {
+    return try {
+      val ranking = NotificationListenerService.Ranking()
+      if (currentRanking?.getRanking(sbn.key, ranking) == true) ranking.importance else null
+    } catch (e: Exception) {
+      Log.w("CrustNotificationListener", "could not read ranking importance", e)
+      null
+    }
   }
 
   override fun onNotificationRemoved(sbn: StatusBarNotification) {

--- a/mobile/modules/crust/src/Crust.types.ts
+++ b/mobile/modules/crust/src/Crust.types.ts
@@ -128,7 +128,12 @@ export type PhoneNotificationEvent = {
   app: string
   title: string
   content: string
-  priority: string
+  /**
+   * Android notification priority: PRIORITY_MIN (-2) through PRIORITY_MAX (2).
+   * Derived from the channel importance when the ranking is available, since
+   * Notification.priority reads 0 for channel-based notifications.
+   */
+  priority: number
   timestamp: number
   packageName: string
 }

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -163,32 +163,62 @@ class MantleManager {
     if (this.suppressedSummaryTimer !== null) return
     this.suppressedSummaryTimer = BgTimer.setTimeout(() => {
       this.suppressedSummaryTimer = null
+      if (this.suppressedNotifications <= 0) return
+
+      // Still talking, or still inside the quiet window — which only starts when
+      // speech ENDS, so this timer (anchored to the first suppressed arrival)
+      // routinely fires early. Reschedule and keep the count.
+      //
+      // This used to zero the count and then return, so a burst landing
+      // mid-announcement — the exact case the summary exists for — produced no
+      // summary at all.
+      if (this.speakingNotification || Date.now() - this.lastSpokenAt < SPOKEN_NOTIFICATION_GAP_MS) {
+        this.scheduleSuppressedSummary()
+        return
+      }
+
       const count = this.suppressedNotifications
       this.suppressedNotifications = 0
-      if (count <= 0) return
-      if (this.speakingNotification) return
       void this.speakAloud(`${count} more notification${count === 1 ? "" : "s"}.`)
     }, SPOKEN_NOTIFICATION_GAP_MS)
   }
 
   /** Synthesize and play one line. Assumes the caller checked the quiet window. */
   private async speakAloud(text: string): Promise<void> {
+    // Claim the slot synchronously, before anything awaits.
+    //
+    // The caller's quiet-window check reads this flag. Setting it only after
+    // `await isModelAvailable()` meant a burst of notifications all passed that
+    // check together, synthesized concurrently, and interrupted one another's
+    // playback — and the first completion callback then cleared the flag while
+    // a later clip was still playing. A check-and-set with no await between the
+    // two is atomic here, so this is the whole fix.
+    if (this.speakingNotification) return
+    this.speakingNotification = true
+
+    // Safety valve: if the completion callback never arrives, the flag would
+    // latch and silence every later notification for the rest of the session.
+    // Losing one announcement beats going permanently quiet. Armed before the
+    // first await so no failure path can leave the flag set without a timer,
+    // and cleared on every exit — a guard left running after a synthesis
+    // failure fires later and clears the flag for a clip still playing.
+    const stuckGuard = BgTimer.setTimeout(() => {
+      this.speakingNotification = false
+    }, SPOKEN_NOTIFICATION_MAX_MS)
+    const release = () => {
+      BgTimer.clearTimeout(stuckGuard)
+      this.speakingNotification = false
+    }
+
     let audio: {audioUrl: string; cleanup: () => Promise<void>} | undefined
     try {
       if (!(await ttsModelManager.isModelAvailable())) {
         console.warn("MantleManager: no on-device TTS voice available, notification not spoken")
+        release()
         return
       }
 
-      this.speakingNotification = true
       this.lastSpokenAt = Date.now()
-      // Safety valve: if the completion callback never arrives, the flag would
-      // latch and silence every later notification for the rest of the session.
-      // Losing one announcement beats going permanently quiet.
-      const stuckGuard = BgTimer.setTimeout(() => {
-        this.speakingNotification = false
-      }, SPOKEN_NOTIFICATION_MAX_MS)
-
       audio = await ttsModelManager.synthesizeToFile(text)
       await audioPlaybackService.play(
         {
@@ -197,8 +227,7 @@ class MantleManager {
           appId: notifyPackageName,
         },
         () => {
-          BgTimer.clearTimeout(stuckGuard)
-          this.speakingNotification = false
+          release()
           // Start the quiet window when speech ENDS, not when it started, so a
           // long announcement isn't immediately followed by another.
           this.lastSpokenAt = Date.now()
@@ -206,7 +235,7 @@ class MantleManager {
         },
       )
     } catch (error) {
-      this.speakingNotification = false
+      release()
       void audio?.cleanup?.()
       console.warn("MantleManager: failed to speak notification audio", error)
     }
@@ -366,6 +395,19 @@ class MantleManager {
     this.activePhoneNotificationId = null
 
     phoneLocationService.stopPhoneLocation()
+
+    // Spoken notifications: a queued summary would otherwise synthesize and play
+    // after the subscriptions that produced it are gone, or carry its count and
+    // speaking flag into the next login in the same process. engine.stop() does
+    // not stop playback, so the notify-owned audio has to be stopped explicitly.
+    if (this.suppressedSummaryTimer !== null) {
+      BgTimer.clearTimeout(this.suppressedSummaryTimer)
+      this.suppressedSummaryTimer = null
+    }
+    this.suppressedNotifications = 0
+    this.speakingNotification = false
+    this.lastSpokenAt = 0
+    void audioPlaybackService.stopForApp(notifyPackageName)
 
     localMiniappRuntime.cleanup()
     micStateCoordinator.cleanup()

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -105,6 +105,8 @@ class MantleManager {
   /** Notifications that arrived during the quiet window, summarised afterwards. */
   private suppressedNotifications: number = 0
   private suppressedSummaryTimer: ReturnType<typeof BgTimer.setTimeout> | null = null
+  /** Bumped by cleanup() so in-flight speech work can detect it is stale. */
+  private speechGeneration: number = 0
 
   public static getInstance(): MantleManager {
     if (!MantleManager.instance) {
@@ -210,6 +212,17 @@ class MantleManager {
       this.speakingNotification = false
     }
 
+    // Restored if nothing is actually announced. The stamp below marks "speech
+    // starting" so the stuck guard has a sane window, but on a failure path it
+    // would otherwise persist and suppress the next SPOKEN_NOTIFICATION_GAP_MS
+    // of notifications into a summary for speech that never happened.
+    const previousSpokenAt = this.lastSpokenAt
+
+    // Generation token: cleanup() bumps this, so work that is already in flight
+    // (a synthesis started before logout) can tell it is stale and stop rather
+    // than playing into the next session.
+    const generation = this.speechGeneration
+
     let audio: {audioUrl: string; cleanup: () => Promise<void>} | undefined
     try {
       if (!(await ttsModelManager.isModelAvailable())) {
@@ -220,6 +233,13 @@ class MantleManager {
 
       this.lastSpokenAt = Date.now()
       audio = await ttsModelManager.synthesizeToFile(text)
+
+      if (generation !== this.speechGeneration) {
+        this.lastSpokenAt = previousSpokenAt
+        release()
+        void audio?.cleanup?.()
+        return
+      }
       await audioPlaybackService.play(
         {
           requestId: `phone_notification_${Date.now()}`,
@@ -229,12 +249,17 @@ class MantleManager {
         () => {
           release()
           // Start the quiet window when speech ENDS, not when it started, so a
-          // long announcement isn't immediately followed by another.
-          this.lastSpokenAt = Date.now()
+          // long announcement isn't immediately followed by another. Skipped for
+          // a stale generation: cleanup() interrupts playback, which fires this
+          // callback, and stamping here would undo the reset it just performed.
+          if (generation === this.speechGeneration) this.lastSpokenAt = Date.now()
           void audio?.cleanup?.()
         },
       )
     } catch (error) {
+      // Nothing was announced, so roll the stamp back rather than opening a
+      // quiet window on a failure.
+      this.lastSpokenAt = previousSpokenAt
       release()
       void audio?.cleanup?.()
       console.warn("MantleManager: failed to speak notification audio", error)
@@ -400,6 +425,18 @@ class MantleManager {
     // after the subscriptions that produced it are gone, or carry its count and
     // speaking flag into the next login in the same process. engine.stop() does
     // not stop playback, so the notify-owned audio has to be stopped explicitly.
+    // Bump first so anything already in flight — a synthesis started before
+    // logout — sees a stale generation and drops out instead of playing into
+    // the next session.
+    this.speechGeneration += 1
+
+    // Stop playback BEFORE resetting the timestamps. stopForApp() interrupts the
+    // current clip and, by design, notifies its completion callback; that
+    // callback stamps lastSpokenAt, so resetting first left the quiet window
+    // armed across a logout→login in the same process and the first
+    // notifications of the new session were summarised instead of read.
+    await audioPlaybackService.stopForApp(notifyPackageName)
+
     if (this.suppressedSummaryTimer !== null) {
       BgTimer.clearTimeout(this.suppressedSummaryTimer)
       this.suppressedSummaryTimer = null
@@ -407,7 +444,6 @@ class MantleManager {
     this.suppressedNotifications = 0
     this.speakingNotification = false
     this.lastSpokenAt = 0
-    void audioPlaybackService.stopForApp(notifyPackageName)
 
     localMiniappRuntime.cleanup()
     micStateCoordinator.cleanup()

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -625,6 +625,12 @@ class MantleManager {
         const title = String(event.title ?? "").trim()
         const content = String(event.content ?? "").trim()
 
+        // Worth logging: priority was hardcoded to "normal" for every
+        // notification, which made every consumer's priority handling dead code
+        // and gave no way to tell from the outside. Log the value, never the
+        // notification text.
+        console.log(`MANTLE: phone_notification from ${app}, priority=${event.priority}`)
+
         // Direct forward to local miniapps subscribed to phone_notification.
         // Gated by READ_NOTIFICATIONS in miniapp.json at subscribe time.
         localMiniappRuntime.forwardEvent("phone_notification", {

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -14,6 +14,7 @@ import {cloudConfigValues} from "@/services/cloudClient"
 import {engine, BgTimer, SETTINGS} from "@mentra/engine"
 import {
   appRegistry,
+  audioPlaybackService,
   displayProcessor,
   gallerySyncService,
   localDisplayManager,
@@ -23,6 +24,7 @@ import {
   miniappLauncher,
   offlineSpeechModelService,
   phoneLocationService,
+  ttsModelManager,
   useAppStatusStore,
 } from "@mentra/engine/internal"
 import GlobalEventEmitter from "@/utils/GlobalEventEmitter"
@@ -68,6 +70,12 @@ function parseBundledMiniappName(name: string): {packageName: string; version: s
 // (PhoneLocationService). MantleManager now drives it through the island service
 // (setupSubscriptions / cleanup) instead of defining the task here.
 
+/**
+ * Longest a spoken notification is assumed to take. Only a backstop for a
+ * completion callback that never arrives — not a playback limit.
+ */
+const SPOKEN_NOTIFICATION_MAX_MS = 30_000
+
 class MantleManager {
   private static instance: MantleManager | null = null
   private calendarSyncTimer: ReturnType<typeof BgTimer.setInterval> | null = null
@@ -78,6 +86,8 @@ class MantleManager {
   private subs: Array<any> = []
   private initialized: boolean = false
   private activePhoneNotificationId: string | null = null
+  /** A notification is being read aloud. Later ones are dropped, not queued. */
+  private speakingNotification: boolean = false
 
   public static getInstance(): MantleManager {
     if (!MantleManager.instance) {
@@ -87,6 +97,69 @@ class MantleManager {
   }
 
   private constructor() {}
+
+  /**
+   * Read a phone notification aloud, for glasses that have no screen.
+   *
+   * Mentra Live has a speaker but no display, so the reference card the display
+   * path requests is invisible there and the wearer learns nothing (OS-1821).
+   *
+   * Best effort by design:
+   *  - Silent on glasses that DO have a display; the card is better than speech.
+   *  - Needs an on-device TTS voice. Without one we log and stay quiet rather
+   *    than reaching for the network on every incoming notification.
+   *  - A burst must not become a monologue, so speech already in flight wins and
+   *    later notifications are dropped instead of queued behind it.
+   */
+  private async speakPhoneNotification(title: string, content: string): Promise<void> {
+    let audio: {audioUrl: string; cleanup: () => Promise<void>} | undefined
+    try {
+      const capabilities = engine.glasses.capabilities()
+      if (!capabilities || capabilities.hasDisplay || !capabilities.hasSpeaker) return
+      if (this.speakingNotification) return
+
+      // Long bodies get truncated: past a sentence or two this stops being a
+      // notification and starts being a reading, with no way to skip it.
+      const spoken = [title, content]
+        .map((part) => part.trim())
+        .filter(Boolean)
+        .join(". ")
+        .slice(0, 300)
+      if (!spoken) return
+
+      if (!(await ttsModelManager.isModelAvailable())) {
+        console.warn("MantleManager: no on-device TTS voice available, notification not spoken")
+        return
+      }
+
+      this.speakingNotification = true
+      // Safety valve: if the completion callback never arrives, the flag would
+      // latch and silence every later notification for the rest of the session.
+      // Losing one announcement beats going permanently quiet.
+      const stuckGuard = BgTimer.setTimeout(() => {
+        this.speakingNotification = false
+      }, SPOKEN_NOTIFICATION_MAX_MS)
+
+      audio = await ttsModelManager.synthesizeToFile(spoken)
+      await audioPlaybackService.play(
+        {
+          requestId: `phone_notification_${Date.now()}`,
+          audioUrl: audio.audioUrl,
+          appId: notifyPackageName,
+        },
+        () => {
+          BgTimer.clearTimeout(stuckGuard)
+          this.speakingNotification = false
+          void audio?.cleanup?.()
+        },
+      )
+    } catch (error) {
+      // Never let a failed announcement break notification capture/storage.
+      this.speakingNotification = false
+      void audio?.cleanup?.()
+      console.warn("MantleManager: failed to speak phone notification", error)
+    }
+  }
 
   private noteMicDataReceived() {
     this.lastMicDataAt = Date.now()
@@ -529,6 +602,10 @@ class MantleManager {
             },
             durationMs: 5_000,
           })
+          // Glasses with no screen (Mentra Live) would otherwise get nothing at
+          // all from the card above — the notification arrives and is stored,
+          // but the wearer never learns about it. Read it out instead (OS-1821).
+          void this.speakPhoneNotification(displayTitle, content)
         }
       }
 

--- a/mobile/src/services/MantleManager.ts
+++ b/mobile/src/services/MantleManager.ts
@@ -10,6 +10,7 @@ import builtInMiniappCatalog from "@/services/miniapps/BuiltInMiniappCatalog"
 import {BUNDLED_MINIAPPS} from "@/generated/bundledMiniapps"
 import {CHINA_HIDDEN_APPS, isChinaBuild, notifyPackageName} from "@/constants/miniapps"
 import {migrate} from "@/services/Migrations"
+import {buildSpokenNotification} from "@/services/notifications/spokenNotification"
 import {cloudConfigValues} from "@/services/cloudClient"
 import {engine, BgTimer, SETTINGS} from "@mentra/engine"
 import {
@@ -76,6 +77,17 @@ function parseBundledMiniappName(name: string): {packageName: string; version: s
  */
 const SPOKEN_NOTIFICATION_MAX_MS = 30_000
 
+/**
+ * Quiet window after an announcement before the next one may be read.
+ *
+ * Notifications do not arrive politely spaced: apps re-post to update a running
+ * download or a music player, and granting notification access replays whatever
+ * is already in the shade. Reading each one turns the glasses into a monologue
+ * the wearer cannot skip. Anything landing inside this window is counted, not
+ * spoken, and summarised once at the end.
+ */
+const SPOKEN_NOTIFICATION_GAP_MS = 10_000
+
 class MantleManager {
   private static instance: MantleManager | null = null
   private calendarSyncTimer: ReturnType<typeof BgTimer.setInterval> | null = null
@@ -86,8 +98,13 @@ class MantleManager {
   private subs: Array<any> = []
   private initialized: boolean = false
   private activePhoneNotificationId: string | null = null
-  /** A notification is being read aloud. Later ones are dropped, not queued. */
+  /** A notification is being read aloud right now. */
   private speakingNotification: boolean = false
+  /** When the last announcement finished, for the quiet window. */
+  private lastSpokenAt: number = 0
+  /** Notifications that arrived during the quiet window, summarised afterwards. */
+  private suppressedNotifications: number = 0
+  private suppressedSummaryTimer: ReturnType<typeof BgTimer.setTimeout> | null = null
 
   public static getInstance(): MantleManager {
     if (!MantleManager.instance) {
@@ -104,35 +121,67 @@ class MantleManager {
    * Mentra Live has a speaker but no display, so the reference card the display
    * path requests is invisible there and the wearer learns nothing (OS-1821).
    *
-   * Best effort by design:
+   * Deliberately conservative, because a notification written to be *seen* is
+   * hostile when read verbatim:
    *  - Silent on glasses that DO have a display; the card is better than speech.
-   *  - Needs an on-device TTS voice. Without one we log and stay quiet rather
-   *    than reaching for the network on every incoming notification.
-   *  - A burst must not become a monologue, so speech already in flight wins and
-   *    later notifications are dropped instead of queued behind it.
+   *  - Needs an on-device TTS voice; no network reach on every notification.
+   *  - buildSpokenNotification() strips URLs and emoji, cuts on a word boundary,
+   *    and drops low-priority and summary rows entirely.
+   *  - A burst is summarised rather than recited (see the quiet window).
    */
-  private async speakPhoneNotification(title: string, content: string): Promise<void> {
-    let audio: {audioUrl: string; cleanup: () => Promise<void>} | undefined
+  private async speakPhoneNotification(app: string, title: string, content: string, priority?: number): Promise<void> {
     try {
       const capabilities = engine.glasses.capabilities()
       if (!capabilities || capabilities.hasDisplay || !capabilities.hasSpeaker) return
-      if (this.speakingNotification) return
 
-      // Long bodies get truncated: past a sentence or two this stops being a
-      // notification and starts being a reading, with no way to skip it.
-      const spoken = [title, content]
-        .map((part) => part.trim())
-        .filter(Boolean)
-        .join(". ")
-        .slice(0, 300)
+      const spoken = buildSpokenNotification({app, title, content, priority})
+      // Nothing worth hearing: a link-only message, a "3 new messages" summary,
+      // or something the app itself marked as do-not-interrupt.
       if (!spoken) return
 
+      // Inside the quiet window (or mid-announcement): count it and let the
+      // trailing summary mention it, rather than talking over the wearer.
+      if (this.speakingNotification || Date.now() - this.lastSpokenAt < SPOKEN_NOTIFICATION_GAP_MS) {
+        this.suppressedNotifications += 1
+        this.scheduleSuppressedSummary()
+        return
+      }
+
+      await this.speakAloud(spoken)
+    } catch (error) {
+      // Never let a failed announcement break notification capture/storage.
+      this.speakingNotification = false
+      console.warn("MantleManager: failed to speak phone notification", error)
+    }
+  }
+
+  /**
+   * After the quiet window, say how many arrived during it — once, as a count.
+   * "Four more notifications" is useful; four notifications read in full is not.
+   */
+  private scheduleSuppressedSummary(): void {
+    if (this.suppressedSummaryTimer !== null) return
+    this.suppressedSummaryTimer = BgTimer.setTimeout(() => {
+      this.suppressedSummaryTimer = null
+      const count = this.suppressedNotifications
+      this.suppressedNotifications = 0
+      if (count <= 0) return
+      if (this.speakingNotification) return
+      void this.speakAloud(`${count} more notification${count === 1 ? "" : "s"}.`)
+    }, SPOKEN_NOTIFICATION_GAP_MS)
+  }
+
+  /** Synthesize and play one line. Assumes the caller checked the quiet window. */
+  private async speakAloud(text: string): Promise<void> {
+    let audio: {audioUrl: string; cleanup: () => Promise<void>} | undefined
+    try {
       if (!(await ttsModelManager.isModelAvailable())) {
         console.warn("MantleManager: no on-device TTS voice available, notification not spoken")
         return
       }
 
       this.speakingNotification = true
+      this.lastSpokenAt = Date.now()
       // Safety valve: if the completion callback never arrives, the flag would
       // latch and silence every later notification for the rest of the session.
       // Losing one announcement beats going permanently quiet.
@@ -140,7 +189,7 @@ class MantleManager {
         this.speakingNotification = false
       }, SPOKEN_NOTIFICATION_MAX_MS)
 
-      audio = await ttsModelManager.synthesizeToFile(spoken)
+      audio = await ttsModelManager.synthesizeToFile(text)
       await audioPlaybackService.play(
         {
           requestId: `phone_notification_${Date.now()}`,
@@ -150,14 +199,16 @@ class MantleManager {
         () => {
           BgTimer.clearTimeout(stuckGuard)
           this.speakingNotification = false
+          // Start the quiet window when speech ENDS, not when it started, so a
+          // long announcement isn't immediately followed by another.
+          this.lastSpokenAt = Date.now()
           void audio?.cleanup?.()
         },
       )
     } catch (error) {
-      // Never let a failed announcement break notification capture/storage.
       this.speakingNotification = false
       void audio?.cleanup?.()
-      console.warn("MantleManager: failed to speak phone notification", error)
+      console.warn("MantleManager: failed to speak notification audio", error)
     }
   }
 
@@ -605,7 +656,16 @@ class MantleManager {
           // Glasses with no screen (Mentra Live) would otherwise get nothing at
           // all from the card above — the notification arrives and is stored,
           // but the wearer never learns about it. Read it out instead (OS-1821).
-          void this.speakPhoneNotification(displayTitle, content)
+          // Pass the raw app/title rather than displayTitle: the speech path
+          // builds its own phrasing, and priority lets it skip the notifications
+          // an app explicitly marked as non-interrupting.
+          const priorityValue = Number(event.priority)
+          void this.speakPhoneNotification(
+            app,
+            title,
+            content,
+            Number.isFinite(priorityValue) ? priorityValue : undefined,
+          )
         }
       }
 

--- a/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
+++ b/mobile/src/services/miniapps/BuiltInMiniappCatalog.ts
@@ -270,8 +270,12 @@ class BuiltInMiniappCatalog {
         running: false,
         loading: false,
         local: false,
+        // A display is the nicest way to surface a notification, not the only
+        // one: camera-only glasses (Mentra Live) speak it instead. Requiring
+        // DISPLAY greyed the app out entirely there, so notifications could not
+        // even be captured or stored on those glasses (OS-1821).
         hardwareRequirements: [
-          {type: HardwareType.DISPLAY, level: HardwareRequirementLevel.REQUIRED},
+          {type: HardwareType.DISPLAY, level: HardwareRequirementLevel.OPTIONAL},
           {type: HardwareType.EXIST, level: HardwareRequirementLevel.REQUIRED},
         ],
       })

--- a/mobile/src/services/notifications/spokenNotification.ts
+++ b/mobile/src/services/notifications/spokenNotification.ts
@@ -1,0 +1,114 @@
+/**
+ * Turning a phone notification into something worth hearing.
+ *
+ * Glasses with no screen (Mentra Live) announce notifications out loud, and a
+ * notification's raw text is written to be *seen*, not heard. Read verbatim it
+ * arrives as noise: URLs get spelled out character by character, emoji and
+ * separators become nonsense syllables, and a long body turns a two-second
+ * announcement into a paragraph the wearer cannot skip or skim (OS-1821).
+ *
+ * So this trims the announcement down to what a person actually needs — who it
+ * is from and the gist — and drops the ones that were never meant to be spoken.
+ */
+
+/** Longest announcement we will speak. Past this it stops being a notification. */
+export const SPOKEN_MAX_CHARS = 140
+
+/**
+ * Notifications that exist to be glanced at, not heard: group summaries and
+ * counters that carry no content ("3 new messages"). The native layer already
+ * drops the exact string "N new messages"; these cover the rest of the family.
+ */
+const SUMMARY_PATTERNS = [
+  /^\d+\s+new\s+(messages?|notifications?|emails?)$/i,
+  /^\d+\s+(messages?|notifications?|updates?)$/i,
+  /^\d+\s+more$/i,
+]
+
+/**
+ * Android priority floor. PRIORITY_LOW (-1) and PRIORITY_MIN (-2) are the
+ * levels apps use for things they explicitly do not want to interrupt you with,
+ * so speaking them aloud is the one thing they asked us not to do.
+ */
+const MIN_SPOKEN_PRIORITY = 0
+
+/**
+ * Strip the parts that only make sense on a screen.
+ *
+ * URLs are the big one: "https://ex.co/a?b=1" read aloud is the single largest
+ * source of what sounds like gibberish. Emoji, box-drawing and zero-width
+ * characters are the rest.
+ */
+export function sanitizeForSpeech(raw: string): string {
+  return (
+    raw
+      // URLs and bare domains, unspeakable and never the point of the message.
+      .replace(/\b(?:https?:\/\/|www\.)\S+/gi, "")
+      .replace(/\b[\w.-]+\.(?:com|org|net|io|co|dev|app|gg|ly)\b\S*/gi, "")
+      // Emoji, pictographs and variation selectors.
+      .replace(/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]/gu, " ")
+      // Variation selectors, dropped separately for the same reason as the
+      // joiner: they combine with the preceding character rather than
+      // standing alone, so a character class is the wrong tool.
+      .replace(/[\u{FE00}-\u{FE0F}]/gu, "")
+      // Zero-width joiner, dropped separately: inside the class above it would
+      // split composed emoji (families, skin tones) into their component parts.
+      .replace(/\u200D/gu, "")
+      // Box drawing, bullets and separators that apps use as visual dividers.
+      .replace(/[\u2500-\u257F\u2022\u00B7\u2219|]+/g, " ")
+      // Control characters, plus the remaining zero-width and bidi marks.
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\u0000-\u001F\u200B\u200C\u200E\u200F\uFEFF]/g, " ")
+      // Runs of punctuation ("!!!", "---", "...") read as stuttering.
+      .replace(/([!?.,\-_~*#])\1{1,}/g, "$1")
+      .replace(/\s+/g, " ")
+      .trim()
+  )
+}
+
+/** Cut to a length without slicing a word in half — a clipped word sounds broken. */
+export function truncateOnWordBoundary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text
+  const clipped = text.slice(0, maxChars)
+  // Prefer ending on a sentence, then a word; fall back to the hard cut only if
+  // the text has no break at all (a single very long token).
+  const sentenceEnd = Math.max(clipped.lastIndexOf(". "), clipped.lastIndexOf("! "), clipped.lastIndexOf("? "))
+  if (sentenceEnd > maxChars * 0.5) return clipped.slice(0, sentenceEnd + 1)
+  const wordEnd = clipped.lastIndexOf(" ")
+  return (wordEnd > 0 ? clipped.slice(0, wordEnd) : clipped).trimEnd()
+}
+
+export interface SpokenNotificationInput {
+  app: string
+  title: string
+  content: string
+  /** Android notification priority, when the platform reported one. */
+  priority?: number
+}
+
+/**
+ * Build the sentence to speak, or null when this notification should stay
+ * silent. Shape is "App: title. body" — who it's from first, because that is
+ * what the wearer needs to decide whether to reach for their phone.
+ */
+export function buildSpokenNotification(input: SpokenNotificationInput): string | null {
+  if (typeof input.priority === "number" && input.priority < MIN_SPOKEN_PRIORITY) return null
+
+  const app = sanitizeForSpeech(input.app)
+  const title = sanitizeForSpeech(input.title)
+  const content = sanitizeForSpeech(input.content)
+
+  // A summary row ("3 new messages") tells you nothing you can act on.
+  if (SUMMARY_PATTERNS.some((pattern) => pattern.test(title) || pattern.test(content))) return null
+
+  // Once URLs and emoji are gone some notifications have nothing left to say —
+  // a link-only message, or a body that was purely decorative.
+  const headline = title && title !== app ? title : ""
+  const body = content && content !== headline ? content : ""
+  if (!headline && !body) return null
+
+  const lead = [app, headline].filter(Boolean).join(": ")
+  const spoken = [lead, body].filter(Boolean).join(". ")
+  const trimmed = truncateOnWordBoundary(spoken, SPOKEN_MAX_CHARS)
+  return trimmed.length > 0 ? trimmed : null
+}

--- a/mobile/test/spokenNotification.test.ts
+++ b/mobile/test/spokenNotification.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Spoken-notification shaping tests.
+ *
+ * The first version of this feature read the raw notification aloud, and on real
+ * traffic it sounded like gibberish: URLs get spelled out character by
+ * character, emoji and separators become nonsense syllables, and long bodies
+ * turn a two-second announcement into a paragraph nobody can skip (OS-1821).
+ *
+ * These pin the shaping rules so a future change cannot quietly bring that back.
+ */
+import {
+  buildSpokenNotification,
+  sanitizeForSpeech,
+  SPOKEN_MAX_CHARS,
+  truncateOnWordBoundary,
+} from "@/services/notifications/spokenNotification"
+
+describe("sanitizeForSpeech", () => {
+  test("strips URLs, the main source of spoken gibberish", () => {
+    expect(sanitizeForSpeech("Check https://example.com/a?b=1 now")).toBe("Check now")
+    expect(sanitizeForSpeech("see www.foo.com/x for details")).toBe("see for details")
+    expect(sanitizeForSpeech("go to example.io/path now")).toBe("go to now")
+  })
+
+  test("strips emoji and decorative separators", () => {
+    expect(sanitizeForSpeech("Deploy 🚀 done ✅")).toBe("Deploy done")
+    expect(sanitizeForSpeech("Alice • Bob | Carol")).toBe("Alice Bob Carol")
+  })
+
+  test("collapses stuttering punctuation and whitespace", () => {
+    expect(sanitizeForSpeech("Wait!!!  what???")).toBe("Wait! what?")
+    expect(sanitizeForSpeech("a   b\n\nc")).toBe("a b c")
+  })
+
+  test("leaves ordinary prose untouched", () => {
+    expect(sanitizeForSpeech("Standup moved to 10:30")).toBe("Standup moved to 10:30")
+  })
+})
+
+describe("truncateOnWordBoundary", () => {
+  test("never cuts a word in half", () => {
+    // A mid-word cut is itself a source of "that sounded like nonsense".
+    expect(truncateOnWordBoundary("alpha bravo charlie delta", 14)).toBe("alpha bravo")
+  })
+
+  test("prefers ending on a sentence when the sentence is most of the budget", () => {
+    expect(truncateOnWordBoundary("This is a full sentence. And more text here", 30)).toBe("This is a full sentence.")
+  })
+
+  test("keeps the extra words when the sentence would throw away half the budget", () => {
+    // Ending at "First thing." would discard 11 of the 22 available characters.
+    // A word boundary is already safe to speak, so prefer the fuller version.
+    expect(truncateOnWordBoundary("First thing. Second thing that runs on", 22)).toBe("First thing. Second")
+  })
+
+  test("leaves short text alone", () => {
+    expect(truncateOnWordBoundary("short", 40)).toBe("short")
+  })
+})
+
+describe("buildSpokenNotification", () => {
+  test("leads with the app and title, which is what the wearer needs", () => {
+    expect(buildSpokenNotification({app: "Slack", title: "Alex", content: "standup in 5"})).toBe(
+      "Slack: Alex. standup in 5",
+    )
+  })
+
+  test("drops group summaries that carry no content", () => {
+    expect(buildSpokenNotification({app: "Gmail", title: "", content: "3 new messages"})).toBeNull()
+    expect(buildSpokenNotification({app: "Slack", title: "2 messages", content: ""})).toBeNull()
+  })
+
+  test("stays silent for notifications the app marked as non-interrupting", () => {
+    // Android PRIORITY_LOW / PRIORITY_MIN: speaking these is the one thing the
+    // app explicitly asked us not to do.
+    expect(buildSpokenNotification({app: "Sync", title: "Backup", content: "done", priority: -1})).toBeNull()
+    expect(buildSpokenNotification({app: "Sync", title: "Backup", content: "done", priority: -2})).toBeNull()
+    expect(buildSpokenNotification({app: "Sync", title: "Backup", content: "done", priority: 0})).not.toBeNull()
+  })
+
+  test("says nothing when sanitising leaves nothing to say", () => {
+    // A link-only message: everything speakable was a URL.
+    expect(buildSpokenNotification({app: "Feeds", title: "", content: "https://example.com/story"})).toBeNull()
+  })
+
+  test("caps length so a long body cannot become a monologue", () => {
+    const body = "word ".repeat(200)
+    const spoken = buildSpokenNotification({app: "Mail", title: "Digest", content: body})
+    expect(spoken).not.toBeNull()
+    expect(spoken!.length).toBeLessThanOrEqual(SPOKEN_MAX_CHARS)
+    // And the cap must not slice a word apart.
+    expect(spoken!.endsWith("word")).toBe(true)
+  })
+
+  test("does not repeat the app name when the title is the app name", () => {
+    expect(buildSpokenNotification({app: "Signal", title: "Signal", content: "new message"})).toBe(
+      "Signal. new message",
+    )
+  })
+
+  test("sanitises before deciding, so a URL-laden notification still reads cleanly", () => {
+    // The leftover "see" is deliberate. Dropping short bodies would also drop
+    // legitimate ones — "Yes", "OK", "On my way" — so a stub word left behind by
+    // a stripped URL is accepted as the lesser cost. What matters is that the
+    // URL and emoji are gone, which is what made this unlistenable.
+    expect(
+      buildSpokenNotification({app: "CI", title: "Build failed 🔥", content: "see https://ci.example.com/42"}),
+    ).toBe("CI: Build failed. see")
+  })
+})


### PR DESCRIPTION
Mentra Live has a speaker and no display, so the reference card the display path requests is invisible there and the wearer learns nothing. This reads the notification aloud instead, and fixes the priority signal that every consumer depends on.

## Reading notifications aloud

`speakPhoneNotification()` is deliberately conservative, because a notification written to be *seen* is hostile when read verbatim:

* Silent on glasses that **do** have a display — the card is better than speech.
* Requires an on-device TTS voice; no network round trip per notification.
* `buildSpokenNotification()` strips URLs and emoji, cuts on a word boundary, and drops summary rows.
* A burst is summarised rather than recited. Notifications do not arrive politely spaced — apps re-post to update a download or a music player, and granting notification access replays whatever is already in the shade. Anything landing inside a 10s quiet window is counted and summarised once ("4 more notifications") instead of read out.

## Priority was a hardcoded placeholder

`onNotificationPosted` reported a fixed value for every notification, so every consumer's priority handling was dead code — including the do-not-interrupt gate in `buildSpokenNotification()`.

The fix reads channel importance from the ranking rather than `Notification.priority`, which was deprecated at API 26 and reads `0` for apps that express intent through a channel — which would make those look ordinary. Only the service can see the ranking, so it is resolved there and passed down, mapped onto the scale consumers already understand (`importance - 3`, so LOW/MIN go negative), falling back to the deprecated field only when no ranking is available.

## Verified on device

Moto g play 2024 (Android 14), listener bound:

```
CrustNotificationListener: Received notification from com.android.shell
CrustNotificationListener: Processing buffered notification from Shell
MANTLE: phone_notification from Shell, priority=0
```

`0` is `IMPORTANCE_DEFAULT` (3) through the mapping — a real value resolved from the channel ranking, where the previous code reported a placeholder. Consistent across repeated posts.

**Not verified:** the negative case. `cmd notification post` always lands on the shell's default-importance channel, so a LOW-channel notification being dropped at the gate has not been observed on device. The arithmetic is trivial and the default case is confirmed live, but that half is reasoning rather than evidence.

`bun test` green, `tsc` clean.

## Note for reviewers

Getting a notification to reach this code at all requires the listener component to be enabled, which lives behind the Debug settings screen. On a device where it is off, `pm dump` shows:

```
disabledComponents:
  com.mentra.crust.services.NotificationListenerServiceImpl
```

and `adb shell pm enable` cannot fix it (`SecurityException: Shell cannot change component state`) — only the app can enable its own component. Worth knowing before concluding notifications are broken.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification listener, Mantle lifecycle/TTS playback, and a breaking type change for `priority` (string → number); behavior is gated by hardware capabilities but logout/cleanup ordering matters for audio state.
> 
> **Overview**
> **Mentra Live (speaker, no display)** now gets audible notification alerts instead of invisible reference cards. `MantleManager` speaks notifications only when capabilities lack a display but have a speaker; display glasses still use the card path.
> 
> **Native priority is fixed end-to-end.** `CrustModule` no longer emits a hardcoded `"normal"` string; it forwards a numeric Android priority. The listener resolves **channel importance** from `NotificationListenerService` ranking (mapped as `importance - 3`), with fallback to deprecated `Notification.priority`. `PhoneNotificationEvent.priority` is typed as `number`.
> 
> **Speech pipeline:** new `spokenNotification` helper sanitizes text (URLs, emoji, summaries), enforces a priority floor, and caps length. `MantleManager` adds TTS playback with a 10s quiet window, burst summarization ("N more notifications"), concurrency/cleanup guards, and explicit teardown on logout.
> 
> **Notify miniapp** no longer requires `DISPLAY` hardware (optional), so notification capture works on Live.
> 
> Tests cover spoken-notification shaping rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91793a43e75174f3769361d24774b03a0ae6d89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->