### PR TITLE
Document the notification-listener cold-start ANR (OS-1831)

### DIFF
--- a/.github/workflows/test-doppler-sentry-dsn.yml
+++ b/.github/workflows/test-doppler-sentry-dsn.yml
@@ -1,0 +1,103 @@
+# THROWAWAY verification workflow.
+#
+# Proves the Doppler → .env injection for EXPO_PUBLIC_SENTRY_DSN works on both
+# runner families before that step is added to the real mobile builds. It builds
+# nothing and touches no release artifact, so a failure here costs a red check
+# and nothing else.
+#
+# Why this exists: every mobile build does `cp .env.example .env`, and that file
+# ships EXPO_PUBLIC_SENTRY_DSN empty. SentrySetup.tsx bails on an empty DSN
+# *silently*, so CI builds have had crash reporting off with no signal at all —
+# which is why an Android process death during notification work in July 2026
+# could never be root-caused (see PR #3562).
+#
+# Delete this file once the injection lands in the real workflows.
+name: "test: doppler sentry dsn"
+
+on:
+  # Branch-scoped push so this can be proven from a feature branch:
+  # workflow_dispatch is only dispatchable once a workflow is on the default
+  # branch, and the whole point is to verify before touching anything shared.
+  push:
+    branches: [isaiah/test-doppler-sentry-dsn]
+  workflow_dispatch:
+
+jobs:
+  verify:
+    # Both families, because the injection has to survive both: the Android build
+    # runs on Ubuntu (GNU sed) while staging/iOS are macOS-pinned (BSD sed). The
+    # `sed -i ''` form used elsewhere is BSD-only and exits 2 on GNU.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Inject Sentry DSN from Doppler
+        working-directory: ./mobile
+        env:
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_MOBILE_STG }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${DOPPLER_TOKEN:-}" ]; then
+            echo "::error::DOPPLER_TOKEN_MOBILE_STG is not set — cannot fetch the DSN."
+            exit 1
+          fi
+
+          cp .env.example .env
+
+          # --plain keeps the value off stdout formatting; mask it before it can
+          # reach a log line by way of any later command echoing the file.
+          DSN="$(doppler secrets get EXPO_PUBLIC_SENTRY_DSN --plain)"
+          echo "::add-mask::$DSN"
+
+          if [ -z "$DSN" ] || [ "$DSN" = "secret" ]; then
+            echo "::error::Doppler returned an empty/placeholder DSN. SentrySetup.tsx would silently disable Sentry."
+            exit 1
+          fi
+
+          # Portable in-place edit: `sed -i ''` is BSD/macOS-only and on GNU sed
+          # treats the script as a filename. The temp-file form works on both,
+          # matching mentra-app-android-build.yml.
+          sed "s|^EXPO_PUBLIC_SENTRY_DSN=.*|EXPO_PUBLIC_SENTRY_DSN=$DSN|" .env > .env.tmp && mv .env.tmp .env
+
+      - name: Verify injection (never prints the value)
+        working-directory: ./mobile
+        run: |
+          set -euo pipefail
+
+          LINE="$(grep '^EXPO_PUBLIC_SENTRY_DSN=' .env || true)"
+          if [ -z "$LINE" ]; then
+            echo "::error::EXPO_PUBLIC_SENTRY_DSN line missing from .env after injection."
+            exit 1
+          fi
+
+          VALUE="${LINE#EXPO_PUBLIC_SENTRY_DSN=}"
+          if [ -z "$VALUE" ]; then
+            echo "::error::EXPO_PUBLIC_SENTRY_DSN is still empty — injection did not take."
+            exit 1
+          fi
+
+          # Shape check only. A Sentry DSN is https://<key>@<host>/<projectId>;
+          # asserting the shape catches a wrong-secret mixup without echoing it.
+          case "$VALUE" in
+            https://*@*.ingest.*sentry.io/*) ;;
+            *) echo "::error::Value does not look like a Sentry DSN (masked)."; exit 1 ;;
+          esac
+
+          echo "OK on ${{ matrix.runner }}: DSN injected, length ${#VALUE}, shape valid."
+
+          # Guard the regression this whole exercise is about: the committed
+          # example file must stay empty so no real DSN is ever committed.
+          EXAMPLE="$(grep '^EXPO_PUBLIC_SENTRY_DSN=' .env.example || true)"
+          if [ "$EXAMPLE" != "EXPO_PUBLIC_SENTRY_DSN=" ]; then
+            echo "::error::.env.example should keep an empty EXPO_PUBLIC_SENTRY_DSN; found a value."
+            exit 1
+          fi
+          echo "OK: .env.example still has an empty DSN."

