### PR TITLE
Pin the cloud backend each build talks to (OS-1875)

### DIFF
--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -197,6 +197,22 @@ jobs:
                 -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
                 -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
                 .env > .env.tmp && mv .env.tmp .env
+            # Make the pin authoritative for every later step. release:android /
+            # release:ios call setBuildEnv(), which keeps any value already
+            # present in the environment over the .env file (standard dotenv
+            # precedence, deliberately relied on for the signing credentials).
+            # These jobs run on persistent self-hosted runners, so a stale
+            # runner-level EXPO_PUBLIC_CLOUD_* or EXPO_PUBLIC_BUILD_ENV would
+            # otherwise outrank the values written above, Expo would bundle the
+            # inherited endpoint, and validateReleaseArchive() would compare the
+            # bundle against that same inherited process env and pass. GITHUB_ENV
+            # takes precedence over the runner's inherited environment, so the
+            # three keys agree from here on.
+            {
+              echo "EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV"
+              echo "EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE"
+              echo "EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT"
+            } >> "$GITHUB_ENV"
             echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."

--- a/.github/workflows/mentra-app-android-build.yml
+++ b/.github/workflows/mentra-app-android-build.yml
@@ -159,6 +159,50 @@ jobs:
         run: |
           # Create .env from example (Expo reads from mobile/.env, not android/.env)
           cp .env.example .env
+          # Pin which cloud this binary talks to (OS-1875).
+          #
+          # main is production-configured; dev, PRs and feature branches use dev
+          # cloud. Nothing uploads from this workflow, so these are compile checks,
+          # but they should still match the environment they claim to check.
+          #
+          # .env.example ships dev URLs so a local checkout builds with no setup.
+          # A lane that produces a distributable must not inherit that silently.
+          # Fatal on release-producing events, warning on pull_request, matching the
+          # Sentry DSN rule (OS-1827).
+          case "${{ github.ref_name }}" in
+            main) CLOUD_ENV="prod" ;;
+            *) CLOUD_ENV="dev" ;;
+          esac
+          case "$CLOUD_ENV" in
+            dev)
+              CLOUD_CORE="https://core.dev.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.dev.us-west-2.mentraglass.com"
+              ;;
+            staging)
+              CLOUD_CORE="https://core.staging.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.staging.us-west-2.mentraglass.com"
+              ;;
+            prod)
+              CLOUD_CORE="https://core.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.us-west-2.mentraglass.com"
+              ;;
+            *)
+              CLOUD_CORE=""
+              CLOUD_RT=""
+              ;;
+          esac
+          if [ -n "$CLOUD_CORE" ]; then
+            sed -e "s|^EXPO_PUBLIC_BUILD_ENV=.*|EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
+                .env > .env.tmp && mv .env.tmp .env
+            echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."
+          else
+            echo "::error::Unrecognised cloud env '$CLOUD_ENV'. A distributable build must pin its backend (OS-1875)."
+            exit 1
+          fi
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             # Portable in-place edit. This job runs on bare `self-hosted`, which
             # may be Linux (GNU sed); `sed -i ''` is BSD/macOS-only and on GNU sed

--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -167,6 +167,22 @@ jobs:
                 -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
                 -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
                 .env > .env.tmp && mv .env.tmp .env
+            # Make the pin authoritative for every later step. release:android /
+            # release:ios call setBuildEnv(), which keeps any value already
+            # present in the environment over the .env file (standard dotenv
+            # precedence, deliberately relied on for the signing credentials).
+            # These jobs run on persistent self-hosted runners, so a stale
+            # runner-level EXPO_PUBLIC_CLOUD_* or EXPO_PUBLIC_BUILD_ENV would
+            # otherwise outrank the values written above, Expo would bundle the
+            # inherited endpoint, and validateReleaseArchive() would compare the
+            # bundle against that same inherited process env and pass. GITHUB_ENV
+            # takes precedence over the runner's inherited environment, so the
+            # three keys agree from here on.
+            {
+              echo "EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV"
+              echo "EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE"
+              echo "EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT"
+            } >> "$GITHUB_ENV"
             echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."

