### PR TITLE
Fix iOS staging bundle environment propagation

### DIFF
--- a/mobile/scripts/release-bundle-config.mjs
+++ b/mobile/scripts/release-bundle-config.mjs
@@ -28,17 +28,28 @@ function shellQuote(value) {
   return `'${String(value).replaceAll("'", `'"'"'`)}'`
 }
 
-export function xcodeEnvironmentExports(env, nodeBinary) {
+function xcodeEnvironmentEntries(env, nodeBinary) {
   const entries = Object.entries(env)
     .filter(([key, value]) => key.startsWith("EXPO_PUBLIC_") && value != null && String(value) !== "")
+    .map(([key, value]) => [key, String(value)])
     .sort(([left], [right]) => left.localeCompare(right))
 
   if (env.MENTRAOS_PINNED_BUILD_NUMBER) {
-    entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", env.MENTRAOS_PINNED_BUILD_NUMBER])
+    entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", String(env.MENTRAOS_PINNED_BUILD_NUMBER)])
   }
   entries.push(["NODE_BINARY", nodeBinary])
 
+  return entries
+}
+
+export function xcodeEnvironmentExports(env, nodeBinary) {
+  const entries = xcodeEnvironmentEntries(env, nodeBinary)
+
   return entries.map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+}
+
+export function xcodeBuildSettings(env, nodeBinary) {
+  return xcodeEnvironmentEntries(env, nodeBinary).map(([key, value]) => `${key}=${value}`)
 }
 
 export async function appendXcodeEnvironment(filePath, env, nodeBinary) {

--- a/mobile/scripts/release-bundle-config.test.mjs
+++ b/mobile/scripts/release-bundle-config.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict"
 import {execFileSync} from "node:child_process"
 import test from "node:test"
 
-import {assertBundleEnvironment, xcodeEnvironmentExports} from "./release-bundle-config.mjs"
+import {assertBundleEnvironment, xcodeBuildSettings, xcodeEnvironmentExports} from "./release-bundle-config.mjs"
 
 test("xcodeEnvironmentExports exports public and pinned build values safely", () => {
   const lines = xcodeEnvironmentExports(
@@ -29,6 +29,24 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
     },
   )
   assert.equal(output.trim(), "https://example.test/it's-pinned.json")
+})
+
+test("xcodeBuildSettings exposes the same public values to every build phase", () => {
+  const settings = xcodeBuildSettings(
+    {
+      EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/pin.json?channel=staging build",
+      EXPO_PUBLIC_EMPTY: "",
+      MENTRAOS_PINNED_BUILD_NUMBER: 123,
+      PRIVATE_SECRET: "do-not-export",
+    },
+    "/opt/node with spaces/bin/node",
+  )
+
+  assert.deepEqual(settings, [
+    "EXPO_PUBLIC_ASG_OTA_VERSION_URL=https://example.test/pin.json?channel=staging build",
+    "MENTRAOS_PINNED_BUILD_NUMBER=123",
+    "NODE_BINARY=/opt/node with spaces/bin/node",
+  ])
 })
 
 test("assertBundleEnvironment accepts expected nonempty runtime values", () => {

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -2,7 +2,11 @@
 
 import { setBuildEnv } from './set-build-env.mjs';
 import { withRetry, isSPMOrSentryTransientError, writeSummary } from './release-utils.mjs';
-import { appendXcodeEnvironment, validateReleaseArchive } from './release-bundle-config.mjs';
+import {
+  appendXcodeEnvironment,
+  validateReleaseArchive,
+  xcodeBuildSettings,
+} from './release-bundle-config.mjs';
 import { getBuildNumber } from './build-number.mjs';
 import { existsSync } from 'fs';
 import path from 'path';
@@ -95,8 +99,10 @@ const exportedXcodeVariables = await appendXcodeEnvironment(
   process.env,
   process.execPath,
 );
+const archiveBuildSettings = xcodeBuildSettings(process.env, process.execPath);
 console.log(`Pinned NODE_BINARY=${process.execPath} (node ${process.version}) for Xcode build phases`);
 console.log(`Exported ${exportedXcodeVariables - 1} build variables for Xcode child processes`);
+console.log(`Passing ${archiveBuildSettings.length - 1} build variables as Xcode archive settings`);
 
 // In CI, switch the Mentra app target's Release config to MANUAL signing
 // with the fastlane match-installed AppStore profile. Without this,
@@ -203,10 +209,16 @@ const archivePath = path.resolve('build/Mentra.xcarchive');
 // against the match profile, so xcodebuild just uses that. On a laptop
 // the project is left in Automatic mode and -allowProvisioningUpdates
 // lets Xcode fetch a profile on-demand.
+//
+// Pass the public runtime environment as command-line build settings as well as
+// writing .xcode.env.local above. Xcode exports command-line settings before it
+// starts every build phase. This is necessary because Sentry's wrapper around
+// "Bundle React Native code and images" does not reliably preserve variables
+// sourced from .xcode.env.local before it launches Expo/Metro.
 await withRetry(
   'xcodebuild archive',
   () => {
-    const p = $`xcodebuild archive -workspace ios/Mentra.xcworkspace -scheme Mentra -configuration Release -destination generic/platform=iOS -archivePath ${archivePath} -derivedDataPath ${derivedDataPath} -allowProvisioningUpdates DEVELOPMENT_TEAM=${teamId} SWIFT_STRICT_CONCURRENCY=minimal`;
+    const p = $`xcodebuild archive -workspace ios/Mentra.xcworkspace -scheme Mentra -configuration Release -destination generic/platform=iOS -archivePath ${archivePath} -derivedDataPath ${derivedDataPath} -allowProvisioningUpdates DEVELOPMENT_TEAM=${teamId} SWIFT_STRICT_CONCURRENCY=minimal ${archiveBuildSettings}`;
     p.stdout.pipe(process.stdout);
     p.stderr.pipe(process.stderr);
     return p;


### PR DESCRIPTION
## Summary

- pass every non-empty `EXPO_PUBLIC_*` value, the pinned build number, and `NODE_BINARY` to `xcodebuild archive` as explicit command-line build settings
- derive `.xcode.env.local` exports and Xcode build settings from one shared filtered entry list
- retain the post-export IPA validator as the publication backstop

## Follow-up to #3646

The first staging run containing #3646 proved that its artifact validation works, but also showed that the environment propagation fix was incomplete. In staging run 30595881144, `release-ios.mjs` generated the correct per-run OTA URL and build metadata and appended 15 values to `.xcode.env.local`. The archive and IPA export succeeded, but validation rejected the IPA because its Hermes bundle still lacked:

- `EXPO_PUBLIC_ASG_OTA_VERSION_URL`
- `EXPO_PUBLIC_BUILD_COMMIT`
- `EXPO_PUBLIC_BUILD_TIME`
- `EXPO_PUBLIC_BUILD_USER`

The Xcode trace showed the values being sourced by a later Sentry debug-symbol phase, but they were not effective build settings for the earlier Sentry-wrapped `Bundle React Native code and images` phase. The bad IPA was correctly blocked from TestFlight and the staging release.

## Fix

Xcode exports command-line build settings into every build phase before its shell script starts. The release archive now receives the same filtered public values directly as `KEY=value` settings. This does not depend on whether the generated React Native or Sentry shell wrapper sources `.xcode.env.local`. The local file remains in place for tools and phases that do source it.

Private variables remain excluded. Values are passed as individual zx arguments, preserving spaces and URL punctuation. The release script logs only the number of settings added; the existing validator remains responsible for proving that the final IPA contains each configured runtime value before publication.

## Verification

- `node --test mobile/scripts/*.test.mjs`
- `node --check mobile/scripts/release-ios.mjs`
- Prettier check for the shared helper and test
- `git diff --check`
- verified zx expands the settings array into separate arguments while preserving spaces and URL syntax
- verified with `xcodebuild -showBuildSettings` that an `EXPO_PUBLIC_*` command-line setting is present with `https://...?...` punctuation and spaces intact

The definitive end-to-end check remains the next signed staging iOS build: it must log `Verified iOS release JS bundle configuration` and proceed past the validator.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the iOS release pipeline and what values are baked into shipped JS bundles, but uses the same filtered env as before and the existing IPA bundle validator still blocks bad artifacts.
> 
> **Overview**
> Fixes **incomplete propagation** of `EXPO_PUBLIC_*`, pinned build number, and `NODE_BINARY` into the Hermes bundle when Sentry’s wrapper around **Bundle React Native code and images** does not honor `.xcode.env.local`.
> 
> **`release-bundle-config.mjs`** now builds one shared filtered entry list (`xcodeEnvironmentEntries`) used for both shell `export` lines and a new **`xcodeBuildSettings`** helper that emits `KEY=value` pairs for `xcodebuild`. Values are normalized with `String()` for consistency.
> 
> **`release-ios.mjs`** passes those settings as extra arguments on **`xcodebuild archive`**, so Xcode exports them into every build phase before scripts run, while still appending `.xcode.env.local` for phases that source it. Logging notes how many settings are passed.
> 
> A unit test asserts **`xcodeBuildSettings`** matches the same public/pinned values and preserves spaces and URL query syntax.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afeb51729bba8940f73893ab7667a6bb55614524. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->