### PR TITLE
Fix mobile Bun cache keys

### DIFF
--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -141,7 +141,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.environment }}-${{ runner.os }}-${{ hashFiles('mobile/bun.lockb') }}
+          key: bun-${{ runner.environment }}-${{ runner.os }}-${{ hashFiles('mobile/bun.lock') }}
           restore-keys: |
             bun-${{ runner.environment }}-${{ runner.os }}-
 

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -150,7 +150,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('mobile/bun.lockb') }}
+          key: bun-${{ runner.os }}-${{ hashFiles('mobile/bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
 
@@ -383,7 +383,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('mobile/bun.lockb') }}
+          key: bun-${{ runner.os }}-${{ hashFiles('mobile/bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-
 


### PR DESCRIPTION
## Summary

- Hash the tracked `mobile/bun.lock` when keying Bun dependency caches.
- Apply the correction to both staging mobile jobs and the standalone Mentra App Android workflow.

## Root cause

The workflows still referenced the removed `mobile/bun.lockb`. Because `hashFiles('mobile/bun.lockb')` matched nothing, the staging iOS job generated the incomplete cache key `bun-macOS-`.

In staging run 30584189117, the iOS post-job step then reported:

```text
Failed to save: Unable to reserve cache with key bun-macOS-, another job may be creating this cache.
```

This made all lockfile revisions share the same restore prefix and caused the parallel Android/iOS jobs to contend for the same empty key. The app archive and TestFlight upload in that run still succeeded; this PR fixes the cache correctness/reliability issue seen around it.

## Validation

- `git diff --check`
- Parsed both changed workflow YAML files with Ruby/Psych
- Verified `mobile/bun.lock` is tracked and `mobile/bun.lockb` does not exist
- Verified no workflow still references `mobile/bun.lockb`

`actionlint` was not available locally; GitHub workflow checks remain the authoritative validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only cache key path change; no runtime, security, or application code impact.
> 
> **Overview**
> Updates **Bun dependency cache** keys in mobile CI so they hash the tracked **`mobile/bun.lock`** instead of the removed **`mobile/bun.lockb`**.
> 
> **`hashFiles('mobile/bun.lockb')`** matched nothing, so keys collapsed to prefixes like **`bun-macOS-`**. Parallel staging Android/iOS jobs then fought over the same empty cache key (e.g. “Unable to reserve cache with key bun-macOS-”). Lockfile changes no longer bust or scope restores correctly.
> 
> The same fix is applied in **`mentra-app-android-build.yml`** and **`staging-builds.yml`** (Android and iOS Bun cache steps). No app or build logic changes—only cache key correctness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d13cf5d7e90d31cd2b493a0b68edf109c20b1b3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->