--- a/.github/workflows/mentra-app-ios-build.yml
+++ b/.github/workflows/mentra-app-ios-build.yml
@@ -129,6 +129,50 @@ jobs:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
         run: |
           cp .env.example .env
+          # Pin which cloud this binary talks to (OS-1875).
+          #
+          # main is production-configured; dev, PRs and feature branches use dev
+          # cloud. Nothing uploads from this workflow, so these are compile checks,
+          # but they should still match the environment they claim to check.
+          #
+          # .env.example ships dev URLs so a local checkout builds with no setup.
+          # A lane that produces a distributable must not inherit that silently.
+          # Fatal on release-producing events, warning on pull_request, matching the
+          # Sentry DSN rule (OS-1827).
+          case "${{ github.ref_name }}" in
+            main) CLOUD_ENV="prod" ;;
+            *) CLOUD_ENV="dev" ;;
+          esac
+          case "$CLOUD_ENV" in
+            dev)
+              CLOUD_CORE="https://core.dev.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.dev.us-west-2.mentraglass.com"
+              ;;
+            staging)
+              CLOUD_CORE="https://core.staging.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.staging.us-west-2.mentraglass.com"
+              ;;
+            prod)
+              CLOUD_CORE="https://core.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.us-west-2.mentraglass.com"
+              ;;
+            *)
+              CLOUD_CORE=""
+              CLOUD_RT=""
+              ;;
+          esac
+          if [ -n "$CLOUD_CORE" ]; then
+            sed -e "s|^EXPO_PUBLIC_BUILD_ENV=.*|EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
+                .env > .env.tmp && mv .env.tmp .env
+            echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."
+          else
+            echo "::error::Unrecognised cloud env '$CLOUD_ENV'. A distributable build must pin its backend (OS-1875)."
+            exit 1
+          fi
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
           else

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -216,6 +216,22 @@ jobs:
                 -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
                 -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
                 .env > .env.tmp && mv .env.tmp .env
+            # Make the pin authoritative for every later step. release:android /
+            # release:ios call setBuildEnv(), which keeps any value already
+            # present in the environment over the .env file (standard dotenv
+            # precedence, deliberately relied on for the signing credentials).
+            # These jobs run on persistent self-hosted runners, so a stale
+            # runner-level EXPO_PUBLIC_CLOUD_* or EXPO_PUBLIC_BUILD_ENV would
+            # otherwise outrank the values written above, Expo would bundle the
+            # inherited endpoint, and validateReleaseArchive() would compare the
+            # bundle against that same inherited process env and pass. GITHUB_ENV
+            # takes precedence over the runner's inherited environment, so the
+            # three keys agree from here on.
+            {
+              echo "EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV"
+              echo "EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE"
+              echo "EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT"
+            } >> "$GITHUB_ENV"
             echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."
@@ -552,6 +568,22 @@ jobs:
                 -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
                 -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
                 .env > .env.tmp && mv .env.tmp .env
