### PR TITLE
Point prod at the Doppler-synced env group (OS-1869)

### DIFF
--- a/cloud-v2/porter.prod.yaml
+++ b/cloud-v2/porter.prod.yaml
@@ -2,7 +2,12 @@ version: v2
 name: cloud-prod
 
 envGroups:
-  - cloud-v2-prod-doppler
+  # Doppler-synced group. The old `cloud-v2-prod-doppler` was, despite the name,
+  # a plain Porter-stored group with no sync behind it, so a stale hand-entered
+  # SUPABASE_URL kept prod pointed at the dead auth.augmentos.org host and Google
+  # SSO returned a Cloudflare 1014 for every user (OS-1869). Doppler had the
+  # correct value the whole time; nothing was reading it.
+  - cloud-v2-prod-doppler-sync
 
 build:
   method: docker


### PR DESCRIPTION
One line change, plus a comment explaining why it matters.

## What was wrong

`cloud-v2/porter.prod.yaml` declared `cloud-v2-prod-doppler`. Despite the name, that Porter env group is **not Doppler-backed** — it is a plain Porter-stored group, hand populated, with no sync behind it. Every sibling group carries the Doppler badge in the Porter UI; prod is the only one that does not.

It held a stale `SUPABASE_URL` of `https://auth.augmentos.org`, the pre-rebrand host, which Cloudflare refuses with **error 1014 (CNAME Cross-User Banned)**. So every Google SSO attempt on prod landed on a Cloudflare error page instead of the account chooser.

Doppler had the correct value the whole time:

| layer | value |
|---|---|
| Doppler `cloud-v2/prod` | `https://auth.mentra.glass` ✅ |
| Doppler `cloud-v2/staging` | `https://auth.mentra.glass` ✅ |
| Doppler `cloud-v2/dev` | `https://auth.mentra.glass` ✅ |
| what prod actually served | `https://auth.augmentos.org` ❌ |

Nothing was reading it. Dev and staging were fine because their groups are genuinely Doppler-synced.

`gotrue.client.ts:22` is the only consumer and it throws when the variable is unset, so there is no fallback path and no code involved. Confirmed with `grep`: the string `auth.augmentos.org` appears nowhere in `cloud-v2/` outside a design doc.

## Why this change is needed even though prod already works

A real synced group, `cloud-v2-prod-doppler-sync`, was created and attached to `cloud-prod` through the Porter dashboard, and the redeploy fixed sign-in. But that change only exists in the dashboard. `porter apply -f porter.prod.yaml` is declarative, so **the next deploy would have re-attached the stale group and silently reverted the fix**, with no obvious cause.

This makes the file match what is actually running.

## Verification (after the dashboard change, before this PR)

```
$ curl -i ".../api/account/oauth/google/start?..."
HTTP/2 302
location: https://auth.mentra.glass/auth/v1/authorize?provider=google&...
```

302 on **20/20** consecutive requests. All four prod hosts `200`. End to end on a Moto g play 2024 pointed at prod: OAuth, account backend, subject-token exchange, runtime websocket, into the app.

## Blast radius

None on merge. Prod is deployed by `workflow_dispatch` only — the `push: branches: [main]` trigger is dead because `main` contains no `cloud-v2/` tree. This does not deploy anything by itself; it makes the next manual dispatch safe.

`porter.staging.yaml` and `porter.dev.yaml` are untouched.

Refs OS-1869.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 14ffb2e60a59d69da739a4ad5b51dad6a982221a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `cloud-v2/porter.prod.yaml` to attach the Doppler-synced env group `cloud-v2-prod-doppler-sync` instead of the stale `cloud-v2-prod-doppler`. This keeps `SUPABASE_URL` sourced from Doppler so prod Google SSO stays on `https://auth.mentra.glass` and prevents the Cloudflare 1014 redirect regression noted in OS-1869.

<sup>Written for commit 14ffb2e60a59d69da739a4ad5b51dad6a982221a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

