### PR TITLE
Keep G2 EvenHub alive in the iOS background with IMU

### DIFF
--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -11,6 +11,12 @@ import CoreBluetooth
 import Foundation
 import UIKit
 
+/// Keep a low-rate, non-audio EvenHub sensor stream active so iOS continues receiving BLE
+/// notifications while the Mentra App is backgrounded. The samples stay internal unless IMU was
+/// explicitly enabled through Mentra's developer-facing setting.
+private let g2ImuKeepaliveEnabled = true
+private let g2ImuKeepaliveReportPace: Int32 = 1000
+
 // MARK: - Data Little-Endian Helpers (for BMP construction)
 
 extension Data {
@@ -2959,11 +2965,12 @@ class G2: NSObject, SGCManager {
         }
         signalDisplayDirty()
 
-        try? await Task.sleep(nanoseconds: 300_000_000)  // 300ms to settle
+        try? await Task.sleep(nanoseconds: 300_000_000) // 300ms to settle
+        syncImuReportingWithIntent()
         restartMicIfAlreadyEnabled()
     }
 
-    /// Single coalesced recovery: rebuild the page + re-arm the mic from intent, but never
+    /// Single coalesced recovery: rebuild the page + re-arm sensor streams from intent, but never
     /// stack rebuilds. The firmware spams systemExit/dashboard-close ~1×/sec; without this
     /// guard each one triggered a rebuild that was torn down again → rebuild→exit→rebuild
     /// storm. At most one rebuild in flight, and at most one per RECOVERY_DEBOUNCE_MS.
@@ -3492,6 +3499,32 @@ class G2: NSObject, SGCManager {
         }
     }
 
+    /// Keep the firmware IMU stream alive at its slowest supported pace even when no miniapp
+    /// requested motion data. Incoming keepalive samples are discarded in `handleTouchEvent`.
+    private func syncImuReportingWithIntent(
+        _ intentEnabled: Bool? = nil,
+        requestedReportPace: Int32 = EvenHubProto.imuPaceP100
+    ) {
+        guard pageCreated else { return }
+
+        let shouldForwardSamples =
+            intentEnabled
+                ?? (DeviceStore.shared.get("bluetooth", "imu_enabled") as? Bool ?? false)
+        let shouldStream = shouldForwardSamples || g2ImuKeepaliveEnabled
+        let reportPace =
+            shouldForwardSamples ? requestedReportPace : g2ImuKeepaliveReportPace
+
+        Bridge.log(
+            "G2: syncing IMU stream — hardware=\(shouldStream), forward=\(shouldForwardSamples), pace=\(reportPace)"
+        )
+        let msg = EvenHubProto.imuControlMessage(
+            enable: shouldStream,
+            reportFrq: reportPace,
+            magicRandom: sendManager.nextMagicRandom()
+        )
+        sendEvenHubCommand(msg)
+    }
+
     func restartMic() {
         // Intent is "mic on". The mic only exists inside a live EvenHub page, so we
         // toggle it off then back on (the firmware needs the off→on edge to re-arm).
@@ -3829,21 +3862,7 @@ class G2: NSObject, SGCManager {
             await rebuildState()
         }
 
-        let send = { [weak self] in
-            guard let self = self else { return }
-            let msg = EvenHubProto.imuControlMessage(
-                enable: enabled, reportFrq: reportFrq,
-                magicRandom: self.sendManager.nextMagicRandom()
-            )
-            self.sendEvenHubCommand(msg)
-        }
-
-        // If we just asked for a page, give it a moment to be created first.
-        if enabled, !pageCreated {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: send)
-        } else {
-            send()
-        }
+        syncImuReportingWithIntent(enabled, requestedReportPace: reportFrq)
     }
 
     // MARK: - SGCManager: Device Control