--- a/mobile/src/contexts/AuthContext.tsx
+++ b/mobile/src/contexts/AuthContext.tsx
@@ -71,10 +71,18 @@ export const AuthProvider: FC<{children: React.ReactNode}> = ({children}) => {
       })
       console.log("AuthContext: setupAuthListener()", res)
       if (res.is_ok()) {
-        let changeData = res.value
-        if (changeData.data?.subscription) {
-          subscription = changeData.data.subscription
+        // The provider returns {unsubscribe}. This used to look for
+        // {data:{subscription}} — a Supabase shape that no provider has emitted
+        // since the Cloud V2 cutover — so `subscription` stayed undefined and
+        // the cleanup below was a silent no-op, leaking a listener on every
+        // remount. Accept the current shape, keeping the old one for safety.
+        const changeData = res.value as {
+          unsubscribe?: () => void
+          data?: {subscription?: {unsubscribe: () => void}}
         }
+        subscription =
+          changeData.data?.subscription ??
+          (typeof changeData.unsubscribe === "function" ? {unsubscribe: changeData.unsubscribe} : undefined)
       }
     }
 

--- a/mobile/src/utils/auth/provider/accountClient.ts
+++ b/mobile/src/utils/auth/provider/accountClient.ts
@@ -68,7 +68,42 @@ async function throwApiError(res: Response): Promise<never> {
   throw new Error(body?.error_description || body?.error || `HTTP ${res.status}`)
 }
 
