### PR TITLE
Fix iOS release Expo environment inlining

### DIFF
--- a/mobile/scripts/release-bundle-config.mjs
+++ b/mobile/scripts/release-bundle-config.mjs
@@ -37,6 +37,9 @@ function xcodeEnvironmentEntries(env, nodeBinary) {
   if (env.MENTRAOS_PINNED_BUILD_NUMBER) {
     entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", String(env.MENTRAOS_PINNED_BUILD_NUMBER)])
   }
+  if (env.NODE_ENV) {
+    entries.push(["NODE_ENV", String(env.NODE_ENV)])
+  }
   entries.push(["NODE_BINARY", nodeBinary])
 
   return entries

--- a/mobile/scripts/release-bundle-config.test.mjs
+++ b/mobile/scripts/release-bundle-config.test.mjs
@@ -10,6 +10,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/it's-pinned.json",
       EXPO_PUBLIC_EMPTY: "",
       MENTRAOS_PINNED_BUILD_NUMBER: "123",
+      NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
     },
     "/opt/node with spaces/bin/node",
@@ -18,6 +19,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
   assert.deepEqual(lines, [
     `export EXPO_PUBLIC_ASG_OTA_VERSION_URL='https://example.test/it'"'"'s-pinned.json'`,
     "export MENTRAOS_PINNED_BUILD_NUMBER='123'",
+    "export NODE_ENV='production'",
     "export NODE_BINARY='/opt/node with spaces/bin/node'",
   ])
 
@@ -37,6 +39,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/pin.json?channel=staging build",
       EXPO_PUBLIC_EMPTY: "",
       MENTRAOS_PINNED_BUILD_NUMBER: 123,
+      NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
     },
     "/opt/node with spaces/bin/node",
@@ -45,6 +48,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
   assert.deepEqual(settings, [
     "EXPO_PUBLIC_ASG_OTA_VERSION_URL=https://example.test/pin.json?channel=staging build",
     "MENTRAOS_PINNED_BUILD_NUMBER=123",
+    "NODE_ENV=production",
     "NODE_BINARY=/opt/node with spaces/bin/node",
   ])
 })

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -12,6 +12,11 @@ import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
 
+// Expo's export:embed command sets production mode after the CLI starts, which
+// is too late for its Babel transform to inline inherited EXPO_PUBLIC_* values.
+// Start every release subprocess in production mode instead.
+process.env.NODE_ENV = 'production';
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function parseVersion(version) {


### PR DESCRIPTION
## Summary

Fix iOS release bundles dropping build-specific `EXPO_PUBLIC_*` configuration by starting Expo's native bundle process with `NODE_ENV=production` already set.

The failed staging iOS job archived and exported an IPA successfully, but the post-build artifact validator found these four expected values missing from the Hermes bundle:

- `EXPO_PUBLIC_ASG_OTA_VERSION_URL`
- `EXPO_PUBLIC_BUILD_COMMIT`
- `EXPO_PUBLIC_BUILD_TIME`
- `EXPO_PUBLIC_BUILD_USER`

Android, ASG, Xcode archive, and IPA export all succeeded. Publication correctly stopped before the bad iOS artifact reached GitHub Releases or TestFlight.

Failed job: https://github.com/Mentra-Community/MentraOS/actions/runs/30598839493/job/91056980542

## Root cause

PR #3652 successfully propagated all public release values into Xcode. The failed job proves that the values were present as command-line Xcode build settings and were exported in the actual `Bundle React Native code and images` phase. That ruled out Xcode and the Sentry shell wrapper losing the variables.

The remaining issue is Expo environment inlining. A local reproduction using Expo's `export:embed` command showed:

- When `NODE_ENV` is absent when Expo CLI starts, the four inherited build-specific values are absent from the generated bundle.
- When Expo CLI starts with `NODE_ENV=production`, the same unique values are present in the generated bundle.
- Compiling that successful bundle to Hermes bytecode retains all four values.

Expo's `export:embed` implementation sets production mode internally, but it happens after CLI startup and is too late for this environment substitution path. This explains why values already established in the long-lived `.env` configuration survived while values generated for this particular release did not.

## Changes

- Force `process.env.NODE_ENV = "production"` at the start of `release-ios.mjs`, before prebuild or any Expo child process is launched.
- Include `NODE_ENV` in the existing Xcode environment entries so it is written to `.xcode.env.local` and passed as an explicit `xcodebuild` setting.
- Extend the release configuration tests to require `NODE_ENV=production` in both propagation paths.
- Keep the final IPA bundle validator unchanged so publication still fails closed if any expected runtime value is missing.

## Validation

- `node --test scripts/release-bundle-config.test.mjs`
- `node --check scripts/release-ios.mjs`
- `node --check scripts/release-bundle-config.mjs`
- `git diff --check`
- Reproduced Expo `export:embed` behavior with unique values both without and with startup `NODE_ENV=production`.
- Compiled the successful probe bundle with `hermesc` and confirmed all four unique values remained in the bytecode.

A full signed IPA build was not run locally. The staging workflow remains the end-to-end verification, with the artifact-level validator guarding publication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to iOS release scripting and env propagation; no runtime app logic changes beyond fixing missing inlined config in production bundles.
> 
> **Overview**
> Fixes iOS release bundles that passed archive/export but failed validation because **release-specific `EXPO_PUBLIC_*` values** (e.g. build commit/time/user, ASG OTA URL) were not inlined into the Hermes JS bundle.
> 
> **`release-ios.mjs`** now sets **`NODE_ENV=production`** at startup, before prebuild and any Expo/Metro child process. Expo’s `export:embed` path switches to production too late for Babel to pick up those inherited public env vars.
> 
> **`release-bundle-config.mjs`** also forwards **`NODE_ENV`** into the existing Xcode propagation paths (`.xcode.env.local` exports and `xcodebuild` build settings), alongside the pinned build number and `NODE_BINARY`. Tests assert `NODE_ENV=production` in both paths. The post-build bundle validator is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1eb764dc8fba14c4bb9833e1169120518cee3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->