@@ -4541,12 +4560,16 @@ class G2: NSObject, SGCManager {
             // IMU data report: eventType == IMU_DATA_REPORT (8), imuData in field 3
             // (IMU_Report_Data { x, y, z } as 32-bit floats). Handle and return before
             // the gesture-mapping path.
-            if (sysFields[1] as? Int32) == OsEventType.imuDataReport.rawValue,
-                let imuData = sysFields[3] as? Data,
-                let imu = parseImuReportData(imuData)
-            {
-                Bridge.log("G2: IMU data report: \(imu.x), \(imu.y), \(imu.z)")
-                Bridge.sendAccelEvent(x: imu.x, y: imu.y, z: imu.z, timestamp: timestamp)
+            if (sysFields[1] as? Int32) == OsEventType.imuDataReport.rawValue {
+                let shouldForwardSamples =
+                    DeviceStore.shared.get("bluetooth", "imu_enabled") as? Bool ?? false
+                if shouldForwardSamples,
+                   let imuData = sysFields[3] as? Data,
+                   let imu = parseImuReportData(imuData)
+                {
+                    Bridge.log("G2: IMU data report: \(imu.x), \(imu.y), \(imu.z)")
+                    Bridge.sendAccelEvent(x: imu.x, y: imu.y, z: imu.z, timestamp: timestamp)
+                }
                 return
             }
 

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -4386,16 +4386,9 @@ class G2: NSObject, SGCManager {
             return
         }
 
-
         if cmdValue == EvenHubResponseCmd.osNotifyEventToApp.rawValue {
-            // Touch/gesture event from glasses
+            // Device event from glasses (touch/gesture or sensor data)
             guard let devEventData = fields[13] as? Data else { return }
-            let timestamp = Int64(Date().timeIntervalSince1970 * 1000)
-            if lastClickTimestamp != nil && timestamp - lastClickTimestamp! < 100 {
-                // Bridge.log("G2: Double click ignored (too soon)")
-                return
-            }
-            lastClickTimestamp = timestamp
             handleTouchEvent(devEventData)
         } else if cmdValue == 17 {
             // Miniapp selection from glasses dashboard menu (cmdId=17)
@@ -4545,21 +4538,13 @@ class G2: NSObject, SGCManager {
 
         let timestamp = Int64(Date().timeIntervalSince1970 * 1000)
 
-        // if we are receiving touch events we are fully booted:
-        setFullyConnected()
-
-        // Bridge.log("G2: handleTouchEvent: \(fields)")
-        // Bridge.log(
-        //     "G2: handleTouchEvent: \(devEventData.map { String(format: "%02X", $0) }.joined())")
-
-        // SysEvent (field 3) - system-level gestures
+        // Classify IMU reports before applying the click debounce. Keepalive samples arrive
+        // continuously and must not update `lastClickTimestamp`, or a real gesture delivered
+        // within 100 ms of a sample can be dropped.
+        var parsedSysFields: [Int: Any]?
         if let sysData = fields[3] as? Data {
             var sysReader = ProtobufReader(sysData)
             let sysFields = sysReader.parseFields()
-
-            // IMU data report: eventType == IMU_DATA_REPORT (8), imuData in field 3
-            // (IMU_Report_Data { x, y, z } as 32-bit floats). Handle and return before
-            // the gesture-mapping path.
             if (sysFields[1] as? Int32) == OsEventType.imuDataReport.rawValue {
                 let shouldForwardSamples =
                     DeviceStore.shared.get("bluetooth", "imu_enabled") as? Bool ?? false
@@ -4572,7 +4557,24 @@ class G2: NSObject, SGCManager {
                 }
                 return
             }
+            parsedSysFields = sysFields
+        }
 
+        if lastClickTimestamp != nil && timestamp - lastClickTimestamp! < 100 {
+            // Bridge.log("G2: Double click ignored (too soon)")
+            return
+        }
+        lastClickTimestamp = timestamp
+
+        // if we are receiving touch events we are fully booted:
+        setFullyConnected()
+
+        // Bridge.log("G2: handleTouchEvent: \(fields)")
+        // Bridge.log(
+        //     "G2: handleTouchEvent: \(devEventData.map { String(format: "%02X", $0) }.joined())")
+
+        // SysEvent (field 3) - system-level gestures
+        if let sysFields = parsedSysFields {
             var eventType: OsEventType? = nil
             var eventSource: Int32? = nil
             if let normalType = sysFields[1] as? Int32 {

--- a/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
+++ b/mobile/modules/bluetooth-sdk/ios/Source/sgcs/G2.swift
@@ -16,6 +16,8 @@ import UIKit
 /// explicitly enabled through Mentra's developer-facing setting.
 private let g2ImuKeepaliveEnabled = true
 private let g2ImuKeepaliveReportPace: Int32 = 1000
+private let g2ImuConfirmationDelay: TimeInterval = 2
+private let g2ImuMaxControlAttempts = 3
 
 // MARK: - Data Little-Endian Helpers (for BMP construction)
 
@@ -1530,6 +1532,8 @@ class G2: NSObject, SGCManager {
     private var foregroundObserver: NSObjectProtocol?
     private var startupPageCreated: Bool = false  // createStartUpPageContainer can only be called once
     private var pageCreated: Bool = false
+    private var pageGeneration: UInt64 = 0
+    private var lastImuReportTimestamp: Int64?
     // Live hardware truth: is the firmware mic actually streaming. DISTINCT from the
     // glasses/micEnabled DeviceStore flag, which is *intent* (does the user want the mic on).
     // Cleared on every page teardown (the firmware kills the mic with the page) WITHOUT touching
@@ -2967,6 +2971,11 @@ class G2: NSObject, SGCManager {
 
         try? await Task.sleep(nanoseconds: 300_000_000) // 300ms to settle
         syncImuReportingWithIntent()
+        confirmImuReporting(
+            forPageGeneration: pageGeneration,
+            commandSentAt: Int64(Date().timeIntervalSince1970 * 1000),
+            attemptsRemaining: g2ImuMaxControlAttempts - 1
+        )
         restartMicIfAlreadyEnabled()
     }
 
@@ -3488,6 +3497,8 @@ class G2: NSObject, SGCManager {
                 appId: activeMenuAppId
             )
         }
+        pageGeneration &+= 1
+        lastImuReportTimestamp = nil
         sendEvenHubCommand(msg)
         pageCreated = true
     }
@@ -3523,6 +3534,36 @@ class G2: NSObject, SGCManager {
             magicRandom: sendManager.nextMagicRandom()
         )
         sendEvenHubCommand(msg)
+    }
+
+    /// EvenHub does not ACK IMU control commands, so use the data stream itself as confirmation.
+    /// A page-generation guard prevents a delayed retry from targeting a replacement page.
+    private func confirmImuReporting(
+        forPageGeneration generation: UInt64,
+        commandSentAt: Int64,
+        attemptsRemaining: Int
+    ) {
+        guard attemptsRemaining > 0 else { return }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + g2ImuConfirmationDelay) { [weak self] in
+            guard let self,
+                  self.pageCreated,
+                  self.pageGeneration == generation,
+                  g2ImuKeepaliveEnabled
+                  || (DeviceStore.shared.get("bluetooth", "imu_enabled") as? Bool ?? false),
+                  !(self.lastImuReportTimestamp.map { $0 >= commandSentAt } ?? false)
+            else { return }
+
+            Bridge.log(
+                "G2: no IMU report received for page generation \(generation); retrying control (\(attemptsRemaining) remaining)"
+            )
+            self.syncImuReportingWithIntent()
+            self.confirmImuReporting(
+                forPageGeneration: generation,
+                commandSentAt: Int64(Date().timeIntervalSince1970 * 1000),
+                attemptsRemaining: attemptsRemaining - 1
+            )
+        }
     }
 
     func restartMic() {
@@ -4546,6 +4587,7 @@ class G2: NSObject, SGCManager {
             var sysReader = ProtobufReader(sysData)
             let sysFields = sysReader.parseFields()
             if (sysFields[1] as? Int32) == OsEventType.imuDataReport.rawValue {
+                lastImuReportTimestamp = timestamp
                 let shouldForwardSamples =
                     DeviceStore.shared.get("bluetooth", "imu_enabled") as? Bool ?? false
                 if shouldForwardSamples,


### PR DESCRIPTION
## Summary

- enable G2's supported EvenHub IMU stream at the slowest `P1000` pace while an EvenHub page is live
- put the behavior behind `g2ImuKeepaliveEnabled` at the top of `G2.swift`
- re-arm the internal stream after every page rebuild
- discard keepalive samples unless Mentra's `bluetooth.imu_enabled` intent is on, preserving existing developer-facing behavior

## Why

The reported Teleprompter failure occurs on iOS with G2 when the miniapp does not request the microphone. After the Mentra App is backgrounded, timer-driven outbound heartbeats can stop; the G2 page later exits, while tapping the glasses produces an inbound BLE event and wakes the session again. Mic streaming masks the issue because it already supplies continuous inbound BLE notifications.

This change uses a non-audio inbound notification instead. Even Realities documents IMU as a supported EvenHub primitive via `imuControl`, `ImuReportPace`, and `IMU_DATA_REPORT`: https://www.npmjs.com/package/@evenrealities/even_hub_sdk

Context: https://mentra-labs.slack.com/archives/C096YCLEBFW/p1785360453092299

## Validation

- `xcodebuild -scheme MentraBluetoothSDK -destination 'generic/platform=iOS Simulator' -sdk iphonesimulator ... build` (passes for arm64 and x86_64)
- SwiftFormat passes on all touched line ranges
- `git diff --check`

## Hardware test

Use current G2 firmware on iOS, run Teleprompter with AI scroll/microphone off, background the Mentra App for several minutes, and verify the EvenHub page remains present and captions continue without requiring a glasses tap. Also confirm no accelerometer events reach miniapps while Mentra IMU intent is off.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep G2 EvenHub alive on iOS in the background by enabling a low‑rate IMU keepalive, preventing Teleprompter exits when the mic is off. IMU data is forwarded only when `bluetooth.imu_enabled` is on; keepalive samples are excluded from gesture debounce, and IMU control is retried after page rebuilds until a report arrives.

- **Bug Fixes**
  - Added `g2ImuKeepaliveEnabled` with slow `P1000` pacing to keep BLE notifications flowing whenever a page exists.
  - Introduced `syncImuReportingWithIntent()`; called after rebuilds, and `setImuEnabled` now routes through it using keepalive pace when intent is off; added `confirmImuReporting()` with a `pageGeneration` guard to retry IMU until the first report.
  - Classified IMU reports before gesture handling and excluded them from click debounce; forward IMU only when the IMU intent is enabled.

<sup>Written for commit 488181357f1fc9ae163609d9ccfcdbc22152bbd3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core G2 EvenHub page lifecycle, BLE event routing, and gesture debounce; behavior is gated by a compile-time flag but is on by default and affects background connectivity for all G2 users.
> 
> **Overview**
> Adds an **optional G2 EvenHub IMU keepalive** (`g2ImuKeepaliveEnabled`) so iOS keeps receiving BLE notifications while the Mentra app is backgrounded when the mic is off—addressing Teleprompter-style page drops.
> 
> **IMU control** is centralized in `syncImuReportingWithIntent()`: hardware streams at slow **P1000** when only keepalive is needed, or at the requested pace when `bluetooth.imu_enabled` is on; samples are forwarded to miniapps only when that intent is set. After page create/rebuild, the stream is re-armed and **`confirmImuReporting`** retries control if no IMU reports arrive (page-generation guarded). `setImuEnabled` now delegates to this path instead of sending IMU commands inline.
> 
> **Gesture handling** parses IMU reports before the 100 ms click debounce so keepalive samples no longer block real taps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 488181357f1fc9ae163609d9ccfcdbc22152bbd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->