### PR TITLE
Make BLE JSON compaction lossless

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompact.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompact.java
@@ -14,7 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff. */
+/** BLE Wire Protocol v2 JSON compaction with lossless fallback for ambiguous payloads. */
 public final class BleJsonCompact {
 
     private static final Map<String, String> LONG_TO_SHORT = new HashMap<>();
@@ -47,8 +47,6 @@ public final class BleJsonCompact {
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("ck", "chunked_msg")));
 
     private static long sessionConnectEpochMs;
-    private static boolean resolvedConfigSent;
-    private static String currentSessionResolvedConfigHash;
     private static final Map<String, JSONObject> resolvedConfigByHash = new HashMap<>();
 
     static {
@@ -102,8 +100,6 @@ public final class BleJsonCompact {
 
     public static void resetSession() {
         sessionConnectEpochMs = 0L;
-        resolvedConfigSent = false;
-        currentSessionResolvedConfigHash = null;
         resolvedConfigByHash.clear();
     }
 
@@ -160,7 +156,7 @@ public final class BleJsonCompact {
             return json;
         }
         String messageType = extractMessageType(json);
-        if (!shouldCompactOutbound(messageType)) {
+        if (!shouldCompactOutbound(messageType) || !canCompactLosslessly(json, true)) {
             return json;
         }
         return compactObject(json, true);
@@ -224,46 +220,79 @@ public final class BleJsonCompact {
         fromInt.put(code, value);
     }
 
+    /**
+     * Compact JSON has reserved short keys and enum integers. If an otherwise valid future payload
+     * already uses one of those wire representations, sending verbose JSON is the only way an older
+     * decoder can distinguish the original value.
+     */
+    private static boolean canCompactLosslessly(JSONObject input, boolean topLevel)
+            throws JSONException {
+        String messageType = input.optString("type", input.optString("t", ""));
+        Iterator<String> keys = input.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value = input.get(key);
+            if (SHORT_TO_LONG.containsKey(key)
+                    || (topLevel && KEY_RESOLVED_CONFIG_HASH.equals(key))
+                    || isAmbiguousEnumValue(key, value, messageType)) {
+                return false;
+            }
+            if (value instanceof JSONObject
+                    && !canCompactLosslessly((JSONObject) value, false)) {
+                return false;
+            }
+            if (value instanceof JSONArray
+                    && !canCompactArrayLosslessly((JSONArray) value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean canCompactArrayLosslessly(JSONArray array) throws JSONException {
+        for (int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if (value instanceof JSONObject
+                    && !canCompactLosslessly((JSONObject) value, false)) {
+                return false;
+            }
+            if (value instanceof JSONArray
+                    && !canCompactArrayLosslessly((JSONArray) value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAmbiguousEnumValue(
+            String key, Object value, String messageType) {
+        if (!(value instanceof Number)) {
+            return false;
+        }
+        return "kind".equals(key)
+                || "source".equals(key)
+                || "aeStateName".equals(key)
+                || ("status".equals(key) && "photo_status".equals(messageType));
+    }
+
     private static JSONObject compactObject(JSONObject input, boolean topLevel) throws JSONException {
         JSONObject output = new JSONObject();
         String messageType = input.optString("type", input.optString("t", ""));
-        boolean skipResolvedConfig = false;
-
-        if (topLevel
-                && shouldDiffResolvedConfig(messageType)
-                && input.opt("resolvedConfig") instanceof JSONObject) {
-            JSONObject resolvedConfig = input.getJSONObject("resolvedConfig");
-            String hash = hashConfig(resolvedConfig);
-            resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
-            if (resolvedConfigSent && hash.equals(currentSessionResolvedConfigHash)) {
-                output.put(KEY_RESOLVED_CONFIG_HASH, hash);
-                skipResolvedConfig = true;
-            } else {
-                currentSessionResolvedConfigHash = hash;
-                resolvedConfigSent = true;
-            }
-        }
 
         Iterator<String> keys = input.keys();
         while (keys.hasNext()) {
             String key = keys.next();
-            if (skipResolvedConfig && "resolvedConfig".equals(key)) {
-                continue;
-            }
             Object value = input.get(key);
-            String shortKey = LONG_TO_SHORT.getOrDefault(key, key);
+            // Keep the absolute timestamp under its verbose key. Legacy peers recognize it and
+            // therefore do not mistake it for the old session-relative `ts` representation.
+            String shortKey =
+                    topLevel && "timestamp".equals(key)
+                            ? key
+                            : LONG_TO_SHORT.getOrDefault(key, key);
             Object compacted = compactValue(key, value, messageType);
             output.put(shortKey, compacted);
         }
-
-        if (topLevel) {
-            compactTimestamp(output);
-        }
         return output;
-    }
-
-    private static boolean shouldDiffResolvedConfig(String messageType) {
-        return "photo_status".equals(messageType) || "stream_status".equals(messageType);
     }
 
     private static Object compactValue(String longKey, Object value, String messageType)
@@ -321,28 +350,6 @@ public final class BleJsonCompact {
         return out;
     }
 
-    private static void compactTimestamp(JSONObject output) throws JSONException {
-        String tsKey = output.has("timestamp") ? "timestamp" : (output.has("ts") ? "ts" : null);
-        if (tsKey == null) {
-            return;
-        }
-        Object timestamp = output.opt(tsKey);
-        if (!(timestamp instanceof Number)) {
-            return;
-        }
-        long absolute = ((Number) timestamp).longValue();
-        if (absolute <= 0) {
-            return;
-        }
-        if (sessionConnectEpochMs <= 0) {
-            sessionConnectEpochMs = absolute;
-        }
-        output.put("ts", absolute - sessionConnectEpochMs);
-        if (!"ts".equals(tsKey)) {
-            output.remove(tsKey);
-        }
-    }
-
     private static JSONObject expandObject(JSONObject input, boolean topLevel) throws JSONException {
         JSONObject output = new JSONObject();
         String messageType = input.optString("type", input.optString("t", ""));
@@ -375,8 +382,6 @@ public final class BleJsonCompact {
         JSONObject resolvedConfig = output.getJSONObject("resolvedConfig");
         String hash = hashConfig(resolvedConfig);
         resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
-        currentSessionResolvedConfigHash = hash;
-        resolvedConfigSent = true;
     }
 
     private static void expandResolvedConfigHash(JSONObject output) throws JSONException {
@@ -387,8 +392,8 @@ public final class BleJsonCompact {
         JSONObject cached = resolvedConfigByHash.get(hash);
         if (cached != null) {
             output.put("resolvedConfig", cloneObject(cached));
+            output.remove(KEY_RESOLVED_CONFIG_HASH);
         }
-        output.remove(KEY_RESOLVED_CONFIG_HASH);
     }
 
     private static Object expandValue(String longKey, Object value, String messageType)

--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompact.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompact.java
@@ -14,7 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, omitted defaults, config diff. */
+/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff. */
 public final class BleJsonCompact {
 
     private static final Map<String, String> LONG_TO_SHORT = new HashMap<>();
@@ -229,7 +229,9 @@ public final class BleJsonCompact {
         String messageType = input.optString("type", input.optString("t", ""));
         boolean skipResolvedConfig = false;
 
-        if (topLevel && shouldDiffResolvedConfig(messageType) && input.has("resolvedConfig")) {
+        if (topLevel
+                && shouldDiffResolvedConfig(messageType)
+                && input.opt("resolvedConfig") instanceof JSONObject) {
             JSONObject resolvedConfig = input.getJSONObject("resolvedConfig");
             String hash = hashConfig(resolvedConfig);
             resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
@@ -251,9 +253,6 @@ public final class BleJsonCompact {
             Object value = input.get(key);
             String shortKey = LONG_TO_SHORT.getOrDefault(key, key);
             Object compacted = compactValue(key, value, messageType);
-            if (shouldOmit(compacted)) {
-                continue;
-            }
             output.put(shortKey, compacted);
         }
 
@@ -270,7 +269,7 @@ public final class BleJsonCompact {
     private static Object compactValue(String longKey, Object value, String messageType)
             throws JSONException {
         if (value == JSONObject.NULL || value == null) {
-            return null;
+            return JSONObject.NULL;
         }
         if (value instanceof JSONObject) {
             return compactObject((JSONObject) value, false);
@@ -322,28 +321,16 @@ public final class BleJsonCompact {
         return out;
     }
 
-    private static boolean shouldOmit(Object value) {
-        if (value == null || value == JSONObject.NULL) {
-            return true;
-        }
-        if (value instanceof Boolean && !((Boolean) value)) {
-            return true;
-        }
-        if (value instanceof JSONObject && ((JSONObject) value).length() == 0) {
-            return true;
-        }
-        if (value instanceof JSONArray && ((JSONArray) value).length() == 0) {
-            return true;
-        }
-        return false;
-    }
-
     private static void compactTimestamp(JSONObject output) throws JSONException {
         String tsKey = output.has("timestamp") ? "timestamp" : (output.has("ts") ? "ts" : null);
         if (tsKey == null) {
             return;
         }
-        long absolute = output.optLong(tsKey);
+        Object timestamp = output.opt(tsKey);
+        if (!(timestamp instanceof Number)) {
+            return;
+        }
+        long absolute = ((Number) timestamp).longValue();
         if (absolute <= 0) {
             return;
         }
@@ -370,9 +357,6 @@ public final class BleJsonCompact {
             }
             String longKey = SHORT_TO_LONG.getOrDefault(key, key);
             Object expanded = expandValue(longKey, value, messageType);
-            if (expanded == null || expanded == JSONObject.NULL) {
-                continue;
-            }
             output.put(longKey, expanded);
         }
 
@@ -385,7 +369,7 @@ public final class BleJsonCompact {
     }
 
     private static void cacheResolvedConfigIfPresent(JSONObject output) throws JSONException {
-        if (!output.has("resolvedConfig")) {
+        if (!(output.opt("resolvedConfig") instanceof JSONObject)) {
             return;
         }
         JSONObject resolvedConfig = output.getJSONObject("resolvedConfig");
@@ -410,7 +394,7 @@ public final class BleJsonCompact {
     private static Object expandValue(String longKey, Object value, String messageType)
             throws JSONException {
         if (value == JSONObject.NULL || value == null) {
-            return null;
+            return JSONObject.NULL;
         }
         if (value instanceof JSONObject) {
             return expandObject((JSONObject) value, false);
@@ -449,7 +433,13 @@ public final class BleJsonCompact {
 
     private static void expandTimestamp(JSONObject output) throws JSONException {
         if (!output.has("timestamp") && output.has("ts")) {
-            long delta = output.optLong("ts");
+            Object timestamp = output.opt("ts");
+            if (!(timestamp instanceof Number)) {
+                output.put("timestamp", timestamp);
+                output.remove("ts");
+                return;
+            }
+            long delta = ((Number) timestamp).longValue();
             long absolute = sessionConnectEpochMs > 0 ? sessionConnectEpochMs + delta : delta;
             output.put("timestamp", absolute);
             output.remove("ts");

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompactTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompactTest.java
@@ -37,9 +37,11 @@ public class BleJsonCompactTest {
         assertThat(compact.getString("r")).isEqualTo("p1");
         assertThat(compact.getInt("s")).isEqualTo(3);
         assertThat(compact.getLong("ts")).isEqualTo(100L);
-        assertThat(compact.has("rc")).isFalse();
+        assertThat(compact.has("rc")).isTrue();
+        assertThat(compact.getBoolean("rc")).isFalse();
         assertThat(compact.getJSONObject("cm").getInt("aes")).isEqualTo(0);
-        assertThat(compact.getJSONObject("cm").has("m")).isFalse();
+        assertThat(compact.getJSONObject("cm").has("m")).isTrue();
+        assertThat(compact.getJSONObject("cm").getBoolean("m")).isFalse();
     }
 
     @Test
@@ -124,6 +126,59 @@ public class BleJsonCompactTest {
 
         assertThat(BleJsonCompact.encode(photoStatus).getString("t")).isEqualTo("photo_status");
         assertThat(BleJsonCompact.encode(streamStatus).getString("t")).isEqualTo("stream_status");
+    }
+
+    @Test
+    public void jsonValuesRoundTripAtEveryDepth() throws Exception {
+        JSONObject status =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"status\":\"stopped\","
+                                + "\"streaming\":false,\"reconnecting\":false,"
+                                + "\"resolvedConfig\":{\"audio\":{\"echoCancellation\":false,"
+                                + "\"noiseSuppression\":false}},"
+                                + "\"nullValue\":null,\"emptyObject\":{},\"emptyArray\":[]}");
+
+        JSONObject wire = BleJsonCompact.encode(status);
+
+        assertThat(wire.has("streaming")).isTrue();
+        assertThat(wire.getBoolean("streaming")).isFalse();
+        assertThat(wire.has("rc")).isTrue();
+        assertThat(wire.getBoolean("rc")).isFalse();
+        JSONObject wireAudio = wire.getJSONObject("resolvedConfig").getJSONObject("audio");
+        assertThat(wireAudio.has("echoCancellation")).isTrue();
+        assertThat(wireAudio.getBoolean("echoCancellation")).isFalse();
+        assertThat(wireAudio.has("noiseSuppression")).isTrue();
+        assertThat(wireAudio.getBoolean("noiseSuppression")).isFalse();
+        assertThat(wire.has("nullValue")).isTrue();
+        assertThat(wire.isNull("nullValue")).isTrue();
+        assertThat(wire.getJSONObject("emptyObject").length()).isZero();
+        assertThat(wire.getJSONArray("emptyArray").length()).isZero();
+
+        JSONObject restored = BleJsonCompact.decode(wire);
+        assertThat(restored.getBoolean("streaming")).isFalse();
+        assertThat(restored.getBoolean("reconnecting")).isFalse();
+        JSONObject restoredAudio =
+                restored.getJSONObject("resolvedConfig").getJSONObject("audio");
+        assertThat(restoredAudio.getBoolean("echoCancellation")).isFalse();
+        assertThat(restoredAudio.getBoolean("noiseSuppression")).isFalse();
+        assertThat(restored.has("nullValue")).isTrue();
+        assertThat(restored.isNull("nullValue")).isTrue();
+        assertThat(restored.getJSONObject("emptyObject").length()).isZero();
+        assertThat(restored.getJSONArray("emptyArray").length()).isZero();
+    }
+
+    @Test
+    public void wifiScanPreservesIncompleteMarker() throws Exception {
+        JSONObject result =
+                new JSONObject(
+                        "{\"type\":\"wifi_scan_result\",\"networks\":[\"one\"],"
+                                + "\"scan_complete\":false}");
+
+        JSONObject wire = BleJsonCompact.encode(result);
+
+        assertThat(wire.has("scan_complete")).isTrue();
+        assertThat(wire.getBoolean("scan_complete")).isFalse();
+        assertThat(BleJsonCompact.decode(wire).getBoolean("scan_complete")).isFalse();
     }
 
     @Test

--- a/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompactTest.java
+++ b/asg_client/app/src/test/java/com/mentra/asg_client/io/bluetooth/utils/BleJsonCompactTest.java
@@ -36,12 +36,14 @@ public class BleJsonCompactTest {
         assertThat(compact.getString("t")).isEqualTo("photo_status");
         assertThat(compact.getString("r")).isEqualTo("p1");
         assertThat(compact.getInt("s")).isEqualTo(3);
-        assertThat(compact.getLong("ts")).isEqualTo(100L);
+        assertThat(compact.getLong("timestamp")).isEqualTo(1_700_000_000_100L);
+        assertThat(compact.has("ts")).isFalse();
         assertThat(compact.has("rc")).isTrue();
         assertThat(compact.getBoolean("rc")).isFalse();
         assertThat(compact.getJSONObject("cm").getInt("aes")).isEqualTo(0);
         assertThat(compact.getJSONObject("cm").has("m")).isTrue();
         assertThat(compact.getJSONObject("cm").getBoolean("m")).isFalse();
+        assertThat(compact.toString().length()).isLessThan(input.toString().length());
     }
 
     @Test
@@ -65,7 +67,7 @@ public class BleJsonCompactTest {
     }
 
     @Test
-    public void resolvedConfigDiffOmitsRepeatPayload() throws Exception {
+    public void resolvedConfigIsAlwaysSent() throws Exception {
         BleJsonCompact.markSessionConnected(1_000L);
         JSONObject config = new JSONObject("{\"source\":\"sdk\",\"manual\":false}");
         JSONObject first =
@@ -91,13 +93,100 @@ public class BleJsonCompactTest {
         JSONObject secondWire = BleJsonCompact.encode(second);
 
         assertThat(firstWire.has("resolvedConfig")).isTrue();
-        assertThat(secondWire.has("resolvedConfig")).isFalse();
-        assertThat(secondWire.getString(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH))
-                .isEqualTo(BleJsonCompact.hashConfig(config));
+        assertThat(secondWire.has("resolvedConfig")).isTrue();
+        assertThat(secondWire.has(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH)).isFalse();
 
+        BleJsonCompact.markSessionConnected(9_000L);
         JSONObject restoredSecond = BleJsonCompact.decode(secondWire);
         assertThat(restoredSecond.getJSONObject("resolvedConfig").getString("source"))
                 .isEqualTo("sdk");
+        assertThat(restoredSecond.getLong("timestamp")).isEqualTo(1_100L);
+    }
+
+    @Test
+    public void legacyResolvedConfigHashStillDecodesWhenCached() throws Exception {
+        JSONObject config = new JSONObject("{\"source\":\"sdk\",\"manual\":false}");
+        JSONObject full =
+                new JSONObject(
+                        "{\"t\":\"photo_status\",\"s\":2,\"resolvedConfig\":"
+                                + config
+                                + "}");
+        BleJsonCompact.decode(full);
+        JSONObject hashOnly =
+                new JSONObject(
+                        "{\"t\":\"photo_status\",\"s\":2,\"rch\":\""
+                                + BleJsonCompact.hashConfig(config)
+                                + "\"}");
+
+        JSONObject restored = BleJsonCompact.decode(hashOnly);
+
+        assertThat(restored.getJSONObject("resolvedConfig").getString("source"))
+                .isEqualTo("sdk");
+        assertThat(restored.has(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH)).isFalse();
+    }
+
+    @Test
+    public void legacyResolvedConfigCacheMissKeepsHashForDiagnostics() throws Exception {
+        JSONObject hashOnly =
+                new JSONObject(
+                        "{\"t\":\"stream_status\",\"s\":\"streaming\",\"rch\":\"deadbeef\"}");
+
+        JSONObject restored = BleJsonCompact.decode(hashOnly);
+
+        assertThat(restored.getString(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH))
+                .isEqualTo("deadbeef");
+        assertThat(restored.has("resolvedConfig")).isFalse();
+    }
+
+    @Test
+    public void ambiguousNestedWireKeysFallBackToVerboseJson() throws Exception {
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"payload\":{"
+                                + "\"s\":\"literal\",\"kind\":0,\"source\":1}}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+
+        assertThat(wire.has("type")).isTrue();
+        assertThat(wire.has("t")).isFalse();
+        assertThat(wire.getJSONObject("payload").getString("s")).isEqualTo("literal");
+        assertThat(wire.getJSONObject("payload").getInt("kind")).isZero();
+        assertThat(wire.getJSONObject("payload").getInt("source")).isEqualTo(1);
+        JSONObject restored = BleJsonCompact.decodeIfSupported(wire);
+        assertThat(restored.getJSONObject("payload").getString("s")).isEqualTo("literal");
+        assertThat(restored.getJSONObject("payload").getInt("kind")).isZero();
+        assertThat(restored.getJSONObject("payload").getInt("source")).isEqualTo(1);
+    }
+
+    @Test
+    public void numericEnumFieldsFallBackToVerboseJson() throws Exception {
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"payload\":{\"kind\":0,\"source\":1}}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+
+        assertThat(wire.has("type")).isTrue();
+        assertThat(wire.has("t")).isFalse();
+        assertThat(wire.getJSONObject("payload").getInt("kind")).isZero();
+        assertThat(wire.getJSONObject("payload").getInt("source")).isEqualTo(1);
+    }
+
+    @Test
+    public void absoluteTimestampSurvivesDifferentSessionEpochs() throws Exception {
+        BleJsonCompact.markSessionConnected(1_000L);
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"status\":\"streaming\","
+                                + "\"timestamp\":1700000000123}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+        BleJsonCompact.markSessionConnected(9_000L);
+        JSONObject restored = BleJsonCompact.decode(wire);
+
+        assertThat(wire.getLong("timestamp")).isEqualTo(1_700_000_000_123L);
+        assertThat(wire.has("ts")).isFalse();
+        assertThat(restored.getLong("timestamp")).isEqualTo(1_700_000_000_123L);
     }
 
     @Test

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
@@ -250,7 +250,7 @@ public final class BleJsonCompact {
             Object value = input.get(key);
             String shortKey = LONG_TO_SHORT.getOrDefault(key, key);
             Object compacted = compactValue(key, value, messageType);
-            if (shouldOmit(compacted)) {
+            if (shouldOmit(key, compacted, messageType)) {
                 continue;
             }
             output.put(shortKey, compacted);
@@ -321,12 +321,14 @@ public final class BleJsonCompact {
         return out;
     }
 
-    private static boolean shouldOmit(Object value) {
+    private static boolean shouldOmit(String longKey, Object value, String messageType) {
         if (value == null || value == JSONObject.NULL) {
             return true;
         }
         if (value instanceof Boolean && !((Boolean) value)) {
-            return true;
+            // start_stream.sound defaults to true on the glasses, so false is an
+            // override rather than an omittable default.
+            return !("start_stream".equals(messageType) && "sound".equals(longKey));
         }
         if (value instanceof JSONObject && ((JSONObject) value).length() == 0) {
             return true;

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
@@ -14,7 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff. */
+/** BLE Wire Protocol v2 JSON compaction with lossless fallback for ambiguous payloads. */
 public final class BleJsonCompact {
 
     private static final Map<String, String> LONG_TO_SHORT = new HashMap<>();
@@ -47,8 +47,6 @@ public final class BleJsonCompact {
             Collections.unmodifiableSet(new HashSet<>(Arrays.asList("ck", "chunked_msg")));
 
     private static long sessionConnectEpochMs;
-    private static boolean resolvedConfigSent;
-    private static String currentSessionResolvedConfigHash;
     private static final Map<String, JSONObject> resolvedConfigByHash = new HashMap<>();
 
     static {
@@ -102,8 +100,6 @@ public final class BleJsonCompact {
 
     public static void resetSession() {
         sessionConnectEpochMs = 0L;
-        resolvedConfigSent = false;
-        currentSessionResolvedConfigHash = null;
         resolvedConfigByHash.clear();
     }
 
@@ -160,7 +156,7 @@ public final class BleJsonCompact {
             return json;
         }
         String messageType = extractMessageType(json);
-        if (!shouldCompactOutbound(messageType)) {
+        if (!shouldCompactOutbound(messageType) || !canCompactLosslessly(json, true)) {
             return json;
         }
         return compactObject(json, true);
@@ -223,46 +219,79 @@ public final class BleJsonCompact {
         fromInt.put(code, value);
     }
 
+    /**
+     * Compact JSON has reserved short keys and enum integers. If an otherwise valid future payload
+     * already uses one of those wire representations, sending verbose JSON is the only way an older
+     * decoder can distinguish the original value.
+     */
+    private static boolean canCompactLosslessly(JSONObject input, boolean topLevel)
+            throws JSONException {
+        String messageType = input.optString("type", input.optString("t", ""));
+        Iterator<String> keys = input.keys();
+        while (keys.hasNext()) {
+            String key = keys.next();
+            Object value = input.get(key);
+            if (SHORT_TO_LONG.containsKey(key)
+                    || (topLevel && KEY_RESOLVED_CONFIG_HASH.equals(key))
+                    || isAmbiguousEnumValue(key, value, messageType)) {
+                return false;
+            }
+            if (value instanceof JSONObject
+                    && !canCompactLosslessly((JSONObject) value, false)) {
+                return false;
+            }
+            if (value instanceof JSONArray
+                    && !canCompactArrayLosslessly((JSONArray) value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean canCompactArrayLosslessly(JSONArray array) throws JSONException {
+        for (int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if (value instanceof JSONObject
+                    && !canCompactLosslessly((JSONObject) value, false)) {
+                return false;
+            }
+            if (value instanceof JSONArray
+                    && !canCompactArrayLosslessly((JSONArray) value)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAmbiguousEnumValue(
+            String key, Object value, String messageType) {
+        if (!(value instanceof Number)) {
+            return false;
+        }
+        return "kind".equals(key)
+                || "source".equals(key)
+                || "aeStateName".equals(key)
+                || ("status".equals(key) && "photo_status".equals(messageType));
+    }
+
     private static JSONObject compactObject(JSONObject input, boolean topLevel) throws JSONException {
         JSONObject output = new JSONObject();
         String messageType = input.optString("type", input.optString("t", ""));
-        boolean skipResolvedConfig = false;
-
-        if (topLevel
-                && shouldDiffResolvedConfig(messageType)
-                && input.opt("resolvedConfig") instanceof JSONObject) {
-            JSONObject resolvedConfig = input.getJSONObject("resolvedConfig");
-            String hash = hashConfig(resolvedConfig);
-            resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
-            if (resolvedConfigSent && hash.equals(currentSessionResolvedConfigHash)) {
-                output.put(KEY_RESOLVED_CONFIG_HASH, hash);
-                skipResolvedConfig = true;
-            } else {
-                currentSessionResolvedConfigHash = hash;
-                resolvedConfigSent = true;
-            }
-        }
 
         Iterator<String> keys = input.keys();
         while (keys.hasNext()) {
             String key = keys.next();
-            if (skipResolvedConfig && "resolvedConfig".equals(key)) {
-                continue;
-            }
             Object value = input.get(key);
-            String shortKey = LONG_TO_SHORT.getOrDefault(key, key);
+            // Keep the absolute timestamp under its verbose key. Legacy peers recognize it and
+            // therefore do not mistake it for the old session-relative `ts` representation.
+            String shortKey =
+                    topLevel && "timestamp".equals(key)
+                            ? key
+                            : LONG_TO_SHORT.getOrDefault(key, key);
             Object compacted = compactValue(key, value, messageType);
             output.put(shortKey, compacted);
         }
-
-        if (topLevel) {
-            compactTimestamp(output);
-        }
         return output;
-    }
-
-    private static boolean shouldDiffResolvedConfig(String messageType) {
-        return "photo_status".equals(messageType) || "stream_status".equals(messageType);
     }
 
     private static Object compactValue(String longKey, Object value, String messageType)
@@ -320,28 +349,6 @@ public final class BleJsonCompact {
         return out;
     }
 
-    private static void compactTimestamp(JSONObject output) throws JSONException {
-        String tsKey = output.has("timestamp") ? "timestamp" : (output.has("ts") ? "ts" : null);
-        if (tsKey == null) {
-            return;
-        }
-        Object timestamp = output.opt(tsKey);
-        if (!(timestamp instanceof Number)) {
-            return;
-        }
-        long absolute = ((Number) timestamp).longValue();
-        if (absolute <= 0) {
-            return;
-        }
-        if (sessionConnectEpochMs <= 0) {
-            sessionConnectEpochMs = absolute;
-        }
-        output.put("ts", absolute - sessionConnectEpochMs);
-        if (!"ts".equals(tsKey)) {
-            output.remove(tsKey);
-        }
-    }
-
     private static JSONObject expandObject(JSONObject input, boolean topLevel) throws JSONException {
         JSONObject output = new JSONObject();
         String messageType = input.optString("type", input.optString("t", ""));
@@ -374,8 +381,6 @@ public final class BleJsonCompact {
         JSONObject resolvedConfig = output.getJSONObject("resolvedConfig");
         String hash = hashConfig(resolvedConfig);
         resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
-        currentSessionResolvedConfigHash = hash;
-        resolvedConfigSent = true;
     }
 
     private static void expandResolvedConfigHash(JSONObject output) throws JSONException {
@@ -386,8 +391,8 @@ public final class BleJsonCompact {
         JSONObject cached = resolvedConfigByHash.get(hash);
         if (cached != null) {
             output.put("resolvedConfig", cloneObject(cached));
+            output.remove(KEY_RESOLVED_CONFIG_HASH);
         }
-        output.remove(KEY_RESOLVED_CONFIG_HASH);
     }
 
     private static Object expandValue(String longKey, Object value, String messageType)

--- a/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
+++ b/mobile/modules/bluetooth-sdk/android/src/main/java/com/mentra/bluetoothsdk/utils/BleJsonCompact.java
@@ -14,7 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, omitted defaults, config diff. */
+/** BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff. */
 public final class BleJsonCompact {
 
     private static final Map<String, String> LONG_TO_SHORT = new HashMap<>();
@@ -228,7 +228,9 @@ public final class BleJsonCompact {
         String messageType = input.optString("type", input.optString("t", ""));
         boolean skipResolvedConfig = false;
 
-        if (topLevel && shouldDiffResolvedConfig(messageType) && input.has("resolvedConfig")) {
+        if (topLevel
+                && shouldDiffResolvedConfig(messageType)
+                && input.opt("resolvedConfig") instanceof JSONObject) {
             JSONObject resolvedConfig = input.getJSONObject("resolvedConfig");
             String hash = hashConfig(resolvedConfig);
             resolvedConfigByHash.put(hash, cloneObject(resolvedConfig));
@@ -250,9 +252,6 @@ public final class BleJsonCompact {
             Object value = input.get(key);
             String shortKey = LONG_TO_SHORT.getOrDefault(key, key);
             Object compacted = compactValue(key, value, messageType);
-            if (shouldOmit(key, compacted, messageType)) {
-                continue;
-            }
             output.put(shortKey, compacted);
         }
 
@@ -269,7 +268,7 @@ public final class BleJsonCompact {
     private static Object compactValue(String longKey, Object value, String messageType)
             throws JSONException {
         if (value == JSONObject.NULL || value == null) {
-            return null;
+            return JSONObject.NULL;
         }
         if (value instanceof JSONObject) {
             return compactObject((JSONObject) value, false);
@@ -321,30 +320,16 @@ public final class BleJsonCompact {
         return out;
     }
 
-    private static boolean shouldOmit(String longKey, Object value, String messageType) {
-        if (value == null || value == JSONObject.NULL) {
-            return true;
-        }
-        if (value instanceof Boolean && !((Boolean) value)) {
-            // start_stream.sound defaults to true on the glasses, so false is an
-            // override rather than an omittable default.
-            return !("start_stream".equals(messageType) && "sound".equals(longKey));
-        }
-        if (value instanceof JSONObject && ((JSONObject) value).length() == 0) {
-            return true;
-        }
-        if (value instanceof JSONArray && ((JSONArray) value).length() == 0) {
-            return true;
-        }
-        return false;
-    }
-
     private static void compactTimestamp(JSONObject output) throws JSONException {
         String tsKey = output.has("timestamp") ? "timestamp" : (output.has("ts") ? "ts" : null);
         if (tsKey == null) {
             return;
         }
-        long absolute = output.optLong(tsKey);
+        Object timestamp = output.opt(tsKey);
+        if (!(timestamp instanceof Number)) {
+            return;
+        }
+        long absolute = ((Number) timestamp).longValue();
         if (absolute <= 0) {
             return;
         }
@@ -371,9 +356,6 @@ public final class BleJsonCompact {
             }
             String longKey = SHORT_TO_LONG.getOrDefault(key, key);
             Object expanded = expandValue(longKey, value, messageType);
-            if (expanded == null || expanded == JSONObject.NULL) {
-                continue;
-            }
             output.put(longKey, expanded);
         }
 
@@ -386,7 +368,7 @@ public final class BleJsonCompact {
     }
 
     private static void cacheResolvedConfigIfPresent(JSONObject output) throws JSONException {
-        if (!output.has("resolvedConfig")) {
+        if (!(output.opt("resolvedConfig") instanceof JSONObject)) {
             return;
         }
         JSONObject resolvedConfig = output.getJSONObject("resolvedConfig");
@@ -411,7 +393,7 @@ public final class BleJsonCompact {
     private static Object expandValue(String longKey, Object value, String messageType)
             throws JSONException {
         if (value == JSONObject.NULL || value == null) {
-            return null;
+            return JSONObject.NULL;
         }
         if (value instanceof JSONObject) {
             return expandObject((JSONObject) value, false);
@@ -450,7 +432,13 @@ public final class BleJsonCompact {
 
     private static void expandTimestamp(JSONObject output) throws JSONException {
         if (!output.has("timestamp") && output.has("ts")) {
-            long delta = output.optLong("ts");
+            Object timestamp = output.opt("ts");
+            if (!(timestamp instanceof Number)) {
+                output.put("timestamp", timestamp);
+                output.remove("ts");
+                return;
+            }
+            long delta = ((Number) timestamp).longValue();
             long absolute = sessionConnectEpochMs > 0 ? sessionConnectEpochMs + delta : delta;
             output.put("timestamp", absolute);
             output.remove("ts");

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
@@ -136,6 +136,21 @@ public class BleJsonCompactTest {
     }
 
     @Test
+    public void startStreamPreservesDisabledSound() throws Exception {
+        JSONObject start =
+                new JSONObject(
+                        "{\"type\":\"start_stream\",\"streamUrl\":\"https://example.test/whip\","
+                                + "\"sound\":false}");
+
+        JSONObject wire = BleJsonCompact.encode(start);
+
+        assertEquals("start_stream", wire.getString("t"));
+        assertTrue(wire.has("sound"));
+        assertFalse(wire.getBoolean("sound"));
+        assertFalse(BleJsonCompact.decode(wire).getBoolean("sound"));
+    }
+
+    @Test
     public void streamTelemetryRoundTripsWithCompactKeys() throws Exception {
         JSONObject status =
                 new JSONObject(

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
@@ -43,11 +43,13 @@ public class BleJsonCompactTest {
         assertEquals("photo_status", compact.getString("t"));
         assertEquals("p1", compact.getString("r"));
         assertEquals(3, compact.getInt("s"));
-        assertEquals(100L, compact.getLong("ts"));
+        assertEquals(1_700_000_000_100L, compact.getLong("timestamp"));
+        assertFalse(compact.has("ts"));
         assertTrue(compact.has("rc"));
         assertFalse(compact.getBoolean("rc"));
         assertEquals(1, compact.getJSONObject("cm").getInt("aes"));
         assertEquals(1, compact.getJSONObject("cm").getInt("src"));
+        assertTrue(compact.toString().length() < input.toString().length());
     }
 
     @Test
@@ -74,7 +76,7 @@ public class BleJsonCompactTest {
     }
 
     @Test
-    public void resolvedConfigDiffOmitsRepeatPayload() throws Exception {
+    public void resolvedConfigIsAlwaysSent() throws Exception {
         BleJsonCompact.markSessionConnected(1_000L);
         JSONObject config = new JSONObject("{\"source\":\"sdk\",\"transferMethod\":\"auto\"}");
         JSONObject first =
@@ -100,13 +102,97 @@ public class BleJsonCompactTest {
         JSONObject secondWire = BleJsonCompact.encode(second);
 
         assertTrue(firstWire.has("resolvedConfig"));
-        assertFalse(secondWire.has("resolvedConfig"));
-        assertEquals(
-                BleJsonCompact.hashConfig(config),
-                secondWire.getString(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH));
+        assertTrue(secondWire.has("resolvedConfig"));
+        assertFalse(secondWire.has(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH));
 
+        BleJsonCompact.markSessionConnected(9_000L);
         JSONObject restoredSecond = BleJsonCompact.decode(secondWire);
         assertEquals("sdk", restoredSecond.getJSONObject("resolvedConfig").getString("source"));
+        assertEquals(1_200L, restoredSecond.getLong("timestamp"));
+    }
+
+    @Test
+    public void legacyResolvedConfigHashStillDecodesWhenCached() throws Exception {
+        JSONObject config = new JSONObject("{\"source\":\"sdk\",\"transferMethod\":\"auto\"}");
+        JSONObject full =
+                new JSONObject(
+                        "{\"t\":\"stream_status\",\"s\":\"streaming\",\"resolvedConfig\":"
+                                + config
+                                + "}");
+        BleJsonCompact.decode(full);
+        JSONObject hashOnly =
+                new JSONObject(
+                        "{\"t\":\"stream_status\",\"s\":\"streaming\",\"rch\":\""
+                                + BleJsonCompact.hashConfig(config)
+                                + "\"}");
+
+        JSONObject restored = BleJsonCompact.decode(hashOnly);
+
+        assertEquals("sdk", restored.getJSONObject("resolvedConfig").getString("source"));
+        assertFalse(restored.has(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH));
+    }
+
+    @Test
+    public void legacyResolvedConfigCacheMissKeepsHashForDiagnostics() throws Exception {
+        JSONObject hashOnly =
+                new JSONObject(
+                        "{\"t\":\"stream_status\",\"s\":\"streaming\",\"rch\":\"deadbeef\"}");
+
+        JSONObject restored = BleJsonCompact.decode(hashOnly);
+
+        assertEquals("deadbeef", restored.getString(BleJsonCompact.KEY_RESOLVED_CONFIG_HASH));
+        assertFalse(restored.has("resolvedConfig"));
+    }
+
+    @Test
+    public void ambiguousNestedWireKeysFallBackToVerboseJson() throws Exception {
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"payload\":{"
+                                + "\"s\":\"literal\",\"kind\":0,\"source\":1}}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+
+        assertTrue(wire.has("type"));
+        assertFalse(wire.has("t"));
+        assertEquals("literal", wire.getJSONObject("payload").getString("s"));
+        assertEquals(0, wire.getJSONObject("payload").getInt("kind"));
+        assertEquals(1, wire.getJSONObject("payload").getInt("source"));
+        JSONObject restored = BleJsonCompact.decodeIfSupported(wire);
+        assertEquals("literal", restored.getJSONObject("payload").getString("s"));
+        assertEquals(0, restored.getJSONObject("payload").getInt("kind"));
+        assertEquals(1, restored.getJSONObject("payload").getInt("source"));
+    }
+
+    @Test
+    public void numericEnumFieldsFallBackToVerboseJson() throws Exception {
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"payload\":{\"kind\":0,\"source\":1}}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+
+        assertTrue(wire.has("type"));
+        assertFalse(wire.has("t"));
+        assertEquals(0, wire.getJSONObject("payload").getInt("kind"));
+        assertEquals(1, wire.getJSONObject("payload").getInt("source"));
+    }
+
+    @Test
+    public void absoluteTimestampSurvivesDifferentSessionEpochs() throws Exception {
+        BleJsonCompact.markSessionConnected(1_000L);
+        JSONObject input =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"status\":\"streaming\","
+                                + "\"timestamp\":1700000000123}");
+
+        JSONObject wire = BleJsonCompact.encode(input);
+        BleJsonCompact.markSessionConnected(9_000L);
+        JSONObject restored = BleJsonCompact.decode(wire);
+
+        assertEquals(1_700_000_000_123L, wire.getLong("timestamp"));
+        assertFalse(wire.has("ts"));
+        assertEquals(1_700_000_000_123L, restored.getLong("timestamp"));
     }
 
     @Test

--- a/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
+++ b/mobile/modules/bluetooth-sdk/android/src/test/java/com/mentra/bluetoothsdk/utils/BleJsonCompactTest.java
@@ -44,7 +44,8 @@ public class BleJsonCompactTest {
         assertEquals("p1", compact.getString("r"));
         assertEquals(3, compact.getInt("s"));
         assertEquals(100L, compact.getLong("ts"));
-        assertFalse(compact.has("rc"));
+        assertTrue(compact.has("rc"));
+        assertFalse(compact.getBoolean("rc"));
         assertEquals(1, compact.getJSONObject("cm").getInt("aes"));
         assertEquals(1, compact.getJSONObject("cm").getInt("src"));
     }
@@ -148,6 +149,45 @@ public class BleJsonCompactTest {
         assertTrue(wire.has("sound"));
         assertFalse(wire.getBoolean("sound"));
         assertFalse(BleJsonCompact.decode(wire).getBoolean("sound"));
+    }
+
+    @Test
+    public void jsonValuesRoundTripAtEveryDepth() throws Exception {
+        JSONObject status =
+                new JSONObject(
+                        "{\"type\":\"stream_status\",\"status\":\"stopped\","
+                                + "\"streaming\":false,\"reconnecting\":false,"
+                                + "\"resolvedConfig\":{\"audio\":{\"echoCancellation\":false,"
+                                + "\"noiseSuppression\":false}},"
+                                + "\"nullValue\":null,\"emptyObject\":{},\"emptyArray\":[]}");
+
+        JSONObject wire = BleJsonCompact.encode(status);
+
+        assertTrue(wire.has("streaming"));
+        assertFalse(wire.getBoolean("streaming"));
+        assertTrue(wire.has("rc"));
+        assertFalse(wire.getBoolean("rc"));
+        JSONObject wireAudio = wire.getJSONObject("resolvedConfig").getJSONObject("audio");
+        assertTrue(wireAudio.has("echoCancellation"));
+        assertFalse(wireAudio.getBoolean("echoCancellation"));
+        assertTrue(wireAudio.has("noiseSuppression"));
+        assertFalse(wireAudio.getBoolean("noiseSuppression"));
+        assertTrue(wire.has("nullValue"));
+        assertTrue(wire.isNull("nullValue"));
+        assertEquals(0, wire.getJSONObject("emptyObject").length());
+        assertEquals(0, wire.getJSONArray("emptyArray").length());
+
+        JSONObject restored = BleJsonCompact.decode(wire);
+        assertFalse(restored.getBoolean("streaming"));
+        assertFalse(restored.getBoolean("reconnecting"));
+        JSONObject restoredAudio =
+                restored.getJSONObject("resolvedConfig").getJSONObject("audio");
+        assertFalse(restoredAudio.getBoolean("echoCancellation"));
+        assertFalse(restoredAudio.getBoolean("noiseSuppression"));
+        assertTrue(restored.has("nullValue"));
+        assertTrue(restored.isNull("nullValue"));
+        assertEquals(0, restored.getJSONObject("emptyObject").length());
+        assertEquals(0, restored.getJSONArray("emptyArray").length());
     }
 
     @Test

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// BLE Wire Protocol v2 JSON compaction: short keys, enum ints, omitted defaults, config diff.
+/// BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff.
 enum BleJsonCompact {
     static let keyResolvedConfigHash = "rch"
 
@@ -191,13 +191,9 @@ enum BleJsonCompact {
 
         for (key, value) in input {
             if skipResolvedConfig, key == "resolvedConfig" { continue }
-            let shortKey = longToShort[key] ?? key
-            guard let compacted = compactValue(longKey: key, value: value, messageType: messageType),
-                  !shouldOmit(longKey: key, value: compacted, messageType: messageType)
-            else {
-                continue
+            if let compacted = compactValue(longKey: key, value: value, messageType: messageType) {
+                output[longToShort[key] ?? key] = compacted
             }
-            output[shortKey] = compacted
         }
 
         if topLevel {
@@ -211,7 +207,7 @@ enum BleJsonCompact {
     }
 
     private static func compactValue(longKey: String, value: Any, messageType: String) -> Any? {
-        if value is NSNull { return nil }
+        if value is NSNull { return NSNull() }
         if let nested = value as? [String: Any] {
             return compactObject(nested, topLevel: false)
         }
@@ -239,18 +235,6 @@ enum BleJsonCompact {
         return value
     }
 
-    private static func shouldOmit(longKey: String, value: Any, messageType: String) -> Bool {
-        if value is NSNull { return true }
-        if let boolValue = value as? Bool, !boolValue {
-            // start_stream.sound defaults to true on the glasses, so false is an
-            // override rather than an omittable default.
-            return !(messageType == "start_stream" && longKey == "sound")
-        }
-        if let dict = value as? [String: Any], dict.isEmpty { return true }
-        if let array = value as? [Any], array.isEmpty { return true }
-        return false
-    }
-
     private static func compactTimestamp(_ output: inout [String: Any]) {
         let tsKey: String?
         if output["timestamp"] != nil {
@@ -261,7 +245,7 @@ enum BleJsonCompact {
             tsKey = nil
         }
         guard let key = tsKey else { return }
-        let absolute = int64Value(output[key]) ?? 0
+        guard let absolute = int64Value(output[key]) else { return }
         guard absolute > 0 else { return }
         if sessionConnectEpochMs <= 0 {
             sessionConnectEpochMs = absolute
@@ -282,10 +266,9 @@ enum BleJsonCompact {
                 continue
             }
             let longKey = shortToLong[key] ?? key
-            guard let expanded = expandValue(longKey: longKey, value: value, messageType: messageType) else {
-                continue
+            if let expanded = expandValue(longKey: longKey, value: value, messageType: messageType) {
+                output[longKey] = expanded
             }
-            output[longKey] = expanded
         }
 
         if topLevel {
@@ -316,7 +299,7 @@ enum BleJsonCompact {
     }
 
     private static func expandValue(longKey: String, value: Any, messageType: String) -> Any? {
-        if value is NSNull { return nil }
+        if value is NSNull { return NSNull() }
         if let nested = value as? [String: Any] {
             return expandObject(nested, topLevel: false)
         }
@@ -344,7 +327,12 @@ enum BleJsonCompact {
     }
 
     private static func expandTimestamp(_ output: inout [String: Any]) {
-        guard output["timestamp"] == nil, let delta = int64Value(output["ts"]) else { return }
+        guard output["timestamp"] == nil, let timestamp = output["ts"] else { return }
+        guard let delta = int64Value(timestamp) else {
+            output["timestamp"] = timestamp
+            output.removeValue(forKey: "ts")
+            return
+        }
         let absolute = sessionConnectEpochMs > 0 ? sessionConnectEpochMs + delta : delta
         output["timestamp"] = absolute
         output.removeValue(forKey: "ts")

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// BLE Wire Protocol v2 JSON compaction: short keys, enum ints, and config diff.
+/// BLE Wire Protocol v2 JSON compaction with lossless fallback for ambiguous payloads.
 enum BleJsonCompact {
     static let keyResolvedConfigHash = "rch"
 
@@ -64,8 +64,6 @@ enum BleJsonCompact {
     }()
 
     private static var sessionConnectEpochMs: Int64 = 0
-    private static var resolvedConfigSent = false
-    private static var currentSessionResolvedConfigHash: String?
     private static var resolvedConfigByHash: [String: [String: Any]] = [:]
 
     private static let highRoiMessageTypes: Set<String> = [
@@ -103,8 +101,6 @@ enum BleJsonCompact {
 
     static func resetSession() {
         sessionConnectEpochMs = 0
-        resolvedConfigSent = false
-        currentSessionResolvedConfigHash = nil
         resolvedConfigByHash.removeAll()
     }
 
@@ -125,7 +121,7 @@ enum BleJsonCompact {
             return json
         }
         let messageType = extractMessageType(json)
-        if !shouldCompactOutbound(messageType) {
+        if !shouldCompactOutbound(messageType) || !canCompactLosslessly(json, topLevel: true) {
             return json
         }
         return compactObject(json, topLevel: true)
@@ -170,40 +166,77 @@ enum BleJsonCompact {
         return decode(json)
     }
 
+    /// Compact JSON reserves short keys and enum integers. Fall back to verbose JSON whenever an
+    /// otherwise valid future payload already uses one of those wire representations.
+    private static func canCompactLosslessly(
+        _ input: [String: Any],
+        topLevel: Bool
+    ) -> Bool {
+        let messageType = stringValue(input["type"]) ?? stringValue(input["t"]) ?? ""
+        for (key, value) in input {
+            if shortToLong[key] != nil
+                || (topLevel && key == keyResolvedConfigHash)
+                || isAmbiguousEnumValue(key: key, value: value, messageType: messageType)
+            {
+                return false
+            }
+            if let nested = value as? [String: Any],
+               !canCompactLosslessly(nested, topLevel: false)
+            {
+                return false
+            }
+            if let array = value as? [Any], !canCompactArrayLosslessly(array) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func canCompactArrayLosslessly(_ array: [Any]) -> Bool {
+        for value in array {
+            if let nested = value as? [String: Any],
+               !canCompactLosslessly(nested, topLevel: false)
+            {
+                return false
+            }
+            if let nestedArray = value as? [Any],
+               !canCompactArrayLosslessly(nestedArray)
+            {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func isAmbiguousEnumValue(
+        key: String,
+        value: Any,
+        messageType: String
+    ) -> Bool {
+        guard let number = value as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID()
+        else {
+            return false
+        }
+        return key == "kind"
+            || key == "source"
+            || key == "aeStateName"
+            || (key == "status" && messageType == "photo_status")
+    }
+
     private static func compactObject(_ input: [String: Any], topLevel: Bool) -> [String: Any] {
         var output: [String: Any] = [:]
         let messageType = stringValue(input["type"]) ?? stringValue(input["t"]) ?? ""
-        var skipResolvedConfig = false
-
-        if topLevel, shouldDiffResolvedConfig(messageType),
-           let resolvedConfig = input["resolvedConfig"] as? [String: Any]
-        {
-            let hash = hashConfig(resolvedConfig)
-            resolvedConfigByHash[hash] = resolvedConfig
-            if resolvedConfigSent, hash == currentSessionResolvedConfigHash {
-                output[keyResolvedConfigHash] = hash
-                skipResolvedConfig = true
-            } else {
-                currentSessionResolvedConfigHash = hash
-                resolvedConfigSent = true
-            }
-        }
 
         for (key, value) in input {
-            if skipResolvedConfig, key == "resolvedConfig" { continue }
             if let compacted = compactValue(longKey: key, value: value, messageType: messageType) {
-                output[longToShort[key] ?? key] = compacted
+                // Legacy peers treat top-level `ts` as a session-relative delta. Preserve the
+                // verbose key so an absolute timestamp remains absolute across mixed versions.
+                let wireKey = topLevel && key == "timestamp" ? key : (longToShort[key] ?? key)
+                output[wireKey] = compacted
             }
         }
-
-        if topLevel {
-            compactTimestamp(&output)
-        }
         return output
-    }
-
-    private static func shouldDiffResolvedConfig(_ messageType: String) -> Bool {
-        messageType == "photo_status" || messageType == "stream_status"
     }
 
     private static func compactValue(longKey: String, value: Any, messageType: String) -> Any? {
@@ -235,27 +268,6 @@ enum BleJsonCompact {
         return value
     }
 
-    private static func compactTimestamp(_ output: inout [String: Any]) {
-        let tsKey: String?
-        if output["timestamp"] != nil {
-            tsKey = "timestamp"
-        } else if output["ts"] != nil {
-            tsKey = "ts"
-        } else {
-            tsKey = nil
-        }
-        guard let key = tsKey else { return }
-        guard let absolute = int64Value(output[key]) else { return }
-        guard absolute > 0 else { return }
-        if sessionConnectEpochMs <= 0 {
-            sessionConnectEpochMs = absolute
-        }
-        output["ts"] = absolute - sessionConnectEpochMs
-        if key != "ts" {
-            output.removeValue(forKey: key)
-        }
-    }
-
     private static func expandObject(_ input: [String: Any], topLevel: Bool) -> [String: Any] {
         var output: [String: Any] = [:]
         let messageType = stringValue(input["type"]) ?? stringValue(input["t"]) ?? ""
@@ -283,8 +295,6 @@ enum BleJsonCompact {
         guard let resolvedConfig = output["resolvedConfig"] as? [String: Any] else { return }
         let hash = hashConfig(resolvedConfig)
         resolvedConfigByHash[hash] = resolvedConfig
-        currentSessionResolvedConfigHash = hash
-        resolvedConfigSent = true
     }
 
     private static func expandResolvedConfigHash(_ output: inout [String: Any]) {

--- a/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/utils/BleJsonCompact.swift
@@ -193,7 +193,7 @@ enum BleJsonCompact {
             if skipResolvedConfig, key == "resolvedConfig" { continue }
             let shortKey = longToShort[key] ?? key
             guard let compacted = compactValue(longKey: key, value: value, messageType: messageType),
-                  !shouldOmit(compacted)
+                  !shouldOmit(longKey: key, value: compacted, messageType: messageType)
             else {
                 continue
             }
@@ -239,9 +239,13 @@ enum BleJsonCompact {
         return value
     }
 
-    private static func shouldOmit(_ value: Any) -> Bool {
+    private static func shouldOmit(longKey: String, value: Any, messageType: String) -> Bool {
         if value is NSNull { return true }
-        if let boolValue = value as? Bool, !boolValue { return true }
+        if let boolValue = value as? Bool, !boolValue {
+            // start_stream.sound defaults to true on the glasses, so false is an
+            // override rather than an omittable default.
+            return !(messageType == "start_stream" && longKey == "sound")
+        }
         if let dict = value as? [String: Any], dict.isEmpty { return true }
         if let array = value as? [Any], array.isEmpty { return true }
         return false


### PR DESCRIPTION
## What changed

- preserve explicit JSON values instead of dropping `false`, `null`, empty objects, or empty arrays
- always send `resolvedConfig` rather than relying on an unacknowledged cross-message hash cache
- preserve top-level timestamps as absolute epoch values instead of rebasing them against independently captured session epochs
- retain stateless key shortening and known enum integers for normal high-ROI messages
- fall back to the original verbose JSON whenever reserved short keys or numeric enum fields would make compaction ambiguous
- retain decoding support for legacy hash-only configs and delta timestamps during mixed-version rollout
- apply the behavior consistently in the Android Bluetooth SDK, iOS Bluetooth SDK, and ASG client codecs

## Root cause

BLE v2 compaction performed generic, schema-unaware transformations that were not guaranteed to round-trip. Explicit falsy values could disappear, hash-only `resolvedConfig` messages could not recover after a dropped first packet or cache reset, independently captured timestamp epochs changed timestamp meaning, and recursive aliases/enums could reinterpret legitimate future payload fields.

The initial fix special-cased `start_stream.sound`. This revision makes outbound compaction lossless: safe payloads remain compact, while ambiguous payloads use verbose JSON that existing peers already understand.

## Compatibility and impact

The change is backward-compatible in both directions:

- new sender → old receiver: full configs and verbose absolute `timestamp` fields are already accepted
- old sender → new receiver: legacy config hashes and timestamp deltas are still decoded
- ambiguous payloads: sent verbose and passed through unchanged

Key aliases and enum integers still provide meaningful savings; the representative regression fixture shrinks from 172 to 95 bytes.

Livestreamer can reliably suppress glasses-side stream start/stop tones, and other BLE v2 messages no longer silently change meaning for optimization.

Bug report: `rep_01KYQK7PR7F8E91J7XWY989DJR`

## Validation

- `cd mobile/android && ./gradlew -PmentraPublicSdk=true :mentra-bluetooth-sdk:testDebugUnitTest --tests 'com.mentra.bluetoothsdk.utils.BleJsonCompactTest'`
- `cd asg_client && ./gradlew :app:testDebugUnitTest --tests 'com.mentra.asg_client.io.bluetooth.utils.BleJsonCompactTest'`
- compile and execute a Swift codec probe covering value preservation, config repetition, timestamp epoch changes, ambiguity fallback, legacy cache misses, and retained compaction
- Android test assertions verify safe payloads remain smaller than their verbose form

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BLE wire encoding for high-ROI message types across phone and glasses; behavior is safer but alters payload size and mixed-version interoperability compared to prior omission and config-diff rules.
> 
> **Overview**
> **BLE v2 JSON compaction** no longer drops explicit `false`, `null`, empty objects, or empty arrays, so commands like `start_stream` with `sound: false` are not reinterpreted as receiver defaults.
> 
> The same **lossless rules** are applied in the ASG client, Android Bluetooth SDK, and iOS `BleJsonCompact` codecs. **Outbound** compaction still uses short keys and enum integers when safe, but **`encode` skips compaction** when a payload would be ambiguous (reserved short keys, numeric enum fields used as literals, etc.) and sends verbose JSON instead. **Timestamps** stay on the verbose `timestamp` key on the wire (no session-relative `ts` on encode). **`resolvedConfig`** is always sent in full on encode; repeat **`rch`** hashing on outbound is removed while **decode** still expands legacy hash-only messages when the config is cached.
> 
> Regression tests cover round-trips, legacy `rch`, ambiguous payloads, and flags such as `scan_complete: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7287dd5236b12f89804be3f7067180ee5a8502c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->