### PR TITLE
Prepare Bluetooth SDK 0.1.21-dev.3 release

### DIFF
--- a/asg_client/ota_manifests/firmware_live.json
+++ b/asg_client/ota_manifests/firmware_live.json
@@ -44,8 +44,8 @@
     }
   ],
   "bes_firmware": {
-    "version": "26.7.29.0",
-    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.29.0.bin",
-    "sha256": "139686e454e9715f5afed26e661666f40b05e4249321adae39304cdcfbd43c3b"
+    "version": "26.7.30.4",
+    "url": "https://firmwarecdn.mentraglass.com/bes_firmware_26.7.30.4.bin",
+    "sha256": "9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c"
   }
 }

--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-dev.3")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.3")
 }
 ```
 

--- a/mintlify-docs/mentra-live/android.mdx
+++ b/mintlify-docs/mentra-live/android.mdx
@@ -41,7 +41,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.2")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-dev.3")
 }
 ```
 

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -453,7 +453,7 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.2` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-dev.3` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 

--- a/mintlify-docs/mentra-live/api-reference.mdx
+++ b/mintlify-docs/mentra-live/api-reference.mdx
@@ -453,7 +453,7 @@ Mentra Live has camera, microphone, speaker, Wi-Fi, LED, and OTA capabilities. G
 
 ## OTA Updates
 
-Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-dev.3` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
+Each Bluetooth SDK release has a matching Mentra Live glasses software release with the same version number. When your app checks for an update, the SDK uses the OTA manifest for its own release. For the current `0.1.21-beta.3` software and complete installation instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 Mentra Live OTA installation is glasses-owned. The SDK checks its release-specific manifest on the phone, then sends `ota_start` with that same manifest URL when the user accepts the update:
 

--- a/mintlify-docs/mentra-live/examples.mdx
+++ b/mintlify-docs/mentra-live/examples.mdx
@@ -6,7 +6,7 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
-The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-dev.3` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.3` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git

--- a/mintlify-docs/mentra-live/examples.mdx
+++ b/mintlify-docs/mentra-live/examples.mdx
@@ -6,7 +6,7 @@ icon: "mobile"
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) contains complete example apps for Android, iOS, and React Native / Expo.
 
-The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-beta.2` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
+The examples include the required OTA flow for installing the Mentra Live glasses software that matches their Bluetooth SDK version. For the current `0.1.21-dev.3` example builds and step-by-step update instructions, see [Update Mentra Live](/mentra-live/software-update).
 
 ```bash
 git clone https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit.git

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.2`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-dev.3`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.2"
+  from: "0.1.21-dev.3"
 )
 ```
 

--- a/mintlify-docs/mentra-live/ios.mdx
+++ b/mintlify-docs/mentra-live/ios.mdx
@@ -21,14 +21,14 @@ The public SwiftPM repository is:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-dev.3`, and add the `MentraBluetoothSDK` product to your app target.
+In Xcode, choose **File > Add Package Dependencies**, enter that URL, select version `0.1.21-beta.3`, and add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-dev.3"
+  from: "0.1.21-beta.3"
 )
 ```
 

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -27,7 +27,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
-- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-dev.3`.
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.3`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
@@ -35,7 +35,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-dev.3` must use the matching Mentra Live `0.1.21-dev.3` software release.
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.3` must use the matching Mentra Live `0.1.21-beta.3` software release.
 </Warning>
 
 <CardGroup cols={2}>

--- a/mintlify-docs/mentra-live/overview.mdx
+++ b/mintlify-docs/mentra-live/overview.mdx
@@ -27,7 +27,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 
 ## Requirements
 
-- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-beta.2`.
+- The Bluetooth SDK and Mentra Live glasses software must use the same release version. The latest matching pair is `0.1.21-dev.3`.
 - A physical Android phone or iPhone for real Bluetooth testing.
 - Android min SDK `28` or newer.
 - iOS deployment target `15.1` or newer.
@@ -35,7 +35,7 @@ In Summer 2026, we'll release MentraOS 3.0, a new SDK for building apps that run
 - Bluetooth permissions, plus Android location permission where BLE scanning requires it.
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-beta.2` must use the matching Mentra Live `0.1.21-beta.2` software release.
+Bluetooth connection alone does not confirm version compatibility. Before testing SDK features, [update Mentra Live to the glasses software matching your SDK version](/mentra-live/software-update). An app using Bluetooth SDK `0.1.21-dev.3` must use the matching Mentra Live `0.1.21-dev.3` software release.
 </Warning>
 
 <CardGroup cols={2}>

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -11,7 +11,7 @@ Use a physical phone for Bluetooth testing. Simulators and emulators are useful 
 </Warning>
 
 <Warning>
-This quickstart uses Bluetooth SDK `0.1.21-beta.2`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.2` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+This quickstart uses Bluetooth SDK `0.1.21-dev.3`. Before testing SDK features, [install the matching Mentra Live `0.1.21-dev.3` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
 </Warning>
 
 ## Step 1: Install The SDK
@@ -20,7 +20,7 @@ This quickstart uses Bluetooth SDK `0.1.21-beta.2`. Before testing SDK features,
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.2
+bun add @mentra/bluetooth-sdk@0.1.21-dev.3
 bunx expo install expo-build-properties
 ```
 
@@ -95,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.2")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-dev.3")
 }
 ```
 
@@ -112,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.21-beta.2`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.21-dev.3`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-beta.2"
+  from: "0.1.21-dev.3"
 )
 ```
 

--- a/mintlify-docs/mentra-live/quickstart.mdx
+++ b/mintlify-docs/mentra-live/quickstart.mdx
@@ -11,7 +11,7 @@ Use a physical phone for Bluetooth testing. Simulators and emulators are useful 
 </Warning>
 
 <Warning>
