### PR TITLE
Advance Bluetooth SDK dev release and ship BES 26.7.29.0 in the live manifest

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "17.26.07.28",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.07.28.bin",
-    "sha256": "8145194fbb771cc3bde1de42af8e77fb0d995f370630e514bff9fce513fb8f95"
+    "version": "26.7.29.0",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.29.0.bin",
+    "sha256": "139686e454e9715f5afed26e661666f40b05e4249321adae39304cdcfbd43c3b"
   }
 }

--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.1")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.2")
 }
 ```
 

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -453,7 +453,7 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.1` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.2` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 

--- a/mintlify-docs/mentra-live/examples.mdx
+++ b/mintlify-docs/mentra-live/examples.mdx
@@ -6,7 +6,7 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
-The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.1` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.2` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.1`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.2`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.1"
+  from: "0.1.21-beta.2"
 )
 ```
 

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -27,7 +27,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
-- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.1`.
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.2`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
@@ -35,7 +35,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.1` must use the matching Mentra Live `0.1.21-beta.1` software release.
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.2` must use the matching Mentra Live `0.1.21-beta.2` software release.
 </Warning>
 
 <CardGroup cols={2}>

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -11,7 +11,7 @@ Use a physical phone for Bluetooth testing. Simulators and emulators are useful 
 </Warning>
 
 <Warning>
-This quickstart uses Bluetooth SDK `0.1.21-beta.1`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.1` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+This quickstart uses Bluetooth SDK `0.1.21-beta.2`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.2` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
 </Warning>
 
 ## Step 1: Install The SDK
@@ -20,7 +20,7 @@ This quickstart uses Bluetooth SDK `0.1.21-beta.1`. Before testing SDK features,
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.1
+bun add @mentra/bluetooth-sdk@0.1.21-beta.2
 bunx expo install expo-build-properties
 ```
 
@@ -95,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.1")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.2")
 }
 ```
 
@@ -112,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.21-beta.1`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.21-beta.2`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.1"
+  from: "0.1.21-beta.2"
 )
 ```
 

--- a/mintlify-docs/mentra-live/react-native-expo.mdx
+++ b/mintlify-docs/mentra-live/react-native-expo.mdx
@@ -11,13 +11,13 @@ Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the
 </Warning>
 
 <Warning>
-SDK `0.1.21-beta.1` requires the matching Mentra Live `0.1.21-beta.1` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+SDK `0.1.21-beta.2` requires the matching Mentra Live `0.1.21-beta.2` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
 </Warning>
 
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.1
+bun add @mentra/bluetooth-sdk@0.1.21-beta.2
 bunx expo install expo-build-properties
 ```
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -10,12 +10,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.1` | Mentra Live software `0.1.21-beta.1` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.1` | Mentra Live software `0.1.21-beta.1` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.1` | Mentra Live software `0.1.21-beta.1` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
+| iOS `MentraBluetoothSDK` version `0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.1`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.1` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.2`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.2` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -28,7 +28,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.1`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.1/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-beta.2`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.2/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -60,7 +60,7 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 6. Wait until the app reports that the update is complete. The glasses may restart during installation.
 7. Reconnect and run **Check OTA** again to confirm that no update remains.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.1`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.2`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
@@ -68,7 +68,7 @@ Use this path when the software currently installed on Mentra Live cannot run th
 
 All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-For the latest `0.1.21-beta.1` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.1-`.
+For the latest `0.1.21-beta.2` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.2-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,13 +80,13 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.1-build>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.2-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.1` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.1` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-beta.2` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.2` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App

--- a/mintlify-docs/mentra-live/troubleshooting.mdx
+++ b/mintlify-docs/mentra-live/troubleshooting.mdx
@@ -62,7 +62,7 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 
 Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
 
-If your app uses SDK `0.1.21-beta.1`, [install the matching Mentra Live `0.1.21-beta.1` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+If your app uses SDK `0.1.21-beta.2`, [install the matching Mentra Live `0.1.21-beta.2` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
 
 ## Optional Local Stream Preview Does Not Show Video
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -244,7 +244,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.1",
+      "version": "0.1.21-dev.2",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.21-dev.1",
+  "version": "0.1.21-dev.2",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -263,7 +263,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.1",
+      "version": "0.1.21-dev.2",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",


### PR DESCRIPTION
## Scope

Bluetooth SDK dev-channel release plus the matching live-firmware BES promotion, following the same release shape as #3609.

### 1. Advance the Bluetooth SDK release

Bump `0.1.21-dev.1` to `0.1.21-dev.2` in:

- `mobile/modules/bluetooth-sdk/package.json`
- `mobile/bun.lock`
- `sdk/bun.lock`

The channel-promotion workflow rewrites the prerelease tag downstream, so promoting `dev` to `staging` publishes `0.1.21-beta.2`.

### 2. Promote the new BES firmware

Update `asg_client/ota_manifests/firmware_live.json` from BES `17.26.07.28` to `26.7.29.0`:

| | Old | New |
|---|---|---|
| Version | `17.26.07.28` | `26.7.29.0` |
| File | `bes_firmware_26.07.28.bin` | `bes_firmware_26.7.29.0.bin` |
| SHA-256 | `8145194f…` | `139686e4…` |

Release provenance:

- BES workflow: https://github.com/fengyue120/mentra-live-bes/actions/runs/30472412082
- Source commit: `20ac2a9db7327c54300f292ad7bc8f5c2b9acd45`
- GitHub release: https://github.com/fengyue120/mentra-live-bes/releases/tag/main-26.7.29.0-20ac2a9d
- Immutable firmware: https://firmwarecdn.mentraglass.com/bes_firmware_26.7.29.0.bin
- Size: `1,138,433` bytes
- SHA-256: `139686e454e9715f5afed26e661666f40b05e4249321adae39304cdcfbd43c3b`

The immutable CDN artifact was downloaded and its byte count and digest were independently verified against the publication metadata. The OTA comparators compare dotted components numerically, so `26.7.29.0` is newer than deployed `17.x` firmware and can be installed directly without intermediate BES releases.

### 3. Update Mentra Live documentation

Move all current Mentra Live dependency pins, matching-version warnings, OTA artifact examples, and Starter Kit release links from `0.1.21-beta.1` to `0.1.21-beta.2`.

## Validation

- `bun install --frozen-lockfile --ignore-scripts` in `mobile/`
- `bun install --frozen-lockfile --ignore-scripts` in `sdk/`
- `CI=1 bun run build` in `mobile/modules/bluetooth-sdk/`
- `jq empty asg_client/ota_manifests/firmware_live.json`
- `git diff --check`
- Verified immutable BES CDN content length and SHA-256

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updating `firmware_live.json` directly affects which BES image glasses OTA installs; incorrect URL or hash could brick or strand updates, though MTK patches are unchanged.
> 
> **Overview**
> **Promotes BES firmware** in `asg_client/ota_manifests/firmware_live.json` from `17.26.07.28` to **`26.7.29.0`**, with an updated immutable CDN URL and SHA-256. Mentra Live OTA flows that consume this live manifest will offer the new BES image when version checks show it is newer (numeric dotted comparison).
> 
> The same change set **bumps the documented and workspace Bluetooth SDK version** from `0.1.21-beta.1` / `0.1.21-dev.1` to **`0.1.21-beta.2`** / **`0.1.21-dev.2`** across Mentra Live Mintlify pages (install snippets, OTA/software-update guidance, example APK links) and `mobile/modules/bluetooth-sdk` lockfiles—no runtime SDK logic changes in the diff beyond version strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c79204ba1305c61d56a9f67e9dbb9097c555849. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->