### PR TITLE
Inject the runtime Sentry DSN into mobile CI builds (OS-1827) [staging hotfix]

### DIFF
--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -156,6 +156,7 @@ jobs:
         # manifest (com.mapbox.token) for the Nav SDK.
         env:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_MOBILE_PRD }}
         run: |
           # Create .env from example (Expo reads from mobile/.env, not android/.env)
           cp .env.example .env
@@ -167,6 +168,56 @@ jobs:
             sed "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env > .env.tmp && mv .env.tmp .env
           else
             echo "::warning::MAPBOX_PUBLIC_TOKEN secret not set — Android build will use the dummy token and on-device navigation will not work."
+          fi
+          # .env.example ships an empty EXPO_PUBLIC_SENTRY_DSN and SentrySetup.tsx
+          # returns early on an empty DSN *without logging*, so every CI build has
+          # shipped with crash reporting silently off (OS-1827). Warn rather than
+          # fail, but never be silent about it again.
+          # A release-producing lane must never ship a green build with crash
+          # reporting silently off -- that is the exact failure OS-1827 exists to
+          # remove. pull_request runs legitimately have no secrets (forks, and
+          # secrets are not exposed to PRs from outside collaborators), so those
+          # still warn and continue. Everything else -- push to a release branch,
+          # workflow_dispatch, staging -- is fatal.
+          #
+          # Note the curl below keeps `|| true` on purpose: a network failure or a
+          # changed response shape lands here as an empty DSN and is reported with
+          # an actionable message, rather than killing the step with a bare
+          # non-zero exit that says nothing about crash reporting.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SENTRY_DSN_REQUIRED=false
+          else
+            SENTRY_DSN_REQUIRED=true
+          fi
+          sentry_dsn_unavailable() {
+            if [ "$SENTRY_DSN_REQUIRED" = "true" ]; then
+              echo "::error::$1 A release build must have crash reporting (OS-1827)."
+              exit 1
+            fi
+            echo "::warning::$1 This PR build will have no crash reporting (OS-1827)."
+          }
+          if [ -n "$DOPPLER_TOKEN" ]; then
+            # curl, not the Doppler CLI action: that action verifies its own
+            # download with gpg and hard-fails where gpg is absent, which is the
+            # case on our self-hosted macOS runners. curl needs nothing that is
+            # not already on every runner. The single-secret endpoint keeps the
+            # rest of the config (MAPBOX_DOWNLOADS_TOKEN) out of the shell; a
+            # service token implies its own project and config.
+            SENTRY_DSN_RESPONSE="$(curl -sS --fail-with-body --retry 3 --retry-connrefused \
+              -u "$DOPPLER_TOKEN:" \
+              "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN" || true)"
+            # A DSN contains no double quote, so this extraction is exact.
+            SENTRY_DSN_VALUE="$(printf '%s' "$SENTRY_DSN_RESPONSE" | sed -n 's/.*"computed":"\([^"]*\)".*/\1/p')"
+            echo "::add-mask::$SENTRY_DSN_VALUE"
+            if [ -n "$SENTRY_DSN_VALUE" ]; then
+              # Same portable temp-file form as the Mapbox edit above: this job
+              # runs on Linux (GNU sed), where `sed -i ''` exits 2.
+              sed "s|^EXPO_PUBLIC_SENTRY_DSN=.*|EXPO_PUBLIC_SENTRY_DSN=$SENTRY_DSN_VALUE|" .env > .env.tmp && mv .env.tmp .env
+            else
+              sentry_dsn_unavailable "Doppler returned an empty EXPO_PUBLIC_SENTRY_DSN."
+            fi
+          else
+            sentry_dsn_unavailable "DOPPLER_TOKEN_MOBILE_PRD secret not set."
           fi
 
       - name: Run Expo prebuild

--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -127,12 +127,61 @@ jobs:
         # (MBXAccessToken) for the Nav SDK.
         env:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_MOBILE_PRD }}
         run: |
           cp .env.example .env
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
           else
             echo "::warning::MAPBOX_PUBLIC_TOKEN secret not set — iOS build will use the dummy token and on-device navigation will not work."