-This quickstart uses Bluetooth SDK `0.1.21-dev.3`. Before testing SDK features, [install the matching Mentra Live `0.1.21-dev.3` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
+This quickstart uses Bluetooth SDK `0.1.21-beta.3`. Before testing SDK features, [install the matching Mentra Live `0.1.21-beta.3` glasses software](/mentra-live/software-update). Every SDK release requires the Mentra Live software release with the same version number.
 </Warning>
 
 ## Step 1: Install The SDK
@@ -20,7 +20,7 @@ This quickstart uses Bluetooth SDK `0.1.21-dev.3`. Before testing SDK features, 
   <Tab title="React Native / Expo">
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-dev.3
+bun add @mentra/bluetooth-sdk@0.1.21-beta.3
 bunx expo install expo-build-properties
 ```
 
@@ -95,7 +95,7 @@ android {
 }
 
 dependencies {
-    implementation("com.mentraglass:bluetooth-sdk:0.1.21-dev.3")
+    implementation("com.mentraglass:bluetooth-sdk:0.1.21-beta.3")
 }
 ```
 
@@ -112,14 +112,14 @@ In Xcode, add this package URL:
 https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git
 ```
 
-Select version `0.1.21-dev.3`, then add the `MentraBluetoothSDK` product to your app target.
+Select version `0.1.21-beta.3`, then add the `MentraBluetoothSDK` product to your app target.
 
 For `Package.swift` consumers:
 
 ```swift
 .package(
   url: "https://github.com/Mentra-Community/mentra-bluetooth-sdk-ios.git",
-  from: "0.1.21-dev.3"
+  from: "0.1.21-beta.3"
 )
 ```
 

--- a/mintlify-docs/mentra-live/react-native-expo.mdx
+++ b/mintlify-docs/mentra-live/react-native-expo.mdx
@@ -11,13 +11,13 @@ Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the
 </Warning>
 
 <Warning>
-SDK `0.1.21-dev.3` requires the matching Mentra Live `0.1.21-dev.3` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+SDK `0.1.21-beta.3` requires the matching Mentra Live `0.1.21-beta.3` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
 </Warning>
 
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-dev.3
+bun add @mentra/bluetooth-sdk@0.1.21-beta.3
 bunx expo install expo-build-properties
 ```
 

--- a/mintlify-docs/mentra-live/react-native-expo.mdx
+++ b/mintlify-docs/mentra-live/react-native-expo.mdx
@@ -11,13 +11,13 @@ Expo Go cannot load `@mentra/bluetooth-sdk` because Expo Go does not include the
 </Warning>
 
 <Warning>
-SDK `0.1.21-beta.2` requires the matching Mentra Live `0.1.21-beta.2` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
+SDK `0.1.21-dev.3` requires the matching Mentra Live `0.1.21-dev.3` glasses software. [Update Mentra Live before testing SDK features](/mentra-live/software-update).
 </Warning>
 
 ## Install
 
 ```bash
-bun add @mentra/bluetooth-sdk@0.1.21-beta.2
+bun add @mentra/bluetooth-sdk@0.1.21-dev.3
 bunx expo install expo-build-properties
 ```
 

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -10,12 +10,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
-| iOS `MentraBluetoothSDK` version `0.1.21-beta.2` | Mentra Live software `0.1.21-beta.2` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
+| iOS `MentraBluetoothSDK` version `0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.2`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.2` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-dev.3`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-dev.3` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -28,7 +28,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-beta.2`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.2/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-dev.3`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-dev.3/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -60,7 +60,7 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 6. Wait until the app reports that the update is complete. The glasses may restart during installation.
 7. Reconnect and run **Check OTA** again to confirm that no update remains.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.2`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-dev.3`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
@@ -68,7 +68,7 @@ Use this path when the software currently installed on Mentra Live cannot run th
 
 All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-For the latest `0.1.21-beta.2` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.2-`.
+For the latest `0.1.21-dev.3` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-dev.3-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,13 +80,13 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.2-build>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-dev.3-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-beta.2` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.2` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-dev.3` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-dev.3` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App

--- a/mintlify-docs/mentra-live/software-update.mdx
+++ b/mintlify-docs/mentra-live/software-update.mdx
@@ -10,12 +10,12 @@ The latest matching pair is:
 
 | Mobile app dependency | Required glasses software |
 | --- | --- |
-| React Native `@mentra/bluetooth-sdk@0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
-| Android `com.mentraglass:bluetooth-sdk:0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
-| iOS `MentraBluetoothSDK` version `0.1.21-dev.3` | Mentra Live software `0.1.21-dev.3` |
+| React Native `@mentra/bluetooth-sdk@0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
+| Android `com.mentraglass:bluetooth-sdk:0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
+| iOS `MentraBluetoothSDK` version `0.1.21-beta.3` | Mentra Live software `0.1.21-beta.3` |
 
 <Warning>
-Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-dev.3`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-dev.3` glasses software before testing SDK features.
+Bluetooth connection alone does not confirm version compatibility. Glasses running an older software release may connect to an app using SDK `0.1.21-beta.3`, but SDK features may fail or behave incorrectly. Install the matching `0.1.21-beta.3` glasses software before testing SDK features.
 </Warning>
 
 ## How Version Matching Works
@@ -28,7 +28,7 @@ When you upgrade your app to a new Bluetooth SDK release, run the OTA check agai
 
 The [Mentra Bluetooth SDK Starter Kit](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit) includes the complete OTA flow. You can build an example app from source or install the recommended prebuilt React Native Android app.
 
-- [Download the React Native example APK for SDK `0.1.21-dev.3`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-dev.3/mentra-example-react-native.apk)
+- [Download the React Native example APK for SDK `0.1.21-beta.3`](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/releases/download/sdk-0.1.21-beta.3/mentra-example-react-native.apk)
 
 For another SDK version, open the [Starter Kit tags page](https://github.com/Mentra-Community/Mentra-Bluetooth-SDK-Starter-Kit/tags), choose the matching `sdk-<version>` tag, and select **Downloads** to find its React Native example APK.
 
@@ -60,7 +60,7 @@ Use the serial shown by `adb devices`. If only one Android device is connected, 
 6. Wait until the app reports that the update is complete. The glasses may restart during installation.
 7. Reconnect and run **Check OTA** again to confirm that no update remains.
 
-The example app uses the release-specific OTA manifest selected by SDK `0.1.21-dev.3`, so it installs the glasses software components matching that SDK release.
+The example app uses the release-specific OTA manifest selected by SDK `0.1.21-beta.3`, so it installs the glasses software components matching that SDK release.
 
 ## Bootstrap The Update With ADB
 
@@ -68,7 +68,7 @@ Use this path when the software currently installed on Mentra Live cannot run th
 
 All supported versions are available on the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota). Choose the ASG client APK whose filename starts with `asg-client-sdk-<sdk-version>-`, using the same version as your app's Bluetooth SDK dependency.
 
-For the latest `0.1.21-dev.3` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-dev.3-`.
+For the latest `0.1.21-beta.3` release, open the [Bluetooth SDK OTA Artifacts release page](https://github.com/Mentra-Community/MentraOS/releases/tag/bluetooth-sdk-ota) and download the APK whose filename starts with `asg-client-sdk-0.1.21-beta.3-`.
 
 Install [ADB](https://developer.android.com/tools/adb), connect Mentra Live to the computer with a data-capable USB cable, and verify that the glasses appear:
 
@@ -80,13 +80,13 @@ Install the ASG client using the glasses serial shown by that command:
 
 ```bash
 adb -s <glasses-serial> install -r \
-  "$HOME/Downloads/<asg-client-sdk-0.1.21-dev.3-build>.apk"
+  "$HOME/Downloads/<asg-client-sdk-0.1.21-beta.3-build>.apk"
 ```
 
 If only the glasses are connected, you can omit `-s <glasses-serial>`.
 
 <Warning>
-This command installs only the `0.1.21-dev.3` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-dev.3` example app's OTA flow to install any remaining components and complete the matching glasses software release.
+This command installs only the `0.1.21-beta.3` ASG client application. It does not necessarily install the matching MTK system software or BES firmware. After installing the APK, use the `0.1.21-beta.3` example app's OTA flow to install any remaining components and complete the matching glasses software release.
 </Warning>
 
 ## Add The OTA Requirement To Your App

--- a/mintlify-docs/mentra-live/troubleshooting.mdx
+++ b/mintlify-docs/mentra-live/troubleshooting.mdx
@@ -62,7 +62,7 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 
 Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
 
-If your app uses SDK `0.1.21-beta.2`, [install the matching Mentra Live `0.1.21-beta.2` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+If your app uses SDK `0.1.21-dev.3`, [install the matching Mentra Live `0.1.21-dev.3` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
 
 ## Optional Local Stream Preview Does Not Show Video
 

--- a/mintlify-docs/mentra-live/troubleshooting.mdx
+++ b/mintlify-docs/mentra-live/troubleshooting.mdx
@@ -62,7 +62,7 @@ If your app also uses Firebase with static frameworks, Firebase modular header c
 
 Bluetooth connection does not confirm that the mobile SDK and glasses software versions match. Each Bluetooth SDK release requires the Mentra Live software release with the same version number.
 
-If your app uses SDK `0.1.21-dev.3`, [install the matching Mentra Live `0.1.21-dev.3` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
+If your app uses SDK `0.1.21-beta.3`, [install the matching Mentra Live `0.1.21-beta.3` software](/mentra-live/software-update), then reconnect and check again. Do not debug individual feature failures until the OTA check succeeds with no update remaining.
 
 ## Optional Local Stream Preview Does Not Show Video
 

--- a/mobile/bun.lock
+++ b/mobile/bun.lock
@@ -244,7 +244,7 @@
     },
     "modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.2",
+      "version": "0.1.21-dev.3",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",

--- a/mobile/modules/bluetooth-sdk/package.json
+++ b/mobile/modules/bluetooth-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mentra/bluetooth-sdk",
-  "version": "0.1.21-dev.2",
+  "version": "0.1.21-dev.3",
   "description": "SDK for communicating with smart glasses",
   "main": "build/index.js",
   "react-native": "src/index.ts",

--- a/sdk/bun.lock
+++ b/sdk/bun.lock
@@ -263,7 +263,7 @@
     },
     "../mobile/modules/bluetooth-sdk": {
       "name": "@mentra/bluetooth-sdk",
-      "version": "0.1.21-dev.2",
+      "version": "0.1.21-dev.3",
       "devDependencies": {
         "@types/node": "^25.9.3",
         "expo-module-scripts": "^55.0.2",


### PR DESCRIPTION
## Summary

- bump the Bluetooth SDK base version and both workspace lockfiles to `0.1.21-dev.3`
- update `firmware_live.json` to BES `26.7.30.4` from the current firmware CDN manifest
- update public Mentra Live install, OTA, and compatibility documentation to the promoted `0.1.21-beta.3` release
- carry the Mentra Live product serial path merged in #3647 into a new SDK release so `bluetooth_sdk_glasses_identified` can report it as `glasses_device_id` in PostHog

## Release channels

The source version on `dev` is `0.1.21-dev.3`. Promotion to `staging` derives `0.1.21-beta.3`, which is the version shown in the public Mentra Live documentation.

## BES firmware

Source: `https://firmwarecdn.mentraglass.com/latest.json`

- version: `26.7.30.4`
- file: `bes_firmware_26.7.30.4.bin`
- tag: `main-26.7.30.4-09ccc873`
- commit: `09ccc873102ed57fe065def34b87fb0fa8c03be7`
- size: `1,137,045` bytes
- SHA-256: `9e8d127033d41c4bafad3d9e70a871fe24351c7b315fb341ff97f2e46c00b29c`

The binary was downloaded from the manifest URL and its size and digest were verified locally.

## Validation

- `git diff --check`
- `cd mobile && bun install --frozen-lockfile`
- `cd sdk && bun install --frozen-lockfile`
- `cd mobile/modules/bluetooth-sdk && CI=1 bun run build`
- exercised the iOS SDK version prepack/postpack injection for `0.1.21-dev.3`
- `npm pack --dry-run --ignore-scripts --json`
- `GITHUB_REF_NAME=dev GITHUB_EVENT_NAME=pull_request node .github/scripts/bluetooth-sdk-release-info.mjs`
- `cd mintlify-docs && jq empty docs.json`
- `cd mintlify-docs && bunx --bun mint export --output /tmp/mentra-live-sdk-0.1.21-beta.3-docs`

The release detector reports that npm, Maven, and SwiftPM do not yet contain `0.1.21-dev.3` and that the dev release should run after merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> OTA manifest and public version pins affect glasses firmware delivery and SDK/glasses compatibility expectations; incorrect BES metadata or version strings could mislead installs or failed OTA.
> 
> **Overview**
> Prepares **Bluetooth SDK `0.1.21-dev.3`** for release by bumping `@mentra/bluetooth-sdk` in `mobile/modules/bluetooth-sdk/package.json` and syncing **`mobile/bun.lock`** and **`sdk/bun.lock`**.
> 
> Updates **`asg_client/ota_manifests/firmware_live.json`** so OTA pulls **BES `26.7.30.4`** from the firmware CDN (new URL and SHA-256; MTK patch entries unchanged).
> 
> Across **Mentra Live Mintlify docs**, every install, quickstart, OTA, compatibility, and troubleshooting reference moves from **`0.1.21-beta.2`** to **`0.1.21-beta.3`** (Android Maven, iOS SwiftPM, React Native npm, example APK links, and ADB bootstrap filenames).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d9e63c645bfe5d6c932f3e31c83b9e2a6dbbe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->