### PR TITLE
Read Mentra Live serial from current BES version reply

### DIFF
--- a/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
+++ b/asg_client/app/src/main/java/com/mentra/asg_client/io/bluetooth/managers/K900BluetoothManager.java
@@ -1203,7 +1203,7 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
             }
 
             cacheBesBaudSwitchVersion(bData);
-            cacheBesVersionFromSyvrBField(bData);
+            cacheBesMetadataFromSyvrBField(bData);
 
             if (result == BesUartTransportCoordinator.SystemVersionResult.READY) {
                 linkState.srSyvrParsed(null);
@@ -1403,14 +1403,16 @@ public class K900BluetoothManager extends BaseBluetoothManager implements Serial
         }
     }
 
-    /**
-     * Picks the display BES string from sr_syvr B payload: same semantics as {@code hs_syvr} when
-     * possible.
-     */
-    private void cacheBesVersionFromSyvrBField(JSONObject bData) {
+    /** Cache the firmware version and manufacturing serial from the current sr_syvr response. */
+    private void cacheBesMetadataFromSyvrBField(JSONObject bData) {
         if (bData == null) {
             return;
         }
+        String manufacturingSerial = bData.optString("serial_number", "");
+        AsgSettings settings = new AsgSettings(context);
+        settings.setBesManufacturingSerial(manufacturingSerial);
+        Log.i(TAG, "Manufacturing serial available: " + !settings.getBesManufacturingSerial().isEmpty());
+
         String v = bData.optString("version", "");
         if (v.isEmpty()) {
             v = bData.optString("dpj", "");

--- a/asg_client/docs/mentra-live-spec.md
+++ b/asg_client/docs/mentra-live-spec.md
@@ -147,12 +147,12 @@ The MTK↔BES UART always starts at 460800 baud. Firmware that supports the nego
 
 ### Diagnostics and reporting
 
-The BES `hs_syvr` system-version response includes the provisioned
-manufacturing serial as `serial_number`. `asg_client` caches a valid value and
-forwards it to the phone in `version_info_3`; the all-zero factory default is
-treated as unprovisioned and omitted. This is the canonical inventory identity
-for Mentra Live. Android's `ro.serialno` and Bluetooth MAC addresses are not
-substitutes for it.
+The BES `sr_syvr` system-version response includes the provisioned manufacturing
+serial as `serial_number`. The legacy factory `hs_syvr` response exposes the same
+field. `asg_client` caches a valid value and forwards it to the phone in
+`version_info_3`; the all-zero factory default is treated as unprovisioned and
+omitted. This is the canonical inventory identity for Mentra Live. Android's
+`ro.serialno` and Bluetooth MAC addresses are not substitutes for it.
 
 `asg_client` includes logging, crash/error reporting, incident log buffering, and debug receivers for development and OTA testing. Production behavior should prioritize device stability and useful logs for support while avoiding secrets in logs.
 


### PR DESCRIPTION
## Summary

- Cache `serial_number` from the current BES `sr_syvr` response path.
- Reuse the existing serial validation, storage, and `version_info_3` forwarding behavior.
- Correct the Mentra Live protocol documentation to distinguish current `sr_syvr` from legacy factory `hs_syvr`.

## Why

Current ASG clients consume `sr_syvr` directly in `K900BluetoothManager`, before `McuEventParser`. The previous implementation only parsed `hs_syvr`, so the current response path discarded the glasses identity even when BES supplied it.

## Analytics behavior

This PR does not add or rename analytics events or properties. The existing `bluetooth_sdk_glasses_identified` event still fires once per connection only after a valid manufacturing serial reaches the Bluetooth SDK. Empty and all-zero values remain omitted.

## Validation

- `./scripts/check-android-compile.sh asg`
- On physical hardware, confirmed the current protocol is `cs_syvr` -> `sr_syvr`.
- Installed the patched ASG and successfully OTA-updated the paired BES firmware to 26.7.30.5.
- Captured `sr_syvr` carrying `serial_number: "0000000000000000"`; the ASG correctly rejected it and omitted it from `version_info_3`. This unit therefore cannot emit `bluetooth_sdk_glasses_identified` until its BES manufacturing serial is provisioned.

## Dependency

- BES firmware: https://github.com/fengyue120/mentra-live-bes/pull/27