+          fi
+          # .env.example ships an empty EXPO_PUBLIC_SENTRY_DSN and SentrySetup.tsx
+          # returns early on an empty DSN *without logging*, so every CI build has
+          # shipped with crash reporting silently off (OS-1827). Warn rather than
+          # fail, but never be silent about it again.
+          # A release-producing lane must never ship a green build with crash
+          # reporting silently off -- that is the exact failure OS-1827 exists to
+          # remove. pull_request runs legitimately have no secrets (forks, and
+          # secrets are not exposed to PRs from outside collaborators), so those
+          # still warn and continue. Everything else -- push to a release branch,
+          # workflow_dispatch, staging -- is fatal.
+          #
+          # Note the curl below keeps `|| true` on purpose: a network failure or a
+          # changed response shape lands here as an empty DSN and is reported with
+          # an actionable message, rather than killing the step with a bare
+          # non-zero exit that says nothing about crash reporting.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SENTRY_DSN_REQUIRED=false
+          else
+            SENTRY_DSN_REQUIRED=true
+          fi
+          sentry_dsn_unavailable() {
+            if [ "$SENTRY_DSN_REQUIRED" = "true" ]; then
+              echo "::error::$1 A release build must have crash reporting (OS-1827)."
+              exit 1
+            fi
+            echo "::warning::$1 This PR build will have no crash reporting (OS-1827)."
+          }
+          if [ -n "$DOPPLER_TOKEN" ]; then
+            # curl, not the Doppler CLI action: that action verifies its own
+            # download with gpg and hard-fails where gpg is absent, which is the
+            # case on our self-hosted macOS runners. curl needs nothing that is
+            # not already on every runner. The single-secret endpoint keeps the
+            # rest of the config (MAPBOX_DOWNLOADS_TOKEN) out of the shell; a
+            # service token implies its own project and config.
+            SENTRY_DSN_RESPONSE="$(curl -sS --fail-with-body --retry 3 --retry-connrefused \
+              -u "$DOPPLER_TOKEN:" \
+              "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN" || true)"
+            # A DSN contains no double quote, so this extraction is exact.
+            SENTRY_DSN_VALUE="$(printf '%s' "$SENTRY_DSN_RESPONSE" | sed -n 's/.*"computed":"\([^"]*\)".*/\1/p')"
+            echo "::add-mask::$SENTRY_DSN_VALUE"
+            if [ -n "$SENTRY_DSN_VALUE" ]; then
+              sed "s|^EXPO_PUBLIC_SENTRY_DSN=.*|EXPO_PUBLIC_SENTRY_DSN=$SENTRY_DSN_VALUE|" .env > .env.tmp && mv .env.tmp .env
+            else
+              sentry_dsn_unavailable "Doppler returned an empty EXPO_PUBLIC_SENTRY_DSN."
+            fi
+          else
+            sentry_dsn_unavailable "DOPPLER_TOKEN_MOBILE_PRD secret not set."
           fi
 
       - name: Configure Mapbox SPM credentials (~/.netrc)

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -167,6 +167,7 @@ jobs:
         # it into the Android manifest (com.mapbox.token) for the Nav SDK.
         env:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_MOBILE_STG }}
         run: |
           cp .env.example .env
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
@@ -174,6 +175,55 @@ jobs:
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
           else
             echo "::warning::MAPBOX_PUBLIC_TOKEN secret not set — Android build will use the dummy token and on-device navigation will not work."