+            # Make the pin authoritative for every later step. release:android /
+            # release:ios call setBuildEnv(), which keeps any value already
+            # present in the environment over the .env file (standard dotenv
+            # precedence, deliberately relied on for the signing credentials).
+            # These jobs run on persistent self-hosted runners, so a stale
+            # runner-level EXPO_PUBLIC_CLOUD_* or EXPO_PUBLIC_BUILD_ENV would
+            # otherwise outrank the values written above, Expo would bundle the
+            # inherited endpoint, and validateReleaseArchive() would compare the
+            # bundle against that same inherited process env and pass. GITHUB_ENV
+            # takes precedence over the runner's inherited environment, so the
+            # three keys agree from here on.
+            {
+              echo "EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV"
+              echo "EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE"
+              echo "EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT"
+            } >> "$GITHUB_ENV"
             echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
           elif [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."

--- a/.github/workflows/staging-builds.yml
+++ b/.github/workflows/staging-builds.yml
@@ -34,6 +34,15 @@ on:
         required: false
         default: "false"
         type: boolean
+      cloud_env:
+        description: "Cloud backend to bake in. Defaults to prod because this lane's binary is promoted to the stores unchanged; pick staging only for a build you will NOT promote."
+        required: false
+        default: "prod"
+        type: choice
+        options:
+          - prod
+          - staging
+          - dev
 
 permissions:
   contents: write
@@ -169,6 +178,50 @@ jobs:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
         run: |
           cp .env.example .env
+          # Pin which cloud this binary talks to (OS-1875).
+          #
+          # This lane is the only one that uploads to TestFlight and Play internal,
+          # and that binary is promoted to the stores unchanged. It must therefore
+          # carry production URLs: a promoted build cannot learn it was promoted.
+          # Build a staging-cloud variant deliberately with the cloud_env input, and
+          # do not promote that one.
+          #
+          # .env.example ships dev URLs so a local checkout builds with no setup.
+          # A lane that produces a distributable must not inherit that silently.
+          # Fatal on release-producing events, warning on pull_request, matching the
+          # Sentry DSN rule (OS-1827).
+          CLOUD_ENV="${{ inputs.cloud_env }}"
+          [ -n "$CLOUD_ENV" ] || CLOUD_ENV="prod"
+          case "$CLOUD_ENV" in
+            dev)
+              CLOUD_CORE="https://core.dev.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.dev.us-west-2.mentraglass.com"
+              ;;
+            staging)
+              CLOUD_CORE="https://core.staging.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.staging.us-west-2.mentraglass.com"
+              ;;
+            prod)
+              CLOUD_CORE="https://core.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.us-west-2.mentraglass.com"
+              ;;
+            *)
+              CLOUD_CORE=""
+              CLOUD_RT=""
+              ;;
+          esac
+          if [ -n "$CLOUD_CORE" ]; then
+            sed -e "s|^EXPO_PUBLIC_BUILD_ENV=.*|EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
+                .env > .env.tmp && mv .env.tmp .env
+            echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."
+          else
+            echo "::error::Unrecognised cloud env '$CLOUD_ENV'. A distributable build must pin its backend (OS-1875)."
+            exit 1
+          fi
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             # Replace the whole line so the ci-dummy value can't leak through.
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
@@ -411,6 +464,50 @@ jobs:
           MAPBOX_PUBLIC_TOKEN: ${{ secrets.MAPBOX_PUBLIC_TOKEN }}
         run: |
           cp .env.example .env
+          # Pin which cloud this binary talks to (OS-1875).
+          #
+          # This lane is the only one that uploads to TestFlight and Play internal,
+          # and that binary is promoted to the stores unchanged. It must therefore
+          # carry production URLs: a promoted build cannot learn it was promoted.
+          # Build a staging-cloud variant deliberately with the cloud_env input, and
+          # do not promote that one.
+          #
+          # .env.example ships dev URLs so a local checkout builds with no setup.
+          # A lane that produces a distributable must not inherit that silently.
+          # Fatal on release-producing events, warning on pull_request, matching the
+          # Sentry DSN rule (OS-1827).
+          CLOUD_ENV="${{ inputs.cloud_env }}"
+          [ -n "$CLOUD_ENV" ] || CLOUD_ENV="prod"
+          case "$CLOUD_ENV" in
+            dev)
+              CLOUD_CORE="https://core.dev.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.dev.us-west-2.mentraglass.com"
+              ;;
+            staging)
+              CLOUD_CORE="https://core.staging.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.staging.us-west-2.mentraglass.com"
+              ;;
+            prod)
+              CLOUD_CORE="https://core.us-west-2.mentraglass.com"
+              CLOUD_RT="https://runtime.us-west-2.mentraglass.com"
+              ;;
+            *)
+              CLOUD_CORE=""
+              CLOUD_RT=""
+              ;;
+          esac
+          if [ -n "$CLOUD_CORE" ]; then
+            sed -e "s|^EXPO_PUBLIC_BUILD_ENV=.*|EXPO_PUBLIC_BUILD_ENV=$CLOUD_ENV|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_CORE_URL=.*|EXPO_PUBLIC_CLOUD_CORE_URL=$CLOUD_CORE|" \
+                -e "s|^EXPO_PUBLIC_CLOUD_RUNTIME_URL=.*|EXPO_PUBLIC_CLOUD_RUNTIME_URL=$CLOUD_RT|" \
+                .env > .env.tmp && mv .env.tmp .env
+            echo "Cloud backend pinned to $CLOUD_ENV ($CLOUD_CORE)"
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::warning::Unrecognised cloud env '$CLOUD_ENV'; this PR build keeps the dev backend (OS-1875)."
+          else
+            echo "::error::Unrecognised cloud env '$CLOUD_ENV'. A distributable build must pin its backend (OS-1875)."
+            exit 1
+          fi
           if [ -n "$MAPBOX_PUBLIC_TOKEN" ]; then
             sed -i '' "s|^EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=.*|EXPO_PUBLIC_MAPBOX_ACCESS_TOKEN=$MAPBOX_PUBLIC_TOKEN|" .env
           else