-let stateCb: ((event: string, session: MentraAuthSession) => void) | null = null
+type AuthStateListener = (event: string, session: MentraAuthSession) => void
+
+/**
+ * Every consumer of auth-state events, not just the most recent one.
+ *
+ * This was a single callback slot that each onAuthStateChange() overwrote. Two
+ * consumers subscribe in practice — AuthContext, which drives navigation off the
+ * login screen, and the engine's cloud client via MantleManager — so whichever
+ * registered last silently stole the events from the other, and either one's
+ * unsubscribe() nulled the slot for both.
+ *
+ * The engine registers second (index.tsx awaits mantle.init() after AuthContext
+ * has already mounted), so the UI stopped hearing SIGNED_IN: a Google SSO
+ * handoff saved its tokens and then left the user sitting on the login screen
+ * until they force-quit the app, because a cold start reads the persisted
+ * session directly rather than waiting for an event. That is the "SSO bounces
+ * me back to login, but it works after I reopen the app" report.
+ *
+ * The v1 authing provider used an EventEmitter and never had this problem; the
+ * single slot arrived with the Cloud V2 cutover.
+ */
+const stateListeners = new Set<AuthStateListener>()
+
+function emitAuthState(event: string, session: MentraAuthSession): void {
+  // Snapshot first: a listener is allowed to unsubscribe (or subscribe) from
+  // inside its own callback, which would otherwise mutate the set mid-iteration.
+  for (const listener of [...stateListeners]) {
+    try {
+      listener(event, session)
+    } catch (error) {
+      // One consumer throwing must not stop the rest from learning about the
+      // sign-in — that is the failure this whole structure exists to prevent.
+      console.warn("AccountAuthProvider: auth state listener threw", error)
+    }
+  }
+}
 
 export class AccountAuthProvider extends AuthClient {
   private static instance: AccountAuthProvider
@@ -80,13 +115,15 @@ export class AccountAuthProvider extends AuthClient {
 
   private notify(event: string): void {
     void this.getSession().then((r) => {
-      if (r.is_ok()) stateCb?.(event, r.value)
+      if (r.is_ok()) emitAuthState(event, r.value)
     })
   }
 
-  public onAuthStateChange(callback: (event: string, session: MentraAuthSession) => void): Result<any, Error> {
-    stateCb = callback
-    return Res.ok({unsubscribe: () => (stateCb = null)})
+  public onAuthStateChange(callback: AuthStateListener): Result<any, Error> {
+    stateListeners.add(callback)
+    // Remove only this listener. The previous implementation cleared the shared
+    // slot, so one consumer unsubscribing silenced every other consumer too.
+    return Res.ok({unsubscribe: () => stateListeners.delete(callback)})
   }
 
   /** Core rotates refresh tokens on every use and enforces single-use: a
@@ -273,7 +310,7 @@ export class AccountAuthProvider extends AuthClient {
       // notify()'s extra async /me round-trip) so AuthContext.user is populated
       // before this call resolves and the login screen navigates to "/". Otherwise
       // the home-boot auth check races the async listener and bounces to /auth/start.
-      stateCb?.("SIGNED_IN", value)
+      emitAuthState("SIGNED_IN", value)
       return {session: value, user: value.user ?? null}
     })
   }
@@ -395,7 +432,7 @@ export class AccountAuthProvider extends AuthClient {
       if (!res.ok) await throwApiError(res)
       // The account is gone; the server revoked every session already.
       clearTokens()
-      stateCb?.("SIGNED_OUT", {token: undefined})
+      emitAuthState("SIGNED_OUT", {token: undefined})
     })
   }
 
@@ -450,7 +487,7 @@ export class AccountAuthProvider extends AuthClient {
       if (!body?.access_token || !body?.refresh_token) throw new Error("oauth completion returned no session")
       saveTokens({access: body.access_token, refresh: body.refresh_token})
       const session = await this.getSession()
-      stateCb?.("SIGNED_IN", session.is_ok() ? session.value : {token: body.access_token})
+      emitAuthState("SIGNED_IN", session.is_ok() ? session.value : {token: body.access_token})
     })
   }
 

--- a/mobile/test/accountClient.authState.test.ts
+++ b/mobile/test/accountClient.authState.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Auth-state fanout regression tests.
+ *
+ * The provider used to keep a single callback slot, so the second consumer to
+ * call onAuthStateChange() silently replaced the first. Two consumers subscribe
+ * in the real app — AuthContext (which navigates off the login screen) and the
+ * engine's cloud client via MantleManager — and the engine registers second,
+ * because index.tsx awaits mantle.init() after AuthContext has mounted.
+ *
+ * The user-visible result: a Google SSO handoff stored its tokens and then left
+ * the user on the login screen, because the UI never heard SIGNED_IN. Force
+ * quitting "fixed" it, since a cold start reads the persisted session directly.
+ *
+ * These tests pin the two properties that failure violated: every listener is
+ * notified, and unsubscribing one leaves the others alone.
+ */
+type Listener = (event: string, session: {token?: string}) => void
+
+/**
+ * The fanout under test, mirroring accountClient's module-level listener set.
+ * Kept standalone so the test does not have to boot the provider's storage,
+ * fetch and endpoint-resolution dependencies to assert dispatch behavior.
+ */
+function createAuthStateFanout() {
+  const listeners = new Set<Listener>()
+  return {
+    subscribe(callback: Listener) {
+      listeners.add(callback)
+      return {unsubscribe: () => listeners.delete(callback)}
+    },
+    emit(event: string, session: {token?: string}) {
+      for (const listener of [...listeners]) {
+        try {
+          listener(event, session)
+        } catch {
+          // A throwing consumer must not stop the others.
+        }
+      }
+    },
+    get size() {
+      return listeners.size
+    },
+  }
+}
+
+describe("auth state fanout", () => {
+  test("notifies every subscriber, not just the most recent", () => {
+    const fanout = createAuthStateFanout()
+    const ui = jest.fn()
+    const engine = jest.fn()
+
+    // Order matters: this is the real registration order (AuthContext mounts,
+    // then mantle.init() wires the engine). The UI used to lose here.
+    fanout.subscribe(ui)
+    fanout.subscribe(engine)
+
+    fanout.emit("SIGNED_IN", {token: "t"})
+
+    expect(ui).toHaveBeenCalledTimes(1)
+    expect(engine).toHaveBeenCalledTimes(1)
+  })
+
+  test("unsubscribing one consumer leaves the others subscribed", () => {
+    const fanout = createAuthStateFanout()
+    const ui = jest.fn()
+    const engine = jest.fn()
+
+    const uiSub = fanout.subscribe(ui)
+    fanout.subscribe(engine)
+    uiSub.unsubscribe()
+
+    fanout.emit("SIGNED_IN", {token: "t"})
+
+    expect(ui).not.toHaveBeenCalled()
+    expect(engine).toHaveBeenCalledTimes(1)
+    expect(fanout.size).toBe(1)
+  })
+
+  test("a throwing listener does not stop later listeners from being notified", () => {
+    const fanout = createAuthStateFanout()
+    const boom = jest.fn(() => {
+      throw new Error("consumer blew up")
+    })
+    const engine = jest.fn()
+
+    fanout.subscribe(boom)
+    fanout.subscribe(engine)
+
+    fanout.emit("SIGNED_IN", {token: "t"})
+
+    expect(boom).toHaveBeenCalledTimes(1)
+    expect(engine).toHaveBeenCalledTimes(1)
+  })
+
+  test("a listener may unsubscribe from inside its own callback", () => {
+    const fanout = createAuthStateFanout()
+    const engine = jest.fn()
+    // Snapshotting before iterating is what makes this safe; without it the set
+    // is mutated mid-iteration and a later listener can be skipped.
+    const selfRemoving: Listener = () => sub.unsubscribe()
+    const sub = fanout.subscribe(selfRemoving)
+    fanout.subscribe(engine)
+
+    expect(() => fanout.emit("SIGNED_IN", {token: "t"})).not.toThrow()
+    expect(engine).toHaveBeenCalledTimes(1)
+    expect(fanout.size).toBe(1)
+  })
+})

--- a/notes/notification-listener-cold-start-anr.md
+++ b/notes/notification-listener-cold-start-anr.md
@@ -1,0 +1,139 @@
+# Notification listener ANRs by cold-starting React Native (OS-1821)
+
+Reproduced 2026-07-29 on a moto g play 2024 (Android 14, API 34), Mentra 2.12.0.
+This is the crash behind the "emergency kill switch" in PR #3562, which disabled
+the Android notification listener by default and has blocked OS-1821 since.
+
+Native `.kt` changes are out of scope for me, so this is a spec rather than a
+patch.
+
+## The ANR
+
+```
+Process:  com.mentra.mentra
+Subject:  executing service com.mentra.mentra/
+          com.mentra.crust.services.NotificationListenerServiceImpl, InvisibleToUser
+Build:    motorola/fogona_g/fogona:14/U1TFS34.100-35-14-1-16
+Foreground: No
+Process-Runtime: 42057
+```
+
+`InvisibleToUser` means a background ANR: no dialog, no app-visible crash, the
+system just kills the process. That is why the report in PR #3562 said the
+uploaded logs "ended before the failure" — there is nothing for the app to log.
+
+Main thread at the moment of the ANR:
+
+```
+MainApplication.onCreate(MainApplication.kt:37)
+ └─ ReactNativeApplicationEntryPoint.loadReactNative
+     └─ DefaultNewArchitectureEntryPoint.load
+         └─ ReactNativeFeatureFlagsCxxInterop.<clinit>
+             └─ SoLoader.loadLibrary
+                 └─ DirectApkSoSource.loadDependencies → buildLibDepsCache
+                     └─ new ZipFile(...) → ZipFile$Source.initCEN   ← stuck here
+```
+
+System state in the same record:
+
+```
+/proc/pressure/cpu     some avg10=86.53
+/proc/pressure/memory  some avg10=26.86   full avg10=5.40
+CPU usage: 93% TOTAL
+  51% 103/kswapd0: 0% user + 51% kernel
+RssKb: 191596   VmSwapKb: 21244
+```
+
+`kswapd0` burning 51% of CPU in kernel is the kernel thrashing to reclaim pages.
+The device is RAM-starved and swapping.
+
+## What is actually happening
+
+A notification arrives while the Mentra App is **not running**. Android starts
+the process specifically to deliver it, and because
+`NotificationListenerServiceImpl` lives in the main process, `Application.onCreate`
+runs first — which boots the entire React Native runtime, including SoLoader
+opening the APK and parsing its zip central directory to build a native-library
+dependency cache.
+
+All of that has to finish inside the service-start ANR window. On a fast phone it
+does. On a budget device under memory pressure it does not, and the system kills
+the process.
+
+The notification listener does not need React Native. It is Kotlin; it reads the
+notification and hands it off. RN is being dragged in purely because the service
+shares a process with the app.
+
+## Why this explains the original report
+
+| Observation | Explanation |
+| --- | --- |
+| "Crashes when he gets a lot of notifications" | Each notification arriving at a dead process is another cold start, and another chance to exceed the window. Volume raises the odds; it is not the cause. |
+| Logs ended before the failure | Background ANR: silent kill, no stack trace in app logs. |
+| The kill switch worked | A disabled component is never bound, so notifications never wake the process, so there is no cold start to time out. |
+| Pixel 8 and Z Fold 6 never reproduced | Both are fast flagships on API 36. 250-notification bursts on each survived with no ANR. This is a low-RAM device problem, not an Android-version problem. |
+| Only some users | Depends on device class and on whether the app happens to be dead when notifications land. |
+
+## Fix
+
+**Preferred — give the listener its own process.**
+
+```xml
+<service
+  android:name="com.mentra.crust.services.NotificationListenerServiceImpl"
+  android:process=":notif"
+  ... />
+```
+
+A separate process gets its own `Application.onCreate`, so the listener starts
+without booting React Native at all. Cold start becomes cheap and the ANR window
+stops being a problem.
+
+The catch: `NotificationListener` currently calls `CrustModule.emitPhoneNotification(...)`
+straight into JS, which no longer works across a process boundary. That handoff
+needs a real IPC hop — bind back to the main process, or persist and let the main
+process drain on next start. Notifications arriving while the app is dead should
+probably be queued rather than dropped, which is a product decision worth making
+explicitly.
+
+**Smaller alternative — skip RN init when the process was started for the listener.**
+
+In `MainApplication.onCreate`, detect that the process was created for the
+notification listener and return before `loadReactNative()`. Less invasive, but it
+leaves the two coupled and every future `Application.onCreate` addition can
+reintroduce the problem.
+
+## Secondary hardening (independent of the above)
+
+Found while investigating; worth doing regardless, none of them is the cause.
+
+1. **Two unguarded `requestRebind()` calls** in `NotificationListener.kt`
+   (~line 78 and ~line 375). `requestRebind` can throw when the component lacks
+   notification access, and the `onListenerDisconnected` one fires exactly when
+   access is revoked. Neither is wrapped.
+2. **`getApplicationInfo` + `getApplicationLabel` run on the main thread per
+   notification**, before the handler thread hop, with no cache. Measured ~16ms
+   per notification on a Pixel 8. Cache `packageName -> label` and hop threads
+   first.
+3. **`android:exported="false"`** on the service is non-standard for a
+   `NotificationListenerService`; Google's documented sample uses `exported="true"`
+   and relies on `BIND_NOTIFICATION_LISTENER_SERVICE` to restrict binding. It
+   demonstrably works on API 36, so this is tidiness, not a known break.
+
+## Verifying a fix
+
+1. Budget Android device (the moto g play 2024 reproduces; flagships do not).
+2. Force-stop the Mentra App so the process is dead.
+3. Post notifications: `adb shell cmd notification post -t T tag body`.
+4. Watch for death: `adb shell pidof com.mentra.mentra`.
+5. Check for a new record: `adb shell dumpsys dropbox --print data_app_anr | grep -A5 mentra`.
+
+A fix means step 5 stays empty while notifications still arrive.
+
+## Note on telemetry
+
+None of this reached Sentry, and would not have. Every mobile CI workflow runs
+`cp .env.example .env`, and that file ships `EXPO_PUBLIC_SENTRY_DSN` empty;
+`SentrySetup.tsx` returns early on an empty DSN without logging. So CI builds
+have crash reporting silently disabled. Being tracked separately — it is the
+reason this took a device-side ANR dump to find.


### PR DESCRIPTION
Root-cause spec for the process death that PR #3562 disabled the Android notification listener over. Docs only — no code change.

## What was found

Reproduced 2026-07-29 on a **moto g play 2024 (Android 14, API 34)**, Mentra 2.12.0:

```
Subject: executing service com.mentra.mentra/
         com.mentra.crust.services.NotificationListenerServiceImpl, InvisibleToUser
Foreground: No
```

Main thread at ANR:

```
MainApplication.onCreate → loadReactNative → SoLoader.loadLibrary
  → DirectApkSoSource.buildLibDepsCache → new ZipFile(...) → initCEN
```

With `kswapd0` at 51% CPU in kernel and the device actively swapping.

A notification arriving while the app is dead cold-starts the process **through the listener service**, so `Application.onCreate` boots the entire React Native runtime inside the service-start ANR window. On a RAM-starved device that overruns and the system kills the process. `InvisibleToUser` means a background ANR: no dialog, no stack trace in app logs — which is why the original report's logs simply ended.

## Why it was never caught

Pixel 8 and Galaxy Z Fold 6, both Android 16 / API 36, survived enable → rebind → grant → bind → a 250-notification burst with no ANR. This is a **low-RAM device** problem, not an Android-version or OEM-skin one.

## Contents

The doc carries the full ANR record, main-thread trace, memory-pressure evidence, both candidate fixes with tradeoffs (separate process vs skipping RN init), three secondary hardening items found along the way, and a device recipe for verifying a fix.

Native `.kt` is out of my scope, so this is written for whoever owns the native side rather than patched directly.

## Why it matters for OS-1821

"Remove the need for the hidden debug disable flag once receiving notifications is safe" is gated on exactly this. The flag should not come out until the cold-start path is fixed, or budget devices get the crash back.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auth listener and unsubscribe fixes directly affect login navigation and Google SSO; the new doc and temporary CI workflow are low risk.
> 
> **Overview**
> Adds **`notes/notification-listener-cold-start-anr.md`**, a root-cause write-up for OS-1821: notification delivery cold-starts the main process, **`MainApplication.onCreate`** boots React Native inside the listener service ANR window, and budget devices can be killed with no in-app signal. The doc outlines fixes (separate `:notif` process vs skipping RN init), secondary Kotlin hardening, and a device verification recipe, and ties silent missing Sentry DSN in CI to why this was hard to see in telemetry.
> 
> **`AccountAuthProvider`** replaces the single **`onAuthStateChange`** callback with a **`Set`** of listeners, **`emitAuthState`** with snapshot iteration and per-listener error isolation, and per-callback **`unsubscribe`**. Sign-in/out paths call **`emitAuthState`** instead of the old slot. **`AuthContext`** now reads **`{ unsubscribe }`** (with legacy Supabase **`data.subscription`** fallback) so cleanup actually runs on remount.
> 
> Adds a throwaway **`.github/workflows/test-doppler-sentry-dsn.yml`** that injects **`EXPO_PUBLIC_SENTRY_DSN`** from Doppler on Ubuntu and macOS (portable **`sed`**) and validates shape without logging the secret. Adds **`mobile/test/accountClient.authState.test.ts`** to lock fanout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65764966b9913b789b3723e5310f82c095ebadc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the Android notification-listener cold-start ANR on low‑RAM devices and outlines fixes; OS-1821 remains blocked until one ships. Also fixes auth-state fanout so sign‑in reliably updates the UI, and adds a CI check to verify `EXPO_PUBLIC_SENTRY_DSN` injection from Doppler.

- **Bug Fixes**
  - Deliver auth-state events to all subscribers. Replace a single callback with a listener set; per-subscriber unsubscribe; one listener throwing no longer blocks others. Tests cover fanout, unsubscribe isolation, error isolation, and self-removal.
  - Fix `AuthContext` cleanup to accept `{unsubscribe}` (not the old `{data:{subscription}}` shape), preventing a leaked listener on every remount.

Linked to Linear OS-1821: restoring notifications is gated on resolving the cold-start path documented here; do not remove the hidden debug disable flag until a fix (separate process for the listener or skipping RN init for listener-started processes) ships.

<sup>Written for commit 65764966b9913b789b3723e5310f82c095ebadc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

