### PR TITLE
Serialize miniapp screenshot persistence

### DIFF
--- a/mobile/src/effects/CapsuleMenu.tsx
+++ b/mobile/src/effects/CapsuleMenu.tsx
@@ -18,6 +18,7 @@ import AppIcon from "@/components/home/AppIcon"
 import {SETTINGS, useSetting} from "@mentra/engine"
 import {useNavigationStore} from "@/stores/navigation"
 import {SYSTEM_APPS} from "@/constants/miniapps"
+import {enqueueScreenshotPersistence} from "@/effects/screenshotPersistenceQueue"
 
 interface CapsuleButtonProps {
   onRightPress?: () => void
@@ -167,6 +168,7 @@ export default function CapsuleMenu({forceShow}: {forceShow: boolean}) {
 
 /** Longest we'll delay a close waiting for the UI to go idle before capturing. */
 const CAPTURE_SETTLE_TIMEOUT_MS = 300
+let screenshotFileSequence = 0
 
 /**
  * Resolve once the UI has settled enough to photograph, or after
@@ -233,36 +235,39 @@ export async function captureScreenshot(
       screenshotUri = cropped.uri
     }
 
-    const screenshotDirectory = new Directory(Paths.document, "miniapp-screenshots")
-    if (!screenshotDirectory.exists) screenshotDirectory.create()
+    await enqueueScreenshotPersistence(async () => {
+      const screenshotDirectory = new Directory(Paths.document, "miniapp-screenshots")
+      if (!screenshotDirectory.exists) screenshotDirectory.create()
 
-    const safePackageName = packageName.replace(/[^a-zA-Z0-9._-]/g, "_")
-    // Unique filename per capture. The app switcher renders this uri through
-    // expo-image, which caches by uri, so reusing one path meant every fresh
-    // capture landed on disk but the card kept showing the first image ever
-    // loaded (OS-1810). Changing the uri is what actually invalidates it.
-    const prefix = `${safePackageName}-`
-    const legacyName = `${safePackageName}.jpg`
-    const persistentFile = new File(screenshotDirectory, `${prefix}${Date.now()}.jpg`)
-    new File(screenshotUri).copy(persistentFile)
+      const safePackageName = packageName.replace(/[^a-zA-Z0-9._-]/g, "_")
+      // Unique filename per capture. The app switcher renders this uri through
+      // expo-image, which caches by uri, so reusing one path meant every fresh
+      // capture landed on disk but the card kept showing the first image ever
+      // loaded (OS-1810). Changing the uri is what actually invalidates it.
+      const prefix = `${safePackageName}-`
+      const legacyName = `${safePackageName}.jpg`
+      const captureId = `${Date.now()}-${screenshotFileSequence++}`
+      const persistentFile = new File(screenshotDirectory, `${prefix}${captureId}.jpg`)
+      new File(screenshotUri).copy(persistentFile)
 
-    // Keep only the capture we just wrote; older ones for this package are
-    // unreachable now that the stored uri points here.
-    for (const entry of screenshotDirectory.list()) {
-      if (
-        entry instanceof File &&
-        (entry.name === legacyName || entry.name.startsWith(prefix)) &&
-        entry.name !== persistentFile.name
-      ) {
-        try {
-          entry.delete()
-        } catch {
-          // A stale file we can't remove is harmless; don't fail the capture.
+      // Publish the new URI before removing older files. Persistence is
+      // serialized so another capture cannot publish a file this sweep deletes.
+      await engine.miniapps.saveScreenshot(packageName, persistentFile.uri)
+
+      for (const entry of screenshotDirectory.list()) {
+        if (
+          entry instanceof File &&
+          (entry.name === legacyName || entry.name.startsWith(prefix)) &&
+          entry.name !== persistentFile.name
+        ) {
+          try {
+            entry.delete()
+          } catch {
+            // A stale file we can't remove is harmless; don't fail the capture.
+          }
         }
       }
-    }
-
-    await engine.miniapps.saveScreenshot(packageName, persistentFile.uri)
+    })
   } catch (error) {
     console.warn("screenshot failed:", error)
   }

--- a/mobile/src/effects/screenshotPersistenceQueue.test.ts
+++ b/mobile/src/effects/screenshotPersistenceQueue.test.ts
@@ -1,0 +1,38 @@
+import {enqueueScreenshotPersistence} from "./screenshotPersistenceQueue"
+
+describe("enqueueScreenshotPersistence", () => {
+  test("does not start a later persistence task until the current one finishes", async () => {
+    const events: string[] = []
+    let finishFirst!: () => void
+    const firstCanFinish = new Promise<void>((resolve) => {
+      finishFirst = resolve
+    })
+
+    const first = enqueueScreenshotPersistence(async () => {
+      events.push("first:start")
+      await firstCanFinish
+      events.push("first:end")
+    })
+    const second = enqueueScreenshotPersistence(async () => {
+      events.push("second:start")
+      events.push("second:end")
+    })
+
+    await Promise.resolve()
+    expect(events).toEqual(["first:start"])
+
+    finishFirst()
+    await Promise.all([first, second])
+    expect(events).toEqual(["first:start", "first:end", "second:start", "second:end"])
+  })
+
+  test("continues processing after a persistence task fails", async () => {
+    await expect(
+      enqueueScreenshotPersistence(async () => {
+        throw new Error("write failed")
+      }),
+    ).rejects.toThrow("write failed")
+
+    await expect(enqueueScreenshotPersistence(async () => "saved")).resolves.toBe("saved")
+  })
+})

--- a/mobile/src/effects/screenshotPersistenceQueue.ts
+++ b/mobile/src/effects/screenshotPersistenceQueue.ts
@@ -1,0 +1,14 @@
+let persistenceTail: Promise<void> = Promise.resolve()
+
+/**
+ * Serialize screenshot file writes, URI updates, and cleanup. Capture itself
+ * stays concurrent so gesture handlers still begin it synchronously.
+ */
+export function enqueueScreenshotPersistence<T>(task: () => Promise<T>): Promise<T> {
+  const result = persistenceTail.then(task)
+  persistenceTail = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return result
+}


### PR DESCRIPTION
## Summary

- serialize screenshot file writes, stored-URI updates, and cleanup so overlapping captures cannot delete each other’s live files
- publish the new screenshot URI before sweeping older package screenshots
- make timestamped filenames collision-safe and add regression coverage for overlapping and failed persistence tasks

## Context

The main OS-1810 screenshot fix already reached `dev` through #3607. This focused follow-up addresses the remaining concurrent-cleanup finding from #3623 without carrying the now-superseded Livestreamer or streaming-metrics changes.

## Testing

- `bun compile`
- `bun run test --runInBand` — 77 suites passed, 585 tests passed
- `bunx eslint src/effects/screenshotPersistenceQueue.ts src/effects/screenshotPersistenceQueue.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to miniapp screenshot persistence with clear ordering fixes and regression tests; no auth or shared infrastructure impact.
> 
> **Overview**
> **Serializes** miniapp screenshot **disk persistence** so overlapping captures cannot delete each other’s live files or race on cleanup.
> 
> `captureScreenshot` still runs capture concurrently; only the write / `engine.miniapps.saveScreenshot` / stale-file sweep runs through a new **`enqueueScreenshotPersistence`** queue. The stored URI is **published before** deleting older package screenshots, and filenames use a **timestamp + sequence** suffix to avoid collisions. Unit tests cover strict ordering and queue recovery after a failed task.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ae5e65c8cbd9a0e7912bedc47b2807556100957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize miniapp screenshot persistence to prevent race conditions and ensure fresh captures display by invalidating `expo-image` cache with unique URIs. Adds collision-safe filenames and tests to cover overlapping and failed tasks. Part of OS-1810.

- **Bug Fixes**
  - Serialize file write, saved-URI update, and cleanup with `enqueueScreenshotPersistence` so overlapping captures don’t delete active files.
  - Publish the new screenshot URI before sweeping old files to avoid races.
  - Use timestamp+sequence filenames per capture to force a new URI and break `expo-image` caching of stale images.
  - Add tests to verify task ordering and that the queue continues after failures.

<sup>Written for commit 5ae5e65c8cbd9a0e7912bedc47b2807556100957. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

