### PR TITLE
dev -> staging

### DIFF
--- a/mobile/metro.config.js
+++ b/mobile/metro.config.js
@@ -1,6 +1,7 @@
 const {getSentryExpoConfig} = require("@sentry/react-native/metro")
 const {withUniwindConfig} = require("uniwind/metro")
 const path = require("path")
+const {withExpoPublicEnvCacheVersion} = require("./scripts/metro-cache-version.cjs")
 
 /** @type {import('expo/metro-config').MetroConfig} */
 var config = getSentryExpoConfig(__dirname)
@@ -147,5 +148,10 @@ config = withUniwindConfig(config, {
   // defaults to project's root
   dtsFile: "./src/uniwind-types.d.ts",
 })
+
+// Babel inlines EXPO_PUBLIC_* values, but Metro's default transform cache key
+// does not include them. Expo also keeps that cache when CI=true, so concurrent
+// builds on our shared runners could reuse transforms from a different release.
+config.cacheVersion = withExpoPublicEnvCacheVersion(config.cacheVersion)
 
 module.exports = config

--- a/mobile/scripts/metro-cache-version.cjs
+++ b/mobile/scripts/metro-cache-version.cjs
@@ -1,0 +1,13 @@
+const {createHash} = require("node:crypto")
+
+function withExpoPublicEnvCacheVersion(baseCacheVersion, env = process.env) {
+  const publicEnvironment = Object.entries(env)
+    .filter(([key, value]) => key.startsWith("EXPO_PUBLIC_") && value !== undefined)
+    .map(([key, value]) => [key, String(value)])
+    .sort(([left], [right]) => left.localeCompare(right))
+
+  const digest = createHash("sha256").update(JSON.stringify(publicEnvironment)).digest("hex")
+  return `${baseCacheVersion ?? "1.0"}:expo-public:${digest}`
+}
+
+module.exports = {withExpoPublicEnvCacheVersion}

--- a/mobile/scripts/metro-cache-version.test.mjs
+++ b/mobile/scripts/metro-cache-version.test.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict"
+import test from "node:test"
+
+import cacheVersion from "./metro-cache-version.cjs"
+
+const {withExpoPublicEnvCacheVersion} = cacheVersion
+
+test("Expo public environment participates in the Metro cache version", () => {
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-b",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+
+  assert.notEqual(first, second)
+})
+
+test("cache version is stable across environment insertion order", () => {
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_TIME: "time-a",
+    EXPO_PUBLIC_BUILD_COMMIT: "commit-a",
+  })
+
+  assert.equal(first, second)
+})
+
+test("cache version distinguishes missing and empty public values", () => {
+  const missing = withExpoPublicEnvCacheVersion("base", {})
+  const empty = withExpoPublicEnvCacheVersion("base", {EXPO_PUBLIC_BUILD_COMMIT: ""})
+
+  assert.notEqual(missing, empty)
+})
+
+test("cache version ignores private environment and does not expose public values", () => {
+  const publicValue = "public-value-that-must-not-appear"
+  const first = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: publicValue,
+    PRIVATE_SECRET: "private-a",
+  })
+  const second = withExpoPublicEnvCacheVersion("base", {
+    EXPO_PUBLIC_BUILD_COMMIT: publicValue,
+    PRIVATE_SECRET: "private-b",
+  })
+
+  assert.equal(first, second)
+  assert.doesNotMatch(first, new RegExp(publicValue))
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Build-tooling only; no runtime app logic, auth, or data paths—risk is limited to cache invalidation behavior on Metro builds.
> 
> **Overview**
> Fixes **incorrect Metro transform cache reuse** on shared CI runners when `EXPO_PUBLIC_*` values differ between builds (e.g. commit/time), even though Babel inlines those vars at transform time.
> 
> `metro.config.js` now sets `config.cacheVersion` via **`withExpoPublicEnvCacheVersion`**, which SHA-256 hashes all defined `EXPO_PUBLIC_*` entries (sorted for stability) and appends that digest to Metro’s base cache version. Non-public env vars are excluded, and the cache string does not embed raw public values.
> 
> Unit tests in `metro-cache-version.test.mjs` cover value changes, key order, missing vs empty, and privacy of secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 512f436133c8be9ceb75f0069af5828593966419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->