### PR TITLE
Fix missing runtime configuration in iOS release bundles

### DIFF
--- a/.github/workflows/augmentos-manager-jest.yml
+++ b/.github/workflows/augmentos-manager-jest.yml
@@ -55,6 +55,10 @@ jobs:
         working-directory: ./mobile
         run: bun run compile
 
+      - name: Run release tooling tests
+        working-directory: ./mobile
+        run: node --test scripts/*.test.mjs
+
       - name: Run Jest tests
         working-directory: ./mobile
         run: bun run test

--- a/mobile/scripts/release-android.mjs
+++ b/mobile/scripts/release-android.mjs
@@ -2,6 +2,7 @@
 
 import { setBuildEnv } from './set-build-env.mjs';
 import { withRetry, isSentryTransientError, writeSummary } from './release-utils.mjs';
+import { validateReleaseArchive } from './release-bundle-config.mjs';
 import { getBuildNumber } from './build-number.mjs';
 import { cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
@@ -101,6 +102,12 @@ if (!existsSync(apkPath)) {
   process.exit(1);
 }
 console.log('APK built successfully');
+
+// Keep the same artifact-level contract as iOS. Android currently exports with
+// a clean Metro cache, but this prevents a future release-script regression
+// from publishing an APK with missing runtime configuration.
+validateReleaseArchive(apkPath, 'Android');
+console.log('Verified Android release JS bundle configuration');
 
 // ── Step 6: Determine beta number & rename APK ───────────────────────────────
 

--- a/mobile/scripts/release-bundle-config.mjs
+++ b/mobile/scripts/release-bundle-config.mjs
@@ -1,0 +1,78 @@
+import {execFileSync} from "node:child_process"
+import {appendFile} from "node:fs/promises"
+
+const MAX_BUNDLE_BYTES = 512 * 1024 * 1024
+
+// These values are read by shipped JavaScript. Values used only by native
+// app.config or unused compatibility entries do not belong in this check.
+export const RELEASE_BUNDLE_ENV_KEYS = [
+  "EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY",
+  "EXPO_PUBLIC_AR99_RELEASE_DEVELOPER_ID",
+  "EXPO_PUBLIC_ASG_OTA_VERSION_URL",
+  "EXPO_PUBLIC_AUTHING_APP_HOST",
+  "EXPO_PUBLIC_AUTHING_APP_ID",
+  "EXPO_PUBLIC_BUILD_BRANCH",
+  "EXPO_PUBLIC_BUILD_COMMIT",
+  "EXPO_PUBLIC_BUILD_TIME",
+  "EXPO_PUBLIC_BUILD_USER",
+  "EXPO_PUBLIC_CLOUD_CORE_URL",
+  "EXPO_PUBLIC_CLOUD_RUNTIME_URL",
+  "EXPO_PUBLIC_DEPLOYMENT_REGION",
+  "EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN",
+  "EXPO_PUBLIC_MENTRAOS_VERSION",
+  "EXPO_PUBLIC_POSTHOG_API_KEY",
+  "EXPO_PUBLIC_SENTRY_DSN",
+]
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `'"'"'`)}'`
+}
+
+export function xcodeEnvironmentExports(env, nodeBinary) {
+  const entries = Object.entries(env)
+    .filter(([key, value]) => key.startsWith("EXPO_PUBLIC_") && value != null && String(value) !== "")
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  if (env.MENTRAOS_PINNED_BUILD_NUMBER) {
+    entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", env.MENTRAOS_PINNED_BUILD_NUMBER])
+  }
+  entries.push(["NODE_BINARY", nodeBinary])
+
+  return entries.map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+}
+
+export async function appendXcodeEnvironment(filePath, env, nodeBinary) {
+  const exports = xcodeEnvironmentExports(env, nodeBinary)
+  await appendFile(filePath, `\n# Exported for child processes launched by Xcode.\n${exports.join("\n")}\n`)
+  return exports.length
+}
+
+export function assertBundleEnvironment(bundle, env, platform) {
+  const missing = RELEASE_BUNDLE_ENV_KEYS.filter((key) => {
+    const value = env[key]
+    return value != null && String(value) !== "" && !bundle.includes(Buffer.from(String(value)))
+  })
+
+  if (missing.length > 0) {
+    throw new Error(`${platform} release JS bundle is missing expected build configuration: ${missing.join(", ")}`)
+  }
+}
+
+export function validateReleaseArchive(archivePath, platform, env = process.env) {
+  const entry = platform === "iOS" ? "Payload/*.app/main.jsbundle" : "assets/index.android.bundle"
+  let bundle
+  try {
+    bundle = execFileSync("unzip", ["-p", archivePath, entry], {
+      encoding: null,
+      maxBuffer: MAX_BUNDLE_BYTES,
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+  } catch (error) {
+    throw new Error(`Could not read ${platform} release JS bundle from ${archivePath}`, {cause: error})
+  }
+
+  if (bundle.length === 0) {
+    throw new Error(`${platform} release JS bundle is empty in ${archivePath}`)
+  }
+  assertBundleEnvironment(bundle, env, platform)
+}

--- a/mobile/scripts/release-bundle-config.test.mjs
+++ b/mobile/scripts/release-bundle-config.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict"
+import {execFileSync} from "node:child_process"
+import test from "node:test"
+
+import {assertBundleEnvironment, xcodeEnvironmentExports} from "./release-bundle-config.mjs"
+
+test("xcodeEnvironmentExports exports public and pinned build values safely", () => {
+  const lines = xcodeEnvironmentExports(
+    {
+      EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/it's-pinned.json",
+      EXPO_PUBLIC_EMPTY: "",
+      MENTRAOS_PINNED_BUILD_NUMBER: "123",
+      PRIVATE_SECRET: "do-not-export",
+    },
+    "/opt/node with spaces/bin/node",
+  )
+
+  assert.deepEqual(lines, [
+    `export EXPO_PUBLIC_ASG_OTA_VERSION_URL='https://example.test/it'"'"'s-pinned.json'`,
+    "export MENTRAOS_PINNED_BUILD_NUMBER='123'",
+    "export NODE_BINARY='/opt/node with spaces/bin/node'",
+  ])
+
+  const output = execFileSync(
+    "sh",
+    ["-c", `${lines.join("\n")}\nprintf '%s\\n' \"$EXPO_PUBLIC_ASG_OTA_VERSION_URL\"`],
+    {
+      encoding: "utf8",
+    },
+  )
+  assert.equal(output.trim(), "https://example.test/it's-pinned.json")
+})
+
+test("assertBundleEnvironment accepts expected nonempty runtime values", () => {
+  const env = {
+    EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/pin.json",
+    EXPO_PUBLIC_BUILD_COMMIT: "abc1234",
+    EXPO_PUBLIC_SENTRY_DSN: "",
+  }
+  const bundle = Buffer.from("prefix https://example.test/pin.json abc1234 suffix")
+
+  assert.doesNotThrow(() => assertBundleEnvironment(bundle, env, "iOS"))
+})
+
+test("assertBundleEnvironment reports keys without leaking values", () => {
+  const secretValue = "public-client-key-value"
+
+  assert.throws(
+    () =>
+      assertBundleEnvironment(
+        Buffer.from("bundle without expected configuration"),
+        {EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY: secretValue},
+        "iOS",
+      ),
+    (error) => {
+      assert.match(error.message, /EXPO_PUBLIC_AR99_RELEASE_CLIENT_KEY/)
+      assert.doesNotMatch(error.message, new RegExp(secretValue))
+      return true
+    },
+  )
+})

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -2,6 +2,7 @@
 
 import { setBuildEnv } from './set-build-env.mjs';
 import { withRetry, isSPMOrSentryTransientError, writeSummary } from './release-utils.mjs';
+import { appendXcodeEnvironment, validateReleaseArchive } from './release-bundle-config.mjs';
 import { getBuildNumber } from './build-number.mjs';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -76,7 +77,10 @@ console.log(`buildNumber: ${buildNumber}`);
 console.log('\n━━━ Step 3: Prebuild iOS ━━━');
 await $({ stdio: 'inherit' })`bun expo prebuild --platform ios`;
 
-// Copy .env to ios/.xcode.env.local so build env vars are available
+// Copy .env for tools that load it directly, then explicitly export public
+// runtime values for child processes launched by Xcode. Plain KEY=value lines
+// become shell variables when sourced by React Native's with-environment.sh,
+// but are not inherited by the Expo/Metro bundling process.
 await $({ stdio: 'inherit' })`cp .env ios/.xcode.env.local`;
 
 // Pin NODE_BINARY to THIS node (the one running release:ios, i.e. the Node 20
@@ -86,10 +90,13 @@ await $({ stdio: 'inherit' })`cp .env ios/.xcode.env.local`;
 // (/usr/local/bin/node → Node 18). Node 18 lacks util.parseEnv, so @expo/env
 // throws "parseEnv is not a function" and the archive fails with exit 65.
 // .xcode.env.local is sourced after .xcode.env, so this overrides it.
-await import('fs').then(fs =>
-  fs.appendFileSync('ios/.xcode.env.local', `\nexport NODE_BINARY=${process.execPath}\n`),
+const exportedXcodeVariables = await appendXcodeEnvironment(
+  'ios/.xcode.env.local',
+  process.env,
+  process.execPath,
 );
 console.log(`Pinned NODE_BINARY=${process.execPath} (node ${process.version}) for Xcode build phases`);
+console.log(`Exported ${exportedXcodeVariables - 1} build variables for Xcode child processes`);
 
 // In CI, switch the Mentra app target's Release config to MANUAL signing
 // with the fastlane match-installed AppStore profile. Without this,
@@ -238,6 +245,12 @@ if (ipaFiles.length === 0) {
 }
 const ipaPath = ipaFiles[0];
 console.log('IPA exported:', ipaPath);
+
+// Validate the artifact, not only the parent shell. A green archive can still
+// contain stale or missing Expo public configuration if Xcode did not pass the
+// build environment into Metro. Refuse to publish that binary anywhere.
+validateReleaseArchive(ipaPath, 'iOS');
+console.log('Verified iOS release JS bundle configuration');
 
 // ── Step 6: Upload to App Store Connect (TestFlight) ──────────────────────────
 


### PR DESCRIPTION
## Summary

- explicitly export every non-empty `EXPO_PUBLIC_*` value, the pinned build number, and `NODE_BINARY` from `ios/.xcode.env.local`
- validate the finished iOS IPA before either TestFlight or GitHub publication
- apply the same artifact-level validation to Android APK releases
- run the release-tooling unit tests in Mobile App Quality Checks

## Problem

The staging iOS workflow correctly logged the immutable per-run OTA manifest URL before invoking `release-ios.mjs`, but the URL was absent from the shipped Hermes bundle. The affected Mentra iOS build therefore fell through to the Bluetooth SDK's own manifest and installed ASG `0.1.21-dev.2` (`versionCode` `49785565`) instead of the ASG paired with that staging app build.

This was not only an OTA display issue. Inspection of the published iOS IPA showed these expected per-build values were absent from `Payload/Mentra.app/main.jsbundle`:

- `EXPO_PUBLIC_ASG_OTA_VERSION_URL`
- `EXPO_PUBLIC_BUILD_COMMIT`
- `EXPO_PUBLIC_BUILD_TIME`
- `EXPO_PUBLIC_BUILD_USER`

Static configuration such as the current Cloud Core/Runtime URLs and Mapbox token was present. The corresponding Android staging APK contained the expected OTA pin and generated build metadata.

`release-ios.mjs` copied `.env` directly to `ios/.xcode.env.local`. React Native's `with-environment.sh` sources that file, but plain `KEY=value` entries are shell variables rather than exported environment values inherited by the Expo/Metro child process. This change appends safely quoted `export` statements for the public runtime configuration.

## Publication guard

A successful native archive is not sufficient evidence that Metro received the intended environment. Before any iOS upload, the release script now extracts `Payload/*.app/main.jsbundle` from the IPA and checks every configured runtime value on an explicit allowlist. Android performs the equivalent check against `assets/index.android.bundle` before publishing its APK.

Validation errors report only missing variable names, never their values. Empty optional configuration is ignored. The allowlist excludes values used only by native `app.config` and unused compatibility entries.

## Verification

- `node --test mobile/scripts/*.test.mjs`
- `node --check mobile/scripts/release-bundle-config.mjs`
- `node --check mobile/scripts/release-ios.mjs`
- `node --check mobile/scripts/release-android.mjs`
- Prettier check for new helper, tests, and workflow
- YAML parse check for Mobile App Quality Checks
- `git diff --check`
- ran the validator against the published affected iOS IPA: correctly rejected it and named the four missing variables above
- ran the validator against the published staging Android APK: passed with its exact per-run OTA URL and build metadata

## Rollout

This intentionally keeps the immutable per-run staging pin model. It does not switch staging builds to mutable `staging_live_version.json`, and it does not change OTA URL precedence or Engine APIs. After merge to `dev`, the fix must reach `staging` and produce a new iOS build; that IPA should contain its `asg-staging-r<run_id>-version.json` URL and pass validation before TestFlight upload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the mobile release path and can block uploads if bundle validation fails; impact is limited to release tooling, not in-app runtime logic after a good build ships.
> 
> **Overview**
> Fixes **iOS release bundles shipping without per-build `EXPO_PUBLIC_*` config** (e.g. OTA pin URL and build metadata) because copying `.env` into `ios/.xcode.env.local` only set shell variables, not exports Metro inherits.
> 
> **iOS (`release-ios.mjs`)** now appends safely quoted `export` lines for every non-empty `EXPO_PUBLIC_*` value, `MENTRAOS_PINNED_BUILD_NUMBER`, and `NODE_BINARY` via new **`release-bundle-config.mjs`**. After export, it **unzips the IPA** and asserts the Hermes bundle contains each allowlisted runtime value before TestFlight or GitHub upload.
> 
> **Android (`release-android.mjs`)** runs the same **artifact check** on the APK bundle before publish (parity guard).
> 
> CI **Mobile App Quality Checks** adds `node --test scripts/*.test.mjs` for the new helper (quoting, bundle assertions, errors that name keys only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de321e7430d1004cf4ba778c137db9d62f251970. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->