### PR TITLE
Fix stale Expo environment values in Metro release bundles

### DIFF
--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,6 +1,7 @@
 const {getSentryExpoConfig} = require("@sentry/react-native/metro")
 const {withUniwindConfig} = require("uniwind/metro")
 const path = require("path")
+const {withExpoPublicEnvCacheVersion} = require("./scripts/metro-cache-version.cjs")
 
 /** @type {import('expo/metro-config').MetroConfig} */
 var config = getSentryExpoConfig(__dirname)
@@ -147,5 +148,10 @@ config = withUniwindConfig(config, {
   // defaults to project's root
   dtsFile: "./src/uniwind-types.d.ts",
 })
+
+// Babel inlines EXPO_PUBLIC_* values, but Metro's default transform cache key
+// does not include them. Expo also keeps that cache when CI=true, so concurrent
+// builds on our shared runners could reuse transforms from a different release.
+config.cacheVersion = withExpoPublicEnvCacheVersion(config.cacheVersion)
 
 module.exports = config

--- a/mobile/scripts/metro-cache-version.cjs
+++ b/mobile/scripts/metro-cache-version.cjs
@@ -1,0 +1,13 @@
+const {createHash} = require("node:crypto")
+
+function withExpoPublicEnvCacheVersion(baseCacheVersion, env = process.env) {
+  const publicEnvironment = Object.entries(env)
+    .filter(([key, value]) => key.startsWith("EXPO_PUBLIC_") && value !== undefined)
+    .map(([key, value]) => [key, String(value)])
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  const digest = createHash("sha256").update(JSON.stringify(publicEnvironment)).digest("hex")
+  return `${baseCacheVersion ?? "1.0"}:expo-public:${digest}`
+}
+
+module.exports = {withExpoPublicEnvCacheVersion}

--- a/mobile/scripts/metro-cache-version.test.mjs
+++ b/mobile/scripts/metro-cache-version.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import cacheVersion from "./metro-cache-version.cjs"
+
+const {withExpoPublicEnvCacheVersion} = cacheVersion
+
+test("Expo public environment participates in the Metro cache version", () => {
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-b",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+
+  assert.notEqual(first, second)
+})
+
+test("cache version is stable across environment insertion order", () => {
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+  })
+
+  assert.equal(first, second)
+})
+
+test("cache version distinguishes missing and empty public values", () => {
+  const missing = withExpoPublicEnvCacheVersion("base", {})
+  const empty = withExpoPublicEnvCacheVersion("base", {EXPO_PUBLIC_BUILD_COMMIT: ""})
+
+  assert.notEqual(missing, empty)
+})
+
+test("cache version ignores private environment and does not expose public values", () => {
+  const publicValue = "public-value-that-must-not-appear"
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: publicValue,
+    PRIVATE_SECRET: "private-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: publicValue,
+    PRIVATE_SECRET: "private-b",
+  })
+
+  assert.equal(first, second)
+  assert.doesNotMatch(first, new RegExp(publicValue))
+})


### PR DESCRIPTION
## Problem

Staging iOS run [30600834497](https://github.com/Mentra-Community/MentraOS/actions/runs/30600834497) received the correct release environment in Xcode, successfully archived and exported its IPA, but artifact validation found that these per-build values were absent from the shipped Hermes bundle:

- `EXPO_PUBLIC_ASG_OTA_VERSION_URL`
- `EXPO_PUBLIC_BUILD_COMMIT`
- `EXPO_PUBLIC_BUILD_TIME`
- `EXPO_PUBLIC_BUILD_USER`

The environment propagation added in #3655 was working: the archive command, Xcode build settings, `.xcode.env.local`, and bundle phase all showed the expected values plus `NODE_ENV=production`. The remaining failure was stale Metro transform-cache reuse.

Expo intentionally changes `export:embed --reset-cache` to `resetCache=false` when `CI=true`. Metro stores transforms in `os.tmpdir()/metro-cache`, which is shared by all three self-hosted runners because they execute under the same `bigbob` account. Metro keys a transform by source path/content and transform options, but not by the `EXPO_PUBLIC_*` values read by Babel while transforming that source.

Immediately before the staging archive, the `dev -> staging` PR iOS build transformed the same source files without the four release-generated values. The staging build then reused those cached transforms even though its own process environment was correct. Static values from `.env.example` remained valid, which is why artifact validation reported only the four values that differ per build.

## Change

Add a SHA-256 fingerprint of the complete, sorted `EXPO_PUBLIC_*` environment to Metro's `cacheVersion`. Different release environments now produce different transform keys, while identical environments retain normal Metro cache reuse.

Only the fingerprint enters the cache key. Public values themselves are not exposed in the cache-version string, and unrelated/private environment variables do not invalidate the cache. Missing and explicitly empty public variables remain distinct because Babel produces different output for them.

## Verification

- `node --test scripts/*.test.mjs`: 8/8 passing.
- Loaded the real Metro config under two build commits and confirmed distinct cache versions with no raw values in either key.
- Reproduced the original failure before the fix using two `CI=1` production `export:embed` invocations with `--reset-cache`: bundle B incorrectly contained every A value and none of the B values.
- Repeated the same end-to-end probe with this cache fingerprint: bundle B contained all expected B values and zero A values.
- Repeated bundle B without changing the environment: Metro reused the cache and completed in 1.9 seconds, confirming that the fix preserves caching when transformed output is genuinely reusable.
- `git diff --check` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release bundling and shared Metro cache behavior on CI; wrong hashing could hurt cache hit rate or still miss env changes, but scope is limited to cache key computation with tests.
> 
> **Overview**
> Fixes release bundles shipping **stale `EXPO_PUBLIC_*` values** when Metro reuses transform cache across CI jobs on shared runners (Babel inlines those vars, but the default cache key did not).
> 
> Metro’s `cacheVersion` is now extended via `withExpoPublicEnvCacheVersion`, which hashes the sorted set of `EXPO_PUBLIC_*` entries and appends a SHA-256 digest—**not** the raw values—so different per-build envs get distinct cache keys while identical envs still cache normally. Private env vars are ignored.
> 
> Adds `metro-cache-version.cjs` plus node tests for env sensitivity, stable ordering, missing vs empty values, and no leakage of public values into the version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7e7d304c9ff5880d4584eb0628da92db6c83f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->