+          fi
+          # .env.example ships an empty EXPO_PUBLIC_SENTRY_DSN and SentrySetup.tsx
+          # returns early on an empty DSN *without logging*, so every CI build has
+          # shipped with crash reporting silently off (OS-1827). Warn rather than
+          # fail — a missing DSN should not block a release — but never be silent
+          # about it again.
+          # A release-producing lane must never ship a green build with crash
+          # reporting silently off -- that is the exact failure OS-1827 exists to
+          # remove. pull_request runs legitimately have no secrets (forks, and
+          # secrets are not exposed to PRs from outside collaborators), so those
+          # still warn and continue. Everything else -- push to a release branch,
+          # workflow_dispatch, staging -- is fatal.
+          #
+          # Note the curl below keeps `|| true` on purpose: a network failure or a
+          # changed response shape lands here as an empty DSN and is reported with
+          # an actionable message, rather than killing the step with a bare
+          # non-zero exit that says nothing about crash reporting.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SENTRY_DSN_REQUIRED=false
+          else
+            SENTRY_DSN_REQUIRED=true
+          fi
+          sentry_dsn_unavailable() {
+            if [ "$SENTRY_DSN_REQUIRED" = "true" ]; then
+              echo "::error::$1 A release build must have crash reporting (OS-1827)."
+              exit 1
+            fi
+            echo "::warning::$1 This PR build will have no crash reporting (OS-1827)."
+          }
+          if [ -n "$DOPPLER_TOKEN" ]; then
+            # curl, not the Doppler CLI action: that action verifies its own
+            # download with gpg and hard-fails where gpg is absent, which is the
+            # case on our self-hosted macOS runners. curl needs nothing that is
+            # not already on every runner. The single-secret endpoint keeps the
+            # rest of the config (MAPBOX_DOWNLOADS_TOKEN) out of the shell; a
+            # service token implies its own project and config.
+            SENTRY_DSN_RESPONSE="$(curl -sS --fail-with-body --retry 3 --retry-connrefused \
+              -u "$DOPPLER_TOKEN:" \
+              "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN" || true)"
+            # A DSN contains no double quote, so this extraction is exact.
+            SENTRY_DSN_VALUE="$(printf '%s' "$SENTRY_DSN_RESPONSE" | sed -n 's/.*"computed":"\([^"]*\)".*/\1/p')"
+            echo "::add-mask::$SENTRY_DSN_VALUE"
+            if [ -n "$SENTRY_DSN_VALUE" ]; then
+              sed "s|^EXPO_PUBLIC_SENTRY_DSN=.*|EXPO_PUBLIC_SENTRY_DSN=$SENTRY_DSN_VALUE|" .env > .env.tmp && mv .env.tmp .env
+            else
+              sentry_dsn_unavailable "Doppler returned an empty EXPO_PUBLIC_SENTRY_DSN."
+            fi
+          else
+            sentry_dsn_unavailable "DOPPLER_TOKEN_MOBILE_STG secret not set."
           fi
           # Pin this app build's glasses OTA manifest to the ASG paired with it
           # (immutable per-run asset uploaded by upload-releases).
@@ -409,12 +459,58 @@ jobs:
         # file (not a shell env var) is the source of truth.
         env:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
+          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_MOBILE_STG }}
         run: |
           cp .env.example .env
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
           else
             echo "::warning::MAPBOX_PUBLIC_TOKEN secret not set — iOS build will use the dummy token and on-device navigation will not work."
