### PR TITLE
Run engine test files in isolated bun processes

### DIFF
--- a/mobile/modules/engine/README.md
+++ b/mobile/modules/engine/README.md
@@ -77,3 +77,20 @@ import {miniappRunningRegistry} from "@mentra/engine/devtools"
 Inside `mobile/modules/engine/src/`, use **relative paths** (`./services/...`,
 `../utils/...`). The mobile app's `@/*` alias is not configured here — there
 is no build-time path rewriter for this module.
+
+## Testing
+
+Run the suite with `bun run test` (from this directory). It executes
+`scripts/test.sh`, which runs **each test file in its own bun process** — do
+not replace it with a single `bun test src`.
+
+Why: bun's `mock.module` patches one process-wide module registry with live
+ESM bindings, last write wins. Several suites mock the same specifiers
+(`"@mentra/bluetooth-sdk/internal"` alone is mocked by `audioTestMocks.ts`,
+`PhonePhotoCoordinator.test.ts`, and others), so in a shared process one
+file's mock clobbers another's and suites that pass alone fail in the
+combined run. Per-file processes give every suite an isolated registry.
+
+The same rule applies when writing tests: it is fine to `mock.module` any
+specifier your suite needs, but never rely on a mock installed by a
+*different* test file — each file must set up everything it imports.

--- a/mobile/modules/engine/package.json
+++ b/mobile/modules/engine/package.json
@@ -36,7 +36,7 @@
     "build": "expo-module build",
     "clean": "expo-module clean",
     "lint": "expo-module lint",
-    "test": "bun test src",
+    "test": "./scripts/test.sh",
     "build:module": "expo-module prepare",
     "prepublishOnly": "expo-module prepublishOnly",
     "expo-module": "expo-module"

--- a/mobile/modules/engine/scripts/test.sh
+++ b/mobile/modules/engine/scripts/test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Run each test file in its own bun process.
+#
+# bun's mock.module patches one process-wide module registry with live ESM
+# bindings, last write wins. Several suites mock the same specifiers (e.g.
+# "@mentra/bluetooth-sdk/internal" is mocked by audioTestMocks.ts,
+# PhonePhotoCoordinator.test.ts, MicStateCoordinator.test.ts, ...), so a
+# single `bun test src` lets one file's mock clobber another's and suites
+# that pass alone fail in the combined run. Per-file processes give every
+# suite an isolated registry.
+set -u
+cd "$(dirname "$0")/.."
+
+fail=0
+failed_files=()
+while IFS= read -r f; do
+  bun test "$f" || {
+    fail=1
+    failed_files+=("$f")
+  }
+done < <(find src \( -name '*.test.ts' -o -name '*.test.tsx' \) | sort)
+
+echo
+if [ "$fail" -ne 0 ]; then
+  echo "Failing test files:"
+  printf '  %s\n' "${failed_files[@]}"
+else
+  echo "All test files passed."
+fi
+exit $fail


### PR DESCRIPTION
## Scope

Fixes the `mobile/modules/engine` test runner so `bun run test` is green again.

bun's `mock.module` patches one process-wide module registry with live ESM bindings, last write wins. Several engine suites mock the same specifiers — `"@mentra/bluetooth-sdk/internal"` alone is mocked by six files (audioTestMocks, PhonePhotoCoordinator, MicStateCoordinator, LocalDisplayManager, PhoneStreamCoordinator, DeviceStoreHydration) — so the single-process `bun test src` let one file's mock clobber another's: on dev, ~14 failures (PhoneCameraFovCoordinator, AudioCloudUplink, …) that all pass when their file runs alone.

Changes:
- New `scripts/test.sh`: runs **each test file in its own bun process** (isolated module registry), collects failures across all files instead of stopping at the first, prints a failing-file summary, exits non-zero if any file failed.
- `package.json` `test` script now points at the script instead of `bun test src`.
- README gains a Testing section explaining the constraint and warning test authors never to rely on a mock installed by a different test file.

## Test evidence

- Baseline reproduced on dev: `bun test src` → 327 pass / **14 fail / 1 error** across 35 files.
- After: `bun run test` → **359 pass / 0 fail** across 35 files, exit 0. (Old total undercounted because the clobbering aborted part of a suite.)
- Failure propagation verified with a temporary deliberately-failing test file → exit 1.
- No CI workflow invokes engine's `test` script (oem-host-gate / oem-app-apk only run `bun run build`), so no pipeline changes needed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit ccb1a429015559b25847eff379b205eac868e4be. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->