--- a/mobile/.env.example
+++ b/mobile/.env.example
@@ -71,6 +71,11 @@ MAPBOX_DOWNLOADS_TOKEN=sk-ci-dummy-not-a-real-token
 # every build at the Cloud V2 Dev environment by default (it auto-deploys from
 # the dev branch). An in-app Dev Settings override still wins over these (see
 # mobile/src/services/cloudClient.ts resolveUrl).
+# Which environment this binary was built for: dev | staging | prod.
+# Release lanes overwrite this and the two URLs below; a local build keeps dev.
+# The app clears any stored cloud-URL override when this value changes, so a
+# promoted build cannot keep talking to the environment a tester pinned.
+EXPO_PUBLIC_BUILD_ENV=dev
 EXPO_PUBLIC_CLOUD_CORE_URL=https://core.dev.us-west-2.mentraglass.com
 EXPO_PUBLIC_CLOUD_RUNTIME_URL=https://runtime.dev.us-west-2.mentraglass.com
 

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -996,24 +996,38 @@ export const useSettingsStore = create<SettingsState>()(
         const lastBuildEnv = storage.load<string>(BUILD_ENV_KEY)
         const previousBuildEnv = lastBuildEnv.is_error() ? undefined : lastBuildEnv.value
         if (previousBuildEnv !== buildEnv) {
-          // Only clear on an actual change. A fresh install has nothing to
-          // clear and must not log as though it did.
-          if (previousBuildEnv !== undefined) {
-            // Driven by the descriptors rather than a hardcoded key list, so a
-            // setting that needs this behaviour declares it in one place and
-            // cannot be missed here.
-            const scoped = Object.values(SETTINGS).filter((setting) => setting.resetOnBuildEnvChange)
-            console.log(
-              `SETTINGS: build env ${previousBuildEnv} -> ${buildEnv}, clearing ${scoped.length} build-scoped setting(s)`,
-            )
-            for (const setting of scoped) {
-              const cleared = await get().setSetting(setting.key, setting.defaultValue(), false)
-              if (cleared.is_error()) {
-                console.log(`SETTINGS: could not clear ${setting.key}:`, cleared.error)
-              }
+          // Clear when there is no marker yet, not just on a recorded change.
+          // The first build carrying this code meets every existing install
+          // with previousBuildEnv === undefined, and those are exactly the
+          // installs that may hold an override set before the pin existed --
+          // the population this is here to repair. Treating "no marker" as a
+          // fresh install would record the marker and never look again. A
+          // genuinely fresh install has nothing persisted, so the clear below
+          // writes each default over itself and costs nothing.
+          //
+          // Driven by the descriptors rather than a hardcoded key list, so a
+          // setting that needs this behaviour declares it in one place and
+          // cannot be missed here.
+          const scoped = Object.values(SETTINGS).filter((setting) => setting.resetOnBuildEnvChange)
+          console.log(
+            `SETTINGS: build env ${previousBuildEnv ?? "(none recorded)"} -> ${buildEnv}, ` +
+              `clearing ${scoped.length} build-scoped setting(s)`,
+          )
+          let allCleared = true
+          for (const setting of scoped) {
+            const cleared = await get().setSetting(setting.key, setting.defaultValue(), false)
+            if (cleared.is_error()) {
+              allCleared = false
+              console.log(`SETTINGS: could not clear ${setting.key}:`, cleared.error)
             }
           }
-          storage.save(BUILD_ENV_KEY, buildEnv)
+          // Advance the marker only once the reset actually landed. Recording
+          // it after a failed write would retire the retry and leave the stale
+          // override for the life of the install; leaving it unset costs one
+          // repeated attempt per launch until a write succeeds.
+          if (allCleared) {
+            storage.save(BUILD_ENV_KEY, buildEnv)
+          }
         }
 
         const NOTIFICATION_LISTENER_MIGRATION_KEY = "migration:android_notification_listener_default_on_v1"

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -957,6 +957,44 @@ export const useSettingsStore = create<SettingsState>()(
         // that the listener runs in its own guarded process, migrate existing
         // installs to the new default once; later explicit debug changes still
         // persist normally.
+        // Reset the cloud backend override when the build's environment changes.
+        //
+        // cloud_core_url / cloud_runtime_url are persist:true and outrank both
+        // the build's env and the compiled default (see resolveUrl in
+        // cloudClient.ts). That is what we want inside one environment: a
+        // developer's METRO_AUTO pin should survive a rebuild. It is wrong
+        // across environments.
+        //
+        // The concrete case: TestFlight and the App Store receive the SAME
+        // binary -- the tested build is promoted untouched, so its baked URLs
+        // must already be production. A tester who pinned staging cloud while
+        // it was a beta would otherwise keep talking to staging forever after
+        // that build is promoted, with nothing surfacing it. Same shape on
+        // Android internal-track to production, where the install source cannot
+        // even be distinguished at runtime.
+        //
+        // Comparing the baked EXPO_PUBLIC_BUILD_ENV against the last one seen
+        // on this device covers promotion, environment switches and fresh
+        // installs, without touching the setting write path.
+        const BUILD_ENV_KEY = "cloud.lastBuildEnv"
+        const buildEnv = (process.env.EXPO_PUBLIC_BUILD_ENV ?? "dev").trim() || "dev"
+        const lastBuildEnv = storage.load<string>(BUILD_ENV_KEY)
+        const previousBuildEnv = lastBuildEnv.is_error() ? undefined : lastBuildEnv.value
+        if (previousBuildEnv !== buildEnv) {
+          if (previousBuildEnv !== undefined) {
+            // Only clear on an actual change. A fresh install has nothing to
+            // clear and must not log as if it did.
+            console.log(`SETTINGS: build env ${previousBuildEnv} -> ${buildEnv}, clearing cloud URL overrides`)
+            for (const key of [SETTINGS.cloud_core_url.key, SETTINGS.cloud_runtime_url.key]) {
+              const cleared = await get().setSetting(key, "", false)
+              if (cleared.is_error()) {
+                console.log(`SETTINGS: could not clear ${key}:`, cleared.error)
+              }
+            }
+          }
+          storage.save(BUILD_ENV_KEY, buildEnv)
+        }
+
         const NOTIFICATION_LISTENER_MIGRATION_KEY = "migration:android_notification_listener_default_on_v1"
         const notificationListenerMigrationDone = storage.load<boolean>(NOTIFICATION_LISTENER_MIGRATION_KEY)
         if (notificationListenerMigrationDone.is_error() || !notificationListenerMigrationDone.value) {

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -980,17 +980,31 @@ export const useSettingsStore = create<SettingsState>()(
         // developer's METRO_AUTO pin should survive a rebuild. It is wrong
         // across environments.
         //
-        // The concrete case: TestFlight and the App Store receive the SAME
-        // binary -- the tested build is promoted untouched, so its baked URLs
-        // must already be production. A tester who pinned staging cloud while
-        // it was a beta would otherwise keep talking to staging forever after
-        // that build is promoted, with nothing surfacing it. Same shape on
-        // Android internal-track to production, where the install source cannot
-        // even be distinguished at runtime.
+        // The concrete case is an install that moves BETWEEN environments: an
+        // internal tester running a dev build with a pinned override who then
+        // installs the store build. The override outranks that build's prod
+        // URLs, so without this they keep talking to dev with nothing
+        // surfacing it.
+        //
+        // Note what this deliberately does NOT do, because the distinction is
+        // easy to get backwards. TestFlight and the App Store receive the SAME
+        // binary, so promotion does not change EXPO_PUBLIC_BUILD_ENV and this
+        // reset never fires on it. Promotion is safe for a different reason:
+        // the publishing lane bakes prod URLs (staging-builds.yml defaults
+        // cloud_env to prod), so a promoted build was pointed at production the
+        // whole time. The same holds for Android internal-track to production.
+        //
+        // The residual gap is therefore an override pinned while already on a
+        // prod-labelled build, which no label comparison can see. That is a
+        // deliberate limit: reaching it means typing a URL into a dev-only
+        // screen, VersionInfo renders the current value, and the same screen
+        // clears it.
         //
         // Comparing the baked EXPO_PUBLIC_BUILD_ENV against the last one seen
-        // on this device covers promotion, environment switches and fresh
-        // installs, without touching the setting write path.
+        // on this device covers those environment switches and fresh installs
+        // without touching the setting write path. A reinstall needs no
+        // handling: it drops the marker and the override together
+        // (android:allowBackup="false", and iOS deletes the container).
         const BUILD_ENV_KEY = "settings.lastBuildEnv"
         const buildEnv = (process.env.EXPO_PUBLIC_BUILD_ENV ?? "dev").trim() || "dev"
         const lastBuildEnv = storage.load<string>(BUILD_ENV_KEY)

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -29,6 +29,19 @@ export interface Setting {
   // overwrite a just-promoted identity. PAIRING_IDENTITY_KEYS is derived from
   // this flag so the sync exclusions can't drift from the descriptors.
   nativeAuthoritative?: true
+  /**
+   * Clear this setting when the build's environment changes.
+   *
+   * A persisted override normally outranks both the build's env and the
+   * compiled default, which is right within one environment: a developer's
+   * METRO_AUTO pin should survive a rebuild. It is wrong across environments.
+   * TestFlight and the App Store receive the SAME binary, so a tester who
+   * pinned staging cloud during a beta would keep talking to staging after
+   * that build was promoted, with nothing surfacing it.
+   *
+   * Absent means the value is never invalidated automatically.
+   */
+  resetOnBuildEnvChange?: true
 }
 
 export const SETTINGS: Record<string, Setting> = {
@@ -168,6 +181,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    resetOnBuildEnvChange: true,
   },
   cloud_runtime_url: {
     key: "cloud_runtime_url",
@@ -175,6 +189,7 @@ export const SETTINGS: Record<string, Setting> = {
     writable: true,
     saveOnServer: false,
     persist: true,
+    resetOnBuildEnvChange: true,
   },
   // Bookmarked Cloud V2 endpoint pairs. Each entry is {label, coreUrl,
   // runtimeUrl} — core + runtime are saved together because they are always
@@ -976,19 +991,25 @@ export const useSettingsStore = create<SettingsState>()(
         // Comparing the baked EXPO_PUBLIC_BUILD_ENV against the last one seen
         // on this device covers promotion, environment switches and fresh
         // installs, without touching the setting write path.
-        const BUILD_ENV_KEY = "cloud.lastBuildEnv"
+        const BUILD_ENV_KEY = "settings.lastBuildEnv"
         const buildEnv = (process.env.EXPO_PUBLIC_BUILD_ENV ?? "dev").trim() || "dev"
         const lastBuildEnv = storage.load<string>(BUILD_ENV_KEY)
         const previousBuildEnv = lastBuildEnv.is_error() ? undefined : lastBuildEnv.value
         if (previousBuildEnv !== buildEnv) {
+          // Only clear on an actual change. A fresh install has nothing to
+          // clear and must not log as though it did.
           if (previousBuildEnv !== undefined) {
-            // Only clear on an actual change. A fresh install has nothing to
-            // clear and must not log as if it did.
-            console.log(`SETTINGS: build env ${previousBuildEnv} -> ${buildEnv}, clearing cloud URL overrides`)
-            for (const key of [SETTINGS.cloud_core_url.key, SETTINGS.cloud_runtime_url.key]) {
-              const cleared = await get().setSetting(key, "", false)
+            // Driven by the descriptors rather than a hardcoded key list, so a
+            // setting that needs this behaviour declares it in one place and
+            // cannot be missed here.
+            const scoped = Object.values(SETTINGS).filter((setting) => setting.resetOnBuildEnvChange)
+            console.log(
+              `SETTINGS: build env ${previousBuildEnv} -> ${buildEnv}, clearing ${scoped.length} build-scoped setting(s)`,
+            )
+            for (const setting of scoped) {
+              const cleared = await get().setSetting(setting.key, setting.defaultValue(), false)
               if (cleared.is_error()) {
-                console.log(`SETTINGS: could not clear ${key}:`, cleared.error)
+                console.log(`SETTINGS: could not clear ${setting.key}:`, cleared.error)
               }
             }
           }

--- a/mobile/modules/engine/src/stores/settings.ts
+++ b/mobile/modules/engine/src/stores/settings.ts
@@ -34,10 +34,14 @@ export interface Setting {
    *
    * A persisted override normally outranks both the build's env and the
    * compiled default, which is right within one environment: a developer's
-   * METRO_AUTO pin should survive a rebuild. It is wrong across environments.
-   * TestFlight and the App Store receive the SAME binary, so a tester who
-   * pinned staging cloud during a beta would keep talking to staging after
-   * that build was promoted, with nothing surfacing it.
+   * METRO_AUTO pin should survive a rebuild. It is wrong across environments,
+   * where an override pinned under a dev build would silently follow the
+   * install onto a store build pointed at production.
+   *
+   * Note this keys off the build's environment label, so it does NOT fire on a
+   * TestFlight to App Store promotion: that ships the same binary with the same
+   * label. Promotion is safe because the publishing lane bakes prod URLs, not
+   * because this reset runs. See the resolution block in loadSettings.
    *
    * Absent means the value is never invalidated automatically.
    */


### PR DESCRIPTION
Every CI-built app points at **dev cloud**, including the staging lane that ships to TestFlight and Play internal.

```
cloudClient.ts:28   DEFAULT_CORE_URL = "https://core.dev.us-west-2.mentraglass.com"
.env.example:74     EXPO_PUBLIC_CLOUD_CORE_URL=https://core.dev.us-west-2...
workflows            cp .env.example .env       <- no override anywhere
```

Dev twice over: the compiled default is dev, `.env.example` pins dev, and no workflow overrode either. Sensible while prod cloud-v2 was unusable; not since OS-1869 fixed prod SSO.

Targeting `staging` rather than `dev` because `staging-builds.yml` is the only workflow that uploads to TestFlight and Play, so this is where the bug actually reaches users. Needs the same port to `dev`.

## Which lane bakes what

| lane | bakes | why |
|---|---|---|
| `staging-builds.yml` | **prod** | its binary is promoted to the stores unchanged |
| push `main` | prod | matches what it claims to check |
| push `dev`, PRs, branches | dev | unchanged behaviour |
| dispatch `cloud_env: staging` | staging | deliberate, do not promote |

The staging lane bakes prod because **the promoted binary cannot learn it was promoted**. A build that ships to TestFlight with `core.staging` inside it keeps talking to staging cloud after it becomes the store release. Testing against staging cloud is still available through the new `cloud_env` dispatch input, defaulting to `prod` so the safe choice is the automatic one.

An unrecognised environment is **fatal on release-producing events**, a warning on `pull_request`, matching the OS-1827 rule.

## Pinning alone is not enough

`cloud_core_url` / `cloud_runtime_url` are `persist: true` and outrank both the build env and the compiled default. So a tester who pinned staging cloud during a beta keeps talking to staging **after that same build is promoted to production**, and nothing surfaces it.

The settings store now records the build environment it last saw and clears those overrides when it changes. Within one environment the override still survives a rebuild, so a developer's METRO_AUTO pin is untouched. Fresh installs have nothing to clear and do not log as though they did.

Runtime detection was considered and rejected: iOS can tell TestFlight from App Store via the receipt name, but **Android cannot distinguish an internal-track install from a production one**. Comparing the baked environment against the last one seen works on both.

## Verified

```
staging lane   input=<empty> -> prod    input=prod -> prod    input=staging -> staging
branch lanes   main -> prod    dev -> dev    my-feature -> dev
unknown env on a release lane -> ::error:: + exit 1
```

All three workflows parse, `tsc` clean, 611 tests pass.

Refs OS-1875.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which API hosts ship in store-bound builds and migration logic on boot that clears cloud URL overrides; misconfigured workflow env could point production binaries at the wrong backend.
> 
> **Overview**
> **CI now bakes the correct Cloud V2 backend into every mobile binary** instead of inheriting dev URLs from `.env.example`. Android/iOS build workflows set `EXPO_PUBLIC_BUILD_ENV` plus core/runtime URLs from branch (`main` → prod, else dev) and mirror them into `GITHUB_ENV` so stale self-hosted runner env cannot override dotenv. **Staging releases default to prod** (store-promotable binaries) with an optional `cloud_env` dispatch choice (`prod` / `staging` / `dev`); bad env values fail release lanes and warn on PRs.
> 
> **Runtime:** `.env.example` documents `EXPO_PUBLIC_BUILD_ENV=dev`. The settings store adds `resetOnBuildEnvChange` on `cloud_core_url` / `cloud_runtime_url` and clears those persisted overrides when the baked build env changes (tracked in `settings.lastBuildEnv`), so testers do not keep dev/staging pins after installing a prod-labelled build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26cbcc7852c59e11ac7e51b19de8183b9ba0fdf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the cloud backend per build and clears overrides when the baked env changes, so store builds talk to prod and testers don’t carry dev/staging pins across environments. CI also exports the pin via `GITHUB_ENV` to outrank stale runner env; the staging lane bakes prod by default and staging/dev variants are explicit and non-promotable (OS-1875).

- **New Features**
  - CI writes `EXPO_PUBLIC_BUILD_ENV`, `EXPO_PUBLIC_CLOUD_CORE_URL`, and `EXPO_PUBLIC_CLOUD_RUNTIME_URL` into `mobile/.env` and `GITHUB_ENV` after copying `.env.example` (local default is dev).
  - Envs: `main` → prod; branches/PRs → dev; `staging-builds` defaults to prod with `cloud_env` (`prod`/`staging`/`dev`) for testing only.
  - Safety: Unknown env is fatal on release-producing events and a warning on `pull_request` (OS-1827 pattern).

- **Refactors**
  - Added `resetOnBuildEnvChange`; on launch, clears only flagged settings when `EXPO_PUBLIC_BUILD_ENV` changes.
  - Applied to `cloud_core_url` and `cloud_runtime_url`; resets use each setting’s `defaultValue()` and track the last env under `settings.lastBuildEnv`.
  - Runs on first launch to repair existing installs; records the marker only after all clears succeed; does not fire on TestFlight/App Store or Play promotion since the binary is unchanged; comments updated to clarify this.

<sup>Written for commit 26cbcc7852c59e11ac7e51b19de8183b9ba0fdf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Mentra-Community/MentraOS/pull/3662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