+          fi
+          # See the Android job: an empty DSN disables Sentry silently (OS-1827).
+          # A release-producing lane must never ship a green build with crash
+          # reporting silently off -- that is the exact failure OS-1827 exists to
+          # remove. pull_request runs legitimately have no secrets (forks, and
+          # secrets are not exposed to PRs from outside collaborators), so those
+          # still warn and continue. Everything else -- push to a release branch,
+          # workflow_dispatch, staging -- is fatal.
+          #
+          # Note the curl below keeps `|| true` on purpose: a network failure or a
+          # changed response shape lands here as an empty DSN and is reported with
+          # an actionable message, rather than killing the step with a bare
+          # non-zero exit that says nothing about crash reporting.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            SENTRY_DSN_REQUIRED=false
+          else
+            SENTRY_DSN_REQUIRED=true
+          fi
+          sentry_dsn_unavailable() {
+            if [ "$SENTRY_DSN_REQUIRED" = "true" ]; then
+              echo "::error::$1 A release build must have crash reporting (OS-1827)."
+              exit 1
+            fi
+            echo "::warning::$1 This PR build will have no crash reporting (OS-1827)."
+          }
+          if [ -n "$DOPPLER_TOKEN" ]; then
+            # curl, not the Doppler CLI action: that action verifies its own
+            # download with gpg and hard-fails where gpg is absent, which is the
+            # case on our self-hosted macOS runners. curl needs nothing that is
+            # not already on every runner. The single-secret endpoint keeps the
+            # rest of the config (MAPBOX_DOWNLOADS_TOKEN) out of the shell; a
+            # service token implies its own project and config.
+            SENTRY_DSN_RESPONSE="$(curl -sS --fail-with-body --retry 3 --retry-connrefused \
+              -u "$DOPPLER_TOKEN:" \
+              "https://api.doppler.com/v3/configs/config/secret?name=EXPO_PUBLIC_SENTRY_DSN" || true)"
+            # A DSN contains no double quote, so this extraction is exact.
+            SENTRY_DSN_VALUE="$(printf '%s' "$SENTRY_DSN_RESPONSE" | sed -n 's/.*"computed":"\([^"]*\)".*/\1/p')"
+            echo "::add-mask::$SENTRY_DSN_VALUE"
+            if [ -n "$SENTRY_DSN_VALUE" ]; then
+              sed "s|^EXPO_PUBLIC_SENTRY_DSN=.*|EXPO_PUBLIC_SENTRY_DSN=$SENTRY_DSN_VALUE|" .env > .env.tmp && mv .env.tmp .env
+            else
+              sentry_dsn_unavailable "Doppler returned an empty EXPO_PUBLIC_SENTRY_DSN."
+            fi
+          else
+            sentry_dsn_unavailable "DOPPLER_TOKEN_MOBILE_STG secret not set."
           fi
           # Pin this app build's glasses OTA manifest to the ASG paired with it
           # (immutable per-run asset uploaded by upload-releases).


### PR DESCRIPTION
Port of [#3634](https://github.com/Mentra-Community/MentraOS/pull/3634), already merged to `dev`. Staging is in feature freeze and no longer takes `dev` merges, so this goes in directly.

## Why

`.env.example` ships an empty `EXPO_PUBLIC_SENTRY_DSN`, and `SentrySetup.tsx` returns early on an empty DSN **without logging**. So every CI build has shipped with crash reporting silently off, with no signal at all. That is why an Android process death during notification work could never be root-caused.

Staging is the lane that matters most here: it is the only workflow that uploads to TestFlight and Play internal, and those binaries are promoted to the stores unchanged.

## What it does

Each mobile lane fetches the DSN from Doppler and writes it into `.env` before the build.

Missing, unreadable, or empty DSN is **fatal on release-producing events** and a **warning on `pull_request`**, where secrets are legitimately unavailable on forks and from outside collaborators. `staging-builds.yml` only triggers on `push: [staging]` and `workflow_dispatch`, so both of its jobs are always in the strict path.

Uses Doppler's HTTP API over plain `curl` rather than `dopplerhq/cli-action`. That action verifies its own download with gpg and hard-fails on our self-hosted macOS runners, which have none. The first version of this change used the CLI and would have failed exactly the two lanes that ship to testers, warning rather than failing, and shipping another Sentry-less build. Caught by running against the real runner labels rather than `ubuntu-latest` / `macos-latest` stand-ins.

## Identical to dev

The three workflow files on `staging` were byte-equal to `dev`'s pre-merge state, so this is the same 196 line change with no adaptation and no conflict resolution.

```
mentra-app-android-build.yml   +51
mentra-app-ios-build.yml       +49
staging-builds.yml             +96
```

All four DSN call sites carry the release-lane guard. YAML validates on all three files.

Refs OS-1827.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 8925c859612c7adcc79801f1647096bc8fd11c30. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Inject the runtime Sentry DSN into all mobile CI builds and block release builds when it’s missing. Fixes OS-1827 where staging/TestFlight/Play builds shipped with Sentry silently disabled.

- **Bug Fixes**
  - Fetch `EXPO_PUBLIC_SENTRY_DSN` from Doppler and write to `mobile/.env` in `staging-builds.yml`, `mentra-app-android-build.yml`, and `mentra-app-ios-build.yml`.
  - Fail release-producing runs on missing/empty DSN; log a warning (do not fail) on `pull_request`.
  - Use Doppler’s HTTP API with `curl` (instead of `dopplerhq/cli-action`) to avoid `gpg` dependency on self-hosted macOS; DSN is masked in logs.
  - Use `DOPPLER_TOKEN_MOBILE_STG` for staging and `DOPPLER_TOKEN_MOBILE_PRD` for prod builds.

<sup>Written for commit 8925c859612c7adcc79801f1647096bc8fd11c30. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

