### PR TITLE
Enable OTA for pinned staging builds

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -37,6 +37,10 @@ The user-facing app version (`CFBundleShortVersionString` on iOS,
 - The build number (`CFBundleVersion` / `versionCode`) is derived at
   build time from wall-clock seconds — see `mobile/scripts/build-number.mjs`.
   Nothing to bump manually; just don't downgrade `EXPO_PUBLIC_MENTRAOS_VERSION`.
+- Automatic glasses OTA is enabled only when the mobile bundle contains an
+  `EXPO_PUBLIC_ASG_OTA_VERSION_URL` release pin. Local and compile-only builds
+  without a pin fail closed; a Super Mode manifest override remains available
+  for deliberate local OTA testing.
 
 ### Testing
 

--- a/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
+++ b/mobile/modules/engine/src/services/OtaUpdateCheckService.ts
@@ -401,6 +401,18 @@ export async function checkCurrentGlassesForUpdate(
     return emptyCheckResult("disconnected")
   }
 
+  const embeddedManifestUrl = process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL?.trim()
+  const superMode = useSettingsStore.getState().getSetting(SETTINGS.super_mode.key)
+  const overrideUrl = useSettingsStore.getState().getSetting(SETTINGS.ota_version_url.key)
+  const overrideActive = superMode && typeof overrideUrl === "string" && overrideUrl.trim() !== ""
+  if (!embeddedManifestUrl && !overrideActive) {
+    console.log("OTA: check skipped - mobile app has no embedded OTA manifest pin")
+    return emptyCheckResult("dev_build")
+  }
+  if (!embeddedManifestUrl) {
+    console.log("OTA: no embedded manifest pin, but super-mode manifest override is active - checking anyway")
+  }
+
   if (refreshVersionInfo) {
     void BluetoothSdk.requestVersionInfo().catch((error) => {
       console.warn("OTA: Failed to request version_info from glasses:", error)
@@ -418,22 +430,6 @@ export async function checkCurrentGlassesForUpdate(
     // cannot parse means nothing is verifiable, so skip rather than ghost an
     // "up to date" result from a comparison that never really ran.
     return emptyCheckResult("missing_build")
-  }
-
-  // Development builds (debug buildType) report a "-dev" versionName suffix and are exempt
-  // from OTA: a sideloaded dev build must not be prompted to roll back to the app's pinned
-  // release on every check. A super-mode manifest override re-enables checks so OTA flows can
-  // still be exercised against dev glasses deliberately.
-  const glassesAppVersion = useGlassesStore.getState().appVersion
-  if (glassesAppVersion?.endsWith("-dev")) {
-    const superMode = useSettingsStore.getState().getSetting(SETTINGS.super_mode.key)
-    const overrideUrl = useSettingsStore.getState().getSetting(SETTINGS.ota_version_url.key)
-    const overrideActive = superMode && typeof overrideUrl === "string" && overrideUrl.trim() !== ""
-    if (!overrideActive) {
-      console.log(`OTA: check skipped - glasses run a development build (${glassesAppVersion})`)
-      return emptyCheckResult("dev_build")
-    }
-    console.log("OTA: dev build detected but super-mode manifest override active - checking anyway")
   }
 
   if (!glassesConnectedNow()) {

--- a/mobile/src/__tests__/otaUpdateCheckService.test.ts
+++ b/mobile/src/__tests__/otaUpdateCheckService.test.ts
@@ -1,13 +1,18 @@
 import {checkCurrentGlassesForUpdate} from "../../modules/engine/src/services/OtaUpdateCheckService"
 import {useGlassesStore} from "../../modules/engine/src/stores/glasses"
+import {SETTINGS} from "@mentra/engine"
+import {useSettingsStore} from "@mentra/engine/internal"
 import {resetBluetoothSdkMock} from "@/test-utils/mockBluetoothSdk"
 
 describe("OtaUpdateCheckService", () => {
   const originalFetch = global.fetch
+  const originalEmbeddedManifestUrl = process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL
 
   beforeEach(() => {
+    process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL = "https://ota.example/app-pinned-version.json"
     resetBluetoothSdkMock()
     useGlassesStore.getState().reset()
+    useSettingsStore.getState().resetAllSettingsLocally()
     useGlassesStore.getState().setGlassesInfo({
       connection: {state: "connected", fullyBooted: true},
       buildNumber: "10",
@@ -21,8 +26,17 @@ describe("OtaUpdateCheckService", () => {
     global.fetch = originalFetch
   })
 
-  it("skips the check entirely for development builds", async () => {
-    useGlassesStore.getState().setGlassesInfo({appVersion: "49076573-dev"})
+  afterAll(() => {
+    if (originalEmbeddedManifestUrl === undefined) {
+      delete process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL
+    } else {
+      process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL = originalEmbeddedManifestUrl
+    }
+  })
+
+  it("skips the check entirely when the mobile app has no embedded OTA manifest pin", async () => {
+    delete process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL
+    useGlassesStore.getState().setGlassesInfo({appVersion: "staging.20260731.022348.189fe56"})
     global.fetch = jest.fn() as unknown as typeof fetch
 
     const result = await checkCurrentGlassesForUpdate({
@@ -34,8 +48,58 @@ describe("OtaUpdateCheckService", () => {
 
     expect(result.skippedReason).toBe("dev_build")
     expect(result.updateAvailable).toBe(false)
-    // The manifest must not even be fetched for a dev build.
+    // An unpinned phone build must not fetch or apply an automatic OTA manifest.
     expect(global.fetch).not.toHaveBeenCalled()
+  })
+
+  it("allows a pinned mobile build regardless of the ASG app version", async () => {
+    useGlassesStore.getState().setGlassesInfo({appVersion: "49076573-dev", buildNumber: "40"})
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({apps: {"com.mentra.asg_client": {versionCode: 10}}}),
+      } as unknown as Response),
+    ) as unknown as typeof fetch
+
+    const result = await checkCurrentGlassesForUpdate({
+      refreshVersionInfo: false,
+      fixClockBeforeCheck: false,
+      waitForBesVersionMs: 0,
+      waitForMtkVersionMs: 0,
+    })
+
+    expect(result.skippedReason).toBeUndefined()
+    expect(result.hasCheckCompleted).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith("https://ota.example/app-pinned-version.json")
+  })
+
+  it("allows an explicit super-mode manifest override from an unpinned mobile build", async () => {
+    delete process.env.EXPO_PUBLIC_ASG_OTA_VERSION_URL
+    useGlassesStore.getState().setGlassesInfo({buildNumber: "40"})
+    useSettingsStore.setState((state) => ({
+      settings: {
+        ...state.settings,
+        [SETTINGS.super_mode.key]: true,
+        [SETTINGS.ota_version_url.key]: "https://ota.example/manual-version.json",
+      },
+    }))
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({apps: {"com.mentra.asg_client": {versionCode: 40}}}),
+      } as unknown as Response),
+    ) as unknown as typeof fetch
+
+    const result = await checkCurrentGlassesForUpdate({
+      refreshVersionInfo: false,
+      fixClockBeforeCheck: false,
+      waitForBesVersionMs: 0,
+      waitForMtkVersionMs: 0,
+    })
+
+    expect(result.skippedReason).toBeUndefined()
+    expect(result.hasCheckCompleted).toBe(true)
+    expect(global.fetch).toHaveBeenCalledWith("https://ota.example/manual-version.json")
   })
 
   it("reports a failed check (never up-to-date) for a zeroed pin on modern glasses", async () => {

--- a/mobile/src/app/ota/check-for-updates.tsx
+++ b/mobile/src/app/ota/check-for-updates.tsx
@@ -122,9 +122,9 @@ export default function OtaCheckForUpdatesScreen() {
         }
 
         if (result.skippedReason === "dev_build") {
-          // Development builds are exempt from OTA. Shown as its own state — NOT
+          // Locally built mobile apps are exempt from OTA. Shown as its own state — NOT
           // "up to date", which would be an unverified claim.
-          console.log("OTA: Check skipped (dev_build) - glasses run a development build")
+          console.log("OTA: Check skipped (dev_build) - mobile app is a development build")
           checkCompletedRef.current = true
           engine.ota.clearUpdateAvailable()
           setCheckState("dev_build")
@@ -291,7 +291,7 @@ export default function OtaCheckForUpdatesScreen() {
       )
     }
 
-    // Development build: OTA exempt — distinct from "up to date" (unverified claim).
+    // Local mobile development build: OTA exempt — distinct from "up to date".
     if (checkState === "dev_build") {
       return (
         <>

--- a/mobile/src/i18n/en.ts
+++ b/mobile/src/i18n/en.ts
@@ -398,7 +398,8 @@ const en = {
     updateLater: "Later",
     upToDate: "Up to Date",
     devBuild: "Development Build",
-    devBuildNoOta: "These glasses run a development build, so automatic updates are disabled. Use the developer settings manifest override to update them manually.",
+    devBuildNoOta:
+      "This mobile app is a development build, so automatic glasses updates are disabled. Use the developer settings manifest override to update them manually.",
     noUpdatesAvailable: "Your glasses are running the latest version.",
     checkFailed: "Check Failed",
     checkFailedMessage: "Couldn't check for updates. Please check your connection and try again.",


### PR DESCRIPTION
## Summary

- gate automatic glasses OTA on the mobile bundle's embedded manifest pin instead of the connected ASG version name
- preserve Super Mode manifest overrides for deliberate OTA testing from unpinned local builds
- update the development-build UI copy and focused regression coverage

## Root cause

The OTA check treated an ASG `appVersion` ending in `-dev` as evidence that OTA should be disabled. The current staging phone builds already embed an immutable per-run `EXPO_PUBLIC_ASG_OTA_VERSION_URL`, but a glasses build reporting a development-style version name caused the phone to skip the check anyway and show the development-build warning.

OTA eligibility belongs to the phone artifact. A staging or promoted production phone binary has an embedded manifest pin and should run the normal OTA flow regardless of how the connected ASG identifies its own build. An unpinned local or compile-only phone build still fails closed unless the developer explicitly enables Super Mode and supplies a manifest override.

## Validation

- `bun run test --runTestsByPath src/__tests__/otaUpdateCheckService.test.ts --runInBand` (9 tests passed)
- `bun run compile`
- `node --test scripts/release-bundle-config.test.mjs` (4 tests passed)
- `git diff --check`

## Scope

This is the narrow staging hotfix. The broader coordinated release/versioning proposal is intentionally excluded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when automatic OTA runs and which builds can push updates to glasses; incorrect gating could skip needed updates or allow checks from unpinned dev builds without override.
> 
> **Overview**
> **Automatic glasses OTA is now keyed to the phone build**, not the connected ASG `appVersion` (e.g. names ending in `-dev`). Staging or production mobile binaries that embed `EXPO_PUBLIC_ASG_OTA_VERSION_URL` run the normal check even when glasses report a dev-style version name.
> 
> **Unpinned local/compile-only mobile builds fail closed**: `checkCurrentGlassesForUpdate` skips early with `dev_build` unless Super Mode supplies a manifest override URL, so unpinned apps do not fetch or apply OTA manifests.
> 
> Docs (`AGENTS.md`), OTA screen copy/i18n, and tests were updated to describe **mobile development builds** (not “glasses run a dev build”) and to cover pinned builds, unpinned skip, and super-mode override paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e072c0571c7522effc2c665875c563eea791479a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->