### PR TITLE
dev -> staging

### DIFF
--- a/cloud-v2/porter.prod.yaml
+++ b/cloud-v2/porter.prod.yaml
@@ -2,7 +2,12 @@ version: v2
 name: cloud-prod
 
 envGroups:
-  - cloud-v2-prod-doppler
+  # Doppler-synced group. The old `cloud-v2-prod-doppler` was, despite the name,
+  # a plain Porter-stored group with no sync behind it, so a stale hand-entered
+  # SUPABASE_URL kept prod pointed at the dead auth.augmentos.org host and Google
+  # SSO returned a Cloudflare 1014 for every user (OS-1869). Doppler had the
+  # correct value the whole time; nothing was reading it.
+  - cloud-v2-prod-doppler-sync
 
 build:
   method: docker

--- a/mobile/scripts/release-bundle-config.mjs
+++ b/mobile/scripts/release-bundle-config.mjs
@@ -37,6 +37,9 @@ function xcodeEnvironmentEntries(env, nodeBinary) {
   if (env.MENTRAOS_PINNED_BUILD_NUMBER) {
     entries.push(["MENTRAOS_PINNED_BUILD_NUMBER", String(env.MENTRAOS_PINNED_BUILD_NUMBER)])
   }
+  if (env.NODE_ENV) {
+    entries.push(["NODE_ENV", String(env.NODE_ENV)])
+  }
   entries.push(["NODE_BINARY", nodeBinary])
 
   return entries

--- a/mobile/scripts/release-bundle-config.test.mjs
+++ b/mobile/scripts/release-bundle-config.test.mjs
@@ -10,6 +10,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/it's-pinned.json",
       EXPO_PUBLIC_EMPTY: "",
       MENTRAOS_PINNED_BUILD_NUMBER: "123",
+      NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
     },
     "/opt/node with spaces/bin/node",
@@ -18,6 +19,7 @@ test("xcodeEnvironmentExports exports public and pinned build values safely", ()
   assert.deepEqual(lines, [
     `export EXPO_PUBLIC_ASG_OTA_VERSION_URL='https://example.test/it'"'"'s-pinned.json'`,
     "export MENTRAOS_PINNED_BUILD_NUMBER='123'",
+    "export NODE_ENV='production'",
     "export NODE_BINARY='/opt/node with spaces/bin/node'",
   ])
 
@@ -37,6 +39,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
       EXPO_PUBLIC_ASG_OTA_VERSION_URL: "https://example.test/pin.json?channel=staging build",
       EXPO_PUBLIC_EMPTY: "",
       MENTRAOS_PINNED_BUILD_NUMBER: 123,
+      NODE_ENV: "production",
       PRIVATE_SECRET: "do-not-export",
     },
     "/opt/node with spaces/bin/node",
@@ -45,6 +48,7 @@ test("xcodeBuildSettings exposes the same public values to every build phase", (
   assert.deepEqual(settings, [
     "EXPO_PUBLIC_ASG_OTA_VERSION_URL=https://example.test/pin.json?channel=staging build",
     "MENTRAOS_PINNED_BUILD_NUMBER=123",
+    "NODE_ENV=production",
     "NODE_BINARY=/opt/node with spaces/bin/node",
   ])
 })

--- a/mobile/scripts/release-ios.mjs
+++ b/mobile/scripts/release-ios.mjs
@@ -12,6 +12,11 @@ import { existsSync } from 'fs';
 import path from 'path';
 import os from 'os';
 
+// Expo's export:embed command sets production mode after the CLI starts, which
+// is too late for its Babel transform to inline inherited EXPO_PUBLIC_* values.
+// Start every release subprocess in production mode instead.
+process.env.NODE_ENV = 'production';
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function parseVersion(version) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The Porter prod env group change affects live auth configuration and should be verified after deploy; mobile changes are limited to release scripting with test coverage.
> 
> **Overview**
> Fixes **production Google SSO** (OS-1869) by switching Porter prod from the misnamed `cloud-v2-prod-doppler` group—which was not Doppler-synced and kept a stale `SUPABASE_URL` on the dead `auth.augmentos.org` host—to **`cloud-v2-prod-doppler-sync`** so prod reads the correct Supabase URL from Doppler.
> 
> For **iOS release builds**, sets **`NODE_ENV=production`** at the start of `release-ios.mjs` and threads it through Xcode env exports/build settings so Babel can inline `EXPO_PUBLIC_*` before Expo’s `export:embed` flips mode too late. Tests cover the new `NODE_ENV` propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb4a58f412549fccc4ca67421384602ac3ec4bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->